### PR TITLE
fix(gateway): detect stale scoped locks via cmdline when start_time is absent

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -512,6 +512,20 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
                     and current_start != existing.get("start_time")
                 ):
                     stale = True
+                # Fallback: when start_time is unavailable (macOS has no
+                # /proc) or the lock record was written without start_time,
+                # check whether the live PID still looks like a Hermes
+                # gateway.  If it does not, the lock is stale — the PID was
+                # reused by an unrelated process (#16376).
+                if not stale:
+                    _record_ok = _record_looks_like_gateway(existing)
+                    _proc_ok = _looks_like_gateway_process(existing_pid)
+                    if _record_ok and not _proc_ok:
+                        stale = True
+                    elif not _record_ok and not _proc_ok:
+                        # Legacy lock without kind/argv metadata *and* the
+                        # live process is not a gateway — treat as stale.
+                        stale = True
                 # Check if process is stopped (Ctrl+Z / SIGTSTP) — stopped
                 # processes still respond to os.kill(pid, 0) but are not
                 # actually running. Treat them as stale so --replace works.


### PR DESCRIPTION
## Problem

On macOS, `_get_process_start_time()` always returns `None` because `/proc` doesn't exist. When a scoped lock record also has `start_time=None` (legacy locks or locks written on macOS), the staleness check in `acquire_scoped_lock()` is inconclusive — it cannot determine whether the PID was reused by an unrelated process.

From #16376: The recorded PID in the Telegram scoped lock had been reused by an unrelated macOS application (`UURemote.app`). Since the PID was alive and the start_time check was inconclusive, Hermes refused to start the Telegram adapter.

## Fix

After the `start_time` comparison, add a fallback that checks whether the live PID still looks like a Hermes gateway via `_looks_like_gateway_process()`. Two cases:

1. **Lock record has gateway metadata** (`kind == "gateway"`) but the live process is NOT a gateway → **stale** (PID reused)
2. **Lock record lacks metadata** (legacy) AND the live process is NOT a gateway → **stale** (safe assumption — if it were a gateway, cmdline would match)

If the live process IS a gateway (cmdline matches), the lock is valid regardless of metadata presence — this handles legacy locks from older versions.

Fixes #16376
