### PR TITLE
fix(approval): harden YOLO mode env parsing against quoted-bool strings

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -78,7 +78,7 @@ _COMMAND_SPINNER_FRAMES = ("⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧
 # User-managed env files should override stale shell exports on restart.
 from hermes_constants import get_hermes_home, display_hermes_home
 from hermes_cli.env_loader import load_hermes_dotenv
-from utils import base_url_host_matches
+from utils import base_url_host_matches, is_truthy_value
 
 _hermes_home = get_hermes_home()
 _project_env = Path(__file__).parent / '.env'
@@ -6786,7 +6786,7 @@ class HermesCLI:
         import os
         from hermes_cli.colors import Colors as _Colors
 
-        current = bool(os.environ.get("HERMES_YOLO_MODE"))
+        current = is_truthy_value(os.environ.get("HERMES_YOLO_MODE"))
         if current:
             os.environ.pop("HERMES_YOLO_MODE", None)
             _cprint(

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -224,6 +224,21 @@ def test_config_set_yolo_toggles_session_scope():
         server._sessions.clear()
 
 
+def test_config_set_yolo_process_scope_treats_false_like_env_as_disabled(monkeypatch):
+    monkeypatch.setenv("HERMES_YOLO_MODE", "false")
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "config.set",
+            "params": {"key": "yolo"},
+        }
+    )
+
+    assert resp["result"]["value"] == "1"
+    assert os.environ.get("HERMES_YOLO_MODE") == "1"
+
+
 def test_config_get_statusbar_survives_non_dict_display(monkeypatch):
     monkeypatch.setattr(server, "_load_cfg", lambda: {"display": "broken"})
 

--- a/tests/tools/test_yolo_mode.py
+++ b/tests/tools/test_yolo_mode.py
@@ -125,6 +125,33 @@ class TestYoloMode:
                                          approval_callback=lambda *a: "deny")
         assert not result["approved"]
 
+    @pytest.mark.parametrize("value", ["false", "False", "0", "off", "no"])
+    def test_false_like_yolo_values_do_not_bypass_dangerous_command(self, monkeypatch, value):
+        """False-like env strings must not silently enable YOLO bypass."""
+        monkeypatch.setenv("HERMES_YOLO_MODE", value)
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        monkeypatch.setenv("HERMES_SESSION_KEY", "test-session")
+
+        result = check_dangerous_command(
+            "rm -rf /tmp/stuff",
+            "local",
+            approval_callback=lambda *a: "deny",
+        )
+        assert not result["approved"]
+
+    @pytest.mark.parametrize("value", ["false", "False", "0", "off", "no"])
+    def test_false_like_yolo_values_do_not_bypass_combined_guard(self, monkeypatch, value):
+        """Combined guard must treat false-like YOLO env strings as disabled."""
+        monkeypatch.setenv("HERMES_YOLO_MODE", value)
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+
+        result = check_all_command_guards(
+            "rm -rf /tmp/stuff",
+            "local",
+            approval_callback=lambda *a: "deny",
+        )
+        assert not result["approved"]
+
     def test_session_scoped_yolo_only_bypasses_current_session(self, monkeypatch):
         """Gateway /yolo should only bypass approvals for the active session."""
         monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -18,6 +18,8 @@ import time
 import unicodedata
 from typing import Optional
 
+from utils import is_truthy_value
+
 logger = logging.getLogger(__name__)
 
 # Per-thread/per-task gateway session identity.
@@ -724,7 +726,7 @@ def check_dangerous_command(command: str, env_type: str,
 
     # --yolo: bypass all approval prompts. Gateway /yolo is session-scoped;
     # CLI --yolo remains process-scoped via the env var for local use.
-    if os.getenv("HERMES_YOLO_MODE") or is_current_session_yolo_enabled():
+    if is_truthy_value(os.getenv("HERMES_YOLO_MODE")) or is_current_session_yolo_enabled():
         return {"approved": True, "message": None}
 
     is_dangerous, pattern_key, description = detect_dangerous_command(command)
@@ -849,7 +851,7 @@ def check_all_command_guards(command: str, env_type: str,
     # --yolo or approvals.mode=off: bypass all approval prompts.
     # Gateway /yolo is session-scoped; CLI --yolo remains process-scoped.
     approval_mode = _get_approval_mode()
-    if os.getenv("HERMES_YOLO_MODE") or is_current_session_yolo_enabled() or approval_mode == "off":
+    if is_truthy_value(os.getenv("HERMES_YOLO_MODE")) or is_current_session_yolo_enabled() or approval_mode == "off":
         return {"approved": True, "message": None}
 
     is_cli = os.getenv("HERMES_INTERACTIVE")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -17,6 +17,7 @@ from typing import Optional
 
 from hermes_constants import get_hermes_home
 from hermes_cli.env_loader import load_hermes_dotenv
+from utils import is_truthy_value
 from tui_gateway.transport import (
     StdioTransport,
     Transport,
@@ -2694,7 +2695,7 @@ def _(rid, params: dict) -> dict:
                     enable_session_yolo(session["session_key"])
                     nv = "1"
             else:
-                current = bool(os.environ.get("HERMES_YOLO_MODE"))
+                current = is_truthy_value(os.environ.get("HERMES_YOLO_MODE"))
                 if current:
                     os.environ.pop("HERMES_YOLO_MODE", None)
                     nv = "0"


### PR DESCRIPTION
## Summary

This fixes a dangerous-command approval bypass caused by treating any non-empty
`HERMES_YOLO_MODE` value as enabled.

Before this change, values like `"false"`, `"0"`, `"off"`, or `"no"` were still
truthy at the env-read sites that gate YOLO mode, which could silently disable
approval prompts for dangerous commands.

## What changed

- switched YOLO env parsing in `tools/approval.py` to use the shared boolean coercion helper
- aligned CLI YOLO toggle state detection with the same semantics
- aligned TUI gateway YOLO toggle state detection with the same semantics
- added regression tests for false-like YOLO env values in both the approval path and combined guard path
- added a TUI regression test to ensure process-scoped YOLO toggling recovers correctly from `HERMES_YOLO_MODE=false`

## Why this matters

This is a small security hardening fix with a deterministic repro:
setting `HERMES_YOLO_MODE=false` should not bypass dangerous-command approval.

The change keeps existing intended behavior for truthy values like `1`, `true`,
`yes`, and `on`, while closing the false-like string hole.

## Testing

Passed locally:

- `tests/tools/test_yolo_mode.py`
- `tests/test_tui_gateway_server.py`

Manual run summary:
- `87 passed, 4 warnings in 6.33s`
