### PR TITLE
feat(plugins): allow pre_tool_call hooks to block tool execution

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -405,7 +405,10 @@ def handle_function_call(
 
         try:
             from hermes_cli.plugins import invoke_hook
-            invoke_hook("pre_tool_call", tool_name=function_name, args=function_args, task_id=task_id or "")
+            _hook_results = invoke_hook("pre_tool_call", tool_name=function_name, args=function_args, task_id=task_id or "")
+            for _r in _hook_results or []:
+                if isinstance(_r, dict) and _r.get("block"):
+                    return json.dumps({"error": "BLOCKED by pre_tool_call hook", "reason": _r.get("reason", "policy")})
         except Exception:
             pass
 


### PR DESCRIPTION
## What does this PR do?

Makes `pre_tool_call` plugin hooks **blockable**.

Currently, return values from `invoke_hook("pre_tool_call", ...)` at `model_tools.py:408` are discarded — hooks can observe but cannot prevent unsafe tool calls. This PR is a 5-line additive change that short-circuits the dispatcher when any `pre_tool_call` hook returns `{"block": True, "reason": "..."}`.

The agent core sees an error JSON (same shape as the existing early-return at line 404) and the LLM gets a chance to react. Mirrors the existing `pre_llm_call` return-value contract.

## Related Issue

No existing issue. Happy to file one first if preferred — flagging because the change is small enough that a PR seemed cleaner.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix (enables security plugins)

## Changes Made

- `model_tools.py:407-413` — collect hook return values, short-circuit if any hook returns a `{"block": True}` dict

```diff
         try:
             from hermes_cli.plugins import invoke_hook
-            invoke_hook("pre_tool_call", tool_name=function_name, args=function_args, task_id=task_id or "")
+            _hook_results = invoke_hook("pre_tool_call", tool_name=function_name, args=function_args, task_id=task_id or "")
+            for _r in _hook_results or []:
+                if isinstance(_r, dict) and _r.get("block"):
+                    return json.dumps({"error": "BLOCKED by pre_tool_call hook", "reason": _r.get("reason", "policy")})
         except Exception:
             pass
```

## How to Test

End-to-end (drives the actual dispatcher):

```python
import sys; sys.path.insert(0, '/path/to/hermes-agent')
from hermes_cli.plugins import discover_plugins, get_plugin_manager
discover_plugins()

# Register a blocking hook ad-hoc
def block_send(tool_name, args, task_id, **kw):
    if tool_name == "send_message":
        return {"block": True, "reason": "test"}
    return None
get_plugin_manager()._hooks.setdefault("pre_tool_call", []).append(block_send)

import model_tools
result = model_tools.handle_function_call(
    function_name="send_message",
    function_args={"action":"send","target":"telegram","message":"hi"},
    task_id="test",
)
assert "BLOCKED by pre_tool_call hook" in result
```

Hook-only:

```python
from hermes_cli.plugins import invoke_hook
results = invoke_hook("pre_tool_call", tool_name="send_message", args={...}, task_id="t")
# Existing observation-only hooks: results is `[]` or list of non-block dicts → no behavior change
# New blocking hooks: dispatcher short-circuits with the JSON above
```

## Use case

We're integrating Hermes for WhatsApp messaging at ISA (Intelligent Solutions Agency). Built a security plugin (`isa-exfil-guard`, ~150 LOC, Hermes plugin pattern) that scans outbound messages for accidental secret leaks (API keys, JWTs, SSH private keys, password assignments) before send. The plugin already loads cleanly via `hermes plugins install`, but without this change it can only log — it can't actually prevent the leak.

With this PR merged, security/policy plugins can ship cleanly without monkey-patching.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) — no duplicates found
- [x] My PR contains **only** changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass — *running locally is non-trivial in our setup; happy to add a CI green proof in a follow-up commit if that's preferred. The change is additive and the patched try/except wraps no new exceptions.*
- [ ] I've added tests for my changes — *can add a small test for this if you want; would slot under `tests/test_plugins.py` (mock plugin returning block dict, assert dispatcher returns BLOCKED JSON). Let me know if you'd like that bundled.*
- [x] I've tested on my platform: Ubuntu 24.04 (WSL2)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation — *not in this PR; happy to add a paragraph to the plugin section of `CONTRIBUTING.md` describing the block-dict contract if you'd like.*
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config changes)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture — N/A (no architecture change)
- [x] I've considered cross-platform impact — pure Python, stdlib `json`, no platform-specific code
- [x] I've updated tool descriptions/schemas — N/A

## Backwards compatibility

- All existing hooks unchanged — `invoke_hook` already returns `List[Any]` of non-`None` returns
- Plugins not returning block dicts behave identically (the new loop is a no-op for them)
- No new dependencies, no new config, no new hook names