### PR TITLE
[codex] Fix cron jobs when croniter is missing

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -287,6 +287,35 @@ def _compute_grace_seconds(schedule: dict) -> int:
     return MIN_GRACE
 
 
+def _is_recurring_schedule(schedule: Dict[str, Any]) -> bool:
+    return isinstance(schedule, dict) and schedule.get("kind") in ("cron", "interval")
+
+
+def _next_run_failure_message(schedule: Dict[str, Any], error: Optional[BaseException] = None) -> str:
+    kind = schedule.get("kind", "unknown") if isinstance(schedule, dict) else "unknown"
+    if error:
+        return f"Failed to compute next run for recurring {kind} schedule: {error}"
+    if kind == "cron" and not HAS_CRONITER:
+        return "Failed to compute next run for cron schedule because the 'croniter' package is not installed"
+    return f"Failed to compute next run for recurring {kind} schedule"
+
+
+def _mark_next_run_failure(
+    job: Dict[str, Any],
+    schedule: Dict[str, Any],
+    error: Optional[BaseException] = None,
+) -> None:
+    message = _next_run_failure_message(schedule, error)
+    existing_error = job.get("last_error")
+    if existing_error and message not in existing_error:
+        job["last_error"] = f"{existing_error}; {message}"
+    else:
+        job["last_error"] = message
+    job["last_status"] = "error"
+    if job.get("state") != "paused":
+        job["state"] = "error"
+
+
 def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None) -> Optional[str]:
     """
     Compute the next run time for a schedule.
@@ -696,12 +725,28 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                         return
                 
                 # Compute next run
-                job["next_run_at"] = compute_next_run(job["schedule"], now)
+                next_run_error = None
+                schedule = job.get("schedule", {})
+                try:
+                    job["next_run_at"] = compute_next_run(schedule, now)
+                except Exception as e:
+                    if not _is_recurring_schedule(schedule):
+                        raise
+                    job["next_run_at"] = None
+                    next_run_error = e
 
                 # If no next run (one-shot completed), disable
                 if job["next_run_at"] is None:
-                    job["enabled"] = False
-                    job["state"] = "completed"
+                    if _is_recurring_schedule(schedule):
+                        _mark_next_run_failure(job, schedule, next_run_error)
+                        logger.error(
+                            "Job '%s' remains enabled but errored because next_run_at could not be computed: %s",
+                            job.get("name", job["id"]),
+                            job["last_error"],
+                        )
+                    else:
+                        job["enabled"] = False
+                        job["state"] = "completed"
                 elif job.get("state") != "paused":
                     job["state"] = "scheduled"
 
@@ -760,24 +805,48 @@ def get_due_jobs() -> List[Dict[str, Any]]:
 
         next_run = job.get("next_run_at")
         if not next_run:
-            recovered_next = _recoverable_oneshot_run_at(
-                job.get("schedule", {}),
-                now,
-                last_run_at=job.get("last_run_at"),
-            )
+            schedule = job.get("schedule", {})
+            recovery_error = None
+            if _is_recurring_schedule(schedule):
+                try:
+                    recovered_next = compute_next_run(schedule, job.get("last_run_at"))
+                except Exception as e:
+                    recovered_next = None
+                    recovery_error = e
+            else:
+                recovered_next = _recoverable_oneshot_run_at(
+                    schedule,
+                    now,
+                    last_run_at=job.get("last_run_at"),
+                )
             if not recovered_next:
+                if _is_recurring_schedule(schedule):
+                    for rj in raw_jobs:
+                        if rj["id"] == job["id"]:
+                            _mark_next_run_failure(rj, schedule, recovery_error)
+                            needs_save = True
+                            break
+                    logger.error(
+                        "Job '%s' has no next_run_at and could not be recovered: %s",
+                        job.get("name", job["id"]),
+                        _next_run_failure_message(schedule, recovery_error),
+                    )
                 continue
 
             job["next_run_at"] = recovered_next
             next_run = recovered_next
+            schedule_kind = schedule.get("kind", "unknown") if isinstance(schedule, dict) else "unknown"
             logger.info(
-                "Job '%s' had no next_run_at; recovering one-shot run at %s",
+                "Job '%s' had no next_run_at; recovering %s run at %s",
                 job.get("name", job["id"]),
+                schedule_kind,
                 recovered_next,
             )
             for rj in raw_jobs:
                 if rj["id"] == job["id"]:
                     rj["next_run_at"] = recovered_next
+                    if _is_recurring_schedule(schedule) and rj.get("state") != "paused":
+                        rj["state"] = "scheduled"
                     needs_save = True
                     break
 
@@ -793,7 +862,12 @@ def get_due_jobs() -> List[Dict[str, Any]]:
             if kind in ("cron", "interval") and (now - next_run_dt).total_seconds() > grace:
                 # Job is past its catch-up grace window — this is a stale missed run.
                 # Grace scales with schedule period: daily=2h, hourly=30m, 10min=5m.
-                new_next = compute_next_run(schedule, now.isoformat())
+                fast_forward_error = None
+                try:
+                    new_next = compute_next_run(schedule, now.isoformat())
+                except Exception as e:
+                    new_next = None
+                    fast_forward_error = e
                 if new_next:
                     logger.info(
                         "Job '%s' missed its scheduled time (%s, grace=%ds). "
@@ -810,6 +884,17 @@ def get_due_jobs() -> List[Dict[str, Any]]:
                             needs_save = True
                             break
                     continue  # Skip this run
+                for rj in raw_jobs:
+                    if rj["id"] == job["id"]:
+                        _mark_next_run_failure(rj, schedule, fast_forward_error)
+                        needs_save = True
+                        break
+                logger.error(
+                    "Job '%s' missed its scheduled time but could not be fast-forwarded: %s",
+                    job.get("name", job["id"]),
+                    _next_run_failure_message(schedule, fast_forward_error),
+                )
+                continue
 
             due.append(job)
 

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -188,6 +188,33 @@ def tmp_cron_dir(tmp_path, monkeypatch):
     return tmp_path
 
 
+def _stored_cron_job(
+    job_id="cron-job",
+    next_run_at="2026-04-27T07:00:00+00:00",
+    last_run_at=None,
+):
+    return {
+        "id": job_id,
+        "name": "Cron job",
+        "prompt": "Daily report",
+        "schedule": {"kind": "cron", "expr": "0 7 * * *", "display": "0 7 * * *"},
+        "schedule_display": "0 7 * * *",
+        "repeat": {"times": None, "completed": 0},
+        "enabled": True,
+        "state": "scheduled",
+        "paused_at": None,
+        "paused_reason": None,
+        "created_at": "2026-04-26T07:00:00+00:00",
+        "next_run_at": next_run_at,
+        "last_run_at": last_run_at,
+        "last_status": None,
+        "last_error": None,
+        "last_delivery_error": None,
+        "deliver": "local",
+        "origin": None,
+    }
+
+
 class TestJobCRUD:
     def test_create_and_get(self, tmp_cron_dir):
         job = create_job(prompt="Check server status", schedule="30m")
@@ -368,6 +395,20 @@ class TestMarkJobRun:
         assert updated["last_status"] == "error"
         assert updated["last_error"] == "model timeout"
         assert updated["last_delivery_error"] == "platform 'discord' not enabled"
+
+    def test_recurring_cron_missing_croniter_stays_enabled(self, tmp_cron_dir, monkeypatch):
+        monkeypatch.setattr("cron.jobs.HAS_CRONITER", False)
+        save_jobs([_stored_cron_job("cron-missing")])
+
+        mark_job_run("cron-missing", success=True)
+
+        updated = get_job("cron-missing")
+        assert updated["enabled"] is True
+        assert updated["state"] == "error"
+        assert updated["next_run_at"] is None
+        assert updated["last_status"] == "error"
+        assert "croniter" in updated["last_error"]
+        assert updated["repeat"]["completed"] == 1
 
 
 class TestAdvanceNextRun:
@@ -564,6 +605,45 @@ class TestGetDueJobs:
 
         assert get_due_jobs() == []
         assert get_job("oneshot-stale")["next_run_at"] is None
+
+    def test_recurring_cron_without_next_run_is_recovered(self, tmp_cron_dir, monkeypatch):
+        pytest.importorskip("croniter")
+        now = datetime(2026, 4, 27, 6, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        save_jobs([
+            _stored_cron_job(
+                "cron-recover",
+                next_run_at=None,
+                last_run_at="2026-04-26T07:00:00+00:00",
+            )
+        ])
+
+        due = get_due_jobs()
+
+        assert due == []
+        updated = get_job("cron-recover")
+        assert updated["enabled"] is True
+        assert updated["state"] == "scheduled"
+        assert updated["next_run_at"] is not None
+        assert datetime.fromisoformat(updated["next_run_at"]) > now
+
+    def test_recurring_cron_without_next_run_missing_croniter_records_error(
+        self,
+        tmp_cron_dir,
+        monkeypatch,
+    ):
+        monkeypatch.setattr("cron.jobs.HAS_CRONITER", False)
+        save_jobs([_stored_cron_job("cron-unrecoverable", next_run_at=None)])
+
+        due = get_due_jobs()
+
+        assert due == []
+        updated = get_job("cron-unrecoverable")
+        assert updated["enabled"] is True
+        assert updated["state"] == "error"
+        assert updated["next_run_at"] is None
+        assert updated["last_status"] == "error"
+        assert "croniter" in updated["last_error"]
 
 
 class TestEnabledToolsets:


### PR DESCRIPTION
## Summary

Fixes #16265.

Recurring cron jobs could be persisted as `enabled: false` / `state: completed` when the gateway runtime could not compute the next cron occurrence, such as when `croniter` is missing. This keeps recurring jobs enabled and marks them with a clear scheduling error instead of treating them as completed one-shot jobs.

## Changes

- Keep recurring cron/interval jobs enabled when `next_run_at` cannot be computed after a run.
- Record a clear `last_status: error` / `last_error` for next-run computation failures.
- Recover enabled recurring jobs that have `next_run_at: null` when the dependency/runtime issue is fixed.
- Avoid executing stale recurring jobs when they cannot be fast-forwarded safely.
- Add regression coverage for missing `croniter` and recovery from `next_run_at: null`.

## Validation

- `/Users/xuefusong/.hermes/hermes-agent/venv/bin/python -m pytest tests/cron/test_jobs.py -q` -> 64 passed
- `/Users/xuefusong/.hermes/hermes-agent/venv/bin/python -m pytest tests/cron -q` -> 252 passed