### PR TITLE
fix: guard flock(LOCK_UN) in finally blocks against OSError

### DIFF
--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -623,7 +623,10 @@ def _locked_update_approvals() -> Iterator[Dict[str, Any]]:
             yield data
             save_allowlist(data)
         finally:
-            fcntl.flock(lock_fh.fileno(), fcntl.LOCK_UN)
+            try:
+                fcntl.flock(lock_fh.fileno(), fcntl.LOCK_UN)
+            except OSError:
+                pass
 
 
 def _prompt_and_record(

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1311,7 +1311,10 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
         return sum(_results)
     finally:
         if fcntl:
-            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            try:
+                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            except OSError:
+                pass
         elif msvcrt:
             try:
                 msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -751,7 +751,10 @@ def _auth_store_lock(timeout_seconds: float = AUTH_LOCK_TIMEOUT_SECONDS):
         finally:
             _auth_lock_holder.depth = 0
             if fcntl:
-                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+                try:
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+                except OSError:
+                    pass
             elif msvcrt:
                 try:
                     lock_file.seek(0)

--- a/tools/environments/file_sync.py
+++ b/tools/environments/file_sync.py
@@ -283,7 +283,10 @@ class FileSyncManager:
             fcntl.flock(lock_fd, fcntl.LOCK_EX)
             self._sync_back_impl()
         finally:
-            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            try:
+                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            except OSError:
+                pass
             lock_fd.close()
 
     def _sync_back_impl(self) -> None:

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -167,7 +167,10 @@ class MemoryStore:
             yield
         finally:
             if fcntl:
-                fcntl.flock(fd, fcntl.LOCK_UN)
+                try:
+                    fcntl.flock(fd, fcntl.LOCK_UN)
+                except OSError:
+                    pass
             elif msvcrt:
                 try:
                     fd.seek(0)


### PR DESCRIPTION
## Problem

Five `finally` blocks call `fcntl.flock(fd, LOCK_UN)` without a `try/except` guard. If the unlock raises `OSError` (e.g., file descriptor already closed, NFS stale handle, kernel interrupt), the subsequent `fd.close()` is **skipped** and the lock file remains open and locked indefinitely.

This is the same pattern that was already guarded for `msvcrt` (Windows) in every one of these files — but the `fcntl` (Linux/macOS) path was missed.

## Affected modules

| File | Lock protects |
|------|--------------|
| `agent/shell_hooks.py` | Shell hooks allowlist |
| `tools/memory_tool.py` | Memory tool file operations |
| `tools/environments/file_sync.py` | Remote sync-back serialization |
| `hermes_cli/auth.py` | Auth credential store |
| `cron/scheduler.py` | Cron tick scheduling |

## Fix

Wrap each `fcntl.flock(fd, LOCK_UN)` in `try/except OSError: pass`, matching the defensive pattern already used for `msvcrt.unlock` in the same blocks.

## Before vs After

```python
# BEFORE — if unlock raises, close() is never called
finally:
    fcntl.flock(fd, fcntl.LOCK_UN)   # ← can raise OSError
    fd.close()                        # ← skipped on error

# AFTER — unlock failure doesn't prevent cleanup
finally:
    try:
        fcntl.flock(fd, fcntl.LOCK_UN)
    except OSError:
        pass
    fd.close()                        # ← always runs
```
