### PR TITLE
fix(discord_tool): coerce limit parameter to int before min() call

### DIFF
--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -328,6 +328,10 @@ def _member_info(token: str, guild_id: str, user_id: str, **_kwargs: Any) -> str
 
 def _search_members(token: str, guild_id: str, query: str, limit: int = 20, **_kwargs: Any) -> str:
     """Search for guild members by name."""
+    try:
+        limit = int(limit)
+    except (TypeError, ValueError):
+        limit = 20
     params = {"query": query, "limit": str(min(limit, 100))}
     members = _discord_request("GET", f"/guilds/{guild_id}/members/search", token, params=params)
     result = []
@@ -350,6 +354,10 @@ def _fetch_messages(
     **_kwargs: Any,
 ) -> str:
     """Fetch recent messages from a channel."""
+    try:
+        limit = int(limit)
+    except (TypeError, ValueError):
+        limit = 50
     params: Dict[str, str] = {"limit": str(min(limit, 100))}
     if before:
         params["before"] = before


### PR DESCRIPTION
Salvage of #16245 — cherry-picks only the Discord hunk. Dropped three unrelated commits (whatsapp regex guard, shell_hooks bool parsing, timeouts except-Exception swallow) that were in the original PR without being mentioned in title/body.

## Summary
LLM tool calls can send `limit` as a string; `min("10", 100)` raises `TypeError`. Fix coerces via `int()` with a safe fallback (20 for member search, 50 for message fetch).

## Changes
- tools/discord_tool.py: int-coerce `limit` at the top of `_search_members` and `_fetch_messages`.

## Validation
Confirmed `min("10", 100)` raises TypeError on main. Coercion loop handles str/int/None/garbage + clamps >100 correctly.

Authored by @sprmn24, cherry-picked with authorship preserved.