### PR TITLE
fix: feature-detect context focus compression support

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -28,6 +28,7 @@ these paths see no behavioural change.
 
 from __future__ import annotations
 
+import inspect
 import logging
 import os
 import tempfile
@@ -432,6 +433,71 @@ def _ensure_compressed_has_user_turn(original_messages: list, compressed: list) 
     })
 
 
+def _compress_signature_target(compress_fn: Any) -> Any:
+    """Return the callable whose signature best reflects this compress call.
+
+    Most production context engines expose a normal bound ``compress`` method,
+    so inspecting ``compress_fn`` is enough. Several tests patch that method
+    with ``unittest.mock`` and put the real callable on ``side_effect``; the mock
+    itself advertises ``**kwargs`` and would make us forward optional kwargs the
+    side-effect callable cannot accept.  Inspect the side effect when present so
+    the compatibility shim behaves the same under patched call sites.
+    """
+    side_effect = getattr(compress_fn, "side_effect", None)
+    if callable(side_effect):
+        return side_effect
+    wraps = getattr(compress_fn, "_mock_wraps", None)
+    if callable(wraps):
+        return wraps
+    return compress_fn
+
+
+def _compress_kwargs_for_engine(
+    compress_fn: Any,
+    *,
+    approx_tokens: Optional[int],
+    focus_topic: Optional[str],
+    force: bool,
+) -> dict[str, Any]:
+    """Return kwargs supported by a context engine's ``compress`` method.
+
+    ``focus_topic`` and ``force`` are host-side optional capabilities. Older
+    external context engines may implement the pre-focus/pre-force signature;
+    those engines should keep working, but real ``TypeError`` bugs raised from
+    inside ``compress`` must not be swallowed as a signature mismatch.
+    """
+    kwargs: dict[str, Any] = {"current_tokens": approx_tokens}
+    signature_target = _compress_signature_target(compress_fn)
+    try:
+        signature = inspect.signature(signature_target)
+    except (TypeError, ValueError):
+        return kwargs
+
+    parameters = signature.parameters
+    accepts_var_kwargs = any(
+        param.kind == inspect.Parameter.VAR_KEYWORD
+        for param in parameters.values()
+    )
+
+    def accepts(name: str) -> bool:
+        return accepts_var_kwargs or name in parameters
+
+    if focus_topic is not None and accepts("focus_topic"):
+        kwargs["focus_topic"] = focus_topic
+    elif focus_topic is not None:
+        engine = getattr(compress_fn, "__self__", None)
+        logger.debug(
+            "Context engine '%s' does not accept focus_topic; compressing without it",
+            getattr(engine, "name", None)
+            or getattr(compress_fn, "__qualname__", type(compress_fn).__name__),
+        )
+
+    if accepts("force"):
+        kwargs["force"] = force
+
+    return kwargs
+
+
 def compress_context(
     agent: Any,
     messages: list,
@@ -621,15 +687,13 @@ def compress_context(
             pass
 
     try:
-        compressed = agent.context_compressor.compress(messages, current_tokens=approx_tokens, focus_topic=focus_topic, force=force)
-    except TypeError:
-        # Plugin context engine with strict signature that doesn't accept
-        # focus_topic / force — fall back to calling without them.
-        try:
-            compressed = agent.context_compressor.compress(messages, current_tokens=approx_tokens)
-        except BaseException:
-            _release_lock()
-            raise
+        compress_kwargs = _compress_kwargs_for_engine(
+            agent.context_compressor.compress,
+            approx_tokens=approx_tokens,
+            focus_topic=focus_topic,
+            force=force,
+        )
+        compressed = agent.context_compressor.compress(messages, **compress_kwargs)
     except BaseException:
         # ANY exception during compress() must release the lock so the
         # session isn't permanently blocked from future compression.

--- a/tests/agent/test_compression_concurrent_fork.py
+++ b/tests/agent/test_compression_concurrent_fork.py
@@ -346,8 +346,8 @@ def test_abort_warning_exception_stops_lock_refresher(tmp_path: Path, monkeypatc
     assert db.try_acquire_compression_lock(parent_sid, "probe", ttl_seconds=1.0) is True
 
 
-def test_typeerror_fallback_exception_stops_lock_refresher(tmp_path: Path, monkeypatch) -> None:
-    """A strict-signature fallback failure must still release the refreshed lock."""
+def test_compression_exception_stops_lock_refresher(tmp_path: Path, monkeypatch) -> None:
+    """A compressor exception must still release the refreshed lock."""
     real_try_acquire = SessionDB.try_acquire_compression_lock
 
     def _short_ttl(self, session_id: str, holder: str, ttl_seconds: float = 300.0) -> bool:
@@ -363,16 +363,15 @@ def test_typeerror_fallback_exception_stops_lock_refresher(tmp_path: Path, monke
     agent._compression_lock_ttl_seconds = 1.0
     agent._compression_lock_refresh_interval = 0.1
 
-    def _strict_signature(*_a, **_kw):
-        if "focus_topic" in _kw or "force" in _kw:
-            raise TypeError("strict signature")
-        raise RuntimeError("fallback boom")
+    def _compress_failure(_messages, current_tokens=None):
+        assert current_tokens == 120_000
+        raise RuntimeError("compress boom")
 
-    agent.context_compressor.compress.side_effect = _strict_signature
+    agent.context_compressor.compress.side_effect = _compress_failure
 
     messages = [{"role": "user", "content": f"m{i}"} for i in range(20)]
 
-    with pytest.raises(RuntimeError, match="fallback boom"):
+    with pytest.raises(RuntimeError, match="compress boom"):
         agent._compress_context(messages, "sys", approx_tokens=120_000)
 
     time.sleep(1.3)

--- a/tests/run_agent/test_compress_focus_plugin_fallback.py
+++ b/tests/run_agent/test_compress_focus_plugin_fallback.py
@@ -1,14 +1,8 @@
-"""Regression test: _compress_context tolerates plugin engines with strict signatures.
-
-Added to ``ContextEngine.compress`` ABC signature (Apr 2026) allows passing
-``focus_topic`` to all engines. Older plugins written against the prior ABC
-(no focus_topic kwarg) would raise TypeError. _compress_context retries
-without focus_topic on TypeError so manual /compress <focus> doesn't crash
-on older plugins.
-"""
+"""Regression tests for optional context-engine compression kwargs."""
 
 from unittest.mock import MagicMock
 
+import pytest
 
 from run_agent import AIAgent
 
@@ -21,38 +15,42 @@ def _make_agent_with_engine(engine):
     agent.platform = "cli"
     agent.logs_dir = MagicMock()
     agent.quiet_mode = True
+    setattr(agent, "status_callback", None)
     agent._todo_store = MagicMock()
     agent._todo_store.format_for_injection.return_value = ""
     agent._memory_manager = None
     agent._session_db = None
     agent._cached_system_prompt = None
+    setattr(agent, "_compression_feasibility_checked", True)
+    setattr(agent, "compression_in_place", False)
+    setattr(agent, "tools", [])
+    setattr(agent, "event_callback", None)
     agent.log_prefix = ""
     agent._vprint = lambda *a, **kw: None
+    agent._emit_status = lambda *a, **kw: None
+    agent._emit_warning = lambda *a, **kw: None
     agent._last_flushed_db_idx = 0
-    # Stub the few AIAgent methods _compress_context uses.
     agent._invalidate_system_prompt = lambda *a, **kw: None
     agent._build_system_prompt = lambda *a, **kw: "new-system-prompt"
     agent.commit_memory_session = lambda *a, **kw: None
     return agent
 
 
-def test_compress_context_falls_back_when_engine_rejects_focus_topic():
-    """Older plugins without focus_topic in compress() signature don't crash."""
+def test_compress_context_skips_optional_kwargs_for_legacy_engine():
+    """Older plugins without focus_topic/force in compress() signature don't crash."""
     captured_kwargs = []
 
     class _StrictOldPluginEngine:
-        """Mimics a plugin written against the pre-focus_topic ABC."""
-
+        name = "strict-old"
         compression_count = 0
+        last_prompt_tokens = 0
+        last_completion_tokens = 0
 
         def compress(self, messages, current_tokens=None):
-            # NOTE: no focus_topic kwarg — TypeError if caller passes one.
             captured_kwargs.append({"current_tokens": current_tokens})
             return [messages[0], messages[-1]]
 
-    engine = _StrictOldPluginEngine()
-    agent = _make_agent_with_engine(engine)
-
+    agent = _make_agent_with_engine(_StrictOldPluginEngine())
     messages = [
         {"role": "user", "content": "one"},
         {"role": "assistant", "content": "two"},
@@ -60,15 +58,99 @@ def test_compress_context_falls_back_when_engine_rejects_focus_topic():
         {"role": "assistant", "content": "four"},
     ]
 
-    # Directly invoke the compression call site — this is the line that
-    # used to blow up with TypeError under focus_topic+strict plugin.
-    try:
-        compressed = engine.compress(messages, current_tokens=100, focus_topic="foo")
-    except TypeError:
-        compressed = engine.compress(messages, current_tokens=100)
+    compressed, _ = agent._compress_context(
+        messages,
+        "system prompt",
+        approx_tokens=100,
+        focus_topic="database schema",
+        force=True,
+    )
 
-    # Fallback succeeded: engine was called once without focus_topic.
     assert compressed == [messages[0], messages[-1]]
     assert captured_kwargs == [{"current_tokens": 100}]
-    # Silence unused-var warning on agent.
-    assert agent.context_compressor is engine
+
+
+def test_compress_context_passes_optional_kwargs_to_kwargs_engine():
+    """Engines accepting **kwargs receive supported focus and force hints."""
+    captured_kwargs = []
+
+    class _KwargsEngine:
+        name = "kwargs"
+        compression_count = 0
+        last_prompt_tokens = 0
+        last_completion_tokens = 0
+
+        def compress(self, messages, **kwargs):
+            captured_kwargs.append(kwargs)
+            return list(messages)
+
+    agent = _make_agent_with_engine(_KwargsEngine())
+    messages = [{"role": "user", "content": "hello"}]
+
+    agent._compress_context(
+        messages,
+        "system prompt",
+        approx_tokens=1234,
+        focus_topic="database schema",
+        force=True,
+    )
+
+    assert captured_kwargs == [
+        {"current_tokens": 1234, "focus_topic": "database schema", "force": True}
+    ]
+
+
+def test_compress_context_preserves_focus_when_engine_lacks_force():
+    """Engines updated for focus_topic but not force keep their focus hint."""
+    captured_kwargs = []
+
+    class _FocusOnlyEngine:
+        name = "focus-only"
+        compression_count = 0
+        last_prompt_tokens = 0
+        last_completion_tokens = 0
+
+        def compress(self, messages, current_tokens=None, focus_topic=None):
+            captured_kwargs.append(
+                {"current_tokens": current_tokens, "focus_topic": focus_topic}
+            )
+            return list(messages)
+
+    agent = _make_agent_with_engine(_FocusOnlyEngine())
+    messages = [{"role": "user", "content": "hello"}]
+
+    agent._compress_context(
+        messages,
+        "system prompt",
+        approx_tokens=4321,
+        focus_topic="database schema",
+        force=True,
+    )
+
+    assert captured_kwargs == [
+        {"current_tokens": 4321, "focus_topic": "database schema"}
+    ]
+
+
+def test_compress_context_does_not_mask_internal_type_errors():
+    """Internal TypeErrors should not be retried as signature mismatch."""
+
+    class _FailingEngine:
+        name = "failing"
+        compression_count = 0
+        last_prompt_tokens = 0
+        last_completion_tokens = 0
+
+        def compress(self, messages, current_tokens=None, focus_topic=None, force=False):
+            raise TypeError("internal compression bug")
+
+    agent = _make_agent_with_engine(_FailingEngine())
+
+    with pytest.raises(TypeError, match="internal compression bug"):
+        agent._compress_context(
+            [{"role": "user", "content": "hello"}],
+            "system prompt",
+            approx_tokens=1234,
+            focus_topic="database schema",
+            force=True,
+        )


### PR DESCRIPTION
## What does this PR do?

Keeps manual `/compress <focus>` and forced manual compression compatible with external context engines that were written against older `compress(...)` signatures, without masking real internal `TypeError` bugs from those engines.

Current `main` moved the compression call site from `run_agent.py` into `agent/conversation_compression.py`, but the bug class still existed there: Hermes caught any `TypeError` from `context_compressor.compress(...)` and retried without optional kwargs. That fallback preserved old plugins, but it could also hide a genuine engine bug as if the engine merely lacked `focus_topic` / `force` support.

This refresh feature-detects optional kwargs before calling the engine instead:

- legacy engines receive only `current_tokens`
- engines that accept `focus_topic` keep the `/compress <focus>` hint
- engines that accept `force` receive the manual retry flag
- engines that accept `**kwargs` receive both optional kwargs
- internal `TypeError`s now propagate instead of being treated as signature mismatch

## Related Issue

Follow-up slice from the closed broad host-support PR #13370. Related context: #16306 salvaged and merged the compression-boundary signal from that same broader lane.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/conversation_compression.py`: add signature-based optional kwarg detection for `context_compressor.compress(...)` before invoking the engine.
- `tests/run_agent/test_compress_focus_plugin_fallback.py`: cover legacy engines, `**kwargs` engines, focus-only engines, and propagation of internal `TypeError`s.
- `tests/agent/test_compression_concurrent_fork.py`: update the lock-refresher exception regression now that broad `TypeError` retry fallback is intentionally removed.

## How to Test

1. Run the focused regression and adjacent compression coverage:
   - `./scripts/run_tests.sh tests/run_agent/test_compress_focus_plugin_fallback.py tests/run_agent/test_413_compression.py tests/agent/test_compression_concurrent_fork.py tests/agent/test_compress_focus.py tests/agent/test_compression_rotation_state.py -q --tb=short`
2. Run static/syntax checks:
   - `python3 -m compileall -q agent/conversation_compression.py tests/run_agent/test_compress_focus_plugin_fallback.py tests/agent/test_compression_concurrent_fork.py`
   - `git diff --check`
   - `ruff check agent/conversation_compression.py tests/run_agent/test_compress_focus_plugin_fallback.py tests/agent/test_compression_concurrent_fork.py`

## Validation

Local validation on refreshed head `0e746f2c43359774a147e4cebd8a9a7b7d653d1e`:

- `python3 -m compileall -q agent/conversation_compression.py tests/run_agent/test_compress_focus_plugin_fallback.py tests/agent/test_compression_concurrent_fork.py` — passed
- `git diff --check` — passed
- `ruff check agent/conversation_compression.py tests/run_agent/test_compress_focus_plugin_fallback.py tests/agent/test_compression_concurrent_fork.py` — passed
- `./scripts/run_tests.sh tests/run_agent/test_compress_focus_plugin_fallback.py tests/run_agent/test_413_compression.py tests/agent/test_compression_concurrent_fork.py tests/agent/test_compress_focus.py tests/agent/test_compression_rotation_state.py -q --tb=short` — `52 passed`
- contributor attribution check reproduced locally for the PR delta — passed

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 26.04 / Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no platform-specific paths or shell behavior changed
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

N/A

## Screenshots / Logs

Focused local validation logs are summarized above. No UI screenshots; this is a host-side runtime compatibility fix.
