### PR TITLE
fix(skills_hub): use atomic writes for lock.json and taps.json

### DIFF
--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -17,6 +17,7 @@ import hashlib
 import json
 import logging
 import os
+import tempfile
 import re
 import shutil
 import subprocess
@@ -2562,7 +2563,15 @@ class HubLockFile:
 
     def save(self, data: dict) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        self.path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n")
+        payload = json.dumps(data, indent=2, ensure_ascii=False) + "\n"
+        fd, tmp = tempfile.mkstemp(dir=str(self.path.parent))
+        try:
+            os.write(fd, payload.encode())
+            os.close(fd)
+            os.replace(tmp, str(self.path))
+        except BaseException:
+            os.unlink(tmp)
+            raise
 
     def record_install(
         self,
@@ -2629,7 +2638,15 @@ class TapsManager:
 
     def save(self, taps: List[dict]) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        self.path.write_text(json.dumps({"taps": taps}, indent=2) + "\n")
+        payload = json.dumps({"taps": taps}, indent=2) + "\n"
+        fd, tmp = tempfile.mkstemp(dir=str(self.path.parent))
+        try:
+            os.write(fd, payload.encode())
+            os.close(fd)
+            os.replace(tmp, str(self.path))
+        except BaseException:
+            os.unlink(tmp)
+            raise
 
     def add(self, repo: str, path: str = "skills/") -> bool:
         """Add a tap. Returns False if already exists."""


### PR DESCRIPTION
## Problem

`tools/skills_hub.py` has two `save()` methods that write JSON state files non-atomically using `write_text()`:

1. **HubLockFile.save()** (line ~2565): writes `skills/.hub/lock.json` — tracks installed skills, trust levels, and hashes
2. **TapsManager.save()** (line ~2632): writes `taps.json` — tracks custom skill source taps

If the process is killed mid-write (OOM, signal, power loss), the file is truncated/corrupted and **all installed skill state is lost**.

## Fix

Replace `write_text()` with the atomic write pattern used elsewhere in the codebase (e.g. `memory_tool.py:441`, `mcp_oauth.py:161`, `skill_manager_tool.py:306`):

1. `tempfile.mkstemp(dir=parent_dir)` — create temp file in same directory (same filesystem for atomic rename)
2. `os.write(fd, payload.encode())` — write full JSON payload
3. `os.replace(tmp, path)` — atomic rename on POSIX
4. `except BaseException: os.unlink(tmp); raise` — cleanup on failure
