### PR TITLE
fix(session-search): prioritize non-cron sessions in recent list (#16253)

### DIFF
--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -12,6 +12,8 @@ from tools.session_search_tool import (
     _get_session_search_max_concurrency,
     _list_recent_sessions,
     _HIDDEN_SESSION_SOURCES,
+    _RECENT_SESSIONS_FETCH_BUDGET,
+    _list_recent_sessions,
     MAX_SESSION_CHARS,
     SESSION_SEARCH_SCHEMA,
 )
@@ -483,3 +485,63 @@ class TestSessionSearch:
         assert result["count"] == 0
         assert result["results"] == []
         assert result["sessions_searched"] == 0
+
+
+# =========================================================================
+# _list_recent_sessions: cron-flood regression (#16253)
+# =========================================================================
+
+@pytest.fixture()
+def _real_db(tmp_path):
+    """Minimal real SessionDB for integration-style recent-sessions tests."""
+    from hermes_state import SessionDB
+    return SessionDB(db_path=tmp_path / "state.db")
+
+
+class TestListRecentSessionsCronFlood:
+    """After many cron sessions run, interactive sessions must still appear
+    in the recent list (_RECENT_SESSIONS_FETCH_BUDGET fix for #16253)."""
+
+    def test_fetch_budget_constant_is_large_enough(self):
+        assert _RECENT_SESSIONS_FETCH_BUDGET >= 50, (
+            "_RECENT_SESSIONS_FETCH_BUDGET must be large enough to look past "
+            "typical cron-job bursts; 50 is the minimum reasonable floor."
+        )
+
+    def test_interactive_session_survives_cron_flood(self, _real_db):
+        """An interactive session should appear in _list_recent_sessions even
+        when many cron sessions were created after it (#16253)."""
+        db = _real_db
+        # Interactive session created first (lower started_at)
+        db.create_session("interactive_evening", "cli")
+        db.append_message("interactive_evening", "user", "Evening work session content")
+
+        # Simulate a flood of cron sessions created after the interactive one.
+        # Previously, limit+5 = 8 would hide the interactive session if 8+
+        # cron sessions ran afterwards.
+        for i in range(20):
+            sid = f"cron_{i:03d}"
+            db.create_session(sid, "cron")
+            db.append_message(sid, "user", f"automated cron job {i}")
+
+        result = json.loads(_list_recent_sessions(db, limit=3))
+
+        assert result["success"] is True
+        session_ids = [s["session_id"] for s in result["results"]]
+        assert "interactive_evening" in session_ids, (
+            f"Interactive session was dropped from recent list when 20 cron "
+            f"sessions followed it — _RECENT_SESSIONS_FETCH_BUDGET too small. "
+            f"Got: {session_ids}"
+        )
+
+    def test_recent_sessions_count_respects_limit(self, _real_db):
+        """_list_recent_sessions must not return more than `limit` results."""
+        db = _real_db
+        for i in range(10):
+            db.create_session(f"s{i}", "cli")
+
+        result = json.loads(_list_recent_sessions(db, limit=3))
+
+        assert result["success"] is True
+        assert result["count"] <= 3
+        assert len(result["results"]) <= 3

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -495,7 +495,11 @@ class TestSessionSearch:
 def _real_db(tmp_path):
     """Minimal real SessionDB for integration-style recent-sessions tests."""
     from hermes_state import SessionDB
-    return SessionDB(db_path=tmp_path / "state.db")
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        yield db
+    finally:
+        db.close()
 
 
 class TestListRecentSessionsCronFlood:

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -262,11 +262,17 @@ async def _summarize_session(
 # HERMES_SESSION_SOURCE=tool so they don't clutter the user's session history.
 _HIDDEN_SESSION_SOURCES = ("tool",)
 
+# How many raw sessions to fetch from the DB before filtering down to `limit`
+# results in _list_recent_sessions.  Must be large enough to look past a burst
+# of cron sessions that ran after the last interactive session; otherwise those
+# automated jobs crowd out the user's real conversations (#16253).
+_RECENT_SESSIONS_FETCH_BUDGET = 100
+
 
 def _list_recent_sessions(db, limit: int, current_session_id: str = None) -> str:
     """Return metadata for the most recent sessions (no LLM calls)."""
     try:
-        sessions = db.list_sessions_rich(limit=limit + 5, exclude_sources=list(_HIDDEN_SESSION_SOURCES))  # fetch extra to skip current
+        sessions = db.list_sessions_rich(limit=_RECENT_SESSIONS_FETCH_BUDGET, exclude_sources=list(_HIDDEN_SESSION_SOURCES))
 
         # Resolve current session lineage to exclude it
         current_root = None
@@ -284,7 +290,11 @@ def _list_recent_sessions(db, limit: int, current_session_id: str = None) -> str
             except Exception:
                 current_root = current_session_id
 
-        results = []
+        # Two-pass collection: non-cron sessions first so that a burst of
+        # automated cron jobs doesn't crowd out the user's interactive
+        # conversations in the "what were we working on?" view (#16253).
+        non_cron: list = []
+        cron_sessions: list = []
         for s in sessions:
             sid = s.get("id", "")
             if current_root and (sid == current_root or sid == current_session_id):
@@ -292,7 +302,7 @@ def _list_recent_sessions(db, limit: int, current_session_id: str = None) -> str
             # Skip child/delegation sessions (they have parent_session_id)
             if s.get("parent_session_id"):
                 continue
-            results.append({
+            entry = {
                 "session_id": sid,
                 "title": s.get("title") or None,
                 "source": s.get("source", ""),
@@ -300,9 +310,15 @@ def _list_recent_sessions(db, limit: int, current_session_id: str = None) -> str
                 "last_active": s.get("last_active", ""),
                 "message_count": s.get("message_count", 0),
                 "preview": s.get("preview", ""),
-            })
-            if len(results) >= limit:
-                break
+            }
+            if s.get("source") == "cron":
+                cron_sessions.append(entry)
+            else:
+                non_cron.append(entry)
+
+        # Fill results: non-cron sessions first, then cron to fill remaining slots.
+        combined = non_cron + cron_sessions
+        results = combined[:limit]
 
         return json.dumps({
             "success": True,
@@ -355,12 +371,14 @@ def session_search(
         if role_filter and role_filter.strip():
             role_list = [r.strip() for r in role_filter.split(",") if r.strip()]
 
-        # FTS5 search -- get matches ranked by relevance
+        # FTS5 search -- get matches ranked by relevance.  Fetch limit * 50 raw
+        # matches so that a burst of cron sessions with overlapping keywords
+        # doesn't crowd out unique interactive sessions (#16253).
         raw_results = db.search_messages(
             query=query,
             role_filter=role_list,
             exclude_sources=list(_HIDDEN_SESSION_SOURCES),
-            limit=50,  # Get more matches to find unique sessions
+            limit=min(limit * 50, 500),
             offset=0,
         )
 


### PR DESCRIPTION
## Summary

Fixes #16253 — interactive sessions disappeared from the `session_search` recent-sessions view after several cron jobs ran.

**Root cause (two-part):**

1. `_list_recent_sessions` fetched only `limit + 5` sessions from the DB (e.g., 8 when `limit=3`). Sessions are ordered by `started_at DESC`, so cron sessions that started after the interactive session filled every slot, hiding the user's conversation entirely.

2. The FTS5 keyword-search path had a hard cap of 50 raw matches. If cron sessions accumulated many messages containing the same query terms, they could occupy all 50 BM25 slots before any message from the interactive session was seen.

**Changes:**

- `_RECENT_SESSIONS_FETCH_BUDGET = 100`: increase the internal DB fetch from `limit + 5` to 100 — big enough to look past a typical cron burst.
- Two-pass collection in `_list_recent_sessions`: non-cron sessions are placed first in the output, then cron sessions fill remaining slots. This ensures a cron flood can never fully crowd out interactive conversations in the "what were we working on?" view.
- FTS5 raw match limit raised from a fixed 50 to `min(limit * 50, 500)` so keyword searches are robust to cron-session noise at higher query relevance.

## Test plan

- [x] `test_interactive_session_survives_cron_flood` — creates 20 cron sessions after one CLI session, asserts the CLI session appears in `_list_recent_sessions(limit=3)`
- [x] `test_recent_sessions_count_respects_limit` — verifies result count does not exceed `limit`
- [x] `test_fetch_budget_constant_is_large_enough` — guards against accidental reduction of the budget constant
- [x] All 38 tests in `tests/tools/test_session_search.py` pass
- [x] All 178 tests in `tests/test_hermes_state.py` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)