### PR TITLE
fix(aux-client): honor api_mode in explicit_base_url path; read key_env in task config (#16254)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1870,7 +1870,9 @@ def resolve_provider_client(
             if api_mode == "anthropic_messages":
                 try:
                     from agent.anthropic_adapter import build_anthropic_client
-                    real_client = build_anthropic_client(custom_key, _clean_base)
+                    # Pass the original URL; build_anthropic_client handles
+                    # query params internally (e.g. Azure api-version).
+                    real_client = build_anthropic_client(custom_key, custom_base)
                 except ImportError:
                     logger.warning(
                         "resolve_provider_client: explicit_base_url declares "
@@ -1881,7 +1883,7 @@ def resolve_provider_client(
                     return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                             else (client, final_model))
                 sync_anthropic = AnthropicAuxiliaryClient(
-                    real_client, final_model, custom_key, _clean_base, is_oauth=False,
+                    real_client, final_model, custom_key, custom_base, is_oauth=False,
                 )
                 if async_mode:
                     return AsyncAnthropicAuxiliaryClient(sync_anthropic), final_model

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1709,7 +1709,8 @@ def resolve_provider_client(
             instead of wrapping in CodexAuxiliaryClient.  Use this when
             the caller needs direct access to responses.stream() (e.g.,
             the main agent loop).
-        explicit_base_url: Optional direct OpenAI-compatible endpoint.
+        explicit_base_url: Optional direct endpoint URL. The SDK client
+            selected is determined by api_mode (OpenAI, Anthropic, Codex).
         explicit_api_key: Optional API key paired with explicit_base_url.
         api_mode: API mode override.  One of "chat_completions",
             "codex_responses", or None (auto-detect).  When set to
@@ -1861,6 +1862,30 @@ def resolve_provider_client(
                 extra["default_headers"] = copilot_request_headers(
                     is_agent_turn=True, is_vision=is_vision
                 )
+            # anthropic_messages: route through the Anthropic Messages API
+            # via AnthropicAuxiliaryClient.  Mirrors the named-custom-provider
+            # branch (path 2) above.  Without this, api_mode is silently
+            # ignored for explicit_base_url configs — causing Anthropic-format
+            # bodies to be sent to the wrong endpoint (#16254).
+            if api_mode == "anthropic_messages":
+                try:
+                    from agent.anthropic_adapter import build_anthropic_client
+                    real_client = build_anthropic_client(custom_key, _clean_base)
+                except ImportError:
+                    logger.warning(
+                        "resolve_provider_client: explicit_base_url declares "
+                        "api_mode=anthropic_messages but the anthropic SDK is "
+                        "not installed — falling back to OpenAI-wire."
+                    )
+                    client = OpenAI(api_key=custom_key, base_url=_clean_base, **extra)
+                    return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+                            else (client, final_model))
+                sync_anthropic = AnthropicAuxiliaryClient(
+                    real_client, final_model, custom_key, _clean_base, is_oauth=False,
+                )
+                if async_mode:
+                    return AsyncAnthropicAuxiliaryClient(sync_anthropic), final_model
+                return sync_anthropic, final_model
             client = OpenAI(api_key=custom_key, base_url=_clean_base, **extra)
             client = _wrap_if_needed(client, final_model, custom_base)
             return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
@@ -2706,6 +2731,11 @@ def _resolve_task_provider_model(
         cfg_model = str(task_config.get("model", "")).strip() or None
         cfg_base_url = str(task_config.get("base_url", "")).strip() or None
         cfg_api_key = str(task_config.get("api_key", "")).strip() or None
+        _cfg_key_env = str(task_config.get("key_env", "")).strip()
+        if not cfg_api_key and _cfg_key_env:
+            # Mirrors _get_named_custom_provider so auxiliary.<task> configs
+            # honour key_env identically to providers: entries (#16254).
+            cfg_api_key = os.getenv(_cfg_key_env, "").strip() or None
         cfg_api_mode = str(task_config.get("api_mode", "")).strip() or None
 
     resolved_model = model or cfg_model

--- a/tests/agent/test_aux_client_path3_anthropic.py
+++ b/tests/agent/test_aux_client_path3_anthropic.py
@@ -200,3 +200,37 @@ def test_resolve_task_provider_model_no_key_env_set_returns_none(monkeypatch):
 
     # Unset env var → None, not empty string or "no-key-required"
     assert resolved_key is None
+
+
+def test_explicit_base_url_query_params_preserved_for_anthropic_client():
+    """build_anthropic_client must receive the original URL including query params.
+
+    Before the fix, _clean_base (query params stripped) was passed instead of
+    custom_base, so Azure-style ?api-version= params were silently dropped
+    before build_anthropic_client could route them via default_query.
+    """
+    from agent.auxiliary_client import resolve_provider_client
+
+    received_urls: list[str] = []
+
+    def _capture_build_anthropic_client(api_key, base_url=None, **kw):
+        received_urls.append(base_url or "")
+        return MagicMock(name="anthropic_client")
+
+    with patch(
+        "agent.anthropic_adapter.build_anthropic_client",
+        side_effect=_capture_build_anthropic_client,
+    ):
+        resolve_provider_client(
+            "custom",
+            model="claude-3-haiku",
+            explicit_base_url="https://my-azure-endpoint.openai.azure.com/v1?api-version=2025-04-15",
+            explicit_api_key="sk-azure",
+            api_mode="anthropic_messages",
+        )
+
+    assert received_urls, "build_anthropic_client was never called"
+    assert "api-version=2025-04-15" in received_urls[0], (
+        f"Query params were stripped before passing to build_anthropic_client: {received_urls[0]!r}.  "
+        "Pass the original URL so the function can route api-version via default_query."
+    )

--- a/tests/agent/test_aux_client_path3_anthropic.py
+++ b/tests/agent/test_aux_client_path3_anthropic.py
@@ -1,0 +1,202 @@
+"""Tests for the explicit_base_url (path 3) anthropic_messages fix (#16254).
+
+Before this fix, ``resolve_provider_client`` with ``explicit_base_url`` set
+always built a plain OpenAI client regardless of ``api_mode``, silently sending
+Anthropic-format bodies to the OpenAI endpoint.  The fix mirrors the identical
+dispatch that path 2 (named custom providers) has had since #15059.
+
+Also tests the ``key_env`` fix in ``_resolve_task_provider_model``: auxiliary
+task configs that specify ``key_env`` instead of ``api_key`` must resolve the
+env var, matching the behaviour of ``providers:`` dict entries.
+"""
+
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    for key in ("OPENAI_API_KEY", "OPENAI_BASE_URL", "ANTHROPIC_API_KEY",
+                "ANTHROPIC_TOKEN", "ZENMUX_API_KEY", "TEST_KEY_ENV"):
+        monkeypatch.delenv(key, raising=False)
+
+
+# ── Path 3: explicit_base_url + api_mode=anthropic_messages ─────────────────
+
+def _make_anthropic_mock():
+    """Return a fake Anthropic client and the patcher."""
+    fake_client = MagicMock(name="anthropic_real_client")
+    patcher = patch(
+        "agent.anthropic_adapter.build_anthropic_client",
+        return_value=fake_client,
+    )
+    return fake_client, patcher
+
+
+def test_explicit_base_url_anthropic_messages_returns_anthropic_client():
+    """Path 3: api_mode=anthropic_messages must return AnthropicAuxiliaryClient."""
+    from agent.auxiliary_client import (
+        AnthropicAuxiliaryClient,
+        resolve_provider_client,
+    )
+
+    fake_raw, patcher = _make_anthropic_mock()
+    with patcher:
+        client, model = resolve_provider_client(
+            "custom",
+            model="moonshotai/kimi-k2.6",
+            explicit_base_url="https://zenmux.ai/api/anthropic",
+            explicit_api_key="sk-test-key",
+            api_mode="anthropic_messages",
+        )
+
+    assert isinstance(client, AnthropicAuxiliaryClient), (
+        f"Expected AnthropicAuxiliaryClient, got {type(client).__name__}.  "
+        "Path 3 is silently routing to OpenAI-wire when api_mode=anthropic_messages "
+        "is set — this is the #16254 regression."
+    )
+    assert model == "moonshotai/kimi-k2.6"
+
+
+def test_explicit_base_url_no_api_mode_returns_openai_client():
+    """Path 3 without api_mode must still return a plain OpenAI-wire client."""
+    from agent.auxiliary_client import AnthropicAuxiliaryClient, resolve_provider_client
+
+    client, model = resolve_provider_client(
+        "custom",
+        model="gpt-4o-mini",
+        explicit_base_url="https://my-openai-proxy.example.com/v1",
+        explicit_api_key="sk-test",
+        api_mode=None,
+    )
+    assert not isinstance(client, AnthropicAuxiliaryClient), (
+        "Without api_mode, path 3 should return an OpenAI-wire client."
+    )
+
+
+def test_explicit_base_url_anthropic_sdk_missing_falls_back_to_openai(monkeypatch):
+    """If anthropic SDK absent, path 3 falls back gracefully to OpenAI-wire."""
+    from agent.auxiliary_client import AnthropicAuxiliaryClient, resolve_provider_client
+
+    # Simulate ImportError from build_anthropic_client
+    with patch(
+        "agent.anthropic_adapter.build_anthropic_client",
+        side_effect=ImportError("anthropic not installed"),
+    ):
+        client, model = resolve_provider_client(
+            "custom",
+            model="test-model",
+            explicit_base_url="https://anthropic-gateway.example.com",
+            explicit_api_key="sk-x",
+            api_mode="anthropic_messages",
+        )
+
+    assert not isinstance(client, AnthropicAuxiliaryClient), (
+        "On ImportError, path 3 must fall back to OpenAI-wire rather than raise."
+    )
+
+
+def test_explicit_base_url_anthropic_messages_async_returns_async_wrapper():
+    """Path 3 + async_mode=True must wrap in AsyncAnthropicAuxiliaryClient."""
+    from agent.auxiliary_client import (
+        AsyncAnthropicAuxiliaryClient,
+        resolve_provider_client,
+    )
+
+    _, patcher = _make_anthropic_mock()
+    with patcher:
+        client, _ = resolve_provider_client(
+            "custom",
+            model="claude-3-haiku",
+            explicit_base_url="https://zenmux.ai/api/anthropic",
+            explicit_api_key="sk-z",
+            api_mode="anthropic_messages",
+            async_mode=True,
+        )
+
+    assert isinstance(client, AsyncAnthropicAuxiliaryClient)
+
+
+# ── key_env fix: _resolve_task_provider_model reads key_env from task config ─
+
+def test_resolve_task_provider_model_reads_key_env(monkeypatch):
+    """auxiliary.<task>.key_env must be resolved from the environment.
+
+    Before the fix, ``key_env`` was silently dropped, leaving ``api_key``
+    as "no-key-required" and causing 403 access_denied from the upstream
+    provider even though the env var was set (#16254 sibling bug).
+    """
+    monkeypatch.setenv("TEST_KEY_ENV", "resolved-from-env-key")
+
+    task_config = {
+        "provider": "custom",
+        "model": "some-model",
+        "base_url": "https://example.com/v1",
+        "key_env": "TEST_KEY_ENV",
+        # no 'api_key' — only key_env
+        "api_mode": "anthropic_messages",
+    }
+
+    from agent.auxiliary_client import _get_auxiliary_task_config, _resolve_task_provider_model
+
+    with patch(
+        "agent.auxiliary_client._get_auxiliary_task_config",
+        return_value=task_config,
+    ):
+        _, _, _, resolved_key, _ = _resolve_task_provider_model(task="vision")
+
+    assert resolved_key == "resolved-from-env-key", (
+        f"Expected 'resolved-from-env-key', got {resolved_key!r}.  "
+        "key_env is not being read from the auxiliary task config."
+    )
+
+
+def test_resolve_task_provider_model_api_key_wins_over_key_env(monkeypatch):
+    """Explicit api_key takes precedence over key_env when both are set."""
+    monkeypatch.setenv("TEST_KEY_ENV", "env-key")
+
+    task_config = {
+        "provider": "custom",
+        "base_url": "https://example.com",
+        "api_key": "explicit-key",
+        "key_env": "TEST_KEY_ENV",
+        "api_mode": None,
+    }
+
+    from agent.auxiliary_client import _resolve_task_provider_model
+
+    with patch(
+        "agent.auxiliary_client._get_auxiliary_task_config",
+        return_value=task_config,
+    ):
+        _, _, _, resolved_key, _ = _resolve_task_provider_model(task="compression")
+
+    assert resolved_key == "explicit-key"
+
+
+def test_resolve_task_provider_model_no_key_env_set_returns_none(monkeypatch):
+    """When key_env names an unset env var, api_key should remain None."""
+    monkeypatch.delenv("MISSING_ENV_KEY", raising=False)
+
+    task_config = {
+        "provider": "custom",
+        "base_url": "https://example.com",
+        "key_env": "MISSING_ENV_KEY",
+        "api_mode": None,
+    }
+
+    from agent.auxiliary_client import _resolve_task_provider_model
+
+    with patch(
+        "agent.auxiliary_client._get_auxiliary_task_config",
+        return_value=task_config,
+    ):
+        _, _, _, resolved_key, _ = _resolve_task_provider_model(task="compression")
+
+    # Unset env var → None, not empty string or "no-key-required"
+    assert resolved_key is None


### PR DESCRIPTION
## Summary

- Fixes the remaining broken code path (path 3) in `agent/auxiliary_client.py` where `api_mode: anthropic_messages` was silently ignored when `explicit_base_url` was set
- Fixes `key_env` being silently dropped from `auxiliary.<task>` configs, causing 403 errors even when the env var was set

## The bugs

`resolve_provider_client()` has three independent branches that each construct an SDK client from `(base_url, api_key, api_mode)`:

| # | Path | Triggered by | `api_mode` dispatch | Status |
|---|---|---|---|---|
| 1 | `_try_custom_endpoint` (~L1177) | `OPENAI_BASE_URL` env | inline `if custom_mode == "anthropic_messages":` | ✅ fixed by #7648 |
| 2 | named-custom branch (~L1895) | `provider: myrelay` + `providers.myrelay` dict | inline `if entry_api_mode == "anthropic_messages":` | ✅ fixed by #15059 |
| 3 | **explicit-base-url branch (~L1850)** | `auxiliary.<task>.base_url` flowed via `explicit_base_url` | **none — always built plain OpenAI client** | ❌ **this PR** |

Path 3 result: Anthropic-format body sent to `<base_url>/chat/completions` (OpenAI endpoint) instead of `/v1/messages`, returning `404 invalid_model` or `403`.

**Bug 2** — `_resolve_task_provider_model()` parsed `api_key` from task config but had no equivalent for `key_env`. Result: auxiliary task configs that specify `key_env` always sent `api_key="no-key-required"`, producing 403 even when the env var was set. (Contrast with path 2's `_get_named_custom_provider()` which correctly reads `key_env`.)

## The fix

**Path 3**: added the same `if api_mode == "anthropic_messages":` dispatch block that path 2 has at L1895-1914 (lines 1856-1878 here). Updated the `explicit_base_url` docstring to remove the hardcoded "OpenAI-compatible" assumption.

**key_env**: added two-line `os.getenv(_cfg_key_env)` resolution in `_resolve_task_provider_model`, mirroring `_get_named_custom_provider`.

## Test plan

- [x] **Before**: `test_explicit_base_url_anthropic_messages_returns_anthropic_client` fails (`isinstance(client, AnthropicAuxiliaryClient)` → False, got OpenAI-wire client)
- [x] **After**: 7 new tests all pass; 95 existing auxiliary client tests unchanged
- [x] **Regression guard**: reverted path 3 block → observed assertion failure; restored → 0 failures
- [x] **key_env**: `test_resolve_task_provider_model_reads_key_env` confirms env var is now resolved; `test_resolve_task_provider_model_api_key_wins_over_key_env` confirms precedence

## Related / Positioning

- Fixes #16254
- Completes the api_mode dispatch coverage started by #7648 (path 1) and #15059 / #15033 (path 2); those PRs only fixed their respective code paths — path 3 was still broken on HEAD `755a2804`
- PR #13831 (ms-alan) addresses `explicit_base_url` in ACP sessions specifically; this PR addresses `auxiliary.<task>` configs via `_resolve_task_provider_model` → `resolve_provider_client` with `explicit_base_url`

🤖 Generated with [Claude Code](https://claude.com/claude-code)