### PR TITLE
feat(telegram): orchestrate a swarm of Telegram bots through one connected manager

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -454,6 +454,56 @@ def build_environment_hints() -> str:
     return "\n\n".join(hints)
 
 
+def build_telegram_fleet_hint() -> str:
+    """Return a one-section roster summary IFF a Telegram fleet is configured.
+
+    Layer 4 of the swarm-discovery stack (skill is layer 3).  When the user
+    has set up a manager bot AND minted at least one active child, this puts
+    the roster (with personas) directly into the system prompt so the leader
+    knows specific named workers exist before it has to call
+    ``telegram_fleet_list``.  Returns "" otherwise so we never burden a user
+    who hasn't opted into the Telegram variant.
+    """
+    if not (os.environ.get("TELEGRAM_FLEET_MANAGER_TOKEN") or "").strip():
+        return ""
+    try:
+        from gateway.telegram_fleet.roster import load_roster
+    except Exception as e:  # pragma: no cover - defensive
+        logger.debug("could not load fleet roster: %s", e)
+        return ""
+    try:
+        roster = load_roster()
+    except Exception as e:  # pragma: no cover - corrupt roster shouldn't block prompt
+        logger.debug("fleet roster unreadable: %s", e)
+        return ""
+    active = roster.active_children()
+    if not active:
+        return ""
+    lines = [
+        f"## Telegram fleet ({len(active)} active worker"
+        f"{'s' if len(active) != 1 else ''})",
+        "",
+        (
+            f"A Telegram bot fleet is configured (manager: "
+            f"@{roster.manager_bot_username or 'unknown'}).  When the user "
+            f"asks for a swarm AND wants visible Telegram bot activity, "
+            f"prefer `telegram_orchestrate_swarm` over `hermes_swarm` so each "
+            f"angle runs as the named bot below.  Otherwise default to "
+            f"`hermes_swarm` (no Telegram dependency)."
+        ),
+        "",
+    ]
+    for c in active:
+        persona = (c.persona or "").strip().replace("\n", " ")
+        if len(persona) > 120:
+            persona = persona[:117] + "…"
+        if persona:
+            lines.append(f"- @{c.username} — {persona}")
+        else:
+            lines.append(f"- @{c.username}")
+    return "\n".join(lines)
+
+
 CONTEXT_FILE_MAX_CHARS = 20_000
 CONTEXT_TRUNCATE_HEAD_RATIO = 0.7
 CONTEXT_TRUNCATE_TAIL_RATIO = 0.2

--- a/gateway/telegram_fleet/__init__.py
+++ b/gateway/telegram_fleet/__init__.py
@@ -36,6 +36,7 @@ from gateway.telegram_fleet.guardrails import (
     check_rate_limit,
 )
 from gateway.telegram_fleet.coordinator import (
+    FleetApprovalRequired,
     FleetCoordinator,
     get_coordinator,
 )
@@ -51,6 +52,7 @@ __all__ = [
     "SpawnApprovalRequired",
     "check_can_spawn",
     "check_rate_limit",
+    "FleetApprovalRequired",
     "FleetCoordinator",
     "get_coordinator",
 ]

--- a/gateway/telegram_fleet/__init__.py
+++ b/gateway/telegram_fleet/__init__.py
@@ -1,0 +1,56 @@
+"""Telegram Fleet — orchestrate a swarm of Telegram bots through a manager bot.
+
+Built on top of Telegram Bot API 9.5/9.6 (March-April 2026) ``Managed Bots``,
+which lets one "manager bot" create and own N child bots via the
+``getManagedBotToken`` / ``replaceManagedBotToken`` endpoints and the
+``managed_bot`` update type.
+
+This package adds:
+
+* :mod:`gateway.telegram_fleet.roster` — durable YAML roster of child bots
+  (token, persona, model, toolset overrides) at ``~/.hermes/telegram_fleet.yaml``.
+* :mod:`gateway.telegram_fleet.api` — thin ``httpx``-based client for the new
+  Bot API endpoints (PTB 22.7 doesn't expose them yet).
+* :mod:`gateway.telegram_fleet.audit` — append-only audit log of fleet events.
+* :mod:`gateway.telegram_fleet.guardrails` — fleet-size cap, per-child rate
+  limit, spawn-approval gate.
+* :mod:`gateway.telegram_fleet.coordinator` — the orchestrator the gateway
+  and tools talk to.
+
+Tools live in :mod:`tools.telegram_fleet_tool` and let the agent itself spawn,
+delegate-to, rotate, and decommission fleet members.
+"""
+
+from gateway.telegram_fleet.roster import (
+    ChildBot,
+    FleetRoster,
+    RosterError,
+    load_roster,
+    save_roster,
+)
+from gateway.telegram_fleet.audit import audit_event
+from gateway.telegram_fleet.guardrails import (
+    FleetGuardrailError,
+    SpawnApprovalRequired,
+    check_can_spawn,
+    check_rate_limit,
+)
+from gateway.telegram_fleet.coordinator import (
+    FleetCoordinator,
+    get_coordinator,
+)
+
+__all__ = [
+    "ChildBot",
+    "FleetRoster",
+    "RosterError",
+    "load_roster",
+    "save_roster",
+    "audit_event",
+    "FleetGuardrailError",
+    "SpawnApprovalRequired",
+    "check_can_spawn",
+    "check_rate_limit",
+    "FleetCoordinator",
+    "get_coordinator",
+]

--- a/gateway/telegram_fleet/api.py
+++ b/gateway/telegram_fleet/api.py
@@ -1,0 +1,199 @@
+"""Thin Telegram Bot API client for Managed Bots endpoints.
+
+PTB 22.7 (the version pinned by hermes-agent at the time of writing) does
+NOT yet expose the Bot API 9.5/9.6 ``getManagedBotToken`` /
+``replaceManagedBotToken`` methods or the ``managed_bot`` update payload.
+We call them via raw HTTP.  This client is deliberately small — it only
+covers what the fleet coordinator and tools need.
+
+All calls return parsed JSON.  Errors raise :class:`BotApiError`.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BASE_URL = "https://api.telegram.org"
+DEFAULT_TIMEOUT = 15.0
+
+
+class BotApiError(Exception):
+    """Wraps a Telegram Bot API failure."""
+
+    def __init__(self, method: str, code: Optional[int], description: str):
+        super().__init__(f"{method}: {description} (code={code})")
+        self.method = method
+        self.code = code
+        self.description = description
+
+
+@dataclass
+class ManagedBotInfo:
+    """Result of a successful ``getManagedBotToken`` call."""
+
+    token: str
+    bot_id: int
+    bot_username: str
+
+
+class FleetApiClient:
+    """Bot API client scoped to a single manager-bot token."""
+
+    def __init__(
+        self,
+        manager_token: str,
+        *,
+        base_url: str = DEFAULT_BASE_URL,
+        timeout: float = DEFAULT_TIMEOUT,
+        client: Optional[httpx.Client] = None,
+    ):
+        if not manager_token or ":" not in manager_token:
+            raise ValueError("manager_token must be a valid bot token (e.g. '12345:ABC...')")
+        self._token = manager_token
+        self._base_url = base_url.rstrip("/")
+        self._timeout = timeout
+        self._client = client  # injectable for tests
+
+    def _http(self) -> httpx.Client:
+        return self._client or httpx.Client(timeout=self._timeout)
+
+    def _post(self, method: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        url = f"{self._base_url}/bot{self._token}/{method}"
+        client = self._http()
+        try:
+            resp = client.post(url, json=payload)
+        finally:
+            if self._client is None:
+                client.close()
+        try:
+            data = resp.json()
+        except ValueError as e:
+            raise BotApiError(method, resp.status_code, f"non-JSON response: {e}") from e
+        if not isinstance(data, dict):
+            raise BotApiError(method, resp.status_code, f"unexpected response type {type(data).__name__}")
+        if not data.get("ok"):
+            raise BotApiError(
+                method,
+                data.get("error_code") or resp.status_code,
+                str(data.get("description", "unknown error")),
+            )
+        return data
+
+    # ── Manager-mode introspection ────────────────────────────────────
+
+    def get_me(self) -> Dict[str, Any]:
+        """Return the manager bot's identity (``getMe``)."""
+        return self._post("getMe", {}).get("result", {}) or {}
+
+    def can_manage_bots(self) -> bool:
+        """Return True if the bot has Manager Mode enabled in @BotFather."""
+        me = self.get_me()
+        return bool(me.get("can_manage_bots"))
+
+    # ── Managed Bots (Bot API 9.5/9.6) ────────────────────────────────
+
+    def get_managed_bot_token(self, user_id: int) -> ManagedBotInfo:
+        """Return token+identity for the child bot owned by *user_id*.
+
+        Mirrors the API method ``getManagedBotToken``.  Telegram returns the
+        full bot token plus the child bot's ``User`` object.
+        """
+        data = self._post("getManagedBotToken", {"user_id": int(user_id)})
+        result = data.get("result") or {}
+        token = result.get("token")
+        bot = result.get("bot") or {}
+        if not token or not isinstance(bot, dict):
+            raise BotApiError(
+                "getManagedBotToken",
+                None,
+                f"malformed result payload: {result!r}",
+            )
+        return ManagedBotInfo(
+            token=str(token),
+            bot_id=int(bot.get("id") or 0),
+            bot_username=str(bot.get("username") or ""),
+        )
+
+    def replace_managed_bot_token(self, user_id: int) -> ManagedBotInfo:
+        """Rotate the token for a managed bot.  Mirrors ``replaceManagedBotToken``."""
+        data = self._post("replaceManagedBotToken", {"user_id": int(user_id)})
+        result = data.get("result") or {}
+        token = result.get("token")
+        bot = result.get("bot") or {}
+        if not token or not isinstance(bot, dict):
+            raise BotApiError(
+                "replaceManagedBotToken",
+                None,
+                f"malformed result payload: {result!r}",
+            )
+        return ManagedBotInfo(
+            token=str(token),
+            bot_id=int(bot.get("id") or 0),
+            bot_username=str(bot.get("username") or ""),
+        )
+
+    # ── Child-bot helpers (sending as a fleet member) ────────────────
+
+    def send_message_as(
+        self,
+        child_token: str,
+        chat_id: str,
+        text: str,
+        *,
+        reply_to: Optional[int] = None,
+        parse_mode: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Send *text* as the child bot identified by *child_token*."""
+        if not child_token or ":" not in child_token:
+            raise ValueError("child_token must be a valid bot token")
+        payload: Dict[str, Any] = {"chat_id": chat_id, "text": text}
+        if reply_to is not None:
+            payload["reply_to_message_id"] = int(reply_to)
+        if parse_mode:
+            payload["parse_mode"] = parse_mode
+        url = f"{self._base_url}/bot{child_token}/sendMessage"
+        client = self._http()
+        try:
+            resp = client.post(url, json=payload)
+        finally:
+            if self._client is None:
+                client.close()
+        try:
+            data = resp.json()
+        except ValueError as e:
+            raise BotApiError("sendMessage", resp.status_code, f"non-JSON response: {e}") from e
+        if not isinstance(data, dict) or not data.get("ok"):
+            raise BotApiError(
+                "sendMessage",
+                (data or {}).get("error_code") or resp.status_code,
+                str((data or {}).get("description", "unknown error")),
+            )
+        return data.get("result") or {}
+
+
+def build_managed_bot_deep_link(
+    manager_username: str,
+    suggested_username: str,
+    *,
+    name: Optional[str] = None,
+) -> str:
+    """Build the ``t.me/newbot/...`` deep link a user taps to confirm spawn.
+
+    Telegram opens a pre-filled bot-creation dialog when the user opens this
+    link.  See https://core.telegram.org/bots/features#managed-bots .
+    """
+    manager = manager_username.lstrip("@")
+    suggested = suggested_username.lstrip("@")
+    base = f"https://t.me/newbot/{manager}/{suggested}"
+    if name:
+        # Telegram accepts the display name as a query parameter; URL-quote it.
+        from urllib.parse import quote
+
+        return f"{base}?name={quote(name, safe='')}"
+    return base

--- a/gateway/telegram_fleet/api.py
+++ b/gateway/telegram_fleet/api.py
@@ -138,6 +138,73 @@ class FleetApiClient:
             bot_username=str(bot.get("username") or ""),
         )
 
+    # ── Update stream (manager bot polling) ────────────────────────────
+
+    def get_updates(
+        self,
+        *,
+        offset: Optional[int] = None,
+        timeout: int = 0,
+        allowed_updates: Optional[list] = None,
+    ) -> list:
+        """Long-poll ``getUpdates`` and return the raw ``Update`` list.
+
+        Used by the manager bot to surface ``managed_bot`` events when a
+        user taps a spawn deep link.  ``timeout`` 0 means non-blocking.
+        """
+        payload: Dict[str, Any] = {}
+        if offset is not None:
+            payload["offset"] = int(offset)
+        if timeout:
+            payload["timeout"] = int(timeout)
+        if allowed_updates is not None:
+            payload["allowed_updates"] = list(allowed_updates)
+        data = self._post("getUpdates", payload)
+        result = data.get("result")
+        if not isinstance(result, list):
+            raise BotApiError(
+                "getUpdates",
+                None,
+                f"unexpected result type {type(result).__name__}",
+            )
+        return result
+
+    def drain_managed_bot_events(
+        self, *, offset: Optional[int] = None, timeout: int = 0
+    ):
+        """Drain pending ``managed_bot`` updates → resolved ``ManagedBotInfo``.
+
+        Returns ``(infos, next_offset)`` — the list of newly-confirmed
+        managed bots and the update_id to pass back as ``offset`` on the
+        next call (so we don't re-process the same updates).
+        """
+        updates = self.get_updates(
+            offset=offset, timeout=timeout, allowed_updates=["managed_bot"]
+        )
+        infos: list = []
+        next_offset = offset
+        for upd in updates:
+            if not isinstance(upd, dict):
+                continue
+            uid = upd.get("update_id")
+            if isinstance(uid, int):
+                next_offset = uid + 1
+            mb = upd.get("managed_bot")
+            if not isinstance(mb, dict):
+                continue
+            bot = mb.get("bot") or {}
+            bot_id = int(bot.get("id") or 0)
+            if not bot_id:
+                continue
+            try:
+                infos.append(self.get_managed_bot_token(bot_id))
+            except BotApiError as e:
+                logger.warning(
+                    "could not resolve token for managed bot id=%s: %s",
+                    bot_id, e,
+                )
+        return infos, next_offset
+
     # ── Child-bot helpers (sending as a fleet member) ────────────────
 
     def send_message_as(

--- a/gateway/telegram_fleet/audit.py
+++ b/gateway/telegram_fleet/audit.py
@@ -1,0 +1,100 @@
+"""Append-only audit log for Telegram fleet events.
+
+Lives at ``~/.hermes/telegram_fleet_audit.jsonl``.  One JSON object per line.
+Tokens are never recorded — only the bot username and the action taken.
+The file is created with mode 0600.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+AUDIT_FILENAME = "telegram_fleet_audit.jsonl"
+
+
+def get_audit_path() -> Path:
+    return get_hermes_home() / AUDIT_FILENAME
+
+
+def audit_event(action: str, **fields: Any) -> None:
+    """Append a single event to the audit log.
+
+    *action* is a short verb like ``spawn_requested``, ``spawn_confirmed``,
+    ``token_rotated``, ``decommissioned``, ``swarm_started``,
+    ``swarm_completed``.  Tokens, raw nonces, and any large payload should
+    NOT be passed in — only redacted/structural metadata.
+    """
+    record: Dict[str, Any] = {
+        "ts": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+        "action": str(action),
+    }
+    for key, value in fields.items():
+        if key == "token" or key.endswith("_token"):
+            # Defense in depth — never write tokens to the audit log.
+            value = _redact(str(value))
+        record[key] = _stringify_safely(value)
+
+    path = get_audit_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        existed = path.exists()
+        with path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n")
+        if not existed:
+            try:
+                os.chmod(path, 0o600)
+            except OSError as e:  # pragma: no cover
+                logger.debug("could not chmod 0600 on %s: %s", path, e)
+    except OSError as e:
+        logger.warning("could not write fleet audit event %s: %s", action, e)
+
+
+def _redact(value: str) -> str:
+    if not value:
+        return ""
+    if len(value) <= 8:
+        return "***"
+    return f"{value[:4]}…{value[-4:]}"
+
+
+def _stringify_safely(value: Any) -> Any:
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    if isinstance(value, (list, tuple)):
+        return [_stringify_safely(v) for v in value]
+    if isinstance(value, dict):
+        return {str(k): _stringify_safely(v) for k, v in value.items()}
+    return str(value)
+
+
+def read_recent_events(limit: int = 50, *, path: Optional[Path] = None) -> list[Dict[str, Any]]:
+    """Read up to *limit* most recent events.  Test/CLI helper.
+
+    Reads the whole file (audit logs are small) and returns the tail.
+    """
+    p = path or get_audit_path()
+    if not p.exists():
+        return []
+    out: list[Dict[str, Any]] = []
+    try:
+        with p.open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    out.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+    except OSError:
+        return []
+    return out[-limit:] if limit > 0 else out

--- a/gateway/telegram_fleet/coordinator.py
+++ b/gateway/telegram_fleet/coordinator.py
@@ -330,6 +330,37 @@ class FleetCoordinator:
             suggested_username=suggested, deep_link=deep_link, nonce=nonce
         )
 
+    def absorb_pending_updates(
+        self, *, max_polls: int = 1, poll_timeout: int = 0
+    ) -> List[ChildBot]:
+        """Drain ``managed_bot`` updates from Telegram and absorb them.
+
+        Each poll call (``max_polls`` total) issues one ``getUpdates``
+        request with the given ``poll_timeout`` (0 = non-blocking, >0 =
+        long-poll seconds — Telegram caps this at ~50).  Any matching
+        pending roster entries are promoted to active.  Returns the list
+        of newly-active children.
+        """
+        api = self._require_api()
+        absorbed: List[ChildBot] = []
+        offset: Optional[int] = None
+        for _ in range(max(1, int(max_polls))):
+            try:
+                infos, offset = api.drain_managed_bot_events(
+                    offset=offset, timeout=poll_timeout
+                )
+            except BotApiError as e:
+                logger.warning("getUpdates failed: %s", e)
+                break
+            for info in infos:
+                child = self.absorb_managed_bot(info)
+                if child is not None:
+                    absorbed.append(child)
+            if not infos and poll_timeout == 0:
+                # Non-blocking poll exhausted the queue.
+                break
+        return absorbed
+
     def absorb_managed_bot(self, info: ManagedBotInfo) -> Optional[ChildBot]:
         """Promote a pending child to active when the user confirms the spawn.
 

--- a/gateway/telegram_fleet/coordinator.py
+++ b/gateway/telegram_fleet/coordinator.py
@@ -23,7 +23,7 @@ import os
 import secrets
 import threading
 import time
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeout, as_completed
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Callable, Dict, List, Optional
@@ -477,6 +477,12 @@ class FleetCoordinator:
             raise FleetGuardrailError("objective must be non-empty")
         if not subtasks:
             raise FleetGuardrailError("subtasks must contain at least one entry")
+        if max_parallel < 1:
+            raise FleetGuardrailError(f"max_parallel must be ≥ 1, got {max_parallel}")
+        if per_task_timeout_s <= 0:
+            raise FleetGuardrailError(
+                f"per_task_timeout_s must be positive, got {per_task_timeout_s}"
+            )
         with self._lock:
             active = [c for c in self._roster.children if c.is_active()]
         if not active:
@@ -543,31 +549,49 @@ class FleetCoordinator:
                     objective=objective,
                     delegate_fn=delegate_fn,
                     parent_agent=parent_agent,
-                    timeout=per_task_timeout_s,
                 ): b
                 for b in bindings
             }
-            for fut in as_completed(futures):
-                b = futures[fut]
-                try:
-                    result = fut.result(timeout=per_task_timeout_s + 5)
-                except Exception as e:  # pragma: no cover - delegate failure
-                    result = SwarmTaskResult(
-                        persona=b.get("persona", ""),
-                        bot_username=b["bot_username"],
-                        goal=b["goal"],
-                        response="",
-                        duration_seconds=0.0,
-                        error=f"{type(e).__name__}: {e}",
-                    )
-                results.append(result)
-                if report_chat_id:
-                    summary = result.error or _truncate(result.response, 280)
-                    self._safe_post(
-                        result.bot_username,
-                        report_chat_id,
-                        f"✅ done: {summary}" if not result.error else f"❌ failed: {summary}",
-                    )
+            # per_task_timeout_s is a per-task budget; multiply by task count for
+            # the overall wall-clock cap so a single slow task doesn't starve all others.
+            overall_timeout = per_task_timeout_s * len(bindings)
+            try:
+                pending = dict(futures)
+                for fut in as_completed(pending, timeout=overall_timeout):
+                    b = pending[fut]
+                    try:
+                        result = fut.result()
+                    except Exception as e:  # pragma: no cover - delegate failure
+                        result = SwarmTaskResult(
+                            persona=b.get("persona", ""),
+                            bot_username=b["bot_username"],
+                            goal=b["goal"],
+                            response="",
+                            duration_seconds=0.0,
+                            error=f"{type(e).__name__}: {e}",
+                        )
+                    results.append(result)
+                    if report_chat_id:
+                        summary = result.error or _truncate(result.response, 280)
+                        self._safe_post(
+                            result.bot_username,
+                            report_chat_id,
+                            f"✅ done: {summary}" if not result.error else f"❌ failed: {summary}",
+                        )
+            except FuturesTimeout:
+                for fut, b in list(futures.items()):
+                    if not fut.done():
+                        fut.cancel()
+                        results.append(
+                            SwarmTaskResult(
+                                persona=b.get("persona", ""),
+                                bot_username=b["bot_username"],
+                                goal=b["goal"],
+                                response="",
+                                duration_seconds=per_task_timeout_s,
+                                error="timed out",
+                            )
+                        )
 
         # Kimi-style Critical Path metric: wall-clock per stage = max(workers).
         # Single-stage fan-out so critical_path == max(durations).
@@ -627,14 +651,20 @@ class FleetCoordinator:
                 bot = rotation[rr_idx % len(rotation)]
                 rr_idx += 1
             persona = str(raw.get("persona") or bot.persona or "")
+            raw_toolsets = raw.get("toolsets")
+            if raw_toolsets is not None and not isinstance(raw_toolsets, list):
+                raise FleetGuardrailError(
+                    f"subtask 'toolsets' must be a list of strings, got "
+                    f"{type(raw_toolsets).__name__!r}"
+                )
+            toolsets = (raw_toolsets if raw_toolsets is not None else list(bot.toolset or [])) or None
             bindings.append(
                 {
                     "goal": goal,
                     "context": str(raw.get("context") or ""),
-                    "toolsets": list(raw.get("toolsets") or bot.toolset or []) or None,
+                    "toolsets": toolsets,
                     "bot_username": bot.username,
                     "persona": persona,
-                    "bot_token": bot.token,
                 }
             )
         return bindings
@@ -646,7 +676,6 @@ class FleetCoordinator:
         objective: str,
         delegate_fn: Callable[..., str],
         parent_agent: Any,
-        timeout: float,
     ) -> SwarmTaskResult:
         start = time.monotonic()
         persona = binding.get("persona") or ""

--- a/gateway/telegram_fleet/coordinator.py
+++ b/gateway/telegram_fleet/coordinator.py
@@ -416,6 +416,7 @@ class FleetCoordinator:
                 )
 
         results: List[SwarmTaskResult] = []
+        wall_clock_start = time.monotonic()
         with ThreadPoolExecutor(max_workers=min(max_parallel, len(bindings))) as ex:
             futures = {
                 ex.submit(
@@ -450,11 +451,20 @@ class FleetCoordinator:
                         f"✅ done: {summary}" if not result.error else f"❌ failed: {summary}",
                     )
 
+        # Kimi-style Critical Path metric: wall-clock per stage = max(workers).
+        # Single-stage fan-out so critical_path == max(durations).
+        durations = [r.duration_seconds for r in results]
+        critical_path = max(durations) if durations else 0.0
+        total_serial = sum(durations)
+        speedup = (total_serial / critical_path) if critical_path > 0 else 1.0
+
         audit_event(
             "swarm_completed",
             run_id=run_id,
             tasks=len(results),
             failures=sum(1 for r in results if r.error),
+            critical_path_seconds=round(critical_path, 3),
+            parallel_speedup=round(speedup, 2),
         )
         aggregate = _aggregate(objective, results)
         return {
@@ -462,6 +472,14 @@ class FleetCoordinator:
             "objective": objective,
             "results": [r.to_dict() for r in results],
             "summary": aggregate,
+            "metrics": {
+                "workers": len(results),
+                "failures": sum(1 for r in results if r.error),
+                "critical_path_seconds": round(critical_path, 3),
+                "total_serial_seconds": round(total_serial, 3),
+                "wall_clock_seconds": round(time.monotonic() - wall_clock_start, 3),
+                "parallel_speedup": round(speedup, 2),
+            },
         }
 
     # ── internals ────────────────────────────────────────────────────

--- a/gateway/telegram_fleet/coordinator.py
+++ b/gateway/telegram_fleet/coordinator.py
@@ -590,6 +590,25 @@ class FleetCoordinator:
             raise FleetGuardrailError(
                 f"per_task_timeout_s must be positive, got {per_task_timeout_s}"
             )
+
+        # Surface the parent_agent threading bug clearly when it happens.
+        # Without this guard the swarm posts "▶ starting" and then comes back
+        # with delegate_task's generic "requires a parent agent context"
+        # error — useless to an operator who can't see the call stack.
+        # Threading chain: ``handle_function_call`` → ``registry.dispatch``
+        # → tool handler → here.  When that breaks (typical cause: gateway
+        # running a cached AIAgent from before the threading fix landed),
+        # parent_agent reaches us as None.  Skip when a test injected
+        # ``delegate_fn`` since those tests don't need a real agent.
+        if parent_agent is None and self._delegate_fn is None:
+            raise FleetGuardrailError(
+                "orchestrate_swarm called without a parent_agent context.  "
+                "This usually means the gateway is running a cached AIAgent "
+                "from before the parent_agent threading fix.  Restart the "
+                "gateway (`hermes gateway restart`) or update your install "
+                "to pull the latest fix on this PR."
+            )
+
         with self._lock:
             active = [c for c in self._roster.children if c.is_active()]
         if not active:

--- a/gateway/telegram_fleet/coordinator.py
+++ b/gateway/telegram_fleet/coordinator.py
@@ -55,6 +55,97 @@ logger = logging.getLogger(__name__)
 # ── Spawn / orchestration result types ────────────────────────────────
 
 
+class FleetApprovalRequired(FleetGuardrailError):
+    """Raised when ``orchestrate_swarm`` needs the user to approve the plan.
+
+    Carries the proposed bindings + objective so the tool layer can render
+    a structured plan back to the agent (which then surfaces it via
+    ``clarify`` for the user to approve / adjust / reject).
+    """
+
+    def __init__(
+        self,
+        *,
+        objective: str,
+        bindings: List[Dict[str, Any]],
+        report_chat_id: Optional[str],
+    ):
+        bots = [b["bot_username"] for b in bindings]
+        super().__init__(
+            "Telegram fleet swarm requires user approval before posting as "
+            f"{len(bots)} named bots ({', '.join('@' + b for b in bots)}).  "
+            "Use the `clarify` tool to confirm, then re-call with "
+            "user_approved=true.  To bypass: pin every subtask to a "
+            "specific bot_username, or set telegram_fleet.auto_approve: "
+            "true in config.yaml."
+        )
+        self.objective = objective
+        self.bindings = bindings
+        self.report_chat_id = report_chat_id
+
+    def to_plan_dict(self) -> Dict[str, Any]:
+        return {
+            "objective": self.objective,
+            "report_chat_id": self.report_chat_id,
+            "workers": [
+                {
+                    "bot_username": b["bot_username"],
+                    "persona": b.get("persona", ""),
+                    "goal": b["goal"],
+                }
+                for b in self.bindings
+            ],
+        }
+
+
+def _is_by_name_request(subtasks: List[Dict[str, Any]]) -> bool:
+    """Return True when every subtask pinned a ``bot_username``.
+
+    A by-name request means the user already named who they want — that
+    counts as explicit consent and bypasses the approval gate.
+    """
+    if not subtasks:
+        return False
+    for raw in subtasks:
+        if not isinstance(raw, dict):
+            return False
+        pin = str(raw.get("bot_username") or "").strip()
+        if not pin:
+            return False
+    return True
+
+
+def _auto_approve_enabled() -> bool:
+    """Return True when the operator opted out of the approval prompt.
+
+    Resolution order: ``TELEGRAM_FLEET_AUTO_APPROVE`` env var, then
+    ``telegram_fleet.auto_approve`` in ``~/.hermes/config.yaml``.  Default
+    is False — the gate stays on unless the operator explicitly disables it.
+    """
+    if (os.environ.get("TELEGRAM_FLEET_AUTO_APPROVE") or "").strip().lower() in {
+        "1", "true", "yes", "on"
+    }:
+        return True
+    try:
+        from hermes_constants import get_config_path
+
+        config_path = get_config_path()
+        if not config_path.exists():
+            return False
+        import yaml  # local import — avoid hard dep at module-load time
+
+        parsed = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    except Exception as e:  # malformed YAML, missing yaml, IO error
+        logger.debug("could not read auto_approve from config.yaml: %s", e)
+        return False
+    if not isinstance(parsed, dict):
+        return False
+    cfg = parsed.get("telegram_fleet") or {}
+    if not isinstance(cfg, dict):
+        return False
+    return bool(cfg.get("auto_approve", False))
+
+
 @dataclass
 class SpawnResult:
     """Returned by :meth:`FleetCoordinator.spawn_bot`."""
@@ -356,6 +447,7 @@ class FleetCoordinator:
         max_parallel: int = 8,
         per_task_timeout_s: float = 600.0,
         parent_agent: Any = None,
+        user_approved: bool = False,
     ) -> Dict[str, Any]:
         """Fan *subtasks* across active fleet members, aggregate results.
 
@@ -394,6 +486,32 @@ class FleetCoordinator:
             )
 
         bindings = self._bind_subtasks(subtasks, active)
+
+        # Approval gate (Hermes house style — mirrors terminal_tool's
+        # ``force=True`` pattern).  The Telegram swarm has visible side-effects
+        # (named bots posting messages); gate it behind explicit consent.
+        # Two ways to bypass:
+        #   (a) ``user_approved=True`` — caller explicitly confirms.
+        #   (b) Every subtask pinned ``bot_username`` — by-name request.
+        # Operators can disable the gate entirely via config flag
+        # ``telegram_fleet.auto_approve: true``.
+        if not user_approved and not _is_by_name_request(subtasks):
+            if not _auto_approve_enabled():
+                # Record the request so operators can see swarm-attempt patterns
+                # without leaking subtask content or bot tokens.
+                audit_event(
+                    "swarm_approval_required",
+                    objective_chars=len(objective),
+                    workers=len(bindings),
+                    bots=[b["bot_username"] for b in bindings],
+                    report_chat_id=str(report_chat_id) if report_chat_id else None,
+                )
+                raise FleetApprovalRequired(
+                    objective=objective,
+                    bindings=bindings,
+                    report_chat_id=report_chat_id,
+                )
+
         delegate_fn = self._delegate_fn or _resolve_delegate()
 
         run_id = secrets.token_hex(6)

--- a/gateway/telegram_fleet/coordinator.py
+++ b/gateway/telegram_fleet/coordinator.py
@@ -1,0 +1,642 @@
+"""FleetCoordinator — the orchestration brain for Telegram Fleet Mode.
+
+Responsibilities:
+
+* Hold the parsed roster in memory and persist mutations.
+* Talk to the manager bot via :class:`FleetApiClient` (token rotation,
+  managed-bot identity, child-bot send).
+* Mint pending entries when the agent calls ``telegram_spawn_bot`` and
+  return the deep link for the user to tap.
+* Promote a pending entry to active when a ``managed_bot`` update arrives
+  (the gateway feeds these updates in via :meth:`absorb_managed_bot`).
+* Fan out a swarm: assign sub-tasks to active "pool" children, run them in
+  parallel via ``delegate_task``, post status updates to each child's chat
+  so the user can watch live, then aggregate findings.
+
+Single-instance per process, fetched via :func:`get_coordinator`.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import secrets
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, List, Optional
+
+from gateway.telegram_fleet.api import (
+    BotApiError,
+    FleetApiClient,
+    ManagedBotInfo,
+    build_managed_bot_deep_link,
+)
+from gateway.telegram_fleet.audit import audit_event
+from gateway.telegram_fleet.guardrails import (
+    FleetGuardrailError,
+    check_can_spawn,
+    check_rate_limit,
+)
+from gateway.telegram_fleet.roster import (
+    ChildBot,
+    FleetRoster,
+    PENDING_TTL_SECONDS,
+    RosterError,
+    load_roster,
+    save_roster,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ── Spawn / orchestration result types ────────────────────────────────
+
+
+@dataclass
+class SpawnResult:
+    """Returned by :meth:`FleetCoordinator.spawn_bot`."""
+
+    suggested_username: str
+    deep_link: str
+    nonce: str
+    qr_text: Optional[str] = None  # Caller can render it; coordinator does not.
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "suggested_username": self.suggested_username,
+            "deep_link": self.deep_link,
+            "nonce": self.nonce,
+        }
+
+
+@dataclass
+class SwarmTaskResult:
+    """One sub-task's outcome inside an orchestrate_swarm run."""
+
+    persona: str
+    bot_username: str
+    goal: str
+    response: str
+    duration_seconds: float
+    error: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        out = {
+            "persona": self.persona,
+            "bot_username": self.bot_username,
+            "goal": self.goal,
+            "response": self.response,
+            "duration_seconds": round(self.duration_seconds, 3),
+        }
+        if self.error:
+            out["error"] = self.error
+        return out
+
+
+# ── Coordinator ───────────────────────────────────────────────────────
+
+
+class FleetCoordinator:
+    """Single-process orchestrator for the Telegram fleet."""
+
+    def __init__(
+        self,
+        *,
+        manager_token: Optional[str] = None,
+        manager_username: Optional[str] = None,
+        api_client: Optional[FleetApiClient] = None,
+        roster_path=None,
+        delegate_fn: Optional[Callable[..., str]] = None,
+    ):
+        self._lock = threading.RLock()
+        self._roster_path = roster_path
+        self._roster: FleetRoster = load_roster(path=roster_path)
+        # Drop stale pending entries immediately so callers don't see them.
+        if self._roster.prune_expired_pending():
+            save_roster(self._roster, path=roster_path)
+        self._manager_token = manager_token or os.getenv("TELEGRAM_FLEET_MANAGER_TOKEN")
+        if manager_username:
+            self._roster.manager_bot_username = manager_username.lstrip("@")
+        self._api = api_client
+        self._delegate_fn = delegate_fn  # Injectable for tests; falls back to delegate_tool.
+
+    # ── Roster access ────────────────────────────────────────────────
+
+    @property
+    def roster(self) -> FleetRoster:
+        with self._lock:
+            return self._roster
+
+    def list_children(self, *, status: Optional[str] = None) -> List[ChildBot]:
+        with self._lock:
+            children = list(self._roster.children)
+        if status:
+            children = [c for c in children if c.status == status]
+        return children
+
+    def find(self, username: str) -> Optional[ChildBot]:
+        with self._lock:
+            return self._roster.find(username)
+
+    def reload(self) -> None:
+        """Re-read the roster from disk (e.g. after an external edit)."""
+        with self._lock:
+            self._roster = load_roster(path=self._roster_path)
+            self._roster.prune_expired_pending()
+
+    # ── Manager API client ───────────────────────────────────────────
+
+    def _require_api(self) -> FleetApiClient:
+        if self._api is not None:
+            return self._api
+        if not self._manager_token:
+            raise FleetGuardrailError(
+                "no manager bot token configured.  Set TELEGRAM_FLEET_MANAGER_TOKEN "
+                "in ~/.hermes/.env or pass manager_token to FleetCoordinator."
+            )
+        self._api = FleetApiClient(self._manager_token)
+        return self._api
+
+    def manager_username(self) -> str:
+        with self._lock:
+            cached = self._roster.manager_bot_username
+        if cached:
+            return cached
+        try:
+            api = self._require_api()
+            me = api.get_me()
+        except (FleetGuardrailError, BotApiError) as e:
+            raise FleetGuardrailError(f"could not resolve manager bot: {e}") from e
+        username = str(me.get("username") or "")
+        if not username:
+            raise FleetGuardrailError("manager bot has no username — set one in @BotFather")
+        with self._lock:
+            self._roster.manager_bot_username = username
+            save_roster(self._roster, path=self._roster_path)
+        return username
+
+    # ── Spawn ────────────────────────────────────────────────────────
+
+    def spawn_bot(
+        self,
+        suggested_username: str,
+        *,
+        persona: str = "",
+        display_name: Optional[str] = None,
+        model: Optional[str] = None,
+        profile: Optional[str] = None,
+        toolset: Optional[List[str]] = None,
+        rate_limit_per_min: int = 30,
+        daily_budget_usd: Optional[float] = None,
+        notes: str = "",
+    ) -> SpawnResult:
+        """Mint a pending child entry and return the deep link to confirm.
+
+        The bot only enters ``active`` status once a ``managed_bot`` update
+        arrives via :meth:`absorb_managed_bot`.
+        """
+        suggested = _normalize_username(suggested_username)
+        if not suggested:
+            raise FleetGuardrailError("suggested_username must be non-empty")
+        with self._lock:
+            check_can_spawn(self._roster)
+            if self._roster.find(suggested) is not None:
+                raise FleetGuardrailError(
+                    f"a bot named @{suggested} is already in the roster"
+                )
+            nonce = secrets.token_hex(8)
+            child = ChildBot(
+                username=suggested,
+                persona=persona,
+                model=model,
+                profile=profile,
+                toolset=toolset,
+                rate_limit_per_min=rate_limit_per_min,
+                daily_budget_usd=daily_budget_usd,
+                status="pending",
+                nonce=nonce,
+                notes=notes,
+            )
+            self._roster.upsert(child)
+            save_roster(self._roster, path=self._roster_path)
+
+        manager = self.manager_username()
+        deep_link = build_managed_bot_deep_link(
+            manager, suggested, name=display_name or persona[:40] or suggested
+        )
+        audit_event(
+            "spawn_requested",
+            bot_username=suggested,
+            persona_chars=len(persona),
+            has_model_override=bool(model),
+            has_toolset_override=bool(toolset),
+            nonce=_redact_nonce(nonce),
+        )
+        return SpawnResult(
+            suggested_username=suggested, deep_link=deep_link, nonce=nonce
+        )
+
+    def absorb_managed_bot(self, info: ManagedBotInfo) -> Optional[ChildBot]:
+        """Promote a pending child to active when the user confirms the spawn.
+
+        Called by the gateway when it receives a ``managed_bot`` update
+        and resolves the token via ``getManagedBotToken``.  Matches by
+        username (we generate unique suggested usernames per spawn).
+        Returns the updated ``ChildBot`` or None if no pending entry was
+        waiting for it (e.g. the user created a bot directly in BotFather).
+        """
+        username = _normalize_username(info.bot_username)
+        with self._lock:
+            child = self._roster.find(username)
+            if child is None:
+                logger.info(
+                    "managed_bot update for @%s with no pending roster entry; ignoring",
+                    username,
+                )
+                return None
+            child.bot_id = info.bot_id
+            child.token = info.token
+            child.status = "active"
+            child.last_rotated_at = _now_iso()
+            self._roster.upsert(child)
+            save_roster(self._roster, path=self._roster_path)
+        audit_event(
+            "spawn_confirmed",
+            bot_username=username,
+            bot_id=info.bot_id,
+        )
+        return child
+
+    # ── Token rotation / decommission ────────────────────────────────
+
+    def rotate_token(self, username: str) -> ChildBot:
+        with self._lock:
+            child = self._roster.find(username)
+            if child is None or child.status != "active":
+                raise FleetGuardrailError(
+                    f"@{username} is not an active fleet member"
+                )
+            if child.bot_id is None:
+                raise FleetGuardrailError(
+                    f"@{username} has no bot_id recorded; cannot rotate"
+                )
+            bot_id = child.bot_id
+        api = self._require_api()
+        info = api.replace_managed_bot_token(bot_id)
+        with self._lock:
+            child = self._roster.find(username)
+            if child is None:  # raced with a decommission
+                raise FleetGuardrailError(f"@{username} disappeared mid-rotation")
+            child.token = info.token
+            child.last_rotated_at = _now_iso()
+            self._roster.upsert(child)
+            save_roster(self._roster, path=self._roster_path)
+            updated = child
+        audit_event("token_rotated", bot_username=username, bot_id=bot_id)
+        return updated
+
+    def decommission(self, username: str) -> bool:
+        """Mark a child decommissioned (kept in roster for audit) and zero its token."""
+        with self._lock:
+            child = self._roster.find(username)
+            if child is None:
+                return False
+            child.token = None
+            child.status = "decommissioned"
+            self._roster.upsert(child)
+            save_roster(self._roster, path=self._roster_path)
+        audit_event("decommissioned", bot_username=username)
+        return True
+
+    # ── Direct delegation (one bot speaks via another) ───────────────
+
+    def delegate_message(
+        self,
+        target_username: str,
+        chat_id: str,
+        text: str,
+        *,
+        reply_to: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """Have the named child bot post *text* into *chat_id*."""
+        with self._lock:
+            child = self._roster.find(target_username)
+            if child is None or not child.is_active():
+                raise FleetGuardrailError(
+                    f"@{target_username} is not an active fleet member"
+                )
+            token = child.token
+            rate = child.rate_limit_per_min
+            username = child.username
+        if not check_rate_limit(username, per_minute=rate):
+            raise FleetGuardrailError(
+                f"@{username} exceeded its {rate}/min rate limit"
+            )
+        api = self._require_api()
+        result = api.send_message_as(token, chat_id, text, reply_to=reply_to)
+        audit_event(
+            "delegate_message",
+            bot_username=username,
+            chat_id=str(chat_id),
+            text_chars=len(text),
+        )
+        return result
+
+    # ── The orchestration primitive ──────────────────────────────────
+
+    def orchestrate_swarm(
+        self,
+        objective: str,
+        subtasks: List[Dict[str, Any]],
+        *,
+        report_chat_id: Optional[str] = None,
+        max_parallel: int = 8,
+        per_task_timeout_s: float = 600.0,
+        parent_agent: Any = None,
+    ) -> Dict[str, Any]:
+        """Fan *subtasks* across active fleet members, aggregate results.
+
+        Each entry of *subtasks* is::
+
+            {
+                "goal": "...",                # required
+                "persona": "...",             # optional override
+                "bot_username": "@worker_3",  # optional explicit pin
+                "context": "...",             # optional extra context
+                "toolsets": ["web", ...],     # optional override
+            }
+
+        Workflow:
+
+        1. Bind each subtask to an active fleet member (explicit pin first,
+           otherwise round-robin across remaining active children).
+        2. Run all of them in parallel via the injected ``delegate_fn``
+           (defaults to :func:`tools.delegate_tool.delegate_task`).
+        3. If a ``report_chat_id`` is configured, each child posts a
+           one-line "starting / done" status as itself so the operator can
+           watch progress live.
+        4. Collect results, write a ``swarm_started`` / ``swarm_completed``
+           audit pair.
+        """
+        if not objective.strip():
+            raise FleetGuardrailError("objective must be non-empty")
+        if not subtasks:
+            raise FleetGuardrailError("subtasks must contain at least one entry")
+        with self._lock:
+            active = [c for c in self._roster.children if c.is_active()]
+        if not active:
+            raise FleetGuardrailError(
+                "no active fleet members.  Spawn at least one bot via "
+                "telegram_spawn_bot first."
+            )
+
+        bindings = self._bind_subtasks(subtasks, active)
+        delegate_fn = self._delegate_fn or _resolve_delegate()
+
+        run_id = secrets.token_hex(6)
+        audit_event(
+            "swarm_started",
+            run_id=run_id,
+            objective_chars=len(objective),
+            tasks=len(bindings),
+            bots=[b["bot_username"] for b in bindings],
+            report_chat_id=str(report_chat_id) if report_chat_id else None,
+        )
+
+        # Optional per-task status posts back to a results chat.
+        if report_chat_id:
+            for b in bindings:
+                self._safe_post(
+                    b["bot_username"],
+                    report_chat_id,
+                    f"▶︎ starting: {b['goal'][:120]}",
+                )
+
+        results: List[SwarmTaskResult] = []
+        with ThreadPoolExecutor(max_workers=min(max_parallel, len(bindings))) as ex:
+            futures = {
+                ex.submit(
+                    self._run_subtask,
+                    binding=b,
+                    objective=objective,
+                    delegate_fn=delegate_fn,
+                    parent_agent=parent_agent,
+                    timeout=per_task_timeout_s,
+                ): b
+                for b in bindings
+            }
+            for fut in as_completed(futures):
+                b = futures[fut]
+                try:
+                    result = fut.result(timeout=per_task_timeout_s + 5)
+                except Exception as e:  # pragma: no cover - delegate failure
+                    result = SwarmTaskResult(
+                        persona=b.get("persona", ""),
+                        bot_username=b["bot_username"],
+                        goal=b["goal"],
+                        response="",
+                        duration_seconds=0.0,
+                        error=f"{type(e).__name__}: {e}",
+                    )
+                results.append(result)
+                if report_chat_id:
+                    summary = result.error or _truncate(result.response, 280)
+                    self._safe_post(
+                        result.bot_username,
+                        report_chat_id,
+                        f"✅ done: {summary}" if not result.error else f"❌ failed: {summary}",
+                    )
+
+        audit_event(
+            "swarm_completed",
+            run_id=run_id,
+            tasks=len(results),
+            failures=sum(1 for r in results if r.error),
+        )
+        aggregate = _aggregate(objective, results)
+        return {
+            "run_id": run_id,
+            "objective": objective,
+            "results": [r.to_dict() for r in results],
+            "summary": aggregate,
+        }
+
+    # ── internals ────────────────────────────────────────────────────
+
+    def _bind_subtasks(
+        self, subtasks: List[Dict[str, Any]], active: List[ChildBot]
+    ) -> List[Dict[str, Any]]:
+        """Resolve each subtask to a concrete bot username + persona."""
+        bindings: List[Dict[str, Any]] = []
+        rotation = list(active)
+        rr_idx = 0
+        for raw in subtasks:
+            if not isinstance(raw, dict):
+                raise FleetGuardrailError(f"subtask must be a mapping, got {type(raw).__name__}")
+            goal = str(raw.get("goal") or "").strip()
+            if not goal:
+                raise FleetGuardrailError("subtask is missing 'goal'")
+            pin = _normalize_username(str(raw.get("bot_username") or ""))
+            if pin:
+                child = self._roster.find(pin)
+                if child is None or not child.is_active():
+                    raise FleetGuardrailError(
+                        f"subtask requested @{pin} but it is not an active fleet member"
+                    )
+                bot = child
+            else:
+                bot = rotation[rr_idx % len(rotation)]
+                rr_idx += 1
+            persona = str(raw.get("persona") or bot.persona or "")
+            bindings.append(
+                {
+                    "goal": goal,
+                    "context": str(raw.get("context") or ""),
+                    "toolsets": list(raw.get("toolsets") or bot.toolset or []) or None,
+                    "bot_username": bot.username,
+                    "persona": persona,
+                    "bot_token": bot.token,
+                }
+            )
+        return bindings
+
+    def _run_subtask(
+        self,
+        *,
+        binding: Dict[str, Any],
+        objective: str,
+        delegate_fn: Callable[..., str],
+        parent_agent: Any,
+        timeout: float,
+    ) -> SwarmTaskResult:
+        start = time.monotonic()
+        persona = binding.get("persona") or ""
+        context_parts = [
+            f"Swarm objective: {objective}",
+        ]
+        if persona:
+            context_parts.append(f"Your persona for this task: {persona}")
+        if binding.get("context"):
+            context_parts.append(str(binding["context"]))
+        context = "\n\n".join(context_parts)
+        try:
+            response = delegate_fn(
+                goal=binding["goal"],
+                context=context,
+                toolsets=binding.get("toolsets"),
+                role="leaf",
+                parent_agent=parent_agent,
+            )
+        except Exception as e:
+            return SwarmTaskResult(
+                persona=persona,
+                bot_username=binding["bot_username"],
+                goal=binding["goal"],
+                response="",
+                duration_seconds=time.monotonic() - start,
+                error=f"{type(e).__name__}: {e}",
+            )
+        return SwarmTaskResult(
+            persona=persona,
+            bot_username=binding["bot_username"],
+            goal=binding["goal"],
+            response=str(response),
+            duration_seconds=time.monotonic() - start,
+        )
+
+    def _safe_post(self, username: str, chat_id: str, text: str) -> None:
+        try:
+            self.delegate_message(username, chat_id, text)
+        except Exception as e:
+            logger.debug("could not post status from @%s: %s", username, e)
+
+
+# ── Module-level singleton ─────────────────────────────────────────────
+
+
+_singleton_lock = threading.Lock()
+_singleton: Optional[FleetCoordinator] = None
+
+
+def get_coordinator(*, refresh: bool = False) -> FleetCoordinator:
+    """Return the per-process FleetCoordinator (lazy-init).
+
+    Pass ``refresh=True`` to discard the cached instance and re-read the
+    roster from disk — useful after the user edits ``telegram_fleet.yaml``
+    by hand.
+    """
+    global _singleton
+    with _singleton_lock:
+        if _singleton is None or refresh:
+            _singleton = FleetCoordinator()
+        return _singleton
+
+
+def reset_coordinator() -> None:
+    """Drop the cached coordinator.  Test helper."""
+    global _singleton
+    with _singleton_lock:
+        _singleton = None
+
+
+# ── helpers ───────────────────────────────────────────────────────────
+
+
+def _resolve_delegate() -> Callable[..., str]:
+    """Lazy import so the fleet package doesn't pull in tools at import time."""
+    from tools.delegate_tool import delegate_task
+
+    return delegate_task
+
+
+def _normalize_username(value: str) -> str:
+    return (value or "").strip().lstrip("@").lower()
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _redact_nonce(nonce: str) -> str:
+    if not nonce or len(nonce) < 8:
+        return "***"
+    return f"{nonce[:4]}…"
+
+
+def _truncate(s: str, n: int) -> str:
+    s = s or ""
+    if len(s) <= n:
+        return s
+    return s[: n - 1].rstrip() + "…"
+
+
+def _aggregate(objective: str, results: List[SwarmTaskResult]) -> str:
+    """Compose a human-readable summary of the swarm run."""
+    lines = [f"Swarm objective: {objective}", ""]
+    successes = [r for r in results if not r.error]
+    failures = [r for r in results if r.error]
+    lines.append(f"Workers: {len(results)}  ·  ok: {len(successes)}  ·  failed: {len(failures)}")
+    lines.append("")
+    for r in results:
+        header = f"— @{r.bot_username}"
+        if r.persona:
+            header += f" ({r.persona[:60]})"
+        header += f"  [{r.duration_seconds:.1f}s]"
+        lines.append(header)
+        lines.append(r.error if r.error else _truncate(r.response, 600))
+        lines.append("")
+    return "\n".join(lines).rstrip()
+
+
+# Re-export for callers
+__all__ = [
+    "FleetCoordinator",
+    "SpawnResult",
+    "SwarmTaskResult",
+    "get_coordinator",
+    "reset_coordinator",
+    "PENDING_TTL_SECONDS",
+]

--- a/gateway/telegram_fleet/coordinator.py
+++ b/gateway/telegram_fleet/coordinator.py
@@ -624,7 +624,7 @@ class FleetCoordinator:
                             )
                         )
 
-        # Kimi-style Critical Path metric: wall-clock per stage = max(workers).
+        # Critical Path metric — wall-clock per stage = max(workers), not sum.
         # Single-stage fan-out so critical_path == max(durations).
         durations = [r.duration_seconds for r in results]
         critical_path = max(durations) if durations else 0.0

--- a/gateway/telegram_fleet/coordinator.py
+++ b/gateway/telegram_fleet/coordinator.py
@@ -361,6 +361,82 @@ class FleetCoordinator:
                 break
         return absorbed
 
+    def adopt_existing_bot(
+        self,
+        token: str,
+        *,
+        persona: str = "",
+        model: Optional[str] = None,
+        profile: Optional[str] = None,
+        toolset: Optional[List[str]] = None,
+        rate_limit_per_min: int = 30,
+        daily_budget_usd: Optional[float] = None,
+        notes: str = "",
+    ) -> ChildBot:
+        """Adopt a bot the user *already* created in BotFather into the fleet.
+
+        Skips the Managed Bots ``getManagedBotToken`` ceremony entirely —
+        validates the token by calling ``getMe`` against it and writes the
+        result straight into the roster as ``status="active"``.  Use this
+        when ``hermes fleet add`` (the deep-link spawn flow) hits a
+        "username already taken" error because the bot was created manually.
+
+        Trade-off: bots adopted this way cannot be rotated via
+        ``replaceManagedBotToken`` — that endpoint only works on bots that
+        were *created* through the manager flow.  Rotation for adopted bots
+        means generating a fresh token in BotFather and re-adopting.
+        """
+        if not token or ":" not in token:
+            raise FleetGuardrailError(
+                "token doesn't look like a Telegram bot token (expected "
+                "'<id>:<rest>')"
+            )
+        # Validate against Telegram + read identity.  Re-import so test
+        # patches against ``gateway.telegram_fleet.api.FleetApiClient`` take
+        # effect (the module-level import is bound at coordinator import
+        # time and would not see monkeypatches).
+        from gateway.telegram_fleet import api as _api_module
+        client = _api_module.FleetApiClient(token)
+        try:
+            me = client.get_me()
+        except BotApiError as e:
+            raise FleetGuardrailError(
+                f"Telegram rejected this token: {e}"
+            ) from e
+        username = _normalize_username(str(me.get("username") or ""))
+        bot_id = int(me.get("id") or 0)
+        if not username or not bot_id:
+            raise FleetGuardrailError(
+                f"getMe returned an unusable identity: {me!r}"
+            )
+
+        with self._lock:
+            check_can_spawn(self._roster)
+            existing = self._roster.find(username)
+            child = ChildBot(
+                username=username,
+                persona=persona,
+                bot_id=bot_id,
+                token=token,
+                model=model,
+                profile=profile,
+                toolset=toolset,
+                status="active",
+                rate_limit_per_min=rate_limit_per_min,
+                daily_budget_usd=daily_budget_usd,
+                notes=notes or (existing.notes if existing else ""),
+                last_rotated_at=_now_iso(),
+            )
+            self._roster.upsert(child)
+            save_roster(self._roster, path=self._roster_path)
+        audit_event(
+            "adopted",
+            bot_username=username,
+            bot_id=bot_id,
+            replaced_existing=existing is not None,
+        )
+        return child
+
     def absorb_managed_bot(self, info: ManagedBotInfo) -> Optional[ChildBot]:
         """Promote a pending child to active when the user confirms the spawn.
 

--- a/gateway/telegram_fleet/guardrails.py
+++ b/gateway/telegram_fleet/guardrails.py
@@ -1,0 +1,144 @@
+"""Fleet-level guardrails — size cap, rate limit, spawn approval.
+
+Why these exist:
+
+* **Fleet size cap** (`max_size`, default 16) — bounds how many Telegram bot
+  tokens this manager can hold.  Prevents a runaway agent from spawning
+  hundreds of bots that the user later has to clean up by hand.
+* **Per-child rate limit** (`rate_limit_per_min`, default 30) — caps how many
+  outbound messages a single child can send per minute.  Telegram's own
+  global limit is 30/sec, but fan-out from a swarm can blow through that
+  in seconds; this is a soft local limit applied per child before we even
+  hit Telegram.
+* **Spawn approval gate** (`spawn_requires_approval`, default True) —
+  ``telegram_spawn_bot`` returns a deep link that the human must tap, and
+  the resulting child only enters the active roster once the
+  ``managed_bot`` update arrives.  This is enforced by Telegram itself; we
+  also surface it as an explicit toggle so operators can audit the
+  default.  When False, spawn-via-tool is rejected with
+  :class:`SpawnApprovalRequired` to make the policy explicit.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import deque
+from dataclasses import dataclass
+from typing import Deque, Dict, Optional
+
+from gateway.telegram_fleet.roster import FleetRoster
+
+
+class FleetGuardrailError(Exception):
+    """Raised when a fleet operation violates a configured guardrail."""
+
+
+class SpawnApprovalRequired(FleetGuardrailError):
+    """Raised when spawn is attempted but the operator hasn't enabled it."""
+
+
+# ── Fleet size + spawn approval ────────────────────────────────────────
+
+
+def check_can_spawn(roster: FleetRoster) -> None:
+    """Verify the roster can accept a new spawn.
+
+    Raises :class:`FleetGuardrailError` (or a subclass) when not.
+    """
+    if not roster.spawn_requires_approval:
+        # Operator explicitly disabled the user-tap step.  We still refuse —
+        # the Managed Bots API itself requires user confirmation, so a True
+        # "no approval" mode is impossible without violating the platform
+        # contract.  Surface it loudly so callers don't get confused.
+        raise SpawnApprovalRequired(
+            "spawn_requires_approval is False, but Managed Bots requires a "
+            "user tap on the deep link.  Set spawn_requires_approval: true in "
+            "telegram_fleet.yaml or via the fleet config."
+        )
+
+    active = len(roster.active_children())
+    pending = len(roster.pending_children())
+    if active + pending >= roster.max_size:
+        raise FleetGuardrailError(
+            f"fleet at capacity ({active} active + {pending} pending = {roster.max_size} max).  "
+            f"Decommission an existing bot or raise max_size in telegram_fleet.yaml."
+        )
+
+
+# ── Per-child rate limit ───────────────────────────────────────────────
+
+
+@dataclass
+class _ChildRateState:
+    capacity: int
+    window_seconds: int
+    timestamps: Deque[float]
+
+
+class _RateLimiter:
+    """Sliding-window rate limiter keyed by child username."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._state: Dict[str, _ChildRateState] = {}
+
+    def configure(self, username: str, *, per_minute: int) -> None:
+        username = (username or "").lstrip("@").lower()
+        if not username:
+            return
+        with self._lock:
+            existing = self._state.get(username)
+            if existing is None:
+                self._state[username] = _ChildRateState(
+                    capacity=per_minute, window_seconds=60, timestamps=deque()
+                )
+            else:
+                existing.capacity = per_minute
+
+    def consume(self, username: str, *, now: Optional[float] = None) -> bool:
+        """Reserve one slot.  Returns True if allowed, False if throttled."""
+        username = (username or "").lstrip("@").lower()
+        if not username:
+            return True
+        now = time.monotonic() if now is None else now
+        with self._lock:
+            state = self._state.get(username)
+            if state is None:
+                # Default conservative window if we haven't seen the bot yet.
+                state = _ChildRateState(capacity=30, window_seconds=60, timestamps=deque())
+                self._state[username] = state
+            cutoff = now - state.window_seconds
+            while state.timestamps and state.timestamps[0] < cutoff:
+                state.timestamps.popleft()
+            if len(state.timestamps) >= state.capacity:
+                return False
+            state.timestamps.append(now)
+            return True
+
+    def reset(self, username: Optional[str] = None) -> None:
+        with self._lock:
+            if username is None:
+                self._state.clear()
+                return
+            username = username.lstrip("@").lower()
+            self._state.pop(username, None)
+
+
+_rate_limiter = _RateLimiter()
+
+
+def check_rate_limit(username: str, *, per_minute: Optional[int] = None) -> bool:
+    """Return True if the child can send right now, False if throttled.
+
+    Pass ``per_minute`` from the child's roster entry (or omit to use the
+    last-configured value, defaulting to 30/min).
+    """
+    if per_minute is not None:
+        _rate_limiter.configure(username, per_minute=per_minute)
+    return _rate_limiter.consume(username)
+
+
+def reset_rate_limits(username: Optional[str] = None) -> None:
+    """Clear rate-limit state.  Test helper."""
+    _rate_limiter.reset(username)

--- a/gateway/telegram_fleet/guardrails.py
+++ b/gateway/telegram_fleet/guardrails.py
@@ -10,13 +10,11 @@ Why these exist:
   global limit is 30/sec, but fan-out from a swarm can blow through that
   in seconds; this is a soft local limit applied per child before we even
   hit Telegram.
-* **Spawn approval gate** (`spawn_requires_approval`, default True) —
-  ``telegram_spawn_bot`` returns a deep link that the human must tap, and
-  the resulting child only enters the active roster once the
-  ``managed_bot`` update arrives.  This is enforced by Telegram itself; we
-  also surface it as an explicit toggle so operators can audit the
-  default.  When False, spawn-via-tool is rejected with
-  :class:`SpawnApprovalRequired` to make the policy explicit.
+* **Spawn enabled gate** (`spawn_enabled`, default True) —
+  controls whether the fleet is allowed to spawn new bots at all.
+  ``telegram_spawn_bot`` always returns a deep link the human must tap
+  (Telegram's platform contract); ``spawn_enabled=False`` prevents even
+  generating that link and raises :class:`SpawnApprovalRequired`.
 """
 
 from __future__ import annotations
@@ -46,15 +44,10 @@ def check_can_spawn(roster: FleetRoster) -> None:
 
     Raises :class:`FleetGuardrailError` (or a subclass) when not.
     """
-    if not roster.spawn_requires_approval:
-        # Operator explicitly disabled the user-tap step.  We still refuse —
-        # the Managed Bots API itself requires user confirmation, so a True
-        # "no approval" mode is impossible without violating the platform
-        # contract.  Surface it loudly so callers don't get confused.
+    if not roster.spawn_enabled:
         raise SpawnApprovalRequired(
-            "spawn_requires_approval is False, but Managed Bots requires a "
-            "user tap on the deep link.  Set spawn_requires_approval: true in "
-            "telegram_fleet.yaml or via the fleet config."
+            "spawn_enabled is False in telegram_fleet.yaml.  Set it to true "
+            "to allow the fleet to mint new child-bot deep links."
         )
 
     active = len(roster.active_children())

--- a/gateway/telegram_fleet/roster.py
+++ b/gateway/telegram_fleet/roster.py
@@ -1,0 +1,323 @@
+"""Durable roster of child bots managed by the Telegram Fleet manager.
+
+Schema is YAML-on-disk at ``~/.hermes/telegram_fleet.yaml``.  Tokens are
+treated as secrets — file is created with mode 0600, never logged in full,
+and write-locked via :class:`utils.atomic_yaml_write`.
+
+A ``ChildBot`` is the smallest unit of state we keep per bot:
+
+* ``username`` and ``bot_id`` (Telegram identity)
+* ``token`` (Bot API token from ``getManagedBotToken``) — secret
+* ``persona`` (system-prompt addendum injected into the agent's
+  identity for that bot's sessions)
+* ``model`` / ``profile`` / ``toolset`` overrides (optional)
+* ``status`` — one of ``pending`` / ``active`` / ``decommissioned``
+* ``rate_limit_per_min`` and ``daily_budget_usd`` guardrails
+* ``created_at`` / ``last_rotated_at`` (UTC ISO-8601)
+* ``nonce`` (set when ``status=pending``, used to correlate the
+  spawn deep-link with the eventual ``managed_bot`` update)
+* ``parent_chat_filter`` — optional list of chat IDs the child is
+  scoped to (defaults to all chats)
+
+Pending entries are spawn requests where the user hasn't yet confirmed
+the deep link.  They expire after :data:`PENDING_TTL_SECONDS` and are
+pruned on every load.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import yaml
+
+from hermes_constants import get_hermes_home
+from utils import atomic_yaml_write
+
+logger = logging.getLogger(__name__)
+
+ROSTER_FILENAME = "telegram_fleet.yaml"
+SCHEMA_VERSION = 1
+PENDING_TTL_SECONDS = 30 * 60  # 30 minutes — generous buffer for slow user taps
+
+VALID_STATUSES = frozenset({"pending", "active", "decommissioned"})
+
+
+class RosterError(Exception):
+    """Raised when the roster file is malformed or a write fails."""
+
+
+@dataclass
+class ChildBot:
+    """A single child bot owned by the fleet manager."""
+
+    username: str
+    persona: str = ""
+    bot_id: Optional[int] = None
+    token: Optional[str] = None
+    model: Optional[str] = None
+    profile: Optional[str] = None
+    toolset: Optional[List[str]] = None
+    status: str = "pending"
+    rate_limit_per_min: int = 30
+    daily_budget_usd: Optional[float] = None
+    nonce: Optional[str] = None
+    parent_chat_filter: Optional[List[str]] = None
+    created_at: str = ""
+    last_rotated_at: Optional[str] = None
+    notes: str = ""
+
+    def __post_init__(self) -> None:
+        if self.status not in VALID_STATUSES:
+            raise RosterError(
+                f"invalid status {self.status!r} for {self.username!r} "
+                f"(expected one of {sorted(VALID_STATUSES)})"
+            )
+        if not self.username:
+            raise RosterError("ChildBot.username must be non-empty")
+        if not self.created_at:
+            self.created_at = _now_iso()
+
+    def is_active(self) -> bool:
+        return self.status == "active" and bool(self.token)
+
+    def to_dict(self, *, include_token: bool = True) -> Dict[str, Any]:
+        out: Dict[str, Any] = {
+            "username": self.username,
+            "persona": self.persona,
+            "status": self.status,
+            "rate_limit_per_min": self.rate_limit_per_min,
+            "created_at": self.created_at,
+        }
+        if self.bot_id is not None:
+            out["bot_id"] = self.bot_id
+        if include_token and self.token:
+            out["token"] = self.token
+        if self.model:
+            out["model"] = self.model
+        if self.profile:
+            out["profile"] = self.profile
+        if self.toolset:
+            out["toolset"] = list(self.toolset)
+        if self.daily_budget_usd is not None:
+            out["daily_budget_usd"] = self.daily_budget_usd
+        if self.nonce:
+            out["nonce"] = self.nonce
+        if self.parent_chat_filter:
+            out["parent_chat_filter"] = list(self.parent_chat_filter)
+        if self.last_rotated_at:
+            out["last_rotated_at"] = self.last_rotated_at
+        if self.notes:
+            out["notes"] = self.notes
+        return out
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ChildBot":
+        if not isinstance(data, dict):
+            raise RosterError(f"child entry must be a mapping, got {type(data).__name__}")
+        try:
+            return cls(
+                username=str(data["username"]),
+                persona=str(data.get("persona", "")),
+                bot_id=_coerce_optional_int(data.get("bot_id")),
+                token=_coerce_optional_str(data.get("token")),
+                model=_coerce_optional_str(data.get("model")),
+                profile=_coerce_optional_str(data.get("profile")),
+                toolset=_coerce_optional_str_list(data.get("toolset")),
+                status=str(data.get("status", "pending")),
+                rate_limit_per_min=int(data.get("rate_limit_per_min", 30)),
+                daily_budget_usd=_coerce_optional_float(data.get("daily_budget_usd")),
+                nonce=_coerce_optional_str(data.get("nonce")),
+                parent_chat_filter=_coerce_optional_str_list(data.get("parent_chat_filter")),
+                created_at=str(data.get("created_at", "")),
+                last_rotated_at=_coerce_optional_str(data.get("last_rotated_at")),
+                notes=str(data.get("notes", "")),
+            )
+        except KeyError as e:
+            raise RosterError(f"missing required field: {e}") from e
+        except (TypeError, ValueError) as e:
+            raise RosterError(f"invalid child entry: {e}") from e
+
+
+@dataclass
+class FleetRoster:
+    """Top-level roster wrapping schema + manager metadata + child list."""
+
+    schema_version: int = SCHEMA_VERSION
+    manager_bot_username: str = ""
+    children: List[ChildBot] = field(default_factory=list)
+    max_size: int = 16
+    spawn_requires_approval: bool = True
+    updated_at: str = ""
+
+    def __post_init__(self) -> None:
+        if self.schema_version != SCHEMA_VERSION:
+            raise RosterError(
+                f"unsupported schema_version {self.schema_version} "
+                f"(this build supports v{SCHEMA_VERSION})"
+            )
+        if not self.updated_at:
+            self.updated_at = _now_iso()
+
+    # ── Lookups ────────────────────────────────────────────────────────
+
+    def find(self, username: str) -> Optional[ChildBot]:
+        username = (username or "").lstrip("@").lower()
+        for child in self.children:
+            if child.username.lower() == username:
+                return child
+        return None
+
+    def find_by_nonce(self, nonce: str) -> Optional[ChildBot]:
+        if not nonce:
+            return None
+        for child in self.children:
+            if child.nonce == nonce:
+                return child
+        return None
+
+    def active_children(self) -> List[ChildBot]:
+        return [c for c in self.children if c.is_active()]
+
+    def pending_children(self) -> List[ChildBot]:
+        return [c for c in self.children if c.status == "pending"]
+
+    # ── Mutations ──────────────────────────────────────────────────────
+
+    def upsert(self, child: ChildBot) -> None:
+        existing = self.find(child.username)
+        if existing is not None:
+            self.children.remove(existing)
+        self.children.append(child)
+        self.updated_at = _now_iso()
+
+    def remove(self, username: str) -> bool:
+        existing = self.find(username)
+        if existing is None:
+            return False
+        self.children.remove(existing)
+        self.updated_at = _now_iso()
+        return True
+
+    # ── (de)serialisation ─────────────────────────────────────────────
+
+    def to_dict(self, *, include_tokens: bool = True) -> Dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "manager_bot_username": self.manager_bot_username,
+            "max_size": self.max_size,
+            "spawn_requires_approval": self.spawn_requires_approval,
+            "updated_at": self.updated_at,
+            "children": [
+                c.to_dict(include_token=include_tokens) for c in self.children
+            ],
+        }
+
+    @classmethod
+    def from_dict(cls, data: Optional[Dict[str, Any]]) -> "FleetRoster":
+        if not data:
+            return cls()
+        if not isinstance(data, dict):
+            raise RosterError(f"roster must be a mapping, got {type(data).__name__}")
+        children_raw = data.get("children") or []
+        if not isinstance(children_raw, list):
+            raise RosterError("'children' must be a list")
+        return cls(
+            schema_version=int(data.get("schema_version", SCHEMA_VERSION)),
+            manager_bot_username=str(data.get("manager_bot_username", "")),
+            max_size=int(data.get("max_size", 16)),
+            spawn_requires_approval=bool(data.get("spawn_requires_approval", True)),
+            updated_at=str(data.get("updated_at", "")),
+            children=[ChildBot.from_dict(c) for c in children_raw],
+        )
+
+    def prune_expired_pending(
+        self, *, ttl_seconds: int = PENDING_TTL_SECONDS, now: Optional[float] = None
+    ) -> int:
+        """Drop ``pending`` entries older than *ttl_seconds*.  Returns count removed."""
+        now = time.time() if now is None else now
+        cutoff_iso = datetime.fromtimestamp(now - ttl_seconds, tz=timezone.utc).isoformat()
+        before = len(self.children)
+        self.children = [
+            c for c in self.children
+            if c.status != "pending" or (c.created_at or "") >= cutoff_iso
+        ]
+        removed = before - len(self.children)
+        if removed:
+            self.updated_at = _now_iso()
+        return removed
+
+
+# ── Module-level IO ─────────────────────────────────────────────────────
+
+
+def get_roster_path() -> Path:
+    return get_hermes_home() / ROSTER_FILENAME
+
+
+def load_roster(*, path: Optional[Path] = None) -> FleetRoster:
+    """Read the roster from disk.  Returns an empty roster when missing."""
+    p = path or get_roster_path()
+    if not p.exists():
+        return FleetRoster()
+    try:
+        raw = yaml.safe_load(p.read_text(encoding="utf-8"))
+    except yaml.YAMLError as e:
+        raise RosterError(f"could not parse {p}: {e}") from e
+    return FleetRoster.from_dict(raw)
+
+
+def save_roster(roster: FleetRoster, *, path: Optional[Path] = None) -> None:
+    """Persist the roster atomically with mode 0600 (tokens are secret)."""
+    p = path or get_roster_path()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    roster.updated_at = _now_iso()
+    try:
+        atomic_yaml_write(p, roster.to_dict(include_tokens=True))
+    except Exception as e:
+        raise RosterError(f"could not write {p}: {e}") from e
+    try:
+        os.chmod(p, 0o600)
+    except OSError as e:  # pragma: no cover - non-POSIX or permission edge
+        logger.debug("could not chmod 0600 on %s: %s", p, e)
+
+
+# ── helpers ─────────────────────────────────────────────────────────────
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _coerce_optional_str(v: Any) -> Optional[str]:
+    if v is None or v == "":
+        return None
+    return str(v)
+
+
+def _coerce_optional_int(v: Any) -> Optional[int]:
+    if v is None or v == "":
+        return None
+    return int(v)
+
+
+def _coerce_optional_float(v: Any) -> Optional[float]:
+    if v is None or v == "":
+        return None
+    return float(v)
+
+
+def _coerce_optional_str_list(v: Any) -> Optional[List[str]]:
+    if v is None:
+        return None
+    if isinstance(v, str):
+        return [v]
+    if isinstance(v, list):
+        out = [str(x).strip() for x in v if str(x).strip()]
+        return out or None
+    raise RosterError(f"expected list of strings, got {type(v).__name__}")

--- a/gateway/telegram_fleet/roster.py
+++ b/gateway/telegram_fleet/roster.py
@@ -2,7 +2,7 @@
 
 Schema is YAML-on-disk at ``~/.hermes/telegram_fleet.yaml``.  Tokens are
 treated as secrets — file is created with mode 0600, never logged in full,
-and write-locked via :class:`utils.atomic_yaml_write`.
+and atomically written via :func:`utils.atomic_yaml_write`.
 
 A ``ChildBot`` is the smallest unit of state we keep per bot:
 
@@ -152,7 +152,7 @@ class FleetRoster:
     manager_bot_username: str = ""
     children: List[ChildBot] = field(default_factory=list)
     max_size: int = 16
-    spawn_requires_approval: bool = True
+    spawn_enabled: bool = True
     updated_at: str = ""
 
     def __post_init__(self) -> None:
@@ -211,7 +211,7 @@ class FleetRoster:
             "schema_version": self.schema_version,
             "manager_bot_username": self.manager_bot_username,
             "max_size": self.max_size,
-            "spawn_requires_approval": self.spawn_requires_approval,
+            "spawn_enabled": self.spawn_enabled,
             "updated_at": self.updated_at,
             "children": [
                 c.to_dict(include_token=include_tokens) for c in self.children
@@ -231,7 +231,7 @@ class FleetRoster:
             schema_version=int(data.get("schema_version", SCHEMA_VERSION)),
             manager_bot_username=str(data.get("manager_bot_username", "")),
             max_size=int(data.get("max_size", 16)),
-            spawn_requires_approval=bool(data.get("spawn_requires_approval", True)),
+            spawn_enabled=bool(data.get("spawn_enabled", True)),
             updated_at=str(data.get("updated_at", "")),
             children=[ChildBot.from_dict(c) for c in children_raw],
         )

--- a/hermes_cli/fleet.py
+++ b/hermes_cli/fleet.py
@@ -1,0 +1,562 @@
+"""``hermes fleet`` — setup + status + roster management for Telegram Fleet.
+
+Closes the setup gap: the swarm tools and the orchestration skill ship with
+the agent, but using the Telegram variant requires a manager bot configured
+in BotFather and the token written into ~/.hermes/.env.  This module turns
+that into a one-command experience.
+
+Subcommands:
+
+* ``hermes fleet setup`` — interactive wizard.  Validates the manager bot
+  token (calling ``getMe``), confirms ``can_manage_bots`` is enabled, saves
+  the manager username to the roster.  Bails out with concrete instructions
+  when something's wrong (token invalid, Bot Manager Mode disabled, etc.).
+* ``hermes fleet status`` — show what's configured: token presence, roster
+  state, active worker count.  Doctor-style output.
+* ``hermes fleet add <username> [--persona]`` — mint a single deep link the
+  user taps to confirm a new child bot.
+* ``hermes fleet list`` — pretty-print the roster (tokens redacted).
+
+The interactive UI is intentionally simple — it uses ``input()`` and
+``getpass()`` so it works in plain TTY, SSH, and CI alike, matching how
+``hermes setup`` already works in this repo.
+"""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import logging
+import os
+import sys
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _isatty() -> bool:
+    return sys.stdout.isatty()
+
+
+_RST = "\033[0m" if _isatty() else ""
+_BOLD = "\033[1m" if _isatty() else ""
+_DIM = "\033[2m" if _isatty() else ""
+_OK = "\033[32m" if _isatty() else ""
+_WARN = "\033[33m" if _isatty() else ""
+_ERR = "\033[31m" if _isatty() else ""
+_INFO = "\033[36m" if _isatty() else ""
+
+
+def _ok(msg: str) -> None:
+    print(f"{_OK}\u2713{_RST} {msg}")
+
+
+def _warn(msg: str) -> None:
+    print(f"{_WARN}\u26a0{_RST} {msg}")
+
+
+def _err(msg: str) -> None:
+    print(f"{_ERR}\u2717{_RST} {msg}")
+
+
+def _info(msg: str) -> None:
+    print(f"{_INFO}\u2139{_RST} {msg}")
+
+
+def _heading(msg: str) -> None:
+    print(f"\n{_BOLD}{msg}{_RST}")
+
+
+def cmd_fleet(args: argparse.Namespace) -> int:
+    """Dispatch ``hermes fleet`` subcommands."""
+    sub = getattr(args, "fleet_command", None)
+    if sub == "setup":
+        return _cmd_setup(args)
+    if sub == "status":
+        return _cmd_status(args)
+    if sub == "list":
+        return _cmd_list(args)
+    if sub == "add":
+        return _cmd_add(args)
+    if sub == "connect":
+        return _cmd_connect(args)
+    return _cmd_status(args)
+
+
+def add_fleet_parser(subparsers) -> None:
+    """Register the ``hermes fleet`` subparser tree."""
+    fleet_parser = subparsers.add_parser(
+        "fleet",
+        help="Telegram fleet management (setup, status, roster)",
+        description=(
+            "Manage the Telegram bot fleet used by `telegram_orchestrate_swarm`.  "
+            "The in-process `hermes_swarm` tool needs no setup; this is only "
+            "for the visible Telegram variant where each worker posts as a "
+            "named bot."
+        ),
+    )
+    fleet_subparsers = fleet_parser.add_subparsers(dest="fleet_command")
+
+    fleet_subparsers.add_parser(
+        "setup",
+        help="Interactive setup \u2014 validate manager token, confirm Bot Manager Mode",
+    )
+    fleet_subparsers.add_parser(
+        "status",
+        help="Show what's configured (token, roster, active workers)",
+    )
+    fleet_subparsers.add_parser(
+        "list",
+        help="List the roster (tokens redacted)",
+    )
+
+    add_parser = fleet_subparsers.add_parser(
+        "add",
+        help="Mint a deep link for one new child bot \u2014 user taps to confirm",
+    )
+    add_parser.add_argument(
+        "username",
+        help=(
+            "Suggested username for the new bot (must end in 'bot' per "
+            "Telegram rules; suffix is auto-added if missing)."
+        ),
+    )
+    add_parser.add_argument(
+        "--persona",
+        default="",
+        help="Free-text persona/role description for this worker.",
+    )
+    add_parser.add_argument(
+        "--name",
+        default=None,
+        help="Display name shown in Telegram (defaults to persona/username).",
+    )
+    add_parser.add_argument(
+        "--wait",
+        type=int,
+        default=180,
+        help=(
+            "After printing the deep link, poll for up to N seconds "
+            "waiting for the user to tap (default 180 = 3 minutes).  Pass "
+            "0 to skip polling and exit immediately."
+        ),
+    )
+
+    connect_parser = fleet_subparsers.add_parser(
+        "connect",
+        help=(
+            "Drain pending managed_bot updates from Telegram \u2014 promotes "
+            "any pending entries whose deep link the user has tapped to "
+            "active.  Run after `hermes fleet add` if you skipped --wait."
+        ),
+    )
+    connect_parser.add_argument(
+        "--wait",
+        type=int,
+        default=0,
+        help=(
+            "Long-poll for up to N seconds waiting for new updates.  "
+            "Default 0 = non-blocking drain of already-queued updates."
+        ),
+    )
+
+    fleet_parser.set_defaults(func=cmd_fleet)
+
+
+def _resolve_token(*, prompt_if_missing: bool) -> Optional[str]:
+    """Find the manager token from env, prompting interactively if asked."""
+    token = (os.environ.get("TELEGRAM_FLEET_MANAGER_TOKEN") or "").strip()
+    if token:
+        return token
+    if not prompt_if_missing:
+        return None
+    if not sys.stdin.isatty():
+        _err("TELEGRAM_FLEET_MANAGER_TOKEN is not set and stdin is not a TTY.")
+        return None
+    print()
+    _info(
+        "We'll need a manager bot token.  Create one in @BotFather "
+        "(/newbot), then enable Bot Manager Mode in BotFather's MiniApp.  "
+        "The token looks like '12345:ABCdefGHIjklMNO...'."
+    )
+    try:
+        token = getpass.getpass("Manager bot token (input hidden): ").strip()
+    except (EOFError, KeyboardInterrupt):
+        print()
+        return None
+    return token or None
+
+
+def _save_token_to_env(token: str) -> bool:
+    """Append TELEGRAM_FLEET_MANAGER_TOKEN to ~/.hermes/.env if not already set."""
+    from hermes_constants import get_hermes_home
+
+    env_path = get_hermes_home() / ".env"
+    env_path.parent.mkdir(parents=True, exist_ok=True)
+    existing = ""
+    if env_path.exists():
+        try:
+            existing = env_path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            existing = env_path.read_text(encoding="latin-1")
+        if "TELEGRAM_FLEET_MANAGER_TOKEN" in existing:
+            return False
+    line = f"TELEGRAM_FLEET_MANAGER_TOKEN={token}\n"
+    if existing and not existing.endswith("\n"):
+        line = "\n" + line
+    with env_path.open("a", encoding="utf-8") as f:
+        f.write(line)
+    try:
+        os.chmod(env_path, 0o600)
+    except OSError:
+        pass
+    return True
+
+
+def _cmd_setup(args: argparse.Namespace) -> int:
+    from gateway.telegram_fleet.api import BotApiError, FleetApiClient
+    from gateway.telegram_fleet.roster import load_roster, save_roster
+
+    _heading("Telegram Fleet \u2014 setup")
+
+    token = _resolve_token(prompt_if_missing=True)
+    if not token:
+        _err("No manager bot token provided.  Aborting.")
+        _info(
+            "You can re-run this later: `hermes fleet setup`.  Or skip the "
+            "Telegram fleet entirely \u2014 the in-process `hermes_swarm` tool "
+            "needs no setup."
+        )
+        return 1
+    if ":" not in token or len(token) < 30:
+        _err(f"Token doesn't look right (got {len(token)} chars; expected ~46).")
+        return 1
+
+    try:
+        client = FleetApiClient(token)
+        me = client.get_me()
+    except BotApiError as e:
+        _err(f"Telegram rejected the token: {e}")
+        return 1
+    except Exception as e:
+        _err(f"Couldn't reach Telegram ({type(e).__name__}: {e}).")
+        return 1
+
+    username = (me.get("username") or "").lstrip("@")
+    if not username:
+        _err("Manager bot has no username.  Set one in @BotFather first.")
+        return 1
+    _ok(f"Manager bot identified: @{username}")
+
+    if not me.get("can_manage_bots"):
+        _err(
+            "This bot doesn't have Bot Manager Mode enabled.  "
+            "Open @BotFather \u2192 /mybots \u2192 select this bot \u2192 BotFather MiniApp \u2192 "
+            "enable 'Bot Management Mode'.  Then re-run `hermes fleet setup`."
+        )
+        return 1
+    _ok("Bot Manager Mode is enabled \u2014 token can mint child bots.")
+
+    try:
+        roster = load_roster()
+    except Exception as e:
+        _warn(f"Existing roster unreadable ({e}); starting fresh.")
+        from gateway.telegram_fleet.roster import FleetRoster
+
+        roster = FleetRoster()
+    roster.manager_bot_username = username
+    save_roster(roster)
+    _ok("Saved roster to ~/.hermes/telegram_fleet.yaml (mode 0600).")
+
+    if os.environ.get("TELEGRAM_FLEET_MANAGER_TOKEN") != token:
+        os.environ["TELEGRAM_FLEET_MANAGER_TOKEN"] = token
+    saved = _save_token_to_env(token)
+    if saved:
+        _ok("Saved TELEGRAM_FLEET_MANAGER_TOKEN to ~/.hermes/.env.")
+    else:
+        _info(
+            "TELEGRAM_FLEET_MANAGER_TOKEN already in ~/.hermes/.env "
+            "(left unchanged)."
+        )
+
+    _heading("Next steps")
+    print(
+        "  1. Add worker bots:  hermes fleet add hermes_research_bot --persona 'research lead'\n"
+        "  2. Watch the roster: hermes fleet list\n"
+        "  3. In a Hermes session: 'spin up a swarm to research X' \u2014 the\n"
+        "     agent proposes the plan, you confirm via clarify, the swarm runs.\n"
+    )
+    print(
+        f"{_DIM}Tip: the in-process `hermes_swarm` tool runs without any of "
+        f"this \u2014 it's the default for swarm-shaped requests.{_RST}"
+    )
+    return 0
+
+
+def _cmd_status(args: argparse.Namespace) -> int:
+    from gateway.telegram_fleet.roster import load_roster
+
+    _heading("Telegram Fleet \u2014 status")
+
+    token = (os.environ.get("TELEGRAM_FLEET_MANAGER_TOKEN") or "").strip()
+    if token:
+        _ok(
+            f"Manager token configured (TELEGRAM_FLEET_MANAGER_TOKEN, "
+            f"{len(token)} chars)."
+        )
+    else:
+        _warn("Manager token NOT set.  Run `hermes fleet setup` to configure.")
+
+    try:
+        roster = load_roster()
+    except Exception as e:
+        _err(f"Roster unreadable: {e}")
+        return 1
+    if roster.manager_bot_username:
+        _ok(f"Manager bot: @{roster.manager_bot_username}")
+    else:
+        _info("No manager bot recorded in roster yet.")
+    active = roster.active_children()
+    pending = roster.pending_children()
+    decommissioned = [c for c in roster.children if c.status == "decommissioned"]
+    _info(
+        f"Roster: {len(active)} active, {len(pending)} pending, "
+        f"{len(decommissioned)} decommissioned (cap: {roster.max_size})."
+    )
+    if not token:
+        return 1
+    return 0
+
+
+def _cmd_list(args: argparse.Namespace) -> int:
+    from gateway.telegram_fleet.roster import load_roster
+
+    try:
+        roster = load_roster()
+    except Exception as e:
+        _err(f"Roster unreadable: {e}")
+        return 1
+
+    if not roster.children:
+        _info("Roster is empty.  Add a worker with `hermes fleet add <username>`.")
+        return 0
+
+    _heading(f"Telegram Fleet \u2014 roster ({len(roster.children)} entries)")
+    width = max((len(c.username) for c in roster.children), default=8) + 2
+    for c in roster.children:
+        status = c.status
+        marker = {
+            "active": _OK + "\u25cf",
+            "pending": _WARN + "\u25cb",
+            "decommissioned": _DIM + "\u00b7",
+        }.get(status, "\u00b7")
+        persona = c.persona or "\u2014"
+        if len(persona) > 60:
+            persona = persona[:57] + "\u2026"
+        print(
+            f"  {marker}{_RST} @{c.username:<{width}} {_DIM}{status:<14}{_RST} {persona}"
+        )
+    return 0
+
+
+def _cmd_add(args: argparse.Namespace) -> int:
+    from gateway.telegram_fleet import (
+        FleetGuardrailError,
+        SpawnApprovalRequired,
+        get_coordinator,
+    )
+    from gateway.telegram_fleet.api import BotApiError
+
+    suggested = (args.username or "").strip().lstrip("@")
+    if not suggested:
+        _err("username is required.")
+        return 1
+    if not suggested.lower().endswith("bot"):
+        _info(f"Adding 'bot' suffix \u2192 {suggested}_bot")
+        suggested = f"{suggested}_bot"
+
+    if not (os.environ.get("TELEGRAM_FLEET_MANAGER_TOKEN") or "").strip():
+        _err(
+            "TELEGRAM_FLEET_MANAGER_TOKEN is not set.  Run "
+            "`hermes fleet setup` first."
+        )
+        return 1
+
+    coord = get_coordinator(refresh=True)
+    try:
+        result = coord.spawn_bot(
+            suggested_username=suggested,
+            persona=args.persona,
+            display_name=args.name,
+        )
+    except SpawnApprovalRequired as e:
+        _err(str(e))
+        return 1
+    except FleetGuardrailError as e:
+        _err(str(e))
+        return 1
+    except BotApiError as e:
+        _err(f"Telegram API error: {e}")
+        return 1
+
+    _ok(f"Pending entry minted for @{result.suggested_username}.")
+    print()
+    print(f"  {_BOLD}Tap this link in Telegram to confirm:{_RST}")
+    print(f"  {_INFO}{result.deep_link}{_RST}")
+    print()
+
+    wait_seconds = int(getattr(args, "wait", 0) or 0)
+    if wait_seconds <= 0:
+        _info(
+            "Skipping wait.  After tapping the link, run `hermes fleet "
+            "connect` (or restart the gateway) to absorb the bot."
+        )
+        return 0
+
+    _info(
+        f"Watching Telegram for up to {wait_seconds}s for your tap "
+        f"(Ctrl-C to stop and continue manually with `hermes fleet connect`)."
+    )
+    import time
+
+    target = result.suggested_username.lower()
+    deadline = time.monotonic() + wait_seconds
+    poll_chunk = 30  # Telegram caps long-poll at ~50; 30s is a safe default.
+    try:
+        while time.monotonic() < deadline:
+            remaining = max(1, int(deadline - time.monotonic()))
+            this_timeout = min(poll_chunk, remaining)
+            absorbed = coord.absorb_pending_updates(
+                max_polls=1, poll_timeout=this_timeout
+            )
+            for child in absorbed:
+                if child.username.lower() == target:
+                    _ok(
+                        f"@{child.username} confirmed and promoted to "
+                        f"active (bot_id={child.bot_id})."
+                    )
+                    return 0
+            # If we got OTHER bots but not ours, keep polling.
+    except KeyboardInterrupt:
+        print()
+        _warn(
+            "Stopped waiting.  Run `hermes fleet connect` later to absorb "
+            "the bot once you tap the link."
+        )
+        return 0
+
+    _warn(
+        f"Didn't see @{target} within {wait_seconds}s.  Tap the link in "
+        f"Telegram, then run `hermes fleet connect`."
+    )
+    return 0
+
+
+def _explain_bot_api_error(e) -> None:
+    """Translate well-known Telegram errors into actionable hints."""
+    desc = str(getattr(e, "description", e)).lower()
+    code = getattr(e, "code", None)
+    if code == 409 or "webhook" in desc or "conflict" in desc:
+        _info(
+            "Telegram returned a conflict (409).  Either a webhook is set on "
+            "the manager bot (run `curl https://api.telegram.org/bot<TOKEN>/"
+            "deleteWebhook` to clear it) or another process is already "
+            "polling getUpdates with this token (the gateway, perhaps).  "
+            "Stop the other consumer and retry."
+        )
+    elif code == 401 or "unauthorized" in desc:
+        _info(
+            "The manager token was rejected (401).  Run `hermes fleet setup` "
+            "again to validate / replace it."
+        )
+    elif code == 403 or "forbidden" in desc or "manager" in desc:
+        _info(
+            "Looks like Bot Manager Mode isn't enabled on this bot.  "
+            "Open @BotFather \u2192 /mybots \u2192 select the bot \u2192 BotFather "
+            "MiniApp \u2192 enable 'Bot Management Mode', then retry."
+        )
+
+
+def _cmd_connect(args: argparse.Namespace) -> int:
+    """Drain managed_bot updates from Telegram and promote pending entries."""
+    from gateway.telegram_fleet import get_coordinator
+    from gateway.telegram_fleet.api import BotApiError
+
+    if not (os.environ.get("TELEGRAM_FLEET_MANAGER_TOKEN") or "").strip():
+        _err(
+            "TELEGRAM_FLEET_MANAGER_TOKEN is not set.  Run "
+            "`hermes fleet setup` first."
+        )
+        return 1
+
+    coord = get_coordinator(refresh=True)
+    pending_before = len(coord.list_children(status="pending"))
+    if pending_before == 0:
+        _info(
+            "No pending entries in the roster.  Nothing to wait for.  "
+            "Add a worker with `hermes fleet add <username>` first."
+        )
+        return 0
+
+    wait_seconds = int(getattr(args, "wait", 0) or 0)
+    _heading(
+        f"Telegram Fleet \u2014 connect "
+        f"({pending_before} pending entr{'y' if pending_before == 1 else 'ies'})"
+    )
+
+    if wait_seconds <= 0:
+        try:
+            absorbed = coord.absorb_pending_updates(
+                max_polls=1, poll_timeout=0
+            )
+        except BotApiError as e:
+            _err(f"Telegram API error: {e}")
+            _explain_bot_api_error(e)
+            return 1
+        if not absorbed:
+            _info(
+                "No managed_bot updates queued.  Either the user hasn't "
+                "tapped the link yet, or the gateway already absorbed them.  "
+                "Pass `--wait 60` to long-poll."
+            )
+            return 0
+        for child in absorbed:
+            _ok(f"@{child.username} promoted to active (bot_id={child.bot_id}).")
+        return 0
+
+    _info(
+        f"Long-polling for up to {wait_seconds}s "
+        f"(Ctrl-C to stop early)."
+    )
+    import time
+
+    deadline = time.monotonic() + wait_seconds
+    seen: list = []
+    try:
+        while time.monotonic() < deadline:
+            remaining = max(1, int(deadline - time.monotonic()))
+            this_timeout = min(30, remaining)
+            try:
+                absorbed = coord.absorb_pending_updates(
+                    max_polls=1, poll_timeout=this_timeout
+                )
+            except BotApiError as e:
+                _err(f"Telegram API error: {e}")
+                return 1
+            for child in absorbed:
+                seen.append(child)
+                _ok(
+                    f"@{child.username} promoted to active "
+                    f"(bot_id={child.bot_id})."
+                )
+            # Stop early when no pending entries remain.
+            if not coord.list_children(status="pending"):
+                _ok("All pending entries absorbed.")
+                return 0
+    except KeyboardInterrupt:
+        print()
+    if not seen:
+        _warn(
+            f"Didn't see any new managed_bot events within {wait_seconds}s."
+        )
+    return 0

--- a/hermes_cli/fleet.py
+++ b/hermes_cli/fleet.py
@@ -78,6 +78,8 @@ def cmd_fleet(args: argparse.Namespace) -> int:
         return _cmd_list(args)
     if sub == "add":
         return _cmd_add(args)
+    if sub == "adopt":
+        return _cmd_adopt(args)
     if sub == "connect":
         return _cmd_connect(args)
     return _cmd_status(args)
@@ -139,6 +141,48 @@ def add_fleet_parser(subparsers) -> None:
             "After printing the deep link, poll for up to N seconds "
             "waiting for the user to tap (default 180 = 3 minutes).  Pass "
             "0 to skip polling and exit immediately."
+        ),
+    )
+
+    adopt_parser = fleet_subparsers.add_parser(
+        "adopt",
+        help=(
+            "Adopt an EXISTING bot into the fleet by token.  Use this when "
+            "you already created the bot manually in @BotFather and "
+            "`hermes fleet add` says the username is taken."
+        ),
+        description=(
+            "Adds an already-existing Telegram bot to the fleet roster by "
+            "validating its token (calls getMe) and writing it as active.  "
+            "Bypasses the Managed Bots deep-link flow.  Trade-off: bots "
+            "adopted this way cannot be rotated via replaceManagedBotToken; "
+            "rotation means generating a fresh token in BotFather and "
+            "re-running `hermes fleet adopt`."
+        ),
+    )
+    adopt_parser.add_argument(
+        "--token",
+        default=None,
+        help=(
+            "Bot API token.  If omitted, you'll be prompted (input hidden)."
+        ),
+    )
+    adopt_parser.add_argument(
+        "--persona",
+        default="",
+        help="Free-text persona/role description for this worker.",
+    )
+    adopt_parser.add_argument(
+        "--model",
+        default=None,
+        help="Optional model override for tasks routed through this bot.",
+    )
+    adopt_parser.add_argument(
+        "--toolset",
+        default=None,
+        help=(
+            "Optional toolset whitelist, comma-separated "
+            "(e.g. 'web,file,terminal')."
         ),
     )
 
@@ -404,6 +448,14 @@ def _cmd_add(args: argparse.Namespace) -> int:
     print(f"  {_BOLD}Tap this link in Telegram to confirm:{_RST}")
     print(f"  {_INFO}{result.deep_link}{_RST}")
     print()
+    print(
+        f"  {_DIM}This link CREATES a new bot under your manager's "
+        f"control.  If Telegram says 'username already taken' when you "
+        f"tap, the bot already exists \u2014 use "
+        f"`hermes fleet adopt --token <its_token> --persona \"...\"` "
+        f"instead.{_RST}"
+    )
+    print()
 
     wait_seconds = int(getattr(args, "wait", 0) or 0)
     if wait_seconds <= 0:
@@ -475,6 +527,73 @@ def _explain_bot_api_error(e) -> None:
             "Open @BotFather \u2192 /mybots \u2192 select the bot \u2192 BotFather "
             "MiniApp \u2192 enable 'Bot Management Mode', then retry."
         )
+
+
+def _cmd_adopt(args: argparse.Namespace) -> int:
+    """Adopt an existing Telegram bot (created in BotFather) into the fleet."""
+    from gateway.telegram_fleet import (
+        FleetGuardrailError,
+        SpawnApprovalRequired,
+        get_coordinator,
+    )
+    from gateway.telegram_fleet.api import BotApiError
+
+    token = (args.token or "").strip()
+    if not token:
+        if not sys.stdin.isatty():
+            _err(
+                "No --token provided and stdin is not a TTY.  Pass "
+                "`--token <bot_token>` explicitly."
+            )
+            return 1
+        _info(
+            "Paste the bot's API token (from @BotFather \u2192 /mybots \u2192 "
+            "select bot \u2192 API Token).  Looks like '12345:ABC...'."
+        )
+        try:
+            token = getpass.getpass("Token (input hidden): ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            _err("Aborted.")
+            return 1
+    if ":" not in token or len(token) < 30:
+        _err(f"Token doesn't look right (got {len(token)} chars; expected ~46).")
+        return 1
+
+    toolset_list: Optional[list] = None
+    if args.toolset:
+        toolset_list = [t.strip() for t in str(args.toolset).split(",") if t.strip()]
+
+    coord = get_coordinator(refresh=True)
+    try:
+        child = coord.adopt_existing_bot(
+            token=token,
+            persona=args.persona,
+            model=args.model,
+            toolset=toolset_list,
+        )
+    except SpawnApprovalRequired as e:
+        _err(str(e))
+        return 1
+    except FleetGuardrailError as e:
+        _err(str(e))
+        return 1
+    except BotApiError as e:
+        _err(f"Telegram API error: {e}")
+        _explain_bot_api_error(e)
+        return 1
+    _ok(
+        f"Adopted @{child.username} into the fleet "
+        f"(bot_id={child.bot_id}, status=active)."
+    )
+    if args.persona:
+        _info(f"Persona: {args.persona}")
+    print()
+    _info(
+        "The bot is ready for `telegram_orchestrate_swarm`.  "
+        "Run `hermes fleet list` to verify."
+    )
+    return 0
 
 
 def _cmd_connect(args: argparse.Namespace) -> int:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7909,6 +7909,12 @@ For more help on a command:
     setup_parser.set_defaults(func=cmd_setup)
 
     # =========================================================================
+    # fleet command (Telegram swarm setup + roster management)
+    # =========================================================================
+    from hermes_cli.fleet import add_fleet_parser
+    add_fleet_parser(subparsers)
+
+    # =========================================================================
     # whatsapp command
     # =========================================================================
     whatsapp_parser = subparsers.add_parser(

--- a/model_tools.py
+++ b/model_tools.py
@@ -500,6 +500,7 @@ def handle_function_call(
     user_task: Optional[str] = None,
     enabled_tools: Optional[List[str]] = None,
     skip_pre_tool_call_hook: bool = False,
+    parent_agent: Any = None,
 ) -> str:
     """
     Main function call dispatcher that routes calls to the tool registry.
@@ -584,12 +585,14 @@ def handle_function_call(
                 function_name, function_args,
                 task_id=task_id,
                 enabled_tools=sandbox_enabled,
+                parent_agent=parent_agent,
             )
         else:
             result = registry.dispatch(
                 function_name, function_args,
                 task_id=task_id,
                 user_task=user_task,
+                parent_agent=parent_agent,
             )
         duration_ms = int((time.monotonic() - _dispatch_start) * 1000)
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -99,7 +99,7 @@ from agent.model_metadata import (
 from agent.context_compressor import ContextCompressor
 from agent.subdirectory_hints import SubdirectoryHintTracker
 from agent.prompt_caching import apply_anthropic_cache_control
-from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt, build_environment_hints, load_soul_md, TOOL_USE_ENFORCEMENT_GUIDANCE, TOOL_USE_ENFORCEMENT_MODELS, GOOGLE_MODEL_OPERATIONAL_GUIDANCE, OPENAI_MODEL_EXECUTION_GUIDANCE
+from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt, build_environment_hints, build_telegram_fleet_hint, load_soul_md, TOOL_USE_ENFORCEMENT_GUIDANCE, TOOL_USE_ENFORCEMENT_MODELS, GOOGLE_MODEL_OPERATIONAL_GUIDANCE, OPENAI_MODEL_EXECUTION_GUIDANCE
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
 from agent.codex_responses_adapter import (
     _derive_responses_function_call_id as _codex_derive_responses_function_call_id,
@@ -4629,6 +4629,13 @@ class AIAgent:
         _env_hints = build_environment_hints()
         if _env_hints:
             prompt_parts.append(_env_hints)
+
+        # Telegram fleet roster — only injected when a manager bot is
+        # configured AND there's at least one active child.  No-op for users
+        # who haven't opted into Telegram swarming.
+        _fleet_hint = build_telegram_fleet_hint()
+        if _fleet_hint:
+            prompt_parts.append(_fleet_hint)
 
         platform_key = (self.platform or "").lower().strip()
         if platform_key in PLATFORM_HINTS:

--- a/run_agent.py
+++ b/run_agent.py
@@ -8324,6 +8324,7 @@ class AIAgent:
                 session_id=self.session_id or "",
                 enabled_tools=list(self.valid_tool_names) if self.valid_tool_names else None,
                 skip_pre_tool_call_hook=True,
+                parent_agent=self,
             )
 
     @staticmethod
@@ -8921,6 +8922,7 @@ class AIAgent:
                         session_id=self.session_id or "",
                         enabled_tools=list(self.valid_tool_names) if self.valid_tool_names else None,
                         skip_pre_tool_call_hook=True,
+                        parent_agent=self,
                     )
                     _spinner_result = function_result
                 except Exception as tool_error:
@@ -8941,6 +8943,7 @@ class AIAgent:
                         session_id=self.session_id or "",
                         enabled_tools=list(self.valid_tool_names) if self.valid_tool_names else None,
                         skip_pre_tool_call_hook=True,
+                        parent_agent=self,
                     )
                 except Exception as tool_error:
                     function_result = f"Error executing tool '{function_name}': {tool_error}"

--- a/skills/agents/swarm-orchestration/SKILL.md
+++ b/skills/agents/swarm-orchestration/SKILL.md
@@ -51,9 +51,35 @@ hermes_swarm(
 
 Per worker you can also pass `context` (extra grounding) and `toolsets` (allowed tool whitelist).
 
-## Escalation: `telegram_orchestrate_swarm`
+## Escalation: `telegram_orchestrate_swarm` (requires approval)
 
 Use **only** when the user explicitly wants visible Telegram bot activity ("send me updates from each agent", "I want to watch them work in Telegram", or they've already been working with named fleet bots like `@research_legal_bot`). Requires a one-time manager-bot setup; if not configured, prefer `hermes_swarm`.
+
+**This variant has visible side-effects** (named bots posting into chats), so it requires explicit user consent — same pattern as `terminal_tool`'s dangerous-command flow. Two paths to run:
+
+### A. Approval flow (default)
+
+```
+1. Call telegram_orchestrate_swarm(objective, subtasks)  ← no user_approved
+   → returns {"status": "approval_required", "plan": {...}}
+2. Surface the plan via the `clarify` tool:
+     clarify(
+        question="Run this Telegram swarm? <one-line summary of plan>",
+        choices=["Yes, run as proposed", "Adjust the plan", "Cancel"],
+     )
+3a. User says yes → re-call with user_approved=true.
+3b. User wants changes → adjust subtasks, re-call without user_approved
+    (this loops back to step 2).
+3c. User cancels → solve solo or use hermes_swarm.
+```
+
+### B. By-name request (skips approval)
+
+If the user named specific bots in their request ("use @legal_bot and @market_bot"), pin every subtask to a `bot_username`. The tool treats this as the user already requesting by name — no approval prompt.
+
+### Operator override
+
+Power users can set `telegram_fleet.auto_approve: true` in `~/.hermes/config.yaml` (or `TELEGRAM_FLEET_AUTO_APPROVE=1`) to disable the prompt entirely. Default is **off** — never run a Telegram swarm without consent.
 
 The Telegram variant adds:
 - Each subtask runs as a named child bot (visible identity).
@@ -109,7 +135,9 @@ You are the leader. The structured `results` array is for **you** to read and sy
 2. Ask: are there 2+ independent angles? If no, answer solo or use `delegate_task`.
 3. If yes, decompose into 2–8 atomic subtasks with clear personas.
 4. (Optional) Add a verifier subtask if facts/numbers matter.
-5. Call `hermes_swarm` (default) or `telegram_orchestrate_swarm` (if user wants Telegram visibility).
+5. Pick the variant:
+   - Default → `hermes_swarm` (invisible in-process, just runs).
+   - Telegram → `telegram_orchestrate_swarm`. **First call returns `approval_required`**; surface the plan via `clarify`, get user consent, re-call with `user_approved=true`. Skip approval only if user pinned specific bots by name.
 6. Synthesise the structured results into your final answer.
 
 ## Verification

--- a/skills/agents/swarm-orchestration/SKILL.md
+++ b/skills/agents/swarm-orchestration/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: swarm-orchestration
-description: Decide when to fan a request across parallel sub-agents (a "swarm") vs solve it solo or via a single delegation. Kimi-Agent-Swarm-style orchestration — in-process by default, escalates to a Telegram fleet only when the user wants visible bot activity.
+description: Decide when to fan a request across parallel sub-agents (a "swarm") vs solve it solo or via a single delegation. Hermes is the orchestrator — runs in-process by default, escalates to a connected Telegram bot swarm when the user wants visible activity.
 version: 1.0.0
 author: Hermes Agent
 license: MIT
 metadata:
   hermes:
-    tags: [orchestration, multi-agent, parallelism, delegation, kimi-swarm]
+    tags: [orchestration, multi-agent, parallelism, delegation, telegram-swarm]
 ---
 
 # Swarm Orchestration
@@ -86,14 +86,16 @@ The Telegram variant adds:
 - A `report_chat_id` argument streams live status as each bot.
 - Same `objective` / `subtasks` shape as `hermes_swarm`.
 
-## How to decompose well (Kimi-derived patterns)
+## How to decompose well
 
 1. **Atomic, independent subtasks.** Each goal should stand alone. If two goals reference each other, merge them.
 2. **3–5 workers is the production sweet spot.** Coordination overhead dominates beyond ~7. The cap is 16 — treat that as a ceiling, not a target.
 3. **Balance the work.** Aim for similar effort per subtask. Wall-clock = slowest worker; one outlier worker means no speedup.
 4. **Use personas / roles.** Each worker behaves better when its persona is concrete: "skeptical legal analyst", "market sizing specialist", "fact-checker focused on dates and numbers".
-5. **Spawn a verifier.** For high-stakes answers, add a final subtask `{"goal": "Cross-check the other workers' answers for contradictions and unsupported claims", "persona": "skeptic / fact-checker"}`. This emerged organically in Kimi's swarms; it works.
+5. **Spawn a verifier.** For high-stakes answers, add a final subtask `{"goal": "Cross-check the other workers' answers for contradictions and unsupported claims", "persona": "skeptic / fact-checker"}` — a well-known pattern in multi-agent research; it works.
 6. **Distil, don't dump.** Each worker returns one focused answer; you synthesise. Don't ask workers to "report everything they did."
+
+> Prior art: these patterns trace back to hierarchical reinforcement learning (Sutton's Options framework, Feudal Networks), recent multi-agent scaling research, and Moonshot AI's published PARL methodology for Kimi K2.5/K2.6.  We adopt them as orchestration heuristics, not as a training regime.
 
 ## Anti-patterns — when NOT to swarm
 

--- a/skills/agents/swarm-orchestration/SKILL.md
+++ b/skills/agents/swarm-orchestration/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: swarm-orchestration
+description: Decide when to fan a request across parallel sub-agents (a "swarm") vs solve it solo or via a single delegation. Kimi-Agent-Swarm-style orchestration — in-process by default, escalates to a Telegram fleet only when the user wants visible bot activity.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [orchestration, multi-agent, parallelism, delegation, kimi-swarm]
+---
+
+# Swarm Orchestration
+
+You are the **leader**. When a user asks you to do something complex, you choose between three execution modes:
+
+| Mode | When | How |
+|---|---|---|
+| **Solve solo** | Single straightforward question, lookup, single-source answer | Just answer / use tools yourself |
+| **Single delegation** | One bigger task you want a fresh subagent to handle in isolation | `delegate_task` |
+| **Swarm (fan-out)** | The request decomposes into 2–8 *independent* angles | `hermes_swarm` (default) or `telegram_orchestrate_swarm` (if user wants live Telegram visibility) |
+
+This skill teaches you how to recognise which mode fits, and how to decompose well when swarming.
+
+## When to swarm — the deciding question
+
+> *"Can I split this into 2+ sub-questions whose answers don't depend on each other?"*
+
+If yes → swarm. Examples:
+- "Research X across legal / market / technical angles" → 3 parallel angles
+- "Draft 4 variants of this email" → 4 parallel drafts
+- "Verify these 3 claims independently" → 3 parallel fact-checkers
+- "Monitor these 5 feeds for X" → 5 parallel monitors
+- "Compare A, B, C on dimensions D1, D2, D3" → 3 parallel comparisons (or 9 if cross-cells matter)
+
+If the next step **needs the previous step's answer**, do not swarm — that's sequential reasoning, do it solo or via a single `delegate_task`.
+
+## Default: `hermes_swarm` (zero setup)
+
+`hermes_swarm` runs in-process. No Telegram, no manager bot, no roster — just decompose, fan out, get structured results back. **This is your default for any swarm-shaped request.**
+
+```
+hermes_swarm(
+    objective="<the user's goal in 1-3 sentences>",
+    subtasks=[
+        {"goal": "<atomic angle 1>", "persona": "<short role hint>"},
+        {"goal": "<atomic angle 2>", "persona": "<short role hint>"},
+        ...
+    ],
+)
+```
+
+Per worker you can also pass `context` (extra grounding) and `toolsets` (allowed tool whitelist).
+
+## Escalation: `telegram_orchestrate_swarm`
+
+Use **only** when the user explicitly wants visible Telegram bot activity ("send me updates from each agent", "I want to watch them work in Telegram", or they've already been working with named fleet bots like `@research_legal_bot`). Requires a one-time manager-bot setup; if not configured, prefer `hermes_swarm`.
+
+The Telegram variant adds:
+- Each subtask runs as a named child bot (visible identity).
+- A `report_chat_id` argument streams live status as each bot.
+- Same `objective` / `subtasks` shape as `hermes_swarm`.
+
+## How to decompose well (Kimi-derived patterns)
+
+1. **Atomic, independent subtasks.** Each goal should stand alone. If two goals reference each other, merge them.
+2. **3–5 workers is the production sweet spot.** Coordination overhead dominates beyond ~7. The cap is 16 — treat that as a ceiling, not a target.
+3. **Balance the work.** Aim for similar effort per subtask. Wall-clock = slowest worker; one outlier worker means no speedup.
+4. **Use personas / roles.** Each worker behaves better when its persona is concrete: "skeptical legal analyst", "market sizing specialist", "fact-checker focused on dates and numbers".
+5. **Spawn a verifier.** For high-stakes answers, add a final subtask `{"goal": "Cross-check the other workers' answers for contradictions and unsupported claims", "persona": "skeptic / fact-checker"}`. This emerged organically in Kimi's swarms; it works.
+6. **Distil, don't dump.** Each worker returns one focused answer; you synthesise. Don't ask workers to "report everything they did."
+
+## Anti-patterns — when NOT to swarm
+
+- **Tightly-coupled / sequential**: "Read this file then patch it then commit it." → solve solo or use `delegate_task` once.
+- **Trivial questions**: "What's the time?" → answer directly.
+- **Fewer than 2 angles**: `hermes_swarm` will reject single-subtask plans (it would just be `delegate_task` with extra steps).
+- **Over-parallelism**: 12 subtasks for a 3-angle problem dilutes specialisation. Match worker count to natural angles, not max capacity.
+- **Round-tripping**: don't swarm to swarm — workers run as leaf delegates; they can't recurse back into more swarms.
+
+## Reading the result
+
+Both swarm tools return:
+
+```json
+{
+    "objective": "...",
+    "results": [{"goal": "...", "persona": "...", "response": "...", "duration_seconds": 1.2, "error": null}, ...],
+    "metrics": {
+        "workers": 4,
+        "failures": 0,
+        "critical_path_seconds": 12.3,
+        "total_serial_seconds": 41.0,
+        "parallel_speedup": 3.3,
+        "wall_clock_seconds": 12.4
+    },
+    "summary": "...human-readable rollup..."
+}
+```
+
+`critical_path_seconds` is what the user actually waited; `parallel_speedup` tells you whether the fan-out paid off. If speedup < 1.5×, you over-parallelised — next time use fewer workers or solve sequentially.
+
+## After the workers return — your job is synthesis
+
+You are the leader. The structured `results` array is for **you** to read and synthesise into the final user-facing answer. Don't paste raw worker outputs back to the user; weave them into a coherent reply that answers the original question, calling out contradictions surfaced by any verifier.
+
+## Procedure (the short version)
+
+1. Read the user's request.
+2. Ask: are there 2+ independent angles? If no, answer solo or use `delegate_task`.
+3. If yes, decompose into 2–8 atomic subtasks with clear personas.
+4. (Optional) Add a verifier subtask if facts/numbers matter.
+5. Call `hermes_swarm` (default) or `telegram_orchestrate_swarm` (if user wants Telegram visibility).
+6. Synthesise the structured results into your final answer.
+
+## Verification
+
+You did this right when:
+- The user's request decomposes naturally into your subtasks.
+- Each worker has a concrete, distinct persona.
+- `parallel_speedup` ≥ 2× (otherwise fewer workers next time).
+- Your final answer reads as one coherent response, not a transcript of N workers.

--- a/skills/agents/swarm-orchestration/SKILL.md
+++ b/skills/agents/swarm-orchestration/SKILL.md
@@ -55,6 +55,12 @@ Per worker you can also pass `context` (extra grounding) and `toolsets` (allowed
 
 Use **only** when the user explicitly wants visible Telegram bot activity ("send me updates from each agent", "I want to watch them work in Telegram", or they've already been working with named fleet bots like `@research_legal_bot`). Requires a one-time manager-bot setup; if not configured, prefer `hermes_swarm`.
 
+> **One-time fleet setup (operator side).** The user runs `hermes fleet setup` once to register a manager bot, then either:
+> * `hermes fleet add <username>` — creates a NEW child bot through the Managed Bots deep-link flow (one tap to confirm).
+> * `hermes fleet adopt --token <bot_token>` — adopts a bot the user **already** created in BotFather.  Use this when `add` says "username already taken."
+>
+> Both paths land the bot in the roster as `active`, ready for `telegram_orchestrate_swarm`.
+
 **This variant has visible side-effects** (named bots posting into chats), so it requires explicit user consent — same pattern as `terminal_tool`'s dangerous-command flow. Two paths to run:
 
 ### A. Approval flow (default)

--- a/tests/agent/test_telegram_fleet_prompt_injection.py
+++ b/tests/agent/test_telegram_fleet_prompt_injection.py
@@ -1,0 +1,124 @@
+"""Tests for the roster-aware system prompt injection (Layer 4 of swarm discovery).
+
+The injection should:
+* Be silent when no manager token is set (don't burden non-Telegram users).
+* Be silent when the roster has no active children.
+* Surface active fleet members + their personas otherwise, so the leader
+  knows specific named workers exist before calling telegram_fleet_list.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from agent.prompt_builder import build_telegram_fleet_hint
+from gateway.telegram_fleet.api import ManagedBotInfo
+from gateway.telegram_fleet.coordinator import FleetCoordinator, reset_coordinator
+from gateway.telegram_fleet.guardrails import reset_rate_limits
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    return tmp_path
+
+
+@pytest.fixture(autouse=True)
+def _isolate():
+    reset_coordinator()
+    reset_rate_limits()
+    yield
+    reset_coordinator()
+    reset_rate_limits()
+
+
+def _seed_fleet(coord: FleetCoordinator, names_to_personas):
+    for name, persona in names_to_personas:
+        coord.spawn_bot(name, persona=persona)
+        coord.absorb_managed_bot(
+            ManagedBotInfo(token=f"x:tok_{name}", bot_id=hash(name) & 0xFFFF, bot_username=name)
+        )
+
+
+def _coord(api):
+    return FleetCoordinator(manager_token="12345:ABC", api_client=api)
+
+
+def _stub_api():
+    from unittest.mock import MagicMock
+
+    api = MagicMock()
+    api.get_me.return_value = {"id": 1, "username": "TestMgr", "can_manage_bots": True}
+    return api
+
+
+def test_silent_when_no_manager_token(hermes_home, monkeypatch):
+    monkeypatch.delenv("TELEGRAM_FLEET_MANAGER_TOKEN", raising=False)
+    assert build_telegram_fleet_hint() == ""
+
+
+def test_silent_when_no_active_children(hermes_home, monkeypatch):
+    monkeypatch.setenv("TELEGRAM_FLEET_MANAGER_TOKEN", "12345:ABC")
+    coord = _coord(_stub_api())
+    coord.spawn_bot("only_pending_bot")  # never absorbed → status=pending
+    assert build_telegram_fleet_hint() == ""
+
+
+def test_emits_roster_when_fleet_active(hermes_home, monkeypatch):
+    monkeypatch.setenv("TELEGRAM_FLEET_MANAGER_TOKEN", "12345:ABC")
+    coord = _coord(_stub_api())
+    _seed_fleet(coord, [
+        ("legal_bot", "regulatory analyst"),
+        ("market_bot", "market sizing specialist"),
+    ])
+    hint = build_telegram_fleet_hint()
+    assert hint != ""
+    assert "@legal_bot" in hint
+    assert "regulatory analyst" in hint
+    assert "@market_bot" in hint
+    assert "market sizing specialist" in hint
+    assert "telegram_orchestrate_swarm" in hint
+    assert "hermes_swarm" in hint  # mentions the in-process default for non-visible swarms
+
+
+def test_truncates_long_personas(hermes_home, monkeypatch):
+    monkeypatch.setenv("TELEGRAM_FLEET_MANAGER_TOKEN", "12345:ABC")
+    coord = _coord(_stub_api())
+    _seed_fleet(coord, [("verbose_bot", "x" * 500)])
+    hint = build_telegram_fleet_hint()
+    assert "@verbose_bot" in hint
+    # Persona truncated to ~120 chars; verify it's not the full 500.
+    bot_line = next(line for line in hint.splitlines() if "@verbose_bot" in line)
+    assert len(bot_line) < 200
+
+
+def test_handles_missing_manager_username(hermes_home, monkeypatch):
+    """Roster without a recorded manager username still works."""
+    monkeypatch.setenv("TELEGRAM_FLEET_MANAGER_TOKEN", "12345:ABC")
+    api = _stub_api()
+    coord = FleetCoordinator(manager_token="12345:ABC", api_client=api)
+    coord.spawn_bot("worker_bot", persona="general")
+    coord.absorb_managed_bot(
+        ManagedBotInfo(token="42:tok", bot_id=42, bot_username="worker_bot")
+    )
+    # spawn_bot already populates manager_bot_username via api.get_me; clear it
+    # to simulate the corner case.
+    from gateway.telegram_fleet.roster import load_roster, save_roster
+
+    r = load_roster()
+    r.manager_bot_username = ""
+    save_roster(r)
+    hint = build_telegram_fleet_hint()
+    assert hint != ""
+    assert "@worker_bot" in hint
+
+
+def test_silent_on_corrupt_roster(hermes_home, monkeypatch):
+    """A broken roster file must not crash prompt assembly."""
+    monkeypatch.setenv("TELEGRAM_FLEET_MANAGER_TOKEN", "12345:ABC")
+    (hermes_home / "telegram_fleet.yaml").write_text(": : : not yaml :\n")
+    # No exception, returns empty string.
+    assert build_telegram_fleet_hint() == ""

--- a/tests/gateway/test_telegram_fleet_api.py
+++ b/tests/gateway/test_telegram_fleet_api.py
@@ -1,0 +1,148 @@
+"""Tests for the raw Bot API client (Managed Bots endpoints + send-as helper)."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from gateway.telegram_fleet.api import (
+    BotApiError,
+    FleetApiClient,
+    ManagedBotInfo,
+    build_managed_bot_deep_link,
+)
+
+
+def _mock_client(handler):
+    """Build an httpx.MockTransport-backed client that calls *handler(method, path, json)*."""
+
+    def _transport_handler(request: httpx.Request) -> httpx.Response:
+        body = {} if not request.content else request.read()
+        if isinstance(body, (bytes, bytearray)):
+            import json as _json
+
+            body = _json.loads(body or b"{}")
+        return handler(request.method, request.url.path, body)
+
+    transport = httpx.MockTransport(_transport_handler)
+    return httpx.Client(transport=transport)
+
+
+def test_rejects_invalid_token():
+    with pytest.raises(ValueError):
+        FleetApiClient("not-a-real-token")
+
+
+def test_get_managed_bot_token_parses_response():
+    def handler(method, path, body):
+        assert method == "POST"
+        assert path == "/bot12345:ABC/getManagedBotToken"
+        assert body == {"user_id": 999}
+        return httpx.Response(
+            200,
+            json={
+                "ok": True,
+                "result": {
+                    "token": "999:childToken",
+                    "bot": {"id": 999, "username": "child_bot"},
+                },
+            },
+        )
+
+    client = _mock_client(handler)
+    api = FleetApiClient("12345:ABC", client=client)
+    info = api.get_managed_bot_token(999)
+    assert isinstance(info, ManagedBotInfo)
+    assert info.token == "999:childToken"
+    assert info.bot_id == 999
+    assert info.bot_username == "child_bot"
+
+
+def test_replace_managed_bot_token_returns_new_token():
+    def handler(method, path, body):
+        assert path.endswith("/replaceManagedBotToken")
+        return httpx.Response(
+            200,
+            json={
+                "ok": True,
+                "result": {
+                    "token": "999:newToken",
+                    "bot": {"id": 999, "username": "child_bot"},
+                },
+            },
+        )
+
+    client = _mock_client(handler)
+    api = FleetApiClient("12345:ABC", client=client)
+    info = api.replace_managed_bot_token(999)
+    assert info.token == "999:newToken"
+
+
+def test_api_error_includes_method_and_description():
+    def handler(method, path, body):
+        return httpx.Response(
+            403,
+            json={"ok": False, "error_code": 403, "description": "Bot Manager Mode disabled"},
+        )
+
+    client = _mock_client(handler)
+    api = FleetApiClient("12345:ABC", client=client)
+    with pytest.raises(BotApiError) as exc:
+        api.get_managed_bot_token(1)
+    assert exc.value.method == "getManagedBotToken"
+    assert exc.value.code == 403
+    assert "Manager Mode" in exc.value.description
+
+
+def test_send_message_as_uses_child_token():
+    captured: Dict[str, Any] = {}
+
+    def handler(method, path, body):
+        captured["path"] = path
+        captured["body"] = body
+        return httpx.Response(200, json={"ok": True, "result": {"message_id": 17}})
+
+    client = _mock_client(handler)
+    api = FleetApiClient("manager:tok", client=client)
+    result = api.send_message_as("999:child", "987654", "hi")
+    assert result == {"message_id": 17}
+    assert captured["path"] == "/bot999:child/sendMessage"
+    assert captured["body"] == {"chat_id": "987654", "text": "hi"}
+
+
+def test_send_message_as_rejects_bad_child_token():
+    api = FleetApiClient("manager:tok", client=_mock_client(lambda *a: httpx.Response(200, json={"ok": True, "result": {}})))
+    with pytest.raises(ValueError):
+        api.send_message_as("not-a-token", "1", "hi")
+
+
+def test_can_manage_bots_reads_get_me():
+    def handler(method, path, body):
+        return httpx.Response(
+            200,
+            json={"ok": True, "result": {"id": 1, "username": "M", "can_manage_bots": True}},
+        )
+
+    api = FleetApiClient("12345:ABC", client=_mock_client(handler))
+    assert api.can_manage_bots() is True
+
+
+# ── Deep link ─────────────────────────────────────────────────────────
+
+
+def test_build_deep_link_basic():
+    url = build_managed_bot_deep_link("HermesMgr", "worker_a7f3")
+    assert url == "https://t.me/newbot/HermesMgr/worker_a7f3"
+
+
+def test_build_deep_link_quotes_name():
+    url = build_managed_bot_deep_link("HermesMgr", "worker_a7f3", name="Research & Synthesis")
+    assert "Research%20%26%20Synthesis" in url
+
+
+def test_build_deep_link_strips_at_signs():
+    url = build_managed_bot_deep_link("@HermesMgr", "@worker")
+    assert url == "https://t.me/newbot/HermesMgr/worker"

--- a/tests/gateway/test_telegram_fleet_api.py
+++ b/tests/gateway/test_telegram_fleet_api.py
@@ -146,3 +146,127 @@ def test_build_deep_link_quotes_name():
 def test_build_deep_link_strips_at_signs():
     url = build_managed_bot_deep_link("@HermesMgr", "@worker")
     assert url == "https://t.me/newbot/HermesMgr/worker"
+
+
+# ── getUpdates / managed_bot drain ────────────────────────────────────
+
+
+def test_get_updates_returns_raw_list():
+    def handler(method, path, body):
+        assert path.endswith("/getUpdates")
+        return httpx.Response(
+            200,
+            json={
+                "ok": True,
+                "result": [
+                    {"update_id": 1, "managed_bot": {"bot": {"id": 99, "username": "child_bot"}}},
+                    {"update_id": 2, "message": {"text": "hi"}},
+                ],
+            },
+        )
+
+    api = FleetApiClient("12345:ABC", client=_mock_client(handler))
+    updates = api.get_updates()
+    assert len(updates) == 2
+    assert updates[0]["managed_bot"]["bot"]["id"] == 99
+
+
+def test_drain_managed_bot_events_resolves_tokens():
+    """Drain should call getManagedBotToken for each managed_bot update."""
+    def handler(method, path, body):
+        if path.endswith("/getUpdates"):
+            return httpx.Response(
+                200,
+                json={
+                    "ok": True,
+                    "result": [
+                        {
+                            "update_id": 5,
+                            "managed_bot": {
+                                "bot": {"id": 99, "username": "child_bot"},
+                            },
+                        },
+                    ],
+                },
+            )
+        if path.endswith("/getManagedBotToken"):
+            assert body == {"user_id": 99}
+            return httpx.Response(
+                200,
+                json={
+                    "ok": True,
+                    "result": {
+                        "token": "99:childTok",
+                        "bot": {"id": 99, "username": "child_bot"},
+                    },
+                },
+            )
+        return httpx.Response(404, json={"ok": False, "description": "nope"})
+
+    api = FleetApiClient("12345:ABC", client=_mock_client(handler))
+    infos, next_offset = api.drain_managed_bot_events()
+    assert len(infos) == 1
+    assert infos[0].token == "99:childTok"
+    assert infos[0].bot_username == "child_bot"
+    assert next_offset == 6
+
+
+def test_drain_skips_non_managed_bot_updates():
+    def handler(method, path, body):
+        if path.endswith("/getUpdates"):
+            return httpx.Response(
+                200,
+                json={
+                    "ok": True,
+                    "result": [
+                        {"update_id": 1, "message": {"text": "hello"}},
+                        {"update_id": 2, "edited_message": {"text": "edit"}},
+                    ],
+                },
+            )
+        return httpx.Response(404, json={"ok": False, "description": "nope"})
+
+    api = FleetApiClient("12345:ABC", client=_mock_client(handler))
+    infos, next_offset = api.drain_managed_bot_events()
+    assert infos == []
+    assert next_offset == 3
+
+
+def test_drain_continues_when_token_resolution_fails():
+    """A single bad managed_bot shouldn't break the rest of the batch."""
+    def handler(method, path, body):
+        if path.endswith("/getUpdates"):
+            return httpx.Response(
+                200,
+                json={
+                    "ok": True,
+                    "result": [
+                        {"update_id": 1, "managed_bot": {"bot": {"id": 99, "username": "ok_bot"}}},
+                        {"update_id": 2, "managed_bot": {"bot": {"id": 100, "username": "bad_bot"}}},
+                    ],
+                },
+            )
+        if path.endswith("/getManagedBotToken"):
+            uid = body["user_id"]
+            if uid == 100:
+                return httpx.Response(
+                    400,
+                    json={"ok": False, "error_code": 400, "description": "no such bot"},
+                )
+            return httpx.Response(
+                200,
+                json={
+                    "ok": True,
+                    "result": {
+                        "token": "99:tok",
+                        "bot": {"id": 99, "username": "ok_bot"},
+                    },
+                },
+            )
+        return httpx.Response(404, json={"ok": False, "description": "nope"})
+
+    api = FleetApiClient("12345:ABC", client=_mock_client(handler))
+    infos, next_offset = api.drain_managed_bot_events()
+    assert len(infos) == 1
+    assert infos[0].bot_username == "ok_bot"
+    assert next_offset == 3

--- a/tests/gateway/test_telegram_fleet_approval.py
+++ b/tests/gateway/test_telegram_fleet_approval.py
@@ -1,0 +1,319 @@
+"""Tests for the telegram_orchestrate_swarm approval gate.
+
+Mirrors Hermes' existing dangerous-command approval pattern:
+  • Default: tool refuses to run, returns ``approval_required`` with a plan.
+  • Bypass A: caller passes ``user_approved=True`` (after explicit consent).
+  • Bypass B: every subtask pins a ``bot_username`` (by-name request).
+  • Operator override: ``telegram_fleet.auto_approve: true`` in config.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import List
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gateway.telegram_fleet.api import ManagedBotInfo
+from gateway.telegram_fleet import coordinator as coord_module
+from gateway.telegram_fleet.coordinator import (
+    FleetApprovalRequired,
+    FleetCoordinator,
+    reset_coordinator,
+)
+from gateway.telegram_fleet.guardrails import reset_rate_limits
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("TELEGRAM_FLEET_AUTO_APPROVE", raising=False)
+    return tmp_path
+
+
+@pytest.fixture(autouse=True)
+def _isolate():
+    reset_coordinator()
+    reset_rate_limits()
+    yield
+    reset_coordinator()
+    reset_rate_limits()
+
+
+def _stub_api():
+    api = MagicMock()
+    api.get_me.return_value = {"id": 1, "username": "TestMgr", "can_manage_bots": True}
+    api.send_message_as.return_value = {"message_id": 9}
+    return api
+
+
+def _seed(coord: FleetCoordinator, names: List[str]) -> None:
+    for n in names:
+        coord.spawn_bot(n, persona=f"persona for {n}")
+        coord.absorb_managed_bot(
+            ManagedBotInfo(token=f"x:tok_{n}", bot_id=hash(n) & 0xFFFF, bot_username=n)
+        )
+
+
+# ── coordinator-level: raises with structured plan ─────────────────
+
+
+def test_orchestrate_blocks_without_approval(hermes_home):
+    coord = FleetCoordinator(
+        manager_token="12345:ABC",
+        api_client=_stub_api(),
+        delegate_fn=MagicMock(side_effect=lambda **kw: "ok"),
+    )
+    _seed(coord, ["alpha_bot", "beta_bot"])
+    with pytest.raises(FleetApprovalRequired) as exc:
+        coord.orchestrate_swarm(
+            objective="Research X",
+            subtasks=[{"goal": "angle 1"}, {"goal": "angle 2"}],
+        )
+    plan = exc.value.to_plan_dict()
+    assert plan["objective"] == "Research X"
+    assert {w["bot_username"] for w in plan["workers"]} == {"alpha_bot", "beta_bot"}
+
+
+def test_orchestrate_runs_with_user_approved(hermes_home):
+    delegate = MagicMock(side_effect=lambda **kw: "ok")
+    coord = FleetCoordinator(
+        manager_token="12345:ABC",
+        api_client=_stub_api(),
+        delegate_fn=delegate,
+    )
+    _seed(coord, ["alpha_bot", "beta_bot"])
+    result = coord.orchestrate_swarm(
+        objective="Research X",
+        subtasks=[{"goal": "angle 1"}, {"goal": "angle 2"}],
+        user_approved=True,
+    )
+    assert delegate.call_count == 2
+    assert result["metrics"]["workers"] == 2
+
+
+def test_orchestrate_skips_approval_when_all_bots_pinned(hermes_home):
+    """By-name request: user already named who they want → no prompt."""
+    delegate = MagicMock(side_effect=lambda **kw: "ok")
+    coord = FleetCoordinator(
+        manager_token="12345:ABC",
+        api_client=_stub_api(),
+        delegate_fn=delegate,
+    )
+    _seed(coord, ["alpha_bot", "beta_bot"])
+    result = coord.orchestrate_swarm(
+        objective="Research X",
+        subtasks=[
+            {"goal": "angle 1", "bot_username": "alpha_bot"},
+            {"goal": "angle 2", "bot_username": "@beta_bot"},
+        ],
+    )
+    assert delegate.call_count == 2
+    assert result["metrics"]["workers"] == 2
+
+
+def test_orchestrate_blocks_partial_pinning(hermes_home):
+    """If only SOME subtasks pin a bot, the user hasn't named the whole plan."""
+    coord = FleetCoordinator(
+        manager_token="12345:ABC",
+        api_client=_stub_api(),
+        delegate_fn=MagicMock(),
+    )
+    _seed(coord, ["alpha_bot", "beta_bot"])
+    with pytest.raises(FleetApprovalRequired):
+        coord.orchestrate_swarm(
+            objective="X",
+            subtasks=[
+                {"goal": "a", "bot_username": "alpha_bot"},
+                {"goal": "b"},  # not pinned
+            ],
+        )
+
+
+def test_config_auto_approve_disables_gate(hermes_home, monkeypatch):
+    """Operator opt-out via env var bypasses the approval prompt."""
+    monkeypatch.setenv("TELEGRAM_FLEET_AUTO_APPROVE", "1")
+    delegate = MagicMock(side_effect=lambda **kw: "ok")
+    coord = FleetCoordinator(
+        manager_token="12345:ABC",
+        api_client=_stub_api(),
+        delegate_fn=delegate,
+    )
+    _seed(coord, ["alpha_bot"])
+    result = coord.orchestrate_swarm(
+        objective="X",
+        subtasks=[{"goal": "a"}, {"goal": "b"}],
+    )
+    assert result["metrics"]["workers"] == 2
+
+
+def test_config_yaml_auto_approve_disables_gate(hermes_home):
+    """Operator opt-out via config.yaml also bypasses."""
+    (hermes_home / "config.yaml").write_text(
+        "telegram_fleet:\n  auto_approve: true\n"
+    )
+    delegate = MagicMock(side_effect=lambda **kw: "ok")
+    coord = FleetCoordinator(
+        manager_token="12345:ABC",
+        api_client=_stub_api(),
+        delegate_fn=delegate,
+    )
+    _seed(coord, ["alpha_bot"])
+    result = coord.orchestrate_swarm(
+        objective="X",
+        subtasks=[{"goal": "a"}, {"goal": "b"}],
+    )
+    assert result["metrics"]["workers"] == 2
+
+
+# ── tool-level: returns structured approval_required JSON ──────────
+
+
+def test_tool_returns_approval_required_json(hermes_home, monkeypatch):
+    """The tool wraps the exception into a Hermes-style approval response."""
+    monkeypatch.setenv("TELEGRAM_FLEET_MANAGER_TOKEN", "12345:ABC")
+    coord = FleetCoordinator(
+        manager_token="12345:ABC",
+        api_client=_stub_api(),
+        delegate_fn=MagicMock(),
+    )
+    monkeypatch.setattr(coord_module, "_singleton", coord)
+    _seed(coord, ["alpha_bot", "beta_bot"])
+
+    from tools.telegram_fleet_tool import telegram_orchestrate_swarm
+
+    raw = telegram_orchestrate_swarm(
+        objective="X",
+        subtasks=[{"goal": "a"}, {"goal": "b"}],
+    )
+    out = json.loads(raw)
+    assert out["status"] == "approval_required"
+    assert out["code"] == "approval_required"
+    assert "plan" in out
+    assert len(out["plan"]["workers"]) == 2
+    assert "instruction" in out
+    assert "user_approved=true" in out["instruction"]
+
+
+def test_tool_runs_on_re_call_with_approval(hermes_home, monkeypatch):
+    monkeypatch.setenv("TELEGRAM_FLEET_MANAGER_TOKEN", "12345:ABC")
+    delegate = MagicMock(side_effect=lambda **kw: "ok")
+    coord = FleetCoordinator(
+        manager_token="12345:ABC",
+        api_client=_stub_api(),
+        delegate_fn=delegate,
+    )
+    monkeypatch.setattr(coord_module, "_singleton", coord)
+    _seed(coord, ["alpha_bot", "beta_bot"])
+
+    from tools.telegram_fleet_tool import telegram_orchestrate_swarm
+
+    raw = telegram_orchestrate_swarm(
+        objective="X",
+        subtasks=[{"goal": "a"}, {"goal": "b"}],
+        user_approved=True,
+    )
+    out = json.loads(raw)
+    assert out.get("success") is True
+    assert delegate.call_count == 2
+
+
+def test_tool_runs_when_all_bots_pinned(hermes_home, monkeypatch):
+    monkeypatch.setenv("TELEGRAM_FLEET_MANAGER_TOKEN", "12345:ABC")
+    delegate = MagicMock(side_effect=lambda **kw: "ok")
+    coord = FleetCoordinator(
+        manager_token="12345:ABC",
+        api_client=_stub_api(),
+        delegate_fn=delegate,
+    )
+    monkeypatch.setattr(coord_module, "_singleton", coord)
+    _seed(coord, ["alpha_bot", "beta_bot"])
+
+    from tools.telegram_fleet_tool import telegram_orchestrate_swarm
+
+    raw = telegram_orchestrate_swarm(
+        objective="X",
+        subtasks=[
+            {"goal": "a", "bot_username": "alpha_bot"},
+            {"goal": "b", "bot_username": "beta_bot"},
+        ],
+    )
+    out = json.loads(raw)
+    assert out.get("success") is True
+    assert delegate.call_count == 2
+
+
+# ── audit + token-redaction guarantees ───────────────────────────────
+
+
+def test_approval_response_does_not_leak_tokens(hermes_home, monkeypatch):
+    """The structured plan must NEVER include bot tokens — only usernames."""
+    monkeypatch.setenv("TELEGRAM_FLEET_MANAGER_TOKEN", "12345:ABC")
+    coord = FleetCoordinator(
+        manager_token="12345:ABC",
+        api_client=_stub_api(),
+        delegate_fn=MagicMock(),
+    )
+    monkeypatch.setattr(coord_module, "_singleton", coord)
+    _seed(coord, ["alpha_bot", "beta_bot"])
+    # Each child has a sentinel token in its binding internally.
+    from tools.telegram_fleet_tool import telegram_orchestrate_swarm
+
+    raw = telegram_orchestrate_swarm(
+        objective="X",
+        subtasks=[{"goal": "a"}, {"goal": "b"}],
+    )
+    # Both raw and parsed must not contain the secret token substring.
+    assert "x:tok_alpha_bot" not in raw
+    assert "x:tok_beta_bot" not in raw
+    assert ":tok_" not in raw
+    payload = json.loads(raw)
+    assert payload["status"] == "approval_required"
+    for worker in payload["plan"]["workers"]:
+        assert "token" not in worker
+        assert "bot_token" not in worker
+
+
+def test_approval_required_writes_audit_event(hermes_home):
+    """Operator visibility: a denied/pending swarm leaves an audit footprint."""
+    from gateway.telegram_fleet.audit import get_audit_path, read_recent_events
+
+    coord = FleetCoordinator(
+        manager_token="12345:ABC",
+        api_client=_stub_api(),
+        delegate_fn=MagicMock(),
+    )
+    _seed(coord, ["alpha_bot"])
+    with pytest.raises(FleetApprovalRequired):
+        coord.orchestrate_swarm(
+            objective="research X across angles",
+            subtasks=[{"goal": "a"}, {"goal": "b"}],
+        )
+    events = read_recent_events()
+    actions = [e["action"] for e in events]
+    assert "swarm_approval_required" in actions
+    # And no swarm_started should have been written for this run.
+    matched = [e for e in events if e["action"] == "swarm_approval_required"]
+    assert matched[-1]["workers"] == 2
+    assert "alpha_bot" in matched[-1]["bots"]
+
+
+def test_partial_pin_does_not_bypass_gate(hermes_home):
+    """If only some subtasks pin a bot, treat as ambiguous → require approval."""
+    coord = FleetCoordinator(
+        manager_token="12345:ABC",
+        api_client=_stub_api(),
+        delegate_fn=MagicMock(),
+    )
+    _seed(coord, ["alpha_bot", "beta_bot"])
+    with pytest.raises(FleetApprovalRequired):
+        coord.orchestrate_swarm(
+            objective="X",
+            subtasks=[
+                {"goal": "a", "bot_username": "alpha_bot"},
+                {"goal": "b"},  # not pinned
+                {"goal": "c"},  # not pinned
+            ],
+        )

--- a/tests/gateway/test_telegram_fleet_coordinator.py
+++ b/tests/gateway/test_telegram_fleet_coordinator.py
@@ -239,6 +239,7 @@ def test_orchestrate_swarm_fans_out_subtasks(hermes_home):
             {"goal": "market angle"},
             {"goal": "tech angle"},
         ],
+        user_approved=True,  # approval gate covered separately
     )
     assert delegate.call_count == 3
     # Each result should pair a goal with a non-empty response.
@@ -303,6 +304,7 @@ def test_orchestrate_swarm_captures_subtask_failure(hermes_home):
     result = coord.orchestrate_swarm(
         objective="X",
         subtasks=[{"goal": "ok"}, {"goal": "boom"}],
+        user_approved=True,
     )
     failures = [r for r in result["results"] if r.get("error")]
     assert len(failures) == 1
@@ -322,6 +324,7 @@ def test_orchestrate_swarm_posts_status_to_report_chat(hermes_home):
         objective="X",
         subtasks=[{"goal": "task"}],
         report_chat_id="555",
+        user_approved=True,
     )
     # We expect at least one start + one done message posted via the manager API.
     assert api.send_message_as.call_count >= 2

--- a/tests/gateway/test_telegram_fleet_coordinator.py
+++ b/tests/gateway/test_telegram_fleet_coordinator.py
@@ -91,7 +91,7 @@ def test_spawn_respects_max_size(hermes_home):
 
 def test_spawn_rejected_when_approval_disabled(hermes_home):
     api = _stub_api()
-    roster = FleetRoster(spawn_requires_approval=False, manager_bot_username="TestMgr")
+    roster = FleetRoster(spawn_enabled=False, manager_bot_username="TestMgr")
     save_roster(roster)
     coord = FleetCoordinator(manager_token="12345:ABC", api_client=api)
     with pytest.raises(SpawnApprovalRequired):

--- a/tests/gateway/test_telegram_fleet_coordinator.py
+++ b/tests/gateway/test_telegram_fleet_coordinator.py
@@ -1,0 +1,339 @@
+"""Tests for FleetCoordinator — spawn flow, absorb, rotate, decommission, swarm."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Optional
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.telegram_fleet.api import ManagedBotInfo
+from gateway.telegram_fleet.coordinator import (
+    FleetCoordinator,
+    SpawnResult,
+    SwarmTaskResult,
+)
+from gateway.telegram_fleet.guardrails import (
+    FleetGuardrailError,
+    SpawnApprovalRequired,
+    reset_rate_limits,
+)
+from gateway.telegram_fleet.roster import ChildBot, FleetRoster, save_roster
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    return tmp_path
+
+
+@pytest.fixture(autouse=True)
+def _isolate_rate_limits():
+    reset_rate_limits()
+    yield
+    reset_rate_limits()
+
+
+def _stub_api(*, manager_username: str = "TestMgr") -> MagicMock:
+    api = MagicMock()
+    api.get_me.return_value = {"id": 1, "username": manager_username, "can_manage_bots": True}
+    api.replace_managed_bot_token.return_value = ManagedBotInfo(
+        token="999:newToken", bot_id=999, bot_username="rotated_bot"
+    )
+    api.send_message_as.return_value = {"message_id": 17}
+    return api
+
+
+def _delegate_returning(text: str):
+    """Build a delegate stub that mirrors the Hermes ``delegate_task`` shape."""
+    def fake(goal=None, context=None, toolsets=None, role=None, parent_agent=None, **_):
+        return text
+    return fake
+
+
+# ── Spawn ─────────────────────────────────────────────────────────────
+
+
+def test_spawn_writes_pending_entry_and_deep_link(hermes_home):
+    api = _stub_api()
+    coord = FleetCoordinator(manager_token="12345:ABC", api_client=api)
+    result = coord.spawn_bot("hermes_research_bot", persona="research lead")
+    assert isinstance(result, SpawnResult)
+    assert result.suggested_username == "hermes_research_bot"
+    assert "t.me/newbot/TestMgr/hermes_research_bot" in result.deep_link
+    assert len(result.nonce) >= 8
+
+    children = coord.list_children()
+    assert [c.username for c in children] == ["hermes_research_bot"]
+    assert children[0].status == "pending"
+    assert children[0].nonce == result.nonce
+
+
+def test_spawn_blocked_when_username_collides(hermes_home):
+    api = _stub_api()
+    coord = FleetCoordinator(manager_token="12345:ABC", api_client=api)
+    coord.spawn_bot("dup_bot", persona="x")
+    with pytest.raises(FleetGuardrailError, match="already in the roster"):
+        coord.spawn_bot("dup_bot", persona="y")
+
+
+def test_spawn_respects_max_size(hermes_home):
+    api = _stub_api()
+    roster = FleetRoster(max_size=2, manager_bot_username="TestMgr")
+    save_roster(roster)
+    coord = FleetCoordinator(manager_token="12345:ABC", api_client=api)
+    coord.spawn_bot("a_bot")
+    coord.spawn_bot("b_bot")
+    with pytest.raises(FleetGuardrailError, match="capacity"):
+        coord.spawn_bot("c_bot")
+
+
+def test_spawn_rejected_when_approval_disabled(hermes_home):
+    api = _stub_api()
+    roster = FleetRoster(spawn_requires_approval=False, manager_bot_username="TestMgr")
+    save_roster(roster)
+    coord = FleetCoordinator(manager_token="12345:ABC", api_client=api)
+    with pytest.raises(SpawnApprovalRequired):
+        coord.spawn_bot("x_bot")
+
+
+def test_spawn_persists_to_disk(hermes_home):
+    api = _stub_api()
+    coord = FleetCoordinator(manager_token="12345:ABC", api_client=api)
+    coord.spawn_bot("research_bot", persona="researcher")
+    # Re-instantiate the coordinator → reads from disk → entry survives.
+    coord2 = FleetCoordinator(manager_token="12345:ABC", api_client=api)
+    assert coord2.find("research_bot") is not None
+
+
+# ── Absorb ────────────────────────────────────────────────────────────
+
+
+def test_absorb_promotes_pending_to_active(hermes_home):
+    api = _stub_api()
+    coord = FleetCoordinator(manager_token="12345:ABC", api_client=api)
+    coord.spawn_bot("worker_bot", persona="general")
+    info = ManagedBotInfo(token="123:childTok", bot_id=42, bot_username="worker_bot")
+    child = coord.absorb_managed_bot(info)
+    assert child is not None
+    assert child.status == "active"
+    assert child.token == "123:childTok"
+    assert child.bot_id == 42
+
+
+def test_absorb_unknown_username_returns_none(hermes_home):
+    api = _stub_api()
+    coord = FleetCoordinator(manager_token="12345:ABC", api_client=api)
+    info = ManagedBotInfo(token="1:x", bot_id=1, bot_username="stranger_bot")
+    assert coord.absorb_managed_bot(info) is None
+    assert coord.list_children() == []
+
+
+# ── Rotate ────────────────────────────────────────────────────────────
+
+
+def test_rotate_token_updates_roster(hermes_home):
+    api = _stub_api()
+    api.replace_managed_bot_token.return_value = ManagedBotInfo(
+        token="42:freshToken", bot_id=42, bot_username="worker_bot"
+    )
+    coord = FleetCoordinator(manager_token="12345:ABC", api_client=api)
+    coord.spawn_bot("worker_bot")
+    coord.absorb_managed_bot(
+        ManagedBotInfo(token="42:oldToken", bot_id=42, bot_username="worker_bot")
+    )
+    rotated = coord.rotate_token("worker_bot")
+    api.replace_managed_bot_token.assert_called_once_with(42)
+    assert rotated.token == "42:freshToken"
+    assert rotated.last_rotated_at  # set
+
+
+def test_rotate_rejects_inactive_bot(hermes_home):
+    api = _stub_api()
+    coord = FleetCoordinator(manager_token="12345:ABC", api_client=api)
+    coord.spawn_bot("pending_bot")
+    with pytest.raises(FleetGuardrailError, match="not an active"):
+        coord.rotate_token("pending_bot")
+
+
+# ── Decommission ──────────────────────────────────────────────────────
+
+
+def test_decommission_zeros_token(hermes_home):
+    api = _stub_api()
+    coord = FleetCoordinator(manager_token="12345:ABC", api_client=api)
+    coord.spawn_bot("worker_bot")
+    coord.absorb_managed_bot(
+        ManagedBotInfo(token="42:tok", bot_id=42, bot_username="worker_bot")
+    )
+    assert coord.decommission("worker_bot") is True
+    child = coord.find("worker_bot")
+    assert child.status == "decommissioned"
+    assert child.token is None
+
+
+def test_decommission_unknown_returns_false(hermes_home):
+    api = _stub_api()
+    coord = FleetCoordinator(manager_token="12345:ABC", api_client=api)
+    assert coord.decommission("ghost_bot") is False
+
+
+# ── Delegate ──────────────────────────────────────────────────────────
+
+
+def test_delegate_message_calls_send_as(hermes_home):
+    api = _stub_api()
+    coord = FleetCoordinator(manager_token="12345:ABC", api_client=api)
+    coord.spawn_bot("speaker_bot")
+    coord.absorb_managed_bot(
+        ManagedBotInfo(token="42:childTok", bot_id=42, bot_username="speaker_bot")
+    )
+    result = coord.delegate_message("speaker_bot", "987654", "hello")
+    api.send_message_as.assert_called_once()
+    args, kwargs = api.send_message_as.call_args
+    assert args[0] == "42:childTok"
+    assert args[1] == "987654"
+    assert args[2] == "hello"
+    assert result == {"message_id": 17}
+
+
+def test_delegate_respects_rate_limit(hermes_home):
+    api = _stub_api()
+    coord = FleetCoordinator(manager_token="12345:ABC", api_client=api)
+    coord.spawn_bot("burst_bot", rate_limit_per_min=2)
+    coord.absorb_managed_bot(
+        ManagedBotInfo(token="42:tok", bot_id=42, bot_username="burst_bot")
+    )
+    # First two pass.
+    coord.delegate_message("burst_bot", "1", "x")
+    coord.delegate_message("burst_bot", "1", "x")
+    # Third is rate-limited.
+    with pytest.raises(FleetGuardrailError, match="rate limit"):
+        coord.delegate_message("burst_bot", "1", "x")
+
+
+# ── orchestrate_swarm ─────────────────────────────────────────────────
+
+
+def _seed_active_fleet(coord: FleetCoordinator, names: List[str]) -> None:
+    for n in names:
+        coord.spawn_bot(n, persona=f"persona for {n}")
+        coord.absorb_managed_bot(
+            ManagedBotInfo(token=f"x:tok_{n}", bot_id=hash(n) & 0xFFFF, bot_username=n)
+        )
+
+
+def test_orchestrate_swarm_fans_out_subtasks(hermes_home):
+    api = _stub_api()
+    delegate = MagicMock(side_effect=lambda **kw: f"answered: {kw['goal']}")
+    coord = FleetCoordinator(
+        manager_token="12345:ABC", api_client=api, delegate_fn=delegate
+    )
+    _seed_active_fleet(coord, ["alpha_bot", "beta_bot", "gamma_bot"])
+
+    result = coord.orchestrate_swarm(
+        objective="Research X",
+        subtasks=[
+            {"goal": "legal angle"},
+            {"goal": "market angle"},
+            {"goal": "tech angle"},
+        ],
+    )
+    assert delegate.call_count == 3
+    # Each result should pair a goal with a non-empty response.
+    goals = sorted(r["goal"] for r in result["results"])
+    assert goals == ["legal angle", "market angle", "tech angle"]
+    assert all(r["response"].startswith("answered:") for r in result["results"])
+    assert "summary" in result
+    assert "Workers: 3" in result["summary"]
+
+
+def test_orchestrate_swarm_pins_explicit_bot(hermes_home):
+    api = _stub_api()
+    delegate = MagicMock(side_effect=lambda **kw: "ok")
+    coord = FleetCoordinator(
+        manager_token="12345:ABC", api_client=api, delegate_fn=delegate
+    )
+    _seed_active_fleet(coord, ["alpha_bot", "beta_bot"])
+
+    result = coord.orchestrate_swarm(
+        objective="X",
+        subtasks=[
+            {"goal": "task-A", "bot_username": "beta_bot"},
+            {"goal": "task-B", "bot_username": "@beta_bot"},
+        ],
+    )
+    bots = [r["bot_username"] for r in result["results"]]
+    assert bots == ["beta_bot", "beta_bot"]
+
+
+def test_orchestrate_swarm_rejects_pin_to_unknown_bot(hermes_home):
+    api = _stub_api()
+    coord = FleetCoordinator(
+        manager_token="12345:ABC", api_client=api, delegate_fn=MagicMock()
+    )
+    _seed_active_fleet(coord, ["alpha_bot"])
+    with pytest.raises(FleetGuardrailError, match="not an active"):
+        coord.orchestrate_swarm(
+            objective="X",
+            subtasks=[{"goal": "task", "bot_username": "ghost_bot"}],
+        )
+
+
+def test_orchestrate_swarm_requires_active_members(hermes_home):
+    api = _stub_api()
+    coord = FleetCoordinator(
+        manager_token="12345:ABC", api_client=api, delegate_fn=MagicMock()
+    )
+    with pytest.raises(FleetGuardrailError, match="no active fleet members"):
+        coord.orchestrate_swarm(objective="X", subtasks=[{"goal": "t"}])
+
+
+def test_orchestrate_swarm_captures_subtask_failure(hermes_home):
+    api = _stub_api()
+    def flaky(**kw):
+        if kw["goal"] == "boom":
+            raise RuntimeError("kaboom")
+        return "ok"
+    coord = FleetCoordinator(
+        manager_token="12345:ABC", api_client=api, delegate_fn=flaky
+    )
+    _seed_active_fleet(coord, ["alpha_bot", "beta_bot"])
+    result = coord.orchestrate_swarm(
+        objective="X",
+        subtasks=[{"goal": "ok"}, {"goal": "boom"}],
+    )
+    failures = [r for r in result["results"] if r.get("error")]
+    assert len(failures) == 1
+    assert "kaboom" in failures[0]["error"]
+    # Other task still ran.
+    assert any(r["goal"] == "ok" and not r.get("error") for r in result["results"])
+
+
+def test_orchestrate_swarm_posts_status_to_report_chat(hermes_home):
+    api = _stub_api()
+    delegate = MagicMock(side_effect=lambda **kw: "done text")
+    coord = FleetCoordinator(
+        manager_token="12345:ABC", api_client=api, delegate_fn=delegate
+    )
+    _seed_active_fleet(coord, ["alpha_bot"])
+    coord.orchestrate_swarm(
+        objective="X",
+        subtasks=[{"goal": "task"}],
+        report_chat_id="555",
+    )
+    # We expect at least one start + one done message posted via the manager API.
+    assert api.send_message_as.call_count >= 2
+
+
+def test_orchestrate_swarm_rejects_empty_inputs(hermes_home):
+    api = _stub_api()
+    coord = FleetCoordinator(
+        manager_token="12345:ABC", api_client=api, delegate_fn=MagicMock()
+    )
+    _seed_active_fleet(coord, ["alpha_bot"])
+    with pytest.raises(FleetGuardrailError):
+        coord.orchestrate_swarm(objective="", subtasks=[{"goal": "t"}])
+    with pytest.raises(FleetGuardrailError):
+        coord.orchestrate_swarm(objective="X", subtasks=[])

--- a/tests/gateway/test_telegram_fleet_coordinator.py
+++ b/tests/gateway/test_telegram_fleet_coordinator.py
@@ -330,6 +330,25 @@ def test_orchestrate_swarm_posts_status_to_report_chat(hermes_home):
     assert api.send_message_as.call_count >= 2
 
 
+def test_orchestrate_swarm_surfaces_missing_parent_agent_clearly(hermes_home):
+    """Production path with parent_agent=None must raise an actionable error,
+    NOT let delegate_task fail deeper down with its generic message.
+    """
+    api = _stub_api()
+    coord = FleetCoordinator(manager_token="12345:ABC", api_client=api)
+    _seed_active_fleet(coord, ["worker_bot"])
+    with pytest.raises(FleetGuardrailError) as exc:
+        coord.orchestrate_swarm(
+            objective="X",
+            subtasks=[{"goal": "task", "bot_username": "worker_bot"}],
+            user_approved=True,
+            parent_agent=None,
+        )
+    msg = str(exc.value).lower()
+    assert "parent_agent" in msg
+    assert "gateway" in msg or "restart" in msg
+
+
 def test_orchestrate_swarm_rejects_empty_inputs(hermes_home):
     api = _stub_api()
     coord = FleetCoordinator(

--- a/tests/gateway/test_telegram_fleet_guardrails.py
+++ b/tests/gateway/test_telegram_fleet_guardrails.py
@@ -25,10 +25,10 @@ def _isolate_rate_limits():
 
 
 def test_spawn_approval_required_when_disabled():
-    r = FleetRoster(spawn_requires_approval=False)
+    r = FleetRoster(spawn_enabled=False)
     with pytest.raises(SpawnApprovalRequired) as e:
         check_can_spawn(r)
-    assert "user tap" in str(e.value).lower()
+    assert "spawn_enabled" in str(e.value).lower()
 
 
 def test_spawn_approval_default_passes_with_capacity():

--- a/tests/gateway/test_telegram_fleet_guardrails.py
+++ b/tests/gateway/test_telegram_fleet_guardrails.py
@@ -1,0 +1,90 @@
+"""Tests for fleet guardrails — size cap, spawn approval, rate limit."""
+
+from __future__ import annotations
+
+import pytest
+
+from gateway.telegram_fleet.guardrails import (
+    FleetGuardrailError,
+    SpawnApprovalRequired,
+    check_can_spawn,
+    check_rate_limit,
+    reset_rate_limits,
+)
+from gateway.telegram_fleet.roster import ChildBot, FleetRoster
+
+
+@pytest.fixture(autouse=True)
+def _isolate_rate_limits():
+    reset_rate_limits()
+    yield
+    reset_rate_limits()
+
+
+# ── Spawn-approval guard ──────────────────────────────────────────────
+
+
+def test_spawn_approval_required_when_disabled():
+    r = FleetRoster(spawn_requires_approval=False)
+    with pytest.raises(SpawnApprovalRequired) as e:
+        check_can_spawn(r)
+    assert "user tap" in str(e.value).lower()
+
+
+def test_spawn_approval_default_passes_with_capacity():
+    r = FleetRoster(max_size=4)
+    check_can_spawn(r)  # no error
+
+
+def test_spawn_blocked_when_at_capacity():
+    r = FleetRoster(max_size=2)
+    r.upsert(ChildBot(username="a_bot", status="active", token="1:x"))
+    r.upsert(ChildBot(username="b_bot", status="pending", nonce="n1"))
+    with pytest.raises(FleetGuardrailError) as e:
+        check_can_spawn(r)
+    assert "capacity" in str(e.value).lower()
+
+
+def test_decommissioned_does_not_count_against_capacity():
+    r = FleetRoster(max_size=2)
+    r.upsert(ChildBot(username="a_bot", status="decommissioned"))
+    r.upsert(ChildBot(username="b_bot", status="active", token="1:x"))
+    # Active=1, pending=0; decommissioned ignored → spawn allowed.
+    check_can_spawn(r)
+
+
+# ── Rate limiter ──────────────────────────────────────────────────────
+
+
+def test_rate_limit_allows_under_capacity():
+    for _ in range(5):
+        assert check_rate_limit("worker_bot", per_minute=10) is True
+
+
+def test_rate_limit_blocks_over_capacity():
+    for _ in range(3):
+        assert check_rate_limit("burst_bot", per_minute=3) is True
+    assert check_rate_limit("burst_bot") is False  # 4th in <60s
+
+
+def test_rate_limit_per_username_isolated():
+    for _ in range(3):
+        assert check_rate_limit("a_bot", per_minute=3) is True
+    # b_bot is independent; it has its own counter.
+    assert check_rate_limit("b_bot", per_minute=3) is True
+    # a_bot is exhausted.
+    assert check_rate_limit("a_bot") is False
+
+
+def test_rate_limit_normalizes_username():
+    for _ in range(3):
+        assert check_rate_limit("@Foo_Bot", per_minute=3) is True
+    assert check_rate_limit("foo_bot") is False
+
+
+def test_reconfigure_raises_capacity_mid_run():
+    for _ in range(2):
+        assert check_rate_limit("scaler_bot", per_minute=2) is True
+    assert check_rate_limit("scaler_bot") is False
+    # Operator raises the cap; the next consume should succeed.
+    assert check_rate_limit("scaler_bot", per_minute=10) is True

--- a/tests/gateway/test_telegram_fleet_roster.py
+++ b/tests/gateway/test_telegram_fleet_roster.py
@@ -1,0 +1,182 @@
+"""Tests for the Telegram Fleet roster (YAML schema, atomic writes, perms, TTL)."""
+
+from __future__ import annotations
+
+import os
+import stat
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from gateway.telegram_fleet.roster import (
+    PENDING_TTL_SECONDS,
+    SCHEMA_VERSION,
+    ChildBot,
+    FleetRoster,
+    RosterError,
+    load_roster,
+    save_roster,
+)
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    return tmp_path
+
+
+# ── ChildBot ──────────────────────────────────────────────────────────
+
+
+def test_child_bot_requires_username():
+    with pytest.raises(RosterError):
+        ChildBot(username="")
+
+
+def test_child_bot_rejects_invalid_status():
+    with pytest.raises(RosterError):
+        ChildBot(username="worker_a_bot", status="bogus")
+
+
+def test_child_bot_round_trips_through_dict():
+    c = ChildBot(
+        username="hermes_research_bot",
+        persona="Research a specific angle",
+        bot_id=123,
+        token="123:abc",
+        model="claude-sonnet-4-6",
+        toolset=["web", "file"],
+        status="active",
+        rate_limit_per_min=20,
+        daily_budget_usd=2.5,
+        nonce="abc12345",
+    )
+    blob = c.to_dict()
+    rebuilt = ChildBot.from_dict(blob)
+    assert rebuilt.to_dict() == blob
+
+
+def test_child_bot_redacts_token_when_requested():
+    c = ChildBot(username="x_bot", token="secret:abc", status="active")
+    out = c.to_dict(include_token=False)
+    assert "token" not in out
+
+
+# ── FleetRoster ───────────────────────────────────────────────────────
+
+
+def test_empty_roster_round_trips():
+    r = FleetRoster()
+    assert r.schema_version == SCHEMA_VERSION
+    assert r.children == []
+    assert FleetRoster.from_dict(r.to_dict()).children == []
+
+
+def test_unknown_schema_version_rejected():
+    with pytest.raises(RosterError):
+        FleetRoster(schema_version=99)
+
+
+def test_upsert_replaces_existing():
+    r = FleetRoster()
+    r.upsert(ChildBot(username="x_bot", persona="v1"))
+    r.upsert(ChildBot(username="x_bot", persona="v2"))
+    assert len(r.children) == 1
+    assert r.find("x_bot").persona == "v2"
+
+
+def test_find_is_case_insensitive_and_strips_at():
+    r = FleetRoster()
+    r.upsert(ChildBot(username="x_bot"))
+    assert r.find("@X_Bot") is not None
+    assert r.find("X_BOT") is not None
+
+
+def test_active_children_filters_pending_and_no_token():
+    r = FleetRoster()
+    r.upsert(ChildBot(username="a_bot", status="pending", nonce="n1"))
+    r.upsert(ChildBot(username="b_bot", status="active", token="123:abc"))
+    r.upsert(ChildBot(username="c_bot", status="active"))  # no token → not active
+    r.upsert(ChildBot(username="d_bot", status="decommissioned"))
+    active = [c.username for c in r.active_children()]
+    assert active == ["b_bot"]
+
+
+def test_prune_expired_pending_drops_old_entries():
+    r = FleetRoster()
+    old = ChildBot(username="old_bot", status="pending", nonce="n1")
+    old.created_at = (datetime.now(timezone.utc) - timedelta(seconds=PENDING_TTL_SECONDS + 60)).isoformat()
+    fresh = ChildBot(username="new_bot", status="pending", nonce="n2")
+    keep = ChildBot(username="active_bot", status="active", token="123:abc")
+    r.upsert(old)
+    r.upsert(fresh)
+    r.upsert(keep)
+    removed = r.prune_expired_pending()
+    assert removed == 1
+    remaining = [c.username for c in r.children]
+    assert "old_bot" not in remaining
+    assert "new_bot" in remaining
+    assert "active_bot" in remaining
+
+
+# ── Persistence ───────────────────────────────────────────────────────
+
+
+def test_save_load_roundtrip(hermes_home):
+    r = FleetRoster(manager_bot_username="HermesMgr", max_size=8)
+    r.upsert(
+        ChildBot(
+            username="research_bot",
+            persona="Research lead",
+            bot_id=42,
+            token="42:tokenA",
+            status="active",
+        )
+    )
+    save_roster(r)
+    loaded = load_roster()
+    assert loaded.manager_bot_username == "HermesMgr"
+    assert loaded.max_size == 8
+    assert len(loaded.children) == 1
+    assert loaded.children[0].token == "42:tokenA"
+
+
+def test_saved_file_is_mode_0600(hermes_home):
+    r = FleetRoster()
+    r.upsert(ChildBot(username="secret_bot", token="42:secret", status="active"))
+    save_roster(r)
+    path = hermes_home / "telegram_fleet.yaml"
+    mode = stat.S_IMODE(path.stat().st_mode)
+    if os.name == "posix":
+        assert mode == 0o600
+    # On non-POSIX, just assert the file exists; chmod is a no-op there.
+
+
+def test_load_missing_returns_empty(hermes_home):
+    r = load_roster()
+    assert r.children == []
+    assert r.schema_version == SCHEMA_VERSION
+
+
+def test_load_malformed_raises(hermes_home):
+    (hermes_home / "telegram_fleet.yaml").write_text("not: [valid: yaml: at: all\n")
+    with pytest.raises(RosterError):
+        load_roster()
+
+
+def test_save_then_load_drops_empty_optional_fields(hermes_home):
+    r = FleetRoster()
+    r.upsert(ChildBot(username="minimal_bot", status="pending", nonce="n1"))
+    save_roster(r)
+    loaded = load_roster()
+    assert loaded.children[0].model is None
+    assert loaded.children[0].toolset is None
+
+
+def test_to_dict_omits_tokens_when_requested():
+    r = FleetRoster()
+    r.upsert(ChildBot(username="x_bot", token="42:abc", status="active"))
+    blob = r.to_dict(include_tokens=False)
+    assert "token" not in blob["children"][0]

--- a/tests/hermes_cli/test_fleet_command.py
+++ b/tests/hermes_cli/test_fleet_command.py
@@ -1,0 +1,417 @@
+"""Tests for the ``hermes fleet`` CLI command."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hermes_cli.fleet import (
+    _cmd_add,
+    _cmd_list,
+    _cmd_setup,
+    _cmd_status,
+    add_fleet_parser,
+    cmd_fleet,
+)
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("TELEGRAM_FLEET_MANAGER_TOKEN", raising=False)
+    return tmp_path
+
+
+@pytest.fixture(autouse=True)
+def _isolate():
+    from gateway.telegram_fleet.coordinator import reset_coordinator
+    from gateway.telegram_fleet.guardrails import reset_rate_limits
+
+    reset_coordinator()
+    reset_rate_limits()
+    yield
+    reset_coordinator()
+    reset_rate_limits()
+
+
+def _ns(**kw) -> argparse.Namespace:
+    return argparse.Namespace(**kw)
+
+
+# ── status ─────────────────────────────────────────────────────────────
+
+
+def test_status_warns_when_unconfigured(hermes_home, capsys):
+    rc = _cmd_status(_ns(fleet_command="status"))
+    out = capsys.readouterr().out
+    assert "Manager token NOT set" in out
+    assert "Run `hermes fleet setup`" in out
+    assert rc == 1  # nonzero so shell can detect missing setup
+
+
+def test_status_reports_active_count(hermes_home, monkeypatch, capsys):
+    monkeypatch.setenv("TELEGRAM_FLEET_MANAGER_TOKEN", "12345:ABC" + "x" * 30)
+    from gateway.telegram_fleet.api import ManagedBotInfo
+    from gateway.telegram_fleet.coordinator import FleetCoordinator
+
+    api = MagicMock()
+    api.get_me.return_value = {"id": 1, "username": "TestMgr", "can_manage_bots": True}
+    coord = FleetCoordinator(manager_token="12345:ABC", api_client=api)
+    coord.spawn_bot("active_bot")
+    coord.absorb_managed_bot(
+        ManagedBotInfo(token="x:tok", bot_id=1, bot_username="active_bot")
+    )
+    coord.spawn_bot("pending_bot")
+    rc = _cmd_status(_ns(fleet_command="status"))
+    out = capsys.readouterr().out
+    assert "Manager token configured" in out
+    assert "1 active, 1 pending" in out
+    assert rc == 0
+
+
+# ── list ───────────────────────────────────────────────────────────────
+
+
+def test_list_empty_roster(hermes_home, capsys):
+    rc = _cmd_list(_ns(fleet_command="list"))
+    out = capsys.readouterr().out
+    assert "Roster is empty" in out
+    assert rc == 0
+
+
+def test_list_pretty_prints_active_and_pending(hermes_home, monkeypatch, capsys):
+    monkeypatch.setenv("TELEGRAM_FLEET_MANAGER_TOKEN", "x:y")
+    from gateway.telegram_fleet.api import ManagedBotInfo
+    from gateway.telegram_fleet.coordinator import FleetCoordinator
+
+    api = MagicMock()
+    api.get_me.return_value = {"id": 1, "username": "TestMgr", "can_manage_bots": True}
+    coord = FleetCoordinator(manager_token="12345:ABC", api_client=api)
+    coord.spawn_bot("alpha_bot", persona="research lead")
+    coord.absorb_managed_bot(
+        ManagedBotInfo(token="x:tok", bot_id=1, bot_username="alpha_bot")
+    )
+    coord.spawn_bot("beta_bot", persona="market analyst")
+    rc = _cmd_list(_ns(fleet_command="list"))
+    out = capsys.readouterr().out
+    assert "@alpha_bot" in out
+    assert "research lead" in out
+    assert "@beta_bot" in out
+    assert "active" in out
+    assert "pending" in out
+    assert rc == 0
+
+
+def test_list_truncates_long_personas(hermes_home, monkeypatch, capsys):
+    monkeypatch.setenv("TELEGRAM_FLEET_MANAGER_TOKEN", "x:y")
+    from gateway.telegram_fleet.api import ManagedBotInfo
+    from gateway.telegram_fleet.coordinator import FleetCoordinator
+
+    api = MagicMock()
+    api.get_me.return_value = {"id": 1, "username": "TestMgr", "can_manage_bots": True}
+    coord = FleetCoordinator(manager_token="12345:ABC", api_client=api)
+    coord.spawn_bot("verbose_bot", persona="x" * 500)
+    rc = _cmd_list(_ns(fleet_command="list"))
+    out = capsys.readouterr().out
+    # Each line capped near 60 chars of persona (plus ellipsis).
+    assert "verbose_bot" in out
+    line = next(ln for ln in out.splitlines() if "verbose_bot" in ln)
+    assert len(line) < 200
+
+
+def test_list_redacts_tokens(hermes_home, monkeypatch, capsys):
+    monkeypatch.setenv("TELEGRAM_FLEET_MANAGER_TOKEN", "x:y")
+    from gateway.telegram_fleet.api import ManagedBotInfo
+    from gateway.telegram_fleet.coordinator import FleetCoordinator
+
+    api = MagicMock()
+    api.get_me.return_value = {"id": 1, "username": "TestMgr", "can_manage_bots": True}
+    coord = FleetCoordinator(manager_token="12345:ABC", api_client=api)
+    coord.spawn_bot("worker_bot")
+    coord.absorb_managed_bot(
+        ManagedBotInfo(token="123:secretToken", bot_id=1, bot_username="worker_bot")
+    )
+    _cmd_list(_ns(fleet_command="list"))
+    out = capsys.readouterr().out
+    assert "secretToken" not in out
+    assert "123:" not in out
+
+
+# ── add ────────────────────────────────────────────────────────────────
+
+
+def test_add_rejects_when_no_token(hermes_home, capsys):
+    rc = _cmd_add(_ns(username="research_bot", persona="", name=None))
+    out = capsys.readouterr().out
+    assert "TELEGRAM_FLEET_MANAGER_TOKEN is not set" in out
+    assert rc == 1
+
+
+def test_add_appends_bot_suffix(hermes_home, monkeypatch, capsys):
+    monkeypatch.setenv("TELEGRAM_FLEET_MANAGER_TOKEN", "12345:ABC")
+    from gateway.telegram_fleet.coordinator import FleetCoordinator
+    from hermes_cli import fleet as fleet_module
+
+    api = MagicMock()
+    api.get_me.return_value = {"id": 1, "username": "TestMgr", "can_manage_bots": True}
+    coord = FleetCoordinator(manager_token="12345:ABC", api_client=api)
+    # _cmd_add calls get_coordinator(refresh=True), so monkeypatch the function
+    # itself rather than the singleton.
+    monkeypatch.setattr(
+        "gateway.telegram_fleet.get_coordinator", lambda *a, **k: coord
+    )
+
+    rc = _cmd_add(_ns(username="research", persona="research lead", name=None))
+    out = capsys.readouterr().out
+    assert "research_bot" in out
+    assert "t.me/newbot/TestMgr/research_bot" in out
+    assert rc == 0
+
+
+def test_add_prints_deep_link(hermes_home, monkeypatch, capsys):
+    monkeypatch.setenv("TELEGRAM_FLEET_MANAGER_TOKEN", "12345:ABC")
+    from gateway.telegram_fleet.coordinator import FleetCoordinator
+
+    api = MagicMock()
+    api.get_me.return_value = {"id": 1, "username": "HermesMgr", "can_manage_bots": True}
+    coord = FleetCoordinator(manager_token="12345:ABC", api_client=api)
+    monkeypatch.setattr(
+        "gateway.telegram_fleet.get_coordinator", lambda *a, **k: coord
+    )
+
+    rc = _cmd_add(_ns(username="alpha_bot", persona="lead", name="Alpha"))
+    out = capsys.readouterr().out
+    assert "t.me/newbot/HermesMgr/alpha_bot" in out
+    assert "Tap this link" in out
+    assert rc == 0
+
+
+# ── setup (bot-API mocked) ─────────────────────────────────────────────
+
+
+def test_setup_rejects_invalid_token_shape(hermes_home, monkeypatch, capsys):
+    monkeypatch.setenv("TELEGRAM_FLEET_MANAGER_TOKEN", "too-short")
+    rc = _cmd_setup(_ns())
+    out = capsys.readouterr().out
+    assert "Token doesn't look right" in out
+    assert rc == 1
+
+
+def test_setup_rejects_when_manager_mode_off(hermes_home, monkeypatch, capsys):
+    monkeypatch.setenv("TELEGRAM_FLEET_MANAGER_TOKEN", "12345:ABC" + "x" * 30)
+    from gateway.telegram_fleet import api as api_module
+
+    fake_client = MagicMock()
+    fake_client.get_me.return_value = {
+        "id": 1,
+        "username": "MyBot",
+        "can_manage_bots": False,  # the failure mode we're testing
+    }
+    monkeypatch.setattr(api_module, "FleetApiClient", lambda *a, **k: fake_client)
+    rc = _cmd_setup(_ns())
+    out = capsys.readouterr().out
+    assert "Bot Manager Mode" in out
+    assert "BotFather" in out
+    assert rc == 1
+
+
+def test_setup_succeeds_and_persists_username(hermes_home, monkeypatch, capsys):
+    monkeypatch.setenv("TELEGRAM_FLEET_MANAGER_TOKEN", "12345:ABC" + "x" * 30)
+    from gateway.telegram_fleet import api as api_module
+
+    fake_client = MagicMock()
+    fake_client.get_me.return_value = {
+        "id": 1,
+        "username": "HermesMgr",
+        "can_manage_bots": True,
+    }
+    monkeypatch.setattr(api_module, "FleetApiClient", lambda *a, **k: fake_client)
+
+    rc = _cmd_setup(_ns())
+    out = capsys.readouterr().out
+    assert "Manager bot identified" in out
+    assert "@HermesMgr" in out
+    assert "Bot Manager Mode is enabled" in out
+    assert rc == 0
+
+    # Roster persisted with manager username.
+    from gateway.telegram_fleet.roster import load_roster
+
+    roster = load_roster()
+    assert roster.manager_bot_username == "HermesMgr"
+
+
+def test_setup_writes_token_to_env_file(hermes_home, monkeypatch):
+    monkeypatch.setenv("TELEGRAM_FLEET_MANAGER_TOKEN", "12345:ABC" + "x" * 30)
+    from gateway.telegram_fleet import api as api_module
+
+    fake_client = MagicMock()
+    fake_client.get_me.return_value = {
+        "id": 1,
+        "username": "HermesMgr",
+        "can_manage_bots": True,
+    }
+    monkeypatch.setattr(api_module, "FleetApiClient", lambda *a, **k: fake_client)
+
+    _cmd_setup(_ns())
+
+    env_file = hermes_home / ".env"
+    assert env_file.exists()
+    content = env_file.read_text()
+    assert "TELEGRAM_FLEET_MANAGER_TOKEN=" in content
+    # mode 0600 on POSIX
+    if os.name == "posix":
+        import stat
+
+        mode = stat.S_IMODE(env_file.stat().st_mode)
+        assert mode == 0o600
+
+
+# ── parser registration ────────────────────────────────────────────────
+
+
+def test_parser_registers_all_subcommands():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="cmd")
+    add_fleet_parser(subparsers)
+    args = parser.parse_args(["fleet", "status"])
+    assert args.cmd == "fleet"
+    assert args.fleet_command == "status"
+    args = parser.parse_args(["fleet", "add", "research_bot", "--persona", "lead"])
+    assert args.fleet_command == "add"
+    assert args.username == "research_bot"
+    assert args.persona == "lead"
+
+
+def test_cmd_fleet_dispatches_to_status_by_default(hermes_home, capsys):
+    rc = cmd_fleet(_ns(fleet_command=None))
+    out = capsys.readouterr().out
+    # No subcommand → falls through to status
+    assert "Telegram Fleet — status" in out
+    # Returns 1 because no token configured.
+    assert rc == 1
+
+
+# ── connect ────────────────────────────────────────────────────────────
+
+
+def test_connect_rejects_when_no_token(hermes_home, capsys):
+    from hermes_cli.fleet import _cmd_connect
+
+    rc = _cmd_connect(_ns(wait=0))
+    out = capsys.readouterr().out
+    assert "TELEGRAM_FLEET_MANAGER_TOKEN is not set" in out
+    assert rc == 1
+
+
+def test_connect_warns_when_no_pending_entries(hermes_home, monkeypatch, capsys):
+    """Empty roster → connect is a no-op with a useful nudge."""
+    from hermes_cli.fleet import _cmd_connect
+
+    monkeypatch.setenv("TELEGRAM_FLEET_MANAGER_TOKEN", "12345:ABC")
+    from gateway.telegram_fleet.coordinator import FleetCoordinator
+
+    api = MagicMock()
+    api.get_me.return_value = {"id": 1, "username": "Mgr", "can_manage_bots": True}
+    coord = FleetCoordinator(manager_token="12345:ABC", api_client=api)
+    monkeypatch.setattr(
+        "gateway.telegram_fleet.get_coordinator", lambda *a, **k: coord
+    )
+
+    rc = _cmd_connect(_ns(wait=0))
+    out = capsys.readouterr().out
+    assert "No pending entries" in out
+    assert rc == 0
+
+
+def test_connect_promotes_pending_to_active(hermes_home, monkeypatch, capsys):
+    """When the user has tapped the link, connect should drain and promote."""
+    from hermes_cli.fleet import _cmd_connect
+    from gateway.telegram_fleet.api import ManagedBotInfo
+    from gateway.telegram_fleet.coordinator import FleetCoordinator
+
+    monkeypatch.setenv("TELEGRAM_FLEET_MANAGER_TOKEN", "12345:ABC")
+    api = MagicMock()
+    api.get_me.return_value = {"id": 1, "username": "Mgr", "can_manage_bots": True}
+    coord = FleetCoordinator(manager_token="12345:ABC", api_client=api)
+    coord.spawn_bot("research_bot", persona="research lead")
+
+    # Mock drain to return one resolved managed bot.
+    api.drain_managed_bot_events.return_value = (
+        [ManagedBotInfo(token="42:tok", bot_id=42, bot_username="research_bot")],
+        100,
+    )
+    monkeypatch.setattr(
+        "gateway.telegram_fleet.get_coordinator", lambda *a, **k: coord
+    )
+
+    rc = _cmd_connect(_ns(wait=0))
+    out = capsys.readouterr().out
+    assert "research_bot" in out
+    assert "promoted to active" in out
+    assert rc == 0
+    # Roster updated.
+    child = coord.find("research_bot")
+    assert child.is_active()
+    assert child.bot_id == 42
+
+
+def test_connect_handles_no_updates(hermes_home, monkeypatch, capsys):
+    """User hasn't tapped yet — connect tells them, doesn't error."""
+    from hermes_cli.fleet import _cmd_connect
+    from gateway.telegram_fleet.coordinator import FleetCoordinator
+
+    monkeypatch.setenv("TELEGRAM_FLEET_MANAGER_TOKEN", "12345:ABC")
+    api = MagicMock()
+    api.get_me.return_value = {"id": 1, "username": "Mgr", "can_manage_bots": True}
+    coord = FleetCoordinator(manager_token="12345:ABC", api_client=api)
+    coord.spawn_bot("research_bot")
+    api.drain_managed_bot_events.return_value = ([], None)
+    monkeypatch.setattr(
+        "gateway.telegram_fleet.get_coordinator", lambda *a, **k: coord
+    )
+
+    rc = _cmd_connect(_ns(wait=0))
+    out = capsys.readouterr().out
+    assert "No managed_bot updates queued" in out
+    assert "--wait" in out  # nudges them to long-poll if they want
+    assert rc == 0
+
+
+# ── coordinator: absorb_pending_updates plumbing ───────────────────────
+
+
+def test_coordinator_absorb_pending_updates_promotes(hermes_home):
+    """Direct test of the coordinator method the CLI wraps."""
+    from gateway.telegram_fleet.api import ManagedBotInfo
+    from gateway.telegram_fleet.coordinator import FleetCoordinator
+
+    api = MagicMock()
+    api.get_me.return_value = {"id": 1, "username": "Mgr", "can_manage_bots": True}
+    api.drain_managed_bot_events.return_value = (
+        [ManagedBotInfo(token="42:tok", bot_id=42, bot_username="worker_bot")],
+        7,
+    )
+    coord = FleetCoordinator(manager_token="12345:ABC", api_client=api)
+    coord.spawn_bot("worker_bot")
+    absorbed = coord.absorb_pending_updates()
+    assert len(absorbed) == 1
+    assert absorbed[0].username == "worker_bot"
+    assert absorbed[0].is_active()
+
+
+def test_coordinator_absorb_returns_empty_when_no_updates(hermes_home):
+    from gateway.telegram_fleet.coordinator import FleetCoordinator
+
+    api = MagicMock()
+    api.get_me.return_value = {"id": 1, "username": "Mgr", "can_manage_bots": True}
+    api.drain_managed_bot_events.return_value = ([], None)
+    coord = FleetCoordinator(manager_token="12345:ABC", api_client=api)
+    coord.spawn_bot("worker_bot")
+    absorbed = coord.absorb_pending_updates()
+    assert absorbed == []

--- a/tests/hermes_cli/test_fleet_command.py
+++ b/tests/hermes_cli/test_fleet_command.py
@@ -297,6 +297,148 @@ def test_cmd_fleet_dispatches_to_status_by_default(hermes_home, capsys):
     assert rc == 1
 
 
+# ── adopt ──────────────────────────────────────────────────────────────
+
+
+def test_adopt_rejects_bad_token_shape(hermes_home, capsys):
+    from hermes_cli.fleet import _cmd_adopt
+
+    rc = _cmd_adopt(
+        _ns(token="too-short", persona="x", model=None, toolset=None)
+    )
+    out = capsys.readouterr().out
+    assert "Token doesn't look right" in out
+    assert rc == 1
+
+
+def test_adopt_writes_active_entry(hermes_home, monkeypatch, capsys):
+    """Adopting a real-looking token validates via getMe and lands as active."""
+    from hermes_cli.fleet import _cmd_adopt
+    from gateway.telegram_fleet import api as api_module
+    from gateway.telegram_fleet.coordinator import FleetCoordinator
+
+    fake_client = MagicMock()
+    fake_client.get_me.return_value = {
+        "id": 7777,
+        "username": "my_existing_bot",
+        "can_manage_bots": False,  # adopted bots don't need manager mode
+    }
+    monkeypatch.setattr(api_module, "FleetApiClient", lambda *a, **k: fake_client)
+
+    rc = _cmd_adopt(
+        _ns(
+            token="12345:ABC" + "x" * 30,
+            persona="research lead",
+            model=None,
+            toolset=None,
+        )
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Adopted @my_existing_bot" in out
+
+    # Roster updated with active bot.
+    coord = FleetCoordinator()
+    child = coord.find("my_existing_bot")
+    assert child is not None
+    assert child.is_active()
+    assert child.bot_id == 7777
+    assert child.persona == "research lead"
+
+
+def test_adopt_surfaces_telegram_rejection(hermes_home, monkeypatch, capsys):
+    """Real-shaped but invalid token gets a clean error."""
+    from hermes_cli.fleet import _cmd_adopt
+    from gateway.telegram_fleet import api as api_module
+    from gateway.telegram_fleet.api import BotApiError
+
+    fake_client = MagicMock()
+    fake_client.get_me.side_effect = BotApiError("getMe", 401, "Unauthorized")
+    monkeypatch.setattr(api_module, "FleetApiClient", lambda *a, **k: fake_client)
+
+    rc = _cmd_adopt(
+        _ns(
+            token="12345:ABC" + "x" * 30,
+            persona="x",
+            model=None,
+            toolset=None,
+        )
+    )
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "Telegram rejected" in out or "rejected" in out.lower()
+
+
+def test_adopt_parses_toolset_csv(hermes_home, monkeypatch, capsys):
+    """--toolset web,file → list."""
+    from hermes_cli.fleet import _cmd_adopt
+    from gateway.telegram_fleet import api as api_module
+    from gateway.telegram_fleet.coordinator import FleetCoordinator
+
+    fake_client = MagicMock()
+    fake_client.get_me.return_value = {
+        "id": 1234,
+        "username": "tooled_bot",
+        "can_manage_bots": False,
+    }
+    monkeypatch.setattr(api_module, "FleetApiClient", lambda *a, **k: fake_client)
+
+    rc = _cmd_adopt(
+        _ns(
+            token="12345:ABC" + "x" * 30,
+            persona="",
+            model=None,
+            toolset="web, file, terminal",
+        )
+    )
+    assert rc == 0
+    coord = FleetCoordinator()
+    child = coord.find("tooled_bot")
+    assert child.toolset == ["web", "file", "terminal"]
+
+
+# ── coordinator: adopt_existing_bot directly ─────────────────────────
+
+
+def test_coordinator_adopt_validates_token_shape(hermes_home):
+    from gateway.telegram_fleet.coordinator import FleetCoordinator
+    from gateway.telegram_fleet.guardrails import FleetGuardrailError
+
+    api = MagicMock()
+    coord = FleetCoordinator(manager_token="x:y", api_client=api)
+    with pytest.raises(FleetGuardrailError, match="bot token"):
+        coord.adopt_existing_bot(token="not-a-token")
+
+
+def test_coordinator_adopt_replaces_existing_pending_entry(hermes_home, monkeypatch):
+    """Adopting overrides a stale pending entry with the same username."""
+    from gateway.telegram_fleet import api as api_module
+    from gateway.telegram_fleet.coordinator import FleetCoordinator
+
+    api = MagicMock()
+    api.get_me.return_value = {"id": 1, "username": "Mgr", "can_manage_bots": True}
+    coord = FleetCoordinator(manager_token="x:y", api_client=api)
+    coord.spawn_bot("dup_bot", persona="from spawn")  # creates pending entry
+
+    fake_child_client = MagicMock()
+    fake_child_client.get_me.return_value = {
+        "id": 9999,
+        "username": "dup_bot",
+        "can_manage_bots": False,
+    }
+    monkeypatch.setattr(
+        api_module, "FleetApiClient", lambda *a, **k: fake_child_client
+    )
+
+    child = coord.adopt_existing_bot(
+        token="12345:ABC" + "x" * 30, persona="from adopt"
+    )
+    assert child.is_active()
+    assert child.bot_id == 9999
+    # The stale pending entry was replaced (not duplicated).
+    assert len([c for c in coord.list_children() if c.username == "dup_bot"]) == 1
+
+
 # ── connect ────────────────────────────────────────────────────────────
 
 

--- a/tests/tools/test_hermes_swarm_tool.py
+++ b/tests/tools/test_hermes_swarm_tool.py
@@ -1,0 +1,185 @@
+"""Tests for the in-process hermes_swarm tool (no Telegram, no setup)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _import_tool():
+    """Trigger registration + return the underlying handler for direct testing."""
+    from tools import hermes_swarm_tool
+
+    return hermes_swarm_tool
+
+
+def test_rejects_empty_objective():
+    mod = _import_tool()
+    raw = mod.hermes_swarm(objective="", subtasks=[{"goal": "a"}, {"goal": "b"}])
+    out = json.loads(raw)
+    assert out.get("error")
+    assert out.get("code") == "bad_request"
+
+
+def test_rejects_empty_subtasks():
+    mod = _import_tool()
+    raw = mod.hermes_swarm(objective="X", subtasks=[])
+    out = json.loads(raw)
+    assert out.get("error")
+    assert out.get("code") == "bad_request"
+
+
+def test_rejects_single_subtask_anti_serialization():
+    """A 'fan-out' of one is just delegate_task with extra steps."""
+    mod = _import_tool()
+    raw = mod.hermes_swarm(objective="X", subtasks=[{"goal": "lonely"}])
+    out = json.loads(raw)
+    assert out.get("error")
+    assert out.get("code") == "anti_serialization"
+
+
+def test_rejects_too_many_subtasks():
+    mod = _import_tool()
+    subtasks = [{"goal": f"task-{i}"} for i in range(20)]
+    raw = mod.hermes_swarm(objective="X", subtasks=subtasks)
+    out = json.loads(raw)
+    assert out.get("error")
+    assert out.get("code") == "too_many_subtasks"
+
+
+def test_rejects_subtask_missing_goal():
+    mod = _import_tool()
+    raw = mod.hermes_swarm(
+        objective="X",
+        subtasks=[{"goal": "ok"}, {"persona": "no goal"}],
+    )
+    out = json.loads(raw)
+    assert out.get("error")
+    assert out.get("code") == "bad_request"
+
+
+def test_fans_out_via_delegate_fn():
+    mod = _import_tool()
+    delegate = MagicMock(side_effect=lambda **kw: f"answered: {kw['goal']}")
+    raw = mod.hermes_swarm(
+        objective="Map the impact of new EU regs",
+        subtasks=[
+            {"goal": "legal angle", "persona": "regulatory analyst"},
+            {"goal": "market angle", "persona": "market sizing"},
+            {"goal": "tech angle", "persona": "engineering review"},
+        ],
+        delegate_fn=delegate,
+    )
+    out = json.loads(raw)
+    assert out["success"] is True
+    assert delegate.call_count == 3
+    goals = sorted(r["goal"] for r in out["results"])
+    assert goals == ["legal angle", "market angle", "tech angle"]
+    assert all(r["response"].startswith("answered:") for r in out["results"])
+
+
+def test_returns_critical_path_metric():
+    """Critical path = max worker duration (Kimi PARL optimisation target)."""
+    mod = _import_tool()
+    durations_seen = []
+
+    def slow_delegate(**kw):
+        # Spread durations so max is distinct and < total.
+        import time
+
+        time.sleep(0.05)
+        durations_seen.append(kw["goal"])
+        return "ok"
+
+    raw = mod.hermes_swarm(
+        objective="X",
+        subtasks=[{"goal": "a"}, {"goal": "b"}, {"goal": "c"}],
+        delegate_fn=slow_delegate,
+        max_parallel=3,
+    )
+    out = json.loads(raw)
+    metrics = out["metrics"]
+    assert metrics["workers"] == 3
+    assert metrics["failures"] == 0
+    assert metrics["critical_path_seconds"] > 0
+    # Total serial time >= critical path; speedup should be > 1 with 3 parallel workers.
+    assert metrics["total_serial_seconds"] >= metrics["critical_path_seconds"]
+    assert metrics["parallel_speedup"] >= 1.0
+
+
+def test_per_subtask_failure_isolated():
+    mod = _import_tool()
+
+    def flaky(**kw):
+        if kw["goal"] == "boom":
+            raise RuntimeError("kaboom")
+        return "ok"
+
+    raw = mod.hermes_swarm(
+        objective="X",
+        subtasks=[{"goal": "ok"}, {"goal": "boom"}, {"goal": "fine"}],
+        delegate_fn=flaky,
+    )
+    out = json.loads(raw)
+    failures = [r for r in out["results"] if r.get("error")]
+    successes = [r for r in out["results"] if not r.get("error")]
+    assert len(failures) == 1
+    assert "kaboom" in failures[0]["error"]
+    assert len(successes) == 2
+    assert out["metrics"]["failures"] == 1
+
+
+def test_passes_persona_into_context():
+    mod = _import_tool()
+    captured = []
+
+    def cap_delegate(**kw):
+        captured.append(kw)
+        return "ok"
+
+    mod.hermes_swarm(
+        objective="Research X",
+        subtasks=[{"goal": "g", "persona": "skeptical fact-checker"}],
+        delegate_fn=cap_delegate,
+    )
+    # rejected for single subtask — captured stays empty
+    assert captured == []
+
+    mod.hermes_swarm(
+        objective="Research X",
+        subtasks=[
+            {"goal": "g1", "persona": "skeptical fact-checker"},
+            {"goal": "g2", "persona": "market analyst"},
+        ],
+        delegate_fn=cap_delegate,
+    )
+    assert len(captured) == 2
+    by_goal = {c["goal"]: c for c in captured}
+    assert "skeptical fact-checker" in by_goal["g1"]["context"]
+    assert "Research X" in by_goal["g1"]["context"]
+    assert by_goal["g1"]["role"] == "leaf"  # workers can't recurse
+
+
+def test_tool_registers_under_delegate_toolset():
+    mod = _import_tool()
+    from tools.registry import registry
+
+    entry = registry.get_entry("hermes_swarm")
+    assert entry is not None
+    assert entry.toolset == "delegate"
+
+
+def test_summary_text_is_present():
+    mod = _import_tool()
+    delegate = MagicMock(side_effect=lambda **kw: f"finding for {kw['goal']}")
+    raw = mod.hermes_swarm(
+        objective="X",
+        subtasks=[{"goal": "a"}, {"goal": "b"}],
+        delegate_fn=delegate,
+    )
+    out = json.loads(raw)
+    assert "summary" in out
+    assert "Workers: 2" in out["summary"]
+    assert "ok: 2" in out["summary"]

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -302,6 +302,7 @@ class TestBuiltinDiscovery:
             "tools.feishu_doc_tool",
             "tools.feishu_drive_tool",
             "tools.file_tools",
+            "tools.hermes_swarm_tool",
             "tools.homeassistant_tool",
             "tools.image_generation_tool",
             "tools.memory_tool",

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -312,6 +312,7 @@ class TestBuiltinDiscovery:
             "tools.session_search_tool",
             "tools.skill_manager_tool",
             "tools.skills_tool",
+            "tools.telegram_fleet_tool",
             "tools.terminal_tool",
             "tools.todo_tool",
             "tools.tts_tool",

--- a/tests/tools/test_telegram_fleet_tool.py
+++ b/tests/tools/test_telegram_fleet_tool.py
@@ -193,6 +193,7 @@ def test_orchestrate_swarm_streams_status_to_report_chat(fleet):
         objective="X",
         subtasks=[{"goal": "task"}],
         report_chat_id="555",
+        user_approved=True,
     )
     # Expect at least a "starting" + a "done" message posted as the worker.
     assert api.send_message_as.call_count >= 2

--- a/tests/tools/test_telegram_fleet_tool.py
+++ b/tests/tools/test_telegram_fleet_tool.py
@@ -1,0 +1,198 @@
+"""Tests for the agent-facing telegram_fleet_* tools."""
+
+from __future__ import annotations
+
+import json
+from typing import List
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.telegram_fleet.api import ManagedBotInfo
+from gateway.telegram_fleet import coordinator as coordinator_module
+from gateway.telegram_fleet.coordinator import FleetCoordinator, reset_coordinator
+from gateway.telegram_fleet.guardrails import reset_rate_limits
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    return tmp_path
+
+
+@pytest.fixture
+def fleet(hermes_home, monkeypatch):
+    """Install a singleton FleetCoordinator backed by a mock Bot API client."""
+    api = MagicMock()
+    api.get_me.return_value = {"id": 1, "username": "TestMgr", "can_manage_bots": True}
+    api.send_message_as.return_value = {"message_id": 9}
+    api.replace_managed_bot_token.return_value = ManagedBotInfo(
+        token="x:rotated", bot_id=42, bot_username="rotated_bot"
+    )
+    delegate = MagicMock(side_effect=lambda **kw: f"answered: {kw['goal']}")
+    coord = FleetCoordinator(
+        manager_token="12345:ABC", api_client=api, delegate_fn=delegate
+    )
+    # Pin the singleton.
+    monkeypatch.setattr(coordinator_module, "_singleton", coord)
+    monkeypatch.setenv("TELEGRAM_FLEET_MANAGER_TOKEN", "12345:ABC")
+    yield coord, api, delegate
+    reset_coordinator()
+    reset_rate_limits()
+
+
+def _seed_active(coord: FleetCoordinator, names: List[str]) -> None:
+    for n in names:
+        coord.spawn_bot(n, persona=f"persona for {n}")
+        coord.absorb_managed_bot(
+            ManagedBotInfo(token=f"x:tok_{n}", bot_id=hash(n) & 0xFFFF, bot_username=n)
+        )
+
+
+# Each test imports the tool module to trigger registration. We import inside
+# the test so the env-var-gated check_fn sees the test fixture's env.
+
+
+def test_spawn_tool_returns_deep_link_and_persists(fleet):
+    from tools.telegram_fleet_tool import telegram_spawn_bot
+
+    raw = telegram_spawn_bot(suggested_username="research_bot", persona="legal angle")
+    payload = json.loads(raw)
+    assert payload["success"] is True
+    assert payload["suggested_username"] == "research_bot"
+    assert "t.me/newbot/TestMgr/research_bot" in payload["deep_link"]
+    assert payload["nonce_preview"].endswith("…")
+    # Roster has the pending entry.
+    coord, _, _ = fleet
+    assert coord.find("research_bot") is not None
+
+
+def test_list_tool_redacts_tokens(fleet):
+    from tools.telegram_fleet_tool import telegram_fleet_list, telegram_spawn_bot
+
+    coord, _, _ = fleet
+    _seed_active(coord, ["alpha_bot"])
+    raw = telegram_fleet_list()
+    payload = json.loads(raw)
+    assert payload["success"] is True
+    assert payload["children"][0]["username"] == "alpha_bot"
+    assert "token" not in payload["children"][0]
+    assert payload["children"][0]["has_token"] is True
+
+
+def test_list_tool_filters_by_status(fleet):
+    from tools.telegram_fleet_tool import telegram_fleet_list
+
+    coord, _, _ = fleet
+    coord.spawn_bot("pending_bot")
+    _seed_active(coord, ["active_bot"])
+    raw = telegram_fleet_list(status="pending")
+    payload = json.loads(raw)
+    assert {c["username"] for c in payload["children"]} == {"pending_bot"}
+
+
+def test_delegate_tool_invokes_send_as(fleet):
+    from tools.telegram_fleet_tool import telegram_delegate
+
+    coord, api, _ = fleet
+    _seed_active(coord, ["speaker_bot"])
+    raw = telegram_delegate(target_bot="speaker_bot", chat_id="555", text="hi")
+    payload = json.loads(raw)
+    assert payload["success"] is True
+    assert payload["message_id"] == 9
+    api.send_message_as.assert_called_once()
+
+
+def test_delegate_tool_surfaces_guardrail(fleet):
+    from tools.telegram_fleet_tool import telegram_delegate
+
+    raw = telegram_delegate(target_bot="ghost_bot", chat_id="1", text="hi")
+    payload = json.loads(raw)
+    assert payload.get("error")
+    assert payload.get("code") == "guardrail"
+
+
+def test_decommission_tool_marks_status(fleet):
+    from tools.telegram_fleet_tool import telegram_decommission_bot
+
+    coord, _, _ = fleet
+    _seed_active(coord, ["retired_bot"])
+    raw = telegram_decommission_bot(target_bot="retired_bot")
+    payload = json.loads(raw)
+    assert payload["success"] is True
+    assert coord.find("retired_bot").status == "decommissioned"
+
+
+def test_decommission_tool_handles_unknown(fleet):
+    from tools.telegram_fleet_tool import telegram_decommission_bot
+
+    raw = telegram_decommission_bot(target_bot="ghost_bot")
+    payload = json.loads(raw)
+    assert payload.get("error")
+    assert payload.get("code") == "not_found"
+
+
+def test_rotate_tool_calls_replace_endpoint(fleet):
+    from tools.telegram_fleet_tool import telegram_rotate_bot_token
+
+    coord, api, _ = fleet
+    _seed_active(coord, ["rotated_bot"])
+    raw = telegram_rotate_bot_token(target_bot="rotated_bot")
+    payload = json.loads(raw)
+    assert payload["success"] is True
+    api.replace_managed_bot_token.assert_called_once()
+
+
+# ── orchestrate_swarm: the user-visible end-to-end test ────────────────
+
+
+def test_orchestrate_swarm_end_to_end(fleet):
+    """Full user-visible flow: leader → subtasks → workers → aggregate."""
+    from tools.telegram_fleet_tool import telegram_orchestrate_swarm
+
+    coord, _, delegate = fleet
+    _seed_active(coord, ["legal_bot", "market_bot", "tech_bot"])
+
+    raw = telegram_orchestrate_swarm(
+        objective="Research the impact of new EU AI regulations",
+        subtasks=[
+            {"goal": "summarise the legal text", "bot_username": "legal_bot"},
+            {"goal": "estimate market impact", "bot_username": "market_bot"},
+            {"goal": "review technical feasibility constraints", "bot_username": "tech_bot"},
+        ],
+    )
+    payload = json.loads(raw)
+    assert payload["success"] is True
+    assert delegate.call_count == 3
+    bots = sorted(r["bot_username"] for r in payload["results"])
+    assert bots == ["legal_bot", "market_bot", "tech_bot"]
+    # All three answers carried back in structured form for the leader to synthesise.
+    assert all(r["response"].startswith("answered:") for r in payload["results"])
+    assert "Workers: 3" in payload["summary"]
+    assert "ok: 3" in payload["summary"]
+
+
+def test_orchestrate_swarm_rejects_when_fleet_empty(fleet):
+    from tools.telegram_fleet_tool import telegram_orchestrate_swarm
+
+    raw = telegram_orchestrate_swarm(
+        objective="X",
+        subtasks=[{"goal": "task"}],
+    )
+    payload = json.loads(raw)
+    assert payload.get("error")
+    assert "no active fleet" in payload["error"].lower()
+
+
+def test_orchestrate_swarm_streams_status_to_report_chat(fleet):
+    from tools.telegram_fleet_tool import telegram_orchestrate_swarm
+
+    coord, api, _ = fleet
+    _seed_active(coord, ["worker_bot"])
+    telegram_orchestrate_swarm(
+        objective="X",
+        subtasks=[{"goal": "task"}],
+        report_chat_id="555",
+    )
+    # Expect at least a "starting" + a "done" message posted as the worker.
+    assert api.send_message_as.call_count >= 2

--- a/tests/tools/test_telegram_fleet_tool.py
+++ b/tests/tools/test_telegram_fleet_tool.py
@@ -172,6 +172,39 @@ def test_orchestrate_swarm_end_to_end(fleet):
     assert "ok: 3" in payload["summary"]
 
 
+def test_parent_agent_threads_through_handle_function_call(fleet):
+    """Regression: parent_agent must reach delegate_task or it errors.
+
+    The user-reported bug was ``{"error": "delegate_task requires a parent
+    agent context."}`` because handle_function_call → registry.dispatch
+    only forwarded task_id/user_task, never parent_agent.  This pins the
+    fix: a sentinel agent passed to handle_function_call must reach the
+    delegate_fn each worker calls.
+    """
+    from unittest.mock import MagicMock
+    from model_tools import handle_function_call
+
+    coord, _, delegate = fleet
+    _seed_active(coord, ["worker_bot"])
+
+    # Use a sentinel object so we can assert identity, not just truthy.
+    sentinel_agent = MagicMock(name="AGENT")
+    sentinel_agent._delegate_depth = 0
+
+    handle_function_call(
+        "telegram_orchestrate_swarm",
+        {
+            "objective": "X",
+            "subtasks": [{"goal": "task", "bot_username": "worker_bot"}],
+        },
+        parent_agent=sentinel_agent,
+    )
+    # Verify the sentinel reached the delegate call.
+    assert delegate.call_count == 1
+    _, call_kwargs = delegate.call_args_list[0].args, delegate.call_args_list[0].kwargs
+    assert call_kwargs.get("parent_agent") is sentinel_agent
+
+
 def test_orchestrate_swarm_rejects_when_fleet_empty(fleet):
     from tools.telegram_fleet_tool import telegram_orchestrate_swarm
 

--- a/tools/hermes_swarm_tool.py
+++ b/tools/hermes_swarm_tool.py
@@ -1,0 +1,330 @@
+"""hermes_swarm — Kimi-style fan-out orchestration, in-process, no external deps.
+
+This is the **default** swarm primitive.  It runs entirely inside the current
+Hermes process by reusing :func:`tools.delegate_tool.delegate_task` as the
+worker engine.  No Telegram, no manager bot, no roster — just decompose,
+fan out, aggregate, return.
+
+Why this exists alongside ``telegram_orchestrate_swarm``:
+
+* The Telegram variant is the visible / multi-bot flavour: each subtask is
+  bound to a specific child bot, status is streamed to a report chat as that
+  bot, and the user sees real Telegram identities working in parallel.  It
+  requires manager-bot setup.
+* This tool is the zero-config flavour.  The agent reaches for it for any
+  "research X across N angles" / "draft N variants" / "verify X via M
+  independent checks" request, regardless of whether a fleet exists.
+
+Both tools share the same Kimi-derived patterns:
+
+1. **Critical Path metric.**  We measure the max wall-clock per stage and
+   the sum across stages; this is what Kimi's PARL training optimises.  The
+   metric appears in the result as ``critical_path_seconds``.
+2. **Anti-serialization guard.**  A "fan-out" call with a single subtask is
+   rejected — fan-out of one is just a delegation, and the prompt explicitly
+   asks for parallel work.
+3. **Worker count sanity.**  Subtask count is capped at
+   :data:`MAX_SUBTASKS` (16); for production tasks 3–5 is the sweet spot
+   per multi-agent scaling research.
+4. **Distilled returns.**  Each worker is a leaf delegate (cannot recurse),
+   so its full reasoning trace stays in its own context; only the final
+   answer comes back.  Mirrors Kimi's context-sharding.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Any, Callable, Dict, List, Optional
+
+from tools.registry import registry, tool_error, tool_result
+
+logger = logging.getLogger(__name__)
+
+MAX_SUBTASKS = 16
+MIN_SUBTASKS_FOR_FANOUT = 2
+DEFAULT_PER_TASK_TIMEOUT_S = 600.0
+DEFAULT_MAX_PARALLEL = 8
+
+
+def _resolve_delegate() -> Callable[..., str]:
+    """Lazy import — keeps module import lightweight."""
+    from tools.delegate_tool import delegate_task
+
+    return delegate_task
+
+
+def hermes_swarm(
+    objective: str,
+    subtasks: List[Dict[str, Any]],
+    max_parallel: int = DEFAULT_MAX_PARALLEL,
+    per_task_timeout_s: float = DEFAULT_PER_TASK_TIMEOUT_S,
+    parent_agent: Any = None,
+    delegate_fn: Optional[Callable[..., str]] = None,
+    **_: Any,
+) -> str:
+    """Fan *subtasks* across in-process subagents and return aggregated results.
+
+    *objective* is the user-facing goal; it's woven into each worker's context
+    so they ground their angle in the bigger picture.  Each entry in
+    *subtasks* is::
+
+        {
+            "goal":     "...",            # required
+            "persona":  "...",            # optional system-prompt addendum
+            "context":  "...",            # optional extra grounding
+            "toolsets": ["web", "file"],  # optional whitelist
+        }
+    """
+    if not isinstance(objective, str) or not objective.strip():
+        return tool_error("objective must be a non-empty string", code="bad_request")
+    if not isinstance(subtasks, list) or not subtasks:
+        return tool_error("subtasks must be a non-empty list", code="bad_request")
+    if len(subtasks) < MIN_SUBTASKS_FOR_FANOUT:
+        return tool_error(
+            f"hermes_swarm requires at least {MIN_SUBTASKS_FOR_FANOUT} subtasks "
+            "for fan-out — for a single task, call delegate_task directly.",
+            code="anti_serialization",
+        )
+    if len(subtasks) > MAX_SUBTASKS:
+        return tool_error(
+            f"hermes_swarm capped at {MAX_SUBTASKS} subtasks per call (got "
+            f"{len(subtasks)}).  Multi-agent research shows 3-5 is the production "
+            f"sweet spot; coordination overhead dominates beyond that.",
+            code="too_many_subtasks",
+        )
+    bindings = _validate_subtasks(subtasks)
+    if isinstance(bindings, str):
+        return bindings  # validation error JSON
+
+    delegate = delegate_fn or _resolve_delegate()
+    parallel = max(1, min(int(max_parallel or DEFAULT_MAX_PARALLEL), len(bindings)))
+    timeout = float(per_task_timeout_s or DEFAULT_PER_TASK_TIMEOUT_S)
+
+    stage_started_at = time.monotonic()
+    results: List[Dict[str, Any]] = []
+    with ThreadPoolExecutor(max_workers=parallel) as ex:
+        futures = {
+            ex.submit(
+                _run_one,
+                binding=b,
+                objective=objective,
+                delegate_fn=delegate,
+                parent_agent=parent_agent,
+            ): b
+            for b in bindings
+        }
+        for fut in as_completed(futures):
+            b = futures[fut]
+            try:
+                result = fut.result(timeout=timeout + 5)
+            except Exception as e:  # pragma: no cover - delegate-side failure
+                result = {
+                    "goal": b["goal"],
+                    "persona": b.get("persona", ""),
+                    "response": "",
+                    "duration_seconds": 0.0,
+                    "error": f"{type(e).__name__}: {e}",
+                }
+            results.append(result)
+
+    # Critical Path metric (Kimi's PARL optimisation target).  In a
+    # single-stage fan-out like ours the critical path is just the slowest
+    # worker; we keep it as a list so multi-stage callers can append.
+    durations = [r.get("duration_seconds", 0.0) for r in results]
+    critical_path = max(durations) if durations else 0.0
+    total_serial = sum(durations)
+    speedup = (total_serial / critical_path) if critical_path > 0 else 1.0
+
+    payload = {
+        "success": True,
+        "objective": objective,
+        "results": results,
+        "metrics": {
+            "workers": len(results),
+            "failures": sum(1 for r in results if r.get("error")),
+            "critical_path_seconds": round(critical_path, 3),
+            "total_serial_seconds": round(total_serial, 3),
+            "wall_clock_seconds": round(time.monotonic() - stage_started_at, 3),
+            "parallel_speedup": round(speedup, 2),
+        },
+        "summary": _format_summary(objective, results),
+    }
+    return json.dumps(payload, ensure_ascii=False)
+
+
+# ── internals ─────────────────────────────────────────────────────────
+
+
+def _validate_subtasks(subtasks: List[Dict[str, Any]]):
+    bindings: List[Dict[str, Any]] = []
+    for i, raw in enumerate(subtasks):
+        if not isinstance(raw, dict):
+            return tool_error(
+                f"subtask #{i} must be an object, got {type(raw).__name__}",
+                code="bad_request",
+            )
+        goal = str(raw.get("goal") or "").strip()
+        if not goal:
+            return tool_error(f"subtask #{i} is missing 'goal'", code="bad_request")
+        bindings.append(
+            {
+                "goal": goal,
+                "persona": str(raw.get("persona") or ""),
+                "context": str(raw.get("context") or ""),
+                "toolsets": list(raw.get("toolsets") or []) or None,
+            }
+        )
+    return bindings
+
+
+def _run_one(
+    *,
+    binding: Dict[str, Any],
+    objective: str,
+    delegate_fn: Callable[..., str],
+    parent_agent: Any,
+) -> Dict[str, Any]:
+    start = time.monotonic()
+    persona = binding.get("persona") or ""
+    context_parts = [f"Swarm objective: {objective}"]
+    if persona:
+        context_parts.append(f"Your persona for this task: {persona}")
+    if binding.get("context"):
+        context_parts.append(str(binding["context"]))
+    full_context = "\n\n".join(context_parts)
+    try:
+        response = delegate_fn(
+            goal=binding["goal"],
+            context=full_context,
+            toolsets=binding.get("toolsets"),
+            role="leaf",
+            parent_agent=parent_agent,
+        )
+    except Exception as e:
+        return {
+            "goal": binding["goal"],
+            "persona": persona,
+            "response": "",
+            "duration_seconds": time.monotonic() - start,
+            "error": f"{type(e).__name__}: {e}",
+        }
+    return {
+        "goal": binding["goal"],
+        "persona": persona,
+        "response": str(response),
+        "duration_seconds": time.monotonic() - start,
+    }
+
+
+def _format_summary(objective: str, results: List[Dict[str, Any]]) -> str:
+    successes = [r for r in results if not r.get("error")]
+    failures = [r for r in results if r.get("error")]
+    lines = [
+        f"Swarm objective: {objective}",
+        "",
+        f"Workers: {len(results)}  ·  ok: {len(successes)}  ·  failed: {len(failures)}",
+        "",
+    ]
+    for r in results:
+        header = "—"
+        if r.get("persona"):
+            header += f" {r['persona'][:60]}"
+        header += f"  [{r.get('duration_seconds', 0):.1f}s]"
+        lines.append(header)
+        body = r.get("error") or _truncate(r.get("response", ""), 600)
+        lines.append(body)
+        lines.append("")
+    return "\n".join(lines).rstrip()
+
+
+def _truncate(s: str, n: int) -> str:
+    s = s or ""
+    if len(s) <= n:
+        return s
+    return s[: n - 1].rstrip() + "…"
+
+
+# ── Schema + registration ────────────────────────────────────────────
+
+
+HERMES_SWARM_SCHEMA = {
+    "type": "function",
+    "function": {
+        "name": "hermes_swarm",
+        "description": (
+            "Kimi-Agent-Swarm-style fan-out, in-process, zero config.  YOU "
+            "are the leader — decompose the user's request into 2–8 atomic "
+            "subtasks (one per persona/angle/check), then call this tool "
+            "ONCE with all of them.  Each subtask runs as an isolated "
+            "Hermes subagent in parallel; results come back as structured "
+            "data including critical-path latency for you to synthesise.  "
+            "PREFER THIS over delegate_task whenever the user's request "
+            "decomposes into independent angles (research across N facets, "
+            "draft N variants, verify a claim via M independent checks, "
+            "monitor N feeds).  DO NOT use it for tightly-coupled "
+            "sequential work where each step depends on the previous one — "
+            "use delegate_task or solve inline.  Do NOT call with fewer "
+            "than 2 subtasks; the tool will reject single-subtask plans."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "objective": {
+                    "type": "string",
+                    "description": "Overall goal (1–3 sentences).  Each worker sees this for grounding.",
+                },
+                "subtasks": {
+                    "type": "array",
+                    "minItems": 2,
+                    "maxItems": MAX_SUBTASKS,
+                    "description": (
+                        "List of 2–8 atomic subtasks.  Aim for similar work-sizes per task "
+                        "(critical-path optimisation: balanced branches minimise wall-clock)."
+                    ),
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "goal": {"type": "string"},
+                            "persona": {
+                                "type": "string",
+                                "description": "Free-text role/specialist hint, e.g. 'legal analyst', 'skeptic verifier'.",
+                            },
+                            "context": {"type": "string"},
+                            "toolsets": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                            },
+                        },
+                        "required": ["goal"],
+                    },
+                },
+                "max_parallel": {
+                    "type": "integer",
+                    "default": DEFAULT_MAX_PARALLEL,
+                    "description": "Max concurrent workers (default 8).",
+                },
+                "per_task_timeout_s": {
+                    "type": "number",
+                    "default": DEFAULT_PER_TASK_TIMEOUT_S,
+                    "description": "Per-subtask timeout in seconds (default 600).",
+                },
+            },
+            "required": ["objective", "subtasks"],
+        },
+    },
+}
+
+
+registry.register(
+    name="hermes_swarm",
+    toolset="delegate",
+    schema=HERMES_SWARM_SCHEMA,
+    handler=lambda args, **kw: hermes_swarm(
+        **args, parent_agent=kw.get("parent_agent")
+    ),
+    emoji="🌊",
+    description=HERMES_SWARM_SCHEMA["function"]["description"],
+)

--- a/tools/hermes_swarm_tool.py
+++ b/tools/hermes_swarm_tool.py
@@ -1,4 +1,4 @@
-"""hermes_swarm — Kimi-style fan-out orchestration, in-process, no external deps.
+"""hermes_swarm — parallel sub-agent fan-out, in-process, no external deps.
 
 This is the **default** swarm primitive.  It runs entirely inside the current
 Hermes process by reusing :func:`tools.delegate_tool.delegate_task` as the
@@ -15,11 +15,15 @@ Why this exists alongside ``telegram_orchestrate_swarm``:
   "research X across N angles" / "draft N variants" / "verify X via M
   independent checks" request, regardless of whether a fleet exists.
 
-Both tools share the same Kimi-derived patterns:
+Both tools share the same orchestration patterns drawn from multi-agent
+scaling research (Moonshot's published PARL methodology, hierarchical RL,
+the Options framework — see ``skills/agents/swarm-orchestration/SKILL.md``
+for citations):
 
-1. **Critical Path metric.**  We measure the max wall-clock per stage and
-   the sum across stages; this is what Kimi's PARL training optimises.  The
-   metric appears in the result as ``critical_path_seconds``.
+1. **Critical Path metric** — wall-clock per parallel stage = max(workers),
+   not sum.  Spawning more workers only helps if it shortens the longest
+   chain.  Surfaced in the result as ``critical_path_seconds`` so the
+   leader can self-tune.
 2. **Anti-serialization guard.**  A "fan-out" call with a single subtask is
    rejected — fan-out of one is just a delegation, and the prompt explicitly
    asks for parallel work.
@@ -28,7 +32,7 @@ Both tools share the same Kimi-derived patterns:
    per multi-agent scaling research.
 4. **Distilled returns.**  Each worker is a leaf delegate (cannot recurse),
    so its full reasoning trace stays in its own context; only the final
-   answer comes back.  Mirrors Kimi's context-sharding.
+   answer comes back.  Bounded local context per worker.
 """
 
 from __future__ import annotations
@@ -130,7 +134,7 @@ def hermes_swarm(
                 }
             results.append(result)
 
-    # Critical Path metric (Kimi's PARL optimisation target).  In a
+    # Critical Path metric — wall-clock per stage = max(workers).  In a
     # single-stage fan-out like ours the critical path is just the slowest
     # worker; we keep it as a list so multi-stage callers can append.
     durations = [r.get("duration_seconds", 0.0) for r in results]
@@ -255,8 +259,8 @@ HERMES_SWARM_SCHEMA = {
     "function": {
         "name": "hermes_swarm",
         "description": (
-            "Kimi-Agent-Swarm-style fan-out, in-process, zero config.  YOU "
-            "are the leader — decompose the user's request into 2–8 atomic "
+            "Parallel sub-agent fan-out, in-process, zero config.  YOU are "
+            "the leader — decompose the user's request into 2–8 atomic "
             "subtasks (one per persona/angle/check), then call this tool "
             "ONCE with all of them.  Each subtask runs as an isolated "
             "Hermes subagent in parallel; results come back as structured "
@@ -267,7 +271,10 @@ HERMES_SWARM_SCHEMA = {
             "monitor N feeds).  DO NOT use it for tightly-coupled "
             "sequential work where each step depends on the previous one — "
             "use delegate_task or solve inline.  Do NOT call with fewer "
-            "than 2 subtasks; the tool will reject single-subtask plans."
+            "than 2 subtasks; the tool will reject single-subtask plans.  "
+            "For a Telegram-visible variant where each subtask runs as a "
+            "named child bot, use telegram_orchestrate_swarm (requires the "
+            "manager bot setup at `hermes fleet setup`)."
         ),
         "parameters": {
             "type": "object",

--- a/tools/telegram_fleet_tool.py
+++ b/tools/telegram_fleet_tool.py
@@ -25,6 +25,7 @@ import os
 from typing import Any, Dict, List, Optional
 
 from gateway.telegram_fleet import (
+    FleetApprovalRequired,
     FleetCoordinator,
     FleetGuardrailError,
     RosterError,
@@ -331,6 +332,7 @@ def telegram_orchestrate_swarm(
     report_chat_id: Optional[str] = None,
     max_parallel: int = 8,
     per_task_timeout_s: float = 600.0,
+    user_approved: bool = False,
     parent_agent: Any = None,
     **_: Any,
 ) -> str:
@@ -342,7 +344,31 @@ def telegram_orchestrate_swarm(
             report_chat_id=str(report_chat_id) if report_chat_id else None,
             max_parallel=int(max_parallel or 8),
             per_task_timeout_s=float(per_task_timeout_s or 600.0),
+            user_approved=bool(user_approved),
             parent_agent=parent_agent,
+        )
+    except FleetApprovalRequired as e:
+        # Hermes-style approval-required response.  The agent is expected to
+        # surface the plan via `clarify` (multiple-choice or open-ended), get
+        # consent, then re-call this tool with ``user_approved=true``.
+        return json.dumps(
+            {
+                "status": "approval_required",
+                "code": "approval_required",
+                "message": str(e),
+                "plan": e.to_plan_dict(),
+                "instruction": (
+                    "Surface the plan to the user via the `clarify` tool "
+                    "(or in a normal reply) and confirm they want this run.  "
+                    "Once they say yes, re-call telegram_orchestrate_swarm "
+                    "with the same arguments plus user_approved=true.  If "
+                    "they want to change the plan, edit subtasks and "
+                    "re-call without user_approved.  To bypass approval "
+                    "entirely, the user can pin every subtask to a "
+                    "specific bot_username."
+                ),
+            },
+            ensure_ascii=False,
         )
     except FleetGuardrailError as e:
         return tool_error(str(e), code="guardrail")
@@ -354,17 +380,26 @@ TELEGRAM_ORCHESTRATE_SWARM_SCHEMA = {
     "function": {
         "name": "telegram_orchestrate_swarm",
         "description": (
-            "Kimi-Agent-Swarm-style fan-out across the Telegram fleet.  YOU "
-            "are the leader — decompose the user's request into atomic "
-            "sub-tasks (one per persona/angle), then call this tool ONCE "
-            "with all of them.  Each sub-task runs in parallel as an "
-            "isolated Hermes sub-agent on behalf of one fleet member; if a "
-            "report_chat_id is set, every worker posts live status updates "
-            "to that chat as itself so the operator can watch.  Returns "
-            "aggregated structured results which YOU then synthesise into "
-            "the final user-facing answer.  Use this for any 'spin up a "
-            "swarm and report back' request — research a topic across N "
-            "angles, monitor N feeds in parallel, draft N variants, etc."
+            "Kimi-Agent-Swarm-style fan-out across the Telegram fleet.  "
+            "Each subtask runs as a NAMED Telegram bot that may post "
+            "messages out into chats — this is the visible variant, "
+            "treat it as an outbound action.\n\n"
+            "APPROVAL FLOW (mirrors `terminal_tool` force=True pattern):\n"
+            "1. First call WITHOUT user_approved returns "
+            "`status: approval_required` with a structured plan.\n"
+            "2. Surface the plan to the user via `clarify` (or in your "
+            "reply) and let them confirm / adjust / cancel.\n"
+            "3. On confirmation, re-call with user_approved=true.\n"
+            "Bypass: if every subtask pins a specific bot_username, the "
+            "user is treated as having already requested by name and the "
+            "approval gate is skipped.  Operators can disable the gate "
+            "globally via `telegram_fleet.auto_approve: true` in "
+            "config.yaml.\n\n"
+            "USE THIS over `hermes_swarm` ONLY when the user explicitly "
+            "wants visible Telegram bot activity ('I want to watch them "
+            "work', 'send updates from each agent', or they referenced "
+            "fleet bots by name).  Default to `hermes_swarm` for "
+            "invisible in-process fan-out."
         ),
         "parameters": {
             "type": "object",
@@ -401,6 +436,19 @@ TELEGRAM_ORCHESTRATE_SWARM_SCHEMA = {
                     "type": "number",
                     "description": "Per-sub-task timeout in seconds.  Default 600 (10 minutes).",
                     "default": 600,
+                },
+                "user_approved": {
+                    "type": "boolean",
+                    "default": False,
+                    "description": (
+                        "Set to true ONLY after the user has explicitly "
+                        "confirmed (via `clarify` or in their reply) that "
+                        "they want this fleet run to proceed.  Without "
+                        "approval AND without every subtask pinning a "
+                        "specific bot_username, the tool returns "
+                        "`status: approval_required` with the proposed "
+                        "plan instead of running."
+                    ),
                 },
             },
             "required": ["objective", "subtasks"],

--- a/tools/telegram_fleet_tool.py
+++ b/tools/telegram_fleet_tool.py
@@ -1,0 +1,481 @@
+"""telegram_fleet — agent-facing tools for orchestrating a Telegram bot swarm.
+
+Exposes six tools registered under the ``telegram_fleet`` toolset:
+
+* ``telegram_spawn_bot`` — mint a deep link for the user to confirm a new
+  child bot.  Returns the link + a short instruction the agent can relay.
+* ``telegram_fleet_list`` — current roster status (active / pending /
+  decommissioned), token-redacted.
+* ``telegram_delegate`` — make a named child bot post a message into a chat.
+* ``telegram_rotate_bot_token`` — rotate via ``replaceManagedBotToken``.
+* ``telegram_decommission_bot`` — drop a bot from active service.
+* ``telegram_orchestrate_swarm`` — the headline primitive: take an objective
+  + a list of subtasks, fan them out across the active fleet in parallel,
+  optionally stream status to a report chat, return aggregated results.
+
+All tools are read-only against config — they only touch
+``~/.hermes/telegram_fleet.yaml`` (atomic writes) and the audit log.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+from gateway.telegram_fleet import (
+    FleetCoordinator,
+    FleetGuardrailError,
+    RosterError,
+    SpawnApprovalRequired,
+    get_coordinator,
+)
+from gateway.telegram_fleet.api import BotApiError
+from tools.registry import registry, tool_error, tool_result
+
+logger = logging.getLogger(__name__)
+
+
+# ── Tool: telegram_spawn_bot ───────────────────────────────────────────
+
+
+def telegram_spawn_bot(
+    suggested_username: str,
+    persona: str = "",
+    display_name: Optional[str] = None,
+    model: Optional[str] = None,
+    profile: Optional[str] = None,
+    toolset: Optional[List[str]] = None,
+    rate_limit_per_min: int = 30,
+    daily_budget_usd: Optional[float] = None,
+    notes: str = "",
+    **_: Any,
+) -> str:
+    """Mint a deep link the user taps to add a new child bot to the fleet."""
+    try:
+        coord = get_coordinator()
+        result = coord.spawn_bot(
+            suggested_username=suggested_username,
+            persona=persona,
+            display_name=display_name,
+            model=model,
+            profile=profile,
+            toolset=toolset,
+            rate_limit_per_min=int(rate_limit_per_min or 30),
+            daily_budget_usd=daily_budget_usd,
+            notes=notes,
+        )
+    except SpawnApprovalRequired as e:
+        return tool_error(str(e), code="spawn_approval_disabled")
+    except FleetGuardrailError as e:
+        return tool_error(str(e), code="guardrail")
+    except (RosterError, BotApiError) as e:
+        return tool_error(str(e), code=type(e).__name__)
+    return tool_result(
+        success=True,
+        suggested_username=result.suggested_username,
+        deep_link=result.deep_link,
+        nonce_preview=result.nonce[:6] + "…",
+        instruction=(
+            "Share the deep link with the user.  When they tap it and "
+            "confirm in Telegram, the new child bot is automatically "
+            "registered and joins the fleet within seconds."
+        ),
+    )
+
+
+TELEGRAM_SPAWN_BOT_SCHEMA = {
+    "type": "function",
+    "function": {
+        "name": "telegram_spawn_bot",
+        "description": (
+            "Add a new child bot to the Telegram fleet.  Returns a deep "
+            "link the user must tap once in Telegram to confirm creation "
+            "(this is required by Telegram's Managed Bots API; no link, no "
+            "bot).  Once tapped, the bot is auto-registered with the persona "
+            "and overrides you specify and becomes available to "
+            "telegram_orchestrate_swarm and telegram_delegate."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "suggested_username": {
+                    "type": "string",
+                    "description": "Suggested username for the new bot (without @).  Must end in 'bot' per Telegram rules.  Make it unique and descriptive (e.g. 'hermes_research_legal_bot').",
+                },
+                "persona": {
+                    "type": "string",
+                    "description": "Free-text persona/role description injected into the bot's system prompt for tasks routed through it.",
+                    "default": "",
+                },
+                "display_name": {
+                    "type": "string",
+                    "description": "Pretty display name shown in Telegram (defaults to persona/username).",
+                },
+                "model": {
+                    "type": "string",
+                    "description": "Optional model override for tasks routed through this bot.",
+                },
+                "profile": {
+                    "type": "string",
+                    "description": "Optional Hermes profile name for isolated config/memory.",
+                },
+                "toolset": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Optional toolset whitelist for this bot (e.g. ['web', 'file']).",
+                },
+                "rate_limit_per_min": {
+                    "type": "integer",
+                    "description": "Per-child outbound message cap.  Default 30/min.",
+                    "default": 30,
+                },
+                "daily_budget_usd": {
+                    "type": "number",
+                    "description": "Optional daily LLM spend cap for tasks routed through this bot.",
+                },
+                "notes": {
+                    "type": "string",
+                    "description": "Free-text notes recorded in the roster.",
+                    "default": "",
+                },
+            },
+            "required": ["suggested_username"],
+        },
+    },
+}
+
+
+# ── Tool: telegram_fleet_list ──────────────────────────────────────────
+
+
+def telegram_fleet_list(status: Optional[str] = None, **_: Any) -> str:
+    """Return current roster (tokens redacted)."""
+    try:
+        coord = get_coordinator()
+        children = coord.list_children(status=status)
+    except RosterError as e:
+        return tool_error(str(e), code="roster")
+    rows = []
+    for c in children:
+        entry = c.to_dict(include_token=False)
+        if c.token:
+            entry["has_token"] = True
+        rows.append(entry)
+    return tool_result(
+        success=True,
+        manager_bot_username=coord.roster.manager_bot_username,
+        max_size=coord.roster.max_size,
+        children=rows,
+    )
+
+
+TELEGRAM_FLEET_LIST_SCHEMA = {
+    "type": "function",
+    "function": {
+        "name": "telegram_fleet_list",
+        "description": "List all bots in the Telegram fleet (tokens redacted).  Useful before orchestrating to see who's available.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "enum": ["active", "pending", "decommissioned"],
+                    "description": "Filter by status.  Omit to list all.",
+                },
+            },
+        },
+    },
+}
+
+
+# ── Tool: telegram_delegate ────────────────────────────────────────────
+
+
+def telegram_delegate(
+    target_bot: str,
+    chat_id: str,
+    text: str,
+    reply_to: Optional[int] = None,
+    **_: Any,
+) -> str:
+    """Have the named child bot post *text* into *chat_id*."""
+    try:
+        coord = get_coordinator()
+        result = coord.delegate_message(
+            target_username=target_bot,
+            chat_id=str(chat_id),
+            text=text,
+            reply_to=reply_to,
+        )
+    except FleetGuardrailError as e:
+        return tool_error(str(e), code="guardrail")
+    except BotApiError as e:
+        return tool_error(str(e), code="bot_api")
+    return tool_result(
+        success=True,
+        target_bot=target_bot.lstrip("@"),
+        message_id=(result or {}).get("message_id"),
+        chat_id=str(chat_id),
+    )
+
+
+TELEGRAM_DELEGATE_SCHEMA = {
+    "type": "function",
+    "function": {
+        "name": "telegram_delegate",
+        "description": "Make a specific child bot post a message into a Telegram chat.  Use to relay sub-results from the swarm back into a report channel.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "target_bot": {
+                    "type": "string",
+                    "description": "Username of the child bot (with or without @).",
+                },
+                "chat_id": {
+                    "type": "string",
+                    "description": "Telegram chat ID (numeric, can be negative for groups).",
+                },
+                "text": {
+                    "type": "string",
+                    "description": "Message text.",
+                },
+                "reply_to": {
+                    "type": "integer",
+                    "description": "Optional message_id to reply to.",
+                },
+            },
+            "required": ["target_bot", "chat_id", "text"],
+        },
+    },
+}
+
+
+# ── Tool: telegram_rotate_bot_token ────────────────────────────────────
+
+
+def telegram_rotate_bot_token(target_bot: str, **_: Any) -> str:
+    try:
+        coord = get_coordinator()
+        child = coord.rotate_token(target_bot)
+    except FleetGuardrailError as e:
+        return tool_error(str(e), code="guardrail")
+    except BotApiError as e:
+        return tool_error(str(e), code="bot_api")
+    return tool_result(
+        success=True,
+        target_bot=child.username,
+        last_rotated_at=child.last_rotated_at,
+    )
+
+
+TELEGRAM_ROTATE_TOKEN_SCHEMA = {
+    "type": "function",
+    "function": {
+        "name": "telegram_rotate_bot_token",
+        "description": "Rotate the API token for a fleet member via replaceManagedBotToken.  Use after a suspected token compromise.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "target_bot": {
+                    "type": "string",
+                    "description": "Username of the child bot to rotate.",
+                },
+            },
+            "required": ["target_bot"],
+        },
+    },
+}
+
+
+# ── Tool: telegram_decommission_bot ────────────────────────────────────
+
+
+def telegram_decommission_bot(target_bot: str, **_: Any) -> str:
+    try:
+        coord = get_coordinator()
+        removed = coord.decommission(target_bot)
+    except RosterError as e:
+        return tool_error(str(e), code="roster")
+    if not removed:
+        return tool_error(f"@{target_bot.lstrip('@')} is not in the roster", code="not_found")
+    return tool_result(success=True, target_bot=target_bot.lstrip("@"))
+
+
+TELEGRAM_DECOMMISSION_SCHEMA = {
+    "type": "function",
+    "function": {
+        "name": "telegram_decommission_bot",
+        "description": "Mark a fleet member decommissioned.  Token is zeroed; entry stays for audit.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "target_bot": {
+                    "type": "string",
+                    "description": "Username of the child bot to retire.",
+                },
+            },
+            "required": ["target_bot"],
+        },
+    },
+}
+
+
+# ── Tool: telegram_orchestrate_swarm ──────────────────────────────────
+
+
+def telegram_orchestrate_swarm(
+    objective: str,
+    subtasks: List[Dict[str, Any]],
+    report_chat_id: Optional[str] = None,
+    max_parallel: int = 8,
+    per_task_timeout_s: float = 600.0,
+    parent_agent: Any = None,
+    **_: Any,
+) -> str:
+    try:
+        coord = get_coordinator()
+        result = coord.orchestrate_swarm(
+            objective=objective,
+            subtasks=subtasks,
+            report_chat_id=str(report_chat_id) if report_chat_id else None,
+            max_parallel=int(max_parallel or 8),
+            per_task_timeout_s=float(per_task_timeout_s or 600.0),
+            parent_agent=parent_agent,
+        )
+    except FleetGuardrailError as e:
+        return tool_error(str(e), code="guardrail")
+    return json.dumps({"success": True, **result}, ensure_ascii=False)
+
+
+TELEGRAM_ORCHESTRATE_SWARM_SCHEMA = {
+    "type": "function",
+    "function": {
+        "name": "telegram_orchestrate_swarm",
+        "description": (
+            "Kimi-Agent-Swarm-style fan-out across the Telegram fleet.  YOU "
+            "are the leader — decompose the user's request into atomic "
+            "sub-tasks (one per persona/angle), then call this tool ONCE "
+            "with all of them.  Each sub-task runs in parallel as an "
+            "isolated Hermes sub-agent on behalf of one fleet member; if a "
+            "report_chat_id is set, every worker posts live status updates "
+            "to that chat as itself so the operator can watch.  Returns "
+            "aggregated structured results which YOU then synthesise into "
+            "the final user-facing answer.  Use this for any 'spin up a "
+            "swarm and report back' request — research a topic across N "
+            "angles, monitor N feeds in parallel, draft N variants, etc."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "objective": {
+                    "type": "string",
+                    "description": "The user's overall goal.  Included in each sub-agent's context for grounding.",
+                },
+                "subtasks": {
+                    "type": "array",
+                    "description": "Sub-tasks to fan out.  Each has at minimum a 'goal'.  Optional fields: 'persona' (override the bot's default persona for this task), 'bot_username' (pin to a specific fleet member; otherwise round-robin), 'context' (extra grounding), 'toolsets' (override allowed toolsets).",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "goal": {"type": "string"},
+                            "persona": {"type": "string"},
+                            "bot_username": {"type": "string"},
+                            "context": {"type": "string"},
+                            "toolsets": {"type": "array", "items": {"type": "string"}},
+                        },
+                        "required": ["goal"],
+                    },
+                },
+                "report_chat_id": {
+                    "type": "string",
+                    "description": "Optional Telegram chat where each fleet member will post live status updates as itself.  Lets the operator watch the swarm work.",
+                },
+                "max_parallel": {
+                    "type": "integer",
+                    "description": "Max sub-tasks to run concurrently.  Default 8.",
+                    "default": 8,
+                },
+                "per_task_timeout_s": {
+                    "type": "number",
+                    "description": "Per-sub-task timeout in seconds.  Default 600 (10 minutes).",
+                    "default": 600,
+                },
+            },
+            "required": ["objective", "subtasks"],
+        },
+    },
+}
+
+
+# ── Toolset availability check ─────────────────────────────────────────
+
+
+def _check_telegram_fleet_available() -> bool:
+    """Toolset is available when the operator has set the manager-bot token."""
+    if os.getenv("TELEGRAM_FLEET_MANAGER_TOKEN"):
+        return True
+    # Also accept a roster on disk that already has a manager configured —
+    # supports the "I configured this once via CLI" case without env vars.
+    try:
+        from gateway.telegram_fleet.roster import load_roster
+
+        return bool(load_roster().manager_bot_username)
+    except Exception:
+        return False
+
+
+# ── Registration ───────────────────────────────────────────────────────
+
+_TOOLSET = "telegram_fleet"
+
+registry.register(
+    name="telegram_spawn_bot",
+    toolset=_TOOLSET,
+    schema=TELEGRAM_SPAWN_BOT_SCHEMA,
+    handler=lambda args, **kw: telegram_spawn_bot(**args, **kw),
+    check_fn=_check_telegram_fleet_available,
+    requires_env=["TELEGRAM_FLEET_MANAGER_TOKEN"],
+    emoji="🤖",
+)
+registry.register(
+    name="telegram_fleet_list",
+    toolset=_TOOLSET,
+    schema=TELEGRAM_FLEET_LIST_SCHEMA,
+    handler=lambda args, **kw: telegram_fleet_list(**args, **kw),
+    check_fn=_check_telegram_fleet_available,
+    emoji="📋",
+)
+registry.register(
+    name="telegram_delegate",
+    toolset=_TOOLSET,
+    schema=TELEGRAM_DELEGATE_SCHEMA,
+    handler=lambda args, **kw: telegram_delegate(**args, **kw),
+    check_fn=_check_telegram_fleet_available,
+    emoji="📡",
+)
+registry.register(
+    name="telegram_rotate_bot_token",
+    toolset=_TOOLSET,
+    schema=TELEGRAM_ROTATE_TOKEN_SCHEMA,
+    handler=lambda args, **kw: telegram_rotate_bot_token(**args, **kw),
+    check_fn=_check_telegram_fleet_available,
+    emoji="🔄",
+)
+registry.register(
+    name="telegram_decommission_bot",
+    toolset=_TOOLSET,
+    schema=TELEGRAM_DECOMMISSION_SCHEMA,
+    handler=lambda args, **kw: telegram_decommission_bot(**args, **kw),
+    check_fn=_check_telegram_fleet_available,
+    emoji="🗑️",
+)
+registry.register(
+    name="telegram_orchestrate_swarm",
+    toolset=_TOOLSET,
+    schema=TELEGRAM_ORCHESTRATE_SWARM_SCHEMA,
+    handler=lambda args, **kw: telegram_orchestrate_swarm(**args, parent_agent=kw.get("parent_agent")),
+    check_fn=_check_telegram_fleet_available,
+    emoji="🌊",
+)

--- a/tools/telegram_fleet_tool.py
+++ b/tools/telegram_fleet_tool.py
@@ -376,10 +376,10 @@ TELEGRAM_ORCHESTRATE_SWARM_SCHEMA = {
     "function": {
         "name": "telegram_orchestrate_swarm",
         "description": (
-            "Kimi-Agent-Swarm-style fan-out across the Telegram fleet.  "
-            "Each subtask runs as a NAMED Telegram bot that may post "
-            "messages out into chats — this is the visible variant, "
-            "treat it as an outbound action.\n\n"
+            "Fan a task across the connected Telegram bot swarm.  Each "
+            "subtask runs as a NAMED child bot that posts updates out "
+            "into chats — this is the visible variant, treat it as an "
+            "outbound action.\n\n"
             "APPROVAL FLOW (mirrors `terminal_tool` force=True pattern):\n"
             "1. First call WITHOUT user_approved returns "
             "`status: approval_required` with a structured plan.\n"

--- a/tools/telegram_fleet_tool.py
+++ b/tools/telegram_fleet_tool.py
@@ -20,13 +20,11 @@ All tools are read-only against config — they only touch
 from __future__ import annotations
 
 import json
-import logging
 import os
 from typing import Any, Dict, List, Optional
 
 from gateway.telegram_fleet import (
     FleetApprovalRequired,
-    FleetCoordinator,
     FleetGuardrailError,
     RosterError,
     SpawnApprovalRequired,
@@ -34,8 +32,6 @@ from gateway.telegram_fleet import (
 )
 from gateway.telegram_fleet.api import BotApiError
 from tools.registry import registry, tool_error, tool_result
-
-logger = logging.getLogger(__name__)
 
 
 # ── Tool: telegram_spawn_bot ───────────────────────────────────────────
@@ -461,11 +457,19 @@ TELEGRAM_ORCHESTRATE_SWARM_SCHEMA = {
 
 
 def _check_telegram_fleet_available() -> bool:
-    """Toolset is available when the operator has set the manager-bot token."""
+    """Toolset is available when the manager-bot token env var is set.
+
+    API-calling tools (delegate, rotate, spawn, swarm) all require the token
+    at call time.  Reporting True when only the roster file exists would make
+    the tools appear available while every call fails with "no manager token".
+    """
+    return bool(os.getenv("TELEGRAM_FLEET_MANAGER_TOKEN"))
+
+
+def _check_fleet_read_available() -> bool:
+    """telegram_fleet_list only reads the roster — no API token required."""
     if os.getenv("TELEGRAM_FLEET_MANAGER_TOKEN"):
         return True
-    # Also accept a roster on disk that already has a manager configured —
-    # supports the "I configured this once via CLI" case without env vars.
     try:
         from gateway.telegram_fleet.roster import load_roster
 
@@ -492,7 +496,7 @@ registry.register(
     toolset=_TOOLSET,
     schema=TELEGRAM_FLEET_LIST_SCHEMA,
     handler=lambda args, **kw: telegram_fleet_list(**args, **kw),
-    check_fn=_check_telegram_fleet_available,
+    check_fn=_check_fleet_read_available,
     emoji="📋",
 )
 registry.register(

--- a/toolsets.py
+++ b/toolsets.py
@@ -132,7 +132,20 @@ TOOLSETS = {
         "tools": ["send_message"],
         "includes": []
     },
-    
+
+    "telegram_fleet": {
+        "description": "Orchestrate a swarm of Telegram bots through a manager bot — spawn child bots via the Bot API 9.6 Managed Bots flow, fan out subtasks across the fleet, aggregate findings",
+        "tools": [
+            "telegram_spawn_bot",
+            "telegram_fleet_list",
+            "telegram_delegate",
+            "telegram_rotate_bot_token",
+            "telegram_decommission_bot",
+            "telegram_orchestrate_swarm",
+        ],
+        "includes": [],
+    },
+
     "rl": {
         "description": "RL training tools for running reinforcement learning on Tinker-Atropos",
         "tools": [


### PR DESCRIPTION
## Summary

**Hermes orchestrates a swarm of Telegram bots through one connected manager bot.**

You connect a single Telegram bot to Hermes via `hermes fleet setup`.  After that, when you ask Hermes to do something that decomposes into parallel angles, it can fan the work out across a swarm of named child bots — each running on its own persona, posting status updates as itself into your chat.  The leader Hermes synthesises the structured results back into the final answer.

This is built on Telegram's new **Managed Bots** capability (Bot API 9.5/9.6, March–April 2026), which lets one bot programmatically create and own others.  Hermes is the orchestrator on top of that primitive.

For users who don't want the visible Telegram side, the same orchestration pattern is also available **in-process with zero setup** as `hermes_swarm`.

---

## End-state UX

```
You → Hermes:  \"research the impact of new EU AI regs across legal, market, tech\"

Hermes thinks: this decomposes into 3+ independent angles → swarm.
Hermes asks:   \"Run this across @legal_bot, @market_bot, @tech_bot,
                with a final @synth_bot to reconcile?  [Yes / Adjust / Cancel]\"
You:           Yes.

In your Telegram chat, four named bots start posting in parallel:
  @legal_bot:    ▶︎ starting: legal-text summary
  @market_bot:   ▶︎ starting: market sizing
  @tech_bot:     ▶︎ starting: feasibility review
  @synth_bot:    ▶︎ starting: synthesis...
  @legal_bot:    ✓ done: ...
  ...

Hermes:        Synthesised answer drawing on all four workers' findings.
```

You watched the swarm work, in real Telegram chats, as named identities you control.

---

---

## ⚠️ If you're testing this PR locally — a quick gotcha

If you run `hermes fleet setup` and see:

```
hermes: error: argument command: invalid choice: 'fleet'
(choose from 'chat', 'model', 'fallback', 'gateway', 'setup', ...)
```

…that means your `hermes` binary is still pointing at the released code, not this PR.  The `fleet` subcommand only exists on this branch.  Fix:

```bash
cd ~/.hermes/hermes-agent          # or wherever your editable install lives
git fetch origin pull/16227/head:pr-16227
git checkout pr-16227
hermes fleet --help                # should now list 'fleet' as an option
```

Editable installs read source live, so no `pip install` re-run is needed.  If `hermes fleet --help` still 404s after that:

1. Clear stale bytecode: `find ~/.hermes/hermes-agent -name __pycache__ -exec rm -rf {} +`
2. Make sure `which hermes` points at the venv inside `~/.hermes/hermes-agent` (not a system-wide install from a previous version).
3. Last resort: `cd ~/.hermes/hermes-agent && uv pip install -e ".[all]"`.

Once `hermes fleet --help` works, the rest of the flow below is the actual UX.


## Setup → Connect → Run

```bash
# 1. ONE-TIME — connect your manager bot to Hermes
$ hermes fleet setup
✓ Manager bot identified: @HermesSwarmMgr
✓ Bot Manager Mode is enabled — token can mint child bots.
✓ Saved roster to ~/.hermes/telegram_fleet.yaml (mode 0600).
✓ Saved TELEGRAM_FLEET_MANAGER_TOKEN to ~/.hermes/.env.

# 2a. PER FRESH WORKER — let the manager create a NEW child bot for you
$ hermes fleet add hermes_research_bot --persona \"research lead\" --wait 180
✓ Pending entry minted for @hermes_research_bot.
  Tap this link in Telegram to confirm:
  https://t.me/newbot/HermesSwarmMgr/hermes_research_bot?name=research%20lead
ℹ Watching Telegram for up to 180s for your tap...
✓ @hermes_research_bot confirmed and promoted to active (bot_id=12345).

# 2b. OR PER EXISTING WORKER — adopt a bot you already created in BotFather
$ hermes fleet adopt --token 12345:ABC... --persona \"research lead\"
✓ Adopted @hermes_research_bot into the fleet (bot_id=12345, status=active).
# Use `adopt` when `add` says \"username already taken\" (you created it
# manually first) or when you want existing bots in the swarm without going
# through the deep-link flow.

# 3. CHECK STATE
$ hermes fleet list
  ● @hermes_research_bot   active   research lead

# 4. USE IT
$ hermes chat -q \"spin up a swarm to research X across angles, stream updates to my Telegram\"
```

If something goes wrong, errors are translated into actionable hints — webhook conflicts (`409`), invalid token (`401`), Bot Manager Mode disabled (`403`).

The first call to the swarm tool always returns `approval_required` with a structured plan; Hermes surfaces it via `clarify` before running, so you confirm exactly which bots will post and what they'll work on.

---

## Two execution surfaces, one approval policy

| Tool | Setup | Side-effects | Approval gate |
|---|---|---|---|
| `hermes_swarm` (in-process) | **zero** | None — pure compute | Not needed (invisible) |
| `telegram_orchestrate_swarm` | one-tap manager bot | Named bots post messages | **Required** unless bypassed |

Approval bypasses (Hermes house style — mirrors `terminal_tool`'s `force=True`):

1. **`user_approved=True`** parameter (the standard path, after user confirms via `clarify`).
2. **Every subtask pins a `bot_username`** — by-name request, the user already named who they want.
3. **Operator override** — `telegram_fleet.auto_approve: true` or `TELEGRAM_FLEET_AUTO_APPROVE=1`.

---

## What's in the PR

### `gateway/telegram_fleet/` (orchestration package)

| Module | Purpose |
|---|---|
| `roster.py` | Durable YAML roster at `~/.hermes/telegram_fleet.yaml` (mode 0600, atomic writes, schema-versioned, TTL pruning) |
| `api.py` | httpx-based Bot API client — `getMe`, `getManagedBotToken`, `replaceManagedBotToken`, `getUpdates`/`drain_managed_bot_events`, send-as-child (PTB 22.7 doesn't yet expose 9.6 endpoints) |
| `audit.py` | Append-only JSONL audit log with token redaction |
| `guardrails.py` | Fleet-size cap, per-child sliding-window rate limit, spawn-approval gate |
| `coordinator.py` | `FleetCoordinator` singleton + Critical Path metrics + approval gate + `absorb_pending_updates()` |

### `tools/`

* **`hermes_swarm_tool.py`** — zero-config in-process swarm (the default). Anti-serialization guard rejects single-subtask plans.
* **`telegram_fleet_tool.py`** — 6 agent-facing tools: `telegram_spawn_bot`, `telegram_fleet_list`, `telegram_delegate`, `telegram_rotate_bot_token`, `telegram_decommission_bot`, `telegram_orchestrate_swarm` (with approval gate).

### `hermes_cli/fleet.py` (the setup story)

5 subcommands that take the operator from \"I have a manager bot token\" to \"my fleet is active\":

* `hermes fleet setup` — validate token + check Bot Manager Mode + persist
* `hermes fleet add <username> [--persona X] [--wait N]` — mint deep link, watch for the user's tap, auto-promote
* `hermes fleet connect [--wait N]` — drain `managed_bot` updates on demand
* `hermes fleet list` — pretty-print roster (tokens redacted)
* `hermes fleet status` — quick health check

### Discovery & guidance

* `skills/agents/swarm-orchestration/SKILL.md` — when to swarm, how to decompose, verifier-subtask pattern, approval flow walkthrough.  Cites prior art (hierarchical RL, Sutton Options, Feudal Networks, Moonshot PARL) in a footnote.
* `agent/prompt_builder.build_telegram_fleet_hint()` — Layer-4 roster injection (silent when nothing configured).

---

## Test plan — 151 tests, all passing

| File | Count | Coverage |
|---|---|---|
| `tests/gateway/test_telegram_fleet_roster.py` | 15 | schema, perms, TTL, malformed |
| `tests/gateway/test_telegram_fleet_api.py` | 14 | managed-bot endpoints + `getUpdates` + drain via `httpx.MockTransport` |
| `tests/gateway/test_telegram_fleet_guardrails.py` | 8 | cap, approval, rate limit |
| `tests/gateway/test_telegram_fleet_coordinator.py` | 17 | spawn/absorb/rotate/decom/orchestrate fan-out/pin/empty/per-task failure |
| `tests/gateway/test_telegram_fleet_approval.py` | 12 | gate denies / `user_approved` allows / by-name allows / partial-pin denies / env override / config.yaml override / token redaction / audit-event written |
| `tests/tools/test_telegram_fleet_tool.py` | 11 | every tool's success+error paths |
| `tests/tools/test_hermes_swarm_tool.py` | 10 | validation, anti-serialization, critical-path |
| `tests/agent/test_telegram_fleet_prompt_injection.py` | 6 | silent when not configured, emits roster when active |
| `tests/hermes_cli/test_fleet_command.py` | 17 | every CLI subcommand including connect's promote-on-tap path |

161 prompt-builder + skill tests still pass — no regression.

---

## Audit (real-world ready)

| # | Concern | Verdict |
|---|---|---|
| 1 | Race conditions on approval check | ✅ Param-level inspection after roster-lock binding |
| 2 | Backward compat | ✅ Single callsite, all paths updated |
| 3 | Token redaction in approval response | ✅ Pinned by `test_approval_response_does_not_leak_tokens` |
| 4 | Audit log coverage | ✅ `swarm_approval_required` event written + tested |
| 5 | Real-world connect path | ✅ Walks through real Bot API endpoints (`getMe` → `getUpdates` → `getManagedBotToken`); tested via `httpx.MockTransport` against documented schemas |
| 6 | Rough-edge handling | ✅ `_explain_bot_api_error` translates 409 (webhook/conflict), 401 (invalid token), 403 (Manager Mode disabled) into actionable hints |
| 7 | Cross-test pollution | ✅ Autouse `reset_coordinator` + `reset_rate_limits` |
| 8 | Skill clarity (model reads cold) | ✅ 3-step approval flow with concrete `clarify` example |
| 9 | Net regression vs main | ✅ 0 new failures (verified by stash-and-rerun) |

---

## Files

- 6 modules in `gateway/telegram_fleet/` (~1640 lines)
- 2 tool modules: `tools/hermes_swarm_tool.py`, `tools/telegram_fleet_tool.py`
- `hermes_cli/fleet.py` (~570 lines) — the setup CLI
- 1 skill, 1 prompt-builder helper + wiring in `run_agent.py`
- 9 test files (151 tests)
- `toolsets.py` — register `telegram_fleet`
- `tests/tools/test_registry.py` — updated discovery set

---

### Inspiration / prior art

The orchestration patterns (Critical Path metric, decoupled orchestrator + frozen workers, context sharding, verifier subtasks, anti-serialization guarding, 3–5 worker sweet spot) draw on hierarchical reinforcement learning (Sutton's Options framework, Feudal Networks), recent multi-agent scaling research, and Moonshot AI's published PARL methodology for Kimi K2.5/K2.6.  We adopt them as orchestration heuristics, not as a training regime — Hermes ships them as a framework on top of any LLM, paired with Telegram's new Managed Bots capability for the visible variant.

