### PR TITLE
fix(memory): return existing entry previews on zero-match in replace/remove

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -145,6 +145,17 @@ class TestMemoryStoreReplace:
         result = store.replace("memory", "nonexistent", "new")
         assert result["success"] is False
 
+    def test_replace_no_match_returns_existing_previews(self, store):
+        store.add("memory", "fact A")
+        store.add("memory", "fact B with a much longer body that should be truncated to eighty characters in the preview")
+        result = store.replace("memory", "nonexistent", "new")
+        assert result["success"] is False
+        assert "existing_entries" in result
+        assert len(result["existing_entries"]) == 2
+        assert result["existing_entries"][0] == "fact A"
+        assert result["existing_entries"][1].endswith("...")
+        assert len(result["existing_entries"][1]) <= 83  # 80 + "..."
+
     def test_replace_ambiguous_match(self, store):
         store.add("memory", "server A runs nginx")
         store.add("memory", "server B runs nginx")
@@ -177,6 +188,14 @@ class TestMemoryStoreRemove:
     def test_remove_no_match(self, store):
         result = store.remove("memory", "nonexistent")
         assert result["success"] is False
+
+    def test_remove_no_match_returns_existing_previews(self, store):
+        store.add("memory", "fact A")
+        store.add("memory", "fact B")
+        result = store.remove("memory", "nonexistent")
+        assert result["success"] is False
+        assert "existing_entries" in result
+        assert result["existing_entries"] == ["fact A", "fact B"]
 
     def test_remove_empty_old_text(self, store):
         result = store.remove("memory", "  ")

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -285,7 +285,12 @@ class MemoryStore:
             matches = [(i, e) for i, e in enumerate(entries) if old_text in e]
 
             if not matches:
-                return {"success": False, "error": f"No entry matched '{old_text}'."}
+                previews = [e[:80] + ("..." if len(e) > 80 else "") for e in entries]
+                return {
+                    "success": False,
+                    "error": f"No entry matched '{old_text}'.",
+                    "existing_entries": previews,
+                }
 
             if len(matches) > 1:
                 # If all matches are identical (exact duplicates), operate on the first one
@@ -335,7 +340,12 @@ class MemoryStore:
             matches = [(i, e) for i, e in enumerate(entries) if old_text in e]
 
             if not matches:
-                return {"success": False, "error": f"No entry matched '{old_text}'."}
+                previews = [e[:80] + ("..." if len(e) > 80 else "") for e in entries]
+                return {
+                    "success": False,
+                    "error": f"No entry matched '{old_text}'.",
+                    "existing_entries": previews,
+                }
 
             if len(matches) > 1:
                 # If all matches are identical (exact duplicates), remove the first one


### PR DESCRIPTION
Closes #16266.

## Problem

`memory.replace` / `memory.remove` zero-match returned a bare `"No entry matched '...'"` error with no context about what entries actually exist. LLMs that paraphrased instead of substring-matching would burn a full tool round trip every time, producing the consistent `[error]` → retry-success pattern @ahmadhawamdah documented.

## Fix

Mirror the multi-match branch behavior on zero-match: return the same 80-char truncated previews under a new `existing_entries` field so the next LLM call can pick a correct `old_text`. Symmetric in `remove()`.

## Diff

`tools/memory_tool.py` — replace + remove zero-match returns:

```python
previews = [e[:80] + ("..." if len(e) > 80 else "") for e in entries]
return {
    "success": False,
    "error": f"No entry matched '{old_text}'.",
    "existing_entries": previews,
}
```

Additive on the error response — no schema change for callers.

## Tests

`tests/tools/test_memory_tool.py` — 2 new tests:
- `test_replace_no_match_returns_existing_previews` — asserts `existing_entries` shape, truncation, ellipsis bound.
- `test_remove_no_match_returns_existing_previews` — same for remove.

```
pytest tests/tools/test_memory_tool.py -q
35 passed (33 pre-existing + 2 new)
```