### PR TITLE
test(cron): isolate tick file lock in TestSilentDelivery to fix xdist flakiness

### DIFF
--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1164,6 +1164,16 @@ class TestRunJobSkillBacked:
 class TestSilentDelivery:
     """Verify that [SILENT] responses suppress delivery while still saving output."""
 
+    @pytest.fixture(autouse=True)
+    def _isolate_tick_lock(self, tmp_path):
+        """Point the tick file lock at a per-test temp dir to avoid xdist contention."""
+        lock_dir = tmp_path / "cron"
+        lock_dir.mkdir()
+        with patch("cron.scheduler._LOCK_DIR", lock_dir), \
+             patch("cron.scheduler._LOCK_FILE", lock_dir / ".tick.lock"), \
+             patch("cron.scheduler.advance_next_run"):
+            yield
+
     def _make_job(self):
         return {
             "id": "monitor-job",


### PR DESCRIPTION
## Summary
- Add `_isolate_tick_lock` autouse fixture to `TestSilentDelivery` (same pattern already used in `TestParallelTick`)
- Mock `advance_next_run` in the same fixture to prevent real I/O against `~/.hermes/cron/jobs.json` for synthetic test jobs

## The bug

`TestSilentDelivery` tests call `tick()` without redirecting `_LOCK_FILE`, so concurrent xdist workers compete for the real `~/.hermes/cron/.tick.lock`. Workers that lose the non-blocking acquire (`LOCK_EX | LOCK_NB`) return 0 without executing any jobs. This means:

- `_deliver_result` is never called → `test_failed_job_always_delivers` fails (`assert_called_once()`)
- `save_job_output` is never called → `test_output_saved_even_when_delivery_suppressed` fails (`assert_called_once_with(...)`)
- The `[SILENT]` log message is never emitted → `test_silent_response_suppresses_delivery` fails

Which tests fail depends on xdist worker scheduling — 2–3 failures per run, different tests each time.

`TestParallelTick` (added at the same time the parallel executor was introduced) already has the fix via `_isolate_tick_lock`. `TestSilentDelivery` was added later in `b8076bb0b` and missed it.

## The fix

Copy the exact `_isolate_tick_lock` fixture from `TestParallelTick` into `TestSilentDelivery`:

```python
@pytest.fixture(autouse=True)
def _isolate_tick_lock(self, tmp_path):
    """Point the tick file lock at a per-test temp dir to avoid xdist contention."""
    lock_dir = tmp_path / "cron"
    lock_dir.mkdir()
    with patch("cron.scheduler._LOCK_DIR", lock_dir), \
         patch("cron.scheduler._LOCK_FILE", lock_dir / ".tick.lock"), \
         patch("cron.scheduler.advance_next_run"):
        yield
```

`advance_next_run` is also mocked here because `tick()` calls it with the synthetic `"monitor-job"` ID before spawning `_process_job`. The real function silently no-ops on a missing job, but it reads `~/.hermes/cron/jobs.json` which is unnecessary I/O for unit tests.

## Test plan
- [x] **Before**: 3 tests in `TestSilentDelivery` fail consistently under xdist — `test_silent_response_suppresses_delivery`, `test_output_saved_even_when_delivery_suppressed`, `test_failed_job_always_delivers`
- [x] **After**: `245 passed, 4 skipped` across the full `tests/cron/` suite (the 4 skips are pre-existing baseline)
- [x] **Regression guard**: reverted the fixture → observed 3 failures; restored → 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)