### PR TITLE
Add deterministic memory answer renderer

### DIFF
--- a/gateway/context_budget.py
+++ b/gateway/context_budget.py
@@ -1,0 +1,378 @@
+"""Observe-only context budget compiler for Hermes gateway prompts."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from hashlib import sha256
+import json
+import re
+from typing import Any, Mapping, Sequence
+
+
+SCHEMA_VERSION = "hermes.context_budget.v1"
+
+SECRET_SHAPED_RE = re.compile(
+    r"(?i)(sk-[a-z0-9_-]{12,}|api[_-]?key|token|secret|password|bearer\s+[a-z0-9._-]{12,})"
+)
+PRIVATE_PATH_RE = re.compile(r"(?<![\w.-])/(?:home|Users)/[^\s'\"`]+")
+
+PROTECTED_CATEGORIES = {
+    "answerability",
+    "answer_evidence",
+    "forbidden_claims",
+    "conflict_degraded_status",
+    "current_assignment_authority_status",
+    "current_user_message",
+}
+
+CATEGORY_PRIORITY = {
+    "answerability": 0,
+    "answer_evidence": 1,
+    "forbidden_claims": 2,
+    "conflict_degraded_status": 3,
+    "current_assignment_authority_status": 4,
+    "current_user_message": 5,
+    "tool_schema": 6,
+    "memory_packet": 7,
+    "supporting_context": 8,
+    "recent_history": 9,
+    "diagnostics": 10,
+}
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def _hash_text(text: str) -> str:
+    return sha256(text.encode("utf-8")).hexdigest()
+
+
+def estimate_text_tokens(text: str) -> int:
+    return max(1, len(text) // 4)
+
+
+def estimate_json_tokens(value: Any) -> int:
+    return estimate_text_tokens(_canonical_json(value))
+
+
+def redact_model_facing_text(text: str) -> str:
+    text = SECRET_SHAPED_RE.sub("[REDACTED_SECRET_SHAPED]", text)
+    return PRIVATE_PATH_RE.sub("[REDACTED_PRIVATE_PATH]", text)
+
+
+@dataclass(frozen=True)
+class ContextBudget:
+    total_input_budget_tokens: int
+    static_system_budget_tokens: int
+    tool_schema_budget_tokens: int
+    memory_packet_budget_tokens: int
+    recent_history_budget_tokens: int
+    safety_margin_tokens: int
+    overflow_policy: tuple[str, ...] = (
+        "drop_low_authority_supporting_context",
+        "replace_verbose_diagnostics_with_inspect_ref",
+        "compress_recent_history",
+        "minimum_viable_context",
+        "fail_or_degrade_visible_if_required_evidence_cannot_fit",
+    )
+
+    @property
+    def dynamic_budget_tokens(self) -> int:
+        reserved = self.static_system_budget_tokens + self.tool_schema_budget_tokens + self.safety_margin_tokens
+        return max(0, self.total_input_budget_tokens - reserved)
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["overflow_policy"] = list(self.overflow_policy)
+        data["dynamic_budget_tokens"] = self.dynamic_budget_tokens
+        return data
+
+
+@dataclass(frozen=True)
+class ContextItem:
+    item_id: str
+    category: str
+    text: str
+    tokens_est: int
+    protected: bool
+    priority: int
+    source: str = "runtime"
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ToolResponseEnvelope:
+    tool_name: str
+    model_facing: dict[str, Any]
+    inspect_ref: str
+    truncated: bool
+    continuation_token: str | None
+    cap_tokens: int
+    tokens_est: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class PromptAssembly:
+    schema: str
+    profile_name: str
+    static_prefix_hash: str
+    dynamic_suffix_hash: str
+    total_tokens_est: int
+    static_tokens_est: int
+    dynamic_tokens_est: int
+    selected_items: tuple[ContextItem, ...]
+    dropped_items: tuple[ContextItem, ...]
+    minimum_viable_context_used: bool
+    overflow: bool
+    overflow_reason: str | None
+    provider_cache_observable: bool
+    provider_reported_cached_tokens: int | None
+    provider_cache_hit: bool | None
+    cache_candidate: bool
+    cache_break_reason: str | None
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["selected_items"] = [item.to_dict() for item in self.selected_items]
+        data["dropped_items"] = [item.to_dict() for item in self.dropped_items]
+        return data
+
+
+def make_context_item(
+    item_id: str,
+    category: str,
+    text: str,
+    *,
+    source: str = "runtime",
+    tokens_est: int | None = None,
+) -> ContextItem:
+    redacted = redact_model_facing_text(text)
+    protected = category in PROTECTED_CATEGORIES
+    return ContextItem(
+        item_id=item_id,
+        category=category,
+        text=redacted,
+        tokens_est=tokens_est if tokens_est is not None else estimate_text_tokens(redacted),
+        protected=protected,
+        priority=CATEGORY_PRIORITY.get(category, 50),
+        source=source,
+    )
+
+
+def build_policy_static_prefix(
+    *,
+    profile_name: str,
+    tool_profile: str,
+    max_claim_strength: str,
+    latency_mode: str,
+    forbidden_claims: Sequence[str],
+) -> str:
+    policy = {
+        "schema": "hermes.policy_variables.v1",
+        "profile_name": profile_name,
+        "tool_profile": tool_profile,
+        "max_claim_strength": max_claim_strength,
+        "latency_mode": latency_mode,
+        "forbidden_claims": sorted(set(forbidden_claims)),
+        "rule": "Use memory answerability and answer evidence as upper bound for memory claims.",
+    }
+    return "Hermes gateway base prompt\n" + _canonical_json(policy)
+
+
+def compact_tool_response(
+    tool_name: str,
+    payload: Mapping[str, Any],
+    *,
+    cap_tokens: int,
+    inspect_ref: str,
+    continuation_token: str | None = None,
+) -> ToolResponseEnvelope:
+    model_facing: dict[str, Any] = {
+        "tool_name": tool_name,
+        "answerability": payload.get("answerability") or payload.get("memory_answerability"),
+        "answer_evidence": payload.get("answer_evidence", []),
+        "supporting_context": payload.get("supporting_context", []),
+        "forbidden_claims": payload.get("forbidden_claims", []),
+        "inspect_ref": inspect_ref,
+    }
+    raw_tokens = estimate_json_tokens(model_facing)
+    truncated = raw_tokens > cap_tokens
+    if truncated:
+        model_facing["supporting_context"] = []
+        model_facing["truncated"] = True
+        model_facing["continuation_token"] = continuation_token
+    else:
+        model_facing["truncated"] = False
+        model_facing["continuation_token"] = continuation_token
+    model_facing = json.loads(redact_model_facing_text(_canonical_json(model_facing)))
+    return ToolResponseEnvelope(
+        tool_name=tool_name,
+        model_facing=model_facing,
+        inspect_ref=inspect_ref,
+        truncated=truncated,
+        continuation_token=continuation_token,
+        cap_tokens=cap_tokens,
+        tokens_est=min(raw_tokens, estimate_json_tokens(model_facing)),
+    )
+
+
+def compile_context_budget(
+    *,
+    profile_name: str,
+    budget: ContextBudget,
+    static_prefix: str,
+    tool_schema_tokens_est: int,
+    items: Sequence[ContextItem],
+    provider_cache_observable: bool = False,
+    provider_reported_cached_tokens: int | None = None,
+    provider_cache_hit: bool | None = None,
+    previous_static_prefix_hash: str | None = None,
+) -> PromptAssembly:
+    static_tokens = estimate_text_tokens(static_prefix)
+    dynamic_budget = budget.total_input_budget_tokens - budget.safety_margin_tokens - static_tokens - tool_schema_tokens_est
+    dynamic_budget = max(0, dynamic_budget)
+    sorted_items = sorted(items, key=lambda item: (item.priority, item.item_id))
+
+    selected: list[ContextItem] = []
+    dropped: list[ContextItem] = []
+    used = 0
+    protected_overflow = False
+    for item in sorted_items:
+        if item.protected:
+            selected.append(item)
+            used += item.tokens_est
+            if used > dynamic_budget:
+                protected_overflow = True
+            continue
+        if used + item.tokens_est <= dynamic_budget:
+            selected.append(item)
+            used += item.tokens_est
+        else:
+            dropped.append(item)
+
+    minimum_viable = False
+    overflow_reason = None
+    if protected_overflow:
+        minimum_viable = True
+        selected = [item for item in selected if item.protected]
+        dropped = [item for item in sorted_items if not item.protected]
+        overflow_reason = "PROTECTED_CONTEXT_EXCEEDS_DYNAMIC_BUDGET"
+    elif dropped:
+        overflow_reason = "DROPPED_LOW_PRIORITY_CONTEXT"
+
+    dynamic_suffix = "\n".join(item.text for item in selected)
+    static_hash = _hash_text(static_prefix)
+    cache_break_reason = None
+    if previous_static_prefix_hash and previous_static_prefix_hash != static_hash:
+        cache_break_reason = "STATIC_PREFIX_HASH_CHANGED_REQUIRES_PROFILE_VERSION_BUMP"
+
+    return PromptAssembly(
+        schema=SCHEMA_VERSION,
+        profile_name=profile_name,
+        static_prefix_hash=static_hash,
+        dynamic_suffix_hash=_hash_text(dynamic_suffix),
+        total_tokens_est=static_tokens + tool_schema_tokens_est + used + budget.safety_margin_tokens,
+        static_tokens_est=static_tokens,
+        dynamic_tokens_est=used,
+        selected_items=tuple(selected),
+        dropped_items=tuple(dropped),
+        minimum_viable_context_used=minimum_viable,
+        overflow=bool(dropped or protected_overflow),
+        overflow_reason=overflow_reason,
+        provider_cache_observable=provider_cache_observable,
+        provider_reported_cached_tokens=provider_reported_cached_tokens,
+        provider_cache_hit=provider_cache_hit,
+        cache_candidate=True,
+        cache_break_reason=cache_break_reason,
+    )
+
+
+def default_budget_for_profile(profile_name: str, tool_schema_tokens_est: int) -> ContextBudget:
+    if profile_name == "conversation_direct":
+        return ContextBudget(
+            total_input_budget_tokens=5000,
+            static_system_budget_tokens=1800,
+            tool_schema_budget_tokens=0,
+            memory_packet_budget_tokens=900,
+            recent_history_budget_tokens=1200,
+            safety_margin_tokens=500,
+        )
+    if profile_name == "conversation_tools":
+        return ContextBudget(
+            total_input_budget_tokens=6500,
+            static_system_budget_tokens=2000,
+            tool_schema_budget_tokens=min(tool_schema_tokens_est, 1500),
+            memory_packet_budget_tokens=1000,
+            recent_history_budget_tokens=1400,
+            safety_margin_tokens=600,
+        )
+    return ContextBudget(
+        total_input_budget_tokens=18000,
+        static_system_budget_tokens=2500,
+        tool_schema_budget_tokens=tool_schema_tokens_est,
+        memory_packet_budget_tokens=1600,
+        recent_history_budget_tokens=3500,
+        safety_margin_tokens=1000,
+    )
+
+
+def build_budget_proof(
+    *,
+    profile_name: str,
+    tool_schema_tokens_est: int,
+    answerability: Mapping[str, Any],
+    answer_evidence: Sequence[Mapping[str, Any]],
+    forbidden_claims: Sequence[str],
+    current_user_message: str,
+    supporting_context: Sequence[str] = (),
+    recent_history: Sequence[str] = (),
+    diagnostics: Sequence[str] = (),
+) -> dict[str, Any]:
+    budget = default_budget_for_profile(profile_name, tool_schema_tokens_est)
+    static_prefix = build_policy_static_prefix(
+        profile_name=profile_name,
+        tool_profile=profile_name,
+        max_claim_strength=str(answerability.get("max_claim_strength", "none")),
+        latency_mode="conversation_warm" if profile_name.startswith("conversation") else "heavy_visible_progress",
+        forbidden_claims=forbidden_claims,
+    )
+    items: list[ContextItem] = [
+        make_context_item("answerability", "answerability", _canonical_json(answerability)),
+        make_context_item("forbidden_claims", "forbidden_claims", _canonical_json(sorted(set(forbidden_claims)))),
+        make_context_item("current_user_message", "current_user_message", current_user_message),
+    ]
+    for idx, evidence in enumerate(answer_evidence):
+        items.append(make_context_item(f"answer_evidence:{idx}", "answer_evidence", _canonical_json(evidence)))
+    for idx, text in enumerate(supporting_context):
+        items.append(make_context_item(f"supporting:{idx}", "supporting_context", text))
+    for idx, text in enumerate(recent_history):
+        items.append(make_context_item(f"history:{idx}", "recent_history", text))
+    for idx, text in enumerate(diagnostics):
+        items.append(make_context_item(f"diagnostic:{idx}", "diagnostics", text))
+
+    assembly = compile_context_budget(
+        profile_name=profile_name,
+        budget=budget,
+        static_prefix=static_prefix,
+        tool_schema_tokens_est=tool_schema_tokens_est,
+        items=items,
+        provider_cache_observable=False,
+    )
+    selected_ids = {item.item_id for item in assembly.selected_items}
+    protected_ids = {item.item_id for item in items if item.protected}
+    return {
+        "schema": SCHEMA_VERSION,
+        "profile_name": profile_name,
+        "budget": budget.to_dict(),
+        "assembly": assembly.to_dict(),
+        "protected_ids": sorted(protected_ids),
+        "protected_preserved": protected_ids.issubset(selected_ids),
+        "tool_schema_budget_zero": tool_schema_tokens_est == 0,
+        "provider_cache_observable": False,
+    }

--- a/gateway/memory_answer_renderer.py
+++ b/gateway/memory_answer_renderer.py
@@ -1,0 +1,328 @@
+"""Deterministic renderer for simple Gateway memory answerability packets."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Mapping, Sequence
+
+from gateway.context_budget import redact_model_facing_text
+
+
+SCHEMA_VERSION = "hermes.memory_answer_renderer.v1"
+
+SUPPORTED_FACT_TYPES = {"explicit_user_fact", "exact_literal"}
+SUPPORTED_EVENT_TYPES = {"conversation_event", "prior_conversation_event", "bounded_event"}
+SUPPORTED_ASSIGNMENT_TYPES = {"current_assignment", "current_assignment_absence"}
+BAD_BACKEND_STATES = {"degraded", "unavailable", "down", "error", "missing"}
+HEAVY_OR_EXTERNAL_PROFILES = {"heavy", "heavy_work", "heavy_web", "heavy_file", "heavy_code", "heavy_full_debug"}
+TYPED_ASSIGNMENT_AUTHORITIES = {"typed_current_assignment", "current_assignment_authority"}
+LIFETIME_CERTAINTY_WORDS = ("always", "never", "forever", "lifetime")
+
+
+@dataclass(frozen=True)
+class RendererEligibility:
+    schema: str
+    eligible: bool
+    answer_type: str
+    reason_code: str
+    fallback_reason: str | None
+    evidence_ids: tuple[str, ...]
+    renderer_claim_style: str
+    no_tool_call: bool = True
+    no_memory_mutation: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["evidence_ids"] = list(self.evidence_ids)
+        return data
+
+
+@dataclass(frozen=True)
+class RenderedMemoryAnswer:
+    schema: str
+    used_renderer: bool
+    text: str
+    answer_type: str
+    reason_code: str
+    fallback_reason: str | None
+    evidence_ids: tuple[str, ...]
+    renderer_claim_style: str
+    redacted: bool
+    no_tool_call: bool = True
+    no_memory_mutation: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["evidence_ids"] = list(self.evidence_ids)
+        return data
+
+
+def evaluate_renderer_eligibility(
+    *,
+    turn_contract: Mapping[str, Any] | Any,
+    answerability: Mapping[str, Any],
+    answer_evidence: Sequence[Mapping[str, Any]] = (),
+    capability_health: Mapping[str, str] | None = None,
+) -> RendererEligibility:
+    """Return fail-closed eligibility for deterministic memory rendering."""
+
+    contract = _as_mapping(turn_contract)
+    answer_type = str(answerability.get("answer_type", "none"))
+    state = str(answerability.get("state", "unanswerable"))
+    max_claim_strength = str(answerability.get("max_claim_strength", "none"))
+    evidence_ids = _evidence_ids(answerability, answer_evidence)
+
+    if _is_heavy_or_external(contract):
+        return _ineligible(answer_type, "HEAVY_OR_EXTERNAL_TASK", "provider_required_for_heavy_or_external_task")
+
+    if state in {"conflicted", "conflict"}:
+        return _ineligible(answer_type, "CONFLICT_REQUIRES_MODEL", "conflict_requires_model")
+
+    if state == "degraded":
+        return _ineligible(answer_type, "DEGRADED_STATE_REQUIRES_MODEL", "degraded_state_requires_model")
+
+    backend_reason = _degraded_required_backend(answerability, capability_health or {})
+    if backend_reason:
+        return _ineligible(answer_type, "REQUIRED_BACKEND_DEGRADED", backend_reason)
+
+    if max_claim_strength == "supporting_context":
+        return _ineligible(answer_type, "ONLY_SUPPORTING_CONTEXT", "supporting_context_is_not_answer_truth")
+
+    if _is_unsupported(answer_type, state, max_claim_strength, answerability, answer_evidence):
+        return _eligible(
+            answer_type="none",
+            reason_code="UNSUPPORTED_ABSTAIN",
+            evidence_ids=(),
+            claim_style="unsupported",
+        )
+
+    if answer_type in SUPPORTED_FACT_TYPES:
+        if state != "answerable" or max_claim_strength != "memory_truth":
+            return _ineligible(answer_type, "FACT_NOT_MEMORY_TRUTH", "fact_requires_memory_truth_answerability")
+        if len(answer_evidence) != 1 or not evidence_ids:
+            return _ineligible(answer_type, "FACT_REQUIRES_SINGLE_EVIDENCE", "fact_requires_single_answer_evidence")
+        return _eligible(answer_type, "AUTHORITATIVE_SIMPLE_FACT", evidence_ids, "explicit_fact")
+
+    if answer_type in SUPPORTED_EVENT_TYPES:
+        if state != "answerable" or max_claim_strength != "bounded_event":
+            return _ineligible(answer_type, "EVENT_NOT_BOUNDED", "event_requires_bounded_event_strength")
+        if not evidence_ids:
+            return _ineligible(answer_type, "EVENT_REQUIRES_EVIDENCE", "event_requires_evidence_id")
+        return _eligible(answer_type, "BOUNDED_EVENT", evidence_ids, "bounded_event")
+
+    if answer_type in SUPPORTED_ASSIGNMENT_TYPES:
+        return _assignment_eligibility(answer_type, answerability, answer_evidence, evidence_ids)
+
+    return _ineligible(answer_type, "UNSUPPORTED_ANSWER_TYPE", f"unsupported_answer_type:{answer_type}")
+
+
+def render_memory_answer(
+    *,
+    turn_contract: Mapping[str, Any] | Any,
+    answerability: Mapping[str, Any],
+    answer_evidence: Sequence[Mapping[str, Any]] = (),
+    capability_health: Mapping[str, str] | None = None,
+) -> RenderedMemoryAnswer:
+    """Render simple memory answer or return explicit provider fallback trace."""
+
+    eligibility = evaluate_renderer_eligibility(
+        turn_contract=turn_contract,
+        answerability=answerability,
+        answer_evidence=answer_evidence,
+        capability_health=capability_health,
+    )
+    if not eligibility.eligible:
+        return RenderedMemoryAnswer(
+            schema=SCHEMA_VERSION,
+            used_renderer=False,
+            text="",
+            answer_type=eligibility.answer_type,
+            reason_code=eligibility.reason_code,
+            fallback_reason=eligibility.fallback_reason,
+            evidence_ids=eligibility.evidence_ids,
+            renderer_claim_style=eligibility.renderer_claim_style,
+            redacted=False,
+        )
+
+    raw = _render_text(eligibility.answer_type, eligibility.renderer_claim_style, answer_evidence)
+    text = redact_model_facing_text(raw)
+    return RenderedMemoryAnswer(
+        schema=SCHEMA_VERSION,
+        used_renderer=True,
+        text=text,
+        answer_type=eligibility.answer_type,
+        reason_code=eligibility.reason_code,
+        fallback_reason=None,
+        evidence_ids=eligibility.evidence_ids,
+        renderer_claim_style=eligibility.renderer_claim_style,
+        redacted=text != raw,
+    )
+
+
+def _as_mapping(value: Mapping[str, Any] | Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+    if hasattr(value, "to_dict"):
+        mapped = value.to_dict()
+        if isinstance(mapped, Mapping):
+            return mapped
+    return {}
+
+
+def _is_heavy_or_external(contract: Mapping[str, Any]) -> bool:
+    profile = str(contract.get("allowed_tool_profile", ""))
+    external = bool(contract.get("external_capability_required_for_memory_answer", False))
+    return external or profile in HEAVY_OR_EXTERNAL_PROFILES or profile.startswith("heavy_")
+
+
+def _degraded_required_backend(answerability: Mapping[str, Any], capability_health: Mapping[str, str]) -> str | None:
+    if bool(answerability.get("required_backend_degraded", False)):
+        return "answerability_marked_required_backend_degraded"
+    required = answerability.get("required_backends") or answerability.get("required_backend_keys") or ()
+    if isinstance(required, str):
+        required = (required,)
+    for backend in required:
+        status = str(capability_health.get(str(backend), "unknown")).lower()
+        if status in BAD_BACKEND_STATES:
+            return f"required_backend_{backend}_{status}"
+    return None
+
+
+def _is_unsupported(
+    answer_type: str,
+    state: str,
+    max_claim_strength: str,
+    answerability: Mapping[str, Any],
+    answer_evidence: Sequence[Mapping[str, Any]],
+) -> bool:
+    no_answer_type = answer_type in {"none", "unsupported", "no_evidence"}
+    no_evidence = not answer_evidence and int(answerability.get("answer_evidence_count", 0) or 0) == 0
+    return state == "unanswerable" and max_claim_strength == "none" and no_answer_type and no_evidence
+
+
+def _assignment_eligibility(
+    answer_type: str,
+    answerability: Mapping[str, Any],
+    answer_evidence: Sequence[Mapping[str, Any]],
+    evidence_ids: tuple[str, ...],
+) -> RendererEligibility:
+    state = str(answerability.get("state", "unanswerable"))
+    reason_code = str(answerability.get("reason_code", "UNKNOWN"))
+    if answer_type == "current_assignment_absence" or reason_code == "NO_TYPED_CURRENT_ASSIGNMENT_EVIDENCE":
+        return _eligible(
+            answer_type="current_assignment_absence",
+            reason_code="NO_TYPED_CURRENT_ASSIGNMENT_EVIDENCE",
+            evidence_ids=evidence_ids,
+            claim_style="current_assignment_absence",
+        )
+
+    if state != "answerable":
+        return _ineligible(answer_type, "ASSIGNMENT_NOT_ANSWERABLE", "assignment_presence_requires_answerable_state")
+
+    authority = str(answerability.get("authority", ""))
+    if authority not in TYPED_ASSIGNMENT_AUTHORITIES and not any(
+        _has_typed_assignment_authority(evidence) for evidence in answer_evidence
+    ):
+        return _ineligible(answer_type, "ASSIGNMENT_REQUIRES_TYPED_AUTHORITY", "no_typed_assignment_authority")
+
+    if not evidence_ids:
+        return _ineligible(answer_type, "ASSIGNMENT_REQUIRES_EVIDENCE", "assignment_requires_evidence_id")
+
+    return _eligible(answer_type, "TYPED_CURRENT_ASSIGNMENT", evidence_ids, "current_assignment_presence")
+
+
+def _has_typed_assignment_authority(evidence: Mapping[str, Any]) -> bool:
+    if bool(evidence.get("current_assignment_authority", False)):
+        return True
+    schema = str(evidence.get("current_assignment_authority_schema", ""))
+    authority = str(evidence.get("authority", ""))
+    return bool(schema) or authority in TYPED_ASSIGNMENT_AUTHORITIES
+
+
+def _evidence_ids(
+    answerability: Mapping[str, Any],
+    answer_evidence: Sequence[Mapping[str, Any]],
+) -> tuple[str, ...]:
+    ids: list[str] = []
+    raw = answerability.get("answer_evidence_ids") or answerability.get("evidence_ids") or ()
+    if isinstance(raw, str):
+        raw = (raw,)
+    for value in raw:
+        _append_unique(ids, str(value))
+    for evidence in answer_evidence:
+        for key in ("evidence_id", "id", "candidate_id", "stable_key"):
+            value = evidence.get(key)
+            if value:
+                _append_unique(ids, str(value))
+                break
+    return tuple(ids)
+
+
+def _append_unique(values: list[str], value: str) -> None:
+    if value and value not in values:
+        values.append(value)
+
+
+def _render_text(answer_type: str, claim_style: str, answer_evidence: Sequence[Mapping[str, Any]]) -> str:
+    if claim_style == "unsupported":
+        return "No supported memory evidence for this request."
+    if claim_style == "current_assignment_absence":
+        return "No typed current-assignment evidence is recorded. Background runtime/Pulse evidence alone is not current assignment."
+
+    value = _answer_value(answer_evidence)
+    if claim_style == "bounded_event":
+        return f"Recorded event in searched scope: {value}."
+    if claim_style == "current_assignment_presence":
+        return f"Typed current assignment: {value}."
+    if answer_type == "exact_literal":
+        return f"Recorded identifier: {value}."
+    return f"Recorded value: {value}."
+
+
+def _answer_value(answer_evidence: Sequence[Mapping[str, Any]]) -> str:
+    if not answer_evidence:
+        return "none"
+    evidence = answer_evidence[0]
+    for key in ("value", "literal", "recorded_value", "answer", "summary", "preview", "text", "content"):
+        value = evidence.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+        if isinstance(value, Mapping):
+            nested = _answer_value((value,))
+            if nested != "recorded evidence":
+                return nested
+    return "recorded evidence"
+
+
+def _eligible(
+    answer_type: str,
+    reason_code: str,
+    evidence_ids: Sequence[str],
+    claim_style: str,
+) -> RendererEligibility:
+    return RendererEligibility(
+        schema=SCHEMA_VERSION,
+        eligible=True,
+        answer_type=answer_type,
+        reason_code=reason_code,
+        fallback_reason=None,
+        evidence_ids=tuple(evidence_ids),
+        renderer_claim_style=claim_style,
+    )
+
+
+def _ineligible(answer_type: str, reason_code: str, fallback_reason: str) -> RendererEligibility:
+    return RendererEligibility(
+        schema=SCHEMA_VERSION,
+        eligible=False,
+        answer_type=answer_type,
+        reason_code=reason_code,
+        fallback_reason=fallback_reason,
+        evidence_ids=(),
+        renderer_claim_style="provider_fallback",
+    )
+
+
+def contains_lifetime_certainty(text: str) -> bool:
+    lowered = text.lower()
+    return any(word in lowered for word in LIFETIME_CERTAINTY_WORDS)

--- a/scripts/hermes_memory_renderer_proof.py
+++ b/scripts/hermes_memory_renderer_proof.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Write Phase 155 memory answer renderer proof artifact."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from time import perf_counter
+import sys
+from typing import Any, Mapping
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from gateway.memory_answer_renderer import contains_lifetime_certainty, render_memory_answer  # noqa: E402
+
+
+DEFAULT_PHASE_DIR = (
+    Path("/home/lauratom/Asztal/ai/atado/Brainstack-phase50")
+    / ".planning/phases/155-memory-answer-renderer-gate"
+)
+
+CONTRACT = {
+    "allowed_tool_profile": "conversation_direct",
+    "external_capability_required_for_memory_answer": False,
+}
+
+
+def _json_dump(path: Path, data: Mapping[str, Any]) -> None:
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True) + "\n")
+
+
+def _run_case(
+    *,
+    name: str,
+    answerability: Mapping[str, Any],
+    answer_evidence: list[Mapping[str, Any]],
+    expected_used: bool,
+    expected_text: str | None = None,
+    turn_contract: Mapping[str, Any] | None = None,
+    capability_health: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    start = perf_counter()
+    answer = render_memory_answer(
+        turn_contract=turn_contract or CONTRACT,
+        answerability=answerability,
+        answer_evidence=answer_evidence,
+        capability_health=capability_health,
+    )
+    latency_ms = int((perf_counter() - start) * 1000)
+    data = answer.to_dict()
+    pass_conditions = {
+        "expected_renderer_usage": answer.used_renderer is expected_used,
+        "expected_text": expected_text is None or answer.text == expected_text,
+        "no_tool_call": answer.no_tool_call is True,
+        "no_memory_mutation": answer.no_memory_mutation is True,
+        "bounded_event_humble": answer.renderer_claim_style != "bounded_event"
+        or not contains_lifetime_certainty(answer.text),
+        "sub_second": latency_ms < 1000,
+    }
+    return {
+        "name": name,
+        "latency_ms": latency_ms,
+        "result": data,
+        "pass_conditions": pass_conditions,
+        "passed": all(pass_conditions.values()),
+    }
+
+
+def build_proof() -> dict[str, Any]:
+    scenarios = [
+        _run_case(
+            name="explicit_fact",
+            answerability={
+                "state": "answerable",
+                "max_claim_strength": "memory_truth",
+                "answer_type": "explicit_user_fact",
+            },
+            answer_evidence=[{"id": "profile:debug_marker", "value": "1231231X"}],
+            expected_used=True,
+            expected_text="Recorded value: 1231231X.",
+        ),
+        _run_case(
+            name="exact_literal",
+            answerability={
+                "state": "answerable",
+                "max_claim_strength": "memory_truth",
+                "answer_type": "exact_literal",
+            },
+            answer_evidence=[{"id": "profile:debug_marker", "literal": "1231231X"}],
+            expected_used=True,
+            expected_text="Recorded identifier: 1231231X.",
+        ),
+        _run_case(
+            name="unsupported_abstain",
+            answerability={
+                "state": "unanswerable",
+                "max_claim_strength": "none",
+                "answer_type": "none",
+                "answer_evidence_count": 0,
+                "reason_code": "NO_SUPPORTED_MEMORY_TRUTH",
+            },
+            answer_evidence=[],
+            expected_used=True,
+            expected_text="No supported memory evidence for this request.",
+        ),
+        _run_case(
+            name="typed_assignment_absence",
+            answerability={
+                "state": "unanswerable",
+                "max_claim_strength": "none",
+                "answer_type": "current_assignment_absence",
+                "reason_code": "NO_TYPED_CURRENT_ASSIGNMENT_EVIDENCE",
+            },
+            answer_evidence=[],
+            expected_used=True,
+            expected_text="No typed current-assignment evidence is recorded.",
+        ),
+        _run_case(
+            name="bounded_prior_event",
+            answerability={
+                "state": "answerable",
+                "max_claim_strength": "bounded_event",
+                "answer_type": "conversation_event",
+            },
+            answer_evidence=[{"id": "event:turn-7", "preview": "User asked about marker 1231231X"}],
+            expected_used=True,
+            expected_text="Recorded event in searched scope: User asked about marker 1231231X.",
+        ),
+        _run_case(
+            name="pulse_background_assignment_forbidden",
+            answerability={
+                "state": "answerable",
+                "max_claim_strength": "memory_truth",
+                "answer_type": "current_assignment",
+                "authority": "runtime_state_supporting",
+            },
+            answer_evidence=[{"id": "operating:pulse", "value": "Pulse running", "source_role": "runtime"}],
+            expected_used=False,
+        ),
+        _run_case(
+            name="conflict_forbidden",
+            answerability={
+                "state": "conflicted",
+                "max_claim_strength": "none",
+                "answer_type": "conflict_report",
+            },
+            answer_evidence=[{"id": "profile:old", "value": "1231231Y"}],
+            expected_used=False,
+        ),
+        _run_case(
+            name="degraded_backend_forbidden",
+            answerability={
+                "state": "answerable",
+                "max_claim_strength": "memory_truth",
+                "answer_type": "explicit_user_fact",
+                "required_backends": ["chroma"],
+            },
+            answer_evidence=[{"id": "profile:debug_marker", "value": "1231231X"}],
+            capability_health={"chroma": "unavailable"},
+            expected_used=False,
+        ),
+        _run_case(
+            name="heavy_external_forbidden",
+            answerability={
+                "state": "answerable",
+                "max_claim_strength": "memory_truth",
+                "answer_type": "explicit_user_fact",
+            },
+            answer_evidence=[{"id": "profile:repo", "value": "https://example.test"}],
+            turn_contract={
+                "allowed_tool_profile": "heavy_web",
+                "external_capability_required_for_memory_answer": False,
+            },
+            expected_used=False,
+        ),
+        _run_case(
+            name="redaction_private_path",
+            answerability={
+                "state": "answerable",
+                "max_claim_strength": "memory_truth",
+                "answer_type": "explicit_user_fact",
+            },
+            answer_evidence=[{"id": "profile:path", "value": "/home/lauratom/private/project"}],
+            expected_used=True,
+            expected_text="Recorded value: [REDACTED_PRIVATE_PATH]",
+        ),
+    ]
+    passed = all(case["passed"] for case in scenarios)
+    return {
+        "schema": "hermes.phase155.memory_renderer_proof.v1",
+        "phase": 155,
+        "verdict": "pass" if passed else "fail",
+        "no_provider_call_required": True,
+        "no_tool_call": True,
+        "no_memory_mutation": True,
+        "canary_type": "deterministic_renderer_gate",
+        "scenarios": scenarios,
+        "summary": {
+            "scenario_count": len(scenarios),
+            "passed_count": sum(1 for case in scenarios if case["passed"]),
+            "max_latency_ms": max(case["latency_ms"] for case in scenarios),
+            "sub_second_all": all(case["pass_conditions"]["sub_second"] for case in scenarios),
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_PHASE_DIR)
+    args = parser.parse_args()
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    proof = build_proof()
+    _json_dump(args.output_dir / "155-RENDERER-PROOF.json", proof)
+    _json_dump(args.output_dir / "155-RENDERER-CANARY.json", proof)
+    print(json.dumps({"verdict": proof["verdict"], "summary": proof["summary"]}, sort_keys=True))
+    return 0 if proof["verdict"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/gateway/test_context_budget.py
+++ b/tests/gateway/test_context_budget.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from gateway.context_budget import (
+    ContextBudget,
+    build_budget_proof,
+    build_policy_static_prefix,
+    compact_tool_response,
+    compile_context_budget,
+    make_context_item,
+)
+
+
+def test_conversation_direct_can_prove_zero_tool_schema_budget() -> None:
+    proof = build_budget_proof(
+        profile_name="conversation_direct",
+        tool_schema_tokens_est=0,
+        answerability={"state": "answerable", "max_claim_strength": "memory_truth"},
+        answer_evidence=[{"id": "profile:debug_marker", "value": "1231231X"}],
+        forbidden_claims=["external_verification"],
+        current_user_message="Mi volt a debug markerem?",
+    )
+
+    assert proof["tool_schema_budget_zero"] is True
+    assert proof["protected_preserved"] is True
+    assert proof["assembly"]["provider_cache_observable"] is False
+
+
+def test_overflow_drops_supporting_context_before_answer_evidence() -> None:
+    budget = ContextBudget(
+        total_input_budget_tokens=200,
+        static_system_budget_tokens=20,
+        tool_schema_budget_tokens=0,
+        memory_packet_budget_tokens=50,
+        recent_history_budget_tokens=50,
+        safety_margin_tokens=20,
+    )
+    static_prefix = "stable"
+    items = [
+        make_context_item("answerability", "answerability", '{"state":"answerable"}', tokens_est=10),
+        make_context_item("answer_evidence", "answer_evidence", "debug marker 1231231X", tokens_est=10),
+        make_context_item("forbidden", "forbidden_claims", "do not guess", tokens_est=10),
+        make_context_item("user", "current_user_message", "Mi volt?", tokens_est=10),
+        make_context_item("support", "supporting_context", "noise " * 1000, tokens_est=400),
+        make_context_item("history", "recent_history", "old chat " * 1000, tokens_est=400),
+    ]
+
+    assembly = compile_context_budget(
+        profile_name="conversation_direct",
+        budget=budget,
+        static_prefix=static_prefix,
+        tool_schema_tokens_est=0,
+        items=items,
+    )
+    selected = {item.item_id for item in assembly.selected_items}
+    dropped = {item.item_id for item in assembly.dropped_items}
+
+    assert {"answerability", "answer_evidence", "forbidden", "user"}.issubset(selected)
+    assert {"support", "history"}.issubset(dropped)
+    assert assembly.overflow is True
+
+
+def test_minimum_viable_context_preserves_protected_when_budget_tiny() -> None:
+    budget = ContextBudget(
+        total_input_budget_tokens=20,
+        static_system_budget_tokens=10,
+        tool_schema_budget_tokens=0,
+        memory_packet_budget_tokens=5,
+        recent_history_budget_tokens=0,
+        safety_margin_tokens=5,
+    )
+    items = [
+        make_context_item("answerability", "answerability", '{"state":"answerable"}', tokens_est=10),
+        make_context_item("answer_evidence", "answer_evidence", "1231231X", tokens_est=10),
+        make_context_item("support", "supporting_context", "drop me", tokens_est=10),
+    ]
+
+    assembly = compile_context_budget(
+        profile_name="conversation_direct",
+        budget=budget,
+        static_prefix="stable static prefix",
+        tool_schema_tokens_est=0,
+        items=items,
+    )
+
+    assert assembly.minimum_viable_context_used is True
+    assert {item.item_id for item in assembly.selected_items} == {"answerability", "answer_evidence"}
+    assert {item.item_id for item in assembly.dropped_items} == {"support"}
+
+
+def test_static_prefix_hash_stable_when_dynamic_suffix_changes() -> None:
+    prefix = build_policy_static_prefix(
+        profile_name="conversation_direct",
+        tool_profile="conversation_direct",
+        max_claim_strength="memory_truth",
+        latency_mode="conversation_warm",
+        forbidden_claims=["external_verification"],
+    )
+    budget = ContextBudget(1000, 100, 0, 100, 100, 50)
+
+    first = compile_context_budget(
+        profile_name="conversation_direct",
+        budget=budget,
+        static_prefix=prefix,
+        tool_schema_tokens_est=0,
+        items=[make_context_item("user", "current_user_message", "first")],
+    )
+    second = compile_context_budget(
+        profile_name="conversation_direct",
+        budget=budget,
+        static_prefix=prefix,
+        tool_schema_tokens_est=0,
+        items=[make_context_item("user", "current_user_message", "second")],
+        previous_static_prefix_hash=first.static_prefix_hash,
+    )
+    changed = compile_context_budget(
+        profile_name="conversation_direct",
+        budget=budget,
+        static_prefix=prefix + " changed",
+        tool_schema_tokens_est=0,
+        items=[make_context_item("user", "current_user_message", "second")],
+        previous_static_prefix_hash=first.static_prefix_hash,
+    )
+
+    assert first.static_prefix_hash == second.static_prefix_hash
+    assert first.dynamic_suffix_hash != second.dynamic_suffix_hash
+    assert second.cache_break_reason is None
+    assert changed.cache_break_reason == "STATIC_PREFIX_HASH_CHANGED_REQUIRES_PROFILE_VERSION_BUMP"
+
+
+def test_tool_response_model_facing_cap_preserves_answerability_and_inspect_ref() -> None:
+    payload = {
+        "memory_answerability": {"state": "answerable", "max_claim_strength": "memory_truth"},
+        "answer_evidence": [{"id": "profile:debug_marker", "value": "1231231X"}],
+        "supporting_context": ["noise " * 1000],
+        "forbidden_claims": ["external_verification"],
+        "diagnostics": ["full candidate trace should not be model-facing"],
+    }
+
+    envelope = compact_tool_response(
+        "brainstack_recall",
+        payload,
+        cap_tokens=80,
+        inspect_ref="inspect://trace-1",
+        continuation_token="cont-1",
+    )
+
+    assert envelope.truncated is True
+    assert envelope.model_facing["answerability"]["state"] == "answerable"
+    assert envelope.model_facing["answer_evidence"][0]["value"] == "1231231X"
+    assert envelope.model_facing["supporting_context"] == []
+    assert envelope.model_facing["inspect_ref"] == "inspect://trace-1"
+
+
+def test_secret_and_private_path_are_redacted_from_model_facing_items() -> None:
+    item = make_context_item(
+        "diagnostic",
+        "diagnostics",
+        "secret sk-abcdef1234567890 path /home/lauratom/secret/file.txt",
+    )
+
+    assert "sk-abcdef" not in item.text
+    assert "/home/lauratom" not in item.text
+    assert "[REDACTED_SECRET_SHAPED]" in item.text
+    assert "[REDACTED_PRIVATE_PATH]" in item.text

--- a/tests/gateway/test_memory_answer_renderer.py
+++ b/tests/gateway/test_memory_answer_renderer.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+from gateway.memory_answer_renderer import (
+    contains_lifetime_certainty,
+    evaluate_renderer_eligibility,
+    render_memory_answer,
+)
+
+
+CONTRACT = {
+    "allowed_tool_profile": "conversation_direct",
+    "external_capability_required_for_memory_answer": False,
+}
+
+
+def test_explicit_fact_renders_single_authoritative_evidence() -> None:
+    answer = render_memory_answer(
+        turn_contract=CONTRACT,
+        answerability={
+            "state": "answerable",
+            "max_claim_strength": "memory_truth",
+            "answer_type": "explicit_user_fact",
+        },
+        answer_evidence=[{"id": "profile:debug_marker", "value": "1231231X"}],
+    )
+
+    assert answer.used_renderer is True
+    assert answer.text == "Recorded value: 1231231X."
+    assert answer.evidence_ids == ("profile:debug_marker",)
+    assert answer.no_tool_call is True
+    assert answer.no_memory_mutation is True
+
+
+def test_unsupported_abstain_renders_without_evidence() -> None:
+    answer = render_memory_answer(
+        turn_contract=CONTRACT,
+        answerability={
+            "state": "unanswerable",
+            "max_claim_strength": "none",
+            "answer_type": "none",
+            "answer_evidence_count": 0,
+            "reason_code": "NO_SUPPORTED_MEMORY_TRUTH",
+        },
+        answer_evidence=[],
+    )
+
+    assert answer.used_renderer is True
+    assert answer.text == "No supported memory evidence for this request."
+    assert answer.evidence_ids == ()
+
+
+def test_forbidden_cases_fall_back_to_provider() -> None:
+    cases = [
+        (
+            {"state": "conflicted", "max_claim_strength": "none", "answer_type": "conflict_report"},
+            {},
+        ),
+        (
+            {"state": "degraded", "max_claim_strength": "memory_truth", "answer_type": "explicit_user_fact"},
+            {},
+        ),
+        (
+            {
+                "state": "answerable",
+                "max_claim_strength": "memory_truth",
+                "answer_type": "explicit_user_fact",
+                "required_backends": ["chroma"],
+            },
+            {"chroma": "unavailable"},
+        ),
+    ]
+
+    for answerability, health in cases:
+        answer = render_memory_answer(
+            turn_contract=CONTRACT,
+            answerability=answerability,
+            answer_evidence=[{"id": "profile:x", "value": "x"}],
+            capability_health=health,
+        )
+        assert answer.used_renderer is False
+        assert answer.fallback_reason
+
+
+def test_heavy_or_external_turn_falls_back() -> None:
+    eligibility = evaluate_renderer_eligibility(
+        turn_contract={
+            "allowed_tool_profile": "heavy_web",
+            "external_capability_required_for_memory_answer": False,
+        },
+        answerability={
+            "state": "answerable",
+            "max_claim_strength": "memory_truth",
+            "answer_type": "explicit_user_fact",
+        },
+        answer_evidence=[{"id": "profile:repo", "value": "https://example.test"}],
+    )
+
+    assert eligibility.eligible is False
+    assert eligibility.reason_code == "HEAVY_OR_EXTERNAL_TASK"
+
+
+def test_private_path_and_secret_shaped_values_are_redacted() -> None:
+    path_answer = render_memory_answer(
+        turn_contract=CONTRACT,
+        answerability={
+            "state": "answerable",
+            "max_claim_strength": "memory_truth",
+            "answer_type": "explicit_user_fact",
+        },
+        answer_evidence=[{"id": "profile:path", "value": "/home/lauratom/private/project"}],
+    )
+    secret_answer = render_memory_answer(
+        turn_contract=CONTRACT,
+        answerability={
+            "state": "answerable",
+            "max_claim_strength": "memory_truth",
+            "answer_type": "exact_literal",
+        },
+        answer_evidence=[{"id": "profile:secret", "value": "sk-abc123456789xyz"}],
+    )
+
+    assert "[REDACTED_PRIVATE_PATH]" in path_answer.text
+    assert path_answer.redacted is True
+    assert "[REDACTED_SECRET_SHAPED]" in secret_answer.text
+    assert secret_answer.redacted is True
+
+
+def test_supporting_context_never_becomes_answer_truth() -> None:
+    answer = render_memory_answer(
+        turn_contract=CONTRACT,
+        answerability={
+            "state": "answerable",
+            "max_claim_strength": "supporting_context",
+            "answer_type": "explicit_user_fact",
+        },
+        answer_evidence=[{"id": "continuity:bg", "value": "maybe 1231231Y"}],
+    )
+
+    assert answer.used_renderer is False
+    assert answer.reason_code == "ONLY_SUPPORTING_CONTEXT"
+
+
+def test_pulse_background_never_assignment_authority() -> None:
+    answer = render_memory_answer(
+        turn_contract=CONTRACT,
+        answerability={
+            "state": "answerable",
+            "max_claim_strength": "memory_truth",
+            "answer_type": "current_assignment",
+            "authority": "runtime_state_supporting",
+        },
+        answer_evidence=[
+            {
+                "id": "operating:pulse",
+                "value": "Brainstack Proactive Pulse running",
+                "source_role": "runtime",
+            }
+        ],
+    )
+
+    assert answer.used_renderer is False
+    assert answer.reason_code == "ASSIGNMENT_REQUIRES_TYPED_AUTHORITY"
+
+
+def test_typed_assignment_and_absence_have_humble_claims() -> None:
+    presence = render_memory_answer(
+        turn_contract=CONTRACT,
+        answerability={
+            "state": "answerable",
+            "max_claim_strength": "memory_truth",
+            "answer_type": "current_assignment",
+            "authority": "typed_current_assignment",
+        },
+        answer_evidence=[{"id": "task:current", "value": "Phase 155", "current_assignment_authority": True}],
+    )
+    absence = render_memory_answer(
+        turn_contract=CONTRACT,
+        answerability={
+            "state": "unanswerable",
+            "max_claim_strength": "none",
+            "answer_type": "current_assignment_absence",
+            "reason_code": "NO_TYPED_CURRENT_ASSIGNMENT_EVIDENCE",
+        },
+        answer_evidence=[],
+    )
+
+    assert presence.used_renderer is True
+    assert presence.text == "Typed current assignment: Phase 155."
+    assert absence.used_renderer is True
+    assert absence.text == (
+        "No typed current-assignment evidence is recorded. "
+        "Background runtime/Pulse evidence alone is not current assignment."
+    )
+
+
+def test_bounded_event_never_claims_lifetime_certainty() -> None:
+    answer = render_memory_answer(
+        turn_contract=CONTRACT,
+        answerability={
+            "state": "answerable",
+            "max_claim_strength": "bounded_event",
+            "answer_type": "conversation_event",
+        },
+        answer_evidence=[{"id": "event:turn-7", "preview": "User asked about marker 1231231X"}],
+    )
+
+    assert answer.used_renderer is True
+    assert answer.renderer_claim_style == "bounded_event"
+    assert contains_lifetime_certainty(answer.text) is False
+    assert answer.text == "Recorded event in searched scope: User asked about marker 1231231X."


### PR DESCRIPTION
Refs #16107.

Adds a fail-closed Hermes-owned renderer for simple authoritative memory packets, with redaction and fallback behavior for non-eligible cases.
