### PR TITLE
fix(aux-client): resolve named-provider credential when base_url overrides endpoint (#16290)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3042,7 +3042,22 @@ def _resolve_task_provider_model(
     if task:
         # Config.yaml is the primary source for per-task overrides.
         if cfg_base_url:
-            return "custom", resolved_model, cfg_base_url, cfg_api_key, resolved_api_mode
+            # When the user configures a named provider (e.g. zai) with a custom
+            # base_url but leaves api_key blank, look up that provider's credential
+            # from the registry so env vars like ZAI_API_KEY are honoured.
+            resolved_key = cfg_api_key
+            if not resolved_key and cfg_provider and cfg_provider not in ("auto", "custom", ""):
+                try:
+                    from hermes_cli.auth import (
+                        PROVIDER_REGISTRY,
+                        resolve_api_key_provider_credentials,
+                    )
+                    if cfg_provider in PROVIDER_REGISTRY:
+                        creds = resolve_api_key_provider_credentials(cfg_provider)
+                        resolved_key = str(creds.get("api_key", "")).strip() or None
+                except ImportError:
+                    pass
+            return "custom", resolved_model, cfg_base_url, resolved_key, resolved_api_mode
         if cfg_provider and cfg_provider != "auto":
             return cfg_provider, resolved_model, None, None, resolved_api_mode
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3052,8 +3052,10 @@ def _resolve_task_provider_model(
                         PROVIDER_REGISTRY,
                         resolve_api_key_provider_credentials,
                     )
-                    if cfg_provider in PROVIDER_REGISTRY:
-                        creds = resolve_api_key_provider_credentials(cfg_provider)
+                    norm_provider = cfg_provider.lower()
+                    pconfig = PROVIDER_REGISTRY.get(norm_provider)
+                    if pconfig and getattr(pconfig, "auth_type", None) == "api_key":
+                        creds = resolve_api_key_provider_credentials(norm_provider)
                         resolved_key = str(creds.get("api_key", "")).strip() or None
                 except ImportError:
                     pass

--- a/tests/agent/test_aux_vision_named_provider_key.py
+++ b/tests/agent/test_aux_vision_named_provider_key.py
@@ -1,0 +1,136 @@
+"""Tests for _resolve_task_provider_model credential lookup when a named
+provider is configured with a custom base_url but no explicit api_key.
+
+Regression for #16290: ZAI_API_KEY (and any PROVIDER_REGISTRY env var) was
+silently ignored when auxiliary.vision.base_url was set because the function
+returned "custom" without consulting the provider's credential pool.
+"""
+
+from unittest.mock import patch
+
+
+def _make_task_config(provider, base_url, api_key=""):
+    return {
+        "provider": provider,
+        "model": "glm-4v",
+        "base_url": base_url,
+        "api_key": api_key,
+    }
+
+
+def _patch_aux_config(task_cfg, monkeypatch):
+    monkeypatch.setattr(
+        "agent.auxiliary_client._get_auxiliary_task_config",
+        lambda task: task_cfg if task == "vision" else {},
+    )
+
+
+class TestResolveTaskProviderModelCredentialLookup:
+    def test_named_provider_with_base_url_resolves_env_key(self, monkeypatch):
+        """ZAI_API_KEY must be used when provider=zai, base_url set, api_key empty."""
+        from agent.auxiliary_client import _resolve_task_provider_model
+
+        _patch_aux_config(
+            _make_task_config("zai", "https://open.bigmodel.cn/api/paas/v4"),
+            monkeypatch,
+        )
+
+        fake_creds = {"api_key": "zai-test-key-123"}
+        with patch(
+            "hermes_cli.auth.resolve_api_key_provider_credentials",
+            return_value=fake_creds,
+        ):
+            provider, model, base_url, api_key, api_mode = _resolve_task_provider_model("vision")
+
+        assert provider == "custom"
+        assert base_url == "https://open.bigmodel.cn/api/paas/v4"
+        assert api_key == "zai-test-key-123"
+
+    def test_explicit_api_key_in_config_takes_precedence(self, monkeypatch):
+        """An explicit api_key in config.yaml must not be overwritten."""
+        from agent.auxiliary_client import _resolve_task_provider_model
+
+        _patch_aux_config(
+            _make_task_config("zai", "https://open.bigmodel.cn/api/paas/v4", api_key="hardcoded-key"),
+            monkeypatch,
+        )
+
+        with patch(
+            "hermes_cli.auth.resolve_api_key_provider_credentials",
+            return_value={"api_key": "env-key-should-not-win"},
+        ) as mock_creds:
+            provider, model, base_url, api_key, api_mode = _resolve_task_provider_model("vision")
+
+        mock_creds.assert_not_called()
+        assert api_key == "hardcoded-key"
+
+    def test_unknown_provider_in_registry_leaves_key_none(self, monkeypatch):
+        """Providers not in PROVIDER_REGISTRY must not raise; api_key returns None."""
+        from agent.auxiliary_client import _resolve_task_provider_model
+
+        _patch_aux_config(
+            _make_task_config("my-local-llm", "http://localhost:11434/v1"),
+            monkeypatch,
+        )
+
+        provider, model, base_url, api_key, api_mode = _resolve_task_provider_model("vision")
+
+        assert provider == "custom"
+        assert base_url == "http://localhost:11434/v1"
+        assert api_key is None
+
+    def test_custom_provider_name_skips_registry_lookup(self, monkeypatch):
+        """provider=custom with base_url set must not attempt registry lookup."""
+        from agent.auxiliary_client import _resolve_task_provider_model
+
+        _patch_aux_config(
+            _make_task_config("custom", "http://custom-endpoint.example.com/v1"),
+            monkeypatch,
+        )
+
+        with patch(
+            "hermes_cli.auth.resolve_api_key_provider_credentials",
+        ) as mock_creds:
+            provider, model, base_url, api_key, api_mode = _resolve_task_provider_model("vision")
+
+        mock_creds.assert_not_called()
+        assert provider == "custom"
+        assert api_key is None
+
+    def test_missing_credentials_do_not_raise(self, monkeypatch):
+        """If the credential pool has no key for the provider, api_key returns None."""
+        from agent.auxiliary_client import _resolve_task_provider_model
+
+        _patch_aux_config(
+            _make_task_config("zai", "https://open.bigmodel.cn/api/paas/v4"),
+            monkeypatch,
+        )
+
+        with patch(
+            "hermes_cli.auth.resolve_api_key_provider_credentials",
+            return_value={"api_key": ""},
+        ):
+            provider, model, base_url, api_key, api_mode = _resolve_task_provider_model("vision")
+
+        assert provider == "custom"
+        assert api_key is None
+
+    def test_fix_applies_to_non_vision_tasks_too(self, monkeypatch):
+        """Same fix applies to compression/review/other auxiliary tasks."""
+        from agent.auxiliary_client import _resolve_task_provider_model
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            lambda task: _make_task_config("deepseek", "https://api.deepseek.com/v1") if task == "compression" else {},
+        )
+
+        fake_creds = {"api_key": "deepseek-key-456"}
+        with patch(
+            "hermes_cli.auth.resolve_api_key_provider_credentials",
+            return_value=fake_creds,
+        ):
+            provider, model, base_url, api_key, api_mode = _resolve_task_provider_model("compression")
+
+        assert provider == "custom"
+        assert base_url == "https://api.deepseek.com/v1"
+        assert api_key == "deepseek-key-456"

--- a/tests/agent/test_aux_vision_named_provider_key.py
+++ b/tests/agent/test_aux_vision_named_provider_key.py
@@ -134,3 +134,40 @@ class TestResolveTaskProviderModelCredentialLookup:
         assert provider == "custom"
         assert base_url == "https://api.deepseek.com/v1"
         assert api_key == "deepseek-key-456"
+
+    def test_uppercase_provider_name_normalizes_to_registry_key(self, monkeypatch):
+        """provider=ZAI (uppercase) must be lowercased before registry lookup."""
+        from agent.auxiliary_client import _resolve_task_provider_model
+
+        _patch_aux_config(
+            _make_task_config("ZAI", "https://open.bigmodel.cn/api/paas/v4"),
+            monkeypatch,
+        )
+
+        fake_creds = {"api_key": "zai-key-from-env"}
+        with patch(
+            "hermes_cli.auth.resolve_api_key_provider_credentials",
+            return_value=fake_creds,
+        ) as mock_creds:
+            provider, model, base_url, api_key, api_mode = _resolve_task_provider_model("vision")
+
+        mock_creds.assert_called_once_with("zai")
+        assert api_key == "zai-key-from-env"
+
+    def test_non_api_key_provider_does_not_raise(self, monkeypatch):
+        """OAuth/external providers (e.g. nous) must not raise; api_key returns None."""
+        from agent.auxiliary_client import _resolve_task_provider_model
+
+        _patch_aux_config(
+            _make_task_config("nous", "https://custom-nous-endpoint.example.com/v1"),
+            monkeypatch,
+        )
+
+        with patch(
+            "hermes_cli.auth.resolve_api_key_provider_credentials",
+        ) as mock_creds:
+            provider, model, base_url, api_key, api_mode = _resolve_task_provider_model("vision")
+
+        mock_creds.assert_not_called()
+        assert provider == "custom"
+        assert api_key is None


### PR DESCRIPTION
## Summary

- When `auxiliary.vision.provider: zai` (or any PROVIDER_REGISTRY provider) is set alongside `auxiliary.vision.base_url`, the credential pool for `zai` was never consulted — the api_key silently fell through to `OPENAI_API_KEY` or `\"no-key-required\"`, causing a `401` at the API.
- `_resolve_task_provider_model()` now looks up the named provider's credentials when `cfg_base_url` is set and `cfg_api_key` is empty.
- Explicit `api_key` in `config.yaml` always takes precedence. `provider: custom` and `provider: auto` are excluded from the lookup.

## The bug

`_resolve_task_provider_model()` returns `"custom"` as the provider name whenever `cfg_base_url` is set, discarding `cfg_provider`. Downstream, `resolve_provider_client("custom", ..., explicit_api_key="")` has no knowledge of the original `"zai"` intent and falls through to `OPENAI_API_KEY` or `"no-key-required"` — producing a `401` even when `ZAI_API_KEY` is correctly configured in `.env`.

## The fix

In the config-reading branch of `_resolve_task_provider_model()`, when `cfg_base_url` is set and `cfg_api_key` is blank, attempt a one-shot `resolve_api_key_provider_credentials(cfg_provider)` lookup for the named provider. The resolved key is then forwarded as `explicit_api_key` into `resolve_provider_client("custom", ...)`, which uses it directly for the custom endpoint.

The change is isolated to the config-read path (the `if task:` block) and applies uniformly to all auxiliary task types (vision, compression, review, etc.).

## Test plan

- [x] **Before**: `_resolve_task_provider_model("vision")` with `provider=zai, base_url=..., api_key=""` returns `api_key=None` → 401
- [x] **After**: returns `api_key="zai-test-key-123"` (the env-var value)
- [x] **Regression guard**: reverted fix → `test_named_provider_with_base_url_resolves_env_key` fails; restored → 6 tests pass
- [x] Explicit `api_key` in config is never overwritten (`test_explicit_api_key_in_config_takes_precedence`)
- [x] Unknown providers (not in PROVIDER_REGISTRY) return `None` without raising (`test_unknown_provider_in_registry_leaves_key_none`)
- [x] `provider: custom` skips the registry lookup (`test_custom_provider_name_skips_registry_lookup`)
- [x] Missing credentials return `None` gracefully (`test_missing_credentials_do_not_raise`)
- [x] Fix applies to non-vision tasks too (`test_fix_applies_to_non_vision_tasks_too`)
- [x] Full adjacent suite: 160 passed, 0 failures (`tests/agent/test_auxiliary_client.py`, `test_auxiliary_config_bridge.py`, `test_auxiliary_named_custom_providers.py`, `test_auxiliary_main_first.py`, `test_vision_resolved_args.py`, `test_minimax_auxiliary_url.py`)

## Related

- Fixes #16290

🤖 Generated with [Claude Code](https://claude.com/claude-code)