### PR TITLE
fix(stt): read local_command config from config.yaml, not just env var (#16185)

### DIFF
--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -409,6 +409,155 @@ class TestTranscribeLocalCommand:
         assert result["transcript"] == "hello from local command"
         assert result["provider"] == "local_command"
 
+    def test_reads_command_from_config_yaml(self, monkeypatch):
+        """stt.local_command.command in config.yaml is used when env var is absent."""
+        monkeypatch.delenv("HERMES_LOCAL_STT_COMMAND", raising=False)
+        monkeypatch.setattr("tools.transcription_tools._find_whisper_binary", lambda: None)
+        monkeypatch.setattr(
+            "tools.transcription_tools._load_stt_config",
+            lambda: {"local_command": {"command": "/opt/mywhisper {input_path}"}},
+        )
+
+        from tools.transcription_tools import _get_local_command_template
+
+        template = _get_local_command_template()
+
+        assert template == "/opt/mywhisper {input_path}"
+
+    def test_env_var_takes_precedence_over_config(self, monkeypatch):
+        """HERMES_LOCAL_STT_COMMAND env var wins over stt.local_command.command."""
+        monkeypatch.setenv("HERMES_LOCAL_STT_COMMAND", "/env/whisper {input_path}")
+        monkeypatch.setattr(
+            "tools.transcription_tools._load_stt_config",
+            lambda: {"local_command": {"command": "/config/whisper {input_path}"}},
+        )
+
+        from tools.transcription_tools import _get_local_command_template
+
+        template = _get_local_command_template()
+
+        assert template == "/env/whisper {input_path}"
+
+    def test_file_placeholder_alias(self, monkeypatch, sample_ogg, tmp_path):
+        """{file} is accepted as an alias for {input_path}."""
+        out_dir = tmp_path / "local-out"
+        out_dir.mkdir()
+
+        monkeypatch.delenv("HERMES_LOCAL_STT_COMMAND", raising=False)
+        monkeypatch.setattr(
+            "tools.transcription_tools._load_stt_config",
+            lambda: {"local_command": {"command": '/opt/mywhisper "{file}"'}},
+        )
+
+        captured = []
+
+        def fake_tempdir(prefix=None):
+            class _TempDir:
+                def __enter__(self_inner):
+                    return str(out_dir)
+
+                def __exit__(self_inner, *_):
+                    return False
+
+            return _TempDir()
+
+        def fake_run(cmd, *args, **kwargs):
+            if isinstance(cmd, list):
+                # ffmpeg conversion call — write a dummy WAV so prepare succeeds
+                converted = cmd[-1]
+                with open(converted, "wb") as fh:
+                    fh.write(b"RIFF\x00\x00\x00\x00WAVEfmt ")
+            else:
+                captured.append(cmd)
+                (out_dir / "audio.txt").write_text("transcribed via file alias\n", encoding="utf-8")
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        monkeypatch.setattr("tools.transcription_tools.tempfile.TemporaryDirectory", fake_tempdir)
+        monkeypatch.setattr("tools.transcription_tools._find_ffmpeg_binary", lambda: "/usr/bin/ffmpeg")
+        monkeypatch.setattr("tools.transcription_tools.subprocess.run", fake_run)
+
+        from tools.transcription_tools import _transcribe_local_command
+
+        result = _transcribe_local_command(sample_ogg, "base")
+
+        assert result["success"] is True
+        assert result["transcript"] == "transcribed via file alias"
+        # The shell command must not contain the literal {file} placeholder
+        assert captured and "{file}" not in captured[0]
+
+    def test_language_from_local_command_config(self, monkeypatch, sample_ogg, tmp_path):
+        """stt.local_command.language is passed to the command."""
+        out_dir = tmp_path / "local-out"
+        out_dir.mkdir()
+
+        monkeypatch.delenv("HERMES_LOCAL_STT_COMMAND", raising=False)
+        monkeypatch.delenv("HERMES_LOCAL_STT_LANGUAGE", raising=False)
+
+        captured = []
+
+        monkeypatch.setattr(
+            "tools.transcription_tools._load_stt_config",
+            lambda: {
+                "local_command": {
+                    "command": "whisper {input_path} --language {language} --output_dir {output_dir}",
+                    "language": "ru",
+                }
+            },
+        )
+
+        def fake_tempdir(prefix=None):
+            class _TempDir:
+                def __enter__(self_inner):
+                    return str(out_dir)
+
+                def __exit__(self_inner, *_):
+                    return False
+
+            return _TempDir()
+
+        def fake_run(cmd, *args, **kwargs):
+            if isinstance(cmd, list):
+                converted = cmd[-1]
+                with open(converted, "wb") as fh:
+                    fh.write(b"RIFF\x00\x00\x00\x00WAVEfmt ")
+            else:
+                captured.append(cmd)
+                (out_dir / "audio.txt").write_text("здравствуйте\n", encoding="utf-8")
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        monkeypatch.setattr("tools.transcription_tools.tempfile.TemporaryDirectory", fake_tempdir)
+        monkeypatch.setattr("tools.transcription_tools._find_ffmpeg_binary", lambda: "/usr/bin/ffmpeg")
+        monkeypatch.setattr("tools.transcription_tools.subprocess.run", fake_run)
+
+        from tools.transcription_tools import _transcribe_local_command
+
+        result = _transcribe_local_command(sample_ogg, "small")
+
+        assert result["success"] is True
+        assert captured and "ru" in captured[0]
+
+    def test_model_from_local_command_config(self, monkeypatch, sample_ogg):
+        """stt.local_command.model is used for provider=local_command."""
+        import tools.transcription_tools as ttools
+
+        calls = []
+
+        def fake_transcribe(file_path, model_name):
+            calls.append(model_name)
+            return {"success": True, "transcript": "ok", "provider": "local_command"}
+
+        monkeypatch.setattr(ttools, "_transcribe_local_command", fake_transcribe)
+        monkeypatch.setattr(ttools, "_get_provider", lambda _cfg: "local_command")
+        monkeypatch.setattr(
+            ttools,
+            "_load_stt_config",
+            lambda: {"provider": "local_command", "local_command": {"model": "small"}},
+        )
+
+        ttools.transcribe_audio(str(sample_ogg))
+
+        assert calls == ["small"]
+
 
 # ============================================================================
 # _transcribe_local — additional tests

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -146,9 +146,16 @@ def _find_whisper_binary() -> Optional[str]:
 
 
 def _get_local_command_template() -> Optional[str]:
+    # HERMES_LOCAL_STT_COMMAND env var wins so deploy-time overrides work.
     configured = os.getenv(LOCAL_STT_COMMAND_ENV, "").strip()
     if configured:
         return configured
+
+    # Fall back to stt.local_command.command in config.yaml so users can set
+    # the wrapper path without needing a separate shell environment.
+    config_command = _load_stt_config().get("local_command", {}).get("command", "").strip()
+    if config_command:
+        return config_command
 
     whisper_binary = _find_whisper_binary()
     if whisper_binary:
@@ -473,9 +480,11 @@ def _transcribe_local_command(file_path: str, model_name: str) -> Dict[str, Any]
             ),
         }
 
-    # Language: config.yaml (stt.local.language) > env var > "en" default.
+    # Language: stt.local_command.language > stt.local.language > env var > default.
+    _stt_cfg = _load_stt_config()
     language = (
-        _load_stt_config().get("local", {}).get("language")
+        _stt_cfg.get("local_command", {}).get("language")
+        or _stt_cfg.get("local", {}).get("language")
         or os.getenv(LOCAL_STT_LANGUAGE_ENV)
         or DEFAULT_LOCAL_STT_LANGUAGE
     )
@@ -487,7 +496,11 @@ def _transcribe_local_command(file_path: str, model_name: str) -> Dict[str, Any]
             if prep_error:
                 return {"success": False, "transcript": "", "error": prep_error}
 
-            command = command_template.format(
+            # {file} is accepted as a friendlier alias for {input_path} so that
+            # simple wrapper scripts like `whisper "{file}"` work without the
+            # full placeholder set.
+            normalized_template = command_template.replace("{file}", "{input_path}")
+            command = normalized_template.format(
                 input_path=shlex.quote(prepared_input),
                 output_dir=shlex.quote(output_dir),
                 language=shlex.quote(language),
@@ -821,9 +834,11 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
         return _transcribe_local(file_path, model_name)
 
     if provider == "local_command":
-        local_cfg = stt_config.get("local", {})
+        local_command_cfg = stt_config.get("local_command", {})
         model_name = _normalize_local_command_model(
-            model or local_cfg.get("model", DEFAULT_LOCAL_MODEL)
+            model
+            or local_command_cfg.get("model")
+            or stt_config.get("local", {}).get("model", DEFAULT_LOCAL_MODEL)
         )
         return _transcribe_local_command(file_path, model_name)
 

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -145,7 +145,7 @@ def _find_whisper_binary() -> Optional[str]:
     return _find_binary("whisper")
 
 
-def _get_local_command_template() -> Optional[str]:
+def _get_local_command_template(stt_config: Optional[dict] = None) -> Optional[str]:
     # HERMES_LOCAL_STT_COMMAND env var wins so deploy-time overrides work.
     configured = os.getenv(LOCAL_STT_COMMAND_ENV, "").strip()
     if configured:
@@ -153,7 +153,9 @@ def _get_local_command_template() -> Optional[str]:
 
     # Fall back to stt.local_command.command in config.yaml so users can set
     # the wrapper path without needing a separate shell environment.
-    config_command = _load_stt_config().get("local_command", {}).get("command", "").strip()
+    cfg = stt_config if stt_config is not None else _load_stt_config()
+    raw_command = cfg.get("local_command", {}).get("command")
+    config_command = raw_command.strip() if isinstance(raw_command, str) else ""
     if config_command:
         return config_command
 
@@ -470,7 +472,10 @@ def _prepare_local_audio(file_path: str, work_dir: str) -> tuple[Optional[str], 
 
 def _transcribe_local_command(file_path: str, model_name: str) -> Dict[str, Any]:
     """Run the configured local STT command template and read back a .txt transcript."""
-    command_template = _get_local_command_template()
+    # Load config once and share with _get_local_command_template to avoid
+    # two load_config() calls per transcription request.
+    _stt_cfg = _load_stt_config()
+    command_template = _get_local_command_template(_stt_cfg)
     if not command_template:
         return {
             "success": False,
@@ -481,7 +486,6 @@ def _transcribe_local_command(file_path: str, model_name: str) -> Dict[str, Any]
         }
 
     # Language: stt.local_command.language > stt.local.language > env var > default.
-    _stt_cfg = _load_stt_config()
     language = (
         _stt_cfg.get("local_command", {}).get("language")
         or _stt_cfg.get("local", {}).get("language")


### PR DESCRIPTION
## Summary
- `stt.local_command.command` in `config.yaml` was silently ignored; `_get_local_command_template()` only checked the `HERMES_LOCAL_STT_COMMAND` env var and a binary auto-detect
- Model and language under `stt.local_command.*` were also not read; the code read from `stt.local.*` instead
- `{file}` placeholder (natural alias for `{input_path}`) caused a `KeyError` when used in wrapper scripts

## The bug

`tools/transcription_tools.py:_get_local_command_template()` (line ~142) read only from `HERMES_LOCAL_STT_COMMAND` and the binary auto-detect.  Users who put their wrapper path in `config.yaml` as `stt.local_command.command` saw the provider silently fall back to `"none"` and voice messages were never transcribed.

Two sibling gaps existed in the same code path:
- `_transcribe_local_command()` resolved language from `stt.local.language` instead of `stt.local_command.language`
- `transcribe_audio()` resolved model from `stt.local.model` instead of `stt.local_command.model`

## The fix

`_get_local_command_template()` now checks `stt.local_command.command` from config.yaml as a fallback between the env var and binary auto-detect:

```
HERMES_LOCAL_STT_COMMAND (env) > stt.local_command.command (config) > binary auto-detect
```

Model and language resolution in `_transcribe_local_command` and `transcribe_audio` now check `stt.local_command.*` before `stt.local.*`.

`{file}` is now normalized to `{input_path}` before the template `.format()` call, so wrappers configured as `whisper "{file}"` work without needing the full `{output_dir}`/`{model}` placeholder set.

## Test plan
- [x] **Before** (`_get_local_command_template` with config set, no env var): returns `None` → provider falls back to `"none"` → no transcription
- [x] **After**: returns the command from config.yaml correctly
- [x] **Regression guard**: reverted `_get_local_command_template` to original → `test_reads_command_from_config_yaml` fails; restored → 0 failures
- [x] **`test_env_var_takes_precedence_over_config`**: env var still wins over config.yaml
- [x] **`test_file_placeholder_alias`**: `{file}` alias resolves correctly in the shell command
- [x] **`test_language_from_local_command_config`**: `stt.local_command.language` is passed to the command
- [x] **`test_model_from_local_command_config`**: `stt.local_command.model` is used in `transcribe_audio`
- [x] 90 total tests pass; 7 pre-existing baseline failures (`faster_whisper` not installed) unchanged

## Related
- Fixes #16185

🤖 Generated with [Claude Code](https://claude.com/claude-code)