### PR TITLE
fix(agent): #16050 avoid false auxiliary compression warning at startup

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2184,6 +2184,12 @@ class AIAgent:
                 "compression",
                 main_runtime=self._current_main_runtime(),
             )
+            # Be resilient to startup-time runtime resolution quirks.
+            # If runtime-scoped resolution returns empty, retry using only
+            # task config so valid custom auxiliary providers do not get
+            # reported as missing.
+            if client is None or not aux_model:
+                client, aux_model = get_text_auxiliary_client("compression")
             if client is None or not aux_model:
                 msg = (
                     "⚠ No auxiliary LLM provider configured — context "

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -273,6 +273,29 @@ def test_warns_when_no_auxiliary_provider(mock_get_client):
     assert agent._compression_warning is not None
 
 
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_uses_config_only_fallback_when_runtime_resolution_is_empty(mock_get_client):
+    """When runtime-scoped resolution is empty at startup, a second
+    config-only lookup should prevent false-positive 'no provider' warnings."""
+    agent = _make_agent()
+    mock_client = MagicMock()
+    mock_client.base_url = "https://coding.dashscope.aliyuncs.com/v1"
+    mock_client.api_key = "sk-test"
+    mock_get_client.side_effect = [
+        (None, None),  # runtime-scoped resolution path
+        (mock_client, "qwen3.6-plus"),  # config-only fallback path
+    ]
+
+    messages = []
+    agent._emit_status = lambda msg: messages.append(msg)
+
+    agent._check_compression_model_feasibility()
+
+    assert len(messages) == 0
+    assert agent._compression_warning is None
+    assert mock_get_client.call_count == 2
+
+
 def test_skips_check_when_compression_disabled():
     """No check performed when compression is disabled."""
     agent = _make_agent(compression_enabled=False)


### PR DESCRIPTION
## What does this PR do?

Fixes a startup false-positive where Hermes could warn that no auxiliary compression provider is configured even when a valid task-specific custom provider is present in config.
The compression feasibility check now performs a config-only fallback lookup before emitting the warning.

## Related Issue

Fixes #16050

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `run_agent.py` in `_check_compression_model_feasibility()` to retry `get_text_auxiliary_client("compression")` without `main_runtime` when the startup runtime-scoped lookup returns empty.
- Preserved existing warning behavior when both lookups fail, so real misconfiguration is still surfaced.
- Added regression test `test_uses_config_only_fallback_when_runtime_resolution_is_empty` in `tests/run_agent/test_compression_feasibility.py`.

## How to Test

1. Configure `auxiliary.compression.provider` to a valid custom provider (for example from `providers:` in `config.yaml`).
2. Start Hermes Gateway and verify no false "No auxiliary LLM provider configured" warning appears during startup.
3. Run `pytest tests/run_agent/test_compression_feasibility.py -q` and verify the new regression test passes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10 (static checks + targeted script validation)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Local environment note: `python -m pytest` is unavailable in this shell (`No module named pytest`), so full test execution should be run in CI or a configured dev environment.
