### PR TITLE
fix(maps): include seconds in timezone UTC offset output

### DIFF
--- a/skills/productivity/maps/scripts/maps_client.py
+++ b/skills/productivity/maps/scripts/maps_client.py
@@ -926,13 +926,18 @@ def cmd_timezone(args):
                 os_ = offset_info.get("seconds", 0)
                 sign = "+" if oh >= 0 else "-"
                 utc_offset = f"{sign}{abs(oh):02d}:{om:02d}"
+                if os_:
+                    utc_offset = f"{utc_offset}:{os_:02d}"
             elif tz_data.get("standardUtcOffset"):
                 offset_info2 = tz_data["standardUtcOffset"]
-                if isinstance(offset_info2, dict):
+if isinstance(offset_info2, dict):
                     oh = offset_info2.get("hours", 0)
                     om = abs(offset_info2.get("minutes", 0))
+                    os_ = offset_info2.get("seconds", 0)
                     sign = "+" if oh >= 0 else "-"
                     utc_offset = f"{sign}{abs(oh):02d}:{om:02d}"
+                    if os_:
+                        utc_offset = f"{utc_offset}:{os_:02d}"
             timezone_src = "timeapi.io"
     except (RuntimeError, KeyError, TypeError):
         pass  # API may be down; continue to fallback

--- a/skills/productivity/maps/scripts/maps_client.py
+++ b/skills/productivity/maps/scripts/maps_client.py
@@ -930,7 +930,7 @@ def cmd_timezone(args):
                     utc_offset = f"{utc_offset}:{os_:02d}"
             elif tz_data.get("standardUtcOffset"):
                 offset_info2 = tz_data["standardUtcOffset"]
-if isinstance(offset_info2, dict):
+                if isinstance(offset_info2, dict):
                     oh = offset_info2.get("hours", 0)
                     om = abs(offset_info2.get("minutes", 0))
                     os_ = offset_info2.get("seconds", 0)


### PR DESCRIPTION
Salvage of #15086 by @0z1-ghb onto current main. Authorship preserved via cherry-pick + rebase-merge.

## Summary
Maps `timezone` command now includes seconds in the UTC offset string when timeapi.io reports a non-zero `seconds` field. Previously the `currentUtcOffset` path extracted `seconds` but discarded it, and the `standardUtcOffset` path didn't read it at all.

## Changes
- `skills/productivity/maps/scripts/maps_client.py`: append `:SS` to utc_offset when seconds != 0, on both currentUtcOffset and standardUtcOffset code paths.

## Validation
| offset_info | output |
|---|---|
| hours=5, minutes=30, seconds=0 | +05:30 |
| hours=5, minutes=30, seconds=45 | +05:30:45 |
| hours=-8, minutes=0, seconds=0 | -08:00 |

Closes #15086.