### PR TITLE
fix(gateway): keep Feishu topic replies in thread

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -2723,7 +2723,7 @@ class FeishuAdapter(BasePlatformAdapter):
             chat_type=self._resolve_source_chat_type(chat_info=chat_info, event_chat_type=chat_type),
             user_id=sender_profile["user_id"],
             user_name=sender_profile["user_name"],
-            thread_id=getattr(message, "thread_id", None) or None,
+            thread_id=getattr(message, "root_id", None) or getattr(message, "thread_id", None) or None,
             user_id_alt=sender_profile["user_id_alt"],
         )
         normalized = MessageEvent(
@@ -4051,7 +4051,7 @@ class FeishuAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]],
     ) -> Any:
         last_error: Optional[Exception] = None
-        active_reply_to = reply_to
+        active_reply_to = reply_to or self._metadata_thread_reply_target(metadata)
         for attempt in range(_FEISHU_SEND_ATTEMPTS):
             try:
                 response = await self._send_raw_message(
@@ -4099,6 +4099,21 @@ class FeishuAdapter(BasePlatformAdapter):
                 )
                 await asyncio.sleep(wait_seconds)
         raise last_error or RuntimeError("Feishu send failed")
+
+    @staticmethod
+    def _metadata_thread_reply_target(metadata: Optional[Dict[str, Any]]) -> Optional[str]:
+        """Return a Feishu message-id reply target carried in thread metadata.
+
+        Hermes stores Feishu topic roots in ``metadata["thread_id"]`` so shared
+        gateway code can keep sessions isolated. Feishu's reply API needs a
+        message ID (``om_...``), not the topic resource ID (``omt_...``), so only
+        use metadata as an implicit reply target when it has the message-id shape.
+        """
+        thread_id = (metadata or {}).get("thread_id")
+        if not thread_id:
+            return None
+        candidate = str(thread_id).strip()
+        return candidate if candidate.startswith("om_") else None
 
     async def _release_app_lock(self) -> None:
         if not self._app_lock_identity:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9326,6 +9326,7 @@ class GatewayRunner:
                         chat_id=source.chat_id,
                         config=_consumer_cfg,
                         metadata=_thread_metadata,
+                        reply_to=event_message_id if source.thread_id else None,
                     )
             except Exception as _sc_err:
                 logger.debug("Proxy: could not set up stream consumer: %s", _sc_err)
@@ -10024,6 +10025,7 @@ class GatewayRunner:
                             chat_id=source.chat_id,
                             config=_consumer_cfg,
                             metadata={"thread_id": _progress_thread_id} if _progress_thread_id else None,
+                            reply_to=event_message_id if source.thread_id else None,
                         )
                         if _want_stream_deltas:
                             def _stream_delta_cb(text: str) -> None:

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -59,7 +59,7 @@ class GatewayStreamConsumer:
 
     Usage::
 
-        consumer = GatewayStreamConsumer(adapter, chat_id, config, metadata=metadata)
+        consumer = GatewayStreamConsumer(adapter, chat_id, config, metadata=metadata, reply_to=message_id)
         # Pass consumer.on_delta as stream_delta_callback to AIAgent
         agent = AIAgent(..., stream_delta_callback=consumer.on_delta)
         # Start the consumer as an asyncio task
@@ -91,11 +91,13 @@ class GatewayStreamConsumer:
         chat_id: str,
         config: Optional[StreamConsumerConfig] = None,
         metadata: Optional[dict] = None,
+        reply_to: Optional[str] = None,
     ):
         self.adapter = adapter
         self.chat_id = chat_id
         self.cfg = config or StreamConsumerConfig()
         self.metadata = metadata
+        self.reply_to = reply_to
         self._queue: queue.Queue = queue.Queue()
         self._accumulated = ""
         self._message_id: Optional[str] = None
@@ -519,10 +521,11 @@ class GatewayStreamConsumer:
             return reply_to_id
         try:
             meta = dict(self.metadata) if self.metadata else {}
+            active_reply_to = reply_to_id or self.reply_to
             result = await self.adapter.send(
                 chat_id=self.chat_id,
                 content=text,
-                reply_to=reply_to_id,
+                reply_to=active_reply_to,
                 metadata=meta,
             )
             if result.success and result.message_id:
@@ -628,6 +631,7 @@ class GatewayStreamConsumer:
                 result = await self.adapter.send(
                     chat_id=self.chat_id,
                     content=chunk,
+                    reply_to=last_message_id or self._message_id or self.reply_to,
                     metadata=self.metadata,
                 )
                 if result.success:
@@ -700,6 +704,7 @@ class GatewayStreamConsumer:
             result = await self.adapter.send(
                 chat_id=self.chat_id,
                 content=tail,
+                reply_to=(self._message_id if self._message_id != "__no_edit__" else None) or self.reply_to,
                 metadata=self.metadata,
             )
             if result.success:
@@ -737,6 +742,7 @@ class GatewayStreamConsumer:
             result = await self.adapter.send(
                 chat_id=self.chat_id,
                 content=text,
+                reply_to=self.reply_to,
                 metadata=self.metadata,
             )
             # Note: do NOT set _already_sent = True here.
@@ -784,6 +790,7 @@ class GatewayStreamConsumer:
             result = await self.adapter.send(
                 chat_id=self.chat_id,
                 content=text,
+                reply_to=self.reply_to,
                 metadata=self.metadata,
             )
         except Exception as e:
@@ -953,6 +960,7 @@ class GatewayStreamConsumer:
                 result = await self.adapter.send(
                     chat_id=self.chat_id,
                     content=text,
+                    reply_to=self.reply_to,
                     metadata=self.metadata,
                 )
                 if result.success:

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1856,6 +1856,87 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertTrue(captured["request"].request_body.reply_in_thread)
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_send_uses_root_thread_metadata_as_reply_target(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _ReplyAPI:
+            def reply(self, request):
+                captured["request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_reply"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_ReplyAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.send(
+                    chat_id="oc_chat",
+                    content="progress in topic",
+                    metadata={"thread_id": "om_topic_root"},
+                )
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.message_id, "om_reply")
+        self.assertEqual(captured["request"].message_id, "om_topic_root")
+        self.assertTrue(captured["request"].request_body.reply_in_thread)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_does_not_use_topic_resource_id_as_reply_target(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _MessageAPI:
+            def create(self, request):
+                captured["request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_created"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.send(
+                    chat_id="oc_chat",
+                    content="plain topic resource",
+                    metadata={"thread_id": "omt_topic_resource"},
+                )
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.message_id, "om_created")
+        self.assertEqual(captured["request"].request_body.receive_id, "oc_chat")
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_send_retries_transient_failure(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter
@@ -4095,6 +4176,31 @@ class TestFeishuProcessInboundMessage(unittest.TestCase):
         event = adapter._dispatch_inbound_event.call_args.args[0]
         self.assertEqual(event.text, "/help")
         self.assertEqual(event.message_type, MessageType.COMMAND)
+
+    def test_topic_root_id_is_used_as_thread_id(self):
+        adapter = self._build_adapter()
+        message = SimpleNamespace(
+            content=json.dumps({"text": "topic reply"}),
+            message_type="text",
+            message_id="m_topic_reply",
+            mentions=[],
+            chat_id="oc_chat",
+            parent_id=None,
+            upper_message_id=None,
+            root_id="om_topic_root",
+        )
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=message,
+                message=message,
+                sender_id=None,
+                chat_type="group",
+                message_id="m_topic_reply",
+            )
+        )
+
+        self.assertEqual(adapter.build_source.call_args.kwargs["thread_id"], "om_topic_root")
 
     def test_non_command_message_with_mentions_injects_hint(self):
         from gateway.platforms.base import MessageType

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -190,6 +190,25 @@ class TestSendOrEditMediaStripping:
         assert "Here is your image" in sent_text
 
     @pytest.mark.asyncio
+    async def test_first_stream_send_uses_initial_reply_to(self):
+        """Threaded platform streams must start by replying to the inbound message."""
+        adapter = MagicMock()
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="msg_1"))
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_123",
+            metadata={"thread_id": "thread_root"},
+            reply_to="incoming_msg",
+        )
+        await consumer._send_or_edit("Streaming reply")
+
+        adapter.send.assert_called_once()
+        assert adapter.send.call_args.kwargs["reply_to"] == "incoming_msg"
+        assert adapter.send.call_args.kwargs["metadata"] == {"thread_id": "thread_root"}
+
+    @pytest.mark.asyncio
     async def test_edit_strips_media(self):
         """Edit call removes MEDIA: tags from visible text."""
         adapter = MagicMock()


### PR DESCRIPTION
## What does this PR do?

Fixes Feishu topic-mode replies so Hermes responses stay inside the originating topic instead of falling back to the main group. Feishu topic events carry the topic root as `root_id`, and Feishu only places messages in a topic when the reply API has a message-id target plus `reply_in_thread=true`.

This PR keeps the fix narrow:
- Prefer `message.root_id` when deriving `SessionSource.thread_id` for Feishu inbound messages.
- Pass the inbound message id into gateway streaming so the first streamed reply can use the reply API.
- Add a Feishu adapter-level fallback for metadata-only sends (progress/status/approval/background paths): when `metadata["thread_id"]` is an `om_...` root message id, use it as the implicit reply target; reject `omt_...` topic resource ids as reply targets.

Related context: #16131, #9118, #9760. This is not just a duplicate of #16131 because it also fixes streamed replies and metadata-only Feishu sends; it is narrower than #9118 and does not add auto-threading.

## Related Issue

Related to #6969

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/feishu.py`
  - maps Feishu `root_id` before `thread_id` for topic/session routing
  - uses `om_...` thread metadata as a safe implicit reply target for metadata-only topic sends
  - avoids treating `omt_...` topic resource ids as message reply targets
- `gateway/stream_consumer.py`
  - adds optional `reply_to` support and carries it through first-send/fallback/fresh/commentary stream sends
- `gateway/run.py`
  - passes the inbound `event_message_id` to stream consumers only when `source.thread_id` exists
- `tests/gateway/test_feishu.py`
  - adds root_id mapping, implicit metadata reply target, and `omt_...` rejection coverage
- `tests/gateway/test_stream_consumer.py`
  - adds streaming first-send `reply_to` coverage

## How to Test

1. In a Feishu topic-mode group, send a message inside an existing topic.
2. Verify Hermes processes it and replies inside the same topic, not the main group.
3. Run regression tests:

```bash
scripts/run_tests.sh tests/gateway/test_feishu.py tests/gateway/test_stream_consumer.py tests/gateway/test_run_progress_topics.py::test_run_agent_progress_stays_in_originating_topic -q
.venv/bin/python -m py_compile gateway/platforms/feishu.py gateway/stream_consumer.py gateway/run.py tests/gateway/test_feishu.py tests/gateway/test_stream_consumer.py
```

Observed locally after rebasing onto latest `origin/main`:
- Targeted tests: `232 passed, 37 skipped, 4 warnings`
- `py_compile`: passed

Full-suite note:
- `scripts/run_tests.sh` with no args currently exits before pytest with `ARGS[@]: unbound variable`.
- `scripts/run_tests.sh tests/` was attempted and reached pytest, but the local environment/mainline suite failed on unrelated existing/optional-dependency issues (for example missing `faster_whisper`, ACP/TTS optional imports, Slack progress default test, and other broad current-main failures). The Feishu/streaming targeted suite above passes cleanly.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS / Darwin

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Targeted regression output:

```text
232 passed, 37 skipped, 4 warnings
```