### PR TITLE
fix(gateway): preserve assistant metadata when branching sessions

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7479,8 +7479,12 @@ class GatewayRunner:
                     tool_name=msg.get("tool_name") or msg.get("name"),
                     tool_calls=msg.get("tool_calls"),
                     tool_call_id=msg.get("tool_call_id"),
+                    finish_reason=msg.get("finish_reason"),
                     reasoning=msg.get("reasoning"),
                     reasoning_content=msg.get("reasoning_content"),
+                    reasoning_details=msg.get("reasoning_details"),
+                    codex_reasoning_items=msg.get("codex_reasoning_items"),
+                    codex_message_items=msg.get("codex_message_items"),
                 )
             except Exception:
                 pass  # Best-effort copy

--- a/tests/gateway/test_session_boundary_security_state.py
+++ b/tests/gateway/test_session_boundary_security_state.py
@@ -172,6 +172,38 @@ async def test_branch_clears_session_scoped_approval_and_yolo_state():
     assert other_key in runner._update_prompt_pending
 
 
+@pytest.mark.asyncio
+async def test_branch_preserves_persisted_assistant_metadata():
+    runner, _session_key = _make_branch_runner()
+    runner.session_store.load_transcript.return_value = [
+        {"role": "user", "content": "hello"},
+        {
+            "role": "assistant",
+            "content": "world",
+            "finish_reason": "stop",
+            "reasoning": "thinking",
+            "reasoning_content": "provider scratchpad",
+            "reasoning_details": [{"type": "summary", "text": "step"}],
+            "codex_reasoning_items": [{"id": "r1", "type": "reasoning"}],
+            "codex_message_items": [{"id": "m1", "type": "message"}],
+        },
+    ]
+
+    result = await runner._handle_branch_command(_make_event("/branch"))
+
+    assert "Branched to" in result
+    append_calls = runner._session_db.append_message.call_args_list
+    assert len(append_calls) == 2
+    assistant_kwargs = append_calls[1].kwargs
+    assert assistant_kwargs["role"] == "assistant"
+    assert assistant_kwargs["finish_reason"] == "stop"
+    assert assistant_kwargs["reasoning"] == "thinking"
+    assert assistant_kwargs["reasoning_content"] == "provider scratchpad"
+    assert assistant_kwargs["reasoning_details"] == [{"type": "summary", "text": "step"}]
+    assert assistant_kwargs["codex_reasoning_items"] == [{"id": "r1", "type": "reasoning"}]
+    assert assistant_kwargs["codex_message_items"] == [{"id": "m1", "type": "message"}]
+
+
 def test_clear_session_boundary_security_state_is_scoped():
     """The helper must wipe only the target session's approval/yolo state.
 


### PR DESCRIPTION
## What does this PR do?

Fixes a transcript-fidelity bug in the gateway `/branch` flow.

Before this change, branching a session only copied a subset of persisted assistant message metadata into the new session transcript. That meant branched sessions could silently lose provider/runtime state already stored on assistant messages, including `finish_reason`, `reasoning_details`, `codex_reasoning_items`, and `codex_message_items`.

This PR updates the branch copy path to forward the full persisted assistant metadata already supported by `SessionDB.append_message()`, and adds a regression test to lock that behavior in.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Updated `gateway/run.py` so `/branch` preserves additional persisted assistant metadata when copying transcript messages into the branched session:
  - `finish_reason`
  - `reasoning_details`
  - `codex_reasoning_items`
  - `codex_message_items`
- Added a regression test in `tests/gateway/test_session_boundary_security_state.py` to verify that `/branch` forwards those fields to `append_message()`.

## How to Test

1. Run:
   `scripts/run_tests.sh tests/gateway/test_session_boundary_security_state.py`
2. Confirm the targeted gateway tests pass, including the new branch metadata regression test.
3. Optionally inspect the `/branch` path in `gateway/run.py` and verify that the metadata fields above are forwarded into `self._session_db.append_message(...)`.
