### PR TITLE
fix: strip leaked declare-x env dump from terminal output on macOS (#15459)

### DIFF
--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -386,9 +386,16 @@ class BaseEnvironment(ABC):
 
         parts = []
 
-        # Source snapshot (env vars from previous commands)
+        # Source snapshot (env vars from previous commands).
+        # Redirect stdout to /dev/null: on macOS (bash 3.2 and certain
+        # Homebrew bash builds) sourcing a file containing ``declare -x``
+        # can emit the declarations to stdout, leaking ~60 lines of env
+        # vars into every tool response (issue #15459).  Linux bash is
+        # silent here, but the redirect is harmless.
         if self._snapshot_ready:
-            parts.append(f"source {self._snapshot_path} 2>/dev/null || true")
+            parts.append(
+                f"source {self._snapshot_path} >/dev/null 2>&1 || true"
+            )
 
         # Preserve bare ``~`` expansion, but rewrite ``~/...`` through
         # ``$HOME`` so suffixes with spaces remain a single shell word.

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1851,7 +1851,7 @@ def terminal_tool(
             # Extract output
             output = result.get("output", "")
             returncode = result.get("returncode", 0)
-            
+
             # Add helpful message for sudo failures in messaging context
             output = _handle_sudo_failure(output, env_type)
 


### PR DESCRIPTION
## Summary
macOS `source` of the persistent-shell snapshot file no longer leaks `declare -x` env var dumps into terminal tool output.

Root cause: `tools/environments/base.py` sourced `self._snapshot_path` with `source ... 2>/dev/null` — only stderr suppressed. On macOS (bash 3.2 / certain Homebrew bash builds) sourcing a file of `declare -x` statements echoes each declaration to **stdout**. Linux bash is silent. Result on macOS: ~60 lines of env vars prepended to every terminal tool response, blowing out context and triggering HTTP 400s on context-limited providers.

Fix: redirect stdout too — `source ... >/dev/null 2>&1 || true`.

## Changes
- `tools/environments/base.py`: one-line change to `_wrap_command` snapshot-source step.

## Validation
| | Before (simulated macOS) | After |
|---|---|---|
| Snapshot w/ `declare -x` lines | 60+ leaked lines in output | Clean output |
| Env var propagation across commands | Works | Still works (`source` still runs) |

E2E-tested via direct `LocalEnvironment.execute()` on Linux: env vars propagate across calls, no `declare -x` leak. Macos-style leak simulated with a snapshot that echoes declarations to stdout — old wrapper leaks, new wrapper does not. `tests/tools/test_base_environment.py` + `tests/tools/test_terminal_tool.py` + `tests/tools/test_terminal_exit_semantics.py`: 58 passed.

## Credit
Salvaged from #15472 (@vominh1919, first to file — authorship preserved) with duplicate fix proposal by #15474 (@Sanjays2402, credited as co-author). Both PRs will be closed pointing here.