### PR TITLE
fix(timeouts): guard load_config() call against runtime exceptions

### DIFF
--- a/hermes_cli/timeouts.py
+++ b/hermes_cli/timeouts.py
@@ -20,10 +20,10 @@ def get_provider_request_timeout(
 
     try:
         from hermes_cli.config import load_config
-    except ImportError:
+        config = load_config()
+    except (ImportError, Exception):
         return None
 
-    config = load_config()
     providers = config.get("providers", {}) if isinstance(config, dict) else {}
     provider_config = (
         providers.get(provider_id, {}) if isinstance(providers, dict) else {}
@@ -49,10 +49,10 @@ def get_provider_stale_timeout(
 
     try:
         from hermes_cli.config import load_config
-    except ImportError:
+        config = load_config()
+    except (ImportError, Exception):
         return None
 
-    config = load_config()
     providers = config.get("providers", {}) if isinstance(config, dict) else {}
     provider_config = (
         providers.get(provider_id, {}) if isinstance(providers, dict) else {}


### PR DESCRIPTION
## What does this PR do?

Both `get_provider_request_timeout()` and `get_provider_stale_timeout()` in `hermes_cli/timeouts.py` wrapped the `load_config` import in `try/except ImportError` but left the actual `load_config()` call unprotected outside the block.

## Type of Change
- [x] Bug fix

## Root Cause

If `load_config()` raises at runtime (corrupt YAML, parse error, permission failure), the exception propagates up instead of returning `None` safely — breaking any provider timeout resolution silently.

## Changes Made

- Moved `load_config()` call inside the `try` block in both functions
- Broadened the except clause to `(ImportError, Exception)` to catch all failure modes
- Both functions now return `None` safely on any config load failure

## How to Test

1. Write malformed YAML to `~/.hermes/config.yaml`
2. Call `get_provider_request_timeout("openai")`
3. Before: raises exception
4. After: returns `None` safely

## Checklist
- [x] No new dependencies
- [x] Both functions fixed with the same pattern
- [x] Only touches the try/except blocks in `hermes_cli/timeouts.py`