### PR TITLE
fix(cron): resume_job() sets state=error when compute_next_run() returns None

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -607,6 +607,30 @@ def resume_job(job_id: str) -> Optional[Dict[str, Any]]:
         return None
 
     next_run_at = compute_next_run(job["schedule"])
+
+    # Parity with mark_job_run() (#16265): when compute_next_run() cannot
+    # produce a timestamp for a recurring schedule (e.g. croniter absent),
+    # mark state=error rather than scheduling with next_run_at=None.  A job
+    # sitting at state="scheduled" with no next_run_at silently never fires,
+    # giving the user no indication that the resume failed.
+    if next_run_at is None:
+        kind = job.get("schedule", {}).get("kind")
+        if kind in ("cron", "interval"):
+            return update_job(
+                job_id,
+                {
+                    "enabled": True,
+                    "state": "error",
+                    "paused_at": None,
+                    "paused_reason": None,
+                    "next_run_at": None,
+                    "last_error": (
+                        "Cannot resume: failed to compute next run for recurring "
+                        "schedule (is the 'croniter' package installed?)"
+                    ),
+                },
+            )
+
     return update_job(
         job_id,
         {

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -299,6 +299,54 @@ class TestPauseResumeJob:
         assert resumed["paused_at"] is None
         assert resumed["paused_reason"] is None
 
+    def test_resume_cron_sets_error_when_croniter_missing(self, tmp_cron_dir, monkeypatch):
+        """Parity with mark_job_run() fix (#16265): resume_job() must set
+        state=error when croniter is absent and compute_next_run() cannot
+        produce a next_run_at for a cron-kind job.
+
+        Before this fix, resume_job() called update_job() with next_run_at=None,
+        leaving the job at state="scheduled" with no next run — it silently
+        never fired and the user had no visible signal.
+        """
+        pytest.importorskip("croniter")  # need croniter to create the cron job
+        job = create_job(prompt="Cron job", schedule="0 9 * * 1-5")
+        assert job["schedule"]["kind"] == "cron"
+        pause_job(job["id"])
+
+        # Simulate croniter going missing after the job was persisted.
+        monkeypatch.setattr("cron.jobs.HAS_CRONITER", False)
+
+        resumed = resume_job(job["id"])
+
+        assert resumed is not None
+        assert resumed["enabled"] is True, (
+            "job must stay enabled — croniter-missing is a runtime dep issue, "
+            "not a reason to silently disable the job"
+        )
+        assert resumed["state"] == "error"
+        assert resumed["next_run_at"] is None
+        assert resumed["last_error"]
+        assert "croniter" in resumed["last_error"].lower()
+
+    def test_resume_recurring_any_kind_sets_error_when_next_run_none(self, tmp_cron_dir, monkeypatch):
+        """Defensive sibling: any recurring job whose compute_next_run() returns
+        None (e.g. future regression or corrupt schedule) must get state=error,
+        not state=scheduled with a phantom next_run_at.  Mirrors the interval
+        guard in TestMarkJobRun.
+        """
+        job = create_job(prompt="Interval job", schedule="every 1h")
+        assert job["schedule"]["kind"] == "interval"
+        pause_job(job["id"])
+
+        monkeypatch.setattr("cron.jobs.compute_next_run", lambda *a, **kw: None)
+
+        resumed = resume_job(job["id"])
+
+        assert resumed is not None
+        assert resumed["enabled"] is True
+        assert resumed["state"] == "error"
+        assert resumed["next_run_at"] is None
+
 
 class TestMarkJobRun:
     def test_increments_completed(self, tmp_cron_dir):


### PR DESCRIPTION
## What does this PR do?

\`resume_job()\` calls \`compute_next_run()\` and passes the result directly to \`update_job()\` without checking for \`None\`. When \`croniter\` is absent, \`compute_next_run()\` returns \`None\` for \`cron\`-kind schedules. The job was saved as \`state="scheduled"\` with \`next_run_at=None\` — \`get_due_jobs()\` skips jobs with no \`next_run_at\`, so the job silently never fired while appearing resumed to the user.

**Parity with \`mark_job_run()\` fix (#16265, commit 7c63c246):** that fix added a \`kind in ("cron", "interval")\` guard so \`mark_job_run()\` marks \`state=error\` and sets a \`last_error\` with a \`"croniter"\` hint when \`next_run_at\` is \`None\` on the post-run path. \`resume_job()\` is the same silent-disable pattern on the explicit-resume path — this PR mirrors that guard.

## Related Issue

Parity fix — no separate issue. Follows the pattern established by #16265.

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made
- \`cron/jobs.py\`: in \`resume_job()\`, check \`next_run_at is None\` and \`kind in ("cron", "interval")\` before calling \`update_job()\` — set \`state=error\` + \`last_error\` instead of scheduling with no next run time. Symmetric with \`mark_job_run()\` lines 709–727.
- \`tests/cron/test_jobs.py\`: two tests added to \`TestPauseResumeJob\`:
  - \`test_resume_cron_sets_error_when_croniter_missing\` — cron job, \`HAS_CRONITER=False\`, asserts \`state=error\`, \`enabled=True\`, \`next_run_at=None\`, \`"croniter" in last_error\`
  - \`test_resume_recurring_any_kind_sets_error_when_next_run_none\` — interval job, \`compute_next_run\` patched to \`None\`, defensive sibling matching the interval test in \`TestMarkJobRun\`

## How to Test
\`\`\`bash
python3.11 -m pytest tests/cron/test_jobs.py::TestPauseResumeJob -v --override-ini="addopts="
\`\`\`

## Checklist
### Code
- [x] Contributing Guide read
- [x] Conventional Commits
- [x] No duplicate PR
- [x] This fix only
- [x] pytest passed — 58 passed, 5 skipped (croniter skip expected)
- [x] Tests added
- [x] Platform: macOS

### Documentation & Housekeeping
- [x] Docs updated — N/A
- [x] cli-config.yaml.example — N/A
- [x] CONTRIBUTING.md/AGENTS.md — N/A
- [x] Cross-platform impact — N/A
- [x] Tool descriptions — N/A