### PR TITLE
feat(docker): docker_network config field for sandbox network attachment

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -191,6 +191,11 @@ terminal:
 #   docker_forward_env:
 #     - "GITHUB_TOKEN"
 #     - "NPM_TOKEN"
+#   # Optional: attach the container to a user-defined Docker network so it can
+#   # reach compose-deployed sibling services (DBs, MCP servers, internal HTTP)
+#   # by container DNS. Default: True (Docker's default bridge). False sets
+#   # --network=none (fully isolated). A string sets --network=<name>.
+#   docker_network: "my-net"
 
 # -----------------------------------------------------------------------------
 # OPTION 4: Singularity/Apptainer container

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -414,7 +414,9 @@ def test_security_args_include_setuid_setgid_for_gosu_drop(monkeypatch):
     }
     assert "SETUID" in added, "SETUID cap missing — gosu drop in entrypoint will fail"
     assert "SETGID" in added, "SETGID cap missing — gosu drop in entrypoint will fail"
-
+    # Sanity: the hardening posture is still in place.
+    assert "--cap-drop" in run_args and "ALL" in run_args
+    assert "--security-opt" in run_args and "no-new-privileges" in run_args
 
 # ── run_as_host_user tests ────────────────────────────────────────
 
@@ -512,3 +514,40 @@ def test_run_as_host_user_warns_and_skips_when_no_posix_ids(monkeypatch, caplog)
         "does not expose POSIX uid/gid" in rec.getMessage()
         for rec in caplog.records
     ), "expected a warning when POSIX ids are unavailable"
+
+
+def test_network_true_omits_network_flag(monkeypatch):
+    """network=True (default) should add no --network flag — uses docker default bridge."""
+    calls = _mock_subprocess_run(monkeypatch)
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/custom/docker")
+
+    _make_dummy_env(network=True)
+
+    run_call = next(c for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run")
+    cmd = run_call[0]
+    assert "--network=none" not in cmd
+    assert not any(arg.startswith("--network=") for arg in cmd)
+
+
+def test_network_false_adds_network_none(monkeypatch):
+    """network=False should add --network=none (current behavior preserved)."""
+    calls = _mock_subprocess_run(monkeypatch)
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/custom/docker")
+
+    _make_dummy_env(network=False)
+
+    run_call = next(c for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run")
+    assert "--network=none" in run_call[0]
+
+
+def test_network_string_adds_named_network(monkeypatch):
+    """network='hermes-mcp-net' should add --network=hermes-mcp-net (the new feature)."""
+    calls = _mock_subprocess_run(monkeypatch)
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/custom/docker")
+
+    _make_dummy_env(network="hermes-mcp-net")
+
+    run_call = next(c for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run")
+    cmd = run_call[0]
+    assert "--network=hermes-mcp-net" in cmd
+    assert "--network=none" not in cmd

--- a/tests/tools/test_parse_env_var.py
+++ b/tests/tools/test_parse_env_var.py
@@ -105,3 +105,48 @@ class TestImportTimeEnvParsing:
                 assert mod.DISK_USAGE_WARNING_THRESHOLD_GB == 500.0
         finally:
             importlib.reload(_tt_mod)
+
+
+def test_create_environment_threads_docker_network(monkeypatch):
+    """_create_environment must extract docker_network from container_config and pass to _DockerEnvironment."""
+    from tools import terminal_tool as _tt_mod
+
+    captured_kwargs = {}
+
+    def fake_docker_environment(**kwargs):
+        captured_kwargs.update(kwargs)
+        # Return a stub object — we only care about constructor kwargs
+        return object()
+
+    with patch.object(_tt_mod, "_DockerEnvironment", side_effect=fake_docker_environment):
+        _tt_mod._create_environment(
+            "docker",
+            image="test:latest",
+            cwd="/root",
+            timeout=60,
+            container_config={"docker_network": "hermes-mcp-net"},
+        )
+
+    assert captured_kwargs.get("network") == "hermes-mcp-net"
+
+
+def test_create_environment_default_network_is_true(monkeypatch):
+    """When docker_network is absent, _create_environment passes network=True (current behavior)."""
+    from tools import terminal_tool as _tt_mod
+
+    captured_kwargs = {}
+
+    def fake_docker_environment(**kwargs):
+        captured_kwargs.update(kwargs)
+        return object()
+
+    with patch.object(_tt_mod, "_DockerEnvironment", side_effect=fake_docker_environment):
+        _tt_mod._create_environment(
+            "docker",
+            image="test:latest",
+            cwd="/root",
+            timeout=60,
+            container_config={},  # no docker_network key
+        )
+
+    assert captured_kwargs.get("network") is True

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -296,7 +296,7 @@ class DockerEnvironment(BaseEnvironment):
         volumes: list = None,
         forward_env: list[str] | None = None,
         env: dict | None = None,
-        network: bool = True,
+        network: bool | str = True,
         host_cwd: str = None,
         auto_mount_cwd: bool = False,
         run_as_host_user: bool = False,
@@ -332,8 +332,11 @@ class DockerEnvironment(BaseEnvironment):
                     "Docker storage driver does not support per-container disk limits "
                     "(requires overlay2 on XFS with pquota). Container will run without disk quota."
                 )
-        if not network:
+        if network is False:
             resource_args.append("--network=none")
+        elif isinstance(network, str):
+            resource_args.append(f"--network={network}")
+        # else (network is True / default): no --network flag — uses docker default bridge
 
         # Persistent workspace via bind mounts from a configurable host directory
         # (TERMINAL_SANDBOX_DIR, default ~/.hermes/sandboxes/). Non-persistent

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1093,6 +1093,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
     volumes = cc.get("docker_volumes", [])
     docker_forward_env = cc.get("docker_forward_env", [])
     docker_env = cc.get("docker_env", {})
+    docker_network = cc.get("docker_network", True)
 
     if env_type == "local":
         return _LocalEnvironment(cwd=cwd, timeout=timeout)
@@ -1107,6 +1108,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
             auto_mount_cwd=cc.get("docker_mount_cwd_to_workspace", False),
             forward_env=docker_forward_env,
             env=docker_env,
+            network=docker_network,
             run_as_host_user=cc.get("docker_run_as_host_user", False),
         )
     
@@ -1756,6 +1758,7 @@ def terminal_tool(
                                 "docker_forward_env": config.get("docker_forward_env", []),
                                 "docker_env": config.get("docker_env", {}),
                                 "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
+                                "docker_network": config.get("docker_network", True),
                             }
 
                         local_config = None


### PR DESCRIPTION
## What does this PR do?

Adds a `docker_network` field to the `terminal:` config schema, exposed by widening `DockerEnvironment.network` from `bool` to `bool | str`. Lets the sandbox container attach to a user-defined docker network so it can reach compose-deployed sibling services (databases, MCP servers, monitoring) by container DNS — a common deployment pattern that's currently unreachable without heavyweight workarounds (`HERMES_DOCKER_BINARY` wrapper, iptables, or tailscale routing).

Specifically narrower than a generic `docker_extra_args` knob — single-purpose, no privilege-escalation surface (no way to bypass `_SECURITY_ARGS`).

## Related Issue

No prior issue — opening speculatively. Happy to file one and convert if maintainers prefer that flow.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `tools/environments/docker.py`: signature `network: bool` → `network: bool | str`; body conditional rewritten to handle three cases (`is False` → `--network=none`, `isinstance(_, str)` → `--network=<value>`, else default).
- `tools/terminal_tool.py`: extract `docker_network` from `container_config` (default `True`) in `_create_environment`; pass `network=docker_network` to `_DockerEnvironment`; add `"docker_network": config.get("docker_network", True)` to the `container_config` builder so the YAML field actually reaches the call site.
- `cli-config.yaml.example`: document the new field under the Docker backend section, alongside the existing `docker_forward_env` / `docker_mount_cwd_to_workspace` examples.
- `tests/tools/test_docker_environment.py`: 3 new constructor tests (`network=True` omits flag, `network=False` adds `--network=none`, `network="name"` adds `--network=name`).
- `tests/tools/test_parse_env_var.py`: 2 new threading tests (`docker_network` extracted from `container_config` reaches `_DockerEnvironment`; absence defaults to `True`).

## How to Test

1. `pytest tests/tools/test_docker_environment.py tests/tools/test_parse_env_var.py -v` — all green (5 new + pre-existing 31 = 36 passed).
2. End-to-end: in `~/.hermes/config.yaml`, set:
   ```yaml
   terminal:
     backend: "docker"
     docker_network: "my-named-net"
   ```
   and start a sibling container on `my-named-net` (e.g. `docker run --rm --network=my-named-net --name sibling alpine sleep 3600`). Then in a hermes session: `getent hosts sibling` resolves; `curl http://sibling:<port>` succeeds.
3. Backward compatibility: same config without `docker_network` runs identically (no `--network` flag — Docker's default bridge).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (single commit)
- [x] I've run `pytest tests/tools/test_docker_environment.py tests/tools/test_parse_env_var.py -q` and all tests pass (36 passed, including the 5 new)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 / Docker via OrbStack, deployed to Debian 12 LXC

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`cli-config.yaml.example` + behavior described in commit body)
- [x] I've updated `cli-config.yaml.example` for the new config key
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact: the `--network=<name>` flag is identical across Docker on Linux/macOS/Windows; no platform-specific code paths touched
- [x] N/A — not a tool, this is a config field

## Notes for reviewer

One subtle behavior change worth disclosing: the body conditional changed from `if not network:` to `if network is False: ... elif isinstance(network, str): ...`. Previously any falsy non-bool (`None`, `""`, `0`) would trigger `--network=none`. Now only literal `False` does. In practice the only caller is `cc.get("docker_network", True)` which returns `True | False | str`, so users with existing configs see no change. Mentioning explicitly so it doesn't surprise future spelunkers.