### PR TITLE
fix(sms): mark missing-config errors as non-retryable; default bind to 127.0.0.1 (#16258)

### DIFF
--- a/gateway/platforms/sms.py
+++ b/gateway/platforms/sms.py
@@ -10,7 +10,7 @@ Shares credentials with the optional telephony skill — same env vars:
 
 Gateway-specific env vars:
   - SMS_WEBHOOK_PORT     (default 8080)
-  - SMS_WEBHOOK_HOST     (default 0.0.0.0)
+  - SMS_WEBHOOK_HOST     (default 127.0.0.1)
   - SMS_WEBHOOK_URL      (public URL for Twilio signature validation — required)
   - SMS_INSECURE_NO_SIGNATURE  (true to disable signature validation — dev only)
   - SMS_ALLOWED_USERS    (comma-separated E.164 phone numbers)
@@ -41,7 +41,7 @@ logger = logging.getLogger(__name__)
 TWILIO_API_BASE = "https://api.twilio.com/2010-04-01/Accounts"
 MAX_SMS_LENGTH = 1600  # ~10 SMS segments
 DEFAULT_WEBHOOK_PORT = 8080
-DEFAULT_WEBHOOK_HOST = "0.0.0.0"
+DEFAULT_WEBHOOK_HOST = "127.0.0.1"
 
 
 def check_sms_requirements() -> bool:
@@ -91,19 +91,23 @@ class SmsAdapter(BasePlatformAdapter):
         from aiohttp import web
 
         if not self._from_number:
-            logger.error("[sms] TWILIO_PHONE_NUMBER not set — cannot send replies")
+            msg = "[sms] TWILIO_PHONE_NUMBER not set — cannot send replies"
+            logger.error(msg)
+            self._set_fatal_error("sms_missing_phone_number", msg, retryable=False)
             return False
 
         insecure_no_sig = os.getenv("SMS_INSECURE_NO_SIGNATURE", "").lower() == "true"
 
         if not self._webhook_url and not insecure_no_sig:
-            logger.error(
+            msg = (
                 "[sms] Refusing to start: SMS_WEBHOOK_URL is required for Twilio "
                 "signature validation. Set it to the public URL configured in your "
                 "Twilio console (e.g. https://example.com/webhooks/twilio). "
                 "For local development without validation, set "
-                "SMS_INSECURE_NO_SIGNATURE=true (NOT recommended for production).",
+                "SMS_INSECURE_NO_SIGNATURE=true (NOT recommended for production)."
             )
+            logger.error(msg)
+            self._set_fatal_error("sms_missing_webhook_url", msg, retryable=False)
             return False
 
         if insecure_no_sig and not self._webhook_url:

--- a/tests/gateway/test_sms.py
+++ b/tests/gateway/test_sms.py
@@ -260,7 +260,7 @@ class TestStartupGuard:
             "TWILIO_PHONE_NUMBER": "",
             "SMS_WEBHOOK_URL": "",
         }
-        with patch.dict(os.environ, env, clear=False):
+        with patch.dict(os.environ, env, clear=True):
             pc = PlatformConfig(enabled=True, api_key="tok")
             adapter = SmsAdapter(pc)
         await adapter.connect()

--- a/tests/gateway/test_sms.py
+++ b/tests/gateway/test_sms.py
@@ -257,6 +257,8 @@ class TestStartupGuard:
         env = {
             "TWILIO_ACCOUNT_SID": "ACtest",
             "TWILIO_AUTH_TOKEN": "tok",
+            "TWILIO_PHONE_NUMBER": "",
+            "SMS_WEBHOOK_URL": "",
         }
         with patch.dict(os.environ, env, clear=False):
             pc = PlatformConfig(enabled=True, api_key="tok")

--- a/tests/gateway/test_sms.py
+++ b/tests/gateway/test_sms.py
@@ -169,23 +169,23 @@ class TestSmsRequirements:
 class TestWebhookHostConfig:
     """Verify SMS_WEBHOOK_HOST env var and default."""
 
-    def test_default_host_is_all_interfaces(self):
+    def test_default_host_is_localhost(self):
         from gateway.platforms.sms import DEFAULT_WEBHOOK_HOST
-        assert DEFAULT_WEBHOOK_HOST == "0.0.0.0"
+        assert DEFAULT_WEBHOOK_HOST == "127.0.0.1"
 
-    def test_host_from_env(self):
+    def test_host_from_env_overrides_default(self):
         from gateway.platforms.sms import SmsAdapter
 
         env = {
             "TWILIO_ACCOUNT_SID": "ACtest",
             "TWILIO_AUTH_TOKEN": "tok",
             "TWILIO_PHONE_NUMBER": "+15550001111",
-            "SMS_WEBHOOK_HOST": "127.0.0.1",
+            "SMS_WEBHOOK_HOST": "0.0.0.0",
         }
         with patch.dict(os.environ, env):
             pc = PlatformConfig(enabled=True, api_key="tok")
             adapter = SmsAdapter(pc)
-            assert adapter._webhook_host == "127.0.0.1"
+            assert adapter._webhook_host == "0.0.0.0"
 
     def test_webhook_url_from_env(self):
         from gateway.platforms.sms import SmsAdapter
@@ -241,6 +241,46 @@ class TestStartupGuard:
         adapter = self._make_adapter()
         result = await adapter.connect()
         assert result is False
+
+    @pytest.mark.asyncio
+    async def test_missing_webhook_url_is_non_retryable(self):
+        adapter = self._make_adapter()
+        await adapter.connect()
+        assert adapter.has_fatal_error is True
+        assert adapter.fatal_error_retryable is False
+        assert "sms_missing_webhook_url" == adapter.fatal_error_code
+
+    @pytest.mark.asyncio
+    async def test_missing_phone_number_is_non_retryable(self):
+        from gateway.platforms.sms import SmsAdapter
+
+        env = {
+            "TWILIO_ACCOUNT_SID": "ACtest",
+            "TWILIO_AUTH_TOKEN": "tok",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            pc = PlatformConfig(enabled=True, api_key="tok")
+            adapter = SmsAdapter(pc)
+        await adapter.connect()
+        assert adapter.has_fatal_error is True
+        assert adapter.fatal_error_retryable is False
+        assert adapter.fatal_error_code == "sms_missing_phone_number"
+
+    @pytest.mark.asyncio
+    async def test_insecure_flag_does_not_set_fatal_error(self):
+        mock_session = AsyncMock()
+        with patch.dict(os.environ, {"SMS_INSECURE_NO_SIGNATURE": "true"}), \
+             patch("aiohttp.web.AppRunner") as mock_runner_cls, \
+             patch("aiohttp.web.TCPSite") as mock_site_cls, \
+             patch("aiohttp.ClientSession", return_value=mock_session):
+            mock_runner_cls.return_value.setup = AsyncMock()
+            mock_runner_cls.return_value.cleanup = AsyncMock()
+            mock_site_cls.return_value.start = AsyncMock()
+            adapter = self._make_adapter()
+            result = await adapter.connect()
+            assert result is True
+            assert adapter.has_fatal_error is False
+            await adapter.disconnect()
 
     @pytest.mark.asyncio
     async def test_insecure_flag_allows_start_without_url(self):


### PR DESCRIPTION
## Summary

- Config-validation failures in `SmsAdapter.connect()` (missing `SMS_WEBHOOK_URL`, missing `TWILIO_PHONE_NUMBER`) now call `_set_fatal_error(..., retryable=False)` before returning `False`, so the reconnect watcher removes them from the retry queue immediately and never re-enqueues them.
- `DEFAULT_WEBHOOK_HOST` changed from `0.0.0.0` to `127.0.0.1` — aligns with the recommended Cloudflare Tunnel deployment model (tunnel routes to `127.0.0.1:<port>`). Operators who need `0.0.0.0` can set `SMS_WEBHOOK_HOST=0.0.0.0`.

## The bugs

**Retry-after-giving-up loop**: when `SMS_WEBHOOK_URL` is unset, `connect()` returned `False` without setting `has_fatal_error`. The reconnect watcher treated this as a transient failure, scheduled exponential back-off retries, and logged an error on every attempt — up to 20 times before finally logging "Giving up reconnecting sms after N attempts". For a permanent configuration error this cycle is pure log noise. After the fix, the gateway recognises the error as non-retryable on the first attempt and drops SMS from the retry queue immediately.

**0.0.0.0 bind**: the Twilio webhook listener bound to all interfaces by default, exposing it to other hosts on the same network even though Cloudflare Tunnel (the recommended public-facing setup) only routes to `127.0.0.1`. Changing the default eliminates the unnecessary exposure; the env-var override path `SMS_WEBHOOK_HOST` is unchanged for operators who require the old behaviour.

## The fix

`gateway/platforms/sms.py`:
- `DEFAULT_WEBHOOK_HOST`: `"0.0.0.0"` → `"127.0.0.1"` (+ module docstring)
- `connect()`: two `return False` paths that previously set no fatal-error state now call `self._set_fatal_error("<code>", msg, retryable=False)` before returning

`tests/gateway/test_sms.py`:
- `test_default_host_is_all_interfaces` renamed to `test_default_host_is_localhost`, assertion updated
- `test_host_from_env` updated to verify env-var override to `0.0.0.0` still works (was testing override to the new default, which added no coverage)
- Three new `TestStartupGuard` tests: `test_missing_webhook_url_is_non_retryable`, `test_missing_phone_number_is_non_retryable`, `test_insecure_flag_does_not_set_fatal_error`

## Test plan

- [x] **Before**: `test_missing_webhook_url_is_non_retryable` fails — `has_fatal_error` is `False` on the old code path
- [x] **After**: 39 tests pass in `tests/gateway/test_sms.py`
- [x] **Regression guard**: reverted both `_set_fatal_error` calls → both new non-retryable tests fail as expected; restored → 0 failures
- [x] Adjacent suite (`tests/gateway/`) unchanged

## Related

- Fixes #16258

🤖 Generated with [Claude Code](https://claude.com/claude-code)