### PR TITLE
fix(telegram): accept /cmd@botname from bot menu in groups

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2353,6 +2353,26 @@ class TelegramAdapter(BasePlatformAdapter):
                     user = getattr(entity, "user", None)
                     if user and getattr(user, "id", None) == bot_id:
                         return True
+                elif entity_type == "bot_command" and expected:
+                    # Telegram's official group-disambiguation form for slash
+                    # commands (``/cmd@botname``) is emitted as a single
+                    # ``bot_command`` entity covering the whole span — there
+                    # is no accompanying ``mention`` entity. Treat it as a
+                    # direct address to this bot when the ``@botname`` suffix
+                    # matches. This is the form Telegram's own command menu
+                    # autocomplete produces in groups, so dropping it at the
+                    # mention gate would break /new, /reset, /help, ... for
+                    # every group that has ``require_mention`` enabled (#15415).
+                    offset = int(getattr(entity, "offset", -1))
+                    length = int(getattr(entity, "length", 0))
+                    if offset < 0 or length <= 0:
+                        continue
+                    command_text = source_text[offset:offset + length]
+                    at_index = command_text.find("@")
+                    if at_index < 0:
+                        continue
+                    if command_text[at_index:].strip().lower() == expected:
+                        return True
         return False
 
     def _message_matches_mention_patterns(self, message: Message) -> bool:

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -59,6 +59,17 @@ def _mention_entity(text, mention="@hermes_bot"):
     return SimpleNamespace(type="mention", offset=offset, length=len(mention))
 
 
+def _bot_command_entity(text, command):
+    """Entity Telegram emits for a ``/cmd`` or ``/cmd@botname`` token.
+
+    Telegram parses slash commands server-side. For ``/cmd@botname`` the
+    client does NOT emit a separate ``mention`` entity — the whole span
+    is a single ``bot_command`` entity.
+    """
+    offset = text.index(command)
+    return SimpleNamespace(type="bot_command", offset=offset, length=len(command))
+
+
 def test_group_messages_can_be_opened_via_config():
     adapter = _make_adapter(require_mention=False)
 
@@ -73,12 +84,34 @@ def test_group_messages_can_require_direct_trigger_via_config():
     assert adapter._should_process_message(_group_message("replying", reply_to_bot=True)) is True
     # Commands must also respect require_mention when it is enabled
     assert adapter._should_process_message(_group_message("/status"), is_command=True) is False
-    # But commands with @mention still pass (Telegram emits a MENTION entity
-    # for /cmd@botname — the bot menu and python-telegram-bot's CommandHandler
-    # rely on this same mechanism)
+    # Telegram's group command menu sends ``/cmd@botname`` as a single
+    # ``bot_command`` entity spanning the whole token (no separate mention
+    # entity). We must accept it so the menu works when require_mention is on.
     assert adapter._should_process_message(
-        _group_message("/status@hermes_bot", entities=[_mention_entity("/status@hermes_bot")])
+        _group_message(
+            "/status@hermes_bot",
+            entities=[_bot_command_entity("/status@hermes_bot", "/status@hermes_bot")],
+        ),
+        is_command=True,
     ) is True
+    # A bot_command entity addressed at a different bot must not satisfy
+    # the mention gate — Telegram groups can host multiple bots that
+    # register the same command name.
+    assert adapter._should_process_message(
+        _group_message(
+            "/status@other_bot",
+            entities=[_bot_command_entity("/status@other_bot", "/status@other_bot")],
+        ),
+        is_command=True,
+    ) is False
+    # Bare ``/status`` (no @botname) must still be dropped in groups with
+    # require_mention=True — Telegram delivers it only when the bot's
+    # privacy mode is off, and even then we should not respond unless the
+    # user explicitly addressed the bot.
+    assert adapter._should_process_message(
+        _group_message("/status", entities=[_bot_command_entity("/status", "/status")]),
+        is_command=True,
+    ) is False
     # And commands still pass unconditionally when require_mention is disabled
     adapter_no_mention = _make_adapter(require_mention=False)
     assert adapter_no_mention._should_process_message(_group_message("/status"), is_command=True) is True


### PR DESCRIPTION
Salvage of #15417 onto current main with @alblez's commit authorship preserved via cherry-pick.

## Summary
Accepts Telegram's `/cmd@botname` bot-menu form as a direct mention in groups with `require_mention=true`. Previously, tapping any slash command (`/new`, `/reset`, `/help`, …) from the bot menu in a group was silently dropped — the only workaround was typing `/new @hermes_bot` with a literal space, which is the wrong form (no longer disambiguates between multiple bots sharing the command name).

Root cause: Telegram parses `/cmd@botname` server-side as a single `bot_command` entity covering the whole span (no separate `mention` entity). `_message_mentions_bot` in `gateway/platforms/telegram.py` only inspected `mention` and `text_mention` entity types, so the menu form failed the group-mention gate. The downstream `get_command()` parser already strips `@botname` correctly — the bug was purely in the gate.

The existing test fixture at `tests/gateway/test_telegram_group_gating.py::test_group_messages_can_require_direct_trigger_via_config` hid the bug by attaching a `mention` entity to `/status@hermes_bot`, which Telegram does not actually emit for the menu form.

## Changes
- `gateway/platforms/telegram.py` — recognize `bot_command` entities whose `@botname` suffix matches `self._bot.username` (case-insensitive) as a direct mention. `/cmd@other_bot` still correctly rejected.
- `tests/gateway/test_telegram_group_gating.py` — add `_bot_command_entity` helper, fix the stale fixture, add regressions for `/cmd@other_bot` (rejected) and bare `/cmd` (still rejected under `require_mention=true`).

## Validation
- 27/27 targeted tests pass (`test_telegram_group_gating.py` + `test_telegram_mention_boundaries.py`).
- E2E-verified five entity shapes against the real `_message_mentions_bot`: bot-menu `/new@hermes_bot` → accept, `/new@other_bot` → reject, bare `/new` → reject, uppercase suffix → accept, classic `@mention` → accept.

Closes #15415. Supersedes #15417 (contributor's commit carried over with authorship intact).