### PR TITLE
fix(gateway): classify service-managed status pids

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4182,8 +4182,22 @@ def _gateway_command_inner(args):
             # Check for manually running processes
             pids = list(snapshot.gateway_pids)
             if pids:
-                print(f"✓ Gateway is running (PID: {', '.join(map(str, pids))})")
-                print("  (Running manually, not as a system service)")
+                service_pids = _get_service_pids()
+                managed_pids = [pid for pid in pids if pid in service_pids]
+                manual_pids = [pid for pid in pids if pid not in service_pids]
+                if managed_pids:
+                    pid_text = ", ".join(map(str, managed_pids))
+                    if supports_systemd_services():
+                        print(f"✓ Gateway is running as a systemd service (PID: {pid_text})")
+                    elif is_macos():
+                        print(f"✓ Gateway is running as a launchd service (PID: {pid_text})")
+                    else:
+                        print(f"✓ Gateway is running as a system service (PID: {pid_text})")
+                    if manual_pids:
+                        print(f"  Also found manual PID(s): {', '.join(map(str, manual_pids))}")
+                else:
+                    print(f"✓ Gateway is running (PID: {', '.join(map(str, pids))})")
+                    print("  (Running manually, not as a system service)")
                 runtime_lines = _runtime_health_lines()
                 if runtime_lines:
                     print()
@@ -4194,6 +4208,10 @@ def _gateway_command_inner(args):
                 if is_termux():
                     print("Termux note:")
                     print("  Android may stop background jobs when Termux is suspended")
+                elif managed_pids and supports_systemd_services():
+                    print("To inspect the service:")
+                    print("  systemctl --user status 'hermes-gateway*'")
+                    print("  sudo systemctl status 'hermes-gateway*'")
                 elif is_wsl():
                     print("WSL note:")
                     print("  The gateway is running in foreground/manual mode (recommended for WSL).")

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -693,7 +693,9 @@ class TestGatewaySystemServiceRouting:
             lambda deep=False, system=False, full=False: calls.append((deep, system, full)),
         )
 
-        gateway_cli.gateway_command(SimpleNamespace(gateway_command="status", deep=False, system=False))
+        gateway_cli.gateway_command(
+            SimpleNamespace(gateway_command="status", deep=False, system=False)
+        )
 
         assert calls == [(False, False, False)]
 
@@ -732,6 +734,38 @@ class TestGatewaySystemServiceRouting:
         assert "service stopped" in out
         assert "Gateway process is running for this profile" in out
         assert "PID(s): 4321" in out
+
+    def test_gateway_status_does_not_label_systemd_pid_manual_when_unit_file_is_profile_scoped(
+        self, monkeypatch, capsys
+    ):
+        missing_unit = SimpleNamespace(exists=lambda: False)
+
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: True)
+        monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_wsl", lambda: False)
+        monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: missing_unit)
+        monkeypatch.setattr(gateway_cli, "_get_service_pids", lambda: {1896})
+        monkeypatch.setattr(gateway_cli, "_runtime_health_lines", lambda: [])
+        monkeypatch.setattr(
+            gateway_cli,
+            "get_gateway_runtime_snapshot",
+            lambda system=False: gateway_cli.GatewayRuntimeSnapshot(
+                manager="systemd (user)",
+                service_installed=False,
+                service_running=False,
+                gateway_pids=(1896,),
+                service_scope="user",
+            ),
+        )
+
+        gateway_cli.gateway_command(SimpleNamespace(gateway_command="status", deep=False, system=False))
+
+        out = capsys.readouterr().out
+        assert "Gateway is running as a systemd service" in out
+        assert "PID: 1896" in out
+        assert "Running manually" not in out
+        assert "To install as a service" not in out
 
     def test_gateway_status_on_termux_shows_manual_guidance(self, monkeypatch, capsys):
         monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)


### PR DESCRIPTION
## Summary
- fixes `hermes gateway status` fallback output when the detected gateway PID is already managed by systemd/launchd
- avoids telling users a systemd-owned gateway is "Running manually" just because the current profile's expected unit file is not present
- adds a regression test for the profile-scoped missing-unit case from #16264

Fixes #16264

## Tests
- `pytest tests/hermes_cli/test_gateway_service.py::TestGatewaySystemServiceRouting::test_gateway_status_prefers_system_service_when_only_system_unit_exists tests/hermes_cli/test_gateway_service.py::TestGatewaySystemServiceRouting::test_gateway_status_reports_manual_process_when_service_is_stopped tests/hermes_cli/test_gateway_service.py::TestGatewaySystemServiceRouting::test_gateway_status_does_not_label_systemd_pid_manual_when_unit_file_is_profile_scoped tests/hermes_cli/test_gateway_service.py::TestGatewaySystemServiceRouting::test_gateway_status_on_termux_shows_manual_guidance -q`
- `git diff --check`

Note: running the full `tests/hermes_cli/test_gateway_service.py` file on macOS currently hits unrelated user-systemd preflight failures in existing `systemd_start/restart` tests; the status-path regression tests above pass.
