### PR TITLE
fix: add context engine session transition helper

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7405,6 +7405,7 @@ class GatewayRunner:
                                     skip_memory=True,
                                     enabled_toolsets=["memory"],
                                     session_id=session_entry.session_id,
+                                    gateway_session_key=session_key,
                                 )
                                 try:
                                     _hyg_agent._print_fn = lambda *a, **kw: None
@@ -10425,6 +10426,7 @@ class GatewayRunner:
             self._reasoning_config = reasoning_config
             self._service_tier = self._load_service_tier()
             turn_route = self._resolve_turn_agent_config(prompt, model, runtime_kwargs)
+            session_key = self._session_key_for_source(source)
 
             # Enrich the prompt with image descriptions so the background
             # agent can see user-attached images (same as the main flow).
@@ -10469,6 +10471,7 @@ class GatewayRunner:
                     chat_name=source.chat_name,
                     chat_type=source.chat_type,
                     thread_id=source.thread_id,
+                    gateway_session_key=session_key,
                     session_db=self._session_db,
                     fallback_model=self._fallback_model,
                 )
@@ -10924,6 +10927,7 @@ class GatewayRunner:
                 skip_memory=True,
                 enabled_toolsets=["memory"],
                 session_id=session_entry.session_id,
+                gateway_session_key=session_key,
             )
             try:
                 tmp_agent._print_fn = lambda *a, **kw: None

--- a/run_agent.py
+++ b/run_agent.py
@@ -2389,6 +2389,7 @@ class AIAgent:
                     platform=self.platform or "cli",
                     model=self.model,
                     context_length=getattr(self.context_compressor, "context_length", 0),
+                    conversation_id=self._gateway_session_key,
                 )
             except Exception as _ce_err:
                 logger.debug("Context engine on_session_start: %s", _ce_err)
@@ -2583,6 +2584,7 @@ class AIAgent:
                 "platform": getattr(self, "platform", None) or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
                 "model": getattr(self, "model", ""),
                 "context_length": getattr(engine, "context_length", None),
+                "conversation_id": getattr(self, "_gateway_session_key", None),
             }
             start_context.update(extra_context)
             start_context = {k: v for k, v in start_context.items() if v not in (None, "")}
@@ -10538,6 +10540,7 @@ class AIAgent:
                     self.session_id or "",
                     boundary_reason="compression",
                     old_session_id=_old_sid,
+                    conversation_id=getattr(self, "_gateway_session_key", None),
                 )
         except Exception as _ce_err:
             logger.debug("context engine on_session_start (compression): %s", _ce_err)

--- a/run_agent.py
+++ b/run_agent.py
@@ -2540,7 +2540,74 @@ class AIAgent:
                 "Session DB creation failed (will retry next turn): %s", e
             )
 
-    def reset_session_state(self):
+    def _transition_context_engine_session(
+        self,
+        *,
+        old_session_id: str | None = None,
+        new_session_id: str | None = None,
+        previous_messages: list | None = None,
+        carry_over_context: bool = False,
+        reset_engine: bool = True,
+        **extra_context,
+    ) -> None:
+        """Notify the active context engine about a host session transition.
+
+        This is a generic host-side lifecycle helper for external context
+        engines. The built-in compressor keeps its existing reset behavior,
+        while engines that implement richer hooks can flush old-session state,
+        reset runtime counters, bind to the new session, and optionally carry
+        retained context forward.
+        """
+        engine = getattr(self, "context_compressor", None)
+        if not engine:
+            return
+
+        if old_session_id and previous_messages is not None and hasattr(engine, "on_session_end"):
+            try:
+                engine.on_session_end(old_session_id, previous_messages)
+            except Exception as exc:
+                logger.debug("context engine on_session_end during transition: %s", exc)
+
+        if reset_engine and hasattr(engine, "on_session_reset"):
+            try:
+                engine.on_session_reset()
+            except Exception as exc:
+                logger.debug("context engine on_session_reset during transition: %s", exc)
+
+        should_start = bool(old_session_id or previous_messages is not None or carry_over_context or extra_context)
+        target_session_id = new_session_id or getattr(self, "session_id", "") or ""
+        if should_start and target_session_id and hasattr(engine, "on_session_start"):
+            start_context = {
+                "old_session_id": old_session_id,
+                "carry_over_context": carry_over_context,
+                "platform": getattr(self, "platform", None) or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+                "model": getattr(self, "model", ""),
+                "context_length": getattr(engine, "context_length", None),
+            }
+            start_context.update(extra_context)
+            start_context = {k: v for k, v in start_context.items() if v not in (None, "")}
+            try:
+                engine.on_session_start(target_session_id, **start_context)
+            except Exception as exc:
+                logger.debug("context engine on_session_start during transition: %s", exc)
+
+        if (
+            carry_over_context
+            and old_session_id
+            and target_session_id
+            and hasattr(engine, "carry_over_new_session_context")
+        ):
+            try:
+                engine.carry_over_new_session_context(old_session_id, target_session_id)
+            except Exception as exc:
+                logger.debug("context engine carry_over_new_session_context during transition: %s", exc)
+
+    def reset_session_state(
+        self,
+        previous_messages: list | None = None,
+        old_session_id: str | None = None,
+        carry_over_context: bool = False,
+    ):
         """Reset all session-scoped token counters to 0 for a fresh session.
         
         This method encapsulates the reset logic for all session-level metrics
@@ -2575,9 +2642,14 @@ class AIAgent:
         # Turn counter (added after reset_session_state was first written — #2635)
         self._user_turn_count = 0
 
-        # Context engine reset (works for both built-in compressor and plugins)
-        if hasattr(self, "context_compressor") and self.context_compressor:
-            self.context_compressor.on_session_reset()
+        # Context engine reset/transition (works for both built-in compressor and plugins)
+        self._transition_context_engine_session(
+            old_session_id=old_session_id,
+            new_session_id=getattr(self, "session_id", None),
+            previous_messages=previous_messages,
+            carry_over_context=carry_over_context,
+            reset_engine=True,
+        )
 
     def _ensure_lmstudio_runtime_loaded(self, config_context_length: Optional[int] = None) -> None:
         """

--- a/tests/run_agent/test_compression_boundary_hook.py
+++ b/tests/run_agent/test_compression_boundary_hook.py
@@ -30,6 +30,7 @@ class TestCompressionBoundaryHook:
                 quiet_mode=True,
                 session_db=session_db,
                 session_id="original-session",
+                gateway_session_key="agent:main:telegram:group:-1002285219667:17585",
                 skip_context_files=True,
                 skip_memory=True,
             )
@@ -85,6 +86,7 @@ class TestCompressionBoundaryHook:
                 f"Expected new session_id as first positional arg, got {call!r}"
             assert call.kwargs.get("old_session_id") == original_sid, \
                 f"Expected old_session_id={original_sid!r}, got {call.kwargs!r}"
+            assert call.kwargs.get("conversation_id") == "agent:main:telegram:group:-1002285219667:17585"
 
     def test_no_hook_when_no_session_db(self):
         """Without session_db, session_id does not rotate and the hook is not fired."""

--- a/tests/run_agent/test_plugin_context_engine_init.py
+++ b/tests/run_agent/test_plugin_context_engine_init.py
@@ -7,6 +7,8 @@ context_length, causing the CLI status bar to show 'ctx --'.
 from unittest.mock import MagicMock, patch
 
 from agent.context_engine import ContextEngine
+from gateway.config import Platform
+from gateway.session import SessionSource, build_session_key
 
 
 class _StubEngine(ContextEngine):
@@ -89,3 +91,49 @@ def test_plugin_engine_update_model_args():
     assert "provider" in kw
     # Should NOT pass api_mode — the ABC doesn't accept it
     assert "api_mode" not in kw
+
+def test_plugin_engine_gets_gateway_conversation_id_on_session_start():
+    """Gateway sessions should bind plugin engines to the stable chat key."""
+    engine = _StubEngine()
+    engine.on_session_start = MagicMock()
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1002285219667",
+        chat_type="group",
+        thread_id="17585",
+        user_id="alice",
+    )
+    gateway_session_key = build_session_key(source)
+    assert gateway_session_key == "agent:main:telegram:group:-1002285219667:17585"
+
+    cfg = {"context": {"engine": "stub"}, "agent": {}}
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("plugins.context_engine.load_context_engine", return_value=engine),
+        patch("agent.model_metadata.get_model_context_length", return_value=131_072),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        AIAgent(
+            model="openrouter/auto",
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            platform="telegram",
+            chat_id=source.chat_id,
+            chat_type=source.chat_type,
+            thread_id=source.thread_id,
+            gateway_session_key=gateway_session_key,
+        )
+
+    engine.on_session_start.assert_called_once()
+    kw = engine.on_session_start.call_args.kwargs
+    assert kw["conversation_id"] == gateway_session_key
+    assert kw["platform"] == "telegram"

--- a/tests/run_agent/test_session_reset_fix.py
+++ b/tests/run_agent/test_session_reset_fix.py
@@ -119,3 +119,50 @@ class TestResetSessionState:
         agent.reset_session_state()
 
         assert agent._user_turn_count == 0
+
+
+    def test_plugin_context_engine_restarts_with_new_session_id(self):
+        """Plugin engines can flush old messages, reset, bind, and carry context."""
+        agent = _make_minimal_agent()
+        agent.session_id = "new-session-id"
+        agent.platform = "cli"
+        agent.model = "test-model"
+
+        class FakePluginEngine:
+            context_length = 1234
+
+            def __init__(self):
+                self.reset_called = False
+                self.started_with = None
+                self.ended_with = None
+                self.carried_over = None
+
+            def on_session_end(self, session_id, messages):
+                self.ended_with = (session_id, list(messages))
+
+            def on_session_reset(self):
+                self.reset_called = True
+
+            def on_session_start(self, session_id, **kwargs):
+                self.started_with = (session_id, kwargs)
+
+            def carry_over_new_session_context(self, old_session_id, new_session_id):
+                self.carried_over = (old_session_id, new_session_id)
+
+        engine = FakePluginEngine()
+        agent.context_compressor = engine
+
+        agent.reset_session_state(
+            previous_messages=[{"role": "user", "content": "old stuff"}],
+            old_session_id="old-session-id",
+            carry_over_context=True,
+        )
+
+        assert engine.ended_with == ("old-session-id", [{"role": "user", "content": "old stuff"}])
+        assert engine.reset_called is True
+        assert engine.started_with is not None
+        assert engine.started_with[0] == "new-session-id"
+        assert engine.started_with[1]["old_session_id"] == "old-session-id"
+        assert engine.started_with[1]["carry_over_context"] is True
+        assert engine.started_with[1]["context_length"] == 1234
+        assert engine.carried_over == ("old-session-id", "new-session-id")

--- a/tests/run_agent/test_session_reset_fix.py
+++ b/tests/run_agent/test_session_reset_fix.py
@@ -127,6 +127,7 @@ class TestResetSessionState:
         agent.session_id = "new-session-id"
         agent.platform = "cli"
         agent.model = "test-model"
+        agent._gateway_session_key = "agent:main:telegram:dm:123"
 
         class FakePluginEngine:
             context_length = 1234
@@ -165,4 +166,5 @@ class TestResetSessionState:
         assert engine.started_with[1]["old_session_id"] == "old-session-id"
         assert engine.started_with[1]["carry_over_context"] is True
         assert engine.started_with[1]["context_length"] == 1234
+        assert engine.started_with[1]["conversation_id"] == "agent:main:telegram:dm:123"
         assert engine.carried_over == ("old-session-id", "new-session-id")


### PR DESCRIPTION
## Summary

This keeps #16453 focused on the host contract for context-engine session transitions.

- adds `_transition_context_engine_session(...)` on `AIAgent`
- lets `reset_session_state(...)` pass old-session metadata into external context engines for flush, reset, rebind, and optional carry-over
- passes the gateway `conversation_id` into context-engine session start hooks, so gateway sessions get a stable conversation identity instead of only a per-session id
- keeps the existing no-argument reset behavior for the built-in compressor and default paths
- adds regression coverage for transition ordering and gateway context-engine initialization

## Why

External context engines need a generic Hermes host contract for session boundaries. This gives plugins a stable transition point without vendoring or coupling Hermes Agent to one context-engine implementation.

## Validation

- `./scripts/run_tests.sh -n 0 tests/run_agent/test_session_reset_fix.py tests/run_agent/test_plugin_context_engine_init.py tests/run_agent/test_compression_boundary_hook.py -q --tb=short`, `11 passed`
- `python -m compileall -q run_agent.py gateway/run.py tests/run_agent/test_session_reset_fix.py tests/run_agent/test_plugin_context_engine_init.py tests/run_agent/test_compression_boundary_hook.py`
- `git diff --check origin/main...HEAD`
- read-only audit of the rebuilt branch found no stale baseline, optional-dependency, CI, or workflow files in the PR diff

## Notes

- Host lifecycle support only
- No external context-engine implementation is vendored or bundled
- Rebuilt on current `main` after #21012 so the old lazy optional-dependency baseline fix is no longer part of this PR
