### PR TITLE
fix: resolve type-annotation and style issues in run_agent.py and cli.py

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6613,7 +6613,7 @@ class HermesCLI:
                             f' --user-data-dir="{_data_dir}"'
                             f" --no-first-run --no-default-browser-check"
                         )
-                    print(f"     Launch Chrome manually:")
+                    print("     Launch Chrome manually:")
                     print(f"     {chrome_cmd}")
             else:
                 print(f"   ⚠ Port {_port} is not reachable at {cdp_url}")

--- a/run_agent.py
+++ b/run_agent.py
@@ -39,7 +39,7 @@ import threading
 from types import SimpleNamespace
 import urllib.request
 import uuid
-from typing import List, Dict, Any, Optional
+from typing import TYPE_CHECKING, List, Dict, Any, Optional
 from urllib.parse import urlparse, parse_qs, urlunparse
 from openai import OpenAI
 import fire
@@ -119,6 +119,10 @@ from agent.trajectory import (
 )
 from utils import atomic_json_write, base_url_host_matches, base_url_hostname, env_var_enabled, normalize_proxy_url
 
+
+
+if TYPE_CHECKING:
+    from agent.rate_limit_tracker import RateLimitState
 
 
 class _SafeWriter:
@@ -2671,7 +2675,6 @@ class AIAgent:
         eff_api_mode = api_mode if api_mode is not None else (self.api_mode or "")
         eff_model = (model if model is not None else self.model) or ""
 
-        base_lower = eff_base_url.lower()
         model_lower = eff_model.lower()
         provider_lower = eff_provider.lower()
         is_claude = "claude" in model_lower
@@ -3550,7 +3553,8 @@ class AIAgent:
                     
                     # Add tool calls wrapped in XML tags
                     for tool_call in msg["tool_calls"]:
-                        if not tool_call or not isinstance(tool_call, dict): continue
+                        if not tool_call or not isinstance(tool_call, dict):
+                            continue
                         # Parse arguments - should always succeed since we validate during conversation
                         # but keep try-except as safety net
                         try:
@@ -10171,7 +10175,7 @@ class AIAgent:
                         elif _resp_error_code == 504:
                             _failure_hint = f"upstream gateway timeout (504, {api_duration:.0f}s)"
                         elif _resp_error_code == 429:
-                            _failure_hint = f"rate limited by upstream provider (429)"
+                            _failure_hint = "rate limited by upstream provider (429)"
                         elif _resp_error_code in (500, 502):
                             _failure_hint = f"upstream server error ({_resp_error_code}, {api_duration:.0f}s)"
                         elif _resp_error_code in (503, 529):
@@ -12407,7 +12411,8 @@ class AIAgent:
                             if isinstance(m, dict) and m.get("role") == "tool"
                         }
                         for tc in msg["tool_calls"]:
-                            if not tc or not isinstance(tc, dict): continue
+                            if not tc or not isinstance(tc, dict):
+                                continue
                             if tc["id"] not in answered_ids:
                                 err_msg = {
                                     "role": "tool",


### PR DESCRIPTION
## Summary

Resolves four small but real issues surfaced by lint analysis of `run_agent.py` and `cli.py`.

### Changes

**run_agent.py**

1. **`TYPE_CHECKING` block with `RateLimitState` import (F821)**
   - `Optional["RateLimitState"]` was used in a type annotation at line 1182 but `RateLimitState` was never imported, causing `ruff` to report `F821: Undefined name 'RateLimitState'`.
   - Added `TYPE_CHECKING` guard and conditional import of `RateLimitState` from `agent.rate_limit_tracker`, mirroring the pattern already used in the module.

2. **Remove unused `base_lower` variable (F841)**
   - `base_lower = eff_base_url.lower()` was assigned at line 2678 but never referenced. The surrounding code uses `eff_base_url` directly with `base_url_host_matches` / `base_url_hostname`. Removed the dead assignment.

3. **Split multi-statement lines (E701 × 2)**
   - `if not tool_call or not isinstance(tool_call, dict): continue` at line 3556 — split across two lines.
   - `if not tc or not isinstance(tc, dict): continue` at line 12413 — split across two lines.

4. **Remove unnecessary `f` prefix (F541)**
   - `_failure_hint = f"rate limited by upstream provider (429)"` — the string has no placeholders; removed the `f` prefix.

**cli.py**

5. **Remove unnecessary `f` prefix (F541)**
   - `print(f"     Launch Chrome manually:")` — no interpolation; removed the `f` prefix.

### Verification

- All modified files pass `python3 -m py_compile` with no syntax errors.
- `ruff check` on `run_agent.py` and `cli.py` reports zero `F821`/`F841`/`F541`/`E701` errors after the fixes.
- Related test suite (`tests/agent/test_nous_rate_guard.py`, `test_rate_limit_tracker.py`, `test_model_metadata.py`) passes: **149 passed, 4 warnings** (warnings are pre-existing `DeprecationWarning` in `conftest.py` unrelated to these changes).
