### PR TITLE
fix(signal): avoid TOCTOU race in send_image_file

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -824,11 +824,14 @@ class SignalAdapter(BasePlatformAdapter):
                 logger.warning("Signal: failed to download image: %s", e)
                 return SendResult(success=False, error=str(e))
 
-        if not file_path or not Path(file_path).exists():
+        if not file_path:
             return SendResult(success=False, error="Image file not found")
 
-        # Validate size
-        file_size = Path(file_path).stat().st_size
+        # Validate size (use stat() directly to avoid TOCTOU race with exists())
+        try:
+            file_size = Path(file_path).stat().st_size
+        except FileNotFoundError:
+            return SendResult(success=False, error=f"Image file not found: {file_path}")
         if file_size > SIGNAL_MAX_ATTACHMENT_SIZE:
             return SendResult(success=False, error=f"Image too large ({file_size} bytes)")
 


### PR DESCRIPTION
## Summary

Fix a TOCTOU (Time-of-Check-Time-of-Use) race condition in `SignalAdapter.send_image_file()`.

The code used `.exists()` followed by `.stat()` to validate an image file before sending. Between these two calls, the file could be deleted, causing an unhandled `FileNotFoundError`.

## Bug

```python
# Before (race condition):
if not file_path or not Path(file_path).exists():
    return SendResult(success=False, error="Image file not found")
file_size = Path(file_path).stat().st_size  # FileNotFoundError if file deleted between check and stat
```

## Fix

```python
# After (safe):
if not file_path:
    return SendResult(success=False, error="Image file not found")
try:
    file_size = Path(file_path).stat().st_size
except FileNotFoundError:
    return SendResult(success=False, error=f"Image file not found: {file_path}")
```

## Notes

- This matches the existing safe pattern used in `_send_generic_media()` at line 866-868 which already handles `FileNotFoundError` correctly
- The fix is minimal (6 lines changed) and maintains identical behavior for the happy path
- Also improves the error message to include the file path for easier debugging

## Related

- Same pattern issue reported in #16293 (Weixin) — this fix addresses the Signal variant
