### PR TITLE
fix(cli): skip /v1/models health check for MiniMax providers

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -941,9 +941,11 @@ def run_doctor(args):
         ("Hugging Face",     ("HF_TOKEN",),                                   "https://router.huggingface.co/v1/models", "HF_BASE_URL", True),
         ("NVIDIA NIM",       ("NVIDIA_API_KEY",),                             "https://integrate.api.nvidia.com/v1/models", "NVIDIA_BASE_URL", True),
         ("Alibaba/DashScope", ("DASHSCOPE_API_KEY",),                         "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/models", "DASHSCOPE_BASE_URL", True),
-        # MiniMax: the /anthropic endpoint doesn't support /models, but the /v1 endpoint does.
-        ("MiniMax",          ("MINIMAX_API_KEY",),                            "https://api.minimax.io/v1/models",    "MINIMAX_BASE_URL", True),
-        ("MiniMax (China)",  ("MINIMAX_CN_API_KEY",),                         "https://api.minimaxi.com/v1/models",  "MINIMAX_CN_BASE_URL", True),
+        # MiniMax APIs do not support /v1/models on either the international or China region (verified 2026-04-26).
+        # Skip the health check and just show "(key configured)" when the env var is set.
+        # Reverts the relevant portion of d442f25a.
+        ("MiniMax",          ("MINIMAX_API_KEY",),                            None,                                  "MINIMAX_BASE_URL", False),
+        ("MiniMax (China)",  ("MINIMAX_CN_API_KEY",),                         None,                                  "MINIMAX_CN_BASE_URL", False),
         ("Vercel AI Gateway",       ("AI_GATEWAY_API_KEY",),                          "https://ai-gateway.vercel.sh/v1/models", "AI_GATEWAY_BASE_URL", True),
         ("Kilo Code",        ("KILOCODE_API_KEY",),                            "https://api.kilo.ai/api/gateway/models",  "KILOCODE_BASE_URL", True),
         ("OpenCode Zen",     ("OPENCODE_ZEN_API_KEY",),                        "https://opencode.ai/zen/v1/models",  "OPENCODE_ZEN_BASE_URL", True),


### PR DESCRIPTION
## What does this PR do?

`hermes doctor` calls `/v1/models` for both MiniMax variants when the env var is set. Both regions return `HTTP 404` on that path:

```
$ curl -I https://api.minimaxi.com/v1/models   # China
HTTP/2 404
$ curl -I https://api.minimax.io/v1/models     # International
HTTP/2 404
```

So configured MiniMax keys show up as `(HTTP 404)` in doctor even though the actual `/v1/chat/completions` endpoint works. Reported in #16120 against MiniMax (China) — verified to also affect the international region.

The Apr 10 commit d442f25a re-enabled the check with the comment "the /v1 endpoint does support /models". That assumption holds for neither region; the existing test suite already documents the same constraint at the model-validation layer (`tests/test_minimax_model_validation.py`: "MiniMax and MiniMax-CN providers don't expose /v1/models").

This PR flips both MiniMax tuples in `_apikey_providers` back to `supports_models_endpoint=False` so doctor prints `(key configured)` without a network call when `MINIMAX_API_KEY` or `MINIMAX_CN_API_KEY` is set. The existing `if not _supports_health_check:` branch in `run_doctor` already handles this case — no logic changes needed.

## Related Issue

Fixes #16120

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/doctor.py`: in the `_apikey_providers` list, set `supports_models_endpoint=False` and `default_url=None` for both `MiniMax` and `MiniMax (China)`. Update the inline comment to explain why. The control flow handling `not _supports_health_check` already exists; this just routes both MiniMax variants into it.

## How to Test

1. Export `MINIMAX_CN_API_KEY=sk-anything` (or `MINIMAX_API_KEY`).
2. Run `hermes doctor`.
3. Before this PR: line shows `✗ MiniMax (China) (HTTP 404)`.
4. After this PR: line shows `✓ MiniMax (China) (key configured)` with no network call.
5. With no env var set: the line is omitted entirely (existing behavior, unchanged).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A locally (this environment is missing transitive deps like `dotenv`); the change is a 5-line edit to a static config table with no new control flow, and the existing `if not _supports_health_check:` branch already covers this code path. CI will confirm.
- [ ] I've added tests for my changes — the existing `tests/test_minimax_model_validation.py` already documents the same constraint (MiniMax has no `/v1/models`). Happy to add a doctor-level test if reviewer wants.
- [x] I've tested on my platform: macOS 15.7 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no public-facing docs reference this internal table)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (no platform-dependent code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
$ curl -s -o /dev/null -w "HTTP %{http_code}\n" https://api.minimaxi.com/v1/models -H "Authorization: Bearer dummy"
HTTP 404
$ curl -s -o /dev/null -w "HTTP %{http_code}\n" https://api.minimax.io/v1/models -H "Authorization: Bearer dummy"
HTTP 404
```

This was developed with AI assistance (Claude Code orchestrating Codex CLI). The fix is structurally identical to the pre-d442f25a state of these two table rows.
