### PR TITLE
feat(web_search): add topic + days params for Tavily news-recency filtering

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -542,6 +542,7 @@ AUTHOR_MAP = {
     "shamork@outlook.com": "shamork",
     # April 2026 Discord Copilot /model salvage (#15030)
     "cshong2017@outlook.com": "Nicecsh",
+    "sky.cool.ezreal@gmail.com": "cola-runner",
     # no-github-match — keep as display names
     "clio-agent@sisyphuslabs.ai": "Sisyphus",
     "marco@rutimka.de": "Marco Rutsch",

--- a/tests/tools/test_web_tools_tavily.py
+++ b/tests/tools/test_web_tools_tavily.py
@@ -181,6 +181,104 @@ class TestWebSearchTavily:
             assert result["data"]["web"][0]["title"] == "Result"
 
 
+class TestWebSearchTavilyTopicAndDays:
+    """Tavily topic / days parameter plumbing (issue #16233)."""
+
+    def _post_payload(self, mock_post):
+        call_kwargs = mock_post.call_args
+        return call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
+
+    def test_default_topic_is_general(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"results": []}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("tools.web_tools._get_backend", return_value="tavily"), \
+             patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test"}), \
+             patch("tools.web_tools.httpx.post", return_value=mock_response) as mock_post, \
+             patch("tools.interrupt.is_interrupted", return_value=False):
+            from tools.web_tools import web_search_tool
+            web_search_tool("anything")
+            payload = self._post_payload(mock_post)
+            assert payload["topic"] == "general"
+            assert "days" not in payload
+
+    def test_news_topic_with_days_threads_through(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"results": []}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("tools.web_tools._get_backend", return_value="tavily"), \
+             patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test"}), \
+             patch("tools.web_tools.httpx.post", return_value=mock_response) as mock_post, \
+             patch("tools.interrupt.is_interrupted", return_value=False):
+            from tools.web_tools import web_search_tool
+            web_search_tool("breaking story", topic="news", days=3)
+            payload = self._post_payload(mock_post)
+            assert payload["topic"] == "news"
+            assert payload["days"] == 3
+
+    def test_days_dropped_when_topic_is_general(self):
+        """days only meaningful for news; payload should not carry it otherwise."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"results": []}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("tools.web_tools._get_backend", return_value="tavily"), \
+             patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test"}), \
+             patch("tools.web_tools.httpx.post", return_value=mock_response) as mock_post, \
+             patch("tools.interrupt.is_interrupted", return_value=False):
+            from tools.web_tools import web_search_tool
+            web_search_tool("evergreen topic", topic="general", days=7)
+            payload = self._post_payload(mock_post)
+            assert payload["topic"] == "general"
+            assert "days" not in payload
+
+    def test_invalid_topic_rejected(self):
+        from tools.web_tools import web_search_tool
+        result = json.loads(web_search_tool("q", topic="research"))
+        assert result["success"] is False
+        assert "Invalid topic" in result.get("error", "")
+
+    def test_invalid_days_rejected(self):
+        from tools.web_tools import web_search_tool
+        result = json.loads(web_search_tool("q", topic="news", days=0))
+        assert result["success"] is False
+        assert "days" in result.get("error", "")
+
+        result = json.loads(web_search_tool("q", topic="news", days="abc"))
+        assert result["success"] is False
+        assert "days" in result.get("error", "")
+
+    def test_news_without_days_omits_days(self):
+        """topic='news' with no days set should still hit Tavily without injecting days."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"results": []}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("tools.web_tools._get_backend", return_value="tavily"), \
+             patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test"}), \
+             patch("tools.web_tools.httpx.post", return_value=mock_response) as mock_post, \
+             patch("tools.interrupt.is_interrupted", return_value=False):
+            from tools.web_tools import web_search_tool
+            web_search_tool("recent news", topic="news")
+            payload = self._post_payload(mock_post)
+            assert payload["topic"] == "news"
+            assert "days" not in payload
+
+
+class TestWebSearchSchema:
+    def test_schema_exposes_topic_and_days(self):
+        from tools.web_tools import WEB_SEARCH_SCHEMA
+        props = WEB_SEARCH_SCHEMA["parameters"]["properties"]
+        assert "topic" in props
+        assert props["topic"]["enum"] == ["general", "news"]
+        assert "days" in props
+        assert props["days"]["type"] == "integer"
+        # Neither should be required — backwards-compatible.
+        assert WEB_SEARCH_SCHEMA["parameters"]["required"] == ["query"]
+
+
 # ─── web_extract_tool (Tavily dispatch) ───────────────────────────────────────
 
 class TestWebExtractTavily:

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -1032,7 +1032,15 @@ async def _parallel_extract(urls: List[str]) -> List[Dict[str, Any]]:
     return results
 
 
-def web_search_tool(query: str, limit: int = 5) -> str:
+_TAVILY_VALID_TOPICS = ("general", "news")
+
+
+def web_search_tool(
+    query: str,
+    limit: int = 5,
+    topic: str = "general",
+    days: Optional[int] = None,
+) -> str:
     """
     Search the web for information using available search API backend.
 
@@ -1041,11 +1049,16 @@ def web_search_tool(query: str, limit: int = 5) -> str:
 
     Note: This function returns search result metadata only (URLs, titles, descriptions).
     Use web_extract_tool to get full content from specific URLs.
-    
+
     Args:
         query (str): The search query to look up
         limit (int): Maximum number of results to return (default: 5)
-    
+        topic (str): Search topic — ``"general"`` (default) or ``"news"``.
+                     Only honoured by the Tavily backend; ignored by others.
+        days (Optional[int]): When ``topic="news"``, restrict results to the
+                              last N days. Tavily-only.  Ignored when unset
+                              or when ``topic != "news"``.
+
     Returns:
         str: JSON string containing search results with the following structure:
              {
@@ -1062,21 +1075,42 @@ def web_search_tool(query: str, limit: int = 5) -> str:
                      ]
                  }
              }
-    
+
     Raises:
         Exception: If search fails or API key is not set
     """
+    if topic not in _TAVILY_VALID_TOPICS:
+        return tool_error(
+            f"Invalid topic '{topic}'. Must be one of: {', '.join(_TAVILY_VALID_TOPICS)}.",
+            success=False,
+        )
+    if days is not None:
+        try:
+            days = int(days)
+        except (TypeError, ValueError):
+            return tool_error(
+                f"Invalid days value '{days}'. Must be a positive integer.",
+                success=False,
+            )
+        if days <= 0:
+            return tool_error(
+                f"days must be a positive integer (got {days}).",
+                success=False,
+            )
+
     debug_call_data = {
         "parameters": {
             "query": query,
-            "limit": limit
+            "limit": limit,
+            "topic": topic,
+            "days": days,
         },
         "error": None,
         "results_count": 0,
         "original_response_size": 0,
         "final_response_size": 0
     }
-    
+
     try:
         from tools.interrupt import is_interrupted
         if is_interrupted():
@@ -1103,13 +1137,21 @@ def web_search_tool(query: str, limit: int = 5) -> str:
             return result_json
 
         if backend == "tavily":
-            logger.info("Tavily search: '%s' (limit: %d)", query, limit)
-            raw = _tavily_request("search", {
+            payload = {
                 "query": query,
                 "max_results": min(limit, 20),
                 "include_raw_content": False,
                 "include_images": False,
-            })
+                "topic": topic,
+            }
+            if topic == "news" and days is not None:
+                payload["days"] = days
+            logger.info(
+                "Tavily search: '%s' (limit: %d, topic: %s%s)",
+                query, limit, topic,
+                f", days: {days}" if (topic == "news" and days is not None) else "",
+            )
+            raw = _tavily_request("search", payload)
             response_data = _normalize_tavily_search_results(raw)
             debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
             result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
@@ -2054,6 +2096,16 @@ WEB_SEARCH_SCHEMA = {
             "query": {
                 "type": "string",
                 "description": "The search query to look up on the web"
+            },
+            "topic": {
+                "type": "string",
+                "enum": ["general", "news"],
+                "description": "Search topic. Use 'news' for time-sensitive queries (briefings, current events) — pairs with 'days' to bound recency. Defaults to 'general'. Tavily-only; ignored on other backends."
+            },
+            "days": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "When topic='news', restrict results to the last N days. Tavily-only; ignored when topic='general'."
             }
         },
         "required": ["query"]
@@ -2081,7 +2133,12 @@ registry.register(
     name="web_search",
     toolset="web",
     schema=WEB_SEARCH_SCHEMA,
-    handler=lambda args, **kw: web_search_tool(args.get("query", ""), limit=5),
+    handler=lambda args, **kw: web_search_tool(
+        args.get("query", ""),
+        limit=5,
+        topic=args.get("topic", "general"),
+        days=args.get("days"),
+    ),
     check_fn=check_web_api_key,
     requires_env=_web_requires_env(),
     emoji="🔍",


### PR DESCRIPTION
## Summary

Closes #16233. Adds `topic` (`general` | `news`) and `days` parameters to `web_search_tool`, threading them through to the Tavily search payload, and surfaces them in `WEB_SEARCH_SCHEMA` so the agent sees them as planning parameters.

Briefing agents previously appended `"news"` / `"today"` to the query string for time-sensitive workflows — worked inconsistently and was invisible to the LLM as a structured choice.

## Changes

- `tools/web_tools.py`
  - `web_search_tool(query, limit, topic="general", days=None)` — new optional params
  - Validates `topic` against `{general, news}`; rejects non-positive / non-numeric `days`
  - When `topic="news"` and `days` is set, both flow into the Tavily payload
  - When `topic="general"`, `days` is dropped (Tavily ignores it there anyway)
  - Other backends (Parallel, Exa, Firecrawl) ignore the new params — backwards compatible
  - `WEB_SEARCH_SCHEMA` exposes both to the LLM with usage hints
- `tests/tools/test_web_tools_tavily.py` — 7 new tests:
  - Default `topic` is `general`, no `days` in payload
  - `topic="news"` + `days=3` flows to payload
  - `days` dropped when `topic="general"`
  - Invalid `topic` rejected with clear error
  - Invalid `days` (`0`, `"abc"`) rejected
  - `topic="news"` without `days` still hits Tavily
  - Schema sanity check (enum, types, `query`-only required)

## Test plan

- [x] `pytest tests/tools/test_web_tools_tavily.py` — 22 passed locally
- [x] Backwards compat — existing single-arg `web_search_tool("query")` calls and the schema's `required: ["query"]` unchanged