### PR TITLE
fix(terminal): suppress declare -x stdout leak when sourcing snapshot on macOS

### DIFF
--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -386,9 +386,14 @@ class BaseEnvironment(ABC):
 
         parts = []
 
-        # Source snapshot (env vars from previous commands)
+        # Source snapshot (env vars from previous commands).
+        # Redirect stdout to /dev/null because on macOS, sourcing a file
+        # that contains `declare -x` statements prints each declaration to
+        # stdout, leaking 60+ lines of env vars into the LLM context
+        # (issue #15459). On Linux this is silent, so the redirect is
+        # harmless there.
         if self._snapshot_ready:
-            parts.append(f"source {self._snapshot_path} 2>/dev/null || true")
+            parts.append(f"source {self._snapshot_path} > /dev/null 2>&1 || true")
 
         # Preserve bare ``~`` expansion, but rewrite ``~/...`` through
         # ``$HOME`` so suffixes with spaces remain a single shell word.


### PR DESCRIPTION
Salvage of #15474 by @Sanjays2402 onto current main (original branch was stale and deleted unrelated comments).

## Summary
Terminal output on macOS no longer leaks ~60 lines of `declare -x` env var declarations into the LLM context on every command execution.

**Root cause:** `_wrap_command()` in `tools/environments/base.py` sourced the session snapshot with only stderr suppressed (`source $snap 2>/dev/null || true`). On macOS bash 3.2 / certain Homebrew builds, sourcing a file of `declare -x` lines echoes each declaration to stdout — silent on Linux, noisy on macOS.

**Fix:** redirect stdout too: `source $snap > /dev/null 2>&1 || true`. The `source` builtin still applies the env vars to the current shell; only print output is suppressed. Harmless on Linux.

## Changes
- `tools/environments/base.py`: one-line redirect change + comment

## Validation
- Wrapped command inspection: now shows `> /dev/null 2>&1`
- Live E2E on local backend with `TERMINAL_PERSISTENT_SHELL=True`: `echo Hello World` → output is `Hello World\n`, nothing else
- Env var persistence across commands still works (verified `export MYTEST=...` → subsequent command reads it)
- `tests/tools/test_terminal_tool.py`: 10/10 passed

## Credit
Both @Sanjays2402 (#15474) and @vominh1919 (#15472) diagnosed the same root cause. Going with Sanjays2402's simpler single-line fix — no defense-in-depth regex strip needed.

Closes #15459