### PR TITLE
fix(gateway): clear pending model note on all session-boundary resets

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5195,6 +5195,8 @@ class GatewayRunner:
         # picks up configured defaults instead of previous session switches.
         self._session_model_overrides.pop(session_key, None)
         self._set_session_reasoning_override(session_key, None)
+        if hasattr(self, "_pending_model_notes"):
+            self._pending_model_notes.pop(session_key, None)
 
         # Clear session-scoped dangerous-command approvals and /yolo state.
         # /new is a conversation-boundary operation — approval state from the

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4221,7 +4221,14 @@ class GatewayRunner:
         session_entry = self.session_store.get_or_create_session(source)
         session_key = session_entry.session_key
         if getattr(session_entry, "was_auto_reset", False):
+            # Treat auto-reset as a full conversation boundary — drop every
+            # session-scoped transient state so the fresh session does not
+            # inherit the previous conversation's model/reasoning overrides
+            # or a queued "/model switched" note.
+            self._session_model_overrides.pop(session_key, None)
             self._set_session_reasoning_override(session_key, None)
+            if hasattr(self, "_pending_model_notes"):
+                self._pending_model_notes.pop(session_key, None)
         
         # Emit session:start for new or auto-reset sessions
         _is_new_session = (
@@ -4901,6 +4908,8 @@ class GatewayRunner:
                 self._evict_cached_agent(session_key)
                 self._session_model_overrides.pop(session_key, None)
                 self._set_session_reasoning_override(session_key, None)
+                if hasattr(self, "_pending_model_notes"):
+                    self._pending_model_notes.pop(session_key, None)
                 response = (response or "") + (
                     "\n\n🔄 Session auto-reset — the conversation exceeded the "
                     "maximum context size and could not be compressed further. "

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -43,6 +43,7 @@ AUTHOR_MAP = {
     "teknium1@gmail.com": "teknium1",
     "teknium@nousresearch.com": "teknium1",
     "127238744+teknium1@users.noreply.github.com": "teknium1",
+    "johnnncenaaa77@gmail.com": "johnncenae",
     "focusflow.app.help@gmail.com": "yes999zc",
     "343873859@qq.com": "DrStrangerUJN",
     "uzmpsk.dilekakbas@gmail.com": "dlkakbs",

--- a/tests/gateway/test_session_model_reset.py
+++ b/tests/gateway/test_session_model_reset.py
@@ -81,11 +81,13 @@ async def test_new_command_clears_session_model_override():
         "api_mode": "openai",
     }
     runner._session_reasoning_overrides[session_key] = {"enabled": True, "effort": "high"}
+    runner._pending_model_notes[session_key] = "[Note: switched to gpt-4o.]"
 
     await runner._handle_reset_command(_make_event("/new"))
 
     assert session_key not in runner._session_model_overrides
     assert session_key not in runner._session_reasoning_overrides
+    assert session_key not in runner._pending_model_notes
 
 
 @pytest.mark.asyncio
@@ -126,6 +128,8 @@ async def test_new_command_only_clears_own_session():
     }
     runner._session_reasoning_overrides[session_key] = {"enabled": True, "effort": "high"}
     runner._session_reasoning_overrides[other_key] = {"enabled": True, "effort": "low"}
+    runner._pending_model_notes[session_key] = "[Note: switched to gpt-4o.]"
+    runner._pending_model_notes[other_key] = "[Note: switched to claude-sonnet-4-6.]"
 
     await runner._handle_reset_command(_make_event("/new"))
 
@@ -133,3 +137,5 @@ async def test_new_command_only_clears_own_session():
     assert other_key in runner._session_model_overrides
     assert session_key not in runner._session_reasoning_overrides
     assert other_key in runner._session_reasoning_overrides
+    assert session_key not in runner._pending_model_notes
+    assert other_key in runner._pending_model_notes


### PR DESCRIPTION
Salvages #16013 by @johnncenae onto current main and widens the fix to the two sibling session-boundary reset sites that had the same bug.

## Summary
`_pending_model_notes[session_key]` is an ephemeral prompt-state entry set by `/model` (and the picker flow) and popped on the next user message. Three session-boundary paths reset other transient session state but skipped this dict, so a stale "switched to X" note could prepend to the first message of a fresh session.

## Changes
- `gateway/run.py` `_handle_reset_command` (`/new` / `/reset`): clear `_pending_model_notes[session_key]` alongside existing model/reasoning override cleanup. *(contributor commit, @johnncenae)*
- `gateway/run.py` auto-reset path at top of `_handle_message` (`was_auto_reset`: inactivity / suspended-session): now drops model override + pending note in addition to reasoning. Previous version cleared only reasoning.
- `gateway/run.py` compression-exhaustion auto-reset: adds pending-note cleanup next to existing model/reasoning cleanup.
- `tests/gateway/test_session_model_reset.py`: regression coverage for the `/new` case (same-session clears, sibling-session untouched). *(contributor commit)*
- `scripts/release.py`: AUTHOR_MAP entry for @johnncenae.

## Validation
```
scripts/run_tests.sh tests/gateway/test_session_model_reset.py \
  tests/gateway/test_session_boundary_hooks.py \
  tests/gateway/test_session_boundary_security_state.py \
  tests/gateway/test_model_switch_persistence.py \
  tests/gateway/test_discord_model_picker.py \
  tests/gateway/test_model_command_custom_providers.py
23 passed in 6.10s
```

Closes #16013 (salvage). Credit to @johnncenae — cherry-picked with authorship preserved.