### PR TITLE
feat: make gpt-5.5 the default model

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2612,7 +2612,7 @@ class HermesCLI:
 
         # 2. Replace untouched default with a Codex model
         if self._model_is_default:
-            fallback_model = "gpt-5.3-codex"
+            fallback_model = "gpt-5.5"
             try:
                 from hermes_cli.codex_models import get_codex_model_ids
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -141,6 +141,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     # Native OpenAI Chat Completions (api.openai.com). Used by /model counts and
     # provider_model_ids fallback when /v1/models is unavailable.
     "openai": [
+        "gpt-5.5",
         "gpt-5.4",
         "gpt-5.4-mini",
         "gpt-5-mini",
@@ -155,6 +156,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "copilot-acp",
     ],
     "copilot": [
+        "gpt-5.5",
         "gpt-5.4",
         "gpt-5.4-mini",
         "gpt-5-mini",
@@ -1615,6 +1617,7 @@ def provider_label(provider: Optional[str]) -> str:
 # See https://openai.com/api-priority-processing/ for the canonical list.
 # Only the bare model slug is stored (no vendor prefix).
 _PRIORITY_PROCESSING_MODELS: frozenset[str] = frozenset({
+    "gpt-5.5",
     "gpt-5.4",
     "gpt-5.4-mini",
     "gpt-5.2",

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -74,6 +74,7 @@ _DEFAULT_PROVIDER_MODELS = {
         "copilot-acp",
     ],
     "copilot": [
+        "gpt-5.5",
         "gpt-5.4",
         "gpt-5.4-mini",
         "gpt-5-mini",

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -312,15 +312,15 @@ class TestNormalizeModelForProvider:
         assert cli._model_is_default is True
         with patch(
             "hermes_cli.codex_models.get_codex_model_ids",
-            return_value=["gpt-5.3-codex", "gpt-5.4"],
+            return_value=["gpt-5.5", "gpt-5.4"],
         ):
             changed = cli._normalize_model_for_provider("openai-codex")
         assert changed is True
         # Uses first from available list
-        assert cli.model == "gpt-5.3-codex"
+        assert cli.model == "gpt-5.5"
 
     def test_default_fallback_when_api_fails(self):
-        """No model configured falls back to gpt-5.3-codex when API unreachable."""
+        """No model configured falls back to gpt-5.5 when API unreachable."""
         import cli as _cli_mod
         _clean_config = {
             "model": {
@@ -346,4 +346,4 @@ class TestNormalizeModelForProvider:
         ):
             changed = cli._normalize_model_for_provider("openai-codex")
         assert changed is True
-        assert cli.model == "gpt-5.3-codex"
+        assert cli.model == "gpt-5.5"

--- a/tests/test_empty_model_fallback.py
+++ b/tests/test_empty_model_fallback.py
@@ -11,8 +11,7 @@ class TestGetDefaultModelForProvider:
         from hermes_cli.models import get_default_model_for_provider
         result = get_default_model_for_provider("openai-codex")
         # Should return first model from _PROVIDER_MODELS["openai-codex"]
-        assert result
-        assert isinstance(result, str)
+        assert result == "gpt-5.5"
 
     def test_openrouter_returns_empty(self):
         """OpenRouter uses dynamic model fetch, no static catalog entry."""


### PR DESCRIPTION
Summary:
- make gpt-5.5 the default untouched Codex fallback
- promote gpt-5.5 to the top of relevant provider fallback catalogs
- add gpt-5.5 to priority-processing supported models
- update tests for the new default behavior

Note: I also updated my local ~/.hermes/config.yaml to use gpt-5.5 + codex_responses, but that local config change is not part of this PR.