### PR TITLE
fix(auxiliary.vision): keep named-provider credential pool with custom base_url

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2293,7 +2293,7 @@ def resolve_provider_client(
         # Honour an explicit api_key override (e.g. from a fallback_model entry
         # or a custom_providers entry) so callers that pass an explicit
         # credential can authenticate against endpoints where no built-in
-        # credential is registered for this provider alias.
+        # credential is registered for this provider alias. See #16290.
         if explicit_api_key:
             api_key = explicit_api_key.strip() or api_key
         if not api_key:
@@ -2309,7 +2309,9 @@ def resolve_provider_client(
         base_url = _to_openai_base_url(raw_base_url)
         # Honour an explicit base_url override from the caller — used when a
         # fallback_model entry (or custom_providers lookup) routes through a
-        # built-in provider name but targets a user-specified endpoint.
+        # built-in provider name but targets a user-specified endpoint
+        # (e.g. user pinning zai to open.bigmodel.cn while still using the
+        # named provider's credential pool). See #16290.
         if explicit_base_url:
             base_url = _to_openai_base_url(explicit_base_url.strip().rstrip("/"))
 
@@ -2538,6 +2540,32 @@ def _strict_vision_backend_available(provider: str) -> bool:
     return _resolve_strict_vision_backend(provider)[0] is not None
 
 
+def _named_provider_has_credentials(provider: str) -> bool:
+    """Return True if the given API-key provider has at least one usable key.
+
+    Used by ``resolve_vision_provider_client`` to decide whether an
+    explicit base_url override should keep routing through the named
+    provider's credential pool, or fall back to the generic ``custom``
+    endpoint. See #16290.
+    """
+    try:
+        from hermes_cli.auth import (
+            PROVIDER_REGISTRY,
+            resolve_api_key_provider_credentials,
+        )
+    except ImportError:
+        return False
+
+    pconfig = PROVIDER_REGISTRY.get(provider)
+    if pconfig is None or pconfig.auth_type != "api_key":
+        return False
+    try:
+        creds = resolve_api_key_provider_credentials(provider)
+    except Exception:  # noqa: BLE001 — credential lookup must never raise here
+        return False
+    return bool(str(creds.get("api_key", "")).strip())
+
+
 def get_available_vision_backends() -> List[str]:
     """Return the currently available vision backends in auto-selection order.
 
@@ -2593,6 +2621,31 @@ def resolve_vision_provider_client(
         return resolved_provider, sync_client, final_model
 
     if resolved_base_url:
+        # When the user explicitly named a provider (e.g. provider=zai) AND
+        # supplied a custom base_url (e.g. open.bigmodel.cn), keep routing
+        # through the named provider so its credential pool is consulted
+        # (ZAI_API_KEY etc). Falling back to "custom" here would silently
+        # drop the named provider's credentials and only honour OPENAI_API_KEY,
+        # producing 401s when the user expects ZAI_API_KEY auto-resolution
+        # (#16290).
+        if (
+            requested
+            and requested not in ("auto", "custom")
+            and not resolved_api_key
+            and _named_provider_has_credentials(requested)
+        ):
+            client, final_model = resolve_provider_client(
+                requested,
+                model=resolved_model,
+                async_mode=async_mode,
+                explicit_base_url=resolved_base_url,
+                explicit_api_key=resolved_api_key,
+                api_mode=resolved_api_mode,
+            )
+            if client is not None:
+                return requested, client, final_model
+            # Fall through to generic custom path if the named provider
+            # turned up no credentials — preserves prior behaviour.
         client, final_model = resolve_provider_client(
             "custom",
             model=resolved_model,

--- a/tests/agent/test_vision_provider_base_url_routing.py
+++ b/tests/agent/test_vision_provider_base_url_routing.py
@@ -1,0 +1,153 @@
+"""Regression tests for vision provider routing with custom base_url (#16290).
+
+When a user configures `auxiliary.vision.provider = zai` together with a
+custom `base_url` (e.g. `https://open.bigmodel.cn/api/paas/v4`), the
+resolver previously forced provider="custom" and dropped the named
+provider's credential pool, producing 401s when the user expected
+`ZAI_API_KEY` to be auto-resolved.
+
+The fix keeps routing through the named provider so its credential pool
+is consulted, while honouring the explicit base_url override.
+"""
+
+from unittest.mock import patch
+
+from agent import auxiliary_client
+
+
+def _fake_resolve_task_provider_model_factory(
+    provider: str,
+    *,
+    base_url: str = "",
+    api_key: str = "",
+    model: str = "",
+):
+    def _fake(_task, *args, **kwargs):
+        return (provider, model, base_url, api_key, "chat_completions")
+
+    return _fake
+
+
+def test_vision_with_named_provider_and_base_url_routes_through_named_provider():
+    """provider=zai + base_url should route through "zai", not "custom".
+
+    Direct repro for #16290: when ZAI_API_KEY is in the credential pool
+    and the user pins base_url to open.bigmodel.cn, the named provider
+    (and its credential pool) must be used.
+    """
+    with (
+        patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            side_effect=_fake_resolve_task_provider_model_factory(
+                "zai",
+                base_url="https://open.bigmodel.cn/api/paas/v4",
+                api_key="",  # left empty: expecting credential-pool auto-resolve
+                model="glm-4v",
+            ),
+        ),
+        patch(
+            "agent.auxiliary_client._named_provider_has_credentials",
+            return_value=True,
+        ),
+        patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=("zai-client-sentinel", "glm-4v"),
+        ) as mock_resolve,
+    ):
+        provider, client, model = auxiliary_client.resolve_vision_provider_client(
+            provider="zai",
+            model="glm-4v",
+            base_url="https://open.bigmodel.cn/api/paas/v4",
+        )
+
+    assert provider == "zai"
+    assert client == "zai-client-sentinel"
+    assert model == "glm-4v"
+
+    # Most importantly: the router was called with provider="zai", not "custom",
+    # and it forwarded the explicit base_url override.
+    call_args = mock_resolve.call_args
+    assert call_args.args[0] == "zai"
+    assert call_args.kwargs["explicit_base_url"] == "https://open.bigmodel.cn/api/paas/v4"
+
+
+def test_vision_with_base_url_falls_back_to_custom_when_named_provider_has_no_creds():
+    """If the named provider has no credentials, fall back to "custom".
+
+    Preserves prior behaviour for users who have base_url configured but
+    no provider-specific key in their pool.
+    """
+    custom_calls = []
+
+    def _record_resolve(provider, *args, **kwargs):
+        custom_calls.append(provider)
+        if provider == "custom":
+            return ("custom-client-sentinel", "glm-4v")
+        return (None, None)
+
+    with (
+        patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            side_effect=_fake_resolve_task_provider_model_factory(
+                "zai",
+                base_url="https://open.bigmodel.cn/api/paas/v4",
+                api_key="",
+                model="glm-4v",
+            ),
+        ),
+        patch(
+            "agent.auxiliary_client._named_provider_has_credentials",
+            return_value=False,
+        ),
+        patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            side_effect=_record_resolve,
+        ),
+    ):
+        provider, client, _ = auxiliary_client.resolve_vision_provider_client(
+            provider="zai",
+            model="glm-4v",
+            base_url="https://open.bigmodel.cn/api/paas/v4",
+        )
+
+    assert custom_calls == ["custom"]
+    assert provider == "custom"
+    assert client == "custom-client-sentinel"
+
+
+def test_vision_with_explicit_api_key_skips_named_provider_routing():
+    """When the user already supplied api_key in config, don't try the
+    credential pool — go straight to the custom path with the explicit
+    key. Preserves prior behaviour for the documented workaround.
+    """
+    custom_calls = []
+
+    def _record_resolve(provider, *args, **kwargs):
+        custom_calls.append(provider)
+        return ("custom-client-sentinel", "glm-4v")
+
+    with (
+        patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            side_effect=_fake_resolve_task_provider_model_factory(
+                "zai",
+                base_url="https://open.bigmodel.cn/api/paas/v4",
+                api_key="hardcoded-key",
+                model="glm-4v",
+            ),
+        ),
+        patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            side_effect=_record_resolve,
+        ),
+    ):
+        provider, _, _ = auxiliary_client.resolve_vision_provider_client(
+            provider="zai",
+            model="glm-4v",
+            base_url="https://open.bigmodel.cn/api/paas/v4",
+            api_key="hardcoded-key",
+        )
+
+    # Goes straight to custom — no detour through "zai".
+    assert custom_calls == ["custom"]
+    assert provider == "custom"


### PR DESCRIPTION
Closes #16290.

## Problem

`auxiliary.vision` configured with `provider: zai` and a custom `base_url` (e.g. `https://open.bigmodel.cn/api/paas/v4`) failed to auto-resolve `ZAI_API_KEY` from the credential pool — every request hit `401 - {'error': {'code': '401', 'message': '令牌已过期或验证不正确'}}`. Workaround was to hardcode `api_key` in `config.yaml`.

Root cause is exactly as @hackdion identified: in `agent/auxiliary_client.py::resolve_vision_provider_client()`, any non-empty `resolved_base_url` forced the call to `resolve_provider_client("custom", ...)`. That branch only consults `OPENAI_API_KEY` / `explicit_api_key`, so the named provider's credential pool (which knows about `ZAI_API_KEY`, `KIMI_API_KEY`, etc.) was never asked.

## Fix

Three small changes:

1. **`resolve_vision_provider_client`** — when a named non-`custom` provider with credentials in the pool is requested *and* a custom `base_url` is supplied, route through the named provider with `explicit_base_url`. Falls back to the existing `"custom"` path if the named provider has no key, preserving prior behaviour for `OPENAI_API_KEY`-only setups.

2. **`resolve_provider_client` (api-key branch)** — honour `explicit_base_url` / `explicit_api_key` overrides. These were already accepted by the `"custom"` branch but ignored for named api-key providers.

3. **`_named_provider_has_credentials(provider)`** — small helper used by (1) so the routing decision stays cheap (no client construction) and never raises out of the hot path.

The doc'd workaround (hardcoded `api_key` in `config.yaml`) still works — when `explicit_api_key` is supplied the resolver goes straight to the `custom` path, same as before.

## Tests

`tests/agent/test_vision_provider_base_url_routing.py` — 3 new focused tests:

- `test_vision_with_named_provider_and_base_url_routes_through_named_provider` — direct repro of #16290: provider="zai" + base_url="open.bigmodel.cn" routes through `"zai"` (not `"custom"`) and forwards the explicit base_url.
- `test_vision_with_base_url_falls_back_to_custom_when_named_provider_has_no_creds` — preserves prior behaviour when the credential pool is empty.
- `test_vision_with_explicit_api_key_skips_named_provider_routing` — preserves the documented hardcoded-key workaround.

```
pytest tests/agent/test_vision_provider_base_url_routing.py \
       tests/agent/test_vision_resolved_args.py \
       tests/agent/test_auxiliary_client.py \
       tests/agent/test_auxiliary_client_anthropic_custom.py -q
99 passed (95 pre-existing + 4 new)
```