### PR TITLE
fix(agent): respect fallback api_mode overrides

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -763,6 +763,7 @@ def init_agent(
     # router-based implicit auth) can apply it consistently.  Bedrock
     # Claude uses its own timeout path and is not covered here.
     _provider_timeout = get_provider_request_timeout(agent.provider, agent.model)
+    _init_fallback_api_mode = None
 
     if agent.api_mode == "anthropic_messages":
         from agent.anthropic_adapter import build_anthropic_client, resolve_anthropic_token
@@ -1032,14 +1033,22 @@ def init_agent(
                             _fb_key_env = (_fb.get("key_env") or _fb.get("api_key_env") or "").strip()
                             if _fb_key_env:
                                 _fb_explicit_key = os.getenv(_fb_key_env, "").strip() or None
+                        from hermes_cli.runtime_provider import _parse_api_mode
+
+                        _init_fallback_api_mode = _parse_api_mode(_fb.get("api_mode"))
                         _fb_client, _fb_model = resolve_provider_client(
                             _fb["provider"], model=_fb["model"], raw_codex=True,
                             explicit_base_url=_fb.get("base_url"),
                             explicit_api_key=_fb_explicit_key,
+                            api_mode=_init_fallback_api_mode,
                         )
                         if _fb_client is not None:
                             agent.provider = _fb["provider"]
                             agent.model = _fb_model or _fb["model"]
+                            if _init_fallback_api_mode is not None:
+                                agent.api_mode = _init_fallback_api_mode
+                                if hasattr(agent, "_transport_cache"):
+                                    agent._transport_cache.clear()
                             agent._fallback_activated = True
                             client_kwargs = {
                                 "api_key": _fb_client.api_key,
@@ -1132,7 +1141,33 @@ def init_agent(
             from agent.ssl_guard import verify_ca_bundle_with_fallback
 
             verify_ca_bundle_with_fallback()
-            agent.client = agent._create_openai_client(client_kwargs, reason="agent_init", shared=True)
+            if _init_fallback_api_mode == "anthropic_messages":
+                from agent.anthropic_adapter import build_anthropic_client, _is_oauth_token
+
+                agent._anthropic_api_key = agent.api_key
+                agent._anthropic_base_url = agent.base_url
+                agent._anthropic_client = build_anthropic_client(
+                    agent.api_key,
+                    agent.base_url,
+                    timeout=get_provider_request_timeout(agent.provider, agent.model),
+                )
+                agent._is_anthropic_oauth = (
+                    _is_oauth_token(agent.api_key)
+                    if agent.provider == "anthropic"
+                    else False
+                )
+                agent.client = None
+                agent._client_kwargs = {}
+            else:
+                agent.client = agent._create_openai_client(
+                    client_kwargs,
+                    reason="agent_init",
+                    shared=True,
+                )
+            if getattr(agent, "_fallback_activated", False):
+                agent._use_prompt_caching, agent._use_native_cache_layout = (
+                    agent._anthropic_prompt_cache_policy()
+                )
             if not agent.quiet_mode:
                 print(f"🤖 AI Agent initialized with model: {agent.model}")
                 if base_url:

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1427,6 +1427,14 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         # falling through to OpenRouter defaults.
         fb_base_url_hint = (fb.get("base_url") or "").strip() or None
         fb_api_key_hint = (fb.get("api_key") or "").strip() or None
+        fb_api_mode_hint = (fb.get("api_mode") or "").strip() or None
+        if fb_api_mode_hint not in {
+            "chat_completions",
+            "codex_responses",
+            "anthropic_messages",
+            "bedrock_converse",
+        }:
+            fb_api_mode_hint = None
         if not fb_api_key_hint:
             # key_env and api_key_env are both documented aliases (see
             # _normalize_custom_provider_entry in hermes_cli/config.py).
@@ -1441,7 +1449,8 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         fb_client, _resolved_fb_model = resolve_provider_client(
             fb_provider, model=fb_model, raw_codex=True,
             explicit_base_url=fb_base_url_hint,
-            explicit_api_key=fb_api_key_hint)
+            explicit_api_key=fb_api_key_hint,
+            api_mode=fb_api_mode_hint)
         if fb_client is None:
             logger.warning(
                 "Fallback to %s failed: provider not configured",
@@ -1458,43 +1467,43 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
                 fb_model, fb_provider, _norm_err,
             )
 
-        # Determine api_mode from provider / base URL / model
-        fb_api_mode = "chat_completions"
+        fb_api_mode = fb_api_mode_hint or "chat_completions"
         fb_base_url = str(fb_client.base_url)
         _fb_is_azure = agent._is_azure_openai_url(fb_base_url)
-        if fb_provider == "openai-codex":
-            fb_api_mode = "codex_responses"
-        elif (
-            fb_provider == "anthropic"
-            or fb_base_url.rstrip("/").lower().endswith("/anthropic")
-            or base_url_hostname(fb_base_url) == "api.anthropic.com"
-        ):
-            # Custom providers (e.g. cron-anthropic) point at the native
-            # api.anthropic.com host with no "/anthropic" path suffix, so the
-            # name/suffix checks above miss them and they default to
-            # chat_completions → POST /v1/chat/completions → 404. Match the
-            # host the same way determine_api_mode() and _detect_api_mode_for_url()
-            # do on the primary path. (#32243, #49247)
-            fb_api_mode = "anthropic_messages"
-        elif _fb_is_azure:
-            # Azure OpenAI serves gpt-5.x on /chat/completions — does NOT
-            # support the Responses API. Stay on chat_completions.
-            fb_api_mode = "chat_completions"
-        elif agent._is_direct_openai_url(fb_base_url):
-            fb_api_mode = "codex_responses"
-        elif agent._provider_model_requires_responses_api(
-            fb_model,
-            provider=fb_provider,
-        ):
-            # GPT-5.x models usually need Responses API, but keep
-            # provider-specific exceptions like Copilot gpt-5-mini on
-            # chat completions.
-            fb_api_mode = "codex_responses"
-        elif fb_provider == "bedrock" or (
-            base_url_hostname(fb_base_url).startswith("bedrock-runtime.")
-            and base_url_host_matches(fb_base_url, "amazonaws.com")
-        ):
-            fb_api_mode = "bedrock_converse"
+        if fb_api_mode_hint is None:
+            if fb_provider == "openai-codex":
+                fb_api_mode = "codex_responses"
+            elif (
+                fb_provider == "anthropic"
+                or fb_base_url.rstrip("/").lower().endswith("/anthropic")
+                or base_url_hostname(fb_base_url) == "api.anthropic.com"
+            ):
+                # Custom providers (e.g. cron-anthropic) point at the native
+                # api.anthropic.com host with no "/anthropic" path suffix, so the
+                # name/suffix checks above miss them and they default to
+                # chat_completions → POST /v1/chat/completions → 404. Match the
+                # host the same way determine_api_mode() and _detect_api_mode_for_url()
+                # do on the primary path. (#32243, #49247)
+                fb_api_mode = "anthropic_messages"
+            elif _fb_is_azure:
+                # Azure OpenAI serves gpt-5.x on /chat/completions — does NOT
+                # support the Responses API. Stay on chat_completions.
+                fb_api_mode = "chat_completions"
+            elif agent._is_direct_openai_url(fb_base_url):
+                fb_api_mode = "codex_responses"
+            elif agent._provider_model_requires_responses_api(
+                fb_model,
+                provider=fb_provider,
+            ):
+                # GPT-5.x models usually need Responses API, but keep
+                # provider-specific exceptions like Copilot gpt-5-mini on
+                # chat completions.
+                fb_api_mode = "codex_responses"
+            elif fb_provider == "bedrock" or (
+                base_url_hostname(fb_base_url).startswith("bedrock-runtime.")
+                and base_url_host_matches(fb_base_url, "amazonaws.com")
+            ):
+                fb_api_mode = "bedrock_converse"
 
         old_model = agent.model
         old_provider = agent.provider

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1427,14 +1427,9 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         # falling through to OpenRouter defaults.
         fb_base_url_hint = (fb.get("base_url") or "").strip() or None
         fb_api_key_hint = (fb.get("api_key") or "").strip() or None
-        fb_api_mode_hint = (fb.get("api_mode") or "").strip() or None
-        if fb_api_mode_hint not in {
-            "chat_completions",
-            "codex_responses",
-            "anthropic_messages",
-            "bedrock_converse",
-        }:
-            fb_api_mode_hint = None
+        from hermes_cli.runtime_provider import _parse_api_mode
+
+        fb_api_mode_hint = _parse_api_mode(fb.get("api_mode"))
         if not fb_api_key_hint:
             # key_env and api_key_env are both documented aliases (see
             # _normalize_custom_provider_entry in hermes_cli/config.py).

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1996,6 +1996,8 @@ def _try_resolve_fallback_provider() -> dict | None:
                     requested=entry.get("provider"),
                     explicit_base_url=entry.get("base_url"),
                     explicit_api_key=explicit_api_key,
+                    target_model=entry.get("model"),
+                    explicit_api_mode=entry.get("api_mode"),
                 )
                 # Log the literal `provider` key from config, not the resolved
                 # runtime category — an Ollama fallback resolves through the

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1512,7 +1512,7 @@ def _resolve_explicit_runtime(
     return None
 
 
-def resolve_runtime_provider(
+def _resolve_runtime_provider_base(
     *,
     requested: Optional[str] = None,
     explicit_api_key: Optional[str] = None,
@@ -2082,6 +2082,26 @@ def resolve_runtime_provider(
     )
     runtime["requested_provider"] = requested_provider
     return runtime
+
+
+def resolve_runtime_provider(
+    *,
+    requested: Optional[str] = None,
+    explicit_api_key: Optional[str] = None,
+    explicit_base_url: Optional[str] = None,
+    target_model: Optional[str] = None,
+    explicit_api_mode: Optional[str] = None,
+) -> Dict[str, Any]:
+    runtime = _resolve_runtime_provider_base(
+        requested=requested,
+        explicit_api_key=explicit_api_key,
+        explicit_base_url=explicit_base_url,
+        target_model=target_model,
+    )
+    api_mode = _parse_api_mode(explicit_api_mode)
+    if api_mode is None:
+        return runtime
+    return {**runtime, "api_mode": api_mode}
 
 
 def format_runtime_provider_error(error: Exception) -> str:

--- a/tests/gateway/test_auth_fallback.py
+++ b/tests/gateway/test_auth_fallback.py
@@ -54,6 +54,47 @@ class TestResolveRuntimeAgentKwargsAuthFallback:
         # Should have been called at least twice (primary + fallback)
         assert call_count["n"] >= 2
 
+    def test_auth_fallback_passes_model_and_explicit_api_mode_atomically(
+        self, tmp_path, monkeypatch
+    ):
+        from hermes_cli.auth import AuthError
+
+        (tmp_path / "config.yaml").write_text(
+            "model:\n  provider: openai-codex\n"
+            "fallback_model:\n  provider: openrouter\n"
+            "  model: gpt-5.6-codex\n"
+            "  api_mode: codex_app_server\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+        calls = []
+
+        def fake_resolve(**kwargs):
+            calls.append(kwargs)
+            if len(calls) == 1:
+                raise AuthError("primary unavailable")
+            return {
+                "api_key": "fallback-key",
+                "base_url": "https://openrouter.ai/api/v1",
+                "provider": "openrouter",
+                "api_mode": kwargs.get("explicit_api_mode") or "chat_completions",
+                "command": None,
+                "args": None,
+                "credential_pool": None,
+            }
+
+        with patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            side_effect=fake_resolve,
+        ):
+            from gateway.run import _resolve_runtime_agent_kwargs
+
+            result = _resolve_runtime_agent_kwargs()
+
+        assert calls[1]["target_model"] == "gpt-5.6-codex"
+        assert calls[1]["explicit_api_mode"] == "codex_app_server"
+        assert result["api_mode"] == "codex_app_server"
+
     def test_auth_error_no_fallback_raises(self, tmp_path, monkeypatch):
         """When primary fails and no fallback configured, RuntimeError is raised."""
         from hermes_cli.auth import AuthError

--- a/tests/gateway/test_session_model_override_routing.py
+++ b/tests/gateway/test_session_model_override_routing.py
@@ -186,11 +186,20 @@ fallback_providers:
     )
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
 
-    def fake_resolve_runtime_provider(*, requested=None, explicit_base_url=None, explicit_api_key=None):
+    def fake_resolve_runtime_provider(
+        *,
+        requested=None,
+        explicit_base_url=None,
+        explicit_api_key=None,
+        target_model=None,
+        explicit_api_mode=None,
+    ):
         if requested in {None, "", "openai-codex"}:
             from hermes_cli.auth import AuthError
             raise AuthError("No Codex credentials stored. Run `hermes auth` to authenticate.")
         assert requested == "openrouter"
+        assert target_model == "minimax/minimax-m2.7"
+        assert explicit_api_mode is None
         return {
             "api_key": "sk-openrouter",
             "base_url": "https://openrouter.ai/api/v1",
@@ -235,10 +244,19 @@ fallback_providers:
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     monkeypatch.setenv("MY_FALLBACK_KEY", "env-secret")
 
-    def fake_resolve_runtime_provider(*, requested=None, explicit_base_url=None, explicit_api_key=None):
+    def fake_resolve_runtime_provider(
+        *,
+        requested=None,
+        explicit_base_url=None,
+        explicit_api_key=None,
+        target_model=None,
+        explicit_api_mode=None,
+    ):
         assert requested == "custom"
         assert explicit_base_url == "https://fallback.example/v1"
         assert explicit_api_key == "env-secret"
+        assert target_model == "fallback-model"
+        assert explicit_api_mode is None
         return {
             "api_key": explicit_api_key,
             "base_url": explicit_base_url,
@@ -260,4 +278,3 @@ fallback_providers:
     assert runtime_kwargs["api_key"] == "env-secret"
     assert runtime_kwargs["base_url"] == "https://fallback.example/v1"
     assert runtime_kwargs["model"] == "fallback-model"
-

--- a/tests/run_agent/test_init_fallback_on_exhausted_pool.py
+++ b/tests/run_agent/test_init_fallback_on_exhausted_pool.py
@@ -24,7 +24,7 @@ def test_init_tries_fallback_when_primary_returns_none():
     fb = _mock_client()
 
     def fake_resolve(provider, model=None, raw_codex=False,
-                     explicit_base_url=None, explicit_api_key=None):
+                     explicit_base_url=None, explicit_api_key=None, api_mode=None):
         if provider == "tencent-token-plan":
             return fb, "kimi2.5"
         return None, None  # primary exhausted
@@ -47,6 +47,48 @@ def test_init_tries_fallback_when_primary_returns_none():
         assert agent.provider == "tencent-token-plan"
         assert agent.model == "kimi2.5"
         assert agent._fallback_activated is True
+
+
+def test_init_fallback_honors_explicit_anthropic_api_mode():
+    fallback_client = _mock_client(base_url="https://relay.example.com/claude-proxy")
+    resolved_modes = []
+
+    def fake_resolve(provider, model=None, raw_codex=False,
+                     explicit_base_url=None, explicit_api_key=None, api_mode=None):
+        if provider == "custom":
+            resolved_modes.append(api_mode)
+            return fallback_client, "claude-sonnet-4-6"
+        return None, None
+
+    with (
+        patch("agent.auxiliary_client.resolve_provider_client", side_effect=fake_resolve),
+        patch(
+            "agent.anthropic_adapter.build_anthropic_client",
+            return_value=MagicMock(),
+        ) as mock_build,
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs()),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI", return_value=MagicMock()),
+    ):
+        agent = AIAgent(
+            provider="alibaba-coding-plan",
+            model="glm-5",
+            api_key=None,
+            base_url=None,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            fallback_model=[{
+                "provider": "custom",
+                "model": "claude-sonnet-4-6",
+                "api_mode": "anthropic_messages",
+            }],
+        )
+
+    assert resolved_modes == ["anthropic_messages"]
+    assert agent.api_mode == "anthropic_messages"
+    assert agent.client is None
+    mock_build.assert_called_once()
 
 
 def test_init_raises_when_no_fallback_configured():

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -211,6 +211,40 @@ class TestFallbackChainAdvancement:
             assert agent._try_activate_fallback() is True
             assert agent.api_mode == "anthropic_messages"
 
+    def test_explicit_anthropic_api_mode_overrides_fallback_heuristics(self):
+        fallback = {
+            "provider": "custom",
+            "model": "claude-compatible-model",
+            "base_url": "https://relay.example.com/claude-proxy",
+            "api_key": "custom-secret",
+            "api_mode": "anthropic_messages",
+        }
+        agent = _make_agent(fallback_model=[fallback])
+        mock_client = _mock_client(
+            base_url=fallback["base_url"],
+            api_key=fallback["api_key"],
+        )
+
+        with (
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(mock_client, fallback["model"]),
+            ) as mock_resolve,
+            patch(
+                "agent.anthropic_adapter.build_anthropic_client",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "hermes_cli.model_normalize.normalize_model_for_provider",
+                side_effect=lambda model, provider: model,
+            ),
+        ):
+            activated = agent._try_activate_fallback()
+
+        assert activated is True
+        assert agent.api_mode == "anthropic_messages"
+        assert agent.client is None
+        assert mock_resolve.call_args.kwargs["api_mode"] == "anthropic_messages"
 
 # ── Pool-rotation vs fallback gating (#11314) ────────────────────────────
 

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -246,6 +246,27 @@ class TestFallbackChainAdvancement:
         assert agent.client is None
         assert mock_resolve.call_args.kwargs["api_mode"] == "anthropic_messages"
 
+    def test_explicit_codex_app_server_mode_uses_canonical_validator(self):
+        fallback = {
+            "provider": "custom",
+            "model": "gpt-5.6-codex",
+            "base_url": "https://relay.example.com/v1",
+            "api_key": "custom-secret",
+            "api_mode": "codex_app_server",
+        }
+        agent = _make_agent(fallback_model=[fallback])
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(_mock_client(fallback["base_url"]), fallback["model"]),
+        ) as mock_resolve:
+            activated = agent._try_activate_fallback()
+
+        assert activated is True
+        assert agent.api_mode == "codex_app_server"
+        assert mock_resolve.call_args.kwargs["api_mode"] == "codex_app_server"
+
+
 # ── Pool-rotation vs fallback gating (#11314) ────────────────────────────
 
 


### PR DESCRIPTION
## What does this PR do?

Makes provider fallback activation honor an explicit `api_mode` on `fallback_providers` entries before falling back to provider/base URL/model heuristics.

This fixes custom fallback providers that need Anthropic Messages routing (`/v1/messages`) but do not use a base URL ending in `/anthropic`. Before this change, those fallbacks were treated as OpenAI chat completions and could hit the wrong endpoint.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `run_agent.py`
  - Reads a valid `api_mode` override from fallback config entries.
  - Passes the override through `resolve_provider_client(...)`.
  - Uses the explicit override before auto-detecting fallback API mode from provider/base URL/model heuristics.
  - Propagates the active fallback `api_mode` into the context compressor update.
- `tests/run_agent/test_fallback_model.py`
  - Adds a regression test for `provider: custom` fallbacks that explicitly set `api_mode: anthropic_messages` while using a non-`/anthropic` base URL.

## How to Test

1. Configure a fallback provider like:
   ```yaml
   fallback_providers:
     - provider: custom
       model: claude-compatible-model
       base_url: https://relay.example.com/claude-proxy
       api_key: test-key
       api_mode: anthropic_messages
   ```
2. Trigger fallback activation.
3. Verify Hermes switches to `anthropic_messages` mode and builds the native Anthropic client instead of keeping an OpenAI chat-completions client.

Test commands run locally:

```bash
.venv/bin/python -m py_compile run_agent.py tests/run_agent/test_fallback_model.py
scripts/run_tests.sh tests/run_agent/test_fallback_model.py -q
scripts/run_tests.sh tests/run_agent/test_fallback_model.py::TestTryActivateFallback::test_custom_fallback_honors_explicit_anthropic_api_mode -q
scripts/run_tests.sh tests/run_agent/test_provider_fallback.py -q
```

Results:

- `tests/run_agent/test_fallback_model.py`: 29 passed
- New focused regression test: 1 passed
- `tests/run_agent/test_provider_fallback.py`: 19 passed

I also attempted the full wrapper command required by the local development guide:

```bash
scripts/run_tests.sh
scripts/run_tests.sh tests/
```

Notes:

- `scripts/run_tests.sh` with no args failed locally with `ARGS[@]: unbound variable` before pytest collection.
- `scripts/run_tests.sh tests/` completed collection/execution but failed on unrelated local environment/platform issues, including missing optional modules such as `faster_whisper` and ACP/MCP/TTS/web/platform-specific tests. The new fallback tests above passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

N/A