### PR TITLE
fix(file-tools): stop read_file dedup status from corrupting written files

### DIFF
--- a/tests/tools/test_file_read_guards.py
+++ b/tests/tools/test_file_read_guards.py
@@ -20,6 +20,7 @@ from tools.file_tools import (
     reset_file_dedup,
     _is_blocked_device,
     _invalidate_dedup_for_path,
+    _READ_DEDUP_STATUS_MESSAGE,
     _get_max_read_chars,
     _DEFAULT_MAX_READ_CHARS,
     _read_tracker,
@@ -163,7 +164,7 @@ class TestFileDedup(unittest.TestCase):
 
     @patch("tools.file_tools._get_file_ops")
     def test_second_read_returns_dedup_stub(self, mock_ops):
-        """Second read of same file+range returns dedup stub."""
+        """Second read of same file+range returns non-content dedup status."""
         mock_ops.return_value = _make_fake_ops(
             content="line one\nline two\n", file_size=20,
         )
@@ -174,7 +175,27 @@ class TestFileDedup(unittest.TestCase):
         # Second read — should get dedup stub
         r2 = json.loads(read_file_tool(self._tmpfile, task_id="dup"))
         self.assertTrue(r2.get("dedup"), "Second read should return dedup stub")
-        self.assertIn("unchanged", r2.get("content", ""))
+        self.assertEqual(r2.get("status"), "unchanged")
+        self.assertIn("unchanged", r2.get("message", ""))
+        self.assertFalse(r2.get("content_returned"))
+        self.assertNotIn("content", r2)
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_write_rejects_internal_read_status_text(self, mock_ops):
+        """write_file must not persist internal read_file status text."""
+        fake = MagicMock()
+        fake.write_file = MagicMock()
+        mock_ops.return_value = fake
+
+        result = json.loads(write_file_tool(
+            self._tmpfile,
+            _READ_DEDUP_STATUS_MESSAGE,
+            task_id="guard",
+        ))
+
+        self.assertIn("error", result)
+        self.assertIn("internal read_file status text", result["error"])
+        fake.write_file.assert_not_called()
 
     @patch("tools.file_tools._get_file_ops")
     def test_modified_file_not_deduped(self, mock_ops):

--- a/tests/tools/test_file_read_guards.py
+++ b/tests/tools/test_file_read_guards.py
@@ -198,6 +198,62 @@ class TestFileDedup(unittest.TestCase):
         fake.write_file.assert_not_called()
 
     @patch("tools.file_tools._get_file_ops")
+    def test_write_rejects_status_text_with_small_framing(self, mock_ops):
+        """write_file rejects small wrappers around the status text too.
+
+        Real-world corruption shapes aren't always the verbatim message — the
+        model sometimes prepends a short note or appends a trailing comment
+        before calling write_file.  A short, status-dominated write is still
+        corruption, not legitimate file content.
+        """
+        fake = MagicMock()
+        fake.write_file = MagicMock()
+        mock_ops.return_value = fake
+
+        wrapped = "Note: " + _READ_DEDUP_STATUS_MESSAGE + "\n\n(continuing.)"
+        result = json.loads(write_file_tool(
+            self._tmpfile,
+            wrapped,
+            task_id="guard",
+        ))
+
+        self.assertIn("error", result)
+        self.assertIn("internal read_file status text", result["error"])
+        fake.write_file.assert_not_called()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_write_allows_large_file_that_quotes_status_text(self, mock_ops):
+        """Legitimate large content that happens to quote the status is allowed.
+
+        Hermes' own docs / SKILL.md files may legitimately mention the dedup
+        message verbatim.  Only short, status-dominated writes are rejected —
+        a normal file that contains the message as one line out of many must
+        still write successfully.
+        """
+        fake = MagicMock()
+        fake.write_file = lambda path, content: MagicMock(
+            to_dict=lambda: {"success": True, "path": path}
+        )
+        mock_ops.return_value = fake
+
+        # Build content that contains the status text but is much larger,
+        # so the status doesn't "dominate" — this is a legitimate file.
+        large_content = (
+            "# Skill reference\n\n"
+            "Example internal message (do not write back):\n\n"
+            f"    {_READ_DEDUP_STATUS_MESSAGE}\n\n"
+            + ("This is documentation content. " * 200)
+        )
+        result = json.loads(write_file_tool(
+            self._tmpfile,
+            large_content,
+            task_id="guard",
+        ))
+
+        self.assertNotIn("error", result)
+        self.assertTrue(result.get("success"))
+
+    @patch("tools.file_tools._get_file_ops")
     def test_modified_file_not_deduped(self, mock_ops):
         """After the file is modified, dedup returns full content."""
         mock_ops.return_value = _make_fake_ops(

--- a/tests/tools/test_file_read_guards.py
+++ b/tests/tools/test_file_read_guards.py
@@ -16,8 +16,10 @@ from unittest.mock import patch, MagicMock
 
 from tools.file_tools import (
     read_file_tool,
+    write_file_tool,
     reset_file_dedup,
     _is_blocked_device,
+    _invalidate_dedup_for_path,
     _get_max_read_chars,
     _DEFAULT_MAX_READ_CHARS,
     _read_tracker,
@@ -372,6 +374,175 @@ class TestConfigOverride(unittest.TestCase):
         result = json.loads(read_file_tool("/tmp/cfgtest2.txt", task_id="cfg2"))
         self.assertNotIn("error", result)
         self.assertIn("content", result)
+
+
+# ---------------------------------------------------------------------------
+# Write invalidates dedup cache (fixes #13144)
+# ---------------------------------------------------------------------------
+
+class TestWriteInvalidatesDedup(unittest.TestCase):
+    """write_file_tool and patch_tool must invalidate the read_file dedup
+    cache for the written path.  Without this, a read→write→read sequence
+    within the same mtime second returns a stale 'File unchanged' stub.
+
+    Regression test for https://github.com/NousResearch/hermes-agent/issues/13144
+    """
+
+    def setUp(self):
+        _read_tracker.clear()
+        self._tmpdir = tempfile.mkdtemp()
+        self._tmpfile = os.path.join(self._tmpdir, "write_dedup.txt")
+        with open(self._tmpfile, "w") as f:
+            f.write("original content\n")
+
+    def tearDown(self):
+        _read_tracker.clear()
+        try:
+            os.unlink(self._tmpfile)
+            os.rmdir(self._tmpdir)
+        except OSError:
+            pass
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_write_invalidates_dedup_same_second(self, mock_ops):
+        """read→write→read within the same mtime second returns fresh content.
+
+        This is the core #13144 scenario: on filesystems with ≥1ms mtime
+        granularity, a write that lands in the same timestamp as the prior
+        read would previously cause the second read to return a stale dedup
+        stub because the mtime comparison saw no change.
+        """
+        fake = MagicMock()
+        fake.read_file = lambda path, offset=1, limit=500: _FakeReadResult(
+            content="original content\n", total_lines=1, file_size=18,
+        )
+        fake.write_file = lambda path, content: MagicMock(
+            to_dict=lambda: {"success": True, "path": path}
+        )
+        mock_ops.return_value = fake
+
+        # 1. Read — populates dedup cache.
+        r1 = json.loads(read_file_tool(self._tmpfile, task_id="wr"))
+        self.assertNotEqual(r1.get("dedup"), True)
+
+        # 2. Write — must invalidate dedup for this path.
+        #    (No sleep — we intentionally stay in the same mtime second.)
+        write_file_tool(self._tmpfile, "new content\n", task_id="wr")
+
+        # 3. Read again — should get full content, NOT dedup stub.
+        fake.read_file = lambda path, offset=1, limit=500: _FakeReadResult(
+            content="new content\n", total_lines=1, file_size=13,
+        )
+        r2 = json.loads(read_file_tool(self._tmpfile, task_id="wr"))
+        self.assertNotEqual(r2.get("dedup"), True,
+                            "read after write must not return dedup stub")
+        self.assertIn("content", r2)
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_write_invalidates_all_offsets(self, mock_ops):
+        """A write invalidates dedup entries for ALL offset/limit combos."""
+        fake = MagicMock()
+        fake.read_file = lambda path, offset=1, limit=500: _FakeReadResult(
+            content="line1\nline2\nline3\n", total_lines=3, file_size=20,
+        )
+        fake.write_file = lambda path, content: MagicMock(
+            to_dict=lambda: {"success": True, "path": path}
+        )
+        mock_ops.return_value = fake
+
+        # Read with different offsets to populate multiple dedup entries.
+        read_file_tool(self._tmpfile, offset=1, limit=100, task_id="off")
+        read_file_tool(self._tmpfile, offset=50, limit=100, task_id="off")
+
+        # Write — should invalidate BOTH dedup entries.
+        write_file_tool(self._tmpfile, "replaced\n", task_id="off")
+
+        # Both reads should return fresh content.
+        r1 = json.loads(read_file_tool(self._tmpfile, offset=1, limit=100, task_id="off"))
+        r2 = json.loads(read_file_tool(self._tmpfile, offset=50, limit=100, task_id="off"))
+        self.assertNotEqual(r1.get("dedup"), True,
+                            "offset=1 should not dedup after write")
+        self.assertNotEqual(r2.get("dedup"), True,
+                            "offset=50 should not dedup after write")
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_write_does_not_invalidate_other_files(self, mock_ops):
+        """Writing file A should not invalidate dedup for file B."""
+        other = os.path.join(self._tmpdir, "other.txt")
+        with open(other, "w") as f:
+            f.write("other content\n")
+
+        fake = MagicMock()
+        fake.read_file = lambda path, offset=1, limit=500: _FakeReadResult(
+            content="other content\n", total_lines=1, file_size=15,
+        )
+        fake.write_file = lambda path, content: MagicMock(
+            to_dict=lambda: {"success": True, "path": path}
+        )
+        mock_ops.return_value = fake
+
+        # Read file B.
+        read_file_tool(other, task_id="iso")
+
+        # Write file A.
+        write_file_tool(self._tmpfile, "changed A\n", task_id="iso")
+
+        # File B should still dedup (untouched).
+        r2 = json.loads(read_file_tool(other, task_id="iso"))
+        self.assertTrue(r2.get("dedup"),
+                        "Unrelated file should still dedup after writing another file")
+
+        try:
+            os.unlink(other)
+        except OSError:
+            pass
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_write_does_not_invalidate_other_tasks(self, mock_ops):
+        """Writing in task A should not invalidate dedup for task B."""
+        fake = MagicMock()
+        fake.read_file = lambda path, offset=1, limit=500: _FakeReadResult(
+            content="original content\n", total_lines=1, file_size=18,
+        )
+        fake.write_file = lambda path, content: MagicMock(
+            to_dict=lambda: {"success": True, "path": path}
+        )
+        mock_ops.return_value = fake
+
+        # Both tasks read the file.
+        read_file_tool(self._tmpfile, task_id="taskA")
+        read_file_tool(self._tmpfile, task_id="taskB")
+
+        # Task A writes.
+        write_file_tool(self._tmpfile, "new\n", task_id="taskA")
+
+        # Task A's dedup should be invalidated.
+        rA = json.loads(read_file_tool(self._tmpfile, task_id="taskA"))
+        self.assertNotEqual(rA.get("dedup"), True,
+                            "Writing task's dedup should be invalidated")
+
+        # Task B still sees dedup (its cache is separate — the file
+        # *may* have changed on disk, but mtime comparison handles that;
+        # here we test that invalidation is scoped to the writing task).
+        # Note: on real FS, task B's dedup might or might not hit depending
+        # on mtime.  The point is that _invalidate_dedup_for_path is
+        # correctly scoped to task_id.
+
+    def test_invalidate_dedup_for_path_noop_on_missing_task(self):
+        """_invalidate_dedup_for_path is safe when task_id doesn't exist."""
+        _read_tracker.clear()
+        # Should not raise.
+        _invalidate_dedup_for_path("/nonexistent/path", "no_such_task")
+
+    def test_invalidate_dedup_for_path_noop_on_empty_dedup(self):
+        """_invalidate_dedup_for_path is safe when dedup dict is empty."""
+        _read_tracker.clear()
+        _read_tracker["t"] = {
+            "last_key": None, "consecutive": 0,
+            "read_history": set(), "dedup": {},
+        }
+        _invalidate_dedup_for_path("/some/path", "t")
+        self.assertEqual(_read_tracker["t"]["dedup"], {})
 
 
 if __name__ == "__main__":

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -214,6 +214,11 @@ _read_tracker: dict = {}
 _READ_HISTORY_CAP = 500       # set; used only by get_read_files_summary
 _DEDUP_CAP = 1000             # dict; skip-identical-reread guard
 _READ_TIMESTAMPS_CAP = 1000   # dict; external-edit detection for write/patch
+_READ_DEDUP_STATUS_MESSAGE = (
+    "File unchanged since last read. The content from "
+    "the earlier read_file result in this conversation is "
+    "still current — refer to that instead of re-reading."
+)
 
 
 def _cap_read_tracker_data(task_data: dict) -> None:
@@ -256,6 +261,13 @@ def _cap_read_tracker_data(task_data: dict) -> None:
                 ts.pop(next(iter(ts)))
             except (StopIteration, KeyError):
                 break
+
+
+def _is_internal_file_status_text(content: str) -> bool:
+    """Return True when content is an internal file-tool status, not file bytes."""
+    if not isinstance(content, str):
+        return False
+    return content.strip() == _READ_DEDUP_STATUS_MESSAGE
 
 
 def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
@@ -451,13 +463,11 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
                 current_mtime = os.path.getmtime(resolved_str)
                 if current_mtime == cached_mtime:
                     return json.dumps({
-                        "content": (
-                            "File unchanged since last read. The content from "
-                            "the earlier read_file result in this conversation is "
-                            "still current — refer to that instead of re-reading."
-                        ),
+                        "status": "unchanged",
+                        "message": _READ_DEDUP_STATUS_MESSAGE,
                         "path": path,
                         "dedup": True,
+                        "content_returned": False,
                     }, ensure_ascii=False)
             except OSError:
                 pass  # stat failed — fall through to full read
@@ -702,6 +712,11 @@ def write_file_tool(path: str, content: str, task_id: str = "default") -> str:
     sensitive_err = _check_sensitive_path(path, task_id)
     if sensitive_err:
         return tool_error(sensitive_err)
+    if _is_internal_file_status_text(content):
+        return tool_error(
+            "Refusing to write internal read_file status text as file content. "
+            "Re-read the file or reconstruct the intended file contents before writing."
+        )
     try:
         # Resolve once for the registry lock + stale check.  Failures here
         # fall back to the legacy path — write proceeds, per-task staleness

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -264,10 +264,34 @@ def _cap_read_tracker_data(task_data: dict) -> None:
 
 
 def _is_internal_file_status_text(content: str) -> bool:
-    """Return True when content is an internal file-tool status, not file bytes."""
+    """Return True when content looks like an internal file-tool status, not real file bytes.
+
+    The read_file dedup status message must never be persisted as file
+    content.  The obvious shape is the model echoing the message verbatim,
+    but in practice it also wraps it with small framing text (a leading
+    "Note:", a trailing newline + short comment, etc.) before calling
+    write_file.  We treat any short-ish write whose body is dominated by
+    the status message as the same class of corruption.
+
+    Heuristic:
+      * Strict equality (after strip) — the verbatim shape.
+      * OR the stripped content contains the full status message AND is
+        short enough that the status dominates it (<=2x the message length).
+        Short, status-dominated writes can't plausibly be real files —
+        legitimate docs/notes that happen to quote this internal message
+        are always dramatically longer.
+    """
     if not isinstance(content, str):
         return False
-    return content.strip() == _READ_DEDUP_STATUS_MESSAGE
+    stripped = content.strip()
+    if not stripped:
+        return False
+    if stripped == _READ_DEDUP_STATUS_MESSAGE:
+        return True
+    if _READ_DEDUP_STATUS_MESSAGE in stripped and \
+            len(stripped) <= 2 * len(_READ_DEDUP_STATUS_MESSAGE):
+        return True
+    return False
 
 
 def _get_file_ops(task_id: str = "default") -> ShellFileOperations:

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -612,13 +612,48 @@ def notify_other_tool_call(task_id: str = "default"):
             task_data["consecutive"] = 0
 
 
+def _invalidate_dedup_for_path(filepath: str, task_id: str) -> None:
+    """Remove all dedup cache entries whose resolved path matches *filepath*.
+
+    Called after write_file and patch so that a subsequent read_file on
+    the same path always returns fresh content instead of a stale
+    "File unchanged" stub.  The dedup cache keys are tuples of
+    ``(resolved_path, offset, limit)``; we must evict **all** offset/limit
+    combinations for the written path because any cached range could now
+    be stale.
+
+    Must be called with ``_read_tracker_lock`` **not** held — acquires it
+    internally.
+    """
+    try:
+        resolved = str(_resolve_path(filepath))
+    except (OSError, ValueError):
+        return
+    with _read_tracker_lock:
+        task_data = _read_tracker.get(task_id)
+        if task_data is None:
+            return
+        dedup = task_data.get("dedup")
+        if not dedup:
+            return
+        # Collect keys to remove (can't mutate dict during iteration).
+        stale_keys = [k for k in dedup if k[0] == resolved]
+        for k in stale_keys:
+            del dedup[k]
+
+
 def _update_read_timestamp(filepath: str, task_id: str) -> None:
     """Record the file's current modification time after a successful write.
 
     Called after write_file and patch so that consecutive edits by the
     same task don't trigger false staleness warnings — each write
     refreshes the stored timestamp to match the file's new state.
+
+    Also invalidates the dedup cache for the written path so that
+    subsequent reads return fresh content (fixes #13144).
     """
+    # Invalidate dedup first (before acquiring lock for timestamp update).
+    _invalidate_dedup_for_path(filepath, task_id)
     try:
         resolved = str(_resolve_path_for_task(filepath, task_id))
         current_mtime = os.path.getmtime(resolved)


### PR DESCRIPTION
## Summary

The `read_file` dedup "File unchanged since last read..." status was being returned in the `content` field of the tool result. Models read that back as real file bytes and, during entity-consolidation workflows, called `write_file` with that text — silently overwriting the user's actual file content. Reported by @jetpen on Discord against llm-wiki consolidation.

This PR salvages two external contributor fixes and tightens the write-side guard so small wrapper text can't slip past.

## Credit

- @voidborne-d (#13207) — invalidate dedup cache after `write_file`/`patch` so reads in the same mtime second return fresh bytes instead of a stale stub.
- @helix4u (#16223) — move the dedup status out of the `content` field (so it can never look like file bytes to the model) and add a `write_file` guard that refuses to persist the status string.

Both authorships are preserved via rebase-merge.

## Changes

- `tools/file_tools.py`:
  - `_invalidate_dedup_for_path()` — clears dedup entries for a written path across all offset/limit combos, scoped to the writing `task_id`. Called from `_update_read_timestamp()`.
  - Dedup read response now returns `status` / `message` / `dedup: true` / `content_returned: false` instead of `content`. No way for the status to be echoed into a later `write_file`.
  - `_is_internal_file_status_text()` — broadened from strict equality to also reject short, status-dominated writes (stripped content contains the status AND total length ≤2× the status). Legitimate docs that quote the message remain writable.
- `tests/tools/test_file_read_guards.py` — 9 new tests total: 6 for write-invalidates-dedup, 1 for the no-`content` dedup shape, 2 for the broadened guard (small-wrapper reject, large-legitimate allow).

## Validation

E2E with real imports against an isolated `HERMES_HOME`:

| | Before | After |
|---|---|---|
| `read_file` dedup response | `content: "File unchanged..."` | `status/message/content_returned:false`, no `content` |
| `write_file(file, DEDUP_MESSAGE)` | wrote the status into the file | `error: Refusing to write internal read_file status text...` |
| `write_file(file, "Note: " + DEDUP + "\n...")` | wrote wrapper+status into the file | rejected by broadened guard |
| `write_file` of legitimate doc that quotes the message | (worked) | still works |
| read → write → read within same mtime second | stale "unchanged" stub | fresh content |

Targeted tests: `tests/tools/test_file_read_guards.py` + `tests/tools/test_file_tools.py` — 51 passed.

Closes the corruption path reported against llm-wiki entity consolidation. Supersedes #13207 and #16223.
