### PR TITLE
fix(skills): add future annotations for Python 3.9 compatibility (#16257)

### DIFF
--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -20,6 +20,8 @@ Usage:
   python google_api.py docs get DOC_ID
 """
 
+from __future__ import annotations  # PEP 604 union syntax on Python 3.9
+
 import argparse
 import base64
 import json

--- a/skills/productivity/powerpoint/scripts/add_slide.py
+++ b/skills/productivity/powerpoint/scripts/add_slide.py
@@ -18,6 +18,8 @@ To see available layouts: ls unpacked/ppt/slideLayouts/
 Prints the <p:sldId> element to add to presentation.xml.
 """
 
+from __future__ import annotations  # PEP 604 union syntax on Python 3.9
+
 import re
 import shutil
 import sys

--- a/skills/productivity/powerpoint/scripts/office/pack.py
+++ b/skills/productivity/powerpoint/scripts/office/pack.py
@@ -10,6 +10,8 @@ Examples:
     python pack.py unpacked/ output.pptx --validate false
 """
 
+from __future__ import annotations  # PEP 604 union syntax on Python 3.9
+
 import argparse
 import sys
 import shutil


### PR DESCRIPTION
## Problem

Multiple skill scripts use PEP 604 union syntax (`str | None`) which requires Python 3.10+ at runtime. On Python 3.9 (macOS system Python, older containers), these scripts crash with `TypeError: unsupported operand type(s) for |`.

Issue #16257 reports `google_api.py` crashing, but the same pattern exists in two additional files.

## Fix

Added `from __future__ import annotations` to all affected skill scripts. This makes type annotations lazy (stored as strings), so Python 3.9 won't evaluate PEP 604 syntax at runtime. Zero functional change for Python 3.10+.

### Affected files

| File | Lines using `X | None` |
|------|----------------------|
| `google_api.py` | `_gws_binary() -> str | None`, `_run_gws(params: dict | None)` |
| `pack.py` | `original_file: str | None`, `pack() -> tuple[bool, str | None]` |
| `add_slide.py` | `parse_source() -> tuple[str, str | None]` |

Note: `setup.py` (google-workspace) already has the future import.

## Testing

```bash
# Verify syntax on Python 3.9+
python3.9 -c "import ast; ast.parse(open('google_api.py').read())"
python3.9 -c "import ast; ast.parse(open('pack.py').read())"
python3.9 -c "import ast; ast.parse(open('add_slide.py').read())"
```

Fixes #16257
