### PR TITLE
fix(tui): prefer raw text over rendered ANSI in TUI message display

### DIFF
--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -474,4 +474,31 @@ describe('createGatewayEventHandler', () => {
 
     expect(getTurnState().activity).toMatchObject([{ text: 'boom', tone: 'error' }])
   })
+
+  it('message.complete prefers text over rendered to avoid ANSI garble in TUI', () => {
+    const appended: Msg[] = []
+    const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+    onEvent({ payload: {}, type: 'message.start' } as any)
+    onEvent({
+      payload: { text: 'plain markdown', rendered: '\x1b[A\x1b[K\x1b[31mANSI\x1b[0m' },
+      type: 'message.complete'
+    } as any)
+
+    const assistantMsg = appended.find(m => m.role === 'assistant')
+    expect(assistantMsg?.text).toBe('plain markdown')
+  })
+
+  it('message.delta accumulates raw text and ignores rendered ANSI fragments', () => {
+    const appended: Msg[] = []
+    const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+    onEvent({ payload: {}, type: 'message.start' } as any)
+    onEvent({ payload: { text: 'hello ', rendered: '\x1b[A' }, type: 'message.delta' } as any)
+    onEvent({ payload: { text: 'world', rendered: '\x1b[K' }, type: 'message.delta' } as any)
+    onEvent({ payload: {}, type: 'message.complete' } as any)
+
+    const assistantMsg = appended.find(m => m.role === 'assistant')
+    expect(assistantMsg?.text).toBe('hello world')
+  })
 })

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -423,7 +423,7 @@ class TurnController {
   recordMessageComplete(payload: { rendered?: string; reasoning?: string; text?: string }) {
     this.closeReasoningSegment()
 
-    const rawText = (payload.rendered ?? payload.text ?? this.bufRef).trimStart()
+    const rawText = (payload.text ?? payload.rendered ?? this.bufRef).trimStart()
     const split = splitReasoning(rawText)
     const finalText = finalTail(split.text, this.segmentMessages)
     const existingReasoning = this.reasoningText.trim() || String(payload.reasoning ?? '').trim()
@@ -516,7 +516,7 @@ class TurnController {
       return
     }
 
-    this.bufRef = rendered ?? this.bufRef + text
+    this.bufRef = this.bufRef + text
 
     if (getUiState().streaming) {
       this.scheduleStreaming()

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -508,7 +508,7 @@ class TurnController {
     return { finalMessages, finalText, wasInterrupted }
   }
 
-  recordMessageDelta({ rendered, text }: { rendered?: string; text?: string }) {
+  recordMessageDelta({ text }: { text?: string }) {
     this.pruneTransient()
     this.endReasoningPhase()
 


### PR DESCRIPTION
## Summary

Fixes #16391 — TUI garbles output when `final_response_markdown: render` is active.

When this config key is set, the gateway sends a `payload.rendered` field containing Rich-generated ANSI output (cursor movement `\x1b[A`, line clear `\x1b[K`, colour codes). The Ink-based TUI renderer does not support these complex escape sequences but `turnController.ts` had `rendered` taking priority over `text` in two places:

- **`recordMessageComplete` (line 426)**: `payload.rendered ?? payload.text ?? this.bufRef` → picked ANSI over raw markdown, Ink rendered it as garbled overlapping text.
- **`recordMessageDelta` (line 519)**: `rendered ?? this.bufRef + text` → replaced the accumulated streaming buffer with an incomplete ANSI fragment on every chunk, discarding all prior text.

### Changes

- `recordMessageComplete`: flipped priority to `payload.text ?? payload.rendered ?? this.bufRef` so TUI always gets raw markdown.
- `recordMessageDelta`: removed the `rendered ??` branch; since `text` is already guard-checked above (line 515), we always accumulate cleanly via `this.bufRef + text`.

### Tests

Two new cases added to `createGatewayEventHandler.test.ts`:
- `message.complete prefers text over rendered to avoid ANSI garble in TUI`
- `message.delta accumulates raw text and ignores rendered ANSI fragments`

Both pass; no pre-existing tests broken (7 failures due to missing `dist/ink-bundle.js` build artifact are pre-existing on `main`).

### Platforms affected

TUI only (`hermes --tui`). CLI and gateway platforms handle Rich ANSI correctly via their terminal emulators — this change does not affect them since `rendered` is never injected into those paths.