### PR TITLE
fix(web_tools): add _get_extraction_backend() for SearXNG extraction fallback

### DIFF
--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -577,3 +577,124 @@ def test_web_requires_env_includes_exa_key():
     from tools.web_tools import _web_requires_env
 
     assert "EXA_API_KEY" in _web_requires_env()
+
+
+# ── _get_extraction_backend() tests ────────────────────────────────────────
+
+class TestExtractionBackend:
+    """Tests for _get_extraction_backend() — searxng fallback logic.
+
+    SearXNG only supports web search, not content extraction.  When the
+    configured backend is searxng, extraction operations should fall back
+    to the first available extraction-capable backend.
+    """
+
+    def setup_method(self):
+        """Clear web-backend env vars before each test."""
+        for key in (
+            "FIRECRAWL_API_KEY", "FIRECRAWL_API_URL",
+            "PARALLEL_API_KEY", "TAVILY_API_KEY", "EXA_API_KEY",
+        ):
+            os.environ.pop(key, None)
+
+    def teardown_method(self):
+        for key in (
+            "FIRECRAWL_API_KEY", "FIRECRAWL_API_URL",
+            "PARALLEL_API_KEY", "TAVILY_API_KEY", "EXA_API_KEY",
+        ):
+            os.environ.pop(key, None)
+
+    # ── Pass-through: non-searxng backends ────────────────────────────
+
+    def test_passthrough_tavily(self):
+        """web.backend=tavily → 'tavily' (no fallback needed)."""
+        from tools.web_tools import _get_extraction_backend
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "tavily"}):
+            assert _get_extraction_backend() == "tavily"
+
+    def test_passthrough_parallel(self):
+        """web.backend=parallel → 'parallel' (no fallback needed)."""
+        from tools.web_tools import _get_extraction_backend
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "parallel"}):
+            assert _get_extraction_backend() == "parallel"
+
+    def test_passthrough_firecrawl(self):
+        """web.backend=firecrawl → 'firecrawl' (no fallback needed)."""
+        from tools.web_tools import _get_extraction_backend
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "firecrawl"}):
+            assert _get_extraction_backend() == "firecrawl"
+
+    def test_passthrough_exa(self):
+        """web.backend=exa → 'exa' (no fallback needed)."""
+        from tools.web_tools import _get_extraction_backend
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "exa"}):
+            assert _get_extraction_backend() == "exa"
+
+    # ── SearXNG fallback: searxng is search-only ──────────────────────
+
+    def test_searxng_fallsback_to_tavily(self):
+        """backend=searxng + TAVILY_API_KEY → 'tavily'."""
+        from tools.web_tools import _get_extraction_backend
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "searxng"}), \
+             patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test"}):
+            assert _get_extraction_backend() == "tavily"
+
+    def test_searxng_fallsback_to_parallel(self):
+        """backend=searxng + PARALLEL_API_KEY (no tavily) → 'parallel'."""
+        from tools.web_tools import _get_extraction_backend
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "searxng"}), \
+             patch.dict(os.environ, {"PARALLEL_API_KEY": "par-test"}):
+            assert _get_extraction_backend() == "parallel"
+
+    def test_searxng_fallsback_to_exa(self):
+        """backend=searxng + EXA_API_KEY (no tavily/parallel) → 'exa'."""
+        from tools.web_tools import _get_extraction_backend
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "searxng"}), \
+             patch.dict(os.environ, {"EXA_API_KEY": "exa-test"}):
+            assert _get_extraction_backend() == "exa"
+
+    def test_searxng_fallsback_to_firecrawl(self):
+        """backend=searxng + FIRECRAWL_API_KEY (no others) → 'firecrawl'."""
+        from tools.web_tools import _get_extraction_backend
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "searxng"}), \
+             patch.dict(os.environ, {"FIRECRAWL_API_KEY": "fc-test"}):
+            assert _get_extraction_backend() == "firecrawl"
+
+    def test_searxng_no_extraction_backend_available(self):
+        """backend=searxng + no extraction keys → ValueError."""
+        from tools.web_tools import _get_extraction_backend
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "searxng"}):
+            with pytest.raises(ValueError, match="FIRECRAWL_API_KEY"):
+                _get_extraction_backend()
+
+    # ── Priority: tavily > parallel > exa > firecrawl ─────────────────
+
+    def test_searxng_tavily_priority_over_parallel(self):
+        """tavily selected over parallel when both keys are present."""
+        from tools.web_tools import _get_extraction_backend
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "searxng"}), \
+             patch.dict(os.environ, {
+                 "TAVILY_API_KEY": "tvly-test",
+                 "PARALLEL_API_KEY": "par-test",
+             }):
+            assert _get_extraction_backend() == "tavily"
+
+    def test_searxng_parallel_priority_over_exa(self):
+        """parallel selected over exa when both keys are present (no tavily)."""
+        from tools.web_tools import _get_extraction_backend
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "searxng"}), \
+             patch.dict(os.environ, {
+                 "PARALLEL_API_KEY": "par-test",
+                 "EXA_API_KEY": "exa-test",
+             }):
+            assert _get_extraction_backend() == "parallel"
+
+    def test_searxng_exa_priority_over_firecrawl(self):
+        """exa selected over firecrawl when both keys are present (no higher)."""
+        from tools.web_tools import _get_extraction_backend
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "searxng"}), \
+             patch.dict(os.environ, {
+                 "EXA_API_KEY": "exa-test",
+                 "FIRECRAWL_API_KEY": "fc-test",
+             }):
+            assert _get_extraction_backend() == "exa"

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -119,6 +119,51 @@ def _is_backend_available(backend: str) -> bool:
         return _has_env("TAVILY_API_KEY")
     return False
 
+
+def _get_extraction_backend() -> str:
+    """Get the backend to use for content-extraction operations.
+
+    Like :func:`_get_backend` but when the configured backend is
+    ``searxng`` (which only supports search — not page-content
+    extraction), falls back to the first available extraction-capable
+    backend.
+
+    Extraction backends in priority order:
+    ``tavily`` > ``parallel`` > ``exa`` > ``firecrawl``.
+
+    Raises:
+        ValueError: When the configured backend is ``searxng`` and no
+            extraction-capable backend is configured.
+    """
+    backend = _get_backend()
+
+    if backend != "searxng":
+        return backend
+
+    # SearXNG is search-only — find an extraction-capable fallback.
+    extraction_candidates = (
+        ("tavily", _has_env("TAVILY_API_KEY")),
+        ("parallel", _has_env("PARALLEL_API_KEY")),
+        ("exa", _has_env("EXA_API_KEY")),
+        ("firecrawl", (
+            _has_env("FIRECRAWL_API_KEY")
+            or _has_env("FIRECRAWL_API_URL")
+            or _is_tool_gateway_ready()
+        )),
+    )
+    for candidate, available in extraction_candidates:
+        if available:
+            logger.info(
+                "Backend '%s' doesn't support extraction — "
+                "falling back to '%s'.",
+                backend, candidate,
+            )
+            return candidate
+
+    # No extraction backend available.
+    _raise_web_backend_configuration_error()
+    return ""  # unreachable — silences type-checkers
+
 # ─── Firecrawl Client ────────────────────────────────────────────────────────
 
 _firecrawl_client = None
@@ -1239,7 +1284,7 @@ async def web_extract_tool(
         if not safe_urls:
             results = []
         else:
-            backend = _get_backend()
+            backend = _get_extraction_backend()
 
             if backend == "parallel":
                 results = await _parallel_extract(safe_urls)
@@ -1541,7 +1586,7 @@ async def web_crawl_tool(
     try:
         effective_model = model or _get_default_summarizer_model()
         auxiliary_available = check_auxiliary_model()
-        backend = _get_backend()
+        backend = _get_extraction_backend()
 
         # Tavily supports crawl via its /crawl endpoint
         if backend == "tavily":


### PR DESCRIPTION
## Summary

When the web backend is configured as `searxng`, content extraction (`web_extract`) and crawling failed because SearXNG only supports search, not page-content extraction. The code fell through to Firecrawl which often isn't configured, resulting in "Firecrawl not configured" errors.

This PR adds `_get_extraction_backend()` — auto-detects when the primary backend doesn't support extraction and falls back to the first available extraction-capable backend.

### Fallback Priority

`tavily` > `parallel` > `exa` > `firecrawl`

### Changes

- `tools/web_tools.py`: +47 lines — new `_get_extraction_backend()` function + updated dispatch in `web_extract_tool` and `web_crawl_tool`
- `tests/tools/test_web_tools_config.py`: +121 lines — tests for backend resolution

### Behavior

| Config | TAVILY_API_KEY | Result |
|--------|---------------|--------|
| `searxng` | set | extract via Tavily ✅ |
| `searxng` | unset, Firecrawl configured | extract via Firecrawl |
| `searxng` | nothing configured | clear configuration error |
| `tavily` / `parallel` / etc. | — | uses configured backend (no change) |

### Background

Resolves `web_extract` failure from session 20260427_102745_6a4ffe.