### PR TITLE
fix(debug): sweep expired paste.rs uploads on a real timer

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11153,13 +11153,16 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
     cron delivery path so live adapters can be used for E2EE rooms.
 
     Also refreshes the channel directory every 5 minutes and prunes the
-    image/audio/document cache once per hour.
+    image/audio/document cache + expired ``hermes debug share`` pastes
+    once per hour.
     """
     from cron.scheduler import tick as cron_tick
     from gateway.platforms.base import cleanup_image_cache, cleanup_document_cache
+    from hermes_cli.debug import _sweep_expired_pastes
 
     IMAGE_CACHE_EVERY = 60   # ticks — once per hour at default 60s interval
     CHANNEL_DIR_EVERY = 5    # ticks — every 5 minutes
+    PASTE_SWEEP_EVERY = 60   # ticks — once per hour
 
     logger.info("Cron ticker started (interval=%ds)", interval)
     tick_count = 0
@@ -11199,6 +11202,17 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
                     logger.info("Document cache cleanup: removed %d stale file(s)", removed)
             except Exception as e:
                 logger.debug("Document cache cleanup error: %s", e)
+
+        if tick_count % PASTE_SWEEP_EVERY == 0:
+            try:
+                deleted, remaining = _sweep_expired_pastes()
+                if deleted:
+                    logger.info(
+                        "Paste sweep: deleted %d expired paste(s), %d pending",
+                        deleted, remaining,
+                    )
+            except Exception as e:
+                logger.debug("Paste sweep error: %s", e)
 
         stop_event.wait(timeout=interval)
     logger.info("Cron ticker stopped")

--- a/hermes_cli/debug.py
+++ b/hermes_cli/debug.py
@@ -45,8 +45,13 @@ def _pending_file() -> Path:
     Each entry: ``{"url": "...", "expire_at": <unix_ts>}``.  Scheduled
     DELETEs used to be handled by spawning a detached Python process per
     paste that slept for 6 hours; those accumulated forever if the user
-    ran ``hermes debug share`` repeatedly.  We now persist the schedule
-    to disk and sweep expired entries on the next debug invocation.
+    ran ``hermes debug share`` repeatedly.
+
+    Deletion is now driven by the gateway's cron ticker
+    (``gateway/run.py::_start_cron_ticker``) which calls
+    ``_sweep_expired_pastes`` once per hour.  ``hermes debug share`` also
+    runs an opportunistic sweep on entry as a fallback for CLI-only users
+    who never start the gateway.
     """
     return get_hermes_home() / "pastes" / "pending.json"
 
@@ -223,9 +228,10 @@ def _schedule_auto_delete(urls: list[str], delay_seconds: int = _AUTO_DELETE_SEC
     interpreters that never exited until the sleep completed.
 
     The replacement is stateless: we append to ``~/.hermes/pastes/pending.json``
-    and rely on opportunistic sweeps (``_sweep_expired_pastes``) called from
-    every ``hermes debug`` invocation.  If the user never runs ``hermes debug``
-    again, paste.rs's own retention policy handles cleanup.
+    and the gateway's cron ticker sweeps expired entries once per hour.
+    ``hermes debug share`` also runs an opportunistic sweep as a fallback
+    for CLI-only users.  If neither runs again, paste.rs's own retention
+    policy handles cleanup.
     """
     _record_pending(urls, delay_seconds=delay_seconds)
 


### PR DESCRIPTION
## Summary
'hermes debug share' pastes now actually auto-delete after 6 hours. Previously the sweep only ran when the user re-invoked 'hermes debug share' — a user who uploaded once and never came back left pastes up indefinitely (paste.rs doesn't GC them).

## Changes
- `gateway/run.py`: `_start_cron_ticker` now calls `_sweep_expired_pastes` once per hour, alongside the existing image/document cache cleanups.
- `hermes_cli/debug.py`: updated docstrings to reflect the gateway ticker as the primary cleanup path. Kept the opportunistic sweep in 'hermes debug share' as a fallback for CLI-only users who never start the gateway.

## Validation
- Targeted tests: `tests/hermes_cli/test_debug.py` + `tests/gateway/test_debug_command.py` — 60/60 pass.
- E2E: uploaded two real paste.rs entries, seeded pending.json with one expired + one future, called `_sweep_expired_pastes()` — expired paste returned 404 afterwards, future one stayed alive, pending.json shrank to 1 entry.

## Context
Community user Bob Dobolina (@bob_dobalinaa) uploaded debug reports via 'hermes debug share' yesterday; the 6-hour auto-delete never fired because he didn't re-invoke the command. This caught the hole in the cleanup mechanism.