### PR TITLE
fix(timeouts): guard load_config() call against runtime exceptions

### DIFF
--- a/hermes_cli/timeouts.py
+++ b/hermes_cli/timeouts.py
@@ -20,10 +20,10 @@ def get_provider_request_timeout(
 
     try:
         from hermes_cli.config import load_config
-    except ImportError:
+        config = load_config()
+    except (ImportError, Exception):
         return None
 
-    config = load_config()
     providers = config.get("providers", {}) if isinstance(config, dict) else {}
     provider_config = (
         providers.get(provider_id, {}) if isinstance(providers, dict) else {}
@@ -49,10 +49,10 @@ def get_provider_stale_timeout(
 
     try:
         from hermes_cli.config import load_config
-    except ImportError:
+        config = load_config()
+    except (ImportError, Exception):
         return None
 
-    config = load_config()
     providers = config.get("providers", {}) if isinstance(config, dict) else {}
     provider_config = (
         providers.get(provider_id, {}) if isinstance(providers, dict) else {}

--- a/hermes_cli/timeouts.py
+++ b/hermes_cli/timeouts.py
@@ -21,7 +21,7 @@ def get_provider_request_timeout(
     try:
         from hermes_cli.config import load_config
         config = load_config()
-    except (ImportError, Exception):
+    except Exception:
         return None
 
     providers = config.get("providers", {}) if isinstance(config, dict) else {}
@@ -50,7 +50,7 @@ def get_provider_stale_timeout(
     try:
         from hermes_cli.config import load_config
         config = load_config()
-    except (ImportError, Exception):
+    except Exception:
         return None
 
     providers = config.get("providers", {}) if isinstance(config, dict) else {}


### PR DESCRIPTION
Salvage of #16232 by @sprmn24.

## Summary
`get_provider_request_timeout()` and `get_provider_stale_timeout()` wrapped only the `load_config` **import** in try/except. The actual `load_config()` call sat outside. `load_config()` calls `ensure_hermes_home()` before its own internal YAML-parse guard — so PermissionError on mkdir, RuntimeError in managed mode, or any other bootstrap failure would propagate up into ~14 call sites in run_agent.py and crash the agent loop on every API call.

## Changes
- `hermes_cli/timeouts.py`: move `load_config()` inside the try block in both helpers, broaden to `except Exception` (follow-up commit dropped redundant `(ImportError, Exception)`).

## Validation
| | Before | After |
|---|---|---|
| load_config() raises PermissionError | propagates | returns None |
| Existing tests | 12 passed | 12 passed |

E2E verified by monkey-patching `load_config` to raise PermissionError — both helpers return None cleanly.

Closes #16232. Contributor authorship preserved via rebase merge.