### PR TITLE
fix: handle stream=True in CopilotACPClient to avoid SimpleNamespace iteration error

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -361,6 +361,7 @@ class CopilotACPClient:
         timeout: float | None = None,
         tools: list[dict[str, Any]] | None = None,
         tool_choice: Any = None,
+        stream: bool = False,
         **_: Any,
     ) -> Any:
         prompt_text = _format_messages_as_prompt(
@@ -407,11 +408,35 @@ class CopilotACPClient:
         )
         finish_reason = "tool_calls" if tool_calls else "stop"
         choice = SimpleNamespace(message=assistant_message, finish_reason=finish_reason)
-        return SimpleNamespace(
+        response = SimpleNamespace(
             choices=[choice],
             usage=usage,
             model=model or "copilot-acp",
         )
+
+        if stream:
+            # When stream=True the caller iterates over the return value
+            # (e.g. ``for chunk in stream: ...``).  Wrap the single response
+            # in a generator so it is iterable, avoiding the TypeError:
+            # "'types.SimpleNamespace' object is not iterable".
+            def _stream_chunks():
+                delta = SimpleNamespace(
+                    content=cleaned_text,
+                    tool_calls=tool_calls or None,
+                    reasoning=reasoning_text or None,
+                    reasoning_content=reasoning_text or None,
+                    reasoning_details=None,
+                )
+                chunk_choice = SimpleNamespace(delta=delta, finish_reason=finish_reason)
+                yield SimpleNamespace(
+                    choices=[chunk_choice],
+                    usage=usage,
+                    model=model or "copilot-acp",
+                )
+
+            return _stream_chunks()
+
+        return response
 
     def _run_prompt(self, prompt_text: str, *, timeout_seconds: float) -> tuple[str, str]:
         try:


### PR DESCRIPTION
## Summary

Fixes #16271

When `stream=True` is passed to `CopilotACPClient._create_chat_completion()`, the `stream` parameter was silently discarded via `**_: Any`, and the method always returned a `types.SimpleNamespace` object. The caller in `run_agent.py` then tried to iterate over it (`for chunk in stream:`), causing:

```
TypeError: 'types.SimpleNamespace' object is not iterable
```

## Changes

**`agent/copilot_acp_client.py`**:
- Added explicit `stream: bool = False` parameter to `_create_chat_completion()`
- When `stream=True`: returns a generator yielding a chunk with `delta` attribute (matching the streaming response format expected by `run_agent.py`)
- When `stream=False`: returns the `SimpleNamespace` as before (backward compatible)

## Root Cause

The `**_: Any` catch-all on line 364 silently swallowed the `stream=True` kwarg. The method always returned a non-iterable `SimpleNamespace`, but the streaming code path in `run_agent.py` expects an iterable.

## Testing

- Non-streaming calls continue to work as before (no behavior change)
- Streaming calls now receive a generator that yields properly structured chunks

cc @maintainers — this is a blocking bug for ACP Copilot CLI users. Would appreciate a timely review 🙏