### PR TITLE
fix(error_classifier): avoid large-context false overflow heuristics

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -520,7 +520,12 @@ def classify_api_error(
 
     is_disconnect = any(p in error_msg for p in _SERVER_DISCONNECT_PATTERNS)
     if is_disconnect and not status_code:
-        is_large = approx_tokens > context_length * 0.6 or approx_tokens > 120000 or num_messages > 200
+        # Absolute token/message-count thresholds are only a proxy for smaller
+        # context windows.  Large-context sessions can have hundreds of
+        # messages while still being far below their actual token budget.
+        is_large = approx_tokens > context_length * 0.6 or (
+            context_length <= 256000 and (approx_tokens > 120000 or num_messages > 200)
+        )
         if is_large:
             return _result(
                 FailoverReason.context_overflow,
@@ -766,7 +771,12 @@ def _classify_400(
         if not err_body_msg:
             err_body_msg = str(body.get("message") or "").strip().lower()
     is_generic = len(err_body_msg) < 30 or err_body_msg in ("error", "")
-    is_large = approx_tokens > context_length * 0.4 or approx_tokens > 80000 or num_messages > 80
+    # Absolute token/message-count thresholds are only a proxy for smaller
+    # context windows.  Large-context sessions can have many messages while
+    # still being far below their actual token budget.
+    is_large = approx_tokens > context_length * 0.4 or (
+        context_length <= 256000 and (approx_tokens > 80000 or num_messages > 80)
+    )
 
     if is_generic and is_large:
         return result_fn(

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -410,6 +410,24 @@ class TestClassifyApiError:
         result = classify_api_error(e, approx_tokens=1000, context_length=200000)
         assert result.reason == FailoverReason.format_error
 
+    def test_400_generic_many_messages_below_large_context_pressure_is_format_error(self):
+        """Large-context sessions should not overflow solely due to message count."""
+        e = MockAPIError(
+            "Error",
+            status_code=400,
+            body={"error": {"message": "Error"}},
+        )
+        result = classify_api_error(
+            e,
+            provider="openai-codex",
+            model="gpt-5.5",
+            approx_tokens=74320,
+            context_length=1_000_000,
+            num_messages=432,
+        )
+        assert result.reason == FailoverReason.format_error
+        assert result.should_compress is False
+
     # ── Server disconnect + large session ──
 
     def test_disconnect_large_session_context_overflow(self):
@@ -424,6 +442,20 @@ class TestClassifyApiError:
         e = Exception("server disconnected without sending complete message")
         result = classify_api_error(e, approx_tokens=5000, context_length=200000)
         assert result.reason == FailoverReason.timeout
+
+    def test_disconnect_many_messages_below_large_context_pressure_is_timeout(self):
+        """Large-context disconnects should not overflow solely due to message count."""
+        e = Exception("server disconnected without sending complete message")
+        result = classify_api_error(
+            e,
+            provider="openai-codex",
+            model="gpt-5.5",
+            approx_tokens=74320,
+            context_length=1_000_000,
+            num_messages=432,
+        )
+        assert result.reason == FailoverReason.timeout
+        assert result.should_compress is False
 
     # ── Provider-specific: Anthropic thinking signature ──
 


### PR DESCRIPTION
## Summary

Fixes a large-context false-positive in `agent.error_classifier`: generic HTTP 400 responses and server disconnects should not be classified as `context_overflow` solely because a 1M-context session has many messages.

The previous heuristic used absolute fallbacks:

```python
approx_tokens > 80000 or num_messages > 80
approx_tokens > 120000 or num_messages > 200
```

Those thresholds are useful proxies for smaller context windows, but they are too aggressive for explicitly large windows. A 1M-context session can have 432 messages and ~74K estimated tokens while still being far below the real budget.

This patch keeps the relative pressure checks for all models, but gates the absolute token/message-count fallbacks to smaller context windows (`<= 256000`).

## Behavior covered

- Generic 400 with `approx_tokens=74320`, `context_length=1_000_000`, `num_messages=432` is now `format_error`, not `context_overflow`.
- Server disconnect with the same low-pressure 1M context shape is now `timeout`, not `context_overflow`.
- Existing smaller-window behavior remains covered by existing tests.

## Test plan

RED before fix:

```bash
/home/ubuntu/.hermes/hermes-agent/venv/bin/python -m pytest \
  tests/agent/test_error_classifier.py::TestClassifyApiError::test_400_generic_many_messages_below_large_context_pressure_is_format_error \
  tests/agent/test_error_classifier.py::TestClassifyApiError::test_disconnect_many_messages_below_large_context_pressure_is_timeout \
  -v -o 'addopts='
```

Both tests failed with `FailoverReason.context_overflow`.

GREEN after fix:

```bash
/home/ubuntu/.hermes/hermes-agent/venv/bin/python -m pytest tests/agent/test_error_classifier.py -q -o 'addopts='
/home/ubuntu/.hermes/hermes-agent/venv/bin/python -m py_compile agent/error_classifier.py tests/agent/test_error_classifier.py
git diff --check
```

Result:

```text
120 passed
```

Manual reproduction after fix:

```text
FakeHTTP400 FailoverReason.format_error False False
Exception FailoverReason.timeout True False
```

Fixes #16351

Related: #14499, #14858, #14953, #15844, #6751
