### PR TITLE
fix(weixin): fail fast on permanent iLink error codes instead of retrying

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -90,7 +90,7 @@ RETRY_DELAY_SECONDS = 2
 BACKOFF_DELAY_SECONDS = 30
 SESSION_EXPIRED_ERRCODE = -14
 # iLink error codes that retrying cannot resolve (e.g. message payload too large
-# or malformed request).  Returning -2 for these skips the backoff loop.
+# or malformed request). Receiving ret/errcode -2 fails fast without retrying.
 NON_RETRYABLE_ERRCODES = frozenset({-2})
 MESSAGE_DEDUP_TTL_SECONDS = 300
 

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -89,6 +89,9 @@ MAX_CONSECUTIVE_FAILURES = 3
 RETRY_DELAY_SECONDS = 2
 BACKOFF_DELAY_SECONDS = 30
 SESSION_EXPIRED_ERRCODE = -14
+# iLink error codes that retrying cannot resolve (e.g. message payload too large
+# or malformed request).  Returning -2 for these skips the backoff loop.
+NON_RETRYABLE_ERRCODES = frozenset({-2})
 MESSAGE_DEDUP_TTL_SECONDS = 300
 
 MEDIA_IMAGE = 1
@@ -97,6 +100,10 @@ MEDIA_FILE = 3
 MEDIA_VOICE = 4
 
 _LIVE_ADAPTERS: Dict[str, Any] = {}
+
+
+class _ILinkPermanentError(RuntimeError):
+    """Raised for iLink error codes where retrying the same payload cannot help."""
 
 
 def _make_ssl_connector() -> Optional["aiohttp.TCPConnector"]:
@@ -1496,6 +1503,10 @@ class WeixinAdapter(BasePlatformAdapter):
         *without* ``context_token`` — iLink accepts tokenless sends as a
         degraded fallback, which keeps cron-initiated push messages working
         even when no user message has refreshed the session recently.
+
+        Errors in ``NON_RETRYABLE_ERRCODES`` (e.g. ret=-2, invalid payload)
+        are raised immediately without retrying — the same payload cannot
+        succeed on subsequent attempts.
         """
         last_error: Optional[Exception] = None
         retried_without_token = False
@@ -1532,13 +1543,14 @@ class WeixinAdapter(BasePlatformAdapter):
                             )
                             continue
                         errmsg = resp.get("errmsg") or resp.get("msg") or "unknown error"
-                        raise RuntimeError(
-                            f"iLink sendmessage error: ret={ret} errcode={errcode} errmsg={errmsg}"
-                        )
+                        error_msg = f"iLink sendmessage error: ret={ret} errcode={errcode} errmsg={errmsg}"
+                        if ret in NON_RETRYABLE_ERRCODES or errcode in NON_RETRYABLE_ERRCODES:
+                            raise _ILinkPermanentError(error_msg)
+                        raise RuntimeError(error_msg)
                 return
             except Exception as exc:
                 last_error = exc
-                if attempt >= self._send_chunk_retries:
+                if attempt >= self._send_chunk_retries or isinstance(exc, _ILinkPermanentError):
                     break
                 wait = self._send_chunk_retry_delay_seconds * (attempt + 1)
                 logger.warning(

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -415,7 +415,7 @@ class TestWeixinNonRetryableErrors:
             calls["n"] += 1
             if calls["n"] == 1:
                 raise RuntimeError("transient network error")
-            return None
+            return {"ret": 0}
 
         send_message_mock.side_effect = fail_then_succeed
         adapter = self._connected_adapter()

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -359,6 +359,88 @@ class TestWeixinChunkDelivery:
         assert first_try["client_id"] == retry["client_id"]
 
 
+class TestWeixinNonRetryableErrors:
+    """Permanent iLink error codes must not be retried."""
+
+    def _connected_adapter(self) -> WeixinAdapter:
+        adapter = _make_adapter()
+        adapter._session = object()
+        adapter._send_session = adapter._session
+        adapter._token = "test-token"
+        adapter._base_url = "https://weixin.example.com"
+        adapter._send_chunk_retries = 3
+        adapter._token_store.get = lambda account_id, chat_id: None
+        return adapter
+
+    @patch("gateway.platforms.weixin._send_message", new_callable=AsyncMock)
+    def test_ret_minus_2_fails_without_retry(self, send_message_mock):
+        send_message_mock.return_value = {"ret": -2, "errmsg": "message too long"}
+        adapter = self._connected_adapter()
+
+        import pytest
+        with pytest.raises(RuntimeError, match="ret=-2"):
+            asyncio.run(
+                adapter._send_text_chunk(
+                    chat_id="wxid_abc",
+                    chunk="x" * 5000,
+                    context_token=None,
+                    client_id="cid-1",
+                )
+            )
+        assert send_message_mock.await_count == 1
+
+    @patch("gateway.platforms.weixin._send_message", new_callable=AsyncMock)
+    def test_errcode_minus_2_fails_without_retry(self, send_message_mock):
+        send_message_mock.return_value = {"ret": 0, "errcode": -2, "errmsg": "invalid message"}
+        adapter = self._connected_adapter()
+
+        import pytest
+        with pytest.raises(RuntimeError, match="errcode=-2"):
+            asyncio.run(
+                adapter._send_text_chunk(
+                    chat_id="wxid_abc",
+                    chunk="content",
+                    context_token=None,
+                    client_id="cid-2",
+                )
+            )
+        assert send_message_mock.await_count == 1
+
+    @patch("gateway.platforms.weixin.asyncio.sleep", new_callable=AsyncMock)
+    @patch("gateway.platforms.weixin._send_message", new_callable=AsyncMock)
+    def test_transient_error_still_retries(self, send_message_mock, sleep_mock):
+        calls = {"n": 0}
+
+        async def fail_then_succeed(*args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("transient network error")
+            return None
+
+        send_message_mock.side_effect = fail_then_succeed
+        adapter = self._connected_adapter()
+
+        asyncio.run(
+            adapter._send_text_chunk(
+                chat_id="wxid_abc",
+                chunk="short message",
+                context_token=None,
+                client_id="cid-3",
+            )
+        )
+        assert send_message_mock.await_count == 2
+
+    @patch("gateway.platforms.weixin._send_message", new_callable=AsyncMock)
+    def test_send_returns_failure_on_permanent_error(self, send_message_mock):
+        send_message_mock.return_value = {"ret": -2, "errmsg": "message too long"}
+        adapter = self._connected_adapter()
+
+        result = asyncio.run(adapter.send("wxid_abc", "hello"))
+        assert result.success is False
+        assert "ret=-2" in result.error
+        assert send_message_mock.await_count == 1
+
+
 class TestWeixinOutboundMedia:
     def test_send_image_file_accepts_keyword_image_path(self):
         adapter = _make_adapter()


### PR DESCRIPTION
## Summary
- Adds `NON_RETRYABLE_ERRCODES = frozenset({-2})` constant for iLink error codes that cannot be resolved by retrying
- Introduces `_ILinkPermanentError` sentinel raised when a permanent error code is received
- `_send_text_chunk` now breaks the retry loop immediately on `ret=-2` or `errcode=-2`; transient errors and session-expiry (-14) continue to retry as before

## The bug

When iLink returns `ret=-2` (invalid payload / message too long), `_send_text_chunk` caught the resulting `RuntimeError` in its retry loop and re-sent the **identical** chunk up to `send_chunk_retries` times (default 2 retries), producing spurious warning logs and unnecessary latency before the final failure:

```
WARNING gateway.platforms.weixin: [Weixin] send chunk failed to=wxid_xxx attempt=1/3, retrying in 1.00s: iLink sendmessage error: ret=-2
WARNING gateway.platforms.weixin: [Weixin] send chunk failed to=wxid_xxx attempt=2/3, retrying in 2.00s: iLink sendmessage error: ret=-2
```

Since `ret=-2` indicates a permanent payload rejection (the content itself is invalid or too long for the endpoint), resending the same payload cannot succeed.

## The fix

`_ILinkPermanentError(RuntimeError)` is raised instead of a plain `RuntimeError` for codes in `NON_RETRYABLE_ERRCODES`. The `except Exception` handler checks `isinstance(exc, _ILinkPermanentError)` and breaks the loop immediately, equivalent to having exhausted all retries.

## Test plan
- [x] **Before**: simulation confirms old code makes 4 `_send_message` calls (3 retries) for `ret=-2`
- [x] **After**: `test_ret_minus_2_fails_without_retry` — exactly 1 call, error raised immediately
- [x] `test_errcode_minus_2_fails_without_retry` — same fast-fail via the `errcode` field
- [x] `test_transient_error_still_retries` — transient `RuntimeError` still triggers the retry path
- [x] `test_send_returns_failure_on_permanent_error` — `send()` propagates the error correctly
- [x] All 46 existing `tests/gateway/test_weixin.py` tests pass unchanged

## Related
- Fixes #16411

🤖 Generated with [Claude Code](https://claude.com/claude-code)