### PR TITLE
fix(auxiliary): include model in client cache key

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2358,6 +2358,7 @@ _CLIENT_CACHE_MAX_SIZE = 64  # safety belt — evict oldest when exceeded
 def _client_cache_key(
     provider: str,
     *,
+    model: Optional[str] = None,
     async_mode: bool,
     base_url: Optional[str] = None,
     api_key: Optional[str] = None,
@@ -2366,7 +2367,7 @@ def _client_cache_key(
 ) -> tuple:
     runtime = _normalize_main_runtime(main_runtime)
     runtime_key = tuple(runtime.get(field, "") for field in _MAIN_RUNTIME_FIELDS) if provider == "auto" else ()
-    return (provider, async_mode, base_url or "", api_key or "", api_mode or "", runtime_key)
+    return (provider, model or "", async_mode, base_url or "", api_key or "", api_mode or "", runtime_key)
 
 
 def _store_cached_client(cache_key: tuple, client: Any, default_model: Optional[str], *, bound_loop: Any = None) -> None:
@@ -2415,6 +2416,7 @@ def _refresh_nous_auxiliary_client(
 
     cache_key = _client_cache_key(
         cache_provider,
+        model=model,
         async_mode=async_mode,
         base_url=base_url,
         api_key=api_key,
@@ -2580,6 +2582,7 @@ def _get_cached_client(
     runtime = _normalize_main_runtime(main_runtime)
     cache_key = _client_cache_key(
         provider,
+        model=model,
         async_mode=async_mode,
         base_url=base_url,
         api_key=api_key,

--- a/tests/agent/test_auxiliary_cache_key_model.py
+++ b/tests/agent/test_auxiliary_cache_key_model.py
@@ -1,0 +1,68 @@
+"""Regression test: auxiliary client cache key includes model.
+
+When multiple auxiliary tasks (vision, compression, title_generation) share
+the same provider but specify different models, each task should receive its
+own model — not whichever model warmed the cache first.
+
+Refs #16387, #14249.
+"""
+
+from __future__ import annotations
+
+from agent.auxiliary_client import _client_cache_key
+
+
+class TestClientCacheKeyIncludesModel:
+    """_client_cache_key() must include model so different models get
+    distinct cache entries even when provider/base_url/api_key match."""
+
+    def test_different_models_produce_different_keys(self) -> None:
+        key_a = _client_cache_key(
+            "myrelay",
+            model="google/gemini-3.1-flash-image-preview",
+            async_mode=False,
+            base_url="https://example.test/v1",
+            api_key="sk-test",
+            api_mode="chat_completions",
+        )
+        key_b = _client_cache_key(
+            "myrelay",
+            model="google/gemini-3-flash-preview",
+            async_mode=False,
+            base_url="https://example.test/v1",
+            api_key="sk-test",
+            api_mode="chat_completions",
+        )
+        assert key_a != key_b, (
+            "Different models must produce different cache keys"
+        )
+
+    def test_same_model_produces_same_key(self) -> None:
+        kwargs = dict(
+            provider="myrelay",
+            model="google/gemini-3.1-flash-image-preview",
+            async_mode=False,
+            base_url="https://example.test/v1",
+            api_key="sk-test",
+            api_mode="chat_completions",
+        )
+        assert _client_cache_key(**kwargs) == _client_cache_key(**kwargs)
+
+    def test_none_model_equals_empty_string(self) -> None:
+        key_none = _client_cache_key(
+            "p", model=None, async_mode=False,
+        )
+        key_empty = _client_cache_key(
+            "p", model="", async_mode=False,
+        )
+        assert key_none == key_empty
+
+    def test_model_independent_of_provider(self) -> None:
+        """Same model on different providers still yields different keys."""
+        key_a = _client_cache_key(
+            "provider-a", model="mymodel", async_mode=False,
+        )
+        key_b = _client_cache_key(
+            "provider-b", model="mymodel", async_mode=False,
+        )
+        assert key_a != key_b


### PR DESCRIPTION
## Problem

`agent/auxiliary_client._client_cache_key()` omits `model` from the cache key. When multiple auxiliary tasks (vision, compression, title_generation) share the same provider but specify different models, all tasks receive whichever model first warmed the cache.

**Reproduction** (from #16387):
```yaml
auxiliary:
  vision:
    provider: myrelay
    model: google/gemini-3.1-flash-image-preview
  compression:
    provider: myrelay
    model: google/gemini-3-flash-preview
  title_generation:
    provider: myrelay
    model: google/gemini-3.1-flash-lite-preview
```

After vision warms the cache, compression and title_generation also use `flash-image-preview`.

## Fix

Add `model` to the cache key tuple so each unique `(provider, model, ...)` combination gets its own cache entry.

**Before:** `(provider, async_mode, base_url, api_key, api_mode, runtime_key)`
**After:** `(provider, model, async_mode, base_url, api_key, api_mode, runtime_key)`

## Tests

New regression test in `tests/agent/test_auxiliary_cache_key_model.py`:
- Different models produce different cache keys
- Same model produces same key
- None model equals empty string
- Model is independent of provider

Fixes #16387
Fixes #14249
