### PR TITLE
fix(logging): attach gateway log after cli init

### DIFF
--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -195,10 +195,6 @@ def setup_logging(
         The ``logs/`` directory where files are written.
     """
     global _logging_initialized
-    if _logging_initialized and not force:
-        home = hermes_home or get_hermes_home()
-        return home / "logs"
-
     home = hermes_home or get_hermes_home()
     log_dir = home / "logs"
     log_dir.mkdir(parents=True, exist_ok=True)
@@ -247,6 +243,9 @@ def setup_logging(
             formatter=RedactingFormatter(_LOG_FORMAT),
             log_filter=_ComponentFilter(COMPONENT_PREFIXES["gateway"]),
         )
+
+    if _logging_initialized and not force:
+        return log_dir
 
     # Ensure root logger level is low enough for the handlers to fire.
     if root.level == logging.NOTSET or root.level > level:

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -261,6 +261,42 @@ class TestGatewayMode:
         ]
         assert len(gw_handlers) == 0
 
+    def test_gateway_log_created_after_cli_init(self, hermes_home):
+        """Gateway mode attaches gateway.log even after earlier CLI init."""
+        hermes_logging.setup_logging(hermes_home=hermes_home, mode="cli")
+        hermes_logging.setup_logging(hermes_home=hermes_home, mode="gateway")
+
+        root = logging.getLogger()
+        gw_handlers = [
+            h for h in root.handlers
+            if isinstance(h, RotatingFileHandler)
+            and "gateway.log" in getattr(h, "baseFilename", "")
+        ]
+        assert len(gw_handlers) == 1
+
+        logging.getLogger("gateway.run").info("gateway connected after cli init")
+
+        for h in root.handlers:
+            h.flush()
+
+        gw_log = hermes_home / "logs" / "gateway.log"
+        assert gw_log.exists()
+        assert "gateway connected after cli init" in gw_log.read_text()
+
+    def test_gateway_log_created_after_cli_init_without_duplicate_handlers(self, hermes_home):
+        """Repeated gateway setup calls do not attach duplicate gateway handlers."""
+        hermes_logging.setup_logging(hermes_home=hermes_home, mode="cli")
+        hermes_logging.setup_logging(hermes_home=hermes_home, mode="gateway")
+        hermes_logging.setup_logging(hermes_home=hermes_home, mode="gateway")
+
+        root = logging.getLogger()
+        gw_handlers = [
+            h for h in root.handlers
+            if isinstance(h, RotatingFileHandler)
+            and "gateway.log" in getattr(h, "baseFilename", "")
+        ]
+        assert len(gw_handlers) == 1
+
     def test_gateway_log_receives_gateway_records(self, hermes_home):
         """gateway.log captures records from gateway.* loggers."""
         hermes_logging.setup_logging(hermes_home=hermes_home, mode="gateway")


### PR DESCRIPTION
## What does this PR do?

Fixes the `gateway.log` handler not being attached when logging is initialized in CLI mode before gateway startup.

The normal `hermes gateway run` path initializes logging early through the CLI entrypoint, then calls `setup_logging(mode="gateway")` later from `gateway/run.py`. Before this change, the second call returned immediately when `_logging_initialized` was already true, so the gateway-specific `gateway.log` handler was never attached.

This keeps logging setup idempotent, but allows a later gateway-mode call to attach the missing gateway handler. The existing rotating-handler helper already deduplicates by file path, so repeated gateway setup calls do not add duplicate handlers.

## Related Issue

Fixes #8404

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_logging.py`: move the idempotency return until after the gateway handler attachment path so `setup_logging(mode="gateway")` can add `gateway.log` after earlier CLI setup.
- `tests/test_hermes_logging.py`: add regression coverage for CLI → gateway initialization and repeated gateway setup calls.

## How to Test

1. Run `hermes_logging.setup_logging(mode="cli")`.
2. Run `hermes_logging.setup_logging(mode="gateway")`.
3. Verify exactly one `gateway.log` handler exists and receives `gateway.*` records.

Targeted test:

` .venv/bin/python -m pytest tests/test_hermes_logging.py -n 4 `

Result: `50 passed in 0.80s`

Full suite:

` .venv/bin/python -m pytest -n 4 `

Result: `108 failed, 16071 passed, 41 skipped, 210 warnings in 351.86s`

The full-suite failures are broad existing repo failures outside this logging change. Examples include API server default port/config expectations, gateway approval/Tirith setup, DingTalk mocked SDK behavior, broad Discord gateway tests, backup/profile restoration, web server schema, tool arg coercion, Tirith marker cleanup, and TUI provider tests. The targeted logging regression file passes.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this is not a duplicate; the previous fix PRs for #8404 were closed without merging
- [x] My PR contains only changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu/WSL

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact; this is Python logging setup shared by Docker/local gateway startup
- [x] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

Targeted test output: `50 passed in 0.80s`

Full-suite output: `108 failed, 16071 passed, 41 skipped, 210 warnings in 351.86s`