### PR TITLE
fix(image_gen): soft-accept configured provider in check_fn (#16027)

### DIFF
--- a/tests/tools/test_image_generation_check_fn.py
+++ b/tests/tools/test_image_generation_check_fn.py
@@ -1,0 +1,110 @@
+"""Regression tests for #16027: image_generate `check_fn` must not be
+gated by a plugin-discovery race at session init.
+
+The previous behavior gated `image_generate` on a successful probe of
+the plugin registry. When session init fired `check_fn` before plugin
+discovery had registered providers, the tool was permanently excluded
+from the session — even though `_handle_image_generate` works correctly
+when invoked directly because it does its own retry with
+`_ensure_plugins_discovered(force=True)`.
+
+The fix adds a soft-accept gate: an explicitly configured
+`image_gen.provider` in config.yaml means "the user wants this tool" —
+the actual availability check is deferred to call time.
+"""
+from __future__ import annotations
+
+import pytest
+
+from agent import image_gen_registry
+from agent.image_gen_provider import ImageGenProvider
+from tools import image_generation_tool
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    image_gen_registry._reset_for_tests()
+    yield
+    image_gen_registry._reset_for_tests()
+
+
+@pytest.fixture(autouse=True)
+def _no_fal_key(monkeypatch):
+    # Strip every variant of the FAL key plus any managed-gateway env so
+    # the in-tree FAL branch never short-circuits the test.
+    for var in (
+        "FAL_KEY", "FAL_AI_API_KEY", "FAL_API_KEY",
+        "FAL_GATEWAY_URL", "FAL_GATEWAY_TOKEN",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _force_no_fal(monkeypatch):
+    """Belt-and-suspenders: also stub check_fal_api_key to False."""
+    monkeypatch.setattr(image_generation_tool, "check_fal_api_key", lambda: False)
+
+
+class _UnavailableProvider(ImageGenProvider):
+    """A provider that's registered but not available — simulates a plugin
+    that has loaded its module but its underlying SDK/credentials aren't
+    ready (e.g. OAuth still pending)."""
+
+    @property
+    def name(self) -> str:
+        return "codex"
+
+    def is_available(self) -> bool:
+        return False
+
+    def generate(self, prompt, aspect_ratio="landscape", **kwargs):
+        return {"success": False, "error": "unavailable"}
+
+
+def test_check_fn_returns_true_when_provider_configured_but_registry_empty(monkeypatch):
+    """The original repro from #16027: image_gen.provider is set, but
+    plugin discovery hasn't populated the registry yet at session init.
+    Without the fix, the tool is excluded for the entire session."""
+    _force_no_fal(monkeypatch)
+    monkeypatch.setattr(
+        image_generation_tool, "_read_configured_image_provider",
+        lambda: "openai-codex",
+    )
+    # Registry is intentionally empty — simulates pre-discovery state.
+    assert image_generation_tool.check_image_generation_requirements() is True
+
+
+def test_check_fn_returns_true_when_provider_configured_but_unavailable(monkeypatch):
+    """If the provider is registered but its is_available() is still
+    flaky at session init, the soft-accept gate must still surface the
+    tool. Provider availability is re-checked per call."""
+    _force_no_fal(monkeypatch)
+    image_gen_registry.register_provider(_UnavailableProvider())
+    monkeypatch.setattr(
+        image_generation_tool, "_read_configured_image_provider",
+        lambda: "codex",
+    )
+    assert image_generation_tool.check_image_generation_requirements() is True
+
+
+def test_check_fn_returns_false_with_no_fal_no_config_no_providers(monkeypatch):
+    """Regression guard: with nothing configured and no providers
+    registered, the tool stays gated. The fix must not flip the default
+    on for users who have never opted in."""
+    _force_no_fal(monkeypatch)
+    monkeypatch.setattr(
+        image_generation_tool, "_read_configured_image_provider",
+        lambda: None,
+    )
+    assert image_generation_tool.check_image_generation_requirements() is False
+
+
+def test_check_fn_returns_false_when_only_fal_configured_but_unavailable(monkeypatch):
+    """If image_gen.provider is "fal" but FAL_KEY is unset, we should
+    NOT soft-accept — fal is the in-tree backend handled by the FAL
+    branch above, not by the dispatcher's plugin lookup."""
+    _force_no_fal(monkeypatch)
+    monkeypatch.setattr(
+        image_generation_tool, "_read_configured_image_provider",
+        lambda: "fal",
+    )
+    assert image_generation_tool.check_image_generation_requirements() is False

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -744,7 +744,11 @@ def check_image_generation_requirements() -> bool:
     Providers are considered in this order:
 
     1. The in-tree FAL backend (FAL_KEY or managed gateway).
-    2. Any plugin-registered provider whose ``is_available()`` returns True.
+    2. An ``image_gen.provider`` explicitly set in ``config.yaml``. We
+       trust this as a soft-accept gate even if the named plugin hasn't
+       registered yet — see #16027 below.
+    3. Any plugin-registered provider whose ``is_available()`` returns
+       True.
 
     Plugins win only when the in-tree FAL path is NOT ready, which matches
     the historical behavior: shipping hermes with a FAL key configured
@@ -760,6 +764,26 @@ def check_image_generation_requirements() -> bool:
             _load_fal_client()
             return True
     except ImportError:
+        pass
+
+    # Soft-accept gate: if the user has explicitly chosen an image_gen
+    # provider in config.yaml, trust the configuration and surface the
+    # tool. The actual provider lookup happens at call time inside
+    # `_dispatch_to_plugin_provider`, which retries discovery with
+    # `force=True` and returns a clear "provider_not_registered" error
+    # if the named plugin still isn't available.
+    #
+    # Without this gate, plugin discovery races at gateway/session
+    # startup can leave the registry empty when this check_fn fires,
+    # causing the tool to be permanently excluded from the session even
+    # though the plugin loads moments later and `_handle_image_generate`
+    # works correctly when called directly. Mirrors the soft-accept
+    # pattern used for browser-cdp (#15952). (#16027)
+    try:
+        configured = _read_configured_image_provider()
+        if configured and configured != "fal":
+            return True
+    except Exception:
         pass
 
     # Probe plugin providers. Discovery is idempotent and cheap.


### PR DESCRIPTION
## What does this PR do?

`check_image_generation_requirements` returned False when:

1. `FAL_KEY` was not set, AND
2. Plugin discovery hadn't yet registered the provider named in `image_gen.provider`.

The cached `check_fn` result determines tool availability for the session's lifetime, so a discovery race at gateway/session init left `image_generate` permanently excluded from the session — even though `_handle_image_generate` (which retries discovery with `force=True`, courtesy of #14502) and the underlying provider both work fine when invoked directly. The user sees the tool simply missing, with no diagnostic.

This PR is the missing companion to #14502: that PR fixed the symptom at *call* time; this one fixes it at *check* time. Without both, the tool isn't in the session's tool list to be retried at call time.

Adds a soft-accept gate between the FAL branch and the plugin probe in `check_image_generation_requirements`: if `image_gen.provider` is explicitly set in `config.yaml` (and is not `fal`, which is the in-tree backend), trust that the user wants this tool and surface it. Provider availability is re-checked at call time in `_dispatch_to_plugin_provider`, which retries discovery and returns a clear `provider_not_registered` error if the named plugin still isn't there.

Mirrors the soft-accept pattern used for browser-cdp (#15952) and openai-codex models (#16172).

## Related Issue

Fixes #16027

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/image_generation_tool.py`: insert a soft-accept gate in `check_image_generation_requirements()` between the FAL branch and the plugin probe. If `_read_configured_image_provider()` returns a non-`fal` value, return True without requiring registry population.
- `tests/tools/test_image_generation_check_fn.py` (new): 4 tests covering the new behavior plus regression guards.

## How to Test

1. `scripts/run_tests.sh tests/tools/test_image_generation_check_fn.py tests/tools/test_image_generation_env.py tests/tools/test_image_generation.py tests/tools/test_image_generation_plugin_dispatch.py` — 65 pass.
2. Revert `tools/image_generation_tool.py` change → 2 of 4 new tests fail (the new-behavior tests; the 2 regression guards still pass).
3. Manual repro from the issue: configure `image_gen.provider: openai-codex` with valid Codex OAuth, restart gateway, send a message — `image_generate` is now in the session's tool list (previously missing in some sessions due to the race).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
scripts/run_tests.sh tests/tools/test_image_generation_check_fn.py tests/tools/test_image_generation_env.py tests/tools/test_image_generation.py tests/tools/test_image_generation_plugin_dispatch.py
# 65 pass
```
