### PR TITLE
fix: discover external context engine plugins before fallback

### DIFF
--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -815,11 +815,30 @@ def _discover_memory_providers() -> list[tuple[str, str]]:
 
 def _discover_context_engines() -> list[tuple[str, str]]:
     """Return [(name, description), ...] for available context engines."""
+    engines: list[tuple[str, str]] = []
+    seen: set[str] = set()
+
     try:
         from plugins.context_engine import discover_context_engines
-        return [(name, desc) for name, desc, _avail in discover_context_engines()]
+
+        for name, desc, _avail in discover_context_engines():
+            if name not in seen:
+                engines.append((name, desc))
+                seen.add(name)
     except Exception:
-        return []
+        pass
+
+    try:
+        from hermes_cli.plugins import discover_plugins, get_plugin_context_engine
+
+        discover_plugins()
+        plugin_engine = get_plugin_context_engine()
+        if plugin_engine and plugin_engine.name not in seen:
+            engines.append((plugin_engine.name, "installed plugin"))
+    except Exception:
+        pass
+
+    return engines
 
 
 def _get_current_memory_provider() -> str:

--- a/run_agent.py
+++ b/run_agent.py
@@ -2289,7 +2289,9 @@ class AIAgent:
             # Try general plugin system as fallback
             if _selected_engine is None:
                 try:
-                    from hermes_cli.plugins import get_plugin_context_engine
+                    from hermes_cli.plugins import discover_plugins, get_plugin_context_engine
+
+                    discover_plugins()
                     _candidate = get_plugin_context_engine()
                     if _candidate and _candidate.name == _engine_name:
                         _selected_engine = _candidate

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -651,12 +651,42 @@ class TestProviderDiscovery:
             assert result == []
 
     def test_discover_context_engines_empty(self):
-        """Discovery returns empty list when import fails."""
+        """Discovery returns empty list when both discovery paths are unavailable."""
         with patch("plugins.context_engine.discover_context_engines",
-                    side_effect=ImportError("no module")):
+                    side_effect=ImportError("no module")), \
+             patch("hermes_cli.plugins.discover_plugins", side_effect=ImportError("no plugins")):
             from hermes_cli.plugins_cmd import _discover_context_engines
             result = _discover_context_engines()
             assert result == []
+
+    def test_discover_context_engines_includes_external_plugin_engine(self):
+        """External context-engine plugins should appear in the provider picker."""
+
+        class StubPluginEngine:
+            name = "lcm"
+
+        with patch("plugins.context_engine.discover_context_engines", return_value=[]), \
+             patch("hermes_cli.plugins.discover_plugins") as mock_discover_plugins, \
+             patch("hermes_cli.plugins.get_plugin_context_engine", return_value=StubPluginEngine()):
+            from hermes_cli.plugins_cmd import _discover_context_engines
+            result = _discover_context_engines()
+
+        mock_discover_plugins.assert_called_once()
+        assert result == [("lcm", "installed plugin")]
+
+    def test_discover_context_engines_deduplicates_repo_and_plugin_engine(self):
+        """Repo-shipped context engines keep their richer description when names collide."""
+
+        class StubPluginEngine:
+            name = "lcm"
+
+        with patch("plugins.context_engine.discover_context_engines", return_value=[("lcm", "repo engine", True)]), \
+             patch("hermes_cli.plugins.discover_plugins"), \
+             patch("hermes_cli.plugins.get_plugin_context_engine", return_value=StubPluginEngine()):
+            from hermes_cli.plugins_cmd import _discover_context_engines
+            result = _discover_context_engines()
+
+        assert result == [("lcm", "repo engine")]
 
 
 # ── Auto-activation fix ──────────────────────────────────────────────────

--- a/tests/run_agent/test_context_engine_plugin_discovery.py
+++ b/tests/run_agent/test_context_engine_plugin_discovery.py
@@ -1,0 +1,72 @@
+"""Tests for external context engine plugin discovery fallback."""
+
+from unittest.mock import patch
+
+from run_agent import AIAgent
+
+
+class StubPluginEngine:
+    name = "lcm"
+    threshold_tokens = 0
+    context_length = 0
+    compression_count = 0
+    last_prompt_tokens = 0
+    last_completion_tokens = 0
+    last_total_tokens = 0
+
+    def __init__(self):
+        self.update_model_calls = []
+        self.started = None
+
+    def update_model(self, **kwargs):
+        self.update_model_calls.append(kwargs)
+        self.context_length = kwargs["context_length"]
+        self.threshold_tokens = int(kwargs["context_length"] * 0.75)
+
+    def get_tool_schemas(self):
+        return [
+            {
+                "name": "lcm_grep",
+                "description": "Search the external context engine",
+                "parameters": {"type": "object", "properties": {}},
+            }
+        ]
+
+    def on_session_start(self, session_id, **kwargs):
+        self.started = (session_id, kwargs)
+
+    def compress(self, messages, current_tokens=None, focus_topic=None):
+        return list(messages)
+
+
+def test_aiagent_discovers_external_plugin_engine_before_fallback():
+    config = {
+        "context": {"engine": "lcm"},
+        "model": {"context_length": 131072},
+        "compression": {"enabled": True},
+    }
+    engine = StubPluginEngine()
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=config),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch("plugins.context_engine.load_context_engine", return_value=None),
+        patch("hermes_cli.plugins.discover_plugins") as mock_discover_plugins,
+        patch("hermes_cli.plugins.get_plugin_context_engine", return_value=engine),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://llm.example.com/v1",
+            provider="custom",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    mock_discover_plugins.assert_called_once()
+    assert agent.context_compressor is engine
+    assert engine.update_model_calls
+    assert engine.context_length == 131072
+    assert "lcm_grep" in agent.valid_tool_names


### PR DESCRIPTION
## Summary

- call `discover_plugins()` before querying the general plugin-system context-engine fallback
- include plugin-registered context engines in the `hermes plugins` context-engine picker
- deduplicate repo-shipped and plugin-registered engines by name so repo-shipped descriptions stay stable when names collide
- add regression coverage for the runtime fallback and picker discovery paths

## Why

Installed external context-engine plugins can be invisible unless the plugin manager has been discovered before `get_plugin_context_engine()` is queried. This keeps the built-in compressor as the default while making explicitly selected external engines discoverable and selectable.

## Validation

- `./scripts/run_tests.sh -n 0 tests/hermes_cli/test_plugins_cmd.py::TestProviderDiscovery tests/run_agent/test_context_engine_plugin_discovery.py -q --tb=short`, `9 passed`
- `python -m compileall -q run_agent.py hermes_cli/plugins_cmd.py tests/hermes_cli/test_plugins_cmd.py tests/run_agent/test_context_engine_plugin_discovery.py`
- `git diff --check origin/main...HEAD`

## Notes

- Host discovery and selection support only
- No external context-engine implementation is vendored or bundled
- Rebuilt on current `main` after #21012 so the old shared baseline commit is no longer part of this PR
