### PR TITLE
fix: preserve gateway resume context across restarts

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -83,17 +83,27 @@ def _strip_provider_prefix(model: str) -> str:
     """Strip a recognised provider prefix from a model string.
 
     ``"local:my-model"`` → ``"my-model"``
+    ``"openai-codex/gpt-5.5"`` → ``"gpt-5.5"``
     ``"qwen3.5:27b"``   → ``"qwen3.5:27b"``  (unchanged — not a provider prefix)
     ``"qwen:0.5b"``     → ``"qwen:0.5b"``    (unchanged — Ollama model:tag)
     ``"deepseek:latest"``→ ``"deepseek:latest"``(unchanged — Ollama model:tag)
     """
-    if ":" not in model or model.startswith("http"):
+    if model.startswith("http"):
         return model
-    prefix, suffix = model.split(":", 1)
+
+    separator = None
+    if ":" in model:
+        separator = ":"
+    elif "/" in model and model.split("/", 1)[0].strip().lower() == "openai-codex":
+        separator = "/"
+    if not separator:
+        return model
+
+    prefix, suffix = model.split(separator, 1)
     prefix_lower = prefix.strip().lower()
     if prefix_lower in _PROVIDER_PREFIXES:
         # Don't strip if suffix looks like an Ollama tag (e.g. "7b", "latest", "q4_0")
-        if _OLLAMA_TAG_PATTERN.match(suffix.strip()):
+        if separator == ":" and _OLLAMA_TAG_PATTERN.match(suffix.strip()):
             return model
         return suffix
     return model
@@ -134,10 +144,13 @@ OPENAI_CODEX_GPT55_EFFECTIVE_CONTEXT = 272_000
 
 
 def _is_openai_codex_gpt55(model: str, provider: str = "", base_url: str = "") -> bool:
-    model_lower = (model or "").strip().lower()
+    raw_model = (model or "").strip().lower()
+    model_lower = _strip_provider_prefix(raw_model)
+    provider_lower = (provider or "").strip().lower()
+    if raw_model.startswith("openai-codex/") or raw_model.startswith("openai-codex:") or raw_model == "gpt-5.5-codex":
+        provider_lower = provider_lower or "openai-codex"
     if model_lower not in {"gpt-5.5", "gpt-5.5-codex"}:
         return False
-    provider_lower = (provider or "").strip().lower()
     return provider_lower == "openai-codex" or base_url_host_matches(base_url, "chatgpt.com")
 
 # Thin fallback defaults — only broad model family patterns.
@@ -1258,14 +1271,20 @@ def get_model_context_length(
         except Exception:
             pass  # fall through to probing
 
-    # Normalise provider-prefixed model names (e.g. "local:model-name" →
-    # "model-name") so cache lookups and server queries use the bare ID that
-    # local servers actually know about.  Ollama "model:tag" colons are preserved.
+    # Normalise provider-prefixed model names (e.g. "local:model-name" or
+    # "openai-codex/gpt-5.5" → "model-name") so cache lookups and server
+    # queries use the bare ID that local servers actually know about. Ollama
+    # "model:tag" colons are preserved.
+    original_model = model
     model = _strip_provider_prefix(model)
 
     # GPT-5.5 on ChatGPT/Codex currently has a 272k effective cap for agent
     # budgeting even if cache/discovery sources advertise a larger native window.
-    if _is_openai_codex_gpt55(model, provider=provider, base_url=base_url):
+    if _is_openai_codex_gpt55(model, provider=provider, base_url=base_url) or _is_openai_codex_gpt55(
+        original_model,
+        provider=provider or ("openai-codex" if str(original_model).strip().lower().startswith("openai-codex/") else ""),
+        base_url=base_url,
+    ):
         return OPENAI_CODEX_GPT55_EFFECTIVE_CONTEXT
 
     # 1. Check persistent cache (model+provider)

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -126,6 +126,20 @@ DEFAULT_FALLBACK_CONTEXT = CONTEXT_PROBE_TIERS[0]
 # Sessions, model switches, and cron jobs should reject models below this.
 MINIMUM_CONTEXT_LENGTH = 64_000
 
+# GPT-5.5 is currently exposed through ChatGPT/Codex with a smaller effective
+# agent-usable window than the larger native/advertised GPT-5 family windows.
+# Keep compaction and preflight budgeting fail-closed until a larger window is
+# explicitly verified and configured.
+OPENAI_CODEX_GPT55_EFFECTIVE_CONTEXT = 272_000
+
+
+def _is_openai_codex_gpt55(model: str, provider: str = "", base_url: str = "") -> bool:
+    model_lower = (model or "").strip().lower()
+    if model_lower not in {"gpt-5.5", "gpt-5.5-codex"}:
+        return False
+    provider_lower = (provider or "").strip().lower()
+    return provider_lower == "openai-codex" or base_url_host_matches(base_url, "chatgpt.com")
+
 # Thin fallback defaults — only broad model family patterns.
 # These fire only when provider is unknown AND models.dev/OpenRouter/Anthropic
 # all miss. Replaced the previous 80+ entry dict.
@@ -145,9 +159,9 @@ DEFAULT_CONTEXT_LENGTHS = {
     "claude": 200000,
     # OpenAI — GPT-5 family (most have 400k; specific overrides first)
     # Source: https://developers.openai.com/api/docs/models
-    # GPT-5.5 (launched Apr 23 2026) is 1.05M on the direct OpenAI API and
-    # ChatGPT Codex OAuth caps it at 272K; both paths resolve via their own
-    # provider-aware branches (_resolve_codex_oauth_context_length + models.dev).
+    # GPT-5.5 (launched Apr 23 2026) is 1.05M on the direct OpenAI API.
+    # ChatGPT/Codex OAuth is guarded separately at 272k until a larger
+    # effective window is explicitly verified.
     # This hardcoded value is only reached when every probe misses.
     "gpt-5.5": 1050000,
     "gpt-5.4-nano": 400000,           # 400k (not 1.05M like full 5.4)
@@ -1248,6 +1262,11 @@ def get_model_context_length(
     # "model-name") so cache lookups and server queries use the bare ID that
     # local servers actually know about.  Ollama "model:tag" colons are preserved.
     model = _strip_provider_prefix(model)
+
+    # GPT-5.5 on ChatGPT/Codex currently has a 272k effective cap for agent
+    # budgeting even if cache/discovery sources advertise a larger native window.
+    if _is_openai_codex_gpt55(model, provider=provider, base_url=base_url):
+        return OPENAI_CODEX_GPT55_EFFECTIVE_CONTEXT
 
     # 1. Check persistent cache (model+provider)
     if base_url:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -227,6 +227,116 @@ def _discord_tools_loaded() -> bool:
         return False
 
 
+def _load_resource_ownership_config() -> Dict[str, Any]:
+    """Return optional requester/resource ownership policy from config.yaml.
+
+    This is deliberately prompt-layer policy: it gives the model a hard,
+    per-session boundary without granting or routing credentials. Invalid config
+    fails closed to the generic non-owner boundary.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+        policy = cfg.get("resource_ownership") or {}
+        return policy if isinstance(policy, dict) else {}
+    except Exception:
+        return {}
+
+
+def _resource_entry_ids(entry: Dict[str, Any], platform: Platform) -> List[str]:
+    """Extract configured identifiers for a resource principal on *platform*."""
+    ids: List[str] = []
+    if not isinstance(entry, dict):
+        return ids
+
+    platforms = entry.get("platforms")
+    if isinstance(platforms, dict):
+        raw = platforms.get(platform.value) or platforms.get(str(platform.value))
+        if isinstance(raw, (list, tuple, set)):
+            ids.extend(str(v) for v in raw if str(v).strip())
+        elif raw:
+            ids.append(str(raw))
+
+    raw_ids = entry.get("user_ids")
+    if isinstance(raw_ids, dict):
+        raw = raw_ids.get(platform.value) or raw_ids.get(str(platform.value))
+        if isinstance(raw, (list, tuple, set)):
+            ids.extend(str(v) for v in raw if str(v).strip())
+        elif raw:
+            ids.append(str(raw))
+    elif isinstance(raw_ids, (list, tuple, set)):
+        ids.extend(str(v) for v in raw_ids if str(v).strip())
+    return ids
+
+
+def _source_identity_values(source: SessionSource) -> set[str]:
+    """Return platform/user/chat identifiers that may identify the requester."""
+    values: set[str] = set()
+    for value in (source.user_id, source.user_id_alt, source.chat_id, source.chat_id_alt):
+        if value is not None and str(value).strip():
+            values.add(str(value))
+    return values
+
+
+def _resource_ownership_lines(context: SessionContext, *, redact_pii: bool = False) -> List[str]:
+    """Build prompt lines for requester-owned resource boundaries.
+
+    Core rule: personal-resource words like "my calendar" or "my files" bind
+    to the requester/principal, not blindly to the machine running the agent.
+    """
+    src = context.source
+    if src.platform == Platform.LOCAL:
+        return []
+
+    policy = _load_resource_ownership_config()
+    owner = policy.get("owner") if isinstance(policy.get("owner"), dict) else {}
+    owner_name = owner.get("name") or "the agent owner"
+    requester_label = src.user_name or src.user_id or src.chat_name or "the requester"
+    if redact_pii and src.user_id and not src.user_name:
+        requester_label = _hash_sender_id(src.user_id)
+
+    source_ids = _source_identity_values(src)
+    owner_ids = set(_resource_entry_ids(owner, src.platform))
+    is_owner = bool(source_ids & owner_ids) if owner_ids else False
+
+    matched_collaborator = None
+    collaborators = policy.get("collaborators") or []
+    if isinstance(collaborators, list):
+        for entry in collaborators:
+            if not isinstance(entry, dict):
+                continue
+            ids = set(_resource_entry_ids(entry, src.platform))
+            if ids and source_ids & ids:
+                matched_collaborator = entry
+                requester_label = entry.get("name") or requester_label
+                break
+
+    lines = ["", "**Resource ownership boundary:**"]
+    if context.shared_multi_user_session:
+        lines.extend([
+            "- This is a shared multi-user session; each message sender is the resource principal for that message.",
+            "- Personal-resource words like `my calendar`, `my email`, `my Drive`, `my files`, `my Desktop`, `my Downloads`, or `my local machine` refer to the sender's own accounts/machines, not automatically to the machine running this agent.",
+            f"- Do not use {owner_name}'s Google tokens, email, Drive, Calendar, browser sessions, Keychain, local filesystem, or machine files for another sender unless an explicit shared/owner-authorized resource is named.",
+            "- If sender-owned OAuth, SSH, local-agent, or filesystem access is not configured, stop and ask to connect it; do not fall back to owner credentials.",
+        ])
+    elif is_owner:
+        lines.extend([
+            f"- Requester/principal: {owner_name} (owner).",
+            "- Owner-owned Google, local filesystem, browser, and machine resources may be in scope subject to normal safety and confirmation rules.",
+        ])
+    else:
+        role = "trusted collaborator" if matched_collaborator else "non-owner requester"
+        lines.extend([
+            f"- Requester/principal: {requester_label} ({role}).",
+            f"- Personal-resource words like `my calendar`, `my email`, `my Drive`, `my files`, `my Desktop`, `my Downloads`, or `my local machine` refer to {requester_label}'s own accounts/machines, not {owner_name}'s.",
+            f"- Do not use {owner_name}'s Google tokens, email, Drive, Calendar, browser sessions, Keychain, local filesystem, or machine files for this requester unless an explicit shared/owner-authorized resource is named.",
+            "- If requester-owned OAuth, SSH, local-agent, or filesystem access is not configured, stop and ask to connect it; do not fall back to owner credentials.",
+            "- Before external side effects, name the target resource owner/account/host in the confirmation.",
+        ])
+    return lines
+
+
 def build_session_context_prompt(
     context: SessionContext,
     *,
@@ -302,6 +412,8 @@ def build_session_context_prompt(
         if redact_pii:
             uid = _hash_sender_id(uid)
         lines.append(f"**User ID:** {uid}")
+
+    lines.extend(_resource_ownership_lines(context, redact_pii=redact_pii))
     
     # Platform-specific behavioral notes
     if context.source.platform == Platform.SLACK:

--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -54,6 +54,72 @@ SCOPES = [
 ]
 
 
+def _load_resource_ownership_policy() -> dict:
+    try:
+        import yaml
+    except Exception:
+        return {}
+    try:
+        cfg_path = HERMES_HOME / "config.yaml"
+        if not cfg_path.exists():
+            return {}
+        data = yaml.safe_load(cfg_path.read_text()) or {}
+        policy = data.get("resource_ownership") or {}
+        return policy if isinstance(policy, dict) else {}
+    except Exception:
+        return {}
+
+
+def _entry_platform_ids(entry: dict, platform: str) -> set[str]:
+    if not isinstance(entry, dict):
+        return set()
+    values: set[str] = set()
+    platforms = entry.get("platforms")
+    if isinstance(platforms, dict):
+        raw = platforms.get(platform) or platforms.get(str(platform))
+        if isinstance(raw, (list, tuple, set)):
+            values.update(str(v) for v in raw if str(v).strip())
+        elif raw:
+            values.add(str(raw))
+    raw_ids = entry.get("user_ids")
+    if isinstance(raw_ids, dict):
+        raw = raw_ids.get(platform) or raw_ids.get(str(platform))
+        if isinstance(raw, (list, tuple, set)):
+            values.update(str(v) for v in raw if str(v).strip())
+        elif raw:
+            values.add(str(raw))
+    elif isinstance(raw_ids, (list, tuple, set)):
+        values.update(str(v) for v in raw_ids if str(v).strip())
+    return values
+
+
+def _guard_profile_google_token_for_requester():
+    """Prevent collaborator sessions from silently using owner Google OAuth.
+
+    CLI and cron runs have no HERMES_SESSION_* metadata and are left unchanged.
+    Gateway-originated non-owner sessions must connect requester-owned Google
+    OAuth instead of falling back to HERMES_HOME/google_token.json.
+    """
+    platform = os.getenv("HERMES_SESSION_PLATFORM", "").strip()
+    if not platform:
+        return
+    user_id = os.getenv("HERMES_SESSION_USER_ID", "").strip()
+    chat_id = os.getenv("HERMES_SESSION_CHAT_ID", "").strip()
+    source_ids = {v for v in (user_id, chat_id) if v}
+    policy = _load_resource_ownership_policy()
+    owner = policy.get("owner") if isinstance(policy.get("owner"), dict) else {}
+    owner_ids = _entry_platform_ids(owner, platform)
+    if owner_ids and source_ids & owner_ids:
+        return
+    owner_name = owner.get("name") or "the agent owner"
+    print(
+        "Blocked: this Google Workspace helper is configured with the profile owner's OAuth token. "
+        f"Requester-owned Google authorization is required; not using {owner_name}'s Google token by fallback.",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+
 def _normalize_authorized_user_payload(payload: dict) -> dict:
     normalized = dict(payload)
     if not normalized.get("type"):
@@ -62,6 +128,7 @@ def _normalize_authorized_user_payload(payload: dict) -> dict:
 
 
 def _ensure_authenticated():
+    _guard_profile_google_token_for_requester()
     if not TOKEN_PATH.exists():
         print("Not authenticated. Run the setup script first:", file=sys.stderr)
         print(f"  python {Path(__file__).parent / 'setup.py'}", file=sys.stderr)

--- a/skills/productivity/google-workspace/scripts/gws_bridge.py
+++ b/skills/productivity/google-workspace/scripts/gws_bridge.py
@@ -22,6 +22,60 @@ def get_token_path() -> Path:
     return get_hermes_home() / "google_token.json"
 
 
+def _load_resource_ownership_policy() -> dict:
+    try:
+        import yaml
+    except Exception:
+        return {}
+    try:
+        cfg_path = get_hermes_home() / "config.yaml"
+        if not cfg_path.exists():
+            return {}
+        data = yaml.safe_load(cfg_path.read_text()) or {}
+        policy = data.get("resource_ownership") or {}
+        return policy if isinstance(policy, dict) else {}
+    except Exception:
+        return {}
+
+
+def _entry_platform_ids(entry: dict, platform: str) -> set[str]:
+    if not isinstance(entry, dict):
+        return set()
+    values: set[str] = set()
+    for key in ("platforms", "user_ids"):
+        raw_map = entry.get(key)
+        raw = raw_map.get(platform) if isinstance(raw_map, dict) else None
+        if isinstance(raw, (list, tuple, set)):
+            values.update(str(v) for v in raw if str(v).strip())
+        elif raw:
+            values.add(str(raw))
+    return values
+
+
+def _guard_profile_google_token_for_requester():
+    platform = os.getenv("HERMES_SESSION_PLATFORM", "").strip()
+    if not platform:
+        return
+    source_ids = {
+        v for v in (
+            os.getenv("HERMES_SESSION_USER_ID", "").strip(),
+            os.getenv("HERMES_SESSION_CHAT_ID", "").strip(),
+        ) if v
+    }
+    policy = _load_resource_ownership_policy()
+    owner = policy.get("owner") if isinstance(policy.get("owner"), dict) else {}
+    owner_ids = _entry_platform_ids(owner, platform)
+    if owner_ids and source_ids & owner_ids:
+        return
+    owner_name = owner.get("name") or "the agent owner"
+    print(
+        "Blocked: requester-owned Google authorization is required; "
+        f"not using {owner_name}'s Google token by fallback.",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+
 def _normalize_authorized_user_payload(payload: dict) -> dict:
     normalized = dict(payload)
     if not normalized.get("type"):
@@ -73,6 +127,7 @@ def refresh_token(token_data: dict) -> dict:
 
 def get_valid_token() -> str:
     """Return a valid access token, refreshing if needed."""
+    _guard_profile_google_token_for_requester()
     token_path = get_token_path()
     if not token_path.exists():
         print("ERROR: No Google token found. Run setup.py --auth-url first.", file=sys.stderr)

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -281,9 +281,9 @@ class TestCodexOAuthContextLength:
                     "(models.dev leakage?)"
                 )
 
-    def test_live_probe_overrides_fallback(self):
+    def test_live_probe_overrides_fallback_for_non_gpt55_codex_models(self):
         """When a token is provided, the live /models probe is preferred
-        and its context_window drives the result."""
+        for Codex models that do not have an explicit temporary cap."""
         from agent.model_metadata import get_model_context_length
 
         fake_response = MagicMock()
@@ -310,7 +310,7 @@ class TestCodexOAuthContextLength:
                 api_key="fake-token",
                 provider="openai-codex",
             )
-        assert ctx_55 == 300_000
+        assert ctx_55 == 272_000
         assert ctx_54 == 400_000
 
     def test_probe_failure_falls_back_to_hardcoded(self):
@@ -358,12 +358,10 @@ class TestCodexOAuthContextLength:
             "leaked outside openai-codex provider"
         )
 
-    def test_stale_codex_cache_over_400k_is_invalidated(self, tmp_path, monkeypatch):
-        """Pre-PR #14935 builds cached gpt-5.5 at 1.05M (from models.dev)
-        before the Codex-aware branch existed. Upgrading users keep that
-        stale entry on disk and the cache-first lookup returns it forever.
-        Codex OAuth caps at 272k for every slug, so any cached Codex
-        entry >= 400k must be dropped and re-resolved via the live probe.
+    def test_stale_codex_cache_over_400k_is_bypassed_by_gpt55_cap(self, tmp_path, monkeypatch):
+        """Pre-PR builds may have cached gpt-5.5 at 1.05M from catalog
+        metadata. The explicit GPT-5.5 Codex cap must bypass both stale cache
+        and live probe metadata so compaction stays fail-closed at 272k.
         """
         from agent import model_metadata as mm
 
@@ -380,13 +378,7 @@ class TestCodexOAuthContextLength:
             other_key: 128_000,     # unrelated, must survive
         }}))
 
-        fake_response = MagicMock()
-        fake_response.status_code = 200
-        fake_response.json.return_value = {
-            "models": [{"slug": "gpt-5.5", "context_window": 272_000}]
-        }
-
-        with patch("agent.model_metadata.requests.get", return_value=fake_response), \
+        with patch("agent.model_metadata.requests.get") as mock_get, \
              patch("agent.model_metadata.save_context_length") as mock_save:
             ctx = mm.get_model_context_length(
                 model="gpt-5.5",
@@ -395,12 +387,12 @@ class TestCodexOAuthContextLength:
                 provider="openai-codex",
             )
 
-        assert ctx == 272_000, f"Stale entry should have been re-resolved to 272k, got {ctx}"
-        # Live save was called with the fresh value
-        mock_save.assert_called_with("gpt-5.5", base_url, 272_000)
-        # The stale entry was removed from disk; unrelated entries survived
+        assert ctx == 272_000, f"Stale entry should be bypassed by GPT-5.5 cap, got {ctx}"
+        mock_get.assert_not_called()
+        mock_save.assert_not_called()
+        # The stale entry may remain on disk, but it is no longer consulted for GPT-5.5 Codex.
         remaining = _yaml.safe_load(cache_file.read_text()).get("context_lengths", {})
-        assert stale_key not in remaining, "Stale entry was not invalidated from the cache file"
+        assert remaining.get(stale_key) == 1_050_000
         assert remaining.get(other_key) == 128_000, "Unrelated cache entries must not be touched"
 
     def test_fresh_codex_cache_under_400k_is_respected(self, tmp_path, monkeypatch):
@@ -467,6 +459,25 @@ class TestGetModelContextLength:
     def test_fallback_to_defaults(self, mock_fetch):
         mock_fetch.return_value = {}
         assert get_model_context_length("anthropic/claude-sonnet-4") == 200000
+
+    @patch("agent.model_metadata.fetch_model_metadata")
+    @patch("agent.models_dev.lookup_models_dev_context")
+    @patch("agent.model_metadata.get_cached_context_length")
+    def test_gpt55_codex_uses_safe_effective_context_cap(self, mock_cache, mock_models_dev, mock_fetch):
+        """GPT-5.5 Codex must fail closed to the current 272k effective cap.
+
+        Discovery/cache sources may advertise a larger native context window;
+        compaction should not budget against that until explicitly lifted.
+        """
+        mock_cache.return_value = 1_050_000
+        mock_models_dev.return_value = 1_050_000
+        mock_fetch.return_value = {"gpt-5.5": {"context_length": 1_050_000}}
+
+        assert get_model_context_length(
+            "gpt-5.5",
+            provider="openai-codex",
+            base_url="https://chatgpt.com/backend-api/codex",
+        ) == 272_000
 
     @patch("agent.model_metadata.fetch_model_metadata")
     def test_unknown_model_returns_first_probe_tier(self, mock_fetch):

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -281,6 +281,24 @@ class TestCodexOAuthContextLength:
                     "(models.dev leakage?)"
                 )
 
+    def test_provider_prefixed_gpt55_codex_slug_uses_effective_cap(self):
+        """A persisted or cron-style provider/model slug must not bypass the
+        GPT-5.5 Codex cap when provider/base_url were not passed separately.
+        """
+        from agent.model_metadata import get_model_context_length
+
+        with patch("agent.model_metadata.get_cached_context_length", return_value=None), \
+             patch("agent.model_metadata.save_context_length"), \
+             patch("agent.models_dev.lookup_models_dev_context", return_value=1_050_000):
+            for model in ("openai-codex/gpt-5.5", "gpt-5.5-codex"):
+                ctx = get_model_context_length(
+                    model=model,
+                    base_url="",
+                    api_key="",
+                    provider="",
+                )
+                assert ctx == 272_000
+
     def test_live_probe_overrides_fallback_for_non_gpt55_codex_models(self):
         """When a token is provided, the live /models probe is preferred
         for Codex models that do not have an explicit temporary cap."""

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -420,6 +420,63 @@ class TestBuildSessionContextPrompt:
         assert "**User:** Alice" in prompt
         assert "Multi-user thread" not in prompt
 
+    def test_owner_resource_boundary_for_configured_owner(self):
+        config = GatewayConfig(
+            platforms={
+                Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake"),
+            },
+        )
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="1425151324",
+            chat_type="dm",
+            user_id="1425151324",
+            user_name="Roger Gimbel",
+        )
+        policy = {
+            "resource_ownership": {
+                "owner": {"name": "Roger Gimbel", "platforms": {"telegram": ["1425151324"]}},
+                "collaborators": [],
+            }
+        }
+        with patch("hermes_cli.config.load_config", return_value=policy):
+            ctx = build_session_context(source, config)
+            prompt = build_session_context_prompt(ctx)
+
+        assert "**Resource ownership boundary:**" in prompt
+        assert "Requester/principal: Roger Gimbel (owner)" in prompt
+        assert "Owner-owned Google" in prompt
+
+    def test_collaborator_resource_boundary_blocks_owner_resources(self):
+        config = GatewayConfig(
+            platforms={
+                Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake"),
+            },
+        )
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="222",
+            chat_type="dm",
+            user_id="222",
+            user_name="Stuart Seligman",
+        )
+        policy = {
+            "resource_ownership": {
+                "owner": {"name": "Roger Gimbel", "platforms": {"telegram": ["1425151324"]}},
+                "collaborators": [
+                    {"name": "Stuart Seligman", "platforms": {"telegram": ["222"]}},
+                ],
+            }
+        }
+        with patch("hermes_cli.config.load_config", return_value=policy):
+            ctx = build_session_context(source, config)
+            prompt = build_session_context_prompt(ctx)
+
+        assert "Requester/principal: Stuart Seligman (trusted collaborator)" in prompt
+        assert "refer to Stuart Seligman's own accounts/machines" in prompt
+        assert "Do not use Roger Gimbel's Google tokens" in prompt
+        assert "do not fall back to owner credentials" in prompt
+
 
 class TestSessionStoreRewriteTranscript:
     """Regression: /retry and /undo must persist truncated history to disk."""

--- a/tests/tools/test_resource_ownership_guards.py
+++ b/tests/tools/test_resource_ownership_guards.py
@@ -1,0 +1,108 @@
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from gateway.session_context import clear_session_vars, set_session_vars
+
+
+OWNER_POLICY_PLATFORMS = {
+    "resource_ownership": {
+        "owner": {"name": "Roger Gimbel", "platforms": {"telegram": ["1425151324"]}},
+        "collaborators": [{"name": "Stuart Seligman", "platforms": {"telegram": ["222"]}}],
+    }
+}
+
+OWNER_POLICY_USER_IDS = {
+    "resource_ownership": {
+        "owner": {"name": "Roger Gimbel", "user_ids": {"telegram": ["1425151324"]}},
+        "collaborators": [],
+    }
+}
+
+
+def _set_gateway_session(user_id: str):
+    return set_session_vars(
+        platform="telegram",
+        chat_id=user_id,
+        user_id=user_id,
+        user_name="Test User",
+        session_key=f"agent:main:telegram:dm:{user_id}",
+    )
+
+
+def test_file_and_terminal_owner_guards_accept_user_ids_config():
+    tokens = _set_gateway_session("1425151324")
+    try:
+        with patch("hermes_cli.config.load_config", return_value=OWNER_POLICY_USER_IDS):
+            from tools import file_tools, terminal_tool
+
+            assert file_tools._current_requester_is_owner() is True
+            assert terminal_tool._current_requester_is_owner() is True
+    finally:
+        clear_session_vars(tokens)
+
+
+def test_file_and_terminal_owner_guards_fail_closed_on_config_error():
+    tokens = _set_gateway_session("222")
+    try:
+        with patch("hermes_cli.config.load_config", side_effect=RuntimeError("config unavailable")):
+            from tools import file_tools, terminal_tool
+
+            assert file_tools._current_requester_is_owner() is False
+            assert terminal_tool._current_requester_is_owner() is False
+    finally:
+        clear_session_vars(tokens)
+
+
+def test_execute_code_blocks_non_owner_local_session_before_running_code():
+    tokens = _set_gateway_session("222")
+    try:
+        with patch("hermes_cli.config.load_config", return_value=OWNER_POLICY_PLATFORMS), \
+             patch("tools.terminal_tool._get_env_config", return_value={"env_type": "local"}):
+            from tools.code_execution_tool import execute_code
+
+            result = json.loads(execute_code("print('should_not_run')"))
+            assert result["status"] == "blocked"
+            assert "Roger's M5 is not used by fallback" in result["error"]
+    finally:
+        clear_session_vars(tokens)
+
+
+def test_terminal_session_env_injection_replaces_stale_snapshot_identity(tmp_path):
+    from tools import terminal_tool
+
+    snapshot = tmp_path / "snapshot.sh"
+    snapshot.write_text(
+        "export HERMES_SESSION_PLATFORM='telegram'\n"
+        "export HERMES_SESSION_USER_ID='1425151324'\n"
+        "export KEEP_ME='yes'\n"
+    )
+    env = SimpleNamespace(env={"HERMES_SESSION_USER_ID": "1425151324"}, _snapshot_path=str(snapshot))
+
+    tokens = _set_gateway_session("222")
+    try:
+        terminal_tool._inject_session_env(env)
+    finally:
+        clear_session_vars(tokens)
+
+    assert env.env["HERMES_SESSION_USER_ID"] == "222"
+    text = snapshot.read_text()
+    assert "KEEP_ME" in text
+    assert "1425151324" not in text
+    assert "HERMES_SESSION_USER_ID=222" in text
+
+
+def test_gws_bridge_owner_ids_config_accepts_owner():
+    import importlib.util
+
+    path = Path("skills/productivity/google-workspace/scripts/gws_bridge.py")
+    spec = importlib.util.spec_from_file_location("gws_bridge_under_test", path)
+    gws_bridge = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(gws_bridge)
+
+    assert gws_bridge._entry_platform_ids(
+        {"user_ids": {"telegram": ["1425151324"]}},
+        "telegram",
+    ) == {"1425151324"}

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -930,8 +930,18 @@ def execute_code(
         return tool_error("No code provided.")
 
     # Dispatch: remote backends use file-based RPC, local uses UDS
-    from tools.terminal_tool import _get_env_config
+    from tools.terminal_tool import _get_env_config, _current_requester_is_owner
     env_type = _get_env_config()["env_type"]
+    if env_type == "local" and not _current_requester_is_owner():
+        return json.dumps({
+            "success": False,
+            "error": (
+                "Blocked: execute_code would run Python on the local filesystem/machine running this agent. "
+                "For non-owner collaborators, code execution must use their own machine/local-agent/SSH connector "
+                "or an explicitly authorized shared resource; Roger's M5 is not used by fallback."
+            ),
+            "status": "blocked",
+        }, ensure_ascii=False)
     if env_type != "local":
         return _execute_remote(code, task_id, enabled_tools)
 
@@ -1022,6 +1032,22 @@ def execute_code(
             # Allow vars with known safe prefixes.
             if any(k.startswith(p) for p in _SAFE_ENV_PREFIXES):
                 child_env[k] = v
+        try:
+            from gateway.session_context import get_session_env as _gse
+            for _key in (
+                "HERMES_SESSION_PLATFORM",
+                "HERMES_SESSION_CHAT_ID",
+                "HERMES_SESSION_CHAT_NAME",
+                "HERMES_SESSION_THREAD_ID",
+                "HERMES_SESSION_USER_ID",
+                "HERMES_SESSION_USER_NAME",
+                "HERMES_SESSION_KEY",
+            ):
+                _value = _gse(_key, "")
+                if _value:
+                    child_env[_key] = _value
+        except Exception:
+            pass
         child_env["HERMES_RPC_SOCKET"] = sock_path
         child_env["PYTHONDONTWRITEBYTECODE"] = "1"
         # Ensure the hermes-agent root is importable in the sandbox so

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -59,6 +59,58 @@ def _get_max_read_chars() -> int:
     _max_read_chars_cached = _DEFAULT_MAX_READ_CHARS
     return _max_read_chars_cached
 
+
+def _resource_entry_platform_ids(entry: dict, platform: str) -> set[str]:
+    ids: set[str] = set()
+    if not isinstance(entry, dict):
+        return ids
+    for key in ("platforms", "user_ids"):
+        raw_map = entry.get(key)
+        raw = raw_map.get(platform) if isinstance(raw_map, dict) else None
+        if isinstance(raw, (list, tuple, set)):
+            ids.update(str(v) for v in raw if str(v).strip())
+        elif raw:
+            ids.add(str(raw))
+    return ids
+
+
+def _current_requester_is_owner() -> bool:
+    """Return True for owner/no-session contexts; False for collaborator sessions.
+
+    File tools run on the local machine. In Telegram/Discord/etc. sessions, a
+    non-owner asking for "my files" must not silently get Roger's filesystem.
+    CLI/cron contexts have no HERMES_SESSION_* metadata and retain existing
+    behavior. Gateway sessions fail closed if ownership cannot be resolved.
+    """
+    try:
+        from gateway.session_context import get_session_env
+        platform = get_session_env("HERMES_SESSION_PLATFORM", "").strip()
+        if not platform:
+            return True
+        source_ids = {
+            v for v in (
+                get_session_env("HERMES_SESSION_USER_ID", "").strip(),
+                get_session_env("HERMES_SESSION_CHAT_ID", "").strip(),
+            ) if v
+        }
+        from hermes_cli.config import load_config
+        policy = (load_config() or {}).get("resource_ownership") or {}
+        owner = policy.get("owner") if isinstance(policy.get("owner"), dict) else {}
+        owner_ids = _resource_entry_platform_ids(owner, platform)
+        return bool(owner_ids and source_ids & owner_ids)
+    except Exception:
+        return False
+
+
+def _collaborator_file_guard_error(action: str) -> Optional[str]:
+    if _current_requester_is_owner():
+        return None
+    return (
+        f"Blocked: {action} would access the local filesystem of the machine running this agent. "
+        "For non-owner collaborators, personal file requests must use their own machine/local-agent/SSH connector "
+        "or an explicitly authorized shared resource; Roger's M5 filesystem is not used by fallback."
+    )
+
 # If the total file size exceeds this AND the caller didn't specify a narrow
 # range (limit <= 200), we include a hint encouraging targeted reads.
 _LARGE_FILE_HINT_BYTES = 512_000  # 512 KB
@@ -401,6 +453,9 @@ def clear_file_ops_cache(task_id: str = None):
 def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = "default") -> str:
     """Read a file with pagination and line numbers."""
     try:
+        guard_err = _collaborator_file_guard_error("read_file")
+        if guard_err:
+            return json.dumps({"error": guard_err}, ensure_ascii=False)
         offset, limit = normalize_read_pagination(offset, limit)
 
         # ── Device path guard ─────────────────────────────────────────
@@ -664,6 +719,9 @@ def _check_file_staleness(filepath: str, task_id: str) -> str | None:
 
 def write_file_tool(path: str, content: str, task_id: str = "default") -> str:
     """Write content to a file."""
+    guard_err = _collaborator_file_guard_error("write_file")
+    if guard_err:
+        return tool_error(guard_err)
     sensitive_err = _check_sensitive_path(path, task_id)
     if sensitive_err:
         return tool_error(sensitive_err)
@@ -718,6 +776,9 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                new_string: str = None, replace_all: bool = False, patch: str = None,
                task_id: str = "default") -> str:
     """Patch a file using replace mode or V4A patch format."""
+    guard_err = _collaborator_file_guard_error("patch")
+    if guard_err:
+        return tool_error(guard_err)
     # Check sensitive paths for both replace (explicit path) and V4A patch (extract paths)
     _paths_to_check = []
     if path:
@@ -816,6 +877,9 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
                 task_id: str = "default") -> str:
     """Search for content or files."""
     try:
+        guard_err = _collaborator_file_guard_error("search_files")
+        if guard_err:
+            return json.dumps({"error": guard_err}, ensure_ascii=False)
         offset, limit = normalize_search_pagination(offset, limit)
 
         # Track searches to detect *consecutive* repeated search loops.

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -40,11 +40,114 @@ import time
 import threading
 import atexit
 import shutil
+import shlex
 import subprocess
 from pathlib import Path
 from typing import Optional, Dict, Any, List
 
 logger = logging.getLogger(__name__)
+
+
+_SESSION_ENV_KEYS = (
+    "HERMES_SESSION_PLATFORM",
+    "HERMES_SESSION_CHAT_ID",
+    "HERMES_SESSION_CHAT_NAME",
+    "HERMES_SESSION_THREAD_ID",
+    "HERMES_SESSION_USER_ID",
+    "HERMES_SESSION_USER_NAME",
+    "HERMES_SESSION_KEY",
+)
+
+
+def _current_session_env_vars() -> Dict[str, str]:
+    """Return task-local session metadata for child processes.
+
+    Gateway sessions store requester identity in contextvars, not process-global
+    os.environ.  Child shells still need the values so profile-scoped tools
+    (notably Google Workspace helpers) can enforce requester/owner boundaries.
+    """
+    try:
+        from gateway.session_context import get_session_env
+    except Exception:
+        return {}
+    result: Dict[str, str] = {}
+    for key in _SESSION_ENV_KEYS:
+        value = get_session_env(key, "")
+        if value:
+            result[key] = value
+    return result
+
+
+def _inject_session_env(env: Any) -> None:
+    """Best-effort injection of session metadata into a terminal environment."""
+    values = _current_session_env_vars()
+    if not hasattr(env, "env"):
+        return
+    try:
+        for key in _SESSION_ENV_KEYS:
+            env.env.pop(key, None)
+        env.env.update(values)
+
+        # BaseEnvironment sources a persisted shell snapshot after process env
+        # is set. Keep requester identity out of that snapshot so a reused local
+        # shell cannot re-export the previous Telegram/Discord sender.
+        snapshot_path = getattr(env, "_snapshot_path", None)
+        if snapshot_path:
+            path = Path(snapshot_path)
+            if path.exists():
+                lines = path.read_text(errors="replace").splitlines()
+                filtered = [line for line in lines if not any(key in line for key in _SESSION_ENV_KEYS)]
+                for key, value in values.items():
+                    filtered.append(f"export {key}={shlex.quote(value)}")
+                path.write_text("\n".join(filtered) + ("\n" if filtered else ""))
+    except Exception:
+        logger.debug("Unable to inject session env vars into terminal environment", exc_info=True)
+
+
+def _resource_entry_platform_ids(entry: dict, platform: str) -> set[str]:
+    ids: set[str] = set()
+    if not isinstance(entry, dict):
+        return ids
+    for key in ("platforms", "user_ids"):
+        raw_map = entry.get(key)
+        raw = raw_map.get(platform) if isinstance(raw_map, dict) else None
+        if isinstance(raw, (list, tuple, set)):
+            ids.update(str(v) for v in raw if str(v).strip())
+        elif raw:
+            ids.add(str(raw))
+    return ids
+
+
+def _current_requester_is_owner() -> bool:
+    """Return True for owner/no-session contexts; False for collaborator sessions."""
+    values = _current_session_env_vars()
+    platform = values.get("HERMES_SESSION_PLATFORM", "").strip()
+    if not platform:
+        return True
+    source_ids = {
+        v for v in (
+            values.get("HERMES_SESSION_USER_ID", "").strip(),
+            values.get("HERMES_SESSION_CHAT_ID", "").strip(),
+        ) if v
+    }
+    try:
+        from hermes_cli.config import load_config
+        policy = (load_config() or {}).get("resource_ownership") or {}
+        owner = policy.get("owner") if isinstance(policy.get("owner"), dict) else {}
+        owner_ids = _resource_entry_platform_ids(owner, platform)
+        return bool(owner_ids and source_ids & owner_ids)
+    except Exception:
+        return False
+
+
+def _collaborator_terminal_guard_error(env_type: str) -> Optional[str]:
+    if env_type != "local" or _current_requester_is_owner():
+        return None
+    return (
+        "Blocked: terminal would execute on the local filesystem/machine running this agent. "
+        "For non-owner collaborators, personal local-machine work must use their own machine/local-agent/SSH connector "
+        "or an explicitly authorized shared resource; Roger's M5 is not used by fallback."
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -1498,6 +1601,14 @@ def terminal_tool(
         # Get configuration
         config = _get_env_config()
         env_type = config["env_type"]
+        local_guard_error = _collaborator_terminal_guard_error(env_type)
+        if local_guard_error:
+            return json.dumps({
+                "output": "",
+                "exit_code": -1,
+                "error": local_guard_error,
+                "status": "blocked",
+            }, ensure_ascii=False)
 
         # Use task_id for environment isolation. By default all subagent
         # task_ids collapse back to "default" so the top-level agent and
@@ -1637,6 +1748,11 @@ def terminal_tool(
                         _last_activity[effective_task_id] = time.time()
                         env = new_env
                     logger.info("%s environment ready for task %s", env_type, effective_task_id[:8])
+
+        # Refresh requester/session metadata on every call. Terminal
+        # environments can be reused across sessions, so creation-time env vars
+        # are not sufficient for per-requester resource guards.
+        _inject_session_env(env)
 
         # Pre-exec security checks (tirith + dangerous command detection)
         # Skip check if force=True (user has confirmed they want to run it)


### PR DESCRIPTION
## Summary
- cap OpenAI Codex GPT-5.5 effective context at 272k for provider-prefixed and alias model IDs
- preserve gateway session continuity across restart/shutdown interruptions via resume-pending metadata
- add collaborator resource-ownership guards for local file/terminal/code execution and Google token fallback

## Verification
- `python -m pytest tests/gateway/test_restart_resume_pending.py tests/gateway/test_session.py tests/gateway/test_session_race_guard.py tests/tools/test_resource_ownership_guards.py tests/agent/test_model_metadata.py -q -o addopts=''` → 225 passed
- `python -m pytest tests/gateway/test_restart_resume_pending.py tests/gateway/test_session.py tests/tools/test_resource_ownership_guards.py tests/agent/test_model_metadata.py -q -o addopts=''` → 209 passed post-commit
- `python -m py_compile gateway/run.py gateway/session.py agent/model_metadata.py tools/file_tools.py tools/terminal_tool.py tools/code_execution_tool.py skills/productivity/google-workspace/scripts/google_api.py skills/productivity/google-workspace/scripts/gws_bridge.py`
- live health checked Hermes `127.0.0.1:8642/health` and Rogue `127.0.0.1:8643/health`