### PR TITLE
fix(sessions): delete transcript files during auto-prune (salvage #6613, closes #3015)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -974,6 +974,7 @@ def _run_state_db_auto_maintenance(session_db) -> None:
         return
     try:
         from hermes_cli.config import load_config as _load_full_config
+        from hermes_constants import get_hermes_home as _get_hermes_home
         cfg = (_load_full_config().get("sessions") or {})
         if not cfg.get("auto_prune", False):
             return
@@ -981,6 +982,7 @@ def _run_state_db_auto_maintenance(session_db) -> None:
             retention_days=int(cfg.get("retention_days", 90)),
             min_interval_hours=int(cfg.get("min_interval_hours", 24)),
             vacuum=bool(cfg.get("vacuum_after_prune", True)),
+            sessions_dir=_get_hermes_home() / "sessions",
         )
     except Exception as exc:
         logger.debug("state.db auto-maintenance skipped: %s", exc)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -763,6 +763,7 @@ class GatewayRunner:
                         retention_days=int(_sess_cfg.get("retention_days", 90)),
                         min_interval_hours=int(_sess_cfg.get("min_interval_hours", 24)),
                         vacuum=bool(_sess_cfg.get("vacuum_after_prune", True)),
+                        sessions_dir=self.config.sessions_dir,
                     )
             except Exception as exc:
                 logger.debug("state.db auto-maintenance skipped: %s", exc)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9230,7 +9230,8 @@ Examples:
                 ):
                     print("Cancelled.")
                     return
-            if db.delete_session(resolved_session_id):
+            sessions_dir = get_hermes_home() / "sessions"
+            if db.delete_session(resolved_session_id, sessions_dir=sessions_dir):
                 print(f"Deleted session '{resolved_session_id}'.")
             else:
                 print(f"Session '{args.session_id}' not found.")
@@ -9244,7 +9245,9 @@ Examples:
                 ):
                     print("Cancelled.")
                     return
-            count = db.prune_sessions(older_than_days=days, source=args.source)
+            sessions_dir = get_hermes_home() / "sessions"
+            count = db.prune_sessions(older_than_days=days, source=args.source,
+                                      sessions_dir=sessions_dir)
             print(f"Pruned {count} session(s).")
 
         elif action == "rename":

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1512,12 +1512,45 @@ class SessionDB:
             )
         self._execute_write(_do)
 
-    def delete_session(self, session_id: str) -> bool:
+    @staticmethod
+    def _remove_session_files(sessions_dir: Optional[Path], session_id: str) -> None:
+        """Remove on-disk transcript files for a session.
+
+        Cleans up ``{session_id}.json``, ``{session_id}.jsonl``, and any
+        ``request_dump_{session_id}_*.json`` files left by the gateway.
+        Silently skips files that don't exist and swallows OSError so a
+        filesystem hiccup never blocks a DB operation.
+        """
+        if sessions_dir is None:
+            return
+        for suffix in (".json", ".jsonl"):
+            p = sessions_dir / f"{session_id}{suffix}"
+            try:
+                p.unlink(missing_ok=True)
+            except OSError:
+                pass
+        # request_dump files use session_id as a prefix component
+        try:
+            for p in sessions_dir.glob(f"request_dump_{session_id}_*.json"):
+                try:
+                    p.unlink(missing_ok=True)
+                except OSError:
+                    pass
+        except OSError:
+            pass
+
+    def delete_session(
+        self,
+        session_id: str,
+        sessions_dir: Optional[Path] = None,
+    ) -> bool:
         """Delete a session and all its messages.
 
         Child sessions are orphaned (parent_session_id set to NULL) rather
         than cascade-deleted, so they remain accessible independently.
-        Returns True if the session was found and deleted.
+        When *sessions_dir* is provided, also removes on-disk transcript
+        files (``.json`` / ``.jsonl`` / ``request_dump_*``) for the deleted
+        session. Returns True if the session was found and deleted.
         """
         def _do(conn):
             cursor = conn.execute(
@@ -1534,16 +1567,29 @@ class SessionDB:
             conn.execute("DELETE FROM messages WHERE session_id = ?", (session_id,))
             conn.execute("DELETE FROM sessions WHERE id = ?", (session_id,))
             return True
-        return self._execute_write(_do)
 
-    def prune_sessions(self, older_than_days: int = 90, source: str = None) -> int:
+        deleted = self._execute_write(_do)
+        if deleted:
+            self._remove_session_files(sessions_dir, session_id)
+        return deleted
+
+    def prune_sessions(
+        self,
+        older_than_days: int = 90,
+        source: str = None,
+        sessions_dir: Optional[Path] = None,
+    ) -> int:
         """Delete sessions older than N days. Returns count of deleted sessions.
 
         Only prunes ended sessions (not active ones).  Child sessions outside
         the prune window are orphaned (parent_session_id set to NULL) rather
-        than cascade-deleted.
+        than cascade-deleted.  When *sessions_dir* is provided, also removes
+        on-disk transcript files (``.json`` / ``.jsonl`` /
+        ``request_dump_*``) for every pruned session, outside the DB
+        transaction.
         """
         cutoff = time.time() - (older_than_days * 86400)
+        removed_ids: list[str] = []
 
         def _do(conn):
             if source:
@@ -1573,9 +1619,14 @@ class SessionDB:
             for sid in session_ids:
                 conn.execute("DELETE FROM messages WHERE session_id = ?", (sid,))
                 conn.execute("DELETE FROM sessions WHERE id = ?", (sid,))
+                removed_ids.append(sid)
             return len(session_ids)
 
-        return self._execute_write(_do)
+        count = self._execute_write(_do)
+        # Clean up on-disk files outside the DB transaction
+        for sid in removed_ids:
+            self._remove_session_files(sessions_dir, sid)
+        return count
 
     # ── Meta key/value (for scheduler bookkeeping) ──
 
@@ -1629,12 +1680,17 @@ class SessionDB:
         retention_days: int = 90,
         min_interval_hours: int = 24,
         vacuum: bool = True,
+        sessions_dir: Optional[Path] = None,
     ) -> Dict[str, Any]:
         """Idempotent auto-maintenance: prune old sessions + optional VACUUM.
 
         Records the last run timestamp in state_meta so subsequent calls
         within ``min_interval_hours`` no-op. Designed to be called once at
         startup from long-lived entrypoints (CLI, gateway, cron scheduler).
+
+        When *sessions_dir* is provided, on-disk transcript files
+        (``.json`` / ``.jsonl`` / ``request_dump_*``) for pruned sessions
+        are removed as part of the same sweep (issue #3015).
 
         Never raises. On any failure, logs a warning and returns a dict
         with ``"error"`` set.
@@ -1659,7 +1715,10 @@ class SessionDB:
                 except (TypeError, ValueError):
                     pass  # corrupt meta; treat as no prior run
 
-            pruned = self.prune_sessions(older_than_days=retention_days)
+            pruned = self.prune_sessions(
+                older_than_days=retention_days,
+                sessions_dir=sessions_dir,
+            )
             result["pruned"] = pruned
 
             # Only VACUUM if we actually freed rows — VACUUM on a tight DB

--- a/tests/hermes_cli/test_sessions_delete.py
+++ b/tests/hermes_cli/test_sessions_delete.py
@@ -12,7 +12,7 @@ def test_sessions_delete_accepts_unique_id_prefix(monkeypatch, capsys):
             captured["resolved_from"] = session_id
             return "20260315_092437_c9a6ff"
 
-        def delete_session(self, session_id):
+        def delete_session(self, session_id, **kwargs):
             captured["deleted"] = session_id
             return True
 
@@ -45,7 +45,7 @@ def test_sessions_delete_reports_not_found_when_prefix_is_unknown(monkeypatch, c
         def resolve_session_id(self, session_id):
             return None
 
-        def delete_session(self, session_id):
+        def delete_session(self, session_id, **kwargs):
             raise AssertionError("delete_session should not be called when resolution fails")
 
         def close(self):
@@ -73,7 +73,7 @@ def test_sessions_delete_handles_eoferror_on_confirm(monkeypatch, capsys):
         def resolve_session_id(self, session_id):
             return "20260315_092437_c9a6ff"
 
-        def delete_session(self, session_id):
+        def delete_session(self, session_id, **kwargs):
             raise AssertionError("delete_session should not be called when cancelled")
 
         def close(self):

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1981,3 +1981,58 @@ class TestAutoMaintenance:
         # Should parse as a float timestamp close to now.
         assert abs(float(marker) - time.time()) < 60
 
+    def test_auto_prune_deletes_transcript_files(self, db, tmp_path):
+        """Issue #3015: auto-prune must also delete on-disk transcript files."""
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+
+        self._make_old_ended(db, "old1", days_old=100)
+        self._make_old_ended(db, "old2", days_old=100)
+        db.create_session(session_id="new", source="cli")  # active
+
+        # Transcript files mimicking real gateway/CLI layout
+        (sessions_dir / "old1.json").write_text("{}")
+        (sessions_dir / "old1.jsonl").write_text("{}\n")
+        (sessions_dir / "old2.jsonl").write_text("{}\n")
+        (sessions_dir / "request_dump_old1_001.json").write_text("{}")
+        (sessions_dir / "new.jsonl").write_text("{}\n")  # active, must survive
+
+        result = db.maybe_auto_prune_and_vacuum(
+            retention_days=90, sessions_dir=sessions_dir
+        )
+        assert result["pruned"] == 2
+
+        # Pruned transcript files are gone
+        assert not (sessions_dir / "old1.json").exists()
+        assert not (sessions_dir / "old1.jsonl").exists()
+        assert not (sessions_dir / "old2.jsonl").exists()
+        assert not (sessions_dir / "request_dump_old1_001.json").exists()
+        # Active session's transcript is untouched
+        assert (sessions_dir / "new.jsonl").exists()
+
+    def test_auto_prune_without_sessions_dir_preserves_files(self, db, tmp_path):
+        """Backward-compat: no sessions_dir = DB-only cleanup (legacy behavior)."""
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        self._make_old_ended(db, "old", days_old=100)
+        (sessions_dir / "old.jsonl").write_text("{}\n")
+
+        result = db.maybe_auto_prune_and_vacuum(retention_days=90)
+        assert result["pruned"] == 1
+        # File stays — caller didn't opt in
+        assert (sessions_dir / "old.jsonl").exists()
+
+    def test_prune_sessions_deletes_files_for_pruned_only(self, db, tmp_path):
+        """Active-session transcripts must never be deleted by prune."""
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        self._make_old_ended(db, "old", days_old=100)
+        db.create_session(session_id="active", source="cli")  # not ended
+        (sessions_dir / "old.jsonl").write_text("{}\n")
+        (sessions_dir / "active.jsonl").write_text("{}\n")
+
+        count = db.prune_sessions(older_than_days=90, sessions_dir=sessions_dir)
+        assert count == 1
+        assert not (sessions_dir / "old.jsonl").exists()
+        assert (sessions_dir / "active.jsonl").exists()
+


### PR DESCRIPTION
Rides on #13861's existing `sessions.auto_prune` opt-in to also delete on-disk transcript files — not just SQLite rows — so disk growth from accumulated session JSONs is bounded by the same `retention_days` / `min_interval_hours` knobs users already set. Closes #3015.

Salvage of #6613 by @SeeYangZhi, cherry-picked onto current main with conflict resolution.

## Why this over #8685
@SeeYangZhi's #6613 is the surgical version of the same feature: extends `delete_session()` / `prune_sessions()` with an optional `sessions_dir=` param and best-effort file cleanup. #13861 (already merged) built the auto-maintenance helper and per-user config block; extending that helper to take `sessions_dir` makes file cleanup automatic for users who already opted into `auto_prune`, with zero new knobs. #8685 (pre-#13861) would duplicate the schedule machinery with a parallel daily watcher loop and new CLI flags — useful but separate scope (especially `~/.hermes/checkpoints/`, the actually-largest offender at ~12 GB, which should be its own follow-up PR).

## Conflict resolution notes
- Preserved main's "orphan children on prune/delete" semantics (docstring on `delete_session`: "Child sessions remain accessible independently"). #6613 had switched to cascade-delete children, which is a design regression — dropped from the salvage.
- Extended `maybe_auto_prune_and_vacuum(sessions_dir=...)` to pass through to `prune_sessions()`, then wired `sessions_dir` through from both startup call sites (`cli.py` uses `get_hermes_home() / "sessions"`, `gateway/run.py` uses `self.config.sessions_dir`).

## Changes
- `hermes_state.py`: new `_remove_session_files()` static helper; `delete_session()` and `prune_sessions()` accept `sessions_dir: Optional[Path] = None`; `maybe_auto_prune_and_vacuum()` accepts `sessions_dir` and passes it through.
- `hermes_cli/main.py`: `hermes sessions delete` and `hermes sessions prune` now pass `sessions_dir=get_hermes_home() / "sessions"`.
- `cli.py`, `gateway/run.py`: auto-maintenance call sites pass `sessions_dir`.
- `tests/test_hermes_state.py`: 3 new `TestAutoMaintenance` tests — file deletion with `sessions_dir`, backward-compat without it, active-session files never touched.
- `tests/hermes_cli/test_sessions_delete.py`: `FakeDB.delete_session` helpers accept `**kwargs`.

## Validation
|  | Before | After |
|---|---|---|
| Auto-prune behavior | DB rows removed, `.json` / `.jsonl` / `request_dump_*` files remain on disk forever | All pruned-session transcripts deleted; active sessions never touched |
| Opt-in config | `sessions.auto_prune` already gated by #13861 | Same gate now covers file cleanup too (no new knob) |
| Backward compat | — | `sessions_dir=None` preserves legacy DB-only behavior |
| Targeted tests | — | `TestAutoMaintenance`: 10/10 (7 existing + 3 new); `test_sessions_delete`: 4/4 |
| Broader suite | — | `tests/test_hermes_state.py` + `tests/hermes_cli/`: 3109/3110 (1 pre-existing web_server failure unrelated) |
| E2E with real imports + isolated HERMES_HOME | — | 5 transcript files for 2 pruned sessions deleted, active-session transcript survives, second call within interval skips cleanly |

Closes #3015. Credit to @SeeYangZhi for the original #6613 design; @teknium1's #8685 covers the broader `~/.hermes/checkpoints/` cleanup story which is out of scope here.
