### PR TITLE
fix(gateway): ignore MEDIA examples without local files

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1600,19 +1600,51 @@ class BasePlatformAdapter(ABC):
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$)|\S+)[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|[^\s`"']+)[`"']?'''
         )
-        for match in media_pattern.finditer(content):
+
+        # Build spans covered by fenced code blocks and inline code. MEDIA:
+        # examples inside code should remain literal text, not trigger native
+        # attachment delivery or "file not found" warnings.
+        code_spans: list = []
+        for m in re.finditer(r'```[^\n]*\n.*?```', content, re.DOTALL):
+            code_spans.append((m.start(), m.end()))
+        for m in re.finditer(r'`[^`\n]+`', content):
+            code_spans.append((m.start(), m.end()))
+
+        def _in_code(pos: int) -> bool:
+            return any(s <= pos < e for s, e in code_spans)
+
+        remove_spans: list = []
+        search_content = cleaned
+        for match in media_pattern.finditer(search_content):
+            if _in_code(match.start()):
+                continue
             path = match.group("path").strip()
             if len(path) >= 2 and path[0] == path[-1] and path[0] in "`\"'":
                 path = path[1:-1].strip()
             path = path.lstrip("`\"'").rstrip("`\"',.;:)}]")
-            if path:
-                media.append((os.path.expanduser(path), has_voice_tag))
+            if not path:
+                continue
+            expanded = os.path.expanduser(path)
+            # Only real local files are delivered. Non-existent MEDIA: samples
+            # are left in text instead of being attempted as attachments; this
+            # prevents code snippets and test output from polluting errors.log.
+            if os.path.isfile(expanded):
+                media.append((expanded, has_voice_tag))
+                remove_spans.append((match.start(), match.end()))
 
-        # Remove MEDIA tags from content (including surrounding quote/backtick wrappers)
-        if media:
-            cleaned = media_pattern.sub('', cleaned)
+        # Remove only MEDIA tags that were accepted for delivery. Leave skipped
+        # tags (inside code or missing files) intact so examples are not
+        # mutilated.
+        if remove_spans:
+            pieces = []
+            last = 0
+            for start, end in remove_spans:
+                pieces.append(cleaned[last:start])
+                last = end
+            pieces.append(cleaned[last:])
+            cleaned = ''.join(pieces)
             cleaned = re.sub(r'\n{3,}', '\n\n', cleaned).strip()
         
         return media, cleaned

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -261,65 +261,110 @@ class TestExtractMedia:
         assert media == []
         assert cleaned == "Just text."
 
-    def test_single_media_tag(self):
-        content = "MEDIA:/path/to/audio.ogg"
+    def test_single_media_tag(self, tmp_path):
+        audio = tmp_path / "audio.ogg"
+        audio.write_bytes(b"ogg")
+        content = f"MEDIA:{audio}"
         media, cleaned = BasePlatformAdapter.extract_media(content)
         assert len(media) == 1
-        assert media[0][0] == "/path/to/audio.ogg"
+        assert media[0][0] == str(audio)
         assert media[0][1] is False  # no voice tag
 
-    def test_media_with_voice_directive(self):
-        content = "[[audio_as_voice]]\nMEDIA:/path/to/voice.ogg"
+    def test_media_with_voice_directive(self, tmp_path):
+        voice = tmp_path / "voice.ogg"
+        voice.write_bytes(b"ogg")
+        content = f"[[audio_as_voice]]\nMEDIA:{voice}"
         media, cleaned = BasePlatformAdapter.extract_media(content)
         assert len(media) == 1
-        assert media[0][0] == "/path/to/voice.ogg"
+        assert media[0][0] == str(voice)
         assert media[0][1] is True  # voice tag present
 
-    def test_multiple_media_tags(self):
-        content = "MEDIA:/a.ogg\nMEDIA:/b.ogg"
+    def test_multiple_media_tags(self, tmp_path):
+        a = tmp_path / "a.ogg"
+        b = tmp_path / "b.ogg"
+        a.write_bytes(b"ogg")
+        b.write_bytes(b"ogg")
+        content = f"MEDIA:{a}\nMEDIA:{b}"
         media, _ = BasePlatformAdapter.extract_media(content)
         assert len(media) == 2
 
-    def test_voice_directive_removed_from_content(self):
-        content = "[[audio_as_voice]]\nSome text\nMEDIA:/voice.ogg"
+    def test_voice_directive_removed_from_content(self, tmp_path):
+        voice = tmp_path / "voice.ogg"
+        voice.write_bytes(b"ogg")
+        content = f"[[audio_as_voice]]\nSome text\nMEDIA:{voice}"
         _, cleaned = BasePlatformAdapter.extract_media(content)
         assert "[[audio_as_voice]]" not in cleaned
         assert "MEDIA:" not in cleaned
         assert "Some text" in cleaned
 
-    def test_media_with_text_before(self):
-        content = "Here is your audio:\nMEDIA:/output.ogg"
+    def test_media_with_text_before(self, tmp_path):
+        audio = tmp_path / "output.ogg"
+        audio.write_bytes(b"ogg")
+        content = f"Here is your audio:\nMEDIA:{audio}"
         media, cleaned = BasePlatformAdapter.extract_media(content)
         assert len(media) == 1
         assert "Here is your audio" in cleaned
 
-    def test_cleaned_content_trims_excess_newlines(self):
-        content = "Before\n\nMEDIA:/audio.ogg\n\n\n\nAfter"
+    def test_cleaned_content_trims_excess_newlines(self, tmp_path):
+        audio = tmp_path / "audio.ogg"
+        audio.write_bytes(b"ogg")
+        content = f"Before\n\nMEDIA:{audio}\n\n\n\nAfter"
         _, cleaned = BasePlatformAdapter.extract_media(content)
         assert "\n\n\n" not in cleaned
 
-    def test_media_tag_allows_optional_whitespace_after_colon(self):
-        content = "MEDIA: /path/to/audio.ogg"
+    def test_media_tag_allows_optional_whitespace_after_colon(self, tmp_path):
+        audio = tmp_path / "audio.ogg"
+        audio.write_bytes(b"ogg")
+        content = f"MEDIA: {audio}"
         media, cleaned = BasePlatformAdapter.extract_media(content)
-        assert media == [("/path/to/audio.ogg", False)]
+        assert media == [(str(audio), False)]
         assert cleaned == ""
 
-    def test_media_tag_strips_wrapping_quotes_and_backticks(self):
-        content = "MEDIA: `/path/to/file.png`\nMEDIA:\"/path/to/file2.png\"\nMEDIA:'/path/to/file3.png'"
+    def test_media_tag_strips_wrapping_quotes_and_backticks(self, tmp_path):
+        f1 = tmp_path / "file.png"
+        f2 = tmp_path / "file2.png"
+        f3 = tmp_path / "file3.png"
+        for f in (f1, f2, f3):
+            f.write_bytes(b"png")
+        content = f"MEDIA: `{f1}`\nMEDIA:\"{f2}\"\nMEDIA:'{f3}'"
         media, cleaned = BasePlatformAdapter.extract_media(content)
         assert media == [
-            ("/path/to/file.png", False),
-            ("/path/to/file2.png", False),
-            ("/path/to/file3.png", False),
+            (str(f1), False),
+            (str(f2), False),
+            (str(f3), False),
         ]
         assert cleaned == ""
 
-    def test_media_tag_supports_quoted_paths_with_spaces(self):
-        content = "Here\nMEDIA: '/tmp/my image.png'\nAfter"
+    def test_media_tag_supports_quoted_paths_with_spaces(self, tmp_path):
+        image = tmp_path / "my image.png"
+        image.write_bytes(b"png")
+        content = f"Here\nMEDIA: '{image}'\nAfter"
         media, cleaned = BasePlatformAdapter.extract_media(content)
-        assert media == [("/tmp/my image.png", False)]
+        assert media == [(str(image), False)]
         assert "Here" in cleaned
         assert "After" in cleaned
+
+    def test_missing_media_file_is_left_as_text(self):
+        content = "Example MEDIA:/tmp/definitely-missing-hermes-test.png remains"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == []
+        assert cleaned == content
+
+    def test_media_in_fenced_code_block_is_ignored(self, tmp_path):
+        image = tmp_path / "real.png"
+        image.write_bytes(b"png")
+        content = f"```\nMEDIA:{image}\n```"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == []
+        assert cleaned == content
+
+    def test_media_in_inline_code_is_ignored(self, tmp_path):
+        image = tmp_path / "real.png"
+        image.write_bytes(b"png")
+        content = f"Use `MEDIA:{image}` as an example"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == []
+        assert cleaned == content
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Ignore `MEDIA:` tags inside fenced code blocks and inline code.
- Only extract `MEDIA:` paths for native delivery when the expanded local file exists.
- Preserve skipped `MEDIA:` examples in text instead of removing them or attempting delivery.

## Root cause
`BasePlatformAdapter.extract_media()` treated any `MEDIA:<path>` token as a real attachment directive. Code snippets, grep output, and test examples containing `MEDIA:/tmp/missing.png` were therefore sent through native media delivery and produced noisy `File not found` warnings.

## What changed
- Builds code spans for fenced and inline code and skips matches inside them.
- Validates candidate paths with `os.path.isfile()` before adding them to the media list.
- Removes only accepted delivery tags from the outgoing text; skipped examples remain visible.
- Updates gateway media extraction tests to use real temp files for positive cases and adds coverage for missing files / code examples.

## Tests
- `python -m pytest tests/gateway/test_media_extraction.py tests/gateway/test_platform_base.py -q -o 'addopts='`

## Verification
- Verified that existing local media files are still extracted and removed from text.
- Verified that missing paths, fenced-code examples, and inline-code examples are not extracted and are preserved.

Fixes #16434