### PR TITLE
fix(update): use npm ci to stop rewriting package-lock on every update

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5027,6 +5027,46 @@ def _web_ui_build_needed(web_dir: Path) -> bool:
     return False
 
 
+def _run_npm_install_deterministic(
+    npm: str,
+    cwd: Path,
+    *,
+    extra_args: tuple[str, ...] = (),
+    capture_output: bool = True,
+) -> subprocess.CompletedProcess:
+    """Run a deterministic npm install that does not mutate ``package-lock.json``.
+
+    Prefers ``npm ci`` (strict, lockfile-preserving) when a lockfile is present;
+    falls back to ``npm install`` only if ``npm ci`` fails (e.g. lockfile out of
+    sync on a WIP checkout).  Without this, ``npm install`` on npm ≥ 10 silently
+    rewrites committed lockfiles (stripping ``"peer": true`` etc.), which leaves
+    the working tree dirty and causes the next ``hermes update`` to stash the
+    lockfile — repeatedly.
+    """
+    lockfile = cwd / "package-lock.json"
+    if lockfile.exists():
+        ci_cmd = [npm, "ci", *extra_args]
+        ci_result = subprocess.run(
+            ci_cmd,
+            cwd=cwd,
+            capture_output=capture_output,
+            text=True,
+            check=False,
+        )
+        if ci_result.returncode == 0:
+            return ci_result
+        # Fall through to `npm install` — lockfile may be out of sync on a
+        # WIP fork/branch, or `npm ci` may not be available on very old npm.
+    install_cmd = [npm, "install", *extra_args]
+    return subprocess.run(
+        install_cmd,
+        cwd=cwd,
+        capture_output=capture_output,
+        text=True,
+        check=False,
+    )
+
+
 def _build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
     """Build the web UI frontend if npm is available.
 
@@ -5050,7 +5090,7 @@ def _build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
             print("Install Node.js, then run:  cd web && npm install && npm run build")
         return not fatal
     print("→ Building web UI...")
-    r1 = subprocess.run([npm, "install", "--silent"], cwd=web_dir, capture_output=True)
+    r1 = _run_npm_install_deterministic(npm, web_dir, extra_args=("--silent",))
     if r1.returncode != 0:
         print(
             f"  {'✗' if fatal else '⚠'} Web UI npm install failed"
@@ -5761,12 +5801,10 @@ def _update_node_dependencies() -> None:
         if not (path / "package.json").exists():
             continue
 
-        result = subprocess.run(
-            [npm, "install", "--silent", "--no-fund", "--no-audit", "--progress=false"],
-            cwd=path,
-            capture_output=True,
-            text=True,
-            check=False,
+        result = _run_npm_install_deterministic(
+            npm,
+            path,
+            extra_args=("--silent", "--no-fund", "--no-audit", "--progress=false"),
         )
         if result.returncode == 0:
             print(f"  ✓ {label}")


### PR DESCRIPTION
## Summary
Every `hermes update` leaves the web/ui-tui/root `package-lock.json` dirty, so the next update stashes it — producing a growing trail of `hermes-update-autostash-*` entries.

## Root cause
`_build_web_ui` and `_update_node_dependencies` run `npm install --silent`. On npm ≥ 10 that silently rewrites `package-lock.json` (strips `"peer": true` metadata etc.) whenever the committed lockfile was produced by a different npm version. On Teknium's machine right now `git stash list` has 3 `hermes-update-autostash` entries all carrying just `web/package-lock.json`.

## Changes
- `hermes_cli/main.py`: new `_run_npm_install_deterministic(npm, cwd, extra_args=...)` helper — tries `npm ci` (strict, lockfile-preserving) when a lockfile exists, falls back to `npm install` if `npm ci` fails (out-of-sync WIP checkouts, very old npm).
- Both update call sites (`_build_web_ui`, `_update_node_dependencies`) now go through the helper. WhatsApp bridge install (user setup, not update) left alone.

## Validation
| scenario | result |
|---|---|
| all 3 real lockfiles (web, ui-tui, root) after helper run | exit 0, hashes byte-identical, git status clean |
| deliberately out-of-sync lockfile (is-even in lock, is-odd in package.json) | `npm ci` fails → `npm install` succeeds, deps installed |
| no lockfile, package.json only | skips `npm ci`, `npm install` runs, lockfile created |

py_compile clean.