### PR TITLE
fix(agent): preserve dots in model names for custom providers

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7373,13 +7373,21 @@ class AIAgent:
         ``us.anthropic.claude-sonnet-4-5-20250929-v1:0``) and rejects
         the hyphenated form with
         ``HTTP 400 The provided model identifier is invalid``.
+        Custom providers preserve dots because the user explicitly configured
+        the model name — dot-to-hyphen conversion is only correct for the
+        Anthropic API itself (#16417).
         Regression for #11976; mirrors the opencode-go fix for #5211
         (commit f77be22c), which extended this same allowlist."""
-        if (getattr(self, "provider", "") or "").lower() in {
+        provider = (getattr(self, "provider", "") or "").lower()
+        if provider in {
             "alibaba", "minimax", "minimax-cn",
             "opencode-go", "opencode-zen",
             "zai", "bedrock",
         }:
+            return True
+        # Custom providers point at user-configured endpoints — preserve the
+        # model name as-is since the dot-to-hyphen conversion is Anthropic-specific.
+        if provider == "custom":
             return True
         base = (getattr(self, "base_url", "") or "").lower()
         return (

--- a/tests/agent/test_custom_preserve_dots.py
+++ b/tests/agent/test_custom_preserve_dots.py
@@ -1,0 +1,54 @@
+"""Regression test: custom providers preserve dots in model names.
+
+When provider is "custom", _anthropic_preserve_dots() must return True
+so that model names like "claude-sonnet-4.6" or "glm-4.7" are sent to
+the endpoint unchanged.  Dot-to-hyphen conversion is Anthropic-specific
+and must not be applied to user-configured custom endpoints.
+
+Refs #16417, #13061.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from run_agent import AIAgent
+
+
+def _make_agent(provider: str = "", base_url: str = "") -> AIAgent:
+    agent = MagicMock(spec=AIAgent)
+    agent.provider = provider
+    agent.base_url = base_url
+    # Bind the real method
+    agent._anthropic_preserve_dots = AIAgent._anthropic_preserve_dots.__get__(agent)
+    return agent
+
+
+class TestCustomProviderPreserveDots:
+    """Custom providers must preserve dots in model names."""
+
+    def test_custom_provider_preserves_dots(self) -> None:
+        agent = _make_agent(provider="custom")
+        assert agent._anthropic_preserve_dots() is True
+
+    def test_custom_with_base_url_preserves_dots(self) -> None:
+        agent = _make_agent(
+            provider="custom",
+            base_url="https://my-relay.example.com/v1",
+        )
+        assert agent._anthropic_preserve_dots() is True
+
+    def test_anthropic_provider_still_converts_dots(self) -> None:
+        """Anthropic provider should NOT preserve dots (default behavior)."""
+        agent = _make_agent(provider="anthropic")
+        assert agent._anthropic_preserve_dots() is False
+
+    def test_openrouter_provider_still_converts_dots(self) -> None:
+        agent = _make_agent(provider="openrouter")
+        assert agent._anthropic_preserve_dots() is False
+
+    def test_known_providers_still_preserve_dots(self) -> None:
+        """Existing allowlist providers still work."""
+        for prov in ("alibaba", "minimax", "zai", "bedrock"):
+            agent = _make_agent(provider=prov)
+            assert agent._anthropic_preserve_dots() is True, f"{prov} should preserve dots"


### PR DESCRIPTION
## Problem

When using a custom provider with the `anthropic_messages` protocol, `normalize_model_name()` converts dots to hyphens in model names (e.g. `claude-sonnet-4.6` → `claude-sonnet-4-6`). This is correct for the Anthropic API but wrong for custom endpoints that expect the model name unchanged.

`_anthropic_preserve_dots()` has an allowlist of providers that preserve dots, but "custom" is not included.

## Fix

Add `"custom"` to the provider set in `_anthropic_preserve_dots()`. When the provider is "custom", the user has explicitly configured an external endpoint with a specific model name — dot-to-hyphen conversion is Anthropic-specific and must not be applied.

**Affected model names:** `claude-sonnet-4.6`, `glm-4.7`, `qwen3.5-plus`, `MiniMax-M2.7`, etc.

## Tests

New regression test in `tests/agent/test_custom_preserve_dots.py`:
- Custom provider preserves dots
- Custom with base_url preserves dots
- Anthropic provider still converts dots (no regression)
- Known allowlist providers still work

Fixes #16417
Fixes #13061
