### PR TITLE
feat(skills): salvage airtable skill + wire skill API keys into .env (#15838)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1582,6 +1582,44 @@ OPTIONAL_ENV_VARS = {
         "category": "tool",
     },
 
+    # ── Bundled skills (opt-in: only needed if the user uses that skill) ──
+    # These use category="skill" (distinct from "tool") so the sandbox
+    # env blocklist in tools/environments/local.py does NOT rewrite them —
+    # skills legitimately need these passed through to curl via
+    # tools/env_passthrough.py when the user's skill calls out.
+    "NOTION_API_KEY": {
+        "description": "Notion integration token (used by the `notion` skill)",
+        "prompt": "Notion API key",
+        "url": "https://www.notion.so/my-integrations",
+        "password": True,
+        "category": "skill",
+        "advanced": True,
+    },
+    "LINEAR_API_KEY": {
+        "description": "Linear personal API key (used by the `linear` skill)",
+        "prompt": "Linear API key",
+        "url": "https://linear.app/settings/api",
+        "password": True,
+        "category": "skill",
+        "advanced": True,
+    },
+    "AIRTABLE_API_KEY": {
+        "description": "Airtable personal access token (used by the `airtable` skill)",
+        "prompt": "Airtable API key",
+        "url": "https://airtable.com/create/tokens",
+        "password": True,
+        "category": "skill",
+        "advanced": True,
+    },
+    "TENOR_API_KEY": {
+        "description": "Tenor API key for GIF search (used by the `gif-search` skill)",
+        "prompt": "Tenor API key",
+        "url": "https://developers.google.com/tenor/guides/quickstart",
+        "password": True,
+        "category": "skill",
+        "advanced": True,
+    },
+
     # ── Honcho ──
     "HONCHO_API_KEY": {
         "description": "Honcho API key for AI-native persistent memory",

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -48,6 +48,7 @@ AUTHOR_MAP = {
     "uzmpsk.dilekakbas@gmail.com": "dlkakbs",
     "jefferson@heimdallstrategy.com": "Mind-Dragon",
     "130918800+devorun@users.noreply.github.com": "devorun",
+    "sonoyuncudmr@gmail.com": "Sonoyunchu",
     "maks.mir@yahoo.com": "say8hi",
     "web3blind@users.noreply.github.com": "web3blind",
     "julia@alexland.us": "alexg0bot",

--- a/skills/productivity/airtable/SKILL.md
+++ b/skills/productivity/airtable/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: airtable
-description: Read/write Airtable bases via REST API using curl. List bases, tables, and records; create, update, and delete records. No dependencies beyond curl.
-version: 1.0.0
+description: Airtable REST API via curl. Records CRUD, filters, upserts.
+version: 1.1.0
 author: community
 license: MIT
 prerequisites:
@@ -13,100 +13,216 @@ metadata:
     homepage: https://airtable.com/developers/web/api/introduction
 ---
 
-# Airtable REST API
+# Airtable — Bases, Tables & Records
 
-Use Airtable's REST API via `curl` to list bases, inspect schemas, and run CRUD against records. No extra packages — `curl` plus Python stdlib for URL encoding is enough.
+Work with Airtable's REST API directly via `curl` using the `terminal` tool. No MCP server, no OAuth flow, no Python SDK — just `curl` and a personal access token.
 
-## Setup
+## Prerequisites
 
-1. Create a personal access token (PAT) at https://airtable.com/create/tokens
+1. Create a **Personal Access Token (PAT)** at https://airtable.com/create/tokens (tokens start with `pat...`).
 2. Grant these scopes (minimum):
    - `data.records:read` — read rows
    - `data.records:write` — create / update / delete rows
-   - `schema.bases:read` — list bases and tables (step 2–3 of the procedure below)
-3. Add to `~/.hermes/.env` (or set via `hermes setup`):
+   - `schema.bases:read` — list bases and tables
+3. **Important:** in the same token UI, add each base you want to access to the token's **Access** list. PATs are scoped per-base — a valid token on the wrong base returns `403`.
+4. Store the token in `~/.hermes/.env` (or via `hermes setup`):
    ```
    AIRTABLE_API_KEY=pat_your_token_here
    ```
-4. In the PAT UI, also add each base you want to access to the token's "Access" list. Tokens are scoped per-base.
 
-> Note: legacy `key...` API keys were deprecated in Feb 2024. PATs (starting with `pat`) are the only supported format.
+> Note: legacy `key...` API keys were deprecated Feb 2024. Only PATs and OAuth tokens work now.
 
 ## API Basics
 
-- **Base URL:** `https://api.airtable.com/v0`
+- **Endpoint:** `https://api.airtable.com/v0`
 - **Auth header:** `Authorization: Bearer $AIRTABLE_API_KEY`
-- **Object IDs:** bases `app...`, tables `tbl...`, records `rec...`. Prefer IDs over names when table names have spaces or may change.
-- **Rate limit:** 5 requests/sec/base. On `429`, back off and avoid parallel mutations into the same base.
+- **All requests** use JSON (`Content-Type: application/json` for any POST/PATCH/PUT body).
+- **Object IDs:** bases `app...`, tables `tbl...`, records `rec...`, fields `fld...`. IDs never change; names can. Prefer IDs in automations.
+- **Rate limit:** 5 requests/sec/base. `429` → back off. Burst on a single base will be throttled.
 
-## Quick Reference
-
+Base curl pattern:
 ```bash
-AUTH="Authorization: Bearer $AIRTABLE_API_KEY"
-BASE_ID=appXXXXXXXXXXXXXX
-TABLE=Tasks   # or tblXXXXXXXXXXXXXX
+curl -s "https://api.airtable.com/v0/$BASE_ID/$TABLE?maxRecords=5" \
+  -H "Authorization: Bearer $AIRTABLE_API_KEY" | python3 -m json.tool
 ```
 
-List records (first 10):
+`-s` suppresses curl's progress bar — keep it set for every call so the tool output stays clean for Hermes. Pipe through `python3 -m json.tool` (always present) or `jq` (if installed) for readable JSON.
+
+## Field Types (request body shapes)
+
+| Field type | Write shape |
+|---|---|
+| Single line text | `"Name": "hello"` |
+| Long text | `"Notes": "multi\nline"` |
+| Number | `"Score": 42` |
+| Checkbox | `"Done": true` |
+| Single select | `"Status": "Todo"` (name must already exist unless `typecast: true`) |
+| Multi-select | `"Tags": ["urgent", "bug"]` |
+| Date | `"Due": "2026-04-01"` |
+| DateTime (UTC) | `"At": "2026-04-01T14:30:00.000Z"` |
+| URL / Email / Phone | `"Link": "https://…"` |
+| Attachment | `"Files": [{"url": "https://…"}]` (Airtable fetches + rehosts) |
+| Linked record | `"Owner": ["recXXXXXXXXXXXXXX"]` (array of record IDs) |
+| User | `"AssignedTo": {"id": "usrXXXXXXXXXXXXXX"}` |
+
+Pass `"typecast": true` at the top level of a create/update body to let Airtable auto-coerce values (e.g. create a new select option on the fly, convert `"42"` → `42`).
+
+## Common Queries
+
+### List bases the token can see
 ```bash
-curl -s "https://api.airtable.com/v0/$BASE_ID/$TABLE?maxRecords=10" -H "$AUTH"
+curl -s "https://api.airtable.com/v0/meta/bases" \
+  -H "Authorization: Bearer $AIRTABLE_API_KEY" | python3 -m json.tool
 ```
 
-Create a record:
+### List tables + schema for a base
+```bash
+curl -s "https://api.airtable.com/v0/meta/bases/$BASE_ID/tables" \
+  -H "Authorization: Bearer $AIRTABLE_API_KEY" | python3 -m json.tool
+```
+Use this BEFORE mutating — confirms exact field names and IDs, surfaces `options.choices` for select fields, and shows primary-field names.
+
+### List records (first 10)
+```bash
+curl -s "https://api.airtable.com/v0/$BASE_ID/$TABLE?maxRecords=10" \
+  -H "Authorization: Bearer $AIRTABLE_API_KEY" | python3 -m json.tool
+```
+
+### Get a single record
+```bash
+curl -s "https://api.airtable.com/v0/$BASE_ID/$TABLE/$RECORD_ID" \
+  -H "Authorization: Bearer $AIRTABLE_API_KEY" | python3 -m json.tool
+```
+
+### Filter records (filterByFormula)
+Airtable formulas must be URL-encoded. Let Python stdlib do it — never hand-encode:
+```bash
+FORMULA="{Status}='Todo'"
+ENC=$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$FORMULA")
+curl -s "https://api.airtable.com/v0/$BASE_ID/$TABLE?filterByFormula=$ENC&maxRecords=20" \
+  -H "Authorization: Bearer $AIRTABLE_API_KEY" | python3 -m json.tool
+```
+
+Useful formula patterns:
+- Exact match: `{Email}='user@example.com'`
+- Contains: `FIND('bug', LOWER({Title}))`
+- Multiple conditions: `AND({Status}='Todo', {Priority}='High')`
+- Or: `OR({Owner}='alice', {Owner}='bob')`
+- Not empty: `NOT({Assignee}='')`
+- Date comparison: `IS_AFTER({Due}, TODAY())`
+
+### Sort + select specific fields
+```bash
+curl -s "https://api.airtable.com/v0/$BASE_ID/$TABLE?sort%5B0%5D%5Bfield%5D=Priority&sort%5B0%5D%5Bdirection%5D=asc&fields%5B%5D=Name&fields%5B%5D=Status" \
+  -H "Authorization: Bearer $AIRTABLE_API_KEY" | python3 -m json.tool
+```
+Square brackets in query params MUST be URL-encoded (`%5B` / `%5D`).
+
+### Use a named view
+```bash
+curl -s "https://api.airtable.com/v0/$BASE_ID/$TABLE?view=Grid%20view&maxRecords=50" \
+  -H "Authorization: Bearer $AIRTABLE_API_KEY" | python3 -m json.tool
+```
+Views apply their saved filter + sort server-side.
+
+## Common Mutations
+
+### Create a record
 ```bash
 curl -s -X POST "https://api.airtable.com/v0/$BASE_ID/$TABLE" \
-  -H "$AUTH" -H "Content-Type: application/json" \
-  -d '{"fields":{"Name":"New task","Status":"Todo"}}'
+  -H "Authorization: Bearer $AIRTABLE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"fields":{"Name":"New task","Status":"Todo","Priority":"High"}}' | python3 -m json.tool
 ```
 
-Update a record (partial — PATCH preserves other fields):
+### Create up to 10 records in one call
+```bash
+curl -s -X POST "https://api.airtable.com/v0/$BASE_ID/$TABLE" \
+  -H "Authorization: Bearer $AIRTABLE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "typecast": true,
+    "records": [
+      {"fields": {"Name": "Task A", "Status": "Todo"}},
+      {"fields": {"Name": "Task B", "Status": "In progress"}}
+    ]
+  }' | python3 -m json.tool
+```
+Batch endpoints are capped at **10 records per request**. For larger inserts, loop in batches of 10 with a short sleep to respect 5 req/sec/base.
+
+### Update a record (PATCH — merges, preserves unchanged fields)
 ```bash
 curl -s -X PATCH "https://api.airtable.com/v0/$BASE_ID/$TABLE/$RECORD_ID" \
-  -H "$AUTH" -H "Content-Type: application/json" \
-  -d '{"fields":{"Status":"Done"}}'
+  -H "Authorization: Bearer $AIRTABLE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"fields":{"Status":"Done"}}' | python3 -m json.tool
 ```
 
-Delete a record:
+### Upsert by a merge field (no ID needed)
 ```bash
-curl -s -X DELETE "https://api.airtable.com/v0/$BASE_ID/$TABLE/$RECORD_ID" -H "$AUTH"
+curl -s -X PATCH "https://api.airtable.com/v0/$BASE_ID/$TABLE" \
+  -H "Authorization: Bearer $AIRTABLE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "performUpsert": {"fieldsToMergeOn": ["Email"]},
+    "records": [
+      {"fields": {"Email": "user@example.com", "Status": "Active"}}
+    ]
+  }' | python3 -m json.tool
+```
+`performUpsert` creates records whose merge-field values are new, patches records whose merge-field values already exist. Great for idempotent syncs.
+
+### Delete a record
+```bash
+curl -s -X DELETE "https://api.airtable.com/v0/$BASE_ID/$TABLE/$RECORD_ID" \
+  -H "Authorization: Bearer $AIRTABLE_API_KEY" | python3 -m json.tool
 ```
 
-## Procedure
+### Delete up to 10 records in one call
+```bash
+curl -s -X DELETE "https://api.airtable.com/v0/$BASE_ID/$TABLE?records%5B%5D=rec1&records%5B%5D=rec2" \
+  -H "Authorization: Bearer $AIRTABLE_API_KEY" | python3 -m json.tool
+```
 
-1. **Authenticate.** Confirm `AIRTABLE_API_KEY` is set. If empty, stop and ask the user to add it to `~/.hermes/.env`.
-2. **Find the base.** List all bases the token can see:
-   ```bash
-   curl -s "https://api.airtable.com/v0/meta/bases" -H "$AUTH"
-   ```
-   Requires `schema.bases:read`. If the token lacks that scope, ask the user for the base ID directly.
-3. **Inspect the schema.** List tables and fields for the chosen base:
-   ```bash
-   curl -s "https://api.airtable.com/v0/meta/bases/$BASE_ID/tables" -H "$AUTH"
-   ```
-   Use this to confirm table names, IDs, and field names before mutating data.
-4. **CRUD against the target table.**
-   - Read: `GET /v0/$BASE_ID/$TABLE`
-   - Create: `POST /v0/$BASE_ID/$TABLE` with `{"fields": {...}}`
-   - Update: `PATCH /v0/$BASE_ID/$TABLE/$RECORD_ID` with only the fields to change (use `PUT` for full replacement)
-   - Delete: `DELETE /v0/$BASE_ID/$TABLE/$RECORD_ID`
-5. **Paginate long lists.** The list endpoint caps at 100 records per page. If the response includes `"offset": "..."`, pass it back as `?offset=<value>` on the next call and repeat until the field is absent.
+## Pagination
+
+List endpoints return at most **100 records per page**. If the response includes `"offset": "..."`, pass it back on the next call. Loop until the field is absent:
+
+```bash
+OFFSET=""
+while :; do
+  URL="https://api.airtable.com/v0/$BASE_ID/$TABLE?pageSize=100"
+  [ -n "$OFFSET" ] && URL="$URL&offset=$OFFSET"
+  RESP=$(curl -s "$URL" -H "Authorization: Bearer $AIRTABLE_API_KEY")
+  echo "$RESP" | python3 -c 'import json,sys; d=json.load(sys.stdin); [print(r["id"], r["fields"].get("Name","")) for r in d["records"]]'
+  OFFSET=$(echo "$RESP" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("offset",""))')
+  [ -z "$OFFSET" ] && break
+done
+```
+
+## Typical Hermes Workflow
+
+1. **Confirm auth.** `curl -s -o /dev/null -w "%{http_code}\n" https://api.airtable.com/v0/meta/bases -H "Authorization: Bearer $AIRTABLE_API_KEY"` — expect `200`.
+2. **Find the base.** List bases (step above) OR ask the user for the `app...` ID directly if the token lacks `schema.bases:read`.
+3. **Inspect the schema.** `GET /v0/meta/bases/$BASE_ID/tables` — cache the exact field names and primary-field name locally in the session before mutating anything.
+4. **Read before you write.** For "update X where Y", `filterByFormula` first to resolve the `rec...` ID, then `PATCH /v0/$BASE_ID/$TABLE/$RECORD_ID`. Never guess record IDs.
+5. **Batch writes.** Combine related creates into one 10-record POST to stay under the 5 req/sec budget.
+6. **Destructive ops.** Deletions can't be undone via API. If the user says "delete all Xs", echo back the filter + record count and confirm before firing.
 
 ## Pitfalls
 
-- **`filterByFormula` must be URL-encoded.** Use Python stdlib — no extra packages:
-  ```bash
-  ENC=$(python3 -c "import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "{Status}='Todo'")
-  curl -s "https://api.airtable.com/v0/$BASE_ID/$TABLE?filterByFormula=$ENC" -H "$AUTH"
-  ```
-- **Empty fields are omitted from responses.** If a record looks like it's missing fields, inspect the table schema (step 3) before concluding the field doesn't exist.
-- **Tokens are per-base.** The PAT UI requires adding each base to the token's Access list. A 403 on a specific base usually means the base wasn't granted, not that the token is wrong.
-- **PATCH vs PUT.** `PATCH` merges the supplied fields into the existing record; `PUT` replaces the record entirely, wiping any fields you didn't include. Default to `PATCH` unless you genuinely want to clear other fields.
+- **`filterByFormula` MUST be URL-encoded.** Field names with spaces or non-ASCII also need encoding (`{My Field}` → `%7BMy%20Field%7D`). Use Python stdlib (pattern above) — never hand-escape.
+- **Empty fields are omitted from responses.** A missing `"Assignee"` key doesn't mean the field doesn't exist — it means this record's value is empty. Check the schema (step 3) before concluding a field is missing.
+- **PATCH vs PUT.** `PATCH` merges supplied fields into the record. `PUT` replaces the record entirely and clears any field you didn't include. Default to `PATCH`.
+- **Single-select options must exist.** Writing `"Status": "Shipping"` when `Shipping` isn't in the field's option list errors with `INVALID_MULTIPLE_CHOICE_OPTIONS` unless you pass `"typecast": true` (which auto-creates the option).
+- **Per-base token scoping.** A `403` on one base while another works means the token's Access list doesn't include that base — not a scope or auth issue. Send the user to https://airtable.com/create/tokens to grant it.
+- **Rate limits are per base, not per token.** 5 req/sec on `baseA` and 5 req/sec on `baseB` is fine; 6 req/sec on `baseA` alone will throttle. Monitor the `Retry-After` header on `429`.
 
-## Verification
+## Important Notes for Hermes
 
-```bash
-curl -s -o /dev/null -w "%{http_code}\n" "https://api.airtable.com/v0/meta/bases" \
-  -H "Authorization: Bearer $AIRTABLE_API_KEY"
-```
-
-Expect `200` with a `bases` array. `401` means the key is wrong; `403` means the token is valid but lacks `schema.bases:read` (use step 2 workaround).
+- **Always use the `terminal` tool with `curl`.** Do NOT use `web_extract` (it can't send auth headers) or `browser_navigate` (needs UI auth and is slow).
+- **`AIRTABLE_API_KEY` flows from `~/.hermes/.env` into the subprocess automatically** when this skill is loaded — no need to re-export it before each `curl` call.
+- **Escape curly braces in formulas carefully.** In a heredoc body, `{Status}` is literal. In a shell argument, `{Status}` is safe outside `{...}` brace-expansion context — but pass dynamic strings through `python3 urllib.parse.quote` before splicing into a URL.
+- **Pretty-print with `python3 -m json.tool`** (always present) rather than `jq` (optional). Only reach for `jq` when you need filtering/projection.
+- **Pagination is per-page, not global.** Airtable's 100-record cap is a hard limit; there is no way to bump it. Loop with `offset` until the field is absent.
+- **Read the `errors` array** on non-2xx responses — Airtable returns structured error codes like `AUTHENTICATION_REQUIRED`, `INVALID_PERMISSIONS`, `MODEL_ID_NOT_FOUND`, `INVALID_MULTIPLE_CHOICE_OPTIONS` that tell you exactly what's wrong.

--- a/skills/productivity/airtable/SKILL.md
+++ b/skills/productivity/airtable/SKILL.md
@@ -1,105 +1,112 @@
 ---
 name: airtable
-description: Read/write Airtable bases via REST API
+description: Read/write Airtable bases via REST API using curl. List bases, tables, and records; create, update, and delete records. No dependencies beyond curl.
+version: 1.0.0
+author: community
+license: MIT
+prerequisites:
+  env_vars: [AIRTABLE_API_KEY]
+  commands: [curl]
 metadata:
   hermes:
-    tags: [Productivity, Database, API]
-    config:
-      - key: airtable.api_key
-        description: Airtable personal access token or API key for REST API calls
-        prompt: Airtable API key
+    tags: [Airtable, Productivity, Database, API]
+    homepage: https://airtable.com/developers/web/api/introduction
 ---
 
 # Airtable REST API
 
-Use Airtable's REST API with `curl` and Python stdlib only. Do not add third-party Python packages for this skill.
+Use Airtable's REST API via `curl` to list bases, inspect schemas, and run CRUD against records. No extra packages — `curl` plus Python stdlib for URL encoding is enough.
 
-## When to Use
+## Setup
 
-- Load this skill when the user mentions an Airtable base, table, or record.
-- Use it for listing bases and tables, reading records, filtering records, and creating, updating, or deleting records.
-- Prefer the REST API over browser/UI automation for routine Airtable data work.
+1. Create a personal access token (PAT) at https://airtable.com/create/tokens
+2. Grant these scopes (minimum):
+   - `data.records:read` — read rows
+   - `data.records:write` — create / update / delete rows
+   - `schema.bases:read` — list bases and tables (step 2–3 of the procedure below)
+3. Add to `~/.hermes/.env` (or set via `hermes setup`):
+   ```
+   AIRTABLE_API_KEY=pat_your_token_here
+   ```
+4. In the PAT UI, also add each base you want to access to the token's "Access" list. Tokens are scoped per-base.
+
+> Note: legacy `key...` API keys were deprecated in Feb 2024. PATs (starting with `pat`) are the only supported format.
+
+## API Basics
+
+- **Base URL:** `https://api.airtable.com/v0`
+- **Auth header:** `Authorization: Bearer $AIRTABLE_API_KEY`
+- **Object IDs:** bases `app...`, tables `tbl...`, records `rec...`. Prefer IDs over names when table names have spaces or may change.
+- **Rate limit:** 5 requests/sec/base. On `429`, back off and avoid parallel mutations into the same base.
 
 ## Quick Reference
 
-Use a token header on every request:
-
 ```bash
-AIRTABLE_API_KEY="..."  # from skills.config.airtable.api_key
-AUTH_HEADER="Authorization: Bearer $AIRTABLE_API_KEY"
+AUTH="Authorization: Bearer $AIRTABLE_API_KEY"
+BASE_ID=appXXXXXXXXXXXXXX
+TABLE=Tasks   # or tblXXXXXXXXXXXXXX
 ```
 
-List records:
-
+List records (first 10):
 ```bash
-curl -s "https://api.airtable.com/v0/$BASE_ID/$TABLE?maxRecords=10" \
-  -H "$AUTH_HEADER"
+curl -s "https://api.airtable.com/v0/$BASE_ID/$TABLE?maxRecords=10" -H "$AUTH"
 ```
 
 Create a record:
-
 ```bash
 curl -s -X POST "https://api.airtable.com/v0/$BASE_ID/$TABLE" \
-  -H "$AUTH_HEADER" \
-  -H "Content-Type: application/json" \
+  -H "$AUTH" -H "Content-Type: application/json" \
   -d '{"fields":{"Name":"New task","Status":"Todo"}}'
 ```
 
-Update a record:
-
+Update a record (partial — PATCH preserves other fields):
 ```bash
 curl -s -X PATCH "https://api.airtable.com/v0/$BASE_ID/$TABLE/$RECORD_ID" \
-  -H "$AUTH_HEADER" \
-  -H "Content-Type: application/json" \
+  -H "$AUTH" -H "Content-Type: application/json" \
   -d '{"fields":{"Status":"Done"}}'
 ```
 
 Delete a record:
-
 ```bash
-curl -s -X DELETE "https://api.airtable.com/v0/$BASE_ID/$TABLE/$RECORD_ID" \
-  -H "$AUTH_HEADER"
+curl -s -X DELETE "https://api.airtable.com/v0/$BASE_ID/$TABLE/$RECORD_ID" -H "$AUTH"
 ```
 
 ## Procedure
 
-1. Authenticate first. Read `airtable.api_key` from skill config and use it as the bearer token for every request. If the credential is missing or invalid, stop and ask the user to configure it before continuing.
-2. List bases to find the right `baseId`. Prefer:
+1. **Authenticate.** Confirm `AIRTABLE_API_KEY` is set. If empty, stop and ask the user to add it to `~/.hermes/.env`.
+2. **Find the base.** List all bases the token can see:
    ```bash
-   curl -s "https://api.airtable.com/v0/meta/bases" \
-     -H "$AUTH_HEADER"
+   curl -s "https://api.airtable.com/v0/meta/bases" -H "$AUTH"
    ```
-   If this fails because the token lacks metadata scopes, ask the user for the base ID directly or ask them to provide a token with base schema access.
-3. List tables for the chosen base:
+   Requires `schema.bases:read`. If the token lacks that scope, ask the user for the base ID directly.
+3. **Inspect the schema.** List tables and fields for the chosen base:
    ```bash
-   curl -s "https://api.airtable.com/v0/meta/bases/$BASE_ID/tables" \
-     -H "$AUTH_HEADER"
+   curl -s "https://api.airtable.com/v0/meta/bases/$BASE_ID/tables" -H "$AUTH"
    ```
-   Use this to confirm table names, table IDs, and field names before mutating data.
-4. Perform CRUD against the target table:
-   - Read records with `GET /v0/$BASE_ID/$TABLE`.
-   - Create with `POST /v0/$BASE_ID/$TABLE` and a JSON body shaped like `{"fields": {...}}`.
-   - Update with `PATCH /v0/$BASE_ID/$TABLE/$RECORD_ID` and only the fields that should change.
-   - Delete with `DELETE /v0/$BASE_ID/$TABLE/$RECORD_ID`.
-5. For tables with many records, follow Airtable pagination. Keep requesting the same list endpoint with the returned `offset` value until the response stops including `offset`.
-6. Prefer stable IDs (`app...`, `tbl...`, `rec...`) over human-readable names when the base is large, table names contain spaces, or the user may rename objects while the session is active.
+   Use this to confirm table names, IDs, and field names before mutating data.
+4. **CRUD against the target table.**
+   - Read: `GET /v0/$BASE_ID/$TABLE`
+   - Create: `POST /v0/$BASE_ID/$TABLE` with `{"fields": {...}}`
+   - Update: `PATCH /v0/$BASE_ID/$TABLE/$RECORD_ID` with only the fields to change (use `PUT` for full replacement)
+   - Delete: `DELETE /v0/$BASE_ID/$TABLE/$RECORD_ID`
+5. **Paginate long lists.** The list endpoint caps at 100 records per page. If the response includes `"offset": "..."`, pass it back as `?offset=<value>` on the next call and repeat until the field is absent.
 
 ## Pitfalls
 
-- Airtable's Web API rate limit is `5 req/sec/base`. If you hit HTTP `429`, slow down, retry with backoff, and avoid firing parallel mutations into the same base.
-- `filterByFormula` must be URL-encoded when you are using raw `curl`. Use Python stdlib instead of extra packages:
+- **`filterByFormula` must be URL-encoded.** Use Python stdlib — no extra packages:
   ```bash
-  python -c "import urllib.parse; print(urllib.parse.quote(\"{Status}='Todo'\", safe=''))"
+  ENC=$(python3 -c "import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "{Status}='Todo'")
+  curl -s "https://api.airtable.com/v0/$BASE_ID/$TABLE?filterByFormula=$ENC" -H "$AUTH"
   ```
-  Then pass the encoded value as `filterByFormula=...`.
-- List-record responses can omit empty fields. If field names look incomplete, inspect the table schema first instead of assuming the field does not exist.
+- **Empty fields are omitted from responses.** If a record looks like it's missing fields, inspect the table schema (step 3) before concluding the field doesn't exist.
+- **Tokens are per-base.** The PAT UI requires adding each base to the token's Access list. A 403 on a specific base usually means the base wasn't granted, not that the token is wrong.
+- **PATCH vs PUT.** `PATCH` merges the supplied fields into the existing record; `PUT` replaces the record entirely, wiping any fields you didn't include. Default to `PATCH` unless you genuinely want to clear other fields.
 
 ## Verification
 
-Run:
-
 ```bash
-hermes -q "List records in my Airtable base X"
+curl -s -o /dev/null -w "%{http_code}\n" "https://api.airtable.com/v0/meta/bases" \
+  -H "Authorization: Bearer $AIRTABLE_API_KEY"
 ```
 
-Successful verification means Hermes identifies the right base and table, authenticates, and returns records through the REST API instead of asking for extra dependencies.
+Expect `200` with a `bases` array. `401` means the key is wrong; `403` means the token is valid but lacks `schema.bases:read` (use step 2 workaround).

--- a/skills/productivity/airtable/SKILL.md
+++ b/skills/productivity/airtable/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: airtable
+description: Read/write Airtable bases via REST API
+metadata:
+  hermes:
+    tags: [Productivity, Database, API]
+    config:
+      - key: airtable.api_key
+        description: Airtable personal access token or API key for REST API calls
+        prompt: Airtable API key
+---
+
+# Airtable REST API
+
+Use Airtable's REST API with `curl` and Python stdlib only. Do not add third-party Python packages for this skill.
+
+## When to Use
+
+- Load this skill when the user mentions an Airtable base, table, or record.
+- Use it for listing bases and tables, reading records, filtering records, and creating, updating, or deleting records.
+- Prefer the REST API over browser/UI automation for routine Airtable data work.
+
+## Quick Reference
+
+Use a token header on every request:
+
+```bash
+AIRTABLE_API_KEY="..."  # from skills.config.airtable.api_key
+AUTH_HEADER="Authorization: Bearer $AIRTABLE_API_KEY"
+```
+
+List records:
+
+```bash
+curl -s "https://api.airtable.com/v0/$BASE_ID/$TABLE?maxRecords=10" \
+  -H "$AUTH_HEADER"
+```
+
+Create a record:
+
+```bash
+curl -s -X POST "https://api.airtable.com/v0/$BASE_ID/$TABLE" \
+  -H "$AUTH_HEADER" \
+  -H "Content-Type: application/json" \
+  -d '{"fields":{"Name":"New task","Status":"Todo"}}'
+```
+
+Update a record:
+
+```bash
+curl -s -X PATCH "https://api.airtable.com/v0/$BASE_ID/$TABLE/$RECORD_ID" \
+  -H "$AUTH_HEADER" \
+  -H "Content-Type: application/json" \
+  -d '{"fields":{"Status":"Done"}}'
+```
+
+Delete a record:
+
+```bash
+curl -s -X DELETE "https://api.airtable.com/v0/$BASE_ID/$TABLE/$RECORD_ID" \
+  -H "$AUTH_HEADER"
+```
+
+## Procedure
+
+1. Authenticate first. Read `airtable.api_key` from skill config and use it as the bearer token for every request. If the credential is missing or invalid, stop and ask the user to configure it before continuing.
+2. List bases to find the right `baseId`. Prefer:
+   ```bash
+   curl -s "https://api.airtable.com/v0/meta/bases" \
+     -H "$AUTH_HEADER"
+   ```
+   If this fails because the token lacks metadata scopes, ask the user for the base ID directly or ask them to provide a token with base schema access.
+3. List tables for the chosen base:
+   ```bash
+   curl -s "https://api.airtable.com/v0/meta/bases/$BASE_ID/tables" \
+     -H "$AUTH_HEADER"
+   ```
+   Use this to confirm table names, table IDs, and field names before mutating data.
+4. Perform CRUD against the target table:
+   - Read records with `GET /v0/$BASE_ID/$TABLE`.
+   - Create with `POST /v0/$BASE_ID/$TABLE` and a JSON body shaped like `{"fields": {...}}`.
+   - Update with `PATCH /v0/$BASE_ID/$TABLE/$RECORD_ID` and only the fields that should change.
+   - Delete with `DELETE /v0/$BASE_ID/$TABLE/$RECORD_ID`.
+5. For tables with many records, follow Airtable pagination. Keep requesting the same list endpoint with the returned `offset` value until the response stops including `offset`.
+6. Prefer stable IDs (`app...`, `tbl...`, `rec...`) over human-readable names when the base is large, table names contain spaces, or the user may rename objects while the session is active.
+
+## Pitfalls
+
+- Airtable's Web API rate limit is `5 req/sec/base`. If you hit HTTP `429`, slow down, retry with backoff, and avoid firing parallel mutations into the same base.
+- `filterByFormula` must be URL-encoded when you are using raw `curl`. Use Python stdlib instead of extra packages:
+  ```bash
+  python -c "import urllib.parse; print(urllib.parse.quote(\"{Status}='Todo'\", safe=''))"
+  ```
+  Then pass the encoded value as `filterByFormula=...`.
+- List-record responses can omit empty fields. If field names look incomplete, inspect the table schema first instead of assuming the field does not exist.
+
+## Verification
+
+Run:
+
+```bash
+hermes -q "List records in my Airtable base X"
+```
+
+Successful verification means Hermes identifies the right base and table, authenticates, and returns records through the REST API instead of asking for extra dependencies.

--- a/website/docs/reference/skills-catalog.md
+++ b/website/docs/reference/skills-catalog.md
@@ -132,7 +132,7 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 
 | Skill | Description | Path |
 |-------|-------------|------|
-| [`airtable`](/docs/user-guide/skills/bundled/productivity/productivity-airtable) | Read/write Airtable bases via REST API using curl. List bases, tables, and records; create, update, and delete records. No dependencies beyond curl. | `productivity/airtable` |
+| [`airtable`](/docs/user-guide/skills/bundled/productivity/productivity-airtable) | Airtable REST API via curl. Records CRUD, filters, upserts. | `productivity/airtable` |
 | [`google-workspace`](/docs/user-guide/skills/bundled/productivity/productivity-google-workspace) | Gmail, Calendar, Drive, Contacts, Sheets, and Docs integration for Hermes. Uses Hermes-managed OAuth2 setup, prefers the Google Workspace CLI (`gws`) when available for broader API coverage, and falls back to the Python client libraries... | `productivity/google-workspace` |
 | [`linear`](/docs/user-guide/skills/bundled/productivity/productivity-linear) | Manage Linear issues, projects, and teams via the GraphQL API. Create, update, search, and organize issues. Uses API key auth (no OAuth needed). All operations via curl — no dependencies. | `productivity/linear` |
 | [`maps`](/docs/user-guide/skills/bundled/productivity/productivity-maps) | Location intelligence — geocode a place, reverse-geocode coordinates, find nearby places (46 POI categories), driving/walking/cycling distance + time, turn-by-turn directions, timezone lookup, bounding box + area for a named place, and P... | `productivity/maps` |

--- a/website/docs/reference/skills-catalog.md
+++ b/website/docs/reference/skills-catalog.md
@@ -132,6 +132,7 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 
 | Skill | Description | Path |
 |-------|-------------|------|
+| [`airtable`](/docs/user-guide/skills/bundled/productivity/productivity-airtable) | Read/write Airtable bases via REST API using curl. List bases, tables, and records; create, update, and delete records. No dependencies beyond curl. | `productivity/airtable` |
 | [`google-workspace`](/docs/user-guide/skills/bundled/productivity/productivity-google-workspace) | Gmail, Calendar, Drive, Contacts, Sheets, and Docs integration for Hermes. Uses Hermes-managed OAuth2 setup, prefers the Google Workspace CLI (`gws`) when available for broader API coverage, and falls back to the Python client libraries... | `productivity/google-workspace` |
 | [`linear`](/docs/user-guide/skills/bundled/productivity/productivity-linear) | Manage Linear issues, projects, and teams via the GraphQL API. Create, update, search, and organize issues. Uses API key auth (no OAuth needed). All operations via curl — no dependencies. | `productivity/linear` |
 | [`maps`](/docs/user-guide/skills/bundled/productivity/productivity-maps) | Location intelligence — geocode a place, reverse-geocode coordinates, find nearby places (46 POI categories), driving/walking/cycling distance + time, turn-by-turn directions, timezone lookup, bounding box + area for a named place, and P... | `productivity/maps` |


### PR DESCRIPTION
Closes #15838. Salvages @Sonoyunchu's bundled Airtable skill onto current main and layers on the follow-up work needed to make skill credentials stop falling out of `.env`.

## What this PR makes true

Bundled skills that use API keys (`airtable`, `linear`, `notion`, `gif-search`) now have their credentials registered in Hermes' `OPTIONAL_ENV_VARS` catalog. The user sets the key once — via `hermes setup`, `hermes config set`, or by hand in `~/.hermes/.env` — and every subsequent session can see it. Previously these keys were only mentioned in each SKILL.md's setup section and left as the user's problem to remember, with no persistence hook.

## Commits

1. `feat(skills): add bundled Airtable productivity skill` — @Sonoyunchu's original (cherry-picked, authorship preserved).
2. `fix(skills/airtable): use .env credential pattern matching notion/linear` — SKILL.md rewrite. Original used `metadata.hermes.config.airtable.api_key` (wrong bucket for a secret per `references/skill-config-interface.md` — that interface is for non-secret skill settings; secrets belong in `.env`). Also added version/author/license frontmatter, `prerequisites.commands: [curl]`, PAT-specific setup (legacy `key...` keys were deprecated Feb 2024), the three required token scopes, pagination cap, PATCH vs PUT clarification, and a deterministic `/v0/meta/bases` health check for verification.
3. `feat(config): register bundled-skill API keys in OPTIONAL_ENV_VARS` — adds `NOTION_API_KEY`, `LINEAR_API_KEY`, `TENOR_API_KEY`, `AIRTABLE_API_KEY`. Uses a new `category: "skill"` so the sandbox env blocklist in `tools/environments/local.py` does NOT auto-block them — skills legitimately need `curl` to read `Authorization: Bearer $KEY` from the subprocess environment, which is the opposite of provider/tool credentials (GHSA-rhgp-j443-p4rf). All four entries are `advanced=True` so they don't nag users who have never touched those skills.
4. `chore: docs + attribution` — AUTHOR_MAP entry for `sonoyuncudmr@gmail.com`, skills-catalog.md row.

## Validation

| | Before | After |
|---|---|---|
| airtable SKILL.md frontmatter | custom `skills.config` (wrong) | `prerequisites.env_vars: [AIRTABLE_API_KEY]` |
| `AIRTABLE_API_KEY` in OPTIONAL_ENV_VARS | — | registered, `category=skill`, `advanced=True` |
| `LINEAR_API_KEY`, `NOTION_API_KEY`, `TENOR_API_KEY` | un-tracked (user had to hand-edit .env) | persisted via `save_env_value`, auto-loaded via `reload_env` |
| `_HERMES_PROVIDER_ENV_BLOCKLIST` contains skill keys | — | correctly excluded (verified) |
| `_HERMES_PROVIDER_ENV_BLOCKLIST` contains provider/tool keys | Yes | Yes (unchanged) |
| `env_passthrough.is_env_passthrough(AIRTABLE_API_KEY)` after skill_view | would have been False (blocklisted) | True |

Tests: 171 passed across `tests/hermes_cli/test_config.py`, `tests/tools/test_skills_tool.py`, `tests/tools/test_skill_env_passthrough.py`, `tests/tools/test_env_passthrough.py`, `tests/tools/test_local_env_blocklist.py`, `tests/hermes_cli/test_env_sanitize_on_load.py`.

E2E verified the full round-trip for all four skills: `save_env_value` → `reload_env` → `os.environ` populated → `skill_view` reports `setup_needed=False` → `env_passthrough` registers the key for subprocess inheritance.

Credit to @Sonoyunchu for the original Airtable skill.