### PR TITLE
fix(google-workspace): parse OAuth scopes from full callback URL (salvages #11271)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -136,6 +136,7 @@ AUTHOR_MAP = {
     "1930707+haru398801@users.noreply.github.com": "haru398801",
     "rapabelias@gmail.com": "badgerbees",
     "xnb888@proton.me": "xnbi",
+    "xiahu889889@proton.me": "xiahu88988",
     "nocoo@users.noreply.github.com": "nocoo",
     "30841158+n-WN@users.noreply.github.com": "n-WN",
     "tsuijinglei@gmail.com": "hiddenpuppy",

--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -289,6 +289,7 @@ def exchange_auth_code(code: str):
         sys.exit(1)
 
     pending_auth = _load_pending_auth()
+    raw_callback = code
     code, returned_state = _extract_code_and_state(code)
     if returned_state and returned_state != pending_auth["state"]:
         print("ERROR: OAuth state mismatch. Run --auth-url again to start a fresh session.")
@@ -298,19 +299,13 @@ def exchange_auth_code(code: str):
     from google_auth_oauthlib.flow import Flow
     from urllib.parse import parse_qs, urlparse
 
-    # Extract granted scopes from the callback URL if present
-    if returned_state and "scope" in parse_qs(urlparse(code).query if isinstance(code, str) and code.startswith("http") else {}):
-        granted_scopes = parse_qs(urlparse(code).query)["scope"][0].split()
-    else:
-        # Try to extract from code_or_url parameter
-        if isinstance(code, str) and code.startswith("http"):
-            params = parse_qs(urlparse(code).query)
-            if "scope" in params:
-                granted_scopes = params["scope"][0].split()
-            else:
-                granted_scopes = SCOPES
-        else:
-            granted_scopes = SCOPES
+    # Extract granted scopes from the callback URL if the user pasted the full redirect URL.
+    granted_scopes = list(SCOPES)
+    if isinstance(raw_callback, str) and raw_callback.startswith("http"):
+        params = parse_qs(urlparse(raw_callback).query)
+        scope_val = (params.get("scope") or [""])[0].strip()
+        if scope_val:
+            granted_scopes = scope_val.split()
 
     flow = Flow.from_client_secrets_file(
         str(CLIENT_SECRET_PATH),

--- a/tests/skills/test_google_oauth_setup.py
+++ b/tests/skills/test_google_oauth_setup.py
@@ -177,6 +177,22 @@ class TestExchangeAuthCode:
         flow = FakeFlow.created[-1]
         assert flow.fetch_token_calls == [{"code": "4/extracted-code"}]
 
+    def test_passes_scopes_from_redirect_url_to_flow(self, setup_module):
+        """Callback URL carries space-delimited scope list; Flow must receive it (not full SCOPES)."""
+        setup_module.PENDING_AUTH_PATH.write_text(
+            json.dumps({"state": "saved-state", "code_verifier": "saved-verifier"})
+        )
+        g1 = "https://www.googleapis.com/auth/gmail.readonly"
+        g2 = "https://www.googleapis.com/auth/calendar"
+        from urllib.parse import quote
+
+        scope_q = quote(f"{g1} {g2}", safe="")
+        setup_module.exchange_auth_code(
+            f"http://localhost:1/?code=4/extracted-code&state=saved-state&scope={scope_q}"
+        )
+        flow = FakeFlow.created[-1]
+        assert flow.scopes == [g1, g2]
+
     def test_rejects_state_mismatch(self, setup_module, capsys):
         setup_module.PENDING_AUTH_PATH.write_text(
             json.dumps({"state": "saved-state", "code_verifier": "saved-verifier"})


### PR DESCRIPTION
## Summary
Fixes dead-code scope parsing in Google Workspace OAuth setup — the scope-from-callback-URL branch was unreachable because `_extract_code_and_state` rewrites `code` to the bare token before the `.startswith("http")` check runs. Result: `Flow.from_client_secrets_file` was always constructed with the full `SCOPES` list regardless of what Google actually granted.

Cherry-picked from @xiahu88988's PR #11271 onto current main. Impact on users was minor (`OAUTHLIB_RELAX_TOKEN_SCOPE=1` + post-fetch `creds.granted_scopes` already papered over the bug), but the old code was unreachable branches and the new code is cleaner.

## Changes
- `skills/productivity/google-workspace/scripts/setup.py`: cache `raw_callback = code` before `_extract_code_and_state` overwrites it, then parse scope from the original URL. Collapses 12 lines of dead branches into 5.
- `tests/skills/test_google_oauth_setup.py`: new regression test asserting `Flow.scopes` matches the callback query.
- `scripts/release.py`: AUTHOR_MAP entry for xiahu889889@proton.me.

## Validation
`scripts/run_tests.sh tests/skills/test_google_oauth_setup.py` → 15/15 passed.

Closes #11271. Credit to @xiahu88988.