### PR TITLE
fix(code_execution): add json.JSONDecodeError handling for IPC response parsing

### DIFF
--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -234,7 +234,11 @@ def _call(tool_name, args):
         if buf.endswith(b"\\n"):
             break
     raw = buf.decode().strip()
-    result = json.loads(raw)
+    try:
+        result = json.loads(raw)
+    except json.JSONDecodeError as e:
+        print(f"WARNING: json.loads failed on IPC response: {e}", flush=True)
+        return {"error": f"Malformed IPC response: {e}", "raw": raw[:500]}
     if isinstance(result, str):
         try:
             return json.loads(result)
@@ -286,7 +290,11 @@ def _call(tool_name, args):
     except OSError:
         pass
 
-    result = json.loads(raw)
+    try:
+        result = json.loads(raw)
+    except json.JSONDecodeError as e:
+        print(f"WARNING: json.loads failed on IPC response: {e}", flush=True)
+        return {"error": f"Malformed IPC response: {e}", "raw": raw[:500]}
     if isinstance(result, str):
         try:
             return json.loads(result)


### PR DESCRIPTION
## Problem

In `tools/code_execution_tool.py`, two `json.loads()` calls parse IPC data from sandbox subprocesses with no error handling:

1. **Line 237** (UDS transport template): parses socket data
2. **Line 289** (file-based transport template): parses file-based IPC data

If the sandbox subprocess sends malformed data (crash, partial write, binary garbage, killed mid-write), `JSONDecodeError` propagates unhandled and crashes the RPC loop.

## Fix

Wrap each `json.loads()` in `try/except json.JSONDecodeError` that:
1. Prints a warning with error details
2. Returns a safe error dict: `{"error": "Malformed IPC response: ...", "raw": raw[:500]}`

The raw data is truncated to 500 chars to avoid dumping huge payloads.

These are inside string templates (`_UDS_TRANSPORT_HEADER` and `_FILE_TRANSPORT_HEADER`) that generate Python code for sandbox subprocess RPC stubs.
