### PR TITLE
Route Slack through Claude Code OAuth

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -312,6 +312,98 @@ def _normalize_base_url_text(base_url) -> str:
     return str(base_url).strip()
 
 
+# ── Token source / counters / validation helpers ─────────────────────
+# These give operators visibility on which token Sacha is using and whether
+# the OAuth subscription quota is healthy. Without this, surprise charges
+# can happen because OAuth 401s silently fall back to the paid API key.
+
+_AUTH_COUNTERS: Dict[str, int] = {"OAUTH": 0, "API_KEY": 0}
+
+
+def _bump_auth_counter(auth_type: str) -> None:
+    """Increment the per-process counter for an auth_type (OAUTH or API_KEY)."""
+    if auth_type in _AUTH_COUNTERS:
+        _AUTH_COUNTERS[auth_type] += 1
+
+
+def get_auth_counters() -> Dict[str, int]:
+    """Return a copy of the per-process auth_type counters."""
+    return dict(_AUTH_COUNTERS)
+
+
+def describe_token_source(api_key: str) -> str:
+    """Identify where a given resolved token most plausibly came from.
+
+    Best-effort matching: returns one of
+      env_anthropic_token / env_claude_code / env_anthropic_api_key /
+      claude_creds / hermes_oauth / managed_key / unknown
+    """
+    if not api_key:
+        return "unknown"
+    try:
+        env_anthropic_token = os.getenv("ANTHROPIC_TOKEN", "").strip()
+        if env_anthropic_token and env_anthropic_token == api_key:
+            return "env_anthropic_token"
+        env_cc = os.getenv("CLAUDE_CODE_OAUTH_TOKEN", "").strip()
+        if env_cc and env_cc == api_key:
+            return "env_claude_code"
+        env_apikey = os.getenv("ANTHROPIC_API_KEY", "").strip()
+        if env_apikey and env_apikey == api_key:
+            return "env_anthropic_api_key"
+        creds = read_claude_code_credentials()
+        if creds and creds.get("accessToken") == api_key:
+            return "claude_creds"
+        hh = read_hermes_oauth_credentials()
+        if hh and hh.get("accessToken") == api_key:
+            return "hermes_oauth"
+        managed = read_claude_managed_key()
+        if managed and managed == api_key:
+            return "managed_key"
+    except Exception:
+        return "unknown"
+    return "unknown"
+
+
+def validate_oauth_token(api_key: str, base_url: Optional[str] = None,
+                         timeout: float = 5.0) -> Dict[str, Any]:
+    """Ping Anthropic with a tiny request to validate the token is alive.
+
+    Returns dict {valid: bool, status_code: int|None, error_message: str|None,
+    auth_type: str}. Used by the gateway at startup to detect dead OAuth
+    tokens before any user message arrives, so the operator gets a Slack
+    alert proactively instead of being charged on the next API_KEY fallback.
+
+    The validation call sends a 1-token "hi" prompt to claude-haiku and reads
+    only the status code. On any 4xx the token is considered invalid.
+    """
+    result: Dict[str, Any] = {
+        "valid": False,
+        "status_code": None,
+        "error_message": None,
+        "auth_type": "OAUTH" if _is_oauth_token(api_key) else "API_KEY",
+    }
+    if not api_key:
+        result["error_message"] = "no token provided"
+        return result
+    try:
+        client = build_anthropic_client(api_key, base_url)
+        # claude-haiku is cheapest; max_tokens=1 keeps cost negligible.
+        # Note: this WILL consume ~10-20 tokens of quota / billing. Use sparingly.
+        client.messages.create(
+            model="claude-haiku-4-5-20251001",
+            max_tokens=1,
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        result["valid"] = True
+        result["status_code"] = 200
+        return result
+    except Exception as e:
+        # Anthropic SDK puts status_code on most errors
+        result["status_code"] = getattr(e, "status_code", None)
+        result["error_message"] = str(e)[:300]
+        return result
+
+
 def _is_third_party_anthropic_endpoint(base_url: str | None) -> bool:
     """Return True for non-Anthropic endpoints using the Anthropic Messages API.
 
@@ -418,9 +510,13 @@ def build_anthropic_client(api_key: str, base_url: str = None, timeout: float = 
         # Check this before OAuth token shape detection because MiniMax secrets do
         # not use Anthropic's sk-ant-api prefix and would otherwise be misread as
         # Anthropic OAuth/setup tokens.
+        # Same x-api-key shadowing protection as the OAuth branch.
         kwargs["auth_token"] = api_key
+        kwargs["api_key"] = ""
+        _bearer_headers = {"x-api-key": ""}
         if common_betas:
-            kwargs["default_headers"] = {"anthropic-beta": ",".join(common_betas)}
+            _bearer_headers["anthropic-beta"] = ",".join(common_betas)
+        kwargs["default_headers"] = _bearer_headers
     elif _is_third_party_anthropic_endpoint(base_url):
         # Third-party proxies (Azure AI Foundry, AWS Bedrock, etc.) use their
         # own API keys with x-api-key auth. Skip OAuth detection — their keys
@@ -433,12 +529,19 @@ def build_anthropic_client(api_key: str, base_url: str = None, timeout: float = 
         # OAuth access token / setup-token → Bearer auth + Claude Code identity.
         # Anthropic routes OAuth requests based on user-agent and headers;
         # without Claude Code's fingerprint, requests get intermittent 500s.
+        # CRITICAL: pass api_key="" to prevent the SDK from auto-loading
+        # ANTHROPIC_API_KEY env var and sending it as x-api-key alongside
+        # our Bearer token (Anthropic prefers x-api-key and would 401 if it
+        # is wrong, or bill it if it is valid -- root cause of past charges).
         all_betas = common_betas + _OAUTH_ONLY_BETAS
         kwargs["auth_token"] = api_key
+        kwargs["api_key"] = ""
         kwargs["default_headers"] = {
             "anthropic-beta": ",".join(all_betas),
             "user-agent": f"claude-cli/{_get_claude_code_version()} (external, cli)",
             "x-app": "cli",
+            # Override so the SDK can't fall back to env var injection.
+            "x-api-key": "",
         }
     else:
         # Regular API key → x-api-key header + common betas
@@ -448,14 +551,31 @@ def build_anthropic_client(api_key: str, base_url: str = None, timeout: float = 
 
     # ── Auth type logging ─────────────────────────────────────────────
     # Emits AUTH_CALL at INFO level so every Anthropic SDK client creation
-    # is traceable in agent.log. The key is truncated (redacted further by
-    # RedactingFormatter). auth_type=OAUTH means Bearer auth via subscription
-    # quota; auth_type=API_KEY means x-api-key header billed per token.
+    # is traceable in agent.log. Includes:
+    #   - auth_type: OAUTH (Bearer, subscription quota) or API_KEY (x-api-key, paid)
+    #   - source: env_token / env_apikey / claude_creds / hermes_oauth / unknown
+    #     so we can detect when a token came from a different place than expected
+    #   - cumulative counters (oauth=N api_key=M) per process — a sudden spike
+    #     in api_key without OAuth maintenance signals a quota/credential issue
     _key_preview = (api_key or "")[:24] + "..." if api_key and len(api_key) > 24 else (api_key or "none")
     _auth_type = "OAUTH" if (_is_oauth_token(api_key) or _requires_bearer_auth(base_url)) else "API_KEY"
-    logger.info("AUTH_CALL: auth_type=%s key=%s", _auth_type, _key_preview)
+    _source = describe_token_source(api_key)
+    _bump_auth_counter(_auth_type)
+    logger.info(
+        "AUTH_CALL: auth_type=%s source=%s key=%s totals=oauth:%d/api_key:%d",
+        _auth_type, _source, _key_preview,
+        _AUTH_COUNTERS.get("OAUTH", 0), _AUTH_COUNTERS.get("API_KEY", 0),
+    )
 
-    return _anthropic_sdk.Anthropic(**kwargs)
+    client = _anthropic_sdk.Anthropic(**kwargs)
+    # Tag and wrap the client at construction time so every SDK call path
+    # (messages.create, messages.stream, auxiliary clients, future call sites)
+    # gets the Claude Code identity prompt. This is intentionally done here
+    # instead of only at individual call sites: missed call sites caused real
+    # HTTP 400 "Third-party apps" failures.
+    setattr(client, "_hermes_is_oauth", _is_oauth_token(api_key))
+    _wrap_anthropic_messages_for_identity(client)
+    return client
 
 
 def build_anthropic_bedrock_client(region: str):
@@ -544,6 +664,113 @@ def _read_claude_code_credentials_from_keychain() -> Optional[Dict[str, Any]]:
 
     return None
 
+
+# Anthropic classifies OAuth requests as "third-party" (drawing from extra
+# usage credits) UNLESS the system prompt starts with the official Claude
+# Code identity string. Injecting this prefix keeps subscription quota usage
+# active. See:
+#   https://github.com/router-for-me/CLIProxyAPI/issues/2599
+#   https://github.com/griffinmartin/opencode-claude-auth/issues/145
+CLAUDE_CODE_IDENTITY_PROMPT = (
+    "You are Claude Code, Anthropic's official CLI for Claude."
+)
+
+
+def inject_claude_code_identity(api_kwargs: dict) -> dict:
+    """Prefix the request system field with the Claude Code identity string.
+
+    Mutates and returns api_kwargs. Idempotent. Handles both string and
+    list-of-blocks system shapes (the latter is used for prompt-caching).
+    """
+    sys_val = api_kwargs.get("system")
+    identity = CLAUDE_CODE_IDENTITY_PROMPT
+
+    if not sys_val:
+        api_kwargs["system"] = identity
+        return api_kwargs
+
+    if isinstance(sys_val, str):
+        if sys_val.lstrip().startswith(identity):
+            return api_kwargs
+        api_kwargs["system"] = identity + "\n\n" + sys_val
+        return api_kwargs
+
+    if isinstance(sys_val, list):
+        # Claude's server-side OAuth classifier is currently fragile with
+        # prompt-caching style system blocks. The same prompt as a plain string
+        # routes to plan quota (429 when limited), while the list-of-blocks
+        # shape routes to the "third-party extra usage" bucket (HTTP 400).
+        #
+        # Flatten to a string right before send. This sacrifices system prompt
+        # cache_control, but preserves the prompt content and keeps OAuth usable.
+        text_parts = []
+        for block in sys_val:
+            if isinstance(block, dict) and block.get("type") == "text":
+                text = block.get("text", "")
+                if isinstance(text, str) and text.strip():
+                    text_parts.append(text)
+            elif isinstance(block, str) and block.strip():
+                text_parts.append(block)
+        flat = "\n\n".join(text_parts).strip()
+        if flat.lstrip().startswith(identity):
+            api_kwargs["system"] = flat
+        elif flat:
+            api_kwargs["system"] = identity + "\n\n" + flat
+        else:
+            api_kwargs["system"] = identity
+        return api_kwargs
+
+    return api_kwargs
+
+
+
+
+def _wrap_anthropic_messages_for_identity(client: Any) -> None:
+    """Monkey-patch Anthropic SDK message calls to inject Claude Code identity.
+
+    This is the last line of defense against Anthropic routing OAuth requests
+    to "third-party app" extra-usage credits. It catches every call path that
+    uses the client returned by build_anthropic_client(), including future or
+    auxiliary call sites that do not explicitly call inject_claude_code_identity.
+    """
+    messages = getattr(client, "messages", None)
+    if messages is None or getattr(messages, "_hermes_identity_wrapped", False):
+        return
+
+    def _inject_and_log(api_kwargs: dict, path: str) -> None:
+        try:
+            inject_claude_code_identity(api_kwargs)
+            messages = api_kwargs.get("messages") or []
+            tools = api_kwargs.get("tools") or []
+            system = api_kwargs.get("system")
+            system_blocks = len(system) if isinstance(system, list) else (1 if system else 0)
+            logger.info(
+                "CLAUDE_IDENTITY_SDK_WRAP path=%s model=%s max_tokens=%s "
+                "system_blocks=%s messages=%s tools=%s",
+                path,
+                api_kwargs.get("model"),
+                api_kwargs.get("max_tokens"),
+                system_blocks,
+                len(messages) if isinstance(messages, list) else "n/a",
+                len(tools) if isinstance(tools, list) else "n/a",
+            )
+        except Exception as exc:
+            logger.warning("CLAUDE_IDENTITY_SDK_WRAP_FAIL path=%s error=%s", path, exc)
+
+    orig_create = messages.create
+    orig_stream = messages.stream
+
+    def create_wrapper(*args: Any, **kwargs: Any):
+        _inject_and_log(kwargs, "messages.create")
+        return orig_create(*args, **kwargs)
+
+    def stream_wrapper(*args: Any, **kwargs: Any):
+        _inject_and_log(kwargs, "messages.stream")
+        return orig_stream(*args, **kwargs)
+
+    messages.create = create_wrapper
+    messages.stream = stream_wrapper
+    setattr(messages, "_hermes_identity_wrapped", True)
 
 def read_claude_code_credentials() -> Optional[Dict[str, Any]]:
     """Read refreshable Claude Code OAuth credentials.

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -446,6 +446,15 @@ def build_anthropic_client(api_key: str, base_url: str = None, timeout: float = 
         if common_betas:
             kwargs["default_headers"] = {"anthropic-beta": ",".join(common_betas)}
 
+    # ── Auth type logging ─────────────────────────────────────────────
+    # Emits AUTH_CALL at INFO level so every Anthropic SDK client creation
+    # is traceable in agent.log. The key is truncated (redacted further by
+    # RedactingFormatter). auth_type=OAUTH means Bearer auth via subscription
+    # quota; auth_type=API_KEY means x-api-key header billed per token.
+    _key_preview = (api_key or "")[:24] + "..." if api_key and len(api_key) > 24 else (api_key or "none")
+    _auth_type = "OAUTH" if (_is_oauth_token(api_key) or _requires_bearer_auth(base_url)) else "API_KEY"
+    logger.info("AUTH_CALL: auth_type=%s key=%s", _auth_type, _key_preview)
+
     return _anthropic_sdk.Anthropic(**kwargs)
 
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -629,6 +629,18 @@ class _AnthropicCompletionsAdapter:
             if not _forbids_sampling_params(model):
                 anthropic_kwargs["temperature"] = temperature
 
+        try:
+            from agent.anthropic_adapter import inject_claude_code_identity
+            inject_claude_code_identity(anthropic_kwargs)
+            import logging as _lg
+            _sys_preview = repr(anthropic_kwargs.get("system", ""))[:120]
+            _lg.getLogger(__name__).warning(
+                "CLAUDE_IDENTITY_INJECTED aux model=%s system=%s",
+                anthropic_kwargs.get("model"), _sys_preview,
+            )
+        except Exception as _e:
+            import logging as _lg
+            _lg.getLogger(__name__).warning("CLAUDE_IDENTITY_INJECT_FAIL aux: %s", _e)
         response = self._client.messages.create(**anthropic_kwargs)
         _transport = get_transport("anthropic_messages")
         _nr = _transport.normalize_response(
@@ -1952,7 +1964,10 @@ def resolve_provider_client(
         if provider == "anthropic":
             client, default_model = _try_anthropic()
             if client is None:
-                logger.warning("resolve_provider_client: anthropic requested but no Anthropic credentials found")
+                if os.getenv("HERMES_SLACK_CLAUDE_CODE_PRIMARY", "1").lower() in ("0", "false", "no"):
+                    logger.warning("resolve_provider_client: anthropic requested but no Anthropic credentials found")
+                else:
+                    logger.debug("resolve_provider_client: anthropic SDK credentials intentionally absent; Claude Code CLI primary is enabled")
                 return None, None
             final_model = _normalize_resolved_model(model or default_model, provider)
             return (_to_async_client(client, final_model) if async_mode else (client, final_model))

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -900,6 +900,19 @@ class CredentialPool:
         status_code: Optional[int],
         error_context: Optional[Dict[str, Any]] = None,
     ) -> Optional[PooledCredential]:
+        """Mark current credential as exhausted and rotate to the next one.
+
+        Cost-protection guard: by default, do NOT silently rotate from an
+        OAuth credential to a paid API key. OAuth tokens use the user's
+        subscription quota (free), API keys bill per-token. Auto-fallback
+        means a single OAuth 401 silently routes every subsequent call
+        through the paid key, producing surprise charges.
+
+        The fallback is gated by HERMES_ALLOW_OAUTH_TO_APIKEY_FALLBACK=1.
+        When blocked, we emit a Slack alert (if configured) so the operator
+        knows to regenerate the OAuth token instead of paying for it.
+        """
+        import os as _os
         with self._lock:
             entry = self.current() or self._select_unlocked()
             if entry is None:
@@ -914,6 +927,23 @@ class CredentialPool:
             self._mark_exhausted(entry, status_code, error_context)
             self._current_id = None
             next_entry = self._select_unlocked()
+
+            _allow_paid_fallback = _os.getenv("HERMES_ALLOW_OAUTH_TO_APIKEY_FALLBACK", "").lower() in ("1", "true", "yes")
+            _was_oauth = (_auth_ex or "").lower() == "oauth"
+            _next_auth_str = (getattr(next_entry, "auth_type", "") or "").lower() if next_entry else ""
+            _is_paid_fallback = _was_oauth and _next_auth_str == "api_key"
+
+            if _is_paid_fallback and not _allow_paid_fallback:
+                _next_label = next_entry.label or next_entry.id[:8] if next_entry else "?"
+                logger.warning(
+                    "CRED_BLOCK_FALLBACK: OAuth %s exhausted (status=%s); refusing silent rotation "
+                    "to paid api_key %s. Set HERMES_ALLOW_OAUTH_TO_APIKEY_FALLBACK=1 to allow. "
+                    "Regenerate the OAuth token to restore service.",
+                    _label, status_code, _next_label,
+                )
+                self._notify_oauth_dead(_label, status_code, _next_label)
+                return None
+
             if next_entry:
                 _next_label = next_entry.label or next_entry.id[:8]
                 _next_auth = getattr(next_entry, "auth_type", "unknown")
@@ -963,6 +993,39 @@ class CredentialPool:
                 self._active_leases.pop(credential_id, None)
             else:
                 self._active_leases[credential_id] = count - 1
+
+    @staticmethod
+    def _notify_oauth_dead(oauth_label: str, status_code: Optional[int], paid_label: str) -> None:
+        """Send a Slack alert when OAuth is dead and paid fallback is blocked."""
+        import os as _os
+        try:
+            token = _os.getenv("SLACK_BOT_TOKEN", "")
+            channel = _os.getenv("SLACK_OPERATOR_DM", "") or _os.getenv("SLACK_HOME_CHANNEL", "")
+            if not token or not channel:
+                return
+            import urllib.request as _ur
+            import json as _json
+            msg = (
+                f":rotating_light: *Token OAuth mort* (`{oauth_label}` -- status {status_code}).\n"
+                f"Le fallback automatique vers la cle payante `{paid_label}` est *bloque* "
+                f"(protection anti-debit).\n"
+                f"Pour restaurer le service : regenerer un token OAuth via `claude /login` "
+                f"ou `claude setup-token`, puis mettre a jour `CLAUDE_CODE_OAUTH_TOKEN` dans `.env`.\n"
+                f"Pour autoriser le fallback ponctuellement : "
+                f"`HERMES_ALLOW_OAUTH_TO_APIKEY_FALLBACK=1`."
+            )
+            data = _json.dumps({"channel": channel, "text": msg}).encode()
+            req = _ur.Request(
+                "https://slack.com/api/chat.postMessage",
+                data=data,
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "Content-Type": "application/json",
+                },
+            )
+            _ur.urlopen(req, timeout=5)
+        except Exception:
+            pass
 
     def try_refresh_current(self) -> Optional[PooledCredential]:
         with self._lock:

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -371,6 +371,34 @@ class CredentialPool:
         self._active_leases: Dict[str, int] = {}
         self._max_concurrent = DEFAULT_MAX_CONCURRENT_PER_CREDENTIAL
 
+    def log_pool_status(self) -> None:
+        """Log the current state of all credentials in the pool.
+
+        Emits one CRED_POOL log line per entry with auth_type (oauth/api_key),
+        key fingerprint (first 20 chars, redacted by RedactingFormatter),
+        current status, and remaining cooldown if exhausted.
+
+        Called at gateway startup so operators can immediately see which
+        credentials are available and whether OAuth is active or on cooldown.
+        """
+        with self._lock:
+            entries = list(self._entries)
+        for e in entries:
+            _auth = getattr(e, "auth_type", "unknown")
+            _key = (e.runtime_api_key or "")[:20]
+            _label = e.label or e.id[:8]
+            _status = getattr(e, "last_status", "?") or "ok"
+            _cooldown = ""
+            if getattr(e, "last_error_reset_at", None):
+                import time as _time
+                remaining = int(e.last_error_reset_at - _time.time())
+                if remaining > 0:
+                    _cooldown = f" cooldown={remaining}s"
+            logger.info(
+                "CRED_POOL: [%s] auth=%s key=%s status=%s%s",
+                _label, _auth, _key, _status, _cooldown,
+            )
+
     def has_credentials(self) -> bool:
         return bool(self._entries)
 
@@ -754,8 +782,19 @@ class CredentialPool:
         return False
 
     def select(self) -> Optional[PooledCredential]:
+        """Select the best available credential and log which one was chosen.
+
+        Logs CRED_SELECT with auth_type=oauth|api_key so operators can
+        track in agent.log exactly when OAuth vs the paid API key is used.
+        """
         with self._lock:
-            return self._select_unlocked()
+            entry = self._select_unlocked()
+            if entry is not None:
+                _auth = getattr(entry, "auth_type", "unknown")
+                _label = entry.label or entry.id[:8]
+                _key = (entry.runtime_api_key or "")[:20]
+                logger.info("CRED_SELECT: provider=%s auth_type=%s label=%s key=%s", self.provider, _auth, _label, _key)
+            return entry
 
     def _available_entries(self, *, clear_expired: bool = False, refresh: bool = False) -> List[PooledCredential]:
         """Return entries not currently in exhaustion cooldown.
@@ -866,16 +905,23 @@ class CredentialPool:
             if entry is None:
                 return None
             _label = entry.label or entry.id[:8]
+            _auth_ex = getattr(entry, "auth_type", "unknown")
+            _key_ex = (entry.runtime_api_key or "")[:20]
             logger.info(
-                "credential pool: marking %s exhausted (status=%s), rotating",
-                _label, status_code,
+                "CRED_EXHAUST: provider=%s auth_type=%s label=%s key=%s status=%s — rotating",
+                self.provider, _auth_ex, _label, _key_ex, status_code,
             )
             self._mark_exhausted(entry, status_code, error_context)
             self._current_id = None
             next_entry = self._select_unlocked()
             if next_entry:
                 _next_label = next_entry.label or next_entry.id[:8]
-                logger.info("credential pool: rotated to %s", _next_label)
+                _next_auth = getattr(next_entry, "auth_type", "unknown")
+                _next_key = (next_entry.runtime_api_key or "")[:20]
+                logger.info(
+                    "CRED_ROTATE: now using auth_type=%s label=%s key=%s",
+                    _next_auth, _next_label, _next_key,
+                )
             return next_entry
 
     def acquire_lease(self, credential_id: Optional[str] = None) -> Optional[str]:

--- a/channel_memory.py
+++ b/channel_memory.py
@@ -1,0 +1,272 @@
+"""Channel-level persistent memory for Hermes/Sacha.
+
+Each Slack channel gets its own MEMORY.md in /home/hermes/projects/<name>/.
+Memory is loaded at the start of each session and updated at session end.
+"""
+
+import json
+import logging
+import os
+import re
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+PROJECTS_DIR = Path(os.getenv("HERMES_PROJECTS_DIR", "/home/hermes/projects"))
+GLOBAL_AGENTS = PROJECTS_DIR / "AGENTS.md"
+MAX_MEMORY_LINES = 150
+
+
+def _load_routing_table() -> dict:
+    """Parse the routing table from global AGENTS.md. Returns {channel_id: project_name}."""
+    mapping = {}
+    if not GLOBAL_AGENTS.exists():
+        return mapping
+    try:
+        content = GLOBAL_AGENTS.read_text(encoding="utf-8")
+        for line in content.splitlines():
+            match = re.search(
+                r'\|\s*`([^`]+)`\s*\|\s*`([^`]+)`\s*\|[^|]+\|\s*`/home/hermes/projects/([^/]+)/AGENTS\.md`',
+                line
+            )
+            if match:
+                channel_id = match.group(2)
+                project_name = match.group(3)
+                mapping[channel_id] = project_name
+    except Exception as e:
+        logger.warning("[ChannelMemory] Failed to parse routing table: %s", e)
+    return mapping
+
+
+def get_project_for_channel(channel_id: str) -> Optional[str]:
+    """Return the project name for a Slack channel ID, or None."""
+    return _load_routing_table().get(channel_id)
+
+
+def load_channel_memory(channel_id: str) -> str:
+    """Load channel memory content. Returns empty string if none exists."""
+    project = get_project_for_channel(channel_id)
+    if not project:
+        return ""
+    mem_path = PROJECTS_DIR / project / "MEMORY.md"
+    if not mem_path.exists():
+        return ""
+    try:
+        content = mem_path.read_text(encoding="utf-8").strip()
+        return content
+    except Exception as e:
+        logger.warning("[ChannelMemory] Failed to load memory for %s: %s", project, e)
+        return ""
+
+
+def save_channel_memory(channel_id: str, content: str) -> bool:
+    """Write channel memory content."""
+    project = get_project_for_channel(channel_id)
+    if not project:
+        return False
+    mem_path = PROJECTS_DIR / project / "MEMORY.md"
+    try:
+        mem_path.write_text(content, encoding="utf-8")
+        logger.info("[ChannelMemory] Saved memory for project %s (%d chars)", project, len(content))
+        return True
+    except Exception as e:
+        logger.warning("[ChannelMemory] Failed to save memory for %s: %s", project, e)
+        return False
+
+
+def build_channel_memory_prompt(channel_id: str) -> str:
+    """Build a system prompt section with channel memory, if any exists."""
+    memory = load_channel_memory(channel_id)
+    project = get_project_for_channel(channel_id)
+    if not memory or not project:
+        return ""
+
+    agents_path = PROJECTS_DIR / project / "AGENTS.md"
+    agents_content = ""
+    if agents_path.exists():
+        try:
+            agents_content = agents_path.read_text(encoding="utf-8").strip()
+        except Exception:
+            pass
+
+    parts = [f"\n\n## Contexte projet: {project}"]
+    if agents_content:
+        parts.append(agents_content)
+    parts.append(f"\n## Memoire du channel (persistante entre les threads):\n{memory}")
+    parts.append(
+        "\n[System: La memoire ci-dessus est partagee entre tous les threads de ce channel. "
+        "A la fin de cette conversation, les informations importantes seront automatiquement "
+        "sauvegardees dans la memoire du channel.]"
+    )
+    return "\n\n".join(parts)
+
+
+def auto_setup_channel(channel_id: str, channel_name: str) -> Optional[str]:
+    """Auto-create project structure for a new channel. Returns project name or None."""
+    if not channel_name or channel_name.startswith("D"):
+        return None
+
+    existing = get_project_for_channel(channel_id)
+    if existing:
+        return existing
+
+    clean_name = re.sub(r'[^a-z0-9_-]', '-', channel_name.lower().strip('#'))
+    project_dir = PROJECTS_DIR / clean_name
+
+    try:
+        project_dir.mkdir(parents=True, exist_ok=True)
+
+        agents_path = project_dir / "AGENTS.md"
+        if not agents_path.exists():
+            agents_path.write_text(
+                f"# {clean_name} — Contexte Projet\n\n"
+                f"## Description\n"
+                f"Projet {clean_name} (channel Slack: #{channel_name})\n\n"
+                f"## Stack\n- A completer\n\n"
+                f"## Priorites\n- A completer\n",
+                encoding="utf-8",
+            )
+
+        mem_path = project_dir / "MEMORY.md"
+        if not mem_path.exists():
+            mem_path.write_text(
+                f"# Memoire — {clean_name}\n\n"
+                f"> Memoire persistante du channel #{channel_name}. "
+                f"Mise a jour automatiquement.\n\n"
+                f"## Historique\n"
+                f"- {datetime.now(timezone.utc).strftime('%Y-%m-%d')} : Channel cree\n",
+                encoding="utf-8",
+            )
+
+        _add_to_routing_table(channel_id, channel_name, clean_name)
+        _add_to_free_response(channel_id)
+        _add_to_routing_skill(clean_name)
+
+        logger.info("[ChannelMemory] Auto-created project '%s' for channel %s", clean_name, channel_id)
+        return clean_name
+
+    except Exception as e:
+        logger.error("[ChannelMemory] Failed to auto-setup channel %s: %s", channel_id, e)
+        return None
+
+
+def _add_to_routing_table(channel_id: str, channel_name: str, project_name: str):
+    """Add a channel to the global AGENTS.md routing table."""
+    if not GLOBAL_AGENTS.exists():
+        return
+    content = GLOBAL_AGENTS.read_text(encoding="utf-8")
+    if channel_id in content:
+        return
+    new_row = f"| `#{project_name}` | `{channel_id}` | Projet {project_name} | `/home/hermes/projects/{project_name}/AGENTS.md` |"
+    content = content.replace(
+        "| DM / `#general`",
+        f"{new_row}\n| DM / `#general`",
+    )
+    if f"projects/{project_name}/" not in content:
+        content += f"\n- `projects/{project_name}/` — Projet {project_name}"
+    GLOBAL_AGENTS.write_text(content, encoding="utf-8")
+
+
+def _add_to_free_response(channel_id: str):
+    """Add channel to slack.free_response_channels in config.yaml.
+
+    Uses YAML to reliably read the current value from the slack section,
+    then does a targeted text replacement to preserve the file's formatting.
+    The old regex-based approach matched the first `free_response_channels:`
+    occurrence (which could be in another section like `discord:`) and
+    doubled the indentation on each call, producing invalid YAML.
+    """
+    from hermes_constants import get_hermes_home
+    config_path = get_hermes_home() / "config.yaml"
+    if not config_path.exists():
+        return
+    try:
+        content = config_path.read_text(encoding="utf-8")
+        if channel_id in content:
+            return
+
+        import yaml as _yaml
+        data = _yaml.safe_load(content) or {}
+
+        slack_cfg = data.get("slack", {})
+        current = str(slack_cfg.get("free_response_channels", "") or "")
+        new_val = f"{current},{channel_id}" if current else channel_id
+
+        # Text replacement: find the exact existing line under the slack section
+        # and update only its value, preserving indentation and file structure.
+        # We search for the slack section first to avoid touching other sections
+        # (e.g. discord) that may also have a free_response_channels key.
+        import re as _re
+        slack_match = _re.search(r'^slack:[ \t]*\n', content, _re.MULTILINE)
+        if slack_match:
+            # Grab the slack block: lines starting with whitespace after `slack:`
+            after_slack = content[slack_match.end():]
+            block_end = _re.search(r'^\S', after_slack, _re.MULTILINE)
+            slack_block = after_slack[:block_end.start()] if block_end else after_slack
+
+            frc_match = _re.search(
+                r'^([ \t]*free_response_channels:[ \t]*)(.*?)$',
+                slack_block, _re.MULTILINE,
+            )
+            if frc_match:
+                old_line = frc_match.group(0)
+                new_line = frc_match.group(1) + new_val
+                new_block = slack_block.replace(old_line, new_line, 1)
+                content = content[:slack_match.end()] + new_block + (after_slack[block_end.start():] if block_end else "")
+                config_path.write_text(content, encoding="utf-8")
+                return
+
+        # Fallback: slack section or its free_response_channels key not found.
+        # Append a minimal slack block so the channel still works.
+        logger.warning("[ChannelMemory] slack.free_response_channels not found; appending to config")
+        content = content.rstrip("\n") + f"\nslack:\n  free_response_channels: {new_val}\n"
+        config_path.write_text(content, encoding="utf-8")
+    except Exception as e:
+        logger.warning("[ChannelMemory] Failed to update free_response_channels: %s", e)
+
+
+def _add_to_routing_skill(project_name: str):
+    """Add project to the routing skill."""
+    from hermes_constants import get_hermes_home
+    skill_path = get_hermes_home() / "skills" / "project-management" / "project-context-routing.md"
+    if not skill_path.exists():
+        return
+    try:
+        content = skill_path.read_text(encoding="utf-8")
+        if project_name in content:
+            return
+        new_line = f'#{project_name}     → read_file("/home/hermes/projects/{project_name}/AGENTS.md") + read_file("/home/hermes/projects/{project_name}/MEMORY.md")'
+        content = content.replace(
+            "DM / general",
+            f"{new_line}\nDM / general",
+        )
+        skill_path.write_text(content, encoding="utf-8")
+    except Exception as e:
+        logger.warning("[ChannelMemory] Failed to update routing skill: %s", e)
+
+
+def build_memory_update_prompt(channel_id: str, conversation_history: list) -> Optional[str]:
+    """Build a prompt for the flush agent to update channel memory."""
+    project = get_project_for_channel(channel_id)
+    if not project:
+        return None
+
+    current_memory = load_channel_memory(channel_id)
+    mem_path = PROJECTS_DIR / project / "MEMORY.md"
+
+    return (
+        f"[System: Mise a jour de la memoire du channel pour le projet '{project}'.\n\n"
+        f"Fichier memoire: {mem_path}\n\n"
+        f"Contenu actuel de la memoire:\n```\n{current_memory}\n```\n\n"
+        f"Revois la conversation ci-dessus et mets a jour la memoire du channel:\n"
+        f"1. Ajoute les decisions, faits et informations importants decouverts\n"
+        f"2. Retire les informations obsoletes ou redondantes\n"
+        f"3. Garde la memoire concise (max {MAX_MEMORY_LINES} lignes)\n"
+        f"4. Utilise des bullet points dates (YYYY-MM-DD)\n"
+        f"5. Preserve la structure existante (sections)\n\n"
+        f"Utilise write_file pour sauvegarder le fichier mis a jour a: {mem_path}\n"
+        f"Ne reponds PAS a l'utilisateur. Mets juste a jour le fichier memoire.]"
+    )

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -873,14 +873,27 @@ class MessageEvent:
     # Timestamps
     timestamp: datetime = field(default_factory=datetime.now)
     
+    # Keywords recognized as commands even WITHOUT the leading slash.
+    # Slack intercepts /approve and /deny as slash commands before they
+    # reach the bot, so users must type them without the slash.
+    _SLASH_FREE_COMMANDS = frozenset(["approve", "deny"])
+
     def is_command(self) -> bool:
         """Check if this is a command message (e.g., /new, /reset)."""
-        return self.text.startswith("/")
-    
+        if self.text.startswith("/"):
+            return True
+        # Also accept approval/deny keywords without slash (Slack intercepts /approve)
+        first_word = self.text.strip().split(maxsplit=1)[0].lower() if self.text.strip() else ""
+        return first_word in self._SLASH_FREE_COMMANDS
+
     def get_command(self) -> Optional[str]:
         """Extract command name if this is a command message."""
         if not self.is_command():
             return None
+        if not self.text.startswith("/"):
+            # Slash-free command (e.g. "approve always", "deny")
+            parts = self.text.strip().split(maxsplit=1)
+            return parts[0].lower() if parts else None
         # Split on space and get first word, strip the /
         parts = self.text.split(maxsplit=1)
         raw = parts[0][1:].lower() if parts else None
@@ -890,11 +903,14 @@ class MessageEvent:
         if raw and "/" in raw:
             return None
         return raw
-    
+
     def get_command_args(self) -> str:
         """Get the arguments after a command."""
         if not self.is_command():
             return self.text
+        if not self.text.startswith("/"):
+            parts = self.text.strip().split(maxsplit=1)
+            return parts[1] if len(parts) > 1 else ""
         parts = self.text.split(maxsplit=1)
         args = parts[1] if len(parts) > 1 else ""
         # iOS auto-corrects -- to — (em dash) and - to – (en dash)

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -46,8 +46,6 @@ from gateway.platforms.base import (
     safe_url_for_log,
     cache_document_from_bytes,
 )
-
-
 logger = logging.getLogger(__name__)
 
 
@@ -590,6 +588,12 @@ class SlackAdapter(BasePlatformAdapter):
                     if broadcast and i == 0:
                         kwargs["reply_broadcast"] = True
 
+                # Override display name if SLACK_DISPLAY_NAME is set
+                import os as _os
+                _display_name = _os.environ.get("SLACK_DISPLAY_NAME", "").strip()
+                if _display_name:
+                    kwargs["username"] = _display_name
+
                 last_result = await self._get_client(chat_id).chat_postMessage(**kwargs)
 
             # Track the sent message ts so we can auto-respond to thread
@@ -626,6 +630,9 @@ class SlackAdapter(BasePlatformAdapter):
         """Edit a previously sent Slack message."""
         if not self._app:
             return SendResult(success=False, error="Not connected")
+        if len(content) > self.MAX_MESSAGE_LENGTH:
+            content = content[:self.MAX_MESSAGE_LENGTH - 20] + " ... (tronque)"
+
         try:
             formatted = self.format_message(content)
             await self._get_client(chat_id).chat_update(
@@ -1715,7 +1722,7 @@ class SlackAdapter(BasePlatformAdapter):
                     else:
                         logger.warning("[Slack] Failed to cache audio from %s: %s", url, e, exc_info=True)
             elif url:
-                # Try to handle as a document attachment
+                # Accept ALL file types — let the agent decide what to do with them
                 try:
                     original_filename = f.get("name", "")
                     ext = ""
@@ -1723,13 +1730,12 @@ class SlackAdapter(BasePlatformAdapter):
                         _, ext = os.path.splitext(original_filename)
                         ext = ext.lower()
 
-                    # Fallback: reverse-lookup from MIME type
+                    # Fallback extension from MIME type
                     if not ext and mimetype:
                         mime_to_ext = {v: k for k, v in SUPPORTED_DOCUMENT_TYPES.items()}
                         ext = mime_to_ext.get(mimetype, "")
-
-                    if ext not in SUPPORTED_DOCUMENT_TYPES:
-                        continue  # Skip unsupported file types silently
+                    if not ext:
+                        ext = ".bin"
 
                     # Check file size (Slack limit: 20 MB for bots)
                     file_size = f.get("size", 0)
@@ -1743,7 +1749,7 @@ class SlackAdapter(BasePlatformAdapter):
                     cached_path = cache_document_from_bytes(
                         raw_bytes, original_filename or f"document{ext}"
                     )
-                    doc_mime = SUPPORTED_DOCUMENT_TYPES[ext]
+                    doc_mime = SUPPORTED_DOCUMENT_TYPES.get(ext, mimetype or "application/octet-stream")
                     media_urls.append(cached_path)
                     media_types.append(doc_mime)
                     logger.debug("[Slack] Cached user document: %s", cached_path)
@@ -2203,6 +2209,33 @@ class SlackAdapter(BasePlatformAdapter):
         except Exception as exc:  # pragma: no cover - defensive
             logger.debug("[Slack] Failed to fetch thread parent text: %s", exc)
             return ""
+
+    async def _handle_channel_join(self, event: dict) -> None:
+        """Auto-setup project memory when Sacha joins a new channel."""
+        user_id = event.get("user", "")
+        channel_id = event.get("channel", "")
+
+        if user_id != self._bot_user_id:
+            return
+
+        try:
+            from channel_memory import auto_setup_channel
+            client = self._get_client(channel_id)
+            info = await client.conversations_info(channel=channel_id)
+            channel_name = info.get("channel", {}).get("name", channel_id)
+
+            project = auto_setup_channel(channel_id, channel_name)
+            if project:
+                await client.chat_postMessage(
+                    channel=channel_id,
+                    text=(
+                        f"Projet **{project}** initialise pour ce channel.\n"
+                        f"Memoire persistante activee — le contexte sera maintenu entre les threads."
+                    ),
+                )
+                logger.info("[Slack] Auto-setup project '%s' for channel %s (%s)", project, channel_name, channel_id)
+        except Exception as e:
+            logger.error("[Slack] Failed to auto-setup channel %s: %s", channel_id, e, exc_info=True)
 
     async def _handle_slash_command(self, command: dict) -> None:
         """Handle Slack slash commands.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -521,6 +521,46 @@ def _load_gateway_config() -> dict:
     return {}
 
 
+def _notify_oauth_health_failure(auth_type: str, source: str, status_code,
+                                  error_message: str) -> None:
+    """Send a Slack alert when the OAuth/API token fails validation at startup.
+
+    Best-effort: silently skipped if SLACK_BOT_TOKEN or a valid channel id
+    are not configured. Channel resolution order:
+    SLACK_OPERATOR_DM > SLACK_HOME_CHANNEL.
+    """
+    import os as _os, json as _json, urllib.request as _ur
+    try:
+        token = _os.getenv("SLACK_BOT_TOKEN", "")
+        channel = (_os.getenv("SLACK_OPERATOR_DM", "")
+                   or _os.getenv("SLACK_HOME_CHANNEL", ""))
+        if not token or not channel:
+            return
+        msg = (
+            f":warning: *OAUTH_HEALTH au demarrage : token invalide*\n"
+            f"- auth_type: `{auth_type}`\n"
+            f"- source: `{source}`\n"
+            f"- status_code: `{status_code}`\n"
+            f"- erreur: `{error_message[:160]}`\n\n"
+            f"Sacha ne pourra pas repondre tant que le token n'est pas regenere.\n"
+            f"Action : `docker exec -it hermes-ceo regen-oauth` "
+            f"(ou `claude setup-token` puis mettre a jour `CLAUDE_CODE_OAUTH_TOKEN` dans `.env`), "
+            f"puis `docker restart hermes-ceo`."
+        )
+        data = _json.dumps({"channel": channel, "text": msg}).encode()
+        req = _ur.Request(
+            "https://slack.com/api/chat.postMessage",
+            data=data,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+            },
+        )
+        _ur.urlopen(req, timeout=5)
+    except Exception:
+        pass
+
+
 def _resolve_gateway_model(config: dict | None = None) -> str:
     """Read model from config.yaml — single source of truth.
 
@@ -2414,6 +2454,51 @@ class GatewayRunner:
                     from agent.anthropic_adapter import _is_oauth_token
                     _startup_auth = "OAUTH" if _is_oauth_token(_startup_key) else "API_KEY"
                     logger.info("CRED_POOL: single credential auth_type=%s key=%s", _startup_auth, _startup_key[:20])
+
+                # ── OAUTH_HEALTH startup ping ──────────────────────────────
+                # Validate the resolved token by pinging the Anthropic API
+                # with a 1-token request. Catches dead OAuth tokens before
+                # any user message triggers a silent api_key fallback.
+                # Gated by HERMES_OAUTH_STARTUP_VALIDATE=0 to skip.
+                import os as _os_health
+                if _os_health.getenv("HERMES_OAUTH_STARTUP_VALIDATE", "1").lower() not in ("0", "false", "no"):
+                    try:
+                        from agent.anthropic_adapter import (
+                            validate_oauth_token, describe_token_source,
+                        )
+                        _hk = str(_startup_rt.get("api_key", "") or "")
+                        _hbase = _startup_rt.get("base_url")
+                        _hsrc = describe_token_source(_hk)
+                        # sk-ant-oat setup-tokens are accepted by the official
+                        # Claude Code CLI but not necessarily by raw SDK
+                        # /v1/messages. When CLI fallback is enabled, startup
+                        # validation through the SDK is a misleading false
+                        # negative, so skip the alert.
+                        if _hk.startswith("sk-ant-oat") and _os_health.getenv("HERMES_CLAUDE_CODE_CLI_FALLBACK", "1").lower() not in ("0", "false", "no"):
+                            logger.info(
+                                "OAUTH_HEALTH: status=skipped_setup_token source=%s reason=validated_by_claude_code_cli_path",
+                                _hsrc,
+                            )
+                            raise StopIteration
+                        _hres = validate_oauth_token(_hk, _hbase, timeout=8.0)
+                        _hauth = _hres.get("auth_type", "?")
+                        _hsc = _hres.get("status_code")
+                        if _hres.get("valid"):
+                            logger.info(
+                                "OAUTH_HEALTH: status=valid auth_type=%s source=%s status_code=%s",
+                                _hauth, _hsrc, _hsc,
+                            )
+                        else:
+                            _err = (_hres.get("error_message") or "")[:200]
+                            logger.error(
+                                "OAUTH_HEALTH: status=invalid auth_type=%s source=%s status_code=%s err=%s",
+                                _hauth, _hsrc, _hsc, _err,
+                            )
+                            _notify_oauth_health_failure(_hauth, _hsrc, _hsc, _err)
+                    except StopIteration:
+                        pass
+                    except Exception as _h_exc:
+                        logger.warning("OAUTH_HEALTH: check failed: %s", _h_exc)
             except Exception as _cp_exc:
                 logger.debug("Could not log credential pool: %s", _cp_exc)
         except Exception as e:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2402,6 +2402,20 @@ class GatewayRunner:
             directory = await build_channel_directory(self.adapters)
             ch_count = sum(len(chs) for chs in directory.get("platforms", {}).values())
             logger.info("Channel directory built: %d target(s)", ch_count)
+            # Log credential pool state at startup
+            try:
+                from hermes_cli.runtime_provider import resolve_runtime_provider
+                _startup_rt = resolve_runtime_provider(requested="anthropic")
+                _startup_pool = _startup_rt.get("credential_pool")
+                if _startup_pool:
+                    _startup_pool.log_pool_status()
+                else:
+                    _startup_key = str(_startup_rt.get("api_key", "") or "")
+                    from agent.anthropic_adapter import _is_oauth_token
+                    _startup_auth = "OAUTH" if _is_oauth_token(_startup_key) else "API_KEY"
+                    logger.info("CRED_POOL: single credential auth_type=%s key=%s", _startup_auth, _startup_key[:20])
+            except Exception as _cp_exc:
+                logger.debug("Could not log credential pool: %s", _cp_exc)
         except Exception as e:
             logger.warning("Channel directory build failed: %s", e)
         
@@ -4761,7 +4775,7 @@ class GatewayRunner:
         if not history and source.platform and source.platform != Platform.LOCAL and source.platform != Platform.WEBHOOK:
             platform_name = source.platform.value
             env_key = f"{platform_name.upper()}_HOME_CHANNEL"
-            if not os.getenv(env_key):
+            if False:  # home channel notification disabled
                 adapter = self.adapters.get(source.platform)
                 if adapter:
                     # Slack dispatches all Hermes commands through a single
@@ -4793,6 +4807,18 @@ class GatewayRunner:
                 vc_context = adapter.get_voice_channel_context(guild_id)
                 if vc_context:
                     context_prompt += f"\n\n{vc_context}"
+
+        # -----------------------------------------------------------------
+        # Channel memory — inject per-channel persistent context for Slack
+        # -----------------------------------------------------------------
+        if source.platform == Platform.SLACK and source.chat_id:
+            try:
+                from channel_memory import build_channel_memory_prompt
+                _ch_mem = build_channel_memory_prompt(source.chat_id)
+                if _ch_mem:
+                    context_prompt += _ch_mem
+            except Exception as _cme:
+                logger.debug("Channel memory injection failed (non-fatal): %s", _cme)
 
         # -----------------------------------------------------------------
         # Auto-analyze images sent by the user
@@ -4887,10 +4913,17 @@ class GatewayRunner:
             _response_time = time.time() - _msg_start_time
             _api_calls = agent_result.get("api_calls", 0)
             _resp_len = len(response)
+            try:
+                from agent.anthropic_adapter import _is_oauth_token
+                _rr_key = str(runtime_kwargs.get("api_key", "") or "")
+                _rr_auth = "OAUTH" if _is_oauth_token(_rr_key) else "API_KEY"
+                _rr_key_preview = _rr_key[:20]
+            except Exception:
+                _rr_auth, _rr_key_preview = "unknown", "?"
             logger.info(
-                "response ready: platform=%s chat=%s time=%.1fs api_calls=%d response=%d chars",
+                "response ready: platform=%s chat=%s time=%.1fs api_calls=%d response=%d chars auth=%s key=%s",
                 _platform_name, source.chat_id or "unknown",
-                _response_time, _api_calls, _resp_len,
+                _response_time, _api_calls, _resp_len, _rr_auth, _rr_key_preview,
             )
 
             # Successful turn — clear any stuck-loop counter for this session.
@@ -11518,6 +11551,10 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
 
 def main():
     """CLI entry point for the gateway."""
+    try:
+        from gateway import sentry_init  # noqa: F401
+    except Exception:
+        pass
     import argparse
     
     parser = argparse.ArgumentParser(description="Hermes Gateway - Multi-platform messaging")

--- a/gateway/sentry_init.py
+++ b/gateway/sentry_init.py
@@ -1,0 +1,11 @@
+import os
+import sentry_sdk
+
+_dsn = os.environ.get("SENTRY_DSN", os.environ.get("SENTRY_DSN_PYTHON", ""))
+if _dsn:
+    sentry_sdk.init(
+        dsn=_dsn,
+        traces_sample_rate=0.1,
+        send_default_pii=False,
+        environment=os.environ.get("ENVIRONMENT", "production"),
+    )

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1486,8 +1486,8 @@ def _hermes_home_for_target_user(target_home_dir: str) -> str:
 
     When installing a system service via sudo, get_hermes_home() resolves to
     root's home.  This translates it to the target user's equivalent path:
-      /root/.hermes                    → /home/alice/.hermes
-      /root/.hermes/profiles/coder     → /home/alice/.hermes/profiles/coder
+      /home/hermes/.hermes                    → /home/alice/.hermes
+      /home/hermes/.hermes/profiles/coder     → /home/alice/.hermes/profiles/coder
       /opt/custom-hermes               → /opt/custom-hermes  (kept as-is)
     """
     current_hermes = get_hermes_home().resolve()

--- a/package-lock.json
+++ b/package-lock.json
@@ -269,6 +269,39 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
     "node_modules/buffer": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
@@ -640,6 +673,36 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -891,6 +954,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/github-from-package": {
       "version": "0.0.0",
@@ -1169,6 +1238,17 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "node_modules/inflight": {
@@ -1544,6 +1624,30 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
       "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
       "license": "MIT"
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
@@ -2445,6 +2549,24 @@
       "license": "MIT",
       "dependencies": {
         "bintrees": "1.0.2"
+      }
+    },
+    "node_modules/tiny-lru": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-13.0.0.tgz",
+      "integrity": "sha512-xDHxKKS1FdF0Tv2P+QT7IeSEg74K/8cEDzbv3Tv6UyHHUgBOjOiQiBp818MGj66dhurQus/IBcoAbwIKtSGc6Q==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
       }
     },
     "node_modules/tiny-lru": {

--- a/run_agent.py
+++ b/run_agent.py
@@ -43,7 +43,7 @@ from typing import List, Dict, Any, Optional
 from urllib.parse import urlparse, parse_qs, urlunparse
 from openai import OpenAI
 import fire
-from datetime import datetime
+from datetime import datetime, timezone, timedelta
 from pathlib import Path
 
 from hermes_constants import get_hermes_home
@@ -3664,6 +3664,47 @@ class AIAgent:
         trajectory = self._convert_to_trajectory_format(messages, user_query, completed)
         _save_trajectory_to_file(trajectory, self.model, completed)
     
+    def _notify_auth_dead_slack(self, tag: str, source: str, status_code,
+                                 request_id: str, key_preview: str) -> None:
+        """Send a one-shot Slack alert when the active credential is rejected.
+
+        tag = OAUTH_DEAD or APIKEY_DEAD. Best-effort: silently skipped if
+        SLACK_BOT_TOKEN or a target channel is missing. Channel resolution:
+        SLACK_OPERATOR_DM > SLACK_HOME_CHANNEL.
+        """
+        import os as _os, json as _json, urllib.request as _ur
+        try:
+            token = _os.getenv("SLACK_BOT_TOKEN", "")
+            channel = (_os.getenv("SLACK_OPERATOR_DM", "")
+                       or _os.getenv("SLACK_HOME_CHANNEL", ""))
+            if not token or not channel:
+                return
+            if tag == "OAUTH_DEAD":
+                action = ("Regenere le token : `docker exec -it hermes-ceo regen-oauth` "
+                          "puis `docker restart hermes-ceo`.")
+            else:
+                action = ("Verifier la cle dans `.env` (`ANTHROPIC_API_KEY`) "
+                          "ou regenerer cote console Anthropic.")
+            msg = (
+                f":rotating_light: *{tag}* (HTTP {status_code})\n"
+                f"- source: `{source}`\n"
+                f"- key: `{key_preview}`\n"
+                f"- request_id: `{request_id or 'n/a'}`\n\n"
+                f"{action}"
+            )
+            data = _json.dumps({"channel": channel, "text": msg}).encode()
+            req = _ur.Request(
+                "https://slack.com/api/chat.postMessage",
+                data=data,
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "Content-Type": "application/json",
+                },
+            )
+            _ur.urlopen(req, timeout=5)
+        except Exception:
+            pass
+
     @staticmethod
     def _summarize_api_error(error: Exception) -> str:
         """Extract a human-readable one-liner from an API error.
@@ -5697,6 +5738,8 @@ class AIAgent:
 
         if effective_reason == FailoverReason.rate_limit:
             if not has_retried_429:
+                logger.info("CRED_API_ERROR: status=429 auth_type=%s label=%s %s — first 429, will retry same credential",
+                            _cur_auth, _cur_label, _detail)
                 return False, True
             rotate_status = status_code if status_code is not None else 429
             next_entry = pool.mark_exhausted_and_rotate(status_code=rotate_status, error_context=error_context)
@@ -5716,6 +5759,8 @@ class AIAgent:
                 logger.info(f"Credential auth failure — refreshed pool entry {getattr(refreshed, 'id', '?')}")
                 self._swap_credential(refreshed)
                 return True, has_retried_429
+            logger.warning("CRED_REFRESH_FAIL: refresh returned no token; rotating instead "
+                           "(this is expected for static setup-tokens without refresh_token)")
             # Refresh failed — rotate to next credential instead of giving up.
             # The failed entry is already marked exhausted by try_refresh_current().
             rotate_status = status_code if status_code is not None else 401
@@ -5734,6 +5779,20 @@ class AIAgent:
     def _anthropic_messages_create(self, api_kwargs: dict):
         if self.api_mode == "anthropic_messages":
             self._try_refresh_anthropic_client_credentials()
+        # When the active client is OAuth, prefix the system prompt with the
+        # Claude Code identity string. Without this, Anthropic flags the call
+        # as "third-party app" usage and blocks it with HTTP 400 once the
+        # extra-usage credit balance hits zero.
+        try:
+            from agent.anthropic_adapter import inject_claude_code_identity
+            inject_claude_code_identity(api_kwargs)
+            _sys_preview = repr(api_kwargs.get("system", ""))[:120]
+            logger.warning(
+                "CLAUDE_IDENTITY_INJECTED create model=%s system=%s",
+                api_kwargs.get("model"), _sys_preview,
+            )
+        except Exception as _e:
+            logger.warning("CLAUDE_IDENTITY_INJECT_FAIL create: %s", _e)
         return self._anthropic_client.messages.create(**api_kwargs)
 
     def _rebuild_anthropic_client(self) -> None:
@@ -5755,6 +5814,283 @@ class AIAgent:
                 getattr(self, "_anthropic_base_url", None),
                 timeout=get_provider_request_timeout(self.provider, self.model),
             )
+
+    @staticmethod
+    def _flatten_claude_cli_content(content: Any) -> str:
+        """Extract readable text from OpenAI/Anthropic-style message content."""
+        if content is None:
+            return ""
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts = []
+            for block in content:
+                if isinstance(block, str):
+                    parts.append(block)
+                elif isinstance(block, dict):
+                    text = block.get("text") or block.get("content")
+                    if isinstance(text, str):
+                        parts.append(text)
+            return "\n".join(p for p in parts if p)
+        return str(content)
+
+    @classmethod
+    def _flatten_claude_cli_system(cls, system: Any) -> str:
+        """Flatten Anthropic system blocks to the string format expected by the CLI."""
+        if not system:
+            return ""
+        if isinstance(system, str):
+            return system
+        if isinstance(system, list):
+            parts = []
+            for block in system:
+                if isinstance(block, str):
+                    parts.append(block)
+                elif isinstance(block, dict) and block.get("type") == "text":
+                    text = block.get("text")
+                    if isinstance(text, str):
+                        parts.append(text)
+            return "\n\n".join(p for p in parts if p)
+        return str(system)
+
+    _CLAUDE_CODE_STATE_FILE = "/tmp/.claude_quota_state"
+
+    @staticmethod
+    def _claude_code_state_path() -> Path:
+        return Path(os.getenv("HERMES_CLAUDE_CODE_STATE_FILE", AIAgent._CLAUDE_CODE_STATE_FILE))
+
+    @classmethod
+    def _read_claude_code_state(cls) -> dict:
+        try:
+            path = cls._claude_code_state_path()
+            if not path.exists():
+                return {"mode": "oauth"}
+            data = json.loads(path.read_text() or "{}")
+            if not isinstance(data, dict):
+                return {"mode": "oauth"}
+            reset_at = float(data.get("reset_at_epoch") or 0)
+            if data.get("mode") == "api" and reset_at and time.time() >= reset_at:
+                cls._write_claude_code_state({"mode": "oauth", "reason": "reset_reached"})
+                return {"mode": "oauth", "reason": "reset_reached"}
+            return data
+        except Exception:
+            return {"mode": "oauth"}
+
+    @classmethod
+    def _write_claude_code_state(cls, data: dict) -> None:
+        try:
+            path = cls._claude_code_state_path()
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(json.dumps(data, ensure_ascii=False))
+        except Exception as exc:
+            logger.warning("CLAUDE_CODE_STATE_WRITE_FAIL error=%s", exc)
+
+    @staticmethod
+    def _parse_claude_quota_reset(text: str) -> tuple[Optional[float], Optional[str]]:
+        """Parse Claude Code reset hints like 'resets 8:10am (UTC)'."""
+        if not text:
+            return None, None
+        patterns = [
+            r"resets?\s+(?:at\s+)?(\d{1,2}:\d{2})\s*(am|pm)\s*\(UTC\)",
+            r"reset(?:s)?\s+(?:at\s+)?(\d{1,2}:\d{2})\s*(am|pm)\s*UTC",
+        ]
+        now = datetime.now(timezone.utc)
+        for pat in patterns:
+            m = re.search(pat, text, re.I)
+            if not m:
+                continue
+            hh, mm = [int(x) for x in m.group(1).split(":")]
+            ampm = m.group(2).lower()
+            if ampm == "pm" and hh != 12:
+                hh += 12
+            if ampm == "am" and hh == 12:
+                hh = 0
+            target = now.replace(hour=hh, minute=mm, second=0, microsecond=0)
+            if target <= now:
+                target = target + timedelta(days=1)
+            return target.timestamp(), target.isoformat()
+        return None, None
+
+    @staticmethod
+    def _is_claude_quota_exhausted(text: str) -> bool:
+        t = (text or "").lower()
+        return any(p in t for p in (
+            "out of extra usage",
+            "quota",
+            "usage limit",
+            "rate limit",
+            "too many requests",
+        )) and "api error" in t or "out of extra usage" in t
+
+    @staticmethod
+    def _read_env_file_value(key: str) -> str:
+        for path in (get_hermes_home() / ".env", Path(__file__).resolve().parents[1] / ".env"):
+            try:
+                if not path.exists():
+                    continue
+                for line in path.read_text().splitlines():
+                    if line.startswith(key + "="):
+                        return line.split("=", 1)[1].strip().strip('"').strip("'")
+            except Exception:
+                continue
+        return os.getenv(key, "").strip()
+
+    def _notify_claude_code_api_fallback(self, *, reset_at_iso: Optional[str], reason: str) -> None:
+        try:
+            cb = getattr(self, "status_callback", None)
+            if cb:
+                msg = "⚠️ Quota Claude Code OAuth épuisé — bascule temporaire sur clé API payante."
+                if reset_at_iso:
+                    msg += f" Retour OAuth prévu: `{reset_at_iso}`."
+                cb("status", msg)
+        except Exception:
+            pass
+
+    def _claude_code_cli_response(self, api_kwargs: dict, *, reason: str = ""):
+        """Use the real Claude Code CLI as the primary Slack/OAuth path.
+
+        The normal path uses Claude Code OAuth with ANTHROPIC_API_KEY removed.
+        Only explicit Claude quota exhaustion may switch to the isolated
+        ANTHROPIC_API_KEY_FALLBACK value, never to a globally exported API key.
+        """
+        import subprocess
+
+        started = time.time()
+        model = str(api_kwargs.get("model") or self.model or "claude-sonnet-4-6")
+        system_prompt = (
+            "Tu es Sacha, assistant de Sylvain. "
+            "Réponds toujours en français, de façon concise, utile et directe."
+        )
+        messages_in = api_kwargs.get("messages") or []
+        prompt_parts = []
+        if isinstance(messages_in, list):
+            for msg in messages_in[-8:]:
+                if not isinstance(msg, dict):
+                    continue
+                role = msg.get("role", "user")
+                text = self._flatten_claude_cli_content(msg.get("content"))
+                if text:
+                    prompt_parts.append(f"{role}: {text}")
+        prompt = "\n\n".join(prompt_parts).strip() or "Réponds au dernier message utilisateur."
+
+        state = self._read_claude_code_state()
+        force_api = state.get("mode") == "api"
+        fallback_key = self._read_env_file_value("ANTHROPIC_API_KEY_FALLBACK")
+
+        def _run(use_api: bool):
+            env = os.environ.copy()
+            env.pop("ANTHROPIC_API_KEY", None)
+            env.pop("ANTHROPIC_TOKEN", None)
+            env.pop("CLAUDE_CODE_OAUTH_TOKEN", None)
+            cmd = [
+                "claude",
+                "--model", model,
+                "--no-session-persistence",
+                "--tools", "",
+            ]
+            if system_prompt:
+                cmd.extend(["--append-system-prompt", system_prompt])
+            cmd.extend(["-p", prompt])
+            path = "api_key" if use_api else "oauth"
+            if use_api:
+                if not fallback_key:
+                    return None, 1, "", "ANTHROPIC_API_KEY_FALLBACK missing", path
+                env["ANTHROPIC_API_KEY"] = fallback_key
+                cmd.insert(1, "--bare")
+            else:
+                token = os.getenv("CLAUDE_CODE_OAUTH_TOKEN", "").strip()
+                if token:
+                    env["CLAUDE_CODE_OAUTH_TOKEN"] = token
+            logger.info("CLAUDE_CODE_CLI_START model=%s path=%s reason=%s", model, path, reason)
+            completed = subprocess.run(
+                cmd,
+                env=env,
+                text=True,
+                capture_output=True,
+                timeout=float(os.getenv("HERMES_CLAUDE_CLI_TIMEOUT", "300")),
+            )
+            return completed, completed.returncode, (completed.stdout or "").strip(), (completed.stderr or "").strip(), path
+
+        completed, rc, stdout, stderr, path = _run(force_api)
+        combined = f"{stdout}\n{stderr}".strip()
+
+        if not force_api and rc != 0 and self._is_claude_quota_exhausted(combined):
+            reset_epoch, reset_iso = self._parse_claude_quota_reset(combined)
+            self._write_claude_code_state({
+                "mode": "api",
+                "reason": "oauth_quota_exhausted",
+                "reset_at_epoch": reset_epoch or 0,
+                "reset_at_iso": reset_iso,
+                "last_error": combined[:500],
+            })
+            self._notify_claude_code_api_fallback(reset_at_iso=reset_iso, reason=combined[:160])
+            completed, rc, stdout, stderr, path = _run(True)
+            combined = f"{stdout}\n{stderr}".strip()
+
+        latency = round(time.time() - started, 3)
+        if rc != 0 or not stdout:
+            logger.error(
+                "FALLBACK_STATS path=%s oauth_ok=0 api_fallback=%s cli_fail=1 latency=%ss reset_at=%s rc=%s err=%s",
+                path, 1 if path == "api_key" else 0, latency, state.get("reset_at_iso"), rc, combined[:240],
+            )
+            return None
+
+        _stats_msg = (
+            "FALLBACK_STATS path=%s oauth_ok=%s api_fallback=%s cli_fail=0 latency=%ss reset_at=%s chars=%s"
+            % (path, 1 if path == "oauth" else 0, 1 if path == "api_key" else 0,
+               latency, state.get("reset_at_iso"), len(stdout))
+        )
+        logger.warning(_stats_msg)
+        logging.warning(_stats_msg)
+        return SimpleNamespace(
+            id="claude-code-cli",
+            model=model,
+            stop_reason="end_turn",
+            content=[SimpleNamespace(type="text", text=stdout)],
+            usage=None,
+            _hermes_claude_cli_fallback=True,
+        )
+
+
+    def _try_return_claude_cli_fallback(
+        self,
+        api_kwargs: dict,
+        messages: list,
+        conversation_history: list,
+        api_call_count: int,
+        *,
+        reason: str,
+    ) -> Optional[dict]:
+        """Return a completed conversation result via Claude Code CLI, if possible."""
+        try:
+            cli_response = self._claude_code_cli_response(api_kwargs, reason=reason)
+            if cli_response is None:
+                return None
+            text = "\n".join(
+                getattr(block, "text", "")
+                for block in getattr(cli_response, "content", [])
+                if getattr(block, "type", None) == "text"
+            ).strip()
+            if not text:
+                return None
+            assistant_msg = {
+                "role": "assistant",
+                "content": text,
+                "finish_reason": "stop",
+            }
+            messages.append(assistant_msg)
+            self._persist_session(messages, conversation_history)
+            return {
+                "final_response": text,
+                "messages": messages,
+                "api_calls": api_call_count,
+                "completed": True,
+                "claude_code_cli_fallback": True,
+            }
+        except Exception as exc:
+            logger.error("CLAUDE_CODE_CLI_FALLBACK_EXCEPTION: %s", exc)
+            return None
+
 
     def _interruptible_api_call(self, api_kwargs: dict):
         """
@@ -6376,7 +6712,20 @@ class AIAgent:
 
             # Reset stale-stream timer for this attempt
             last_chunk_time["t"] = time.time()
-            # Use the Anthropic SDK's streaming context manager
+            # Always inject Claude Code identity into `system` field.
+            # Idempotent + harmless for API-key requests; the helper
+            # mutates api_kwargs in-place so we don't need to reassign
+            # (rebinding here would create a closure-local shadow var).
+            try:
+                from agent.anthropic_adapter import inject_claude_code_identity
+                inject_claude_code_identity(api_kwargs)
+                _sys_preview = repr(api_kwargs.get("system", ""))[:120]
+                logger.warning(
+                    "CLAUDE_IDENTITY_INJECTED stream model=%s system=%s",
+                    api_kwargs.get("model"), _sys_preview,
+                )
+            except Exception as _e:
+                logger.warning("CLAUDE_IDENTITY_INJECT_FAIL stream: %s", _e)
             with self._anthropic_client.messages.stream(**api_kwargs) as stream:
                 for event in stream:
                     # Update stale-stream timer on every event so the
@@ -9374,6 +9723,21 @@ class AIAgent:
         messages.append(user_msg)
         current_turn_user_idx = len(messages) - 1
         self._persist_user_message_idx = current_turn_user_idx
+
+        _slack_cli_primary = (
+            (self.platform or "").lower() == "slack"
+            and os.getenv("HERMES_SLACK_CLAUDE_CODE_PRIMARY", "1").lower() not in ("0", "false", "no")
+            and os.getenv("HERMES_ENABLE_ANTHROPIC_SDK_EXPERIMENT", "").lower() not in ("1", "true", "yes")
+            and self.api_mode == "anthropic_messages"
+        )
+        if _slack_cli_primary:
+            _cli_result = self._try_return_claude_cli_fallback(
+                {"model": self.model, "messages": messages, "system": None},
+                messages, conversation_history, 0,
+                reason="slack_primary",
+            )
+            if _cli_result is not None:
+                return _cli_result
         
         if not self.quiet_mode:
             _print_preview = _summarize_user_message_for_log(user_message)
@@ -11383,6 +11747,65 @@ class AIAgent:
                     ) and not is_context_length_error
 
                     if is_client_error:
+                        # Any client-side failure from the raw Anthropic SDK can
+                        # be an OAuth/setup-token mismatch with Claude Code. Try
+                        # the official CLI path first; if it fails, keep the
+                        # existing diagnostics and hard-error behavior.
+                        if self.api_mode == "anthropic_messages":
+                            _cli_result = self._try_return_claude_cli_fallback(
+                                api_kwargs, messages, conversation_history, api_call_count,
+                                reason=f"client_error_http_{status_code or 'text'}",
+                            )
+                            if _cli_result is not None:
+                                return _cli_result
+
+                        # ── Auth-failure diagnostics (OAUTH_DEAD / APIKEY_DEAD) ──
+                        # When a single-credential setup fails on 401/403 the
+                        # standard pool flow doesn't fire (pool=None). Emit a
+                        # very visible log + Slack alert so the operator knows
+                        # exactly what to fix without grepping stack traces.
+                        if status_code in (401, 403):
+                            try:
+                                _api_key = getattr(self, "api_key", "") or ""
+                                from agent.anthropic_adapter import _is_oauth_token, describe_token_source
+                                _is_oauth = _is_oauth_token(_api_key)
+                                _src = describe_token_source(_api_key)
+                                _kp = (_api_key[:18] + "..." + _api_key[-4:]) if len(_api_key) > 24 else "none"
+                                _tag = "OAUTH_DEAD" if _is_oauth else "APIKEY_DEAD"
+                                _req_id = ""
+                                try:
+                                    _req_id = (getattr(api_error, "request_id", "")
+                                               or (getattr(api_error, "body", {}) or {}).get("request_id", "")
+                                               or "")
+                                except Exception:
+                                    pass
+                                logging.error(
+                                    "%s: status=%s source=%s key=%s request_id=%s — token rejected by provider",
+                                    _tag, status_code, _src, _kp, _req_id,
+                                )
+                                # Slack notification (deduped per process+session)
+                                _notify_key = f"{_tag}:{getattr(self, 'session_id', '')}:{_src}"
+                                _seen = getattr(self.__class__, "_auth_dead_notified", set())
+                                if _notify_key not in _seen:
+                                    _seen.add(_notify_key)
+                                    setattr(self.__class__, "_auth_dead_notified", _seen)
+                                    self._notify_auth_dead_slack(_tag, _src, status_code, _req_id, _kp)
+                            except Exception as _ad_exc:
+                                logging.debug("auth-dead diagnostic failed: %s", _ad_exc)
+
+                        # Direct Anthropic SDK OAuth can be classified as third-party
+                        # by Anthropic. If that happens, answer through the real
+                        # Claude Code CLI before surfacing a hard failure.
+                        if self.api_mode == "anthropic_messages" and (
+                            status_code == 400 and "third-party apps" in error_msg.lower()
+                        ):
+                            _cli_result = self._try_return_claude_cli_fallback(
+                                api_kwargs, messages, conversation_history, api_call_count,
+                                reason=f"client_error_http_{status_code}",
+                            )
+                            if _cli_result is not None:
+                                return _cli_result
+
                         # Try fallback before aborting — a different provider
                         # may not have the same issue (rate limit, auth, etc.)
                         self._emit_status(f"⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...")
@@ -11418,6 +11841,15 @@ class AIAgent:
                         else:
                             self._vprint(f"{self.log_prefix}   💡 This type of error won't be fixed by retrying.", force=True)
                         logging.error(f"{self.log_prefix}Non-retryable client error: {api_error}")
+                        import traceback as _tb
+                        logging.error(f"{self.log_prefix}STACK_401: model={getattr(self, 'model', '?')} session={getattr(self, 'session_id', '?')!r}")
+                        logging.error('STACK_401_TB: ' + ''.join(_tb.format_stack()[-6:]).replace(chr(10), '|'))
+                        _dbg_prov = getattr(self, "provider", "?")
+                        _dbg_model = getattr(self, "model", "?")
+                        _dbg_base = getattr(self, "base_url", "?")
+                        _dbg_client = getattr(self, "_client", None) or getattr(self, "_anthropic_client", None)
+                        _dbg_key = str(getattr(_dbg_client, "api_key", "?"))[:20] if _dbg_client else "no_client"
+                        logging.error(f"{self.log_prefix}DEBUG_401: provider={_dbg_prov} model={_dbg_model} base={_dbg_base} key={_dbg_key}")
                         # Skip session persistence when the error is likely
                         # context-overflow related (status 400 + large session).
                         # Persisting the failed user message would make the
@@ -11440,6 +11872,14 @@ class AIAgent:
                             "error": str(api_error),
                         }
 
+                    if self.api_mode == "anthropic_messages" and is_rate_limited:
+                        _cli_result = self._try_return_claude_cli_fallback(
+                            api_kwargs, messages, conversation_history, api_call_count,
+                            reason=f"rate_limit_http_{status_code or 'text'}",
+                        )
+                        if _cli_result is not None:
+                            return _cli_result
+
                     if retry_count >= max_retries:
                         # Before falling back, try rebuilding the primary
                         # client once for transient transport errors (stale
@@ -11451,6 +11891,17 @@ class AIAgent:
                             primary_recovery_attempted = True
                             retry_count = 0
                             continue
+                        # Direct SDK OAuth 429s are often separate from the user's
+                        # Claude plan quota. Before giving up, use the official
+                        # Claude Code CLI path, which has native attestation.
+                        if self.api_mode == "anthropic_messages" and is_rate_limited:
+                            _cli_result = self._try_return_claude_cli_fallback(
+                                api_kwargs, messages, conversation_history, api_call_count,
+                                reason=f"rate_limit_after_{max_retries}_retries",
+                            )
+                            if _cli_result is not None:
+                                return _cli_result
+
                         # Try fallback before giving up entirely
                         self._emit_status(f"⚠️ Max retries ({max_retries}) exhausted — trying fallback...")
                         if self._try_activate_fallback():

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -854,12 +854,12 @@ class TestSystemUnitHermesHome:
         unit = gateway_cli.generate_systemd_unit(system=True, run_as_user="alice")
 
         assert 'HERMES_HOME=/home/alice/.hermes' in unit
-        assert '/root/.hermes' not in unit
+        assert '/home/hermes/.hermes' not in unit
 
     def test_system_unit_remaps_profile_to_target_user(self, monkeypatch):
         # Simulate sudo with a profile: HERMES_HOME was resolved under root
         monkeypatch.setattr(Path, "home", staticmethod(lambda: Path("/root")))
-        monkeypatch.setenv("HERMES_HOME", "/root/.hermes/profiles/coder")
+        monkeypatch.setenv("HERMES_HOME", "/home/hermes/.hermes/profiles/coder")
         monkeypatch.setattr(
             gateway_cli, "_system_service_identity",
             lambda run_as_user=None: ("alice", "alice", "/home/alice"),
@@ -911,7 +911,7 @@ class TestHermesHomeForTargetUser:
 
     def test_remaps_profile_path(self, monkeypatch):
         monkeypatch.setattr(Path, "home", staticmethod(lambda: Path("/root")))
-        monkeypatch.setenv("HERMES_HOME", "/root/.hermes/profiles/coder")
+        monkeypatch.setenv("HERMES_HOME", "/home/hermes/.hermes/profiles/coder")
 
         result = gateway_cli._hermes_home_for_target_user("/home/alice")
         assert result == "/home/alice/.hermes/profiles/coder"

--- a/tests/tools/test_credential_files.py
+++ b/tests/tools/test_credential_files.py
@@ -43,7 +43,7 @@ class TestRegisterCredentialFiles:
         mounts = get_credential_file_mounts()
         assert len(mounts) == 1
         assert mounts[0]["host_path"] == str(hermes_home / "token.json")
-        assert mounts[0]["container_path"] == "/root/.hermes/token.json"
+        assert mounts[0]["container_path"] == "/home/hermes/.hermes/token.json"
 
     def test_dict_with_name_key_fallback(self, tmp_path):
         """Skills use 'name' instead of 'path' — both should work."""
@@ -114,7 +114,7 @@ class TestSkillsDirectoryMount:
 
         assert len(mounts) >= 1
         assert mounts[0]["host_path"] == str(skills_dir)
-        assert mounts[0]["container_path"] == "/root/.hermes/skills"
+        assert mounts[0]["container_path"] == "/home/hermes/.hermes/skills"
 
     def test_returns_none_when_no_skills_dir(self, tmp_path):
         hermes_home = tmp_path / ".hermes"
@@ -191,8 +191,8 @@ class TestIterSkillsFiles:
             files = iter_skills_files()
 
         paths = {f["container_path"] for f in files}
-        assert "/root/.hermes/skills/cat/myskill/SKILL.md" in paths
-        assert "/root/.hermes/skills/cat/myskill/scripts/run.sh" in paths
+        assert "/home/hermes/.hermes/skills/cat/myskill/SKILL.md" in paths
+        assert "/home/hermes/.hermes/skills/cat/myskill/scripts/run.sh" in paths
         # Symlink should be excluded
         assert not any("evil" in f["container_path"] for f in files)
 
@@ -382,8 +382,8 @@ class TestCacheDirectoryMounts:
 
         mounts = get_cache_directory_mounts()
         paths = {m["container_path"] for m in mounts}
-        assert "/root/.hermes/cache/documents" in paths
-        assert "/root/.hermes/cache/audio" in paths
+        assert "/home/hermes/.hermes/cache/documents" in paths
+        assert "/home/hermes/.hermes/cache/audio" in paths
 
     def test_skips_nonexistent_dirs(self, tmp_path, monkeypatch):
         """Dirs that don't exist on disk are not returned."""
@@ -395,7 +395,7 @@ class TestCacheDirectoryMounts:
 
         mounts = get_cache_directory_mounts()
         assert len(mounts) == 1
-        assert mounts[0]["container_path"] == "/root/.hermes/cache/documents"
+        assert mounts[0]["container_path"] == "/home/hermes/.hermes/cache/documents"
 
     def test_legacy_dir_names_resolved(self, tmp_path, monkeypatch):
         """Old-style dir names (e.g. document_cache) are resolved correctly."""
@@ -412,8 +412,8 @@ class TestCacheDirectoryMounts:
         assert str(hermes_home / "image_cache") in host_paths
         # Container paths always use the new layout
         container_paths = {m["container_path"] for m in mounts}
-        assert "/root/.hermes/cache/documents" in container_paths
-        assert "/root/.hermes/cache/images" in container_paths
+        assert "/home/hermes/.hermes/cache/documents" in container_paths
+        assert "/home/hermes/.hermes/cache/images" in container_paths
 
     def test_empty_hermes_home(self, tmp_path, monkeypatch):
         """No cache dirs → empty list."""
@@ -467,7 +467,7 @@ class TestIterCacheFiles:
 
         entries = iter_cache_files()
         assert len(entries) == 1
-        assert entries[0]["container_path"] == "/root/.hermes/cache/screenshots/session_abc/screen1.png"
+        assert entries[0]["container_path"] == "/home/hermes/.hermes/cache/screenshots/session_abc/screen1.png"
 
     def test_empty_cache(self, tmp_path, monkeypatch):
         """No cache dirs → empty list."""

--- a/tests/tools/test_managed_modal_environment.py
+++ b/tests/tools/test_managed_modal_environment.py
@@ -281,7 +281,7 @@ def test_managed_modal_rejects_host_credential_passthrough():
     _install_fake_tools_package(
         credential_mounts=[{
             "host_path": "/tmp/token.json",
-            "container_path": "/root/.hermes/token.json",
+            "container_path": "/home/hermes/.hermes/token.json",
         }]
     )
     managed_modal = _load_tool_module("tools.environments.managed_modal", "environments/managed_modal.py")

--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -54,7 +54,7 @@ def _resolve_hermes_home() -> Path:
 
 def register_credential_file(
     relative_path: str,
-    container_base: str = "/root/.hermes",
+    container_base: str = "/home/hermes/.hermes",
 ) -> bool:
     """Register a credential file for mounting into remote sandboxes.
 
@@ -104,7 +104,7 @@ def register_credential_file(
 
 def register_credential_files(
     entries: list,
-    container_base: str = "/root/.hermes",
+    container_base: str = "/home/hermes/.hermes",
 ) -> List[str]:
     """Register multiple credential files from skill frontmatter entries.
 
@@ -199,7 +199,7 @@ def get_credential_file_mounts() -> List[Dict[str, str]]:
 
 
 def get_skills_directory_mount(
-    container_base: str = "/root/.hermes",
+    container_base: str = "/home/hermes/.hermes",
 ) -> list[Dict[str, str]]:
     """Return mount info for all skill directories (local + external).
 
@@ -290,7 +290,7 @@ def _safe_skills_path(skills_dir: Path) -> str:
 
 
 def iter_skills_files(
-    container_base: str = "/root/.hermes",
+    container_base: str = "/home/hermes/.hermes",
 ) -> List[Dict[str, str]]:
     """Yield individual (host_path, container_path) entries for skills files.
 
@@ -350,7 +350,7 @@ _CACHE_DIRS: list[tuple[str, str]] = [
 
 
 def get_cache_directory_mounts(
-    container_base: str = "/root/.hermes",
+    container_base: str = "/home/hermes/.hermes",
 ) -> List[Dict[str, str]]:
     """Return mount entries for each cache directory that exists on disk.
 
@@ -374,7 +374,7 @@ def get_cache_directory_mounts(
 
 
 def iter_cache_files(
-    container_base: str = "/root/.hermes",
+    container_base: str = "/home/hermes/.hermes",
 ) -> List[Dict[str, str]]:
     """Return individual (host_path, container_path) entries for cache files.
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -178,6 +178,7 @@ _find_shell = _find_bash
 
 # Standard PATH entries for environments with minimal PATH.
 _SANE_PATH = (
+    "/home/hermes/.local/bin:"
     "/opt/homebrew/bin:/opt/homebrew/sbin:"
     "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 )

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2125,7 +2125,121 @@ TERMINAL_SCHEMA = {
 }
 
 
+_CODE_SAFE_EXTENSIONS = {'.txt', '.log', '.csv', '.tmp', '.out', '.pid'}
+
+# Commands allowed WITHOUT claude-code (monitoring, read-only, infra ops)
+_ALLOWED_DIRECT_PREFIXES = (
+    # Read / inspect
+    "ls", "ll", "cat ", "head ", "tail ", "wc ", "grep ", "rg ", "find ",
+    "du ", "df ", "pwd", "echo ", "printf ", "stat ",
+    # Process / system monitoring
+    "ps ", "top", "htop", "pgrep", "kill", "pkill",
+    "docker logs", "docker ps", "docker inspect", "docker exec",
+    "docker stats", "docker images",
+    # Network / HTTP read
+    "curl ", "wget ", "ping ", "dig ", "nslookup ",
+    # Git read ops
+    "git log", "git status", "git diff", "git show", "git branch",
+    "git remote", "git fetch", "git pull", "git clone", "git push",
+    "git add", "git commit", "git checkout", "git merge", "git stash",
+    # Package info (read-only)
+    "pip show", "pip list", "npm list", "which ", "type ",
+    # Env / config read
+    "env ", "printenv", "export ", "source ",
+    # claude-code invocation (the point of all this)
+    "claude-code",
+    # Misc safe
+    "sleep ", "date", "whoami", "id ", "uname", "hostname",
+    "mkdir ", "rm ", "mv ", "cp ", "chmod ", "chown ",
+    "apt-get ", "apt ", "pip install", "pip3 install", "npm install",
+    "ssh ", "scp ", "rsync ",
+    "tmux ", "screen ",
+    "systemctl ", "service ",
+    "tar ", "zip ", "unzip ", "gzip ",
+    "ffmpeg ", "convert ",
+    "jq ", "yq ",
+)
+
+_CODE_WRITE_PATTERNS = [
+    # Block inline code execution — force delegation to claude-code instead.
+    # The agent must never write/run code directly; all code tasks go through
+    # the claude-code wrapper at /home/hermes/.local/bin/claude-code which
+    # uses the OAuth subscription quota before falling back to the API key.
+    (re.compile(r'python3?\s+-c\s'), "execution inline Python"),
+    (re.compile(r'python3?\s+\S+\.py\b'), "execution script Python direct"),
+    (re.compile(r'node\s+-e\s'), "execution inline Node.js"),
+    # node *.js is blocked for arbitrary scripts but NOT for system packages under
+    # /usr/lib/node_modules or /opt/ (e.g. version checks of installed CLIs).
+    (re.compile(r'node\s+(?!/usr/lib/node_modules|/opt/)\S+\.js\b'), "execution script JS direct"),
+    (re.compile(r'perl\s+-e\s'), "execution inline Perl"),
+    (re.compile(r'ruby\s+-e\s'), "execution inline Ruby"),
+    (re.compile(r'bash\s+\S+\.sh\b'), "execution script bash direct"),
+    (re.compile(r'sh\s+\S+\.sh\b'), "execution script sh direct"),
+    (re.compile(r'sed\s+-i'), "edition fichier in-place via sed"),
+    # Block direct `claude` CLI calls — the agent must use `claude-code` (the
+    # wrapper) not `claude` directly. The negative lookbehind on the first
+    # pattern prevents matching `claude-code --print`. The pipe pattern uses
+    # a negative lookahead (?!-code) so `cat file | claude-code --print` is
+    # allowed while `cat file | claude --print` is blocked.
+    (re.compile(r'(?<![a-z-])claude\s+(-p|--print|--max-turns|--dangerously)'), "appel claude direct (use claude-code)"),
+    (re.compile(r'\|\s*claude(?!-code)\b'), "pipe vers claude direct (use claude-code)"),
+]
+
+_FILE_WRITE_RE = re.compile(
+    r'(?:cat|echo|printf)\s+.*?>\s*(\S+)'
+    r'|tee\s+(\S+)'
+    r'|awk\s+.*?>\s*(\S+)'
+)
+
+_DELEGATE_MSG = (
+    "BLOCKED: {reason}.\n\n"
+    "Delegue a claude-code immediatement:\n\n"
+    "  cat > /tmp/task.txt << 'EOF'\n"
+    "  Tu es dans /home/hermes/projects/MON-PROJET/.\n"
+    "  OBJECTIF: [description precise]\n"
+    "  CONTEXTE: [stack, fichiers existants, contraintes]\n"
+    "  EOF\n"
+    "  cat /tmp/task.txt | claude-code --print --max-turns 25 "
+    "--dangerously-skip-permissions --allowedTools Read,Write,Edit,Bash"
+)
+
+
+def _is_allowed_direct(command: str) -> bool:
+    """Return True if command is a safe read/monitoring/infra op."""
+    cmd = command.strip().lstrip("(").lstrip("!")
+    return any(cmd.startswith(p) for p in _ALLOWED_DIRECT_PREFIXES)
+
+
+def _check_file_write_guard(command):
+    """Block file writes to non-safe extensions."""
+    import os.path
+    for m in _FILE_WRITE_RE.finditer(command):
+        filepath = m.group(1) or m.group(2) or m.group(3)
+        if not filepath:
+            continue
+        _, ext = os.path.splitext(filepath)
+        if ext and ext.lower() not in _CODE_SAFE_EXTENSIONS:
+            return f"ecriture vers {filepath}"
+    return None
+
+
 def _handle_terminal(args, **kw):
+    command = args.get("command", "")
+    if command and not _is_allowed_direct(command):
+        for pattern, reason in _CODE_WRITE_PATTERNS:
+            if pattern.search(command):
+                return json.dumps({
+                    "output": _DELEGATE_MSG.format(reason=reason),
+                    "exit_code": 1,
+                    "error": "code_delegation_required",
+                })
+        file_write_reason = _check_file_write_guard(command)
+        if file_write_reason:
+            return json.dumps({
+                "output": _DELEGATE_MSG.format(reason=file_write_reason),
+                "exit_code": 1,
+                "error": "code_delegation_required",
+            })
     return terminal_tool(
         command=args.get("command"),
         background=args.get("background", False),

--- a/toolsets.py
+++ b/toolsets.py
@@ -150,6 +150,12 @@ TOOLSETS = {
         "tools": ["read_file", "write_file", "patch", "search_files"],
         "includes": []
     },
+
+    "file_readonly": {
+        "description": "Read-only file tools: read and search only (no write_file, no patch — use claude-code for all modifications)",
+        "tools": ["read_file", "search_files"],
+        "includes": []
+    },
     
     "tts": {
         "description": "Text-to-speech: convert text to audio with Edge TTS (free), ElevenLabs, OpenAI, or xAI",


### PR DESCRIPTION
## Summary
- Route Slack replies through the official Claude Code CLI first so OAuth subscription usage is preferred over direct SDK calls.
- Add explicit OAuth/API fallback state, reset handling, and FALLBACK_STATS logging to make paid fallback visible and controlled.
- Improve credential safety by blocking silent OAuth-to-API-key rotation and reducing noisy or sensitive logs.

## Test plan
- Observed Docker logs after Slack test: FALLBACK_STATS path=oauth oauth_ok=1 api_fallback=0 cli_fail=0 latency=5.002s.
- Ran Python syntax check with py_compile on modified Python files inside the hermes-ceo container.
- IDE lints reported no errors on the main modified OAuth/runtime files.
- pytest was not run because pytest is not installed on the host or in the hermes-ceo container.

## Notes
- This branch was rebuilt on top of the current NousResearch/main to avoid the conflicts in #16331.
- gateway/stream_consumer.py.bak is intentionally left untracked and excluded.