### PR TITLE
fix: bridge channel_prompts from telegram config section to platform extra

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -722,6 +722,20 @@ def load_gateway_config() -> GatewayConfig:
                         extra = {}
                         plat_data["extra"] = extra
                     extra["disable_link_previews"] = telegram_cfg["disable_link_previews"]
+                if "channel_prompts" in telegram_cfg:
+                    plat_data = platforms_data.setdefault(Platform.TELEGRAM.value, {})
+                    if not isinstance(plat_data, dict):
+                        plat_data = {}
+                        platforms_data[Platform.TELEGRAM.value] = plat_data
+                    extra = plat_data.setdefault("extra", {})
+                    if not isinstance(extra, dict):
+                        extra = {}
+                        plat_data["extra"] = extra
+                    channel_prompts = telegram_cfg["channel_prompts"]
+                    if isinstance(channel_prompts, dict):
+                        extra["channel_prompts"] = {str(k): v for k, v in channel_prompts.items()}
+                    else:
+                        extra["channel_prompts"] = channel_prompts
 
             whatsapp_cfg = yaml_cfg.get("whatsapp", {})
             if isinstance(whatsapp_cfg, dict):


### PR DESCRIPTION
## Problem

When users configure `channel_prompts` under the `telegram` section of `config.yaml`:

```yaml
telegram:
  channel_prompts:
    '2': 'You are SRE Commander, an expert Site Reliability Engineer...'
    '3': 'You are IT Support Commander...'
    '6': 'You are SecOps Commander...'
```

The per-topic personas are silently ignored — all Telegram group topics respond with the same generic persona regardless of `thread_id`.

## Root Cause

In `gateway/config.py`, the Telegram-specific loading block (line ~690) reads settings from `yaml_cfg.get('telegram')` and forwards them into `config.platforms[telegram].extra` or environment variables. However, `channel_prompts` was **not included** in this block.

The generic bridging loop above it handles `channel_prompts` for Discord and Slack, but Telegram has its own separate block and was missed.

As a result, `resolve_channel_prompt()` in `gateway/platforms/base.py` receives an empty `config.extra` dict and always returns `None`, so all topics share the same persona.

## Fix

Add `channel_prompts` handling to the Telegram-specific config block, mirroring the existing pattern used for `disable_link_previews` and the Discord/Slack bridging loop.

## Testing

The existing test `TestLoadGatewayConfig::test_bridges_telegram_channel_prompts_from_config_yaml` in `tests/gateway/test_config.py` covers this exact scenario and now passes.