### PR TITLE
fix(delegate): guard _load_config() against delegation: null in config.yaml

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2276,7 +2276,7 @@ def _load_config() -> dict:
     try:
         from cli import CLI_CONFIG
 
-        cfg = CLI_CONFIG.get("delegation", {})
+        cfg = CLI_CONFIG.get("delegation") or {}
         if cfg:
             return cfg
     except Exception:
@@ -2285,7 +2285,7 @@ def _load_config() -> dict:
         from hermes_cli.config import load_config
 
         full = load_config()
-        return full.get("delegation", {})
+        return full.get("delegation") or {}
     except Exception:
         return {}
 


### PR DESCRIPTION
## Problem

`delegation: null` in `config.yaml` causes `NoneType object has no attribute 'get'` on every API call that triggers the delegation path:

```
File "run_agent.py", line 11938, in run_conversation
    assistant_message.tool_calls = self._cap_delegate_task_calls(
File "run_agent.py", line 4733, in _cap_delegate_task_calls
    max_children = _get_max_concurrent_children()
File "tools/delegate_tool.py", line 335, in _get_max_concurrent_children
    val = cfg.get("max_concurrent_children")
          ^^^^^^^
AttributeError: 'NoneType' object has no attribute 'get'
```

## Root Cause

`_load_config()` uses `dict.get("delegation", {})` which returns the default `{}` **only when the key is missing**. When `delegation: null` is present in YAML, the key exists with value `None`, so `.get()` returns `None` — and downstream `cfg.get(...)` crashes.

This is the same class of bug as the one fixed in fd9b692d (`fix(tui): tolerate null top-level sections in config.yaml`), which guarded 21 sites in `tui_gateway/server.py` but missed `delegate_tool.py`.

Related issues: #7215, #7346

## Fix

Use `dict.get(key) or {}` instead of `dict.get(key, {})` in `_load_config()`, consistent with the pattern from fd9b692d:

```python
# Before
cfg = CLI_CONFIG.get("delegation", {})
return full.get("delegation", {})

# After
cfg = CLI_CONFIG.get("delegation") or {}
return full.get("delegation") or {}
```

## Testing

- Verified that `delegation: null` no longer crashes; `_get_max_concurrent_children()` correctly falls back to the default (3)
- Verified that `delegation: {}` and `delegation: {max_concurrent_children: 5}` still work as expected