### PR TITLE
feat(gateway): default Feishu replies to cards with v2 payloads

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -158,6 +158,7 @@ _MARKDOWN_FENCE_CLOSE_RE = re.compile(r"^```\s*$")
 _MENTION_RE = re.compile(r"@_user_\d+")
 _MULTISPACE_RE = re.compile(r"[ \t]{2,}")
 _POST_CONTENT_INVALID_RE = re.compile(r"content format of the post type is incorrect", re.IGNORECASE)
+_INTERACTIVE_CONTENT_INVALID_RE = re.compile(r"content format of the interactive type is incorrect", re.IGNORECASE)
 # ---------------------------------------------------------------------------
 # Media type sets and upload constants
 # ---------------------------------------------------------------------------
@@ -235,6 +236,8 @@ _FEISHU_REACTION_FAILURE = "CrossMark"
 # drain on completion; the cap is a safeguard against unbounded growth from
 # delete-failures, not a capacity plan.
 _FEISHU_PROCESSING_REACTION_CACHE_SIZE = 1024
+_FEISHU_RENDER_STATE_TTL_SECONDS = 6 * 60 * 60
+_FEISHU_RENDER_STATE_MAX_SIZE = 1000
 
 # QR onboarding constants
 _ONBOARD_ACCOUNTS_URLS = {
@@ -498,6 +501,56 @@ def _coerce_int(value: Any, default: Optional[int] = None, min_value: int = 0) -
 def _coerce_required_int(value: Any, default: int, min_value: int = 0) -> int:
     parsed = _coerce_int(value, default=default, min_value=min_value)
     return default if parsed is None else parsed
+
+
+def _split_markdown_table_row(line: str) -> Optional[List[str]]:
+    stripped = line.strip()
+    if "|" not in stripped:
+        return None
+    if stripped.startswith("|"):
+        stripped = stripped[1:]
+    if stripped.endswith("|"):
+        stripped = stripped[:-1]
+    cells = [cell.strip() for cell in stripped.split("|")]
+    if len(cells) < 2:
+        return None
+    return cells
+
+
+def _is_markdown_table_separator(cells: List[str]) -> bool:
+    if not cells:
+        return False
+    for cell in cells:
+        marker = cell.replace(":", "").replace(" ", "")
+        if not marker or set(marker) != {"-"}:
+            return False
+    return True
+
+
+def _parse_first_markdown_table(content: str) -> Optional[Dict[str, Any]]:
+    lines = content.splitlines()
+    for idx, line in enumerate(lines):
+        headers = _split_markdown_table_row(line)
+        if not headers or idx + 1 >= len(lines):
+            continue
+        divider = _split_markdown_table_row(lines[idx + 1])
+        if not divider or len(divider) != len(headers) or not _is_markdown_table_separator(divider):
+            continue
+        rows: List[List[str]] = []
+        cursor = idx + 2
+        while cursor < len(lines):
+            candidate = _split_markdown_table_row(lines[cursor])
+            if not candidate or len(candidate) != len(headers):
+                break
+            rows.append(candidate)
+            cursor += 1
+        return {
+            "intro": "\n".join(lines[:idx]).strip(),
+            "headers": headers,
+            "rows": rows,
+            "outro": "\n".join(lines[cursor:]).strip(),
+        }
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -1366,6 +1419,7 @@ class FeishuAdapter(BasePlatformAdapter):
         # Feishu reaction deletion requires the opaque reaction_id returned
         # by create, so we cache it per message_id.
         self._pending_processing_reactions: "OrderedDict[str, str]" = OrderedDict()
+        self._render_state_by_message_id: "OrderedDict[str, Dict[str, Any]]" = OrderedDict()
         self._load_seen_message_ids()
 
     @staticmethod
@@ -1631,6 +1685,180 @@ class FeishuAdapter(BasePlatformAdapter):
     # Outbound — send / edit / send_image / send_voice / …
     # =========================================================================
 
+    def _looks_like_interactive_payload(self, content: str) -> bool:
+        try:
+            payload = json.loads(content)
+        except Exception:
+            return False
+        if not isinstance(payload, dict):
+            return False
+        candidate = payload.get("card") if isinstance(payload.get("card"), dict) else payload
+        return isinstance(candidate, dict) and ("elements" in candidate or "header" in candidate)
+
+    def _normalize_interactive_payload(self, content: str) -> str:
+        try:
+            payload = json.loads(content)
+        except Exception:
+            return content
+        if isinstance(payload, dict) and isinstance(payload.get("card"), dict):
+            payload = payload["card"]
+        return json.dumps(payload, ensure_ascii=False)
+
+    @staticmethod
+    def _payload_invalid_for_msg_type(msg_type: str, message: str) -> bool:
+        if msg_type == "interactive":
+            return bool(_INTERACTIVE_CONTENT_INVALID_RE.search(message or ""))
+        if msg_type == "post":
+            return bool(_POST_CONTENT_INVALID_RE.search(message or ""))
+        return False
+
+    @staticmethod
+    def _build_interactive_card_payload(*, title: str, template: str, elements: List[Dict[str, Any]]) -> str:
+        card = {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "title": {"content": title, "tag": "plain_text"},
+                "template": template,
+            },
+            "elements": elements or [{"tag": "div", "text": {"tag": "lark_md", "content": " "}}],
+        }
+        return json.dumps(card, ensure_ascii=False)
+
+    def _build_default_reply_card_payload(
+        self,
+        content: str,
+        *,
+        title: str = "Hermes · 回复",
+        template: str = "blue",
+    ) -> str:
+        body = content.strip() or " "
+        return self._build_interactive_card_payload(
+            title=title,
+            template=template,
+            elements=[{"tag": "div", "text": {"tag": "lark_md", "content": body}}],
+        )
+
+    def _build_tool_progress_card_payload(self, content: str, *, page_no: Optional[int] = None) -> str:
+        title = "Hermes · 工具执行中"
+        if page_no and page_no > 1:
+            title += f"（{page_no}）"
+        body = content.strip() or "_等待工具输出_"
+        return self._build_interactive_card_payload(
+            title=title,
+            template="turquoise",
+            elements=[{"tag": "div", "text": {"tag": "lark_md", "content": body}}],
+        )
+
+    def _build_table_card_payload(
+        self,
+        content: str,
+        *,
+        title: str = "Hermes · 回复",
+        template: str = "blue",
+    ) -> str:
+        parsed = _parse_first_markdown_table(content)
+        if not parsed:
+            return self._build_default_reply_card_payload(content, title=title, template=template)
+
+        elements: List[Dict[str, Any]] = []
+        intro = parsed.get("intro") or ""
+        if intro:
+            elements.append({"tag": "div", "text": {"tag": "lark_md", "content": intro}})
+
+        headers = parsed.get("headers") or []
+        columns = [
+            {"name": f"col_{idx}", "display_name": header or f"列{idx + 1}", "data_type": "text"}
+            for idx, header in enumerate(headers)
+        ]
+        rows = [
+            {
+                f"col_{idx}": row[idx] if idx < len(row) else ""
+                for idx in range(len(columns))
+            }
+            for row in (parsed.get("rows") or [])
+        ]
+        elements.append({"tag": "table", "columns": columns, "rows": rows})
+
+        outro = parsed.get("outro") or ""
+        if outro:
+            elements.append({"tag": "div", "text": {"tag": "lark_md", "content": outro}})
+
+        return self._build_interactive_card_payload(title=title, template=template, elements=elements)
+
+    def _prune_render_states(self) -> None:
+        now = time.time()
+        stale_ids = [
+            message_id
+            for message_id, state in self._render_state_by_message_id.items()
+            if now - float(state.get("updated_at", now)) > _FEISHU_RENDER_STATE_TTL_SECONDS
+        ]
+        for message_id in stale_ids:
+            self._render_state_by_message_id.pop(message_id, None)
+        while len(self._render_state_by_message_id) > _FEISHU_RENDER_STATE_MAX_SIZE:
+            self._render_state_by_message_id.popitem(last=False)
+
+    def _remember_render_state(self, message_id: Optional[str], *, kind: str, page_no: Optional[int] = None) -> None:
+        if not message_id or not kind:
+            return
+        self._prune_render_states()
+        self._render_state_by_message_id[message_id] = {
+            "kind": kind,
+            "page_no": page_no,
+            "updated_at": time.time(),
+        }
+        self._render_state_by_message_id.move_to_end(message_id)
+        self._prune_render_states()
+
+    def _get_render_state(self, message_id: str) -> Optional[Dict[str, Any]]:
+        self._prune_render_states()
+        state = self._render_state_by_message_id.get(message_id)
+        if not state:
+            return None
+        state["updated_at"] = time.time()
+        self._render_state_by_message_id.move_to_end(message_id)
+        return dict(state)
+
+    def _build_fallback_outbound_sequence(
+        self,
+        content: str,
+        *,
+        metadata: Optional[Dict[str, Any]] = None,
+        render_state: Optional[Dict[str, Any]] = None,
+    ) -> List[tuple[str, str, Optional[Dict[str, Any]]]]:
+        if self._looks_like_interactive_payload(content):
+            return [("interactive", self._normalize_interactive_payload(content), None)]
+
+        message_kind = str((metadata or {}).get("message_kind") or "").strip().lower()
+        state_kind = str((render_state or {}).get("kind") or "").strip().lower()
+        if message_kind == "tool_progress" or state_kind == "tool_progress":
+            page_no = _coerce_int((metadata or {}).get("progress_page_no"), default=None, min_value=1)
+            if page_no is None:
+                page_no = _coerce_int((render_state or {}).get("page_no"), default=1, min_value=1) or 1
+            primary = (
+                "interactive",
+                self._build_tool_progress_card_payload(content, page_no=page_no),
+                {"kind": "tool_progress", "page_no": page_no},
+            )
+        elif _parse_first_markdown_table(content):
+            primary = (
+                "interactive",
+                self._build_table_card_payload(content),
+                {"kind": "table_reply"},
+            )
+        else:
+            primary = (
+                "interactive",
+                self._build_default_reply_card_payload(content),
+                {"kind": "default_reply"},
+            )
+
+        text_payload = json.dumps({"text": _strip_markdown_to_plain_text(content)}, ensure_ascii=False)
+        return [
+            primary,
+            ("post", self._build_post_payload(content), None),
+            ("text", text_payload, None),
+        ]
+
     async def send(
         self,
         chat_id: str,
@@ -1648,38 +1876,44 @@ class FeishuAdapter(BasePlatformAdapter):
 
         try:
             for chunk in chunks:
-                msg_type, payload = self._build_outbound_payload(chunk)
-                try:
-                    response = await self._feishu_send_with_retry(
-                        chat_id=chat_id,
-                        msg_type=msg_type,
-                        payload=payload,
-                        reply_to=reply_to,
-                        metadata=metadata,
-                    )
-                except Exception as exc:
-                    if msg_type != "post" or not _POST_CONTENT_INVALID_RE.search(str(exc)):
-                        raise
-                    logger.warning("[Feishu] Invalid post payload rejected by API; falling back to plain text")
-                    response = await self._feishu_send_with_retry(
-                        chat_id=chat_id,
-                        msg_type="text",
-                        payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
-                        reply_to=reply_to,
-                        metadata=metadata,
-                    )
-                if (
-                    msg_type == "post"
-                    and not self._response_succeeded(response)
-                    and _POST_CONTENT_INVALID_RE.search(str(getattr(response, "msg", "") or ""))
+                response = None
+                chosen_state: Optional[Dict[str, Any]] = None
+                for msg_type, payload, render_state in self._build_fallback_outbound_sequence(
+                    chunk,
+                    metadata=metadata,
                 ):
-                    logger.warning("[Feishu] Post payload rejected by API response; falling back to plain text")
-                    response = await self._feishu_send_with_retry(
-                        chat_id=chat_id,
-                        msg_type="text",
-                        payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
-                        reply_to=reply_to,
-                        metadata=metadata,
+                    try:
+                        response = await self._feishu_send_with_retry(
+                            chat_id=chat_id,
+                            msg_type=msg_type,
+                            payload=payload,
+                            reply_to=reply_to,
+                            metadata=metadata,
+                        )
+                    except Exception as exc:
+                        if self._payload_invalid_for_msg_type(msg_type, str(exc)):
+                            logger.warning("[Feishu] Invalid %s payload rejected by API; falling back", msg_type)
+                            response = None
+                            continue
+                        raise
+
+                    if self._response_succeeded(response):
+                        chosen_state = render_state
+                        break
+                    if self._payload_invalid_for_msg_type(msg_type, str(getattr(response, "msg", "") or "")):
+                        logger.warning("[Feishu] %s payload rejected by API response; falling back", msg_type)
+                        response = None
+                        continue
+                    break
+
+                if response is None:
+                    return SendResult(success=False, error="Feishu send failed after exhausting fallback sequence")
+
+                if chosen_state:
+                    self._remember_render_state(
+                        self._extract_response_field(response, "message_id"),
+                        kind=str(chosen_state.get("kind") or ""),
+                        page_no=_coerce_int(chosen_state.get("page_no"), default=None, min_value=1),
                     )
                 last_response = response
 
@@ -1702,23 +1936,53 @@ class FeishuAdapter(BasePlatformAdapter):
 
         content = self.format_message(content)
         try:
-            msg_type, payload = self._build_outbound_payload(content)
-            body = self._build_update_message_body(msg_type=msg_type, content=payload)
-            request = self._build_update_message_request(message_id=message_id, request_body=body)
-            response = await asyncio.to_thread(self._client.im.v1.message.update, request)
-            result = self._finalize_send_result(response, "update failed")
-            if not result.success and msg_type == "post" and _POST_CONTENT_INVALID_RE.search(result.error or ""):
-                logger.warning("[Feishu] Invalid post update payload rejected by API; falling back to plain text")
-                fallback_body = self._build_update_message_body(
-                    msg_type="text",
-                    content=json.dumps({"text": _strip_markdown_to_plain_text(content)}, ensure_ascii=False),
-                )
-                fallback_request = self._build_update_message_request(message_id=message_id, request_body=fallback_body)
-                fallback_response = await asyncio.to_thread(self._client.im.v1.message.update, fallback_request)
-                result = self._finalize_send_result(fallback_response, "update failed")
-            if result.success:
-                result.message_id = message_id
-            return result
+            render_state = self._get_render_state(message_id)
+            if not render_state:
+                msg_type, payload = self._build_outbound_payload(content)
+                body = self._build_update_message_body(msg_type=msg_type, content=payload)
+                request = self._build_update_message_request(message_id=message_id, request_body=body)
+                response = await asyncio.to_thread(self._client.im.v1.message.update, request)
+                result = self._finalize_send_result(response, "update failed")
+                if not result.success and msg_type == "post" and _POST_CONTENT_INVALID_RE.search(result.error or ""):
+                    logger.warning("[Feishu] Invalid post update payload rejected by API; falling back to plain text")
+                    fallback_body = self._build_update_message_body(
+                        msg_type="text",
+                        content=json.dumps({"text": _strip_markdown_to_plain_text(content)}, ensure_ascii=False),
+                    )
+                    fallback_request = self._build_update_message_request(message_id=message_id, request_body=fallback_body)
+                    fallback_response = await asyncio.to_thread(self._client.im.v1.message.update, fallback_request)
+                    result = self._finalize_send_result(fallback_response, "update failed")
+                if result.success:
+                    result.message_id = message_id
+                return result
+
+            final_result: Optional[SendResult] = None
+            for msg_type, payload, next_state in self._build_fallback_outbound_sequence(
+                content,
+                render_state=render_state,
+            ):
+                body = self._build_update_message_body(msg_type=msg_type, content=payload)
+                request = self._build_update_message_request(message_id=message_id, request_body=body)
+                response = await asyncio.to_thread(self._client.im.v1.message.update, request)
+                result = self._finalize_send_result(response, "update failed")
+                if result.success:
+                    result.message_id = message_id
+                    if next_state:
+                        self._remember_render_state(
+                            message_id,
+                            kind=str(next_state.get("kind") or ""),
+                            page_no=_coerce_int(next_state.get("page_no"), default=None, min_value=1),
+                        )
+                    final_result = result
+                    break
+                if self._payload_invalid_for_msg_type(msg_type, result.error or ""):
+                    logger.warning("[Feishu] Invalid %s update payload rejected by API; falling back", msg_type)
+                    continue
+                final_result = result
+                break
+            if final_result is None:
+                return SendResult(success=False, error="Feishu update failed after exhausting fallback sequence")
+            return final_result
         except Exception as exc:
             logger.error("[Feishu] Failed to edit message %s: %s", message_id, exc, exc_info=True)
             return SendResult(success=False, error=str(exc))
@@ -4084,7 +4348,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 return response
             except Exception as exc:
                 last_error = exc
-                if msg_type == "post" and _POST_CONTENT_INVALID_RE.search(str(exc)):
+                if self._payload_invalid_for_msg_type(msg_type, str(exc)):
                     raise
                 if attempt >= _FEISHU_SEND_ATTEMPTS - 1:
                     raise

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1693,7 +1693,12 @@ class FeishuAdapter(BasePlatformAdapter):
         if not isinstance(payload, dict):
             return False
         candidate = payload.get("card") if isinstance(payload.get("card"), dict) else payload
-        return isinstance(candidate, dict) and ("elements" in candidate or "header" in candidate)
+        # v2.0: body.elements; v1.0: root-level elements or header
+        return isinstance(candidate, dict) and (
+            "elements" in candidate
+            or "header" in candidate
+            or (isinstance(candidate.get("body"), dict) and "elements" in candidate.get("body", {}))
+        )
 
     def _normalize_interactive_payload(self, content: str) -> str:
         try:
@@ -1715,12 +1720,18 @@ class FeishuAdapter(BasePlatformAdapter):
     @staticmethod
     def _build_interactive_card_payload(*, title: str, template: str, elements: List[Dict[str, Any]]) -> str:
         card = {
-            "config": {"wide_screen_mode": True},
+            "schema": "2.0",
+            "config": {
+                "update_multi": True,
+                "width_mode": "fill",
+            },
             "header": {
                 "title": {"content": title, "tag": "plain_text"},
                 "template": template,
             },
-            "elements": elements or [{"tag": "div", "text": {"tag": "lark_md", "content": " "}}],
+            "body": {
+                "elements": elements or [{"tag": "markdown", "content": " "}],
+            },
         }
         return json.dumps(card, ensure_ascii=False)
 
@@ -1735,19 +1746,15 @@ class FeishuAdapter(BasePlatformAdapter):
         return self._build_interactive_card_payload(
             title=title,
             template=template,
-            elements=[{"tag": "div", "text": {"tag": "lark_md", "content": body}}],
+            elements=[{"tag": "markdown", "content": body}],
         )
 
-    def _build_tool_progress_card_payload(self, content: str, *, page_no: Optional[int] = None) -> str:
+    def _build_tool_progress_post_body(self, content: str, *, page_no: Optional[int] = None) -> str:
         title = "Hermes · 工具执行中"
         if page_no and page_no > 1:
             title += f"（{page_no}）"
         body = content.strip() or "_等待工具输出_"
-        return self._build_interactive_card_payload(
-            title=title,
-            template="turquoise",
-            elements=[{"tag": "div", "text": {"tag": "lark_md", "content": body}}],
-        )
+        return f"**{title}**\n{body}"
 
     def _build_table_card_payload(
         self,
@@ -1763,7 +1770,7 @@ class FeishuAdapter(BasePlatformAdapter):
         elements: List[Dict[str, Any]] = []
         intro = parsed.get("intro") or ""
         if intro:
-            elements.append({"tag": "div", "text": {"tag": "lark_md", "content": intro}})
+            elements.append({"tag": "markdown", "content": intro})
 
         headers = parsed.get("headers") or []
         columns = [
@@ -1781,7 +1788,7 @@ class FeishuAdapter(BasePlatformAdapter):
 
         outro = parsed.get("outro") or ""
         if outro:
-            elements.append({"tag": "div", "text": {"tag": "lark_md", "content": outro}})
+            elements.append({"tag": "markdown", "content": outro})
 
         return self._build_interactive_card_payload(title=title, template=template, elements=elements)
 
@@ -1834,11 +1841,16 @@ class FeishuAdapter(BasePlatformAdapter):
             page_no = _coerce_int((metadata or {}).get("progress_page_no"), default=None, min_value=1)
             if page_no is None:
                 page_no = _coerce_int((render_state or {}).get("page_no"), default=1, min_value=1) or 1
-            primary = (
-                "interactive",
-                self._build_tool_progress_card_payload(content, page_no=page_no),
-                {"kind": "tool_progress", "page_no": page_no},
-            )
+            progress_content = self._build_tool_progress_post_body(content, page_no=page_no)
+            text_payload = json.dumps({"text": _strip_markdown_to_plain_text(progress_content)}, ensure_ascii=False)
+            return [
+                (
+                    "post",
+                    self._build_post_payload(progress_content),
+                    {"kind": "tool_progress", "page_no": page_no},
+                ),
+                ("text", text_payload, None),
+            ]
         elif _parse_first_markdown_table(content):
             primary = (
                 "interactive",
@@ -2014,26 +2026,32 @@ class FeishuAdapter(BasePlatformAdapter):
                 }
 
             card = {
-                "config": {"wide_screen_mode": True},
+                "schema": "2.0",
+                "config": {
+                    "update_multi": True,
+                    "width_mode": "fill",
+                },
                 "header": {
                     "title": {"content": "⚠️ Command Approval Required", "tag": "plain_text"},
                     "template": "orange",
                 },
-                "elements": [
-                    {
-                        "tag": "markdown",
-                        "content": f"```\n{cmd_preview}\n```\n**Reason:** {description}",
-                    },
-                    {
-                        "tag": "action",
-                        "actions": [
-                            _btn("✅ Allow Once", "approve_once", "primary"),
-                            _btn("✅ Session", "approve_session"),
-                            _btn("✅ Always", "approve_always"),
-                            _btn("❌ Deny", "deny", "danger"),
-                        ],
-                    },
-                ],
+                "body": {
+                    "elements": [
+                        {
+                            "tag": "markdown",
+                            "content": f"```\n{cmd_preview}\n```\n**Reason:** {description}",
+                        },
+                        {
+                            "tag": "action",
+                            "actions": [
+                                _btn("✅ Allow Once", "approve_once", "primary"),
+                                _btn("✅ Session", "approve_session"),
+                                _btn("✅ Always", "approve_always"),
+                                _btn("❌ Deny", "deny", "danger"),
+                            ],
+                        },
+                    ],
+                },
             }
 
             payload = json.dumps(card, ensure_ascii=False)
@@ -2063,17 +2081,23 @@ class FeishuAdapter(BasePlatformAdapter):
         icon = "❌" if choice == "deny" else "✅"
         label = _APPROVAL_LABEL_MAP.get(choice, "Resolved")
         return {
-            "config": {"wide_screen_mode": True},
+            "schema": "2.0",
+            "config": {
+                "update_multi": True,
+                "width_mode": "fill",
+            },
             "header": {
                 "title": {"content": f"{icon} {label}", "tag": "plain_text"},
                 "template": "red" if choice == "deny" else "green",
             },
-            "elements": [
-                {
-                    "tag": "markdown",
-                    "content": f"{icon} **{label}** by {user_name}",
-                },
-            ],
+            "body": {
+                "elements": [
+                    {
+                        "tag": "markdown",
+                        "content": f"{icon} **{label}** by {user_name}",
+                    },
+                ],
+            },
         }
 
     async def send_voice(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -40,6 +40,12 @@ from agent.account_usage import fetch_account_usage, render_account_usage_lines
 # from _enforce_agent_cache_cap() and _session_expiry_watcher() below.
 _AGENT_CACHE_MAX_SIZE = 128
 _AGENT_CACHE_IDLE_TTL_SECS = 3600.0  # evict agents idle for >1h
+_PROGRESS_EDIT_INTERVAL_SECONDS = 1.5
+_PROGRESS_POLL_INTERVAL_SECONDS = 0.3
+_PROGRESS_TYPING_RESTORE_DELAY_SECONDS = 0.3
+_FEISHU_PROGRESS_CARD_MAX_LINES = 12
+_FEISHU_PROGRESS_CARD_MAX_CHARS = 3500
+_FEISHU_PROGRESS_CARD_MAX_EDITS = 40
 
 # ---------------------------------------------------------------------------
 # SSL certificate auto-detection for NixOS and other non-standard systems.
@@ -9553,7 +9559,30 @@ class GatewayRunner:
             progress_msg_id = None   # ID of the progress message to edit
             can_edit = True          # False once an edit fails (platform doesn't support it)
             _last_edit_ts = 0.0      # Throttle edits to avoid Telegram flood control
-            _PROGRESS_EDIT_INTERVAL = 1.5  # Minimum seconds between edits
+            progress_page_no = 1
+            progress_total_count = 0
+            progress_edit_count = 0
+
+            def _progress_message_metadata(page_no: int, total_count: int):
+                if source.platform != Platform.FEISHU:
+                    return _progress_metadata
+                payload = dict(_progress_metadata or {})
+                payload["message_kind"] = "tool_progress"
+                payload["progress_page_no"] = page_no
+                payload["progress_total_count"] = max(1, total_count)
+                return payload
+
+            def _should_rotate_progress_card(next_line: str) -> bool:
+                if source.platform != Platform.FEISHU or progress_msg_id is None:
+                    return False
+                projected_lines = len(progress_lines) + 1
+                projected_chars = len("\n".join(progress_lines + [next_line]))
+                projected_edits = progress_edit_count + 1
+                return (
+                    projected_lines > _FEISHU_PROGRESS_CARD_MAX_LINES
+                    or projected_chars > _FEISHU_PROGRESS_CARD_MAX_CHARS
+                    or projected_edits > _FEISHU_PROGRESS_CARD_MAX_EDITS
+                )
 
             while True:
                 try:
@@ -9591,14 +9620,35 @@ class GatewayRunner:
                         msg = progress_lines[-1] if progress_lines else base_msg
                     else:
                         msg = raw
+                        if _should_rotate_progress_card(msg):
+                            progress_page_no += 1
+                            progress_total_count += 1
+                            progress_lines = [msg]
+                            progress_edit_count = 0
+                            if not _run_still_current():
+                                return
+                            result = await adapter.send(
+                                chat_id=source.chat_id,
+                                content=msg,
+                                metadata=_progress_message_metadata(progress_page_no, progress_total_count),
+                            )
+                            if result.success and result.message_id:
+                                progress_msg_id = result.message_id
+                            _last_edit_ts = time.monotonic()
+                            if _PROGRESS_TYPING_RESTORE_DELAY_SECONDS > 0:
+                                await asyncio.sleep(_PROGRESS_TYPING_RESTORE_DELAY_SECONDS)
+                            if _run_still_current():
+                                await adapter.send_typing(source.chat_id, metadata=_progress_metadata)
+                            continue
                         progress_lines.append(msg)
+                        progress_total_count += 1
 
                     # Throttle edits: batch rapid tool updates into fewer
                     # API calls to avoid hitting Telegram flood control.
                     # (grammY auto-retry pattern: proactively rate-limit
                     # instead of reacting to 429s.)
                     _now = time.monotonic()
-                    _remaining = _PROGRESS_EDIT_INTERVAL - (_now - _last_edit_ts)
+                    _remaining = _PROGRESS_EDIT_INTERVAL_SECONDS - (_now - _last_edit_ts)
                     if _remaining > 0:
                         # Wait out the throttle interval, then loop back to
                         # drain any additional queued messages before sending
@@ -9628,27 +9678,44 @@ class GatewayRunner:
                                     adapter.name,
                                 )
                             can_edit = False
-                            await adapter.send(chat_id=source.chat_id, content=msg, metadata=_progress_metadata)
+                            await adapter.send(
+                                chat_id=source.chat_id,
+                                content=msg,
+                                metadata=_progress_message_metadata(progress_page_no, progress_total_count),
+                            )
+                        else:
+                            progress_edit_count += 1
                     else:
                         if can_edit:
                             # First tool: send all accumulated text as new message
                             full_text = "\n".join(progress_lines)
-                            result = await adapter.send(chat_id=source.chat_id, content=full_text, metadata=_progress_metadata)
+                            result = await adapter.send(
+                                chat_id=source.chat_id,
+                                content=full_text,
+                                metadata=_progress_message_metadata(progress_page_no, progress_total_count),
+                            )
                         else:
                             # Editing unsupported: send just this line
-                            result = await adapter.send(chat_id=source.chat_id, content=msg, metadata=_progress_metadata)
+                            result = await adapter.send(
+                                chat_id=source.chat_id,
+                                content=msg,
+                                metadata=_progress_message_metadata(progress_page_no, progress_total_count),
+                            )
                         if result.success and result.message_id:
                             progress_msg_id = result.message_id
+                            if can_edit:
+                                progress_edit_count = 0
 
                     _last_edit_ts = time.monotonic()
 
                     # Restore typing indicator
-                    await asyncio.sleep(0.3)
+                    if _PROGRESS_TYPING_RESTORE_DELAY_SECONDS > 0:
+                        await asyncio.sleep(_PROGRESS_TYPING_RESTORE_DELAY_SECONDS)
                     if _run_still_current():
                         await adapter.send_typing(source.chat_id, metadata=_progress_metadata)
 
                 except queue.Empty:
-                    await asyncio.sleep(0.3)
+                    await asyncio.sleep(_PROGRESS_POLL_INTERVAL_SECONDS)
                 except asyncio.CancelledError:
                     # Drain remaining queued messages
                     while not progress_queue.empty():

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -453,9 +453,8 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
         payload = json.loads(captured["request"].request_body.content)
         self.assertEqual(payload["header"]["title"]["content"], "Hermes · 回复")
         self.assertEqual(payload["header"]["template"], "blue")
-        self.assertEqual(payload["elements"][0]["tag"], "div")
-        self.assertEqual(payload["elements"][0]["text"]["tag"], "lark_md")
-        self.assertEqual(payload["elements"][0]["text"]["content"], "hello default card")
+        self.assertEqual(payload["body"]["elements"][0]["tag"], "markdown")
+        self.assertEqual(payload["body"]["elements"][0]["content"], "hello default card")
 
     @patch.dict(os.environ, {}, clear=True)
     def test_send_markdown_table_defaults_to_interactive_table_card(self):
@@ -499,18 +498,18 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
         payload = json.loads(captured["request"].request_body.content)
         self.assertEqual(payload["header"]["title"]["content"], "Hermes · 回复")
         self.assertEqual(payload["header"]["template"], "blue")
-        self.assertEqual(payload["elements"][0]["tag"], "div")
-        self.assertEqual(payload["elements"][0]["text"]["content"], "基金排名")
-        self.assertEqual(payload["elements"][1]["tag"], "table")
+        self.assertEqual(payload["body"]["elements"][0]["tag"], "markdown")
+        self.assertEqual(payload["body"]["elements"][0]["content"], "基金排名")
+        self.assertEqual(payload["body"]["elements"][1]["tag"], "table")
         self.assertEqual(
-            payload["elements"][1]["columns"],
+            payload["body"]["elements"][1]["columns"],
             [
                 {"name": "col_0", "display_name": "名称", "data_type": "text"},
                 {"name": "col_1", "display_name": "收益", "data_type": "text"},
             ],
         )
         self.assertEqual(
-            payload["elements"][1]["rows"],
+            payload["body"]["elements"][1]["rows"],
             [
                 {"col_0": "A", "col_1": "10%"},
                 {"col_0": "B", "col_1": "8%"},
@@ -518,7 +517,7 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
         )
 
     @patch.dict(os.environ, {}, clear=True)
-    def test_send_and_edit_tool_progress_use_interactive_progress_card(self):
+    def test_send_and_edit_tool_progress_use_post_progress_message(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter
 
@@ -570,14 +569,14 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
 
         self.assertTrue(send_result.success)
         self.assertTrue(edit_result.success)
-        self.assertEqual(captured["creates"][0].request_body.msg_type, "interactive")
+        self.assertEqual(captured["creates"][0].request_body.msg_type, "post")
         create_payload = json.loads(captured["creates"][0].request_body.content)
-        self.assertEqual(create_payload["header"]["title"]["content"], "Hermes · 工具执行中（2）")
-        self.assertEqual(create_payload["header"]["template"], "turquoise")
-        self.assertEqual(captured["updates"][0].request_body.msg_type, "interactive")
+        self.assertIn("Hermes · 工具执行中（2）", create_payload["zh_cn"]["content"][0][0]["text"])
+        self.assertIn('💻 terminal: "pwd"', create_payload["zh_cn"]["content"][0][0]["text"])
+        self.assertEqual(captured["updates"][0].request_body.msg_type, "post")
         update_payload = json.loads(captured["updates"][0].request_body.content)
-        self.assertEqual(update_payload["header"]["title"]["content"], "Hermes · 工具执行中（2）")
-        self.assertIn('📚 read_file: "/tmp/demo.txt"', update_payload["elements"][0]["text"]["content"])
+        self.assertIn("Hermes · 工具执行中（2）", update_payload["zh_cn"]["content"][0][0]["text"])
+        self.assertIn('📚 read_file: "/tmp/demo.txt"', update_payload["zh_cn"]["content"][0][0]["text"])
 
     @patch.dict(os.environ, {}, clear=True)
     def test_get_chat_info_uses_real_feishu_chat_api(self):
@@ -2566,7 +2565,7 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(captured["request"].request_body.msg_type, "interactive")
         payload = json.loads(captured["request"].request_body.content)
         self.assertEqual(payload["header"]["title"]["content"], "Hermes · 回复")
-        self.assertEqual(payload["elements"][0]["text"]["content"], "可以用 **粗体** 和 *斜体*。")
+        self.assertEqual(payload["body"]["elements"][0]["content"], "可以用 **粗体** 和 *斜体*。")
 
     @patch.dict(os.environ, {}, clear=True)
     def test_send_keeps_fenced_code_blocks_inside_interactive_reply_card(self):
@@ -2617,7 +2616,7 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(captured["request"].request_body.msg_type, "interactive")
         payload = json.loads(captured["request"].request_body.content)
         self.assertEqual(payload["header"]["title"]["content"], "Hermes · 回复")
-        self.assertEqual(payload["elements"][0]["text"]["content"], content)
+        self.assertEqual(payload["body"]["elements"][0]["content"], content)
 
     @patch.dict(os.environ, {}, clear=True)
     def test_build_post_payload_keeps_fence_like_code_lines_inside_code_block(self):
@@ -2821,7 +2820,7 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(payload["header"]["title"]["content"], "Hermes · 回复")
         self.assertEqual(payload["header"]["template"], "blue")
         self.assertEqual(
-            payload["elements"][0]["text"]["content"],
+            payload["body"]["elements"][0]["content"],
             "---\n1. 第一项\n<u>下划线</u>\n~~删除线~~",
         )
 

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -414,6 +414,172 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
         )
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_send_defaults_to_interactive_reply_card(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _MessageAPI:
+            def create(self, request):
+                captured["request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_card_reply"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.send(
+                    chat_id="oc_chat",
+                    content="hello default card",
+                )
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(captured["request"].request_body.msg_type, "interactive")
+        payload = json.loads(captured["request"].request_body.content)
+        self.assertEqual(payload["header"]["title"]["content"], "Hermes · 回复")
+        self.assertEqual(payload["header"]["template"], "blue")
+        self.assertEqual(payload["elements"][0]["tag"], "div")
+        self.assertEqual(payload["elements"][0]["text"]["tag"], "lark_md")
+        self.assertEqual(payload["elements"][0]["text"]["content"], "hello default card")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_markdown_table_defaults_to_interactive_table_card(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _MessageAPI:
+            def create(self, request):
+                captured["request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_table_card"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        content = "基金排名\n\n| 名称 | 收益 |\n| --- | --- |\n| A | 10% |\n| B | 8% |"
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.send(
+                    chat_id="oc_chat",
+                    content=content,
+                )
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(captured["request"].request_body.msg_type, "interactive")
+        payload = json.loads(captured["request"].request_body.content)
+        self.assertEqual(payload["header"]["title"]["content"], "Hermes · 回复")
+        self.assertEqual(payload["header"]["template"], "blue")
+        self.assertEqual(payload["elements"][0]["tag"], "div")
+        self.assertEqual(payload["elements"][0]["text"]["content"], "基金排名")
+        self.assertEqual(payload["elements"][1]["tag"], "table")
+        self.assertEqual(
+            payload["elements"][1]["columns"],
+            [
+                {"name": "col_0", "display_name": "名称", "data_type": "text"},
+                {"name": "col_1", "display_name": "收益", "data_type": "text"},
+            ],
+        )
+        self.assertEqual(
+            payload["elements"][1]["rows"],
+            [
+                {"col_0": "A", "col_1": "10%"},
+                {"col_0": "B", "col_1": "8%"},
+            ],
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_and_edit_tool_progress_use_interactive_progress_card(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {"creates": [], "updates": []}
+
+        class _MessageAPI:
+            def create(self, request):
+                captured["creates"].append(request)
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_progress_card"),
+                )
+
+            def update(self, request):
+                captured["updates"].append(request)
+                return SimpleNamespace(success=lambda: True)
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            send_result = asyncio.run(
+                adapter.send(
+                    chat_id="oc_chat",
+                    content='💻 terminal: "pwd"',
+                    metadata={
+                        "message_kind": "tool_progress",
+                        "progress_page_no": 2,
+                        "progress_total_count": 1,
+                    },
+                )
+            )
+            edit_result = asyncio.run(
+                adapter.edit_message(
+                    chat_id="oc_chat",
+                    message_id="om_progress_card",
+                    content='💻 terminal: "pwd"\n📚 read_file: "/tmp/demo.txt"',
+                )
+            )
+
+        self.assertTrue(send_result.success)
+        self.assertTrue(edit_result.success)
+        self.assertEqual(captured["creates"][0].request_body.msg_type, "interactive")
+        create_payload = json.loads(captured["creates"][0].request_body.content)
+        self.assertEqual(create_payload["header"]["title"]["content"], "Hermes · 工具执行中（2）")
+        self.assertEqual(create_payload["header"]["template"], "turquoise")
+        self.assertEqual(captured["updates"][0].request_body.msg_type, "interactive")
+        update_payload = json.loads(captured["updates"][0].request_body.content)
+        self.assertEqual(update_payload["header"]["title"]["content"], "Hermes · 工具执行中（2）")
+        self.assertIn('📚 read_file: "/tmp/demo.txt"', update_payload["elements"][0]["text"]["content"])
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_get_chat_info_uses_real_feishu_chat_api(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter
@@ -2362,7 +2528,7 @@ class TestAdapterBehavior(unittest.TestCase):
         )
 
     @patch.dict(os.environ, {}, clear=True)
-    def test_send_uses_post_for_inline_markdown(self):
+    def test_send_uses_interactive_reply_card_for_inline_markdown(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter
 
@@ -2397,13 +2563,13 @@ class TestAdapterBehavior(unittest.TestCase):
             )
 
         self.assertTrue(result.success)
-        self.assertEqual(captured["request"].request_body.msg_type, "post")
+        self.assertEqual(captured["request"].request_body.msg_type, "interactive")
         payload = json.loads(captured["request"].request_body.content)
-        elements = payload["zh_cn"]["content"][0]
-        self.assertEqual(elements, [{"tag": "md", "text": "可以用 **粗体** 和 *斜体*。"}])
+        self.assertEqual(payload["header"]["title"]["content"], "Hermes · 回复")
+        self.assertEqual(payload["elements"][0]["text"]["content"], "可以用 **粗体** 和 *斜体*。")
 
     @patch.dict(os.environ, {}, clear=True)
-    def test_send_splits_fenced_code_blocks_into_separate_post_rows(self):
+    def test_send_keeps_fenced_code_blocks_inside_interactive_reply_card(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter
 
@@ -2448,22 +2614,10 @@ class TestAdapterBehavior(unittest.TestCase):
             )
 
         self.assertTrue(result.success)
-        self.assertEqual(captured["request"].request_body.msg_type, "post")
+        self.assertEqual(captured["request"].request_body.msg_type, "interactive")
         payload = json.loads(captured["request"].request_body.content)
-        rows = payload["zh_cn"]["content"]
-        self.assertEqual(
-            rows,
-            [
-                [
-                    {
-                        "tag": "md",
-                        "text": "确认已入库 ✓\n文件路径：`/root/.hermes/profiles/agent_cto/cron/jobs.json`\n**解码后的内容：**",
-                    }
-                ],
-                [{"tag": "md", "text": "```json\n{\"cron\": \"list\"}\n```"}],
-                [{"tag": "md", "text": "后续说明仍应保留。"}],
-            ],
-        )
+        self.assertEqual(payload["header"]["title"]["content"], "Hermes · 回复")
+        self.assertEqual(payload["elements"][0]["text"]["content"], content)
 
     @patch.dict(os.environ, {}, clear=True)
     def test_build_post_payload_keeps_fence_like_code_lines_inside_code_block(self):
@@ -2542,6 +2696,8 @@ class TestAdapterBehavior(unittest.TestCase):
             def create(self, request):
                 captured["calls"].append(request)
                 if len(captured["calls"]) == 1:
+                    raise RuntimeError("content format of the interactive type is incorrect")
+                if len(captured["calls"]) == 2:
                     raise RuntimeError("content format of the post type is incorrect")
                 return SimpleNamespace(
                     success=lambda: True,
@@ -2568,10 +2724,11 @@ class TestAdapterBehavior(unittest.TestCase):
             )
 
         self.assertTrue(result.success)
-        self.assertEqual(captured["calls"][0].request_body.msg_type, "post")
-        self.assertEqual(captured["calls"][1].request_body.msg_type, "text")
+        self.assertEqual(captured["calls"][0].request_body.msg_type, "interactive")
+        self.assertEqual(captured["calls"][1].request_body.msg_type, "post")
+        self.assertEqual(captured["calls"][2].request_body.msg_type, "text")
         self.assertEqual(
-            captured["calls"][1].request_body.content,
+            captured["calls"][2].request_body.content,
             json.dumps({"text": "可以用 粗体 和 斜体。"}, ensure_ascii=False),
         )
 
@@ -2587,6 +2744,8 @@ class TestAdapterBehavior(unittest.TestCase):
             def create(self, request):
                 captured["calls"].append(request)
                 if len(captured["calls"]) == 1:
+                    return SimpleNamespace(success=lambda: False, code=230001, msg="content format of the interactive type is incorrect")
+                if len(captured["calls"]) == 2:
                     return SimpleNamespace(success=lambda: False, code=230001, msg="content format of the post type is incorrect")
                 return SimpleNamespace(
                     success=lambda: True,
@@ -2613,15 +2772,16 @@ class TestAdapterBehavior(unittest.TestCase):
             )
 
         self.assertTrue(result.success)
-        self.assertEqual(captured["calls"][0].request_body.msg_type, "post")
-        self.assertEqual(captured["calls"][1].request_body.msg_type, "text")
+        self.assertEqual(captured["calls"][0].request_body.msg_type, "interactive")
+        self.assertEqual(captured["calls"][1].request_body.msg_type, "post")
+        self.assertEqual(captured["calls"][2].request_body.msg_type, "text")
         self.assertEqual(
-            captured["calls"][1].request_body.content,
+            captured["calls"][2].request_body.content,
             json.dumps({"text": "可以用 粗体 和 斜体。"}, ensure_ascii=False),
         )
 
     @patch.dict(os.environ, {}, clear=True)
-    def test_send_uses_post_for_advanced_markdown_lines(self):
+    def test_send_uses_interactive_reply_card_for_advanced_markdown_lines(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter
 
@@ -2656,12 +2816,13 @@ class TestAdapterBehavior(unittest.TestCase):
             )
 
         self.assertTrue(result.success)
-        self.assertEqual(captured["request"].request_body.msg_type, "post")
+        self.assertEqual(captured["request"].request_body.msg_type, "interactive")
         payload = json.loads(captured["request"].request_body.content)
-        rows = payload["zh_cn"]["content"]
+        self.assertEqual(payload["header"]["title"]["content"], "Hermes · 回复")
+        self.assertEqual(payload["header"]["template"], "blue")
         self.assertEqual(
-            rows,
-            [[{"tag": "md", "text": "---\n1. 第一项\n<u>下划线</u>\n~~删除线~~"}]],
+            payload["elements"][0]["text"]["content"],
+            "---\n1. 第一项\n<u>下划线</u>\n~~删除线~~",
         )
 
 

--- a/tests/gateway/test_run_progress_cards.py
+++ b/tests/gateway/test_run_progress_cards.py
@@ -1,0 +1,213 @@
+"""Focused tests for Feishu tool-progress card rotation and dedup."""
+
+import importlib
+import sys
+import time
+import types
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+from gateway.session import SessionSource
+
+
+class FeishuProgressCaptureAdapter(BasePlatformAdapter):
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="***"), Platform.FEISHU)
+        self.sent = []
+        self.edits = []
+        self.typing = []
+
+    async def connect(self) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        message_id = f"progress-{len(self.sent) + 1}"
+        self.sent.append(
+            {
+                "chat_id": chat_id,
+                "content": content,
+                "reply_to": reply_to,
+                "metadata": metadata,
+                "message_id": message_id,
+            }
+        )
+        return SendResult(success=True, message_id=message_id)
+
+    async def edit_message(self, chat_id, message_id, content) -> SendResult:
+        self.edits.append(
+            {
+                "chat_id": chat_id,
+                "message_id": message_id,
+                "content": content,
+            }
+        )
+        return SendResult(success=True, message_id=message_id)
+
+    async def send_typing(self, chat_id, metadata=None) -> None:
+        self.typing.append({"chat_id": chat_id, "metadata": metadata})
+
+    async def stop_typing(self, chat_id) -> None:
+        self.typing.append({"chat_id": chat_id, "metadata": {"stopped": True}})
+
+    async def get_chat_info(self, chat_id: str):
+        return {"id": chat_id}
+
+
+class RotatingProgressAgent:
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        for preview in ("first command", "second command", "third command"):
+            self.tool_progress_callback("tool.started", "terminal", preview, {})
+            time.sleep(0.35)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class DedupProgressAgent:
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        for _ in range(3):
+            self.tool_progress_callback("tool.started", "terminal", "repeat me", {})
+            time.sleep(0.35)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+def _make_runner(adapter):
+    gateway_run = importlib.import_module("gateway.run")
+    GatewayRunner = gateway_run.GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {adapter.platform: adapter}
+    runner._voice_mode = {}
+    runner._prefill_messages = []
+    runner._ephemeral_system_prompt = ""
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._session_db = None
+    runner._running_agents = {}
+    runner._session_run_generation = {}
+    runner.hooks = SimpleNamespace(loaded_hooks=False)
+    runner.config = SimpleNamespace(
+        thread_sessions_per_user=False,
+        group_sessions_per_user=False,
+        stt_enabled=False,
+    )
+    return runner
+
+
+def _install_fake_agent(monkeypatch, agent_cls):
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = agent_cls
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+    import tools.terminal_tool  # noqa: F401
+
+
+@pytest.mark.asyncio
+async def test_feishu_progress_rotates_to_new_card_when_limit_exceeded(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+    _install_fake_agent(monkeypatch, RotatingProgressAgent)
+
+    adapter = FeishuProgressCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    (tmp_path / "config.yaml").write_text("display:\n  tool_progress: all\n", encoding="utf-8")
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+    monkeypatch.setattr(gateway_run, "_FEISHU_PROGRESS_CARD_MAX_LINES", 2)
+    monkeypatch.setattr(gateway_run, "_FEISHU_PROGRESS_CARD_MAX_CHARS", 10_000)
+    monkeypatch.setattr(gateway_run, "_FEISHU_PROGRESS_CARD_MAX_EDITS", 40)
+    monkeypatch.setattr(gateway_run, "_PROGRESS_EDIT_INTERVAL_SECONDS", 0.01)
+    monkeypatch.setattr(gateway_run, "_PROGRESS_POLL_INTERVAL_SECONDS", 0.01)
+    monkeypatch.setattr(gateway_run, "_PROGRESS_TYPING_RESTORE_DELAY_SECONDS", 0.0)
+
+    source = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_chat",
+        chat_type="group",
+        thread_id=None,
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-feishu-progress-rotate",
+        session_key="agent:main:feishu:group:oc_chat",
+    )
+
+    assert result["final_response"] == "done"
+    assert len(adapter.sent) == 2
+    assert adapter.sent[0]["message_id"] == "progress-1"
+    assert adapter.sent[0]["metadata"]["message_kind"] == "tool_progress"
+    assert adapter.sent[0]["metadata"]["progress_page_no"] == 1
+    assert adapter.sent[1]["message_id"] == "progress-2"
+    assert adapter.sent[1]["metadata"]["message_kind"] == "tool_progress"
+    assert adapter.sent[1]["metadata"]["progress_page_no"] == 2
+    assert any(edit["message_id"] == "progress-1" for edit in adapter.edits)
+    assert "third command" in adapter.sent[1]["content"]
+
+
+@pytest.mark.asyncio
+async def test_feishu_progress_dedup_updates_last_line_without_rotation(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+    _install_fake_agent(monkeypatch, DedupProgressAgent)
+
+    adapter = FeishuProgressCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    (tmp_path / "config.yaml").write_text("display:\n  tool_progress: all\n", encoding="utf-8")
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+    monkeypatch.setattr(gateway_run, "_FEISHU_PROGRESS_CARD_MAX_LINES", 2)
+    monkeypatch.setattr(gateway_run, "_FEISHU_PROGRESS_CARD_MAX_CHARS", 10_000)
+    monkeypatch.setattr(gateway_run, "_FEISHU_PROGRESS_CARD_MAX_EDITS", 40)
+    monkeypatch.setattr(gateway_run, "_PROGRESS_EDIT_INTERVAL_SECONDS", 0.01)
+    monkeypatch.setattr(gateway_run, "_PROGRESS_POLL_INTERVAL_SECONDS", 0.01)
+    monkeypatch.setattr(gateway_run, "_PROGRESS_TYPING_RESTORE_DELAY_SECONDS", 0.0)
+
+    source = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_chat",
+        chat_type="group",
+        thread_id=None,
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-feishu-progress-dedup",
+        session_key="agent:main:feishu:group:oc_chat",
+    )
+
+    assert result["final_response"] == "done"
+    assert len(adapter.sent) == 1
+    combined = " ".join([call["content"] for call in adapter.sent] + [call["content"] for call in adapter.edits])
+    assert 'terminal: "repeat me" (×3)' in combined
+    assert not any(call["metadata"].get("progress_page_no") == 2 for call in adapter.sent if call["metadata"])


### PR DESCRIPTION
## Summary

This PR refreshes the earlier Feishu reply-card branch into the **final two-round version** now validated against current `main`.

### What changes

1. **Default Feishu replies become interactive cards**
   - plain markdown/text replies default to interactive cards
   - markdown tables render via the native card `table` component
   - raw interactive payloads still pass through unchanged

2. **Fallback behavior is stabilized**
   - replies follow `interactive -> post -> text`
   - render-state is remembered per message so send/edit stay on the same rendering rail
   - degraded fallback rails are preserved for later edits

3. **Feishu tool progress gets bounded paging / rotation**
   - `gateway/run.py` now carries Feishu-specific page / count / edit metadata
   - oversized progress updates rotate predictably instead of growing unbounded
   - dedup updates the current page instead of forcing a new page

4. **Card payloads are upgraded to Feishu Card JSON v2.0**
   - `schema: "2.0"`
   - `body.elements`
   - `markdown` elements replace legacy `div.lark_md`

5. **Tool progress intentionally stays on `post -> text`**
   - final assistant replies and markdown tables use interactive cards
   - tool-progress updates keep the Feishu paging/edit semantics from round 1, but render as `post` / `text` instead of interactive cards

## Why this shape

The branch originally covered the first-round default-card rollout. This refresh folds in the second-round stabilization that reflects the final runtime behavior now running locally:
- card payloads use v2.0
- normal replies/tables are card-first
- tool progress remains paginated/editable, but not as interactive cards

## Files changed

- `gateway/platforms/feishu.py`
- `gateway/run.py`
- `tests/gateway/test_feishu.py`
- `tests/gateway/test_run_progress_cards.py`

## Test Plan

Executed on top of current upstream `main`:

```bash
pytest -q tests/gateway/test_feishu.py tests/gateway/test_run_progress_topics.py tests/gateway/test_run_progress_cards.py
```

Result:

- `218 passed, 24 warnings`

## Risk Assessment

Medium, but scoped:
- touches only Feishu send/edit fallback selection and progress rendering
- no cross-platform behavior changes intended
- protected by focused Feishu + progress regression coverage
