### PR TITLE
fix(mattermost): add error handling to _upload_file()

### DIFF
--- a/gateway/platforms/mattermost.py
+++ b/gateway/platforms/mattermost.py
@@ -179,14 +179,18 @@ class MattermostAdapter(BasePlatformAdapter):
             content_type=content_type,
         )
         headers = {"Authorization": f"Bearer {self._token}"}
-        async with self._session.post(url, headers=headers, data=form, timeout=aiohttp.ClientTimeout(total=60)) as resp:
-            if resp.status >= 400:
-                body = await resp.text()
-                logger.error("MM file upload → %s: %s", resp.status, body[:200])
-                return None
-            data = await resp.json()
-            infos = data.get("file_infos", [])
-            return infos[0]["id"] if infos else None
+        try:
+            async with self._session.post(url, headers=headers, data=form, timeout=aiohttp.ClientTimeout(total=60)) as resp:
+                if resp.status >= 400:
+                    body = await resp.text()
+                    logger.error("MM file upload → %s: %s", resp.status, body[:200])
+                    return None
+                data = await resp.json()
+                infos = data.get("file_infos", [])
+                return infos[0]["id"] if infos else None
+        except aiohttp.ClientError as exc:
+            logger.error("MM file upload network error: %s", exc)
+            return None
 
     # ------------------------------------------------------------------
     # Required overrides


### PR DESCRIPTION
## Problem

In `gateway/platforms/mattermost.py`, `_upload_file()` has NO try/except around the HTTP call. The other API methods (`_api_get`, `_api_post`, `_api_put`) all catch `aiohttp.ClientError` and return `{}`, but `_upload_file` lets network errors propagate as unhandled exceptions.

A network error during file upload crashes the message handling loop rather than returning a graceful failure.

## Fix

Wrap the `self._session.post()` async context manager in a `try/except aiohttp.ClientError` block that logs the error and returns `None`, consistent with the method's existing error-return pattern.
