### PR TITLE
fix(web_tools): add _get_extraction_backend() for SearXNG fallback on extract/crawl

### DIFF
--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -577,3 +577,124 @@ def test_web_requires_env_includes_exa_key():
     from tools.web_tools import _web_requires_env
 
     assert "EXA_API_KEY" in _web_requires_env()
+
+
+# ── _get_extraction_backend() tests ────────────────────────────────────────
+
+class TestExtractionBackend:
+    """Tests for _get_extraction_backend() — searxng fallback logic.
+
+    SearXNG only supports web search, not content extraction.  When the
+    configured backend is searxng, extraction operations should fall back
+    to the first available extraction-capable backend.
+    """
+
+    def setup_method(self):
+        """Clear web-backend env vars before each test."""
+        for key in (
+            "FIRECRAWL_API_KEY", "FIRECRAWL_API_URL",
+            "PARALLEL_API_KEY", "TAVILY_API_KEY", "EXA_API_KEY",
+        ):
+            os.environ.pop(key, None)
+
+    def teardown_method(self):
+        for key in (
+            "FIRECRAWL_API_KEY", "FIRECRAWL_API_URL",
+            "PARALLEL_API_KEY", "TAVILY_API_KEY", "EXA_API_KEY",
+        ):
+            os.environ.pop(key, None)
+
+    # ── Pass-through: non-searxng backends ────────────────────────────
+
+    def test_passthrough_tavily(self):
+        """web.backend=tavily → 'tavily' (no fallback needed)."""
+        from tools.web_tools import _get_extraction_backend
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "tavily"}):
+            assert _get_extraction_backend() == "tavily"
+
+    def test_passthrough_parallel(self):
+        """web.backend=parallel → 'parallel' (no fallback needed)."""
+        from tools.web_tools import _get_extraction_backend
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "parallel"}):
+            assert _get_extraction_backend() == "parallel"
+
+    def test_passthrough_firecrawl(self):
+        """web.backend=firecrawl → 'firecrawl' (no fallback needed)."""
+        from tools.web_tools import _get_extraction_backend
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "firecrawl"}):
+            assert _get_extraction_backend() == "firecrawl"
+
+    def test_passthrough_exa(self):
+        """web.backend=exa → 'exa' (no fallback needed)."""
+        from tools.web_tools import _get_extraction_backend
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "exa"}):
+            assert _get_extraction_backend() == "exa"
+
+    # ── SearXNG fallback: searxng is search-only ──────────────────────
+
+    def test_searxng_fallsback_to_tavily(self):
+        """backend=searxng + TAVILY_API_KEY → 'tavily'."""
+        from tools.web_tools import _get_extraction_backend
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "searxng"}), \
+             patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test"}):
+            assert _get_extraction_backend() == "tavily"
+
+    def test_searxng_fallsback_to_parallel(self):
+        """backend=searxng + PARALLEL_API_KEY (no tavily) → 'parallel'."""
+        from tools.web_tools import _get_extraction_backend
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "searxng"}), \
+             patch.dict(os.environ, {"PARALLEL_API_KEY": "par-test"}):
+            assert _get_extraction_backend() == "parallel"
+
+    def test_searxng_fallsback_to_exa(self):
+        """backend=searxng + EXA_API_KEY (no tavily/parallel) → 'exa'."""
+        from tools.web_tools import _get_extraction_backend
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "searxng"}), \
+             patch.dict(os.environ, {"EXA_API_KEY": "exa-test"}):
+            assert _get_extraction_backend() == "exa"
+
+    def test_searxng_fallsback_to_firecrawl(self):
+        """backend=searxng + FIRECRAWL_API_KEY (no others) → 'firecrawl'."""
+        from tools.web_tools import _get_extraction_backend
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "searxng"}), \
+             patch.dict(os.environ, {"FIRECRAWL_API_KEY": "fc-test"}):
+            assert _get_extraction_backend() == "firecrawl"
+
+    def test_searxng_no_extraction_backend_available(self):
+        """backend=searxng + no extraction keys → ValueError."""
+        from tools.web_tools import _get_extraction_backend
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "searxng"}):
+            with pytest.raises(ValueError, match="FIRECRAWL_API_KEY"):
+                _get_extraction_backend()
+
+    # ── Priority: tavily > parallel > exa > firecrawl ─────────────────
+
+    def test_searxng_tavily_priority_over_parallel(self):
+        """tavily selected over parallel when both keys are present."""
+        from tools.web_tools import _get_extraction_backend
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "searxng"}), \
+             patch.dict(os.environ, {
+                 "TAVILY_API_KEY": "tvly-test",
+                 "PARALLEL_API_KEY": "par-test",
+             }):
+            assert _get_extraction_backend() == "tavily"
+
+    def test_searxng_parallel_priority_over_exa(self):
+        """parallel selected over exa when both keys are present (no tavily)."""
+        from tools.web_tools import _get_extraction_backend
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "searxng"}), \
+             patch.dict(os.environ, {
+                 "PARALLEL_API_KEY": "par-test",
+                 "EXA_API_KEY": "exa-test",
+             }):
+            assert _get_extraction_backend() == "parallel"
+
+    def test_searxng_exa_priority_over_firecrawl(self):
+        """exa selected over firecrawl when both keys are present (no higher)."""
+        from tools.web_tools import _get_extraction_backend
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "searxng"}), \
+             patch.dict(os.environ, {
+                 "EXA_API_KEY": "exa-test",
+                 "FIRECRAWL_API_KEY": "fc-test",
+             }):
+            assert _get_extraction_backend() == "exa"

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -121,6 +121,51 @@ def _is_backend_available(backend: str) -> bool:
         return bool(_load_web_config().get("base_url"))
     return False
 
+
+def _get_extraction_backend() -> str:
+    """Get the backend to use for content-extraction operations.
+
+    Like :func:`_get_backend` but when the configured backend is
+    ``searxng`` (which only supports search — not page-content
+    extraction), falls back to the first available extraction-capable
+    backend.
+
+    Extraction backends in priority order:
+    ``tavily`` > ``parallel`` > ``exa`` > ``firecrawl``.
+
+    Raises:
+        ValueError: When the configured backend is ``searxng`` and no
+            extraction-capable backend is configured.
+    """
+    backend = _get_backend()
+
+    if backend != "searxng":
+        return backend
+
+    # SearXNG is search-only — find an extraction-capable fallback.
+    extraction_candidates = (
+        ("tavily", _has_env("TAVILY_API_KEY")),
+        ("parallel", _has_env("PARALLEL_API_KEY")),
+        ("exa", _has_env("EXA_API_KEY")),
+        ("firecrawl", (
+            _has_env("FIRECRAWL_API_KEY")
+            or _has_env("FIRECRAWL_API_URL")
+            or _is_tool_gateway_ready()
+        )),
+    )
+    for candidate, available in extraction_candidates:
+        if available:
+            logger.info(
+                "Backend '%s' doesn't support extraction — "
+                "falling back to '%s'.",
+                backend, candidate,
+            )
+            return candidate
+
+    # No extraction backend available.
+    _raise_web_backend_configuration_error()
+    return ""  # unreachable — silences type-checkers
+
 # ─── Firecrawl Client ────────────────────────────────────────────────────────
 
 _firecrawl_client = None
@@ -1292,7 +1337,7 @@ async def web_extract_tool(
         if not safe_urls:
             results = []
         else:
-            backend = _get_backend()
+            backend = _get_extraction_backend()
 
             if backend == "parallel":
                 results = await _parallel_extract(safe_urls)
@@ -1594,7 +1639,7 @@ async def web_crawl_tool(
     try:
         effective_model = model or _get_default_summarizer_model()
         auxiliary_available = check_auxiliary_model()
-        backend = _get_backend()
+        backend = _get_extraction_backend()
 
         # Tavily supports crawl via its /crawl endpoint
         if backend == "tavily":

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -88,7 +88,7 @@ def _get_backend() -> str:
     keys manually without running setup.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in ("parallel", "firecrawl", "tavily", "exa"):
+    if configured in ("parallel", "firecrawl", "tavily", "exa", "searxng"):
         return configured
 
     # Fallback for manual / legacy config — pick the highest-priority
@@ -117,6 +117,8 @@ def _is_backend_available(backend: str) -> bool:
         return check_firecrawl_api_key()
     if backend == "tavily":
         return _has_env("TAVILY_API_KEY")
+    if backend == "searxng":
+        return bool(_load_web_config().get("base_url"))
     return False
 
 # ─── Firecrawl Client ────────────────────────────────────────────────────────
@@ -871,6 +873,48 @@ def clean_base64_images(text: str) -> str:
     return cleaned_text
 
 
+# ─── SearXNG Client ─────────────────────────────────────────────────────────
+
+def _searxng_search(query: str, limit: int = 10) -> dict:
+    """Search using SearXNG instance."""
+    from tools.interrupt import is_interrupted
+    import urllib.parse
+    import requests
+    
+    if is_interrupted():
+        return {"error": "Interrupted", "success": False}
+
+    config = _load_web_config()
+    base_url = config.get("base_url", "").strip().rstrip("/")
+    if not base_url:
+        return {"error": "SearXNG base_url not configured", "success": False}
+
+    encoded_query = urllib.parse.quote(query)
+    url = f"{base_url}/search?q={encoded_query}&format=json"
+
+    try:
+        response = requests.get(url, timeout=30)
+        response.raise_for_status()
+        data = response.json()
+        
+        web_results = []
+        for i, item in enumerate(data.get("results", [])[:limit]):
+            web_results.append({
+                "title": item.get("title", ""),
+                "url": item.get("url", ""),
+                "description": item.get("content", ""),
+                "position": i + 1
+            })
+            
+        return {
+            "success": True,
+            "data": {"web": web_results}
+        }
+    except Exception as e:
+        logger.error(f"SearXNG search failed: {e}")
+        return {"error": str(e), "success": False}
+
+
 # ─── Exa Client ──────────────────────────────────────────────────────────────
 
 _exa_client = None
@@ -1086,6 +1130,15 @@ def web_search_tool(query: str, limit: int = 5) -> str:
         backend = _get_backend()
         if backend == "parallel":
             response_data = _parallel_search(query, limit)
+            debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
+            result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
+            debug_call_data["final_response_size"] = len(result_json)
+            _debug.log_call("web_search_tool", debug_call_data)
+            _debug.save()
+            return result_json
+
+        if backend == "searxng":
+            response_data = _searxng_search(query, limit)
             debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
             result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
             debug_call_data["final_response_size"] = len(result_json)
@@ -1922,9 +1975,9 @@ def check_firecrawl_api_key() -> bool:
 def check_web_api_key() -> bool:
     """Check whether the configured web backend is available."""
     configured = _load_web_config().get("backend", "").lower().strip()
-    if configured in ("exa", "parallel", "firecrawl", "tavily"):
+    if configured in ("exa", "parallel", "firecrawl", "tavily", "searxng"):
         return _is_backend_available(configured)
-    return any(_is_backend_available(backend) for backend in ("exa", "parallel", "firecrawl", "tavily"))
+    return any(_is_backend_available(backend) for backend in ("exa", "parallel", "firecrawl", "tavily", "searxng"))
 
 
 def check_auxiliary_model() -> bool:


### PR DESCRIPTION
## Summary

When the web backend is configured as `searxng`, content extraction (`web_extract`) and crawling (`web_crawl`) failed because SearXNG only supports search, not page-content extraction. The code fell through to Firecrawl which wasn't configured, resulting in "Firecrawl not configured" errors.

This PR adds `_get_extraction_backend()` — a function that auto-detects when the primary backend doesn't support extraction and falls back to the first available extraction-capable backend.

### Fallback Priority

`tavily` > `parallel` > `exa` > `firecrawl`

### Commits

- **ad6bf19f** feat: add searxng search backend (base dependency)
- **84e625a6** fix(web_tools): add _get_extraction_backend() to handle searxng fallback for extract/crawl
  - New function checks if backend is `searxng` and auto-falls back
  - Uses `_has_env()` to detect available backends
  - Raises clear configuration error when no fallback is available
  - Test: tests/tools/test_web_tools_config.py (121 lines)

### Background

Resolves the `web_extract` failure from session 20260427_102745_6a4ffe where all extraction attempts returned "Firecrawl not configured". With Tavily API key configured, extraction now works automatically without manual backend switching.