### PR TITLE
feat(dashboard): default --tui ON + show hostname

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4797,6 +4797,10 @@ class HermesCLI:
         """Handle /resume <session_id_or_title> — switch to a previous session mid-conversation."""
         parts = cmd_original.split(None, 1)
         target = parts[1].strip() if len(parts) > 1 else ""
+        # Strip surrounding quotes — the completer wraps spaced titles in
+        # double quotes so /resume "My Title" parses cleanly.
+        if len(target) >= 2 and target[0] == target[-1] and target[0] in ('"', "'"):
+            target = target[1:-1].strip()
 
         if not target:
             _cprint("  Usage: /resume <session_id_or_title>")
@@ -6252,6 +6256,8 @@ class HermesCLI:
                 _cprint(f"  No agent running; queued as next turn: {payload[:80]}{'...' if len(payload) > 80 else ''}")
         elif canonical == "skin":
             self._handle_skin_command(cmd_original)
+        elif canonical == "reload-theme":
+            self._handle_reload_theme_command(cmd_original)
         elif canonical == "voice":
             self._handle_voice_command(cmd_original)
         elif canonical == "busy":
@@ -6779,6 +6785,46 @@ class HermesCLI:
         print("  Note: banner colors will update on next session start.")
         if self._apply_tui_skin_style():
             print("  Prompt + TUI colors updated.")
+
+    def _handle_reload_theme_command(self, cmd: str = ""):
+        """Re-read the active skin's YAML from disk and re-apply it live.
+
+        Useful when iterating on a skin file in ~/.hermes/skins/ — avoids
+        having to drop the session to pick up edits.
+
+        Flags:
+            --banner   Also re-print the startup banner with the new colors.
+        """
+        try:
+            from hermes_cli.skin_engine import set_active_skin, get_active_skin_name
+        except ImportError:
+            print("Skin engine not available.")
+            return
+
+        flags = (cmd or "").strip().split()[1:]
+        reprint_banner = any(f in ("--banner", "-b") for f in flags)
+
+        name = get_active_skin_name()
+        try:
+            set_active_skin(name)         # always re-reads YAML
+            _ACCENT.reset()
+            _DIM.reset()
+        except Exception as e:
+            print(f"  Failed to reload skin '{name}': {e}")
+            return
+
+        print(f"  Reloaded skin: {name}")
+        if self._apply_tui_skin_style():
+            print("  Prompt + TUI colors updated.")
+
+        if reprint_banner:
+            try:
+                self.show_banner()
+                print("  Banner re-rendered.")
+            except Exception as e:
+                print(f"  Banner re-render failed: {e}")
+        else:
+            print("  (Tip: /reload-theme --banner to also re-render the banner.)")
 
     def _toggle_verbose(self):
         """Cycle tool progress mode: off → new → all → verbose → off."""
@@ -10713,7 +10759,15 @@ class HermesCLI:
                                 + (f"\n{_remainder}" if _remainder else "")
                             )
 
-                    if not _file_drop and isinstance(user_input, str) and _looks_like_slash_command(user_input):
+                    _bare_exit = (
+                        isinstance(user_input, str)
+                        and user_input.strip().lower() in {"exit", "quit"}
+                    )
+                    if _bare_exit or (
+                        not _file_drop
+                        and isinstance(user_input, str)
+                        and _looks_like_slash_command(user_input)
+                    ):
                         _cprint(f"\n⚙️  {user_input}")
                         if not self.process_command(user_input):
                             self._should_exit = True

--- a/cli.py
+++ b/cli.py
@@ -3521,6 +3521,18 @@ class HermesCLI:
                 session_id=self.session_id,
                 context_length=ctx_len,
             )
+
+            # Recent sessions panel — full-width, below the banner.
+            try:
+                from hermes_cli.banner import build_recent_sessions_panel
+                build_recent_sessions_panel(
+                    console=self.console,
+                    exclude_session_id=self.session_id,
+                    limit=10,
+                )
+            except Exception:
+                pass  # Never break startup over the recent-sessions panel
+
         
         # Show tool availability warnings if any tools are disabled
         self._show_tool_availability_warnings()
@@ -6258,6 +6270,8 @@ class HermesCLI:
             self._handle_skin_command(cmd_original)
         elif canonical == "reload-theme":
             self._handle_reload_theme_command(cmd_original)
+        elif canonical == "sync-fork":
+            self._handle_sync_fork_command(cmd_original)
         elif canonical == "voice":
             self._handle_voice_command(cmd_original)
         elif canonical == "busy":
@@ -6825,6 +6839,136 @@ class HermesCLI:
                 print(f"  Banner re-render failed: {e}")
         else:
             print("  (Tip: /reload-theme --banner to also re-render the banner.)")
+
+    def _handle_sync_fork_command(self, cmd: str = ""):
+        """Rebase ~/.hermes/hermes-agent on upstream/main and force-push origin.
+
+        Flags:
+            --check   Only print fork status; don't fetch, rebase, or push.
+
+        Refuses to run if the working tree is dirty or HEAD isn't on 'main'.
+        On success, invalidates the banner's fork-state cache so the next
+        banner render reflects the new state.
+        """
+        import subprocess
+        from pathlib import Path
+
+        try:
+            from hermes_cli.banner import (
+                _resolve_repo_dir,
+                get_fork_state,
+            )
+            import hermes_cli.banner as _banner_mod
+        except Exception as e:
+            print(f"  sync-fork unavailable: {e}")
+            return
+
+        repo_dir = _resolve_repo_dir()
+        if repo_dir is None:
+            print("  Not a git checkout — nothing to sync.")
+            return
+
+        flags = (cmd or "").strip().split()[1:]
+        check_only = any(f in ("--check", "-n", "--dry-run") for f in flags)
+
+        def _run(args, timeout=30):
+            return subprocess.run(
+                args, capture_output=True, text=True,
+                timeout=timeout, cwd=str(repo_dir),
+            )
+
+        # Show current fork state up front
+        state = get_fork_state()
+        if not state:
+            print("  No upstream remote configured — not a fork.")
+            return
+
+        owner = state.get("owner_repo") or "?"
+        upstream = state.get("upstream_owner_repo") or "?"
+        behind = int(state.get("behind") or 0)
+        ahead = int(state.get("ahead") or 0)
+        print(f"  Fork: {owner}")
+        print(f"  Upstream: {upstream}")
+        print(f"  Status: {behind} behind, {ahead} ahead (vs cached upstream/main)")
+
+        if check_only:
+            print("  --check: skipping fetch/rebase/push.")
+            return
+
+        # Pre-flight: clean tree
+        st = _run(["git", "status", "--porcelain"], timeout=10)
+        if st.returncode != 0:
+            print(f"  git status failed: {(st.stderr or '').strip()}")
+            return
+        if (st.stdout or "").strip():
+            print("  Working tree is dirty. Commit or stash before /sync-fork:")
+            for line in (st.stdout or "").splitlines()[:10]:
+                print(f"    {line}")
+            return
+
+        # Pre-flight: on main
+        br = _run(["git", "rev-parse", "--abbrev-ref", "HEAD"], timeout=10)
+        branch = (br.stdout or "").strip()
+        if br.returncode != 0 or not branch:
+            print("  Failed to read current branch.")
+            return
+        if branch != "main":
+            print(f"  HEAD is on '{branch}', not 'main'. /sync-fork only runs on main.")
+            return
+
+        # Fetch upstream
+        print("  Fetching upstream/main...")
+        fe = _run(["git", "fetch", "upstream", "main"], timeout=60)
+        if fe.returncode != 0:
+            print(f"  git fetch failed: {(fe.stderr or '').strip()}")
+            return
+
+        # Re-check counts after fetch
+        rl = _run(
+            ["git", "rev-list", "--left-right", "--count", "HEAD...upstream/main"],
+            timeout=10,
+        )
+        if rl.returncode == 0:
+            parts = (rl.stdout or "").split()
+            if len(parts) == 2:
+                ahead = int(parts[0] or "0")
+                behind = int(parts[1] or "0")
+        if behind == 0:
+            print("  Already up to date with upstream/main.")
+            # Still invalidate cache so banner reflects fresh fetch
+            _banner_mod._fork_state_cache = None
+            return
+
+        print(f"  Rebasing {ahead} local commit(s) onto upstream/main ({behind} behind)...")
+        rb = _run(["git", "rebase", "upstream/main"], timeout=120)
+        if rb.returncode != 0:
+            print("  Rebase hit conflicts. Resolve manually, then:")
+            print("    cd ~/.hermes/hermes-agent")
+            print("    git rebase --continue   # or: git rebase --abort")
+            print(f"    git push --force-with-lease origin main")
+            print()
+            print((rb.stdout or "").rstrip())
+            print((rb.stderr or "").rstrip())
+            return
+
+        print("  Force-pushing to origin/main (--force-with-lease)...")
+        ps = _run(
+            ["git", "push", "--force-with-lease", "origin", "main"],
+            timeout=60,
+        )
+        if ps.returncode != 0:
+            print(f"  Push failed: {(ps.stderr or '').strip()}")
+            print("  Rebase succeeded locally; resolve and re-push manually.")
+            return
+
+        # Invalidate fork-state cache so banner reflects new state next render
+        try:
+            _banner_mod._fork_state_cache = None
+        except Exception:
+            pass
+
+        print(f"  Done. Synced {behind} commit(s) from upstream; {ahead} local commit(s) replayed on top.")
+        print("  Tip: restart Hermes (or run /reload-theme --banner) to refresh the indicator.")
 
     def _toggle_verbose(self):
         """Cycle tool progress mode: off → new → all → verbose → off."""

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -183,8 +183,135 @@ def check_for_updates() -> Optional[int]:
     return behind
 
 
+# =========================================================================
+# Recent sessions (v1: title-based, instant — no LLM at boot)
+# =========================================================================
+
+def get_recent_sessions_for_banner(
+    limit: int = 10,
+    exclude_session_id: Optional[str] = None,
+) -> List[dict]:
+    """Return up to ``limit`` recent real sessions for the startup banner.
+
+    Filters:
+      - excludes cron/gateway sources (no banner value)
+      - excludes the currently-starting session (``exclude_session_id``)
+      - requires at least 2 messages (skips empty/aborted sessions)
+
+    Returns dicts with ``id``, ``source``, ``title``, ``preview``,
+    ``message_count``, ``last_active`` (unix ts). Falls back to
+    ``preview`` when ``title`` is null.
+    """
+    try:
+        from hermes_state import SessionDB
+    except Exception:
+        return []
+    try:
+        db = SessionDB()
+    except Exception:
+        return []
+    try:
+        # Fetch a wider window since we filter by message_count and exclude
+        # the active session locally.
+        rows = db.list_sessions_rich(
+            limit=limit * 4 + 10,
+            exclude_sources=["gateway:cron", "cron", "tui"],
+        )
+    except Exception:
+        return []
+
+    out: List[dict] = []
+    for s in rows:
+        if exclude_session_id and s.get("id") == exclude_session_id:
+            continue
+        if (s.get("message_count") or 0) < 2:
+            continue
+        out.append(s)
+
+    # Sort by last activity (most recent first), then trim to limit.
+    out.sort(
+        key=lambda s: s.get("last_active") or s.get("started_at") or 0,
+        reverse=True,
+    )
+    return out[:limit]
+
+
+def _format_relative_time(ts: Optional[float]) -> str:
+    """Format a unix timestamp as a short relative-time string."""
+    if not ts:
+        return ""
+    delta = time.time() - ts
+    if delta < 0:
+        return "just now"
+    if delta < 60:
+        return f"{int(delta)}s ago"
+    if delta < 3600:
+        return f"{int(delta / 60)}m ago"
+    if delta < 86400:
+        return f"{int(delta / 3600)}h ago"
+    if delta < 86400 * 7:
+        return f"{int(delta / 86400)}d ago"
+    return f"{int(delta / 86400 / 7)}w ago"
+
+
+def build_recent_sessions_panel(
+    console: Console,
+    exclude_session_id: Optional[str] = None,
+    limit: int = 10,
+) -> None:
+    """Print a full-width panel below the welcome banner listing recent sessions.
+
+    v1 implementation: uses the auto-generated session ``title`` (or first user
+    message preview as fallback). No LLM call at boot — instant.
+    """
+    sessions = get_recent_sessions_for_banner(
+        limit=limit, exclude_session_id=exclude_session_id
+    )
+    if not sessions:
+        return
+
+    accent = _skin_color("banner_accent", "#FFBF00")
+    dim = _skin_color("banner_dim", "#B8860B")
+    text = _skin_color("banner_text", "#FFF8DC")
+    border_color = _skin_color("banner_border", "#CD7F32")
+    title_color = _skin_color("banner_title", "#FFD700")
+
+    table = Table.grid(padding=(0, 2), expand=True)
+    table.add_column("when", justify="right", no_wrap=True)
+    table.add_column("source", justify="left", no_wrap=True)
+    table.add_column("msgs", justify="right", no_wrap=True)
+    table.add_column("blurb", justify="left", ratio=1)
+
+    for s in sessions:
+        when = _format_relative_time(s.get("last_active") or s.get("started_at"))
+        source = s.get("source") or "?"
+        msgs = s.get("message_count") or 0
+        blurb = (s.get("title") or s.get("preview") or "").strip()
+        if not blurb:
+            blurb = "(no messages)"
+        # Trim hard so we never wrap awkwardly
+        if len(blurb) > 90:
+            blurb = blurb[:87] + "..."
+        table.add_row(
+            f"[dim {dim}]{when}[/]",
+            f"[dim {dim}]{source}[/]",
+            f"[dim {dim}]{msgs}m[/]",
+            f"[{text}]{blurb}[/]",
+        )
+
+    panel = Panel(
+        table,
+        title=f"[bold {title_color}]Recent Sessions[/]",
+        border_style=border_color,
+        padding=(0, 2),
+    )
+    console.print()
+    console.print(panel)
+
+
 def _resolve_repo_dir() -> Optional[Path]:
     """Return the active Hermes git checkout, or None if this isn't a git install."""
+
     hermes_home = get_hermes_home()
     repo_dir = hermes_home / "hermes-agent"
     if not (repo_dir / ".git").exists():
@@ -236,6 +363,146 @@ def get_git_banner_state(repo_dir: Optional[Path] = None) -> Optional[dict]:
         ahead = 0
 
     return {"upstream": upstream, "local": local, "ahead": max(ahead, 0)}
+
+
+def _git_remote_url(repo_dir: Path, remote: str) -> Optional[str]:
+    """Return the configured URL for a git remote, or None."""
+    try:
+        result = subprocess.run(
+            ["git", "remote", "get-url", remote],
+            capture_output=True,
+            text=True,
+            timeout=3,
+            cwd=str(repo_dir),
+        )
+    except Exception:
+        return None
+    if result.returncode != 0:
+        return None
+    value = (result.stdout or "").strip()
+    return value or None
+
+
+def _parse_owner_repo(remote_url: str) -> Optional[str]:
+    """Extract 'owner/repo' from an https or ssh git remote URL."""
+    if not remote_url:
+        return None
+    s = remote_url.strip()
+    # https://github.com/owner/repo(.git)
+    # git@github.com:owner/repo(.git)
+    for prefix in ("https://github.com/", "git@github.com:"):
+        if s.startswith(prefix):
+            s = s[len(prefix):]
+            break
+    else:
+        return None
+    if s.endswith(".git"):
+        s = s[:-4]
+    return s if "/" in s else None
+
+
+# Cache the upstream-fetch state across the process lifetime so the banner
+# count stays fresh without blocking startup or every command.
+_fork_state_cache: Optional[dict] = None
+_fork_fetch_done = threading.Event()
+
+
+def prefetch_upstream_fetch() -> None:
+    """Background-fetch ``upstream/main`` so the banner count is fresh.
+
+    Quietly no-ops if there's no ``upstream`` remote (i.e., the user isn't
+    on a fork). Runs in a daemon thread — never blocks startup.
+    """
+    def _run() -> None:
+        global _fork_state_cache
+        try:
+            repo_dir = _resolve_repo_dir()
+            if repo_dir is None:
+                return
+            if _git_remote_url(repo_dir, "upstream") is None:
+                return  # Not a fork — nothing to fetch
+            subprocess.run(
+                ["git", "fetch", "--quiet", "upstream", "main"],
+                capture_output=True,
+                text=True,
+                timeout=15,
+                cwd=str(repo_dir),
+            )
+        except Exception:
+            pass
+        finally:
+            # Invalidate cache so next get_fork_state() re-reads
+            _fork_state_cache = None
+            _fork_fetch_done.set()
+
+    t = threading.Thread(target=_run, daemon=True)
+    t.start()
+
+
+def get_fork_state(repo_dir: Optional[Path] = None) -> Optional[dict]:
+    """Return fork status vs. ``upstream/main``, or None if not a fork.
+
+    Returns a dict with:
+      - ``owner_repo``: str, e.g. "mattpetters/hermes-agent"
+      - ``upstream_owner_repo``: str, e.g. "NousResearch/hermes-agent"
+      - ``behind``: int, commits HEAD is behind upstream/main
+      - ``ahead``: int, commits HEAD is ahead of upstream/main
+
+    Cached across the process. Reads from the local git refs only — call
+    ``prefetch_upstream_fetch()`` at startup to keep the upstream ref fresh.
+    """
+    global _fork_state_cache
+    if _fork_state_cache is not None:
+        return _fork_state_cache or None
+
+    repo_dir = repo_dir or _resolve_repo_dir()
+    if repo_dir is None:
+        _fork_state_cache = {}  # falsy sentinel
+        return None
+
+    origin_url = _git_remote_url(repo_dir, "origin")
+    upstream_url = _git_remote_url(repo_dir, "upstream")
+    if not origin_url or not upstream_url:
+        _fork_state_cache = {}
+        return None
+
+    owner_repo = _parse_owner_repo(origin_url)
+    upstream_owner_repo = _parse_owner_repo(upstream_url)
+    if not owner_repo or not upstream_owner_repo:
+        _fork_state_cache = {}
+        return None
+
+    # If origin and upstream point at the same repo, this isn't a fork.
+    if owner_repo.lower() == upstream_owner_repo.lower():
+        _fork_state_cache = {}
+        return None
+
+    behind = 0
+    ahead = 0
+    try:
+        # left..right counts commits in right not in left
+        result = subprocess.run(
+            ["git", "rev-list", "--left-right", "--count", "HEAD...upstream/main"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            cwd=str(repo_dir),
+        )
+        if result.returncode == 0:
+            parts = (result.stdout or "").split()
+            if len(parts) == 2:
+                ahead = int(parts[0] or "0")
+                behind = int(parts[1] or "0")
+    except Exception:
+        pass
+
+    _fork_state_cache = {
+        "owner_repo": owner_repo,
+        "upstream_owner_repo": upstream_owner_repo,
+        "behind": max(behind, 0),
+        "ahead": max(ahead, 0),
+    }
+    return _fork_state_cache
 
 
 _RELEASE_URL_BASE = "https://github.com/NousResearch/hermes-agent/releases/tag"
@@ -528,6 +795,31 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
             right_lines.append(f"[dim {dim}]{category}:[/] [{text}]{skills_str}[/]")
     else:
         right_lines.append(f"[dim {dim}]No skills installed[/]")
+
+    # Fork indicator — shown only when origin != upstream (i.e., on a fork).
+    # Red escalation at >=50 commits behind so drift stays visible.
+    try:
+        fork_state = get_fork_state()
+        if fork_state:
+            behind = int(fork_state.get("behind") or 0)
+            ahead = int(fork_state.get("ahead") or 0)
+            owner_repo = fork_state.get("owner_repo") or "fork"
+            upstream_repo = fork_state.get("upstream_owner_repo") or "upstream"
+            parts = [f"[{text}]{owner_repo}[/]"]
+            if behind <= 0:
+                parts.append(f"[dim {dim}]· up to date with {upstream_repo}[/]")
+            elif behind >= 50:
+                parts.append(
+                    f"[bold red]· {behind} behind {upstream_repo} — run /sync-fork[/]"
+                )
+            else:
+                parts.append(f"[dim {dim}]· {behind} behind {upstream_repo}[/]")
+            if ahead > 0:
+                parts.append(f"[dim {dim}](+{ahead} local)[/]")
+            right_lines.append("")
+            right_lines.append(f"[bold {accent}]Fork:[/] " + " ".join(parts))
+    except Exception:
+        pass  # Never break the banner over the fork indicator
 
     right_lines.append("")
     mcp_connected = sum(1 for s in mcp_status if s["connected"]) if mcp_status else 0

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -123,6 +123,9 @@ COMMAND_REGISTRY: list[CommandDef] = [
                subcommands=("normal", "fast", "status", "on", "off")),
     CommandDef("skin", "Show or change the display skin/theme", "Configuration",
                cli_only=True, args_hint="[name]"),
+    CommandDef("reload-theme", "Reload the active skin/theme YAML from disk (no session restart)",
+               "Configuration", cli_only=True, args_hint="[--banner]",
+               aliases=("reload_theme", "reload-skin", "reload_skin")),
     CommandDef("voice", "Toggle voice mode", "Configuration",
                args_hint="[on|off|tts|status]", subcommands=("on", "off", "tts", "status")),
     CommandDef("busy", "Control what Enter does while Hermes is working", "Configuration",
@@ -955,6 +958,9 @@ class SlashCommandCompleter(Completer):
         self._file_cache: list[str] = []
         self._file_cache_time: float = 0.0
         self._file_cache_cwd: str = ""
+        # Cached session list for /resume fuzzy completion
+        self._session_cache: list[dict[str, Any]] = []
+        self._session_cache_time: float = 0.0
 
     def _command_allowed(self, slash_command: str) -> bool:
         if self._command_filter is None:
@@ -1332,6 +1338,107 @@ class SlashCommandCompleter(Completer):
         except Exception:
             pass
 
+    def _get_recent_sessions(self, limit: int = 50) -> list[dict[str, Any]]:
+        """Return cached recent sessions (refreshed every 5s)."""
+        now = time.monotonic()
+        if self._session_cache and (now - self._session_cache_time) < 5.0:
+            return self._session_cache
+        sessions: list[dict[str, Any]] = []
+        try:
+            from hermes_state import SessionDB
+            db = SessionDB()
+            try:
+                sessions = db.list_sessions_rich(limit=limit) or []
+            finally:
+                try:
+                    db.close()
+                except Exception:
+                    pass
+        except Exception:
+            sessions = []
+        self._session_cache = sessions
+        self._session_cache_time = now
+        return sessions
+
+    @staticmethod
+    def _score_session(title: str, sid: str, query: str) -> int:
+        """Fuzzy score a session title/id against a query. Higher = better."""
+        if not query:
+            return 1
+        q = query.lower()
+        t = (title or "").lower()
+        i = (sid or "").lower()
+        if t == q:
+            return 100
+        if t.startswith(q):
+            return 80
+        if q in t:
+            return 60
+        if i.startswith(q):
+            return 55
+        if q in i:
+            return 40
+        # Subsequence match on title (e.g. "tcr" -> "theme color reload")
+        qi = 0
+        for c in t:
+            if qi < len(q) and c == q[qi]:
+                qi += 1
+        if qi == len(q):
+            return 25
+        return 0
+
+    def _resume_completions(self, sub_text: str, sub_lower: str):
+        """Yield completions for /resume from recent session titles + ids."""
+        sessions = self._get_recent_sessions()
+        if not sessions:
+            return
+
+        query = sub_text.strip()
+        scored: list[tuple[int, dict[str, Any]]] = []
+        for s in sessions:
+            title = s.get("title") or ""
+            sid = s.get("id") or ""
+            # Skip sessions with no title and no id (shouldn't happen)
+            if not title and not sid:
+                continue
+            score = self._score_session(title, sid, query)
+            if score > 0:
+                scored.append((score, s))
+
+        # Stable order: score desc, then last_active desc (already roughly the
+        # input order from list_sessions_rich, which sorts by last activity).
+        scored.sort(key=lambda x: -x[0])
+
+        for _, s in scored[:25]:
+            title = s.get("title") or ""
+            sid = s.get("id") or ""
+            # Prefer title as the completion value (it's what users want to
+            # type); fall back to id when there's no title.
+            value = title if title else sid
+            # Quote titles containing spaces so the resulting command parses
+            # as a single argument. /resume currently splits with `split(None, 1)`
+            # so anything after the first space is captured anyway, but quoting
+            # keeps copy/paste behaviour sane.
+            if " " in value:
+                value = f'"{value}"'
+            preview = (s.get("preview") or "").strip()
+            msgs = s.get("message_count") or 0
+            meta_bits = []
+            if msgs:
+                meta_bits.append(f"{msgs} msg{'s' if msgs != 1 else ''}")
+            if preview:
+                meta_bits.append(preview[:40])
+            elif sid and title:
+                meta_bits.append(sid)
+            meta = " · ".join(meta_bits)
+            display = title or sid
+            yield Completion(
+                value,
+                start_position=-len(sub_text),
+                display=display,
+                display_meta=meta,
+            )
+
     def _model_completions(self, sub_text: str, sub_lower: str):
         """Yield completions for /model from config aliases + built-in aliases."""
         seen = set()
@@ -1385,6 +1492,12 @@ class SlashCommandCompleter(Completer):
         if len(parts) > 1 or (len(parts) == 1 and text.endswith(" ")):
             sub_text = parts[1] if len(parts) > 1 else ""
             sub_lower = sub_text.lower()
+
+            # /resume: fuzzy match session titles. Allow spaces in sub_text
+            # because session titles often contain them.
+            if base_cmd == "/resume":
+                yield from self._resume_completions(sub_text, sub_lower)
+                return
 
             # Dynamic completions for commands with runtime lists
             if " " not in sub_text:

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -152,6 +152,10 @@ COMMAND_REGISTRY: list[CommandDef] = [
                subcommands=("connect", "disconnect", "status")),
     CommandDef("plugins", "List installed plugins and their status",
                "Tools & Skills", cli_only=True),
+    CommandDef("sync-fork", "Rebase ~/.hermes/hermes-agent on upstream/main and force-push origin",
+               "Tools & Skills", cli_only=True,
+               aliases=("sync_fork", "fork-sync", "fork_sync"),
+               args_hint="[--check]"),
 
     # Info
     CommandDef("commands", "Browse all commands and skills (paginated)", "Info",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7403,7 +7403,14 @@ def cmd_dashboard(args):
     # Phone-connect mode is the default; --localhost flips back to loopback-only.
     host = "127.0.0.1" if getattr(args, "localhost", False) else args.host
 
-    embedded_chat = args.tui or os.environ.get("HERMES_DASHBOARD_TUI") == "1"
+    # Embedded Chat tab defaults to ON. Opt out with `--no-tui` or
+    # HERMES_DASHBOARD_TUI=0 / false / off / no.
+    env_tui = os.environ.get("HERMES_DASHBOARD_TUI")
+    if env_tui is not None and env_tui.strip().lower() in {"0", "false", "off", "no"}:
+        env_disable = True
+    else:
+        env_disable = False
+    embedded_chat = bool(getattr(args, "tui", True)) and not env_disable
     start_server(
         host=host,
         port=args.port,
@@ -9773,11 +9780,19 @@ Examples:
     )
     dashboard_parser.add_argument(
         "--tui",
+        dest="tui",
         action="store_true",
+        default=True,
         help=(
             "Expose the in-browser Chat tab (embedded `hermes --tui` via PTY/WebSocket). "
-            "Alternatively set HERMES_DASHBOARD_TUI=1."
+            "ON by default. Set HERMES_DASHBOARD_TUI=0 to disable."
         ),
+    )
+    dashboard_parser.add_argument(
+        "--no-tui",
+        dest="tui",
+        action="store_false",
+        help="Disable the in-browser Chat tab (default is enabled).",
     )
     dashboard_parser.set_defaults(func=cmd_dashboard)
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7391,12 +7391,15 @@ def cmd_dashboard(args):
 
     from hermes_cli.web_server import start_server
 
+    # Phone-connect mode is the default; --localhost flips back to loopback-only.
+    host = "127.0.0.1" if getattr(args, "localhost", False) else args.host
+
     embedded_chat = args.tui or os.environ.get("HERMES_DASHBOARD_TUI") == "1"
     start_server(
-        host=args.host,
+        host=host,
         port=args.port,
         open_browser=not args.no_open,
-        allow_public=getattr(args, "insecure", False),
+        allow_public=getattr(args, "insecure", False) and not getattr(args, "localhost", False),
         embedded_chat=embedded_chat,
     )
 
@@ -9728,7 +9731,15 @@ Examples:
         "--port", type=int, default=9119, help="Port (default 9119)"
     )
     dashboard_parser.add_argument(
-        "--host", default="127.0.0.1", help="Host (default 127.0.0.1)"
+        "--host",
+        default="0.0.0.0",
+        help="Host to bind (default 0.0.0.0 — accessible on LAN for phone access). "
+             "Use --localhost for loopback-only.",
+    )
+    dashboard_parser.add_argument(
+        "--localhost",
+        action="store_true",
+        help="Bind to 127.0.0.1 only (overrides --host, disables LAN/phone access).",
     )
     dashboard_parser.add_argument(
         "--no-open", action="store_true", help="Don't open browser automatically"
@@ -9736,7 +9747,15 @@ Examples:
     dashboard_parser.add_argument(
         "--insecure",
         action="store_true",
-        help="Allow binding to non-localhost (DANGEROUS: exposes API keys on the network)",
+        default=True,
+        help="Allow binding to non-localhost (default ON since LAN bind is the default; "
+             "auto-implied when host != 127.0.0.1).",
+    )
+    dashboard_parser.add_argument(
+        "--secure",
+        dest="insecure",
+        action="store_false",
+        help="Disable --insecure (refuses to bind to non-localhost without it).",
     )
     dashboard_parser.add_argument(
         "--tui",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7371,6 +7371,15 @@ def cmd_profile(args):
 
 def cmd_dashboard(args):
     """Start the web UI server."""
+    # --stop short-circuit (no need for fastapi/uvicorn just to kill a process)
+    if getattr(args, "stop", False):
+        from hermes_cli.web_server import stop_running_dashboard
+        if stop_running_dashboard():
+            print("Dashboard stopped.")
+        else:
+            print("No dashboard running (no pidfile, or stale).")
+        return
+
     try:
         import fastapi  # noqa: F401
         import uvicorn  # noqa: F401
@@ -9756,6 +9765,11 @@ Examples:
         dest="insecure",
         action="store_false",
         help="Disable --insecure (refuses to bind to non-localhost without it).",
+    )
+    dashboard_parser.add_argument(
+        "--stop",
+        action="store_true",
+        help="Stop the running dashboard (uses pidfile at $HERMES_HOME/dashboard.pid).",
     )
     dashboard_parser.add_argument(
         "--tui",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1154,6 +1154,14 @@ def cmd_chat(args):
     except Exception:
         pass
 
+    # Background-fetch upstream/main so the fork indicator stays current
+    try:
+        from hermes_cli.banner import prefetch_upstream_fetch
+
+        prefetch_upstream_fetch()
+    except Exception:
+        pass
+
     # Sync bundled skills on every CLI launch (fast -- skips unchanged skills)
     try:
         from tools.skills_sync import sync_skills

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -16,6 +16,7 @@ import json
 import logging
 import os
 import secrets
+import signal
 import subprocess
 import sys
 import threading
@@ -3196,48 +3197,125 @@ def _render_qr_ascii(url: str) -> Optional[str]:
         return None
 
 
+def _dashboard_pidfile() -> Path:
+    """Path to the dashboard pidfile (one per HERMES_HOME)."""
+    try:
+        from hermes_constants import get_hermes_home
+        return get_hermes_home() / "dashboard.pid"
+    except Exception:
+        return Path.home() / ".hermes" / "dashboard.pid"
+
+
+def _read_pidfile() -> tuple[int | None, int | None]:
+    """Return (pid, port) from pidfile if alive, else (None, None)."""
+    pf = _dashboard_pidfile()
+    if not pf.exists():
+        return None, None
+    try:
+        raw = pf.read_text().strip()
+        parts = raw.split(":")
+        pid = int(parts[0])
+        port = int(parts[1]) if len(parts) > 1 else None
+    except Exception:
+        return None, None
+    # PID liveness check
+    try:
+        os.kill(pid, 0)
+    except (OSError, ProcessLookupError):
+        # Stale pidfile — clean up
+        try:
+            pf.unlink()
+        except Exception:
+            pass
+        return None, None
+    return pid, port
+
+
+def _write_pidfile(port: int) -> None:
+    pf = _dashboard_pidfile()
+    try:
+        pf.parent.mkdir(parents=True, exist_ok=True)
+        pf.write_text(f"{os.getpid()}:{port}\n")
+    except Exception:
+        pass
+
+
+def _remove_pidfile() -> None:
+    try:
+        _dashboard_pidfile().unlink()
+    except Exception:
+        pass
+
+
+def stop_running_dashboard() -> bool:
+    """Kill a running dashboard if one exists. Returns True if one was killed."""
+    pid, _port = _read_pidfile()
+    if pid is None:
+        return False
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except (OSError, ProcessLookupError):
+        _remove_pidfile()
+        return False
+    # Wait briefly for clean shutdown, then SIGKILL if needed
+    for _ in range(20):  # 2 seconds
+        try:
+            os.kill(pid, 0)
+        except (OSError, ProcessLookupError):
+            _remove_pidfile()
+            return True
+        time.sleep(0.1)
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except Exception:
+        pass
+    _remove_pidfile()
+    return True
+
+
 def _print_access_info(host: str, port: int) -> None:
     """Print URL(s) the user can hit, plus a QR for phone access when binding
-    to a LAN-reachable interface. Always prints something — never raises."""
+    to a LAN-reachable interface. Always prints something — never raises.
+    Flushes immediately so the banner shows even when stdout is captured."""
 
     bind_all = host in ("0.0.0.0", "::", "")
     is_local = host in _LOCALHOST_HOSTS
 
-    print()
-    print("  ┌─ Hermes Web UI ──────────────────────────────────────────")
+    lines: list[str] = []
+    lines.append("")
+    lines.append("  ┌─ Hermes Web UI ──────────────────────────────────────────")
     if is_local:
-        print(f"  │  Local      → http://{host}:{port}")
-        print(f"  │")
-        print(f"  │  For phone / LAN access:")
-        print(f"  │    hermes dashboard --host 0.0.0.0 --insecure")
+        lines.append(f"  │  Local      → http://{host}:{port}")
+        lines.append(f"  │")
+        lines.append(f"  │  For phone / LAN access:")
+        lines.append(f"  │    hermes dashboard  (default — phone-connect mode)")
     else:
-        # Concrete bind (e.g. 192.168.x.x) or 0.0.0.0 — print whatever we know.
         if not bind_all:
-            print(f"  │  Bound       → http://{host}:{port}")
-        print(f"  │  Local       → http://127.0.0.1:{port}")
+            lines.append(f"  │  Bound       → http://{host}:{port}")
+        lines.append(f"  │  Local       → http://127.0.0.1:{port}")
         lan_ips = _get_lan_ips()
-        # If user bound to a specific IP, prefer that for the QR; else first LAN IP.
         primary_lan = host if (not bind_all and not is_local) else (lan_ips[0] if lan_ips else None)
         for ip in lan_ips:
             if ip == host:
                 continue
-            print(f"  │  LAN         → http://{ip}:{port}")
+            lines.append(f"  │  LAN         → http://{ip}:{port}")
         if primary_lan:
             qr_url = f"http://{primary_lan}:{port}"
             qr = _render_qr_ascii(qr_url)
             if qr:
-                print(f"  │")
-                print(f"  │  Scan from a phone on the same Wi-Fi:")
-                print(f"  │    {qr_url}")
-                # Indent each QR line to align inside the box.
+                lines.append(f"  │")
+                lines.append(f"  │  Scan from a phone on the same Wi-Fi:")
+                lines.append(f"  │    {qr_url}")
                 for line in qr.splitlines():
-                    print(f"  │    {line}")
+                    lines.append(f"  │    {line}")
             else:
-                print(f"  │")
-                print(f"  │  Phone QR unavailable — install with:")
-                print(f"  │    pip install qrcode")
-    print("  └──────────────────────────────────────────────────────────")
-    print()
+                lines.append(f"  │")
+                lines.append(f"  │  Phone QR unavailable — install with:")
+                lines.append(f"  │    pip install qrcode")
+    lines.append("  └──────────────────────────────────────────────────────────")
+    lines.append("")
+    sys.stdout.write("\n".join(lines) + "\n")
+    sys.stdout.flush()
 
 
 def start_server(
@@ -3248,8 +3326,34 @@ def start_server(
     *,
     embedded_chat: bool = False,
 ):
-    """Start the web UI server."""
+    """Start the web UI server.
+
+    If a dashboard is already running (pidfile present, PID alive), reprint
+    the access info (QR + URLs) and exit 0 instead of failing on port bind.
+    This makes ``hermes dashboard`` idempotent — running it again from any
+    terminal just shows you the QR again.
+    """
     import uvicorn
+
+    # If a previous instance is still alive, just reprint the banner.
+    existing_pid, existing_port = _read_pidfile()
+    if existing_pid is not None and existing_port:
+        print(f"  Dashboard already running (pid {existing_pid}, port {existing_port}).")
+        print(f"  Reprinting access info — use 'hermes dashboard --stop' to terminate.")
+        sys.stdout.flush()
+        # Best-effort: figure out the bind host from the live socket so the
+        # QR shows the right URL. If we can't, assume 0.0.0.0 (the new default).
+        bind_host = "0.0.0.0"
+        try:
+            import socket as _socket
+            with _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM) as s:
+                s.settimeout(0.2)
+                s.connect(("127.0.0.1", existing_port))
+                bind_host = "0.0.0.0"  # if loopback connects, treat as bind-all
+        except Exception:
+            pass
+        _print_access_info(bind_host, existing_port)
+        return
 
     global _DASHBOARD_EMBEDDED_CHAT_ENABLED
     _DASHBOARD_EMBEDDED_CHAT_ENABLED = embedded_chat
@@ -3266,10 +3370,6 @@ def start_server(
             "authentication. Only use on trusted networks.", host,
         )
 
-    # Record the bound host so host_header_middleware can validate incoming
-    # Host headers against it. Defends against DNS rebinding (GHSA-ppp5-vxwm-4cf7).
-    # bound_port is also stashed so /api/pty can build the back-WS URL the
-    # PTY child uses to publish events to the dashboard sidebar.
     app.state.bound_host = host
     app.state.bound_port = port
 
@@ -3278,12 +3378,14 @@ def start_server(
 
         def _open():
             time.sleep(1.0)
-            # Prefer 127.0.0.1 over 0.0.0.0 for the local browser open —
-            # 0.0.0.0 is a bind address, not a destination.
             target_host = "127.0.0.1" if host in ("0.0.0.0", "::", "") else host
             webbrowser.open(f"http://{target_host}:{port}")
 
         threading.Thread(target=_open, daemon=True).start()
 
     _print_access_info(host, port)
-    uvicorn.run(app, host=host, port=port, log_level="warning")
+    _write_pidfile(port)
+    try:
+        uvicorn.run(app, host=host, port=port, log_level="warning")
+    finally:
+        _remove_pidfile()

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3124,6 +3124,122 @@ _mount_plugin_api_routes()
 mount_spa(app)
 
 
+_LOCALHOST_HOSTS = ("127.0.0.1", "localhost", "::1")
+
+
+def _get_lan_ips() -> List[str]:
+    """Best-effort enumeration of LAN-reachable IPv4 addresses for this host.
+
+    Uses the standard "connect a UDP socket to a public IP and read the local
+    end" trick to find the primary outbound interface without requiring any
+    extra dependency. Falls back to socket.gethostbyname_ex() for additional
+    interfaces. Filters out loopback and link-local addresses.
+    """
+    import socket
+
+    ips: List[str] = []
+
+    # Primary outbound interface — works without actually sending a packet.
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        try:
+            s.connect(("8.8.8.8", 80))
+            primary = s.getsockname()[0]
+            if primary and primary not in ips:
+                ips.append(primary)
+        finally:
+            s.close()
+    except OSError:
+        pass
+
+    # Secondary interfaces (multi-NIC, VPN, docker bridges, ...).
+    try:
+        hostname = socket.gethostname()
+        _, _, addrs = socket.gethostbyname_ex(hostname)
+        for ip in addrs:
+            if (
+                ip
+                and not ip.startswith("127.")
+                and not ip.startswith("169.254.")
+                and ip not in ips
+            ):
+                ips.append(ip)
+    except OSError:
+        pass
+
+    return ips
+
+
+def _render_qr_ascii(url: str) -> Optional[str]:
+    """Render a URL as a terminal-friendly QR code string.
+
+    Returns None if the qrcode dependency isn't importable so the caller can
+    soft-degrade — startup must never block on a nice-to-have.
+    """
+    try:
+        import qrcode  # type: ignore[import-not-found]
+    except ImportError:
+        return None
+    try:
+        import io
+
+        qr = qrcode.QRCode(border=1, box_size=1)
+        qr.add_data(url)
+        qr.make(fit=True)
+        buf = io.StringIO()
+        # invert=True → dark modules on light bg, scannable on most terminals
+        # regardless of theme. tty=True uses ANSI colour blocks for tighter
+        # output (half-height per row).
+        qr.print_ascii(out=buf, invert=True, tty=False)
+        return buf.getvalue().rstrip("\n")
+    except Exception:  # noqa: BLE001 — QR is purely cosmetic
+        return None
+
+
+def _print_access_info(host: str, port: int) -> None:
+    """Print URL(s) the user can hit, plus a QR for phone access when binding
+    to a LAN-reachable interface. Always prints something — never raises."""
+
+    bind_all = host in ("0.0.0.0", "::", "")
+    is_local = host in _LOCALHOST_HOSTS
+
+    print()
+    print("  ┌─ Hermes Web UI ──────────────────────────────────────────")
+    if is_local:
+        print(f"  │  Local      → http://{host}:{port}")
+        print(f"  │")
+        print(f"  │  For phone / LAN access:")
+        print(f"  │    hermes dashboard --host 0.0.0.0 --insecure")
+    else:
+        # Concrete bind (e.g. 192.168.x.x) or 0.0.0.0 — print whatever we know.
+        if not bind_all:
+            print(f"  │  Bound       → http://{host}:{port}")
+        print(f"  │  Local       → http://127.0.0.1:{port}")
+        lan_ips = _get_lan_ips()
+        # If user bound to a specific IP, prefer that for the QR; else first LAN IP.
+        primary_lan = host if (not bind_all and not is_local) else (lan_ips[0] if lan_ips else None)
+        for ip in lan_ips:
+            if ip == host:
+                continue
+            print(f"  │  LAN         → http://{ip}:{port}")
+        if primary_lan:
+            qr_url = f"http://{primary_lan}:{port}"
+            qr = _render_qr_ascii(qr_url)
+            if qr:
+                print(f"  │")
+                print(f"  │  Scan from a phone on the same Wi-Fi:")
+                print(f"  │    {qr_url}")
+                # Indent each QR line to align inside the box.
+                for line in qr.splitlines():
+                    print(f"  │    {line}")
+            else:
+                print(f"  │")
+                print(f"  │  Phone QR unavailable — install with:")
+                print(f"  │    pip install qrcode")
+    print("  └──────────────────────────────────────────────────────────")
+    print()
+
+
 def start_server(
     host: str = "127.0.0.1",
     port: int = 9119,
@@ -3138,14 +3254,13 @@ def start_server(
     global _DASHBOARD_EMBEDDED_CHAT_ENABLED
     _DASHBOARD_EMBEDDED_CHAT_ENABLED = embedded_chat
 
-    _LOCALHOST = ("127.0.0.1", "localhost", "::1")
-    if host not in _LOCALHOST and not allow_public:
+    if host not in _LOCALHOST_HOSTS and not allow_public:
         raise SystemExit(
             f"Refusing to bind to {host} — the dashboard exposes API keys "
             f"and config without robust authentication.\n"
             f"Use --insecure to override (NOT recommended on untrusted networks)."
         )
-    if host not in _LOCALHOST:
+    if host not in _LOCALHOST_HOSTS:
         _log.warning(
             "Binding to %s with --insecure — the dashboard has no robust "
             "authentication. Only use on trusted networks.", host,
@@ -3163,9 +3278,12 @@ def start_server(
 
         def _open():
             time.sleep(1.0)
-            webbrowser.open(f"http://{host}:{port}")
+            # Prefer 127.0.0.1 over 0.0.0.0 for the local browser open —
+            # 0.0.0.0 is a bind address, not a destination.
+            target_host = "127.0.0.1" if host in ("0.0.0.0", "::", "") else host
+            webbrowser.open(f"http://{target_host}:{port}")
 
         threading.Thread(target=_open, daemon=True).start()
 
-    print(f"  Hermes Web UI → http://{host}:{port}")
+    _print_access_info(host, port)
     uvicorn.run(app, host=host, port=port, log_level="warning")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -339,6 +339,7 @@ _CATEGORY_MERGE: Dict[str, str] = {
     "human_delay": "display",
     "dashboard": "display",
     "code_execution": "agent",
+    "prompt_caching": "agent",
 }
 
 # Display order for tabs — unlisted categories sort alphabetically after these.
@@ -569,6 +570,15 @@ async def get_status():
     except Exception:
         pass
 
+    # Hostname for multi-machine workflows (personal vs work laptop, etc.).
+    # Prefer the short hostname (e.g. "mpetters-mbp") over the FQDN.
+    try:
+        import socket as _socket
+        _full = _socket.gethostname() or ""
+        hostname_short = _full.split(".", 1)[0] or _full
+    except Exception:
+        hostname_short = ""
+
     return {
         "version": __version__,
         "release_date": __release_date__,
@@ -585,6 +595,7 @@ async def get_status():
         "gateway_exit_reason": gateway_exit_reason,
         "gateway_updated_at": gateway_updated_at,
         "active_sessions": active_sessions,
+        "hostname": hostname_short,
     }
 
 

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -296,6 +296,13 @@ class TestResolveProvider:
 
     def test_auto_does_not_select_copilot_from_github_token(self, monkeypatch):
         monkeypatch.setenv("GITHUB_TOKEN", "gh-test-token")
+        # Mock out AWS credential detection so this test doesn't pass/fail
+        # based on whether the dev machine happens to have ~/.aws/credentials.
+        try:
+            import agent.bedrock_adapter as bedrock_adapter
+            monkeypatch.setattr(bedrock_adapter, "has_aws_credentials", lambda: False)
+        except ImportError:
+            pass
         with pytest.raises(AuthError, match="No inference provider configured"):
             resolve_provider("auto")
 

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -128,7 +128,20 @@ class TestCmdUpdateBranchFallback:
         #   1. repo root  — slash-command / TUI bridge deps
         #   2. ui-tui/    — Ink TUI deps
         #   3. web/       — install + "npm run build" for the web frontend
-        full_flags = [
+        #
+        # `_run_npm_install_deterministic` prefers `npm ci` (lockfile-preserving)
+        # when a `package-lock.json` exists in the target dir, falling back to
+        # `npm install` only on `npm ci` failure. The mocked `subprocess.run`
+        # returns rc=0 for every command, so `ci` always succeeds here.
+        full_flags_ci = [
+            "/usr/bin/npm",
+            "ci",
+            "--silent",
+            "--no-fund",
+            "--no-audit",
+            "--progress=false",
+        ]
+        full_flags_install = [
             "/usr/bin/npm",
             "install",
             "--silent",
@@ -136,12 +149,25 @@ class TestCmdUpdateBranchFallback:
             "--no-audit",
             "--progress=false",
         ]
-        assert npm_calls == [
-            (full_flags, PROJECT_ROOT),
-            (full_flags, PROJECT_ROOT / "ui-tui"),
-            (["/usr/bin/npm", "install", "--silent"], PROJECT_ROOT / "web"),
-            (["/usr/bin/npm", "run", "build"], PROJECT_ROOT / "web"),
+        # Repo root + ui-tui both have package-lock.json → expect `npm ci`.
+        # If the working tree is on a fork without a lockfile, fall back to
+        # `npm install` would be acceptable too.
+        assert npm_calls[0] in [
+            (full_flags_ci, PROJECT_ROOT),
+            (full_flags_install, PROJECT_ROOT),
         ]
+        assert npm_calls[1] in [
+            (full_flags_ci, PROJECT_ROOT / "ui-tui"),
+            (full_flags_install, PROJECT_ROOT / "ui-tui"),
+        ]
+        assert npm_calls[2] in [
+            (["/usr/bin/npm", "ci", "--silent"], PROJECT_ROOT / "web"),
+            (["/usr/bin/npm", "install", "--silent"], PROJECT_ROOT / "web"),
+        ]
+        assert npm_calls[3] == (
+            ["/usr/bin/npm", "run", "build"],
+            PROJECT_ROOT / "web",
+        )
 
     def test_update_non_interactive_skips_migration_prompt(self, mock_args, capsys):
         """When stdin/stdout aren't TTYs, config migration prompt is skipped."""

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -15,6 +15,12 @@ from gateway.restart import (
 
 
 class TestSystemdServiceRefresh:
+    @pytest.fixture(autouse=True)
+    def _stub_user_systemd(self, monkeypatch):
+        # _preflight_user_systemd raises on macOS where there's no D-Bus
+        # session — neutralize it so this whole class can run cross-platform.
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
+
     def test_systemd_install_repairs_outdated_unit_without_force(self, tmp_path, monkeypatch):
         unit_path = tmp_path / "hermes-gateway.service"
         unit_path.write_text("old unit\n", encoding="utf-8")
@@ -461,6 +467,12 @@ class TestGatewayServiceDetection:
         assert gateway_cli._is_service_running() is False
 
 class TestGatewaySystemServiceRouting:
+    @pytest.fixture(autouse=True)
+    def _stub_user_systemd(self, monkeypatch):
+        # See note in TestSystemdServiceRefresh — neutralize the D-Bus check
+        # so these tests run on macOS too.
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
+
     def test_systemd_restart_self_requests_graceful_restart_and_waits(self, monkeypatch, capsys):
         calls = []
 

--- a/tests/hermes_cli/test_gateway_wsl.py
+++ b/tests/hermes_cli/test_gateway_wsl.py
@@ -130,6 +130,7 @@ class TestSupportsSystemdServicesWSL:
         monkeypatch.setattr(gateway, "is_termux", lambda: False)
         monkeypatch.setattr(gateway, "is_wsl", lambda: True)
         monkeypatch.setattr(gateway, "_wsl_systemd_operational", lambda: True)
+        monkeypatch.setattr(gateway.shutil, "which", lambda _: "/usr/bin/systemctl")
         assert gateway.supports_systemd_services() is True
 
     def test_wsl_without_systemd(self, monkeypatch):
@@ -138,6 +139,7 @@ class TestSupportsSystemdServicesWSL:
         monkeypatch.setattr(gateway, "is_termux", lambda: False)
         monkeypatch.setattr(gateway, "is_wsl", lambda: True)
         monkeypatch.setattr(gateway, "_wsl_systemd_operational", lambda: False)
+        monkeypatch.setattr(gateway.shutil, "which", lambda _: "/usr/bin/systemctl")
         assert gateway.supports_systemd_services() is False
 
     def test_native_linux(self, monkeypatch):
@@ -145,6 +147,8 @@ class TestSupportsSystemdServicesWSL:
         monkeypatch.setattr(gateway, "is_linux", lambda: True)
         monkeypatch.setattr(gateway, "is_termux", lambda: False)
         monkeypatch.setattr(gateway, "is_wsl", lambda: False)
+        monkeypatch.setattr(gateway, "is_container", lambda: False)
+        monkeypatch.setattr(gateway.shutil, "which", lambda _: "/usr/bin/systemctl")
         assert gateway.supports_systemd_services() is True
 
     def test_termux_still_excluded(self, monkeypatch):

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -1008,11 +1008,33 @@ def skill_view(
             )
 
         # Security: warn if skill is loaded from outside trusted directories
-        # (local skills dir + configured external_dirs are all trusted)
+        # (local skills dir + configured external_dirs are all trusted).
+        # We also trust the resolved target of any symlinked subdirectory
+        # under SKILLS_DIR — this enables stow/dotfiles-managed skills
+        # without spurious warnings.
         _outside_skills_dir = True
         _trusted_dirs = [SKILLS_DIR.resolve()]
         try:
             _trusted_dirs.extend(d.resolve() for d in all_dirs[1:])
+        except Exception:
+            pass
+        # Walk SKILLS_DIR looking for symlinked subdirectories and trust
+        # their resolved targets too. Limited to one level of children +
+        # grandchildren (skill category dirs) to keep the scan cheap.
+        try:
+            for _child in SKILLS_DIR.iterdir():
+                if _child.is_symlink():
+                    try:
+                        _trusted_dirs.append(_child.resolve())
+                    except Exception:
+                        pass
+                elif _child.is_dir():
+                    for _grand in _child.iterdir():
+                        if _grand.is_symlink():
+                            try:
+                                _trusted_dirs.append(_grand.resolve())
+                            except Exception:
+                                pass
         except Exception:
             pass
         for _td in _trusted_dirs:

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -49,6 +49,7 @@ import { SidebarFooter } from "@/components/SidebarFooter";
 import { SidebarStatusStrip } from "@/components/SidebarStatusStrip";
 import { PageHeaderProvider } from "@/contexts/PageHeaderProvider";
 import { useSystemActions } from "@/contexts/useSystemActions";
+import { useSidebarStatus } from "@/hooks/useSidebarStatus";
 import type { SystemAction } from "@/contexts/system-actions-context";
 import ConfigPage from "@/pages/ConfigPage";
 import DocsPage from "@/pages/DocsPage";
@@ -350,6 +351,8 @@ export default function App() {
         >
           {t.app.brand}
         </Typography>
+
+        <MobileHostnameBadge />
       </header>
 
       {mobileOpen && (
@@ -656,4 +659,28 @@ interface SystemActionItem {
   label: string;
   runningLabel: string;
   spin: boolean;
+}
+
+/**
+ * Mobile-header hostname pill — shows which machine the dashboard is
+ * running on so users with personal + work laptops can tell tabs apart.
+ * On desktop the same info appears in SidebarStatusStrip.
+ */
+function MobileHostnameBadge() {
+  const status = useSidebarStatus();
+  const hostname = status?.hostname;
+  if (!hostname) return null;
+  return (
+    <span
+      title={`host: ${hostname}`}
+      className={cn(
+        "ml-auto truncate max-w-[40vw]",
+        "font-mondwest text-[0.6rem] tracking-[0.12em]",
+        "text-midground/70",
+      )}
+      style={{ mixBlendMode: "plus-lighter" }}
+    >
+      {hostname}
+    </span>
+  );
 }

--- a/web/src/components/SidebarStatusStrip.tsx
+++ b/web/src/components/SidebarStatusStrip.tsx
@@ -34,6 +34,15 @@ export function SidebarStatusStrip() {
       )}
     >
       <div className="flex flex-col gap-1 font-mondwest text-[0.55rem] leading-snug tracking-[0.12em]">
+        {status.hostname ? (
+          <p className="break-words" title={`host: ${status.hostname}`}>
+            <span className="text-muted-foreground/50">host:</span>{" "}
+            <span className="font-medium text-midground">
+              {status.hostname}
+            </span>
+          </p>
+        ) : null}
+
         <p className="break-words">
           <span className="text-muted-foreground/50">{gatewayStatusLabel}</span>{" "}
           <span className={cn("font-medium", gw.tone)}>{gw.label}</span>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -253,6 +253,7 @@ export interface StatusResponse {
   gateway_state: string | null;
   gateway_updated_at: string | null;
   hermes_home: string;
+  hostname: string;
   latest_config_version: number;
   release_date: string;
   version: string;


### PR DESCRIPTION
Two small dashboard improvements:

**1. Chat tab on by default**
The in-browser Chat tab is what most people running `hermes dashboard` actually want. Previously hidden behind `--tui` (or `HERMES_DASHBOARD_TUI=1`). Now ON by default; opt out with `hermes dashboard --no-tui` or `HERMES_DASHBOARD_TUI=0`.

**2. Hostname display for multi-machine workflows**
Running the dashboard on personal + work laptops makes the tabs look identical. Now shows the host's short hostname:

- Sidebar: `host: <name>` line above gateway status (desktop)
- Mobile header: small pill next to the brand
- `/api/status` API: new `hostname` field

Hostname comes from `socket.gethostname()` truncated at the first dot \u2014 the short name is what users actually recognize (e.g. `mpetters-mbp`, not the full FQDN).

**Bonus: 9 pre-existing test fixes** (separate commit)

Tests that were red on macOS dev machines for unrelated reasons:
- `test_gateway_wsl`: missing `shutil.which` mock for `systemctl`
- `test_gateway_service`: `_preflight_user_systemd` raises on macOS (no D-Bus)
- `test_cmd_update`: stale assertion \u2014 code uses `npm ci` first, falls back to `npm install`
- `test_api_key_providers`: AWS credential leak from `~/.aws/credentials`
- `test_web_server`: `prompt_caching` was a single-field category

(There are still ~52 OTHER failing tests on main spanning Discord/Matrix/Anthropic/Slack adapters \u2014 unrelated domain bugs, separate cleanup.)