### PR TITLE
fix(auxiliary): resolve custom/main via named main provider

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1861,6 +1861,37 @@ def resolve_provider_client(
                 client = _wrap_if_needed(client, final_model, _cbase)
                 return (_to_async_client(client, final_model) if async_mode
                         else (client, final_model))
+        # ``custom/main`` is used by some older auxiliary call sites as a
+        # shorthand for "use whatever the main chat endpoint is".  In v12+
+        # configs the main endpoint may be a named custom provider (for
+        # example ``cliproxyapi_local``) rather than the anonymous
+        # OPENAI_BASE_URL/OPENAI_API_KEY pair handled above.  Falling through
+        # directly would emit a misleading warning even though a valid main
+        # provider is configured, so resolve through the configured main
+        # provider once before declaring custom/main unavailable.
+        if (model or "").strip().lower() in ("", "main"):
+            main_provider = _read_main_provider()
+            main_model = _read_main_model()
+            if (
+                main_provider
+                and main_provider not in ("auto", "", "custom")
+                and not main_provider.startswith("custom:")
+            ):
+                client, resolved = resolve_provider_client(
+                    main_provider,
+                    main_model or None,
+                    async_mode=async_mode,
+                    raw_codex=raw_codex,
+                )
+                if client is not None:
+                    logger.info(
+                        "resolve_provider_client: custom/main resolved via "
+                        "configured main provider %s (%s)",
+                        main_provider,
+                        resolved or main_model or "default",
+                    )
+                    return client, resolved or main_model
+
         logger.warning("resolve_provider_client: custom/main requested "
                        "but no endpoint credentials found")
         return None, None

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -33,7 +33,7 @@ from utils import base_url_host_matches, base_url_hostname
 
 
 def _normalize_custom_provider_name(value: str) -> str:
-    return value.strip().lower().replace(" ", "-")
+    return value.strip().lower().replace("_", "-").replace(" ", "-")
 
 
 def _loopback_hostname(host: str) -> bool:

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -487,6 +487,30 @@ class TestExplicitProviderRouting:
             for record in caplog.records
         )
 
+    def test_custom_main_uses_configured_named_main_provider(self, monkeypatch, caplog):
+        """custom/main should inherit named main providers instead of warning."""
+        with (
+            patch("agent.auxiliary_client._resolve_custom_runtime", return_value=(None, None, None)),
+            patch("agent.auxiliary_client._read_main_provider", return_value="cliproxyapi_local"),
+            patch("agent.auxiliary_client._read_main_model", return_value="gpt-5.4-mini"),
+            patch("hermes_cli.runtime_provider._get_named_custom_provider", return_value={
+                "base_url": "http://127.0.0.1:8317/v1/",
+                "api_key": "test-key",
+                "model": "gpt-5.4-mini",
+            }),
+            patch("agent.auxiliary_client.OpenAI") as mock_openai,
+        ):
+            mock_openai.return_value = MagicMock(base_url="http://127.0.0.1:8317/v1/", api_key="test-key")
+            with caplog.at_level(logging.WARNING, logger="agent.auxiliary_client"):
+                client, model = resolve_provider_client("custom", "main")
+
+        assert client is not None
+        assert model == "gpt-5.4-mini"
+        assert not any(
+            "custom/main requested but no endpoint credentials found" in record.message
+            for record in caplog.records
+        )
+
 class TestGetTextAuxiliaryClient:
     """Test the full resolution chain for get_text_auxiliary_client."""
 


### PR DESCRIPTION
## Summary
- Resolve legacy `custom/main` auxiliary requests through the configured main provider when no anonymous custom endpoint is available.
- Normalize underscores in named custom provider lookup so config names like `cliproxyapi_local` match their normalized provider IDs.
- Add regression coverage for `custom/main` inheriting a named main provider.

## Root cause
Some auxiliary call paths use `custom/main` as a shorthand for "use the main chat endpoint". In v12+ configs, the main endpoint can be a named custom provider rather than the legacy anonymous `OPENAI_BASE_URL` / `OPENAI_API_KEY` custom runtime. When the anonymous endpoint was absent, resolution emitted a misleading warning even though a valid named main provider was configured.

## What changed
- After legacy anonymous custom resolution fails for `custom/main`, try `_read_main_provider()` / `_read_main_model()`.
- If the main provider is a named provider, resolve through the normal named-provider path and return that client/model.
- Treat underscores like spaces when normalizing custom provider names, so `cliproxyapi_local` and `cliproxyapi-local` resolve consistently.

## Tests
- `python -m pytest tests/agent/test_auxiliary_client.py -q -o 'addopts='`

## Verification
- Verified `custom/main` no longer emits `custom/main requested but no endpoint credentials found` when a named main provider is available.
- Verified the existing auxiliary client test suite still passes.

Fixes #16435