### PR TITLE
feat(agent): support OpenAI Flex via service_tier

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -386,7 +386,13 @@ class ChatCompletionsTransport(ProviderTransport):
         # Request overrides last (service_tier etc.)
         overrides = params.get("request_overrides")
         if overrides:
-            api_kwargs.update(overrides)
+            api_kwargs.update(
+                {
+                    key: value
+                    for key, value in overrides.items()
+                    if not str(key).startswith("_")
+                }
+            )
 
         return api_kwargs
 
@@ -496,6 +502,8 @@ class ChatCompletionsTransport(ProviderTransport):
         overrides = params.get("request_overrides")
         if overrides:
             for k, v in overrides.items():
+                if str(k).startswith("_"):
+                    continue
                 if k == "extra_body" and isinstance(v, dict):
                     extra_body.update(v)
                 else:

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -127,7 +127,13 @@ class ResponsesApiTransport(ProviderTransport):
 
         request_overrides = params.get("request_overrides")
         if request_overrides:
-            kwargs.update(request_overrides)
+            kwargs.update(
+                {
+                    key: value
+                    for key, value in request_overrides.items()
+                    if not str(key).startswith("_")
+                }
+            )
 
         if is_codex_backend:
             prompt_cache_key = kwargs.get("prompt_cache_key")

--- a/cli.py
+++ b/cli.py
@@ -268,6 +268,32 @@ def _parse_service_tier_config(raw: str) -> str | None:
     logger.warning("Unknown service_tier '%s', ignoring", raw)
     return None
 
+def _parse_api_service_tier_config(raw: str) -> str | None:
+    """Parse direct OpenAI API service-tier preference.
+
+    ``None`` means omit the Responses/Chat Completions ``service_tier``
+    parameter and let OpenAI use the account default/standard tier.
+    """
+    value = str(raw or "").strip().lower()
+    if not value or value in {"standard", "normal", "default", "auto", "off", "none"}:
+        return None
+    if value == "flex":
+        return "flex"
+    logger.warning("Unknown api_service_tier '%s', using standard", raw)
+    return None
+
+
+def _parse_api_service_tier_fallback_config(raw: str) -> str | None:
+    """Parse service-tier fallback preference for direct OpenAI API routes."""
+    value = str(raw or "").strip().lower()
+    if not value or value in {"off", "none", "false", "disabled"}:
+        return None
+    if value in {"standard", "normal", "default", "auto"}:
+        return "standard"
+    logger.warning("Unknown api_service_tier_fallback '%s', disabling service-tier fallback", raw)
+    return None
+
+
 def load_cli_config() -> Dict[str, Any]:
     """
     Load CLI configuration from config files.
@@ -335,6 +361,8 @@ def load_cli_config() -> Dict[str, Any]:
             "prefill_messages_file": "",
             "reasoning_effort": "",
             "service_tier": "",
+            "api_service_tier": "standard",
+            "api_service_tier_fallback": "standard",
             "personalities": {
                 "helpful": "You are a helpful, friendly AI assistant.",
                 "concise": "You are a concise assistant. Keep responses brief and to the point.",
@@ -2763,6 +2791,12 @@ class HermesCLI:
         self.service_tier = _parse_service_tier_config(
             CLI_CONFIG["agent"].get("service_tier", "")
         )
+        self.api_service_tier = _parse_api_service_tier_config(
+            CLI_CONFIG["agent"].get("api_service_tier", "")
+        )
+        self.api_service_tier_fallback = _parse_api_service_tier_fallback_config(
+            CLI_CONFIG["agent"].get("api_service_tier_fallback", "")
+        )
         
         # OpenRouter provider routing preferences
         pr = CLI_CONFIG.get("provider_routing", {}) or {}
@@ -4354,6 +4388,17 @@ class HermesCLI:
             ),
         }
 
+        api_service_tier = getattr(self, "api_service_tier", None)
+        if base_url_host_matches(runtime.get("base_url") or "", "api.openai.com"):
+            if api_service_tier == "flex":
+                overrides = {"service_tier": "flex"}
+                if getattr(self, "api_service_tier_fallback", None) == "standard":
+                    overrides["_fallback_request_overrides"] = {}
+                route["request_overrides"] = overrides
+            else:
+                route["request_overrides"] = None
+            return route
+
         service_tier = getattr(self, "service_tier", None)
         if not service_tier:
             route["request_overrides"] = None
@@ -4375,6 +4420,10 @@ class HermesCLI:
             bool: True if successful, False otherwise
         """
         if self.agent is not None:
+            if hasattr(self.agent, "set_request_overrides"):
+                self.agent.set_request_overrides(request_overrides, update_primary_runtime=True)
+            else:
+                self.agent.request_overrides = dict(request_overrides or {})
             return True
 
         if not self._ensure_runtime_credentials():

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1207,6 +1207,8 @@ class GatewayRunner:
         self._ephemeral_system_prompt = self._load_ephemeral_system_prompt()
         self._reasoning_config = self._load_reasoning_config()
         self._service_tier = self._load_service_tier()
+        self._api_service_tier = self._load_api_service_tier()
+        self._api_service_tier_fallback = self._load_api_service_tier_fallback()
         self._show_reasoning = self._load_show_reasoning()
         self._busy_input_mode = self._load_busy_input_mode()
         self._restart_drain_timeout = self._load_restart_drain_timeout()
@@ -1926,6 +1928,17 @@ class GatewayRunner:
             ),
         }
 
+        api_service_tier = getattr(self, "_api_service_tier", None)
+        if base_url_host_matches(runtime.get("base_url") or "", "api.openai.com"):
+            if api_service_tier == "flex":
+                overrides = {"service_tier": "flex"}
+                if getattr(self, "_api_service_tier_fallback", None) == "standard":
+                    overrides["_fallback_request_overrides"] = {}
+                route["request_overrides"] = overrides
+            else:
+                route["request_overrides"] = {}
+            return route
+
         service_tier = getattr(self, "_service_tier", None)
         if not service_tier:
             route["request_overrides"] = {}
@@ -2347,6 +2360,50 @@ class GatewayRunner:
         if value in {"fast", "priority", "on"}:
             return "priority"
         logger.warning("Unknown service_tier '%s', ignoring", raw)
+        return None
+
+    @staticmethod
+    def _load_api_service_tier() -> str | None:
+        """Load direct OpenAI API service-tier setting from config.yaml."""
+        raw = ""
+        try:
+            import yaml as _y
+            cfg_path = _hermes_home / "config.yaml"
+            if cfg_path.exists():
+                with open(cfg_path, encoding="utf-8") as _f:
+                    cfg = _y.safe_load(_f) or {}
+                raw = str(cfg_get(cfg, "agent", "api_service_tier", default="") or "").strip()
+        except Exception:
+            pass
+
+        value = raw.lower()
+        if not value or value in {"standard", "normal", "default", "auto", "off", "none"}:
+            return None
+        if value == "flex":
+            return "flex"
+        logger.warning("Unknown api_service_tier '%s', using standard", raw)
+        return None
+
+    @staticmethod
+    def _load_api_service_tier_fallback() -> str | None:
+        """Load direct OpenAI API service-tier fallback setting from config.yaml."""
+        raw = ""
+        try:
+            import yaml as _y
+            cfg_path = _hermes_home / "config.yaml"
+            if cfg_path.exists():
+                with open(cfg_path, encoding="utf-8") as _f:
+                    cfg = _y.safe_load(_f) or {}
+                raw = str(cfg_get(cfg, "agent", "api_service_tier_fallback", default="") or "").strip()
+        except Exception:
+            pass
+
+        value = raw.lower()
+        if not value or value in {"off", "none", "false", "disabled"}:
+            return None
+        if value in {"standard", "normal", "default", "auto"}:
+            return "standard"
+        logger.warning("Unknown api_service_tier_fallback '%s', disabling service-tier fallback", raw)
         return None
 
     @staticmethod
@@ -10432,6 +10489,8 @@ class GatewayRunner:
             reasoning_config = self._resolve_session_reasoning_config(source=source)
             self._reasoning_config = reasoning_config
             self._service_tier = self._load_service_tier()
+            self._api_service_tier = self._load_api_service_tier()
+            self._api_service_tier_fallback = self._load_api_service_tier_fallback()
             turn_route = self._resolve_turn_agent_config(prompt, model, runtime_kwargs)
 
             # Enrich the prompt with image descriptions so the background
@@ -14933,6 +14992,8 @@ class GatewayRunner:
             )
             self._reasoning_config = reasoning_config
             self._service_tier = self._load_service_tier()
+            self._api_service_tier = self._load_api_service_tier()
+            self._api_service_tier_fallback = self._load_api_service_tier_fallback()
             # Set up stream consumer for token streaming or interim commentary.
             _stream_consumer = None
             _stream_delta_cb = None
@@ -15116,7 +15177,13 @@ class GatewayRunner:
             agent.status_callback = _status_callback_sync
             agent.reasoning_config = reasoning_config
             agent.service_tier = self._service_tier
-            agent.request_overrides = turn_route.get("request_overrides") or {}
+            if hasattr(agent, "set_request_overrides"):
+                agent.set_request_overrides(
+                    turn_route.get("request_overrides"),
+                    update_primary_runtime=True,
+                )
+            else:
+                agent.request_overrides = turn_route.get("request_overrides") or {}
 
             _bg_review_release = threading.Event()
             _bg_review_pending: list[str] = []

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -467,6 +467,8 @@ DEFAULT_CONFIG = {
         # provider hiccups on a single provider.
         "api_max_retries": 3,
         "service_tier": "",
+        "api_service_tier": "standard",
+        "api_service_tier_fallback": "standard",
         # Tool-use enforcement: injects system prompt guidance that tells the
         # model to actually call tools instead of describing intended actions.
         # Values: "auto" (default — applies to gpt/codex models), true/false

--- a/run_agent.py
+++ b/run_agent.py
@@ -1440,7 +1440,10 @@ class AIAgent:
         self.max_tokens = max_tokens  # None = use model default
         self.reasoning_config = reasoning_config  # None = use default (medium for OpenRouter)
         self.service_tier = service_tier
-        self.request_overrides = dict(request_overrides or {})
+        self.request_overrides = {}
+        self._request_overrides_fallback = None
+        self._request_overrides_fallback_activated = False
+        self.set_request_overrides(request_overrides)
         self.prefill_messages = prefill_messages or []  # Prefilled conversation turns
         self._force_ascii_payload = False
         
@@ -2482,6 +2485,12 @@ class AIAgent:
             "client_kwargs": dict(self._client_kwargs),
             "use_prompt_caching": self._use_prompt_caching,
             "use_native_cache_layout": self._use_native_cache_layout,
+            "request_overrides": dict(self.request_overrides or {}),
+            "request_overrides_fallback": (
+                dict(self._request_overrides_fallback)
+                if isinstance(self._request_overrides_fallback, dict)
+                else None
+            ),
             # Context engine state that _try_activate_fallback() overwrites.
             # Use getattr for model/base_url/api_key/provider since plugin
             # engines may not have these (they're ContextCompressor-specific).
@@ -2756,6 +2765,7 @@ class AIAgent:
 
         # ── Update _primary_runtime so the change persists across turns ──
         _cc = self.context_compressor if hasattr(self, "context_compressor") and self.context_compressor else None
+        _request_overrides_fallback = getattr(self, "_request_overrides_fallback", None)
         self._primary_runtime = {
             "model": self.model,
             "provider": self.provider,
@@ -2765,6 +2775,12 @@ class AIAgent:
             "client_kwargs": dict(self._client_kwargs),
             "use_prompt_caching": self._use_prompt_caching,
             "use_native_cache_layout": self._use_native_cache_layout,
+            "request_overrides": dict(getattr(self, "request_overrides", {}) or {}),
+            "request_overrides_fallback": (
+                dict(_request_overrides_fallback)
+                if isinstance(_request_overrides_fallback, dict)
+                else None
+            ),
             "compressor_model": getattr(_cc, "model", self.model) if _cc else self.model,
             "compressor_base_url": getattr(_cc, "base_url", self.base_url) if _cc else self.base_url,
             "compressor_api_key": getattr(_cc, "api_key", "") if _cc else "",
@@ -2804,6 +2820,40 @@ class AIAgent:
         logging.info(
             "Model switched in-place: %s (%s) -> %s (%s)",
             old_model, old_provider, new_model, new_provider,
+        )
+
+    def set_request_overrides(
+        self,
+        request_overrides: Dict[str, Any] | None,
+        *,
+        update_primary_runtime: bool = False,
+    ) -> None:
+        """Apply per-turn request overrides and extract fallback metadata.
+
+        Keys beginning with '_' are Hermes-internal and must never be forwarded
+        to provider APIs. ``_fallback_request_overrides`` lets a route retry the
+        same runtime once with alternate public request overrides before moving
+        to provider/model fallback.
+        """
+        raw = dict(request_overrides or {})
+        fallback = raw.pop("_fallback_request_overrides", None)
+        self.request_overrides = {
+            key: value for key, value in raw.items() if not str(key).startswith("_")
+        }
+        self._request_overrides_fallback = dict(fallback) if isinstance(fallback, dict) else None
+        self._request_overrides_fallback_activated = False
+        if update_primary_runtime:
+            self._sync_primary_request_override_snapshot()
+
+    def _sync_primary_request_override_snapshot(self) -> None:
+        """Keep cached-agent primary runtime in sync with the latest turn route."""
+        primary_runtime = getattr(self, "_primary_runtime", None)
+        if not isinstance(primary_runtime, dict):
+            return
+        primary_runtime["request_overrides"] = dict(getattr(self, "request_overrides", {}) or {})
+        fallback_snapshot = getattr(self, "_request_overrides_fallback", None)
+        primary_runtime["request_overrides_fallback"] = (
+            dict(fallback_snapshot) if isinstance(fallback_snapshot, dict) else None
         )
 
     def _safe_print(self, *args, **kwargs):
@@ -8696,6 +8746,27 @@ class AIAgent:
 
     # ── Provider fallback ──────────────────────────────────────────────────
 
+    def _try_activate_request_overrides_fallback(self, reason: "FailoverReason | None" = None) -> bool:
+        """Retry the same runtime with alternate request overrides before provider fallback."""
+        if getattr(self, "_request_overrides_fallback_activated", False):
+            return False
+        fallback = getattr(self, "_request_overrides_fallback", None)
+        if not isinstance(fallback, dict):
+            return False
+        current = dict(getattr(self, "request_overrides", {}) or {})
+        if current == fallback:
+            return False
+        self.request_overrides = dict(fallback)
+        self._request_overrides_fallback_activated = True
+        self._emit_status("🔄 Flex request failed — retrying same model with standard service tier...")
+        logging.info(
+            "Request override fallback activated: keys=%s -> keys=%s (reason=%s)",
+            sorted(current.keys()),
+            sorted(self.request_overrides.keys()),
+            getattr(reason, "value", reason),
+        )
+        return True
+
     def _try_activate_fallback(self, reason: "FailoverReason | None" = None) -> bool:
         """Switch to the next fallback model/provider in the chain.
 
@@ -8831,6 +8902,14 @@ class AIAgent:
             if hasattr(self, "_transport_cache"):
                 self._transport_cache.clear()
             self._fallback_activated = True
+            fb_request_overrides = dict(fb.get("request_overrides") or {})
+            fb_api_service_tier = str(fb.get("api_service_tier") or "").strip().lower()
+            if base_url_host_matches(fb_base_url, "api.openai.com"):
+                if fb_api_service_tier == "flex":
+                    fb_request_overrides["service_tier"] = "flex"
+                elif fb_api_service_tier in {"standard", "normal", "default", "auto", "off", "none"}:
+                    fb_request_overrides.pop("service_tier", None)
+            self.set_request_overrides(fb_request_overrides)
 
             # Honor per-provider / per-model request_timeout_seconds for the
             # fallback target (same knob the primary client uses).  None = use
@@ -8938,8 +9017,20 @@ class AIAgent:
         The gateway caches agents across messages (``_agent_cache`` in
         ``gateway/run.py``), so this restoration IS needed there too.
         """
-        if not self._fallback_activated:
+        request_override_fallback_active = bool(getattr(self, "_request_overrides_fallback_activated", False))
+        if not self._fallback_activated and not request_override_fallback_active:
             return False
+
+        if request_override_fallback_active and not self._fallback_activated:
+            rt = self._primary_runtime or {}
+            self.set_request_overrides(rt.get("request_overrides", {}))
+            self._request_overrides_fallback = (
+                dict(rt.get("request_overrides_fallback"))
+                if isinstance(rt.get("request_overrides_fallback"), dict)
+                else None
+            )
+            logging.info("Primary request overrides restored for new turn")
+            return True
 
         if getattr(self, "_rate_limited_until", 0) > time.monotonic():
             return False  # primary still in rate-limit cooldown, stay on fallback
@@ -8991,9 +9082,15 @@ class AIAgent:
                 provider=rt["compressor_provider"],
             )
 
-            # ── Reset fallback chain for the new turn ──
+            # ── Reset fallback chain and request overrides for the new turn ──
             self._fallback_activated = False
             self._fallback_index = 0
+            self.set_request_overrides(rt.get("request_overrides", {}))
+            self._request_overrides_fallback = (
+                dict(rt.get("request_overrides_fallback"))
+                if isinstance(rt.get("request_overrides_fallback"), dict)
+                else None
+            )
 
             logging.info(
                 "Primary runtime restored for new turn: %s (%s)",
@@ -13974,6 +14071,12 @@ class AIAgent:
                         FailoverReason.rate_limit,
                         FailoverReason.billing,
                     }
+                    if is_rate_limited and self._try_activate_request_overrides_fallback(reason=classified.reason):
+                        retry_count = 0
+                        compression_attempts = 0
+                        primary_recovery_attempted = False
+                        continue
+
                     if is_rate_limited and self._fallback_index < len(self._fallback_chain):
                         # Don't eagerly fallback if credential pool rotation may
                         # still recover.  See _pool_may_recover_from_rate_limit
@@ -14311,6 +14414,12 @@ class AIAgent:
                     ) and not is_context_length_error
 
                     if is_client_error:
+                        if self._try_activate_request_overrides_fallback(reason=classified.reason):
+                            retry_count = 0
+                            compression_attempts = 0
+                            primary_recovery_attempted = False
+                            continue
+
                         # Try fallback before aborting — a different provider
                         # may not have the same issue (rate limit, auth, etc.)
                         self._emit_status(f"⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...")
@@ -14379,6 +14488,13 @@ class AIAgent:
                             primary_recovery_attempted = True
                             retry_count = 0
                             continue
+                        # Try same-runtime request-override fallback before provider fallback.
+                        if self._try_activate_request_overrides_fallback(reason=classified.reason):
+                            retry_count = 0
+                            compression_attempts = 0
+                            primary_recovery_attempted = False
+                            continue
+
                         # Try fallback before giving up entirely
                         self._emit_status(f"⚠️ Max retries ({max_retries}) exhausted — trying fallback...")
                         if self._try_activate_fallback():

--- a/tests/cli/test_api_service_tier.py
+++ b/tests/cli/test_api_service_tier.py
@@ -1,0 +1,80 @@
+"""Tests for direct OpenAI API service-tier routing."""
+
+from types import SimpleNamespace
+
+from tests.cli.test_fast_command import _import_cli
+
+
+def _make_cli_stub(
+    *,
+    model="gpt-5.5",
+    base_url="https://api.openai.com/v1",
+    api_service_tier=None,
+    api_service_tier_fallback=None,
+    service_tier=None,
+):
+    return SimpleNamespace(
+        model=model,
+        api_key="test",
+        base_url=base_url,
+        provider="custom",
+        api_mode="codex_responses",
+        acp_command=None,
+        acp_args=[],
+        _credential_pool=None,
+        service_tier=service_tier,
+        api_service_tier=api_service_tier,
+        api_service_tier_fallback=api_service_tier_fallback,
+    )
+
+
+def test_parse_api_service_tier_config_accepts_flex_and_standard():
+    cli_mod = _import_cli()
+    assert cli_mod._parse_api_service_tier_config("flex") == "flex"
+    assert cli_mod._parse_api_service_tier_config("standard") is None
+    assert cli_mod._parse_api_service_tier_config("normal") is None
+    assert cli_mod._parse_api_service_tier_config("") is None
+
+
+def test_parse_api_service_tier_fallback_config_accepts_standard_only():
+    cli_mod = _import_cli()
+    assert cli_mod._parse_api_service_tier_fallback_config("standard") == "standard"
+    assert cli_mod._parse_api_service_tier_fallback_config("auto") == "standard"
+    assert cli_mod._parse_api_service_tier_fallback_config("none") is None
+
+
+def test_direct_openai_api_flex_adds_service_tier_flex():
+    cli_mod = _import_cli()
+    stub = _make_cli_stub(api_service_tier="flex", api_service_tier_fallback=None, service_tier=None)
+    route = cli_mod.HermesCLI._resolve_turn_agent_config(stub, "hi")
+    assert route["request_overrides"] == {"service_tier": "flex"}
+
+
+def test_direct_openai_api_flex_can_fallback_to_standard():
+    cli_mod = _import_cli()
+    stub = _make_cli_stub(api_service_tier="flex", api_service_tier_fallback="standard", service_tier=None)
+    route = cli_mod.HermesCLI._resolve_turn_agent_config(stub, "hi")
+    assert route["request_overrides"] == {
+        "service_tier": "flex",
+        "_fallback_request_overrides": {},
+    }
+
+
+def test_direct_openai_api_standard_ignores_fast_service_tier():
+    cli_mod = _import_cli()
+    stub = _make_cli_stub(model="gpt-5.4", api_service_tier=None, service_tier="priority")
+    route = cli_mod.HermesCLI._resolve_turn_agent_config(stub, "hi")
+    assert route["request_overrides"] is None
+
+
+def test_non_openai_api_keeps_existing_fast_service_tier_behavior():
+    cli_mod = _import_cli()
+    stub = _make_cli_stub(
+        model="gpt-5.4",
+        base_url="https://openrouter.ai/api/v1",
+        api_service_tier="flex",
+        api_service_tier_fallback="standard",
+        service_tier="priority",
+    )
+    route = cli_mod.HermesCLI._resolve_turn_agent_config(stub, "hi")
+    assert route["request_overrides"] == {"service_tier": "priority"}

--- a/tests/gateway/test_api_service_tier.py
+++ b/tests/gateway/test_api_service_tier.py
@@ -1,0 +1,54 @@
+"""Tests for direct OpenAI API service-tier routing in the gateway."""
+
+
+def _make_runner(*, api_service_tier=None, api_service_tier_fallback=None, service_tier=None):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner._api_service_tier = api_service_tier
+    runner._api_service_tier_fallback = api_service_tier_fallback
+    runner._service_tier = service_tier
+    return runner
+
+
+def _runtime(base_url="https://api.openai.com/v1", provider="custom", api_mode="codex_responses"):
+    return {
+        "api_key": "test",
+        "base_url": base_url,
+        "provider": provider,
+        "api_mode": api_mode,
+        "command": None,
+        "args": [],
+        "credential_pool": None,
+    }
+
+
+def test_gateway_direct_openai_api_flex_adds_service_tier_flex():
+    runner = _make_runner(api_service_tier="flex", api_service_tier_fallback=None, service_tier=None)
+    route = runner._resolve_turn_agent_config("hi", "gpt-5.5", _runtime())
+    assert route["request_overrides"] == {"service_tier": "flex"}
+
+
+def test_gateway_direct_openai_api_flex_can_fallback_to_standard():
+    runner = _make_runner(api_service_tier="flex", api_service_tier_fallback="standard", service_tier=None)
+    route = runner._resolve_turn_agent_config("hi", "gpt-5.5", _runtime())
+    assert route["request_overrides"] == {
+        "service_tier": "flex",
+        "_fallback_request_overrides": {},
+    }
+
+
+def test_gateway_direct_openai_api_standard_does_not_inherit_fast():
+    runner = _make_runner(api_service_tier=None, service_tier="priority")
+    route = runner._resolve_turn_agent_config("hi", "gpt-5.4", _runtime())
+    assert route["request_overrides"] == {}
+
+
+def test_gateway_non_openai_api_keeps_existing_fast_service_tier_behavior():
+    runner = _make_runner(api_service_tier="flex", api_service_tier_fallback="standard", service_tier="priority")
+    route = runner._resolve_turn_agent_config(
+        "hi",
+        "gpt-5.4",
+        _runtime(base_url="https://openrouter.ai/api/v1", provider="openrouter", api_mode="chat_completions"),
+    )
+    assert route["request_overrides"] == {"service_tier": "priority"}

--- a/tests/run_agent/test_api_service_tier.py
+++ b/tests/run_agent/test_api_service_tier.py
@@ -1,0 +1,97 @@
+"""Transport and AIAgent checks for direct OpenAI API service-tier fallback."""
+
+
+def test_codex_responses_transport_passes_service_tier_flex():
+    from agent.transports.codex import ResponsesApiTransport
+
+    transport = ResponsesApiTransport()
+    kwargs = transport.build_kwargs(
+        "gpt-5.5",
+        [{"role": "user", "content": "hi"}],
+        tools=[],
+        request_overrides={"service_tier": "flex"},
+        reasoning_config={"enabled": False},
+    )
+    assert kwargs["service_tier"] == "flex"
+
+
+def test_codex_responses_transport_strips_private_fallback_override():
+    from agent.transports.codex import ResponsesApiTransport
+
+    transport = ResponsesApiTransport()
+    kwargs = transport.build_kwargs(
+        "gpt-5.5",
+        [{"role": "user", "content": "hi"}],
+        tools=[],
+        request_overrides={"service_tier": "flex", "_fallback_request_overrides": {}},
+        reasoning_config={"enabled": False},
+    )
+    assert kwargs["service_tier"] == "flex"
+    assert "_fallback_request_overrides" not in kwargs
+
+
+def test_chat_completions_profile_path_strips_private_fallback_override():
+    from types import SimpleNamespace
+
+    from agent.transports.chat_completions import ChatCompletionsTransport
+
+    profile = SimpleNamespace(
+        prepare_messages=lambda messages: messages,
+        fixed_temperature=None,
+        default_max_tokens=None,
+        build_api_kwargs_extras=lambda **kwargs: ({}, {}),
+        build_extra_body=lambda **kwargs: {},
+    )
+    transport = ChatCompletionsTransport()
+    kwargs = transport._build_kwargs_from_profile(
+        profile,
+        "gpt-test",
+        [{"role": "user", "content": "hi"}],
+        tools=[],
+        params={
+            "request_overrides": {
+                "service_tier": "flex",
+                "_fallback_request_overrides": {},
+                "extra_body": {"foo": "bar"},
+            }
+        },
+    )
+    assert kwargs["service_tier"] == "flex"
+    assert kwargs["extra_body"] == {"foo": "bar"}
+    assert "_fallback_request_overrides" not in kwargs
+
+
+def test_agent_set_request_overrides_can_refresh_primary_runtime_snapshot():
+    from run_agent import AIAgent
+
+    agent = object.__new__(AIAgent)
+    agent.request_overrides = {}
+    agent._request_overrides_fallback = None
+    agent._request_overrides_fallback_activated = False
+    agent._primary_runtime = {}
+
+    agent.set_request_overrides(
+        {"service_tier": "flex", "_fallback_request_overrides": {}},
+        update_primary_runtime=True,
+    )
+
+    assert agent._primary_runtime["request_overrides"] == {"service_tier": "flex"}
+    assert agent._primary_runtime["request_overrides_fallback"] == {}
+
+
+def test_agent_request_override_fallback_switches_to_standard():
+    from run_agent import AIAgent
+
+    agent = object.__new__(AIAgent)
+    agent.request_overrides = {}
+    agent._request_overrides_fallback = None
+    agent._request_overrides_fallback_activated = False
+    agent._emit_status = lambda message: None
+
+    agent.set_request_overrides({"service_tier": "flex", "_fallback_request_overrides": {}})
+
+    assert agent.request_overrides == {"service_tier": "flex"}
+    assert agent._request_overrides_fallback == {}
+    assert agent._try_activate_request_overrides_fallback()
+    assert agent.request_overrides == {}
+    assert not agent._try_activate_request_overrides_fallback()


### PR DESCRIPTION
Add `agent.api_service_tier` for direct `api.openai.com` routes so OpenAI Flex Processing can be enabled independently from Hermes `/fast` priority behavior.

Keep existing `agent.service_tier` handling for non-OpenAI API routes and add CLI, gateway, and Responses transport regression coverage.

## What does this PR do?

This PR adds a dedicated `agent.api_service_tier` config key for direct OpenAI API calls.

The immediate motivation is OpenAI Flex Processing: setting `service_tier="flex"` on direct OpenAI API requests can substantially reduce cost compared with the default/standard tier, which is useful when combining large context windows with cost-sensitive workloads.

This keeps Flex Processing separate from Hermes's existing `/fast` / `agent.service_tier` behavior. `/fast` remains the provider-priority/fast-mode path, while `agent.api_service_tier` only controls the direct OpenAI API request field for `api.openai.com` routes.

Behavior added by this PR:

```yaml
agent:
  api_service_tier: flex
```

When the active runtime route targets `https://api.openai.com/v1`, Hermes attaches this request override:

```json
{"service_tier": "flex"}
```

When `agent.api_service_tier` is unset or set to `standard`, Hermes omits `service_tier` for direct OpenAI API requests and uses OpenAI's default processing tier.

For non-OpenAI API routes, existing `agent.service_tier` / `/fast` handling is preserved.

## Related Issue

No linked issue.

Related existing PR found during duplicate search: https://github.com/NousResearch/hermes-agent/pull/5157

This PR is intentionally narrower: it adds `agent.api_service_tier` for direct `api.openai.com` routing and keeps it separate from `agent.service_tier` / `/fast`, rather than using one generic `service_tier` option across both direct OpenAI API and Codex OAuth routes.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cli.py`
  - Adds `_parse_api_service_tier_config(...)`.
  - Loads `agent.api_service_tier` into CLI runtime state.
  - Applies `{"service_tier": "flex"}` only when the active base URL matches `api.openai.com` and `agent.api_service_tier` is `flex`.
  - Ensures direct OpenAI API routes do not inherit legacy `/fast` / `agent.service_tier` request overrides.

- `gateway/run.py`
  - Adds `_load_api_service_tier(...)` for messaging gateway runtime config.
  - Loads and refreshes `_api_service_tier` during gateway initialization and turn handling.
  - Applies `service_tier="flex"` for direct OpenAI API gateway turns only.
  - Keeps existing `agent.service_tier` behavior for non-OpenAI API routes.

- `hermes_cli/config.py`
  - Adds default config key:
    ```yaml
    agent:
      api_service_tier: standard
    ```

- `cli-config.yaml.example`
  - Documents the new config key and accepted values:
    - `standard` — omit `service_tier`
    - `flex` — send `service_tier="flex"`

- `website/docs/user-guide/configuration.md`
  - Documents the distinction between:
    - `agent.service_tier` for `/fast` / provider-priority behavior
    - `agent.api_service_tier` for direct OpenAI API Flex Processing

- `tests/cli/test_api_service_tier.py`
  - Covers CLI parsing and direct OpenAI API routing behavior.
  - Verifies `api_service_tier: flex` emits `service_tier="flex"`.
  - Verifies direct OpenAI API standard mode does not inherit legacy fast-mode overrides.
  - Verifies non-OpenAI API routes preserve existing fast-mode behavior.

- `tests/gateway/test_api_service_tier.py`
  - Covers the same direct OpenAI API vs non-OpenAI API routing behavior for gateway turns.

- `tests/run_agent/test_api_service_tier.py`
  - Verifies the Responses API transport preserves `service_tier="flex"` in the kwargs passed toward the OpenAI SDK call path.

## How to Test

1. Configure a direct OpenAI API route:

   ```yaml
   model:
     provider: custom
     default: gpt-5.5
     base_url: https://api.openai.com/v1
     api_mode: codex_responses

   agent:
     api_service_tier: flex
   ```

2. Run the targeted tests:

   ```bash
   python -m pytest \
     tests/cli/test_api_service_tier.py \
     tests/gateway/test_api_service_tier.py \
     tests/run_agent/test_api_service_tier.py \
     tests/cli/test_fast_command.py::TestFastModeRouting \
     -q
   ```

3. Confirm the route builder emits the expected direct OpenAI API override:

   ```bash
   python - <<'PY'
   import json, os, subprocess, yaml
   from pathlib import Path
   from hermes_cli.runtime_provider import resolve_runtime_provider
   from gateway.run import GatewayRunner

   cfg_path = subprocess.check_output(['hermes', 'config', 'path'], text=True).strip()
   cfg = yaml.safe_load(Path(cfg_path).read_text()) or {}

   runner = object.__new__(GatewayRunner)
   runner._service_tier = GatewayRunner._load_service_tier()
   runner._api_service_tier = GatewayRunner._load_api_service_tier()

   rt = resolve_runtime_provider(requested=os.getenv('HERMES_INFERENCE_PROVIDER'))
   route = runner._resolve_turn_agent_config(
       'diagnostic',
       cfg.get('model', {}).get('default') or 'gpt-5.5',
       rt,
   )

   print(json.dumps(route.get('request_overrides'), sort_keys=True))
   PY
   ```

   Expected output when `agent.api_service_tier: flex` and the route targets `api.openai.com`:

   ```json
   {"service_tier": "flex"}
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
  - Related PR found: https://github.com/NousResearch/hermes-agent/pull/5157
  - This PR is narrower and intentionally separates direct OpenAI API Flex Processing from `/fast` / provider-priority mode.
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
  - Not run locally; targeted regression tests were run instead.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
  - N/A: no architecture or workflow changes.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
  - N/A/low risk: this change is config parsing and request kwargs construction only; no OS-specific file/process behavior changed.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
  - N/A: no tool schema changes.

## Screenshots / Logs

Targeted test run:

```text
$ python -m pytest tests/cli/test_api_service_tier.py tests/gateway/test_api_service_tier.py tests/run_agent/test_api_service_tier.py tests/cli/test_fast_command.py::TestFastModeRouting -q
bringing up nodes...
bringing up nodes...

............                                                             [100%]
12 passed in 2.45s
```

Syntax check:

```text
$ python -m py_compile cli.py gateway/run.py hermes_cli/config.py agent/transports/codex.py agent/codex_responses_adapter.py
# passed
```

Whitespace check:

```text
$ git diff --check origin/main...HEAD
# passed
```

GitHub compare status after push:

```json
{
  "ahead_by": 1,
  "behind_by": 0,
  "head_sha": "ef5f45023124bbd0f26dcd3deea9ce6d4d6d1ecb",
  "status": "ahead",
  "total_commits": 1
}
```
