### PR TITLE
fix(cli): skip web UI rebuild when dist is fresh (salvage #15863, closes #14898)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4984,6 +4984,43 @@ def _gateway_prompt(prompt_text: str, default: str = "", timeout: float = 300.0)
     return default
 
 
+def _web_ui_build_needed(web_dir: Path) -> bool:
+    """Return True if the web UI dist is missing or stale.
+
+    Mirrors the staleness logic used by ``_tui_build_needed()`` for the TUI.
+    The Vite build outputs to ``hermes_cli/web_dist/`` (per vite.config.ts
+    outDir: "../hermes_cli/web_dist"), NOT to ``web/dist/``.  Uses the Vite
+    manifest as the sentinel because it is written last and therefore has the
+    newest mtime of any build output.
+    """
+    dist_dir = web_dir.parent / "hermes_cli" / "web_dist"
+    sentinel = dist_dir / ".vite" / "manifest.json"
+    if not sentinel.exists():
+        sentinel = dist_dir / "index.html"
+    if not sentinel.exists():
+        return True
+    dist_mtime = sentinel.stat().st_mtime
+    skip = frozenset({"node_modules", "dist"})
+    for dirpath, dirnames, filenames in os.walk(web_dir, topdown=True):
+        dirnames[:] = [d for d in dirnames if d not in skip]
+        for fn in filenames:
+            if fn.endswith((".ts", ".tsx", ".js", ".jsx", ".css", ".html", ".vue")):
+                if os.path.getmtime(os.path.join(dirpath, fn)) > dist_mtime:
+                    return True
+    for meta in (
+        "package.json",
+        "package-lock.json",
+        "yarn.lock",
+        "pnpm-lock.yaml",
+        "vite.config.ts",
+        "vite.config.js",
+    ):
+        mp = web_dir / meta
+        if mp.exists() and mp.stat().st_mtime > dist_mtime:
+            return True
+    return False
+
+
 def _build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
     """Build the web UI frontend if npm is available.
 
@@ -4995,6 +5032,9 @@ def _build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
     Returns True if the build succeeded or was skipped (no package.json).
     """
     if not (web_dir / "package.json").exists():
+        return True
+
+    if not _web_ui_build_needed(web_dir):
         return True
 
     npm = shutil.which("npm")

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -54,6 +54,7 @@ AUTHOR_MAP = {
     "1060770+benjaminsehl@users.noreply.github.com": "benjaminsehl",
     "nerijusn76@gmail.com": "Nerijusas",
     "itonov@proton.me": "Ito-69",
+    "glesstech@gmail.com": "georgeglessner",
     "maxim.smetanin@gmail.com": "maxims-oss",
     # contributors (from noreply pattern)
     "david.vv@icloud.com": "davidvv",

--- a/tests/hermes_cli/test_web_ui_build.py
+++ b/tests/hermes_cli/test_web_ui_build.py
@@ -1,0 +1,121 @@
+"""Tests for _web_ui_build_needed — staleness check for the web UI dist.
+
+Critical invariant: the Vite build outputs to hermes_cli/web_dist/
+(vite.config.ts: outDir: "../hermes_cli/web_dist"), NOT web/dist/.
+The sentinel must be checked in the correct output directory or the
+freshness check is a no-op and the OOM rebuild always runs.
+"""
+
+import os
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.main import _web_ui_build_needed, _build_web_ui
+
+
+def _touch(path: Path, offset: float = 0.0) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.touch()
+    if offset:
+        t = time.time() + offset
+        os.utime(path, (t, t))
+
+
+def _make_web_dir(tmp_path: Path) -> tuple[Path, Path]:
+    """Return (web_dir, dist_dir) matching real repo layout."""
+    web_dir = tmp_path / "web"
+    web_dir.mkdir()
+    (web_dir / "package.json").touch()
+    dist_dir = tmp_path / "hermes_cli" / "web_dist"
+    return web_dir, dist_dir
+
+
+class TestWebUIBuildNeeded:
+
+    def test_returns_true_when_dist_missing(self, tmp_path):
+        web_dir, _ = _make_web_dir(tmp_path)
+        assert _web_ui_build_needed(web_dir) is True
+
+    def test_returns_false_when_vite_manifest_fresh(self, tmp_path):
+        web_dir, dist_dir = _make_web_dir(tmp_path)
+        _touch(web_dir / "src" / "App.tsx", offset=-10)
+        _touch(dist_dir / ".vite" / "manifest.json")
+        assert _web_ui_build_needed(web_dir) is False
+
+    def test_returns_true_when_source_newer_than_manifest(self, tmp_path):
+        web_dir, dist_dir = _make_web_dir(tmp_path)
+        _touch(dist_dir / ".vite" / "manifest.json", offset=-10)
+        _touch(web_dir / "src" / "App.tsx")
+        assert _web_ui_build_needed(web_dir) is True
+
+    def test_falls_back_to_index_html_when_manifest_missing(self, tmp_path):
+        web_dir, dist_dir = _make_web_dir(tmp_path)
+        _touch(web_dir / "src" / "main.ts", offset=-10)
+        _touch(dist_dir / "index.html")
+        assert _web_ui_build_needed(web_dir) is False
+
+    def test_web_dist_dir_not_web_dist_subdir(self, tmp_path):
+        """Regression: sentinel must be in hermes_cli/web_dist/, NOT web/dist/."""
+        web_dir, dist_dir = _make_web_dir(tmp_path)
+        _touch(web_dir / "src" / "App.tsx", offset=-10)
+        # Place manifest in wrong location (web/dist/) — should NOT count as fresh
+        wrong_dist = web_dir / "dist" / ".vite" / "manifest.json"
+        _touch(wrong_dist)
+        # Correct location is empty → still needs build
+        assert _web_ui_build_needed(web_dir) is True
+
+    def test_returns_true_when_package_lock_newer_than_dist(self, tmp_path):
+        web_dir, dist_dir = _make_web_dir(tmp_path)
+        _touch(dist_dir / ".vite" / "manifest.json", offset=-10)
+        _touch(web_dir / "package-lock.json")
+        assert _web_ui_build_needed(web_dir) is True
+
+    def test_returns_true_when_vite_config_newer_than_dist(self, tmp_path):
+        web_dir, dist_dir = _make_web_dir(tmp_path)
+        _touch(dist_dir / ".vite" / "manifest.json", offset=-10)
+        _touch(web_dir / "vite.config.ts")
+        assert _web_ui_build_needed(web_dir) is True
+
+    def test_ignores_node_modules(self, tmp_path):
+        web_dir, dist_dir = _make_web_dir(tmp_path)
+        # package.json older than manifest; only node_modules file is newer
+        _touch(web_dir / "package.json", offset=-20)
+        _touch(dist_dir / ".vite" / "manifest.json", offset=-10)
+        _touch(web_dir / "node_modules" / "react" / "index.js")
+        assert _web_ui_build_needed(web_dir) is False
+
+    def test_ignores_dist_subdir_under_web(self, tmp_path):
+        web_dir, dist_dir = _make_web_dir(tmp_path)
+        # package.json older than manifest; only web/dist file is newer
+        _touch(web_dir / "package.json", offset=-20)
+        _touch(dist_dir / ".vite" / "manifest.json", offset=-10)
+        _touch(web_dir / "dist" / "assets" / "index.js")
+        assert _web_ui_build_needed(web_dir) is False
+
+
+class TestBuildWebUISkipsWhenFresh:
+
+    def test_skips_npm_when_dist_is_fresh(self, tmp_path):
+        web_dir, dist_dir = _make_web_dir(tmp_path)
+        _touch(dist_dir / ".vite" / "manifest.json")
+
+        with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
+             patch("hermes_cli.main.subprocess.run") as mock_run:
+            result = _build_web_ui(web_dir)
+
+        assert result is True
+        mock_run.assert_not_called()
+
+    def test_runs_npm_when_dist_missing(self, tmp_path):
+        web_dir, _ = _make_web_dir(tmp_path)
+
+        mock_cp = __import__("subprocess").CompletedProcess([], 0, stdout=b"", stderr=b"")
+        with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
+             patch("hermes_cli.main.subprocess.run", return_value=mock_cp) as mock_run:
+            result = _build_web_ui(web_dir)
+
+        assert result is True
+        assert mock_run.call_count == 2  # npm install + npm run build


### PR DESCRIPTION
Stops `hermes dashboard` from running `npm install` + Vite build on every startup when the dist is already fresh, so low-memory VPS installs (≤1 GB RAM) no longer get systemd-OOM-killed before the server can start. Closes #14898.

Straight cherry-pick of #15863 by @georgeglessner (the reporter of #14898), clean against current main.

## Why this over #14914
Both PRs add the same `_web_ui_build_needed()` mtime check. #14914 used `web_dir / "dist"` as the sentinel path, but `web/vite.config.ts` sets `outDir: "../hermes_cli/web_dist"` — the build output never lands in `web/dist/`. The sentinel was always missing, so the check always returned True and the full rebuild still ran. #15863 uses the correct `web_dir.parent / "hermes_cli" / "web_dist"` path and includes a dedicated regression test (`test_web_dist_dir_not_web_dist_subdir`) that would have caught the #14914 bug.

#14918 (MANIFEST.in graft for sdist packaging) targets a different issue (#14880) and is out of scope for this fix.

## Changes
- `hermes_cli/main.py`: new `_web_ui_build_needed(web_dir)` helper — sentinel is `hermes_cli/web_dist/.vite/manifest.json`, falls back to `index.html`. Walks `web/` for `.ts`/`.tsx`/`.js`/`.jsx`/`.css`/`.html`/`.vue` newer than the sentinel; also checks `package.json`, lockfiles, `vite.config.*`. Early-return guard added to `_build_web_ui()`.
- `tests/hermes_cli/test_web_ui_build.py` (new, 121 LOC): 11 tests — missing dist, stale sources, fresh dist, sentinel fallback, lockfile changes, vite config changes, node_modules exclusion, wrong-dir regression guard, npm skip, npm run.

## Validation
|  | Before | After |
|---|---|---|
| `hermes dashboard` startup on low-memory VPS | Full `npm install` + Vite build every time, ~388 MB peak → systemd OOM-kill | Skipped when `hermes_cli/web_dist/.vite/manifest.json` is newer than all web sources |
| Targeted tests | — | 11/11 pass (including `test_web_dist_dir_not_web_dist_subdir` regression guard) |
| E2E with real layout | — | Missing dist → rebuilds; fresh dist → skips; source bump → rebuilds; wrong-dir dist (the #14914 mistake) → still detected as missing and rebuilds correct dir |

Closes #14898. Credit to @georgeglessner (original reporter + fix). @nftpoetrist's #14914 was the right idea with a wrong path; acknowledged in the salvage.
