### PR TITLE
fix(installer): add arm64 fallback for Playwright setup

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1258,10 +1258,25 @@ install_node_deps() {
             ubuntu|debian|raspbian|pop|linuxmint|elementary|zorin|kali|parrot)
                 log_info "Playwright may request sudo to install browser system dependencies (shared libraries)."
                 log_info "This is standard Playwright setup — Hermes itself does not require root access."
-                cd "$INSTALL_DIR" && npx playwright install --with-deps chromium 2>/dev/null || {
+                local machine_arch
+                machine_arch="$(uname -m)"
+                if cd "$INSTALL_DIR" && npx playwright install --with-deps chromium 2>/dev/null; then
+                    :
+                elif [[ "$machine_arch" == "aarch64" || "$machine_arch" == "arm64" ]]; then
+                    log_warn "Playwright --with-deps failed on $machine_arch; retrying browser-only install."
+                    if cd "$INSTALL_DIR" && npx playwright install chromium 2>/dev/null; then
+                        log_success "Playwright Chromium installed (without auto system dependency install)."
+                        log_info "If browser tools fail, install deps manually, then rerun:"
+                        log_info "  sudo apt install nss libatk-bridge2.0-0 libdrm2 libxkbcommon0 libgbm1 libasound2t64"
+                        log_info "  cd $INSTALL_DIR && npx playwright install chromium"
+                    else
+                        log_warn "Playwright browser installation failed — browser tools will not work."
+                        log_warn "Try running manually: cd $INSTALL_DIR && npx playwright install chromium"
+                    fi
+                else
                     log_warn "Playwright browser installation failed — browser tools will not work."
                     log_warn "Try running manually: cd $INSTALL_DIR && npx playwright install --with-deps chromium"
-                }
+                fi
                 ;;
             arch|manjaro)
                 if command -v pacman &> /dev/null; then


### PR DESCRIPTION
## What does this PR do?

This patch makes the installer more reliable on Debian/Ubuntu ARM64 hosts during Playwright browser setup.

The current flow uses `npx playwright install --with-deps chromium`. On some ARM64 servers this step fails and leaves users without a clear next step. This PR keeps the existing behavior first, then adds an ARM64 fallback and clearer guidance.

## Related Issue

Fixes #16314

## Changes Made

- Updated `scripts/install.sh` in the Debian/Ubuntu Playwright install branch.
- Kept the default path: `npx playwright install --with-deps chromium`.
- Added ARM64/AArch64 fallback: if that command fails, retry `npx playwright install chromium`.
- Added explicit manual dependency/install instructions when fallback is used.

## How to Test

1. Use an Ubuntu 24.04 ARM64 machine and run the installer.
2. Reproduce a failure in `npx playwright install --with-deps chromium`.
3. Verify the installer retries with `npx playwright install chromium` and prints actionable follow-up instructions.

## Checklist

### Code

- [x] I searched existing PRs to avoid duplicate work.
- [x] This PR only contains changes related to this fix.
- [x] I ran `pytest tests/ -q`.
- [ ] I added tests for this change.
- [x] I validated script syntax with `bash -n scripts/install.sh`.

### Documentation & Housekeeping

- [x] No config template changes required.
- [x] No architecture/workflow doc changes required.
- [x] Cross-platform impact was considered.

## Screenshots / Logs

- `bash -n scripts/install.sh` passed.
