### PR TITLE
fix(cli): enable arrow-key navigation in sessions browser

### DIFF
--- a/hermes_cli/curses_ui.py
+++ b/hermes_cli/curses_ui.py
@@ -66,6 +66,7 @@ def curses_checklist(
 
         def _draw(stdscr):
             curses.curs_set(0)
+            stdscr.keypad(True)
             if curses.has_colors():
                 curses.start_color()
                 curses.use_default_colors()
@@ -195,6 +196,7 @@ def curses_radiolist(
 
         def _draw(stdscr):
             curses.curs_set(0)
+            stdscr.keypad(True)
             if curses.has_colors():
                 curses.start_color()
                 curses.use_default_colors()
@@ -332,6 +334,7 @@ def curses_single_select(
 
         def _draw(stdscr):
             curses.curs_set(0)
+            stdscr.keypad(True)
             if curses.has_colors():
                 curses.start_color()
                 curses.use_default_colors()

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -402,6 +402,7 @@ def _session_browse_picker(sessions: list) -> Optional[str]:
 
         def _curses_browse(stdscr):
             curses.curs_set(0)
+            stdscr.keypad(True)
             if curses.has_colors():
                 curses.start_color()
                 curses.use_default_colors()

--- a/tests/hermes_cli/test_session_browse.py
+++ b/tests/hermes_cli/test_session_browse.py
@@ -270,6 +270,26 @@ class TestCursesBrowse:
                 with patch("curses.has_colors", return_value=False):
                     return _session_browse_picker(sessions)
 
+    def test_curses_enables_keypad_mode(self):
+        import curses
+        sessions = _make_sessions(3)
+
+        mock_stdscr = MagicMock()
+        mock_stdscr.getmaxyx.return_value = (30, 120)
+        mock_stdscr.getch.side_effect = [10]
+
+        with patch("curses.wrapper") as mock_wrapper:
+            def run_inner(func):
+                func(mock_stdscr)
+
+            mock_wrapper.side_effect = run_inner
+            with patch("curses.curs_set"):
+                with patch("curses.has_colors", return_value=False):
+                    result = _session_browse_picker(sessions)
+
+        assert result == sessions[0]["id"]
+        mock_stdscr.keypad.assert_called_once_with(True)
+
     def test_enter_selects_first_session(self):
         sessions = _make_sessions(3)
         result = self._run_with_keys(sessions, [10])  # Enter key


### PR DESCRIPTION
## Summary
- enable `curses` keypad mode in the interactive session browser
- enable keypad mode in shared curses pickers used elsewhere in Hermes
- add a regression test covering keypad initialization in `tests/hermes_cli/test_session_browse.py`

## Problem
`hermes sessions browse` could not be navigated with arrow keys in some terminals. Pressing an arrow key would immediately exit the picker and leave raw escape-sequence fragments in the shell, which users reported as strings like `27D`, `26B`, or similar junk.

Root cause: the curses UI was reading from `stdscr.getch()` without first enabling `stdscr.keypad(True)`, so arrow keys were delivered as raw escape sequences instead of `curses.KEY_UP` / `curses.KEY_DOWN`.

## Exact reproduction steps
1. Open a terminal session where Hermes is installed.
2. Ensure you have at least two saved sessions.
3. Run:
   ```bash
   hermes sessions browse
   ```
4. Press the **Down Arrow** key.
5. Observe the buggy behavior on the unpatched version:
   - the picker exits immediately instead of moving the selection
   - the terminal receives leftover escape-sequence bytes
   - junk such as `27D`, `26B`, `^[` sequences, or similar random-looking strings may appear
6. Re-run the same command on this branch.
7. Press **Up Arrow** / **Down Arrow** again.
8. Observe the fixed behavior:
   - the selection moves correctly
   - the picker stays open
   - pressing **Enter** resumes the selected session normally

## Test plan
- [x] `source venv/bin/activate && pytest -o addopts='' tests/hermes_cli/test_session_browse.py -q`

## Notes
This patch intentionally keeps the numbered fallback path unchanged for environments where curses is unavailable.