### PR TITLE
Scope session_search to the active gateway user

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -803,6 +803,7 @@ class SessionDB:
     def list_sessions_rich(
         self,
         source: str = None,
+        user_id_filter: str = None,
         exclude_sources: List[str] = None,
         limit: int = 20,
         offset: int = 0,
@@ -848,6 +849,9 @@ class SessionDB:
         if source:
             where_clauses.append("s.source = ?")
             params.append(source)
+        if user_id_filter:
+            where_clauses.append("s.user_id = ?")
+            params.append(user_id_filter)
         if exclude_sources:
             placeholders = ",".join("?" for _ in exclude_sources)
             where_clauses.append(f"s.source NOT IN ({placeholders})")
@@ -1310,6 +1314,7 @@ class SessionDB:
         self,
         query: str,
         source_filter: List[str] = None,
+        user_id_filter: str = None,
         exclude_sources: List[str] = None,
         role_filter: List[str] = None,
         limit: int = 20,
@@ -1342,6 +1347,9 @@ class SessionDB:
             source_placeholders = ",".join("?" for _ in source_filter)
             where_clauses.append(f"s.source IN ({source_placeholders})")
             params.extend(source_filter)
+        if user_id_filter:
+            where_clauses.append("s.user_id = ?")
+            params.append(user_id_filter)
 
         if exclude_sources is not None:
             exclude_placeholders = ",".join("?" for _ in exclude_sources)
@@ -1397,6 +1405,9 @@ class SessionDB:
             if source_filter is not None:
                 like_where.append(f"s.source IN ({','.join('?' for _ in source_filter)})")
                 like_params.extend(source_filter)
+            if user_id_filter:
+                like_where.append("s.user_id = ?")
+                like_params.append(user_id_filter)
             if exclude_sources is not None:
                 like_where.append(f"s.source NOT IN ({','.join('?' for _ in exclude_sources)})")
                 like_params.extend(exclude_sources)

--- a/run_agent.py
+++ b/run_agent.py
@@ -8289,6 +8289,8 @@ class AIAgent:
                 limit=function_args.get("limit", 3),
                 db=self._session_db,
                 current_session_id=self.session_id,
+                current_source=self.platform if self._user_id and self.platform else None,
+                current_user_id=self._user_id,
             )
         elif function_name == "memory":
             target = function_args.get("target", "memory")
@@ -8801,6 +8803,8 @@ class AIAgent:
                         limit=function_args.get("limit", 3),
                         db=self._session_db,
                         current_session_id=self.session_id,
+                        current_source=self.platform if self._user_id and self.platform else None,
+                        current_user_id=self._user_id,
                     )
                 tool_duration = time.time() - tool_start_time
                 if self._should_emit_quiet_tool_messages():

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -435,6 +435,17 @@ class TestFTS5Search:
         sources = [r["source"] for r in results]
         assert all(s == "telegram" for s in sources)
 
+    def test_search_with_user_id_filter(self, db):
+        db.create_session(session_id="s1", source="telegram", user_id="user-a")
+        db.append_message("s1", role="user", content="Python question from user A")
+
+        db.create_session(session_id="s2", source="telegram", user_id="user-b")
+        db.append_message("s2", role="user", content="Python question from user B")
+
+        results = db.search_messages("Python", user_id_filter="user-a")
+        session_ids = {r["session_id"] for r in results}
+        assert session_ids == {"s1"}
+
     def test_search_default_sources_include_acp(self, db):
         db.create_session(session_id="s1", source="acp")
         db.append_message("s1", role="user", content="ACP question about Python")
@@ -1506,6 +1517,12 @@ class TestListSessionsRich:
         sessions = db.list_sessions_rich(source="cli")
         assert len(sessions) == 1
         assert sessions[0]["id"] == "s1"
+
+    def test_rich_list_user_id_filter(self, db):
+        db.create_session("s1", "telegram", user_id="user-a")
+        db.create_session("s2", "telegram", user_id="user-b")
+        sessions = db.list_sessions_rich(source="telegram", user_id_filter="user-a")
+        assert [session["id"] for session in sessions] == ["s1"]
 
     def test_preview_newlines_collapsed(self, db):
         db.create_session("s1", "cli")

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -242,6 +242,26 @@ class TestSessionSearchConcurrency:
 
 
 class TestRecentSessionListing:
+    def test_recent_sessions_are_scoped_to_active_gateway_user(self):
+        from unittest.mock import MagicMock
+
+        mock_db = MagicMock()
+        mock_db.list_sessions_rich.return_value = []
+
+        json.loads(_list_recent_sessions(
+            mock_db,
+            limit=5,
+            current_source="telegram",
+            current_user_id="user-a",
+        ))
+
+        mock_db.list_sessions_rich.assert_called_once_with(
+            source="telegram",
+            user_id_filter="user-a",
+            limit=10,
+            exclude_sources=list(_HIDDEN_SESSION_SOURCES),
+        )
+
     def test_current_child_session_excludes_root_lineage_even_when_child_id_is_longer(self):
         from unittest.mock import MagicMock
 
@@ -333,6 +353,31 @@ class TestSessionSearch:
         assert result["success"] is True
         assert result["count"] == 0
         assert result["results"] == []
+
+    def test_gateway_search_scopes_results_to_active_user(self):
+        from unittest.mock import MagicMock
+        from tools.session_search_tool import session_search
+
+        mock_db = MagicMock()
+        mock_db.search_messages.return_value = []
+
+        result = json.loads(session_search(
+            query="deploy",
+            db=mock_db,
+            current_source="telegram",
+            current_user_id="user-a",
+        ))
+
+        assert result["success"] is True
+        mock_db.search_messages.assert_called_once_with(
+            query="deploy",
+            source_filter=["telegram"],
+            user_id_filter="user-a",
+            role_filter=None,
+            exclude_sources=list(_HIDDEN_SESSION_SOURCES),
+            limit=50,
+            offset=0,
+        )
 
     def test_current_session_excluded_keeps_others(self):
         """Other sessions should still be returned when current is excluded."""

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -263,10 +263,21 @@ async def _summarize_session(
 _HIDDEN_SESSION_SOURCES = ("tool",)
 
 
-def _list_recent_sessions(db, limit: int, current_session_id: str = None) -> str:
+def _list_recent_sessions(
+    db,
+    limit: int,
+    current_session_id: str = None,
+    current_source: str = None,
+    current_user_id: str = None,
+) -> str:
     """Return metadata for the most recent sessions (no LLM calls)."""
     try:
-        sessions = db.list_sessions_rich(limit=limit + 5, exclude_sources=list(_HIDDEN_SESSION_SOURCES))  # fetch extra to skip current
+        sessions = db.list_sessions_rich(
+            source=current_source,
+            user_id_filter=current_user_id,
+            limit=limit + 5,
+            exclude_sources=list(_HIDDEN_SESSION_SOURCES),
+        )  # fetch extra to skip current
 
         # Resolve current session lineage to exclude it
         current_root = None
@@ -322,6 +333,8 @@ def session_search(
     limit: int = 3,
     db=None,
     current_session_id: str = None,
+    current_source: str = None,
+    current_user_id: str = None,
 ) -> str:
     """
     Search past sessions and return focused summaries of matching conversations.
@@ -345,7 +358,13 @@ def session_search(
     # Recent sessions mode: when query is empty, return metadata for recent sessions.
     # No LLM calls — just DB queries for titles, previews, timestamps.
     if not query or not query.strip():
-        return _list_recent_sessions(db, limit, current_session_id)
+        return _list_recent_sessions(
+            db,
+            limit,
+            current_session_id,
+            current_source=current_source,
+            current_user_id=current_user_id,
+        )
 
     query = query.strip()
 
@@ -358,6 +377,8 @@ def session_search(
         # FTS5 search -- get matches ranked by relevance
         raw_results = db.search_messages(
             query=query,
+            source_filter=[current_source] if current_source else None,
+            user_id_filter=current_user_id,
             role_filter=role_list,
             exclude_sources=list(_HIDDEN_SESSION_SOURCES),
             limit=50,  # Get more matches to find unique sessions


### PR DESCRIPTION
## Summary

`session_search` was not respecting gateway user ownership on shared platforms.

In gateway sessions, both empty-query "recent sessions" mode and keyword search
could read from the full session store instead of being limited to the active
user's sessions. This patch scopes those queries to the current gateway
`user_id` and platform source.

CLI behavior is unchanged.

## What changed

- added optional `user_id_filter` support to `SessionDB.list_sessions_rich()`
- added optional `user_id_filter` support to `SessionDB.search_messages()`
- applied the same filter in the CJK/LIKE fallback path
- passed `current_source` and `current_user_id` from `AIAgent` into `session_search`
- scoped both recent-session listing and keyword search in `session_search_tool`

## Why this fix belongs here

Shared gateway platforms already persist per-user session ownership in the
session DB. `session_search` was one of the remaining call paths that did not
use that ownership metadata, which allowed cross-user session discovery in
shared environments.

This keeps the fix narrow:
- no behavior change for CLI sessions
- no schema changes
- no refactor outside the search/listing path

## Tests

Added regression coverage for:
- `SessionDB.search_messages(..., user_id_filter=...)`
- `SessionDB.list_sessions_rich(..., user_id_filter=...)`
- gateway-scoped recent-session listing in `session_search_tool`
- gateway-scoped keyword search in `session_search_tool`

## Validation

Ran the targeted regression suites with the same pytest settings used by the
repo's canonical test runner (hermetic env + 4 workers) via an equivalent
Windows command path.

Result:
- `223 passed`
