### PR TITLE
feat: add multimodal recall memory provider

### DIFF
--- a/plugins/memory/multimodal-recall/README.md
+++ b/plugins/memory/multimodal-recall/README.md
@@ -1,0 +1,141 @@
+# multimodal-recall memory provider
+
+Optional external memory provider that adds compact multimodal prefetch over the existing Hermes recall wrappers.
+
+## Purpose
+This provider is the phase-1 entry point for multimodal memory-provider integration.
+It does not replace built-in memory or transcript recall. Instead, it adds bounded prefetch for turns that likely need prior screenshots, PDFs, OCR evidence, attachments, or other artifacts.
+
+Current design:
+- built-in `memory` remains the durable compact fact store
+- `session_search` remains transcript-first recall
+- `multimodal_recall` remains the low-level artifact wrapper
+- `recall_with_artifacts` remains the main hybrid recall tool
+- this provider adds optional compact prefetch on top of that stack
+
+## Current phase-1 behavior
+Implemented now:
+- plugin discovery through `plugins.memory`
+- config-driven activation through `memory.provider`
+- conservative `is_available()` based on local multimodal MCP connectivity
+- compact `system_prompt_block()` contribution
+- bounded `prefetch(query)` for multimodal-style queries
+- background/non-blocking `queue_prefetch(query)` for next-turn warmup using a compact per-query cache
+- minimal `sync_turn(user_content, assistant_content)` lightweight signal capture
+- minimal `on_session_end(messages)` signal capture for multimodal-relevant sessions
+- minimal `on_memory_write(action, target, content)` lightweight signal capture
+- `shutdown()` cleanup for background prefetch thread
+- delegation to `recall_with_artifacts(...)` instead of reimplementing local-mmrag internals
+- no provider-specific tool schemas yet (`get_tool_schemas() == []`)
+- runtime drop protection: if multimodal MCP connectivity disappears, prefetch returns empty and does not attempt recall
+
+Not implemented yet:
+- provider-owned tool surface
+- persistent rich `sync_turn(...)` writes beyond lightweight signal capture
+- richer `on_session_end(...)` extraction beyond lightweight signal capture
+- richer `on_memory_write(...)` mirroring beyond lightweight signal capture
+- richer long-horizon scoring beyond the current lightweight scored trigger and cooldown
+
+## What it does
+- adds bounded multimodal prefetch for turns that likely reference:
+  - screenshots
+  - PDFs
+  - OCR
+  - attachments
+  - evidence
+  - artifacts
+  - reports
+- returns compact context only
+- includes one small evidence hint when available
+- stays additive to the existing Hermes memory stack
+
+## What it does not do
+- replace built-in memory
+- replace `session_search`
+- expose a duplicate large recall tool surface
+- inject raw OCR/PDF dumps into the prompt
+- reimplement local-mmrag retrieval internals inside the provider
+
+## Availability model
+This provider should only activate when the local multimodal MCP layer is actually ready.
+
+Current rule:
+- `is_available()` returns true only when the local multimodal recall wrapper reports connected MCP state
+
+Implication:
+- loading the provider module alone is not enough
+- bare scripts that do not initialize MCP connections will usually see `available = False`
+- this is intentional and prevents false-positive activation
+
+## Prefetch trigger heuristic
+Current heuristic is still conservative, but no longer pure substring matching.
+
+The provider now uses a tiny scored trigger:
+- strong multimodal/artifact terms such as `screenshot`, `pdf`, `attachment`, `image`, `ocr`, `evidence`, `artifact` and common Chinese equivalents can trigger prefetch immediately
+- weaker artifact terms such as `report`, `document`, `file`, `note`, or `scan` are not enough on their own
+- weak artifact queries can become eligible when recent lightweight provider signals (`_turn_signal`, `_session_end_signal`, `_memory_write_signal`) indicate multimodal context
+
+This keeps prefetch selective while still helping follow-up turns like “what was the ETA from that file?” after Hermes has just discussed screenshot/PDF evidence.
+
+## Cadence / cooldown behavior
+The provider also applies a small in-memory cooldown to repeated fresh recalls:
+- repeated identical fresh `prefetch(query)` calls are suppressed for a short window
+- cached `queue_prefetch(...)` results still return normally
+- this reduces low-value duplicate recall attempts without adding persistence
+
+## Runtime behavior
+When active and triggered:
+1. provider checks runtime multimodal connectivity again
+2. provider calls `recall_with_artifacts(query=..., session_limit=2, artifact_top_k=2)`
+3. provider extracts:
+   - `combined_summary`
+   - at most one evidence source path
+4. provider returns a compact block under ~800 chars
+
+This context is later fenced and injected by Hermes into the current user message using `<memory-context>...</memory-context>`.
+
+## Integration points
+Relevant files:
+- provider implementation:
+  - `plugins/memory/multimodal-recall/__init__.py`
+  - `plugins/memory/multimodal-recall/plugin.yaml`
+- Hermes wrappers it depends on:
+  - `tools/multimodal_recall_tool.py`
+  - `tools/recall_with_artifacts_tool.py`
+- manager/runtime integration:
+  - `agent/memory_manager.py`
+  - `run_agent.py`
+
+## How to enable
+Set Hermes config so the active external memory provider is:
+- `multimodal-recall`
+
+Because Hermes only allows one external memory provider at a time, enabling this provider means choosing it instead of another external provider.
+
+## Test coverage
+Main focused tests currently cover:
+- plugin loadability
+- conservative availability checks
+- no tool schemas initially
+- compact prefetch behavior
+- runtime connectivity-drop protection
+- MemoryManager prefetch integration
+- config-driven provider activation in `AIAgent`
+- system prompt block inclusion
+- fenced prefetch injection into the current user message
+
+Representative test files:
+- `tests/plugins/memory/test_multimodal_recall_provider.py`
+- `tests/agent/test_memory_provider.py`
+- `tests/run_agent/test_run_agent.py`
+
+## Recommended next steps
+After this checkpoint, the most natural follow-on work is:
+- richer long-horizon scoring if lightweight scoring proves insufficient
+- optional `on_session_end(...)` enrichment beyond lightweight signal capture
+- stronger confidence/cadence control for prefetch if real usage justifies it
+- only later, consider provider-specific tools if wrappers prove insufficient
+
+## Design rule to preserve
+Keep this provider small, bounded, and additive.
+If behavior starts duplicating wrappers or replacing transcript recall, the design is drifting in the wrong direction.

--- a/plugins/memory/multimodal-recall/__init__.py
+++ b/plugins/memory/multimodal-recall/__init__.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import json
+import re
+import threading
+import time
+from typing import Any, Dict, List
+
+from agent.memory_provider import MemoryProvider
+from tools.multimodal_recall_tool import _local_mmrag_connected
+from tools.recall_with_artifacts_tool import recall_with_artifacts
+
+
+def _local_mmrag_provider_ready() -> bool:
+    try:
+        return bool(_local_mmrag_connected())
+    except Exception:
+        return False
+
+
+def _normalize_prefetch_query(query: str) -> str:
+    return re.sub(r'\s+', ' ', (query or '').strip().lower())
+
+
+def _multimodal_query_score(query: str) -> int:
+    q = _normalize_prefetch_query(query)
+    strong_terms = [
+        'screenshot', 'pdf', 'attachment', 'image', 'ocr', 'evidence', 'artifact',
+        '截圖', '附件', '圖片', '證據',
+    ]
+    weak_terms = [
+        'report', 'slide', 'document', 'file', 'note', 'scan',
+        '報告', '文件', '紀錄', '掃描',
+    ]
+    score = 0
+    for term in strong_terms:
+        if term in q:
+            score += 3
+    for term in weak_terms:
+        if term in q:
+            score += 1
+    return score
+
+
+def _recent_multimodal_signal_score(*signals: str) -> int:
+    joined = ' '.join((s or '') for s in signals)
+    return 2 if _multimodal_query_score(joined) >= 3 else 0
+
+
+def _should_prefetch_multimodal(query: str, *signals: str) -> bool:
+    query_score = _multimodal_query_score(query)
+    if query_score >= 3:
+        return True
+    return (query_score + _recent_multimodal_signal_score(*signals)) >= 3
+
+
+def _format_prefetch_result(raw: str) -> str:
+    try:
+        parsed = json.loads(raw)
+    except Exception:
+        return ''
+    summary = (parsed.get('combined_summary') or '').strip()
+    top = (((parsed.get('artifact_recall') or {}).get('top_evidence') or [])[:1])
+    lines = []
+    if summary:
+        lines.append(summary)
+    for item in top:
+        path = item.get('source_path') or ''
+        source_ref = item.get('source_ref') or ''
+        collection_name = item.get('collection_name') or ''
+        if path:
+            lines.append(f'source: {path}')
+        if source_ref:
+            lines.append(f'source_ref: {source_ref}')
+        if collection_name:
+            lines.append(f'collection: {collection_name}')
+    out = '\n'.join(lines).strip()
+    return out[:780]
+
+
+def _extract_session_end_signal(messages: List[Dict[str, Any]]) -> str:
+    snippets = []
+    for msg in messages:
+        if not isinstance(msg, dict):
+            continue
+        content = (msg.get('content') or '').strip()
+        if not content:
+            continue
+        if _should_prefetch_multimodal(content):
+            snippets.append(' '.join(content.split()))
+        if len(snippets) >= 2:
+            break
+    if not snippets:
+        return ''
+    joined = ' | '.join(snippets)
+    return joined[:380]
+
+
+class MultimodalRecallMemoryProvider(MemoryProvider):
+    def _recent_signal_text(self) -> str:
+        return ' | '.join(
+            s for s in [
+                getattr(self, '_turn_signal', ''),
+                getattr(self, '_session_end_signal', ''),
+                getattr(self, '_memory_write_signal', ''),
+            ]
+            if s
+        )
+
+    def _should_prefetch(self, query: str) -> bool:
+        return _should_prefetch_multimodal(query, self._recent_signal_text())
+
+    def _fresh_recall_allowed(self, query: str, *, session_id: str = '') -> bool:
+        normalized = _normalize_prefetch_query(query)
+        key = (session_id or self._session_id, normalized)
+        now = time.monotonic()
+        last_key = getattr(self, '_last_prefetch_key', None)
+        last_ts = getattr(self, '_last_prefetch_ts', 0.0)
+        cooldown = getattr(self, '_prefetch_cooldown_seconds', 30.0)
+        if last_key == key and (now - last_ts) < cooldown:
+            return False
+        self._last_prefetch_key = key
+        self._last_prefetch_ts = now
+        return True
+
+    @property
+    def name(self) -> str:
+        return 'multimodal-recall'
+
+    def is_available(self) -> bool:
+        return _local_mmrag_provider_ready()
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        self._session_id = session_id
+        self._init_kwargs = kwargs
+        self._prefetch_cache = {}
+        self._prefetch_lock = threading.Lock()
+        self._prefetch_thread = None
+        self._session_end_signal = ''
+        self._turn_signal = ''
+        self._memory_write_signal = ''
+        self._last_prefetch_key = None
+        self._last_prefetch_ts = 0.0
+        self._prefetch_cooldown_seconds = 30.0
+
+    def system_prompt_block(self) -> str:
+        return 'An optional multimodal memory provider may prefetch compact artifact context when screenshots, PDFs, OCR, or evidence from prior work are relevant.'
+
+    def prefetch(self, query: str, *, session_id: str = '') -> str:
+        if not self._should_prefetch(query):
+            return ''
+        _cache_key = (session_id or self._session_id, _normalize_prefetch_query(query))
+        if hasattr(self, '_prefetch_cache'):
+            with self._prefetch_lock:
+                cached = self._prefetch_cache.pop(_cache_key, '')
+        else:
+            cached = ''
+        if cached:
+            return cached
+        if not _local_mmrag_provider_ready():
+            return ''
+        if not self._fresh_recall_allowed(query, session_id=session_id):
+            return ''
+        try:
+            raw = recall_with_artifacts(query=query, session_limit=2, artifact_top_k=2)
+        except Exception:
+            return ''
+        return _format_prefetch_result(raw)
+
+    def queue_prefetch(self, query: str, *, session_id: str = '') -> None:
+        if not self._should_prefetch(query):
+            return
+        if not _local_mmrag_provider_ready():
+            return
+        _cache_key = (session_id or self._session_id, _normalize_prefetch_query(query))
+
+        def _run() -> None:
+            try:
+                raw = recall_with_artifacts(query=query, session_limit=2, artifact_top_k=2)
+                formatted = _format_prefetch_result(raw)
+                if not formatted:
+                    return
+                with self._prefetch_lock:
+                    self._prefetch_cache[_cache_key] = formatted
+            except Exception:
+                return
+
+        self._prefetch_thread = threading.Thread(
+            target=_run,
+            daemon=True,
+            name='multimodal-recall-prefetch',
+        )
+        self._prefetch_thread.start()
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        return []
+
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = '') -> None:
+        messages = [
+            {'role': 'user', 'content': user_content},
+            {'role': 'assistant', 'content': assistant_content},
+        ]
+        self._turn_signal = _extract_session_end_signal(messages)
+
+    def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
+        self._session_end_signal = _extract_session_end_signal(messages)
+
+    def on_memory_write(self, action: str, target: str, content: str) -> None:
+        messages = [
+            {'role': 'memory-write', 'content': content},
+        ]
+        self._memory_write_signal = _extract_session_end_signal(messages)
+
+    def shutdown(self) -> None:
+        thread = getattr(self, '_prefetch_thread', None)
+        if thread and thread.is_alive():
+            thread.join(timeout=5.0)
+        self._prefetch_thread = None
+
+    def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs) -> str:
+        return json.dumps({'error': f'{self.name} exposes no tools'})
+
+
+def register(ctx) -> None:
+    ctx.register_memory_provider(MultimodalRecallMemoryProvider())

--- a/plugins/memory/multimodal-recall/plugin.yaml
+++ b/plugins/memory/multimodal-recall/plugin.yaml
@@ -1,0 +1,6 @@
+name: multimodal-recall
+version: 0.1.0
+description: Compact multimodal prefetch provider over Hermes hybrid recall wrappers and local-mmrag.
+hooks:
+  - prefetch
+  - on_session_end

--- a/tests/plugins/memory/test_multimodal_recall_provider.py
+++ b/tests/plugins/memory/test_multimodal_recall_provider.py
@@ -1,0 +1,495 @@
+import json
+import threading
+
+from plugins.memory import load_memory_provider
+
+
+def test_multimodal_provider_loads():
+    provider = load_memory_provider("multimodal-recall")
+    assert provider is not None
+    assert provider.name == "multimodal-recall"
+
+
+def test_multimodal_provider_is_unavailable_without_local_mmrag(monkeypatch):
+    provider = load_memory_provider("multimodal-recall")
+    assert provider is not None
+    provider_module = __import__(provider.__class__.__module__, fromlist=['dummy'])
+    monkeypatch.setattr(provider_module, '_local_mmrag_provider_ready', lambda: False)
+    assert provider.is_available() is False
+
+
+def test_multimodal_provider_is_available_with_local_mmrag(monkeypatch):
+    provider = load_memory_provider("multimodal-recall")
+    assert provider is not None
+    provider_module = __import__(provider.__class__.__module__, fromlist=['dummy'])
+    monkeypatch.setattr(provider_module, '_local_mmrag_provider_ready', lambda: True)
+    assert provider.is_available() is True
+
+
+def test_multimodal_provider_exposes_no_tools_initially():
+    provider = load_memory_provider("multimodal-recall")
+    assert provider is not None
+    assert provider.get_tool_schemas() == []
+
+
+def test_multimodal_provider_prefetch_uses_hybrid_recall(monkeypatch, tmp_path):
+    provider = load_memory_provider("multimodal-recall")
+    assert provider is not None
+
+    import sys
+    provider_module = sys.modules[provider.__class__.__module__]
+
+    monkeypatch.setattr(provider_module, '_local_mmrag_provider_ready', lambda: True)
+    monkeypatch.setattr(
+        provider_module,
+        "recall_with_artifacts",
+        lambda **kwargs: json.dumps({
+            "combined_summary": "Recovered screenshot evidence for customer waiting ETA.",
+            "artifact_recall": {
+                "top_evidence": [
+                    {"source_path": "/tmp/status.png", "source_type": "image"}
+                ]
+            },
+        }),
+    )
+
+    provider.initialize("session-1", hermes_home=str(tmp_path), platform="cli")
+    result = provider.prefetch("that screenshot from last time")
+    assert "Recovered screenshot evidence" in result
+    assert "status.png" in result
+    assert len(result) < 800
+
+
+def test_multimodal_provider_prefetch_includes_issue_source_ref_when_available(monkeypatch, tmp_path):
+    provider = load_memory_provider("multimodal-recall")
+    assert provider is not None
+
+    import sys
+    provider_module = sys.modules[provider.__class__.__module__]
+
+    monkeypatch.setattr(provider_module, '_local_mmrag_provider_ready', lambda: True)
+    monkeypatch.setattr(
+        provider_module,
+        "recall_with_artifacts",
+        lambda **kwargs: json.dumps({
+            "combined_summary": "Recovered screenshot evidence for customer waiting ETA.",
+            "artifact_recall": {
+                "top_evidence": [
+                    {
+                        "source_path": "/tmp/status.png",
+                        "source_type": "image",
+                        "source_ref": "issue:987",
+                        "collection_name": "gitlab_radar_demo",
+                    }
+                ]
+            },
+        }),
+    )
+
+    provider.initialize("session-1", hermes_home=str(tmp_path), platform="cli")
+    result = provider.prefetch("that screenshot from last time")
+    assert "issue:987" in result
+    assert "gitlab_radar_demo" in result
+
+
+def test_multimodal_provider_prefetch_skips_non_multimodal_queries(tmp_path):
+    provider = load_memory_provider("multimodal-recall")
+    assert provider is not None
+    provider.initialize("session-1", hermes_home=str(tmp_path), platform="cli")
+    assert provider.prefetch("what branch name did we use") == ""
+
+
+def test_multimodal_provider_prefetch_skips_weak_artifact_queries_without_recent_signal(monkeypatch, tmp_path):
+    provider = load_memory_provider("multimodal-recall")
+    assert provider is not None
+    provider_module = __import__(provider.__class__.__module__, fromlist=['dummy'])
+
+    monkeypatch.setattr(provider_module, '_local_mmrag_provider_ready', lambda: True)
+    called = {'value': False}
+
+    def _fake_recall(**kwargs):
+        called['value'] = True
+        return json.dumps({'combined_summary': 'should not be used', 'artifact_recall': {'top_evidence': []}})
+
+    monkeypatch.setattr(provider_module, 'recall_with_artifacts', _fake_recall)
+
+    provider.initialize("session-1", hermes_home=str(tmp_path), platform="cli")
+    assert provider.prefetch("what was the ETA from that file") == ""
+    assert called['value'] is False
+
+
+def test_multimodal_provider_prefetch_uses_recent_signal_boost_for_weak_artifact_queries(monkeypatch, tmp_path):
+    provider = load_memory_provider("multimodal-recall")
+    assert provider is not None
+
+    import sys
+    provider_module = sys.modules[provider.__class__.__module__]
+
+    monkeypatch.setattr(provider_module, '_local_mmrag_provider_ready', lambda: True)
+    monkeypatch.setattr(
+        provider_module,
+        'recall_with_artifacts',
+        lambda **kwargs: json.dumps({
+            'combined_summary': 'Recovered file ETA from prior screenshot context.',
+            'artifact_recall': {'top_evidence': [{'source_path': '/tmp/report.png'}]},
+        }),
+    )
+
+    provider.initialize('session-1', hermes_home=str(tmp_path), platform='cli')
+    provider.sync_turn(
+        'please remember that screenshot evidence from the PDF review',
+        'I checked the attachment and OCR evidence.',
+        session_id='session-1',
+    )
+    result = provider.prefetch('what was the ETA from that file')
+    assert 'Recovered file ETA' in result
+    assert 'report.png' in result
+
+
+def test_memory_manager_prefetch_all_uses_multimodal_provider_after_runtime_style_init(monkeypatch, tmp_path):
+    from agent.memory_manager import MemoryManager
+
+    provider = load_memory_provider("multimodal-recall")
+    assert provider is not None
+    provider_module = __import__(provider.__class__.__module__, fromlist=['dummy'])
+
+    monkeypatch.setattr(provider_module, '_local_mmrag_provider_ready', lambda: True)
+    monkeypatch.setattr(
+        provider_module,
+        'recall_with_artifacts',
+        lambda **kwargs: json.dumps({
+            'combined_summary': 'Recovered attachment evidence from prior work.',
+            'artifact_recall': {'top_evidence': [{'source_path': '/tmp/evidence.png'}]},
+        }),
+    )
+
+    mgr = MemoryManager()
+    mgr.add_provider(provider)
+    provider.initialize('session-1', hermes_home=str(tmp_path), platform='cli')
+
+    result = mgr.prefetch_all('that attachment from last time', session_id='session-1')
+    assert 'Recovered attachment evidence' in result
+    assert 'evidence.png' in result
+
+
+def test_multimodal_provider_prefetch_returns_empty_if_runtime_connectivity_drops(monkeypatch, tmp_path):
+    provider = load_memory_provider('multimodal-recall')
+    assert provider is not None
+    provider_module = __import__(provider.__class__.__module__, fromlist=['dummy'])
+
+    monkeypatch.setattr(provider_module, '_local_mmrag_provider_ready', lambda: False)
+    called = {'value': False}
+
+    def _fake_recall(**kwargs):
+        called['value'] = True
+        return json.dumps({'combined_summary': 'should not be used'})
+
+    monkeypatch.setattr(provider_module, 'recall_with_artifacts', _fake_recall)
+
+    provider.initialize('session-1', hermes_home=str(tmp_path), platform='cli')
+    result = provider.prefetch('that screenshot from last time')
+    assert result == ''
+    assert called['value'] is False
+
+
+def test_multimodal_provider_queue_prefetch_caches_next_turn_context(monkeypatch, tmp_path):
+    provider = load_memory_provider('multimodal-recall')
+    assert provider is not None
+    provider_module = __import__(provider.__class__.__module__, fromlist=['dummy'])
+
+    monkeypatch.setattr(provider_module, '_local_mmrag_provider_ready', lambda: True)
+    calls = {'count': 0}
+
+    def _fake_recall(**kwargs):
+        calls['count'] += 1
+        return json.dumps({
+            'combined_summary': 'Prefetched screenshot evidence.',
+            'artifact_recall': {'top_evidence': [{'source_path': '/tmp/prefetch.png'}]},
+        })
+
+    monkeypatch.setattr(provider_module, 'recall_with_artifacts', _fake_recall)
+
+    provider.initialize('session-1', hermes_home=str(tmp_path), platform='cli')
+    provider.queue_prefetch('that screenshot from last time')
+    provider._prefetch_thread.join(timeout=1)
+    assert calls['count'] == 1
+    result = provider.prefetch('that screenshot from last time')
+    assert 'Prefetched screenshot evidence.' in result
+    assert 'prefetch.png' in result
+    assert calls['count'] == 1
+
+
+def test_multimodal_provider_prefetch_cache_key_normalizes_equivalent_queries(monkeypatch, tmp_path):
+    provider = load_memory_provider('multimodal-recall')
+    assert provider is not None
+    provider_module = __import__(provider.__class__.__module__, fromlist=['dummy'])
+
+    monkeypatch.setattr(provider_module, '_local_mmrag_provider_ready', lambda: True)
+    calls = {'count': 0}
+
+    def _fake_recall(**kwargs):
+        calls['count'] += 1
+        return json.dumps({
+            'combined_summary': 'Prefetched normalized screenshot evidence.',
+            'artifact_recall': {'top_evidence': [{'source_path': '/tmp/normalized.png'}]},
+        })
+
+    monkeypatch.setattr(provider_module, 'recall_with_artifacts', _fake_recall)
+
+    provider.initialize('session-1', hermes_home=str(tmp_path), platform='cli')
+    provider.queue_prefetch('  That Screenshot   From Last Time  ')
+    provider._prefetch_thread.join(timeout=1)
+
+    result = provider.prefetch('that screenshot from last time')
+
+    assert 'Prefetched normalized screenshot evidence.' in result
+    assert 'normalized.png' in result
+    assert calls['count'] == 1
+
+
+def test_multimodal_provider_queue_prefetch_is_non_blocking(monkeypatch, tmp_path):
+    provider = load_memory_provider('multimodal-recall')
+    assert provider is not None
+    provider_module = __import__(provider.__class__.__module__, fromlist=['dummy'])
+
+    monkeypatch.setattr(provider_module, '_local_mmrag_provider_ready', lambda: True)
+    started = threading.Event()
+    release = threading.Event()
+
+    def _slow_recall(**kwargs):
+        started.set()
+        release.wait(timeout=1)
+        return json.dumps({'combined_summary': 'slow prefetch', 'artifact_recall': {'top_evidence': []}})
+
+    monkeypatch.setattr(provider_module, 'recall_with_artifacts', _slow_recall)
+
+    provider.initialize('session-1', hermes_home=str(tmp_path), platform='cli')
+    provider.queue_prefetch('that screenshot from last time')
+    assert provider._prefetch_thread is not None
+    assert started.wait(timeout=1)
+    # queue_prefetch should have returned already; thread still running until released
+    assert provider._prefetch_thread.is_alive()
+    release.set()
+    provider._prefetch_thread.join(timeout=1)
+
+
+def test_multimodal_provider_queue_prefetch_swallows_background_recall_errors(monkeypatch, tmp_path, recwarn):
+    provider = load_memory_provider('multimodal-recall')
+    assert provider is not None
+    provider_module = __import__(provider.__class__.__module__, fromlist=['dummy'])
+
+    monkeypatch.setattr(provider_module, '_local_mmrag_provider_ready', lambda: True)
+
+    def _boom(**kwargs):
+        raise RuntimeError('background recall failed')
+
+    monkeypatch.setattr(provider_module, 'recall_with_artifacts', _boom)
+
+    provider.initialize('session-1', hermes_home=str(tmp_path), platform='cli')
+    provider.queue_prefetch('that screenshot from last time')
+    provider._prefetch_thread.join(timeout=1)
+
+    assert not recwarn.list
+    assert provider.prefetch('that screenshot from last time') == ''
+
+
+def test_multimodal_provider_prefetch_consumes_cache_once_then_recalls_again(monkeypatch, tmp_path):
+    provider = load_memory_provider('multimodal-recall')
+    assert provider is not None
+    provider_module = __import__(provider.__class__.__module__, fromlist=['dummy'])
+
+    monkeypatch.setattr(provider_module, '_local_mmrag_provider_ready', lambda: True)
+    calls = {'count': 0}
+
+    def _fake_recall(**kwargs):
+        calls['count'] += 1
+        return json.dumps({
+            'combined_summary': f'Prefetch call {calls["count"]}',
+            'artifact_recall': {'top_evidence': []},
+        })
+
+    monkeypatch.setattr(provider_module, 'recall_with_artifacts', _fake_recall)
+
+    provider.initialize('session-1', hermes_home=str(tmp_path), platform='cli')
+    provider._prefetch_cooldown_seconds = 0.0
+    provider.queue_prefetch('that screenshot from last time')
+    first = provider.prefetch('that screenshot from last time')
+    second = provider.prefetch('that screenshot from last time')
+
+    assert 'Prefetch call 1' in first
+    assert 'Prefetch call 2' in second
+    assert calls['count'] == 2
+
+
+def test_multimodal_provider_prefetch_applies_cooldown_to_repeated_fresh_recalls(monkeypatch, tmp_path):
+    provider = load_memory_provider('multimodal-recall')
+    assert provider is not None
+    provider_module = __import__(provider.__class__.__module__, fromlist=['dummy'])
+
+    monkeypatch.setattr(provider_module, '_local_mmrag_provider_ready', lambda: True)
+    calls = {'count': 0}
+
+    def _fake_recall(**kwargs):
+        calls['count'] += 1
+        return json.dumps({
+            'combined_summary': f'Fresh recall {calls["count"]}',
+            'artifact_recall': {'top_evidence': []},
+        })
+
+    monkeypatch.setattr(provider_module, 'recall_with_artifacts', _fake_recall)
+
+    provider.initialize('session-1', hermes_home=str(tmp_path), platform='cli')
+    first = provider.prefetch('that screenshot from last time')
+    second = provider.prefetch('that screenshot from last time')
+
+    assert 'Fresh recall 1' in first
+    assert second == ''
+    assert calls['count'] == 1
+
+
+def test_multimodal_provider_on_session_end_captures_lightweight_signal(tmp_path):
+    provider = load_memory_provider('multimodal-recall')
+    assert provider is not None
+    provider.initialize('session-1', hermes_home=str(tmp_path), platform='cli')
+
+    messages = [
+        {'role': 'user', 'content': 'please remember that screenshot evidence from the PDF review'},
+        {'role': 'assistant', 'content': 'I checked the attachment and OCR evidence.'},
+    ]
+    provider.on_session_end(messages)
+
+    assert provider._session_end_signal
+    assert 'screenshot' in provider._session_end_signal.lower() or 'evidence' in provider._session_end_signal.lower()
+    assert len(provider._session_end_signal) < 400
+
+
+def test_multimodal_provider_on_session_end_ignores_non_multimodal_sessions(tmp_path):
+    provider = load_memory_provider('multimodal-recall')
+    assert provider is not None
+    provider.initialize('session-1', hermes_home=str(tmp_path), platform='cli')
+
+    messages = [
+        {'role': 'user', 'content': 'what branch name did we use'},
+        {'role': 'assistant', 'content': 'we used feature/test-branch'},
+    ]
+    provider.on_session_end(messages)
+
+    assert provider._session_end_signal == ''
+
+
+def test_multimodal_provider_session_end_signal_boosts_weak_artifact_queries(monkeypatch, tmp_path):
+    provider = load_memory_provider('multimodal-recall')
+    assert provider is not None
+    provider_module = __import__(provider.__class__.__module__, fromlist=['dummy'])
+
+    monkeypatch.setattr(provider_module, '_local_mmrag_provider_ready', lambda: True)
+    monkeypatch.setattr(
+        provider_module,
+        'recall_with_artifacts',
+        lambda **kwargs: json.dumps({
+            'combined_summary': 'Recovered file ETA from prior session-end screenshot context.',
+            'artifact_recall': {'top_evidence': [{'source_path': '/tmp/session-end.png'}]},
+        }),
+    )
+
+    provider.initialize('session-1', hermes_home=str(tmp_path), platform='cli')
+    provider.on_session_end([
+        {'role': 'user', 'content': 'please remember that screenshot evidence from the PDF review'},
+        {'role': 'assistant', 'content': 'I checked the attachment and OCR evidence.'},
+    ])
+    result = provider.prefetch('what was the ETA from that file')
+    assert 'Recovered file ETA' in result
+    assert 'session-end.png' in result
+
+
+def test_multimodal_provider_sync_turn_captures_lightweight_signal(tmp_path):
+    provider = load_memory_provider('multimodal-recall')
+    assert provider is not None
+    provider.initialize('session-1', hermes_home=str(tmp_path), platform='cli')
+
+    provider.sync_turn(
+        'please remember that screenshot evidence from the PDF review',
+        'I checked the attachment and OCR evidence.',
+        session_id='session-1',
+    )
+
+    assert provider._turn_signal
+    assert 'screenshot' in provider._turn_signal.lower() or 'evidence' in provider._turn_signal.lower()
+    assert len(provider._turn_signal) < 400
+
+
+def test_multimodal_provider_sync_turn_ignores_non_multimodal_turns(tmp_path):
+    provider = load_memory_provider('multimodal-recall')
+    assert provider is not None
+    provider.initialize('session-1', hermes_home=str(tmp_path), platform='cli')
+
+    provider.sync_turn('what branch name did we use', 'we used feature/test-branch', session_id='session-1')
+    assert provider._turn_signal == ''
+
+
+def test_multimodal_provider_on_memory_write_captures_lightweight_signal(tmp_path):
+    provider = load_memory_provider('multimodal-recall')
+    assert provider is not None
+    provider.initialize('session-1', hermes_home=str(tmp_path), platform='cli')
+
+    provider.on_memory_write('add', 'memory', 'Remember the screenshot evidence from the PDF review.')
+    assert provider._memory_write_signal
+    assert 'screenshot' in provider._memory_write_signal.lower() or 'evidence' in provider._memory_write_signal.lower()
+    assert len(provider._memory_write_signal) < 400
+
+
+def test_multimodal_provider_on_memory_write_ignores_non_multimodal_content(tmp_path):
+    provider = load_memory_provider('multimodal-recall')
+    assert provider is not None
+    provider.initialize('session-1', hermes_home=str(tmp_path), platform='cli')
+
+    provider.on_memory_write('add', 'memory', 'Remember that the user prefers concise answers.')
+    assert provider._memory_write_signal == ''
+
+
+def test_multimodal_provider_memory_write_signal_boosts_weak_artifact_queries(monkeypatch, tmp_path):
+    provider = load_memory_provider('multimodal-recall')
+    assert provider is not None
+    provider_module = __import__(provider.__class__.__module__, fromlist=['dummy'])
+
+    monkeypatch.setattr(provider_module, '_local_mmrag_provider_ready', lambda: True)
+    monkeypatch.setattr(
+        provider_module,
+        'recall_with_artifacts',
+        lambda **kwargs: json.dumps({
+            'combined_summary': 'Recovered file ETA from prior memory-write screenshot context.',
+            'artifact_recall': {'top_evidence': [{'source_path': '/tmp/memory-write.png'}]},
+        }),
+    )
+
+    provider.initialize('session-1', hermes_home=str(tmp_path), platform='cli')
+    provider.on_memory_write('add', 'memory', 'Remember the screenshot evidence from the PDF review.')
+    result = provider.prefetch('what was the ETA from that file')
+    assert 'Recovered file ETA' in result
+    assert 'memory-write.png' in result
+
+
+def test_multimodal_provider_shutdown_joins_and_clears_prefetch_thread(monkeypatch, tmp_path):
+    provider = load_memory_provider('multimodal-recall')
+    assert provider is not None
+    provider_module = __import__(provider.__class__.__module__, fromlist=['dummy'])
+
+    monkeypatch.setattr(provider_module, '_local_mmrag_provider_ready', lambda: True)
+    started = threading.Event()
+    release = threading.Event()
+
+    def _slow_recall(**kwargs):
+        started.set()
+        release.wait(timeout=1)
+        return json.dumps({'combined_summary': 'slow prefetch', 'artifact_recall': {'top_evidence': []}})
+
+    monkeypatch.setattr(provider_module, 'recall_with_artifacts', _slow_recall)
+
+    provider.initialize('session-1', hermes_home=str(tmp_path), platform='cli')
+    provider.queue_prefetch('that screenshot from last time')
+    assert started.wait(timeout=1)
+    assert provider._prefetch_thread is not None
+
+    release.set()
+    provider.shutdown()
+    assert provider._prefetch_thread is None

--- a/tests/tools/test_multimodal_recall_tool.py
+++ b/tests/tools/test_multimodal_recall_tool.py
@@ -1,0 +1,42 @@
+import json
+from types import SimpleNamespace
+
+
+def test_multimodal_recall_handler_wraps_mcp(monkeypatch):
+    import tools.multimodal_recall_tool as mrt
+
+    class DummySession:
+        async def call_tool(self, tool_name, arguments=None):
+            return SimpleNamespace(
+                isError=False,
+                content=[SimpleNamespace(text=json.dumps({"tool": tool_name, "arguments": arguments}))],
+                structuredContent=None,
+            )
+
+    monkeypatch.setattr(mrt.mcp_tool, '_servers', {'local_mmrag': SimpleNamespace(session=DummySession())})
+    monkeypatch.setattr(mrt.mcp_tool, '_run_on_mcp_loop', lambda coro, timeout=30: __import__('asyncio').run(coro))
+
+    result = json.loads(mrt.multimodal_recall(action='search', query='customer waiting', top_k=3))
+    assert result['tool'] == 'mm_recall_search'
+    assert result['arguments']['query'] == 'customer waiting'
+    assert result['arguments']['top_k'] == 3
+
+
+def test_multimodal_recall_evidence_mode(monkeypatch):
+    import tools.multimodal_recall_tool as mrt
+
+    class DummySession:
+        async def call_tool(self, tool_name, arguments=None):
+            return SimpleNamespace(
+                isError=False,
+                content=[SimpleNamespace(text=json.dumps({"tool": tool_name, "arguments": arguments}))],
+                structuredContent=None,
+            )
+
+    monkeypatch.setattr(mrt.mcp_tool, '_servers', {'local_mmrag': SimpleNamespace(session=DummySession())})
+    monkeypatch.setattr(mrt.mcp_tool, '_run_on_mcp_loop', lambda coro, timeout=30: __import__('asyncio').run(coro))
+
+    result = json.loads(mrt.multimodal_recall(action='evidence', query='customer waiting', source_ref='issue:123', modality='image'))
+    assert result['tool'] == 'mm_recall_get_evidence_pack'
+    assert result['arguments']['source_ref'] == 'issue:123'
+    assert result['arguments']['modality'] == 'image'

--- a/tests/tools/test_recall_with_artifacts_tool.py
+++ b/tests/tools/test_recall_with_artifacts_tool.py
@@ -1,0 +1,1122 @@
+import json
+from tools.recall_with_artifacts_tool import RECALL_WITH_ARTIFACTS_SCHEMA
+
+
+def test_recall_with_artifacts_schema_mentions_combined_context():
+    description = RECALL_WITH_ARTIFACTS_SCHEMA['description']
+    assert 'session_search' in description
+    assert 'multimodal_recall' in description
+    assert 'Use this first' in description
+
+
+def test_recall_with_artifacts_combines_session_and_multimodal(monkeypatch):
+    import tools.recall_with_artifacts_tool as rwt
+
+    monkeypatch.setattr(rwt, '_session_search_available', lambda: True)
+    monkeypatch.setattr(rwt, '_local_mmrag_connected', lambda: True)
+    monkeypatch.setattr(
+        rwt,
+        '_run_session_search',
+        lambda query, role_filter=None, limit=3: {
+            'success': True,
+            'query': query,
+            'results': [
+                {
+                    'session_id': 's1',
+                    'when': 'April 18, 2026 at 01:39 AM',
+                    'summary': 'We used multimodal recall to inspect customer waiting ETA evidence.',
+                }
+            ],
+            'count': 1,
+        },
+    )
+    monkeypatch.setattr(
+        rwt,
+        '_run_multimodal_recall',
+        lambda **kwargs: {
+            'query': kwargs['query'],
+            'summary': 'OCR shows waiting customer reply and ETA next Monday.',
+            'top_evidence': [
+                {'source_path': '/tmp/status.png', 'source_type': 'image', 'score': 0.99}
+            ],
+            'retrieval_notes': {'collection_name': 'manual_cli_check'},
+        },
+    )
+
+    result = json.loads(rwt.recall_with_artifacts(query='customer waiting ETA', session_limit=2, artifact_top_k=3))
+    assert result['query'] == 'customer waiting ETA'
+    assert result['transcript_recall']['count'] == 1
+    assert result['artifact_recall']['retrieval_notes']['collection_name'] == 'manual_cli_check'
+    assert 'customer waiting ETA' in result['combined_summary']
+    assert 'next Monday' in result['combined_summary']
+
+
+def test_recall_with_artifacts_handles_missing_session_search(monkeypatch):
+    import tools.recall_with_artifacts_tool as rwt
+
+    monkeypatch.setattr(rwt, '_session_search_available', lambda: False)
+    monkeypatch.setattr(rwt, '_local_mmrag_connected', lambda: True)
+    monkeypatch.setattr(
+        rwt,
+        '_run_multimodal_recall',
+        lambda **kwargs: {'summary': 'Artifact-only evidence', 'top_evidence': [], 'retrieval_notes': {}},
+    )
+
+    result = json.loads(rwt.recall_with_artifacts(query='artifact only'))
+    assert 'error' in result['transcript_recall']
+    assert result['artifact_recall']['summary'] == 'Artifact-only evidence'
+
+
+def test_recall_with_artifacts_recent_mode(monkeypatch):
+    import tools.recall_with_artifacts_tool as rwt
+
+    monkeypatch.setattr(rwt, '_session_search_available', lambda: True)
+    monkeypatch.setattr(rwt, '_local_mmrag_connected', lambda: True)
+    monkeypatch.setattr(
+        rwt,
+        '_run_session_search',
+        lambda query, role_filter=None, limit=3: {
+            'success': True,
+            'mode': 'recent',
+            'results': [{'session_id': 's1'}],
+            'count': 1,
+        },
+    )
+    monkeypatch.setattr(
+        rwt,
+        '_run_multimodal_recall',
+        lambda **kwargs: {'artifacts': [{'source_path': '/tmp/a.png'}], 'count': 1},
+    )
+
+    result = json.loads(rwt.recall_with_artifacts(query='', session_limit=1, artifact_top_k=1))
+    assert result['transcript_recall']['mode'] == 'recent'
+    assert result['artifact_recall']['count'] == 1
+
+
+def test_recall_with_artifacts_compacts_long_session_summary(monkeypatch):
+    import tools.recall_with_artifacts_tool as rwt
+
+    monkeypatch.setattr(rwt, '_session_search_available', lambda: True)
+    monkeypatch.setattr(rwt, '_local_mmrag_connected', lambda: True)
+    monkeypatch.setattr(
+        rwt,
+        '_run_session_search',
+        lambda query, role_filter=None, limit=3: {
+            'success': True,
+            'query': query,
+            'results': [{'summary': 'A' * 1200}],
+            'count': 1,
+        },
+    )
+    monkeypatch.setattr(
+        rwt,
+        '_run_multimodal_recall',
+        lambda **kwargs: {'summary': 'B' * 1200, 'top_evidence': []},
+    )
+
+    result = json.loads(rwt.recall_with_artifacts(query='very long'))
+    assert len(result['combined_summary']) < 1000
+
+
+def test_recall_with_artifacts_derives_high_confidence_source_ref_and_soft_collection_hint(monkeypatch):
+    import tools.recall_with_artifacts_tool as rwt
+
+    captured = {}
+    monkeypatch.setattr(rwt, '_session_search_available', lambda: True)
+    monkeypatch.setattr(rwt, '_local_mmrag_connected', lambda: True)
+    monkeypatch.setattr(
+        rwt,
+        '_run_session_search',
+        lambda query, role_filter=None, limit=3: {
+            'success': True,
+            'query': query,
+            'results': [
+                {
+                    'summary': 'We used source_ref issue:123 and collection_name: "gitlab_radar_ae4adda6785fd089" while reviewing attachment evidence.'
+                }
+            ],
+            'count': 1,
+        },
+    )
+
+    def _fake_mm(**kwargs):
+        captured.update(kwargs)
+        return {'summary': 'artifact summary', 'top_evidence': []}
+
+    monkeypatch.setattr(rwt, '_run_multimodal_recall', _fake_mm)
+
+    result = json.loads(rwt.recall_with_artifacts(query='customer waiting ETA'))
+    assert captured['source_ref'] == 'issue:123'
+    assert captured['collection'] == ''
+    assert 'gitlab_radar_ae4adda6785fd089' in captured['query']
+    assert result['derived_hints']['source_ref'] == 'issue:123'
+    assert result['derived_hints']['collection'] == 'gitlab_radar_ae4adda6785fd089'
+    assert result['hint_confidence']['source_ref'] == 'high'
+    assert result['hint_confidence']['collection'] == 'low'
+
+
+def test_explicit_hints_override_derived_hints(monkeypatch):
+    import tools.recall_with_artifacts_tool as rwt
+
+    captured = {}
+    monkeypatch.setattr(rwt, '_session_search_available', lambda: True)
+    monkeypatch.setattr(rwt, '_local_mmrag_connected', lambda: True)
+    monkeypatch.setattr(
+        rwt,
+        '_run_session_search',
+        lambda query, role_filter=None, limit=3: {
+            'success': True,
+            'results': [{'summary': 'source_ref issue:123 collection_name: "gitlab_radar_from_session"'}],
+            'count': 1,
+        },
+    )
+
+    def _fake_mm(**kwargs):
+        captured.update(kwargs)
+        return {'summary': 'artifact summary'}
+
+    monkeypatch.setattr(rwt, '_run_multimodal_recall', _fake_mm)
+
+    json.loads(
+        rwt.recall_with_artifacts(
+            query='customer waiting ETA',
+            source_ref='issue:999',
+            collection='manual_cli_check',
+        )
+    )
+    assert captured['source_ref'] == 'issue:999'
+    assert captured['collection'] == 'manual_cli_check'
+
+
+def test_derived_hints_ignore_ellipsis_like_placeholders(monkeypatch):
+    import tools.recall_with_artifacts_tool as rwt
+
+    captured = {}
+    monkeypatch.setattr(rwt, '_session_search_available', lambda: True)
+    monkeypatch.setattr(rwt, '_local_mmrag_connected', lambda: True)
+    monkeypatch.setattr(
+        rwt,
+        '_run_session_search',
+        lambda query, role_filter=None, limit=3: {
+            'success': True,
+            'results': [{'summary': 'related source_ref: ... collection_name: test_retrieve_returns_ranked_candidates'}],
+            'count': 1,
+        },
+    )
+
+    def _fake_mm(**kwargs):
+        captured.update(kwargs)
+        return {'summary': 'artifact summary'}
+
+    monkeypatch.setattr(rwt, '_run_multimodal_recall', _fake_mm)
+
+    result = json.loads(rwt.recall_with_artifacts(query='customer waiting ETA'))
+    assert captured['source_ref'] == ''
+    assert captured['collection'] == ''
+    assert 'test_retrieve_returns_ranked_candidates' in captured['query']
+    assert result['derived_hints'].get('source_ref', '') == ''
+
+
+def test_high_confidence_collection_hint_is_used_as_hard_filter(monkeypatch):
+    import tools.recall_with_artifacts_tool as rwt
+
+    captured = {}
+    monkeypatch.setattr(rwt, '_session_search_available', lambda: True)
+    monkeypatch.setattr(rwt, '_local_mmrag_connected', lambda: True)
+    monkeypatch.setattr(
+        rwt,
+        '_run_session_search',
+        lambda query, role_filter=None, limit=3: {
+            'success': True,
+            'results': [{'summary': 'collection_name: "manual_cli_check" source_type: attachment'}],
+            'count': 1,
+        },
+    )
+
+    def _fake_mm(**kwargs):
+        captured.update(kwargs)
+        return {'summary': 'artifact summary'}
+
+    monkeypatch.setattr(rwt, '_run_multimodal_recall', _fake_mm)
+
+    result = json.loads(rwt.recall_with_artifacts(query='customer waiting ETA', source_type='attachment'))
+    assert captured['collection'] == 'manual_cli_check'
+    assert result['hint_confidence']['collection'] == 'high'
+
+
+def test_recall_with_artifacts_skips_artifact_recall_for_non_multimodal_query_without_hints(monkeypatch):
+    import tools.recall_with_artifacts_tool as rwt
+
+    called = {'value': False}
+    monkeypatch.setattr(rwt, '_session_search_available', lambda: True)
+    monkeypatch.setattr(rwt, '_local_mmrag_connected', lambda: True)
+    monkeypatch.setattr(
+        rwt,
+        '_run_session_search',
+        lambda query, role_filter=None, limit=3: {
+            'success': True,
+            'results': [
+                {'summary': 'We enabled multimodal provider integration, but did not discuss any screenshot or attachment for this branch question.'}
+            ],
+            'count': 1,
+        },
+    )
+
+    def _fake_mm(**kwargs):
+        called['value'] = True
+        return {'summary': 'should not run'}
+
+    monkeypatch.setattr(rwt, '_run_multimodal_recall', _fake_mm)
+
+    result = json.loads(rwt.recall_with_artifacts(query='what branch name did we use'))
+    assert called['value'] is False
+    assert result['artifact_recall']['skipped'] is True
+    assert result['artifact_recall']['reason'] == 'query does not appear multimodal and no artifact filters were provided'
+
+
+def test_transcript_derived_source_ref_stays_soft_for_screenshot_query_without_corroboration(monkeypatch):
+    import tools.recall_with_artifacts_tool as rwt
+
+    captured = {}
+    monkeypatch.setattr(rwt, '_session_search_available', lambda: True)
+    monkeypatch.setattr(rwt, '_local_mmrag_connected', lambda: True)
+    monkeypatch.setattr(
+        rwt,
+        '_run_session_search',
+        lambda query, role_filter=None, limit=3: {
+            'success': True,
+            'results': [
+                {
+                    'summary': 'Earlier drifted session mentioned source_ref issue:987 and collection_name: "gitlab_radar_49942185f88bf27f" while discussing screenshot evidence.'
+                }
+            ],
+            'count': 1,
+        },
+    )
+
+    def _fake_mm(**kwargs):
+        captured.update(kwargs)
+        return {'summary': 'artifact summary', 'top_evidence': []}
+
+    monkeypatch.setattr(rwt, '_run_multimodal_recall', _fake_mm)
+
+    result = json.loads(rwt.recall_with_artifacts(query='那張截圖顯示現在卡在哪裡？'))
+    assert captured['source_ref'] == ''
+    assert 'gitlab_radar_49942185f88bf27f' in captured['query']
+    assert result['derived_hints']['source_ref'] == 'issue:987'
+    assert result['hint_confidence']['source_ref'] == 'high'
+
+
+def test_transcript_derived_source_ref_stays_soft_for_ocr_query_without_corroboration(monkeypatch):
+    import tools.recall_with_artifacts_tool as rwt
+
+    captured = {}
+    monkeypatch.setattr(rwt, '_session_search_available', lambda: True)
+    monkeypatch.setattr(rwt, '_local_mmrag_connected', lambda: True)
+    monkeypatch.setattr(
+        rwt,
+        '_run_session_search',
+        lambda query, role_filter=None, limit=3: {
+            'success': True,
+            'results': [
+                {
+                    'summary': 'Earlier drifted session mentioned source_ref issue:987 and collection_name: "gitlab_radar_ae4adda6785fd089" source_type: pdf.'
+                }
+            ],
+            'count': 1,
+        },
+    )
+
+    def _fake_mm(**kwargs):
+        captured.update(kwargs)
+        return {'summary': 'artifact summary', 'top_evidence': []}
+
+    monkeypatch.setattr(rwt, '_run_multimodal_recall', _fake_mm)
+
+    result = json.loads(rwt.recall_with_artifacts(query='之前 OCR 抓到的錯誤訊息是什麼？'))
+    assert captured['source_ref'] == ''
+    assert 'gitlab_radar_ae4adda6785fd089' in captured['query']
+    assert 'source_type pdf' in captured['query']
+    assert result['derived_hints']['source_ref'] == 'issue:987'
+    assert result['hint_confidence']['source_ref'] == 'high'
+
+
+def test_broad_pdf_screenshot_query_does_not_append_transcript_attachment_source_type_hint(monkeypatch):
+    import tools.recall_with_artifacts_tool as rwt
+
+    captured = {}
+    monkeypatch.setattr(rwt, '_session_search_available', lambda: True)
+    monkeypatch.setattr(rwt, '_local_mmrag_connected', lambda: True)
+    monkeypatch.setattr(
+        rwt,
+        '_run_session_search',
+        lambda query, role_filter=None, limit=3: {
+            'success': True,
+            'results': [
+                {
+                    'summary': 'Prior session mentioned collection_name: "gitlab_radar_ae4adda6785fd089" source_type: attachment while discussing PDF/screenshot evidence.'
+                }
+            ],
+            'count': 1,
+        },
+    )
+
+    def _fake_mm(**kwargs):
+        captured.update(kwargs)
+        return {'summary': 'artifact summary', 'top_evidence': []}
+
+    monkeypatch.setattr(rwt, '_run_multimodal_recall', _fake_mm)
+
+    result = json.loads(rwt.recall_with_artifacts(query='先前那個 PDF 附件和截圖證據做到哪了？'))
+    assert captured['collection'] == 'gitlab_radar_ae4adda6785fd089'
+    assert 'source_type attachment' not in captured['query']
+    assert captured['source_type'] == ''
+    assert result['derived_hints']['source_type'] == 'attachment'
+    assert result['hint_confidence']['source_type'] == 'medium'
+
+
+def test_soft_transcript_source_ref_does_not_contaminate_issue_brief_provenance(monkeypatch):
+    import tools.recall_with_artifacts_tool as rwt
+
+    monkeypatch.setattr(rwt, '_session_search_available', lambda: True)
+    monkeypatch.setattr(rwt, '_local_mmrag_connected', lambda: True)
+    monkeypatch.setattr(
+        rwt,
+        '_run_session_search',
+        lambda query, role_filter=None, limit=3: {
+            'success': True,
+            'results': [
+                {
+                    'summary': 'Earlier drifted session mentioned source_ref issue:987 and collection_name: "gitlab_radar_49942185f88bf27f" while discussing screenshot evidence.'
+                }
+            ],
+            'count': 1,
+        },
+    )
+    monkeypatch.setattr(
+        rwt,
+        '_run_multimodal_recall',
+        lambda **kwargs: {
+            'summary': '系统有资料, 看来是洗资料有问题',
+            'top_evidence': [
+                {
+                    'source_path': '/tmp/image.png',
+                    'source_type': 'image',
+                    'source_ref': None,
+                    'modality': 'image',
+                    'collection_name': 'gitlab_radar_49942185f88bf27f',
+                    'text': '系统有资料, 看来是洗资料有问题',
+                    'score': 0.9,
+                },
+                {
+                    'source_path': '/tmp/issue_context.md',
+                    'source_type': 'text',
+                    'source_ref': None,
+                    'modality': 'text',
+                    'collection_name': 'gitlab_radar_49942185f88bf27f',
+                    'text': '# Issue context\n\n- title: 客戶反應 2019 以前的學校資料都不存在 => 洗資料有問題',
+                    'score': 0.8,
+                },
+            ],
+            'extracted_fields': {},
+            'retrieval_notes': {'collection_name': 'gitlab_radar_49942185f88bf27f'},
+        },
+    )
+
+    result = json.loads(rwt.recall_with_artifacts(query='那張截圖顯示現在卡在哪裡？'))
+    assert result['issue_evidence_brief']['source_ref'] == ''
+    assert result['issue_evidence_brief']['collections'] == ['gitlab_radar_49942185f88bf27f']
+    assert 'issue:987' not in result['issue_evidence_brief']['evidence_brief']
+
+
+def test_recall_with_artifacts_prefers_prompt_aligned_artifacts_when_multiple_sets_match(monkeypatch):
+    import tools.recall_with_artifacts_tool as rwt
+
+    monkeypatch.setattr(rwt, '_session_search_available', lambda: True)
+    monkeypatch.setattr(rwt, '_local_mmrag_connected', lambda: True)
+    monkeypatch.setattr(
+        rwt,
+        '_run_session_search',
+        lambda query, role_filter=None, limit=3: {
+            'success': True,
+            'results': [{'summary': 'We discussed screenshot evidence for issue:123.'}],
+            'count': 1,
+        },
+    )
+    monkeypatch.setattr(
+        rwt,
+        '_run_multimodal_recall',
+        lambda **kwargs: {
+            'summary': 'mixed artifact summary',
+            'top_evidence': [
+                {
+                    'source_path': '/tmp/adjacent-note.md',
+                    'source_type': 'text',
+                    'source_ref': 'issue:999',
+                    'collection_name': 'adjacent_collection',
+                    'text': 'Customer waiting notes with blocker details but no screenshot context.',
+                    'score': 0.99,
+                },
+                {
+                    'source_path': '/tmp/status.png',
+                    'source_type': 'image',
+                    'source_ref': 'issue:123',
+                    'collection_name': 'target_collection',
+                    'text': 'Screenshot evidence for issue:123 showing ETA next Monday and blocker OCR validation.',
+                    'score': 0.80,
+                },
+            ],
+            'retrieval_notes': {'collection_name': 'adjacent_collection'},
+        },
+    )
+
+    result = json.loads(rwt.recall_with_artifacts(query='issue:123 screenshot blocker ETA'))
+    brief = result['issue_evidence_brief']
+    assert brief['source_ref'] == 'issue:123'
+    assert brief['top_sources'][0] == '/tmp/status.png'
+    assert brief['collections'][0] == 'target_collection'
+    assert 'ETA next monday' in brief['evidence_brief']
+
+
+def test_screenshot_only_followup_reduces_cross_artifact_blending(monkeypatch):
+    import tools.recall_with_artifacts_tool as rwt
+
+    monkeypatch.setattr(rwt, '_session_search_available', lambda: True)
+    monkeypatch.setattr(rwt, '_local_mmrag_connected', lambda: True)
+    monkeypatch.setattr(
+        rwt,
+        '_run_session_search',
+        lambda query, role_filter=None, limit=3: {
+            'success': True,
+            'results': [{'summary': 'We discussed a screenshot in issue:286 and another customer-waiting thread in issue:987.'}],
+            'count': 1,
+        },
+    )
+    monkeypatch.setattr(
+        rwt,
+        '_run_multimodal_recall',
+        lambda **kwargs: {
+            'summary': 'mixed screenshot summary',
+            'top_evidence': [
+                {
+                    'source_path': '/tmp/issue286-shot.png',
+                    'source_type': 'image',
+                    'source_ref': 'issue:286',
+                    'collection_name': 'issue286_collection',
+                    'text': 'Screenshot shows data exists and washing flow looks wrong.',
+                    'score': 0.90,
+                },
+                {
+                    'source_path': '/tmp/issue987-note.md',
+                    'source_type': 'text',
+                    'source_ref': 'issue:987',
+                    'collection_name': 'issue987_collection',
+                    'text': 'Customer waiting note with OCR validation blocker and next Tuesday ETA.',
+                    'score': 0.91,
+                },
+                {
+                    'source_path': '/tmp/issue987-shot.png',
+                    'source_type': 'image',
+                    'source_ref': 'issue:987',
+                    'collection_name': 'issue987_collection',
+                    'text': 'Status waiting customer reply; ETA next Tuesday; screenshot from support handoff.',
+                    'score': 0.89,
+                },
+            ],
+            'retrieval_notes': {'collection_name': 'issue987_collection'},
+        },
+    )
+
+    result = json.loads(rwt.recall_with_artifacts(query='那張截圖顯示現在卡在哪裡？'))
+    brief = result['issue_evidence_brief']
+    assert brief['top_sources'][0] == '/tmp/issue286-shot.png'
+    assert brief['collections'][0] == 'issue286_collection'
+    assert brief['source_ref'] == 'issue:286'
+    assert 'washing flow' in brief['evidence_brief'].lower() or 'data exists' in brief['evidence_brief'].lower()
+
+
+def test_recall_with_artifacts_surfaces_transcript_vs_artifact_attribution_for_ambiguity_queries(monkeypatch):
+    import tools.recall_with_artifacts_tool as rwt
+
+    monkeypatch.setattr(rwt, '_session_search_available', lambda: True)
+    monkeypatch.setattr(rwt, '_local_mmrag_connected', lambda: True)
+    monkeypatch.setattr(
+        rwt,
+        '_run_session_search',
+        lambda query, role_filter=None, limit=3: {
+            'success': True,
+            'results': [
+                {'summary': 'Transcript says the customer was waiting for an ETA update in prior discussion.'}
+            ],
+            'count': 1,
+        },
+    )
+    monkeypatch.setattr(
+        rwt,
+        '_run_multimodal_recall',
+        lambda **kwargs: {
+            'summary': 'Artifact evidence from screenshot and attachment confirms waiting customer status.',
+            'top_evidence': [
+                {
+                    'source_path': '/tmp/status.png',
+                    'source_type': 'image',
+                    'source_ref': 'issue:987',
+                    'collection_name': 'artifact_collection',
+                    'text': 'Status: waiting customer reply; ETA: next Tuesday.',
+                    'score': 0.9,
+                }
+            ],
+            'retrieval_notes': {'collection_name': 'artifact_collection'},
+        },
+    )
+
+    result = json.loads(rwt.recall_with_artifacts(query='那個 waiting customer 的事情，證據是來自對話還是附件？'))
+    summary = result['evidence_channel_summary']
+    assert summary['preferred_evidence_channel'] == 'mixed'
+    assert 'Transcript says the customer was waiting' in summary['transcript_support']
+    assert 'Artifact evidence from screenshot and attachment confirms waiting customer status.' in summary['artifact_support']
+
+
+def test_ocr_error_prompt_prefers_error_message_over_adjacent_status_text(monkeypatch):
+    import tools.recall_with_artifacts_tool as rwt
+
+    monkeypatch.setattr(rwt, '_session_search_available', lambda: True)
+    monkeypatch.setattr(rwt, '_local_mmrag_connected', lambda: True)
+    monkeypatch.setattr(
+        rwt,
+        '_run_session_search',
+        lambda query, role_filter=None, limit=3: {
+            'success': True,
+            'results': [{'summary': 'We reviewed OCR output and a document finding about technical error messages.'}],
+            'count': 1,
+        },
+    )
+    monkeypatch.setattr(
+        rwt,
+        '_run_multimodal_recall',
+        lambda **kwargs: {
+            'summary': 'ocr/document mixed summary',
+            'top_evidence': [
+                {
+                    'source_path': '/tmp/status.png',
+                    'source_type': 'image',
+                    'modality': 'image',
+                    'collection_name': 'status_collection',
+                    'text': 'Status waiting customer reply',
+                    'score': 0.95,
+                },
+                {
+                    'source_path': '/tmp/report.pdf',
+                    'source_type': 'pdf',
+                    'modality': 'pdf',
+                    'collection_name': 'report_collection',
+                    'text': '錯誤訊息非客製化結果而夾帶太多技術訊息',
+                    'score': 0.80,
+                },
+            ],
+            'retrieval_notes': {'collection_name': 'status_collection'},
+        },
+    )
+
+    result = json.loads(rwt.recall_with_artifacts(query='之前 OCR 抓到的錯誤訊息是什麼？'))
+    brief = result['issue_evidence_brief']
+    assert brief['top_sources'][0] == '/tmp/report.pdf'
+    assert brief['collections'][0] == 'report_collection'
+    assert '錯誤訊息非客製化結果而夾帶太多技術訊息' in brief['evidence_brief']
+
+
+def test_phase3_baseline_pdf_screenshot_query_preserves_provenance(monkeypatch):
+    import tools.recall_with_artifacts_tool as rwt
+
+    monkeypatch.setattr(rwt, '_session_search_available', lambda: True)
+    monkeypatch.setattr(rwt, '_local_mmrag_connected', lambda: True)
+    monkeypatch.setattr(
+        rwt,
+        '_run_session_search',
+        lambda query, role_filter=None, limit=3: {
+            'success': True,
+            'results': [{'summary': 'We previously checked the PDF attachment and screenshot evidence for issue:123.'}],
+            'count': 1,
+        },
+    )
+    monkeypatch.setattr(
+        rwt,
+        '_run_multimodal_recall',
+        lambda **kwargs: {
+            'summary': 'GitLab radar automation tracks customer waiting items.',
+            'top_evidence': [
+                {
+                    'source_path': '/tmp/status.png',
+                    'source_type': 'image',
+                    'source_ref': 'issue:123',
+                    'collection_name': 'test_mm_recall_search_filters',
+                    'text': 'Project hermes ETA next Monday status waiting customer reply.',
+                    'score': 0.8,
+                },
+                {
+                    'source_path': '/tmp/report.pdf',
+                    'source_type': 'pdf',
+                    'source_ref': 'issue:123',
+                    'collection_name': 'test_mm_recall_search_filters',
+                    'text': 'Supporting PDF attachment for the same issue context.',
+                    'score': 0.7,
+                },
+            ],
+            'extracted_fields': {'customer_waiting_signals': ['customer_waiting'], 'eta': 'next monday'},
+            'retrieval_notes': {'collection_name': 'test_mm_recall_search_filters'},
+        },
+    )
+
+    result = json.loads(rwt.recall_with_artifacts(query='先前那個 PDF 附件和截圖證據做到哪了？'))
+    assert result['issue_evidence_brief']['source_ref'] == 'issue:123'
+    assert result['radar_ready_summary']['provenance']['collection'] == 'test_mm_recall_search_filters'
+    assert result['radar_ready_summary']['eta'] == 'next monday'
+
+
+def test_phase3_baseline_cross_session_continuity_query_returns_transcript_and_artifact_support(monkeypatch):
+    import tools.recall_with_artifacts_tool as rwt
+
+    monkeypatch.setattr(rwt, '_session_search_available', lambda: True)
+    monkeypatch.setattr(rwt, '_local_mmrag_connected', lambda: True)
+    monkeypatch.setattr(
+        rwt,
+        '_run_session_search',
+        lambda query, role_filter=None, limit=3: {
+            'success': True,
+            'results': [{'summary': 'Prior discussion said the customer was still waiting for an ETA update.'}],
+            'count': 1,
+        },
+    )
+    monkeypatch.setattr(
+        rwt,
+        '_run_multimodal_recall',
+        lambda **kwargs: {
+            'summary': 'Artifact evidence shows waiting customer status and ETA next Tuesday.',
+            'top_evidence': [
+                {
+                    'source_path': '/tmp/status.png',
+                    'source_type': 'image',
+                    'source_ref': 'issue:987',
+                    'collection_name': 'test_realistic_mm_smoke_customer_waiting',
+                    'text': 'Status waiting customer reply; ETA next Tuesday.',
+                    'score': 0.9,
+                }
+            ],
+            'extracted_fields': {'customer_waiting_signals': ['customer_waiting'], 'eta': 'next tuesday'},
+            'retrieval_notes': {'collection_name': 'test_realistic_mm_smoke_customer_waiting'},
+        },
+    )
+
+    result = json.loads(rwt.recall_with_artifacts(query='上次那個客戶等待的 ETA 後來有更新嗎？'))
+    summary = result['evidence_channel_summary']
+    assert summary['preferred_evidence_channel'] == 'mixed'
+    assert 'customer was still waiting' in summary['transcript_support']
+    assert 'Artifact evidence shows waiting customer status' in summary['artifact_support']
+    assert result['radar_ready_summary']['eta'] == 'next tuesday'
+
+
+def test_cluster_ranking_prefers_query_aligned_cluster_over_larger_adjacent_cluster(monkeypatch):
+    import tools.recall_with_artifacts_tool as rwt
+
+    clusters = [
+        [
+            {
+                'source_path': '/tmp/adjacent-note.md',
+                'source_type': 'text',
+                'source_ref': 'issue:999',
+                'collection_name': 'adjacent_collection',
+                'text': 'Customer waiting notes and blocker updates.',
+                'score': 0.95,
+            },
+            {
+                'source_path': '/tmp/adjacent-shot.png',
+                'source_type': 'image',
+                'source_ref': 'issue:999',
+                'collection_name': 'adjacent_collection',
+                'text': 'Status waiting customer reply; ETA next Tuesday.',
+                'score': 0.90,
+            },
+        ],
+        [
+            {
+                'source_path': '/tmp/target-shot.png',
+                'source_type': 'image',
+                'source_ref': 'issue:123',
+                'collection_name': 'target_collection',
+                'text': 'Screenshot evidence for issue:123 showing ETA next Monday and blocker OCR validation.',
+                'score': 0.80,
+            },
+            {
+                'source_path': '/tmp/target-report.pdf',
+                'source_type': 'pdf',
+                'source_ref': 'issue:123',
+                'collection_name': 'target_collection',
+                'text': 'Supporting PDF attachment for the same issue context.',
+                'score': 0.70,
+            },
+        ],
+    ]
+
+    ranked = sorted(
+        clusters,
+        key=lambda cluster: sum(float(item.get('score') or 0.0) for item in cluster),
+        reverse=True,
+    )
+    assert ranked[0][0]['source_ref'] == 'issue:999'
+
+    focus = rwt._select_focus_cluster('issue:123 screenshot blocker ETA', [item for cluster in clusters for item in cluster], resolved_source_ref='issue:123')
+    assert focus
+    assert focus[0]['source_ref'] == 'issue:123'
+    assert all((item.get('source_ref') or '') == 'issue:123' for item in focus)
+
+
+def test_issue_brief_uses_single_focus_cluster_for_live_screenshot_followup(monkeypatch):
+    import tools.recall_with_artifacts_tool as rwt
+
+    monkeypatch.setattr(rwt, '_session_search_available', lambda: True)
+    monkeypatch.setattr(rwt, '_local_mmrag_connected', lambda: True)
+    monkeypatch.setattr(
+        rwt,
+        '_run_session_search',
+        lambda query, role_filter=None, limit=3: {
+            'success': True,
+            'results': [{'summary': 'We saw screenshot-heavy evidence across issue:286 and issue:987.'}],
+            'count': 1,
+        },
+    )
+    monkeypatch.setattr(
+        rwt,
+        '_run_multimodal_recall',
+        lambda **kwargs: {
+            'summary': 'live screenshot mix',
+            'top_evidence': [
+                {
+                    'source_path': '/tmp/issue286-shot.png',
+                    'source_type': 'image',
+                    'modality': 'image',
+                    'source_ref': 'issue:286',
+                    'collection_name': 'issue286_collection',
+                    'text': 'Screenshot shows data exists and washing flow looks wrong.',
+                    'score': 0.86,
+                },
+                {
+                    'source_path': '/tmp/issue286-note.md',
+                    'source_type': 'text',
+                    'modality': 'text',
+                    'source_ref': 'issue:286',
+                    'collection_name': 'issue286_collection',
+                    'text': 'Issue 286 notes: likely data washing flow problem.',
+                    'score': 0.70,
+                },
+                {
+                    'source_path': '/tmp/issue987-shot.png',
+                    'source_type': 'image',
+                    'modality': 'image',
+                    'source_ref': 'issue:987',
+                    'collection_name': 'issue987_collection',
+                    'text': 'Status waiting customer reply; ETA next Tuesday; screenshot from support handoff.',
+                    'score': 0.89,
+                },
+                {
+                    'source_path': '/tmp/issue987-note.md',
+                    'source_type': 'text',
+                    'modality': 'text',
+                    'source_ref': 'issue:987',
+                    'collection_name': 'issue987_collection',
+                    'text': 'Customer waiting note with OCR validation blocker.',
+                    'score': 0.88,
+                },
+            ],
+            'retrieval_notes': {'collection_name': 'issue987_collection'},
+        },
+    )
+
+    result = json.loads(rwt.recall_with_artifacts(query='那張截圖顯示現在卡在哪裡？'))
+    brief = result['issue_evidence_brief']
+    assert brief['source_ref'] == 'issue:286'
+    assert brief['collections'] == ['issue286_collection']
+    assert brief['top_sources'] == ['/tmp/issue286-shot.png', '/tmp/issue286-note.md']
+    assert 'ocr validation' not in brief['evidence_brief'].lower()
+    assert 'washing flow' in brief['evidence_brief'].lower() or 'data exists' in brief['evidence_brief'].lower()
+
+
+def test_ocr_error_query_prefers_error_text_cluster_over_status_cluster(monkeypatch):
+    import tools.recall_with_artifacts_tool as rwt
+
+    evidence = [
+        {
+            'source_path': '/tmp/status.png',
+            'source_type': 'image',
+            'modality': 'image',
+            'source_ref': 'issue:987',
+            'collection_name': 'status_collection',
+            'text': 'Status waiting customer reply; ETA next Tuesday.',
+            'score': 0.95,
+        },
+        {
+            'source_path': '/tmp/status-note.md',
+            'source_type': 'text',
+            'modality': 'text',
+            'source_ref': 'issue:987',
+            'collection_name': 'status_collection',
+            'text': 'Customer waiting follow-up and OCR validation blocker.',
+            'score': 0.92,
+        },
+        {
+            'source_path': '/tmp/error-report.pdf',
+            'source_type': 'pdf',
+            'modality': 'pdf',
+            'source_ref': 'issue:555',
+            'collection_name': 'error_collection',
+            'text': 'Custom error pages expose too much technical detail to users.',
+            'score': 0.80,
+        },
+        {
+            'source_path': '/tmp/error-note.md',
+            'source_type': 'text',
+            'modality': 'text',
+            'source_ref': 'issue:555',
+            'collection_name': 'error_collection',
+            'text': 'Document finding confirms technical detail leakage through non-customized errors.',
+            'score': 0.70,
+        },
+    ]
+
+    focus = rwt._select_focus_cluster('之前 OCR 抓到的錯誤訊息是什麼？', evidence)
+    assert focus
+    assert focus[0]['source_ref'] == 'issue:555'
+    assert all((item.get('source_ref') or '') == 'issue:555' for item in focus)
+
+
+
+def test_phase3_broad_pdf_screenshot_query_prefers_pdf_screenshot_cluster_over_adjacent_status_cluster(monkeypatch):
+    import tools.recall_with_artifacts_tool as rwt
+
+    evidence = [
+        {
+            'source_path': '/tmp/adjacent-note.md',
+            'source_type': 'text',
+            'modality': 'text',
+            'source_ref': 'issue:123',
+            'collection_name': 'adjacent_status_collection',
+            'text': 'Customer waiting note and blocker follow-up without any PDF or screenshot focus.',
+            'score': 0.97,
+        },
+        {
+            'source_path': '/tmp/adjacent-status.png',
+            'source_type': 'image',
+            'modality': 'image',
+            'source_ref': 'issue:123',
+            'collection_name': 'adjacent_status_collection',
+            'text': 'Status waiting customer reply; ETA next Monday.',
+            'score': 0.96,
+        },
+        {
+            'source_path': '/tmp/target-shot.png',
+            'source_type': 'image',
+            'modality': 'image',
+            'source_ref': 'issue:123',
+            'collection_name': 'target_pdf_screenshot_collection',
+            'text': 'Screenshot evidence for issue:123 progress check with key visual context.',
+            'score': 0.82,
+        },
+        {
+            'source_path': '/tmp/target-report.pdf',
+            'source_type': 'pdf',
+            'modality': 'pdf',
+            'source_ref': 'issue:123',
+            'collection_name': 'target_pdf_screenshot_collection',
+            'text': 'PDF attachment for issue:123 containing progress evidence and document context.',
+            'score': 0.81,
+        },
+    ]
+
+    focus = rwt._select_focus_cluster('先前那個 PDF 附件和截圖證據做到哪了？', evidence, resolved_source_ref='issue:123')
+    assert focus
+    assert focus[0]['collection_name'] == 'target_pdf_screenshot_collection'
+    assert all((item.get('collection_name') or '') == 'target_pdf_screenshot_collection' for item in focus)
+
+
+
+def test_recall_with_artifacts_builds_issue_evidence_brief_from_issue_scoped_artifacts(monkeypatch):
+    import tools.recall_with_artifacts_tool as rwt
+
+    monkeypatch.setattr(rwt, '_session_search_available', lambda: True)
+    monkeypatch.setattr(rwt, '_local_mmrag_connected', lambda: True)
+    monkeypatch.setattr(
+        rwt,
+        '_run_session_search',
+        lambda query, role_filter=None, limit=3: {
+            'success': True,
+            'results': [
+                {'summary': 'Issue issue:987 discusses customer waiting and attachment evidence.'}
+            ],
+            'count': 1,
+        },
+    )
+    monkeypatch.setattr(
+        rwt,
+        '_run_multimodal_recall',
+        lambda **kwargs: {
+            'summary': 'ETA next Tuesday. Blocker is OCR validation. Customer is waiting.',
+            'top_evidence': [
+                {
+                    'source_path': '/tmp/status.png',
+                    'source_type': 'attachment',
+                    'source_ref': 'issue:987',
+                    'modality': 'image',
+                    'collection_name': 'gitlab_radar_demo',
+                    'text': 'Status: waiting customer reply. ETA: next Tuesday. Evidence: screenshot.',
+                },
+                {
+                    'source_path': '/tmp/summary.pdf',
+                    'source_type': 'attachment',
+                    'source_ref': 'issue:987',
+                    'modality': 'pdf',
+                    'collection_name': 'gitlab_radar_demo',
+                    'text': 'Blocker: OCR validation for rollout evidence.',
+                },
+                {
+                    'source_path': '/tmp/note.md',
+                    'source_type': 'issue-note',
+                    'source_ref': 'issue:987',
+                    'modality': 'text',
+                    'collection_name': 'gitlab_radar_demo',
+                    'text': 'Customer is waiting for ETA update on the rollout.',
+                },
+            ],
+            'extracted_fields': {
+                'customer_waiting_signals': ['customer_waiting'],
+                'eta': 'next tuesday',
+            },
+            'retrieval_notes': {'collection_name': 'gitlab_radar_demo'},
+        },
+    )
+
+    result = json.loads(rwt.recall_with_artifacts(query='issue:987 customer waiting ETA blocker', source_ref='issue:987'))
+    brief = result['issue_evidence_brief']
+    assert brief['source_ref'] == 'issue:987'
+    assert brief['collections'] == ['gitlab_radar_demo']
+    assert brief['modalities_seen'] == ['image', 'pdf', 'text']
+    assert brief['status_signals'] == ['customer_waiting']
+    assert brief['eta_signals'] == ['next tuesday']
+    assert 'ocr validation' in brief['blocker_signals']
+    assert brief['top_sources'] == ['/tmp/status.png', '/tmp/summary.pdf', '/tmp/note.md']
+    assert 'next tuesday' in brief['evidence_brief'].lower()
+    assert 'ocr validation' in brief['evidence_brief'].lower()
+    assert 'customer waiting' in brief['evidence_brief'].lower()
+
+
+def test_recall_with_artifacts_builds_radar_ready_summary_from_issue_evidence_brief(monkeypatch):
+    import tools.recall_with_artifacts_tool as rwt
+
+    monkeypatch.setattr(rwt, '_session_search_available', lambda: True)
+    monkeypatch.setattr(rwt, '_local_mmrag_connected', lambda: True)
+    monkeypatch.setattr(
+        rwt,
+        '_run_session_search',
+        lambda query, role_filter=None, limit=3: {
+            'success': True,
+            'results': [{'summary': 'Issue issue:987 discusses customer waiting and attachment evidence.'}],
+            'count': 1,
+        },
+    )
+    monkeypatch.setattr(
+        rwt,
+        '_run_multimodal_recall',
+        lambda **kwargs: {
+            'summary': 'ETA next Tuesday. Blocker is OCR validation. Customer is waiting.',
+            'top_evidence': [
+                {
+                    'source_path': '/tmp/status.png',
+                    'source_type': 'attachment',
+                    'source_ref': 'issue:987',
+                    'modality': 'image',
+                    'collection_name': 'gitlab_radar_demo',
+                    'text': 'Status: waiting customer reply. ETA: next Tuesday. Evidence: screenshot.',
+                },
+                {
+                    'source_path': '/tmp/summary.pdf',
+                    'source_type': 'attachment',
+                    'source_ref': 'issue:987',
+                    'modality': 'pdf',
+                    'collection_name': 'gitlab_radar_demo',
+                    'text': 'Blocker: OCR validation for rollout evidence.',
+                },
+            ],
+            'extracted_fields': {
+                'customer_waiting_signals': ['customer_waiting'],
+                'eta': 'next tuesday',
+            },
+            'retrieval_notes': {'collection_name': 'gitlab_radar_demo'},
+        },
+    )
+
+    result = json.loads(rwt.recall_with_artifacts(query='issue:987 customer waiting ETA blocker', source_ref='issue:987'))
+    summary = result['radar_ready_summary']
+    assert summary['source_ref'] == 'issue:987'
+    assert summary['current_evidence_backed_status'] == 'customer_waiting'
+    assert summary['eta'] == 'next tuesday'
+    assert summary['blocker'] == 'ocr validation'
+    assert summary['evidence_basis'] == ['image', 'pdf']
+    assert summary['suggested_next_step']
+    assert 'customer' in summary['suggested_next_step'].lower()
+    assert summary['provenance']['collection'] == 'gitlab_radar_demo'
+    assert summary['provenance']['top_sources'] == ['/tmp/status.png', '/tmp/summary.pdf']
+
+
+def test_recall_with_artifacts_builds_comment_ready_summary_from_radar_ready_summary(monkeypatch):
+    import tools.recall_with_artifacts_tool as rwt
+
+    monkeypatch.setattr(rwt, '_session_search_available', lambda: True)
+    monkeypatch.setattr(rwt, '_local_mmrag_connected', lambda: True)
+    monkeypatch.setattr(
+        rwt,
+        '_run_session_search',
+        lambda query, role_filter=None, limit=3: {
+            'success': True,
+            'results': [{'summary': 'Issue issue:987 discusses customer waiting and attachment evidence.'}],
+            'count': 1,
+        },
+    )
+    monkeypatch.setattr(
+        rwt,
+        '_run_multimodal_recall',
+        lambda **kwargs: {
+            'summary': 'ETA next Tuesday. Blocker is OCR validation. Customer is waiting.',
+            'top_evidence': [
+                {
+                    'source_path': '/tmp/status.png',
+                    'source_type': 'attachment',
+                    'source_ref': 'issue:987',
+                    'modality': 'image',
+                    'collection_name': 'gitlab_radar_demo',
+                    'text': 'Status: waiting customer reply. ETA: next Tuesday. Evidence: screenshot.',
+                },
+                {
+                    'source_path': '/tmp/summary.pdf',
+                    'source_type': 'attachment',
+                    'source_ref': 'issue:987',
+                    'modality': 'pdf',
+                    'collection_name': 'gitlab_radar_demo',
+                    'text': 'Blocker: OCR validation for rollout evidence.',
+                },
+            ],
+            'extracted_fields': {
+                'customer_waiting_signals': ['customer_waiting'],
+                'eta': 'next tuesday',
+            },
+            'retrieval_notes': {'collection_name': 'gitlab_radar_demo'},
+        },
+    )
+
+    result = json.loads(rwt.recall_with_artifacts(query='issue:987 customer waiting ETA blocker', source_ref='issue:987'))
+    comment = result['comment_ready_summary']
+    assert 'Current evidence-backed status: customer_waiting' in comment
+    assert 'ETA: next tuesday' in comment
+    assert 'Blocker: ocr validation' in comment
+    assert 'Evidence basis: image, pdf' in comment
+    assert 'Suggested next step:' in comment
+    assert 'Source ref: issue:987' in comment
+    assert 'Collection: gitlab_radar_demo' in comment
+    assert '/tmp/status.png' in comment

--- a/tools/multimodal_recall_tool.py
+++ b/tools/multimodal_recall_tool.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+import json
+from typing import Any, Dict
+
+from tools.registry import registry
+from tools import mcp_tool
+
+
+def _local_mmrag_connected() -> bool:
+    with mcp_tool._lock:
+        server = mcp_tool._servers.get('local_mmrag')
+    return server is not None and getattr(server, 'session', None) is not None
+
+
+def _call_local_mmrag(tool_name: str, args: Dict[str, Any]) -> str:
+    with mcp_tool._lock:
+        server = mcp_tool._servers.get('local_mmrag')
+    if not server or not getattr(server, 'session', None):
+        return json.dumps({'error': "local_mmrag MCP server is not connected"}, ensure_ascii=False)
+
+    async def _call():
+        result = await server.session.call_tool(tool_name, arguments=args)
+        if result.isError:
+            text = ''.join(block.text for block in (result.content or []) if hasattr(block, 'text'))
+            return json.dumps({'error': text or 'MCP tool returned an error'}, ensure_ascii=False)
+        parts = [block.text for block in (result.content or []) if hasattr(block, 'text')]
+        if getattr(result, 'structuredContent', None) is not None:
+            if parts:
+                return json.dumps({'result': '\n'.join(parts), 'structuredContent': result.structuredContent}, ensure_ascii=False)
+            return json.dumps({'result': result.structuredContent}, ensure_ascii=False)
+        text = '\n'.join(parts) if parts else ''
+        return text if text else json.dumps({'result': ''}, ensure_ascii=False)
+
+    return mcp_tool._run_on_mcp_loop(_call(), timeout=60)
+
+
+def multimodal_recall(action: str = 'evidence', query: str = '', source_ref: str = '', source_type: str = '', modality: str = '', collection: str = '', top_k: int = 5) -> str:
+    action = (action or 'evidence').strip().lower()
+    if action == 'recent':
+        return _call_local_mmrag('mm_recall_recent_artifacts', {'limit': top_k})
+
+    args = {'query': query, 'top_k': top_k}
+    if source_ref:
+        args['source_ref'] = source_ref
+    if source_type:
+        args['source_type'] = source_type
+    if modality:
+        args['modality'] = modality
+    if collection:
+        args['collection'] = collection
+
+    if action == 'search':
+        return _call_local_mmrag('mm_recall_search', args)
+    return _call_local_mmrag('mm_recall_get_evidence_pack', args)
+
+
+MULTIMODAL_RECALL_SCHEMA = {
+    'name': 'multimodal_recall',
+    'description': 'Recall multimodal evidence (PDFs, OCR, screenshots, evidence packs) through the local_mmrag MCP layer. Use this when the user refers to a prior report, screenshot, attachment, OCR result, or evidence pack rather than transcript-only memory. If the user likely needs both past conversation context and artifact evidence, prefer recall_with_artifacts instead.',
+    'parameters': {
+        'type': 'object',
+        'properties': {
+            'action': {
+                'type': 'string',
+                'description': "One of: 'evidence' (default), 'search', or 'recent'."
+            },
+            'query': {
+                'type': 'string',
+                'description': 'Natural-language recall query, e.g. customer waiting eta, prior pentest PDF, screenshot with error message.'
+            },
+            'source_ref': {
+                'type': 'string',
+                'description': 'Optional stable source reference filter, e.g. issue:123 or project:iid.'
+            },
+            'source_type': {
+                'type': 'string',
+                'description': 'Optional filter such as issue, attachment, wiki, local_file.'
+            },
+            'modality': {
+                'type': 'string',
+                'description': 'Optional modality filter such as text, image, pdf, image_ocr.'
+            },
+            'collection': {
+                'type': 'string',
+                'description': 'Optional collection name to limit recall to a known local-mmrag collection.'
+            },
+            'top_k': {
+                'type': 'integer',
+                'description': 'Max number of recalled results/artifacts to return (default 5).',
+                'default': 5,
+            },
+        },
+        'required': [],
+    },
+}
+
+registry.register(
+    name='multimodal_recall',
+    toolset='memory',
+    schema=MULTIMODAL_RECALL_SCHEMA,
+    handler=lambda args, **kw: multimodal_recall(
+        action=args.get('action', 'evidence'),
+        query=args.get('query', ''),
+        source_ref=args.get('source_ref', ''),
+        source_type=args.get('source_type', ''),
+        modality=args.get('modality', ''),
+        collection=args.get('collection', ''),
+        top_k=args.get('top_k', 5),
+    ),
+    check_fn=_local_mmrag_connected,
+    emoji='🧠',
+)

--- a/tools/recall_with_artifacts_tool.py
+++ b/tools/recall_with_artifacts_tool.py
@@ -1,0 +1,721 @@
+#!/usr/bin/env python3
+import json
+import re
+from typing import Any, Dict
+
+from tools.registry import registry
+from tools.multimodal_recall_tool import _local_mmrag_connected, multimodal_recall
+from tools.session_search_tool import check_session_search_requirements, session_search
+
+
+def _session_search_available() -> bool:
+    return check_session_search_requirements()
+
+
+def _safe_json_loads(text: str) -> Dict[str, Any]:
+    if not text:
+        return {}
+    try:
+        parsed = json.loads(text)
+        return parsed if isinstance(parsed, dict) else {"result": parsed}
+    except Exception:
+        return {"result": text}
+
+
+def _run_session_search(query: str, role_filter: str | None = None, limit: int = 3) -> Dict[str, Any]:
+    try:
+        from hermes_state import SessionDB
+    except Exception as e:
+        return {"error": f"SessionDB unavailable: {e}"}
+
+    try:
+        db = SessionDB()
+    except Exception as e:
+        return {"error": f"Failed to open session database: {e}"}
+
+    try:
+        raw = session_search(query=query, role_filter=role_filter, limit=limit, db=db)
+        return _safe_json_loads(raw)
+    finally:
+        try:
+            db.close()
+        except Exception:
+            pass
+
+
+def _run_multimodal_recall(**kwargs) -> Dict[str, Any]:
+    raw = multimodal_recall(**kwargs)
+    parsed = _safe_json_loads(raw)
+    structured = parsed.get('structuredContent')
+    if isinstance(structured, dict):
+        return structured
+    return parsed
+
+
+def _compact_text(text: Any, max_chars: int = 320) -> str:
+    raw = '' if text is None else str(text)
+    compact = ' '.join(raw.split())
+    if len(compact) <= max_chars:
+        return compact
+    return compact[: max_chars - 1].rstrip() + '…'
+
+
+def _normalize_hint(value: str) -> str:
+    value = (value or '').strip().strip('"\'`.,;:()[]{}')
+    if not value:
+        return ''
+    if not re.search(r'[A-Za-z0-9]', value):
+        return ''
+    return value
+
+
+def _extract_hints_from_text(text: str) -> Dict[str, str]:
+    text = text or ''
+    hints: Dict[str, str] = {}
+
+    source_ref_patterns = [
+        r'\bsource_ref\s*[:=]\s*["\']?([A-Za-z0-9_.:-]+)',
+        r'\b(issue:\d+)\b',
+        r'\b(project:[A-Za-z0-9_.:-]+)\b',
+    ]
+    for pattern in source_ref_patterns:
+        match = re.search(pattern, text, re.IGNORECASE)
+        if match:
+            normalized = _normalize_hint(match.group(1))
+            if normalized:
+                hints['source_ref'] = normalized
+                break
+
+    collection_patterns = [
+        r'\bcollection_name\s*[:=]\s*["\']?([A-Za-z0-9_.-]+)',
+        r'\bcollection\s*[:=]\s*["\']?([A-Za-z0-9_.-]+)',
+        r'\b(gitlab_radar_[A-Za-z0-9]+)\b',
+    ]
+    for pattern in collection_patterns:
+        match = re.search(pattern, text, re.IGNORECASE)
+        if match:
+            normalized = _normalize_hint(match.group(1))
+            if normalized:
+                hints['collection'] = normalized
+                break
+
+    source_type_match = re.search(r'\bsource_type\s*[:=]\s*["\']?([A-Za-z0-9_.-]+)', text, re.IGNORECASE)
+    if source_type_match:
+        normalized = _normalize_hint(source_type_match.group(1))
+        if normalized:
+            hints['source_type'] = normalized
+
+    return hints
+
+
+def _merge_hint_confidence(current: Dict[str, str], key: str, value: str, confidence: str) -> None:
+    if not value:
+        return
+    existing = current.get(key)
+    if existing == 'high':
+        return
+    current[key] = confidence
+
+
+def _derive_recall_hints(transcript_recall: Dict[str, Any], explicit_source_type: str = '') -> tuple[Dict[str, str], Dict[str, str]]:
+    hints: Dict[str, str] = {}
+    confidence: Dict[str, str] = {}
+    results = transcript_recall.get('results') if isinstance(transcript_recall, dict) else None
+    if not isinstance(results, list):
+        return hints, confidence
+
+    normalized_explicit_source_type = (explicit_source_type or '').strip().lower()
+
+    for item in results:
+        if not isinstance(item, dict):
+            continue
+        candidate_text = ' '.join(
+            str(item.get(key, '') or '')
+            for key in ('summary', 'preview')
+        )
+        extracted = _extract_hints_from_text(candidate_text)
+        source_type_from_text = (extracted.get('source_type') or '').lower()
+
+        if 'source_ref' not in hints and extracted.get('source_ref'):
+            hints['source_ref'] = extracted['source_ref']
+            confidence['source_ref'] = 'high'
+
+        if 'collection' not in hints and extracted.get('collection'):
+            hints['collection'] = extracted['collection']
+            collection_confidence = 'low'
+            if normalized_explicit_source_type and source_type_from_text and source_type_from_text == normalized_explicit_source_type:
+                collection_confidence = 'high'
+            confidence['collection'] = collection_confidence
+
+        if 'source_type' not in hints and extracted.get('source_type'):
+            hints['source_type'] = extracted['source_type']
+            _merge_hint_confidence(confidence, 'source_type', extracted['source_type'], 'medium')
+
+        if 'source_ref' in hints and 'collection' in hints and confidence.get('collection') == 'high':
+            break
+
+    return hints, confidence
+
+
+def _augment_query_with_soft_hints(query: str, hints: Dict[str, str], confidence: Dict[str, str]) -> str:
+    base = (query or '').strip()
+    additions = []
+    lowered_query = base.lower()
+    if hints.get('collection') and confidence.get('collection') != 'high':
+        additions.append(f'collection {hints["collection"]}')
+    if hints.get('source_type') and confidence.get('source_type') == 'medium':
+        source_type_hint = hints['source_type']
+        generic_attachment = source_type_hint.lower() in {'attachment', 'attachments'}
+        broad_pdf_screenshot = any(term in lowered_query for term in ['pdf', 'screenshot', '截圖', '附件', '證據'])
+        if not (generic_attachment and broad_pdf_screenshot):
+            additions.append(f'source_type {source_type_hint}')
+    if not additions:
+        return base
+    suffix = ' '.join(additions)
+    return f'{base} {suffix}'.strip()
+
+
+def _query_requires_source_ref_corroboration(query: str) -> bool:
+    lowered = (query or '').lower()
+    strong_multimodal_terms = [
+        'screenshot', 'pdf', 'attachment', 'attachments', 'image', 'ocr', 'artifact', 'artifacts',
+        '截圖', '附件', '圖片', '影像', '證據', '文件', '檔案', '報告',
+    ]
+    return any(term in lowered for term in strong_multimodal_terms)
+
+
+def _query_is_broad_pdf_screenshot(query: str) -> bool:
+    lowered = (query or '').lower()
+    has_pdf = 'pdf' in lowered
+    has_visual = any(term in lowered for term in ['screenshot', '截圖', '附件', '證據'])
+    return has_pdf and has_visual
+
+
+def _resolve_effective_source_ref(
+    query: str,
+    explicit_source_ref: str,
+    derived_hints: Dict[str, str],
+    hint_confidence: Dict[str, str],
+) -> str:
+    if explicit_source_ref:
+        return explicit_source_ref
+    derived_source_ref = derived_hints.get('source_ref', '')
+    if not derived_source_ref:
+        return ''
+    lowered_query = (query or '').lower()
+    if derived_source_ref.lower() in lowered_query:
+        return derived_source_ref
+    if not _query_requires_source_ref_corroboration(query):
+        return derived_source_ref
+    if hint_confidence.get('collection') == 'high':
+        return derived_source_ref
+    return ''
+
+
+def _extract_blocker_signals(text: str) -> list[str]:
+    lowered = (text or '').lower()
+    signals: list[str] = []
+    blocker_patterns = [
+        (r'ocr validation', 'ocr validation'),
+        (r'blocker[:\s]+([^.;\n]+)', None),
+        (r'waiting customer reply', 'waiting customer reply'),
+        (r'customer waiting', 'customer waiting'),
+    ]
+    for pattern, label in blocker_patterns:
+        match = re.search(pattern, lowered, re.IGNORECASE)
+        if not match:
+            continue
+        value = label or _normalize_hint(match.group(1))
+        if value and value not in signals:
+            signals.append(value)
+    return signals
+
+
+def _query_looks_multimodal(query: str) -> bool:
+    lowered = (query or '').lower()
+    if not lowered.strip():
+        return False
+    strong_terms = [
+        'screenshot', 'pdf', 'attachment', 'attachments', 'image', 'ocr', 'evidence', 'artifact', 'artifacts',
+        'report', 'document', 'file', 'files', 'photo', 'photos', 'scan', 'scanned',
+        '截圖', '附件', '圖片', '影像', '照片', '證據', '文件', '檔案', '報告', '掃描', 'pdf',
+    ]
+    if any(term in lowered for term in strong_terms):
+        return True
+    status_terms = ['customer waiting', 'waiting customer', 'eta', 'blocker', '客戶等待', '等待客戶', '阻塞', '卡住']
+    matched = [term for term in status_terms if term in lowered]
+    return len(matched) >= 2
+
+
+def _score_evidence_alignment(query: str, item: Dict[str, Any], resolved_source_ref: str = '') -> float:
+    lowered_query = (query or '').lower()
+    text = ' '.join(
+        str(item.get(key, '') or '')
+        for key in ('text', 'source_type', 'modality', 'source_ref', 'collection_name', 'source_path')
+    ).lower()
+    score = float(item.get('score') or 0.0)
+
+    if resolved_source_ref and (item.get('source_ref') or '') == resolved_source_ref:
+        score += 5.0
+
+    keyword_weights = {
+        'screenshot': 3.0,
+        'image': 2.5,
+        'attachment': 2.0,
+        'pdf': 2.0,
+        'ocr': 2.0,
+        'evidence': 1.5,
+        'eta': 1.5,
+        'blocker': 1.5,
+    }
+    for term, weight in keyword_weights.items():
+        if term in lowered_query and term in text:
+            score += weight
+
+    for term in ['截圖', '圖片', '附件', 'pdf', '證據', 'eta', 'blocker']:
+        if term.lower() in lowered_query and term.lower() in text:
+            score += 1.5
+
+    issue_refs = re.findall(r'issue:\d+', lowered_query)
+    for ref in issue_refs:
+        if ref in text:
+            score += 4.0
+
+    if 'screenshot' in lowered_query and (item.get('source_type') == 'image' or item.get('modality') == 'image'):
+        score += 2.0
+    if 'pdf' in lowered_query and (item.get('source_type') == 'pdf' or item.get('modality') == 'pdf'):
+        score += 2.0
+
+    ocr_error_focused = any(term in lowered_query for term in ['ocr', '錯誤訊息', 'error'])
+    if ocr_error_focused:
+        if any(term in text for term in ['錯誤訊息', 'technical error', 'error message', 'technical detail', 'custom error', 'non-customized errors', 'detail leakage']):
+            score += 4.0
+        if (item.get('source_type') == 'pdf' or item.get('modality') == 'pdf'):
+            score += 2.0
+        if 'status waiting customer reply' in text or 'waiting customer reply' in text:
+            score -= 2.0
+
+    return score
+
+
+def _rank_top_evidence_for_prompt(query: str, top_evidence: list[Dict[str, Any]], resolved_source_ref: str = '') -> list[Dict[str, Any]]:
+    ranked = [item for item in top_evidence if isinstance(item, dict)]
+    ranked.sort(
+        key=lambda item: _score_evidence_alignment(query, item, resolved_source_ref=resolved_source_ref),
+        reverse=True,
+    )
+    return ranked
+
+
+def _cluster_evidence_items(top_evidence: list[Dict[str, Any]]) -> list[list[Dict[str, Any]]]:
+    clusters: dict[tuple[str, str], list[Dict[str, Any]]] = {}
+    for item in top_evidence:
+        if not isinstance(item, dict):
+            continue
+        source_ref = item.get('source_ref') or ''
+        collection = item.get('collection_name') or ''
+        key = (source_ref, collection)
+        clusters.setdefault(key, []).append(item)
+    return list(clusters.values())
+
+
+def _score_evidence_cluster(query: str, cluster: list[Dict[str, Any]], resolved_source_ref: str = '') -> float:
+    if not cluster:
+        return float('-inf')
+    scores = [_score_evidence_alignment(query, item, resolved_source_ref=resolved_source_ref) for item in cluster]
+    return max(scores) + (0.05 * len(cluster))
+
+
+def _select_focus_cluster(query: str, top_evidence: list[Dict[str, Any]], resolved_source_ref: str = '') -> list[Dict[str, Any]]:
+    clusters = _cluster_evidence_items(top_evidence)
+    if not clusters:
+        return []
+    clusters.sort(key=lambda cluster: _score_evidence_cluster(query, cluster, resolved_source_ref=resolved_source_ref), reverse=True)
+    focus = clusters[0]
+    focus.sort(key=lambda item: _score_evidence_alignment(query, item, resolved_source_ref=resolved_source_ref), reverse=True)
+    return focus
+
+
+def _build_issue_evidence_brief(
+    artifact_recall: Dict[str, Any],
+    *,
+    query: str = '',
+    source_ref: str = '',
+    derived_hints: Dict[str, str] | None = None,
+) -> Dict[str, Any]:
+    derived_hints = derived_hints or {}
+    if not isinstance(artifact_recall, dict):
+        return {}
+
+    top_evidence = artifact_recall.get('top_evidence')
+    if not isinstance(top_evidence, list) or not top_evidence:
+        return {}
+
+    collections: list[str] = []
+    modalities_seen: list[str] = []
+    top_sources: list[str] = []
+    blocker_signals: list[str] = []
+    combined_text_parts: list[str] = []
+    resolved_source_ref = source_ref or ''
+    derived_source_ref = derived_hints.get('source_ref', '')
+    if not resolved_source_ref and derived_source_ref:
+        if any((item.get('source_ref') or '') == derived_source_ref for item in top_evidence if isinstance(item, dict)):
+            resolved_source_ref = derived_source_ref
+
+    ranked_evidence = _rank_top_evidence_for_prompt(query, top_evidence, resolved_source_ref=resolved_source_ref)
+    screenshot_focused = any(term in (query or '').lower() for term in ['screenshot', '截圖'])
+    ocr_error_focused = any(term in (query or '').lower() for term in ['ocr', '錯誤訊息', 'error'])
+    focus_source_ref = ''
+    focus_collection = ''
+    focus_cluster = _select_focus_cluster(query, ranked_evidence, resolved_source_ref=resolved_source_ref)
+    if focus_cluster:
+        focus_source_ref = focus_cluster[0].get('source_ref') or ''
+        focus_collection = focus_cluster[0].get('collection_name') or artifact_recall.get('retrieval_notes', {}).get('collection_name', '')
+    if screenshot_focused and focus_source_ref:
+        resolved_source_ref = focus_source_ref
+
+    evidence_for_brief = focus_cluster or ranked_evidence
+
+    for item in evidence_for_brief:
+        if not isinstance(item, dict):
+            continue
+        item_source_ref = item.get('source_ref') or ''
+        item_collection = item.get('collection_name') or artifact_recall.get('retrieval_notes', {}).get('collection_name', '')
+        if screenshot_focused:
+            if focus_source_ref and item_source_ref and item_source_ref != focus_source_ref:
+                continue
+            if focus_collection and item_collection and item_collection != focus_collection and item_source_ref != focus_source_ref:
+                continue
+        if not resolved_source_ref and item_source_ref:
+            resolved_source_ref = item_source_ref
+        collection_name = item_collection
+        if collection_name and collection_name not in collections:
+            collections.append(collection_name)
+        modality = item.get('modality') or ''
+        if modality and modality not in modalities_seen:
+            modalities_seen.append(modality)
+        source_path = item.get('source_path') or ''
+        if source_path and source_path not in top_sources:
+            top_sources.append(source_path)
+        text = item.get('text') or ''
+        if text:
+            combined_text_parts.append(text)
+            for signal in _extract_blocker_signals(text):
+                if signal not in blocker_signals:
+                    blocker_signals.append(signal)
+
+    extracted_fields = artifact_recall.get('extracted_fields') if isinstance(artifact_recall.get('extracted_fields'), dict) else {}
+    status_signals = list(extracted_fields.get('customer_waiting_signals') or [])
+    eta_value = extracted_fields.get('eta')
+    eta_signals = [eta_value] if eta_value else []
+
+    if not eta_signals:
+        joined_lower = ' '.join(combined_text_parts).lower()
+        for pattern in [r'eta[:\s]+([^.;\n]+)', r'next tuesday', r'next monday']:
+            match = re.search(pattern, joined_lower)
+            if not match:
+                continue
+            eta_candidate = pattern if pattern in {'next tuesday', 'next monday'} else _normalize_hint(match.group(1))
+            if eta_candidate:
+                eta_signals = [eta_candidate]
+                break
+
+    preferred_blocker = ''
+    for candidate in ['ocr validation']:
+        if candidate in blocker_signals:
+            preferred_blocker = candidate
+            break
+    if not preferred_blocker and blocker_signals:
+        preferred_blocker = blocker_signals[0]
+
+    brief_bits = []
+    if resolved_source_ref:
+        brief_bits.append(f'{resolved_source_ref} evidence')
+    if status_signals:
+        brief_bits.append('shows customer waiting status')
+    if eta_signals:
+        brief_bits.append(f'ETA {eta_signals[0]}')
+    if preferred_blocker:
+        brief_bits.append(f'blocker {preferred_blocker}')
+    if screenshot_focused and combined_text_parts:
+        focus_text = _compact_text(combined_text_parts[0], 120)
+        if focus_text:
+            brief_bits.append(f'focus {focus_text}')
+    if ocr_error_focused and combined_text_parts:
+        focus_text = _compact_text(combined_text_parts[0], 120)
+        if focus_text and focus_text not in brief_bits:
+            brief_bits.append(f'focus {focus_text}')
+    evidence_brief = '; '.join(brief_bits).strip()
+
+    return {
+        'source_ref': resolved_source_ref,
+        'collections': collections,
+        'modalities_seen': modalities_seen,
+        'status_signals': status_signals,
+        'eta_signals': eta_signals,
+        'blocker_signals': blocker_signals,
+        'top_sources': top_sources[:3],
+        'evidence_brief': evidence_brief,
+        'preferred_blocker': preferred_blocker,
+    }
+
+
+def _build_radar_ready_summary(issue_evidence_brief: Dict[str, Any]) -> Dict[str, Any]:
+    if not isinstance(issue_evidence_brief, dict) or not issue_evidence_brief:
+        return {}
+
+    source_ref = issue_evidence_brief.get('source_ref', '')
+    status_signals = list(issue_evidence_brief.get('status_signals') or [])
+    eta_signals = list(issue_evidence_brief.get('eta_signals') or [])
+    blocker = issue_evidence_brief.get('preferred_blocker') or ''
+    modalities_seen = list(issue_evidence_brief.get('modalities_seen') or [])
+    collections = list(issue_evidence_brief.get('collections') or [])
+    top_sources = list(issue_evidence_brief.get('top_sources') or [])
+
+    current_status = status_signals[0] if status_signals else ''
+    eta = eta_signals[0] if eta_signals else ''
+
+    next_step = ''
+    if current_status == 'customer_waiting' and eta:
+        next_step = f'Update the tracking issue with ETA {eta} and follow up with the customer.'
+    elif blocker:
+        next_step = f'Clarify or resolve blocker: {blocker}.'
+    elif top_sources:
+        next_step = 'Review the top evidence sources and update the tracking issue.'
+
+    return {
+        'source_ref': source_ref,
+        'current_evidence_backed_status': current_status,
+        'eta': eta,
+        'blocker': blocker,
+        'evidence_basis': modalities_seen,
+        'suggested_next_step': next_step,
+        'provenance': {
+            'collection': collections[0] if collections else '',
+            'top_sources': top_sources[:3],
+        },
+    }
+
+
+def _build_comment_ready_summary(radar_ready_summary: Dict[str, Any]) -> str:
+    if not isinstance(radar_ready_summary, dict) or not radar_ready_summary:
+        return ''
+
+    lines = []
+    status = radar_ready_summary.get('current_evidence_backed_status') or ''
+    eta = radar_ready_summary.get('eta') or ''
+    blocker = radar_ready_summary.get('blocker') or ''
+    evidence_basis = ', '.join(radar_ready_summary.get('evidence_basis') or [])
+    next_step = radar_ready_summary.get('suggested_next_step') or ''
+    source_ref = radar_ready_summary.get('source_ref') or ''
+    provenance = radar_ready_summary.get('provenance') or {}
+    collection = provenance.get('collection') or ''
+    top_sources = provenance.get('top_sources') or []
+
+    if status:
+        lines.append(f'Current evidence-backed status: {status}')
+    if eta:
+        lines.append(f'ETA: {eta}')
+    if blocker:
+        lines.append(f'Blocker: {blocker}')
+    if evidence_basis:
+        lines.append(f'Evidence basis: {evidence_basis}')
+    if next_step:
+        lines.append(f'Suggested next step: {next_step}')
+    if source_ref:
+        lines.append(f'Source ref: {source_ref}')
+    if collection:
+        lines.append(f'Collection: {collection}')
+    if top_sources:
+        lines.append('Top sources:')
+        lines.extend(f'- {path}' for path in top_sources)
+
+    return '\n'.join(lines).strip()
+
+
+def _build_evidence_channel_summary(
+    query: str,
+    transcript_recall: Dict[str, Any],
+    artifact_recall: Dict[str, Any],
+) -> Dict[str, Any]:
+    lowered_query = (query or '').lower()
+    ambiguity_terms = ['來自對話', '來自附件', 'transcript', 'artifact', '附件', '對話']
+    is_ambiguity_query = any(term in lowered_query for term in ambiguity_terms)
+
+    transcript_support = ''
+    results = transcript_recall.get('results') if isinstance(transcript_recall, dict) else None
+    if isinstance(results, list) and results:
+        first = results[0]
+        if isinstance(first, dict):
+            transcript_support = _compact_text(first.get('summary') or first.get('preview') or '', 220)
+
+    artifact_support = ''
+    if isinstance(artifact_recall, dict):
+        artifact_support = _compact_text(artifact_recall.get('summary') or artifact_recall.get('result') or '', 220)
+        if not artifact_support:
+            top = artifact_recall.get('top_evidence')
+            if isinstance(top, list) and top:
+                artifact_support = _compact_text((top[0] or {}).get('text') or '', 220)
+
+    if not is_ambiguity_query and not (transcript_support and artifact_support):
+        return {}
+
+    if transcript_support and artifact_support:
+        preferred = 'mixed'
+    elif artifact_support:
+        preferred = 'artifact'
+    elif transcript_support:
+        preferred = 'transcript'
+    else:
+        preferred = 'none'
+
+    return {
+        'transcript_support': transcript_support,
+        'artifact_support': artifact_support,
+        'preferred_evidence_channel': preferred,
+    }
+
+
+def _build_combined_summary(query: str, transcript_recall: Dict[str, Any], artifact_recall: Dict[str, Any]) -> str:
+    parts = []
+    if query:
+        parts.append(f"Hybrid recall for query: {query}.")
+
+    transcript_results = transcript_recall.get('results') if isinstance(transcript_recall, dict) else None
+    if isinstance(transcript_results, list) and transcript_results:
+        first = transcript_results[0]
+        if isinstance(first, dict):
+            summary = _compact_text(first.get('summary') or first.get('preview') or '')
+            if summary:
+                parts.append(f"Transcript recall found {len(transcript_results)} relevant session(s); top match: {summary}")
+    elif isinstance(transcript_recall, dict) and transcript_recall.get('error'):
+        parts.append(f"Transcript recall unavailable: {_compact_text(transcript_recall['error'], 180)}")
+
+    if isinstance(artifact_recall, dict):
+        artifact_summary = _compact_text(artifact_recall.get('summary') or artifact_recall.get('result') or '')
+        if artifact_summary:
+            parts.append(f"Artifact recall: {artifact_summary}")
+        elif artifact_recall.get('artifacts'):
+            parts.append(f"Artifact recall returned {artifact_recall.get('count', len(artifact_recall.get('artifacts', [])))} recent artifact(s).")
+        elif artifact_recall.get('error'):
+            parts.append(f"Artifact recall unavailable: {_compact_text(artifact_recall['error'], 180)}")
+
+    return ' '.join(p.strip() for p in parts if p and str(p).strip())
+
+
+def recall_with_artifacts(
+    query: str = '',
+    role_filter: str = '',
+    session_limit: int = 3,
+    artifact_top_k: int = 5,
+    source_ref: str = '',
+    source_type: str = '',
+    modality: str = '',
+    collection: str = '',
+) -> str:
+    transcript_recall: Dict[str, Any]
+    artifact_recall: Dict[str, Any]
+
+    if _session_search_available():
+        transcript_recall = _run_session_search(query=query, role_filter=role_filter or None, limit=session_limit)
+    else:
+        transcript_recall = {'error': 'session_search is not available'}
+
+    derived_hints, hint_confidence = _derive_recall_hints(transcript_recall, explicit_source_type=source_type)
+    effective_source_ref = _resolve_effective_source_ref(
+        query,
+        source_ref,
+        derived_hints,
+        hint_confidence,
+    )
+    use_collection_hard_filter = bool(collection)
+    if not use_collection_hard_filter and derived_hints.get('collection'):
+        if hint_confidence.get('collection') == 'high':
+            use_collection_hard_filter = True
+        elif _query_is_broad_pdf_screenshot(query) and not effective_source_ref:
+            use_collection_hard_filter = True
+    effective_collection = collection or (derived_hints.get('collection', '') if use_collection_hard_filter else '')
+    effective_query = _augment_query_with_soft_hints(query, derived_hints, hint_confidence)
+    has_explicit_artifact_scope = any(
+        (value or '').strip()
+        for value in [source_ref, source_type, modality, collection, effective_source_ref, effective_collection]
+    )
+    should_run_artifact_recall = (not (query or '').strip()) or has_explicit_artifact_scope or _query_looks_multimodal(query)
+
+    if _local_mmrag_connected() and should_run_artifact_recall:
+        mm_action = 'recent' if not (query or '').strip() else 'evidence'
+        artifact_recall = _run_multimodal_recall(
+            action=mm_action,
+            query=effective_query,
+            top_k=artifact_top_k,
+            source_ref=effective_source_ref,
+            source_type=source_type,
+            modality=modality,
+            collection=effective_collection,
+        )
+    elif _local_mmrag_connected():
+        artifact_recall = {
+            'skipped': True,
+            'reason': 'query does not appear multimodal and no artifact filters were provided',
+        }
+    else:
+        artifact_recall = {'error': 'local_mmrag MCP server is not connected'}
+
+    combined = {
+        'query': query,
+        'transcript_recall': transcript_recall,
+        'artifact_recall': artifact_recall,
+        'derived_hints': derived_hints,
+        'hint_confidence': hint_confidence,
+        'effective_artifact_query': effective_query,
+        'issue_evidence_brief': _build_issue_evidence_brief(
+            artifact_recall,
+            query=query,
+            source_ref=effective_source_ref,
+            derived_hints=derived_hints,
+        ),
+        'combined_summary': _build_combined_summary(query, transcript_recall, artifact_recall),
+    }
+    combined['evidence_channel_summary'] = _build_evidence_channel_summary(query, transcript_recall, artifact_recall)
+    combined['radar_ready_summary'] = _build_radar_ready_summary(combined['issue_evidence_brief'])
+    combined['comment_ready_summary'] = _build_comment_ready_summary(combined['radar_ready_summary'])
+    return json.dumps(combined, ensure_ascii=False)
+
+
+RECALL_WITH_ARTIFACTS_SCHEMA = {
+    'name': 'recall_with_artifacts',
+    'description': 'Hybrid recall that combines transcript-first session_search with multimodal_recall artifact evidence. Use this first when the user refers to previous work plus screenshots, PDFs, attachments, OCR, evidence packs, or wants both conversation context and supporting artifacts.',
+    'parameters': {
+        'type': 'object',
+        'properties': {
+            'query': {'type': 'string', 'description': 'Recall query spanning prior conversations and artifacts.'},
+            'role_filter': {'type': 'string', 'description': 'Optional role filter passed to session_search, e.g. user,assistant.'},
+            'session_limit': {'type': 'integer', 'description': 'Max transcript sessions to summarize (default 3).', 'default': 3},
+            'artifact_top_k': {'type': 'integer', 'description': 'Max artifact hits or recent artifacts to return (default 5).', 'default': 5},
+            'source_ref': {'type': 'string', 'description': 'Optional source reference filter for multimodal recall.'},
+            'source_type': {'type': 'string', 'description': 'Optional source type filter for multimodal recall.'},
+            'modality': {'type': 'string', 'description': 'Optional modality filter for multimodal recall.'},
+            'collection': {'type': 'string', 'description': 'Optional local-mmrag collection filter.'},
+        },
+        'required': [],
+    },
+}
+
+
+registry.register(
+    name='recall_with_artifacts',
+    toolset='memory',
+    schema=RECALL_WITH_ARTIFACTS_SCHEMA,
+    handler=lambda args, **kw: recall_with_artifacts(
+        query=args.get('query', ''),
+        role_filter=args.get('role_filter', ''),
+        session_limit=args.get('session_limit', 3),
+        artifact_top_k=args.get('artifact_top_k', 5),
+        source_ref=args.get('source_ref', ''),
+        source_type=args.get('source_type', ''),
+        modality=args.get('modality', ''),
+        collection=args.get('collection', ''),
+    ),
+    check_fn=lambda: _session_search_available() or _local_mmrag_connected(),
+    emoji='🧩',
+)


### PR DESCRIPTION
## Summary
- add local-mmrag backed multimodal_recall and recall_with_artifacts tools
- add optional multimodal-recall memory provider with compact prefetch, queue prefetch, runtime connectivity checks, and lightweight turn/session/memory-write signals
- add focused tests for multimodal recall tools and provider behavior, including normalized prefetch cache keys

## Test Plan
- source venv/bin/activate && pytest -q tests/plugins/memory/test_multimodal_recall_provider.py tests/tools/test_recall_with_artifacts_tool.py tests/tools/test_multimodal_recall_tool.py tests/agent/test_memory_provider.py tests/agent/test_prompt_builder.py tests/test_toolsets.py tests/gateway/test_api_server_toolset.py
- source venv/bin/activate && python -m py_compile plugins/memory/multimodal-recall/__init__.py tools/recall_with_artifacts_tool.py tools/multimodal_recall_tool.py