### PR TITLE
fix(compressor): _prune_old_tool_results boundary direction

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -506,7 +506,16 @@ class ContextCompressor(ContextEngine):
                     break
                 accumulated += msg_tokens
                 boundary = i
-            prune_boundary = max(boundary, len(result) - min_protect)
+            # Translate the budget walk into a "protected count", apply the
+            # floor in count-space (where `max` reads naturally: protect at
+            # least `min_protect` messages or whatever the budget reserved,
+            # whichever is more), then convert back to a prune boundary.
+            # Doing this in index-space with `max` would invert the direction
+            # (smaller index = MORE protected), so a generous budget would
+            # silently get truncated back down to `min_protect`.
+            budget_protect_count = len(result) - boundary
+            protected_count = max(budget_protect_count, min_protect)
+            prune_boundary = len(result) - protected_count
         else:
             prune_boundary = len(result) - protect_tail_count
 

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -937,6 +937,47 @@ class TestTokenBudgetTailProtection:
         assert isinstance(cut, int)
         assert 0 <= cut <= len(messages)
 
+    def test_generous_budget_protects_everything_floor_does_not_override(
+        self, budget_compressor
+    ):
+        """A budget that covers the whole transcript must prune nothing —
+        ``protect_tail_count`` is a minimum floor, not a ceiling."""
+        c = budget_compressor
+
+        # 100 alternating assistant/tool messages.  Each tool result has
+        # *unique* content so the dedup pass (Pass 1, which is independent
+        # of prune_boundary) is a no-op and we isolate the boundary logic.
+        messages = []
+        for i in range(50):
+            messages.append({
+                "role": "assistant", "content": None,
+                "tool_calls": [{
+                    "id": f"c{i}",
+                    "type": "function",
+                    "function": {"name": "noop", "arguments": "{}"},
+                }],
+            })
+            messages.append({
+                "role": "tool",
+                "tool_call_id": f"c{i}",
+                "content": f"unique-tool-output-{i:03d}-" + ("x" * 250),
+            })
+
+        # Budget large enough to cover the whole transcript many times over,
+        # so the budget walk completes without hitting its break condition
+        # and the boundary lands at 0 ("protect everything").
+        _, pruned = c._prune_old_tool_results(
+            messages,
+            protect_tail_count=20,
+            protect_tail_tokens=10_000_000,
+        )
+
+        assert pruned == 0, (
+            "budget said protect everything, but the floor still pruned "
+            f"{pruned} messages — protect_tail_count is acting as a ceiling, "
+            "not a minimum floor"
+        )
+
 
 class TestUpdateModelBudgets:
     """Regression: update_model() must recalculate token budgets."""


### PR DESCRIPTION
## What does this PR do?

Fixes a count/index direction error in `_prune_old_tool_results`. The function's docstring promises "the token budget takes priority and the message count acts as a hard minimum floor", but the line

```python
prune_boundary = max(boundary, len(result) - min_protect)
```

did the opposite in index-space: when the budget walk reserved space for the whole transcript (`boundary == 0`), `max(0, len - min_protect)` truncated protection back down to `min_protect` messages and rewrote every older tool result with a one-line summary. Long-context Claude / Gemini runs silently shed tens of thousands of tokens of recent tool output the budget had room for.

The fix moves the calculation into count-space, where `max` reads naturally and matches the docstring's language. Behaviour is identical to the one-character `max → min` patch on every input, but the next reader doesn't have to re-derive that "min of indices == max of counts" in their head.

## Related Issue

N/A


## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/context_compressor.py`: replace `prune_boundary = max(...)` (index-space) with a 3-line count-space form; comment explains the inversion so it can't drift back.
- `tests/agent/test_context_compressor.py`: add `TestTokenBudgetTailProtection::test_generous_budget_protects_everything_floor_does_not_override` - a generous-budget transcript with unique tool outputs (so dedup is a no-op) must produce `pruned == 0`.


## How to Test

1. Run the targeted regression test:
   ```bash
   pytest tests/agent/test_context_compressor.py::TestTokenBudgetTailProtection::test_generous_budget_protects_everything_floor_does_not_override -q
   ```
2. Run the surrounding class to confirm the tight-budget paths still work (6 originals + 1 new = 7 tests):
   ```bash
   pytest tests/agent/test_context_compressor.py::TestTokenBudgetTailProtection -q
   ```
3. Confirm the new test is a real regression guard: stash the patch, re-run step 1, it fails with `pruned == 40`. `git stash pop`, re-run, it passes.


## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ pytest tests/agent/test_context_compressor.py::TestTokenBudgetTailProtection -q
.......                                                                  [100%]
7 passed, 7 warnings in 1.40s
```
