### PR TITLE
fix(memory): show entry previews on zero-match in replace/remove

### DIFF
--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -285,7 +285,12 @@ class MemoryStore:
             matches = [(i, e) for i, e in enumerate(entries) if old_text in e]
 
             if not matches:
-                return {"success": False, "error": f"No entry matched '{old_text}'."}
+                previews = [e[:80] + ("..." if len(e) > 80 else "") for e in entries]
+                return {
+                    "success": False,
+                    "error": f"No entry matched '{old_text}'.",
+                    "existing_entries": previews,
+                }
 
             if len(matches) > 1:
                 # If all matches are identical (exact duplicates), operate on the first one
@@ -335,7 +340,12 @@ class MemoryStore:
             matches = [(i, e) for i, e in enumerate(entries) if old_text in e]
 
             if not matches:
-                return {"success": False, "error": f"No entry matched '{old_text}'."}
+                previews = [e[:80] + ("..." if len(e) > 80 else "") for e in entries]
+                return {
+                    "success": False,
+                    "error": f"No entry matched '{old_text}'.",
+                    "existing_entries": previews,
+                }
 
             if len(matches) > 1:
                 # If all matches are identical (exact duplicates), remove the first one


### PR DESCRIPTION
## Problem

The memory tool's `replace` and `remove` actions return a bare error when `old_text` doesn't match any entry:

```json
{"success": false, "error": "No entry matched '...'"}
```

The LLM has no context about what entries exist, so it wastes a full tool round trip guessing. In production logs, **every** `replace` call fails on first attempt and succeeds on retry.

The multi-match branch already returns previews of conflicting entries — the zero-match branch should do the same.

## Fix

On zero-match, return an `existing_entries` field with 80-char previews of all existing entries, letting the LLM pick a correct `old_text` on the next call.

### Before
```json
{"success": false, "error": "No entry matched 'For venue work, keep research...'"}
```

### After
```json
{
  "success": false,
  "error": "No entry matched 'For venue work, keep research...'",
  "existing_entries": [
    "For venue work, include all plausible venues, flag concerns, mark likely 18+...",
    "Always respond in Vietnamese for conversation..."
  ]
}
```

Applied to both `replace()` and `remove()` methods for consistency.

Fixes #16266
