### PR TITLE
fix: DeepSeek API fixes and Gemini thinking_config support

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -101,6 +101,7 @@ class ChatCompletionsTransport(ProviderTransport):
             is_github_models: bool
             is_nvidia_nim: bool
             is_kimi: bool
+            is_deepseek: bool
             is_custom_provider: bool
             ollama_num_ctx: int | None
             # Provider routing
@@ -188,6 +189,7 @@ class ChatCompletionsTransport(ProviderTransport):
         anthropic_max_out = params.get("anthropic_max_output")
         is_nvidia_nim = params.get("is_nvidia_nim", False)
         is_kimi = params.get("is_kimi", False)
+        is_deepseek = params.get("is_deepseek", False)
         reasoning_config = params.get("reasoning_config")
 
         if ephemeral is not None and max_tokens_fn:
@@ -219,6 +221,22 @@ class ChatCompletionsTransport(ProviderTransport):
                         _kimi_effort = _e
                 api_kwargs["reasoning_effort"] = _kimi_effort
 
+        # DeepSeek: top-level reasoning_effort
+        # DeepSeek supports "high" and "max" (xhigh → max, low/medium → high)
+        if is_deepseek:
+            _ds_thinking_off = bool(
+                reasoning_config
+                and isinstance(reasoning_config, dict)
+                and reasoning_config.get("enabled") is False
+            )
+            if not _ds_thinking_off:
+                _ds_effort = "high"
+                if reasoning_config and isinstance(reasoning_config, dict):
+                    _e = (reasoning_config.get("effort") or "").strip().lower()
+                    if _e in ("xhigh", "max"):
+                        _ds_effort = "max"
+                api_kwargs["reasoning_effort"] = _ds_effort
+
         # extra_body assembly
         extra_body: Dict[str, Any] = {}
 
@@ -238,6 +256,16 @@ class ChatCompletionsTransport(ProviderTransport):
                     _kimi_thinking_enabled = False
             extra_body["thinking"] = {
                 "type": "enabled" if _kimi_thinking_enabled else "disabled",
+            }
+
+        # DeepSeek extra_body.thinking
+        if is_deepseek:
+            _ds_thinking_enabled = True
+            if reasoning_config and isinstance(reasoning_config, dict):
+                if reasoning_config.get("enabled") is False:
+                    _ds_thinking_enabled = False
+            extra_body["thinking"] = {
+                "type": "enabled" if _ds_thinking_enabled else "disabled",
             }
 
         # Reasoning

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -102,6 +102,7 @@ class ChatCompletionsTransport(ProviderTransport):
             is_nvidia_nim: bool
             is_kimi: bool
             is_deepseek: bool
+            is_gemini: bool
             is_custom_provider: bool
             ollama_num_ctx: int | None
             # Provider routing
@@ -267,6 +268,44 @@ class ChatCompletionsTransport(ProviderTransport):
             extra_body["thinking"] = {
                 "type": "enabled" if _ds_thinking_enabled else "disabled",
             }
+
+        # Gemini thinking_config via extra_body.google (OpenAI-compatible path).
+        # Gemini 3 Flash/Pro always reasons internally; thinking_config controls
+        # whether the reasoning is returned to the client and with what budget.
+        # Only the extra_body.google.thinking_config format actually returns
+        # reasoning_content — top-level reasoning_effort and extra_body.reasoning
+        # are silently accepted but don't expose the thinking chain.
+        #
+        # IMPORTANT: Gemini's thinking_level and thinking_budget are MUTUALLY
+        # EXCLUSIVE — the API rejects requests that set both with 400. We use
+        # thinking_budget exclusively because it gives finer granularity for
+        # mapping hermes effort levels (xhigh→4096, high→2048, etc.).
+        is_gemini = params.get("is_gemini", False)
+        if is_gemini:
+            _g_thinking_off = bool(
+                reasoning_config
+                and isinstance(reasoning_config, dict)
+                and reasoning_config.get("enabled") is False
+            )
+            if not _g_thinking_off:
+                # Map hermes effort levels to Gemini thinking_budget.
+                _g_budget = 1024  # default: medium
+                if reasoning_config and isinstance(reasoning_config, dict):
+                    _e = (reasoning_config.get("effort") or "").strip().lower()
+                    if _e in ("xhigh", "max"):
+                        _g_budget = 4096
+                    elif _e == "high":
+                        _g_budget = 2048
+                    elif _e == "medium":
+                        _g_budget = 1024
+                    elif _e in ("low", "minimal"):
+                        _g_budget = 512
+                extra_body["google"] = {
+                    "thinking_config": {
+                        "include_thoughts": True,
+                        "thinking_budget": _g_budget,
+                    }
+                }
 
         # Reasoning
         if params.get("supports_reasoning", False):

--- a/run_agent.py
+++ b/run_agent.py
@@ -7547,6 +7547,13 @@ class AIAgent:
             or base_url_host_matches(self.base_url, "api.deepseek.com")
         )
 
+        # Gemini detection — model name contains "gemini" (covers Liaobots,
+        # OpenRouter, and other OpenAI-compatible proxies). The native Gemini
+        # adapter (gemini_native_adapter.py) is used only when the base URL
+        # matches generativelanguage.googleapis.com — this flag is for the
+        # chat_completions transport path.
+        _is_gemini = "gemini" in (self.model or "").lower()
+
         # Temperature: _fixed_temperature_for_model may return OMIT_TEMPERATURE
         # sentinel (temperature omitted entirely), a numeric override, or None.
         try:
@@ -7615,6 +7622,7 @@ class AIAgent:
             is_nvidia_nim=_is_nvidia,
             is_kimi=_is_kimi,
             is_deepseek=_is_deepseek,
+            is_gemini=_is_gemini,
             is_custom_provider=self.provider == "custom",
             ollama_num_ctx=self._ollama_num_ctx,
             provider_preferences=_prefs or None,

--- a/run_agent.py
+++ b/run_agent.py
@@ -7541,6 +7541,11 @@ class AIAgent:
             or base_url_host_matches(self.base_url, "moonshot.ai")
             or base_url_host_matches(self.base_url, "moonshot.cn")
         )
+        _is_deepseek = (
+            self.provider == "deepseek"
+            or "deepseek" in (self.model or "").lower()
+            or base_url_host_matches(self.base_url, "api.deepseek.com")
+        )
 
         # Temperature: _fixed_temperature_for_model may return OMIT_TEMPERATURE
         # sentinel (temperature omitted entirely), a numeric override, or None.
@@ -7609,6 +7614,7 @@ class AIAgent:
             is_github_models=_is_gh,
             is_nvidia_nim=_is_nvidia,
             is_kimi=_is_kimi,
+            is_deepseek=_is_deepseek,
             is_custom_provider=self.provider == "custom",
             ollama_num_ctx=self._ollama_num_ctx,
             provider_preferences=_prefs or None,

--- a/run_agent.py
+++ b/run_agent.py
@@ -9076,6 +9076,17 @@ class AIAgent:
             api_messages = []
             for msg in messages:
                 api_msg = msg.copy()
+
+                # DeepSeek / Liaobots thinking mode: null content for
+                # tool-call messages (see main loop for details #15250).
+                if (
+                    api_msg.get("role") == "assistant"
+                    and api_msg.get("content") == ""
+                    and api_msg.get("tool_calls")
+                    and self._needs_deepseek_tool_reasoning()
+                ):
+                    api_msg["content"] = None
+
                 self._copy_reasoning_content_for_api(msg, api_msg)
                 for internal_field in ("reasoning", "finish_reason", "_thinking_prefill"):
                     api_msg.pop(internal_field, None)
@@ -9723,6 +9734,19 @@ class AIAgent:
             api_messages = []
             for idx, msg in enumerate(messages):
                 api_msg = msg.copy()
+
+                # DeepSeek / Liaobots thinking mode: assistant tool-call
+                # messages must use null content (per OpenAI spec) -- empty
+                # string "" triggers Liaobots internal format converter to
+                # reject with HTTP 400 "content[].thinking must be passed
+                # back" (refs #15250).
+                if (
+                    api_msg.get("role") == "assistant"
+                    and api_msg.get("content") == ""
+                    and api_msg.get("tool_calls")
+                    and self._needs_deepseek_tool_reasoning()
+                ):
+                    api_msg["content"] = None
 
                 # Inject ephemeral context into the current turn's user message.
                 # Sources: memory manager prefetch + plugin pre_llm_call hooks

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -385,6 +385,103 @@ class TestChatCompletionsNormalize:
         assert nr.provider_data == {"reasoning_content": "detailed scratchpad"}
 
 
+class TestDeepSeekReasoningEffort:
+    """DeepSeek direct API: top-level reasoning_effort + extra_body.thinking."""
+
+    @pytest.fixture
+    def transport(self):
+        import agent.transports.chat_completions  # noqa: F401
+        from agent.transports import get_transport
+        return get_transport("chat_completions")
+
+    def test_xhigh_maps_to_max(self, transport):
+        """xhigh effort → top-level reasoning_effort='max' + thinking enabled."""
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="deepseek-v4-pro", messages=msgs,
+            is_deepseek=True,
+            reasoning_config={"enabled": True, "effort": "xhigh"},
+        )
+        assert kw["reasoning_effort"] == "max"
+        assert kw["extra_body"]["thinking"] == {"type": "enabled"}
+
+    def test_max_stays_max(self, transport):
+        """'max' effort passed through as-is."""
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="deepseek-v4-pro", messages=msgs,
+            is_deepseek=True,
+            reasoning_config={"enabled": True, "effort": "max"},
+        )
+        assert kw["reasoning_effort"] == "max"
+
+    def test_high_stays_high(self, transport):
+        """'high' effort stays 'high'."""
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="deepseek-v4-pro", messages=msgs,
+            is_deepseek=True,
+            reasoning_config={"enabled": True, "effort": "high"},
+        )
+        assert kw["reasoning_effort"] == "high"
+
+    def test_medium_maps_to_high(self, transport):
+        """DeepSeek doesn't support 'medium' — maps to 'high'."""
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="deepseek-v4-pro", messages=msgs,
+            is_deepseek=True,
+            reasoning_config={"enabled": True, "effort": "medium"},
+        )
+        assert kw["reasoning_effort"] == "high"
+
+    def test_default_no_config_is_high(self, transport):
+        """When no reasoning_config, default to 'high' with thinking enabled."""
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="deepseek-v4-pro", messages=msgs,
+            is_deepseek=True,
+        )
+        assert kw["reasoning_effort"] == "high"
+        assert kw["extra_body"]["thinking"] == {"type": "enabled"}
+
+    def test_disabled_skips_effort_disables_thinking(self, transport):
+        """reasoning_config.enabled=False → no reasoning_effort, thinking=disabled."""
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="deepseek-v4-pro", messages=msgs,
+            is_deepseek=True,
+            reasoning_config={"enabled": False},
+        )
+        assert "reasoning_effort" not in kw
+        assert kw["extra_body"]["thinking"] == {"type": "disabled"}
+
+    def test_no_effect_on_non_deepseek(self, transport):
+        """is_deepseek=False should not add DeepSeek parameters."""
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-4o", messages=msgs,
+            is_deepseek=False,
+            reasoning_config={"enabled": True, "effort": "xhigh"},
+        )
+        assert "reasoning_effort" not in kw
+        eb = kw.get("extra_body", {})
+        assert "thinking" not in eb
+
+    def test_deepseek_does_not_interfere_with_kimi(self, transport):
+        """Kimi and DeepSeek can be independently configured."""
+        msgs = [{"role": "user", "content": "Hi"}]
+        # set is_kimi=True but NOT is_deepseek — DeepSeek block should be skipped
+        kw = transport.build_kwargs(
+            model="kimi-latest", messages=msgs,
+            is_kimi=True,
+            is_deepseek=False,
+            reasoning_config={"enabled": True, "effort": "high"},
+        )
+        # Kimi path sets reasoning_effort to "high" (same value, but via Kimi logic)
+        assert kw["reasoning_effort"] == "high"
+
+
 class TestChatCompletionsCacheStats:
 
     def test_no_usage(self, transport):

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -49,6 +49,81 @@ class TestChatCompletionsBasic:
 
 class TestChatCompletionsBuildKwargs:
 
+    def test_gemini_adds_thinking_config(self, transport):
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gemini-2.5-pro", messages=msgs,
+            is_gemini=True,
+            reasoning_config={"enabled": True, "effort": "medium"}
+        )
+        assert kw["extra_body"]["google"]["thinking_config"]["include_thoughts"] is True
+        assert kw["extra_body"]["google"]["thinking_config"]["thinking_budget"] == 1024
+
+    def test_gemini_effort_mapping(self, transport):
+        msgs = [{"role": "user", "content": "Hi"}]
+        
+        # xhigh -> 4096
+        kw1 = transport.build_kwargs(model="gemini", messages=msgs, is_gemini=True, reasoning_config={"enabled": True, "effort": "xhigh"})
+        assert kw1["extra_body"]["google"]["thinking_config"]["thinking_budget"] == 4096
+        
+        # max -> 4096
+        kw2 = transport.build_kwargs(model="gemini", messages=msgs, is_gemini=True, reasoning_config={"enabled": True, "effort": "max"})
+        assert kw2["extra_body"]["google"]["thinking_config"]["thinking_budget"] == 4096
+        
+        # high -> 2048
+        kw3 = transport.build_kwargs(model="gemini", messages=msgs, is_gemini=True, reasoning_config={"enabled": True, "effort": "high"})
+        assert kw3["extra_body"]["google"]["thinking_config"]["thinking_budget"] == 2048
+        
+        # medium -> 1024
+        kw4 = transport.build_kwargs(model="gemini", messages=msgs, is_gemini=True, reasoning_config={"enabled": True, "effort": "medium"})
+        assert kw4["extra_body"]["google"]["thinking_config"]["thinking_budget"] == 1024
+        
+        # low -> 512
+        kw5 = transport.build_kwargs(model="gemini", messages=msgs, is_gemini=True, reasoning_config={"enabled": True, "effort": "low"})
+        assert kw5["extra_body"]["google"]["thinking_config"]["thinking_budget"] == 512
+        
+        # minimal -> 512
+        kw6 = transport.build_kwargs(model="gemini", messages=msgs, is_gemini=True, reasoning_config={"enabled": True, "effort": "minimal"})
+        assert kw6["extra_body"]["google"]["thinking_config"]["thinking_budget"] == 512
+
+    def test_gemini_disabled_reasoning_skips(self, transport):
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gemini-2.5-pro", messages=msgs,
+            is_gemini=True,
+            reasoning_config={"enabled": False}
+        )
+        eb = kw.get("extra_body", {})
+        assert "google" not in eb
+
+    def test_non_gemini_no_thinking_config(self, transport):
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-4o", messages=msgs,
+            is_gemini=False,
+            reasoning_config={"enabled": True, "effort": "xhigh"}
+        )
+        eb = kw.get("extra_body", {})
+        assert "google" not in eb
+
+    def test_gemini_default_effort_medium(self, transport):
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gemini-2.5-pro", messages=msgs,
+            is_gemini=True,
+            reasoning_config={"enabled": True}  # no effort specified
+        )
+        assert kw["extra_body"]["google"]["thinking_config"]["thinking_budget"] == 1024
+
+    def test_gemini_include_thoughts_true(self, transport):
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gemini-2.5-pro", messages=msgs,
+            is_gemini=True,
+            reasoning_config={"enabled": True, "effort": "high"}
+        )
+        assert kw["extra_body"]["google"]["thinking_config"]["include_thoughts"] is True
+
     def test_basic_kwargs(self, transport):
         msgs = [{"role": "user", "content": "Hello"}]
         kw = transport.build_kwargs(model="gpt-4o", messages=msgs, timeout=30.0)

--- a/tests/run_agent/test_deepseek_content_null.py
+++ b/tests/run_agent/test_deepseek_content_null.py
@@ -1,0 +1,107 @@
+import pytest
+from unittest.mock import MagicMock
+
+# We'll create a minimal mock of AIAgent to test the message preparation logic
+class MockAIAgent:
+    def __init__(self, provider="deepseek", model="deepseek-reasoner"):
+        self.provider = provider
+        self.model = model
+        
+    def _needs_deepseek_tool_reasoning(self):
+        provider = (self.provider or "").lower()
+        model = (self.model or "").lower()
+        return (
+            provider == "deepseek"
+            or provider == "liaobots"
+            or model.startswith("deepseek-reasoner")
+        )
+
+    def _prepare_api_messages(self, messages):
+        # Extracted minimal logic from run_agent.py lines 9060-9079 and 9718-9734
+        api_messages = []
+        for msg in messages:
+            api_msg = msg.copy()
+
+            if (
+                api_msg.get("role") == "assistant"
+                and api_msg.get("content") == ""
+                and api_msg.get("tool_calls")
+                and self._needs_deepseek_tool_reasoning()
+            ):
+                api_msg["content"] = None
+
+            api_messages.append(api_msg)
+        return api_messages
+
+
+def test_content_empty_string_converted_to_none():
+    agent = MockAIAgent(provider="deepseek")
+    messages = [
+        {"role": "assistant", "content": "", "tool_calls": [{"id": "call_1"}]}
+    ]
+    
+    api_messages = agent._prepare_api_messages(messages)
+    
+    assert len(api_messages) == 1
+    assert api_messages[0]["content"] is None
+    assert api_messages[0]["tool_calls"] is not None
+
+
+def test_content_non_empty_unchanged():
+    agent = MockAIAgent(provider="deepseek")
+    messages = [
+        {"role": "assistant", "content": "hello", "tool_calls": [{"id": "call_1"}]}
+    ]
+    
+    api_messages = agent._prepare_api_messages(messages)
+    
+    assert len(api_messages) == 1
+    assert api_messages[0]["content"] == "hello"
+
+
+def test_no_tool_calls_unchanged():
+    agent = MockAIAgent(provider="deepseek")
+    messages = [
+        {"role": "assistant", "content": ""}
+    ]
+    
+    api_messages = agent._prepare_api_messages(messages)
+    
+    assert len(api_messages) == 1
+    assert api_messages[0]["content"] == ""
+
+
+def test_non_deepseek_unchanged():
+    agent = MockAIAgent(provider="openai", model="gpt-4")
+    messages = [
+        {"role": "assistant", "content": "", "tool_calls": [{"id": "call_1"}]}
+    ]
+    
+    api_messages = agent._prepare_api_messages(messages)
+    
+    assert len(api_messages) == 1
+    assert api_messages[0]["content"] == ""
+
+
+def test_user_message_unchanged():
+    agent = MockAIAgent(provider="deepseek")
+    messages = [
+        {"role": "user", "content": "", "tool_calls": [{"id": "call_1"}]}
+    ]
+    
+    api_messages = agent._prepare_api_messages(messages)
+    
+    assert len(api_messages) == 1
+    assert api_messages[0]["content"] == ""
+
+
+def test_tool_message_unchanged():
+    agent = MockAIAgent(provider="deepseek")
+    messages = [
+        {"role": "tool", "content": "", "tool_calls": [{"id": "call_1"}]}
+    ]
+    
+    api_messages = agent._prepare_api_messages(messages)
+    
+    assert len(api_messages) == 1
+    assert api_messages[0]["content"] == ""


### PR DESCRIPTION
## Summary
Fixes for DeepSeek API compatibility and adds Gemini thinking support for OpenAI-compatible providers.

### Changes
- **DeepSeek reasoning_effort**: Send `reasoning_effort` and `extra_body.thinking` to DeepSeek direct API (`agent/transports/chat_completions.py`)
- **DeepSeek content=null**: Set `content=null` for tool-call messages in API replay to match DeepSeek API requirements (`run_agent.py`)
- **Gemini thinking_config**: Support `thinking_config` (thinking_budget) for Gemini models via OpenAI-compatible providers like Liaobots (`agent/transports/chat_completions.py`, `run_agent.py`)

### Test Plan
- `tests/agent/transports/test_chat_completions.py` — Transport-level API format tests
- `tests/run_agent/test_deepseek_content_null.py` — Content=null handling tests
