### PR TITLE
fix(whatsapp_identity): restrict identifiers to ASCII JID charset before mapping lookup

### DIFF
--- a/gateway/whatsapp_identity.py
+++ b/gateway/whatsapp_identity.py
@@ -37,6 +37,11 @@ from typing import Set
 
 logger = logging.getLogger(__name__)
 
+# WhatsApp JIDs are numeric (or plus-prefixed numeric) with optional
+# ``@``, ``.`` and ``:`` separators. ``\w`` is pinned to ASCII so
+# full-width digits / Unicode word chars can't sneak through.
+_SAFE_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9@.+\-]+$")
+
 from hermes_constants import get_hermes_home
 
 
@@ -85,7 +90,15 @@ def expand_whatsapp_aliases(identifier: str) -> Set[str]:
         current = queue.pop(0)
         if not current or current in resolved:
             continue
-        if not re.match(r'^[\w@.+-]+$', current):
+        # Defense-in-depth: reject identifiers that could sneak path
+        # separators / traversal segments into the ``lid-mapping-{current}``
+        # filename below. The hardcoded ``lid-mapping-`` prefix already
+        # prevents escape via pathlib's component split (an attacker can't
+        # create ``lid-mapping-..`` as a real directory in session_dir), but
+        # this keeps the identifier space to the characters WhatsApp JIDs
+        # actually use and avoids depending on that filesystem-layout
+        # invariant.
+        if not _SAFE_IDENTIFIER_RE.match(current):
             continue
 
         resolved.add(current)

--- a/gateway/whatsapp_identity.py
+++ b/gateway/whatsapp_identity.py
@@ -31,7 +31,11 @@ Hermes' own session keys.
 from __future__ import annotations
 
 import json
+import logging
+import re
 from typing import Set
+
+logger = logging.getLogger(__name__)
 
 from hermes_constants import get_hermes_home
 
@@ -81,6 +85,8 @@ def expand_whatsapp_aliases(identifier: str) -> Set[str]:
         current = queue.pop(0)
         if not current or current in resolved:
             continue
+        if not re.match(r'^[\w@.+-]+$', current):
+            continue
 
         resolved.add(current)
         for suffix in ("", "_reverse"):
@@ -91,7 +97,8 @@ def expand_whatsapp_aliases(identifier: str) -> Set[str]:
                 mapped = normalize_whatsapp_identifier(
                     json.loads(mapping_path.read_text(encoding="utf-8"))
                 )
-            except Exception:
+            except (OSError, json.JSONDecodeError) as exc:
+                logger.debug("whatsapp_identity: failed to read %s: %s", mapping_path, exc)
                 continue
             if mapped and mapped not in resolved:
                 queue.append(mapped)


### PR DESCRIPTION
Salvages the substantive change from #16243 (@sprmn24) — rejects anything other than the characters real WhatsApp JIDs use before `expand_whatsapp_aliases()` interpolates an identifier into `lid-mapping-{current}{suffix}.json`, and narrows the bare `except Exception` on mapping-file reads to `(OSError, json.JSONDecodeError)` with a debug log.

## Framing

Defense-in-depth, not a live traversal fix. The hardcoded `lid-mapping-` prefix already prevents escape via pathlib's component split: with `current='../secrets'` the first path component under `session/` is the literal directory name `lid-mapping-..`, which an attacker can't create. Verified locally — `expand_whatsapp_aliases('../secrets')` returns an empty set on current main, no file access outside `session_dir`. Still worth landing — it removes the filesystem-layout dependency and kills the bare `except Exception`.

## Changes
- `gateway/whatsapp_identity.py`: reject identifiers not matching `^[A-Za-z0-9@.+\\-]+$` (compiled once as `_SAFE_IDENTIFIER_RE`, ASCII-pinned so full-width digits / accented chars can't sneak through `\w`).
- Narrow `except Exception` → `except (OSError, json.JSONDecodeError)` with `logger.debug`.

Dropped from the original PR: the unrelated `hermes_cli/timeouts.py` hunk, which changed `except ImportError` to `except (ImportError, Exception)`. That's equivalent to `except Exception` and silently swallows any `load_config()` failure — opposite of what we want.

## Validation

E2E with a real mapping chain + probed attack strings:

| Input | Result |
|---|---|
| `60123@s.whatsapp.net` (legit, chained to `9999@lid`) | `{'60123', '9999'}` — chain resolves |
| `../secrets`, `../../etc/passwd`, `/etc/passwd`, `foo/bar`, `abc;rm`, `<script>` | `set()` — rejected before file access |
| `１２３` (full-width), `𝟏𝟐𝟑`, `café` | `set()` — ASCII pin rejects, `\w` would have accepted |

Closes #16243.

Credit: @sprmn24 — your commit is preserved via rebase-merge.