### PR TITLE
test(acp,tts): skip soft-dep test modules when optional packages absent

### DIFF
--- a/tests/acp/test_entry.py
+++ b/tests/acp/test_entry.py
@@ -1,6 +1,8 @@
 """Tests for acp_adapter.entry startup wiring."""
 
-import acp
+import pytest
+
+acp = pytest.importorskip("acp", reason="agent-client-protocol not installed; install with: pip install 'hermes-agent[acp]'")
 
 from acp_adapter import entry
 

--- a/tests/acp/test_events.py
+++ b/tests/acp/test_events.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-import acp
+acp = pytest.importorskip("acp", reason="agent-client-protocol not installed; install with: pip install 'hermes-agent[acp]'")
 from acp.schema import ToolCallStart, ToolCallProgress, AgentThoughtChunk, AgentMessageChunk
 
 from acp_adapter.events import (

--- a/tests/acp/test_mcp_e2e.py
+++ b/tests/acp/test_mcp_e2e.py
@@ -14,7 +14,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-import acp
+acp = pytest.importorskip("acp", reason="agent-client-protocol not installed; install with: pip install 'hermes-agent[acp]'")
 from acp.schema import (
     EnvVariable,
     HttpHeader,

--- a/tests/acp/test_permissions.py
+++ b/tests/acp/test_permissions.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+pytest.importorskip("acp", reason="agent-client-protocol not installed; install with: pip install 'hermes-agent[acp]'")
 from acp.schema import (
     AllowedOutcome,
     DeniedOutcome,

--- a/tests/acp/test_ping_suppression.py
+++ b/tests/acp/test_ping_suppression.py
@@ -16,6 +16,7 @@ from io import StringIO
 
 import pytest
 
+pytest.importorskip("acp", reason="agent-client-protocol not installed; install with: pip install 'hermes-agent[acp]'")
 from acp.exceptions import RequestError
 
 from acp_adapter.entry import _BenignProbeMethodFilter

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, AsyncMock, patch
 
 import pytest
 
-import acp
+acp = pytest.importorskip("acp", reason="agent-client-protocol not installed; install with: pip install 'hermes-agent[acp]'")
 from acp.agent.router import build_agent_router
 from acp.schema import (
     AgentCapabilities,

--- a/tests/acp/test_tools.py
+++ b/tests/acp/test_tools.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+pytest.importorskip("acp", reason="agent-client-protocol not installed; install with: pip install 'hermes-agent[acp]'")
 from acp_adapter.tools import (
     TOOL_KIND_MAP,
     build_tool_complete,

--- a/tests/tools/test_tts_kittentts.py
+++ b/tests/tools/test_tts_kittentts.py
@@ -3,8 +3,9 @@
 import json
 from unittest.mock import MagicMock, patch
 
-import numpy as np
 import pytest
+
+np = pytest.importorskip("numpy", reason="numpy not installed; install with: pip install numpy")
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary
- Replace bare `import acp` with `pytest.importorskip("acp", ...)` in 7 `tests/acp/` files so they skip cleanly when `agent-client-protocol` is not installed
- Replace `import numpy as np` with `np = pytest.importorskip("numpy", ...)` in `tests/tools/test_tts_kittentts.py`

## The bug
All 7 `tests/acp/test_*.py` files (and `tests/tools/test_tts_kittentts.py`) used bare top-level imports of optional packages (`acp`, `numpy`). When those packages are absent (e.g. in a plain `pip install hermes-agent` without the `[acp]` extra), pytest emits a **collection ERROR** — not a skip — which inflates the failure count, masks the actual test suite health, and makes CI noise much harder to read.

## The fix
Replace bare module-level imports with `pytest.importorskip(...)` placed before any acp-dependent import. When the package is absent, pytest catches the resulting `Skipped` exception and marks the entire module as skipped rather than errored.

This follows the existing convention in the codebase (e.g. `discord = pytest.importorskip("discord")` in `tests/gateway/test_discord_system_messages.py`).

## Test plan
- [x] **Before**: 8 collection ERRORs (`tests/acp/` ×7 + `tests/tools/test_tts_kittentts.py` ×1)
- [x] **After**: 0 collection errors; `43 passed, 8 skipped` — the 43 tests that don't depend on these packages run normally
- [x] **Regression guard**: reverted the fix on one file → collection ERROR reappeared; restored → 0 errors
- [x] Adjacent suites (`tests/gateway/`, `tests/agent/`, `tests/tools/`) unaffected

## Related
- Packages gated: `agent-client-protocol` (install with `pip install 'hermes-agent[acp]'`) and `numpy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)