### PR TITLE
ci(nix): auto-fix stale npm hashes on push to main

### DIFF
--- a/.github/workflows/nix-lockfile-check.yml
+++ b/.github/workflows/nix-lockfile-check.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check:
+  nix-lockfile-check:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/.github/workflows/nix-lockfile-check.yml
+++ b/.github/workflows/nix-lockfile-check.yml
@@ -36,6 +36,12 @@ jobs:
           LINK_SHA: ${{ steps.sha.outputs.full }}
         run: nix run .#fix-lockfiles -- --check
 
+      - name: Fail if check crashed without reporting
+        if: steps.check.outputs.stale != 'true' && steps.check.outputs.stale != 'false'
+        run: |
+          echo "::error::fix-lockfiles exited without reporting stale status — likely an infrastructure or script failure"
+          exit 1
+
       - name: Post sticky PR comment (stale)
         if: steps.check.outputs.stale == 'true' && github.event_name == 'pull_request'
         uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728  # v2.9.1

--- a/.github/workflows/nix-lockfile-fix.yml
+++ b/.github/workflows/nix-lockfile-fix.yml
@@ -1,6 +1,13 @@
 name: Nix Lockfile Fix
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - 'ui-tui/package-lock.json'
+      - 'ui-tui/package.json'
+      - 'web/package-lock.json'
+      - 'web/package.json'
   workflow_dispatch:
     inputs:
       pr_number:
@@ -19,9 +26,43 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # ── Auto-fix on main ───────────────────────────────────────────────
+  # Fires when a push to main touches package.json or package-lock.json
+  # in ui-tui/ or web/. Runs fix-lockfiles --apply and pushes the hash
+  # update commit directly to main so Nix builds never stay broken.
+  #
+  # The fix commit only touches nix/*.nix files, which are NOT in the
+  # paths filter above, so this cannot re-trigger itself.
+  auto-fix-main:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: ./.github/actions/nix-setup
+
+      - name: Apply lockfile hashes
+        id: apply
+        run: nix run .#fix-lockfiles -- --apply
+
+      - name: Commit & push
+        if: steps.apply.outputs.changed == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add nix/tui.nix nix/web.nix
+          git commit -m "fix(nix): auto-refresh npm lockfile hashes"
+          git push
+
+  # ── PR fix (manual / checkbox) ─────────────────────────────────────
+  # Existing behavior: run on manual dispatch OR when a task-list
+  # checkbox in the sticky lockfile-check comment flips from [ ] to [x].
   fix:
-    # Run on manual dispatch OR when a task-list checkbox in the sticky
-    # lockfile-check comment flips from `[ ]` to `[x]`.
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'issue_comment'

--- a/.github/workflows/nix-lockfile-fix.yml
+++ b/.github/workflows/nix-lockfile-fix.yml
@@ -14,11 +14,6 @@ on:
         description: 'PR number to fix (leave empty to run on the selected branch)'
         required: false
         type: string
-      test_auto_fix:
-        description: '[TEMP] Test auto-fix-main app token flow on this branch'
-        required: false
-        type: boolean
-        default: false
   issue_comment:
     types: [edited]
 
@@ -36,14 +31,23 @@ jobs:
   # in ui-tui/ or web/. Runs fix-lockfiles --apply and pushes the hash
   # update commit directly to main so Nix builds never stay broken.
   #
-  # The fix commit only touches nix/*.nix files, which are NOT in the
-  # paths filter above, so this cannot re-trigger itself.
+  # Safety invariants:
+  #   1. The fix commit only touches nix/*.nix files, which are NOT in
+  #      the paths filter above, so this cannot re-trigger itself.
+  #   2. An explicit file-whitelist check before commit aborts if
+  #      fix-lockfiles ever modifies unexpected files.
+  #   3. Job-level concurrency with cancel-in-progress: true ensures
+  #      back-to-back pushes collapse to the newest; ref: main checkout
+  #      always operates on the latest branch state.
+  #   4. Uses a GitHub App token (not GITHUB_TOKEN) so the fix commit
+  #      triggers downstream nix.yml verification.
   auto-fix-main:
-    if: >-
-      github.event_name == 'push' ||
-      (github.event_name == 'workflow_dispatch' && github.event.inputs.test_auto_fix == 'true')
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    concurrency:
+      group: auto-fix-main
+      cancel-in-progress: true
     steps:
       - name: Generate GitHub App token
         id: app-token
@@ -54,6 +58,7 @@ jobs:
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
+          ref: main
           token: ${{ steps.app-token.outputs.token }}
 
       - uses: ./.github/actions/nix-setup
@@ -63,30 +68,63 @@ jobs:
         run: nix run .#fix-lockfiles -- --apply
 
       - name: Commit & push
-        if: steps.apply.outputs.changed == 'true' && github.event_name == 'push'
+        if: steps.apply.outputs.changed == 'true'
         shell: bash
         run: |
           set -euo pipefail
+
+          # Ensure only nix files were modified — prevents accidental
+          # self-triggering if fix-lockfiles ever touches package files.
+          unexpected="$(git diff --name-only | grep -Ev '^nix/(tui|web)\.nix$' || true)"
+          if [ -n "$unexpected" ]; then
+            echo "::error::Unexpected modified files: $unexpected"
+            exit 1
+          fi
+
+          # Record the base SHA before committing — used to detect package
+          # file changes if we need to rebase after a non-fast-forward push.
+          BASE_SHA="$(git rev-parse HEAD)"
+
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git add nix/tui.nix nix/web.nix
-          git commit -m "fix(nix): auto-refresh npm lockfile hashes"
-          git push
+          git commit -m "fix(nix): auto-refresh npm lockfile hashes" \
+            -m "Source: $GITHUB_SHA" \
+            -m "Run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
 
-      - name: '[TEMP] Dry-run summary'
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          echo "✅ App token minted successfully"
-          echo "✅ Checkout with app token succeeded"
-          echo "✅ fix-lockfiles ran (changed=${{ steps.apply.outputs.changed }})"
-          echo "⏭️  Skipped push (dry-run mode)"
+          # Retry push with rebase in case main advanced with an unrelated
+          # commit during the nix build. Without this, a non-fast-forward
+          # rejection silently loses the fix. If package files changed during
+          # the rebase, abort — a fresh auto-fix run will handle the new state.
+          for attempt in 1 2 3; do
+            if git push origin HEAD:main; then
+              exit 0
+            fi
+            echo "::warning::Push attempt $attempt failed (non-fast-forward?), rebasing…"
+            git fetch origin main
+
+            # If package files changed between our base and the new main,
+            # our computed hashes are stale. Abort and let the next triggered
+            # run recompute from the correct package-lock state.
+            pkg_changed="$(git diff --name-only "$BASE_SHA"..origin/main -- \
+              'ui-tui/package-lock.json' 'ui-tui/package.json' \
+              'web/package-lock.json' 'web/package.json' || true)"
+            if [ -n "$pkg_changed" ]; then
+              echo "::warning::Package files changed since hash computation — aborting; a fresh run will recompute"
+              exit 0
+            fi
+
+            git rebase origin/main
+          done
+          echo "::error::Failed to push after 3 rebase attempts"
+          exit 1
 
   # ── PR fix (manual / checkbox) ─────────────────────────────────────
   # Existing behavior: run on manual dispatch OR when a task-list
   # checkbox in the sticky lockfile-check comment flips from [ ] to [x].
   fix:
     if: |
-      (github.event_name == 'workflow_dispatch' && github.event.inputs.test_auto_fix != 'true') ||
+      github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'issue_comment'
        && github.event.issue.pull_request != null
        && contains(github.event.comment.body, '[x] **Apply lockfile fix**')

--- a/.github/workflows/nix-lockfile-fix.yml
+++ b/.github/workflows/nix-lockfile-fix.yml
@@ -14,6 +14,11 @@ on:
         description: 'PR number to fix (leave empty to run on the selected branch)'
         required: false
         type: string
+      test_auto_fix:
+        description: '[TEMP] Test auto-fix-main app token flow on this branch'
+        required: false
+        type: boolean
+        default: false
   issue_comment:
     types: [edited]
 
@@ -34,13 +39,22 @@ jobs:
   # The fix commit only touches nix/*.nix files, which are NOT in the
   # paths filter above, so this cannot re-trigger itself.
   auto-fix-main:
-    if: github.event_name == 'push'
+    if: >-
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.test_auto_fix == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@7bfa3a4717ef143a604ee0a99d859b8886a96d00  # v1.9.3
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: ./.github/actions/nix-setup
 
@@ -49,7 +63,7 @@ jobs:
         run: nix run .#fix-lockfiles -- --apply
 
       - name: Commit & push
-        if: steps.apply.outputs.changed == 'true'
+        if: steps.apply.outputs.changed == 'true' && github.event_name == 'push'
         shell: bash
         run: |
           set -euo pipefail
@@ -59,12 +73,20 @@ jobs:
           git commit -m "fix(nix): auto-refresh npm lockfile hashes"
           git push
 
+      - name: '[TEMP] Dry-run summary'
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          echo "✅ App token minted successfully"
+          echo "✅ Checkout with app token succeeded"
+          echo "✅ fix-lockfiles ran (changed=${{ steps.apply.outputs.changed }})"
+          echo "⏭️  Skipped push (dry-run mode)"
+
   # ── PR fix (manual / checkbox) ─────────────────────────────────────
   # Existing behavior: run on manual dispatch OR when a task-list
   # checkbox in the sticky lockfile-check comment flips from [ ] to [x].
   fix:
     if: |
-      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.test_auto_fix != 'true') ||
       (github.event_name == 'issue_comment'
        && github.event.issue.pull_request != null
        && contains(github.event.comment.body, '[x] **Apply lockfile fix**')

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -187,7 +187,10 @@
 
         if [ "$MODE" = "--apply" ]; then
           sed -i "s|hash = \"sha256-[^\"]*\";|hash = \"$NEW_HASH\";|" "$NIX_FILE"
-          nix build ".#$ATTR.npmDeps" --no-link --print-build-logs
+          if ! nix build ".#$ATTR.npmDeps" --no-link --print-build-logs; then
+            echo "    verification build failed after hash update" >&2
+            exit 1
+          fi
           FIXED=1
           echo "    fixed"
         fi


### PR DESCRIPTION
## Problem

Every time a PR merges to `main` with an updated `package-lock.json` in `ui-tui/` or `web/`, the Nix `npmDepsHash` goes stale. This breaks `nix build` and `nix flake check` for every downstream consumer until someone manually bumps the hash. This has happened repeatedly: #15314, #15272, #15244, #15420.

The existing `fix-lockfiles --apply` pipeline already knows how to detect the stale hash, extract the correct one from the build error, and rewrite the `.nix` file. But it only runs on-demand (checkbox click in PR comment, or manual workflow dispatch). Nothing triggers it automatically when `main` drifts.

## Solution

Add a `push` trigger to `nix-lockfile-fix.yml` with path filters on the four files that cause hash drift:

```yaml
push:
  branches: [main]
  paths:
    - 'ui-tui/package-lock.json'
    - 'ui-tui/package.json'
    - 'web/package-lock.json'
    - 'web/package.json'
```

A new `auto-fix-main` job runs `fix-lockfiles --apply` and pushes the corrected hashes directly to `main`.

### Why this can't loop

The fix commit only modifies `nix/tui.nix` and `nix/web.nix`. These paths are **not** in the `push.paths` filter, so the fix commit cannot re-trigger the workflow.

### What stays the same

The existing `fix` job (checkbox click + manual dispatch for PRs) is completely untouched.

## Files changed

- `.github/workflows/nix-lockfile-fix.yml` — added `push` trigger + `auto-fix-main` job

## Test plan

1. Merge a PR that touches `ui-tui/package-lock.json` without updating the hash
2. Observe the `Nix Lockfile Fix` workflow trigger automatically on `main`
3. Verify it pushes a `fix(nix): auto-refresh npm lockfile hashes` commit
4. Verify the follow-up `nix.yml` run on `main` passes with the new hashes

Closes #15314