### PR TITLE
fix(dingtalk): track background message task for cleanup on disconnect

### DIFF
--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -1343,7 +1343,7 @@ class _IncomingHandler(
             # eventually causing a disconnect.  _on_message is wrapped so
             # exceptions inside the task surface in logs instead of
             # disappearing into the event loop.
-            asyncio.create_task(self._safe_on_message(chatbot_msg))
+            self._adapter._spawn_bg(self._safe_on_message(chatbot_msg))
         except Exception:
             logger.exception(
                 "[%s] Error preparing incoming message", self._adapter.name


### PR DESCRIPTION
## Summary

Track the fire-and-forget message processing task in DingTalk adapter for proper cleanup on disconnect.

## Bug

```python
# Before — untracked task, abandoned on disconnect:
asyncio.create_task(self._safe_on_message(chatbot_msg))
```

The task reference is discarded immediately. While `_safe_on_message` catches exceptions internally, the task cannot be cancelled during graceful disconnect. If the event loop shuts down while the task is running, it is silently abandoned.

## Fix

```python
# After — tracked via _spawn_bg(), cancelled on disconnect:
self._adapter._spawn_bg(self._safe_on_message(chatbot_msg))
```

`_spawn_bg()` (defined at line 457) creates the task, adds it to `_bg_tasks` set, and auto-removes it on completion via `add_done_callback`. This is the same pattern already used at line 1335 for the thinking reaction task.

## Notes

- Single-line change — `asyncio.create_task()` → `self._adapter._spawn_bg()`
- `_spawn_bg` is already used in the same file (line 1335) for the thinking emoji reaction
- Ensures all background tasks are cancelled during graceful shutdown
