### PR TITLE
fix(setup): API key prompt accepts input on Ubuntu after curses

### DIFF
--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -29,6 +29,7 @@ from agent.credential_pool import (
 )
 import hermes_cli.auth as auth_mod
 from hermes_cli.auth import PROVIDER_REGISTRY
+from hermes_cli.curses_ui import reset_terminal_mode
 from hermes_constants import OPENROUTER_BASE_URL
 
 
@@ -104,6 +105,49 @@ def _oauth_default_label(provider: str, count: int) -> str:
 
 def _api_key_default_label(count: int) -> str:
     return f"api-key-{count}"
+
+
+def _read_secret_from_tty(prompt: str) -> str:
+    """Fallback for ``getpass`` failure: read directly from /dev/tty.
+
+    Used by ``_prompt_api_key`` when ``getpass.getpass`` raises ``OSError``
+    (typically because ``/dev/tty`` could not be opened or termios calls
+    failed on the controlling terminal — see #15768).
+    """
+    import termios
+
+    with open("/dev/tty", "r+") as tty_file:
+        fd = tty_file.fileno()
+        old_attrs = termios.tcgetattr(fd)
+        new_attrs = list(old_attrs)
+        new_attrs[3] |= termios.ICANON
+        new_attrs[3] &= ~termios.ECHO
+        try:
+            termios.tcsetattr(fd, termios.TCSANOW, new_attrs)
+            tty_file.write(prompt)
+            tty_file.flush()
+            value = tty_file.readline()
+            tty_file.write("\n")
+            tty_file.flush()
+            return value.rstrip("\r\n")
+        finally:
+            termios.tcsetattr(fd, termios.TCSANOW, old_attrs)
+
+
+def _prompt_api_key() -> str:
+    """Prompt for an API key, robust against earlier curses-induced tty mode.
+
+    Resets the controlling tty to canonical/echo mode (recovers from a
+    curses prompt that exited without restoring it on Linux — #15768)
+    then calls ``getpass``. If ``getpass`` itself raises ``OSError``
+    (no controlling tty, ioctl rejected), falls back to a direct
+    ``/dev/tty`` read with echo disabled via ``termios``.
+    """
+    reset_terminal_mode()
+    try:
+        return getpass("Paste your API key: ")
+    except OSError:
+        return _read_secret_from_tty("Paste your API key: ")
 
 
 def _display_source(source: str) -> str:
@@ -194,7 +238,7 @@ def auth_add_command(args) -> None:
     if requested_type == AUTH_TYPE_API_KEY:
         token = (getattr(args, "api_key", None) or "").strip()
         if not token:
-            token = getpass("Paste your API key: ").strip()
+            token = _prompt_api_key().strip()
         if not token:
             raise SystemExit("No API key provided.")
         default_label = _api_key_default_label(len(pool.entries()) + 1)

--- a/hermes_cli/curses_ui.py
+++ b/hermes_cli/curses_ui.py
@@ -4,6 +4,7 @@ Used by `hermes tools` and `hermes skills` for interactive checklists.
 Provides a curses multi-select with keyboard navigation, plus a
 text-based numbered fallback for terminals without curses support.
 """
+
 import sys
 from typing import Callable, List, Optional, Set
 
@@ -27,7 +28,30 @@ def flush_stdin() -> None:
         if not sys.stdin.isatty():
             return
         import termios
+
         termios.tcflush(sys.stdin, termios.TCIFLUSH)
+    except Exception:
+        pass
+
+
+def reset_terminal_mode() -> None:
+    """Restore canonical + echo mode before hidden prompts.
+
+    Fixes issue #15768: after curses prompts in the setup wizard, some
+    terminals can be left in non-canonical mode, causing ``getpass.getpass()``
+    to read bytes without ever seeing a submitted newline.  This is a no-op
+    on non-TTY stdin and on non-POSIX platforms without ``termios``.
+    """
+    try:
+        if not sys.stdin.isatty():
+            return
+        import termios
+
+        fd = sys.stdin.fileno()
+        attrs = termios.tcgetattr(fd)
+        attrs[3] |= termios.ICANON | termios.ECHO
+        termios.tcsetattr(fd, termios.TCSANOW, attrs)
+        flush_stdin()
     except Exception:
         pass
 
@@ -61,6 +85,7 @@ def curses_checklist(
 
     try:
         import curses
+
         chosen = set(selected)
         result_holder: list = [None]
 
@@ -89,9 +114,11 @@ def curses_checklist(
                         hattr |= curses.color_pair(2)
                     stdscr.addnstr(0, 0, title, max_x - 1, hattr)
                     stdscr.addnstr(
-                        1, 0,
+                        1,
+                        0,
                         "  ↑↓ navigate  SPACE toggle  ENTER confirm  ESC cancel",
-                        max_x - 1, curses.A_DIM,
+                        max_x - 1,
+                        curses.A_DIM,
                     )
                 except curses.error:
                     pass
@@ -132,7 +159,9 @@ def curses_checklist(
                             sattr = curses.A_DIM
                             if curses.has_colors():
                                 sattr |= curses.color_pair(3)
-                            stdscr.addnstr(max_y - 1, sx, status_text, max_x - sx - 1, sattr)
+                            stdscr.addnstr(
+                                max_y - 1, sx, status_text, max_x - sx - 1, sattr
+                            )
                     except curses.error:
                         pass
 
@@ -191,6 +220,7 @@ def curses_radiolist(
 
     try:
         import curses
+
         result_holder: list = [None]
 
         def _draw(stdscr):
@@ -225,9 +255,11 @@ def curses_radiolist(
                         row += 1
 
                     stdscr.addnstr(
-                        row, 0,
+                        row,
+                        0,
                         "  \u2191\u2193 navigate  ENTER/SPACE select  ESC cancel",
-                        max_x - 1, curses.A_DIM,
+                        max_x - 1,
+                        curses.A_DIM,
                     )
                     row += 1
                 except curses.error:
@@ -325,6 +357,7 @@ def curses_single_select(
 
     try:
         import curses
+
         result_holder: list = [None]
 
         all_items = list(items) + [cancel_label]
@@ -350,9 +383,11 @@ def curses_single_select(
                         hattr |= curses.color_pair(2)
                     stdscr.addnstr(0, 0, title, max_x - 1, hattr)
                     stdscr.addnstr(
-                        1, 0,
+                        1,
+                        0,
                         "  ↑↓ navigate  ENTER confirm  ESC/q cancel",
-                        max_x - 1, curses.A_DIM,
+                        max_x - 1,
+                        curses.A_DIM,
                     )
                 except curses.error:
                     pass
@@ -364,7 +399,9 @@ def curses_single_select(
                     scroll_offset = cursor - visible_rows + 1
 
                 for draw_i, i in enumerate(
-                    range(scroll_offset, min(len(all_items), scroll_offset + visible_rows))
+                    range(
+                        scroll_offset, min(len(all_items), scroll_offset + visible_rows)
+                    )
                 ):
                     y = draw_i + 3
                     if y >= max_y - 1:

--- a/tests/hermes_cli/test_auth_commands_paste_api_key.py
+++ b/tests/hermes_cli/test_auth_commands_paste_api_key.py
@@ -1,0 +1,170 @@
+"""Regression tests for #15768: setup wizard hangs at API key prompt on Ubuntu.
+
+The failure mode was that ``getpass.getpass()`` in ``hermes_cli.auth_commands``
+read raw bytes from a terminal that had been left in non-canonical mode by
+an earlier curses prompt.  The fix introduces ``reset_terminal_mode`` in
+``hermes_cli.curses_ui`` and routes the API-key prompt through a wrapper
+(``_prompt_api_key``) that resets the tty before calling ``getpass`` and
+falls back to a direct ``/dev/tty`` read when ``getpass`` raises ``OSError``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+
+# --- reset_terminal_mode -----------------------------------------------------
+
+
+def test_reset_terminal_mode_no_op_on_non_tty():
+    """Non-TTY stdin -> reset_terminal_mode returns without touching termios."""
+    from hermes_cli import curses_ui
+
+    fake_stdin = MagicMock()
+    fake_stdin.isatty.return_value = False
+
+    fake_termios = MagicMock()
+
+    with patch.object(curses_ui, "sys") as mock_sys:
+        mock_sys.stdin = fake_stdin
+        with patch.dict("sys.modules", {"termios": fake_termios}):
+            curses_ui.reset_terminal_mode()
+
+    assert not fake_termios.tcgetattr.called
+    assert not fake_termios.tcsetattr.called
+
+
+def test_reset_terminal_mode_restores_canonical_and_echo():
+    """TTY stdin -> reset_terminal_mode OR-s ICANON|ECHO into local flags."""
+    from hermes_cli import curses_ui
+
+    icanon_bit = 0x2
+    echo_bit = 0x8
+    cflag_local = 0  # No ICANON, no ECHO -- the broken state.
+    attrs = [0, 0, 0, cflag_local, 0, 0, []]
+
+    fake_stdin = MagicMock()
+    fake_stdin.isatty.return_value = True
+    fake_stdin.fileno.return_value = 0
+
+    fake_termios = MagicMock()
+    fake_termios.tcgetattr.return_value = list(attrs)
+    fake_termios.ICANON = icanon_bit
+    fake_termios.ECHO = echo_bit
+    fake_termios.TCSANOW = 0
+    fake_termios.TCIFLUSH = 0
+
+    with patch.object(curses_ui, "sys") as mock_sys:
+        mock_sys.stdin = fake_stdin
+        with patch.dict("sys.modules", {"termios": fake_termios}):
+            curses_ui.reset_terminal_mode()
+
+    fake_termios.tcgetattr.assert_called_once_with(0)
+    written = fake_termios.tcsetattr.call_args[0][2]
+    assert written[3] & icanon_bit, "ICANON not restored"
+    assert written[3] & echo_bit, "ECHO not restored"
+
+
+def test_reset_terminal_mode_swallows_termios_errors():
+    """termios raising should not propagate out of reset_terminal_mode."""
+    from hermes_cli import curses_ui
+
+    fake_stdin = MagicMock()
+    fake_stdin.isatty.return_value = True
+    fake_stdin.fileno.return_value = 0
+
+    fake_termios = MagicMock()
+    fake_termios.tcgetattr.side_effect = OSError("Inappropriate ioctl for device")
+    fake_termios.ICANON = 0x2
+    fake_termios.ECHO = 0x8
+    fake_termios.TCSANOW = 0
+    fake_termios.TCIFLUSH = 0
+
+    with patch.object(curses_ui, "sys") as mock_sys:
+        mock_sys.stdin = fake_stdin
+        with patch.dict("sys.modules", {"termios": fake_termios}):
+            curses_ui.reset_terminal_mode()  # must not raise
+
+    assert not fake_termios.tcsetattr.called
+
+
+# --- _prompt_api_key ---------------------------------------------------------
+
+
+def test_paste_api_key_calls_reset_terminal_mode_before_getpass():
+    """The prompt path resets the tty BEFORE calling getpass."""
+    from hermes_cli import auth_commands
+
+    call_order: list[str] = []
+
+    def fake_reset():
+        call_order.append("reset")
+
+    def fake_getpass(prompt):
+        call_order.append("getpass")
+        return "sk-abc"
+
+    with (
+        patch.object(auth_commands, "reset_terminal_mode", fake_reset),
+        patch.object(auth_commands, "getpass", fake_getpass),
+    ):
+        result = auth_commands._prompt_api_key()
+
+    assert result == "sk-abc"
+    assert call_order == ["reset", "getpass"], (
+        "reset_terminal_mode must run before getpass; saw %r" % call_order
+    )
+
+
+def test_paste_api_key_falls_back_to_dev_tty_when_getpass_oserror():
+    """If getpass raises OSError, _prompt_api_key reads from /dev/tty directly."""
+    from hermes_cli import auth_commands
+
+    def raising_getpass(prompt):
+        raise OSError(25, "Inappropriate ioctl for device")
+
+    with (
+        patch.object(auth_commands, "reset_terminal_mode", lambda: None),
+        patch.object(auth_commands, "getpass", raising_getpass),
+        patch.object(
+            auth_commands, "_read_secret_from_tty", return_value="fallback-key"
+        ) as fallback,
+    ):
+        result = auth_commands._prompt_api_key()
+
+    fallback.assert_called_once_with("Paste your API key: ")
+    assert result == "fallback-key"
+
+
+def test_read_secret_from_tty_disables_echo_and_restores_state():
+    """The /dev/tty fallback must disable ECHO during read and restore on exit."""
+    from hermes_cli import auth_commands
+
+    icanon_bit = 0x2
+    echo_bit = 0x8
+    initial_attrs = [0, 0, 0, icanon_bit | echo_bit, 0, 0, []]
+
+    fake_tty = MagicMock()
+    fake_tty.fileno.return_value = 99
+    fake_tty.readline.return_value = "secret-key\n"
+    fake_tty.__enter__ = MagicMock(return_value=fake_tty)
+    fake_tty.__exit__ = MagicMock(return_value=False)
+
+    fake_termios = MagicMock()
+    fake_termios.tcgetattr.return_value = list(initial_attrs)
+    fake_termios.ICANON = icanon_bit
+    fake_termios.ECHO = echo_bit
+    fake_termios.TCSANOW = 0
+
+    with (
+        patch("builtins.open", return_value=fake_tty),
+        patch.dict("sys.modules", {"termios": fake_termios}),
+    ):
+        result = auth_commands._read_secret_from_tty("Paste your API key: ")
+
+    assert result == "secret-key"
+    assert fake_termios.tcsetattr.call_count == 2
+    written_first = fake_termios.tcsetattr.call_args_list[0][0][2]
+    assert not (written_first[3] & echo_bit), "ECHO not disabled during read"
+    written_restore = fake_termios.tcsetattr.call_args_list[1][0][2]
+    assert written_restore[3] & echo_bit, "ECHO not restored after read"


### PR DESCRIPTION
## Closes #15768

`hermes setup` reaches "Paste your API key:" and hangs on Ubuntu (reproduced on 25.04 with Python 3.13.3): keystrokes don't show, Enter doesn't submit, paste does nothing. The wizard exits only via Ctrl+C.

## Root cause

The same flow works fine on a fresh terminal but fails after the user navigates the curses-based model selector earlier in the wizard. `curses.wrapper(...)` is supposed to restore termios attributes on exit, but on some Linux + terminal-emulator combinations it leaves the tty in non-canonical mode. `getpass.getpass()` then reads bytes immediately and never sees a line terminator, so the prompt blocks forever even though the user is typing or pasting.

The repo already had `flush_stdin()` for a related issue (stray bytes in the buffer), but flushing alone doesn't fix mode.

## Change

1. **`hermes_cli/curses_ui.py:reset_terminal_mode()`** - stronger sibling of `flush_stdin`. ORs `ICANON | ECHO` into the local flags via `termios.tcgetattr` / `tcsetattr(TCSANOW)`, then drains buffered bytes. No-op on non-TTY stdin (pipes, CI), Windows, or when termios calls fail. Safe to call repeatedly.

2. **`hermes_cli/auth_commands.py:_prompt_api_key()`** - thin wrapper around `getpass`. Calls `reset_terminal_mode()` first, then `getpass`. If `getpass` itself raises `OSError` (no controlling tty, ioctl rejected), falls back to a direct `/dev/tty` read with `termios`-disabled echo via `_read_secret_from_tty`.

3. The single `auth_add_command` paste call site now uses the wrapper instead of calling `getpass` directly.

## Verification

```
$ uv run --extra dev python -m pytest tests/hermes_cli/test_auth_commands_paste_api_key.py tests/hermes_cli/test_auth_commands.py -v
======================== 50 passed, 1 warning in 0.84s =========================
```

The 6 new tests cover:
- `reset_terminal_mode` no-op on non-TTY, restores ICANON+ECHO, swallows termios errors
- `_prompt_api_key` resets the tty BEFORE calling getpass (assertion on call ordering)
- `_prompt_api_key` falls back to `_read_secret_from_tty` when getpass raises OSError
- `_read_secret_from_tty` disables ECHO during read and restores original termios state on exit

The 44 existing `tests/hermes_cli/test_auth_commands.py` tests pass unchanged.

## Reproducing the original report

The user's exact path: `hermes setup` -> select model in curses -> answer y to "Add another credential for same-provider fallback?" -> "Paste your API key:" prompt. Before this change the prompt hung; after, it accepts typed and pasted input normally on a TTY where the curses session corrupted termios state.

🤖 Built with assistance from Claude Code and Codex.