### PR TITLE
Add gateway TurnContract profiles

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -41,6 +41,38 @@ from agent.account_usage import fetch_account_usage, render_account_usage_lines
 _AGENT_CACHE_MAX_SIZE = 128
 _AGENT_CACHE_IDLE_TTL_SECS = 3600.0  # evict agents idle for >1h
 
+
+def _agent_timeout_idle_seconds(activity_summary: dict[str, Any]) -> float:
+    """Return idle seconds for timeout decisions.
+
+    ``seconds_since_activity`` includes status heartbeats. Newer agents expose
+    ``seconds_since_progress`` so no-answer provider waits cannot mask live-turn
+    timeout indefinitely.
+    """
+    value = activity_summary.get(
+        "seconds_since_progress",
+        activity_summary.get("seconds_since_activity", 0.0),
+    )
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _format_timeout_duration(seconds: float) -> str:
+    """Render timeout durations without rounding 30s up to 1 minute."""
+    try:
+        value = max(0, int(round(float(seconds))))
+    except (TypeError, ValueError):
+        value = 0
+    if value < 60:
+        return f"{value}s"
+    minutes, remainder = divmod(value, 60)
+    if remainder:
+        return f"{minutes}m {remainder}s"
+    return f"{minutes}m"
+
+
 # ---------------------------------------------------------------------------
 # SSL certificate auto-detection for NixOS and other non-standard systems.
 # Must run BEFORE any HTTP library (discord, aiohttp, etc.) is imported.
@@ -591,20 +623,20 @@ def _parse_session_key(session_key: str) -> "dict | None":
 
 
 def _format_gateway_process_notification(evt: dict) -> "str | None":
-    """Format a watch pattern event from completion_queue into a [IMPORTANT:] message."""
+    """Format a watch pattern event from completion_queue into a [SYSTEM:] message."""
     evt_type = evt.get("type", "completion")
     _sid = evt.get("session_id", "unknown")
     _cmd = evt.get("command", "unknown")
 
     if evt_type == "watch_disabled":
-        return f"[IMPORTANT: {evt.get('message', '')}]"
+        return f"[SYSTEM: {evt.get('message', '')}]"
 
     if evt_type == "watch_match":
         _pat = evt.get("pattern", "?")
         _out = evt.get("output", "")
         _sup = evt.get("suppressed", 0)
         text = (
-            f"[IMPORTANT: Background process {_sid} matched "
+            f"[SYSTEM: Background process {_sid} matched "
             f"watch pattern \"{_pat}\".\n"
             f"Command: {_cmd}\n"
             f"Matched output:\n{_out}"
@@ -682,16 +714,6 @@ class GatewayRunner:
         self._running_agents: Dict[str, Any] = {}
         self._running_agents_ts: Dict[str, float] = {}  # start timestamp per session
         self._pending_messages: Dict[str, str] = {}  # Queued messages during interrupt
-        # Overflow buffer for explicit /queue commands.  The adapter-level
-        # _pending_messages dict is a single slot per session (designed for
-        # "next-turn" follow-ups where repeated sends collapse into one
-        # event).  /queue has different semantics: each invocation must
-        # produce its own full agent turn, in FIFO order, with no merging.
-        # When the slot is occupied, additional /queue items land here and
-        # are promoted one-at-a-time after each run's drain.  Cleared on
-        # /new and /reset.  /model and other mid-session operations
-        # preserve the queue.
-        self._queued_events: Dict[str, List[MessageEvent]] = {}
         self._busy_ack_ts: Dict[str, float] = {}  # last busy-ack timestamp per session (debounce)
         self._session_run_generation: Dict[str, int] = {}
 
@@ -891,74 +913,23 @@ class GatewayRunner:
             return
         if disabled:
             disabled_chats.add(chat_id)
-            # ``/voice off`` also clears any explicit enable — it's a hard override.
-            enabled_chats = getattr(adapter, "_auto_tts_enabled_chats", None)
-            if isinstance(enabled_chats, set):
-                enabled_chats.discard(chat_id)
         else:
             disabled_chats.discard(chat_id)
 
-    def _set_adapter_auto_tts_enabled(self, adapter, chat_id: str, enabled: bool) -> None:
-        """Update an adapter's per-chat auto-TTS opt-in set if present.
-
-        Used for ``/voice on``/``/voice tts`` where the user explicitly wants
-        auto-TTS even when ``voice.auto_tts`` is False globally.
-        """
-        enabled_chats = getattr(adapter, "_auto_tts_enabled_chats", None)
-        if not isinstance(enabled_chats, set):
-            return
-        if enabled:
-            enabled_chats.add(chat_id)
-            # An explicit opt-in clears any stale /voice off for this chat.
-            disabled_chats = getattr(adapter, "_auto_tts_disabled_chats", None)
-            if isinstance(disabled_chats, set):
-                disabled_chats.discard(chat_id)
-        else:
-            enabled_chats.discard(chat_id)
-
     def _sync_voice_mode_state_to_adapter(self, adapter) -> None:
-        """Restore persisted /voice state into a live platform adapter.
-
-        Populates three fields from config + ``self._voice_mode``:
-          - ``_auto_tts_default``: global default from ``voice.auto_tts``
-          - ``_auto_tts_enabled_chats``: chats with mode ``voice_only``/``all``
-          - ``_auto_tts_disabled_chats``: chats with mode ``off``
-        """
+        """Restore persisted /voice off state into a live platform adapter."""
+        disabled_chats = getattr(adapter, "_auto_tts_disabled_chats", None)
+        if not isinstance(disabled_chats, set):
+            return
         platform = getattr(adapter, "platform", None)
         if not isinstance(platform, Platform):
             return
-
-        disabled_chats = getattr(adapter, "_auto_tts_disabled_chats", None)
-        enabled_chats = getattr(adapter, "_auto_tts_enabled_chats", None)
-        if not isinstance(disabled_chats, set) and not isinstance(enabled_chats, set):
-            return
-
-        # Push the global voice.auto_tts default (config.yaml) onto the adapter.
-        # Lazy import to avoid adding a module-level dep from gateway → hermes_cli.
-        try:
-            from hermes_cli.config import load_config as _load_full_config
-            _full_cfg = _load_full_config()
-            _auto_tts_default = bool(
-                (_full_cfg.get("voice") or {}).get("auto_tts", False)
-            )
-        except Exception:
-            _auto_tts_default = False
-        if hasattr(adapter, "_auto_tts_default"):
-            adapter._auto_tts_default = _auto_tts_default
-
+        disabled_chats.clear()
         prefix = f"{platform.value}:"
-        if isinstance(disabled_chats, set):
-            disabled_chats.clear()
-            disabled_chats.update(
-                key[len(prefix):] for key, mode in self._voice_mode.items()
-                if mode == "off" and key.startswith(prefix)
-            )
-        if isinstance(enabled_chats, set):
-            enabled_chats.clear()
-            enabled_chats.update(
-                key[len(prefix):] for key, mode in self._voice_mode.items()
-                if mode in ("voice_only", "all") and key.startswith(prefix)
-            )
+        disabled_chats.update(
+            key[len(prefix):] for key, mode in self._voice_mode.items()
+            if mode == "off" and key.startswith(prefix)
+        )
 
     async def _safe_adapter_disconnect(self, adapter, platform) -> None:
         """Call adapter.disconnect() defensively, swallowing any error.
@@ -1213,76 +1184,6 @@ class GatewayRunner:
 
     def _queue_during_drain_enabled(self) -> bool:
         return self._restart_requested and self._busy_input_mode == "queue"
-
-    # -------- /queue FIFO helpers --------------------------------------
-    # /queue must produce one full agent turn per invocation, in FIFO
-    # order, with no merging.  The adapter's _pending_messages dict is a
-    # single "next-up" slot (shared with photo-burst follow-ups), so we
-    # use it for the head of the queue and an overflow list for the
-    # tail.  Enqueue puts new items in the slot when free, otherwise in
-    # the overflow.  Promotion (called after each run's drain) moves the
-    # next overflow item into the slot so the following recursion picks
-    # it up.  Clearing happens on /new and /reset via
-    # _handle_reset_command.
-
-    def _enqueue_fifo(self, session_key: str, queued_event: "MessageEvent", adapter: Any) -> None:
-        """Append a /queue event to the FIFO chain for a session."""
-        if adapter is None:
-            return
-        pending_slot = getattr(adapter, "_pending_messages", None)
-        if pending_slot is None:
-            return
-        queued_events = getattr(self, "_queued_events", None)
-        if queued_events is None:
-            queued_events = {}
-            self._queued_events = queued_events
-        if session_key in pending_slot:
-            queued_events.setdefault(session_key, []).append(queued_event)
-        else:
-            pending_slot[session_key] = queued_event
-
-    def _promote_queued_event(
-        self,
-        session_key: str,
-        adapter: Any,
-        pending_event: Optional["MessageEvent"],
-    ) -> Optional["MessageEvent"]:
-        """Promote the next overflow item after the slot was drained.
-
-        Called at the drain site after _dequeue_pending_event consumed
-        (or failed to consume) the slot.  If there's an overflow item:
-          - When pending_event is None (slot was empty), return the
-            overflow head as the new pending_event.
-          - When pending_event already exists (slot was populated by an
-            interrupt follow-up or similar), stage the overflow head in
-            the slot so the NEXT recursion picks it up.
-        Returns the (possibly updated) pending_event for drain to use.
-        """
-        queued_events = getattr(self, "_queued_events", None)
-        if not queued_events:
-            return pending_event
-        overflow = queued_events.get(session_key)
-        if not overflow:
-            return pending_event
-        next_queued = overflow.pop(0)
-        if not overflow:
-            queued_events.pop(session_key, None)
-        if pending_event is None:
-            return next_queued
-        if adapter is not None and hasattr(adapter, "_pending_messages"):
-            adapter._pending_messages[session_key] = next_queued
-        else:
-            # No adapter — push back so we don't silently drop the item.
-            queued_events.setdefault(session_key, []).insert(0, next_queued)
-        return pending_event
-
-    def _queue_depth(self, session_key: str, *, adapter: Any = None) -> int:
-        """Total pending /queue items for a session — slot + overflow."""
-        queued_events = getattr(self, "_queued_events", None) or {}
-        depth = len(queued_events.get(session_key, []))
-        if adapter is not None and session_key in getattr(adapter, "_pending_messages", {}):
-            depth += 1
-        return depth
 
     def _update_runtime_status(self, gateway_state: Optional[str] = None, exit_reason: Optional[str] = None) -> None:
         try:
@@ -1709,27 +1610,6 @@ class GatewayRunner:
                 f"⚡ Interrupting current task{status_detail}. "
                 f"I'll respond to your message shortly."
             )
-
-        # First-touch onboarding: the very first time a user sends a message
-        # while the agent is busy, append a one-time hint explaining the
-        # queue/interrupt knob.  Flag is persisted to config.yaml so it never
-        # fires again on this install.
-        try:
-            from agent.onboarding import (
-                BUSY_INPUT_FLAG,
-                busy_input_hint_gateway,
-                is_seen,
-                mark_seen,
-            )
-            _user_cfg = _load_gateway_config()
-            if not is_seen(_user_cfg, BUSY_INPUT_FLAG):
-                message = (
-                    f"{message}\n\n"
-                    f"{busy_input_hint_gateway('queue' if is_queue_mode else 'interrupt')}"
-                )
-                mark_seen(_hermes_home / "config.yaml", BUSY_INPUT_FLAG)
-        except Exception as _onb_err:
-            logger.debug("Failed to apply busy-input onboarding hint: %s", _onb_err)
 
         thread_meta = {"thread_id": event.source.thread_id} if event.source.thread_id else None
         try:
@@ -2334,7 +2214,7 @@ class GatewayRunner:
         # Build initial channel directory for send_message name resolution
         try:
             from gateway.channel_directory import build_channel_directory
-            directory = await build_channel_directory(self.adapters)
+            directory = build_channel_directory(self.adapters)
             ch_count = sum(len(chs) for chs in directory.get("platforms", {}).values())
             logger.info("Channel directory built: %d target(s)", ch_count)
         except Exception as e:
@@ -2618,7 +2498,7 @@ class GatewayRunner:
                         # Rebuild channel directory with the new adapter
                         try:
                             from gateway.channel_directory import build_channel_directory
-                            await build_channel_directory(self.adapters)
+                            build_channel_directory(self.adapters)
                         except Exception:
                             pass
                     else:
@@ -2799,23 +2679,6 @@ class GatewayRunner:
                     logger.error("Failed to launch detached gateway restart: %s", e)
 
             self._finalize_shutdown_agents(active_agents)
-
-            # Also shut down memory providers on idle cached agents.
-            # _finalize_shutdown_agents only handles agents that were
-            # mid-turn at drain time; the _agent_cache may still hold
-            # idle agents whose MemoryProviders never received
-            # on_session_end().
-            _cache_lock = getattr(self, "_agent_cache_lock", None)
-            _cache = getattr(self, "_agent_cache", None)
-            if _cache_lock is not None and _cache is not None:
-                with _cache_lock:
-                    _idle_agents = list(_cache.values())
-                    _cache.clear()
-                for _entry in _idle_agents:
-                    _agent = (
-                        _entry[0] if isinstance(_entry, tuple) else _entry
-                    )
-                    self._cleanup_agent_resources(_agent)
 
             for platform, adapter in list(self.adapters.items()):
                 try:
@@ -3432,9 +3295,11 @@ class GatewayRunner:
             if _stale_agent and hasattr(_stale_agent, "get_activity_summary"):
                 try:
                     _sa = _stale_agent.get_activity_summary()
-                    _stale_idle = _sa.get("seconds_since_activity", float("inf"))
+                    _stale_idle = _agent_timeout_idle_seconds(_sa)
                     _stale_detail = (
                         f" | last_activity={_sa.get('last_activity_desc', 'unknown')} "
+                        f"({_sa.get('seconds_since_activity', 0):.0f}s ago) "
+                        f"| last_progress={_sa.get('last_progress_activity_desc', _sa.get('last_activity_desc', 'unknown'))} "
                         f"({_stale_idle:.0f}s ago) "
                         f"| iteration={_sa.get('api_call_count', 0)}/{_sa.get('max_iterations', 0)}"
                     )
@@ -3513,10 +3378,7 @@ class GatewayRunner:
                 # doesn't think an agent is still active.
                 return await self._handle_reset_command(event)
 
-            # /queue <prompt> — queue without interrupting.
-            # Semantics: each /queue invocation produces its own full agent
-            # turn, processed in FIFO order after the current run (and any
-            # earlier /queue items) finishes.  Messages are NOT merged.
+            # /queue <prompt> — queue without interrupting
             if event.get_command() in ("queue", "q"):
                 queued_text = event.get_command_args().strip()
                 if not queued_text:
@@ -3530,11 +3392,8 @@ class GatewayRunner:
                         message_id=event.message_id,
                         channel_prompt=event.channel_prompt,
                     )
-                    self._enqueue_fifo(_quick_key, queued_event, adapter)
-                depth = self._queue_depth(_quick_key, adapter=self.adapters.get(source.platform))
-                if depth <= 1:
-                    return "Queued for the next turn."
-                return f"Queued for the next turn. ({depth} queued)"
+                    adapter._pending_messages[_quick_key] = queued_event
+                return "Queued for the next turn."
 
             # /steer <prompt> — inject mid-run after the next tool call.
             # Unlike /queue (turn boundary), /steer lands BETWEEN tool-call
@@ -3601,8 +3460,6 @@ class GatewayRunner:
 
             # /background must bypass the running-agent guard — it starts a
             # parallel task and must never interrupt the active conversation.
-            # /btw is an alias of /background and resolves to the same canonical
-            # name, so this branch handles both commands.
             if _cmd_def_inner and _cmd_def_inner.name == "background":
                 return await self._handle_background_command(event)
 
@@ -3877,6 +3734,9 @@ class GatewayRunner:
 
         if canonical == "background":
             return await self._handle_background_command(event)
+
+        if canonical == "btw":
+            return await self._handle_btw_command(event)
 
         if canonical == "steer":
             # No active agent — /steer has no tool call to inject into.
@@ -4335,7 +4195,7 @@ class GatewayRunner:
                     if _loaded:
                         _loaded_skill, _skill_dir, _display_name = _loaded
                         _note = (
-                            f'[IMPORTANT: The "{_display_name}" skill is auto-loaded. '
+                            f'[SYSTEM: The "{_display_name}" skill is auto-loaded. '
                             f"Follow its instructions for this session.]"
                         )
                         _part = _build_skill_message(_loaded_skill, _skill_dir, _note)
@@ -4623,20 +4483,12 @@ class GatewayRunner:
             if not os.getenv(env_key):
                 adapter = self.adapters.get(source.platform)
                 if adapter:
-                    # Slack dispatches all Hermes commands through a single
-                    # parent slash command `/hermes`; bare `/sethome` is not
-                    # registered and would fail with "app did not respond".
-                    sethome_cmd = (
-                        "/hermes sethome"
-                        if source.platform == Platform.SLACK
-                        else "/sethome"
-                    )
                     await adapter.send(
                         source.chat_id,
                         f"📬 No home channel is set for {platform_name.title()}. "
                         f"A home channel is where Hermes delivers cron job results "
                         f"and cross-platform messages.\n\n"
-                        f"Type {sethome_cmd} to make this chat your home channel, "
+                        f"Type /sethome to make this chat your home channel, "
                         f"or ignore to skip."
                     )
         
@@ -5169,13 +5021,6 @@ class GatewayRunner:
                 self._cleanup_agent_resources(_old_agent)
         self._evict_cached_agent(session_key)
 
-        # Discard any /queue overflow for this session — /new is a
-        # conversation-boundary operation, queued follow-ups from the
-        # previous conversation must not bleed into the new one.
-        _qe = getattr(self, "_queued_events", None)
-        if _qe is not None:
-            _qe.pop(session_key, None)
-
         try:
             from tools.env_passthrough import clear_env_passthrough
             clear_env_passthrough()
@@ -5283,10 +5128,6 @@ class GatewayRunner:
         session_key = session_entry.session_key
         is_running = session_key in self._running_agents
 
-        # Count pending /queue follow-ups (slot + overflow).
-        adapter = self.adapters.get(source.platform) if source else None
-        queue_depth = self._queue_depth(session_key, adapter=adapter)
-
         title = None
         if self._session_db:
             try:
@@ -5306,10 +5147,6 @@ class GatewayRunner:
             f"**Last Activity:** {session_entry.updated_at.strftime('%Y-%m-%d %H:%M')}",
             f"**Tokens:** {session_entry.total_tokens:,}",
             f"**Agent Running:** {'Yes ⚡' if is_running else 'No'}",
-        ])
-        if queue_depth:
-            lines.append(f"**Queued follow-ups:** {queue_depth}")
-        lines.extend([
             "",
             f"**Connected Platforms:** {', '.join(connected_platforms)}",
         ])
@@ -6174,7 +6011,7 @@ class GatewayRunner:
             self._voice_mode[voice_key] = "voice_only"
             self._save_voice_modes()
             if adapter:
-                self._set_adapter_auto_tts_enabled(adapter, chat_id, enabled=True)
+                self._set_adapter_auto_tts_disabled(adapter, chat_id, disabled=False)
             return (
                 "Voice mode enabled.\n"
                 "I'll reply with voice when you send voice messages.\n"
@@ -6190,7 +6027,7 @@ class GatewayRunner:
             self._voice_mode[voice_key] = "all"
             self._save_voice_modes()
             if adapter:
-                self._set_adapter_auto_tts_enabled(adapter, chat_id, enabled=True)
+                self._set_adapter_auto_tts_disabled(adapter, chat_id, disabled=False)
             return (
                 "Auto-TTS enabled.\n"
                 "All replies will include a voice message."
@@ -6229,7 +6066,7 @@ class GatewayRunner:
                 self._voice_mode[voice_key] = "voice_only"
                 self._save_voice_modes()
                 if adapter:
-                    self._set_adapter_auto_tts_enabled(adapter, chat_id, enabled=True)
+                    self._set_adapter_auto_tts_disabled(adapter, chat_id, disabled=False)
                 return "Voice mode enabled."
             else:
                 self._voice_mode[voice_key] = "off"
@@ -6280,7 +6117,7 @@ class GatewayRunner:
                 adapter._voice_sources[guild_id] = event.source.to_dict()
             self._voice_mode[self._voice_key(event.source.platform, event.source.chat_id)] = "all"
             self._save_voice_modes()
-            self._set_adapter_auto_tts_enabled(adapter, event.source.chat_id, enabled=True)
+            self._set_adapter_auto_tts_disabled(adapter, event.source.chat_id, disabled=False)
             return (
                 f"Joined voice channel **{voice_channel.name}**.\n"
                 f"I'll speak my replies and listen to you. Use /voice leave to disconnect."
@@ -6794,6 +6631,177 @@ class GatewayRunner:
                     chat_id=source.chat_id,
                     content=f"❌ Background task {task_id} failed: {e}",
                     metadata=_thread_metadata,
+                )
+            except Exception:
+                pass
+
+    async def _handle_btw_command(self, event: MessageEvent) -> str:
+        """Handle /btw <question> — ephemeral side question in the same chat."""
+        question = event.get_command_args().strip()
+        if not question:
+            return (
+                "Usage: /btw <question>\n"
+                "Example: /btw what module owns session title sanitization?\n\n"
+                "Answers using session context. No tools, not persisted."
+            )
+
+        source = event.source
+        session_key = self._session_key_for_source(source)
+
+        # Guard: one /btw at a time per session
+        existing = getattr(self, "_active_btw_tasks", {}).get(session_key)
+        if existing and not existing.done():
+            return "A /btw is already running for this chat. Wait for it to finish."
+
+        if not hasattr(self, "_active_btw_tasks"):
+            self._active_btw_tasks: dict = {}
+
+        import uuid as _uuid
+        task_id = f"btw_{datetime.now().strftime('%H%M%S')}_{_uuid.uuid4().hex[:6]}"
+        _task = asyncio.create_task(self._run_btw_task(question, source, session_key, task_id))
+        self._background_tasks.add(_task)
+        self._active_btw_tasks[session_key] = _task
+
+        def _cleanup(task):
+            self._background_tasks.discard(task)
+            if self._active_btw_tasks.get(session_key) is task:
+                self._active_btw_tasks.pop(session_key, None)
+
+        _task.add_done_callback(_cleanup)
+
+        preview = question[:60] + ("..." if len(question) > 60 else "")
+        return f'💬 /btw: "{preview}"\nReply will appear here shortly.'
+
+    async def _run_btw_task(
+        self, question: str, source, session_key: str, task_id: str,
+    ) -> None:
+        """Execute an ephemeral /btw side question and deliver the answer."""
+        from run_agent import AIAgent
+
+        adapter = self.adapters.get(source.platform)
+        if not adapter:
+            logger.warning("No adapter for platform %s in /btw task %s", source.platform, task_id)
+            return
+
+        _thread_meta = {"thread_id": source.thread_id} if source.thread_id else None
+
+        try:
+            user_config = _load_gateway_config()
+            model, runtime_kwargs = self._resolve_session_agent_runtime(
+                source=source,
+                session_key=session_key,
+                user_config=user_config,
+            )
+            if not runtime_kwargs.get("api_key"):
+                await adapter.send(
+                    source.chat_id,
+                    "❌ /btw failed: no provider credentials configured.",
+                    metadata=_thread_meta,
+                )
+                return
+
+            platform_key = _platform_config_key(source.platform)
+            reasoning_config = self._resolve_session_reasoning_config(
+                source=source,
+                session_key=session_key,
+            )
+            self._service_tier = self._load_service_tier()
+            turn_route = self._resolve_turn_agent_config(question, model, runtime_kwargs)
+            pr = self._provider_routing
+
+            # Snapshot history from running agent or stored transcript
+            running_agent = self._running_agents.get(session_key)
+            if running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
+                history_snapshot = list(getattr(running_agent, "_session_messages", []) or [])
+            else:
+                session_entry = self.session_store.get_or_create_session(source)
+                history_snapshot = self.session_store.load_transcript(session_entry.session_id)
+
+            btw_prompt = (
+                "[Ephemeral /btw side question. Answer using the conversation "
+                "context. No tools available. Be direct and concise.]\n\n"
+                + question
+            )
+
+            def run_sync():
+                agent = AIAgent(
+                    model=turn_route["model"],
+                    **turn_route["runtime"],
+                    max_iterations=8,
+                    quiet_mode=True,
+                    verbose_logging=False,
+                    enabled_toolsets=[],
+                    reasoning_config=reasoning_config,
+                    service_tier=self._service_tier,
+                    request_overrides=turn_route.get("request_overrides"),
+                    providers_allowed=pr.get("only"),
+                    providers_ignored=pr.get("ignore"),
+                    providers_order=pr.get("order"),
+                    provider_sort=pr.get("sort"),
+                    provider_require_parameters=pr.get("require_parameters", False),
+                    provider_data_collection=pr.get("data_collection"),
+                    session_id=task_id,
+                    platform=platform_key,
+                    session_db=None,
+                    fallback_model=self._fallback_model,
+                    skip_memory=True,
+                    skip_context_files=True,
+                    persist_session=False,
+                )
+                try:
+                    return agent.run_conversation(
+                        user_message=btw_prompt,
+                        conversation_history=history_snapshot,
+                        task_id=task_id,
+                    )
+                finally:
+                    self._cleanup_agent_resources(agent)
+
+            result = await self._run_in_executor_with_context(run_sync)
+
+            response = (result.get("final_response") or "") if result else ""
+            if not response and result and result.get("error"):
+                response = f"Error: {result['error']}"
+            if not response:
+                response = "(No response generated)"
+
+            media_files, response = adapter.extract_media(response)
+            images, text_content = adapter.extract_images(response)
+            preview = question[:60] + ("..." if len(question) > 60 else "")
+            header = f'💬 /btw: "{preview}"\n\n'
+
+            if text_content:
+                await adapter.send(
+                    chat_id=source.chat_id,
+                    content=header + text_content,
+                    metadata=_thread_meta,
+                )
+            elif not images and not media_files:
+                await adapter.send(
+                    chat_id=source.chat_id,
+                    content=header + "(No response generated)",
+                    metadata=_thread_meta,
+                )
+
+            for image_url, alt_text in (images or []):
+                try:
+                    await adapter.send_image(chat_id=source.chat_id, image_url=image_url, caption=alt_text)
+                except Exception:
+                    pass
+
+            for media_path, _is_voice in (media_files or []):
+                try:
+                    await adapter.send_file(chat_id=source.chat_id, file_path=media_path)
+                except Exception:
+                    pass
+
+        except Exception as e:
+            logger.exception("/btw task %s failed", task_id)
+            try:
+                await adapter.send(
+                    chat_id=source.chat_id,
+                    content=f"❌ /btw failed: {e}",
+                    metadata=_thread_meta,
                 )
             except Exception:
                 pass
@@ -7599,7 +7607,7 @@ class GatewayRunner:
             change_detail = ". ".join(change_parts) + ". " if change_parts else ""
             reload_msg = {
                 "role": "user",
-                "content": f"[IMPORTANT: MCP servers have been reloaded. {change_detail}{tool_summary}. The tool list for this conversation has been updated accordingly.]",
+                "content": f"[SYSTEM: MCP servers have been reloaded. {change_detail}{tool_summary}. The tool list for this conversation has been updated accordingly.]",
             }
             try:
                 session_entry = self.session_store.get_or_create_session(event.source)
@@ -8538,7 +8546,7 @@ class GatewayRunner:
                     from tools.ansi_strip import strip_ansi
                     _out = strip_ansi(session.output_buffer[-2000:]) if session.output_buffer else ""
                     synth_text = (
-                        f"[IMPORTANT: Background process {session_id} completed "
+                        f"[SYSTEM: Background process {session_id} completed "
                         f"(exit code {session.exit_code}).\n"
                         f"Command: {session.command}\n"
                         f"Output:\n{_out}]"
@@ -8847,25 +8855,6 @@ class GatewayRunner:
         if _lock:
             with _lock:
                 self._agent_cache.pop(session_key, None)
-
-    @staticmethod
-    def _init_cached_agent_for_turn(agent: Any, interrupt_depth: int) -> None:
-        """Reset per-turn state on a cached agent before a new turn starts.
-
-        Both _last_activity_ts and _last_activity_desc are only reset for
-        fresh external turns (depth 0); they are semantically paired —
-        desc describes the activity *at* ts, so updating one without the
-        other would make get_activity_summary() misleading.
-        For interrupt-recursive turns both are preserved so the inactivity
-        watchdog can accumulate stuck-turn idle time and fire the 30-min
-        timeout (#15654).  The depth-0 reset is still needed: a session
-        idle for 29 min would otherwise trip the watchdog before the new
-        turn makes its first API call (#9051).
-        """
-        if interrupt_depth == 0:
-            agent._last_activity_ts = time.time()
-            agent._last_activity_desc = "starting new turn (cached)"
-        agent._api_call_count = 0
 
     def _release_evicted_agent_soft(self, agent: Any) -> None:
         """Soft cleanup for cache-evicted agents — preserves session tool state.
@@ -9360,6 +9349,14 @@ class GatewayRunner:
 
         from hermes_cli.tools_config import _get_platform_tools
         enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
+        from gateway.turn_profiles import resolve_turn_profile
+        turn_profile_resolution = resolve_turn_profile(
+            platform=platform_key,
+            prompt=message,
+            current_enabled_toolsets=enabled_toolsets,
+        )
+        enabled_toolsets = list(turn_profile_resolution.enabled_toolsets)
+        self._last_turn_profile_resolution = turn_profile_resolution.to_dict()
 
         display_config = user_config.get("display", {})
         if not isinstance(display_config, dict):
@@ -9405,61 +9402,15 @@ class GatewayRunner:
         last_tool = [None]  # Mutable container for tracking in closure
         last_progress_msg = [None]  # Track last message for dedup
         repeat_count = [0]  # How many times the same message repeated
-        # First-touch onboarding latch: fires at most once per run, even if
-        # several tools exceed the threshold.
-        long_tool_hint_fired = [False]
-        _LONG_TOOL_THRESHOLD_S = 30.0
-
+        
         def progress_callback(event_type: str, tool_name: str = None, preview: str = None, args: dict = None, **kwargs):
             """Callback invoked by agent on tool lifecycle events."""
             if not progress_queue or not _run_still_current():
                 return
 
-            # First-touch onboarding: the first time a tool takes longer than
-            # _LONG_TOOL_THRESHOLD_S during a run that's streaming every tool
-            # (progress_mode == "all"), append a one-time hint suggesting
-            # /verbose.  We only fire when (a) the user hasn't seen the hint
-            # before and (b) /verbose is actually usable on this platform
-            # (gateway gate must be open).  The CLI has its own trigger.
-            if event_type == "tool.completed" and not long_tool_hint_fired[0]:
-                try:
-                    duration = kwargs.get("duration") or 0
-                    if duration >= _LONG_TOOL_THRESHOLD_S and progress_mode == "all":
-                        from agent.onboarding import (
-                            TOOL_PROGRESS_FLAG,
-                            is_seen,
-                            mark_seen,
-                            tool_progress_hint_gateway,
-                        )
-                        _cfg = _load_gateway_config()
-                        gate_on = bool(_cfg.get("display", {}).get("tool_progress_command", False))
-                        if gate_on and not is_seen(_cfg, TOOL_PROGRESS_FLAG):
-                            long_tool_hint_fired[0] = True
-                            progress_queue.put(tool_progress_hint_gateway())
-                            mark_seen(_hermes_home / "config.yaml", TOOL_PROGRESS_FLAG)
-                except Exception as _hint_err:
-                    logger.debug("tool-progress onboarding hint failed: %s", _hint_err)
-                return
-
             # Only act on tool.started events (ignore tool.completed, reasoning.available, etc.)
             if event_type not in ("tool.started",):
                 return
-
-            # Suppress tool-progress bubbles once the user has sent `stop`.
-            # When the LLM response carries N parallel tool calls, the agent
-            # fires N "tool.started" events back-to-back before checking for
-            # interrupts — without this guard, a late `stop` still renders
-            # all N as 🔍 bubbles, making the interrupt feel ignored.
-            # (agent lives in run_sync's scope; agent_holder[0] is the shared
-            # handle across nested scopes — see line ~9607.)
-            try:
-                _agent_for_interrupt = agent_holder[0] if agent_holder else None
-                if _agent_for_interrupt is not None and getattr(
-                    _agent_for_interrupt, "is_interrupted", False
-                ):
-                    return
-            except Exception:
-                pass
 
             # "new" mode: only report when tool changes
             if progress_mode == "new" and tool_name == last_tool[0]:
@@ -9566,22 +9517,6 @@ class GatewayRunner:
                         return
 
                     raw = progress_queue.get_nowait()
-
-                    # Drain silently when interrupted: events queued in the
-                    # window between tool parse and interrupt processing
-                    # should not render as bubbles.  The "⚡ Interrupting
-                    # current task" message is sent separately and is the
-                    # last progress-flavored bubble the user should see.
-                    try:
-                        _agent_for_interrupt = agent_holder[0] if agent_holder else None
-                        if _agent_for_interrupt is not None and getattr(
-                            _agent_for_interrupt, "is_interrupted", False
-                        ):
-                            # Drop this event and continue draining.
-                            await asyncio.sleep(0)
-                            continue
-                    except Exception:
-                        pass
 
                     # Handle dedup messages: update last line with repeat counter
                     if isinstance(raw, tuple) and len(raw) == 3 and raw[0] == "__dedup__":
@@ -9911,7 +9846,12 @@ class GatewayRunner:
                                 _cache.move_to_end(session_key)
                             except KeyError:
                                 pass
-                        self._init_cached_agent_for_turn(agent, _interrupt_depth)
+                        # Reset activity timestamp so the inactivity timeout
+                        # handler doesn't see stale idle time from the previous
+                        # turn and immediately kill this agent.  (#9051)
+                        agent._last_activity_ts = time.time()
+                        agent._last_activity_desc = "starting new turn (cached)"
+                        agent._api_call_count = 0
                         logger.debug("Reusing cached agent for session %s", session_key)
 
             if agent is None:
@@ -10560,7 +10500,7 @@ class GatewayRunner:
                     if _agent_ref and hasattr(_agent_ref, "get_activity_summary"):
                         try:
                             _act = _agent_ref.get_activity_summary()
-                            _idle_secs = _act.get("seconds_since_activity", 0.0)
+                            _idle_secs = _agent_timeout_idle_seconds(_act)
                         except Exception:
                             pass
                     # Staged warning: fire once before escalating to full timeout.
@@ -10569,14 +10509,14 @@ class GatewayRunner:
                         _warning_fired = True
                         _warn_adapter = self.adapters.get(source.platform)
                         if _warn_adapter:
-                            _elapsed_warn = int(_agent_warning // 60) or 1
-                            _remaining_mins = int((_agent_timeout - _agent_warning) // 60) or 1
+                            _elapsed_warn = _format_timeout_duration(_agent_warning)
+                            _remaining = _format_timeout_duration(_agent_timeout - _agent_warning)
                             try:
                                 await _warn_adapter.send(
                                     source.chat_id,
-                                    f"⚠️ No activity for {_elapsed_warn} min. "
+                                    f"⚠️ No answer-producing progress for {_elapsed_warn}. "
                                     f"If the agent does not respond soon, it will "
-                                    f"be timed out in {_remaining_mins} min. "
+                                    f"be timed out in {_remaining}. "
                                     f"You can continue waiting or use /reset.",
                                     metadata=_status_thread_metadata,
                                 )
@@ -10614,16 +10554,20 @@ class GatewayRunner:
                         pass
 
                 _last_desc = _activity.get("last_activity_desc", "unknown")
-                _secs_ago = _activity.get("seconds_since_activity", 0)
+                _last_progress_desc = _activity.get(
+                    "last_progress_activity_desc",
+                    _last_desc,
+                )
+                _secs_ago = _agent_timeout_idle_seconds(_activity)
                 _cur_tool = _activity.get("current_tool")
                 _iter_n = _activity.get("api_call_count", 0)
                 _iter_max = _activity.get("max_iterations", 0)
 
                 logger.error(
                     "Agent idle for %.0fs (timeout %.0fs) in session %s "
-                    "| last_activity=%s | iteration=%s/%s | tool=%s",
+                    "| last_activity=%s | last_progress=%s | iteration=%s/%s | tool=%s",
                     _secs_ago, _agent_timeout, session_key,
-                    _last_desc, _iter_n, _iter_max,
+                    _last_desc, _last_progress_desc, _iter_n, _iter_max,
                     _cur_tool or "none",
                 )
 
@@ -10632,12 +10576,11 @@ class GatewayRunner:
                 if _timed_out_agent and hasattr(_timed_out_agent, "interrupt"):
                     _timed_out_agent.interrupt(_INTERRUPT_REASON_TIMEOUT)
 
-                _timeout_mins = int(_agent_timeout // 60) or 1
+                _timeout_duration = _format_timeout_duration(_agent_timeout)
 
                 # Construct a user-facing message with diagnostic context.
                 _diag_lines = [
-                    f"⏱️ Agent inactive for {_timeout_mins} min — no tool calls "
-                    f"or API responses."
+                    f"⏱️ Agent made no answer-producing progress for {_timeout_duration}."
                 ]
                 if _cur_tool:
                     _diag_lines.append(
@@ -10649,6 +10592,7 @@ class GatewayRunner:
                     _diag_lines.append(
                         f"Last activity: {_last_desc} ({_secs_ago:.0f}s ago, "
                         f"iteration {_iter_n}/{_iter_max}). "
+                        f"Last progress: {_last_progress_desc}. "
                         "The agent may have been waiting on an API response."
                     )
                 _diag_lines.append(
@@ -10694,13 +10638,6 @@ class GatewayRunner:
             pending = None
             if result and adapter and session_key:
                 pending_event = _dequeue_pending_event(adapter, session_key)
-                # /queue overflow: after consuming the adapter's "next-up"
-                # slot, promote the next queued event into it so the
-                # recursive run's drain will see it.  This keeps the slot
-                # occupied for the full FIFO chain, which (a) preserves
-                # order, and (b) causes any mid-chain /queue to correctly
-                # route to overflow rather than jumping the queue.
-                pending_event = self._promote_queued_event(session_key, adapter, pending_event)
                 if result.get("interrupted") and not pending_event and result.get("interrupt_message"):
                     interrupt_message = result.get("interrupt_message")
                     if _is_control_interrupt_message(interrupt_message):
@@ -10995,15 +10932,7 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
         if tick_count % CHANNEL_DIR_EVERY == 0 and adapters:
             try:
                 from gateway.channel_directory import build_channel_directory
-                if loop is not None:
-                    # build_channel_directory is async (Slack web calls), and
-                    # this ticker runs in a background thread. Schedule onto
-                    # the gateway event loop and wait briefly for completion
-                    # so refresh failures are still logged via the except.
-                    fut = asyncio.run_coroutine_threadsafe(
-                        build_channel_directory(adapters), loop
-                    )
-                    fut.result(timeout=30)
+                build_channel_directory(adapters)
             except Exception as e:
                 logger.debug("Channel directory refresh error: %s", e)
 

--- a/gateway/turn_contract.py
+++ b/gateway/turn_contract.py
@@ -1,0 +1,395 @@
+"""Observe-only turn contract tracing for gateway runtime decisions.
+
+Phase 150 intentionally does not route tools, models, or execution. It records
+the contract the runtime would need before later phases are allowed to change
+Discord defaults.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import time
+from dataclasses import asdict, dataclass, field
+from enum import StrEnum
+from typing import Any, Mapping, Sequence
+
+
+class TurnReasonCode(StrEnum):
+    MEMORY_SUFFICIENT_NO_EXTERNAL_TOOLS = "MEMORY_SUFFICIENT_NO_EXTERNAL_TOOLS"
+    OBSERVE_NO_TOOLS = "OBSERVE_NO_TOOLS"
+    OBSERVE_COMPACT_TOOLS = "OBSERVE_COMPACT_TOOLS"
+    OBSERVE_FULL_TOOLS = "OBSERVE_FULL_TOOLS"
+    STRUCTURAL_EXTERNAL_CANDIDATE = "STRUCTURAL_EXTERNAL_CANDIDATE"
+    HEAVY_COMMAND = "HEAVY_COMMAND"
+    NO_SUPPORTED_MEMORY_TRUTH = "NO_SUPPORTED_MEMORY_TRUTH"
+    UNKNOWN_OBSERVE_ONLY = "UNKNOWN_OBSERVE_ONLY"
+
+
+class ClaimStrength(StrEnum):
+    MEMORY_TRUTH = "memory_truth"
+    BOUNDED_EVENT = "bounded_event"
+    SOURCE_SAYS = "source_says"
+    SUPPORTING_CONTEXT = "supporting_context"
+    NONE = "none"
+
+
+@dataclass(frozen=True)
+class BrainstackSufficiency:
+    state: str = "unknown"
+    max_claim_strength: str = ClaimStrength.NONE.value
+    answer_type: str = "none"
+    answer_evidence_count: int = 0
+    supporting_context_count: int = 0
+    requires_external_tools_for_memory_answer: bool = False
+    reason_code: str = "UNKNOWN"
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any] | None) -> "BrainstackSufficiency":
+        if not value:
+            return cls()
+        return cls(
+            state=str(value.get("state") or "unknown"),
+            max_claim_strength=str(value.get("max_claim_strength") or ClaimStrength.NONE.value),
+            answer_type=str(value.get("answer_type") or "none"),
+            answer_evidence_count=_safe_int(value.get("answer_evidence_count")),
+            supporting_context_count=_safe_int(value.get("supporting_context_count")),
+            requires_external_tools_for_memory_answer=bool(
+                value.get("requires_external_tools_for_memory_answer", False)
+            ),
+            reason_code=str(value.get("reason_code") or "UNKNOWN"),
+        )
+
+
+@dataclass(frozen=True)
+class StructuralSignals:
+    slash_command: str | None = None
+    attachment_count: int = 0
+    url_count: int = 0
+    pending_approval: bool = False
+    active_workflow: bool = False
+    explicit_heavy: bool = False
+
+    @classmethod
+    def from_prompt(
+        cls,
+        prompt: str,
+        *,
+        attachment_count: int = 0,
+        pending_approval: bool = False,
+        active_workflow: bool = False,
+    ) -> "StructuralSignals":
+        stripped = (prompt or "").strip()
+        slash_command = None
+        if stripped.startswith("/"):
+            slash_command = stripped.split(maxsplit=1)[0].casefold()
+        url_count = len(re.findall(r"https?://\S+", prompt or ""))
+        explicit_heavy = bool(slash_command and slash_command.startswith("/heavy"))
+        return cls(
+            slash_command=slash_command,
+            attachment_count=max(0, int(attachment_count or 0)),
+            url_count=url_count,
+            pending_approval=bool(pending_approval),
+            active_workflow=bool(active_workflow),
+            explicit_heavy=explicit_heavy,
+        )
+
+
+@dataclass(frozen=True)
+class TurnContract:
+    schema: str
+    turn_contract_id: str
+    observe_only: bool
+    platform: str
+    turn_class: str
+    evidence_sufficiency: str
+    max_claim_strength: str
+    external_capability_required_for_memory_answer: bool
+    allowed_tool_profile: str
+    allowed_model_profile: str
+    latency_slo: str
+    context_budget_profile: str
+    degradation_policy: str
+    forbidden_claims: tuple[str, ...]
+    reason_code: str
+    structural_signals: dict[str, Any]
+    brainstack_sufficiency: dict[str, Any]
+    idempotency_key_hash: str
+    causal_index: int | None = None
+    superseded_by: str | None = None
+    stale_response_suppressed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class TimingTrace:
+    request_build_ms: float | None = None
+    http_connect_ms: float | None = None
+    provider_queue_or_time_to_first_byte_ms: float | None = None
+    first_token_ms: float | None = None
+    generation_after_first_token_ms: float | None = None
+    provider_final_ms: float | None = None
+    final_latency_ms: float | None = None
+    first_user_visible_commitment_ms: float | None = None
+    output_tokens_est: int | None = None
+    tokens_per_second_after_first: float | None = None
+    observable: bool = False
+    unobservable_reason: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ObserverEffect:
+    extra_provider_calls: int = 0
+    extra_brainstack_recalls: int = 0
+    extra_memory_writes: int = 0
+    trace_write_ms: float = 0.0
+    total_observer_overhead_ms: float = 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class HiddenToolPromptAudit:
+    tools_array_empty: bool
+    tool_count: int
+    tool_names: tuple[str, ...] = field(default_factory=tuple)
+    tool_use_system_prompt_present: bool = False
+    tool_catalog_prose_tokens_est: int = 0
+    hidden_tool_prompt_detected: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def compile_turn_contract(
+    *,
+    platform: str,
+    prompt: str,
+    tool_profile: str,
+    model_profile: str | None = None,
+    brainstack_sufficiency: Mapping[str, Any] | None = None,
+    structural_signals: StructuralSignals | None = None,
+    idempotency_parts: Sequence[str] = (),
+    causal_index: int | None = None,
+) -> TurnContract:
+    """Build observe-only contract. Does not change runtime behavior."""
+    suff = BrainstackSufficiency.from_mapping(brainstack_sufficiency)
+    signals = structural_signals or StructuralSignals.from_prompt(prompt)
+    reason_code = _reason_code(tool_profile, signals, suff)
+    turn_class = _turn_class(signals, suff)
+    allowed_tool_profile = _allowed_tool_profile(tool_profile)
+    forbidden_claims = _forbidden_claims(suff)
+    id_key = _hash_idempotency_parts(idempotency_parts or (platform, prompt[:160]))
+    contract_id = _stable_contract_id(platform, prompt, tool_profile, id_key)
+    return TurnContract(
+        schema="hermes.turn_contract.v1",
+        turn_contract_id=contract_id,
+        observe_only=True,
+        platform=platform,
+        turn_class=turn_class,
+        evidence_sufficiency=suff.state,
+        max_claim_strength=suff.max_claim_strength,
+        external_capability_required_for_memory_answer=(
+            suff.requires_external_tools_for_memory_answer
+        ),
+        allowed_tool_profile=allowed_tool_profile,
+        allowed_model_profile=model_profile or "current_config",
+        latency_slo="observe_only",
+        context_budget_profile="observe_only",
+        degradation_policy="observe_only_no_behavior_change",
+        forbidden_claims=forbidden_claims,
+        reason_code=reason_code.value,
+        structural_signals=asdict(signals),
+        brainstack_sufficiency=asdict(suff),
+        idempotency_key_hash=id_key,
+        causal_index=causal_index,
+    )
+
+
+def build_hidden_tool_prompt_audit(
+    *,
+    tool_profile: str,
+    tool_names: Sequence[str] | None,
+    system_prompt: str = "",
+) -> HiddenToolPromptAudit:
+    names = tuple(sorted({str(name) for name in (tool_names or []) if str(name)}))
+    prompt_norm = " ".join((system_prompt or "").casefold().split())
+    tool_catalog_tokens = 0
+    tool_prompt_present = False
+    if prompt_norm:
+        tool_prompt_present = any(
+            marker in prompt_norm
+            for marker in ("you can use tools", "available tools", "tool calls")
+        )
+        tool_catalog_tokens = len(prompt_norm.split()) if tool_prompt_present else 0
+    hidden = tool_profile == "no-tools" and (bool(names) or tool_prompt_present)
+    return HiddenToolPromptAudit(
+        tools_array_empty=not names,
+        tool_count=len(names),
+        tool_names=names,
+        tool_use_system_prompt_present=tool_prompt_present,
+        tool_catalog_prose_tokens_est=tool_catalog_tokens,
+        hidden_tool_prompt_detected=hidden,
+    )
+
+
+def build_timing_trace(
+    *,
+    start_monotonic: float,
+    final_monotonic: float | None = None,
+    first_token_monotonic: float | None = None,
+    output_tokens_est: int | None = None,
+) -> TimingTrace:
+    final = final_monotonic if final_monotonic is not None else time.monotonic()
+    final_ms = max(0.0, (final - start_monotonic) * 1000.0)
+    first_ms = None
+    generation_ms = None
+    tokens_per_second = None
+    if first_token_monotonic is not None:
+        first_ms = max(0.0, (first_token_monotonic - start_monotonic) * 1000.0)
+        generation_ms = max(0.0, final_ms - first_ms)
+        if output_tokens_est and generation_ms > 0:
+            tokens_per_second = output_tokens_est / (generation_ms / 1000.0)
+    return TimingTrace(
+        provider_queue_or_time_to_first_byte_ms=first_ms,
+        first_token_ms=first_ms,
+        generation_after_first_token_ms=generation_ms,
+        provider_final_ms=final_ms,
+        final_latency_ms=final_ms,
+        first_user_visible_commitment_ms=final_ms,
+        output_tokens_est=output_tokens_est,
+        tokens_per_second_after_first=tokens_per_second,
+        observable=first_token_monotonic is not None,
+        unobservable_reason=None
+        if first_token_monotonic is not None
+        else "gateway_dispatch_only_no_provider_ttfb_hook",
+    )
+
+
+def build_observer_effect(
+    *,
+    started_monotonic: float,
+    finished_monotonic: float | None = None,
+    extra_provider_calls: int = 0,
+    extra_brainstack_recalls: int = 0,
+    extra_memory_writes: int = 0,
+) -> ObserverEffect:
+    finished = finished_monotonic if finished_monotonic is not None else time.monotonic()
+    overhead_ms = max(0.0, (finished - started_monotonic) * 1000.0)
+    return ObserverEffect(
+        extra_provider_calls=max(0, int(extra_provider_calls)),
+        extra_brainstack_recalls=max(0, int(extra_brainstack_recalls)),
+        extra_memory_writes=max(0, int(extra_memory_writes)),
+        trace_write_ms=0.0,
+        total_observer_overhead_ms=overhead_ms,
+    )
+
+
+def sample_size_latency_summary(latencies_seconds: Sequence[float]) -> dict[str, Any]:
+    values = sorted(float(v) for v in latencies_seconds)
+    count = len(values)
+    if not values:
+        return {
+            "sample_size": 0,
+            "max_latency_seconds": 0.0,
+            "p95_seconds": None,
+            "p95_claim_allowed": False,
+            "small_sample_rule": "p95 requires at least 30 warm turns",
+        }
+    return {
+        "sample_size": count,
+        "max_latency_seconds": values[-1],
+        "p50_seconds": _percentile(values, 50),
+        "p90_seconds": _percentile(values, 90),
+        "p95_seconds": _percentile(values, 95) if count >= 30 else None,
+        "p95_claim_allowed": count >= 30,
+        "small_sample_rule": None
+        if count >= 30
+        else "p95 requires at least 30 warm turns",
+    }
+
+
+def _reason_code(
+    tool_profile: str,
+    signals: StructuralSignals,
+    suff: BrainstackSufficiency,
+) -> TurnReasonCode:
+    if signals.explicit_heavy:
+        return TurnReasonCode.HEAVY_COMMAND
+    if signals.attachment_count or signals.url_count or signals.pending_approval or signals.active_workflow:
+        return TurnReasonCode.STRUCTURAL_EXTERNAL_CANDIDATE
+    if suff.state == "answerable" and not suff.requires_external_tools_for_memory_answer:
+        return TurnReasonCode.MEMORY_SUFFICIENT_NO_EXTERNAL_TOOLS
+    if suff.state in {"unanswerable", "none"}:
+        return TurnReasonCode.NO_SUPPORTED_MEMORY_TRUTH
+    if tool_profile == "no-tools":
+        return TurnReasonCode.OBSERVE_NO_TOOLS
+    if tool_profile in {"memory-only", "compact"}:
+        return TurnReasonCode.OBSERVE_COMPACT_TOOLS
+    if tool_profile == "full":
+        return TurnReasonCode.OBSERVE_FULL_TOOLS
+    return TurnReasonCode.UNKNOWN_OBSERVE_ONLY
+
+
+def _turn_class(signals: StructuralSignals, suff: BrainstackSufficiency) -> str:
+    if signals.explicit_heavy:
+        return "external.heavy_requested"
+    if signals.attachment_count or signals.url_count:
+        return "external.capability_candidate"
+    if suff.answer_type and suff.answer_type != "none":
+        return f"conversation.{suff.answer_type}"
+    return "conversation.observe_only"
+
+
+def _allowed_tool_profile(tool_profile: str) -> str:
+    if tool_profile == "no-tools":
+        return "none"
+    if tool_profile in {"memory-only", "compact"}:
+        return "conversation_tools"
+    if tool_profile == "full":
+        return "heavy_work_observed"
+    return f"observed:{tool_profile}"
+
+
+def _forbidden_claims(suff: BrainstackSufficiency) -> tuple[str, ...]:
+    claims = ["external_verification_without_tool"]
+    if suff.max_claim_strength != ClaimStrength.MEMORY_TRUTH.value:
+        claims.append("memory_truth")
+    if suff.answer_type != "current_assignment":
+        claims.append("current_assignment")
+    return tuple(claims)
+
+
+def _hash_idempotency_parts(parts: Sequence[str]) -> str:
+    payload = "\\x1f".join(str(part) for part in parts)
+    return "sha256:" + hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _stable_contract_id(platform: str, prompt: str, tool_profile: str, id_key: str) -> str:
+    payload = "\\x1f".join((platform, prompt[:240], tool_profile, id_key))
+    return "tc_" + hashlib.sha256(payload.encode("utf-8")).hexdigest()[:24]
+
+
+def _safe_int(value: Any) -> int:
+    try:
+        return max(0, int(value))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _percentile(values: Sequence[float], pct: int) -> float:
+    if not values:
+        return 0.0
+    if len(values) == 1:
+        return values[0]
+    rank = (len(values) - 1) * (pct / 100.0)
+    low = int(rank)
+    high = min(low + 1, len(values) - 1)
+    weight = rank - low
+    return values[low] * (1 - weight) + values[high] * weight

--- a/gateway/turn_profiles.py
+++ b/gateway/turn_profiles.py
@@ -1,0 +1,161 @@
+"""Hermes gateway turn profile selection.
+
+Runtime-owned profile selection. Brainstack remains evidence input only.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import os
+import re
+from typing import Mapping, Sequence
+
+
+SCHEMA_VERSION = "hermes.turn_profiles.v1"
+
+CONVERSATION_TOOLSETS = ("conversation_tools",)
+CONVERSATION_DIRECT_TOOLSETS: tuple[str, ...] = ()
+HEAVY_WEB_TOOLSETS = ("heavy_web",)
+HEAVY_FILE_TOOLSETS = ("heavy_file",)
+HEAVY_CODE_TOOLSETS = ("heavy_code",)
+HEAVY_FULL_DEBUG_TOOLSETS = ("heavy_full_debug",)
+
+HEAVY_COMMAND_RE = re.compile(r"^\s*/heavy(?:\s+(?P<bundle>web|file|code|full-debug))?\b", re.I)
+
+
+@dataclass(frozen=True)
+class ResolvedTurnProfile:
+    schema: str
+    platform: str
+    turn_profile: str
+    tool_profile: str
+    enabled_toolsets: tuple[str, ...]
+    reason_code: str
+    explicit_heavy: bool
+    heavy_bundle: str | None
+    url_attachment_candidate_only: bool
+    rollback_override_active: bool
+    cli_local_unchanged: bool
+
+    def to_dict(self) -> dict:
+        data = asdict(self)
+        data["enabled_toolsets"] = list(self.enabled_toolsets)
+        return data
+
+
+def _truthy(value: str | None) -> bool:
+    return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _url_count(prompt: str) -> int:
+    return len(re.findall(r"https?://\S+", prompt or ""))
+
+
+def resolve_turn_profile(
+    *,
+    platform: str,
+    prompt: str,
+    current_enabled_toolsets: Sequence[str],
+    env: Mapping[str, str] | None = None,
+) -> ResolvedTurnProfile:
+    """Resolve tool profile from structural signals only.
+
+    No natural-language intent routing. URL presence alone is not fetch.
+    """
+
+    env = env or os.environ
+    current = tuple(sorted(str(name) for name in current_enabled_toolsets))
+    if platform != "discord":
+        return ResolvedTurnProfile(
+            schema=SCHEMA_VERSION,
+            platform=platform,
+            turn_profile="heavy_work",
+            tool_profile="existing_platform_default",
+            enabled_toolsets=current,
+            reason_code="NON_DISCORD_UNCHANGED",
+            explicit_heavy=False,
+            heavy_bundle=None,
+            url_attachment_candidate_only=False,
+            rollback_override_active=False,
+            cli_local_unchanged=platform == "cli",
+        )
+
+    rollback = (
+        env.get("HERMES_DISCORD_TURN_PROFILE", "").lower() in {"heavy", "heavy_work", "full"}
+        or env.get("HERMES_DISCORD_TOOL_PROFILE", "").lower() in {"heavy", "heavy_work", "full"}
+    )
+    if rollback:
+        return ResolvedTurnProfile(
+            schema=SCHEMA_VERSION,
+            platform=platform,
+            turn_profile="heavy_work",
+            tool_profile="heavy_work",
+            enabled_toolsets=current or HEAVY_FULL_DEBUG_TOOLSETS,
+            reason_code="ROLLBACK_OVERRIDE_FORCE_HEAVY",
+            explicit_heavy=True,
+            heavy_bundle="heavy_work",
+            url_attachment_candidate_only=False,
+            rollback_override_active=True,
+            cli_local_unchanged=False,
+        )
+
+    match = HEAVY_COMMAND_RE.match(prompt or "")
+    if match:
+        bundle = (match.group("bundle") or "work").lower()
+        if bundle == "web":
+            toolsets = HEAVY_WEB_TOOLSETS
+            profile = "heavy_web"
+        elif bundle == "file":
+            toolsets = HEAVY_FILE_TOOLSETS
+            profile = "heavy_file"
+        elif bundle == "code":
+            toolsets = HEAVY_CODE_TOOLSETS
+            profile = "heavy_code"
+        elif bundle == "full-debug":
+            toolsets = HEAVY_FULL_DEBUG_TOOLSETS
+            profile = "heavy_full_debug"
+        else:
+            toolsets = current or HEAVY_FULL_DEBUG_TOOLSETS
+            profile = "heavy_work"
+        return ResolvedTurnProfile(
+            schema=SCHEMA_VERSION,
+            platform=platform,
+            turn_profile=profile,
+            tool_profile=profile,
+            enabled_toolsets=tuple(sorted(toolsets)),
+            reason_code="EXPLICIT_HEAVY_COMMAND",
+            explicit_heavy=True,
+            heavy_bundle=profile,
+            url_attachment_candidate_only=False,
+            rollback_override_active=False,
+            cli_local_unchanged=False,
+        )
+
+    if _truthy(env.get("HERMES_DISCORD_CONVERSATION_DIRECT")):
+        return ResolvedTurnProfile(
+            schema=SCHEMA_VERSION,
+            platform=platform,
+            turn_profile="conversation_direct",
+            tool_profile="conversation_direct",
+            enabled_toolsets=CONVERSATION_DIRECT_TOOLSETS,
+            reason_code="DISCORD_CONVERSATION_DIRECT_OVERRIDE",
+            explicit_heavy=False,
+            heavy_bundle=None,
+            url_attachment_candidate_only=_url_count(prompt) > 0,
+            rollback_override_active=False,
+            cli_local_unchanged=False,
+        )
+
+    return ResolvedTurnProfile(
+        schema=SCHEMA_VERSION,
+        platform=platform,
+        turn_profile="conversation_tools",
+        tool_profile="conversation_tools",
+        enabled_toolsets=CONVERSATION_TOOLSETS,
+        reason_code="DISCORD_DEFAULT_CONVERSATION",
+        explicit_heavy=False,
+        heavy_bundle=None,
+        url_attachment_candidate_only=_url_count(prompt) > 0,
+        rollback_override_active=False,
+        cli_local_unchanged=False,
+    )

--- a/scripts/hermes_turn_profile_canary.py
+++ b/scripts/hermes_turn_profile_canary.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Write Phase 154 structural turn-profile canary artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+from typing import Any, Mapping
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from gateway.tool_profile_snapshot import (  # noqa: E402
+    build_tool_loader_contract,
+    build_tool_registry,
+    evaluate_tool_load_request,
+    normalize_tool_schema,
+)
+from gateway.turn_profiles import SCHEMA_VERSION, resolve_turn_profile  # noqa: E402
+from tools.registry import discover_builtin_tools, registry as tool_registry  # noqa: E402
+
+
+def _json_dump(path: Path, data: Mapping[str, Any]) -> None:
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True) + "\n")
+
+
+def _schemas_by_name() -> dict[str, dict[str, Any]]:
+    discover_builtin_tools()
+    schemas: dict[str, dict[str, Any]] = {}
+    for name in sorted(tool_registry.get_all_tool_names()):
+        schema = tool_registry.get_schema(name)
+        if schema:
+            schemas[name] = normalize_tool_schema(schema)
+    return schemas
+
+
+def build_artifacts() -> dict[str, Any]:
+    current = ["hermes-cli"]
+    conversation = resolve_turn_profile(
+        platform="discord",
+        prompt="Mi volt a debug markerem?",
+        current_enabled_toolsets=current,
+        env={},
+    )
+    url_memory = resolve_turn_profile(
+        platform="discord",
+        prompt="Jegyezd meg ezt az URL-t: https://example.com/repo",
+        current_enabled_toolsets=current,
+        env={},
+    )
+    keyword_not_heavy = resolve_turn_profile(
+        platform="discord",
+        prompt="nézd meg emlékezetből, beszéltünk-e erről",
+        current_enabled_toolsets=current,
+        env={},
+    )
+    direct = resolve_turn_profile(
+        platform="discord",
+        prompt="Mi volt a debug markerem?",
+        current_enabled_toolsets=current,
+        env={"HERMES_DISCORD_CONVERSATION_DIRECT": "1"},
+    )
+    cli = resolve_turn_profile(
+        platform="cli",
+        prompt="run tests",
+        current_enabled_toolsets=current,
+        env={},
+    )
+    rollback = resolve_turn_profile(
+        platform="discord",
+        prompt="Mi volt a debug markerem?",
+        current_enabled_toolsets=["web", "file"],
+        env={"HERMES_DISCORD_TURN_PROFILE": "heavy"},
+    )
+    heavy_web = resolve_turn_profile(
+        platform="discord",
+        prompt="/heavy web https://example.com",
+        current_enabled_toolsets=current,
+        env={},
+    )
+    heavy_file = resolve_turn_profile(
+        platform="discord",
+        prompt="/heavy file README.md",
+        current_enabled_toolsets=current,
+        env={},
+    )
+    heavy_code = resolve_turn_profile(
+        platform="discord",
+        prompt="/heavy code run tests",
+        current_enabled_toolsets=current,
+        env={},
+    )
+    heavy_debug = resolve_turn_profile(
+        platform="discord",
+        prompt="/heavy full-debug inspect everything",
+        current_enabled_toolsets=current,
+        env={},
+    )
+
+    schemas = _schemas_by_name()
+    tool_registry_meta = build_tool_registry(schemas.values())
+    conversation_loader = build_tool_loader_contract(
+        "conversation_tools",
+        ["memory", "session_search", "clarify"],
+        tool_registry_meta,
+    )
+    direct_loader = build_tool_loader_contract(
+        "conversation_direct",
+        [],
+        tool_registry_meta,
+    )
+    allowed_load = evaluate_tool_load_request(
+        conversation_loader,
+        tool_registry_meta,
+        "session_search",
+    )
+    denied_cross_profile = evaluate_tool_load_request(
+        conversation_loader,
+        tool_registry_meta,
+        "terminal",
+    )
+    direct_denied = evaluate_tool_load_request(
+        direct_loader,
+        tool_registry_meta,
+        "session_search",
+    )
+    side_effect_denied = evaluate_tool_load_request(
+        build_tool_loader_contract("heavy_code", ["terminal"], tool_registry_meta),
+        tool_registry_meta,
+        "terminal",
+        approval_granted=False,
+    )
+    side_effect_allowed_with_approval = evaluate_tool_load_request(
+        build_tool_loader_contract("heavy_code", ["terminal"], tool_registry_meta),
+        tool_registry_meta,
+        "terminal",
+        approval_granted=True,
+    )
+
+    config_parity = {
+        "schema": SCHEMA_VERSION,
+        "discord_default": conversation.to_dict(),
+        "conversation_direct_override": direct.to_dict(),
+        "cli_local": cli.to_dict(),
+        "rollback": rollback.to_dict(),
+        "verdict": {
+            "passed": (
+                conversation.turn_profile == "conversation_tools"
+                and direct.enabled_toolsets == ()
+                and cli.enabled_toolsets == ("hermes-cli",)
+                and rollback.rollback_override_active
+            )
+        },
+    }
+    conversation_canary = {
+        "schema": SCHEMA_VERSION,
+        "memory_question": conversation.to_dict(),
+        "url_memory_false_positive": url_memory.to_dict(),
+        "keyword_not_heavy": keyword_not_heavy.to_dict(),
+        "verdict": {
+            "passed": (
+                conversation.enabled_toolsets == ("conversation_tools",)
+                and url_memory.turn_profile == "conversation_tools"
+                and url_memory.url_attachment_candidate_only
+                and not url_memory.explicit_heavy
+                and keyword_not_heavy.turn_profile == "conversation_tools"
+            )
+        },
+    }
+    heavy_canary = {
+        "schema": SCHEMA_VERSION,
+        "heavy_web": heavy_web.to_dict(),
+        "heavy_file": heavy_file.to_dict(),
+        "heavy_code": heavy_code.to_dict(),
+        "heavy_full_debug": heavy_debug.to_dict(),
+        "side_effect_denied_without_approval": {
+            "allowed": side_effect_denied[0],
+            "reason": side_effect_denied[1],
+        },
+        "side_effect_allowed_with_approval": {
+            "allowed": side_effect_allowed_with_approval[0],
+            "reason": side_effect_allowed_with_approval[1],
+        },
+        "verdict": {
+            "passed": (
+                heavy_web.enabled_toolsets == ("heavy_web",)
+                and heavy_file.enabled_toolsets == ("heavy_file",)
+                and heavy_code.enabled_toolsets == ("heavy_code",)
+                and heavy_debug.enabled_toolsets == ("heavy_full_debug",)
+                and not side_effect_denied[0]
+                and side_effect_denied[1] == "TOOL_SIDE_EFFECT_APPROVAL_REQUIRED"
+                and side_effect_allowed_with_approval[0]
+            )
+        },
+    }
+    loader_canary = {
+        "schema": SCHEMA_VERSION,
+        "conversation_tools_loader": conversation_loader.to_dict(),
+        "conversation_direct_loader": direct_loader.to_dict(),
+        "allowed_read_only_load": {"allowed": allowed_load[0], "reason": allowed_load[1]},
+        "denied_cross_profile_load": {
+            "allowed": denied_cross_profile[0],
+            "reason": denied_cross_profile[1],
+        },
+        "denied_direct_load": {"allowed": direct_denied[0], "reason": direct_denied[1]},
+        "cleanup_contract": {
+            "ephemeral_turn_end_cleanup": conversation_loader.turn_end_cleanup_required,
+            "pinned_session_end_cleanup": conversation_loader.session_end_cleanup_required,
+            "profile_change_cleanup": conversation_loader.profile_change_cleanup_required,
+        },
+        "verdict": {
+            "passed": (
+                allowed_load[0]
+                and not denied_cross_profile[0]
+                and denied_cross_profile[1] == "TOOL_NOT_IN_ALLOWED_ENUM"
+                and not direct_denied[0]
+                and direct_denied[1] == "LOADER_UNAVAILABLE_FOR_PROFILE"
+                and conversation_loader.turn_end_cleanup_required
+                and conversation_loader.session_end_cleanup_required
+            )
+        },
+    }
+    return {
+        "config_parity": config_parity,
+        "conversation_canary": conversation_canary,
+        "heavy_canary": heavy_canary,
+        "loader_canary": loader_canary,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", required=True)
+    args = parser.parse_args()
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    artifacts = build_artifacts()
+    _json_dump(output_dir / "154-CONFIG-PARITY.json", artifacts["config_parity"])
+    _json_dump(output_dir / "154-CONVERSATION-CANARY.json", artifacts["conversation_canary"])
+    _json_dump(output_dir / "154-HEAVY-BUNDLE-CANARY.json", artifacts["heavy_canary"])
+    _json_dump(output_dir / "154-TOOL-LOADER-CANARY.json", artifacts["loader_canary"])
+    passed = all(artifact["verdict"]["passed"] for artifact in artifacts.values())
+    print(json.dumps({"schema": SCHEMA_VERSION, "passed": passed}, sort_keys=True))
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/gateway/test_gateway_inactivity_timeout.py
+++ b/tests/gateway/test_gateway_inactivity_timeout.py
@@ -14,11 +14,15 @@ import os
 import sys
 import time
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from gateway.run import _agent_timeout_idle_seconds, _format_timeout_duration  # noqa: E402
+from run_agent import AIAgent  # noqa: E402
 
 
 class FakeAgent:
@@ -103,7 +107,7 @@ class TestStagedInactivityWarning:
         while True:
             done, _ = concurrent.futures.wait({future}, timeout=_POLL_INTERVAL)
             if done:
-                result = future.result()
+                future.result()
                 break
             _idle_secs = 0.0
             if hasattr(agent, "get_activity_summary"):
@@ -313,3 +317,47 @@ class TestWarningThresholdBelowTimeout:
         pool.shutdown(wait=False, cancel_futures=True)
         assert _warning_fired
         assert _timeout_fired
+
+
+class TestProgressAwareTimeout:
+    """Timeouts use productive progress, not provider-wait heartbeats."""
+
+    def test_timeout_idle_prefers_progress_over_status_activity(self):
+        summary = {
+            "seconds_since_activity": 1.0,
+            "seconds_since_progress": 121.0,
+            "last_activity_desc": "waiting for stream response (120s, no chunks yet)",
+            "last_progress_activity_desc": "starting API call #1",
+        }
+
+        assert _agent_timeout_idle_seconds(summary) == 121.0
+
+    def test_timeout_idle_falls_back_for_older_agents(self):
+        summary = {"seconds_since_activity": 17.0}
+
+        assert _agent_timeout_idle_seconds(summary) == 17.0
+
+    def test_timeout_duration_does_not_round_seconds_to_minutes(self):
+        assert _format_timeout_duration(30) == "30s"
+        assert _format_timeout_duration(90) == "1m 30s"
+        assert _format_timeout_duration(120) == "2m"
+
+    def test_non_productive_heartbeat_does_not_reset_progress_timer(self):
+        agent = AIAgent.__new__(AIAgent)
+        now = time.time()
+        agent._last_activity_ts = now - 50.0
+        agent._last_activity_desc = "starting API call #1"
+        agent._last_progress_activity_ts = now - 50.0
+        agent._last_progress_activity_desc = "starting API call #1"
+        agent._current_tool = None
+        agent._api_call_count = 1
+        agent.max_iterations = 120
+        agent.iteration_budget = SimpleNamespace(used=1, max_total=120)
+
+        agent._touch_activity("waiting for stream response (30s, no chunks yet)", productive=False)
+        summary = agent.get_activity_summary()
+
+        assert summary["last_activity_desc"].startswith("waiting for stream response")
+        assert summary["last_progress_activity_desc"] == "starting API call #1"
+        assert summary["seconds_since_activity"] <= 1.0
+        assert summary["seconds_since_progress"] >= 49.0

--- a/tests/gateway/test_turn_contract_observatory.py
+++ b/tests/gateway/test_turn_contract_observatory.py
@@ -1,0 +1,76 @@
+from gateway.turn_contract import (
+    StructuralSignals,
+    build_hidden_tool_prompt_audit,
+    compile_turn_contract,
+    sample_size_latency_summary,
+)
+
+
+def test_turn_contract_is_observe_only_and_profile_local():
+    contract = compile_turn_contract(
+        platform="discord",
+        prompt="Mi volt a markerem?",
+        tool_profile="memory-only",
+        model_profile="kimi",
+        brainstack_sufficiency={
+            "state": "answerable",
+            "max_claim_strength": "memory_truth",
+            "answer_type": "explicit_user_fact",
+            "answer_evidence_count": 1,
+            "requires_external_tools_for_memory_answer": False,
+        },
+        idempotency_parts=("discord", "guild", "channel", "message", "user"),
+        causal_index=3,
+    )
+
+    data = contract.to_dict()
+
+    assert data["schema"] == "hermes.turn_contract.v1"
+    assert data["observe_only"] is True
+    assert data["allowed_tool_profile"] == "conversation_tools"
+    assert data["reason_code"] == "MEMORY_SUFFICIENT_NO_EXTERNAL_TOOLS"
+    assert data["causal_index"] == 3
+    assert data["idempotency_key_hash"].startswith("sha256:")
+
+
+def test_structural_heavy_signal_not_keyword_router():
+    signals = StructuralSignals.from_prompt("/heavy web https://example.com")
+    contract = compile_turn_contract(
+        platform="discord",
+        prompt="/heavy web https://example.com",
+        tool_profile="full",
+        structural_signals=signals,
+    )
+
+    assert contract.reason_code == "HEAVY_COMMAND"
+    assert contract.turn_class == "external.heavy_requested"
+    assert contract.structural_signals["url_count"] == 1
+
+
+def test_no_tools_hidden_prompt_audit_detects_residue():
+    audit = build_hidden_tool_prompt_audit(
+        tool_profile="no-tools",
+        tool_names=["web_search"],
+        system_prompt="You can use tools.",
+    )
+
+    assert audit.hidden_tool_prompt_detected is True
+    assert audit.tools_array_empty is False
+    assert audit.tool_use_system_prompt_present is True
+
+
+def test_small_sample_summary_never_claims_p95():
+    summary = sample_size_latency_summary([1.0, 2.0, 3.0])
+
+    assert summary["sample_size"] == 3
+    assert summary["p95_seconds"] is None
+    assert summary["p95_claim_allowed"] is False
+    assert "30" in summary["small_sample_rule"]
+
+
+def test_large_sample_summary_can_claim_p95():
+    summary = sample_size_latency_summary([float(i) for i in range(30)])
+
+    assert summary["sample_size"] == 30
+    assert summary["p95_seconds"] is not None
+    assert summary["p95_claim_allowed"] is True

--- a/tests/gateway/test_turn_profiles.py
+++ b/tests/gateway/test_turn_profiles.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from gateway.turn_profiles import resolve_turn_profile
+
+
+def test_discord_default_is_conversation_tools() -> None:
+    resolved = resolve_turn_profile(
+        platform="discord",
+        prompt="Mi volt a debug markerem?",
+        current_enabled_toolsets=["hermes-cli"],
+        env={},
+    )
+
+    assert resolved.turn_profile == "conversation_tools"
+    assert resolved.enabled_toolsets == ("conversation_tools",)
+    assert resolved.reason_code == "DISCORD_DEFAULT_CONVERSATION"
+
+
+def test_cli_local_default_unchanged() -> None:
+    resolved = resolve_turn_profile(
+        platform="cli",
+        prompt="run tests",
+        current_enabled_toolsets=["hermes-cli"],
+        env={},
+    )
+
+    assert resolved.cli_local_unchanged is True
+    assert resolved.enabled_toolsets == ("hermes-cli",)
+
+
+def test_heavy_command_selects_structural_bundle() -> None:
+    web = resolve_turn_profile(
+        platform="discord",
+        prompt="/heavy web https://example.com",
+        current_enabled_toolsets=["hermes-cli"],
+        env={},
+    )
+    code = resolve_turn_profile(
+        platform="discord",
+        prompt="/heavy code fix tests",
+        current_enabled_toolsets=["hermes-cli"],
+        env={},
+    )
+
+    assert web.turn_profile == "heavy_web"
+    assert web.enabled_toolsets == ("heavy_web",)
+    assert code.turn_profile == "heavy_code"
+    assert code.enabled_toolsets == ("heavy_code",)
+
+
+def test_url_mention_is_candidate_not_auto_fetch() -> None:
+    resolved = resolve_turn_profile(
+        platform="discord",
+        prompt="Jegyezd meg ezt az URL-t: https://example.com/repo",
+        current_enabled_toolsets=["hermes-cli"],
+        env={},
+    )
+
+    assert resolved.turn_profile == "conversation_tools"
+    assert resolved.url_attachment_candidate_only is True
+    assert resolved.explicit_heavy is False
+
+
+def test_rollback_override_forces_heavy_without_redeploy() -> None:
+    resolved = resolve_turn_profile(
+        platform="discord",
+        prompt="Mi volt a markerem?",
+        current_enabled_toolsets=["web", "file"],
+        env={"HERMES_DISCORD_TURN_PROFILE": "heavy"},
+    )
+
+    assert resolved.turn_profile == "heavy_work"
+    assert resolved.enabled_toolsets == ("file", "web")
+    assert resolved.rollback_override_active is True
+
+
+def test_conversation_direct_override_has_no_tools() -> None:
+    resolved = resolve_turn_profile(
+        platform="discord",
+        prompt="Mi volt a markerem?",
+        current_enabled_toolsets=["hermes-cli"],
+        env={"HERMES_DISCORD_CONVERSATION_DIRECT": "1"},
+    )
+
+    assert resolved.turn_profile == "conversation_direct"
+    assert resolved.enabled_toolsets == ()


### PR DESCRIPTION
Refs #16103.

Adds an observe-only Gateway TurnContract and conversation profile resolver so provider requests can explain tool/model/profile decisions without changing CLI defaults.
