### PR TITLE
fix(session_search): bypass FTS5 for CJK queries, escape LIKE wildcards

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1331,20 +1331,24 @@ class SessionDB:
             LIMIT ? OFFSET ?
         """
 
-        with self._lock:
-            try:
-                cursor = self._conn.execute(sql, params)
-            except sqlite3.OperationalError:
-                # FTS5 query syntax error despite sanitization — return empty
-                # unless query contains CJK (fall back to LIKE below)
-                if not self._contains_cjk(query):
+        # CJK queries bypass FTS5 entirely: the default tokenizer splits CJK
+        # characters into individual tokens, so "大别山项目" becomes
+        # "大 AND 别 AND 山 AND 项 AND 目".  This produces false positives
+        # (all chars scattered in a message) and misses exact phrase matches.
+        # LIKE substring search is more accurate for CJK phrase matching.
+        if self._contains_cjk(query):
+            matches = []
+        else:
+            with self._lock:
+                try:
+                    cursor = self._conn.execute(sql, params)
+                except sqlite3.OperationalError:
+                    # FTS5 query syntax error despite sanitization — return empty
                     return []
-                matches = []
-            else:
-                matches = [dict(row) for row in cursor.fetchall()]
+                else:
+                    matches = [dict(row) for row in cursor.fetchall()]
 
-        # LIKE fallback for CJK queries: FTS5 default tokenizer splits CJK
-        # characters individually, causing multi-character queries to fail.
+        # LIKE search for CJK queries (primary path) or CJK fallback
         if not matches and self._contains_cjk(query):
             raw_query = query.strip('"').strip()
             like_where = ["m.content LIKE ?"]

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1336,7 +1336,8 @@ class SessionDB:
         # "大 AND 别 AND 山 AND 项 AND 目".  This produces false positives
         # (all chars scattered in a message) and misses exact phrase matches.
         # LIKE substring search is more accurate for CJK phrase matching.
-        if self._contains_cjk(query):
+        is_cjk = self._contains_cjk(query)
+        if is_cjk:
             matches = []
         else:
             with self._lock:
@@ -1348,11 +1349,15 @@ class SessionDB:
                 else:
                     matches = [dict(row) for row in cursor.fetchall()]
 
-        # LIKE search for CJK queries (primary path) or CJK fallback
-        if not matches and self._contains_cjk(query):
+        # LIKE substring search for CJK queries (primary path since FTS5
+        # cannot do phrase matching with the unicode61 tokenizer).
+        if not matches and is_cjk:
             raw_query = query.strip('"').strip()
-            like_where = ["m.content LIKE ?"]
-            like_params: list = [f"%{raw_query}%"]
+            # Escape LIKE wildcards so literal %, _ in the query
+            # are not treated as single/multi-char wildcards.
+            escaped = raw_query.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+            like_where = ["m.content LIKE ? ESCAPE '\\'"]
+            like_params: list = [f"%{escaped}%"]
             if source_filter is not None:
                 like_where.append(f"s.source IN ({','.join('?' for _ in source_filter)})")
                 like_params.extend(source_filter)

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -743,6 +743,40 @@ class TestCJKSearchFallback:
         results = db.search_messages("Agent通信")
         assert len(results) == 1
 
+    def test_cjk_partial_fts5_results_supplemented_by_like(self, db):
+        """When FTS5 returns *some* CJK results, LIKE must still find all matches.
+
+        Regression test for #15500 / #14829: FTS5 unicode61 tokenizer drops
+        certain CJK characters, so multi-character queries may return partial
+        results.  The LIKE path must always run for CJK queries.
+        """
+        db.create_session(session_id="s1", source="cli")
+        db.create_session(session_id="s2", source="telegram")
+        db.append_message("s1", role="user", content="昨晚讨论了记忆系统")
+        db.append_message("s2", role="user", content="昨晚的会议纪要已发送")
+        results = db.search_messages("昨晚")
+        assert len(results) == 2
+        session_ids = {r["session_id"] for r in results}
+        assert session_ids == {"s1", "s2"}
+
+    def test_cjk_like_dedup_no_duplicates(self, db):
+        """When FTS5 and LIKE both find the same message, no duplicates."""
+        db.create_session(session_id="s1", source="cli")
+        db.append_message("s1", role="user", content="测试去重逻辑")
+        results = db.search_messages("测试")
+        assert len(results) == 1
+
+    def test_cjk_like_escapes_wildcards(self, db):
+        """LIKE wildcards (%, _) in CJK queries are treated as literals."""
+        db.create_session(session_id="s1", source="cli")
+        db.create_session(session_id="s2", source="cli")
+        db.append_message("s1", role="user", content="达成100%完成率")
+        db.append_message("s2", role="user", content="达成100完成率是目标")
+        # The % in the query must be literal — should only match s1
+        results = db.search_messages("100%完成")
+        assert len(results) == 1
+        assert results[0]["session_id"] == "s1"
+
 
 # =========================================================================
 # Session search and listing


### PR DESCRIPTION
## Salvage of #15509

Closes #15500 (duplicate of #14829). Supersedes #15509 and #14842.

## Problem

`session_search` returns zero or very few results for CJK (Chinese/Japanese/Korean) queries despite session files clearly containing matching content. `grep` finds 148 matches but `session_search` returns only 1.

**Root cause:** FTS5's `unicode61` tokenizer splits CJK characters into individual tokens. A query like `"大别山项目"` becomes `大 AND 别 AND 山 AND 项 AND 目`. The existing LIKE fallback only triggered when FTS5 returned **zero** results — if FTS5 returned even 1-2 accidental matches from scattered character hits, the more accurate LIKE fallback never ran.

## Fix

Cherry-picked from #15509 (author: @vominh1919) with improvements on top:

### From #15509
- For CJK queries, bypass FTS5 entirely and use `LIKE '%query%'` for accurate phrase matching

### Added in this PR
- **Cache `_contains_cjk()` result** in a local var — avoids redundant O(n) scans (was called twice per CJK query)
- **Escape LIKE wildcards** (`%`, `_`) in user queries so they are treated as literals, consistent with other LIKE queries in `hermes_state.py` that use `ESCAPE '\\'`
- **Fix misleading comment** — 'or CJK fallback' no longer describes the new code path
- **3 regression tests** — partial FTS5 results (#15500/#14829), dedup, and wildcard escaping

### Not included (from #15509)
- Hindsight shutdown guard (commit `cfb22a0`) — unrelated fix, should be a separate PR

## Before / After

| Scenario | Before | After |
|----------|--------|-------|
| CJK query, FTS5 returns 0 | ✅ LIKE fallback | ✅ LIKE runs (primary) |
| CJK query, FTS5 returns partial | ❌ LIKE skipped | ✅ LIKE runs (primary) |
| CJK query with `%` or `_` | ❌ Treated as SQL wildcards | ✅ Escaped, literal match |
| English query | ✅ FTS5 only | ✅ FTS5 only (unchanged) |
| Mixed CJK + English | ✅ LIKE fallback on 0 | ✅ LIKE always for CJK |

## Testing

```
pytest tests/test_hermes_state.py::TestCJKSearchFallback -v
# 15 passed (12 existing + 3 new)

pytest tests/test_hermes_state.py -v
# 181 passed
```