### PR TITLE
docs(skills): document URL install across features, reference, guide, and hermes-agent skill

### DIFF
--- a/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -115,7 +115,7 @@ hermes tools disable NAME   Disable a toolset
 
 hermes skills list          List installed skills
 hermes skills search QUERY  Search the skills hub
-hermes skills install ID    Install a skill
+hermes skills install ID    Install a skill (ID can be a hub identifier OR a direct https://…/SKILL.md URL; pass --name to override when frontmatter has no name)
 hermes skills inspect ID    Preview without installing
 hermes skills config        Enable/disable skills per platform
 hermes skills check         Check for updates

--- a/website/docs/guides/work-with-skills.md
+++ b/website/docs/guides/work-with-skills.md
@@ -94,6 +94,10 @@ hermes skills install official/research/arxiv
 
 # Install from the hub in a chat session
 /skills install official/creative/songwriting-and-ai-music
+
+# Install a single-file SKILL.md directly from any HTTP(S) URL
+hermes skills install https://sharethis.chat/SKILL.md
+/skills install https://example.com/SKILL.md --name my-skill
 ```
 
 What happens:

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -617,6 +617,8 @@ hermes skills inspect official/security/1password
 hermes skills inspect skills-sh/vercel-labs/json-render/json-render-react
 hermes skills install official/migration/openclaw-migration
 hermes skills install skills-sh/anthropics/skills/pdf --force
+hermes skills install https://sharethis.chat/SKILL.md                     # Direct URL (single-file SKILL.md)
+hermes skills install https://example.com/SKILL.md --name my-skill        # Override name when frontmatter has none
 hermes skills check
 hermes skills update
 hermes skills config
@@ -627,6 +629,7 @@ Notes:
 - `--force` does not override a `dangerous` scan verdict.
 - `--source skills-sh` searches the public `skills.sh` directory.
 - `--source well-known` lets you point Hermes at a site exposing `/.well-known/skills/index.json`.
+- Passing an `http(s)://…/*.md` URL installs a single-file SKILL.md directly. When frontmatter has no `name:` and the URL slug isn't a valid identifier, an interactive terminal prompts for a name; non-interactive surfaces (`/skills install` inside the TUI, gateway platforms) require `--name <x>` instead.
 
 ## `hermes honcho`
 

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -273,6 +273,8 @@ hermes skills install openai/skills/k8s           # Install with security scan
 hermes skills install official/security/1password
 hermes skills install skills-sh/vercel-labs/json-render/json-render-react --force
 hermes skills install well-known:https://mintlify.com/docs/.well-known/skills/mintlify
+hermes skills install https://sharethis.chat/SKILL.md              # Direct URL (single-file SKILL.md)
+hermes skills install https://example.com/SKILL.md --name my-skill # Override name when frontmatter has none
 hermes skills list --source hub                   # List hub-installed skills
 hermes skills check                               # Check installed hub skills for upstream updates
 hermes skills update                              # Reinstall hub skills with upstream changes when needed
@@ -292,6 +294,7 @@ hermes skills tap add myorg/skills-repo           # Add a custom GitHub source
 | `official` | `official/security/1password` | Optional skills shipped with Hermes. |
 | `skills-sh` | `skills-sh/vercel-labs/agent-skills/vercel-react-best-practices` | Searchable via `hermes skills search <query> --source skills-sh`. Hermes resolves alias-style skills when the skills.sh slug differs from the repo folder. |
 | `well-known` | `well-known:https://mintlify.com/docs/.well-known/skills/mintlify` | Skills served directly from `/.well-known/skills/index.json` on a website. Search using the site or docs URL. |
+| `url` | `https://sharethis.chat/SKILL.md` | Direct HTTP(S) URL to a single-file `SKILL.md`. Name resolution: frontmatter → URL slug → interactive prompt → `--name` flag. |
 | `github` | `openai/skills/k8s` | Direct GitHub repo/path installs and custom taps. |
 | `clawhub`, `lobehub`, `claude-marketplace` | Source-specific identifiers | Community or marketplace integrations. |
 
@@ -383,6 +386,35 @@ Hermes can search and convert agent entries from LobeHub's public catalog into i
 - Public agents index: [chat-agents.lobehub.com](https://chat-agents.lobehub.com/)
 - Backing repo: [lobehub/lobe-chat-agents](https://github.com/lobehub/lobe-chat-agents)
 - Hermes source id: `lobehub`
+
+#### 8. Direct URL (`url`)
+
+Install a single-file `SKILL.md` directly from any HTTP(S) URL — useful when an author hosts a skill on their own site (no hub listing, no GitHub path to type). Hermes fetches the URL, parses the YAML frontmatter, security-scans it, and installs.
+
+- Hermes source id: `url`
+- Identifier: the URL itself (no prefix needed)
+- Scope: **single-file `SKILL.md`** only. Multi-file skills with `references/` or `scripts/` need a manifest and should be published via one of the other sources above.
+
+```bash
+hermes skills install https://sharethis.chat/SKILL.md
+hermes skills install https://example.com/my-skill/SKILL.md --category productivity
+```
+
+Name resolution, in order:
+1. `name:` field in the SKILL.md YAML frontmatter (recommended — every well-formed skill has one).
+2. Parent directory name from the URL path (e.g. `.../my-skill/SKILL.md` → `my-skill`, or `.../my-skill.md` → `my-skill`), when it's a valid identifier (`^[a-z][a-z0-9_-]*$`).
+3. Interactive prompt on a terminal with a TTY.
+4. On non-interactive surfaces (the `/skills install` slash command inside the TUI, gateway platforms, scripts), a clean error pointing at the `--name` override.
+
+```bash
+# Frontmatter has no name and the URL slug is unhelpful — supply one:
+hermes skills install https://example.com/SKILL.md --name sharethis-chat
+
+# Or inside a chat session:
+/skills install https://example.com/SKILL.md --name sharethis-chat
+```
+
+Trust level is always `community` — the same security scan runs as for every other source. The URL is stored as the install identifier, so `hermes skills update` re-fetches from the same URL automatically when you want to refresh.
 
 ### Security scanning and `--force`
 


### PR DESCRIPTION
## Summary
Follow-up to #16323 — the UrlSource adapter landed but four docs surfaces still only showed hub-identifier install examples. This adds URL-install coverage everywhere the hub-identifier form already appears.

## Changes
- `website/docs/user-guide/features/skills.md` — `url` row in the Supported-hub-sources table; new "#### 8. Direct URL (`url`)" section with scope (single-file SKILL.md only), the full name-resolution order (frontmatter → URL slug → interactive prompt → `--name` flag), and examples for both TTY and non-interactive surfaces. Two URL examples added to the top-of-file install-examples block.
- `website/docs/reference/cli-commands.md` — two URL install examples + one note explaining the name-resolution fallback chain.
- `website/docs/guides/work-with-skills.md` — one URL-install example alongside the existing hub-identifier examples.
- `skills/autonomous-ai-agents/hermes-agent/SKILL.md` — Quick Reference block's `hermes skills install` line now says "ID can be a hub identifier OR a direct SKILL.md URL" and mentions `--name`.

## Why
The user-facing docs are the first place someone looks when they're not sure how to install a skill that isn't on an established hub. Without these updates the URL-install path effectively only exists for people who read release notes.

## Validation
| | Before | After |
|---|---|---|
| Source types table | 6 sources listed | 7 sources listed (adds `url`) |
| Install examples in `features/skills.md` | No URL examples | 2 URL examples (basic + `--name`) |
| `reference/cli-commands.md` examples | No URL examples | 2 URL examples + fallback-chain note |
| `guides/work-with-skills.md` | No URL examples | 1 URL example |
| `hermes-agent` skill Quick Reference | `hermes skills install ID` generic | Explicit note about URL IDs + `--name` |

No code changes. No new dependencies.

Ref: tracking issue #16328 (follow-up from @versun's docx feedback).
