### PR TITLE
fix: signal compression boundary to context engine

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -8160,6 +8160,22 @@ class AIAgent:
             except Exception as e:
                 logger.warning("Session DB compression split failed — new session will NOT be indexed: %s", e)
 
+        # Notify the context engine that the session_id rotated because of
+        # compression (not a fresh /new). Plugin engines (e.g. hermes-lcm) use
+        # boundary_reason="compression" to preserve DAG lineage across the
+        # rollover instead of re-initializing fresh per-session state.
+        # See hermes-lcm#68. Built-in ContextCompressor ignores kwargs.
+        try:
+            _old_sid = locals().get("old_session_id")
+            if _old_sid and hasattr(self.context_compressor, "on_session_start"):
+                self.context_compressor.on_session_start(
+                    self.session_id or "",
+                    boundary_reason="compression",
+                    old_session_id=_old_sid,
+                )
+        except Exception as _ce_err:
+            logger.debug("context engine on_session_start (compression): %s", _ce_err)
+
         # Warn on repeated compressions (quality degrades with each pass)
         _cc = self.context_compressor.compression_count
         if _cc >= 2:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -73,6 +73,7 @@ AUTHOR_MAP = {
     "thomasgeorgevii09@gmail.com": "tochukwuada",
     "harryykyle1@gmail.com": "hharry11",
     "kshitijk4poor@gmail.com": "kshitijk4poor",
+    "1294707+Tosko4@users.noreply.github.com": "Tosko4",
     "keira.voss94@gmail.com": "keiravoss94",
     "16443023+stablegenius49@users.noreply.github.com": "stablegenius49",
     "fqsy1416@gmail.com": "EKKOLearnAI",

--- a/tests/run_agent/test_compression_boundary_hook.py
+++ b/tests/run_agent/test_compression_boundary_hook.py
@@ -1,0 +1,156 @@
+"""Test: the context engine is notified of a compression-boundary rollover.
+
+When _compress_context rotates session_id (compression split), the active
+context engine receives on_session_start(new_sid, boundary_reason="compression",
+old_session_id=<old>). This lets plugin engines (e.g. hermes-lcm) preserve
+DAG lineage across the split instead of treating it as a fresh /new.
+
+See hermes-lcm#68: after Hermes compresses and mints a new physical session,
+LCM was losing continuity (compression_count: 1, store_messages: 0,
+dag_nodes: 0). With boundary_reason="compression" plugins can distinguish
+this from a real user-initiated /new.
+"""
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestCompressionBoundaryHook:
+    def _make_agent(self, session_db):
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+            from run_agent import AIAgent
+            return AIAgent(
+                api_key="test-key",
+                base_url="https://openrouter.ai/api/v1",
+                model="test/model",
+                quiet_mode=True,
+                session_db=session_db,
+                session_id="original-session",
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+    def test_on_session_start_called_with_compression_boundary(self):
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = self._make_agent(db)
+
+            # Stub the context compressor: we only need to observe the hook.
+            compressor = MagicMock()
+            compressor.compress.return_value = [
+                {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+                {"role": "user", "content": "tail question"},
+            ]
+            compressor.compression_count = 1
+            compressor.last_prompt_tokens = 0
+            compressor.last_completion_tokens = 0
+            # Avoid the summary-error warning path
+            compressor._last_summary_error = None
+            agent.context_compressor = compressor
+
+            original_sid = agent.session_id
+            messages = [
+                {"role": "user", "content": f"m{i}"} for i in range(10)
+            ]
+
+            agent._compress_context(messages, "sys", approx_tokens=10_000)
+
+            # Session_id rotated
+            assert agent.session_id != original_sid, \
+                "compression should rotate session_id when session_db is set"
+
+            # Hook fired with boundary_reason="compression" and old_session_id
+            calls = [
+                c for c in compressor.on_session_start.call_args_list
+            ]
+            assert calls, "on_session_start was never called on the context engine"
+            # Find the compression boundary call (there may be others from init)
+            comp_calls = [
+                c for c in calls
+                if c.kwargs.get("boundary_reason") == "compression"
+            ]
+            assert comp_calls, (
+                f"Expected an on_session_start call with "
+                f"boundary_reason='compression', got {calls!r}"
+            )
+            call = comp_calls[-1]
+            # Positional new session_id
+            assert call.args and call.args[0] == agent.session_id, \
+                f"Expected new session_id as first positional arg, got {call!r}"
+            assert call.kwargs.get("old_session_id") == original_sid, \
+                f"Expected old_session_id={original_sid!r}, got {call.kwargs!r}"
+
+    def test_no_hook_when_no_session_db(self):
+        """Without session_db, session_id does not rotate and the hook is not fired."""
+        from run_agent import AIAgent
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+            agent = AIAgent(
+                api_key="test-key",
+                base_url="https://openrouter.ai/api/v1",
+                model="test/model",
+                quiet_mode=True,
+                session_db=None,
+                session_id="original-session",
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+        compressor = MagicMock()
+        compressor.compress.return_value = [{"role": "user", "content": "x"}]
+        compressor.compression_count = 1
+        compressor.last_prompt_tokens = 0
+        compressor.last_completion_tokens = 0
+        compressor._last_summary_error = None
+        agent.context_compressor = compressor
+
+        original_sid = agent.session_id
+        agent._compress_context([{"role": "user", "content": "m"}], "sys", approx_tokens=100)
+
+        # No DB => no rotation => no compression-boundary hook
+        assert agent.session_id == original_sid
+        comp_calls = [
+            c for c in compressor.on_session_start.call_args_list
+            if c.kwargs.get("boundary_reason") == "compression"
+        ]
+        assert not comp_calls, (
+            f"No compression hook should fire without session_db rotation, "
+            f"got {comp_calls!r}"
+        )
+
+    def test_hook_failure_does_not_break_compression(self):
+        """If the context engine raises from on_session_start, compression still completes."""
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = self._make_agent(db)
+
+            compressor = MagicMock()
+            compressor.compress.return_value = [{"role": "user", "content": "summary"}]
+            compressor.compression_count = 1
+            compressor.last_prompt_tokens = 0
+            compressor.last_completion_tokens = 0
+            compressor._last_summary_error = None
+
+            # Raise only on the compression-boundary call, not on earlier calls.
+            def _raise_on_compression(*args, **kwargs):
+                if kwargs.get("boundary_reason") == "compression":
+                    raise RuntimeError("plugin exploded")
+                return None
+            compressor.on_session_start.side_effect = _raise_on_compression
+            agent.context_compressor = compressor
+
+            original_sid = agent.session_id
+
+            # Must not raise
+            compressed, _prompt = agent._compress_context(
+                [{"role": "user", "content": "m"}], "sys", approx_tokens=100
+            )
+            assert compressed
+            assert agent.session_id != original_sid


### PR DESCRIPTION
External context engine plugins (e.g. hermes-lcm) now receive `boundary_reason="compression"` when Hermes rotates session_id during context compression, so they can preserve DAG / store lineage across the split instead of treating it as a fresh `/new`.

## Changes
- `run_agent.py` (+16): after the compression-split rotates `session_id`, fire `self.context_compressor.on_session_start(new_sid, boundary_reason="compression", old_session_id=<old>)`. Guarded with `hasattr` + `try/except` so built-in `ContextCompressor` (which accepts `**kwargs` and ignores them) is unaffected.
- `tests/run_agent/test_compression_boundary_hook.py` (new): three tests — boundary hook fires on rollover, no hook when `session_db` is absent (no rotation happens), plugin exception does not break compression.

## Root cause
Closes hermes-lcm#68 symptom: after Hermes compressed and minted a new physical session, LCM saw the new session_id and reset per-session state, giving `compression_count: 1, store_messages: 0, dag_nodes: 0`. The built-in compressor had no way to tell plugins that the rotation was a compression-boundary continuation rather than a fresh user-initiated `/new`. This adds that signal.

## Validation
| | Before | After |
|---|---|---|
| `tests/run_agent/test_compression_boundary_hook.py` (new) | — | 3 passed |
| `tests/run_agent/test_compression_persistence.py` + `tests/cli/test_manual_compress.py` | 10 passed | 10 passed |

## Credit
Salvaged from @Tosko4's PR #13370 — scope minimized to the `boundary_reason` signal only. The broader session-lifecycle refactor (new `_transition_context_engine_session` helper, off-thread memory flush on `/new`, `HERMES_SESSION_ID` contextvar, `conversation_session_id` field on `ProcessSession`, `inspect.signature` introspection for `focus_topic`, plugin discovery re-ordering) will be taken in separate PRs if justified by concrete plugin need. Contributor authorship preserved on the fix commit.