### PR TITLE
fix(file): pass docker_env to file tool containers

### DIFF
--- a/tests/tools/test_file_tools_container_config.py
+++ b/tests/tools/test_file_tools_container_config.py
@@ -21,6 +21,7 @@ def _make_env_config(**overrides):
         "docker_volumes": [],
         "docker_mount_cwd_to_workspace": True,
         "docker_forward_env": ["MY_SECRET", "API_KEY"],
+        "docker_env": {"MY_SECRET": "configured"},
     }
     base.update(overrides)
     return base
@@ -50,6 +51,11 @@ class TestFileToolsContainerConfig:
         cc = self._run(_make_env_config(docker_forward_env=["MY_SECRET"]), "t2")
         assert cc.get("docker_forward_env") == ["MY_SECRET"]
 
+    def test_docker_env_passed(self):
+        """docker_env is forwarded to container_config."""
+        cc = self._run(_make_env_config(docker_env={"MY_SECRET": "configured"}), "t5")
+        assert cc.get("docker_env") == {"MY_SECRET": "configured"}
+
     def test_docker_mount_cwd_defaults_to_false(self):
         """docker_mount_cwd_to_workspace defaults to False when absent from config."""
         cfg = _make_env_config()
@@ -63,3 +69,10 @@ class TestFileToolsContainerConfig:
         del cfg["docker_forward_env"]
         cc = self._run(cfg, "t4")
         assert cc.get("docker_forward_env") == []
+
+    def test_docker_env_defaults_to_empty_dict(self):
+        """docker_env defaults to {} when absent from config."""
+        cfg = _make_env_config()
+        del cfg["docker_env"]
+        cc = self._run(cfg, "t6")
+        assert cc.get("docker_env") == {}

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -381,6 +381,7 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
                     "docker_volumes": config.get("docker_volumes", []),
                     "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
                     "docker_forward_env": config.get("docker_forward_env", []),
+                    "docker_env": config.get("docker_env", {}),
                 }
 
             ssh_config = None


### PR DESCRIPTION
## Summary
- forward `docker_env` through the file-tools container_config path
- extend the existing file-tools container_config tests for explicit `docker_env` and the absent-key default

Fixes #16214.

## Tests
- `source /Users/peter/hermes-agent-upstream/venv/bin/activate && pytest tests/tools/test_file_tools_container_config.py -q`
- `source /Users/peter/hermes-agent-upstream/venv/bin/activate && pytest tests/tools/test_file_tools_container_config.py tests/tools/test_docker_environment.py -q`
