### PR TITLE
fix(error_classifier): gate absolute msg/token heuristics to small context windows

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -484,7 +484,9 @@ def classify_api_error(
 
     is_disconnect = any(p in error_msg for p in _SERVER_DISCONNECT_PATTERNS)
     if is_disconnect and not status_code:
-        is_large = approx_tokens > context_length * 0.6 or approx_tokens > 120000 or num_messages > 200
+        is_large = approx_tokens > context_length * 0.6 or (
+            context_length <= 256000 and (approx_tokens > 120000 or num_messages > 200)
+        )
         if is_large:
             return _result(
                 FailoverReason.context_overflow,
@@ -721,7 +723,9 @@ def _classify_400(
         if not err_body_msg:
             err_body_msg = str(body.get("message") or "").strip().lower()
     is_generic = len(err_body_msg) < 30 or err_body_msg in ("error", "")
-    is_large = approx_tokens > context_length * 0.4 or approx_tokens > 80000 or num_messages > 80
+    is_large = approx_tokens > context_length * 0.4 or (
+        context_length <= 256000 and (approx_tokens > 80000 or num_messages > 80)
+    )
 
     if is_generic and is_large:
         return result_fn(

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -423,6 +423,68 @@ class TestClassifyApiError:
         result = classify_api_error(e, approx_tokens=5000, context_length=200000)
         assert result.reason == FailoverReason.timeout
 
+    # ── Large-context (1M) sessions: don't misclassify on absolute heuristics ──
+
+    def test_400_generic_1m_context_high_message_count_not_overflow(self):
+        """Generic 400 in a 1M-context session with many messages but low token
+        pressure should be format_error, not context_overflow. Regression for #16351."""
+        e = MockAPIError(
+            "Error",
+            status_code=400,
+            body={"error": {"message": "Error"}},
+        )
+        result = classify_api_error(
+            e,
+            provider="openai-codex",
+            model="gpt-5.5",
+            approx_tokens=74320,
+            context_length=1_000_000,
+            num_messages=432,
+        )
+        assert result.reason == FailoverReason.format_error
+        assert result.should_compress is False
+
+    def test_400_generic_1m_context_relative_pressure_still_overflow(self):
+        """Generic 400 in a 1M-context session with > 40% token pressure is
+        still context_overflow — relative threshold is preserved."""
+        e = MockAPIError(
+            "Error",
+            status_code=400,
+            body={"error": {"message": "Error"}},
+        )
+        result = classify_api_error(
+            e,
+            approx_tokens=500_000,
+            context_length=1_000_000,
+            num_messages=10,
+        )
+        assert result.reason == FailoverReason.context_overflow
+
+    def test_disconnect_1m_context_high_message_count_is_timeout(self):
+        """Server disconnect in a 1M-context session with many messages but
+        low token pressure should be timeout, not context_overflow. Regression
+        for #16351."""
+        e = Exception("server disconnected without sending complete message")
+        result = classify_api_error(
+            e,
+            approx_tokens=150_000,
+            context_length=1_000_000,
+            num_messages=300,
+        )
+        assert result.reason == FailoverReason.timeout
+
+    def test_disconnect_1m_context_relative_pressure_still_overflow(self):
+        """Server disconnect in a 1M-context session with > 60% token pressure
+        is still context_overflow."""
+        e = Exception("server disconnected without sending complete message")
+        result = classify_api_error(
+            e,
+            approx_tokens=700_000,
+            context_length=1_000_000,
+            num_messages=10,
+        )
+        assert result.reason == FailoverReason.context_overflow
+
     # ── Provider-specific: Anthropic thinking signature ──
 
     def test_anthropic_thinking_signature(self):


### PR DESCRIPTION
Closes #16351.

## Problem

`agent/error_classifier.py` flagged non-context errors as `context_overflow` in long-context (1M) Codex/GPT-5.x sessions, purely because `num_messages > 80` (generic 400) or `num_messages > 200` (disconnect) — even when `approx_tokens` was a fraction of the actual budget.

Repro from the issue:

```python
classify_api_error(
    FakeHTTP400(),
    provider="openai-codex",
    model="gpt-5.5",
    approx_tokens=74320,
    context_length=1_000_000,
    num_messages=432,
)
# Before: FailoverReason.context_overflow (retryable=True, should_compress=True)
# After:  FailoverReason.format_error      (retryable=False, should_compress=False)
```

That sent format errors into the compression/probe-down path, causing unnecessary compaction and stale handoff pollution on 1M sessions.

## Fix

Apply exactly the gate suggested in the issue body: scope absolute token/message-count fallbacks to `context_length <= 256000`. Relative pressure thresholds (`> 0.6` for disconnect, `> 0.4` for generic 400) still fire on any context size.

```python
# server disconnect path
is_large = approx_tokens > context_length * 0.6 or (
    context_length <= 256000 and (approx_tokens > 120000 or num_messages > 200)
)

# generic 400 path
is_large = approx_tokens > context_length * 0.4 or (
    context_length <= 256000 and (approx_tokens > 80000 or num_messages > 80)
)
```

Existing behavior for ~128K/200K context windows is unchanged.

## Tests

`tests/agent/test_error_classifier.py` — 4 new tests covering the 1M-context regime:

- `test_400_generic_1m_context_high_message_count_not_overflow` — exact repro from issue (74K tokens, 432 msgs, 1M ctx) → `format_error`.
- `test_400_generic_1m_context_relative_pressure_still_overflow` — 500K tokens / 1M ctx still → `context_overflow`.
- `test_disconnect_1m_context_high_message_count_is_timeout` — 150K tokens, 300 msgs, 1M ctx → `timeout`.
- `test_disconnect_1m_context_relative_pressure_still_overflow` — 700K tokens / 1M ctx still → `context_overflow`.

```
pytest tests/agent/test_error_classifier.py -q
122 passed (118 pre-existing + 4 new)
```