### PR TITLE
fix(gateway): dispatch quick_commands type:alias to built-in slash commands (#16094)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2188,7 +2188,20 @@ class BasePlatformAdapter(ABC):
             # session lifecycle and its cleanup races with the running task
             # (see PR #4926).
             cmd = event.get_command()
-            from hermes_cli.commands import should_bypass_active_session
+
+            # Resolve quick_command aliases (#16094). Without this, an
+            # alias like `/halt → /stop` or `/fresh → /new` is unknown
+            # to should_bypass_active_session and gets queued as text or
+            # interrupts the running agent — breaking the contract that
+            # alias commands behave like the built-in they target.
+            from hermes_cli.commands import (
+                resolve_quick_command_alias_text,
+                should_bypass_active_session,
+            )
+            resolved_text = resolve_quick_command_alias_text(event.text)
+            if resolved_text and resolved_text != event.text:
+                event.text = resolved_text
+                cmd = event.get_command()
 
             if should_bypass_active_session(cmd):
                 # /stop, /new, /reset must cancel the in-flight adapter task

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4064,12 +4064,28 @@ class GatewayRunner:
                 elif qcmd.get("type") == "alias":
                     target = qcmd.get("target", "").strip()
                     if target:
+                        # Mirror CLI's process_command(aliased_command) pattern
+                        # (#16094): recurse through _handle_message so the
+                        # canonical command lookup re-runs against the
+                        # resolved target. The previous "fall through" left
+                        # `command` set to the whole compound string (e.g.
+                        # "model claude-sonnet-4-6 --provider anthropic")
+                        # which never matched any canonical built-in, so the
+                        # request landed in the plugin/skill/unknown-command
+                        # branches and returned "Unknown command".
                         target = target if target.startswith("/") else f"/{target}"
-                        target_command = target.lstrip("/")
                         user_args = event.get_command_args().strip()
-                        event.text = f"{target} {user_args}".strip()
-                        command = target_command
-                        # Fall through to normal command dispatch below
+                        aliased_command = f"{target} {user_args}".strip()
+                        # Depth guard against alias-of-alias loops.
+                        depth = getattr(event, "_alias_depth", 0)
+                        if depth >= 5:
+                            return (
+                                f"Quick command alias depth exceeded "
+                                f"resolving '/{command}' → '{target}'."
+                            )
+                        event._alias_depth = depth + 1
+                        event.text = aliased_command
+                        return await self._handle_message(event)
                     else:
                         return f"Quick command '/{command}' has no target defined."
                 else:

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -329,6 +329,58 @@ def should_bypass_active_session(command_name: str | None) -> bool:
     return resolve_command(command_name) is not None if command_name else False
 
 
+def resolve_quick_command_alias_text(text: str | None) -> str | None:
+    """Resolve a quick_command alias to its target text.
+
+    Reads ``quick_commands`` from ``~/.hermes/config.yaml``.  If *text*
+    invokes an entry of ``type: alias`` whose ``target`` is a slash
+    command, returns the full resolved text — target plus the alias's
+    pre-baked args plus any runtime args the user appended.  Returns
+    ``None`` for non-aliases, exec quick_commands, empty/missing target,
+    or non-slash text.
+
+    Used by the gateway adapter (#16094): the active-session bypass
+    check at ``gateway/platforms/base.py`` runs before the runner's
+    quick_command resolution, so aliases like ``/halt → /stop`` or
+    ``/fresh → /new`` would otherwise be queued/interrupted as ordinary
+    text while an agent is running.  Resolving once at the adapter lets
+    those aliases participate in the same Level-1 bypass that built-in
+    commands enjoy.
+    """
+    if not text:
+        return None
+    stripped = text.strip()
+    if not stripped.startswith("/"):
+        return None
+    parts = stripped.split(None, 1)
+    base = parts[0].lstrip("/")
+    user_args = parts[1].strip() if len(parts) > 1 else ""
+    if not base:
+        return None
+
+    try:
+        from hermes_cli.config import read_raw_config
+        cfg = read_raw_config()
+    except Exception:
+        return None
+    if not isinstance(cfg, dict):
+        return None
+    quick_commands = cfg.get("quick_commands")
+    if not isinstance(quick_commands, dict):
+        return None
+    qcmd = quick_commands.get(base)
+    if not isinstance(qcmd, dict):
+        return None
+    if qcmd.get("type") != "alias":
+        return None
+    target = str(qcmd.get("target", "") or "").strip()
+    if not target:
+        return None
+    if not target.startswith("/"):
+        target = "/" + target
+    return f"{target} {user_args}".strip() if user_args else target
+
+
 def _resolve_config_gates() -> set[str]:
     """Return canonical names of commands whose ``gateway_config_gate`` is truthy.
 

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -357,6 +357,13 @@ def resolve_quick_command_alias_text(text: str | None) -> str | None:
     user_args = parts[1].strip() if len(parts) > 1 else ""
     if not base:
         return None
+    # Match MessageEvent.get_command() normalization: lowercase and strip
+    # the bot suffix so /HALT and /halt@HermesBot resolve the same as /halt.
+    if "@" in base:
+        base = base.split("@", 1)[0]
+    base = base.lower()
+    if not base:
+        return None
 
     try:
         from hermes_cli.config import read_raw_config

--- a/tests/gateway/test_quick_commands_alias.py
+++ b/tests/gateway/test_quick_commands_alias.py
@@ -1,0 +1,416 @@
+"""Regression tests for #16094: gateway quick_commands `type: alias`
+must dispatch to built-in slash commands, not return "Unknown command".
+
+The CLI implementation in `cli.py` already does this correctly via
+`process_command(aliased_command)`. The gateway implementation in
+`gateway/run.py` previously stored the whole compound target string into
+`command` and "fell through" to the plugin/skill checks below — none of
+which can dispatch a built-in command, so the user got a confusing
+"Unknown command `/model claude-... --provider ...`" reply.
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource, build_session_key
+
+
+def _build_runner(monkeypatch, tmp_path, quick_commands):
+    (tmp_path / "config.yaml").write_text("", encoding="utf-8")
+    import gateway.run as gateway_run
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner = GatewayRunner(GatewayConfig())
+    # The dispatcher accepts dict OR object-with-attribute for self.config.
+    # A dict carrying just `quick_commands` is the smallest fixture that
+    # exercises the alias branch.
+    runner.config = {"quick_commands": quick_commands}
+    return runner
+
+
+def _make_event(text: str) -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="12345",
+            chat_type="dm",
+            user_id="user-1",
+        ),
+        message_id="m1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_alias_to_built_in_dispatches_to_built_in_handler(monkeypatch, tmp_path):
+    """An alias targeting /help must invoke _handle_help_command."""
+    runner = _build_runner(
+        monkeypatch, tmp_path,
+        {"sonnet": {"type": "alias", "target": "/help"}},
+    )
+    monkeypatch.setattr(GatewayRunner, "_is_user_authorized", lambda self, src: True)
+
+    help_handler = AsyncMock(return_value="HELP RESPONSE")
+    monkeypatch.setattr(GatewayRunner, "_handle_help_command", help_handler)
+
+    result = await runner._handle_message(_make_event("/sonnet"))
+
+    assert help_handler.await_count == 1, (
+        "Without #16094 fix, alias falls through to plugin/skill checks "
+        "and never reaches the built-in canonical dispatch."
+    )
+    assert result == "HELP RESPONSE"
+
+
+@pytest.mark.asyncio
+async def test_alias_forwards_user_args_to_target(monkeypatch, tmp_path):
+    """Args after the alias must be appended to the resolved target text."""
+    runner = _build_runner(
+        monkeypatch, tmp_path,
+        {"m": {"type": "alias", "target": "/model"}},
+    )
+    monkeypatch.setattr(GatewayRunner, "_is_user_authorized", lambda self, src: True)
+
+    captured = []
+
+    async def _capture_model(self, event):
+        captured.append(event.text)
+        return "ok"
+
+    monkeypatch.setattr(GatewayRunner, "_handle_model_command", _capture_model)
+
+    await runner._handle_message(
+        _make_event("/m claude-sonnet-4-6 --provider anthropic --global"),
+    )
+
+    assert captured == [
+        "/model claude-sonnet-4-6 --provider anthropic --global",
+    ], (
+        "The alias's user args must be appended to the target command, and "
+        "the recursive _handle_message call must see the full target text."
+    )
+
+
+@pytest.mark.asyncio
+async def test_alias_target_with_embedded_args_dispatches_correctly(monkeypatch, tmp_path):
+    """Aliases that pre-bake args (the original repro from #16094) must work."""
+    runner = _build_runner(
+        monkeypatch, tmp_path,
+        {
+            "sonnet": {
+                "type": "alias",
+                "target": "/model claude-sonnet-4-6 --provider anthropic --global",
+            },
+        },
+    )
+    monkeypatch.setattr(GatewayRunner, "_is_user_authorized", lambda self, src: True)
+
+    captured = []
+
+    async def _capture_model(self, event):
+        captured.append(event.text)
+        return "model switched"
+
+    monkeypatch.setattr(GatewayRunner, "_handle_model_command", _capture_model)
+
+    result = await runner._handle_message(_make_event("/sonnet"))
+
+    assert captured == [
+        "/model claude-sonnet-4-6 --provider anthropic --global",
+    ]
+    assert result == "model switched"
+
+
+@pytest.mark.asyncio
+async def test_alias_depth_guard_breaks_recursive_loops(monkeypatch, tmp_path):
+    """Alias-of-alias-of-... must terminate, not infinitely recurse."""
+    # a → b → a → b → ... (mutual recursion).
+    runner = _build_runner(
+        monkeypatch, tmp_path,
+        {
+            "a": {"type": "alias", "target": "/b"},
+            "b": {"type": "alias", "target": "/a"},
+        },
+    )
+    monkeypatch.setattr(GatewayRunner, "_is_user_authorized", lambda self, src: True)
+
+    result = await runner._handle_message(_make_event("/a"))
+
+    assert result is not None
+    assert "alias depth exceeded" in result.lower(), (
+        "Mutual-recursion aliases must terminate with an error, not exhaust "
+        "Python's recursion limit."
+    )
+
+
+@pytest.mark.asyncio
+async def test_alias_with_no_target_returns_error(monkeypatch, tmp_path):
+    runner = _build_runner(
+        monkeypatch, tmp_path,
+        {"broken": {"type": "alias", "target": ""}},
+    )
+    monkeypatch.setattr(GatewayRunner, "_is_user_authorized", lambda self, src: True)
+
+    result = await runner._handle_message(_make_event("/broken"))
+    assert result is not None
+    assert "no target defined" in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# Helper unit tests: resolve_quick_command_alias_text
+# ---------------------------------------------------------------------------
+
+
+def _patch_quick_commands(monkeypatch, quick_commands):
+    """Make hermes_cli.commands.read_raw_config return a config dict
+    carrying the supplied quick_commands."""
+    from hermes_cli import config as config_mod
+
+    monkeypatch.setattr(
+        config_mod, "read_raw_config",
+        lambda: {"quick_commands": quick_commands},
+    )
+
+
+class TestResolveQuickCommandAliasText:
+    def test_resolves_simple_alias(self, monkeypatch):
+        from hermes_cli.commands import resolve_quick_command_alias_text
+        _patch_quick_commands(
+            monkeypatch, {"halt": {"type": "alias", "target": "/stop"}},
+        )
+        assert resolve_quick_command_alias_text("/halt") == "/stop"
+
+    def test_resolves_alias_with_user_args_appended(self, monkeypatch):
+        from hermes_cli.commands import resolve_quick_command_alias_text
+        _patch_quick_commands(
+            monkeypatch, {"m": {"type": "alias", "target": "/model"}},
+        )
+        assert (
+            resolve_quick_command_alias_text("/m claude-sonnet-4-6 --provider anthropic")
+            == "/model claude-sonnet-4-6 --provider anthropic"
+        )
+
+    def test_resolves_alias_with_pre_baked_target_args(self, monkeypatch):
+        from hermes_cli.commands import resolve_quick_command_alias_text
+        _patch_quick_commands(
+            monkeypatch,
+            {"sonnet": {
+                "type": "alias",
+                "target": "/model claude-sonnet-4-6 --provider anthropic --global",
+            }},
+        )
+        assert (
+            resolve_quick_command_alias_text("/sonnet")
+            == "/model claude-sonnet-4-6 --provider anthropic --global"
+        )
+
+    def test_normalizes_target_without_leading_slash(self, monkeypatch):
+        from hermes_cli.commands import resolve_quick_command_alias_text
+        _patch_quick_commands(
+            monkeypatch, {"halt": {"type": "alias", "target": "stop"}},
+        )
+        assert resolve_quick_command_alias_text("/halt") == "/stop"
+
+    def test_returns_none_for_exec_quick_commands(self, monkeypatch):
+        from hermes_cli.commands import resolve_quick_command_alias_text
+        _patch_quick_commands(
+            monkeypatch, {"dn": {"type": "exec", "command": "echo daily-note"}},
+        )
+        assert resolve_quick_command_alias_text("/dn") is None
+
+    def test_returns_none_for_unknown_command(self, monkeypatch):
+        from hermes_cli.commands import resolve_quick_command_alias_text
+        _patch_quick_commands(
+            monkeypatch, {"halt": {"type": "alias", "target": "/stop"}},
+        )
+        assert resolve_quick_command_alias_text("/unknown-thing") is None
+
+    def test_returns_none_for_non_slash_text(self, monkeypatch):
+        from hermes_cli.commands import resolve_quick_command_alias_text
+        _patch_quick_commands(
+            monkeypatch, {"halt": {"type": "alias", "target": "/stop"}},
+        )
+        assert resolve_quick_command_alias_text("hello world") is None
+
+    def test_returns_none_for_alias_with_empty_target(self, monkeypatch):
+        from hermes_cli.commands import resolve_quick_command_alias_text
+        _patch_quick_commands(
+            monkeypatch, {"broken": {"type": "alias", "target": "  "}},
+        )
+        assert resolve_quick_command_alias_text("/broken") is None
+
+
+# ---------------------------------------------------------------------------
+# Adapter-level tests: aliased commands bypass active-session guard
+# ---------------------------------------------------------------------------
+
+
+class _StubAdapter(BasePlatformAdapter):
+    """Concrete adapter with abstract methods stubbed out."""
+
+    async def connect(self):
+        pass
+
+    async def disconnect(self):
+        pass
+
+    async def send(self, chat_id, text, **kwargs):
+        pass
+
+    async def get_chat_info(self, chat_id):
+        return {}
+
+
+def _make_stub_adapter():
+    config = PlatformConfig(enabled=True, token="test-token")
+    adapter = _StubAdapter(config, Platform.TELEGRAM)
+    adapter.sent_responses = []
+
+    async def _mock_handler(event):
+        cmd = event.get_command()
+        return f"handled:{cmd}:{event.text}" if cmd else f"handled:text:{event.text}"
+
+    adapter._message_handler = _mock_handler
+
+    async def _mock_send_retry(chat_id, content, **kwargs):
+        adapter.sent_responses.append(content)
+
+    adapter._send_with_retry = _mock_send_retry
+    return adapter
+
+
+def _make_adapter_event(text, chat_id="12345"):
+    source = SessionSource(
+        platform=Platform.TELEGRAM, chat_id=chat_id, chat_type="dm",
+    )
+    return MessageEvent(text=text, message_type=MessageType.TEXT, source=source)
+
+
+def _adapter_session_key(chat_id="12345"):
+    source = SessionSource(
+        platform=Platform.TELEGRAM, chat_id=chat_id, chat_type="dm",
+    )
+    return build_session_key(source)
+
+
+class TestAliasBypassesActiveSessionGuard:
+    """Aliases that resolve to bypass-eligible built-ins must inherit
+    the bypass behavior — otherwise /halt → /stop is queued/interrupted
+    while /stop sails through, defeating the alias."""
+
+    @pytest.mark.asyncio
+    async def test_aliased_stop_bypasses_guard(self, monkeypatch):
+        # /halt is configured as an alias for /stop. With an active session,
+        # /halt must reach the message handler via the bypass path, NOT be
+        # queued as ordinary text.
+        _patch_quick_commands(
+            monkeypatch, {"halt": {"type": "alias", "target": "/stop"}},
+        )
+
+        adapter = _make_stub_adapter()
+        sk = _adapter_session_key()
+        adapter._active_sessions[sk] = asyncio.Event()
+
+        await adapter.handle_message(_make_adapter_event("/halt"))
+
+        assert sk not in adapter._pending_messages, (
+            "/halt was queued as a pending message instead of being "
+            "dispatched — alias bypass missing"
+        )
+        assert any(
+            "handled:stop" in r for r in adapter.sent_responses
+        ), (
+            "Aliased /halt did not reach the message handler as resolved "
+            "/stop. sent_responses=%r" % (adapter.sent_responses,)
+        )
+
+    @pytest.mark.asyncio
+    async def test_aliased_new_bypasses_guard(self, monkeypatch):
+        _patch_quick_commands(
+            monkeypatch, {"fresh": {"type": "alias", "target": "/new"}},
+        )
+
+        adapter = _make_stub_adapter()
+        sk = _adapter_session_key()
+        adapter._active_sessions[sk] = asyncio.Event()
+
+        await adapter.handle_message(_make_adapter_event("/fresh"))
+
+        assert sk not in adapter._pending_messages
+        assert any("handled:new" in r for r in adapter.sent_responses)
+
+    @pytest.mark.asyncio
+    async def test_aliased_status_bypasses_guard_with_args(self, monkeypatch):
+        # /st aliased to /status — bypass-eligible; user appends args.
+        _patch_quick_commands(
+            monkeypatch, {"st": {"type": "alias", "target": "/status"}},
+        )
+
+        adapter = _make_stub_adapter()
+        sk = _adapter_session_key()
+        adapter._active_sessions[sk] = asyncio.Event()
+
+        await adapter.handle_message(_make_adapter_event("/st verbose"))
+
+        assert sk not in adapter._pending_messages
+        # Dispatched message text must reflect the resolved target plus
+        # the user's args.
+        assert any(
+            "handled:status:" in r and "/status verbose" in r
+            for r in adapter.sent_responses
+        ), adapter.sent_responses
+
+    @pytest.mark.asyncio
+    async def test_aliased_to_non_bypass_built_in_still_dispatches(self, monkeypatch):
+        # /m aliased to /model — /model isn't in the dedicated handoff
+        # list (not stop/new/reset) but IS resolvable, so it must
+        # bypass via the direct-dispatch path.
+        _patch_quick_commands(
+            monkeypatch,
+            {"m": {"type": "alias", "target": "/model claude-sonnet-4-6 --provider anthropic --global"}},
+        )
+
+        adapter = _make_stub_adapter()
+        sk = _adapter_session_key()
+        adapter._active_sessions[sk] = asyncio.Event()
+
+        await adapter.handle_message(_make_adapter_event("/m"))
+
+        assert sk not in adapter._pending_messages
+        assert any(
+            "handled:model" in r and "claude-sonnet-4-6" in r
+            for r in adapter.sent_responses
+        ), adapter.sent_responses
+
+    @pytest.mark.asyncio
+    async def test_exec_quick_command_does_not_bypass(self, monkeypatch):
+        # /dn (exec) is NOT a slash-command alias. It should NOT bypass
+        # the active-session guard — exec quick_commands run on the
+        # synchronous CLI path and the runner's quick_commands block
+        # handles them when no session is busy. With an active session,
+        # they should be queued like any normal message.
+        _patch_quick_commands(
+            monkeypatch,
+            {"dn": {"type": "exec", "command": "echo daily-note"}},
+        )
+
+        adapter = _make_stub_adapter()
+        sk = _adapter_session_key()
+        adapter._active_sessions[sk] = asyncio.Event()
+
+        await adapter.handle_message(_make_adapter_event("/dn"))
+
+        # Exec aliases get queued (or interrupt-handled) — the message
+        # handler must NOT be hit via the bypass path.
+        assert not any(
+            "handled:dn" in r for r in adapter.sent_responses
+        ), (
+            "Exec quick_command unexpectedly bypassed the active-session "
+            "guard. sent_responses=%r" % (adapter.sent_responses,)
+        )

--- a/tests/gateway/test_quick_commands_alias.py
+++ b/tests/gateway/test_quick_commands_alias.py
@@ -245,6 +245,32 @@ class TestResolveQuickCommandAliasText:
         )
         assert resolve_quick_command_alias_text("/broken") is None
 
+    def test_resolves_uppercase_alias(self, monkeypatch):
+        from hermes_cli.commands import resolve_quick_command_alias_text
+        _patch_quick_commands(
+            monkeypatch, {"halt": {"type": "alias", "target": "/stop"}},
+        )
+        assert resolve_quick_command_alias_text("/HALT") == "/stop"
+        assert resolve_quick_command_alias_text("/Halt") == "/stop"
+
+    def test_resolves_alias_with_bot_suffix(self, monkeypatch):
+        from hermes_cli.commands import resolve_quick_command_alias_text
+        _patch_quick_commands(
+            monkeypatch, {"halt": {"type": "alias", "target": "/stop"}},
+        )
+        assert resolve_quick_command_alias_text("/halt@HermesBot") == "/stop"
+        assert resolve_quick_command_alias_text("/HALT@HermesBot") == "/stop"
+
+    def test_resolves_uppercase_alias_with_bot_suffix_and_args(self, monkeypatch):
+        from hermes_cli.commands import resolve_quick_command_alias_text
+        _patch_quick_commands(
+            monkeypatch, {"m": {"type": "alias", "target": "/model"}},
+        )
+        assert (
+            resolve_quick_command_alias_text("/M@HermesBot claude-sonnet-4-6")
+            == "/model claude-sonnet-4-6"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Adapter-level tests: aliased commands bypass active-session guard


### PR DESCRIPTION
## What does this PR do?

Fixes the gateway `quick_commands` `type: alias` dispatch so user-defined aliases like `/halt → /stop`, `/fresh → /new`, or `/sonnet → /model claude-sonnet-4-6 --provider anthropic` behave exactly like the canonical command they target — at **both** the runner and adapter layers.

### The bug

The runner's alias branch in `gateway/run.py` stored the whole compound target string (e.g. `"model claude-sonnet-4-6 --provider anthropic"`) into `command` and "fell through" to plugin/skill checks. Built-in commands are dispatched ABOVE the quick_commands block via `if canonical == "X": return await self._handle_X_command()`, so the fall-through could never reach them. Users got:

> `Unknown command \`/model claude-sonnet-4-6 --provider anthropic\`.`

The CLI implementation in `cli.py` already handles this correctly via `return self.process_command(aliased_command)` — a real recursion that re-resolves the canonical command against the rewritten target text.

### Acknowledging prior work

Two prior PRs already address the runner-level half of this bug:

- **#8659** (briandevans) — moves alias resolution to the top of `_handle_message` (early-rewrite approach).
- **#11795** — adds `return await self._handle_message(event)` at the alias branch (recursion approach, similar to mine).

This PR is open in addition because it adds **two pieces of coverage neither prior PR has**, both of which are necessary for the fix to be complete:

| Concern | #8659 | #11795 | This PR |
|---|---|---|---|
| Runner-level alias dispatch | early-rewrite | recursion | recursion |
| Adapter-layer `should_bypass_active_session` | untouched | untouched | pre-resolves alias |
| Alias-of-alias mutual-recursion guard | n/a | none | depth-limited (5) |
| Reusable resolve helper | inline | inline | `resolve_quick_command_alias_text()` |

The adapter-layer gap is load-bearing: `BasePlatformAdapter.handle_message` calls `should_bypass_active_session(cmd)` BEFORE `_handle_message` is ever invoked. With an active session, an alias like `/halt → /stop` returns False from the bypass check (because `"halt"` is unknown to the canonical command registry) and gets queued as ordinary text or interrupts the running agent — defeating the whole point of the alias. A runner-level fix can't reach this code path because the runner is never called for that message.

### What this PR does

1. **Runner** (`gateway/run.py`): mirror the CLI pattern — rewrite `event.text` to the resolved target plus user args, recurse through `_handle_message`. Add `event._alias_depth` guard (max 5) so mutual-recursion aliases (`a → b → a`) terminate with a clear error instead of exhausting Python's recursion limit.
2. **Adapter** (`gateway/platforms/base.py`): new `resolve_quick_command_alias_text()` helper in `hermes_cli/commands.py` reads `quick_commands` from `config.yaml` and resolves a `type: alias` entry to its full target text. Adapter calls it immediately before `should_bypass_active_session` so the bypass check (and downstream dispatch) sees the resolved canonical command. Only `type: alias` entries pointing at slash commands are resolved; `type: exec` quick_commands are left alone.

## Related Issue

Fixes #16094

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/commands.py`: add `resolve_quick_command_alias_text(text)` — reads `quick_commands` from config, resolves a `type: alias` entry to its full target text + user args.
- `gateway/platforms/base.py`: resolve aliases before `should_bypass_active_session` so `/halt → /stop`, `/fresh → /new`, `/m → /model …` bypass the running-agent guard the same way the built-ins do.
- `gateway/run.py`: rewrite the runner's alias branch to recurse through `_handle_message` with depth guard.
- `tests/gateway/test_quick_commands_alias.py` (new): 21 tests across runner-level alias dispatch, helper unit tests, and adapter-level bypass behavior — including 3 regression tests for case-insensitive and `@bot`-suffix normalization (matching `MessageEvent.get_command()`), added in follow-up commit f6599a00 in response to review feedback.

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_quick_commands_alias.py tests/gateway/test_command_bypass_active_session.py` — 61 pass.
2. Revert `gateway/run.py` change → 4 of 5 runner tests fail. Revert `gateway/platforms/base.py` change → 4 of 5 adapter tests fail. (The 5th in each is a regression guard that always passes.)
3. Manual: configure `quick_commands.halt: {type: alias, target: "/stop"}`. Start a long-running agent, send `/halt` from the messaging adapter — agent stops. Without the adapter-layer fix, `/halt` is queued as text or interrupts the agent without dispatching `/stop`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
scripts/run_tests.sh tests/gateway/test_quick_commands_alias.py tests/gateway/test_command_bypass_active_session.py
61 passed
```
