### PR TITLE
fix: check user-defined providers before builtin alias guard

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -333,22 +333,15 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
     if not requested_norm or requested_norm == "custom":
         return None
 
-    # Raw names should only map to custom providers when they are not already
-    # valid built-in providers or aliases. Explicit menu keys like
-    # ``custom:local`` always target the saved custom provider.
     if requested_norm == "auto":
         return None
-    if not requested_norm.startswith("custom:"):
-        try:
-            auth_mod.resolve_provider(requested_norm)
-        except AuthError:
-            pass
-        else:
-            return None
 
     config = load_config()
-    
-    # First check providers: dict (new-style user-defined providers)
+
+    # First check providers: dict (new-style user-defined providers) — do this
+    # BEFORE the builtin provider guard so that user-defined providers whose
+    # name happens to match a _PROVIDER_ALIASES entry (e.g. "llama-cpp" → "custom")
+    # are found in the providers dict instead of being rejected as a builtin.
     providers = config.get("providers")
     if isinstance(providers, dict):
         for ep_name, entry in providers.items():
@@ -441,6 +434,16 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
         if model_name:
             result["model"] = model_name
         return result
+
+    # Only if not found in any user-defined provider, check if this is a
+    # built-in provider (not a custom provider at all).
+    if not requested_norm.startswith("custom:"):
+        try:
+            auth_mod.resolve_provider(requested_norm)
+        except AuthError:
+            pass
+        else:
+            return None
 
     return None
 


### PR DESCRIPTION
## Summary

`_get_named_custom_provider` was checking the builtin provider alias guard \*before\* checking user-defined providers from the `providers:` dict. This caused user-defined providers whose names happen to match a built-in alias (e.g. `llama-cpp`) to be silently rejected as "not a custom provider" — the user's config entry was never examined.

## Root Cause

The guard at the top of the function called `auth_mod.resolve_provider(requested_norm)` and returned `None` if the name matched a known built-in alias. This happened before any user-defined provider lookup.

## Fix

Moved the builtin guard to the end of `_get_named_custom_provider`, after both the `providers:` dict and `custom_providers:` list are checked. User-defined providers now take priority over built-in aliases, which is the correct behavior — user configuration should always win.

## Test Plan

- Verified locally: `_get_named_custom_provider("llama-cpp")` now returns the user's `providers:` entry instead of `None`
- Existing tests should continue to pass (logic is reordered, not removed)

Closes # _(no issue filed)_