### PR TITLE
fix: extend DeepSeek reasoning_content fallback to text-only assistant messages

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7760,12 +7760,20 @@ class AIAgent:
             raw_reasoning_content = getattr(assistant_message, "reasoning_content", None)
             if raw_reasoning_content is not None:
                 msg["reasoning_content"] = _sanitize_surrogates(raw_reasoning_content)
-            elif msg.get("tool_calls") and self._needs_deepseek_tool_reasoning():
-                # DeepSeek thinking mode requires reasoning_content on every
+            elif msg.get("tool_calls") and self._needs_kimi_tool_reasoning():
+                # Kimi thinking mode requires reasoning_content on every
                 # assistant tool-call message. Without it, replaying the
-                # persisted message causes HTTP 400. Include empty string
-                # as a defensive compatibility fallback (refs #15250).
+                # persisted message causes HTTP 400.
                 msg["reasoning_content"] = ""
+            elif self._needs_deepseek_tool_reasoning():
+                # DeepSeek thinking mode requires reasoning_content on EVERY
+                # assistant message (both tool-call AND text-only). Without it,
+                # replaying a text-only response on session resume causes
+                # HTTP 400 (refs #15250, #15998). The replay safety net in
+                # _copy_reasoning_content_for_api catches this too, but storing
+                # correct data from creation time is cleaner (refs #15998).
+                raw_r = msg.get("reasoning")
+                msg["reasoning_content"] = _sanitize_surrogates(raw_r) if isinstance(raw_r, str) and raw_r else ""
 
         if hasattr(assistant_message, 'reasoning_details') and assistant_message.reasoning_details:
             # Pass reasoning_details back unmodified so providers (OpenRouter,


### PR DESCRIPTION
## Bug

When using **DeepSeek in thinking mode** (`reasoning_effort: medium`), text-only assistant responses (the final reply after a tool loop) could be persisted to the session DB **without** a `reasoning_content` field. On session resume, replaying that message to DeepSeek's API produces:

```
HTTP 400: The reasoning_content in the thinking mode must be passed back to the API.
```

This forced users to start a new session to recover.

## Root Cause

`_build_assistant_message` (the creation path at `run_agent.py:7763`) only guaranteed the `reasoning_content=""` fallback for **tool-call** messages under DeepSeek thinking mode. Text-only responses fell through without setting `reasoning_content` at all, because:

1. The API response object may not have `reasoning_content` on every turn
2. The fallback only fired when `msg["tool_calls"]` was truthy AND `_needs_deepseek_tool_reasoning()` was True

## Fix

Separates the Kimi (tool-call-only) and DeepSeek (all messages) fallback logic:

- **Kimi**: unchanged — `reasoning_content=""` only on tool-call messages
- **DeepSeek**: `reasoning_content` set on **every** assistant message, falling back to the content of the `reasoning` field or empty string

The replay safety net in `_copy_reasoning_content_for_api` (step 4) already catches this edge case, but storing correct data from creation time is cleaner and avoids relying on the replay-time catch-all.

## Related

Refs #15250 (original DeepSeek tool-call `reasoning_content` fix), #15998 (this bug).

## Test Plan

- [ ] Existing tests pass: `pytest tests/run_agent/ -x -q`
- [ ] Manual: DeepSeek thinking mode session with tool calls followed by text-only response, then session resume
