### PR TITLE
feat(docker): auto-start dashboard + fix(api_server): use session_id as task_id

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -75,6 +75,21 @@ if [ -d "$INSTALL_DIR/skills" ]; then
     python3 "$INSTALL_DIR/tools/skills_sync.py"
 fi
 
+# Start dashboard in background if HERMES_DASHBOARD=1
+if [ "${HERMES_DASHBOARD:-0}" = "1" ]; then
+    DASHBOARD_HOST="${DASHBOARD_HOST:-0.0.0.0}"
+    DASHBOARD_PORT="${DASHBOARD_PORT:-9119}"
+    (
+        while true; do
+            hermes dashboard --host "$DASHBOARD_HOST" --port "$DASHBOARD_PORT" --no-open --insecure \
+                >> "$HERMES_HOME/logs/dashboard.log" 2>&1
+            echo "$(date): Dashboard exited, restarting in 3s..." >> "$HERMES_HOME/logs/dashboard.log"
+            sleep 3
+        done
+    ) &
+    echo "Dashboard started on $DASHBOARD_HOST:$DASHBOARD_PORT (PID $!)"
+fi
+
 # Final exec: two supported invocation patterns.
 #
 #   docker run <image>                 -> exec `hermes` with no args (legacy default)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2197,7 +2197,7 @@ class APIServerAdapter(BasePlatformAdapter):
             result = agent.run_conversation(
                 user_message=user_message,
                 conversation_history=conversation_history,
-                task_id="default",
+                task_id=session_id,
             )
             usage = {
                 "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
@@ -2366,7 +2366,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     r = agent.run_conversation(
                         user_message=user_message,
                         conversation_history=conversation_history,
-                        task_id="default",
+                        task_id=session_id,
                     )
                     u = {
                         "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,


### PR DESCRIPTION
## 1. feat(docker): auto-start dashboard in entrypoint when HERMES_DASHBOARD=1

Start the web dashboard as a background process before the main exec,
gated by the `HERMES_DASHBOARD` environment variable (default off).

- Configurable via `DASHBOARD_HOST` (default `0.0.0.0`) and `DASHBOARD_PORT` (default `9119`)
- Wrapped in a while-true restart loop with 3s backoff so it auto-recovers on crash
- Logs to `$HERMES_HOME/logs/dashboard.log`
- No impact on container lifecycle (dashboard is a child process, not PID 1)

Usage:
```bash
docker run -e HERMES_DASHBOARD=1 -p 9119:9119 hermes-agent
```

## 2. fix(api_server): use session_id as task_id instead of hardcoded 'default'

Both `_run_agent()` and `_run_and_close()` in `gateway/platforms/api_server.py` passed `task_id="default"` to `agent.run_conversation()`. This caused all concurrent API server requests to share the same task namespace, leading to:

- Terminal sandbox collisions between concurrent sessions
- Browser session cross-contamination
- Process registry conflicts (one session's cleanup killing another's processes)
- File dedup cache resets affecting unrelated sessions

**Fix:** Replace `task_id="default"` with `task_id=session_id` in both call sites. The `session_id` variable was already available and correctly computed. This aligns api_server with `gateway/run.py` which correctly passes `task_id=session_id`.

**Changes:** `gateway/platforms/api_server.py` — 2 lines changed (line 2200, line 2369)