### PR TITLE
fix(model-switch): treat custom:* providers as custom in is_custom guard (#16259)

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -787,6 +787,7 @@ def switch_model(
         # --- Step e: detect_provider_for_model() as last resort ---
         _base = current_base_url or ""
         is_custom = current_provider in ("custom", "local") or (
+            current_provider.startswith("custom:") or
             "localhost" in _base or "127.0.0.1" in _base
         )
 

--- a/tests/hermes_cli/test_model_switch_custom_prefix.py
+++ b/tests/hermes_cli/test_model_switch_custom_prefix.py
@@ -10,9 +10,7 @@ Regression for #16259: is_custom guard only checked for bare "custom" and
 to silently switch to openrouter when it recognized the model slug.
 """
 
-from unittest.mock import patch, MagicMock
-
-import pytest
+from unittest.mock import patch
 
 from hermes_cli.model_switch import switch_model
 
@@ -128,4 +126,4 @@ class TestCustomPrefixIsCustomGuard:
             detect_return=("openrouter", "nvidia/nemotron-3-super-120b-a12b"),
         )
         mock_detect.assert_not_called()
-        assert result.target_provider != "openrouter" or not result.success
+        assert result.target_provider == "custom:custom"

--- a/tests/hermes_cli/test_model_switch_custom_prefix.py
+++ b/tests/hermes_cli/test_model_switch_custom_prefix.py
@@ -79,6 +79,7 @@ class TestCustomPrefixIsCustomGuard:
             current_provider="custom:custom",
         )
         mock_detect.assert_not_called()
+        assert result.target_provider == "custom:custom"
 
     def test_custom_colon_named_does_not_call_detect(self):
         """custom:neuralwatt (any named custom: prefix) must not invoke detect."""
@@ -97,6 +98,7 @@ class TestCustomPrefixIsCustomGuard:
             ],
         )
         mock_detect.assert_not_called()
+        assert result.target_provider == "custom:neuralwatt"
 
     def test_bare_custom_still_does_not_call_detect(self):
         """Bare 'custom' provider remains protected (pre-existing behavior)."""
@@ -106,6 +108,7 @@ class TestCustomPrefixIsCustomGuard:
             current_base_url="https://custom.example.com/v1",
         )
         mock_detect.assert_not_called()
+        assert result.target_provider == "custom"
 
     def test_non_custom_provider_does_call_detect(self):
         """Non-custom providers like openrouter still trigger detect (unchanged behavior)."""

--- a/tests/hermes_cli/test_model_switch_custom_prefix.py
+++ b/tests/hermes_cli/test_model_switch_custom_prefix.py
@@ -1,0 +1,131 @@
+"""Regression tests for /model auto-detect not hijacking custom:* providers.
+
+When current_provider starts with "custom:" (e.g. "custom:custom",
+"custom:neuralwatt"), detect_provider_for_model() must NOT be called —
+these are user-defined endpoints that should never be auto-redirected to
+OpenRouter or another catalog provider.
+
+Regression for #16259: is_custom guard only checked for bare "custom" and
+"local", so "custom:custom" was treated as non-custom, allowing auto-detect
+to silently switch to openrouter when it recognized the model slug.
+"""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from hermes_cli.model_switch import switch_model
+
+
+_MOCK_VALIDATION = {
+    "accepted": True,
+    "persist": True,
+    "recognized": True,
+    "message": None,
+}
+
+_CUSTOM_PROVIDERS = [
+    {
+        "name": "My Nous Portal",
+        "slug": "custom:custom",
+        "base_url": "https://portal.nousresearch.com/v1",
+        "api_key": "np-test-key",
+        "model": "nvidia/nemotron-3-super-120b-a12b",
+    }
+]
+
+
+def _run_switch(raw_input, current_provider, current_base_url="https://portal.nousresearch.com/v1",
+                current_model="nvidia/nemotron-3-super-120b-a12b",
+                detect_return=None, custom_providers=None):
+    if custom_providers is None:
+        custom_providers = _CUSTOM_PROVIDERS
+    with (
+        patch("hermes_cli.model_switch.resolve_alias", return_value=None),
+        patch("hermes_cli.model_switch.list_provider_models", return_value=[]),
+        patch("hermes_cli.model_switch.is_aggregator", return_value=False),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value={
+                "api_key": "np-test-key",
+                "base_url": current_base_url,
+                "api_mode": "chat_completions",
+                "provider": current_provider,
+            },
+        ),
+        patch("hermes_cli.models.validate_requested_model", return_value=_MOCK_VALIDATION),
+        patch("hermes_cli.model_switch.get_model_info", return_value=None),
+        patch("hermes_cli.model_switch.get_model_capabilities", return_value=None),
+        patch(
+            "hermes_cli.models.detect_provider_for_model",
+            return_value=detect_return,
+        ) as mock_detect,
+    ):
+        result = switch_model(
+            raw_input=raw_input,
+            current_provider=current_provider,
+            current_model=current_model,
+            current_base_url=current_base_url,
+            current_api_key="np-test-key",
+            custom_providers=custom_providers,
+        )
+        return result, mock_detect
+
+
+class TestCustomPrefixIsCustomGuard:
+
+    def test_custom_colon_custom_does_not_call_detect(self):
+        """custom:custom provider must not invoke detect_provider_for_model."""
+        result, mock_detect = _run_switch(
+            raw_input="nvidia/nemotron-super-2",
+            current_provider="custom:custom",
+        )
+        mock_detect.assert_not_called()
+
+    def test_custom_colon_named_does_not_call_detect(self):
+        """custom:neuralwatt (any named custom: prefix) must not invoke detect."""
+        result, mock_detect = _run_switch(
+            raw_input="hermes-3-70b",
+            current_provider="custom:neuralwatt",
+            current_base_url="https://api.neuralwatt.ai/v1",
+            custom_providers=[
+                {
+                    "name": "NeuralWatt",
+                    "slug": "custom:neuralwatt",
+                    "base_url": "https://api.neuralwatt.ai/v1",
+                    "api_key": "nw-key",
+                    "model": "hermes-3-70b",
+                }
+            ],
+        )
+        mock_detect.assert_not_called()
+
+    def test_bare_custom_still_does_not_call_detect(self):
+        """Bare 'custom' provider remains protected (pre-existing behavior)."""
+        result, mock_detect = _run_switch(
+            raw_input="some-model",
+            current_provider="custom",
+            current_base_url="https://custom.example.com/v1",
+        )
+        mock_detect.assert_not_called()
+
+    def test_non_custom_provider_does_call_detect(self):
+        """Non-custom providers like openrouter still trigger detect (unchanged behavior)."""
+        _result, mock_detect = _run_switch(
+            raw_input="nvidia/nemotron-super-2",
+            current_provider="openrouter",
+            current_base_url="",
+            detect_return=None,  # detect returns None → provider unchanged
+        )
+        mock_detect.assert_called_once()
+
+    def test_detect_cannot_redirect_custom_colon_to_openrouter(self):
+        """Even if detect_provider_for_model would return openrouter, it must
+        not be called for custom:* providers — provider must stay unchanged."""
+        result, mock_detect = _run_switch(
+            raw_input="nvidia/nemotron-3-super-120b-a12b",
+            current_provider="custom:custom",
+            detect_return=("openrouter", "nvidia/nemotron-3-super-120b-a12b"),
+        )
+        mock_detect.assert_not_called()
+        assert result.target_provider != "openrouter" or not result.success


### PR DESCRIPTION
## Summary
- Extends the `is_custom` guard at step e of `/model`'s no-explicit-provider path to include `current_provider.startswith("custom:")`
- Prevents `detect_provider_for_model()` from firing on `custom:NAME` providers (custom:custom, custom:neuralwatt, etc.)
- 5 new regression tests

## The bug

`model_switch.py:782`: the `is_custom` guard only matched bare `"custom"` and `"local"`:

```python
is_custom = current_provider in ("custom", "local") or (
    "localhost" in _base or "127.0.0.1" in _base
)
```

Any `custom:NAME` provider (e.g. `custom:custom`) evaluated `is_custom=False`. This allowed step e (`detect_provider_for_model()`) to fire and silently rewrite the provider to `openrouter` when the model slug was found in the OpenRouter catalog — causing 401/402 errors for users with no `OPENROUTER_API_KEY`.

## The fix

```python
is_custom = current_provider in ("custom", "local") or (
    current_provider.startswith("custom:") or      # ← new
    "localhost" in _base or "127.0.0.1" in _base
)
```

One-line addition. The `custom:` prefix is already used throughout the codebase (e.g. `model_switch.py:801`, `list_authenticated_providers`, `resolve_provider_full`) as the canonical slug format for user-defined providers. The `is_custom` guard was the only place that didn't recognise this format.

## Test plan
- [x] **Before**: `custom:custom` → `is_custom=False` → `detect_provider_for_model` called → provider rewritten to `openrouter`
- [x] **After**: `custom:custom` → `is_custom=True` → `detect_provider_for_model` skipped → provider unchanged
- [x] Regression guard: reverted the fix → `test_custom_colon_custom_does_not_call_detect` fails (detect IS called); restored → all 5 tests pass
- [x] Full model_switch test suite (35 tests) unchanged

## Related
- Fixes #16259

🤖 Generated with [Claude Code](https://claude.com/claude-code)