### PR TITLE
feat(api-server): honor X-Router-Model for per-request model override

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -579,6 +579,17 @@ class APIServerAdapter(BasePlatformAdapter):
         self._model_name: str = self._resolve_model_name(
             extra.get("model_name", os.getenv("API_SERVER_MODEL_NAME", "")),
         )
+        # Opt-in per-request model override (issue #16216).  When enabled,
+        # callers can route a single request to a non-default model via the
+        # ``X-Router-Model`` header or ``metadata.override_model`` in the body.
+        # Useful for external routing layers that classify requests (cost/
+        # quality tiers) before handing them to Hermes.  Defaults off.
+        self._allow_model_override: bool = bool(
+            extra.get(
+                "allow_model_override",
+                os.getenv("API_SERVER_ALLOW_MODEL_OVERRIDE", "").lower() in ("1", "true", "yes"),
+            )
+        )
         self._app: Optional["web.Application"] = None
         self._runner: Optional["web.AppRunner"] = None
         self._site: Optional["web.TCPSite"] = None
@@ -606,6 +617,64 @@ class APIServerAdapter(BasePlatformAdapter):
             items = [str(value)]
 
         return tuple(str(item).strip() for item in items if str(item).strip())
+
+    # Cap on the length of a per-request model override, large enough for
+    # ``provider/model`` shapes but small enough to reject obvious abuse.
+    _MAX_OVERRIDE_LEN = 256
+    _OVERRIDE_INVALID_CHARS = re.compile(r"[\r\n\x00]")
+
+    def _resolve_request_model_override(
+        self,
+        request: "web.Request",
+        body: Optional[Dict[str, Any]],
+    ) -> Optional[str]:
+        """Pick a per-request model override from header / body, if allowed.
+
+        Lookup order (first non-empty wins):
+          1. ``X-Router-Model`` HTTP header.
+          2. ``metadata.override_model`` in the JSON body.
+
+        Returns ``None`` when the feature is disabled, the override is empty,
+        contains control characters, exceeds ``_MAX_OVERRIDE_LEN``, or matches
+        the advertised default (no-op).  ``body.model`` is intentionally
+        *not* used as a fallback — many OpenAI clients send the advertised
+        ``hermes-agent`` model id verbatim, so reading from there would
+        produce false positives.  Routing layers that want a per-request
+        override must opt in via the dedicated header / metadata field.
+        """
+        if not self._allow_model_override:
+            return None
+
+        candidate = (request.headers.get("X-Router-Model") or "").strip()
+        if not candidate and isinstance(body, dict):
+            meta = body.get("metadata")
+            if isinstance(meta, dict):
+                raw = meta.get("override_model")
+                if isinstance(raw, str):
+                    candidate = raw.strip()
+
+        if not candidate:
+            return None
+        if len(candidate) > self._MAX_OVERRIDE_LEN:
+            logger.warning(
+                "Per-request model override rejected: exceeds %d chars",
+                self._MAX_OVERRIDE_LEN,
+            )
+            return None
+        if self._OVERRIDE_INVALID_CHARS.search(candidate):
+            logger.warning(
+                "Per-request model override rejected: control characters present",
+            )
+            return None
+        if candidate == self._model_name:
+            # Caller asked for the advertised default — same as no override.
+            return None
+
+        logger.info(
+            "Honouring per-request model override: %s (advertised=%s)",
+            candidate, self._model_name,
+        )
+        return candidate
 
     @staticmethod
     def _resolve_model_name(explicit: str) -> str:
@@ -713,6 +782,7 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_progress_callback=None,
         tool_start_callback=None,
         tool_complete_callback=None,
+        model_override: Optional[str] = None,
     ) -> Any:
         """
         Create an AIAgent instance using the gateway's runtime config.
@@ -721,13 +791,19 @@ class APIServerAdapter(BasePlatformAdapter):
         base_url, etc. from config.yaml / env vars.  Toolsets are resolved
         from config.yaml platform_toolsets.api_server (same as all other
         gateway platforms), falling back to the hermes-api-server default.
+
+        When *model_override* is provided (issue #16216), it replaces the
+        config-resolved model for this single agent.  Provider credentials
+        are still resolved from config — the override is intended for
+        models that share the same provider routing, e.g. multiple Claude
+        SKUs on the same Anthropic key.
         """
         from run_agent import AIAgent
         from gateway.run import _resolve_runtime_agent_kwargs, _resolve_gateway_model, _load_gateway_config
         from hermes_cli.tools_config import _get_platform_tools
 
         runtime_kwargs = _resolve_runtime_agent_kwargs()
-        model = _resolve_gateway_model()
+        model = (model_override or "").strip() or _resolve_gateway_model()
 
         user_config = _load_gateway_config()
         enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
@@ -914,7 +990,11 @@ class APIServerAdapter(BasePlatformAdapter):
             # history already set from request body above
 
         completion_id = f"chatcmpl-{uuid.uuid4().hex[:29]}"
-        model_name = body.get("model", self._model_name)
+        model_override = self._resolve_request_model_override(request, body)
+        # ``model_name`` is what the OpenAI response echoes back — when an
+        # override is honoured, surface it so external routers can see which
+        # model actually served the turn.
+        model_name = model_override or body.get("model", self._model_name)
         created = int(time.time())
 
         if stream:
@@ -974,6 +1054,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 stream_delta_callback=_on_delta,
                 tool_progress_callback=_on_tool_progress,
                 agent_ref=agent_ref,
+                model_override=model_override,
             ))
 
             return await self._write_sse_chat_completion(
@@ -988,11 +1069,21 @@ class APIServerAdapter(BasePlatformAdapter):
                 conversation_history=history,
                 ephemeral_system_prompt=system_prompt,
                 session_id=session_id,
+                model_override=model_override,
             )
 
         idempotency_key = request.headers.get("Idempotency-Key")
         if idempotency_key:
-            fp = _make_request_fingerprint(body, keys=["model", "messages", "tools", "tool_choice", "stream"])
+            fp_body = dict(body)
+            if model_override:
+                # Fold the override into the fingerprint so two requests
+                # with the same Idempotency-Key but different routed models
+                # don't collide on the cached response.
+                fp_body["__override_model__"] = model_override
+            fp = _make_request_fingerprint(
+                fp_body,
+                keys=["model", "messages", "tools", "tool_choice", "stream", "__override_model__"],
+            )
             try:
                 result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_completion)
             except Exception as e:
@@ -1776,6 +1867,8 @@ class APIServerAdapter(BasePlatformAdapter):
         # groups the entire conversation under one session entry.
         session_id = stored_session_id or str(uuid.uuid4())
 
+        model_override = self._resolve_request_model_override(request, body)
+
         stream = bool(body.get("stream", False))
         if stream:
             # Streaming branch — emit OpenAI Responses SSE events as the
@@ -1828,10 +1921,11 @@ class APIServerAdapter(BasePlatformAdapter):
                 tool_start_callback=_on_tool_start,
                 tool_complete_callback=_on_tool_complete,
                 agent_ref=agent_ref,
+                model_override=model_override,
             ))
 
             response_id = f"resp_{uuid.uuid4().hex[:28]}"
-            model_name = body.get("model", self._model_name)
+            model_name = model_override or body.get("model", self._model_name)
             created_at = int(time.time())
 
             return await self._write_sse_responses(
@@ -1856,13 +1950,17 @@ class APIServerAdapter(BasePlatformAdapter):
                 conversation_history=conversation_history,
                 ephemeral_system_prompt=instructions,
                 session_id=session_id,
+                model_override=model_override,
             )
 
         idempotency_key = request.headers.get("Idempotency-Key")
         if idempotency_key:
+            fp_body = dict(body)
+            if model_override:
+                fp_body["__override_model__"] = model_override
             fp = _make_request_fingerprint(
-                body,
-                keys=["input", "instructions", "previous_response_id", "conversation", "model", "tools"],
+                fp_body,
+                keys=["input", "instructions", "previous_response_id", "conversation", "model", "tools", "__override_model__"],
             )
             try:
                 result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_response)
@@ -1908,7 +2006,7 @@ class APIServerAdapter(BasePlatformAdapter):
             "object": "response",
             "status": "completed",
             "created_at": created_at,
-            "model": body.get("model", self._model_name),
+            "model": model_override or body.get("model", self._model_name),
             "output": output_items,
             "usage": {
                 "input_tokens": usage.get("input_tokens", 0),
@@ -2252,6 +2350,7 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_start_callback=None,
         tool_complete_callback=None,
         agent_ref: Optional[list] = None,
+        model_override: Optional[str] = None,
     ) -> tuple:
         """
         Create an agent and run a conversation in a thread executor.
@@ -2274,6 +2373,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 tool_progress_callback=tool_progress_callback,
                 tool_start_callback=tool_start_callback,
                 tool_complete_callback=tool_complete_callback,
+                model_override=model_override,
             )
             if agent_ref is not None:
                 agent_ref[0] = agent

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -570,6 +570,7 @@ AUTHOR_MAP = {
     "shamork@outlook.com": "shamork",
     # April 2026 Discord Copilot /model salvage (#15030)
     "cshong2017@outlook.com": "Nicecsh",
+    "sky.cool.ezreal@gmail.com": "cola-runner",
     # no-github-match — keep as display names
     "clio-agent@sisyphuslabs.ai": "Sisyphus",
     "marco@rutimka.de": "Marco Rutsch",

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -290,6 +290,211 @@ class TestAuth:
 
 
 # ---------------------------------------------------------------------------
+# Per-request model override (issue #16216)
+# ---------------------------------------------------------------------------
+
+
+def _request_with_headers(headers: dict) -> MagicMock:
+    req = MagicMock()
+    req.headers = headers
+    return req
+
+
+class TestRequestModelOverride:
+    """``_resolve_request_model_override`` — opt-in routing of a single
+    request to a non-default model via header or body metadata."""
+
+    def test_disabled_by_default_returns_none(self):
+        config = PlatformConfig(enabled=True)
+        adapter = APIServerAdapter(config)
+        req = _request_with_headers({"X-Router-Model": "anthropic/claude-haiku-4-5"})
+        assert adapter._resolve_request_model_override(req, {}) is None
+
+    def test_enabled_via_extra_picks_up_header(self):
+        config = PlatformConfig(enabled=True, extra={"allow_model_override": True})
+        adapter = APIServerAdapter(config)
+        req = _request_with_headers({"X-Router-Model": "anthropic/claude-haiku-4-5"})
+        assert (
+            adapter._resolve_request_model_override(req, {})
+            == "anthropic/claude-haiku-4-5"
+        )
+
+    def test_enabled_via_env(self, monkeypatch):
+        monkeypatch.setenv("API_SERVER_ALLOW_MODEL_OVERRIDE", "true")
+        config = PlatformConfig(enabled=True)
+        adapter = APIServerAdapter(config)
+        req = _request_with_headers({"X-Router-Model": "openrouter/sonnet-4"})
+        assert (
+            adapter._resolve_request_model_override(req, {})
+            == "openrouter/sonnet-4"
+        )
+
+    def test_body_metadata_fallback(self):
+        config = PlatformConfig(enabled=True, extra={"allow_model_override": True})
+        adapter = APIServerAdapter(config)
+        req = _request_with_headers({})
+        body = {"metadata": {"override_model": "anthropic/opus-4-7"}}
+        assert (
+            adapter._resolve_request_model_override(req, body)
+            == "anthropic/opus-4-7"
+        )
+
+    def test_header_takes_precedence_over_body(self):
+        config = PlatformConfig(enabled=True, extra={"allow_model_override": True})
+        adapter = APIServerAdapter(config)
+        req = _request_with_headers({"X-Router-Model": "from-header"})
+        body = {"metadata": {"override_model": "from-body"}}
+        assert adapter._resolve_request_model_override(req, body) == "from-header"
+
+    def test_empty_string_treated_as_unset(self):
+        config = PlatformConfig(enabled=True, extra={"allow_model_override": True})
+        adapter = APIServerAdapter(config)
+        req = _request_with_headers({"X-Router-Model": "   "})
+        body = {"metadata": {"override_model": ""}}
+        assert adapter._resolve_request_model_override(req, body) is None
+
+    def test_advertised_model_treated_as_no_override(self):
+        config = PlatformConfig(
+            enabled=True,
+            extra={"allow_model_override": True, "model_name": "hermes-fast"},
+        )
+        adapter = APIServerAdapter(config)
+        req = _request_with_headers({"X-Router-Model": "hermes-fast"})
+        # Caller is asking for the advertised default — same as no override.
+        assert adapter._resolve_request_model_override(req, {}) is None
+
+    def test_oversized_value_rejected(self):
+        config = PlatformConfig(enabled=True, extra={"allow_model_override": True})
+        adapter = APIServerAdapter(config)
+        req = _request_with_headers({"X-Router-Model": "a" * 257})
+        assert adapter._resolve_request_model_override(req, {}) is None
+
+    def test_control_chars_rejected(self):
+        """CR/LF/NUL must not slip through (header-injection guard)."""
+        config = PlatformConfig(enabled=True, extra={"allow_model_override": True})
+        adapter = APIServerAdapter(config)
+        for bad in ("evil\r\nX-Other: 1", "model\nbad", "with\x00null"):
+            req = _request_with_headers({"X-Router-Model": bad})
+            assert adapter._resolve_request_model_override(req, {}) is None, bad
+
+    def test_non_string_metadata_ignored(self):
+        config = PlatformConfig(enabled=True, extra={"allow_model_override": True})
+        adapter = APIServerAdapter(config)
+        req = _request_with_headers({})
+        body = {"metadata": {"override_model": 42}}  # numeric value, not a string
+        assert adapter._resolve_request_model_override(req, body) is None
+
+    def test_metadata_not_a_dict_ignored(self):
+        config = PlatformConfig(enabled=True, extra={"allow_model_override": True})
+        adapter = APIServerAdapter(config)
+        req = _request_with_headers({})
+        for bad_meta in ("scalar", ["list"], 123):
+            body = {"metadata": bad_meta}
+            assert adapter._resolve_request_model_override(req, body) is None
+
+
+class TestCreateAgentWithOverride:
+    """``_create_agent`` routes to ``model_override`` when provided."""
+
+    def test_override_replaces_resolved_model(self):
+        config = PlatformConfig(enabled=True, extra={"allow_model_override": True})
+        adapter = APIServerAdapter(config)
+
+        captured = {}
+
+        def fake_aiagent(**kwargs):
+            captured.update(kwargs)
+            return MagicMock()
+
+        with patch("run_agent.AIAgent", side_effect=fake_aiagent), \
+             patch(
+                 "gateway.run._resolve_runtime_agent_kwargs",
+                 return_value={"api_key": "k", "base_url": "u", "provider": "p"},
+             ), \
+             patch(
+                 "gateway.run._resolve_gateway_model",
+                 return_value="default-model",
+             ), \
+             patch("gateway.run._load_gateway_config", return_value={}), \
+             patch(
+                 "hermes_cli.tools_config._get_platform_tools",
+                 return_value=set(),
+             ), \
+             patch(
+                 "gateway.run.GatewayRunner._load_fallback_model",
+                 return_value=None,
+             ):
+            adapter._create_agent(model_override="anthropic/haiku")
+
+        assert captured["model"] == "anthropic/haiku"
+
+    def test_no_override_uses_default(self):
+        config = PlatformConfig(enabled=True)
+        adapter = APIServerAdapter(config)
+
+        captured = {}
+
+        def fake_aiagent(**kwargs):
+            captured.update(kwargs)
+            return MagicMock()
+
+        with patch("run_agent.AIAgent", side_effect=fake_aiagent), \
+             patch(
+                 "gateway.run._resolve_runtime_agent_kwargs",
+                 return_value={"api_key": "k", "base_url": "u", "provider": "p"},
+             ), \
+             patch(
+                 "gateway.run._resolve_gateway_model",
+                 return_value="default-model",
+             ), \
+             patch("gateway.run._load_gateway_config", return_value={}), \
+             patch(
+                 "hermes_cli.tools_config._get_platform_tools",
+                 return_value=set(),
+             ), \
+             patch(
+                 "gateway.run.GatewayRunner._load_fallback_model",
+                 return_value=None,
+             ):
+            adapter._create_agent()
+
+        assert captured["model"] == "default-model"
+
+    def test_blank_override_falls_through_to_default(self):
+        """An empty / whitespace override must NOT clobber the resolved model."""
+        config = PlatformConfig(enabled=True)
+        adapter = APIServerAdapter(config)
+
+        captured = {}
+
+        def fake_aiagent(**kwargs):
+            captured.update(kwargs)
+            return MagicMock()
+
+        with patch("run_agent.AIAgent", side_effect=fake_aiagent), \
+             patch(
+                 "gateway.run._resolve_runtime_agent_kwargs",
+                 return_value={"api_key": "k", "base_url": "u", "provider": "p"},
+             ), \
+             patch(
+                 "gateway.run._resolve_gateway_model",
+                 return_value="default-model",
+             ), \
+             patch("gateway.run._load_gateway_config", return_value={}), \
+             patch(
+                 "hermes_cli.tools_config._get_platform_tools",
+                 return_value=set(),
+             ), \
+             patch(
+                 "gateway.run.GatewayRunner._load_fallback_model",
+                 return_value=None,
+             ):
+            adapter._create_agent(model_override="   ")
+
+        assert captured["model"] == "default-model"
+
+
+# ---------------------------------------------------------------------------
 # Helpers for HTTP tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Closes #16216. Adds an opt-in per-request model override for the OpenAI-compatible API server adapter.

External routing layers (cost-tier dashboards, complexity classifiers, quality routers) couldn't pin a single `/v1/chat/completions` or `/v1/responses` request to a non-default model. `body.model` was echoed back in the response payload but ignored for inference — every turn used \`config.yaml\` defaults regardless of what the caller sent.

## Behavior

- **Off by default** — preserves current behavior.
- **Enable** with either:
  ```yaml
  platforms:
    api_server:
      enabled: true
      extra:
        allow_model_override: true
  ```
  or env var: `API_SERVER_ALLOW_MODEL_OVERRIDE=1`.
- **Lookup order**: `X-Router-Model` header → `body.metadata.override_model`. `body.model` is intentionally *not* a fallback (OpenAI clients send the advertised model id verbatim, which would produce false positives).
- **Provider credentials still resolve from config** — the override is intended for SKUs sharing the same provider routing (e.g., multiple Claude models on the same Anthropic key, or `<provider>/<model>` style strings the agent already routes natively).
- **Idempotency-Key fingerprints** fold in the override so two requests with the same key but different routed models don't collide on the cached response.
- **Response echo**: the OpenAI response payload's `model` field reflects the actually routed model, so callers can verify which one served the turn.

## Defensive validation

- Empty / whitespace → no-op
- Length > 256 chars → rejected (logged warning)
- Any CR / LF / NUL → rejected (header-injection guard)
- Override equal to advertised model → treated as no-op
- `metadata.override_model` non-string or `metadata` non-dict → ignored

## Files

- `gateway/platforms/api_server.py` — new `_resolve_request_model_override` helper, plumbed through `_run_agent` and `_create_agent`. Both chat-completions and responses paths (streaming + non-streaming + idempotent) honor the override.
- `tests/gateway/test_api_server.py` — 14 new tests:
  - `TestRequestModelOverride` — disabled by default, header / body / env enable paths, header-precedence, advertised-default no-op, length cap, control-char guard, type guards
  - `TestCreateAgentWithOverride` — override threads to `AIAgent(model=…)`, blank override falls through to default

## Test plan

- [x] `pytest tests/gateway/test_api_server.py` — 133 passed locally (was 119; +14 new)
- [x] No behaviour change when feature is off (default)
- [x] Backwards compatible — existing handlers, schemas, idempotency keys all unchanged