### PR TITLE
fix(sms): replace os.environ[] with clear error for missing Twilio credentials

### DIFF
--- a/gateway/platforms/sms.py
+++ b/gateway/platforms/sms.py
@@ -65,8 +65,15 @@ class SmsAdapter(BasePlatformAdapter):
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.SMS)
-        self._account_sid: str = os.environ["TWILIO_ACCOUNT_SID"]
-        self._auth_token: str = os.environ["TWILIO_AUTH_TOKEN"]
+        _account_sid = os.getenv("TWILIO_ACCOUNT_SID", "")
+        _auth_token = os.getenv("TWILIO_AUTH_TOKEN", "")
+        if not _account_sid or not _auth_token:
+            raise EnvironmentError(
+                "TWILIO_ACCOUNT_SID and TWILIO_AUTH_TOKEN must be set for the SMS "
+                "platform. Add them to ~/.hermes/.env or export as environment variables."
+            )
+        self._account_sid: str = _account_sid
+        self._auth_token: str = _auth_token
         self._from_number: str = os.getenv("TWILIO_PHONE_NUMBER", "")
         self._webhook_port: int = int(
             os.getenv("SMS_WEBHOOK_PORT", str(DEFAULT_WEBHOOK_PORT))


### PR DESCRIPTION
## Summary

Replace raw `os.environ[]` KeyError with a clear, actionable error message when Twilio credentials are missing.

## Bug

```python
# Before — confusing KeyError traceback:
self._account_sid: str = os.environ["TWILIO_ACCOUNT_SID"]  # KeyError: 'TWILIO_ACCOUNT_SID'
self._auth_token: str = os.environ["TWILIO_AUTH_TOKEN"]     # KeyError: 'TWILIO_AUTH_TOKEN'
```

When these env vars are not set, the user sees a raw Python traceback with no guidance on how to fix it.

## Fix

```python
# After — clear error message:
_account_sid = os.getenv("TWILIO_ACCOUNT_SID", "")
_auth_token = os.getenv("TWILIO_AUTH_TOKEN", "")
if not _account_sid or not _auth_token:
    raise EnvironmentError(
        "TWILIO_ACCOUNT_SID and TWILIO_AUTH_TOKEN must be set for the SMS "
        "platform. Add them to ~/.hermes/.env or export as environment variables."
    )
```

## Notes

- This is consistent with how other platforms handle required credentials (e.g., `TWILIO_PHONE_NUMBER` is already checked with `os.getenv()` in `connect()`)
- The `EnvironmentError` clearly tells the user what to do instead of showing a confusing `KeyError` traceback
- Zero behavior change for users who have the env vars properly configured
