### PR TITLE
fix(cli): coerce quoted use_gateway flags in tool routing + UI

### DIFF
--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -9,6 +9,7 @@ from typing import Dict, Iterable, Optional, Set
 from hermes_cli.auth import get_nous_auth_status
 from hermes_cli.config import get_env_value, load_config
 from tools.managed_tool_gateway import is_managed_tool_gateway_ready
+from utils import is_truthy_value
 from tools.tool_backend_helpers import (
     fal_key_is_configured,
     has_direct_modal_credentials,
@@ -23,6 +24,13 @@ from tools.tool_backend_helpers import (
 _DEFAULT_PLATFORM_TOOLSETS = {
     "cli": "hermes-cli",
 }
+
+
+def _uses_gateway(section: object) -> bool:
+    """Return True when a config section explicitly opts into the gateway."""
+    if not isinstance(section, dict):
+        return False
+    return is_truthy_value(section.get("use_gateway"), default=False)
 
 
 @dataclass(frozen=True)
@@ -262,11 +270,11 @@ def get_nous_subscription_features(
     # use_gateway flags — when True, the user explicitly opted into the
     # Tool Gateway via `hermes model`, so direct credentials should NOT
     # prevent gateway routing.
-    web_use_gateway = bool(web_cfg.get("use_gateway"))
-    tts_use_gateway = bool(tts_cfg.get("use_gateway"))
-    browser_use_gateway = bool(browser_cfg.get("use_gateway"))
+    web_use_gateway = _uses_gateway(web_cfg)
+    tts_use_gateway = _uses_gateway(tts_cfg)
+    browser_use_gateway = _uses_gateway(browser_cfg)
     image_gen_cfg = config.get("image_gen") if isinstance(config.get("image_gen"), dict) else {}
-    image_use_gateway = bool(image_gen_cfg.get("use_gateway"))
+    image_use_gateway = _uses_gateway(image_gen_cfg)
 
     direct_exa = bool(get_env_value("EXA_API_KEY"))
     direct_firecrawl = bool(get_env_value("FIRECRAWL_API_KEY") or get_env_value("FIRECRAWL_API_URL"))
@@ -601,10 +609,10 @@ def get_gateway_eligible_tools(
     # no direct keys exist — we only skip the prompt for tools where
     # use_gateway was explicitly set.
     opted_in = {
-        "web": bool((config.get("web") if isinstance(config.get("web"), dict) else {}).get("use_gateway")),
-        "image_gen": bool((config.get("image_gen") if isinstance(config.get("image_gen"), dict) else {}).get("use_gateway")),
-        "tts": bool((config.get("tts") if isinstance(config.get("tts"), dict) else {}).get("use_gateway")),
-        "browser": bool((config.get("browser") if isinstance(config.get("browser"), dict) else {}).get("use_gateway")),
+        "web": _uses_gateway(config.get("web")),
+        "image_gen": _uses_gateway(config.get("image_gen")),
+        "tts": _uses_gateway(config.get("tts")),
+        "browser": _uses_gateway(config.get("browser")),
     }
 
     unconfigured: list[str] = []

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -26,7 +26,7 @@ from hermes_cli.nous_subscription import (
     get_nous_subscription_features,
 )
 from tools.tool_backend_helpers import fal_key_is_configured, managed_nous_tools_enabled
-from utils import base_url_hostname
+from utils import base_url_hostname, is_truthy_value
 
 logger = logging.getLogger(__name__)
 
@@ -1188,7 +1188,7 @@ def _is_provider_active(provider: dict, config: dict) -> bool:
                 configured_provider = image_cfg.get("provider")
                 if configured_provider not in (None, "", "fal"):
                     return False
-                if image_cfg.get("use_gateway") is False:
+                if image_cfg.get("use_gateway") is not None and not is_truthy_value(image_cfg.get("use_gateway"), default=False):
                     return False
             return feature.managed_by_nous
         if provider.get("tts_provider"):
@@ -1220,7 +1220,7 @@ def _is_provider_active(provider: dict, config: dict) -> bool:
         return (
             provider["imagegen_backend"] == "fal"
             and configured_provider in (None, "", "fal")
-            and not image_cfg.get("use_gateway")
+            and not is_truthy_value(image_cfg.get("use_gateway"), default=False)
         )
     return False
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -57,6 +57,7 @@ AUTHOR_MAP = {
     "itonov@proton.me": "Ito-69",
     "glesstech@gmail.com": "georgeglessner",
     "maxim.smetanin@gmail.com": "maxims-oss",
+    "yoimexex@gmail.com": "Yoimex",
     # contributors (from noreply pattern)
     "david.vv@icloud.com": "davidvv",
     "wangqiang@wangqiangdeMac-mini.local": "xiaoqiang243",

--- a/tests/hermes_cli/test_nous_subscription.py
+++ b/tests/hermes_cli/test_nous_subscription.py
@@ -149,3 +149,46 @@ def test_get_nous_subscription_features_requires_agent_browser_for_browserbase(m
     assert features.browser.active is False
     assert features.browser.managed_by_nous is False
     assert features.browser.current_provider == "Browserbase"
+
+
+def test_get_nous_subscription_features_does_not_treat_quoted_false_as_gateway_opt_in(monkeypatch):
+    env = {"EXA_API_KEY": "exa-test"}
+
+    monkeypatch.setattr(ns, "get_env_value", lambda name: env.get(name, ""))
+    monkeypatch.setattr(ns, "get_nous_auth_status", lambda: {"logged_in": True})
+    monkeypatch.setattr(ns, "managed_nous_tools_enabled", lambda: True)
+    monkeypatch.setattr(ns, "_toolset_enabled", lambda config, key: key == "web")
+    monkeypatch.setattr(ns, "_has_agent_browser", lambda: False)
+    monkeypatch.setattr(ns, "resolve_openai_audio_api_key", lambda: "")
+    monkeypatch.setattr(ns, "has_direct_modal_credentials", lambda: False)
+    monkeypatch.setattr(ns, "is_managed_tool_gateway_ready", lambda vendor: vendor == "firecrawl")
+
+    features = ns.get_nous_subscription_features(
+        {"web": {"backend": "exa", "use_gateway": "false"}}
+    )
+
+    assert features.web.available is True
+    assert features.web.active is True
+    assert features.web.managed_by_nous is False
+    assert features.web.direct_override is True
+    assert features.web.current_provider == "exa"
+
+
+def test_get_gateway_eligible_tools_ignores_quoted_false_opt_in(monkeypatch):
+    monkeypatch.setattr(ns, "managed_nous_tools_enabled", lambda: True)
+    monkeypatch.setattr(
+        ns,
+        "_get_gateway_direct_credentials",
+        lambda: {"web": True, "image_gen": False, "tts": False, "browser": False},
+    )
+
+    unconfigured, has_direct, already_managed = ns.get_gateway_eligible_tools(
+        {
+            "model": {"provider": "nous"},
+            "web": {"use_gateway": "false"},
+        }
+    )
+
+    assert "web" in has_direct
+    assert "web" not in already_managed
+    assert set(unconfigured) == {"image_gen", "tts", "browser"}

--- a/tests/tools/test_tool_backend_helpers.py
+++ b/tests/tools/test_tool_backend_helpers.py
@@ -22,6 +22,7 @@ from tools.tool_backend_helpers import (
     managed_nous_tools_enabled,
     normalize_browser_cloud_provider,
     normalize_modal_mode,
+    prefers_gateway,
     resolve_modal_backend_state,
     resolve_openai_audio_api_key,
 )
@@ -187,6 +188,27 @@ class TestHasDirectModalCredentials:
         (tmp_path / ".modal.toml").touch()
         with patch.object(Path, "home", return_value=tmp_path):
             assert has_direct_modal_credentials() is True
+
+
+# ---------------------------------------------------------------------------
+# prefers_gateway
+# ---------------------------------------------------------------------------
+class TestPrefersGateway:
+    """Honor bool-ish config values for tool gateway routing."""
+
+    def test_returns_false_for_quoted_false(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"web": {"use_gateway": "false"}},
+        )
+        assert prefers_gateway("web") is False
+
+    def test_returns_true_for_quoted_true(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"web": {"use_gateway": "true"}},
+        )
+        assert prefers_gateway("web") is True
 
 
 # ---------------------------------------------------------------------------

--- a/tools/tool_backend_helpers.py
+++ b/tools/tool_backend_helpers.py
@@ -6,6 +6,8 @@ import os
 from pathlib import Path
 from typing import Any, Dict
 
+from utils import is_truthy_value
+
 
 _DEFAULT_BROWSER_PROVIDER = "local"
 _DEFAULT_MODAL_MODE = "auto"
@@ -115,7 +117,7 @@ def prefers_gateway(config_section: str) -> bool:
         from hermes_cli.config import load_config
         section = (load_config() or {}).get(config_section)
         if isinstance(section, dict):
-            return bool(section.get("use_gateway"))
+            return is_truthy_value(section.get("use_gateway"), default=False)
     except Exception:
         pass
     return False


### PR DESCRIPTION
Salvage of #15960 by @Yoimex onto current main.

## Summary
Quoted `use_gateway: "false"` in config.yaml now opts out correctly instead of silently activating the Tool Gateway. `bool("false") == True` was routing opted-out tools through the gateway and suppressing direct API keys.

## Changes
- `tools/tool_backend_helpers.prefers_gateway()` — runtime routing
- `hermes_cli/nous_subscription.py` — 4 reads in `get_nous_subscription_features()` + `get_gateway_eligible_tools()` via new `_uses_gateway()` helper
- `hermes_cli/tools_config.py` — 2 UI-detection sites for the FAL-direct active marker (follow-up this salvage; original PR missed these)
- `scripts/release.py` — AUTHOR_MAP entry for yoimexex@gmail.com → Yoimex
- Tests: 3 regression tests from @Yoimex (quoted "false"/"true" coverage for `prefers_gateway`, `get_nous_subscription_features`, `get_gateway_eligible_tools`)

## Validation
| Scenario | Before | After |
|---|---|---|
| `use_gateway: "false"` (quoted) | treated as truthy, gateway activated | opt-out honored |
| `use_gateway: "true"` (quoted) | truthy | truthy (no regression) |
| `use_gateway: true` / `false` (bool) | correct | correct (no regression) |

Targeted suite: 117/117 passing (`tests/tools/test_tool_backend_helpers.py`, `tests/hermes_cli/test_nous_subscription.py`, `tests/hermes_cli/test_image_gen_picker.py`, `tests/hermes_cli/test_tools_config.py`).

E2E verified with a real `config.yaml` containing `use_gateway: "false"` — `prefers_gateway()` returns `False` for all four sections, `get_gateway_eligible_tools()` correctly classifies `web` as direct-credential rather than already-managed.

Closes #15960. Original commit authorship preserved via cherry-pick; merge with --rebase.