### PR TITLE
fix: drop stale background process session notifications

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -761,6 +761,7 @@ def _seed_cron_thread_session(
     thread_id: str,
     mirror_text: str,
     chat_name: Optional[str] = None,
+    loop=None,
 ) -> None:
     """Seed the freshly-opened cron thread's session with the brief.
 
@@ -779,6 +780,8 @@ def _seed_cron_thread_session(
     text = (mirror_text or "").strip()
     if not text:
         return
+    seed_text = f"[Cron delivery: {job.get('name') or job.get('id', 'cron')}]\n{text}"
+    seeded_via_adapter = False
     try:
         from gateway.config import Platform
         from gateway.session import SessionSource
@@ -799,26 +802,49 @@ def _seed_cron_thread_session(
                     user_name="Cron",
                     thread_id=str(thread_id),
                 )
-                # Ensure the thread-keyed session row exists so the mirror has
-                # a target and the user's later reply joins the same session.
-                session_store.get_or_create_session(dest_source)
+                # Ensure the thread-keyed session row exists so the user's later
+                # reply joins the same session. Live delivery has the gateway loop;
+                # standalone callers without one retain the legacy mirror fallback.
+                if loop is not None:
+                    from agent.async_utils import safe_schedule_threadsafe
 
-        from gateway.mirror import mirror_to_session
+                    future = safe_schedule_threadsafe(
+                        adapter.resolve_session_entry(
+                            dest_source,
+                            operation=lambda entry: session_store.append_to_transcript(
+                                entry.session_id,
+                                {
+                                    "role": "user",
+                                    "content": seed_text,
+                                    "mirror": True,
+                                    "mirror_source": "cron",
+                                },
+                            ),
+                        ),
+                        loop,
+                    )
+                    if future is None:
+                        raise RuntimeError("gateway loop unavailable for cron session seed")
+                    future.result(timeout=30)
+                    seeded_via_adapter = True
 
-        # User-role + labelled prefix (see _maybe_mirror_cron_delivery): the
-        # seeded brief must not read as an assistant turn, or the user's first
-        # in-thread reply produces assistant→user→... off a phantom assistant
-        # message. Pass the seed user_id so the mirror resolves the exact
-        # thread-keyed session row we just created.
-        mirror_to_session(
-            platform_name,
-            str(chat_id),
-            f"[Cron delivery: {job.get('name') or job.get('id', 'cron')}]\n{text}",
-            source_label="cron",
-            thread_id=str(thread_id),
-            user_id="system:cron",
-            role="user",
-        )
+        if not seeded_via_adapter:
+            from gateway.mirror import mirror_to_session
+
+            # User-role + labelled prefix (see _maybe_mirror_cron_delivery): the
+            # seeded brief must not read as an assistant turn, or the user's first
+            # in-thread reply produces assistant→user→... off a phantom assistant
+            # message. Pass the seed user_id so the mirror resolves the exact
+            # thread-keyed session row we just created.
+            mirror_to_session(
+                platform_name,
+                str(chat_id),
+                seed_text,
+                source_label="cron",
+                thread_id=str(thread_id),
+                user_id="system:cron",
+                role="user",
+            )
         logger.info(
             "Job '%s': opened continuable thread %s on %s:%s and seeded the brief",
             job.get("id", "?"), thread_id, platform_name, chat_id,
@@ -840,6 +866,7 @@ def _seed_cron_channel_session(
     is_dm: bool,
     user_id: Optional[str],
     chat_name: Optional[str] = None,
+    loop=None,
 ) -> bool:
     """Seed the FLAT (thread_id=None) session for an ``in_channel`` cron delivery.
 
@@ -877,6 +904,8 @@ def _seed_cron_channel_session(
     text = (mirror_text or "").strip()
     if not text:
         return False
+    seed_text = f"[Cron delivery: {job.get('name') or job.get('id', 'cron')}]\n{text}"
+    seeded_via_adapter = False
     try:
         from gateway.config import Platform
         from gateway.session import SessionSource
@@ -897,21 +926,45 @@ def _seed_cron_channel_session(
                     user_id=str(user_id) if user_id else None,
                     thread_id=None,  # flat — the whole-channel/DM session
                 )
-                # Create the flat session row so the mirror has a target and the
-                # user's later plain reply joins the SAME session.
-                session_store.get_or_create_session(dest_source)
+                # Live delivery resolves and appends under one gateway boundary;
+                # standalone callers without a loop retain the mirror fallback.
+                if loop is not None:
+                    from agent.async_utils import safe_schedule_threadsafe
 
-        from gateway.mirror import mirror_to_session
+                    future = safe_schedule_threadsafe(
+                        adapter.resolve_session_entry(
+                            dest_source,
+                            operation=lambda entry: session_store.append_to_transcript(
+                                entry.session_id,
+                                {
+                                    "role": "user",
+                                    "content": seed_text,
+                                    "mirror": True,
+                                    "mirror_source": "cron",
+                                },
+                            ),
+                        ),
+                        loop,
+                    )
+                    if future is None:
+                        raise RuntimeError("gateway loop unavailable for cron session seed")
+                    future.result(timeout=30)
+                    seeded_via_adapter = True
 
-        ok = mirror_to_session(
-            platform_name,
-            str(chat_id),
-            f"[Cron delivery: {job.get('name') or job.get('id', 'cron')}]\n{text}",
-            source_label="cron",
-            thread_id=None,
-            user_id=str(user_id) if user_id else None,
-            role="user",
-        )
+        if seeded_via_adapter:
+            ok = True
+        else:
+            from gateway.mirror import mirror_to_session
+
+            ok = mirror_to_session(
+                platform_name,
+                str(chat_id),
+                seed_text,
+                source_label="cron",
+                thread_id=None,
+                user_id=str(user_id) if user_id else None,
+                role="user",
+            )
         if ok:
             logger.info(
                 "Job '%s': seeded flat in_channel session on %s:%s (chat_type=%s)",
@@ -1859,6 +1912,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                             job, runtime_adapter, platform_name, chat_id,
                             opened_thread_id, mirror_text,
                             chat_name=origin.get("chat_name"),
+                            loop=loop,
                         )
                         thread_seeded = True
                     # in_channel surface: CREATE + seed the flat channel/DM
@@ -1871,6 +1925,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                             mirror_text, is_dm=is_dm_target,
                             user_id=origin_user_id,
                             chat_name=origin.get("chat_name"),
+                            loop=loop,
                         )
                     _maybe_mirror_cron_delivery(
                         job, platform_name, chat_id, mirror_text,

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -34,6 +34,7 @@ _AUDIO_EXTS = frozenset({'.ogg', '.opus', '.mp3', '.wav', '.m4a', '.flac'})
 _TELEGRAM_AUDIO_ATTACHMENT_EXTS = frozenset({'.mp3', '.m4a'})
 _TELEGRAM_VOICE_EXTS = frozenset({'.ogg', '.opus'})
 _POST_DELIVERY_CALLBACK_TIMEOUT_SECONDS = 30.0
+_SESSION_CANCEL_TIMEOUT_SECONDS = 5.0
 
 
 def _platform_name(platform) -> str:
@@ -4472,19 +4473,30 @@ class BasePlatformAdapter(ABC):
         guard = interrupt_event or asyncio.Event()
         self._active_sessions[session_key] = guard
 
-        task = asyncio.create_task(self._process_message_background(event, session_key))
-        self._session_tasks[session_key] = task
+        coroutine = self._process_message_background(event, session_key)
         try:
-            self._background_tasks.add(task)
-        except TypeError:
-            # Tests stub create_task() with lightweight sentinels that are not
-            # hashable and do not support lifecycle callbacks.
-            self._session_tasks.pop(session_key, None)
+            task = asyncio.create_task(coroutine)
+        except Exception:
+            coroutine.close()
+            self._release_session_guard(session_key, guard=guard)
+            raise
+        if not isinstance(task, asyncio.Task):
+            coroutine.close()
             self._release_session_guard(session_key, guard=guard)
             return False
-        if hasattr(task, "add_done_callback"):
+        self._session_tasks[session_key] = task
+        self._background_tasks.add(task)
+        try:
             task.add_done_callback(self._background_tasks.discard)
             task.add_done_callback(self._expected_cancelled_tasks.discard)
+        except Exception:
+            task.cancel()
+            if self._session_tasks.get(session_key) is task:
+                self._session_tasks.pop(session_key, None)
+            self._background_tasks.discard(task)
+            self._expected_cancelled_tasks.discard(task)
+            self._release_session_guard(session_key, guard=guard)
+            raise
         return True
 
     async def cancel_session_processing(
@@ -4493,7 +4505,7 @@ class BasePlatformAdapter(ABC):
         *,
         release_guard: bool = True,
         discard_pending: bool = True,
-    ) -> None:
+    ) -> bool:
         """Cancel in-flight processing for a single session.
 
         ``release_guard=False`` keeps the adapter-level session guard in place
@@ -4506,24 +4518,37 @@ class BasePlatformAdapter(ABC):
         asyncio where the event loop's cancellation-propagation semantics
         differ subtly from a bare ``asyncio.run`` harness.
         """
-        task = self._session_tasks.pop(session_key, None)
+        task = self._session_tasks.get(session_key)
         if task is not None and not task.done():
+            def _drop_finished_owner(done_task: asyncio.Task) -> None:
+                if self._session_tasks.get(session_key) is done_task:
+                    self._session_tasks.pop(session_key, None)
+
+            task.add_done_callback(_drop_finished_owner)
             logger.debug(
                 "[%s] Cancelling active processing for session %s",
                 self.name,
                 session_key,
             )
             self._expected_cancelled_tasks.add(task)
-            task.cancel()
+            cancelling = getattr(task, "cancelling", None)
+            if not callable(cancelling) or cancelling() == 0:
+                task.cancel()
             try:
-                await asyncio.wait_for(asyncio.shield(task), timeout=5.0)
+                await asyncio.wait_for(
+                    asyncio.shield(task),
+                    timeout=_SESSION_CANCEL_TIMEOUT_SECONDS,
+                )
             except asyncio.CancelledError:
-                pass
+                current_task = asyncio.current_task()
+                if current_task is not None and current_task.cancelling():
+                    raise
+                # The shielded owner itself completed as cancelled.
             except asyncio.TimeoutError:
                 logger.warning(
-                    "[%s] Cancelled task for %s did not exit within 5s; "
-                    "unblocking dispatch and letting the task unwind in the background",
-                    self.name, session_key,
+                    "[%s] Cancelled task for %s did not exit within %.1fs; "
+                    "keeping the session guard until owner unwind completes",
+                    self.name, session_key, _SESSION_CANCEL_TIMEOUT_SECONDS,
                 )
             except Exception:
                 logger.debug(
@@ -4532,11 +4557,18 @@ class BasePlatformAdapter(ABC):
                     session_key,
                     exc_info=True,
                 )
+            if not task.done():
+                return False
+            if self._session_tasks.get(session_key) is task:
+                self._session_tasks.pop(session_key, None)
+        elif task is not None and self._session_tasks.get(session_key) is task:
+            self._session_tasks.pop(session_key, None)
         if discard_pending:
             self._pending_messages.pop(session_key, None)
             self._discard_text_debounce(session_key)
         if release_guard:
             self._release_session_guard(session_key)
+        return True
 
     async def _drain_pending_after_session_command(
         self,
@@ -4549,14 +4581,172 @@ class BasePlatformAdapter(ABC):
         command-scoped guard, then — if a follow-up message landed while the
         command was running — spawns a fresh processing task for it.
         """
+        if getattr(self, "_background_task_teardown", False):
+            return
+        if self._active_sessions.get(session_key) is not command_guard:
+            return
         await self._flush_text_debounce_now(session_key)
+        if getattr(self, "_background_task_teardown", False):
+            return
+        if self._active_sessions.get(session_key) is not command_guard:
+            return
+        # No await between the final ownership check, pending pop, exact-guard
+        # release, and publication of the follow-up task.
         pending_event = self._pending_messages.pop(session_key, None)
         self._release_session_guard(session_key, guard=command_guard)
         if pending_event is None:
             return
-        self._start_session_processing(pending_event, session_key)
+        try:
+            started = self._start_session_processing(
+                pending_event, session_key
+            )
+        except Exception:
+            self._pending_messages[session_key] = pending_event
+            raise
+        if not started:
+            self._pending_messages[session_key] = pending_event
+
+    async def _run_with_session_command_lock(
+        self,
+        session_key: str,
+        operation: Callable[[], Awaitable[Any]],
+    ) -> Any:
+        """Run under a refcounted per-session lock and evict it when idle."""
+        command_locks = getattr(self, "_session_command_locks", None)
+        if command_locks is None:
+            command_locks = {}
+            self._session_command_locks = command_locks
+        entry = command_locks.get(session_key)
+        if entry is None:
+            entry = {"lock": asyncio.Lock(), "users": 0}
+            command_locks[session_key] = entry
+        entry["users"] += 1
+        try:
+            async with entry["lock"]:
+                return await operation()
+        finally:
+            entry["users"] -= 1
+            if (
+                entry["users"] == 0
+                and command_locks.get(session_key) is entry
+            ):
+                command_locks.pop(session_key, None)
+
+    def _schedule_session_command_drain(
+        self,
+        session_key: str,
+        command_guard: asyncio.Event,
+    ) -> bool:
+        """Publish a durable exact-guard drain outside the caller task."""
+        if getattr(self, "_background_task_teardown", False):
+            return False
+
+        async def _owned_drain() -> None:
+            if getattr(self, "_background_task_teardown", False):
+                return
+            if self._active_sessions.get(session_key) is not command_guard:
+                return
+            try:
+                await self._drain_pending_after_session_command(
+                    session_key, command_guard
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception(
+                    "[%s] Deferred command drain failed for %s; recovering exact guard",
+                    self.name,
+                    session_key,
+                )
+                if self._active_sessions.get(session_key) is command_guard:
+                    pending_event = self._pending_messages.pop(
+                        session_key, None
+                    )
+                    self._release_session_guard(
+                        session_key, guard=command_guard
+                    )
+                    if pending_event is not None:
+                        try:
+                            started = self._start_session_processing(
+                                pending_event, session_key
+                            )
+                        except Exception:
+                            started = False
+                            logger.exception(
+                                "[%s] Deferred command drain recovery failed for %s",
+                                self.name,
+                                session_key,
+                            )
+                        if not started:
+                            self._pending_messages[session_key] = pending_event
+
+        async def _run() -> None:
+            await self._run_with_session_command_lock(
+                session_key, _owned_drain
+            )
+
+        drain_coroutine = _run()
+        drain_task: Optional[asyncio.Task] = None
+        try:
+            created_task = asyncio.create_task(drain_coroutine)
+            if not isinstance(created_task, asyncio.Task):
+                raise RuntimeError(
+                    "create_task did not return an asyncio.Task"
+                )
+            drain_task = created_task
+            self._background_tasks.add(drain_task)
+            drain_task.add_done_callback(self._background_tasks.discard)
+        except Exception:
+            if drain_task is None:
+                drain_coroutine.close()
+            else:
+                drain_task.cancel()
+                self._background_tasks.discard(drain_task)
+            logger.exception(
+                "[%s] Could not publish deferred command drain for %s",
+                self.name,
+                session_key,
+            )
+            # Preserve the pending event for a later inbound replay, but do not
+            # leave a command guard with no runnable owner behind.
+            self._release_session_guard(session_key, guard=command_guard)
+            return False
+        return True
+
+    def _defer_session_command_drain_until_owner_done(
+        self,
+        session_key: str,
+        command_guard: asyncio.Event,
+        owner_task: asyncio.Task,
+    ) -> None:
+        """Resume an exact command drain after a timed-out owner unwinds."""
+
+        def _resume_drain(done_task: asyncio.Task) -> None:
+            published = self._schedule_session_command_drain(
+                session_key, command_guard
+            )
+            if published and self._session_tasks.get(session_key) is done_task:
+                self._session_tasks.pop(session_key, None)
+
+        owner_task.add_done_callback(_resume_drain)
 
     async def _dispatch_active_session_command(
+        self,
+        event: MessageEvent,
+        session_key: str,
+        cmd: str,
+    ) -> None:
+        """Serialize one reset-like command lifecycle per physical session."""
+        async def _owned_command() -> None:
+            await self._dispatch_active_session_command_owned(
+                event, session_key, cmd
+            )
+
+        await self._run_with_session_command_lock(
+            session_key, _owned_command
+        )
+
+    async def _dispatch_active_session_command_owned(
         self,
         event: MessageEvent,
         session_key: str,
@@ -4581,13 +4771,15 @@ class BasePlatformAdapter(ABC):
             session_key,
         )
 
-        current_guard = self._active_sessions.get(session_key)
+        current_owner_task = self._session_tasks.get(session_key)
         command_guard = asyncio.Event()
         self._active_sessions[session_key] = command_guard
         thread_meta = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
 
         try:
             response = await self._message_handler(event)
+            if self._active_sessions.get(session_key) is not command_guard:
+                return
             _text, _eph_ttl = self._unwrap_ephemeral(response)
             # Send the response BEFORE cancelling the old task so the send
             # cannot be affected by task-cancellation side effects (race
@@ -4616,19 +4808,45 @@ class BasePlatformAdapter(ABC):
                     )
             # Old adapter task (if any) is cancelled AFTER the response has
             # been sent — keeps ordering deterministic and avoids the race.
-            await self.cancel_session_processing(
+            if self._active_sessions.get(session_key) is not command_guard:
+                return
+            owner_task = self._session_tasks.get(session_key)
+            owner_unwound = await self.cancel_session_processing(
                 session_key,
                 release_guard=False,
                 discard_pending=False,
             )
-        except Exception:
-            # On failure, restore the original guard if one still exists so
-            # we don't leave the session in a half-reset state.
+            if not owner_unwound:
+                if owner_task is not None:
+                    self._defer_session_command_drain_until_owner_done(
+                        session_key,
+                        command_guard,
+                        owner_task,
+                    )
+                return
+        except (asyncio.CancelledError, Exception):
+            # Keep the exact command guard as the cancellation-recovery owner.
+            # Restoring the previous guard can orphan pending work when that
+            # owner's callback removes its finished task. Run replay in a
+            # separately tracked continuation so repeated caller cancellation
+            # cannot interrupt the transactional drain.
             if self._active_sessions.get(session_key) is command_guard:
-                if session_key in self._session_tasks and current_guard is not None:
-                    self._active_sessions[session_key] = current_guard
+                mapped_owner = self._session_tasks.get(session_key)
+                owner_done = getattr(current_owner_task, "done", None)
+                previous_owner_is_live = bool(
+                    current_owner_task is not None
+                    and mapped_owner is current_owner_task
+                    and callable(owner_done)
+                    and not owner_done()
+                )
+                if previous_owner_is_live and current_owner_task is not None:
+                    self._defer_session_command_drain_until_owner_done(
+                        session_key, command_guard, current_owner_task
+                    )
                 else:
-                    self._release_session_guard(session_key, guard=command_guard)
+                    self._schedule_session_command_drain(
+                        session_key, command_guard
+                    )
             raise
 
         await self._drain_pending_after_session_command(session_key, command_guard)
@@ -4901,6 +5119,36 @@ class BasePlatformAdapter(ABC):
             await self._stop_typing_refresh(
                 event.source.chat_id,
                 typing_task,
+            )
+
+        async def _wait_for_stamped_release_chain() -> bool:
+            """Wait through release-event handoffs while this guard is owned."""
+            while True:
+                if self._active_sessions.get(session_key) is not interrupt_event:
+                    return False
+                release_event = getattr(
+                    interrupt_event,
+                    "_hermes_stamped_process_release_event",
+                    None,
+                )
+                if release_event is not None:
+                    await release_event.wait()
+                await self._flush_text_debounce_now(session_key)
+                if self._active_sessions.get(session_key) is not interrupt_event:
+                    return False
+                if getattr(
+                    interrupt_event,
+                    "_hermes_stamped_process_release_event",
+                    None,
+                ) is release_event:
+                    return True
+
+        def _current_task_owns_drain() -> bool:
+            current_task = asyncio.current_task()
+            return bool(
+                current_task is not None
+                and self._active_sessions.get(session_key) is interrupt_event
+                and self._session_tasks.get(session_key) is current_task
             )
         
         try:
@@ -5207,49 +5455,47 @@ class BasePlatformAdapter(ABC):
                 ProcessingOutcome.SUCCESS if processing_ok else ProcessingOutcome.FAILURE,
             )
 
-            # The active drain owns debounce state. If a queue-mode timer has
-            # not fired yet, force-flush into _pending_messages here and let
-            # this task hand off the follow-up.
-            await self._flush_text_debounce_now(session_key)
+            # A foreground adapter task that discovered an out-of-band stamped
+            # process owner retains the adapter guard and pending-drain ownership
+            # until that synthetic lifecycle releases it. This prevents both a
+            # recursive redispatch loop and a replay gap outside the adapter guard.
+            # A stamped wrapper may hand ownership directly to a newer stamped
+            # generation while this foreground task waits. Follow that identity
+            # chain and only consume the pending head after a release + debounce
+            # flush where the guard still names the same event. A replacement
+            # command guard owns any pending drain after a guard swap.
+            if not await _wait_for_stamped_release_chain():
+                return
 
-            # Check if there's a pending message that was queued during our processing
-            if session_key in self._pending_messages:
-                pending_event = self._pending_messages.pop(session_key)
-                logger.debug("[%s] Processing queued follow-up message", self.name)
-                # Keep the _active_sessions entry live across the turn chain
-                # and only CLEAR the interrupt Event — do NOT delete the entry.
-                # If we deleted here, a concurrent inbound message arriving
-                # during the awaits below would pass the Level-1 guard, spawn
-                # its own _process_message_background, and run simultaneously
-                # with the recursive drain below.  Two agents on one
-                # session_key = duplicate responses, duplicate tool calls.
-                # Clearing the Event keeps the guard live so follow-ups take
-                # the busy-handler path as intended.
-                _active = self._active_sessions.get(session_key)
-                if _active is not None:
-                    _active.clear()
-                await _stop_typing_task()
-                # Spawn a fresh task for the pending message instead of
-                # recursing.  Issue #17758: `await
-                # self._process_message_background(...)` here grew the
-                # call stack one frame per chained follow-up, and under
-                # sustained pending-queue activity the C stack would
-                # exhaust at ~2000 frames and SIGSEGV the process.
-                # Mirror the late-arrival drain pattern below: hand off
-                # to a new task and return so this frame can unwind.
-                drain_task = asyncio.create_task(
-                    self._process_message_background(pending_event, session_key)
+            # Stop typing before claiming a pending follow-up. This await may
+            # let a reset-like command replace both the guard and owner task,
+            # so ownership must be re-proved immediately before pop/publication.
+            await _stop_typing_task()
+            if not await _wait_for_stamped_release_chain():
+                return
+            if _current_task_owns_drain():
+                # No await between exact guard/task proof, pending pop, and the
+                # transactional handoff to _start_session_processing.
+                pending_event = self._pending_messages.pop(
+                    session_key, None
                 )
-                # Hand ownership of the session to the drain task so
-                # stale-lock detection keeps working while it runs.
-                self._session_tasks[session_key] = drain_task
-                try:
-                    self._background_tasks.add(drain_task)
-                    drain_task.add_done_callback(self._background_tasks.discard)
-                except TypeError:
-                    # Tests stub create_task() with non-hashable sentinels; tolerate.
-                    pass
-                return  # Drain task owns the session now.
+                if pending_event is not None:
+                    logger.debug(
+                        "[%s] Processing queued follow-up message", self.name
+                    )
+                    interrupt_event.clear()
+                    try:
+                        started = self._start_session_processing(
+                            pending_event,
+                            session_key,
+                            interrupt_event=interrupt_event,
+                        )
+                    except Exception:
+                        self._pending_messages[session_key] = pending_event
+                        raise
+                    if not started:
+                        self._pending_messages[session_key] = pending_event
+                    return  # Follow-up task owns the session when started.
                 
         except asyncio.CancelledError:
             current_task = asyncio.current_task()
@@ -5326,9 +5572,20 @@ class BasePlatformAdapter(ABC):
                 None,
                 stop_attempts=1,
             )
-            # Final drain/release boundary: force-flush any timer that missed
-            # the in-band drain before deciding whether the guard can clear.
-            await self._flush_text_debounce_now(session_key)
+            # Final drain/release boundary. Only the task that still owns this
+            # exact guard may wait/flush/pop. A stamped generation can rebind its
+            # release event during cleanup, and a session command can replace the
+            # guard entirely; both handoffs must be honored before consuming work.
+            late_pending = None
+            if _current_task_owns_drain():
+                release_chain_current = (
+                    await _wait_for_stamped_release_chain()
+                )
+                if release_chain_current and _current_task_owns_drain():
+                    # No await between the final ownership check and pop.
+                    late_pending = self._pending_messages.pop(
+                        session_key, None
+                    )
             # Late-arrival drain: a message may have arrived during the
             # cleanup awaits above (typing_task cancel, stop_typing).  Such
             # messages passed the Level-1 guard (entry still live, Event
@@ -5336,45 +5593,25 @@ class BasePlatformAdapter(ABC):
             # busy-handler path.  Without this block, we would delete the
             # active-session entry and the queued message would be silently
             # dropped (user never gets a reply).
-            late_pending = self._pending_messages.pop(session_key, None)
             if late_pending is not None:
-                current_task = asyncio.current_task()
-                existing_task = self._session_tasks.get(session_key)
-                if (
-                    existing_task is not None
-                    and existing_task is not current_task
-                ):
-                    # The in-band drain (or an earlier late-arrival drain)
-                    # already spawned a follow-up task that owns this
-                    # session.  Re-queue the late-arrival event so that
-                    # task picks it up — avoids spawning two concurrent
-                    # _process_message_background tasks for the same key
-                    # (#17758 follow-up: prevents the create_task path
-                    # from racing with itself across the in-band/finally
-                    # boundary).
+                logger.debug(
+                    "[%s] Late-arrival pending message during cleanup — spawning drain task",
+                    self.name,
+                )
+                interrupt_event.clear()
+                try:
+                    started = self._start_session_processing(
+                        late_pending,
+                        session_key,
+                        interrupt_event=interrupt_event,
+                    )
+                except Exception:
                     self._pending_messages[session_key] = late_pending
-                else:
-                    logger.debug(
-                        "[%s] Late-arrival pending message during cleanup — spawning drain task",
-                        self.name,
-                    )
-                    _active = self._active_sessions.get(session_key)
-                    if _active is not None:
-                        _active.clear()
-                    drain_task = asyncio.create_task(
-                        self._process_message_background(late_pending, session_key)
-                    )
-                    # Hand ownership of the session to the drain task so stale-lock
-                    # detection keeps working while it runs.
-                    self._session_tasks[session_key] = drain_task
-                    try:
-                        self._background_tasks.add(drain_task)
-                        drain_task.add_done_callback(self._background_tasks.discard)
-                    except TypeError:
-                        # Tests stub create_task() with non-hashable sentinels; tolerate.
-                        pass
-                # Leave _active_sessions[session_key] populated — the drain
-                # task's own lifecycle will clean it up.
+                    raise
+                if not started:
+                    self._pending_messages[session_key] = late_pending
+                # Leave the exact guard populated when publication succeeds;
+                # the follow-up task's lifecycle owns its release.
             else:
                 # Clean up session tracking.  Guard-match both deletes so a
                 # reset-like command that already swapped in its own
@@ -5428,6 +5665,7 @@ class BasePlatformAdapter(ABC):
         whole shutdown path.  Stragglers are released from our tracking and
         allowed to finish unwinding on their own.
         """
+        self._background_task_teardown = True
         # Loop until no new tasks appear.  Without this, a message
         # arriving during the `await asyncio.gather` below would spawn
         # a fresh _process_message_background task (added to

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2349,6 +2349,7 @@ class BasePlatformAdapter(ABC):
         self.config = config
         self.platform = platform
         self._message_handler: Optional[MessageHandler] = None
+        self._session_resolver: Optional[Callable[[Any], Awaitable[Any]]] = None
         # Optional hook (e.g. Telegram DM topic recovery) that rewrites
         # ``event.source.thread_id`` before session keying. Returns the
         # corrected thread_id or None to leave the source untouched.
@@ -2876,12 +2877,39 @@ class BasePlatformAdapter(ABC):
     def set_session_store(self, session_store: Any) -> None:
         """
         Set the session store for checking active sessions.
-        
+
         Used by adapters that need to check if a thread/conversation
         has an active session before processing messages (e.g., Slack
         thread replies without explicit mentions).
         """
         self._session_store = session_store
+
+    def set_session_resolver(
+        self,
+        resolver: Optional[Callable[[Any], Awaitable[Any]]],
+    ) -> None:
+        """Set the runner-owned, boundary-aware session lookup callback."""
+        self._session_resolver = resolver
+
+    async def resolve_session_entry(
+        self,
+        source: Any,
+        *,
+        operation: Optional[Callable[[Any], Any]] = None,
+    ) -> Any:
+        """Resolve a session without bypassing runner delivery boundaries."""
+        resolver = getattr(self, "_session_resolver", None)
+        if resolver is not None:
+            return await resolver(source, operation=operation)
+        store = getattr(self, "_session_store", None)
+        if store is None:
+            raise RuntimeError("Session store is not configured")
+        entry = await asyncio.to_thread(store.get_or_create_session, source)
+        if operation is not None:
+            result = operation(entry)
+            if inspect.isawaitable(result):
+                await result
+        return entry
     
     @abstractmethod
     async def connect(self, *, is_reconnect: bool = False) -> bool:

--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -1311,7 +1311,7 @@ class RecallGuardMiddleware(InboundMiddleware):
         if cmd not in self._RECALL_COMMANDS:
             await next_fn()
             return
-        self._handle_recall(ctx, cmd)
+        await self._handle_recall(ctx, cmd)
 
     @staticmethod
     def _build_source(adapter, group_code: str, from_account: str):
@@ -1322,7 +1322,7 @@ class RecallGuardMiddleware(InboundMiddleware):
             thread_id="main" if group_code else None,
         )
 
-    def _handle_recall(self, ctx: InboundContext, cmd: str) -> None:
+    async def _handle_recall(self, ctx: InboundContext, cmd: str) -> None:
         adapter = ctx.adapter
         push = ctx.push or {}
 
@@ -1350,7 +1350,13 @@ class RecallGuardMiddleware(InboundMiddleware):
                 self._interrupt_for_recall(adapter, matched_sk, recalled_id, group_code, from_account)
             else:
                 recalled_content = adapter._msg_content_cache.get(recalled_id)
-                self._patch_transcript(adapter, recalled_id, group_code, from_account, recalled_content)
+                await self._patch_transcript(
+                    adapter,
+                    recalled_id,
+                    group_code,
+                    from_account,
+                    recalled_content,
+                )
 
     # -- Branch C: interrupt currently-processing message ---------------
 
@@ -1407,8 +1413,10 @@ class RecallGuardMiddleware(InboundMiddleware):
             if not store:
                 return
             try:
-                sid = store.get_or_create_session(
-                    cls._build_source(adapter, group_code, from_account),
+                sid = (
+                    await adapter.resolve_session_entry(
+                        cls._build_source(adapter, group_code, from_account)
+                    )
                 ).session_id
             except Exception:
                 return
@@ -1438,13 +1446,17 @@ class RecallGuardMiddleware(InboundMiddleware):
     # -- Branch A/B: patch transcript (session idle) --------------------
 
     @classmethod
-    def _patch_transcript(cls, adapter, recalled_id: str, group_code: str,
-                          from_account: str, recalled_content: Optional[str] = None) -> None:
+    async def _patch_transcript(cls, adapter, recalled_id: str, group_code: str,
+                                from_account: str, recalled_content: Optional[str] = None) -> None:
         store = getattr(adapter, "_session_store", None)
         if not store:
             return
         try:
-            sid = store.get_or_create_session(cls._build_source(adapter, group_code, from_account)).session_id
+            sid = (
+                await adapter.resolve_session_entry(
+                    cls._build_source(adapter, group_code, from_account)
+                )
+            ).session_id
         except Exception as exc:
             logger.warning("[%s] Recall: failed to resolve session: %s", adapter.name, exc)
             return
@@ -2200,7 +2212,7 @@ class GroupAtGuardMiddleware(InboundMiddleware):
         )
 
     @classmethod
-    def _observe_group_message(
+    async def _observe_group_message(
         cls,
         adapter, source, sender_display: str, text: str,
         *,
@@ -2219,7 +2231,7 @@ class GroupAtGuardMiddleware(InboundMiddleware):
         if not store:
             return
         try:
-            session_entry = store.get_or_create_session(source)
+            session_entry = await adapter.resolve_session_entry(source)
             user_id = source.user_id or "unknown"
             body_text = text
             if forwarded_records:
@@ -2247,7 +2259,7 @@ class GroupAtGuardMiddleware(InboundMiddleware):
     async def handle(self, ctx: InboundContext, next_fn) -> None:
         adapter = ctx.adapter
         if ctx.chat_type == "group" and not ctx.owner_command and not self._is_at_bot(ctx.msg_body, adapter._bot_id):
-            self._observe_group_message(
+            await self._observe_group_message(
                 adapter, ctx.source, ctx.sender_nickname or ctx.from_account, ctx.raw_text,
                 msg_id=ctx.msg_id or None,
                 forwarded_records=ctx.forwarded_records,
@@ -2384,7 +2396,7 @@ class QuoteContextMiddleware(InboundMiddleware):
             store = getattr(adapter, "_session_store", None)
             if not store or ctx.source is None:
                 return []
-            session_entry = store.get_or_create_session(ctx.source)
+            session_entry = await adapter.resolve_session_entry(ctx.source)
             history = store.load_transcript(session_entry.session_id)
             for msg in reversed(history or []):
                 mid = msg.get("message_id", "")
@@ -3000,7 +3012,7 @@ class MediaResolveMiddleware(InboundMiddleware):
         if not store:
             return [], []
         try:
-            session_entry = store.get_or_create_session(source)
+            session_entry = await adapter.resolve_session_entry(source)
             history = store.load_transcript(session_entry.session_id)
         except Exception as exc:
             logger.warning(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1832,6 +1832,9 @@ def _own_policy_open_startup_violation(config) -> Optional[str]:
 # session from bypassing the "already running" guard during the async gap
 # between the guard check and actual agent creation.
 _AGENT_PENDING_SENTINEL = object()
+# Internal hand-off from _handle_message to the stamped process runner. Process
+# notifications must wait behind a foreground turn, never steer or interrupt it.
+_STAMPED_PROCESS_EVENT_BUSY = object()
 
 
 def _resolve_runtime_agent_kwargs() -> dict:
@@ -2494,7 +2497,7 @@ def _parse_session_key(session_key: str) -> "dict | None":
     """Parse a session key into its component parts.
 
     Session keys follow the format
-    ``agent:main:{platform}:{chat_type}:{chat_id}[:{extra}...]``.
+    ``agent:{profile}:{platform}:{chat_type}:{chat_id}[:{extra}...]``.
     Returns a dict with ``platform``, ``chat_type``, ``chat_id``, and
     optionally ``thread_id`` keys, or None if the key doesn't match.
 
@@ -2504,12 +2507,14 @@ def _parse_session_key(session_key: str) -> "dict | None":
     thread_id, so we leave ``thread_id`` out to avoid mis-routing.
     """
     parts = session_key.split(":")
-    if len(parts) >= 5 and parts[0] == "agent" and parts[1] == "main":
+    if len(parts) >= 5 and parts[0] == "agent" and parts[1]:
         result = {
             "platform": parts[2],
             "chat_type": parts[3],
             "chat_id": parts[4],
         }
+        if parts[1] != "main":
+            result["profile"] = parts[1]
         if len(parts) > 5 and parts[3] in {"dm", "thread"}:
             result["thread_id"] = parts[5]
         return result
@@ -2914,6 +2919,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Key: session_key, Value: AIAgent instance
         self._running_agents: Dict[str, Any] = {}
         self._running_agents_ts: Dict[str, float] = {}  # start timestamp per session
+        self._stamped_process_running_agents: Dict[str, Any] = {}
         self._active_session_leases: Dict[str, Any] = {}
         self._pending_messages: Dict[str, str] = {}  # Queued messages during interrupt
         # Last successfully-resolved (non-empty) model, keyed by session. Used
@@ -2937,6 +2943,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._pending_native_image_paths_by_session: Dict[str, List[str]] = {}
         self._busy_ack_ts: Dict[str, float] = {}  # last busy-ack timestamp per session (debounce)
         self._session_run_generation: Dict[str, int] = {}
+        # Linearizes stamped process delivery against physical-session switches.
+        # A boundary mutation that wins this lock makes the later delivery
+        # recheck fail; a delivery that wins completes before the boundary is
+        # committed, eliminating the final check-to-send TOCTOU window.
+        self._process_delivery_boundary_locks: Dict[str, asyncio.Lock] = {}
         # Startup restore gate: while restart-interrupted sessions are being
         # auto-resumed, real inbound messages are queued instead of competing
         # with the synthetic resume turns for the same session.  The queued
@@ -5411,6 +5422,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return False
 
         running_agent = self._running_agents.get(session_key)
+        if (
+            running_agent is not None
+            and getattr(self, "_stamped_process_running_agents", {}).get(session_key)
+            is running_agent
+        ):
+            # Foreground input must not steer or interrupt a synthetic process
+            # notification turn. Preserve it as the next ordinary user turn.
+            self._queue_or_replace_pending_event(session_key, event)
+            return True
 
         effective_mode = self._busy_input_mode
         busy_text_mode = getattr(self, "_busy_text_mode", "interrupt")
@@ -7063,6 +7083,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             adapter.set_message_handler(self._handle_message)
             adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
             adapter.set_session_store(self.session_store)
+            adapter.set_session_resolver(
+                self._get_or_create_session_at_process_delivery_boundary
+            )
             adapter.set_busy_session_handler(self._handle_active_session_busy_message)
             adapter.set_topic_recovery_fn(self._recover_telegram_topic_thread_id)
             adapter.set_authorization_check(self._make_adapter_auth_check(adapter.platform))
@@ -7566,13 +7589,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Make sure there's an entry in the session_store for this key. If
         # the home channel has never been used, get_or_create_session
         # creates one; switch_session then re-points it.
-        await self.async_session_store.get_or_create_session(dest_source)
+        await self._get_or_create_session_at_process_delivery_boundary(
+            dest_source, session_key
+        )
 
         # Re-bind the destination key to the CLI session_id. switch_session
         # ends the prior session in SQLite and reopens the CLI session under
         # the new key. The CLI's transcript becomes the active one for the
         # gateway from this moment on.
-        switched = await self.async_session_store.switch_session(session_key, cli_session_id)
+        switched = await self._switch_session_at_process_delivery_boundary(
+            session_key, cli_session_id
+        )
         if switched is None:
             raise RuntimeError(
                 f"could not switch session key {session_key} → {cli_session_id}"
@@ -7899,6 +7926,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     adapter.set_message_handler(self._handle_message)
                     adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
                     adapter.set_session_store(self.session_store)
+                    adapter.set_session_resolver(
+                        self._get_or_create_session_at_process_delivery_boundary
+                    )
                     adapter.set_busy_session_handler(self._handle_active_session_busy_message)
                     adapter.set_topic_recovery_fn(self._recover_telegram_topic_thread_id)
                     adapter.set_authorization_check(self._make_adapter_auth_check(adapter.platform))
@@ -8606,6 +8636,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
             adapter.set_session_store(self.session_store)
+            adapter.set_session_resolver(
+                self._make_profile_session_resolver(profile_name)
+            )
             adapter.set_busy_session_handler(self._handle_active_session_busy_message)
             adapter.set_topic_recovery_fn(self._recover_telegram_topic_thread_id)
             adapter.set_authorization_check(self._make_adapter_auth_check(adapter.platform))
@@ -8636,6 +8669,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 pass
             return await self._handle_message(event)
         return _handler
+
+    def _make_profile_session_resolver(self, profile_name: str):
+        """Bind adapter-internal lookups to a multiplexed profile namespace."""
+        async def _resolver(source, **kwargs):
+            if not getattr(source, "profile", None):
+                source.profile = profile_name
+            return await self._get_or_create_session_at_process_delivery_boundary(
+                source, **kwargs
+            )
+        return _resolver
 
     @staticmethod
     def _adapter_credential_fingerprint(adapter: Any) -> Optional[str]:
@@ -9007,7 +9050,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # consumed as update answers instead of being dispatched normally.
         _quick_key = self._session_key_for_source(source)
         _update_prompts = getattr(self, "_update_prompt_pending", {})
-        if _update_prompts.get(_quick_key):
+        if _update_prompts.get(_quick_key) and not is_internal:
             raw = (event.text or "").strip()
             # Accept /approve and /deny as shorthand for yes/no
             cmd = event.get_command()
@@ -9217,6 +9260,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 self._release_running_agent_state(_quick_key)
 
         if _quick_key in self._running_agents:
+            if str(
+                (getattr(event, "metadata", None) or {}).get(
+                    "expected_gateway_session_id"
+                )
+                or ""
+            ).strip():
+                return _STAMPED_PROCESS_EVENT_BUSY
             if event.get_command() == "status":
                 return await self._handle_status_command(event)
 
@@ -9255,12 +9305,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # _interrupt_requested.  Force-clean _running_agents so the session
             # is unlocked and subsequent messages are processed normally.
             if _cmd_def_inner and _cmd_def_inner.name == "stop":
-                await self._interrupt_and_clear_session(
-                    _quick_key,
-                    source,
-                    interrupt_reason=_INTERRUPT_REASON_STOP,
-                    invalidation_reason="stop_command",
-                )
+                async with self._process_delivery_boundary_lock(_quick_key):
+                    await self._interrupt_and_clear_session(
+                        _quick_key,
+                        source,
+                        interrupt_reason=_INTERRUPT_REASON_STOP,
+                        invalidation_reason="stop_command",
+                    )
                 logger.info("STOP for session %s — agent interrupted, session lock released", _quick_key)
                 return EphemeralReply(t("gateway.stop.stopped"))
 
@@ -9272,13 +9323,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # doesn't get re-processed as a user message after the
             # interrupt completes.
             if _cmd_def_inner and _cmd_def_inner.name == "new":
-                # Clear any pending messages so the old text doesn't replay
-                await self._interrupt_and_clear_session(
-                    _quick_key,
-                    source,
-                    interrupt_reason=_INTERRUPT_REASON_RESET,
-                    invalidation_reason="new_command",
-                )
+                # Clear any pending messages so the old text doesn't replay.
+                # Linearize generation invalidation with stamped delivery: if
+                # the send already owns the boundary it finishes first; if this
+                # command wins, the waiting send observes the invalid generation.
+                async with self._process_delivery_boundary_lock(_quick_key):
+                    await self._interrupt_and_clear_session(
+                        _quick_key,
+                        source,
+                        interrupt_reason=_INTERRUPT_REASON_RESET,
+                        invalidation_reason="new_command",
+                    )
                 # Clean up the running agent entry so the reset handler
                 # doesn't think an agent is still active.
                 return await self._handle_reset_command(event)
@@ -9516,6 +9571,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return None
 
             running_agent = self._running_agents.get(_quick_key)
+            if (
+                running_agent is not None
+                and getattr(self, "_stamped_process_running_agents", {}).get(
+                    _quick_key
+                )
+                is running_agent
+            ):
+                logger.debug(
+                    "Queueing foreground input behind stamped process turn for %s",
+                    _quick_key,
+                )
+                self._queue_or_replace_pending_event(_quick_key, event)
+                return None
             if running_agent is _AGENT_PENDING_SENTINEL:
                 # Agent is being set up but not ready yet.
                 if event.get_command() == "stop":
@@ -9971,13 +10039,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             try:
                 event.text = moa_payload
                 event._moa_restore_override = self._session_model_overrides.get(_quick_key)
-                self._session_model_overrides[_quick_key] = {
+                _moa_one_shot_override = {
                     "provider": "moa",
                     "model": preset,
                     "base_url": "moa://local",
                     "api_key": "moa-virtual-provider",
                     "api_mode": "chat_completions",
                 }
+                event._moa_installed_override = _moa_one_shot_override
+                self._session_model_overrides[_quick_key] = _moa_one_shot_override
                 self._evict_cached_agent(_quick_key)
                 event._moa_disable_after_turn = True
             except Exception:
@@ -10275,9 +10345,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._running_agents_ts[_quick_key] = time.time()
         self._persist_active_agents()
         _run_generation = self._begin_session_run_generation(_quick_key)
+        if str(
+            (getattr(event, "metadata", None) or {}).get(
+                "expected_gateway_session_id"
+            )
+            or ""
+        ).strip():
+            if event.metadata is None:
+                event.metadata = {}
+            event.metadata["gateway_run_generation"] = _run_generation
 
         try:
             _agent_result = await self._handle_message_with_agent(event, source, _quick_key, _run_generation)
+            if str(
+                (getattr(event, "metadata", None) or {}).get(
+                    "expected_gateway_session_id"
+                )
+                or ""
+            ).strip():
+                return _agent_result
             # Goal continuation: after the agent returns a final response
             # for this turn, check any standing /goal — the judge will
             # either mark it done, pause it (budget), or enqueue a
@@ -10295,7 +10381,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # on error. Let the user drive the next turn.
                 if _final_text.strip():
                     try:
-                        session_entry = await self.async_session_store.get_or_create_session(source)
+                        session_entry = await self._get_or_create_session_at_process_delivery_boundary(
+                            source, _quick_key
+                        )
                     except Exception:
                         session_entry = None
                     if session_entry is not None:
@@ -10317,14 +10405,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Putting it in finally guarantees the revert on success, exception,
             # and interrupt alike.
             self._restore_moa_one_shot(event, _quick_key)
-            # Unconditional release covers every exit path. _release_running_agent_state
-            # is idempotent (pop-on-absent is harmless) and, called without a
-            # run_generation guard, always clears the slot regardless of which
-            # generation it holds. This evicts the zombie left when session_reset
-            # bumps the generation (N -> N+1) mid-flight: gen-N's guarded release
-            # inside _run_agent returns False, and the old sentinel-only check here
-            # missed the leftover real agent — locking the session out forever (#28686).
-            self._release_running_agent_state(_quick_key)
+            _is_process_turn = bool(
+                str(
+                    (getattr(event, "metadata", None) or {}).get(
+                        "expected_gateway_session_id"
+                    )
+                    or ""
+                ).strip()
+            )
+            if _is_process_turn:
+                # Process turns can outlive a reset while executor work drains;
+                # only release the slot if this generation still owns it.
+                self._release_running_agent_state(
+                    _quick_key,
+                    run_generation=_run_generation,
+                )
+            else:
+                # Preserve ordinary /stop and one-shot MoA lifecycle semantics:
+                # control commands explicitly rely on unconditional old-slot cleanup.
+                self._release_running_agent_state(_quick_key)
 
     def _restore_moa_one_shot(self, event: "MessageEvent", quick_key: str) -> None:
         """Revert a ``/moa <prompt>`` one-shot model override after its turn.
@@ -10338,11 +10437,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not getattr(event, "_moa_disable_after_turn", False):
             return
         try:
-            _restore = getattr(event, "_moa_restore_override", None)
-            if _restore is None:
+            # Restore only while this turn still owns the exact temporary
+            # override it installed. /stop leaves that object in place, so an
+            # invalidated turn still cleans it up. /new or a replacement turn
+            # clears/replaces it, so late unwind cannot overwrite newer state or
+            # evict the replacement cache entry.
+            _installed_override = getattr(event, "_moa_installed_override", None)
+            if (
+                _installed_override is not None
+                and self._session_model_overrides.get(quick_key)
+                is not _installed_override
+            ):
+                return
+            previous = getattr(event, "_moa_restore_override", None)
+            if previous is None:
                 self._session_model_overrides.pop(quick_key, None)
             else:
-                self._session_model_overrides[quick_key] = _restore
+                self._session_model_overrides[quick_key] = previous
             self._evict_cached_agent(quick_key)
         except Exception:
             pass
@@ -10799,10 +10910,34 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception:
                 pass
 
-        session_entry = await self.async_session_store.get_or_create_session(source)
+        session_entry = await self._get_or_create_session_at_process_delivery_boundary(
+            source, _quick_key
+        )
         session_key = session_entry.session_key
+        event_metadata = getattr(event, "metadata", None) or {}
+        expected_process_session_id = str(
+            event_metadata.get("expected_gateway_session_id") or ""
+        ).strip()
+
+        def _process_turn_is_current() -> bool:
+            return self._process_notification_run_is_current(
+                expected_session_id=expected_process_session_id,
+                session_key=session_key,
+                run_generation=run_generation,
+            )
+
+        if expected_process_session_id and not self._process_session_ids_match(
+            expected_process_session_id, session_entry.session_id
+        ):
+            logger.warning(
+                "Process notification expected session %s but routing key %s now owns %s — dropping at final handoff",
+                expected_process_session_id,
+                session_key,
+                session_entry.session_id,
+            )
+            return
         pinned_session_id = str(
-            (getattr(event, "metadata", None) or {}).get("gateway_session_id") or ""
+            event_metadata.get("gateway_session_id") or ""
         ).strip()
         if pinned_session_id and pinned_session_id != session_entry.session_id:
             # Fail closed (#55578): the spawning session may have ENDED since
@@ -10831,7 +10966,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 return
             prior_session_id = session_entry.session_id
-            switched = await self.async_session_store.switch_session(session_key, pinned_session_id)
+            switched = await self._switch_session_at_process_delivery_boundary(
+                session_key, pinned_session_id
+            )
             if switched is not None:
                 session_entry = switched
                 logger.info(
@@ -10881,7 +11018,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # lane session is ended cleanly. Mutating session_entry in
                     # place here created a split-brain state where the JSON
                     # index pointed at one id but code downstream used another.
-                    switched = await self.async_session_store.switch_session(session_key, bound_session_id)
+                    switched = await self._switch_session_at_process_delivery_boundary(
+                        session_key, bound_session_id
+                    )
                     if switched is not None:
                         session_entry = switched
                 # If the stored binding pointed at a parent, rewrite it to the
@@ -10899,6 +11038,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     await asyncio.to_thread(self._record_telegram_topic_binding, source, session_entry)
                 except Exception:
                     logger.debug("Failed to record Telegram topic binding", exc_info=True)
+
+        # Topic binding resolution can override the session selected above.
+        # Revalidate stamped process notifications only after every routing
+        # override so a concurrent /new, /resume, or topic rebind cannot move
+        # old process output into the replacement physical session.
+        if expected_process_session_id and not self._process_session_ids_match(
+            expected_process_session_id, session_entry.session_id
+        ):
+            logger.warning(
+                "Process notification expected session %s but final routing for %s resolved to %s — dropping before agent work",
+                expected_process_session_id,
+                session_key,
+                session_entry.session_id,
+            )
+            return
+
         # Capture and immediately consume was_auto_reset so it does not
         # re-fire on subsequent messages — preventing the cleanup from
         # wiping model/reasoning overrides set between turns (Closes #48031).
@@ -10938,7 +11093,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # onto subsequent messages in the same session (issue #6508).
         if getattr(session_entry, "is_fresh_reset", False):
             session_entry.is_fresh_reset = False
-        if _is_new_session:
+        if _is_new_session and not expected_process_session_id:
             await self.hooks.emit("session:start", {
                 "platform": source.platform.value if source.platform else "",
                 "user_id": source.user_id,
@@ -11070,6 +11225,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         # Load conversation history from transcript
         history = await self.async_session_store.load_transcript(session_entry.session_id)
+        if not _process_turn_is_current():
+            logger.warning(
+                "Process notification for %s became stale while loading history — dropping",
+                session_key,
+            )
+            return None
         
         # -----------------------------------------------------------------
         # Session hygiene: auto-compress pathologically large transcripts
@@ -11189,7 +11350,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception:
                 pass
 
-            if _hyg_compression_enabled:
+            # Synthetic background-process turns must not run model-backed
+            # transcript hygiene. A concurrent /new cannot interrupt the hygiene
+            # agent while the gateway still exposes only the pending sentinel;
+            # defer hygiene until the next ordinary user turn instead.
+            if _hyg_compression_enabled and not expected_process_session_id:
                 _hyg_context_length = await get_model_context_length_async(
                     _hyg_model,
                     base_url=_hyg_base_url or "",
@@ -11562,14 +11727,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # attachments (documents, audio, etc.) are not sent to the vision
         # tool even when they appear in the same message.
         # -----------------------------------------------------------------
-        message_text = await self._prepare_profile_scoped_inbound_message_text(
-            event=event,
-            source=source,
-            history=history,
-            session_key=session_key,
-        )
+        # Synthetic process turns are already normalized text-only internal
+        # events. Do not invoke profile/media enrichment, which can call
+        # externally extensible processors while a concurrent boundary reset
+        # is invalidating this physical session.
+        if expected_process_session_id:
+            message_text = event.text
+        else:
+            message_text = await self._prepare_profile_scoped_inbound_message_text(
+                event=event,
+                source=source,
+                history=history,
+                session_key=session_key,
+            )
         if message_text is None:
-            return
+            return None
 
         # Capture the platform event time as message metadata and keep the
         # persisted transcript clean (strip any leading timestamp prefix).
@@ -11627,7 +11799,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "session_id": session_entry.session_id,
                 "message": message_text[:500],
             }
-            await self.hooks.emit("agent:start", hook_ctx)
+            if not expected_process_session_id:
+                await self.hooks.emit("agent:start", hook_ctx)
+
+            # Every yielding preparation step is now complete. A /new or
+            # /resume may have won while hooks/history/media setup awaited, so
+            # process-triggered turns must prove both routing ownership and run
+            # generation once more before any model or tool work starts.
+            if not self._process_notification_run_is_current(
+                expected_session_id=expected_process_session_id,
+                session_key=session_key,
+                run_generation=run_generation,
+            ):
+                logger.warning(
+                    "Process notification for %s became stale during pre-agent setup — dropping before model/tool execution",
+                    session_key,
+                )
+                return None
 
             # Run the agent. Capture the session id that this run was launched
             # against so post-run compression publication can be identity-guarded
@@ -11647,12 +11835,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 moa_config=getattr(event, "_moa_config", None),
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
+                expected_process_session_id=expected_process_session_id,
             )
 
             # Stop persistent typing indicator now that the agent is done
             try:
                 _typing_adapter = self._adapter_for_source(source)
-                if _typing_adapter and hasattr(_typing_adapter, "stop_typing"):
+                if (
+                    not expected_process_session_id
+                    and _typing_adapter
+                    and hasattr(_typing_adapter, "stop_typing")
+                ):
                     await _typing_adapter.stop_typing(source.chat_id)
             except Exception:
                 pass
@@ -11693,6 +11886,37 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "results. This can happen with some models — try again or "
                     "rephrase your question."
                 )
+
+            # Process notifications use a deliberately narrow post-agent path.
+            # The agent has already persisted its turn to the physical SessionDB;
+            # generic gateway postprocessing is keyed by the stable routing key
+            # and contains many awaited hooks/mutations that a concurrent /new can
+            # retarget onto the replacement session. Internal process turns need
+            # no enrichment, hooks, media/voice delivery, or stable-key metadata
+            # updates, so normalize and return only after one final ownership check.
+            if expected_process_session_id:
+                if not _intentional_silence:
+                    response = _normalize_empty_agent_response(
+                        agent_result,
+                        response,
+                        history_len=len(history),
+                    )
+                    response = _sanitize_gateway_final_response(
+                        source.platform,
+                        response,
+                    )
+                else:
+                    response = ""
+                if not _process_turn_is_current():
+                    logger.info(
+                        "Discarding stale process response for %s before handoff",
+                        session_key,
+                    )
+                    return None
+                if agent_result.get("already_sent") and not agent_result.get("failed"):
+                    return None
+                return response
+
             agent_messages = agent_result.get("messages", [])
             _response_time = time.time() - _msg_start_time
             _api_calls = agent_result.get("api_calls", 0)
@@ -11942,7 +12166,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "Auto-resetting session %s after compression exhaustion.",
                     session_entry.session_id,
                 )
-                new_entry = await self.async_session_store.reset_session(session_key)
+                async with self._process_delivery_boundary_lock(session_key):
+                    new_entry = await self.async_session_store.reset_session(
+                        session_key
+                    )
                 self._evict_cached_agent(session_key)
                 self._session_model_overrides.pop(session_key, None)
                 self._set_session_reasoning_override(session_key, None)
@@ -12198,6 +12425,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return response
             
         except Exception as e:
+            if expected_process_session_id:
+                logger.exception(
+                    "Process notification agent error in session %s",
+                    session_key,
+                )
+                if not _process_turn_is_current():
+                    return None
+                return "⚠️ Background process notification could not be processed."
             # Stop typing indicator on error too
             try:
                 _err_adapter = self._adapter_for_source(source)
@@ -12711,7 +12946,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             logger.debug("goal manager unavailable: %s", exc)
             return None, None
         try:
-            session_entry = await self.async_session_store.get_or_create_session(event.source)
+            session_entry = await self._get_or_create_session_at_process_delivery_boundary(
+                event.source
+            )
         except Exception as exc:
             logger.debug("goal manager: session lookup failed: %s", exc)
             return None, None
@@ -14154,7 +14391,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "content": f"[IMPORTANT: MCP servers have been reloaded. {change_detail}{tool_summary}. The tool list for this conversation has been updated accordingly.]",
             }
             try:
-                session_entry = await self.async_session_store.get_or_create_session(event.source)
+                session_entry = await self._get_or_create_session_at_process_delivery_boundary(
+                    event.source
+                )
                 await self.async_session_store.append_to_transcript(
                     session_entry.session_id, reload_msg
                 )
@@ -15005,6 +15244,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             user_id=str(context.source.user_id) if context.source.user_id else "",
             user_name=str(context.source.user_name) if context.source.user_name else "",
             session_key=context.session_key,
+            session_id=context.session_id,
             message_id=str(context.source.message_id) if context.source.message_id else "",
             profile=getattr(context.source, "profile", "") or "",
             async_delivery=_async_delivery,
@@ -15361,6 +15601,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         derived_platform = ""
         derived_chat_type = ""
         derived_chat_id = ""
+        derived_profile = ""
 
         if session_key:
             try:
@@ -15384,6 +15625,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 derived_platform = _parsed["platform"]
                 derived_chat_type = _parsed["chat_type"]
                 derived_chat_id = _parsed["chat_id"]
+                derived_profile = _parsed.get("profile", "")
 
         platform_name = str(evt.get("platform") or derived_platform or "").strip().lower()
         chat_type = str(evt.get("chat_type") or derived_chat_type or "").strip().lower()
@@ -15424,6 +15666,213 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             thread_id=str(evt.get("thread_id") or "").strip() or None,
             user_id=str(evt.get("user_id") or "").strip() or None,
             user_name=str(evt.get("user_name") or "").strip() or None,
+            profile=str(evt.get("profile") or derived_profile or "").strip() or None,
+        )
+
+    def _is_stale_process_notification(self, payload: dict) -> bool:
+        """Return True when a background-process event belongs to a superseded session."""
+        session_key = str(payload.get("session_key") or "").strip()
+        event_session_id = str(payload.get("conversation_session_id") or "").strip()
+        if not event_session_id:
+            return False
+        if not session_key:
+            logger.info(
+                "Dropping unverifiable process notification: event session=%s has no session key",
+                event_session_id,
+            )
+            return True
+
+        try:
+            self.session_store._ensure_loaded()
+            entry = self.session_store._entries.get(session_key)
+        except Exception:
+            entry = None
+        current_session_id = str(getattr(entry, "session_id", "") or "").strip()
+        if not current_session_id:
+            logger.info(
+                "Dropping unverifiable process notification for %s: event session=%s has no current owner",
+                session_key[:40],
+                event_session_id,
+            )
+            return True
+        if not self._process_session_ids_match(event_session_id, current_session_id):
+            logger.info(
+                "Dropping stale process notification for %s: event session=%s current session=%s",
+                session_key[:40],
+                event_session_id,
+                current_session_id,
+            )
+            return True
+        return False
+
+    def _process_session_ids_match(self, expected_session_id: str, current_session_id: str) -> bool:
+        """Match exact physical sessions or their live compression continuation."""
+        if not expected_session_id or not current_session_id:
+            return False
+        if expected_session_id == current_session_id:
+            return True
+        # Compression rotates the physical session id while preserving the
+        # same conversation. A process spawned before compression should still
+        # notify the live continuation, but /new and /resume boundaries differ.
+        try:
+            session_db = getattr(self, "_session_db", None)
+            db = getattr(session_db, "_db", session_db)
+            get_tip = getattr(db, "get_compression_tip", None)
+            if callable(get_tip):
+                expected_tip = str(
+                    get_tip(expected_session_id) or expected_session_id
+                ).strip()
+                current_tip = str(get_tip(current_session_id) or current_session_id).strip()
+                return bool(expected_tip and expected_tip == current_tip)
+        except Exception:
+            pass
+        return False
+
+    def _process_notification_run_is_current(
+        self,
+        *,
+        expected_session_id: str,
+        session_key: str,
+        run_generation: Optional[int],
+    ) -> bool:
+        """Fail closed before process-triggered model/tool work can begin."""
+        if not expected_session_id:
+            return True
+        if run_generation is not None and not self._is_session_run_current(
+            session_key, run_generation
+        ):
+            return False
+        if self._is_stale_process_notification(
+            {
+                "session_key": session_key,
+                "conversation_session_id": expected_session_id,
+            }
+        ):
+            return False
+        return True
+
+    def _process_delivery_boundary_lock(self, session_key: str) -> asyncio.Lock:
+        locks = getattr(self, "_process_delivery_boundary_locks", None)
+        if locks is None:
+            locks = {}
+            self._process_delivery_boundary_locks = locks
+        lock = locks.get(session_key)
+        if lock is None:
+            lock = asyncio.Lock()
+            locks[session_key] = lock
+        return lock
+
+    async def _deliver_process_notification_guarded(
+        self,
+        *,
+        expected_session_id: str,
+        session_key: str,
+        run_generation: Optional[int],
+        delivery: Callable[[], Any],
+    ) -> Any:
+        """Linearize a stamped delivery with reset/resume session switching."""
+        async with self._process_delivery_boundary_lock(session_key):
+            if not self._process_notification_run_is_current(
+                expected_session_id=expected_session_id,
+                session_key=session_key,
+                run_generation=run_generation,
+            ):
+                return None
+            return await delivery()
+
+    async def _get_or_create_session_at_process_delivery_boundary(
+        self,
+        source: "SessionSource",
+        session_key: Optional[str] = None,
+        *,
+        force_new: bool = False,
+        operation: Optional[Callable[[Any], Any]] = None,
+    ):
+        """Serialize transition-capable lookup and an optional owned operation."""
+        key = session_key or self._session_key_for_source(source)
+        async with self._process_delivery_boundary_lock(key):
+            if force_new:
+                entry = await self.async_session_store.get_or_create_session(
+                    source, force_new=True
+                )
+            else:
+                entry = await self.async_session_store.get_or_create_session(source)
+            if operation is not None:
+                result = operation(entry)
+                if inspect.isawaitable(result):
+                    await result
+            return entry
+
+    async def _switch_session_at_process_delivery_boundary(
+        self, session_key: str, session_id: str
+    ):
+        async with self._process_delivery_boundary_lock(session_key):
+            return await self.async_session_store.switch_session(session_key, session_id)
+
+    async def _reset_session_at_process_delivery_boundary(self, session_key: str):
+        async with self._process_delivery_boundary_lock(session_key):
+            return await self.async_session_store.reset_session(session_key)
+
+    async def _run_and_deliver_stamped_process_event(
+        self,
+        event: "MessageEvent",
+        *,
+        adapter: Any,
+        session_key: str,
+    ) -> Any:
+        """Run a stamped synthetic turn and deliver its text under one boundary."""
+        while True:
+            response = await self._handle_message(event)
+            if response is not _STAMPED_PROCESS_EVENT_BUSY:
+                break
+            metadata = getattr(event, "metadata", None) or {}
+            expected_session_id = str(
+                metadata.get("expected_gateway_session_id") or ""
+            ).strip()
+            if not self._process_notification_run_is_current(
+                expected_session_id=expected_session_id,
+                session_key=session_key,
+                run_generation=None,
+            ):
+                return None
+            await asyncio.sleep(0.05)
+        if not response:
+            return None
+        metadata = getattr(event, "metadata", None) or {}
+        expected_session_id = str(
+            metadata.get("expected_gateway_session_id") or ""
+        ).strip()
+        run_generation = metadata.get("gateway_run_generation")
+        content = str(response)
+        strip_directives = getattr(adapter, "strip_media_directives_for_display", None)
+        if callable(strip_directives):
+            content = strip_directives(content)
+        # Stamped process notifications are deliberately text-only. Their
+        # narrow path must never turn model-produced MEDIA directives into
+        # local-file, image, voice, video, or document delivery side effects.
+        if not content.strip():
+            return None
+        thread_metadata = self._thread_metadata_for_source(
+            event.source,
+            getattr(event, "message_id", None),
+        )
+
+        async def _send():
+            return await adapter.send(
+                event.source.chat_id,
+                content,
+                reply_to=getattr(event, "message_id", None),
+                metadata=_non_conversational_metadata(
+                    thread_metadata,
+                    platform=event.source.platform,
+                ),
+            )
+
+        return await self._deliver_process_notification_guarded(
+            expected_session_id=expected_session_id,
+            session_key=session_key,
+            run_generation=run_generation,
+            delivery=_send,
         )
 
     async def _inject_watch_notification(self, synth_text: str, evt: dict) -> None:
@@ -15432,6 +15881,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         Routing must come from the queued watch event itself, not from whatever
         foreground message happened to be active when the queue was drained.
         """
+        if self._is_stale_process_notification(evt):
+            return
         source = self._build_process_event_source(evt)
         if not source:
             logger.warning(
@@ -15440,15 +15891,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             return
         platform_name = source.platform.value if hasattr(source.platform, "value") else str(source.platform)
-        adapter = None
-        for p, a in self.adapters.items():
-            if p.value == platform_name:
-                adapter = a
-                break
+        adapter = self._adapter_for_source(source)
         if not adapter:
             return
         try:
             metadata = {}
+            expected_session_id = str(evt.get("conversation_session_id") or "").strip()
+            if expected_session_id:
+                # Revalidate at the final gateway handoff too. A /new or
+                # /resume can race the early queue-drain ownership check.
+                metadata["expected_gateway_session_id"] = expected_session_id
             parent_session_id = str(evt.get("parent_session_id") or "").strip()
             if parent_session_id:
                 metadata["gateway_session_id"] = parent_session_id
@@ -15466,9 +15918,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 source.chat_id,
                 source.thread_id,
             )
-            await adapter.handle_message(synth_event)
+            await self._run_and_deliver_stamped_process_event(
+                synth_event,
+                adapter=adapter,
+                session_key=str(evt.get("session_key") or ""),
+            )
         except Exception as e:
             logger.error("Watch notification injection error: %s", e)
+
+    def _adapter_for_process_watcher_delivery(
+        self,
+        source: Optional["SessionSource"],
+        platform_name: str,
+        session_key: str,
+    ) -> Any:
+        """Resolve profile-aware process delivery, with legacy unstamped fallback."""
+        if source is not None:
+            return self._adapter_for_source(source)
+        if session_key:
+            return None
+        try:
+            return self.adapters.get(Platform(platform_name))
+        except Exception:
+            return None
 
     def _enrich_async_delegation_routing(self, evt: dict) -> None:
         """Fill platform/chat_id/thread_id/chat_type on an async-delegation event.
@@ -15564,6 +16036,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         message_id = str(watcher.get("message_id") or "").strip() or None
         agent_notify = watcher.get("notify_on_complete", False)
         notify_mode = self._load_background_notifications_mode()
+        delivery_source = (
+            self._build_process_event_source(watcher) if session_key else None
+        )
 
         logger.debug("Process watcher started: %s (every %ss, notify=%s, agent_notify=%s)",
                       session_id, interval, notify_mode, agent_notify)
@@ -15623,6 +16098,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     })
                     if not synth_text:
                         break
+                    if self._is_stale_process_notification(watcher):
+                        logger.info(
+                            "Process %s finished after session boundary changed for %s — dropping stale agent notification",
+                            session_id,
+                            session_key[:40],
+                        )
+                        break
                     source = self._build_process_event_source({
                         "session_id": session_id,
                         "session_key": session_key,
@@ -15631,6 +16113,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         "thread_id": thread_id,
                         "user_id": user_id,
                         "user_name": user_name,
+                        "conversation_session_id": watcher.get("conversation_session_id", ""),
                     })
                     if not source:
                         logger.warning(
@@ -15639,11 +16122,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         )
                         break
 
-                    adapter = None
-                    for p, a in self.adapters.items():
-                        if p == source.platform:
-                            adapter = a
-                            break
+                    adapter = self._adapter_for_source(source)
                     if adapter and source.chat_id:
                         try:
                             synth_event = MessageEvent(
@@ -15652,6 +16131,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 source=source,
                                 internal=True,
                                 message_id=message_id,
+                                metadata={
+                                    "expected_gateway_session_id": str(
+                                        watcher.get("conversation_session_id") or ""
+                                    ).strip()
+                                },
                             )
                             logger.info(
                                 "Process %s finished — injecting agent notification for session %s chat=%s thread=%s",
@@ -15660,7 +16144,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 source.chat_id,
                                 source.thread_id,
                             )
-                            await adapter.handle_message(synth_event)
+                            await self._run_and_deliver_stamped_process_event(
+                                synth_event,
+                                adapter=adapter,
+                                session_key=session_key,
+                            )
                         except Exception as e:
                             logger.error("Agent notify injection error: %s", e)
                     break
@@ -15672,6 +16160,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     or (notify_mode == "error" and session.exit_code not in {0, None})
                 )
                 if should_notify:
+                    if self._is_stale_process_notification(watcher):
+                        logger.info(
+                            "Process %s finished after session boundary changed for %s — dropping stale text notification",
+                            session_id,
+                            session_key[:40],
+                        )
+                        break
                     new_output = session.output_buffer[-1000:] if session.output_buffer else ""
                     if new_output:
                         from agent.redact import redact_terminal_output
@@ -15682,24 +16177,48 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         f"[Background process {session_id} finished with exit code {session.exit_code}~ "
                         f"Here's the final output:\n{new_output}]"
                     )
-                    adapter = None
-                    for p, a in self.adapters.items():
-                        if p.value == platform_name:
-                            adapter = a
-                            break
+                    adapter = self._adapter_for_process_watcher_delivery(
+                        delivery_source, platform_name, session_key
+                    )
                     if adapter and chat_id:
                         try:
+                            if self._is_stale_process_notification(watcher):
+                                logger.info(
+                                    "Process %s crossed a session boundary before final text delivery — dropping",
+                                    session_id,
+                                )
+                                break
                             send_meta = {"thread_id": thread_id} if thread_id else None
-                            await adapter.send(
-                                chat_id,
-                                message_text,
-                                metadata=_non_conversational_metadata(send_meta, platform=platform_name),
+
+                            async def _send_final_text():
+                                return await adapter.send(
+                                    chat_id,
+                                    message_text,
+                                    metadata=_non_conversational_metadata(
+                                        send_meta, platform=platform_name
+                                    ),
+                                )
+
+                            await self._deliver_process_notification_guarded(
+                                expected_session_id=str(
+                                    watcher.get("conversation_session_id") or ""
+                                ).strip(),
+                                session_key=session_key,
+                                run_generation=None,
+                                delivery=_send_final_text,
                             )
                         except Exception as e:
                             logger.error("Watcher delivery error: %s", e)
                 break
 
             elif has_new_output and notify_mode == "all" and not agent_notify:
+                if self._is_stale_process_notification(watcher):
+                    logger.info(
+                        "Process %s emitted output after session boundary changed for %s — dropping stale text notification",
+                        session_id,
+                        session_key[:40],
+                    )
+                    break
                 # New output available -- deliver status update (only in "all" mode)
                 # Skip periodic updates for agent_notify watchers (they only care about completion)
                 new_output = session.output_buffer[-500:] if session.output_buffer else ""
@@ -15712,18 +16231,35 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     f"[Background process {session_id} is still running~ "
                     f"New output:\n{new_output}]"
                 )
-                adapter = None
-                for p, a in self.adapters.items():
-                    if p.value == platform_name:
-                        adapter = a
-                        break
+                adapter = self._adapter_for_process_watcher_delivery(
+                    delivery_source, platform_name, session_key
+                )
                 if adapter and chat_id:
                     try:
+                        if self._is_stale_process_notification(watcher):
+                            logger.info(
+                                "Process %s crossed a session boundary before running-output delivery — dropping",
+                                session_id,
+                            )
+                            break
                         send_meta = {"thread_id": thread_id} if thread_id else None
-                        await adapter.send(
-                            chat_id,
-                            message_text,
-                            metadata=_non_conversational_metadata(send_meta, platform=platform_name),
+
+                        async def _send_running_text():
+                            return await adapter.send(
+                                chat_id,
+                                message_text,
+                                metadata=_non_conversational_metadata(
+                                    send_meta, platform=platform_name
+                                ),
+                            )
+
+                        await self._deliver_process_notification_guarded(
+                            expected_session_id=str(
+                                watcher.get("conversation_session_id") or ""
+                            ).strip(),
+                            session_key=session_key,
+                            run_generation=None,
+                            delivery=_send_running_text,
                         )
                     except Exception as e:
                         logger.error("Watcher delivery error: %s", e)
@@ -16036,7 +16572,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 lease.release()
             except Exception:
                 logger.debug("Failed to release active session slot", exc_info=True)
-        self._running_agents.pop(session_key, None)
+        running_agent = self._running_agents.pop(session_key, None)
+        process_agents = getattr(self, "_stamped_process_running_agents", {})
+        if running_agent is not None and process_agents.get(session_key) is running_agent:
+            process_agents.pop(session_key, None)
         self._running_agents_ts.pop(session_key, None)
         if hasattr(self, "_busy_ack_ts"):
             self._busy_ack_ts.pop(session_key, None)
@@ -16159,10 +16698,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """Interrupt the current run and clear queued session state consistently."""
         if not session_key:
             return
+        # Invalidate first so a run still constructing its concrete agent cannot
+        # pass a final execution-boundary generation check after this reset has
+        # already decided to clear the session. Once a concrete agent is visible,
+        # interrupt it as usual.
+        self._invalidate_session_run_generation(session_key, reason=invalidation_reason)
         running_agent = self._running_agents.get(session_key)
         if running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
             running_agent.interrupt(interrupt_reason)
-        self._invalidate_session_run_generation(session_key, reason=invalidation_reason)
         adapter = self._adapter_for_source(source)
         if adapter and hasattr(adapter, "interrupt_session_activity"):
             await adapter.interrupt_session_activity(session_key, source.chat_id)
@@ -16256,6 +16799,32 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         _cache[session_key] = (
                             cached[0], cached[1], _live, _snapshot_sid,
                         )
+
+    def _evict_cached_agent_if_identity(self, session_key: str, agent: Any) -> bool:
+        """Evict ``session_key`` only when its cache still owns ``agent``.
+
+        Used by stale async turns during unwind: a replacement turn may already
+        have published a newer cache entry under the same stable routing key.
+        """
+        if not session_key or agent is None:
+            return False
+        cache = getattr(self, "_agent_cache", None)
+        if cache is None:
+            return False
+        cache_lock = getattr(self, "_agent_cache_lock", None)
+
+        def _pop_if_same() -> bool:
+            cached = cache.get(session_key)
+            cached_agent = cached[0] if isinstance(cached, tuple) and cached else None
+            if cached_agent is not agent:
+                return False
+            cache.pop(session_key, None)
+            return True
+
+        if cache_lock is not None:
+            with cache_lock:
+                return _pop_if_same()
+        return _pop_if_same()
 
     def _evict_cached_agent(self, session_key: str) -> None:
         """Remove a cached agent for a session (called on /new, /model, etc).
@@ -16639,6 +17208,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         session_key: str = None,
         run_generation: Optional[int] = None,
         event_message_id: Optional[str] = None,
+        expected_process_session_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Forward the message to a remote Hermes API server instead of
         running a local AIAgent.
@@ -16729,9 +17299,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             user_config, platform_key, "streaming"
         )
         _streaming_enabled = (
-            _scfg.enabled and _scfg.transport != "off"
-            if _plat_streaming is None
-            else bool(_plat_streaming)
+            (
+                _scfg.enabled and _scfg.transport != "off"
+                if _plat_streaming is None
+                else bool(_plat_streaming)
+            )
+            and not expected_process_session_id
         )
 
         _thread_metadata: Optional[Dict[str, Any]] = self._thread_metadata_for_source(source, event_message_id)
@@ -16791,11 +17364,45 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         # Send typing indicator
         _adapter = self._adapter_for_source(source)
-        if _adapter:
+        if _adapter and not expected_process_session_id:
             try:
                 await _adapter.send_typing(source.chat_id, metadata=_thread_metadata)
             except Exception:
                 pass
+
+        # Make a process-triggered proxy request interruptible before its final
+        # execution-boundary check. Reset invalidates generation first, then
+        # cancels this task if the proxy handoff has already become concrete.
+        _proxy_interrupt_handle = None
+        if expected_process_session_id and session_key:
+            _proxy_task = asyncio.current_task()
+
+            class _ProxyInterruptHandle:
+                def interrupt(self, _reason: str) -> None:
+                    if _proxy_task is not None and not _proxy_task.done():
+                        _proxy_task.cancel()
+
+            _proxy_interrupt_handle = _ProxyInterruptHandle()
+            self._running_agents[session_key] = _proxy_interrupt_handle
+            process_agents = getattr(self, "_stamped_process_running_agents", None)
+            if process_agents is None:
+                process_agents = {}
+                self._stamped_process_running_agents = process_agents
+            process_agents[session_key] = _proxy_interrupt_handle
+
+        if not self._process_notification_run_is_current(
+            expected_session_id=expected_process_session_id or "",
+            session_key=session_key or "",
+            run_generation=run_generation,
+        ):
+            return {
+                "final_response": "",
+                "messages": [],
+                "api_calls": 0,
+                "tools": [],
+                "history_offset": len(history),
+                "session_id": session_id,
+            }
 
         # Make the HTTP request with SSE streaming -----------------------
         full_response = ""
@@ -16883,6 +17490,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 }
             # Partial response — return what we got
         finally:
+            # The outer turn lifecycle owns the running handle and stamped marker;
+            # keep both published through all synthetic-turn postprocessing.
             # Finalize stream consumer
             if _stream_consumer:
                 _stream_consumer.finish()
@@ -16943,6 +17552,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         moa_config: Optional[dict] = None,
         persist_user_message: Optional[str] = None,
         persist_user_timestamp: Optional[float] = None,
+        expected_process_session_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Profile-scoping wrapper around the agent run.
 
@@ -16953,6 +17563,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         multiplexing is off this is a transparent pass-through — zero behavior
         change for single-profile gateways.
         """
+        if not self._process_notification_run_is_current(
+            expected_session_id=expected_process_session_id or "",
+            session_key=session_key or "",
+            run_generation=run_generation,
+        ):
+            return {
+                "final_response": "",
+                "messages": [],
+                "api_calls": 0,
+                "tools": [],
+                "history_offset": len(history),
+                "session_id": session_id,
+            }
         if not getattr(getattr(self, "config", None), "multiplex_profiles", False):
             return await self._run_agent_inner(
                 message, context_prompt, history, source, session_id,
@@ -16961,6 +17584,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 channel_prompt=channel_prompt, moa_config=moa_config,
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
+                expected_process_session_id=expected_process_session_id,
             )
 
         profile_home = self._resolve_profile_home_for_source(source)
@@ -16972,6 +17596,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 channel_prompt=channel_prompt, moa_config=moa_config,
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
+                expected_process_session_id=expected_process_session_id,
             )
 
     def _resolve_profile_home_for_source(self, source: SessionSource) -> "Path":
@@ -17004,6 +17629,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         moa_config: Optional[dict] = None,
         persist_user_message: Optional[str] = None,
         persist_user_timestamp: Optional[float] = None,
+        expected_process_session_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -17017,6 +17643,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         This is run in a thread pool to not block the event loop.
         Supports interruption via new messages.
         """
+        if not self._process_notification_run_is_current(
+            expected_session_id=expected_process_session_id or "",
+            session_key=session_key or "",
+            run_generation=run_generation,
+        ):
+            return {
+                "final_response": "",
+                "messages": [],
+                "api_calls": 0,
+                "tools": [],
+                "history_offset": len(history),
+                "session_id": session_id,
+            }
         # ---- Proxy mode: delegate to remote API server ----
         if self._get_proxy_url():
             return await self._run_agent_via_proxy(
@@ -17028,6 +17667,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 session_key=session_key,
                 run_generation=run_generation,
                 event_message_id=event_message_id,
+                expected_process_session_id=expected_process_session_id,
             )
 
         from run_agent import AIAgent
@@ -17974,6 +18614,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # `_resolve_turn_agent_config(message, …)`.
             nonlocal message
 
+            if not self._process_notification_run_is_current(
+                expected_session_id=expected_process_session_id or "",
+                session_key=session_key or "",
+                run_generation=run_generation,
+            ):
+                return {
+                    "final_response": "",
+                    "messages": [],
+                    "api_calls": 0,
+                    "tools": [],
+                    "history_offset": len(history),
+                    "session_id": session_id,
+                }
+
             # session_key is propagated via contextvars in _set_session_env()
             # (_SESSION_KEY) and via set_current_session_key() (_approval_session_key)
             # below — both concurrency-safe and inherited by tool worker threads.
@@ -18052,12 +18706,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             # None = no per-platform override → follow global config
             _streaming_enabled = (
-                _scfg.enabled and _scfg.transport != "off"
-                if _plat_streaming is None
-                else bool(_plat_streaming)
+                (
+                    _scfg.enabled and _scfg.transport != "off"
+                    if _plat_streaming is None
+                    else bool(_plat_streaming)
+                )
+                and not expected_process_session_id
             )
             _want_stream_deltas = _streaming_enabled
-            _want_interim_messages = interim_assistant_messages_enabled
+            _want_interim_messages = (
+                interim_assistant_messages_enabled
+                and not expected_process_session_id
+            )
             _want_interim_consumer = _want_interim_messages
             if _want_stream_deltas or _want_interim_consumer:
                 try:
@@ -18186,9 +18846,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     pass
 
             _xproc_evicted_agent = None
+            _cache_entry_observed = None
             if _cache_lock and _cache is not None:
                 with _cache_lock:
                     cached = _cache.get(session_key)
+                    _cache_entry_observed = cached
                     if cached and cached[1] == _sig:
                         # cached[2] is the message_count at cache time;
                         # stale when a second process appended rows.
@@ -18324,15 +18986,35 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 if _cache_lock and _cache is not None:
                     with _cache_lock:
-                        # Record the session_id the snapshot was taken for
-                        # alongside the message_count, so the cross-process
-                        # guard can skip the (meaningless) count comparison
-                        # when the active session_id later switches under
-                        # the same session_key (#54947).
-                        _cache[session_key] = (
-                            agent, _sig, _current_msg_count, session_id,
+                        # For stamped process turns, make publication a CAS under
+                        # the cache lock and re-check generation inside that same
+                        # critical section. A reset/replacement between constructor
+                        # return and lock acquisition must never be overwritten by
+                        # the stale worker. Ordinary user turns keep the historical
+                        # unconditional publication behavior.
+                        _cache_unchanged = (
+                            _cache.get(session_key) is _cache_entry_observed
                         )
-                        self._enforce_agent_cache_cap()
+                        _publish_agent_cache = (
+                            not expected_process_session_id
+                            or (
+                                _cache_unchanged
+                                and run_generation is not None
+                                and self._is_session_run_current(
+                                    session_key, run_generation
+                                )
+                            )
+                        )
+                        if _publish_agent_cache:
+                            # Record the session_id the snapshot was taken for
+                            # alongside the message_count, so the cross-process
+                            # guard can skip the (meaningless) count comparison
+                            # when the active session_id later switches under
+                            # the same session_key (#54947).
+                            _cache[session_key] = (
+                                agent, _sig, _current_msg_count, session_id,
+                            )
+                            self._enforce_agent_cache_cap()
                 logger.debug("Created new agent for session %s (sig=%s)", session_key, _sig)
 
             # Per-message state — callbacks and reasoning config change every
@@ -18345,18 +19027,36 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # who set thinking_progress:true but kept tool_progress:off got a
             # None callback — so _thinking scratch bubbles never relayed even
             # though the progress queue was created for them.
+            _allow_process_side_channels = not expected_process_session_id
             agent.tool_progress_callback = (
-                progress_callback if (needs_progress_queue or log_mode_enabled) else None
+                progress_callback
+                if _allow_process_side_channels
+                and (needs_progress_queue or log_mode_enabled)
+                else None
             )
             # Discord voice verbal-ack hook (fires once per turn on first tool
             # call; armed only when in a voice channel with the mixer running).
             agent.tool_start_callback = (
-                voice_ack_callback if _voice_ack_guild[0] is not None else None
+                voice_ack_callback
+                if _allow_process_side_channels and _voice_ack_guild[0] is not None
+                else None
             )
-            agent.step_callback = _step_callback_sync if _hooks_ref.loaded_hooks else None
-            agent.stream_delta_callback = _stream_delta_cb
-            agent.interim_assistant_callback = _interim_assistant_cb if _want_interim_messages else None
-            agent.status_callback = _status_callback_sync
+            agent.step_callback = (
+                _step_callback_sync
+                if _allow_process_side_channels and _hooks_ref.loaded_hooks
+                else None
+            )
+            agent.stream_delta_callback = (
+                _stream_delta_cb if _allow_process_side_channels else None
+            )
+            agent.interim_assistant_callback = (
+                _interim_assistant_cb
+                if _allow_process_side_channels and _want_interim_messages
+                else None
+            )
+            agent.status_callback = (
+                _status_callback_sync if _allow_process_side_channels else None
+            )
             # Credits / out-of-band notices (usage bands, depletion, restored).
             # Messaging has no persistent status bar, so each notice is a
             # standalone push: render to a single plaintext line and deliver via
@@ -18386,9 +19086,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     log_message="notice_callback delivery scheduling error",
                 )
 
-            agent.notice_callback = _notice_callback_sync
+            agent.notice_callback = (
+                _notice_callback_sync if _allow_process_side_channels else None
+            )
             agent.notice_clear_callback = None
-            agent.event_callback = _event_callback_sync
+            agent.event_callback = (
+                _event_callback_sync if _allow_process_side_channels else None
+            )
             agent.reasoning_config = reasoning_config
             agent.service_tier = self._service_tier
             agent.request_overrides = turn_route.get("request_overrides") or {}
@@ -18430,10 +19134,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             return
                 _deliver_bg_review_message(message)
 
-            agent.background_review_callback = _bg_review_send
+            agent.background_review_callback = (
+                _bg_review_send if _allow_process_side_channels else None
+            )
             # Register the release hook on the adapter so base.py's finally
             # block can fire it after delivering the main response.
-            if _status_adapter and session_key:
+            if _allow_process_side_channels and _status_adapter and session_key:
                 if getattr(type(_status_adapter), "register_post_delivery_callback", None) is not None:
                     _status_adapter.register_post_delivery_callback(
                         session_key,
@@ -18526,7 +19232,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     return f"[user did not respond within {int(timeout / 60)}m]"
                 return response
 
-            agent.clarify_callback = _clarify_callback_sync
+            agent.clarify_callback = (
+                _clarify_callback_sync if _allow_process_side_channels else None
+            )
 
             # Show assistant thinking between tool calls — independent of
             # tool_progress mode. Mattermost needs an explicit per-platform
@@ -18597,6 +19305,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             from tools.approval import (
                 register_gateway_notify,
                 reset_current_session_key,
+                resolve_gateway_approval,
                 set_current_session_key,
                 unregister_gateway_notify,
             )
@@ -18688,6 +19397,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         _approval_send_fut.result(timeout=15)
                 except Exception as _e:
                     logger.error("Failed to send approval request: %s", _e)
+
+            def _deny_process_approval_sync(_approval_data: dict) -> None:
+                """Fail closed without a visible prompt for synthetic process turns."""
+                resolve_gateway_approval(
+                    _approval_session_key,
+                    "deny",
+                    reason="Background process notifications cannot request approval.",
+                )
 
             # Keep real user text separate from API-only recovery guidance.  If
             # an auto-continue note is prepended below, persist the original
@@ -18857,8 +19574,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
 
             _approval_session_key = session_key or ""
+            if expected_process_session_id:
+                # Approval state is globally keyed. Give synthetic process turns
+                # a generation-owned namespace so their callback/queue cleanup
+                # can never overwrite or remove a replacement foreground turn.
+                _approval_session_key = (
+                    f"{_approval_session_key}:process-run:{run_generation}:"
+                    f"{expected_process_session_id}"
+                )
             _approval_session_token = set_current_session_key(_approval_session_key)
-            register_gateway_notify(_approval_session_key, _approval_notify_sync)
+            register_gateway_notify(
+                _approval_session_key,
+                _deny_process_approval_sync
+                if expected_process_session_id
+                else _approval_notify_sync,
+            )
             try:
                 # If _prepare_inbound_message_text buffered image paths for native
                 # attachment, wrap the user turn as an OpenAI-style multimodal
@@ -18907,7 +19637,43 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _conversation_kwargs["moa_config"] = moa_config
                 if _persist_user_timestamp_override is not None:
                     _conversation_kwargs["persist_user_timestamp"] = _persist_user_timestamp_override
-                result = agent.run_conversation(_api_run_message, **_conversation_kwargs)
+
+                # Make a process-triggered agent interruptible before the final
+                # generation/ownership check. Reset invalidates the generation
+                # before reading this slot, so either this check rejects the run
+                # or /new sees the concrete agent and interrupts it.
+                if expected_process_session_id and session_key:
+                    self._running_agents[session_key] = agent
+                    process_agents = getattr(
+                        self, "_stamped_process_running_agents", None
+                    )
+                    if process_agents is None:
+                        process_agents = {}
+                        self._stamped_process_running_agents = process_agents
+                    process_agents[session_key] = agent
+
+                if not self._process_notification_run_is_current(
+                    expected_session_id=expected_process_session_id,
+                    session_key=session_key,
+                    run_generation=run_generation,
+                ):
+                    logger.warning(
+                        "Dropping stale process notification at local model/tool execution boundary for %s",
+                        session_key or "",
+                    )
+                    self._evict_cached_agent_if_identity(session_key, agent)
+                    result = {
+                        "final_response": "",
+                        "messages": [],
+                        "api_calls": 0,
+                        "tools": [],
+                        "history_offset": len(history),
+                        "session_id": session_id,
+                    }
+                else:
+                    result = agent.run_conversation(
+                        _api_run_message, **_conversation_kwargs
+                    )
             finally:
                 unregister_gateway_notify(_approval_session_key)
                 # Cancel any pending clarify entries so blocked agent
@@ -19439,7 +20205,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 except Exception as _ne:
                     logger.debug("Long-running notification error: %s", _ne)
 
-        _notify_task = asyncio.create_task(_notify_long_running())
+        _notify_task = None
+        if not expected_process_session_id:
+            _notify_task = asyncio.create_task(_notify_long_running())
 
         def _stream_confirmed_final_delivery(
             consumer,
@@ -19534,8 +20302,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         except Exception:
                             pass
                     # Staged warning: fire once before escalating to full timeout.
-                    if (not _warning_fired and _agent_warning is not None
-                            and _idle_secs >= _agent_warning):
+                    if (
+                        not expected_process_session_id
+                        and not _warning_fired
+                        and _agent_warning is not None
+                        and _idle_secs >= _agent_warning
+                    ):
                         _warning_fired = True
                         _warn_adapter = self._adapter_for_source(source)
                         if _warn_adapter:
@@ -19572,6 +20344,42 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             )
                             _backup_agent.interrupt(_bp_text)
                             _interrupt_detected.set()
+
+            if not self._process_notification_run_is_current(
+                expected_session_id=expected_process_session_id,
+                session_key=session_key,
+                run_generation=run_generation,
+            ):
+                logger.info(
+                    "Skipping stale process-run postprocessing for %s",
+                    session_key or "",
+                )
+                return result_holder[0] or {
+                    "final_response": "",
+                    "messages": [],
+                    "api_calls": 0,
+                    "tools": [],
+                    "history_offset": len(history),
+                    "session_id": session_id,
+                }
+
+            if expected_process_session_id:
+                # Stamped process notifications use a narrow, text-only result
+                # path. Leave queued foreground events in the adapter so its
+                # normal lifecycle can dispatch them after this synthetic run;
+                # do not enter heartbeat/timeout/fallback/pending-drain rails.
+                if _inactivity_timeout:
+                    _timed_out_agent = agent_holder[0]
+                    if _timed_out_agent and hasattr(_timed_out_agent, "interrupt"):
+                        _timed_out_agent.interrupt(_INTERRUPT_REASON_TIMEOUT)
+                return result_holder[0] or {
+                    "final_response": "",
+                    "messages": [],
+                    "api_calls": 0,
+                    "tools": [],
+                    "history_offset": len(history),
+                    "session_id": session_id,
+                }
 
             if _inactivity_timeout:
                 # Build a diagnostic summary from the agent's activity tracker.
@@ -19970,7 +20778,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if log_task:
                 log_task.cancel()
             interrupt_monitor.cancel()
-            _notify_task.cancel()
+            if _notify_task:
+                _notify_task.cancel()
 
             # Wait for stream consumer to finish its final edit
             if stream_task:
@@ -20002,12 +20811,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             
             # Clean up tracking
             tracking_task.cancel()
-            if session_key:
-                # Only release the slot if this run's generation still owns
-                # it.  A /stop or /new that bumped the generation while we
-                # were unwinding has already installed its own state; this
-                # guard prevents an old run from clobbering it on the way
-                # out.
+            if session_key and not expected_process_session_id:
+                # Stamped process turns retain their concrete ownership through
+                # surrounding message/transcript postprocessing. The outer
+                # message lifecycle releases both identities at the true turn
+                # boundary.
                 self._release_running_agent_state(
                     session_key, run_generation=run_generation
                 )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1832,6 +1832,41 @@ def _own_policy_open_startup_violation(config) -> Optional[str]:
 # session from bypassing the "already running" guard during the async gap
 # between the guard check and actual agent creation.
 _AGENT_PENDING_SENTINEL = object()
+_REJECTED_EXECUTION_CLEANUP_ATTR = (
+    "_gateway_execution_rejected_pending_cleanup"
+)
+
+
+class _StampedProcessPendingHandle:
+    """Run-owned, cross-thread cancellable placeholder during construction."""
+
+    def __init__(self) -> None:
+        self._cancelled = threading.Event()
+
+    @property
+    def cancelled(self) -> bool:
+        return self._cancelled.is_set()
+
+    def interrupt(self, _reason: str) -> None:
+        self._cancelled.set()
+
+
+def _is_pre_execution_agent_owner(owner: Any) -> bool:
+    """Return True when no local model or proxy execution has started yet."""
+    return owner is _AGENT_PENDING_SENTINEL or isinstance(
+        owner, _StampedProcessPendingHandle
+    )
+
+
+class _StampedProcessReleaseClaim:
+    """Identity-owned adapter-drain claim bound when the stamped turn starts."""
+
+    def __init__(self) -> None:
+        self.generation: Optional[int] = None
+        self.event = asyncio.Event()
+        self.forced_shutdown_owner: Optional[Any] = None
+
+
 # Internal hand-off from _handle_message to the stamped process runner. Process
 # notifications must wait behind a foreground turn, never steer or interrupt it.
 _STAMPED_PROCESS_EVENT_BUSY = object()
@@ -2920,6 +2955,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._running_agents: Dict[str, Any] = {}
         self._running_agents_ts: Dict[str, float] = {}  # start timestamp per session
         self._stamped_process_running_agents: Dict[str, Any] = {}
+        self._stamped_process_release_events: Dict[
+            str, _StampedProcessReleaseClaim
+        ] = {}
+        self._running_agent_state_lock = threading.RLock()
         self._active_session_leases: Dict[str, Any] = {}
         self._pending_messages: Dict[str, str] = {}  # Queued messages during interrupt
         # Last successfully-resolved (non-empty) model, keyed by session. Used
@@ -4400,6 +4439,37 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         else:
             pending_slot[session_key] = queued_event
 
+    def _restore_dequeued_event_ahead_of_newer(
+        self,
+        session_key: str,
+        adapter: Any,
+        dequeued_event: "MessageEvent",
+    ) -> bool:
+        """Restore one exact dequeued head without overwriting newer input."""
+        pending_slot = getattr(adapter, "_pending_messages", None)
+        if pending_slot is None:
+            return False
+        queued_events = getattr(self, "_queued_events", None)
+        if queued_events is None:
+            queued_events = {}
+            self._queued_events = queued_events
+        overflow = queued_events.setdefault(session_key, [])
+        overflow[:] = [
+            event for event in overflow if event is not dequeued_event
+        ]
+        current = pending_slot.get(session_key)
+        if current is dequeued_event:
+            if not overflow:
+                queued_events.pop(session_key, None)
+            return True
+        if current is not None:
+            overflow[:] = [event for event in overflow if event is not current]
+            overflow.insert(0, current)
+        pending_slot[session_key] = dequeued_event
+        if not overflow:
+            queued_events.pop(session_key, None)
+        return True
+
     def _promote_queued_event(
         self,
         session_key: str,
@@ -5093,11 +5163,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 unavailable.clear()
 
     def _snapshot_running_agents(self) -> Dict[str, Any]:
-        return {
-            session_key: agent
-            for session_key, agent in self._running_agents.items()
-            if agent is not _AGENT_PENDING_SENTINEL
-        }
+        state_lock = getattr(self, "_running_agent_state_lock", None)
+        if state_lock is None:
+            state_lock = threading.RLock()
+            self._running_agent_state_lock = state_lock
+        with state_lock:
+            return {
+                session_key: agent
+                for session_key, agent in self._running_agents.items()
+                if not _is_pre_execution_agent_owner(agent)
+            }
 
     def _get_max_concurrent_sessions(self) -> Optional[int]:
         """Return the configured active chat session cap, if enabled."""
@@ -5242,6 +5317,50 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     # follow-ups is far beyond any realistic conversational backlog while
     # still small enough to never threaten memory.
     _BUSY_QUEUE_MAX_PENDING = 32
+
+    def _running_agent_ownership_snapshot(
+        self, session_key: str
+    ) -> tuple[Any, Any]:
+        """Read the generic owner and stamped marker under their publication lock."""
+        state_lock = getattr(self, "_running_agent_state_lock", None)
+        if state_lock is None:
+            state_lock = threading.RLock()
+            self._running_agent_state_lock = state_lock
+        with state_lock:
+            return (
+                self._running_agents.get(session_key),
+                getattr(self, "_stamped_process_running_agents", {}).get(
+                    session_key
+                ),
+            )
+
+    def _defer_adapter_pending_drain_for_stamped_process(
+        self, session_key: str, event: MessageEvent
+    ) -> None:
+        """Give the stamped turn sole ownership of replaying a queued foreground event."""
+        adapter = self._adapter_for_source(event.source)
+        if adapter is None:
+            return
+        interrupt_event = getattr(adapter, "_active_sessions", {}).get(session_key)
+        if interrupt_event is None:
+            return
+        release_claim = getattr(self, "_stamped_process_release_events", {}).get(
+            session_key
+        )
+        if release_claim is None:
+            return
+        release_generation = release_claim.generation
+        release_event = release_claim.event
+        generations = self.__dict__.get("_session_run_generation") or {}
+        if release_generation is None or int(release_generation) != int(
+            generations.get(session_key, 0)
+        ):
+            return
+        setattr(
+            interrupt_event,
+            "_hermes_stamped_process_release_event",
+            release_event,
+        )
 
     def _queue_or_replace_pending_event(self, session_key: str, event: MessageEvent) -> None:
         adapter = self._adapter_for_source(event.source)
@@ -5421,14 +5540,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if getattr(event, "internal", False):
             return False
 
-        running_agent = self._running_agents.get(session_key)
+        running_agent, stamped_process_agent = (
+            self._running_agent_ownership_snapshot(session_key)
+        )
         if (
             running_agent is not None
-            and getattr(self, "_stamped_process_running_agents", {}).get(session_key)
-            is running_agent
+            and stamped_process_agent is running_agent
         ):
             # Foreground input must not steer or interrupt a synthetic process
-            # notification turn. Preserve it as the next ordinary user turn.
+            # notification turn. Preserve it as the next ordinary user turn,
+            # but let the synthetic owner replay it after releasing its slot.
+            self._defer_adapter_pending_drain_for_stamped_process(
+                session_key, event
+            )
             self._queue_or_replace_pending_event(session_key, event)
             return True
 
@@ -5721,15 +5845,78 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _maybe_update_status(force=True)
         return snapshot, timed_out
 
-    def _interrupt_running_agents(self, reason: str) -> None:
-        for session_key, agent in list(self._running_agents.items()):
-            if agent is _AGENT_PENDING_SENTINEL:
-                continue
+    def _capture_running_agents_for_forced_shutdown(
+        self, reason: str
+    ) -> list[tuple[str, Any]]:
+        """Invalidate/classify owners at one linearized shutdown boundary."""
+        state_lock = getattr(self, "_running_agent_state_lock", None)
+        if state_lock is None:
+            state_lock = threading.RLock()
+            self._running_agent_state_lock = state_lock
+        concrete_owners = []
+        pre_execution_owners = []
+        with state_lock:
+            for session_key, agent in list(self._running_agents.items()):
+                # Invalidate first while publication CAS uses this same lock.
+                # An early generic sentinel can no longer advance into
+                # _run_agent, and a stamped pending handle can no longer be
+                # replaced by a concrete local/proxy owner after this point.
+                self._invalidate_session_run_generation(
+                    session_key, reason="forced_gateway_shutdown"
+                )
+                if _is_pre_execution_agent_owner(agent):
+                    if isinstance(agent, _StampedProcessPendingHandle):
+                        try:
+                            agent.interrupt(reason)
+                            logger.debug(
+                                "Cancelled pending stamped owner for session %s during shutdown",
+                                session_key,
+                            )
+                        except Exception as e:
+                            logger.debug(
+                                "Failed cancelling pending stamped owner during shutdown: %s",
+                                e,
+                            )
+                    pre_execution_owners.append((session_key, agent))
+                    continue
+
+                process_agents = getattr(
+                    self, "_stamped_process_running_agents", {}
+                )
+                if process_agents.get(session_key) is agent:
+                    claim = getattr(
+                        self, "_stamped_process_release_events", {}
+                    ).get(session_key)
+                    if isinstance(claim, _StampedProcessReleaseClaim):
+                        claim.forced_shutdown_owner = agent
+                concrete_owners.append((session_key, agent))
+
+        # No model/proxy work exists for these identities. Remove them now so
+        # the post-interrupt grace loop does not wait on an owner that can only
+        # reject publication after its generation was invalidated.
+        for session_key, agent in pre_execution_owners:
+            self._release_running_agent_if_identity(session_key, agent)
+        return concrete_owners
+
+    def _interrupt_captured_running_agents(
+        self,
+        concrete_owners: list[tuple[str, Any]],
+        reason: str,
+    ) -> None:
+        """Interrupt owners captured by the forced-shutdown ownership epoch."""
+        for session_key, agent in concrete_owners:
             try:
                 agent.interrupt(reason)
                 logger.debug("Interrupted running agent for session %s during shutdown", session_key)
             except Exception as e:
                 logger.debug("Failed interrupting agent during shutdown: %s", e)
+
+    def _interrupt_running_agents(self, reason: str) -> None:
+        """Atomically capture then immediately interrupt active owners."""
+        concrete_owners = self._capture_running_agents_for_forced_shutdown(
+            reason
+        )
+        self._interrupt_captured_running_agents(concrete_owners, reason)
 
     async def _notify_active_sessions_of_shutdown(self) -> None:
         """Send shutdown/restart notifications to active chats and home channels.
@@ -6058,6 +6245,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """Best-effort cleanup for temporary or cached agent instances."""
         if agent is None:
             return
+        try:
+            setattr(agent, _REJECTED_EXECUTION_CLEANUP_ATTR, False)
+        except Exception:
+            pass
         try:
             if hasattr(agent, "shutdown_memory_provider"):
                 # Pass the agent's own conversation transcript so memory
@@ -8168,7 +8359,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # gateway boot can recover in-flight sessions (#27856).
             _pre_drain_keys: list[str] = []
             for _sk, _agent in list(self._running_agents.items()):
-                if _agent is _AGENT_PENDING_SENTINEL:
+                if _is_pre_execution_agent_owner(_agent):
                     continue
                 try:
                     await self.async_session_store.mark_resume_pending(
@@ -8194,6 +8385,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _cron_at_start,
                 self._active_cron_job_count(),
             )
+
+            _interrupt_reason = (
+                _INTERRUPT_REASON_GATEWAY_RESTART
+                if self._restart_requested
+                else _INTERRUPT_REASON_GATEWAY_SHUTDOWN
+            )
+            _forced_owners: list[tuple[str, Any]] = []
+            if timed_out:
+                # Freeze ownership before deciding whether this was a dirty
+                # execution timeout. Raw pending owners are invalidated and
+                # removed by the same CAS boundary, but do not make an otherwise
+                # clean shutdown resumable or count toward stuck-loop recovery.
+                _forced_owners = (
+                    self._capture_running_agents_for_forced_shutdown(
+                        _interrupt_reason
+                    )
+                )
+                if (
+                    not _forced_owners
+                    and self._active_cron_job_count() == 0
+                ):
+                    timed_out = False
 
             if not timed_out:
                 # Drain completed gracefully — all running sessions finished.
@@ -8241,18 +8454,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _resume_reason = (
                     "restart_timeout" if self._restart_requested else "shutdown_timeout"
                 )
-                for _sk, _agent in list(self._running_agents.items()):
-                    if _agent is _AGENT_PENDING_SENTINEL:
-                        continue
+                # Ownership was frozen immediately after the drain result.
+                # Every owner in this set was concrete at invalidation; raw
+                # placeholders were removed without making the shutdown dirty.
+                for _sk, _agent in _forced_owners:
+                    # This exact concrete owner became part of shutdown after
+                    # the initial drain snapshot (for example by promoting
+                    # from a pending handle). Preserve it for resource
+                    # finalization and stuck-loop accounting as well.
+                    active_agents[_sk] = _agent
                     try:
-                        await self.async_session_store.mark_resume_pending(_sk, _resume_reason)
+                        await self.async_session_store.mark_resume_pending(
+                            _sk, _resume_reason
+                        )
                     except Exception as _e:
                         logger.debug(
                             "mark_resume_pending failed for %s: %s",
                             _sk, _e,
                         )
-                self._interrupt_running_agents(
-                    _INTERRUPT_REASON_GATEWAY_RESTART if self._restart_requested else _INTERRUPT_REASON_GATEWAY_SHUTDOWN
+                self._interrupt_captured_running_agents(
+                    _forced_owners, _interrupt_reason
                 )
                 interrupt_deadline = asyncio.get_running_loop().time() + 5.0
                 while self._running_agents and asyncio.get_running_loop().time() < interrupt_deadline:
@@ -8417,13 +8638,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "active sessions."
                 )
 
-            # Track sessions that were active at shutdown for stuck-loop
-            # detection (#7536).  On each restart, the counter increments
-            # for sessions that were running.  If a session hits the
-            # threshold (3 consecutive restarts while active), the next
-            # startup auto-suspends it — breaking the loop.
-            if active_agents:
-                self._increment_restart_failure_counts(set(active_agents.keys()))
+            # Track only exact concrete owners that required forced shutdown for
+            # stuck-loop detection (#7536). The drain-start snapshot may contain
+            # work that completed or transitioned back to a pre-execution pending
+            # follow-up before capture; counting that clean transition would
+            # eventually suspend a healthy session.
+            _dirty_owner_keys = {
+                session_key for session_key, _agent in _forced_owners
+            }
+            if _dirty_owner_keys:
+                self._increment_restart_failure_counts(_dirty_owner_keys)
 
             if self._restart_requested and self._restart_command_source is None:
                 try:
@@ -9222,11 +9446,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # created.  Sentinels have no get_activity_summary(), so the
             # idle check below would always evaluate to inf >= timeout and
             # immediately evict them, racing with the setup path.
-            _stale_idle = float("inf")  # assume idle if we can't check
+            _activity_getter = getattr(
+                _stale_agent, "get_activity_summary", None
+            )
+            _has_activity_tracker = callable(_activity_getter)
+            _stale_idle = float("inf")
             _stale_detail = ""
-            if _stale_agent and hasattr(_stale_agent, "get_activity_summary"):
+            if _has_activity_tracker:
                 try:
-                    _sa = _stale_agent.get_activity_summary()
+                    _sa = _activity_getter()
+                    if not isinstance(_sa, dict):
+                        _sa = {}
                     _stale_idle = _sa.get("seconds_since_activity", float("inf"))
                     _stale_detail = (
                         f" | last_activity={_sa.get('last_activity_desc', 'unknown')} "
@@ -9242,7 +9472,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _should_evict = (
                 _stale_agent is not _AGENT_PENDING_SENTINEL
                 and (
-                    (_raw_stale_timeout > 0 and _stale_idle >= _raw_stale_timeout)
+                    (
+                        _has_activity_tracker
+                        and _raw_stale_timeout > 0
+                        and _stale_idle >= _raw_stale_timeout
+                    )
                     or _stale_age > _wall_ttl
                 )
             )
@@ -9386,9 +9620,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 steer_text = event.get_command_args().strip()
                 if not steer_text:
                     return "Usage: /steer <prompt>"
-                running_agent = self._running_agents.get(_quick_key)
-                if running_agent is _AGENT_PENDING_SENTINEL:
-                    # Agent hasn't started yet — queue as turn-boundary fallback.
+                running_agent, stamped_process_agent = (
+                    self._running_agent_ownership_snapshot(_quick_key)
+                )
+                is_stamped_process_owner = bool(
+                    running_agent is not None
+                    and stamped_process_agent is running_agent
+                )
+                if (
+                    running_agent is _AGENT_PENDING_SENTINEL
+                    or is_stamped_process_owner
+                ):
+                    # The agent has not started yet, or this is a stamped
+                    # process turn that foreground commands must not steer.
+                    # Queue the payload as a turn-boundary fallback.
                     adapter = self._adapter_for_source(source)
                     if adapter:
                         queued_event = MessageEvent(
@@ -9398,7 +9643,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             message_id=event.message_id,
                             channel_prompt=event.channel_prompt,
                         )
-                        adapter._pending_messages[_quick_key] = queued_event
+                        if is_stamped_process_owner:
+                            self._defer_adapter_pending_drain_for_stamped_process(
+                                _quick_key, event
+                            )
+                            self._queue_or_replace_pending_event(
+                                _quick_key, queued_event
+                            )
+                        else:
+                            adapter._pending_messages[_quick_key] = queued_event
+                    if is_stamped_process_owner:
+                        return "Process notification is finishing — /steer queued for the next turn."
                     return "Agent still starting — /steer queued for the next turn."
                 if running_agent and hasattr(running_agent, "steer"):
                     try:
@@ -9570,17 +9825,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         )
                 return None
 
-            running_agent = self._running_agents.get(_quick_key)
+            running_agent, stamped_process_agent = (
+                self._running_agent_ownership_snapshot(_quick_key)
+            )
             if (
                 running_agent is not None
-                and getattr(self, "_stamped_process_running_agents", {}).get(
-                    _quick_key
-                )
-                is running_agent
+                and stamped_process_agent is running_agent
             ):
                 logger.debug(
                     "Queueing foreground input behind stamped process turn for %s",
                     _quick_key,
+                )
+                self._defer_adapter_pending_drain_for_stamped_process(
+                    _quick_key, event
                 )
                 self._queue_or_replace_pending_event(_quick_key, event)
                 return None
@@ -10354,6 +10611,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if event.metadata is None:
                 event.metadata = {}
             event.metadata["gateway_run_generation"] = _run_generation
+            release_claim = getattr(
+                event, "_hermes_stamped_process_release_claim", None
+            )
+            if isinstance(release_claim, _StampedProcessReleaseClaim):
+                release_claim.generation = _run_generation
+                self._stamped_process_release_events[_quick_key] = release_claim
+                self._defer_adapter_pending_drain_for_stamped_process(
+                    _quick_key, event
+                )
 
         try:
             _agent_result = await self._handle_message_with_agent(event, source, _quick_key, _run_generation)
@@ -10414,16 +10680,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 ).strip()
             )
             if _is_process_turn:
-                # Process turns can outlive a reset while executor work drains;
-                # only release the slot if this generation still owns it.
+                release_claim = getattr(
+                    event, "_hermes_stamped_process_release_claim", None
+                )
+                if not isinstance(
+                    release_claim, _StampedProcessReleaseClaim
+                ):
+                    # Direct process-handler tests/callers have no outer
+                    # delivery owner, so preserve their historical cleanup.
+                    self._release_running_agent_state(
+                        _quick_key,
+                        run_generation=_run_generation,
+                    )
+            else:
+                # A stale ordinary tail must not clear a replacement owner that
+                # claimed this stable routing key after the inner turn released.
+                # Explicit control-command paths own any unconditional cleanup.
                 self._release_running_agent_state(
                     _quick_key,
                     run_generation=_run_generation,
                 )
-            else:
-                # Preserve ordinary /stop and one-shot MoA lifecycle semantics:
-                # control commands explicitly rely on unconditional old-slot cleanup.
-                self._release_running_agent_state(_quick_key)
 
     def _restore_moa_one_shot(self, event: "MessageEvent", quick_key: str) -> None:
         """Revert a ``/moa <prompt>`` one-shot model override after its turn.
@@ -15735,13 +16011,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         session_key: str,
         run_generation: Optional[int],
     ) -> bool:
-        """Fail closed before process-triggered model/tool work can begin."""
-        if not expected_session_id:
-            return True
-        if run_generation is not None and not self._is_session_run_current(
-            session_key, run_generation
+        """Fail closed before model/tool work can begin."""
+        generations = self.__dict__.get("_session_run_generation") or {}
+        if (
+            run_generation is not None
+            and (expected_session_id or session_key in generations)
+            and not self._is_session_run_current(session_key, run_generation)
         ):
             return False
+        if not expected_session_id:
+            return True
         if self._is_stale_process_notification(
             {
                 "session_key": session_key,
@@ -15814,6 +16093,44 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return await self.async_session_store.reset_session(session_key)
 
     async def _run_and_deliver_stamped_process_event(
+        self,
+        event: "MessageEvent",
+        *,
+        adapter: Any,
+        session_key: str,
+    ) -> Any:
+        """Run a stamped turn and release any foreground adapter waiter."""
+        release_claim = _StampedProcessReleaseClaim()
+        setattr(event, "_hermes_stamped_process_release_claim", release_claim)
+        release_events = self._stamped_process_release_events
+        try:
+            return await self._run_and_deliver_stamped_process_event_inner(
+                event,
+                adapter=adapter,
+                session_key=session_key,
+            )
+        finally:
+            # The stamped owner covers both inference and guarded delivery.
+            # Release its exact generation before waking any foreground adapter
+            # waiter; a reset/replacement makes this a no-op.
+            if release_claim.generation is not None:
+                released = self._release_running_agent_state(
+                    session_key,
+                    run_generation=release_claim.generation,
+                )
+                if (
+                    not released
+                    and release_claim.forced_shutdown_owner is not None
+                ):
+                    self._release_running_agent_if_identity(
+                        session_key,
+                        release_claim.forced_shutdown_owner,
+                    )
+            release_claim.event.set()
+            if release_events.get(session_key) is release_claim:
+                release_events.pop(session_key, None)
+
+    async def _run_and_deliver_stamped_process_event_inner(
         self,
         event: "MessageEvent",
         *,
@@ -16531,6 +16848,124 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         override = self._session_model_overrides.get(session_key)
         return override is not None and override.get("model") == agent_model
 
+    def _release_running_agent_if_identity(
+        self,
+        session_key: str,
+        expected_owner: Any,
+    ) -> bool:
+        """Drop one exact owner without touching a replacement generation."""
+        state_lock = getattr(self, "_running_agent_state_lock", None)
+        if state_lock is None:
+            state_lock = threading.RLock()
+            self._running_agent_state_lock = state_lock
+        lease = None
+        with state_lock:
+            if self._running_agents.get(session_key) is not expected_owner:
+                return False
+            lease = getattr(self, "_active_session_leases", {}).pop(
+                session_key, None
+            )
+            self._running_agents.pop(session_key, None)
+            process_agents = getattr(
+                self, "_stamped_process_running_agents", {}
+            )
+            if process_agents.get(session_key) is expected_owner:
+                process_agents.pop(session_key, None)
+            self._running_agents_ts.pop(session_key, None)
+            if hasattr(self, "_busy_ack_ts"):
+                self._busy_ack_ts.pop(session_key, None)
+        if lease is not None:
+            try:
+                lease.release()
+            except Exception:
+                logger.debug(
+                    "Failed to release active session slot", exc_info=True
+                )
+        self._persist_active_agents()
+        return True
+
+    def _publish_running_agent_at_execution_boundary(
+        self,
+        session_key: str,
+        *,
+        run_generation: Optional[int],
+        pending_owner: Any,
+        concrete_owner: Any,
+        stamped: bool = False,
+    ) -> bool:
+        """CAS a pending owner to concrete immediately before execution."""
+        if not session_key:
+            return True
+        state_lock = getattr(self, "_running_agent_state_lock", None)
+        if state_lock is None:
+            state_lock = threading.RLock()
+            self._running_agent_state_lock = state_lock
+        with state_lock:
+            generations = self.__dict__.get("_session_run_generation") or {}
+            if (
+                stamped and getattr(pending_owner, "cancelled", False)
+            ) or (
+                run_generation is not None
+                and session_key in generations
+                and not self._is_session_run_current(
+                    session_key, run_generation
+                )
+            ):
+                return False
+            current_owner = self._running_agents.get(session_key)
+            if (
+                current_owner is not pending_owner
+                and not (
+                    current_owner is None and run_generation is None
+                )
+            ):
+                return False
+            self._running_agents[session_key] = concrete_owner
+            if stamped:
+                process_agents = getattr(
+                    self, "_stamped_process_running_agents", None
+                )
+                if process_agents is None:
+                    process_agents = {}
+                    self._stamped_process_running_agents = process_agents
+                process_agents[session_key] = concrete_owner
+            return True
+
+    def _transfer_running_agent_to_pending_rebuild(
+        self,
+        session_key: str,
+        *,
+        run_generation: Optional[int],
+        expected_owner: Any,
+    ) -> bool:
+        """Transfer one exact concrete owner back to the pending sentinel."""
+        if not session_key:
+            return True
+        state_lock = getattr(self, "_running_agent_state_lock", None)
+        if state_lock is None:
+            state_lock = threading.RLock()
+            self._running_agent_state_lock = state_lock
+        with state_lock:
+            generations = self.__dict__.get("_session_run_generation") or {}
+            if (
+                run_generation is not None
+                and session_key in generations
+                and not self._is_session_run_current(
+                    session_key, run_generation
+                )
+            ):
+                return False
+            current_owner = self._running_agents.get(session_key)
+            if current_owner is _AGENT_PENDING_SENTINEL:
+                return True
+            if current_owner is None and run_generation is None:
+                self._running_agents[session_key] = _AGENT_PENDING_SENTINEL
+                return True
+            if current_owner is not expected_owner:
+                return False
+            self._running_agents[session_key] = _AGENT_PENDING_SENTINEL
+            return True
+
     def _release_running_agent_state(
         self,
         session_key: str,
@@ -16562,26 +16997,34 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         if not session_key:
             return False
-        if run_generation is not None and not self._is_session_run_current(
-            session_key, run_generation
-        ):
-            return False
-        lease = getattr(self, "_active_session_leases", {}).pop(session_key, None)
+        state_lock = getattr(self, "_running_agent_state_lock", None)
+        if state_lock is None:
+            state_lock = threading.RLock()
+            self._running_agent_state_lock = state_lock
+        with state_lock:
+            if run_generation is not None and not self._is_session_run_current(
+                session_key, run_generation
+            ):
+                return False
+            lease = getattr(self, "_active_session_leases", {}).pop(session_key, None)
+            running_agent = self._running_agents.pop(session_key, None)
+            process_agents = getattr(self, "_stamped_process_running_agents", {})
+            if (
+                running_agent is not None
+                and process_agents.get(session_key) is running_agent
+            ):
+                process_agents.pop(session_key, None)
+            self._running_agents_ts.pop(session_key, None)
+            if hasattr(self, "_busy_ack_ts"):
+                self._busy_ack_ts.pop(session_key, None)
         if lease is not None:
             try:
                 lease.release()
             except Exception:
                 logger.debug("Failed to release active session slot", exc_info=True)
-        running_agent = self._running_agents.pop(session_key, None)
-        process_agents = getattr(self, "_stamped_process_running_agents", {})
-        if running_agent is not None and process_agents.get(session_key) is running_agent:
-            process_agents.pop(session_key, None)
-        self._running_agents_ts.pop(session_key, None)
-        if hasattr(self, "_busy_ack_ts"):
-            self._busy_ack_ts.pop(session_key, None)
-        # Turn boundary: a running-agent slot was just released.  Persist the
+        # Turn boundary: a running-agent slot was just released. Persist the
         # new (lower) in-flight count so the dashboard readout stays current
-        # between lifecycle transitions.  Preserves gateway_state (see
+        # between lifecycle transitions. Preserves gateway_state (see
         # _persist_active_agents).
         self._persist_active_agents()
         return True
@@ -16643,13 +17086,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         if not session_key:
             return 0
-        generations = self.__dict__.get("_session_run_generation")
-        if generations is None:
-            generations = {}
-            self._session_run_generation = generations
-        next_generation = int(generations.get(session_key, 0)) + 1
-        generations[session_key] = next_generation
-        return next_generation
+        state_lock = getattr(self, "_running_agent_state_lock", None)
+        if state_lock is None:
+            state_lock = threading.RLock()
+            self._running_agent_state_lock = state_lock
+        with state_lock:
+            generations = self.__dict__.get("_session_run_generation")
+            if generations is None:
+                generations = {}
+                self._session_run_generation = generations
+            next_generation = int(generations.get(session_key, 0)) + 1
+            generations[session_key] = next_generation
+            return next_generation
 
     def _invalidate_session_run_generation(self, session_key: str, *, reason: str = "") -> int:
         """Invalidate any in-flight run token for ``session_key``."""
@@ -16712,6 +17160,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if adapter and hasattr(adapter, "get_pending_message"):
             adapter.get_pending_message(session_key)  # consume and discard
         self._pending_messages.pop(session_key, None)
+        release_claim = getattr(self, "_stamped_process_release_events", {}).pop(
+            session_key, None
+        )
+        if release_claim is not None:
+            release_claim.event.set()
         if release_running_state:
             self._release_running_agent_state(session_key)
             # Evict the cached agent: ``_interrupt_requested`` is only
@@ -16799,6 +17252,42 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         _cache[session_key] = (
                             cached[0], cached[1], _live, _snapshot_sid,
                         )
+
+    def _agent_is_retained_after_execution_rejection(
+        self,
+        session_key: str,
+        agent: Any,
+    ) -> bool:
+        """Return whether an exact rejected agent still has a legitimate owner."""
+        if not session_key or agent is None:
+            return False
+        state_lock = getattr(self, "_running_agent_state_lock", None)
+        if state_lock is None:
+            state_lock = threading.RLock()
+            self._running_agent_state_lock = state_lock
+        with state_lock:
+            running_owner = self._running_agents.get(session_key)
+            if running_owner is agent:
+                return True
+            cache = getattr(self, "_agent_cache", None)
+            if cache is None:
+                return False
+            cache_lock = getattr(self, "_agent_cache_lock", None)
+
+            def _cache_owns_exact_agent() -> bool:
+                cached = cache.get(session_key)
+                cached_agent = (
+                    cached[0] if isinstance(cached, tuple) and cached else None
+                )
+                if cached_agent is not agent:
+                    return False
+                setattr(agent, _REJECTED_EXECUTION_CLEANUP_ATTR, True)
+                return True
+
+            if cache_lock is not None:
+                with cache_lock:
+                    return _cache_owns_exact_agent()
+            return _cache_owns_exact_agent()
 
     def _evict_cached_agent_if_identity(self, session_key: str, agent: Any) -> bool:
         """Evict ``session_key`` only when its cache still owns ``agent``.
@@ -16990,6 +17479,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         same task_id inherits them.
         """
         if agent is None:
+            return
+        if getattr(agent, _REJECTED_EXECUTION_CLEANUP_ATTR, False):
+            try:
+                setattr(agent, _REJECTED_EXECUTION_CLEANUP_ATTR, False)
+            except Exception:
+                pass
+            self._cleanup_agent_resources(agent)
             return
         try:
             if hasattr(agent, "release_clients"):
@@ -17209,6 +17705,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         run_generation: Optional[int] = None,
         event_message_id: Optional[str] = None,
         expected_process_session_id: Optional[str] = None,
+        process_pending_owner: Optional[Any] = None,
     ) -> Dict[str, Any]:
         """Forward the message to a remote Hermes API server instead of
         running a local AIAgent.
@@ -17357,10 +17854,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception as _sc_err:
                 logger.debug("Proxy: could not set up stream consumer: %s", _sc_err)
 
-        # Run the stream consumer task in the background
+        # The consumer task starts only after execution publication succeeds;
+        # pre-HTTP fail-closed returns must not leave a waiter blocked on _DONE.
         stream_task = None
-        if _stream_consumer:
-            stream_task = asyncio.create_task(_stream_consumer.run())
 
         # Send typing indicator
         _adapter = self._adapter_for_source(source)
@@ -17370,11 +17866,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception:
                 pass
 
-        # Make a process-triggered proxy request interruptible before its final
-        # execution-boundary check. Reset invalidates generation first, then
-        # cancels this task if the proxy handoff has already become concrete.
+        # Publish an interruptible proxy owner at the final execution boundary.
+        # Ordinary and stamped turns use the same generation/identity CAS, so
+        # forced shutdown either invalidates the pending owner before the HTTP
+        # request starts or captures this concrete handle for interruption.
         _proxy_interrupt_handle = None
-        if expected_process_session_id and session_key:
+        if session_key:
             _proxy_task = asyncio.current_task()
 
             class _ProxyInterruptHandle:
@@ -17383,18 +17880,45 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         _proxy_task.cancel()
 
             _proxy_interrupt_handle = _ProxyInterruptHandle()
-            self._running_agents[session_key] = _proxy_interrupt_handle
-            process_agents = getattr(self, "_stamped_process_running_agents", None)
-            if process_agents is None:
-                process_agents = {}
-                self._stamped_process_running_agents = process_agents
-            process_agents[session_key] = _proxy_interrupt_handle
+            expected_owner = (
+                process_pending_owner
+                if expected_process_session_id
+                else _AGENT_PENDING_SENTINEL
+            )
+            if not self._publish_running_agent_at_execution_boundary(
+                session_key,
+                run_generation=run_generation,
+                pending_owner=expected_owner,
+                concrete_owner=_proxy_interrupt_handle,
+                stamped=bool(expected_process_session_id),
+            ):
+                if expected_process_session_id:
+                    self._release_running_agent_if_identity(
+                        session_key, expected_owner
+                    )
+                else:
+                    self._release_running_agent_state(
+                        session_key, run_generation=run_generation
+                    )
+                return {
+                    "final_response": "",
+                    "messages": [],
+                    "api_calls": 0,
+                    "tools": [],
+                    "history_offset": len(history),
+                    "session_id": session_id,
+                    "_execution_boundary_dropped": True,
+                }
 
         if not self._process_notification_run_is_current(
             expected_session_id=expected_process_session_id or "",
             session_key=session_key or "",
             run_generation=run_generation,
         ):
+            if session_key and _proxy_interrupt_handle is not None:
+                self._release_running_agent_if_identity(
+                    session_key, _proxy_interrupt_handle
+                )
             return {
                 "final_response": "",
                 "messages": [],
@@ -17402,7 +17926,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "tools": [],
                 "history_offset": len(history),
                 "session_id": session_id,
+                "_execution_boundary_dropped": True,
             }
+
+        if _stream_consumer:
+            stream_task = asyncio.create_task(_stream_consumer.run())
 
         # Make the HTTP request with SSE streaming -----------------------
         full_response = ""
@@ -17575,7 +18103,38 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "tools": [],
                 "history_offset": len(history),
                 "session_id": session_id,
+                "_execution_boundary_dropped": True,
             }
+        process_pending_owner = None
+        if expected_process_session_id and session_key:
+            state_lock = getattr(self, "_running_agent_state_lock", None)
+            if state_lock is None:
+                state_lock = threading.RLock()
+                self._running_agent_state_lock = state_lock
+            with state_lock:
+                current_owner = self._running_agents.get(session_key)
+                if (
+                    not self._is_session_run_current(session_key, run_generation)
+                    or (
+                        current_owner is not None
+                        and current_owner is not _AGENT_PENDING_SENTINEL
+                    )
+                ):
+                    return {
+                        "final_response": "",
+                        "messages": [],
+                        "api_calls": 0,
+                        "tools": [],
+                        "history_offset": len(history),
+                        "session_id": session_id,
+                        "_execution_boundary_dropped": True,
+                    }
+                process_pending_owner = _StampedProcessPendingHandle()
+                self._running_agents[session_key] = process_pending_owner
+                self._stamped_process_running_agents[session_key] = (
+                    process_pending_owner
+                )
+
         if not getattr(getattr(self, "config", None), "multiplex_profiles", False):
             return await self._run_agent_inner(
                 message, context_prompt, history, source, session_id,
@@ -17585,6 +18144,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
                 expected_process_session_id=expected_process_session_id,
+                process_pending_owner=process_pending_owner,
             )
 
         profile_home = self._resolve_profile_home_for_source(source)
@@ -17597,6 +18157,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
                 expected_process_session_id=expected_process_session_id,
+                process_pending_owner=process_pending_owner,
             )
 
     def _resolve_profile_home_for_source(self, source: SessionSource) -> "Path":
@@ -17630,6 +18191,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         persist_user_message: Optional[str] = None,
         persist_user_timestamp: Optional[float] = None,
         expected_process_session_id: Optional[str] = None,
+        process_pending_owner: Optional[Any] = None,
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -17655,6 +18217,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "tools": [],
                 "history_offset": len(history),
                 "session_id": session_id,
+                "_execution_boundary_dropped": True,
             }
         # ---- Proxy mode: delegate to remote API server ----
         if self._get_proxy_url():
@@ -17668,6 +18231,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 run_generation=run_generation,
                 event_message_id=event_message_id,
                 expected_process_session_id=expected_process_session_id,
+                process_pending_owner=process_pending_owner,
             )
 
         from run_agent import AIAgent
@@ -18626,6 +19190,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "tools": [],
                     "history_offset": len(history),
                     "session_id": session_id,
+                    "_execution_boundary_dropped": True,
                 }
 
             # session_key is propagated via contextvars in _set_session_env()
@@ -18986,21 +19551,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 if _cache_lock and _cache is not None:
                     with _cache_lock:
-                        # For stamped process turns, make publication a CAS under
-                        # the cache lock and re-check generation inside that same
-                        # critical section. A reset/replacement between constructor
-                        # return and lock acquisition must never be overwritten by
-                        # the stale worker. Ordinary user turns keep the historical
-                        # unconditional publication behavior.
+                        # Publish a freshly constructed cache entry only while
+                        # the observed cache identity and this run generation
+                        # are still current. A reset/replacement that wins while
+                        # construction is in flight must not be overwritten by
+                        # the stale worker, for ordinary or stamped turns.
                         _cache_unchanged = (
                             _cache.get(session_key) is _cache_entry_observed
                         )
                         _publish_agent_cache = (
-                            not expected_process_session_id
-                            or (
-                                _cache_unchanged
-                                and run_generation is not None
-                                and self._is_session_run_current(
+                            _cache_unchanged
+                            and (
+                                run_generation is None
+                                or self._is_session_run_current(
                                     session_key, run_generation
                                 )
                             )
@@ -19638,21 +20201,39 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if _persist_user_timestamp_override is not None:
                     _conversation_kwargs["persist_user_timestamp"] = _persist_user_timestamp_override
 
-                # Make a process-triggered agent interruptible before the final
-                # generation/ownership check. Reset invalidates the generation
-                # before reading this slot, so either this check rejects the run
-                # or /new sees the concrete agent and interrupts it.
-                if expected_process_session_id and session_key:
-                    self._running_agents[session_key] = agent
-                    process_agents = getattr(
-                        self, "_stamped_process_running_agents", None
+                # Publish the concrete local owner at the final execution
+                # boundary. Ordinary and stamped turns use the same locked
+                # generation/identity CAS, so shutdown either invalidates the
+                # pending owner or captures this agent before model/tool work.
+                expected_owner = (
+                    process_pending_owner
+                    if expected_process_session_id
+                    else _AGENT_PENDING_SENTINEL
+                )
+                _process_handle_published = (
+                    not session_key
+                    or self._publish_running_agent_at_execution_boundary(
+                        session_key,
+                        run_generation=run_generation,
+                        pending_owner=expected_owner,
+                        concrete_owner=agent,
+                        stamped=bool(expected_process_session_id),
                     )
-                    if process_agents is None:
-                        process_agents = {}
-                        self._stamped_process_running_agents = process_agents
-                    process_agents[session_key] = agent
+                )
 
-                if not self._process_notification_run_is_current(
+                if not _process_handle_published:
+                    if expected_process_session_id:
+                        # Stamped pending handles are run-unique identities.
+                        self._release_running_agent_if_identity(
+                            session_key, expected_owner
+                        )
+                    else:
+                        # The ordinary sentinel is a shared singleton, so an
+                        # identity-only release is ABA-unsafe across generations.
+                        self._release_running_agent_state(
+                            session_key, run_generation=run_generation
+                        )
+                if not _process_handle_published or not self._process_notification_run_is_current(
                     expected_session_id=expected_process_session_id,
                     session_key=session_key,
                     run_generation=run_generation,
@@ -19661,7 +20242,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         "Dropping stale process notification at local model/tool execution boundary for %s",
                         session_key or "",
                     )
-                    self._evict_cached_agent_if_identity(session_key, agent)
+                    if not self._agent_is_retained_after_execution_rejection(
+                        session_key, agent
+                    ):
+                        self._evict_cached_agent_if_identity(session_key, agent)
+                        self._cleanup_agent_resources(agent)
                     result = {
                         "final_response": "",
                         "messages": [],
@@ -19669,8 +20254,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         "tools": [],
                         "history_offset": len(history),
                         "session_id": session_id,
+                        "_execution_boundary_dropped": True,
                     }
                 else:
+                    try:
+                        setattr(
+                            agent,
+                            _REJECTED_EXECUTION_CLEANUP_ATTR,
+                            False,
+                        )
+                    except Exception:
+                        pass
                     result = agent.run_conversation(
                         _api_run_message, **_conversation_kwargs
                     )
@@ -19979,28 +20573,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         stream_task = asyncio.create_task(_start_stream_consumer())
         
-        # Track this agent as running for this session (for interrupt support)
-        # We do this in a callback after the agent is created
+        # Observe construction only for drain-status refresh. Concrete running
+        # ownership is published exclusively by the worker's final execution
+        # CAS immediately before run_conversation(); publishing here would let
+        # shutdown misclassify a constructed-but-never-executed agent.
         async def track_agent():
-            # Wait for agent to be created
             while agent_holder[0] is None:
                 await asyncio.sleep(0.05)
-            if not session_key:
-                return
-            # Only promote the sentinel to the real agent if this run is still
-            # current.  If /stop or /new bumped the generation while we were
-            # spinning up, leave the newer run's slot alone — we'll be
-            # discarded by the stale-result check in _handle_message_with_agent.
-            if run_generation is not None and not self._is_session_run_current(
-                session_key, run_generation
-            ):
-                logger.info(
-                    "Skipping stale agent promotion for %s — generation %s is no longer current",
-                    session_key or "",
-                    run_generation,
-                )
-                return
-            self._running_agents[session_key] = agent_holder[0]
             if self._draining:
                 self._update_runtime_status("draining")
         
@@ -20354,7 +20933,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "Skipping stale process-run postprocessing for %s",
                     session_key or "",
                 )
-                return result_holder[0] or {
+                _worker_drop = (
+                    response
+                    if isinstance(response, dict)
+                    and response.get("_execution_boundary_dropped")
+                    else None
+                )
+                return _worker_drop or result_holder[0] or {
                     "final_response": "",
                     "messages": [],
                     "api_calls": 0,
@@ -20615,7 +21200,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     )
                     adapter = self._adapter_for_source(source)
                     if adapter and pending_event:
-                        merge_pending_message_event(adapter._pending_messages, session_key, pending_event)
+                        self._restore_dequeued_event_ahead_of_newer(
+                            session_key, adapter, pending_event
+                        )
                     elif adapter and hasattr(adapter, 'queue_message'):
                         adapter.queue_message(session_key, pending)
                     return result_holder[0] or {"final_response": response, "messages": history}
@@ -20758,6 +21345,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # what the follow-up's guard will consult.  Fail-safe in helper.
                 await self._refresh_agent_cache_message_count(session_key, session_id)
 
+                # Recursive queued turns may rebuild the agent after fallback
+                # eviction. Transfer only this exact completed concrete owner
+                # back to the pending sentinel before reconstruction; reset or
+                # shutdown replacement ownership fails closed and the dequeued
+                # event is restored transactionally.
+                if not self._transfer_running_agent_to_pending_rebuild(
+                    next_session_key,
+                    run_generation=run_generation,
+                    expected_owner=agent_holder[0],
+                ):
+                    if adapter and pending_event is not None:
+                        self._restore_dequeued_event_ahead_of_newer(
+                            session_key, adapter, pending_event
+                        )
+                    elif adapter and hasattr(adapter, "queue_message"):
+                        adapter.queue_message(session_key, pending)
+                    return result_holder[0] or {
+                        "final_response": response,
+                        "messages": history,
+                    }
+
                 followup_result = await self._run_agent(
                     message=next_message,
                     context_prompt=context_prompt,
@@ -20770,6 +21378,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     event_message_id=next_message_id,
                     channel_prompt=next_channel_prompt,
                 )
+                if followup_result.get("_execution_boundary_dropped"):
+                    if adapter and pending_event is not None:
+                        self._restore_dequeued_event_ahead_of_newer(
+                            session_key, adapter, pending_event
+                        )
+                    elif adapter and hasattr(adapter, "queue_message"):
+                        adapter.queue_message(session_key, pending)
+                    return result_holder[0] or {
+                        "final_response": response,
+                        "messages": history,
+                    }
                 return _preserve_queued_followup_history_offset(result, followup_result)
         finally:
             # Stop progress sender, interrupt monitor, and notification task

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -201,7 +201,7 @@ class GatewaySlashCommandsMixin:
             pass
 
         # Reset the session
-        new_entry = await self.async_session_store.reset_session(session_key)
+        new_entry = await self._reset_session_at_process_delivery_boundary(session_key)
 
         # Clear any session-scoped model/reasoning overrides so the next agent
         # picks up configured defaults instead of previous session switches.
@@ -266,7 +266,9 @@ class GatewaySlashCommandsMixin:
             header = await asyncio.to_thread(self._telegram_topic_new_header, source) or t("gateway.reset.header_default")
         else:
             # No existing session, just create one
-            new_entry = await self.async_session_store.get_or_create_session(source, force_new=True)
+            new_entry = await self._get_or_create_session_at_process_delivery_boundary(
+                source, force_new=True
+            )
             header = await asyncio.to_thread(self._telegram_topic_new_header, source) or t("gateway.reset.header_new")
 
         # Set session title if provided with /new <title>
@@ -498,7 +500,7 @@ class GatewaySlashCommandsMixin:
         from gateway.run import _AGENT_PENDING_SENTINEL, _load_gateway_config, _resolve_gateway_model
 
         source = event.source
-        session_entry = await self.async_session_store.get_or_create_session(source)
+        session_entry = await self._get_or_create_session_at_process_delivery_boundary(source)
 
         connected_platforms = [p.value for p in self.adapters.keys()]
 
@@ -1064,7 +1066,7 @@ class GatewaySlashCommandsMixin:
         """
         from gateway.run import _AGENT_PENDING_SENTINEL, _INTERRUPT_REASON_STOP
         source = event.source
-        session_entry = await self.async_session_store.get_or_create_session(source)
+        session_entry = await self._get_or_create_session_at_process_delivery_boundary(source)
         session_key = session_entry.session_key
 
         agent = self._running_agents.get(session_key)
@@ -1548,7 +1550,7 @@ class GatewaySlashCommandsMixin:
                                 enrich_model_switch_warnings_for_gateway,
                             )
 
-                            enrich_model_switch_warnings_for_gateway(
+                            await enrich_model_switch_warnings_for_gateway(
                                 result,
                                 _self,
                                 session_key=_session_key,
@@ -1601,8 +1603,9 @@ class GatewaySlashCommandsMixin:
                         _sess_db = getattr(_self, "_session_db", None)
                         if _sess_db is not None:
                             try:
-                                _sess_entry = await _self.async_session_store.get_or_create_session(
-                                    event.source
+                                _sess_entry = await _self._get_or_create_session_at_process_delivery_boundary(
+                                    event.source,
+                                    _session_key,
                                 )
                                 await _sess_db.update_session_model(
                                     _sess_entry.session_id, result.new_model
@@ -1792,7 +1795,7 @@ class GatewaySlashCommandsMixin:
                 enrich_model_switch_warnings_for_gateway,
             )
 
-            enrich_model_switch_warnings_for_gateway(
+            await enrich_model_switch_warnings_for_gateway(
                 result,
                 self,
                 session_key=session_key,
@@ -1843,7 +1846,7 @@ class GatewaySlashCommandsMixin:
             _sess_db = getattr(self, "_session_db", None)
             if _sess_db is not None:
                 try:
-                    _sess_entry = await self.async_session_store.get_or_create_session(source)
+                    _sess_entry = await self._get_or_create_session_at_process_delivery_boundary(source)
                     # If this session was auto-reset, consume the flag so the
                     # next regular message's cleanup does not wipe the model
                     # override just stored below (Closes #48031).
@@ -2146,7 +2149,7 @@ class GatewaySlashCommandsMixin:
     async def _handle_retry_command(self, event: MessageEvent) -> str:
         """Handle /retry command - re-send the last user message."""
         source = event.source
-        session_entry = await self.async_session_store.get_or_create_session(source)
+        session_entry = await self._get_or_create_session_at_process_delivery_boundary(source)
         history = await self.async_session_store.load_transcript(session_entry.session_id)
         
         # Find the last user message
@@ -2394,7 +2397,7 @@ class GatewaySlashCommandsMixin:
             if n < 1:
                 n = 1
 
-        session_entry = await self.async_session_store.get_or_create_session(source)
+        session_entry = await self._get_or_create_session_at_process_delivery_boundary(source)
         result = await self.async_session_store.rewind_session(session_entry.session_id, n)
 
         if result is None:
@@ -3094,7 +3097,7 @@ class GatewaySlashCommandsMixin:
         https://code.claude.com/docs/en/whats-new/2026-w20).
         """
         source = event.source
-        session_entry = await self.async_session_store.get_or_create_session(source)
+        session_entry = await self._get_or_create_session_at_process_delivery_boundary(source)
         history = await self.async_session_store.load_transcript(session_entry.session_id)
 
         if not history or len(history) < 4:
@@ -3457,7 +3460,7 @@ class GatewaySlashCommandsMixin:
     async def _handle_title_command(self, event: MessageEvent) -> str:
         """Handle /title command — set or show the current session's title."""
         source = event.source
-        session_entry = await self.async_session_store.get_or_create_session(source)
+        session_entry = await self._get_or_create_session_at_process_delivery_boundary(source)
         session_id = session_entry.session_id
 
         if not self._session_db:
@@ -3640,7 +3643,7 @@ class GatewaySlashCommandsMixin:
             return t("gateway.resume.blocked_not_owner", name=name)
 
         # Check if already on that session
-        current_entry = await self.async_session_store.get_or_create_session(source)
+        current_entry = await self._get_or_create_session_at_process_delivery_boundary(source)
         if current_entry.session_id == target_id:
             return t("gateway.resume.already_on", name=name)
 
@@ -3648,7 +3651,9 @@ class GatewaySlashCommandsMixin:
         self._release_running_agent_state(session_key)
 
         # Switch the session entry to point at the old session
-        new_entry = await self.async_session_store.switch_session(session_key, target_id)
+        new_entry = await self._switch_session_at_process_delivery_boundary(
+            session_key, target_id
+        )
         if not new_entry:
             return t("gateway.resume.switch_failed")
         self._clear_session_boundary_security_state(session_key)
@@ -3736,7 +3741,7 @@ class GatewaySlashCommandsMixin:
         # `/sessions all` and enumerate other origins' session ids / titles /
         # previews / sources — the enumeration half of the /resume IDOR.
         cross_origin = include_all and self._resume_caller_is_admin(source)
-        current_entry = await self.async_session_store.get_or_create_session(source)
+        current_entry = await self._get_or_create_session_at_process_delivery_boundary(source)
         rows = await asyncio.to_thread(
             query_session_listing,
             getattr(self._session_db, "_db", self._session_db),
@@ -3785,7 +3790,7 @@ class GatewaySlashCommandsMixin:
         session_key = self._session_key_for_source(source)
 
         # Load the current session and its transcript
-        current_entry = await self.async_session_store.get_or_create_session(source)
+        current_entry = await self._get_or_create_session_at_process_delivery_boundary(source)
         history = await self.async_session_store.load_transcript(current_entry.session_id)
         if not history:
             return t("gateway.branch.no_conversation")
@@ -3853,7 +3858,9 @@ class GatewaySlashCommandsMixin:
             pass
 
         # Switch the session store entry to the new session
-        new_entry = await self.async_session_store.switch_session(session_key, new_session_id)
+        new_entry = await self._switch_session_at_process_delivery_boundary(
+            session_key, new_session_id
+        )
         if not new_entry:
             return t("gateway.branch.switch_failed")
         self._clear_session_boundary_security_state(session_key)
@@ -3899,7 +3906,7 @@ class GatewaySlashCommandsMixin:
             lines.append("Complete your top-up in the browser — credits will appear in /credits shortly.")
         return "\n".join(lines)
 
-    def _context_breakdown_lines(self, agent, source) -> list[str]:
+    def _context_breakdown_lines(self, agent, history: list[dict]) -> list[str]:
         """Render the per-category context breakdown for /usage.
 
         Estimated (chars/4) — same engine the desktop popover uses. Returns an
@@ -3907,13 +3914,6 @@ class GatewaySlashCommandsMixin:
         """
         try:
             from agent.context_breakdown import compute_session_context_breakdown
-
-            history: list[dict] = []
-            try:
-                entry = self.session_store.get_or_create_session(source)
-                history = self.session_store.load_transcript(entry.session_id) or []
-            except Exception:
-                history = []
 
             payload = compute_session_context_breakdown(agent, history)
             categories = payload.get("categories") or []
@@ -3971,7 +3971,7 @@ class GatewaySlashCommandsMixin:
         api_key = getattr(agent, "api_key", None) if agent and agent is not _AGENT_PENDING_SENTINEL else None
         if not provider and getattr(self, "_session_db", None) is not None:
             try:
-                _entry_for_billing = await self.async_session_store.get_or_create_session(source)
+                _entry_for_billing = await self._get_or_create_session_at_process_delivery_boundary(source)
                 persisted = await self._session_db.get_session(_entry_for_billing.session_id) or {}
             except Exception:
                 persisted = {}
@@ -4044,8 +4044,20 @@ class GatewaySlashCommandsMixin:
             # Same engine the desktop popover uses (PR #54907). The system
             # prompt / tools / skills / memory slices read off the live agent;
             # the conversation slice is estimated from the session transcript.
+            try:
+                session_entry = await self._get_or_create_session_at_process_delivery_boundary(
+                    source
+                )
+                history = (
+                    await self.async_session_store.load_transcript(
+                        session_entry.session_id
+                    )
+                    or []
+                )
+            except Exception:
+                history = []
             breakdown_lines = await asyncio.to_thread(
-                self._context_breakdown_lines, agent, source
+                self._context_breakdown_lines, agent, history
             )
             if breakdown_lines:
                 lines.append("")
@@ -4061,7 +4073,7 @@ class GatewaySlashCommandsMixin:
             return "\n".join(lines)
 
         # No agent at all -- check session history for a rough count
-        session_entry = await self.async_session_store.get_or_create_session(source)
+        session_entry = await self._get_or_create_session_at_process_delivery_boundary(source)
         history = await self.async_session_store.load_transcript(session_entry.session_id)
         if history:
             from agent.model_metadata import estimate_messages_tokens_rough

--- a/hermes_cli/context_switch_guard.py
+++ b/hermes_cli/context_switch_guard.py
@@ -12,6 +12,7 @@ so Herm TUI, CLI, and gateway surfaces that already show switch warnings pick it
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any, Callable, List, Optional
 
 from agent.model_metadata import MINIMUM_CONTEXT_LENGTH
@@ -119,7 +120,7 @@ def merge_preflight_compression_warning(
     _append_warning(result, "".join(parts))
 
 
-def enrich_model_switch_warnings_for_gateway(
+async def enrich_model_switch_warnings_for_gateway(
     result: ModelSwitchResult,
     runner: Any,
     *,
@@ -152,11 +153,24 @@ def enrich_model_switch_warnings_for_gateway(
 
     messages = None
     db = getattr(runner, "_session_db", None)
-    store = getattr(runner, "session_store", None)
-    if db is not None and store is not None:
+    resolve_entry = getattr(
+        runner, "_get_or_create_session_at_process_delivery_boundary", None
+    )
+    if db is not None and resolve_entry is not None:
         try:
-            entry = store.get_or_create_session(source)
-            messages = db.get_messages_as_conversation(entry.session_id)
+            resolved_messages: dict[str, Any] = {}
+
+            async def _read_messages(entry: Any) -> None:
+                resolved_messages["value"] = await asyncio.to_thread(
+                    db.get_messages_as_conversation, entry.session_id
+                )
+
+            await resolve_entry(
+                source,
+                session_key,
+                operation=_read_messages,
+            )
+            messages = resolved_messages.get("value")
         except Exception:
             pass
 

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2471,7 +2471,7 @@ class SlackAdapter(BasePlatformAdapter):
             return merged
         return metadata
 
-    def _seed_assistant_thread_session(self, metadata: Dict[str, str]) -> None:
+    async def _seed_assistant_thread_session(self, metadata: Dict[str, str]) -> None:
         """Prime the session store so assistant threads get stable user scoping."""
         session_store = getattr(self, "_session_store", None)
         if not session_store:
@@ -2493,7 +2493,7 @@ class SlackAdapter(BasePlatformAdapter):
         )
 
         try:
-            session_store.get_or_create_session(source)
+            await self.resolve_session_entry(source)
         except Exception:
             logger.debug(
                 "[Slack] Failed to seed assistant thread session for %s/%s",
@@ -2506,7 +2506,7 @@ class SlackAdapter(BasePlatformAdapter):
         """Handle Slack Assistant lifecycle events that carry user/thread identity."""
         metadata = self._extract_assistant_thread_metadata(event)
         self._cache_assistant_thread_metadata(metadata)
-        self._seed_assistant_thread_session(metadata)
+        await self._seed_assistant_thread_session(metadata)
 
     async def _handle_slack_file_shared(self, event: dict) -> None:
         """Fallback for Slack file shares that do not arrive as message.files.

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -7328,7 +7328,7 @@ class TelegramAdapter(BasePlatformAdapter):
         )
         event.text = self._append_observed_note(event.text, agent_note)
 
-    def _observe_unmentioned_group_message(
+    async def _observe_unmentioned_group_message(
         self,
         message: Message,
         msg_type: MessageType,
@@ -7342,7 +7342,7 @@ class TelegramAdapter(BasePlatformAdapter):
         try:
             event = event or self._build_message_event(message, msg_type, update_id=update_id)
             shared_source = self._telegram_group_observe_shared_source(event.source)
-            session_entry = store.get_or_create_session(shared_source)
+            session_entry = await self.resolve_session_entry(shared_source)
             entry = {
                 "role": "user",
                 "content": self._telegram_group_observe_attributed_text(event),
@@ -7523,7 +7523,7 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         if not self._should_process_message(msg):
             if self._should_observe_unmentioned_group_message(msg):
-                self._observe_unmentioned_group_message(msg, MessageType.TEXT, update_id=update.update_id)
+                await self._observe_unmentioned_group_message(msg, MessageType.TEXT, update_id=update.update_id)
             return
         await self._ensure_forum_commands(update.message)
 
@@ -7569,7 +7569,7 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         if not self._should_process_message(msg):
             if self._should_observe_unmentioned_group_message(msg):
-                self._observe_unmentioned_group_message(msg, MessageType.LOCATION, update_id=update.update_id)
+                await self._observe_unmentioned_group_message(msg, MessageType.LOCATION, update_id=update.update_id)
             return
 
         venue = getattr(msg, "venue", None)
@@ -7778,7 +7778,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 if _m.caption:
                     _event.text = self._clean_bot_trigger_text(_m.caption)
                 await self._cache_observed_media(_m, _event)
-                self._observe_unmentioned_group_message(
+                await self._observe_unmentioned_group_message(
                     _m, _event.message_type, update_id=update.update_id, event=_event
                 )
             return

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1,5 +1,6 @@
 """Tests for cron/scheduler.py — origin resolution, delivery routing, and error logging."""
 
+import asyncio
 import contextlib
 import itertools
 import json
@@ -4516,20 +4517,58 @@ class TestCronDeliveryMirror:
         store = MagicMock()
         adapter = MagicMock()
         adapter._session_store = store
+        resolved_sources = []
 
-        with patch("gateway.mirror.mirror_to_session", return_value=True) as mirror_mock:
+        async def _resolve(source, *, operation=None):
+            resolved_sources.append(source)
+            entry = MagicMock(session_id="thread-session")
+            if operation is not None:
+                operation(entry)
+            return entry
+
+        adapter.resolve_session_entry = AsyncMock(side_effect=_resolve)
+
+        def _run_now(coro, _loop):
+            from concurrent.futures import Future
+
+            future = Future()
+            future.set_result(asyncio.run(coro))
+            return future
+
+        with patch("agent.async_utils.safe_schedule_threadsafe", side_effect=_run_now), \
+             patch("gateway.mirror.mirror_to_session", return_value=True) as mirror_mock:
             _seed_cron_thread_session(
                 {"id": "j1"}, adapter, "telegram", "123", "9001",
-                "Daily brief Task #2", chat_name="Ops",
+                "Daily brief Task #2", chat_name="Ops", loop=MagicMock(),
             )
 
-        # Session row created for the thread, then brief mirrored into it.
-        store.get_or_create_session.assert_called_once()
-        seeded_source = store.get_or_create_session.call_args[0][0]
+        adapter.resolve_session_entry.assert_awaited_once()
+        seeded_source = resolved_sources[0]
         assert seeded_source.chat_type == "thread"
         assert seeded_source.thread_id == "9001"
+        store.append_to_transcript.assert_called_once()
+        assert store.append_to_transcript.call_args.args[0] == "thread-session"
+        mirror_mock.assert_not_called()
+
+    def test_seed_thread_session_no_loop_uses_legacy_mirror_fallback(self):
+        from cron.scheduler import _seed_cron_thread_session
+
+        adapter = MagicMock()
+        adapter._session_store = MagicMock()
+        with patch("gateway.mirror.mirror_to_session", return_value=True) as mirror_mock:
+            _seed_cron_thread_session(
+                {"id": "j1"},
+                adapter,
+                "telegram",
+                "123",
+                "9001",
+                "Daily brief",
+                loop=None,
+            )
+
+        adapter.resolve_session_entry.assert_not_called()
         mirror_mock.assert_called_once()
-        assert mirror_mock.call_args.kwargs.get("thread_id") == "9001"
+        assert mirror_mock.call_args.kwargs["thread_id"] == "9001"
 
     def test_seed_thread_session_noop_on_empty_text(self):
         from cron.scheduler import _seed_cron_thread_session
@@ -4625,6 +4664,16 @@ class TestCronContinuableSurfaceInChannel:
         # session and the brief is lost). Use a plain MagicMock store.
         if with_store:
             adapter._session_store = MagicMock()
+            adapter._resolved_session_sources = []
+
+            async def _resolve(source, *, operation=None):
+                adapter._resolved_session_sources.append(source)
+                entry = MagicMock(session_id="cron-seeded-session")
+                if operation is not None:
+                    operation(entry)
+                return entry
+
+            adapter.resolve_session_entry.side_effect = _resolve
         return adapter
 
     def test_in_channel_skips_thread_open(self):
@@ -4645,9 +4694,9 @@ class TestCronContinuableSurfaceInChannel:
         _, mirror_mock = self._run_inchannel_delivery(
             {"cron_continuable_surface": "in_channel"}, adapter,
         )
-        # The flat session row must be CREATED (this is what was missing).
-        adapter._session_store.get_or_create_session.assert_called_once()
-        seeded = adapter._session_store.get_or_create_session.call_args[0][0]
+        # The flat session row must be resolved through the gateway boundary.
+        adapter.resolve_session_entry.assert_awaited_once()
+        seeded = adapter._resolved_session_sources[0]
         assert seeded.thread_id is None, "seed must be flat (thread_id=None)"
         assert seeded.chat_type == "group", "a channel (non-D) keys as group"
         assert str(seeded.chat_id) == "C123"
@@ -4655,12 +4704,12 @@ class TestCronContinuableSurfaceInChannel:
             "channel session key embeds user_id — the seed MUST use the origin "
             "user's id or the inbound reply keys to a different session"
         )
-        # Brief mirrored flat into that row.
-        mirror_mock.assert_called_once()
-        assert mirror_mock.call_args.kwargs.get("thread_id") is None
-        assert mirror_mock.call_args[0][0] == "slack"
-        assert mirror_mock.call_args[0][1] == "C123"
-        assert "Here is today's brief." in mirror_mock.call_args[0][2]
+        # Brief appended to the exact resolved session under the same boundary.
+        adapter._session_store.append_to_transcript.assert_called_once()
+        appended = adapter._session_store.append_to_transcript.call_args
+        assert appended.args[0] == "cron-seeded-session"
+        assert "Here is today's brief." in appended.args[1]["content"]
+        mirror_mock.assert_not_called()
 
     def test_in_channel_dm_seeds_dm_session(self):
         """1:1 DM (chat_id starts with 'D'): the flat session is created with
@@ -4672,13 +4721,13 @@ class TestCronContinuableSurfaceInChannel:
             {"cron_continuable_surface": "in_channel"}, adapter,
             origin={"platform": "slack", "chat_id": "D999", "user_id": "U_HUMAN"},
         )
-        adapter._session_store.get_or_create_session.assert_called_once()
-        seeded = adapter._session_store.get_or_create_session.call_args[0][0]
+        adapter.resolve_session_entry.assert_awaited_once()
+        seeded = adapter._resolved_session_sources[0]
         assert seeded.chat_type == "dm", "a DM (chat_id starts with 'D') keys as dm"
         assert seeded.thread_id is None
         assert str(seeded.chat_id) == "D999"
-        mirror_mock.assert_called_once()
-        assert mirror_mock.call_args.kwargs.get("thread_id") is None
+        adapter._session_store.append_to_transcript.assert_called_once()
+        mirror_mock.assert_not_called()
 
     def test_thread_mode_default_still_opens_thread(self):
         """G1 regression: the default (thread) mode is byte-identical — the
@@ -4728,14 +4777,33 @@ class TestCronContinuableSurfaceInChannel:
         store = MagicMock()
         adapter = MagicMock()
         adapter._session_store = store
+        resolved_sources = []
 
-        with patch("gateway.mirror.mirror_to_session", return_value=True) as mirror_mock:
+        async def _resolve(source, *, operation=None):
+            resolved_sources.append(source)
+            entry = MagicMock(session_id="channel-session")
+            if operation is not None:
+                operation(entry)
+            return entry
+
+        adapter.resolve_session_entry = AsyncMock(side_effect=_resolve)
+
+        def _run_now(coro, _loop):
+            from concurrent.futures import Future
+
+            future = Future()
+            future.set_result(asyncio.run(coro))
+            return future
+
+        with patch("agent.async_utils.safe_schedule_threadsafe", side_effect=_run_now), \
+             patch("gateway.mirror.mirror_to_session", return_value=True) as mirror_mock:
             ok = _seed_cron_channel_session(
                 {"id": "j1", "name": "Brief"}, adapter, "slack", "C123",
                 "Daily brief", is_dm=False, user_id="U_HUMAN", chat_name="ops",
+                loop=MagicMock(),
             )
         assert ok is True
-        seeded_source = store.get_or_create_session.call_args[0][0]
+        seeded_source = resolved_sources[0]
         seed_key = build_session_key(seeded_source)
 
         # What a plain top-level channel reply (reply_in_thread:false → thread
@@ -4748,9 +4816,9 @@ class TestCronContinuableSurfaceInChannel:
             f"seed key {seed_key} != inbound reply key {build_session_key(inbound)} "
             "— the reply would NOT continue the seeded session"
         )
-        mirror_mock.assert_called_once()
-        assert mirror_mock.call_args.kwargs.get("thread_id") is None
-        assert mirror_mock.call_args.kwargs.get("user_id") == "U_HUMAN"
+        store.append_to_transcript.assert_called_once()
+        assert store.append_to_transcript.call_args.args[0] == "channel-session"
+        mirror_mock.assert_not_called()
 
     def test_seed_channel_session_key_matches_inbound_dm_reply(self):
         """DM case: seeded key (chat_type=dm) equals the inbound DM reply key.
@@ -4763,19 +4831,63 @@ class TestCronContinuableSurfaceInChannel:
         store = MagicMock()
         adapter = MagicMock()
         adapter._session_store = store
+        resolved_sources = []
 
-        with patch("gateway.mirror.mirror_to_session", return_value=True):
+        async def _resolve(source, *, operation=None):
+            resolved_sources.append(source)
+            entry = MagicMock(session_id="dm-session")
+            if operation is not None:
+                operation(entry)
+            return entry
+
+        adapter.resolve_session_entry = AsyncMock(side_effect=_resolve)
+
+        def _run_now(coro, _loop):
+            from concurrent.futures import Future
+
+            future = Future()
+            future.set_result(asyncio.run(coro))
+            return future
+
+        with patch("agent.async_utils.safe_schedule_threadsafe", side_effect=_run_now), \
+             patch("gateway.mirror.mirror_to_session", return_value=True) as mirror_mock:
             _seed_cron_channel_session(
                 {"id": "j1"}, adapter, "slack", "D999", "Daily brief",
-                is_dm=True, user_id="U_HUMAN",
+                is_dm=True, user_id="U_HUMAN", loop=MagicMock(),
             )
-        seeded_source = store.get_or_create_session.call_args[0][0]
+        seeded_source = resolved_sources[0]
         inbound = SessionSource(
             platform=Platform.SLACK, chat_id="D999", chat_type="dm",
             user_id="U_HUMAN", thread_id=None,
         )
         assert build_session_key(seeded_source) == build_session_key(inbound)
         assert seeded_source.chat_type == "dm"
+        store.append_to_transcript.assert_called_once()
+        assert store.append_to_transcript.call_args.args[0] == "dm-session"
+        mirror_mock.assert_not_called()
+
+    def test_seed_channel_session_no_loop_uses_legacy_mirror_fallback(self):
+        from cron.scheduler import _seed_cron_channel_session
+
+        adapter = MagicMock()
+        adapter._session_store = MagicMock()
+        with patch("gateway.mirror.mirror_to_session", return_value=True) as mirror_mock:
+            ok = _seed_cron_channel_session(
+                {"id": "j1"},
+                adapter,
+                "slack",
+                "C123",
+                "Daily brief",
+                is_dm=False,
+                user_id="U_HUMAN",
+                loop=None,
+            )
+
+        assert ok is True
+        adapter.resolve_session_entry.assert_not_called()
+        mirror_mock.assert_called_once()
+        assert mirror_mock.call_args.kwargs["thread_id"] is None
+        assert mirror_mock.call_args.kwargs["user_id"] == "U_HUMAN"
 
     def test_seed_channel_session_noop_on_empty_text(self):
         from cron.scheduler import _seed_cron_channel_session

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -789,6 +789,1707 @@ async def test_stamped_process_turn_does_not_drain_queued_foreground_message(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("process_exit", ["complete", "cancel", "reset"])
+async def test_foreground_adapter_task_waits_once_for_stamped_process_owner(
+    monkeypatch, tmp_path, process_exit
+):
+    from gateway.platforms.base import MessageEvent, MessageType
+    from gateway.session import SessionSource
+    from tests.gateway.restart_test_helpers import RestartTestAdapter
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    runner._run_and_deliver_stamped_process_event = (
+        GatewayRunner._run_and_deliver_stamped_process_event.__get__(
+            runner, GatewayRunner
+        )
+    )
+    adapter = RestartTestAdapter()
+    adapter.config.typing_indicator = False
+    runner.adapters[Platform.TELEGRAM] = adapter
+    monkeypatch.setattr(runner, "_is_user_authorized", lambda _source: True)
+    monkeypatch.setattr(
+        runner, "_process_notification_run_is_current", lambda **_kwargs: True
+    )
+    session_key = "agent:main:telegram:dm:process-owner"
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="process-owner",
+        chat_type="dm",
+        user_id="user",
+    )
+    process_event = MessageEvent(
+        text="[SYSTEM: process completion]",
+        message_type=MessageType.TEXT,
+        source=source,
+        internal=True,
+        metadata={"expected_gateway_session_id": "sess-old"},
+    )
+    foreground_event = MessageEvent(
+        text="normal foreground request",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+    process_started = asyncio.Event()
+    release_process = asyncio.Event()
+    drain_started = asyncio.Event()
+    release_drain = asyncio.Event()
+    owner = SimpleNamespace(interrupt=MagicMock())
+
+    async def _synthetic_agent_handler(_event, _source, key, generation):
+        nonlocal dispatches_while_blocked
+        assert key == session_key
+        assert generation == process_event.metadata["gateway_run_generation"]
+        runner._running_agents[session_key] = owner
+        runner._stamped_process_running_agents[session_key] = owner
+        process_started.set()
+        try:
+            await release_process.wait()
+        finally:
+            dispatches_while_blocked = foreground_dispatches
+        return None
+
+    foreground_dispatches = 0
+    normal_turns = 0
+    dispatches_while_blocked = 0
+
+    async def _foreground_handler(event):
+        nonlocal foreground_dispatches, normal_turns
+        foreground_dispatches += 1
+        if foreground_dispatches >= 20:
+            # Bound the known-bad hot loop so the RED regression terminates.
+            release_process.set()
+        if session_key in runner._running_agents:
+            await runner._handle_active_session_busy_message(event, session_key)
+        else:
+            normal_turns += 1
+        return None
+
+    monkeypatch.setattr(
+        runner, "_handle_message_with_agent", _synthetic_agent_handler
+    )
+    original_flush = adapter._flush_text_debounce_now
+
+    async def _flush_with_reset_gap(key):
+        if (
+            process_exit == "reset"
+            and release_process.is_set()
+            and not drain_started.is_set()
+        ):
+            drain_started.set()
+            await release_drain.wait()
+        await original_flush(key)
+
+    monkeypatch.setattr(adapter, "_flush_text_debounce_now", _flush_with_reset_gap)
+    adapter.set_message_handler(_foreground_handler)
+    adapter.set_busy_session_handler(runner._handle_active_session_busy_message)
+
+    process_task = asyncio.create_task(
+        runner._run_and_deliver_stamped_process_event(
+            process_event,
+            adapter=adapter,
+            session_key=session_key,
+        )
+    )
+    await process_started.wait()
+    release_claim = runner._stamped_process_release_events[session_key]
+    assert release_claim.generation == process_event.metadata[
+        "gateway_run_generation"
+    ]
+    try:
+        await adapter.handle_message(foreground_event)
+        for _ in range(50):
+            if foreground_dispatches == 1:
+                break
+            await asyncio.sleep(0.01)
+        assert foreground_dispatches == 1
+        interrupt_event = adapter._active_sessions[session_key]
+        assert (
+            getattr(
+                interrupt_event,
+                "_hermes_stamped_process_release_event",
+                None,
+            )
+            is release_claim.event
+        )
+        assert not process_task.done()
+        if process_exit == "cancel":
+            process_task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await process_task
+        elif process_exit == "reset":
+            release_process.set()
+            await process_task
+            await asyncio.wait_for(drain_started.wait(), timeout=2)
+            await runner._interrupt_and_clear_session(
+                session_key,
+                source,
+                interrupt_reason="test reset",
+                invalidation_reason="test reset",
+            )
+            release_drain.set()
+        else:
+            release_process.set()
+            await process_task
+        expected_normal_turns = 0 if process_exit == "reset" else 1
+        for _ in range(50):
+            if (
+                normal_turns == expected_normal_turns
+                and not adapter._background_tasks
+            ):
+                break
+            await asyncio.sleep(0.01)
+        assert dispatches_while_blocked == 1
+        assert foreground_dispatches == 1 + expected_normal_turns
+        assert normal_turns == expected_normal_turns
+
+        assert session_key not in adapter._pending_messages
+    finally:
+        release_process.set()
+        release_drain.set()
+        if not process_task.done():
+            process_task.cancel()
+        await asyncio.gather(process_task, return_exceptions=True)
+        await adapter.cancel_background_tasks()
+        adapter._pending_messages.clear()
+        runner._release_running_agent_state(session_key)
+
+
+@pytest.mark.asyncio
+async def test_new_stamped_generation_rebinds_existing_adapter_guard(
+    monkeypatch, tmp_path
+):
+    from gateway.platforms.base import MessageEvent, MessageType
+    from gateway.session import SessionSource
+    from tests.gateway.restart_test_helpers import RestartTestAdapter
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    runner._run_and_deliver_stamped_process_event = (
+        GatewayRunner._run_and_deliver_stamped_process_event.__get__(
+            runner, GatewayRunner
+        )
+    )
+    adapter = RestartTestAdapter()
+    adapter.config.typing_indicator = False
+    runner.adapters[Platform.TELEGRAM] = adapter
+    monkeypatch.setattr(runner, "_is_user_authorized", lambda _source: True)
+    monkeypatch.setattr(
+        runner, "_process_notification_run_is_current", lambda **_kwargs: True
+    )
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="overlapping-process-owner",
+        chat_type="dm",
+        user_id="user",
+    )
+    session_key = runner._session_key_for_source(source)
+    process_event = MessageEvent(
+        text="[SYSTEM: second process completion]",
+        message_type=MessageType.TEXT,
+        source=source,
+        internal=True,
+        metadata={"expected_gateway_session_id": "sess-old"},
+    )
+    adapter_guard = asyncio.Event()
+    stale_release_event = asyncio.Event()
+    stale_release_event.set()
+    setattr(
+        adapter_guard,
+        "_hermes_stamped_process_release_event",
+        stale_release_event,
+    )
+    adapter._active_sessions[session_key] = adapter_guard
+
+    async def _assert_rebound(_event, _source, key, generation):
+        assert key == session_key
+        claim = runner._stamped_process_release_events[key]
+        assert claim.generation == generation
+        assert (
+            getattr(
+                adapter_guard,
+                "_hermes_stamped_process_release_event",
+                None,
+            )
+            is claim.event
+        )
+        return None
+
+    monkeypatch.setattr(runner, "_handle_message_with_agent", _assert_rebound)
+
+    await runner._run_and_deliver_stamped_process_event(
+        process_event,
+        adapter=adapter,
+        session_key=session_key,
+    )
+
+    assert session_key not in runner._stamped_process_release_events
+    assert getattr(
+        process_event, "_hermes_stamped_process_release_claim"
+    ).event.is_set()
+
+
+@pytest.mark.asyncio
+async def test_busy_handler_snapshots_stamped_owner_under_publication_lock(
+    monkeypatch, tmp_path
+):
+    from gateway.platforms.base import MessageEvent, MessageType
+    from gateway.session import SessionSource
+    from tests.gateway.restart_test_helpers import RestartTestAdapter
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    monkeypatch.setattr(runner, "_is_user_authorized", lambda _source: True)
+    adapter = RestartTestAdapter()
+    adapter.config.typing_indicator = False
+    runner.adapters[Platform.TELEGRAM] = adapter
+    runner._busy_input_mode = "steer"
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="publication-lock",
+        chat_type="dm",
+        user_id="user",
+    )
+    session_key = runner._session_key_for_source(source)
+    event = MessageEvent(
+        text="must be retained",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+    pending_owner = SimpleNamespace(interrupt=MagicMock())
+    concrete_owner = SimpleNamespace(
+        interrupt=MagicMock(),
+        steer=MagicMock(return_value=True),
+    )
+    runner._running_agents[session_key] = pending_owner
+    runner._stamped_process_running_agents[session_key] = pending_owner
+    publication_halfway = threading.Event()
+    publication_finished = threading.Event()
+    release_publication = threading.Event()
+
+    def _publish_concrete_owner():
+        with runner._running_agent_state_lock:
+            runner._running_agents[session_key] = concrete_owner
+            publication_halfway.set()
+            assert release_publication.wait(timeout=5)
+            runner._stamped_process_running_agents[session_key] = concrete_owner
+        publication_finished.set()
+
+    publisher = threading.Thread(target=_publish_concrete_owner)
+    publisher.start()
+    assert await asyncio.to_thread(publication_halfway.wait, 5)
+    release_timer = threading.Timer(0.1, release_publication.set)
+    release_timer.start()
+    try:
+        result = await runner._handle_active_session_busy_message(
+            event, session_key
+        )
+        assert publication_finished.is_set()
+    finally:
+        release_publication.set()
+        release_timer.cancel()
+        await asyncio.to_thread(publisher.join, 5)
+
+    assert result is True
+    concrete_owner.interrupt.assert_not_called()
+    concrete_owner.steer.assert_not_called()
+    assert adapter._pending_messages[session_key] is event
+
+
+@pytest.mark.asyncio
+async def test_explicit_steer_is_queued_behind_stamped_process_owner(
+    monkeypatch, tmp_path
+):
+    from gateway.platforms.base import MessageEvent, MessageType
+    from gateway.session import SessionSource
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    monkeypatch.setattr(runner, "_is_user_authorized", lambda _source: True)
+    adapter = runner.adapters[Platform.TELEGRAM]
+    adapter._pending_messages = {}
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="explicit-steer-process-owner",
+        chat_type="dm",
+        user_id="user",
+    )
+    session_key = runner._session_key_for_source(source)
+    process_owner = SimpleNamespace(
+        interrupt=MagicMock(),
+        steer=MagicMock(return_value=True),
+    )
+    runner._running_agents[session_key] = process_owner
+    runner._stamped_process_running_agents[session_key] = process_owner
+    event = MessageEvent(
+        text="/steer retain this",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+
+    response = await runner._handle_message(event)
+
+    assert "queued" in str(response).lower()
+    process_owner.interrupt.assert_not_called()
+    process_owner.steer.assert_not_called()
+    assert adapter._pending_messages[session_key].text == "retain this"
+
+    second = MessageEvent(
+        text="second",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+    runner._queue_or_replace_pending_event(session_key, second)
+    assert adapter._pending_messages[session_key].text == "retain this"
+    assert [item.text for item in runner._queued_events[session_key]] == ["second"]
+
+
+@pytest.mark.asyncio
+async def test_stamped_owner_remains_published_through_guarded_send(
+    monkeypatch, tmp_path
+):
+    from gateway.platforms.base import MessageEvent, MessageType
+    from gateway.session import SessionSource
+    from tests.gateway.restart_test_helpers import RestartTestAdapter
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    runner._run_and_deliver_stamped_process_event = (
+        GatewayRunner._run_and_deliver_stamped_process_event.__get__(
+            runner, GatewayRunner
+        )
+    )
+    adapter = RestartTestAdapter()
+    adapter.config.typing_indicator = False
+    runner.adapters[Platform.TELEGRAM] = adapter
+    monkeypatch.setattr(runner, "_is_user_authorized", lambda _source: True)
+    monkeypatch.setattr(
+        runner, "_process_notification_run_is_current", lambda **_kwargs: True
+    )
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="guarded-send-owner",
+        chat_type="dm",
+        user_id="user",
+    )
+    session_key = runner._session_key_for_source(source)
+    event = MessageEvent(
+        text="[SYSTEM: process completion]",
+        message_type=MessageType.TEXT,
+        source=source,
+        internal=True,
+        metadata={"expected_gateway_session_id": "sess-old"},
+    )
+    owner = SimpleNamespace(interrupt=MagicMock())
+    send_started = asyncio.Event()
+    release_send = asyncio.Event()
+
+    async def _synthetic_agent(_event, _source, key, _generation):
+        runner._running_agents[key] = owner
+        runner._stamped_process_running_agents[key] = owner
+        return {"final_response": "done"}
+
+    async def _blocked_send(*_args, **_kwargs):
+        send_started.set()
+        await release_send.wait()
+        return SimpleNamespace(success=True)
+
+    monkeypatch.setattr(runner, "_handle_message_with_agent", _synthetic_agent)
+    monkeypatch.setattr(adapter, "send", _blocked_send)
+
+    task = asyncio.create_task(
+        runner._run_and_deliver_stamped_process_event(
+            event,
+            adapter=adapter,
+            session_key=session_key,
+        )
+    )
+    await asyncio.wait_for(send_started.wait(), timeout=2)
+    try:
+        assert runner._running_agents[session_key] is owner
+        assert runner._stamped_process_running_agents[session_key] is owner
+    finally:
+        release_send.set()
+        await task
+
+    assert session_key not in runner._running_agents
+    assert session_key not in runner._stamped_process_running_agents
+
+
+@pytest.mark.asyncio
+async def test_adapter_waiter_follows_rebound_stamped_release_event():
+    from gateway.platforms.base import MessageEvent, MessageType
+    from gateway.session import SessionSource
+    from tests.gateway.restart_test_helpers import RestartTestAdapter
+
+    adapter = RestartTestAdapter()
+    adapter.config.typing_indicator = False
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="release-chain",
+        chat_type="dm",
+        user_id="user",
+    )
+    session_key = "agent:main:telegram:dm:release-chain"
+    first = MessageEvent(
+        text="first",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+    second = MessageEvent(
+        text="second",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+    first_dispatch = asyncio.Event()
+    dispatches = 0
+    release_a = asyncio.Event()
+    release_b = asyncio.Event()
+
+    async def _handler(_event):
+        nonlocal dispatches
+        dispatches += 1
+        if dispatches == 1:
+            guard = adapter._active_sessions[session_key]
+            setattr(
+                guard,
+                "_hermes_stamped_process_release_event",
+                release_a,
+            )
+            adapter._pending_messages[session_key] = second
+            first_dispatch.set()
+        return None
+
+    adapter.set_message_handler(_handler)
+    await adapter.handle_message(first)
+    await asyncio.wait_for(first_dispatch.wait(), timeout=2)
+    guard = adapter._active_sessions[session_key]
+    setattr(guard, "_hermes_stamped_process_release_event", release_b)
+
+    release_a.set()
+    await asyncio.sleep(0.05)
+    assert dispatches == 1
+
+    release_b.set()
+    for _ in range(50):
+        if dispatches == 2 and not adapter._background_tasks:
+            break
+        await asyncio.sleep(0.01)
+    assert dispatches == 2
+    await adapter.cancel_background_tasks()
+
+
+@pytest.mark.asyncio
+async def test_in_band_drain_rechecks_release_rebound_during_typing_stop():
+    from gateway.platforms.base import MessageEvent, MessageType
+    from gateway.session import SessionSource
+    from tests.gateway.restart_test_helpers import RestartTestAdapter
+
+    adapter = RestartTestAdapter()
+    adapter.config.typing_indicator = False
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="typing-release-rebind",
+        chat_type="dm",
+        user_id="user",
+    )
+    session_key = "agent:main:telegram:dm:typing-release-rebind"
+    first = MessageEvent(
+        text="first", message_type=MessageType.TEXT, source=source
+    )
+    second = MessageEvent(
+        text="second", message_type=MessageType.TEXT, source=source
+    )
+    first_dispatch = asyncio.Event()
+    stop_rebound = asyncio.Event()
+    release_a = asyncio.Event()
+    release_b = asyncio.Event()
+    dispatches = 0
+    stop_calls = 0
+
+    async def _handler(_event):
+        nonlocal dispatches
+        dispatches += 1
+        if dispatches == 1:
+            guard = adapter._active_sessions[session_key]
+            setattr(
+                guard,
+                "_hermes_stamped_process_release_event",
+                release_a,
+            )
+            adapter._pending_messages[session_key] = second
+            first_dispatch.set()
+        return None
+
+    async def _stop_typing(*_args, **_kwargs):
+        nonlocal stop_calls
+        stop_calls += 1
+        if stop_calls == 1:
+            guard = adapter._active_sessions[session_key]
+            setattr(
+                guard,
+                "_hermes_stamped_process_release_event",
+                release_b,
+            )
+            stop_rebound.set()
+
+    adapter.set_message_handler(_handler)
+    adapter._stop_typing_refresh = _stop_typing
+    await adapter.handle_message(first)
+    await asyncio.wait_for(first_dispatch.wait(), timeout=2)
+    release_a.set()
+    await asyncio.wait_for(stop_rebound.wait(), timeout=2)
+    await asyncio.sleep(0.05)
+    assert dispatches == 1
+    assert adapter._pending_messages[session_key] is second
+
+    release_b.set()
+    for _ in range(100):
+        if dispatches == 2 and not adapter._background_tasks:
+            break
+        await asyncio.sleep(0.01)
+    assert dispatches == 2
+    await adapter.cancel_background_tasks()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("handler_raises", [False, True])
+async def test_late_drain_waits_for_rebound_stamped_release_event(handler_raises):
+    from gateway.platforms.base import MessageEvent, MessageType
+    from gateway.session import SessionSource
+    from tests.gateway.restart_test_helpers import RestartTestAdapter
+
+    adapter = RestartTestAdapter()
+    adapter.config.typing_indicator = False
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id=f"late-release-chain-{handler_raises}",
+        chat_type="dm",
+        user_id="user",
+    )
+    session_key = (
+        f"agent:main:telegram:dm:late-release-chain-{handler_raises}"
+    )
+    first = MessageEvent(
+        text="first",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+    second = MessageEvent(
+        text="second",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+    dispatches = 0
+    stop_calls = 0
+    injected = asyncio.Event()
+    release_b = asyncio.Event()
+
+    async def _handler(_event):
+        nonlocal dispatches
+        dispatches += 1
+        if handler_raises and dispatches == 1:
+            raise RuntimeError("synthetic handler failure")
+        return None
+
+    async def _stop_typing(*_args, **_kwargs):
+        nonlocal stop_calls
+        stop_calls += 1
+        if stop_calls == 2:
+            guard = adapter._active_sessions[session_key]
+            setattr(
+                guard,
+                "_hermes_stamped_process_release_event",
+                release_b,
+            )
+            adapter._pending_messages[session_key] = second
+            injected.set()
+
+    adapter.set_message_handler(_handler)
+    adapter._stop_typing_refresh = _stop_typing
+    await adapter.handle_message(first)
+    await asyncio.wait_for(injected.wait(), timeout=2)
+    await asyncio.sleep(0.05)
+    assert dispatches == 1
+    assert adapter._pending_messages[session_key] is second
+
+    release_b.set()
+    for _ in range(100):
+        if dispatches == 2 and not adapter._background_tasks:
+            break
+        await asyncio.sleep(0.01)
+    assert dispatches == 2
+    await adapter.cancel_background_tasks()
+
+
+@pytest.mark.asyncio
+async def test_stale_finalizer_leaves_pending_for_replacement_command_guard():
+    from gateway.platforms.base import MessageEvent, MessageType
+    from gateway.session import SessionSource
+    from tests.gateway.restart_test_helpers import RestartTestAdapter
+
+    adapter = RestartTestAdapter()
+    adapter.config.typing_indicator = False
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="replacement-command-guard",
+        chat_type="dm",
+        user_id="user",
+    )
+    session_key = "agent:main:telegram:dm:replacement-command-guard"
+    first = MessageEvent(
+        text="first",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+    second = MessageEvent(
+        text="second",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+    command_guard = asyncio.Event()
+    command_guard.set()
+    dispatches = 0
+    stop_calls = 0
+    swapped = asyncio.Event()
+
+    async def _handler(_event):
+        nonlocal dispatches
+        dispatches += 1
+        return None
+
+    async def _stop_typing(*_args, **_kwargs):
+        nonlocal stop_calls
+        stop_calls += 1
+        if stop_calls == 2:
+            adapter._active_sessions[session_key] = command_guard
+            adapter._session_tasks.pop(session_key, None)
+            adapter._pending_messages[session_key] = second
+            swapped.set()
+
+    adapter.set_message_handler(_handler)
+    adapter._stop_typing_refresh = _stop_typing
+    await adapter.handle_message(first)
+    await asyncio.wait_for(swapped.wait(), timeout=2)
+    await asyncio.sleep(0.05)
+
+    assert dispatches == 1
+    assert adapter._active_sessions[session_key] is command_guard
+    assert command_guard.is_set()
+    assert adapter._pending_messages[session_key] is second
+
+    await adapter._drain_pending_after_session_command(
+        session_key, command_guard
+    )
+    for _ in range(100):
+        if dispatches == 2 and not adapter._background_tasks:
+            break
+        await asyncio.sleep(0.01)
+    assert dispatches == 2
+    await adapter.cancel_background_tasks()
+
+
+@pytest.mark.asyncio
+async def test_stale_command_drain_leaves_replacement_pending_owned():
+    from gateway.platforms.base import MessageEvent, MessageType
+    from gateway.session import SessionSource
+    from tests.gateway.restart_test_helpers import RestartTestAdapter
+
+    adapter = RestartTestAdapter()
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="stale-command-drain",
+        chat_type="dm",
+        user_id="user",
+    )
+    session_key = "agent:main:telegram:dm:stale-command-drain"
+    pending = MessageEvent(
+        text="replacement pending",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+    guard_a = asyncio.Event()
+    guard_b = asyncio.Event()
+    flush_entered = asyncio.Event()
+    release_flush = asyncio.Event()
+    started = []
+
+    async def _blocked_flush(_session_key):
+        flush_entered.set()
+        await release_flush.wait()
+
+    adapter._active_sessions[session_key] = guard_a
+    adapter._flush_text_debounce_now = _blocked_flush
+    adapter._start_session_processing = lambda event, key: started.append(
+        (event, key)
+    )
+
+    drain_a = asyncio.create_task(
+        adapter._drain_pending_after_session_command(session_key, guard_a)
+    )
+    await asyncio.wait_for(flush_entered.wait(), timeout=2)
+    adapter._active_sessions[session_key] = guard_b
+    adapter._pending_messages[session_key] = pending
+    release_flush.set()
+    await drain_a
+
+    assert adapter._active_sessions[session_key] is guard_b
+    assert adapter._pending_messages[session_key] is pending
+    assert started == []
+
+
+@pytest.mark.asyncio
+async def test_superseded_session_command_does_not_cancel_replacement_owner():
+    from gateway.platforms.base import MessageEvent, MessageType
+    from gateway.session import SessionSource
+    from tests.gateway.restart_test_helpers import RestartTestAdapter
+
+    adapter = RestartTestAdapter()
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="superseded-command",
+        chat_type="dm",
+        user_id="user",
+    )
+    session_key = "agent:main:telegram:dm:superseded-command"
+    event = MessageEvent(
+        text="/new",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+    old_guard = asyncio.Event()
+    replacement_guard = asyncio.Event()
+    handler_entered = asyncio.Event()
+    release_handler = asyncio.Event()
+
+    async def _handler(_event):
+        handler_entered.set()
+        await release_handler.wait()
+        return None
+
+    adapter.set_message_handler(_handler)
+    adapter._active_sessions[session_key] = old_guard
+    adapter.cancel_session_processing = AsyncMock()
+    adapter._drain_pending_after_session_command = AsyncMock()
+
+    command_a = asyncio.create_task(
+        adapter._dispatch_active_session_command(event, session_key, "new")
+    )
+    await asyncio.wait_for(handler_entered.wait(), timeout=2)
+    adapter._active_sessions[session_key] = replacement_guard
+    release_handler.set()
+    await command_a
+
+    assert adapter._active_sessions[session_key] is replacement_guard
+    adapter.cancel_session_processing.assert_not_awaited()
+    adapter._drain_pending_after_session_command.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reset_like_commands_serialize_through_response_delivery():
+    from gateway.platforms.base import MessageEvent, MessageType
+    from gateway.session import SessionSource
+    from tests.gateway.restart_test_helpers import RestartTestAdapter
+
+    adapter = RestartTestAdapter()
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="serialized-commands",
+        chat_type="dm",
+        user_id="user",
+    )
+    session_key = "agent:main:telegram:dm:serialized-commands"
+    command_a = MessageEvent(
+        text="/new",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+    command_b = MessageEvent(
+        text="/reset",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+    send_a_entered = asyncio.Event()
+    release_send_a = asyncio.Event()
+    handler_calls = []
+    deliveries = []
+
+    async def _handler(event):
+        handler_calls.append(event.text)
+        return event.text.upper()
+
+    async def _send(*_args, **kwargs):
+        content = kwargs["content"]
+        if content == "/NEW":
+            send_a_entered.set()
+            await release_send_a.wait()
+        deliveries.append(content)
+        return SimpleNamespace(success=True, message_id=None)
+
+    adapter.set_message_handler(_handler)
+    adapter._send_with_retry = _send
+    adapter._active_sessions[session_key] = asyncio.Event()
+
+    task_a = asyncio.create_task(
+        adapter._dispatch_active_session_command(
+            command_a, session_key, "new"
+        )
+    )
+    await asyncio.wait_for(send_a_entered.wait(), timeout=2)
+    task_b = asyncio.create_task(
+        adapter._dispatch_active_session_command(
+            command_b, session_key, "reset"
+        )
+    )
+    await asyncio.sleep(0.05)
+    assert handler_calls == ["/new"]
+    assert deliveries == []
+
+    release_send_a.set()
+    await asyncio.gather(task_a, task_b)
+    assert handler_calls == ["/new", "/reset"]
+    assert deliveries == ["/NEW", "/RESET"]
+
+
+@pytest.mark.asyncio
+async def test_cancelled_session_command_keeps_guard_until_live_owner_unwinds():
+    from gateway.platforms.base import MessageEvent, MessageType
+    from gateway.session import SessionSource
+    from tests.gateway.restart_test_helpers import RestartTestAdapter
+
+    adapter = RestartTestAdapter()
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="cancelled-command",
+        chat_type="dm",
+        user_id="user",
+    )
+    session_key = "agent:main:telegram:dm:cancelled-command"
+    event = MessageEvent(
+        text="/new",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+    old_guard = asyncio.Event()
+    handler_entered = asyncio.Event()
+    never_release = asyncio.Event()
+
+    async def _handler(_event):
+        handler_entered.set()
+        await never_release.wait()
+
+    adapter.set_message_handler(_handler)
+    adapter._active_sessions[session_key] = old_guard
+    adapter._session_tasks[session_key] = asyncio.create_task(
+        asyncio.sleep(60)
+    )
+
+    command_task = asyncio.create_task(
+        adapter._dispatch_active_session_command(event, session_key, "new")
+    )
+    await asyncio.wait_for(handler_entered.wait(), timeout=2)
+    command_guard = adapter._active_sessions[session_key]
+    assert command_guard is not old_guard
+    command_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await command_task
+
+    assert adapter._active_sessions[session_key] is command_guard
+    owner = adapter._session_tasks[session_key]
+    owner.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await owner
+    for _ in range(100):
+        if (
+            session_key not in adapter._active_sessions
+            and session_key not in adapter._session_tasks
+            and not adapter._background_tasks
+        ):
+            break
+        await asyncio.sleep(0.01)
+    assert session_key not in adapter._active_sessions
+    assert session_key not in adapter._session_tasks
+
+
+@pytest.mark.asyncio
+async def test_cancelled_session_command_drains_when_previous_owner_is_done():
+    from gateway.platforms.base import MessageEvent, MessageType
+    from gateway.session import SessionSource
+    from tests.gateway.restart_test_helpers import RestartTestAdapter
+
+    adapter = RestartTestAdapter()
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="cancelled-command-done-owner",
+        chat_type="dm",
+        user_id="user",
+    )
+    session_key = "agent:main:telegram:dm:cancelled-command-done-owner"
+    command_event = MessageEvent(
+        text="/new",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+    pending_event = MessageEvent(
+        text="pending-follow-up",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+    old_guard = asyncio.Event()
+    handler_entered = asyncio.Event()
+    pending_started = asyncio.Event()
+    owner_release = asyncio.Event()
+    flush_entered = asyncio.Event()
+    release_flush = asyncio.Event()
+
+    async def _blocked_flush(session_key):
+        del session_key
+        flush_entered.set()
+        await release_flush.wait()
+        return False
+
+    adapter._flush_text_debounce_now = _blocked_flush
+
+    async def _handler(event):
+        if event.text == "/new":
+            handler_entered.set()
+            await asyncio.Future()
+        else:
+            pending_started.set()
+
+    async def _owner():
+        await owner_release.wait()
+
+    adapter.set_message_handler(_handler)
+    adapter._active_sessions[session_key] = old_guard
+    owner_task = asyncio.create_task(_owner())
+    adapter._session_tasks[session_key] = owner_task
+
+    command_task = asyncio.create_task(
+        adapter._dispatch_active_session_command(
+            command_event, session_key, "new"
+        )
+    )
+    await handler_entered.wait()
+    command_guard = adapter._active_sessions[session_key]
+    adapter._pending_messages[session_key] = pending_event
+    owner_release.set()
+    await owner_task
+    assert adapter._session_tasks[session_key] is owner_task
+    assert owner_task.done()
+
+    command_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await command_task
+    await asyncio.wait_for(flush_entered.wait(), timeout=2)
+    # Repeated caller cancellation cannot reach the separately tracked drain.
+    command_task.cancel()
+    release_flush.set()
+    await asyncio.wait_for(pending_started.wait(), timeout=2)
+
+    assert adapter._active_sessions.get(session_key) is not old_guard
+    assert session_key not in adapter._pending_messages
+    for task in list(adapter._background_tasks):
+        if not task.done():
+            await task
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("owner_state", ["done", "live"])
+@pytest.mark.parametrize(
+    "publication_failure", ["raise", "sentinel", "callback"]
+)
+async def test_cancelled_command_drain_publication_failure_is_transactional(
+    monkeypatch, owner_state, publication_failure
+):
+    from gateway.platforms.base import MessageEvent, MessageType
+    from gateway.session import SessionSource
+    from tests.gateway.restart_test_helpers import RestartTestAdapter
+
+    adapter = RestartTestAdapter()
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id=f"cancelled-command-publish-failure-{owner_state}",
+        chat_type="dm",
+        user_id="user",
+    )
+    session_key = (
+        "agent:main:telegram:dm:cancelled-command-publish-failure-"
+        f"{owner_state}"
+    )
+    command_event = MessageEvent(
+        text="/new",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+    pending_event = MessageEvent(
+        text="preserve-on-publication-failure",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+    handler_entered = asyncio.Event()
+    owner_release = asyncio.Event()
+
+    async def _handler(_event):
+        handler_entered.set()
+        await asyncio.Future()
+
+    async def _owner():
+        if owner_state == "live":
+            await owner_release.wait()
+
+    adapter.set_message_handler(_handler)
+    old_guard = asyncio.Event()
+    adapter._active_sessions[session_key] = old_guard
+    owner_task = asyncio.create_task(_owner())
+    if owner_state == "done":
+        await owner_task
+    adapter._session_tasks[session_key] = owner_task
+
+    command_task = asyncio.create_task(
+        adapter._dispatch_active_session_command(
+            command_event, session_key, "new"
+        )
+    )
+    await handler_entered.wait()
+    command_guard = adapter._active_sessions[session_key]
+    adapter._pending_messages[session_key] = pending_event
+
+    create_attempts = 0
+
+    class _CallbackFailTask(asyncio.Task):
+        def add_done_callback(self, *_args, **_kwargs):
+            raise RuntimeError("forced add_done_callback failure")
+
+    def _fail_create_task(coroutine):
+        nonlocal create_attempts
+        create_attempts += 1
+        if publication_failure == "sentinel":
+            return object()
+        if publication_failure == "callback":
+            return _CallbackFailTask(
+                coroutine, loop=asyncio.get_running_loop()
+            )
+        raise RuntimeError("forced continuation publication failure")
+
+    monkeypatch.setattr(asyncio, "create_task", _fail_create_task)
+    command_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await command_task
+
+    if owner_state == "live":
+        assert adapter._active_sessions[session_key] is command_guard
+        owner_release.set()
+        await owner_task
+        await asyncio.sleep(0)
+    elif publication_failure == "callback":
+        await asyncio.sleep(0)
+
+    assert create_attempts == 1
+    assert session_key not in adapter._active_sessions
+    assert adapter._pending_messages[session_key] is pending_event
+    assert adapter._session_tasks[session_key] is owner_task
+    assert owner_task.done()
+    assert not adapter._background_tasks
+
+
+@pytest.mark.asyncio
+async def test_cancellation_waiters_keep_owner_published_until_unwind():
+    from tests.gateway.restart_test_helpers import RestartTestAdapter
+
+    adapter = RestartTestAdapter()
+    session_key = "agent:main:telegram:dm:cancel-waiters"
+    unwind_entered = asyncio.Event()
+    release_unwind = asyncio.Event()
+
+    async def _owner():
+        try:
+            await asyncio.Event().wait()
+        finally:
+            unwind_entered.set()
+            await release_unwind.wait()
+
+    owner = asyncio.create_task(_owner())
+    adapter._session_tasks[session_key] = owner
+    first = asyncio.create_task(
+        adapter.cancel_session_processing(
+            session_key,
+            release_guard=False,
+            discard_pending=False,
+        )
+    )
+    await asyncio.wait_for(unwind_entered.wait(), timeout=2)
+    assert adapter._session_tasks[session_key] is owner
+
+    second = asyncio.create_task(
+        adapter.cancel_session_processing(
+            session_key,
+            release_guard=False,
+            discard_pending=False,
+        )
+    )
+    await asyncio.sleep(0.05)
+    assert adapter._session_tasks[session_key] is owner
+    assert not first.done()
+    assert not second.done()
+
+    release_unwind.set()
+    await asyncio.gather(first, second)
+    assert session_key not in adapter._session_tasks
+
+
+@pytest.mark.asyncio
+async def test_command_cancellation_during_owner_unwind_defers_exact_drain():
+    from gateway.platforms.base import MessageEvent, MessageType
+    from gateway.session import SessionSource
+    from tests.gateway.restart_test_helpers import RestartTestAdapter
+
+    adapter = RestartTestAdapter()
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="cancel-during-unwind",
+        chat_type="dm",
+        user_id="user",
+    )
+    session_key = "agent:main:telegram:dm:cancel-during-unwind"
+    event = MessageEvent(
+        text="/new",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+    pending_event = MessageEvent(
+        text="pending-after-cancelled-command",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+    old_guard = asyncio.Event()
+    unwind_entered = asyncio.Event()
+    release_unwind = asyncio.Event()
+    dispatches = []
+
+    async def _owner():
+        try:
+            await asyncio.Event().wait()
+        finally:
+            unwind_entered.set()
+            await release_unwind.wait()
+
+    async def _handler(message_event):
+        dispatches.append(message_event.text)
+        return None
+
+    owner = asyncio.create_task(_owner())
+    adapter.set_message_handler(_handler)
+    adapter._active_sessions[session_key] = old_guard
+    adapter._session_tasks[session_key] = owner
+    command = asyncio.create_task(
+        adapter._dispatch_active_session_command(event, session_key, "new")
+    )
+    await asyncio.wait_for(unwind_entered.wait(), timeout=2)
+    command_guard = adapter._active_sessions[session_key]
+    adapter._pending_messages[session_key] = pending_event
+    command.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await command
+
+    assert adapter._active_sessions[session_key] is command_guard
+    assert adapter._session_tasks[session_key] is owner
+    release_unwind.set()
+    with pytest.raises(asyncio.CancelledError):
+        await owner
+    for _ in range(100):
+        if (
+            dispatches == ["/new", "pending-after-cancelled-command"]
+            and session_key not in adapter._pending_messages
+            and session_key not in adapter._active_sessions
+            and session_key not in adapter._session_tasks
+        ):
+            break
+        await asyncio.sleep(0.01)
+    assert dispatches == ["/new", "pending-after-cancelled-command"]
+    assert session_key not in adapter._pending_messages
+    assert session_key not in adapter._active_sessions
+    assert session_key not in adapter._session_tasks
+
+
+@pytest.mark.asyncio
+async def test_command_timeout_defers_pending_drain_until_owner_unwinds(
+    monkeypatch,
+):
+    import gateway.platforms.base as base_module
+    from gateway.platforms.base import MessageEvent, MessageType
+    from gateway.session import SessionSource
+    from tests.gateway.restart_test_helpers import RestartTestAdapter
+
+    monkeypatch.setattr(
+        base_module, "_SESSION_CANCEL_TIMEOUT_SECONDS", 0.01, raising=False
+    )
+    adapter = RestartTestAdapter()
+    adapter.config.typing_indicator = False
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="timeout-owner-unwind",
+        chat_type="dm",
+        user_id="user",
+    )
+    session_key = "agent:main:telegram:dm:timeout-owner-unwind"
+    command_event = MessageEvent(
+        text="/new",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+    pending_event = MessageEvent(
+        text="pending",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+    old_guard = asyncio.Event()
+    unwind_entered = asyncio.Event()
+    release_unwind = asyncio.Event()
+    dispatches = []
+
+    async def _owner():
+        try:
+            await asyncio.Event().wait()
+        finally:
+            unwind_entered.set()
+            await release_unwind.wait()
+
+    async def _handler(event):
+        dispatches.append(event.text)
+        return None
+
+    owner = asyncio.create_task(_owner())
+    adapter.set_message_handler(_handler)
+    adapter._active_sessions[session_key] = old_guard
+    adapter._session_tasks[session_key] = owner
+    adapter._pending_messages[session_key] = pending_event
+    await asyncio.sleep(0)
+
+    await adapter._dispatch_active_session_command(
+        command_event, session_key, "new"
+    )
+    assert unwind_entered.is_set()
+    assert not owner.done()
+    assert adapter._session_tasks[session_key] is owner
+    assert adapter._pending_messages[session_key] is pending_event
+    assert dispatches == ["/new"]
+
+    release_unwind.set()
+    with pytest.raises(asyncio.CancelledError):
+        await owner
+    for _ in range(100):
+        if dispatches == ["/new", "pending"]:
+            break
+        await asyncio.sleep(0.01)
+    assert dispatches == ["/new", "pending"]
+    await adapter.cancel_background_tasks()
+
+
+@pytest.mark.asyncio
+async def test_session_command_lock_registry_evicts_idle_entries():
+    from gateway.platforms.base import MessageEvent, MessageType
+    from gateway.session import SessionSource
+    from tests.gateway.restart_test_helpers import RestartTestAdapter
+
+    adapter = RestartTestAdapter()
+
+    async def _handler(_event):
+        return None
+
+    adapter.set_message_handler(_handler)
+    for index in range(250):
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id=f"lock-churn-{index}",
+            chat_type="dm",
+            user_id="user",
+        )
+        session_key = f"agent:main:telegram:dm:lock-churn-{index}"
+        adapter._active_sessions[session_key] = asyncio.Event()
+        await adapter._dispatch_active_session_command(
+            MessageEvent(
+                text="/new",
+                message_type=MessageType.TEXT,
+                source=source,
+            ),
+            session_key,
+            "new",
+        )
+
+    assert getattr(adapter, "_session_command_locks", {}) == {}
+
+
+@pytest.mark.asyncio
+async def test_deferred_drain_failure_recovers_exact_guard_and_pending():
+    from gateway.platforms.base import MessageEvent, MessageType
+    from gateway.session import SessionSource
+    from tests.gateway.restart_test_helpers import RestartTestAdapter
+
+    adapter = RestartTestAdapter()
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="deferred-drain-failure",
+        chat_type="dm",
+        user_id="user",
+    )
+    session_key = "agent:main:telegram:dm:deferred-drain-failure"
+    pending = MessageEvent(
+        text="pending",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+    command_guard = asyncio.Event()
+    owner = asyncio.create_task(asyncio.sleep(0))
+    await owner
+    started = []
+
+    adapter._active_sessions[session_key] = command_guard
+    adapter._pending_messages[session_key] = pending
+    adapter._drain_pending_after_session_command = AsyncMock(
+        side_effect=RuntimeError("forced deferred drain failure")
+    )
+
+    def _start_recovered(event, session_key_arg):
+        started.append((event, session_key_arg))
+        return True
+
+    adapter._start_session_processing = _start_recovered
+
+    adapter._defer_session_command_drain_until_owner_done(
+        session_key, command_guard, owner
+    )
+    for _ in range(100):
+        if started:
+            break
+        await asyncio.sleep(0.01)
+
+    assert started == [(pending, session_key)]
+    assert session_key not in adapter._active_sessions
+    assert session_key not in adapter._pending_messages
+    assert not adapter._background_tasks
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("startup_failure", ["false", "raise"])
+async def test_command_drain_restores_pending_when_startup_fails(
+    startup_failure,
+):
+    from gateway.platforms.base import MessageEvent, MessageType
+    from gateway.session import SessionSource
+    from tests.gateway.restart_test_helpers import RestartTestAdapter
+
+    adapter = RestartTestAdapter()
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="command-drain-startup-failure",
+        chat_type="dm",
+        user_id="user",
+    )
+    session_key = "agent:main:telegram:dm:command-drain-startup-failure"
+    pending = MessageEvent(
+        text="pending",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+    command_guard = asyncio.Event()
+    adapter._active_sessions[session_key] = command_guard
+    adapter._pending_messages[session_key] = pending
+    adapter._flush_text_debounce_now = AsyncMock()
+    if startup_failure == "raise":
+        adapter._start_session_processing = MagicMock(
+            side_effect=RuntimeError("forced startup failure")
+        )
+        with pytest.raises(RuntimeError, match="forced startup failure"):
+            await adapter._drain_pending_after_session_command(
+                session_key, command_guard
+            )
+    else:
+        adapter._start_session_processing = MagicMock(return_value=False)
+        await adapter._drain_pending_after_session_command(
+            session_key, command_guard
+        )
+
+    assert adapter._pending_messages[session_key] is pending
+    assert session_key not in adapter._active_sessions
+
+
+@pytest.mark.asyncio
+async def test_start_session_processing_rolls_back_when_create_task_raises(
+    monkeypatch,
+):
+    from gateway.platforms.base import MessageEvent, MessageType
+    from gateway.session import SessionSource
+    from tests.gateway.restart_test_helpers import RestartTestAdapter
+
+    adapter = RestartTestAdapter()
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="create-task-failure",
+        chat_type="dm",
+        user_id="user",
+    )
+    session_key = "agent:main:telegram:dm:create-task-failure"
+    event = MessageEvent(
+        text="pending",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+
+    def _raise_create_task(coro):
+        coro.close()
+        raise RuntimeError("forced create_task failure")
+
+    monkeypatch.setattr(asyncio, "create_task", _raise_create_task)
+    with pytest.raises(RuntimeError, match="forced create_task failure"):
+        adapter._start_session_processing(event, session_key)
+
+    assert session_key not in adapter._active_sessions
+    assert session_key not in adapter._session_tasks
+
+
+@pytest.mark.asyncio
+async def test_start_session_processing_rejects_hashable_non_task(
+    monkeypatch,
+):
+    import inspect
+
+    from gateway.platforms.base import MessageEvent, MessageType
+    from gateway.session import SessionSource
+    from tests.gateway.restart_test_helpers import RestartTestAdapter
+
+    adapter = RestartTestAdapter()
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="create-task-hashable-sentinel",
+        chat_type="dm",
+        user_id="user",
+    )
+    session_key = "agent:main:telegram:dm:create-task-hashable-sentinel"
+    event = MessageEvent(
+        text="pending",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+    created_coroutines = []
+
+    def _return_hashable_sentinel(coroutine):
+        created_coroutines.append(coroutine)
+        return object()
+
+    monkeypatch.setattr(asyncio, "create_task", _return_hashable_sentinel)
+    assert not adapter._start_session_processing(event, session_key)
+
+    assert session_key not in adapter._active_sessions
+    assert session_key not in adapter._session_tasks
+    assert not adapter._background_tasks
+    assert len(created_coroutines) == 1
+    assert inspect.getcoroutinestate(created_coroutines[0]) == inspect.CORO_CLOSED
+
+
+@pytest.mark.asyncio
+async def test_start_session_processing_rolls_back_callback_failure(
+    monkeypatch,
+):
+    from gateway.platforms.base import MessageEvent, MessageType
+    from gateway.session import SessionSource
+    from tests.gateway.restart_test_helpers import RestartTestAdapter
+
+    adapter = RestartTestAdapter()
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="create-task-callback-failure",
+        chat_type="dm",
+        user_id="user",
+    )
+    session_key = "agent:main:telegram:dm:create-task-callback-failure"
+    event = MessageEvent(
+        text="pending",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+
+    class _CallbackFailTask(asyncio.Task):
+        def add_done_callback(self, *_args, **_kwargs):
+            raise RuntimeError("forced callback registration failure")
+
+    def _return_callback_fail_task(coroutine):
+        return _CallbackFailTask(
+            coroutine, loop=asyncio.get_running_loop()
+        )
+
+    monkeypatch.setattr(asyncio, "create_task", _return_callback_fail_task)
+    with pytest.raises(RuntimeError, match="forced callback registration failure"):
+        adapter._start_session_processing(event, session_key)
+    await asyncio.sleep(0)
+
+    assert session_key not in adapter._active_sessions
+    assert session_key not in adapter._session_tasks
+    assert not adapter._background_tasks
+
+
+@pytest.mark.asyncio
+async def test_in_band_drain_preserves_replacement_command_ownership():
+    from gateway.platforms.base import MessageEvent, MessageType
+    from gateway.session import SessionSource
+    from tests.gateway.restart_test_helpers import RestartTestAdapter
+
+    adapter = RestartTestAdapter()
+    adapter.config.typing_indicator = False
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="in-band-command-replacement",
+        chat_type="dm",
+        user_id="user",
+    )
+    session_key = "agent:main:telegram:dm:in-band-command-replacement"
+    first_event = MessageEvent(
+        text="first",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+    pending_event = MessageEvent(
+        text="second-must-stay-command-owned",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+    handler_entered = asyncio.Event()
+    release_handler = asyncio.Event()
+    stop_entered = asyncio.Event()
+    release_stop = asyncio.Event()
+    replacement_release = asyncio.Event()
+    dispatches = []
+
+    async def _handler(event):
+        dispatches.append(event.text)
+        if event is first_event:
+            handler_entered.set()
+            await release_handler.wait()
+        return None
+
+    async def _blocked_stop(*_args, **_kwargs):
+        if not stop_entered.is_set():
+            stop_entered.set()
+            await release_stop.wait()
+
+    adapter.set_message_handler(_handler)
+    adapter._stop_typing_refresh = _blocked_stop
+    assert adapter._start_session_processing(first_event, session_key)
+    first_task = adapter._session_tasks[session_key]
+    await handler_entered.wait()
+    adapter._pending_messages[session_key] = pending_event
+    release_handler.set()
+    await stop_entered.wait()
+
+    command_guard = asyncio.Event()
+    replacement_task = asyncio.create_task(replacement_release.wait())
+    adapter._active_sessions[session_key] = command_guard
+    adapter._session_tasks[session_key] = replacement_task
+    release_stop.set()
+    await first_task
+    await asyncio.sleep(0)
+
+    assert dispatches == ["first"]
+    assert adapter._pending_messages[session_key] is pending_event
+    assert adapter._active_sessions[session_key] is command_guard
+    assert adapter._session_tasks[session_key] is replacement_task
+
+    replacement_release.set()
+    await replacement_task
+    adapter._active_sessions.pop(session_key, None)
+    adapter._session_tasks.pop(session_key, None)
+
+
+@pytest.mark.asyncio
+async def test_adapter_teardown_fences_deferred_command_drain():
+    from gateway.platforms.base import MessageEvent, MessageType
+    from gateway.session import SessionSource
+    from tests.gateway.restart_test_helpers import RestartTestAdapter
+
+    adapter = RestartTestAdapter()
+    session_key = "agent:main:telegram:dm:teardown-command-drain"
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="teardown-command-drain",
+        chat_type="dm",
+        user_id="user",
+    )
+    pending = MessageEvent(
+        text="must-not-start",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+    handler_calls = []
+    owner_cancelled = asyncio.Event()
+    release_owner = asyncio.Event()
+
+    async def _handler(event):
+        handler_calls.append(event.text)
+
+    async def _owner():
+        try:
+            await asyncio.Future()
+        except asyncio.CancelledError:
+            owner_cancelled.set()
+            await release_owner.wait()
+
+    adapter.set_message_handler(_handler)
+    owner_task = asyncio.create_task(_owner())
+    adapter._background_tasks.add(owner_task)
+    adapter._session_tasks[session_key] = owner_task
+    command_guard = asyncio.Event()
+    adapter._active_sessions[session_key] = command_guard
+    adapter._pending_messages[session_key] = pending
+    adapter._defer_session_command_drain_until_owner_done(
+        session_key, command_guard, owner_task
+    )
+
+    teardown_task = asyncio.create_task(adapter.cancel_background_tasks())
+    await owner_cancelled.wait()
+    release_owner.set()
+    await teardown_task
+    await asyncio.sleep(0)
+
+    assert handler_calls == []
+    assert adapter._background_tasks == set()
+    assert adapter._session_tasks == {}
+    assert adapter._pending_messages == {}
+    assert adapter._active_sessions == {}
+
+
+@pytest.mark.asyncio
+async def test_fresh_trackerless_process_owner_is_not_stale_evicted(
+    monkeypatch, tmp_path
+):
+    from gateway.platforms.base import MessageEvent, MessageType
+    from gateway.session import SessionSource
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    monkeypatch.setattr(runner, "_is_user_authorized", lambda _source: True)
+    adapter = runner.adapters[Platform.TELEGRAM]
+    adapter._pending_messages = {}
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="fresh-trackerless-owner",
+        chat_type="dm",
+        user_id="user",
+    )
+    session_key = runner._session_key_for_source(source)
+    owner = SimpleNamespace(interrupt=MagicMock())
+    runner._running_agents[session_key] = owner
+    runner._stamped_process_running_agents[session_key] = owner
+    runner._running_agents_ts[session_key] = time.time()
+    generation = runner._begin_session_run_generation(session_key)
+    event = MessageEvent(
+        text="retain this",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+
+    await runner._handle_message(event)
+
+    assert runner._session_run_generation[session_key] == generation
+    assert runner._running_agents[session_key] is owner
+    assert runner._stamped_process_running_agents[session_key] is owner
+    assert adapter._pending_messages[session_key] is event
+
+
+@pytest.mark.asyncio
 async def test_foreground_message_queues_behind_stamped_process_agent(
     monkeypatch, tmp_path
 ):
@@ -1317,11 +3018,13 @@ async def test_agent_handoff_rechecks_after_telegram_topic_binding_switch(
 
 
 @pytest.mark.asyncio
-async def test_process_run_aborts_when_reset_wins_during_pre_agent_setup(
-    monkeypatch, tmp_path
+@pytest.mark.parametrize("transition", ["reset", "forced_shutdown"])
+async def test_process_run_aborts_when_boundary_wins_during_pre_agent_setup(
+    monkeypatch, tmp_path, transition
 ):
     from datetime import datetime, timedelta, timezone
 
+    from gateway.run import _AGENT_PENDING_SENTINEL
     from gateway.session import SessionEntry, SessionSource
 
     runner = _build_runner(monkeypatch, tmp_path, "all")
@@ -1341,6 +3044,10 @@ async def test_process_run_aborts_when_reset_wins_during_pre_agent_setup(
     )
     runner.session_store._entries[session_key] = old_entry
     generation = runner._begin_session_run_generation(session_key)
+    runner._running_agents[session_key] = _AGENT_PENDING_SENTINEL
+    runner._running_agents_ts[session_key] = time.time()
+    active_lease = MagicMock()
+    runner._active_session_leases[session_key] = active_lease
 
     history_started = asyncio.Event()
     release_history = asyncio.Event()
@@ -1372,19 +3079,34 @@ async def test_process_run_aborts_when_reset_wins_during_pre_agent_setup(
     )
     await history_started.wait()
 
-    # /new wins while the handler is suspended in awaited pre-agent setup.
-    runner.session_store._entries[session_key] = SessionEntry(
-        session_key=session_key,
-        session_id="sess-new",
-        created_at=now,
-        updated_at=now,
-        origin=source,
-    )
-    runner._session_run_generation[session_key] = generation + 1
+    if transition == "reset":
+        # /new wins while the handler is suspended in awaited pre-agent setup.
+        runner.session_store._entries[session_key] = SessionEntry(
+            session_key=session_key,
+            session_id="sess-new",
+            created_at=now,
+            updated_at=now,
+            origin=source,
+        )
+        runner._session_run_generation[session_key] = generation + 1
+    else:
+        # Forced shutdown must invalidate and identity-remove the early generic
+        # sentinel before a cancellable stamped handle has been published.
+        runner._interrupt_running_agents("test forced shutdown")
+        assert runner._session_run_generation[session_key] > generation
+        assert session_key not in runner._running_agents
+        assert session_key not in runner._running_agents_ts
+        assert session_key not in runner._active_session_leases
+        active_lease.release.assert_called_once_with()
     release_history.set()
     await task
 
     runner._run_agent.assert_not_awaited()
+    if transition == "reset":
+        runner._release_running_agent_state(session_key)
+    else:
+        assert session_key not in runner._running_agents
+        assert session_key not in runner._running_agents_ts
 
 
 @pytest.mark.asyncio
@@ -1465,12 +3187,720 @@ async def test_process_turn_uses_narrow_side_effect_free_handler_path(
 
 
 @pytest.mark.asyncio
-async def test_reset_between_cache_check_and_lock_preserves_replacement_agent(
-    monkeypatch, tmp_path
+@pytest.mark.parametrize(
+    "replacement_stage",
+    [
+        None,
+        "reset_before_recursive",
+        "shutdown_before_recursive",
+        "worker",
+        "publication",
+    ],
+)
+async def test_fallback_eviction_rebuild_runs_queued_ordinary_followup(
+    monkeypatch, tmp_path, replacement_stage
 ):
     import gateway.run as gateway_run
     import run_agent
+    from gateway.platforms.base import MessageEvent, MessageType
     from gateway.session import SessionSource
+    from tests.gateway.test_queued_native_image_session_key import (
+        CaptureAdapter,
+        _make_runner,
+    )
+
+    class _FallbackRebuildAgent:
+        instances = []
+        calls = []
+
+        def __init__(self, **kwargs):
+            type(self).instances.append(self)
+            self.tools = []
+            self.tool_progress_callback = kwargs.get(
+                "tool_progress_callback"
+            )
+            self.model = "fallback-model"
+            self.provider = "openrouter"
+
+        def run_conversation(
+            self, message, conversation_history=None, task_id=None
+        ):
+            type(self).calls.append((self, message))
+            return {
+                "final_response": f"done-{len(type(self).calls)}",
+                "messages": [],
+                "api_calls": 1,
+            }
+
+    monkeypatch.setattr(run_agent, "AIAgent", _FallbackRebuildAgent)
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {"api_key": "***"},
+    )
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_gateway_model",
+        lambda _config=None: "primary-model",
+    )
+
+    adapter = CaptureAdapter()
+    runner = _make_runner(adapter)
+    runner._model = "primary-model"
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="fallback-queue",
+        chat_type="dm",
+        user_id="user",
+    )
+    session_key = "agent:main:telegram:dm:fallback-queue"
+    generation = runner._begin_session_run_generation(session_key)
+    from gateway.run import _AGENT_PENDING_SENTINEL
+
+    runner._running_agents[session_key] = _AGENT_PENDING_SENTINEL
+    replacement_owner = MagicMock(name="boundary-replacement-owner")
+    original_transfer = runner._transfer_running_agent_to_pending_rebuild
+    original_publish = runner._publish_running_agent_at_execution_boundary
+    original_executor = runner._run_in_executor_with_context
+    executor_calls = 0
+
+    def _transfer_or_replace(key, **kwargs):
+        transferred = original_transfer(key, **kwargs)
+        if transferred and replacement_stage in {
+            "reset_before_recursive",
+            "shutdown_before_recursive",
+        }:
+            runner._session_run_generation[key] = generation + 1
+            if replacement_stage == "reset_before_recursive":
+                runner._running_agents[key] = replacement_owner
+            else:
+                runner._running_agents.pop(key, None)
+        return transferred
+
+    def _publish_or_replace(key, **kwargs):
+        concrete_owner = kwargs.get("concrete_owner")
+        if (
+            replacement_stage == "publication"
+            and len(_FallbackRebuildAgent.instances) >= 2
+            and concrete_owner is _FallbackRebuildAgent.instances[1]
+        ):
+            runner._session_run_generation[key] = generation + 1
+            runner._running_agents[key] = replacement_owner
+            return False
+        return original_publish(key, **kwargs)
+
+    async def _execute_or_replace(func, *args):
+        nonlocal executor_calls
+        executor_calls += 1
+        if replacement_stage == "worker" and executor_calls == 2:
+            runner._session_run_generation[session_key] = generation + 1
+            runner._running_agents[session_key] = replacement_owner
+        return await original_executor(func, *args)
+
+    monkeypatch.setattr(
+        runner,
+        "_transfer_running_agent_to_pending_rebuild",
+        _transfer_or_replace,
+    )
+    monkeypatch.setattr(
+        runner,
+        "_publish_running_agent_at_execution_boundary",
+        _publish_or_replace,
+    )
+    monkeypatch.setattr(
+        runner,
+        "_run_in_executor_with_context",
+        _execute_or_replace,
+    )
+    pending_event = MessageEvent(
+        text="queued-after-fallback",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+    adapter._pending_messages[session_key] = pending_event
+
+    result = await runner._run_agent(
+        message="first-turn",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="fallback-queue-session",
+        session_key=session_key,
+        run_generation=generation,
+    )
+
+    if replacement_stage is not None:
+        assert result["final_response"] == "done-1"
+        assert [message for _agent, message in _FallbackRebuildAgent.calls] == [
+            "first-turn"
+        ]
+        assert adapter._pending_messages[session_key] is pending_event
+        if replacement_stage == "shutdown_before_recursive":
+            assert session_key not in runner._running_agents
+        else:
+            assert runner._running_agents[session_key] is replacement_owner
+        expected_instances = (
+            2 if replacement_stage == "publication" else 1
+        )
+        assert len(_FallbackRebuildAgent.instances) == expected_instances
+    else:
+        assert result["final_response"] == "done-2"
+        assert len(_FallbackRebuildAgent.instances) == 2
+        assert [message for _agent, message in _FallbackRebuildAgent.calls] == [
+            "first-turn",
+            "queued-after-fallback",
+        ]
+        assert _FallbackRebuildAgent.calls[0][0] is not _FallbackRebuildAgent.calls[1][0]
+        assert session_key not in adapter._pending_messages
+
+
+@pytest.mark.asyncio
+async def test_proxy_publication_rejection_signals_no_execution(
+    monkeypatch, tmp_path
+):
+    from gateway.run import _AGENT_PENDING_SENTINEL
+    from gateway.session import SessionSource
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    runner.config.streaming.enabled = True
+    runner._get_proxy_url = lambda: "http://proxy.invalid"
+    adapter = SimpleNamespace(send_typing=AsyncMock())
+    monkeypatch.setattr(runner, "_adapter_for_source", lambda _source: adapter)
+
+    import gateway.stream_consumer as stream_consumer_module
+
+    class _ObservedStreamConsumer:
+        instances = []
+
+        def __init__(self, **_kwargs):
+            self.run_calls = 0
+            self.finish_calls = 0
+            self.__class__.instances.append(self)
+
+        async def run(self):
+            self.run_calls += 1
+            await asyncio.Event().wait()
+
+        def finish(self):
+            self.finish_calls += 1
+
+    monkeypatch.setattr(
+        stream_consumer_module,
+        "GatewayStreamConsumer",
+        _ObservedStreamConsumer,
+    )
+    session_key = "agent:main:telegram:dm:proxy-publication-reject"
+    generation = runner._begin_session_run_generation(session_key)
+    runner._running_agents[session_key] = _AGENT_PENDING_SENTINEL
+    runner._publish_running_agent_at_execution_boundary = MagicMock(
+        return_value=False
+    )
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="proxy-publication-reject",
+        chat_type="dm",
+        user_id="user",
+    )
+
+    result = await runner._run_agent_via_proxy(
+        message="queued-turn",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="proxy-publication-reject-session",
+        session_key=session_key,
+        run_generation=generation,
+    )
+
+    assert result["_execution_boundary_dropped"] is True
+    assert session_key not in runner._running_agents
+    assert len(_ObservedStreamConsumer.instances) == 1
+    assert _ObservedStreamConsumer.instances[0].run_calls == 0
+    assert _ObservedStreamConsumer.instances[0].finish_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_proxy_rejection_does_not_release_newer_ordinary_pending_owner(
+    monkeypatch, tmp_path
+):
+    from gateway.run import _AGENT_PENDING_SENTINEL
+    from gateway.session import SessionSource
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    runner.config.streaming.enabled = False
+    runner._get_proxy_url = lambda: "http://proxy.invalid"
+    session_key = "agent:main:telegram:dm:proxy-aba-replacement"
+    generation = runner._begin_session_run_generation(session_key)
+    runner._running_agents[session_key] = _AGENT_PENDING_SENTINEL
+    replacement_lease = MagicMock(name="proxy-replacement-lease")
+    replacement_generation = None
+
+    def _replace_then_reject(*_args, **_kwargs):
+        nonlocal replacement_generation
+        replacement_generation = runner._begin_session_run_generation(
+            session_key
+        )
+        runner._running_agents[session_key] = _AGENT_PENDING_SENTINEL
+        runner._running_agents_ts[session_key] = time.time()
+        runner._active_session_leases[session_key] = replacement_lease
+        return False
+
+    monkeypatch.setattr(
+        runner,
+        "_publish_running_agent_at_execution_boundary",
+        _replace_then_reject,
+    )
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="proxy-aba-replacement",
+        chat_type="dm",
+        user_id="user",
+    )
+
+    result = await runner._run_agent_via_proxy(
+        message="queued-turn",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="proxy-aba-session",
+        session_key=session_key,
+        run_generation=generation,
+    )
+
+    assert result["_execution_boundary_dropped"] is True
+    assert replacement_generation is not None
+    assert replacement_generation > generation
+    assert runner._running_agents[session_key] is _AGENT_PENDING_SENTINEL
+    assert runner._running_agents_ts[session_key] > 0
+    assert runner._active_session_leases[session_key] is replacement_lease
+    replacement_lease.release.assert_not_called()
+
+
+def test_execution_boundary_publication_is_single_use(monkeypatch, tmp_path):
+    from gateway.run import _AGENT_PENDING_SENTINEL
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    session_key = "agent:main:telegram:dm:single-publication"
+    generation = runner._begin_session_run_generation(session_key)
+    concrete_owner = MagicMock(name="single-concrete-owner")
+    runner._running_agents[session_key] = _AGENT_PENDING_SENTINEL
+
+    assert runner._publish_running_agent_at_execution_boundary(
+        session_key,
+        run_generation=generation,
+        pending_owner=_AGENT_PENDING_SENTINEL,
+        concrete_owner=concrete_owner,
+    )
+    assert not runner._publish_running_agent_at_execution_boundary(
+        session_key,
+        run_generation=generation,
+        pending_owner=_AGENT_PENDING_SENTINEL,
+        concrete_owner=concrete_owner,
+    )
+    assert runner._running_agents[session_key] is concrete_owner
+
+
+def test_restore_dequeued_event_preserves_newer_fifo(monkeypatch, tmp_path):
+    from gateway.platforms.base import MessageEvent
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    session_key = "agent:main:telegram:dm:restore-fifo"
+    old_event = MagicMock(spec=MessageEvent)
+    newer_event = MagicMock(spec=MessageEvent)
+    tail_event = MagicMock(spec=MessageEvent)
+    adapter = SimpleNamespace(
+        _pending_messages={session_key: newer_event}
+    )
+    runner._queued_events[session_key] = [tail_event, newer_event, old_event]
+
+    assert runner._restore_dequeued_event_ahead_of_newer(
+        session_key, adapter, old_event
+    )
+    assert adapter._pending_messages[session_key] is old_event
+    assert runner._queued_events[session_key] == [newer_event, tail_event]
+
+    assert runner._restore_dequeued_event_ahead_of_newer(
+        session_key, adapter, old_event
+    )
+    assert adapter._pending_messages[session_key] is old_event
+    assert runner._queued_events[session_key] == [newer_event, tail_event]
+
+
+@pytest.mark.parametrize("replacement_wins", [False, True])
+def test_recursive_rebuild_transfers_only_exact_completed_owner(
+    monkeypatch, tmp_path, replacement_wins
+):
+    from gateway.run import _AGENT_PENDING_SENTINEL
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    session_key = "agent:main:telegram:dm:recursive-fallback-rebuild"
+    generation = runner._begin_session_run_generation(session_key)
+    old_owner = MagicMock(name="fallback-old-owner")
+    new_owner = MagicMock(name="fallback-rebuilt-owner")
+    replacement_owner = MagicMock(name="replacement-owner")
+    runner._running_agents[session_key] = (
+        replacement_owner if replacement_wins else old_owner
+    )
+
+    transferred = runner._transfer_running_agent_to_pending_rebuild(
+        session_key,
+        run_generation=generation,
+        expected_owner=old_owner,
+    )
+
+    if replacement_wins:
+        assert transferred is False
+        assert runner._running_agents[session_key] is replacement_owner
+    else:
+        assert transferred is True
+        assert runner._running_agents[session_key] is _AGENT_PENDING_SENTINEL
+        assert runner._publish_running_agent_at_execution_boundary(
+            session_key,
+            run_generation=generation,
+            pending_owner=_AGENT_PENDING_SENTINEL,
+            concrete_owner=new_owner,
+        )
+        assert runner._running_agents[session_key] is new_owner
+        runner._release_running_agent_if_identity(
+            session_key, new_owner
+        )
+
+
+@pytest.mark.parametrize("winner", ["shutdown", "publication"])
+def test_forced_shutdown_linearizes_ordinary_pending_publication(
+    monkeypatch, tmp_path, winner
+):
+    from gateway.run import _AGENT_PENDING_SENTINEL
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    session_key = "agent:main:telegram:dm:ordinary-shutdown-publication"
+    generation = runner._begin_session_run_generation(session_key)
+    concrete_owner = MagicMock(name="ordinary-concrete-owner")
+    runner._running_agents[session_key] = _AGENT_PENDING_SENTINEL
+    runner._running_agents_ts[session_key] = time.time()
+
+    if winner == "shutdown":
+        captured = runner._capture_running_agents_for_forced_shutdown(
+            "test forced shutdown"
+        )
+        published = runner._publish_running_agent_at_execution_boundary(
+            session_key,
+            run_generation=generation,
+            pending_owner=_AGENT_PENDING_SENTINEL,
+            concrete_owner=concrete_owner,
+        )
+        assert captured == []
+        assert published is False
+        assert not runner._process_notification_run_is_current(
+            expected_session_id="",
+            session_key=session_key,
+            run_generation=generation,
+        )
+        assert session_key not in runner._running_agents
+        concrete_owner.interrupt.assert_not_called()
+    else:
+        published = runner._publish_running_agent_at_execution_boundary(
+            session_key,
+            run_generation=generation,
+            pending_owner=_AGENT_PENDING_SENTINEL,
+            concrete_owner=concrete_owner,
+        )
+        captured = runner._capture_running_agents_for_forced_shutdown(
+            "test forced shutdown"
+        )
+        assert published is True
+        assert captured == [(session_key, concrete_owner)]
+        runner._interrupt_captured_running_agents(
+            captured, "test forced shutdown"
+        )
+        concrete_owner.interrupt.assert_called_once_with(
+            "test forced shutdown"
+        )
+        runner._release_running_agent_if_identity(
+            session_key, concrete_owner
+        )
+
+
+
+def test_forced_shutdown_linearizes_pending_to_concrete_publication(
+    monkeypatch, tmp_path
+):
+    from gateway.run import _StampedProcessPendingHandle
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    session_key = "agent:main:telegram:dm:shutdown-publication-cas"
+    generation = runner._begin_session_run_generation(session_key)
+    pending_owner = _StampedProcessPendingHandle()
+    concrete_owner = MagicMock(name="concrete-owner")
+    publication_attempted = threading.Event()
+    publication_finished = threading.Event()
+    publisher = None
+    original_interrupt = pending_owner.interrupt
+
+    runner._running_agents[session_key] = pending_owner
+    runner._stamped_process_running_agents[session_key] = pending_owner
+
+    def _publish_concrete():
+        publication_attempted.set()
+        with runner._running_agent_state_lock:
+            if (
+                not pending_owner.cancelled
+                and runner._is_session_run_current(session_key, generation)
+                and runner._running_agents.get(session_key) is pending_owner
+            ):
+                runner._running_agents[session_key] = concrete_owner
+                runner._stamped_process_running_agents[session_key] = (
+                    concrete_owner
+                )
+        publication_finished.set()
+
+    def _interrupt_after_publication_attempt(reason):
+        nonlocal publisher
+        publisher = threading.Thread(target=_publish_concrete)
+        publisher.start()
+        assert publication_attempted.wait(timeout=5)
+        original_interrupt(reason)
+
+    pending_owner.interrupt = _interrupt_after_publication_attempt
+    runner._interrupt_running_agents("test forced shutdown")
+    assert publisher is not None
+    publisher.join(timeout=5)
+
+    assert publication_finished.is_set()
+    assert pending_owner.cancelled
+    assert runner._session_run_generation[session_key] > generation
+    assert session_key not in runner._running_agents
+    assert session_key not in runner._stamped_process_running_agents
+    concrete_owner.interrupt.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_forced_shutdown_concrete_owner_finalizer_uses_exact_identity(
+    monkeypatch, tmp_path
+):
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    session_key = "agent:main:telegram:dm:forced-owner-finalizer"
+    concrete_owner = MagicMock(name="forced-concrete-owner")
+    lease = MagicMock()
+    event = SimpleNamespace()
+    identity_release_calls = []
+    original_identity_release = runner._release_running_agent_if_identity
+
+    def _observe_identity_release(key, owner):
+        result = original_identity_release(key, owner)
+        identity_release_calls.append((key, owner, result))
+        return result
+
+    monkeypatch.setattr(
+        runner,
+        "_release_running_agent_if_identity",
+        _observe_identity_release,
+    )
+
+    async def _force_during_inner(event_arg, **_kwargs):
+        claim = event_arg._hermes_stamped_process_release_claim
+        generation = runner._begin_session_run_generation(session_key)
+        claim.generation = generation
+        runner._running_agents[session_key] = concrete_owner
+        runner._stamped_process_running_agents[session_key] = concrete_owner
+        runner._running_agents_ts[session_key] = time.time()
+        runner._active_session_leases[session_key] = lease
+        runner._stamped_process_release_events[session_key] = claim
+        runner._interrupt_running_agents("test forced shutdown")
+        assert claim.forced_shutdown_owner is concrete_owner
+        assert runner._running_agents[session_key] is concrete_owner
+        return None
+
+    monkeypatch.setattr(
+        runner,
+        "_run_and_deliver_stamped_process_event_inner",
+        _force_during_inner,
+    )
+
+    await GatewayRunner._run_and_deliver_stamped_process_event(
+        runner,
+        event,
+        adapter=SimpleNamespace(),
+        session_key=session_key,
+    )
+
+    assert session_key not in runner._running_agents
+    assert session_key not in runner._stamped_process_running_agents
+    assert session_key not in runner._running_agents_ts
+    assert session_key not in runner._active_session_leases
+    assert identity_release_calls == [
+        (session_key, concrete_owner, True)
+    ]
+    lease.release.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_does_not_mark_stamped_pending_handle_resume_pending(
+    monkeypatch,
+    tmp_path,
+):
+    from unittest.mock import patch
+
+    import gateway.run as gateway_run
+    from gateway.run import _StampedProcessPendingHandle
+    from tests.gateway.test_restart_resume_pending import make_restart_runner
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    runner, adapter = make_restart_runner()
+    adapter.disconnect = AsyncMock()
+    runner._restart_drain_timeout = 0.01
+    session_key = "agent:main:telegram:dm:stamped-pending"
+    pending_owner = _StampedProcessPendingHandle()
+    runner._running_agents = {session_key: pending_owner}
+    runner._stamped_process_running_agents = {
+        session_key: pending_owner
+    }
+    session_store = MagicMock()
+    session_store.mark_resume_pending = MagicMock(return_value=True)
+    runner.session_store = session_store
+    runner._finalize_shutdown_agents = AsyncMock()
+    runner._increment_restart_failure_counts = MagicMock()
+
+    with patch("gateway.status.remove_pid_file"), patch(
+        "gateway.status.write_runtime_status"
+    ):
+        await runner.stop()
+
+    session_store.mark_resume_pending.assert_not_called()
+    runner._finalize_shutdown_agents.assert_awaited_once_with({})
+    runner._increment_restart_failure_counts.assert_not_called()
+    assert session_key not in runner._running_agents
+    assert session_key not in runner._stamped_process_running_agents
+    assert (tmp_path / ".clean_shutdown").exists()
+
+
+@pytest.mark.asyncio
+async def test_clean_concrete_to_pending_shutdown_does_not_count_restart_failure(
+    monkeypatch,
+    tmp_path,
+):
+    from unittest.mock import patch
+
+    import gateway.run as gateway_run
+    from gateway.run import _AGENT_PENDING_SENTINEL
+    from tests.gateway.test_restart_resume_pending import make_restart_runner
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    runner, adapter = make_restart_runner()
+    adapter.disconnect = AsyncMock()
+    session_key = "agent:main:telegram:dm:concrete-to-pending-clean"
+    concrete_owner = MagicMock(name="completed-before-capture")
+    runner._running_agents = {session_key: concrete_owner}
+    runner._running_agents_ts[session_key] = time.time()
+    runner._finalize_shutdown_agents = AsyncMock()
+    runner._increment_restart_failure_counts = MagicMock()
+
+    async def _transition_during_drain(_timeout):
+        runner._running_agents[session_key] = _AGENT_PENDING_SENTINEL
+        return {session_key: concrete_owner}, True
+
+    monkeypatch.setattr(
+        runner, "_drain_active_agents", _transition_during_drain
+    )
+
+    with patch("gateway.status.remove_pid_file"), patch(
+        "gateway.status.write_runtime_status"
+    ):
+        await runner.stop()
+
+    runner._increment_restart_failure_counts.assert_not_called()
+    runner._finalize_shutdown_agents.assert_awaited_once_with(
+        {session_key: concrete_owner}
+    )
+    assert (tmp_path / ".clean_shutdown").exists()
+
+
+@pytest.mark.asyncio
+async def test_forced_shutdown_marks_owner_promoted_at_capture_epoch(
+    monkeypatch,
+):
+    from unittest.mock import patch
+
+    from gateway.run import _StampedProcessPendingHandle
+    from tests.gateway.test_restart_resume_pending import make_restart_runner
+
+    runner, adapter = make_restart_runner()
+    adapter.disconnect = AsyncMock()
+    runner._restart_drain_timeout = 0.01
+    session_key = "agent:main:telegram:dm:promote-at-forced-epoch"
+    generation = runner._begin_session_run_generation(session_key)
+    pending_owner = _StampedProcessPendingHandle()
+    concrete_owner = MagicMock(name="promoted-concrete-owner")
+    runner._running_agents = {session_key: pending_owner}
+    runner._stamped_process_running_agents = {
+        session_key: pending_owner
+    }
+    session_store = MagicMock()
+    session_store.mark_resume_pending = MagicMock(return_value=True)
+    runner.session_store = session_store
+    runner._finalize_shutdown_agents = AsyncMock()
+    runner._increment_restart_failure_counts = MagicMock()
+    original_capture = runner._capture_running_agents_for_forced_shutdown
+    promoted = False
+
+    def _promote_then_capture(reason):
+        nonlocal promoted
+        if not promoted:
+            promoted = True
+            with runner._running_agent_state_lock:
+                assert runner._is_session_run_current(
+                    session_key, generation
+                )
+                runner._running_agents[session_key] = concrete_owner
+                runner._stamped_process_running_agents[session_key] = (
+                    concrete_owner
+                )
+        return original_capture(reason)
+
+    def _interrupt_and_unwind(_reason):
+        runner._release_running_agent_if_identity(
+            session_key, concrete_owner
+        )
+
+    concrete_owner.interrupt.side_effect = _interrupt_and_unwind
+    monkeypatch.setattr(
+        runner,
+        "_capture_running_agents_for_forced_shutdown",
+        _promote_then_capture,
+    )
+
+    with patch("gateway.status.remove_pid_file"), patch(
+        "gateway.status.write_runtime_status"
+    ):
+        await runner.stop()
+
+    assert promoted
+    marked_keys = {
+        call.args[0]
+        for call in session_store.mark_resume_pending.call_args_list
+    }
+    assert session_key in marked_keys
+    concrete_owner.interrupt.assert_called_once()
+    finalized_agents = (
+        runner._finalize_shutdown_agents.await_args.args[0]
+    )
+    assert finalized_agents[session_key] is concrete_owner
+    runner._increment_restart_failure_counts.assert_called_once_with(
+        {session_key}
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("transition", ["replacement", "cancel", "shutdown"])
+async def test_reset_between_cache_check_and_lock_preserves_replacement_agent(
+    monkeypatch, tmp_path, transition
+):
+    from datetime import datetime, timezone
+
+    import gateway.run as gateway_run
+    import run_agent
+    from gateway.session import SessionEntry, SessionSource
 
     runner = _build_runner(monkeypatch, tmp_path, "all")
     runner.adapters[Platform.TELEGRAM].get_pending_message = MagicMock(
@@ -1482,35 +3912,35 @@ async def test_reset_between_cache_check_and_lock_preserves_replacement_agent(
         chat_id="123",
         chat_type="dm",
     )
-    runner.session_store._entries[session_key] = SimpleNamespace(
-        session_id="sess-old"
+    runner.session_store._entries[session_key] = SessionEntry(
+        session_key=session_key,
+        session_id="sess-old",
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+        origin=source,
     )
+    runner.session_store._save = MagicMock()
     generation = runner._begin_session_run_generation(session_key)
     runner._agent_cache = {}
 
     publication_waiting = threading.Event()
+    publication_finished = threading.Event()
     release_publication = threading.Event()
 
-    class _PublicationBarrierLock:
+    class _ObservedRunningStateLock:
         def __init__(self):
             self._lock = threading.RLock()
-            self._enters = 0
 
         def __enter__(self):
-            self._enters += 1
-            # First entry is cache lookup; second is publication. Pause before
-            # acquiring the publication lock so reset/replacement wins exactly
-            # in the former check-to-lock TOCTOU window.
-            if self._enters == 2:
-                publication_waiting.set()
-                assert release_publication.wait(timeout=5)
             self._lock.acquire()
             return self
 
         def __exit__(self, *_exc):
             self._lock.release()
+            if threading.current_thread() is not threading.main_thread():
+                publication_finished.set()
 
-    runner._agent_cache_lock = _PublicationBarrierLock()
+    runner._running_agent_state_lock = _ObservedRunningStateLock()
     runner._session_db = None
 
     stale_agent = MagicMock(name="stale-agent")
@@ -1525,6 +3955,8 @@ async def test_reset_between_cache_check_and_lock_preserves_replacement_agent(
     )
 
     def _construct_agent(*_args, **_kwargs):
+        publication_waiting.set()
+        assert release_publication.wait(timeout=5)
         return stale_agent
 
     monkeypatch.setattr(run_agent, "AIAgent", _construct_agent)
@@ -1557,24 +3989,59 @@ async def test_reset_between_cache_check_and_lock_preserves_replacement_agent(
     )
     assert await asyncio.to_thread(publication_waiting.wait, 5)
 
-    # /new wins after lookup but before stale publication acquires the lock.
-    runner._invalidate_session_run_generation(session_key, reason="test-reset")
-    runner.session_store._entries[session_key] = SimpleNamespace(
-        session_id="sess-new"
-    )
-    replacement_agent = MagicMock(name="replacement-agent")
-    runner._agent_cache[session_key] = (
-        replacement_agent,
-        "replacement-sig",
-        0,
-        "sess-new",
-    )
-    release_publication.set()
+    if transition == "cancel":
+        task.cancel()
+        runner._release_running_agent_state(
+            session_key, run_generation=generation
+        )
+        release_publication.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert await asyncio.to_thread(publication_finished.wait, 5)
+        assert session_key not in runner._running_agents
+        assert session_key not in runner._stamped_process_running_agents
+    elif transition == "shutdown":
+        runner._running = False
+        runner._draining = True
+        runner._interrupt_running_agents("test shutdown timeout")
+        release_publication.set()
 
-    result = await task
-    assert result["final_response"] != "must not run"
+        result = await task
+        assert result["final_response"] != "must not run"
+        assert session_key not in runner._running_agents
+        assert session_key not in runner._stamped_process_running_agents
+    else:
+        # /new wins after lookup but before stale publication acquires the lock.
+        runner._invalidate_session_run_generation(session_key, reason="test-reset")
+        runner.session_store._entries[session_key] = SimpleNamespace(
+            session_id="sess-new"
+        )
+        replacement_agent = MagicMock(name="replacement-agent")
+        replacement_running_agent = MagicMock(name="replacement-running-agent")
+        runner._running_agents[session_key] = replacement_running_agent
+        runner._stamped_process_running_agents[session_key] = replacement_running_agent
+        runner._agent_cache[session_key] = (
+            replacement_agent,
+            "replacement-sig",
+            0,
+            "sess-new",
+        )
+        release_publication.set()
+
+        result = await task
+        assert result["final_response"] != "must not run"
+        assert runner._agent_cache[session_key][0] is replacement_agent
+        assert runner._running_agents[session_key] is replacement_running_agent
+        assert (
+            runner._stamped_process_running_agents[session_key]
+            is replacement_running_agent
+        )
     stale_agent.run_conversation.assert_not_called()
-    assert runner._agent_cache[session_key][0] is replacement_agent
+    if transition == "cancel":
+        assert runner._agent_cache[session_key][0] is stale_agent
+        stale_agent.close.assert_not_called()
+    else:
+        stale_agent.close.assert_called_once_with()
     for callback_name in (
         "tool_progress_callback",
         "tool_start_callback",
@@ -1588,6 +4055,492 @@ async def test_reset_between_cache_check_and_lock_preserves_replacement_agent(
         "clarify_callback",
     ):
         assert getattr(stale_agent, callback_name) is None
+
+
+@pytest.mark.asyncio
+async def test_reused_cached_agent_is_retained_when_caller_cancel_removes_pending_owner(
+    monkeypatch, tmp_path
+):
+    from datetime import datetime, timezone
+
+    import gateway.run as gateway_run
+    import run_agent
+    from gateway.run import _AGENT_PENDING_SENTINEL
+    from gateway.session import SessionEntry, SessionSource
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    runner.adapters[Platform.TELEGRAM].get_pending_message = MagicMock(
+        return_value=None
+    )
+    session_key = "agent:main:telegram:dm:reused-cancel"
+    session_id = "sess-reused-cancel"
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="reused-cancel",
+        chat_type="dm",
+    )
+    runner.session_store._entries[session_key] = SessionEntry(
+        session_key=session_key,
+        session_id=session_id,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+        origin=source,
+    )
+    runner.session_store._save = MagicMock()
+    runner._session_db = None
+    generation = runner._begin_session_run_generation(session_key)
+    runner._running_agents[session_key] = _AGENT_PENDING_SENTINEL
+
+    cached_agent = MagicMock(name="reused-cached-agent")
+    cached_agent.model = "test-model"
+    cached_agent.tools = []
+    cached_agent._fallback_activated = False
+    cached_agent._rate_limited_until = 0.0
+    cached_agent._fallback_chain = []
+    cached_agent.context_compressor = SimpleNamespace(
+        context_length=100_000,
+        last_prompt_tokens=0,
+    )
+    cached_agent.run_conversation.return_value = {
+        "final_response": "must not run",
+        "messages": [],
+    }
+    runner._agent_cache[session_key] = (
+        cached_agent,
+        "cached-sig",
+        None,
+        session_id,
+    )
+    monkeypatch.setattr(
+        runner, "_agent_config_signature", lambda *_a, **_kw: "cached-sig"
+    )
+    monkeypatch.setattr(
+        run_agent,
+        "AIAgent",
+        lambda *_a, **_kw: pytest.fail("cached agent should be reused"),
+    )
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {"provider": "test", "api_key": "test-key"},
+    )
+    monkeypatch.setattr(
+        runner,
+        "_resolve_turn_agent_config",
+        lambda _message, _model, runtime: {
+            "model": "test-model",
+            "runtime": runtime,
+        },
+    )
+    monkeypatch.setattr(runner, "_get_proxy_url", lambda: None)
+
+    publication_entered = threading.Event()
+    release_publication = threading.Event()
+    retention_checked = threading.Event()
+    original_publish = runner._publish_running_agent_at_execution_boundary
+    original_retained = runner._agent_is_retained_after_execution_rejection
+
+    def _blocked_publish(*args, **kwargs):
+        publication_entered.set()
+        assert release_publication.wait(timeout=5)
+        return original_publish(*args, **kwargs)
+
+    def _observe_retention(*args, **kwargs):
+        result = original_retained(*args, **kwargs)
+        retention_checked.set()
+        return result
+
+    monkeypatch.setattr(
+        runner, "_publish_running_agent_at_execution_boundary", _blocked_publish
+    )
+    monkeypatch.setattr(
+        runner, "_agent_is_retained_after_execution_rejection", _observe_retention
+    )
+
+    task = asyncio.create_task(
+        runner._run_agent(
+            message="cancel before execution",
+            context_prompt="",
+            history=[],
+            source=source,
+            session_id=session_id,
+            session_key=session_key,
+            run_generation=generation,
+        )
+    )
+    assert await asyncio.to_thread(publication_entered.wait, 5)
+    task.cancel()
+    assert runner._release_running_agent_state(
+        session_key, run_generation=generation
+    )
+    release_publication.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert session_key not in runner._running_agents
+    assert await asyncio.to_thread(retention_checked.wait, 5)
+
+    assert runner._agent_cache[session_key][0] is cached_agent
+    assert cached_agent._gateway_execution_rejected_pending_cleanup is True
+    cached_agent.run_conversation.assert_not_called()
+    cached_agent.close.assert_not_called()
+    cached_agent.shutdown_memory_provider.assert_not_called()
+
+    next_generation = runner._begin_session_run_generation(session_key)
+    runner._running_agents[session_key] = _AGENT_PENDING_SENTINEL
+    cached_agent.run_conversation.return_value = {
+        "final_response": "reused successfully",
+        "messages": [],
+        "api_calls": 1,
+        "tools": [],
+    }
+    next_result = await runner._run_agent(
+        message="next real turn",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id=session_id,
+        session_key=session_key,
+        run_generation=next_generation,
+    )
+
+    assert next_result["final_response"] == "reused successfully"
+    cached_agent.run_conversation.assert_called_once()
+    assert cached_agent._gateway_execution_rejected_pending_cleanup is False
+    cached_agent.close.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("replacement_kind", ["ordinary", "stamped"])
+@pytest.mark.parametrize("eviction_timing", ["before_retention", "after_retention"])
+async def test_reset_soft_eviction_hard_cleans_fresh_rejected_agent(
+    monkeypatch, tmp_path, replacement_kind, eviction_timing
+):
+    from datetime import datetime, timezone
+
+    import gateway.run as gateway_run
+    import run_agent
+    from gateway.run import (
+        _AGENT_PENDING_SENTINEL,
+        _StampedProcessPendingHandle,
+    )
+    from gateway.session import SessionEntry, SessionSource
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    runner.adapters[Platform.TELEGRAM].get_pending_message = MagicMock(
+        return_value=None
+    )
+    session_key = "agent:main:telegram:dm:fresh-reset-after-cache"
+    session_id = "sess-fresh-reset-after-cache"
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="fresh-reset-after-cache",
+        chat_type="dm",
+    )
+    runner.session_store._entries[session_key] = SessionEntry(
+        session_key=session_key,
+        session_id=session_id,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+        origin=source,
+    )
+    runner.session_store._save = MagicMock()
+    runner._session_db = None
+    generation = runner._begin_session_run_generation(session_key)
+    runner._running_agents[session_key] = _AGENT_PENDING_SENTINEL
+
+    fresh_agent = MagicMock(name="fresh-reset-rejected-agent")
+    fresh_agent._gateway_execution_rejected_pending_cleanup = False
+    fresh_agent.model = "test-model"
+    fresh_agent.tools = []
+    fresh_agent.context_compressor = SimpleNamespace(
+        context_length=100_000,
+        last_prompt_tokens=0,
+    )
+    fresh_agent.run_conversation.return_value = {
+        "final_response": "must not run",
+        "messages": [],
+    }
+    monkeypatch.setattr(run_agent, "AIAgent", lambda *_a, **_kw: fresh_agent)
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {"provider": "test", "api_key": "test-key"},
+    )
+    monkeypatch.setattr(
+        runner,
+        "_resolve_turn_agent_config",
+        lambda _message, _model, runtime: {
+            "model": "test-model",
+            "runtime": runtime,
+        },
+    )
+    monkeypatch.setattr(runner, "_get_proxy_url", lambda: None)
+
+    publication_entered = threading.Event()
+    release_publication = threading.Event()
+    retention_seen = threading.Event()
+    release_retention = threading.Event()
+    cleanup_done = threading.Event()
+    original_publish = runner._publish_running_agent_at_execution_boundary
+    original_retained = runner._agent_is_retained_after_execution_rejection
+    original_cleanup = runner._cleanup_agent_resources
+
+    def _blocked_publish(*args, **kwargs):
+        publication_entered.set()
+        assert release_publication.wait(timeout=5)
+        return original_publish(*args, **kwargs)
+
+    def _observe_retention(*args, **kwargs):
+        result = original_retained(*args, **kwargs)
+        if eviction_timing == "after_retention":
+            assert result is True
+            retention_seen.set()
+            assert release_retention.wait(timeout=5)
+        return result
+
+    def _observe_cleanup(agent):
+        try:
+            return original_cleanup(agent)
+        finally:
+            if agent is fresh_agent:
+                cleanup_done.set()
+
+    monkeypatch.setattr(
+        runner, "_publish_running_agent_at_execution_boundary", _blocked_publish
+    )
+    monkeypatch.setattr(
+        runner, "_agent_is_retained_after_execution_rejection", _observe_retention
+    )
+    monkeypatch.setattr(runner, "_cleanup_agent_resources", _observe_cleanup)
+
+    task = asyncio.create_task(
+        runner._run_agent(
+            message="reset before execution",
+            context_prompt="",
+            history=[],
+            source=source,
+            session_id=session_id,
+            session_key=session_key,
+            run_generation=generation,
+        )
+    )
+    assert await asyncio.to_thread(publication_entered.wait, 5)
+    assert runner._agent_cache[session_key][0] is fresh_agent
+    runner._invalidate_session_run_generation(
+        session_key, reason="test-reset-after-cache"
+    )
+    runner._release_running_agent_state(session_key)
+
+    replacement_agent = MagicMock(name="replacement-cache-agent")
+    replacement_lease = MagicMock(name="replacement-pending-lease")
+    replacement_generation = None
+    replacement_owner = None
+
+    def _install_replacement():
+        nonlocal replacement_generation, replacement_owner
+        replacement_generation = runner._begin_session_run_generation(
+            session_key
+        )
+        replacement_owner = (
+            _AGENT_PENDING_SENTINEL
+            if replacement_kind == "ordinary"
+            else _StampedProcessPendingHandle()
+        )
+        runner._running_agents[session_key] = replacement_owner
+        runner._running_agents_ts[session_key] = time.time()
+        runner._active_session_leases[session_key] = replacement_lease
+        runner._agent_cache[session_key] = (
+            replacement_agent,
+            "replacement-sig",
+            None,
+            "sess-replacement",
+        )
+        if replacement_kind == "stamped":
+            runner._stamped_process_running_agents[session_key] = (
+                replacement_owner
+            )
+
+    if eviction_timing == "before_retention":
+        runner._evict_cached_agent(session_key)
+        _install_replacement()
+        release_publication.set()
+    else:
+        release_publication.set()
+        assert await asyncio.to_thread(retention_seen.wait, 5)
+        runner._evict_cached_agent(session_key)
+        _install_replacement()
+        release_retention.set()
+
+    result = await task
+    assert await asyncio.to_thread(cleanup_done.wait, 5)
+    assert result["_execution_boundary_dropped"] is True
+    assert replacement_generation is not None
+    assert replacement_generation > generation
+    fresh_agent.run_conversation.assert_not_called()
+    fresh_agent.shutdown_memory_provider.assert_called_once()
+    fresh_agent.close.assert_called_once_with()
+    assert runner._agent_cache[session_key][0] is replacement_agent
+    assert runner._running_agents[session_key] is replacement_owner
+    assert runner._running_agents_ts[session_key] > 0
+    assert runner._active_session_leases[session_key] is replacement_lease
+    replacement_lease.release.assert_not_called()
+    if replacement_kind == "stamped":
+        assert (
+            runner._stamped_process_running_agents[session_key]
+            is replacement_owner
+        )
+
+
+@pytest.mark.asyncio
+async def test_ordinary_outer_finalizer_preserves_newer_stamped_owner(
+    monkeypatch, tmp_path
+):
+    from gateway.platforms.base import MessageEvent, MessageType
+    from gateway.session import SessionSource
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    monkeypatch.setattr(runner, "_is_user_authorized", lambda _source: True)
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="ordinary-tail-stamped-replacement",
+        chat_type="dm",
+        user_id="user",
+    )
+    session_key = runner._session_key_for_source(source)
+    replacement_owner = MagicMock(name="newer-stamped-owner")
+    replacement_lease = MagicMock(name="newer-stamped-lease")
+    observed_generations = []
+
+    async def _replace_after_inner_release(
+        _event, _source, key, old_generation
+    ):
+        observed_generations.append(old_generation)
+        assert runner._release_running_agent_state(
+            key, run_generation=old_generation
+        )
+        replacement_generation = runner._begin_session_run_generation(key)
+        observed_generations.append(replacement_generation)
+        runner._running_agents[key] = replacement_owner
+        runner._stamped_process_running_agents[key] = replacement_owner
+        runner._running_agents_ts[key] = time.time()
+        runner._active_session_leases[key] = replacement_lease
+        return {"final_response": "", "messages": []}
+
+    monkeypatch.setattr(
+        runner, "_handle_message_with_agent", _replace_after_inner_release
+    )
+    event = MessageEvent(
+        text="ordinary turn",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+
+    await runner._handle_message(event)
+
+    assert observed_generations[1] > observed_generations[0]
+    assert runner._running_agents[session_key] is replacement_owner
+    assert (
+        runner._stamped_process_running_agents[session_key]
+        is replacement_owner
+    )
+    assert runner._active_session_leases[session_key] is replacement_lease
+    replacement_lease.release.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_local_process_agent_waits_for_paired_publication(
+    monkeypatch, tmp_path
+):
+    import gateway.run as gateway_run
+    import run_agent
+    from gateway.session import SessionSource
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    adapter = runner.adapters[Platform.TELEGRAM]
+    adapter.get_pending_message = MagicMock(return_value=None)
+    session_key = "agent:main:telegram:dm:paired-publication"
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="paired-publication",
+        chat_type="dm",
+    )
+    runner.session_store._entries[session_key] = SimpleNamespace(
+        session_id="sess-old"
+    )
+    monkeypatch.setattr(runner.session_store, "_save", lambda: None)
+    generation = runner._begin_session_run_generation(session_key)
+    runner._agent_cache = {}
+    runner._session_db = None
+
+    process_agent = MagicMock(name="process-agent")
+    process_agent.model = "test-model"
+    process_agent.tools = []
+    process_agent.context_compressor = SimpleNamespace(
+        context_length=100_000,
+        last_prompt_tokens=0,
+    )
+    process_agent.run_conversation.return_value = {
+        "final_response": "process result",
+        "messages": [],
+        "api_calls": 1,
+        "tools": [],
+    }
+    monkeypatch.setattr(run_agent, "AIAgent", lambda *_a, **_kw: process_agent)
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {"provider": "test", "api_key": "test-key"},
+    )
+    monkeypatch.setattr(
+        runner,
+        "_resolve_turn_agent_config",
+        lambda _message, _model, runtime: {
+            "model": "test-model",
+            "runtime": runtime,
+        },
+    )
+    monkeypatch.setattr(runner, "_get_proxy_url", lambda: None)
+
+    history_entered = threading.Event()
+    release_history = threading.Event()
+    original_build_history = gateway_run._build_gateway_agent_history
+
+    def _blocked_build_history(*args, **kwargs):
+        history_entered.set()
+        assert release_history.wait(timeout=5)
+        return original_build_history(*args, **kwargs)
+
+    monkeypatch.setattr(
+        gateway_run, "_build_gateway_agent_history", _blocked_build_history
+    )
+
+    task = asyncio.create_task(
+        runner._run_agent(
+            message="[SYSTEM: process completion]",
+            context_prompt="",
+            history=[],
+            source=source,
+            session_id="sess-old",
+            session_key=session_key,
+            run_generation=generation,
+            expected_process_session_id="sess-old",
+        )
+    )
+    assert await asyncio.to_thread(history_entered.wait, 5)
+    await asyncio.sleep(0.12)
+    running_owner, stamped_owner = runner._running_agent_ownership_snapshot(
+        session_key
+    )
+    try:
+        assert running_owner is stamped_owner
+        assert running_owner is not process_agent
+    finally:
+        release_history.set()
+
+    result = await task
+    assert result["final_response"] == "process result"
+    assert runner._running_agents[session_key] is process_agent
+    assert runner._stamped_process_running_agents[session_key] is process_agent
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -8,8 +8,10 @@ Contributed by @PeterFile (PR #593), reimplemented on current main.
 """
 
 import asyncio
+import threading
+import time
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -50,6 +52,13 @@ def _build_runner(monkeypatch, tmp_path, mode: str) -> GatewayRunner:
     runner = GatewayRunner(GatewayConfig())
     adapter = SimpleNamespace(send=AsyncMock(), handle_message=AsyncMock())
     runner.adapters[Platform.TELEGRAM] = adapter
+
+    async def _capture_process_event(event, **_kwargs):
+        return await adapter.handle_message(event)
+
+    runner._run_and_deliver_stamped_process_event = AsyncMock(
+        side_effect=_capture_process_event
+    )
     return runner
 
 
@@ -63,6 +72,31 @@ def _watcher_dict(session_id="proc_test", thread_id=""):
     if thread_id:
         d["thread_id"] = thread_id
     return d
+
+
+def test_set_session_env_exposes_physical_session_id(monkeypatch, tmp_path):
+    """Gateway-bound tools must see the physical session id, not just session_key."""
+    from gateway.session import SessionContext, SessionSource
+    from gateway.session_context import clear_session_vars, get_session_env
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    ctx = SessionContext(
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="123",
+            chat_type="dm",
+        ),
+        connected_platforms=[Platform.TELEGRAM],
+        home_channels={},
+        session_key="agent:main:telegram:dm:123",
+        session_id="sess-current",
+    )
+
+    tokens = runner._set_session_env(ctx)
+    try:
+        assert get_session_env("HERMES_SESSION_ID") == "sess-current"
+    finally:
+        clear_session_vars(tokens)
 
 
 # ---------------------------------------------------------------------------
@@ -205,6 +239,96 @@ async def test_run_process_watcher_respects_notification_mode(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("sessions", "mode"),
+    [
+        ([SimpleNamespace(output_buffer="building...\n", exited=False, exit_code=None), None], "all"),
+        ([SimpleNamespace(output_buffer="done\n", exited=True, exit_code=0)], "result"),
+    ],
+)
+async def test_process_watcher_uses_secondary_profile_adapter(
+    monkeypatch, tmp_path, sessions, mode
+):
+    import tools.process_registry as pr_module
+    from gateway.session import SessionSource
+
+    monkeypatch.setattr(pr_module, "process_registry", _FakeRegistry(sessions))
+
+    async def _instant_sleep(*_a, **_kw):
+        pass
+
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+    runner = _build_runner(monkeypatch, tmp_path, mode)
+    default_adapter = runner.adapters[Platform.TELEGRAM]
+    coder_adapter = SimpleNamespace(send=AsyncMock(), handle_message=AsyncMock())
+    runner._profile_adapters = {"coder": {Platform.TELEGRAM: coder_adapter}}
+    key = "agent:coder:telegram:dm:123"
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        chat_type="dm",
+        user_id="123",
+        profile="coder",
+    )
+    runner.session_store._entries[key] = SimpleNamespace(
+        session_id="sess-coder",
+        origin=source,
+    )
+    watcher = _watcher_dict()
+    watcher.update(
+        {
+            "session_key": key,
+            "conversation_session_id": "sess-coder",
+        }
+    )
+
+    await runner._run_process_watcher(watcher)
+
+    coder_adapter.send.assert_awaited_once()
+    default_adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_injected_process_event_uses_secondary_profile_adapter(
+    monkeypatch, tmp_path
+):
+    from gateway.session import SessionSource
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    default_adapter = runner.adapters[Platform.TELEGRAM]
+    coder_adapter = SimpleNamespace(send=AsyncMock(), handle_message=AsyncMock())
+    runner._profile_adapters = {"coder": {Platform.TELEGRAM: coder_adapter}}
+    key = "agent:coder:telegram:dm:123"
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        chat_type="dm",
+        user_id="123",
+        profile="coder",
+    )
+    runner.session_store._entries[key] = SimpleNamespace(
+        session_id="sess-coder",
+        origin=source,
+    )
+    runner._run_and_deliver_stamped_process_event = AsyncMock()
+
+    await runner._inject_watch_notification(
+        "[SYSTEM: coder process completion]",
+        {
+            "session_id": "proc-coder",
+            "session_key": key,
+            "conversation_session_id": "sess-coder",
+        },
+    )
+
+    selected = runner._run_and_deliver_stamped_process_event.await_args.kwargs[
+        "adapter"
+    ]
+    assert selected is coder_adapter
+    assert selected is not default_adapter
+
+
+@pytest.mark.asyncio
 async def test_thread_id_passed_to_send(monkeypatch, tmp_path):
     """thread_id from watcher dict is forwarded as metadata to adapter.send()."""
     import tools.process_registry as pr_module
@@ -224,7 +348,6 @@ async def test_thread_id_passed_to_send(monkeypatch, tmp_path):
     assert adapter.send.await_count == 1
     _, kwargs = adapter.send.call_args
     assert kwargs["metadata"] == {"thread_id": "42"}
-
 
 @pytest.mark.asyncio
 async def test_no_thread_id_sends_no_metadata(monkeypatch, tmp_path):
@@ -247,7 +370,90 @@ async def test_no_thread_id_sends_no_metadata(monkeypatch, tmp_path):
     _, kwargs = adapter.send.call_args
     assert kwargs["metadata"] is None
 
+@pytest.mark.asyncio
+async def test_run_process_watcher_drops_stale_text_completion_after_reset(monkeypatch, tmp_path):
+    import tools.process_registry as pr_module
 
+    sessions = [SimpleNamespace(output_buffer="done\n", exited=True, exit_code=0)]
+    monkeypatch.setattr(pr_module, "process_registry", _FakeRegistry(sessions))
+
+    async def _instant_sleep(*_a, **_kw):
+        pass
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    adapter = runner.adapters[Platform.TELEGRAM]
+    session_key = "agent:main:telegram:dm:123"
+    runner.session_store._entries[session_key] = SimpleNamespace(session_id="sess-new")
+
+    watcher = _watcher_dict()
+    watcher.update({
+        "session_key": session_key,
+        "conversation_session_id": "sess-old",
+    })
+
+    await runner._run_process_watcher(watcher)
+
+    adapter.send.assert_not_awaited()
+
+@pytest.mark.asyncio
+async def test_run_process_watcher_keeps_text_completion_for_compression_continuation(monkeypatch, tmp_path):
+    import tools.process_registry as pr_module
+
+    sessions = [SimpleNamespace(output_buffer="done\n", exited=True, exit_code=0)]
+    monkeypatch.setattr(pr_module, "process_registry", _FakeRegistry(sessions))
+
+    async def _instant_sleep(*_a, **_kw):
+        pass
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    adapter = runner.adapters[Platform.TELEGRAM]
+    session_key = "agent:main:telegram:dm:123"
+    runner.session_store._entries[session_key] = SimpleNamespace(session_id="sess-new")
+    runner._session_db = SimpleNamespace(
+        _db=SimpleNamespace(
+            get_compression_tip=lambda sid: {
+                "sess-old": "sess-new",
+                "sess-new": "sess-new",
+            }.get(sid, sid)
+        )
+    )
+
+    watcher = _watcher_dict()
+    watcher.update({
+        "session_key": session_key,
+        "conversation_session_id": "sess-old",
+    })
+
+    await runner._run_process_watcher(watcher)
+
+    adapter.send.assert_awaited_once()
+@pytest.mark.asyncio
+async def test_run_process_watcher_drops_stale_text_running_update_after_reset(monkeypatch, tmp_path):
+    import tools.process_registry as pr_module
+
+    sessions = [SimpleNamespace(output_buffer="building...\n", exited=False, exit_code=None)]
+    monkeypatch.setattr(pr_module, "process_registry", _FakeRegistry(sessions))
+
+    async def _instant_sleep(*_a, **_kw):
+        pass
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    adapter = runner.adapters[Platform.TELEGRAM]
+    session_key = "agent:main:telegram:dm:123"
+    runner.session_store._entries[session_key] = SimpleNamespace(session_id="sess-new")
+
+    watcher = _watcher_dict()
+    watcher.update({
+        "session_key": session_key,
+        "conversation_session_id": "sess-old",
+    })
+
+    await runner._run_process_watcher(watcher)
+
+    adapter.send.assert_not_awaited()
 @pytest.mark.asyncio
 async def test_inject_watch_notification_routes_from_session_store_origin(monkeypatch, tmp_path):
     from gateway.session import SessionSource
@@ -284,6 +490,429 @@ async def test_inject_watch_notification_routes_from_session_store_origin(monkey
 
 
 @pytest.mark.asyncio
+async def test_stamped_watch_uses_guarded_production_delivery_rail(
+    monkeypatch, tmp_path
+):
+    from gateway.session import SessionSource
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    adapter = runner.adapters[Platform.TELEGRAM]
+    session_key = "agent:main:telegram:dm:123"
+    runner.session_store._entries[session_key] = SimpleNamespace(
+        session_id="sess-current",
+        origin=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="123",
+            chat_type="dm",
+            user_id="123",
+        ),
+    )
+    runner._run_and_deliver_stamped_process_event = AsyncMock()
+
+    await runner._inject_watch_notification(
+        "[SYSTEM: Background process matched]",
+        {
+            "session_id": "proc_watch",
+            "session_key": session_key,
+            "conversation_session_id": "sess-current",
+        },
+    )
+
+    runner._run_and_deliver_stamped_process_event.assert_awaited_once()
+    synth_event = runner._run_and_deliver_stamped_process_event.await_args.args[0]
+    assert synth_event.metadata["expected_gateway_session_id"] == "sess-current"
+    assert runner._run_and_deliver_stamped_process_event.await_args.kwargs == {
+        "adapter": adapter,
+        "session_key": session_key,
+    }
+
+
+@pytest.mark.asyncio
+async def test_stamped_process_event_waits_without_interrupting_foreground_turn(
+    monkeypatch, tmp_path
+):
+    from gateway.platforms.base import MessageEvent, MessageType
+    from gateway.run import _STAMPED_PROCESS_EVENT_BUSY
+    from gateway.session import SessionSource
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        chat_type="dm",
+        user_id="123",
+    )
+    session_key = runner._session_key_for_source(source)
+    foreground_agent = SimpleNamespace(
+        interrupt=MagicMock(),
+        get_activity_summary=lambda: {"seconds_since_activity": 0},
+    )
+    runner._running_agents[session_key] = foreground_agent
+    runner._running_agents_ts[session_key] = time.time()
+    event = MessageEvent(
+        text="[SYSTEM: process completion]",
+        message_type=MessageType.TEXT,
+        source=source,
+        internal=True,
+        metadata={"expected_gateway_session_id": "sess-current"},
+    )
+
+    result = await runner._handle_message(event)
+
+    assert result is _STAMPED_PROCESS_EVENT_BUSY
+    foreground_agent.interrupt.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_stamped_process_event_returns_through_guarded_direct_send(
+    monkeypatch, tmp_path
+):
+    from gateway.platforms.base import MessageEvent, MessageType
+    from gateway.session import SessionSource
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    runner._run_and_deliver_stamped_process_event = (
+        GatewayRunner._run_and_deliver_stamped_process_event.__get__(runner)
+    )
+    adapter = runner.adapters[Platform.TELEGRAM]
+    adapter.strip_media_directives_for_display = lambda text: text
+    adapter.send.return_value = SimpleNamespace(success=True, message_id="sent-1")
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        chat_type="dm",
+        user_id="123",
+    )
+    session_key = "agent:main:telegram:dm:123"
+    runner.session_store._entries[session_key] = SimpleNamespace(
+        session_id="sess-current"
+    )
+    generation = runner._begin_session_run_generation(session_key)
+    runner._handle_message = AsyncMock(return_value="process result")
+    event = MessageEvent(
+        text="[SYSTEM: process completion]",
+        message_type=MessageType.TEXT,
+        source=source,
+        internal=True,
+        metadata={
+            "expected_gateway_session_id": "sess-current",
+            "gateway_run_generation": generation,
+        },
+    )
+
+    result = await runner._run_and_deliver_stamped_process_event(
+        event,
+        adapter=adapter,
+        session_key=session_key,
+    )
+
+    assert result.message_id == "sent-1"
+    adapter.handle_message.assert_not_awaited()
+    adapter.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_stamped_process_event_suppresses_media_only_response(
+    monkeypatch, tmp_path
+):
+    from gateway.platforms.base import MessageEvent, MessageType
+    from gateway.session import SessionSource
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    runner._run_and_deliver_stamped_process_event = (
+        GatewayRunner._run_and_deliver_stamped_process_event.__get__(runner)
+    )
+    adapter = runner.adapters[Platform.TELEGRAM]
+    adapter.strip_media_directives_for_display = lambda _text: ""
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        chat_type="dm",
+        user_id="123",
+    )
+    session_key = runner._session_key_for_source(source)
+    runner.session_store._entries[session_key] = SimpleNamespace(
+        session_id="sess-current"
+    )
+    runner._handle_message = AsyncMock(return_value="MEDIA:/tmp/untrusted.png")
+    event = MessageEvent(
+        text="[SYSTEM: process completion]",
+        message_type=MessageType.TEXT,
+        source=source,
+        internal=True,
+        metadata={"expected_gateway_session_id": "sess-current"},
+    )
+
+    result = await runner._run_and_deliver_stamped_process_event(
+        event,
+        adapter=adapter,
+        session_key=session_key,
+    )
+
+    assert result is None
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("busy_mode", ["interrupt", "steer"])
+async def test_stamped_process_turn_does_not_drain_queued_foreground_message(
+    monkeypatch, tmp_path, busy_mode
+):
+    import gateway.run as gateway_run
+    import run_agent
+    from gateway.platforms.base import MessageEvent, MessageType
+    from gateway.session import SessionSource
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    monkeypatch.setattr(runner, "_is_user_authorized", lambda _source: True)
+    runner._busy_input_mode = busy_mode
+    runner._busy_text_mode = "interrupt"
+    adapter = runner.adapters[Platform.TELEGRAM]
+    session_key = "agent:main:telegram:dm:123"
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        chat_type="dm",
+        user_id="123",
+    )
+    runner.session_store._entries[session_key] = SimpleNamespace(
+        session_id="sess-old"
+    )
+    runner.session_store._loaded = True
+    monkeypatch.setattr(runner.session_store, "_save", lambda: None)
+    generation = runner._begin_session_run_generation(session_key)
+    runner._agent_cache = {}
+    runner._session_db = None
+
+    queued = MessageEvent(
+        text="real foreground user message",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+    adapter.get_pending_message = MagicMock(return_value=queued)
+    adapter._pending_messages = {}
+    adapter._active_sessions = {}
+    runner._prepare_profile_scoped_inbound_message_text = AsyncMock(
+        return_value="real foreground user message"
+    )
+    runner._refresh_agent_cache_message_count = AsyncMock()
+
+    agent = MagicMock(name="agent")
+    agent.model = "test-model"
+    agent.session_id = "sess-old"
+    agent.tools = []
+    agent.context_compressor = SimpleNamespace(
+        context_length=100_000,
+        last_prompt_tokens=0,
+    )
+    agent.run_conversation.return_value = {
+        "final_response": "MEDIA:/tmp/secret.png",
+        "messages": [],
+        "api_calls": 1,
+        "tools": [],
+    }
+    monkeypatch.setattr(run_agent, "AIAgent", lambda *_a, **_kw: agent)
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {"provider": "test", "api_key": "test-key"},
+    )
+    monkeypatch.setattr(
+        runner,
+        "_resolve_turn_agent_config",
+        lambda _message, _model, runtime: {
+            "model": "test-model",
+            "runtime": runtime,
+        },
+    )
+    monkeypatch.setattr(runner, "_get_proxy_url", lambda: None)
+    backend_finished = asyncio.Event()
+    release_backend_tail = asyncio.Event()
+    original_executor = runner._run_in_executor_with_context
+
+    async def _pause_after_backend(func, *args):
+        backend_result = await original_executor(func, *args)
+        backend_finished.set()
+        await release_backend_tail.wait()
+        return backend_result
+
+    monkeypatch.setattr(runner, "_run_in_executor_with_context", _pause_after_backend)
+
+    run_task = asyncio.create_task(
+        runner._run_agent(
+            message="[SYSTEM: process completion]",
+            context_prompt="",
+            history=[],
+            source=source,
+            session_id="sess-old",
+            session_key=session_key,
+            run_generation=generation,
+            expected_process_session_id="sess-old",
+        )
+    )
+    await backend_finished.wait()
+
+    # Backend completion is not the full synthetic-turn boundary. The concrete
+    # local agent remains marked until the outer gateway lifecycle releases it.
+    assert runner._running_agents[session_key] is agent
+    assert runner._stamped_process_running_agents[session_key] is agent
+    agent.interrupt.reset_mock()
+    agent.steer.reset_mock()
+    tail_foreground = MessageEvent(
+        text="foreground during local postprocessing tail",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+
+    handled = await runner._handle_active_session_busy_message(
+        tail_foreground, session_key
+    )
+
+    assert handled is True
+    agent.interrupt.assert_not_called()
+    agent.steer.assert_not_called()
+    assert adapter._pending_messages[session_key] is tail_foreground
+    release_backend_tail.set()
+    result = await run_task
+
+    assert result["final_response"] == "MEDIA:/tmp/secret.png"
+    adapter.send.assert_not_awaited()
+    adapter.get_pending_message.assert_not_called()
+    assert agent.run_conversation.call_count == 1
+    assert runner._running_agents[session_key] is agent
+    assert runner._stamped_process_running_agents[session_key] is agent
+    runner._release_running_agent_state(
+        session_key, run_generation=generation
+    )
+    assert session_key not in runner._running_agents
+    assert session_key not in runner._stamped_process_running_agents
+
+
+@pytest.mark.asyncio
+async def test_foreground_message_queues_behind_stamped_process_agent(
+    monkeypatch, tmp_path
+):
+    from gateway.platforms.base import MessageEvent, MessageType
+    from gateway.session import SessionSource
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    monkeypatch.setattr(runner, "_is_user_authorized", lambda _source: True)
+    runner._busy_input_mode = "interrupt"
+    adapter = runner.adapters[Platform.TELEGRAM]
+    adapter._pending_messages = {}
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        chat_type="dm",
+        user_id="123",
+    )
+    key = runner._session_key_for_source(source)
+    runner.session_store._entries[key] = SimpleNamespace(session_id="sess-old")
+    process_agent = SimpleNamespace(
+        interrupt=MagicMock(),
+        get_activity_summary=lambda: {"seconds_since_activity": 0},
+    )
+    runner._running_agents[key] = process_agent
+    runner._running_agents_ts[key] = time.time() - 10
+    runner._stamped_process_running_agents[key] = process_agent
+    foreground = MessageEvent(
+        text="real foreground request",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+
+    result = await runner._handle_message(foreground)
+
+    assert result is None
+    process_agent.interrupt.assert_not_called()
+    assert adapter._pending_messages[key] is foreground
+
+
+@pytest.mark.asyncio
+async def test_busy_handler_queues_behind_stamped_process_agent(
+    monkeypatch, tmp_path
+):
+    from gateway.platforms.base import MessageEvent, MessageType
+    from gateway.session import SessionSource
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    runner._busy_input_mode = "steer"
+    monkeypatch.setattr(runner, "_is_user_authorized", lambda _source: True)
+    adapter = runner.adapters[Platform.TELEGRAM]
+    adapter._pending_messages = {}
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        chat_type="dm",
+        user_id="123",
+    )
+    key = runner._session_key_for_source(source)
+    process_agent = SimpleNamespace(interrupt=MagicMock(), steer=MagicMock())
+    runner._running_agents[key] = process_agent
+    runner._stamped_process_running_agents[key] = process_agent
+    foreground = MessageEvent(
+        text="real foreground request",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+
+    handled = await runner._handle_active_session_busy_message(foreground, key)
+
+    assert handled is True
+    process_agent.interrupt.assert_not_called()
+    process_agent.steer.assert_not_called()
+    assert adapter._pending_messages[key] is foreground
+
+
+@pytest.mark.asyncio
+async def test_stamped_process_delivery_retries_after_foreground_turn_finishes(
+    monkeypatch, tmp_path
+):
+    from gateway.platforms.base import MessageEvent, MessageType
+    from gateway.run import _STAMPED_PROCESS_EVENT_BUSY
+    from gateway.session import SessionSource
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    runner._run_and_deliver_stamped_process_event = (
+        GatewayRunner._run_and_deliver_stamped_process_event.__get__(runner)
+    )
+    adapter = runner.adapters[Platform.TELEGRAM]
+    adapter.strip_media_directives_for_display = lambda text: text
+    adapter.send.return_value = SimpleNamespace(success=True, message_id="sent-queued")
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        chat_type="dm",
+        user_id="123",
+    )
+    session_key = runner._session_key_for_source(source)
+    runner.session_store._entries[session_key] = SimpleNamespace(
+        session_id="sess-current"
+    )
+    runner._handle_message = AsyncMock(
+        side_effect=[_STAMPED_PROCESS_EVENT_BUSY, "process result"]
+    )
+    monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+    event = MessageEvent(
+        text="[SYSTEM: process completion]",
+        message_type=MessageType.TEXT,
+        source=source,
+        internal=True,
+        metadata={"expected_gateway_session_id": "sess-current"},
+    )
+
+    result = await runner._run_and_deliver_stamped_process_event(
+        event,
+        adapter=adapter,
+        session_key=session_key,
+    )
+
+    assert result.message_id == "sent-queued"
+    assert runner._handle_message.await_count == 2
+    adapter.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_agent_notification_carries_message_id_reply_anchor(monkeypatch, tmp_path):
     """notify_on_complete injection carries the triggering message_id so the
     synthetic event can be reply-anchored back into a Telegram DM topic.
@@ -303,6 +932,9 @@ async def test_agent_notification_carries_message_id_reply_anchor(monkeypatch, t
 
     runner = _build_runner(monkeypatch, tmp_path, "all")
     adapter = runner.adapters[Platform.TELEGRAM]
+    runner.session_store._entries["agent:main:telegram:dm:123:24296"] = SimpleNamespace(
+        session_id="sess-current"
+    )
 
     watcher = {
         "session_id": "proc_anchor",
@@ -313,6 +945,7 @@ async def test_agent_notification_carries_message_id_reply_anchor(monkeypatch, t
         "thread_id": "24296",
         "message_id": "555",
         "notify_on_complete": True,
+        "conversation_session_id": "sess-current",
     }
     await runner._run_process_watcher(watcher)
 
@@ -321,7 +954,7 @@ async def test_agent_notification_carries_message_id_reply_anchor(monkeypatch, t
     assert synth_event.internal is True
     assert synth_event.message_id == "555"
     assert synth_event.source.thread_id == "24296"
-
+    assert synth_event.metadata["expected_gateway_session_id"] == "sess-current"
 
 @pytest.mark.asyncio
 async def test_agent_notification_no_message_id_is_tolerated(monkeypatch, tmp_path):
@@ -355,7 +988,6 @@ async def test_agent_notification_no_message_id_is_tolerated(monkeypatch, tmp_pa
     adapter.handle_message.assert_awaited_once()
     synth_event = adapter.handle_message.await_args.args[0]
     assert synth_event.message_id is None
-
 
 @pytest.mark.asyncio
 async def test_inject_watch_notification_carries_message_id_reply_anchor(monkeypatch, tmp_path):
@@ -445,7 +1077,6 @@ def test_build_process_event_source_uses_cached_live_source_before_session_key_p
     assert source.user_id == "proc_owner"
     assert source.user_name == "alice"
 
-
 @pytest.mark.asyncio
 async def test_inject_watch_notification_ignores_foreground_event_source(monkeypatch, tmp_path):
     """Negative test: watch notification must NOT route to the foreground thread."""
@@ -479,6 +1110,1059 @@ async def test_inject_watch_notification_ignores_foreground_event_source(monkeyp
     # Must route to thread 42 (process origin), NOT some other thread
     assert synth_event.source.thread_id == "42"
     assert synth_event.source.user_id == "proc_owner"
+
+@pytest.mark.asyncio
+async def test_inject_watch_notification_drops_stale_boundary_after_reset(monkeypatch, tmp_path):
+    from gateway.session import SessionSource
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    adapter = runner.adapters[Platform.TELEGRAM]
+
+    runner.session_store._entries["agent:main:telegram:group:-100:42"] = SimpleNamespace(
+        session_id="sess-new",
+        origin=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-100",
+            chat_type="group",
+            thread_id="42",
+            user_id="proc_owner",
+            user_name="alice",
+        ),
+    )
+
+    evt = {
+        "session_id": "proc_stale_watch",
+        "session_key": "agent:main:telegram:group:-100:42",
+        "conversation_session_id": "sess-old",
+    }
+
+    await runner._inject_watch_notification("[SYSTEM: stale watch match]", evt)
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_inject_watch_notification_drops_stamped_event_when_session_entry_missing(
+    monkeypatch, tmp_path
+):
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    adapter = runner.adapters[Platform.TELEGRAM]
+
+    evt = {
+        "session_id": "proc_orphaned_watch",
+        "session_key": "agent:main:telegram:group:-100:42",
+        "conversation_session_id": "sess-old",
+    }
+
+    await runner._inject_watch_notification("[SYSTEM: orphaned watch match]", evt)
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_inject_watch_notification_drops_stamped_event_when_store_lookup_fails(
+    monkeypatch, tmp_path
+):
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    adapter = runner.adapters[Platform.TELEGRAM]
+
+    def _fail_lookup():
+        raise OSError("session store unavailable")
+
+    monkeypatch.setattr(runner.session_store, "_ensure_loaded", _fail_lookup)
+    evt = {
+        "session_id": "proc_unverifiable_watch",
+        "session_key": "agent:main:telegram:group:-100:42",
+        "conversation_session_id": "sess-old",
+    }
+
+    await runner._inject_watch_notification("[SYSTEM: unverifiable watch match]", evt)
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_inject_watch_notification_keeps_compression_continuation(monkeypatch, tmp_path):
+    from gateway.session import SessionSource
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    adapter = runner.adapters[Platform.TELEGRAM]
+    runner.session_store._entries["agent:main:telegram:group:-100:42"] = SimpleNamespace(
+        session_id="sess-new",
+        origin=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-100",
+            chat_type="group",
+            thread_id="42",
+        ),
+    )
+    runner._session_db = SimpleNamespace(
+        _db=SimpleNamespace(
+            get_compression_tip=lambda sid: {
+                "sess-old": "sess-new",
+                "sess-new": "sess-new",
+            }.get(sid, sid)
+        )
+    )
+
+    evt = {
+        "session_id": "proc_compression",
+        "session_key": "agent:main:telegram:group:-100:42",
+        "conversation_session_id": "sess-old",
+    }
+
+    await runner._inject_watch_notification("[SYSTEM: compression continuation watch]", evt)
+
+    adapter.handle_message.assert_awaited_once()
+    synth_event = adapter.handle_message.await_args.args[0]
+    assert synth_event.metadata["expected_gateway_session_id"] == "sess-old"
+
+
+@pytest.mark.asyncio
+async def test_agent_handoff_drops_when_reset_races_initial_process_check(monkeypatch, tmp_path):
+    from gateway.session import SessionSource
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    adapter = runner.adapters[Platform.TELEGRAM]
+    session_key = "agent:main:telegram:group:-100:42"
+    runner.session_store._entries[session_key] = SimpleNamespace(
+        session_id="sess-old",
+        origin=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-100",
+            chat_type="group",
+            thread_id="42",
+        ),
+    )
+    evt = {
+        "session_id": "proc_handoff_race",
+        "session_key": session_key,
+        "conversation_session_id": "sess-old",
+    }
+
+    # Initial queue-drain validation succeeds and creates the synthetic event.
+    await runner._inject_watch_notification("[SYSTEM: racing watch match]", evt)
+    synth_event = adapter.handle_message.await_args.args[0]
+
+    # /new wins before the adapter hands the event to the gateway agent path.
+    runner._async_session_store = SimpleNamespace(
+        _store=runner.session_store,
+        get_or_create_session=AsyncMock(
+            return_value=SimpleNamespace(session_key=session_key, session_id="sess-new")
+        ),
+    )
+    monkeypatch.setattr(runner, "_recover_telegram_topic_thread_id", lambda _source: None)
+    runner._cache_session_source = MagicMock()
+
+    await runner._handle_message_with_agent(
+        synth_event, synth_event.source, session_key, run_generation=0
+    )
+
+    runner._cache_session_source.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_agent_handoff_rechecks_after_telegram_topic_binding_switch(
+    monkeypatch, tmp_path
+):
+    from gateway.session import SessionSource
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    adapter = runner.adapters[Platform.TELEGRAM]
+    session_key = "agent:main:telegram:dm:123:42"
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        chat_type="dm",
+        thread_id="42",
+    )
+    runner.session_store._entries[session_key] = SimpleNamespace(
+        session_id="sess-old",
+        origin=source,
+    )
+    evt = {
+        "session_id": "proc_topic_rebind_race",
+        "session_key": session_key,
+        "conversation_session_id": "sess-old",
+    }
+
+    await runner._inject_watch_notification("[SYSTEM: topic race]", evt)
+    synth_event = adapter.handle_message.await_args.args[0]
+
+    old_entry = SimpleNamespace(session_key=session_key, session_id="sess-old")
+    new_entry = SimpleNamespace(session_key=session_key, session_id="sess-new")
+    runner._async_session_store = SimpleNamespace(
+        _store=runner.session_store,
+        get_or_create_session=AsyncMock(return_value=old_entry),
+        switch_session=AsyncMock(return_value=new_entry),
+    )
+    runner._session_db = SimpleNamespace(
+        _db=SimpleNamespace(get_compression_tip=lambda sid: sid),
+        get_telegram_topic_binding=AsyncMock(return_value={"session_id": "sess-new"}),
+        get_compression_tip=AsyncMock(side_effect=lambda sid: sid),
+    )
+    monkeypatch.setattr(runner, "_recover_telegram_topic_thread_id", lambda _source: None)
+    monkeypatch.setattr(runner, "_is_telegram_topic_lane", lambda _source: True)
+    runner._cache_session_source = MagicMock()
+    runner.hooks.emit = AsyncMock()
+
+    await runner._handle_message_with_agent(
+        synth_event, synth_event.source, session_key, run_generation=0
+    )
+
+    runner._async_session_store.switch_session.assert_awaited_once_with(
+        session_key, "sess-new"
+    )
+    runner.hooks.emit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_process_run_aborts_when_reset_wins_during_pre_agent_setup(
+    monkeypatch, tmp_path
+):
+    from datetime import datetime, timedelta, timezone
+
+    from gateway.session import SessionEntry, SessionSource
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    session_key = "agent:main:telegram:dm:123"
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        chat_type="dm",
+    )
+    now = datetime.now(timezone.utc)
+    old_entry = SessionEntry(
+        session_key=session_key,
+        session_id="sess-old",
+        created_at=now - timedelta(seconds=1),
+        updated_at=now,
+        origin=source,
+    )
+    runner.session_store._entries[session_key] = old_entry
+    generation = runner._begin_session_run_generation(session_key)
+
+    history_started = asyncio.Event()
+    release_history = asyncio.Event()
+
+    async def _blocked_load_transcript(_session_id):
+        history_started.set()
+        await release_history.wait()
+        return []
+
+    runner._async_session_store = SimpleNamespace(
+        _store=runner.session_store,
+        get_or_create_session=AsyncMock(return_value=old_entry),
+        load_transcript=_blocked_load_transcript,
+    )
+    monkeypatch.setattr(runner, "_recover_telegram_topic_thread_id", lambda _source: None)
+    monkeypatch.setattr(runner, "_is_telegram_topic_lane", lambda _source: False)
+    runner._run_agent = AsyncMock()
+    event = SimpleNamespace(
+        text="[SYSTEM: stale process completion]",
+        source=source,
+        metadata={"expected_gateway_session_id": "sess-old"},
+        auto_skill=None,
+    )
+
+    task = asyncio.create_task(
+        runner._handle_message_with_agent(
+            event, source, session_key, run_generation=generation
+        )
+    )
+    await history_started.wait()
+
+    # /new wins while the handler is suspended in awaited pre-agent setup.
+    runner.session_store._entries[session_key] = SessionEntry(
+        session_key=session_key,
+        session_id="sess-new",
+        created_at=now,
+        updated_at=now,
+        origin=source,
+    )
+    runner._session_run_generation[session_key] = generation + 1
+    release_history.set()
+    await task
+
+    runner._run_agent.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_process_turn_uses_narrow_side_effect_free_handler_path(
+    monkeypatch, tmp_path
+):
+    from datetime import datetime, timedelta, timezone
+
+    from gateway.session import SessionEntry, SessionSource
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    session_key = "agent:main:telegram:dm:123"
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        chat_type="dm",
+    )
+    now = datetime.now(timezone.utc)
+    entry = SessionEntry(
+        session_key=session_key,
+        session_id="sess-old",
+        created_at=now - timedelta(seconds=1),
+        updated_at=now,
+        origin=source,
+    )
+    runner.session_store._entries[session_key] = entry
+    generation = runner._begin_session_run_generation(session_key)
+
+    update_session = AsyncMock()
+    runner._async_session_store = SimpleNamespace(
+        _store=runner.session_store,
+        get_or_create_session=AsyncMock(return_value=entry),
+        load_transcript=AsyncMock(return_value=[]),
+        has_any_sessions=AsyncMock(return_value=True),
+        update_session=update_session,
+    )
+    monkeypatch.setattr(runner, "_recover_telegram_topic_thread_id", lambda _source: None)
+    monkeypatch.setattr(runner, "_is_telegram_topic_lane", lambda _source: False)
+    runner._prepare_profile_scoped_inbound_message_text = AsyncMock(
+        side_effect=AssertionError("process turns must skip enrichment")
+    )
+    runner.hooks.emit = AsyncMock(
+        side_effect=AssertionError("process turns must skip lifecycle hooks")
+    )
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "process result",
+            "messages": [],
+            "api_calls": 1,
+            "tools": [],
+            "history_offset": 0,
+            "session_id": "sess-old",
+        }
+    )
+    event = SimpleNamespace(
+        text="[SYSTEM: process completion]",
+        source=source,
+        metadata={"expected_gateway_session_id": "sess-old"},
+        auto_skill=None,
+        channel_prompt=None,
+        message_id=None,
+        timestamp=None,
+        reply_to_message_id=None,
+        reply_to_text=None,
+    )
+
+    response = await runner._handle_message_with_agent(
+        event,
+        source,
+        session_key,
+        run_generation=generation,
+    )
+
+    assert response == "process result"
+    runner._prepare_profile_scoped_inbound_message_text.assert_not_awaited()
+    runner.hooks.emit.assert_not_awaited()
+    update_session.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reset_between_cache_check_and_lock_preserves_replacement_agent(
+    monkeypatch, tmp_path
+):
+    import gateway.run as gateway_run
+    import run_agent
+    from gateway.session import SessionSource
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    runner.adapters[Platform.TELEGRAM].get_pending_message = MagicMock(
+        return_value=None
+    )
+    session_key = "agent:main:telegram:dm:123"
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        chat_type="dm",
+    )
+    runner.session_store._entries[session_key] = SimpleNamespace(
+        session_id="sess-old"
+    )
+    generation = runner._begin_session_run_generation(session_key)
+    runner._agent_cache = {}
+
+    publication_waiting = threading.Event()
+    release_publication = threading.Event()
+
+    class _PublicationBarrierLock:
+        def __init__(self):
+            self._lock = threading.RLock()
+            self._enters = 0
+
+        def __enter__(self):
+            self._enters += 1
+            # First entry is cache lookup; second is publication. Pause before
+            # acquiring the publication lock so reset/replacement wins exactly
+            # in the former check-to-lock TOCTOU window.
+            if self._enters == 2:
+                publication_waiting.set()
+                assert release_publication.wait(timeout=5)
+            self._lock.acquire()
+            return self
+
+        def __exit__(self, *_exc):
+            self._lock.release()
+
+    runner._agent_cache_lock = _PublicationBarrierLock()
+    runner._session_db = None
+
+    stale_agent = MagicMock(name="stale-agent")
+    stale_agent.model = "test-model"
+    stale_agent.tools = []
+    stale_agent.context_compressor = SimpleNamespace(
+        context_length=100_000,
+        last_prompt_tokens=0,
+    )
+    stale_agent.run_conversation = MagicMock(
+        return_value={"final_response": "must not run", "messages": []}
+    )
+
+    def _construct_agent(*_args, **_kwargs):
+        return stale_agent
+
+    monkeypatch.setattr(run_agent, "AIAgent", _construct_agent)
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {"provider": "test", "api_key": "test-key"},
+    )
+    monkeypatch.setattr(
+        runner,
+        "_resolve_turn_agent_config",
+        lambda _message, _model, runtime: {
+            "model": "test-model",
+            "runtime": runtime,
+        },
+    )
+    monkeypatch.setattr(runner, "_get_proxy_url", lambda: None)
+
+    task = asyncio.create_task(
+        runner._run_agent(
+            message="[SYSTEM: stale process completion]",
+            context_prompt="",
+            history=[],
+            source=source,
+            session_id="sess-old",
+            session_key=session_key,
+            run_generation=generation,
+            expected_process_session_id="sess-old",
+        )
+    )
+    assert await asyncio.to_thread(publication_waiting.wait, 5)
+
+    # /new wins after lookup but before stale publication acquires the lock.
+    runner._invalidate_session_run_generation(session_key, reason="test-reset")
+    runner.session_store._entries[session_key] = SimpleNamespace(
+        session_id="sess-new"
+    )
+    replacement_agent = MagicMock(name="replacement-agent")
+    runner._agent_cache[session_key] = (
+        replacement_agent,
+        "replacement-sig",
+        0,
+        "sess-new",
+    )
+    release_publication.set()
+
+    result = await task
+    assert result["final_response"] != "must not run"
+    stale_agent.run_conversation.assert_not_called()
+    assert runner._agent_cache[session_key][0] is replacement_agent
+    for callback_name in (
+        "tool_progress_callback",
+        "tool_start_callback",
+        "step_callback",
+        "stream_delta_callback",
+        "interim_assistant_callback",
+        "status_callback",
+        "notice_callback",
+        "event_callback",
+        "background_review_callback",
+        "clarify_callback",
+    ):
+        assert getattr(stale_agent, callback_name) is None
+
+
+@pytest.mark.asyncio
+async def test_stamped_process_run_auto_denies_approval_without_platform_prompt(
+    monkeypatch, tmp_path
+):
+    import gateway.run as gateway_run
+    import run_agent
+    import tools.approval as approval
+    from gateway.session import SessionSource
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    adapter = runner.adapters[Platform.TELEGRAM]
+    adapter.get_pending_message = MagicMock(return_value=None)
+    session_key = "agent:main:telegram:dm:123"
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        chat_type="dm",
+    )
+    runner.session_store._entries[session_key] = SimpleNamespace(
+        session_id="sess-old"
+    )
+    monkeypatch.setattr(runner.session_store, "_save", lambda: None)
+    generation = runner._begin_session_run_generation(session_key)
+    runner._agent_cache = {}
+    runner._session_db = None
+
+    process_agent = MagicMock(name="process-agent")
+    process_agent.model = "test-model"
+    process_agent.tools = []
+    process_agent.context_compressor = SimpleNamespace(
+        context_length=100_000,
+        last_prompt_tokens=0,
+    )
+    process_agent.run_conversation.return_value = {
+        "final_response": "process result",
+        "messages": [],
+        "api_calls": 1,
+        "tools": [],
+    }
+    monkeypatch.setattr(run_agent, "AIAgent", lambda *_a, **_kw: process_agent)
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {"provider": "test", "api_key": "test-key"},
+    )
+    monkeypatch.setattr(
+        runner,
+        "_resolve_turn_agent_config",
+        lambda _message, _model, runtime: {
+            "model": "test-model",
+            "runtime": runtime,
+        },
+    )
+    monkeypatch.setattr(runner, "_get_proxy_url", lambda: None)
+
+    registered = []
+    resolved = MagicMock()
+    monkeypatch.setattr(
+        approval,
+        "register_gateway_notify",
+        lambda key, callback: registered.append((key, callback)),
+    )
+    monkeypatch.setattr(approval, "unregister_gateway_notify", lambda _key: None)
+    monkeypatch.setattr(approval, "resolve_gateway_approval", resolved)
+
+    result = await runner._run_agent(
+        message="[SYSTEM: process completion]",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-old",
+        session_key=session_key,
+        run_generation=generation,
+        expected_process_session_id="sess-old",
+    )
+
+    assert result["final_response"] == "process result"
+    assert len(registered) == 1
+    key, callback = registered[0]
+    assert key == f"{session_key}:process-run:{generation}:sess-old"
+    callback({"command": "dangerous"})
+    resolved.assert_called_once_with(
+        key,
+        "deny",
+        reason="Background process notifications cannot request approval.",
+    )
+    adapter.send.assert_not_awaited()
+
+
+def test_process_approval_cleanup_cannot_remove_replacement_foreground_state():
+    import tools.approval as approval
+
+    session_key = "agent:main:telegram:dm:123"
+    process_key = f"{session_key}:process-run:7:sess-old"
+    process_callback = MagicMock()
+    replacement_callback = MagicMock()
+    replacement_entry = approval._ApprovalEntry({"command": "dangerous"})
+
+    try:
+        approval.register_gateway_notify(process_key, process_callback)
+        approval.register_gateway_notify(session_key, replacement_callback)
+        with approval._lock:
+            approval._gateway_queues[session_key] = [replacement_entry]
+
+        approval.unregister_gateway_notify(process_key)
+
+        with approval._lock:
+            assert approval._gateway_notify_cbs[session_key] is replacement_callback
+            assert approval._gateway_queues[session_key] == [replacement_entry]
+        assert not replacement_entry.event.is_set()
+    finally:
+        approval.unregister_gateway_notify(process_key)
+        approval.unregister_gateway_notify(session_key)
+
+
+@pytest.mark.asyncio
+async def test_process_delivery_and_reset_are_linearized_when_delivery_wins(
+    monkeypatch, tmp_path
+):
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    session_key = "agent:main:telegram:dm:delivery-first"
+    runner.session_store._entries[session_key] = SimpleNamespace(
+        session_id="sess-old"
+    )
+    send_started = asyncio.Event()
+    release_send = asyncio.Event()
+    reset_called = asyncio.Event()
+
+    async def _send():
+        send_started.set()
+        await release_send.wait()
+        return "sent"
+
+    async def _reset(_session_key):
+        reset_called.set()
+        runner.session_store._entries[session_key] = SimpleNamespace(
+            session_id="sess-new"
+        )
+        return runner.session_store._entries[session_key]
+
+    runner._async_session_store = SimpleNamespace(
+        _store=runner.session_store,
+        reset_session=_reset,
+    )
+    delivery_task = asyncio.create_task(
+        runner._deliver_process_notification_guarded(
+            expected_session_id="sess-old",
+            session_key=session_key,
+            run_generation=None,
+            delivery=_send,
+        )
+    )
+    await send_started.wait()
+    reset_task = asyncio.create_task(
+        runner._reset_session_at_process_delivery_boundary(session_key)
+    )
+    await asyncio.sleep(0)
+    assert not reset_called.is_set()
+
+    release_send.set()
+    assert await delivery_task == "sent"
+    await reset_task
+    assert reset_called.is_set()
+    assert runner.session_store._entries[session_key].session_id == "sess-new"
+
+
+@pytest.mark.asyncio
+async def test_yuanbao_lookup_waits_for_guarded_process_delivery(
+    monkeypatch, tmp_path
+):
+    from gateway.platforms.yuanbao import QuoteContextMiddleware
+    from gateway.session import SessionSource
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    session_key = "agent:main:yuanbao:dm:direct:123"
+    source = SessionSource(
+        platform=Platform.YUANBAO,
+        chat_id="direct:123",
+        chat_type="dm",
+        user_id="123",
+    )
+    runner.session_store._entries[session_key] = SimpleNamespace(
+        session_id="sess-old"
+    )
+    send_started = asyncio.Event()
+    release_send = asyncio.Event()
+    lookup_called = asyncio.Event()
+
+    async def _send():
+        send_started.set()
+        await release_send.wait()
+        return "sent"
+
+    async def _get_or_create(_source):
+        lookup_called.set()
+        runner.session_store._entries[session_key] = SimpleNamespace(
+            session_id="sess-new"
+        )
+        return runner.session_store._entries[session_key]
+
+    runner._async_session_store = SimpleNamespace(
+        _store=runner.session_store,
+        get_or_create_session=_get_or_create,
+    )
+    adapter = SimpleNamespace(
+        _session_store=SimpleNamespace(load_transcript=lambda _sid: []),
+        resolve_session_entry=lambda resolved_source: (
+            runner._get_or_create_session_at_process_delivery_boundary(
+                resolved_source, session_key
+            )
+        ),
+        name="yuanbao",
+    )
+    ctx = SimpleNamespace(
+        reply_to_message_id="quoted",
+        adapter=adapter,
+        source=source,
+    )
+
+    delivery_task = asyncio.create_task(
+        runner._deliver_process_notification_guarded(
+            expected_session_id="sess-old",
+            session_key=session_key,
+            run_generation=None,
+            delivery=_send,
+        )
+    )
+    await send_started.wait()
+    lookup_task = asyncio.create_task(
+        QuoteContextMiddleware()._extract_media_refs_from_transcript(ctx)
+    )
+    await asyncio.sleep(0)
+    assert not lookup_called.is_set()
+
+    release_send.set()
+    assert await delivery_task == "sent"
+    assert await lookup_task == []
+    assert lookup_called.is_set()
+    assert runner.session_store._entries[session_key].session_id == "sess-new"
+
+
+@pytest.mark.asyncio
+async def test_cron_seed_waits_for_guarded_process_delivery(monkeypatch, tmp_path):
+    from cron.scheduler import _seed_cron_channel_session
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    session_key = "agent:coder:slack:group:C123:U_HUMAN"
+    runner.session_store._entries[session_key] = SimpleNamespace(
+        session_id="sess-old"
+    )
+    append_to_transcript = MagicMock()
+    runner.session_store.append_to_transcript = append_to_transcript
+    lookup_called = asyncio.Event()
+    send_started = asyncio.Event()
+    release_send = asyncio.Event()
+
+    async def _get_or_create(source):
+        lookup_called.set()
+        assert source.profile == "coder"
+        return SimpleNamespace(session_id="sess-old")
+
+    runner._async_session_store = SimpleNamespace(
+        _store=runner.session_store,
+        get_or_create_session=_get_or_create,
+    )
+    profile_resolver = runner._make_profile_session_resolver("coder")
+
+    async def _resolve(source, *, operation=None):
+        return await profile_resolver(source, operation=operation)
+
+    adapter = SimpleNamespace(
+        _session_store=runner.session_store,
+        resolve_session_entry=_resolve,
+    )
+
+    async def _send():
+        send_started.set()
+        await release_send.wait()
+        return "sent"
+
+    delivery_task = asyncio.create_task(
+        runner._deliver_process_notification_guarded(
+            expected_session_id="sess-old",
+            session_key=session_key,
+            run_generation=None,
+            delivery=_send,
+        )
+    )
+    await send_started.wait()
+    loop = asyncio.get_running_loop()
+    seed_task = asyncio.create_task(
+        asyncio.to_thread(
+            _seed_cron_channel_session,
+            {"id": "cron-1"},
+            adapter,
+            "slack",
+            "C123",
+            "Daily brief",
+            is_dm=False,
+            user_id="U_HUMAN",
+            loop=loop,
+        )
+    )
+    await asyncio.sleep(0)
+    assert not lookup_called.is_set()
+
+    release_send.set()
+    assert await delivery_task == "sent"
+    assert await seed_task is True
+    assert lookup_called.is_set()
+    append_to_transcript.assert_called_once()
+    assert append_to_transcript.call_args.args[0] == "sess-old"
+
+
+@pytest.mark.asyncio
+async def test_model_switch_warning_lookup_waits_for_guarded_process_delivery(
+    monkeypatch, tmp_path
+):
+    from hermes_cli.context_switch_guard import (
+        enrich_model_switch_warnings_for_gateway,
+    )
+    from gateway.session import SessionSource
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        chat_type="dm",
+        user_id="123",
+    )
+    session_key = runner._session_key_for_source(source)
+    runner.session_store._entries[session_key] = SimpleNamespace(
+        session_id="sess-old"
+    )
+    runner._agent_cache[session_key] = (
+        SimpleNamespace(context_compressor=None),
+        "signature",
+        0,
+    )
+    lookup_called = asyncio.Event()
+    send_started = asyncio.Event()
+    release_send = asyncio.Event()
+    read_messages = MagicMock(return_value=[])
+    runner._session_db = SimpleNamespace(
+        get_messages_as_conversation=read_messages
+    )
+
+    async def _get_or_create(resolved_source):
+        lookup_called.set()
+        assert resolved_source is source
+        return SimpleNamespace(session_id="sess-old")
+
+    runner._async_session_store = SimpleNamespace(
+        _store=runner.session_store,
+        get_or_create_session=_get_or_create,
+    )
+
+    async def _send():
+        send_started.set()
+        await release_send.wait()
+        return "sent"
+
+    delivery_task = asyncio.create_task(
+        runner._deliver_process_notification_guarded(
+            expected_session_id="sess-old",
+            session_key=session_key,
+            run_generation=None,
+            delivery=_send,
+        )
+    )
+    await send_started.wait()
+    warning_task = asyncio.create_task(
+        enrich_model_switch_warnings_for_gateway(
+            SimpleNamespace(success=True),
+            runner,
+            session_key=session_key,
+            source=source,
+        )
+    )
+    await asyncio.sleep(0)
+    assert not lookup_called.is_set()
+
+    release_send.set()
+    assert await delivery_task == "sent"
+    await warning_task
+    assert lookup_called.is_set()
+    read_messages.assert_called_once_with("sess-old")
+
+
+@pytest.mark.asyncio
+async def test_process_delivery_is_suppressed_when_reset_wins_boundary(
+    monkeypatch, tmp_path
+):
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    session_key = "agent:main:telegram:dm:reset-first"
+    runner.session_store._entries[session_key] = SimpleNamespace(
+        session_id="sess-old"
+    )
+    reset_committed = asyncio.Event()
+    release_reset = asyncio.Event()
+    delivered = False
+
+    async def _reset(_session_key):
+        runner.session_store._entries[session_key] = SimpleNamespace(
+            session_id="sess-new"
+        )
+        reset_committed.set()
+        await release_reset.wait()
+        return runner.session_store._entries[session_key]
+
+    async def _send():
+        nonlocal delivered
+        delivered = True
+        return "sent"
+
+    runner._async_session_store = SimpleNamespace(
+        _store=runner.session_store,
+        reset_session=_reset,
+    )
+    reset_task = asyncio.create_task(
+        runner._reset_session_at_process_delivery_boundary(session_key)
+    )
+    await reset_committed.wait()
+    delivery_task = asyncio.create_task(
+        runner._deliver_process_notification_guarded(
+            expected_session_id="sess-old",
+            session_key=session_key,
+            run_generation=None,
+            delivery=_send,
+        )
+    )
+    await asyncio.sleep(0)
+    assert not delivery_task.done()
+
+    release_reset.set()
+    await reset_task
+    assert await delivery_task is None
+    assert delivered is False
+
+
+@pytest.mark.asyncio
+async def test_process_delivery_is_suppressed_when_session_lookup_auto_reset_wins(
+    monkeypatch, tmp_path
+):
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    session_key = "agent:main:telegram:dm:auto-reset-first"
+    runner.session_store._entries[session_key] = SimpleNamespace(
+        session_id="sess-old"
+    )
+    reset_committed = asyncio.Event()
+    release_lookup = asyncio.Event()
+    delivered = False
+
+    async def _get_or_create(_source):
+        runner.session_store._entries[session_key] = SimpleNamespace(
+            session_id="sess-new"
+        )
+        reset_committed.set()
+        await release_lookup.wait()
+        return runner.session_store._entries[session_key]
+
+    async def _send():
+        nonlocal delivered
+        delivered = True
+        return "sent"
+
+    runner._async_session_store = SimpleNamespace(
+        _store=runner.session_store,
+        get_or_create_session=_get_or_create,
+    )
+    lookup_task = asyncio.create_task(
+        runner._get_or_create_session_at_process_delivery_boundary(
+            SimpleNamespace(), session_key
+        )
+    )
+    await reset_committed.wait()
+    delivery_task = asyncio.create_task(
+        runner._deliver_process_notification_guarded(
+            expected_session_id="sess-old",
+            session_key=session_key,
+            run_generation=None,
+            delivery=_send,
+        )
+    )
+    await asyncio.sleep(0)
+    assert not delivery_task.done()
+
+    release_lookup.set()
+    await lookup_task
+    assert await delivery_task is None
+    assert delivered is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exited", [False, True])
+async def test_text_delivery_rechecks_after_initial_session_validation(
+    monkeypatch, tmp_path, exited
+):
+    import tools.process_registry as pr_module
+
+    session = SimpleNamespace(
+        output_buffer="done\n" if exited else "building\n",
+        exited=exited,
+        exit_code=0 if exited else None,
+        command="echo test",
+    )
+    sessions = [session] if exited else [session, None]
+    monkeypatch.setattr(pr_module, "process_registry", _FakeRegistry(sessions))
+
+    async def _instant_sleep(*_a, **_kw):
+        pass
+
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    adapter = runner.adapters[Platform.TELEGRAM]
+    session_key = "agent:main:telegram:group:-100:42"
+    runner.session_store._entries[session_key] = SimpleNamespace(session_id="sess-old")
+    watcher = _watcher_dict(session_id="proc_text_race")
+    watcher.update(
+        {
+            "session_key": session_key,
+            "conversation_session_id": "sess-old",
+        }
+    )
+
+    original_check = runner._is_stale_process_notification
+    checks = 0
+
+    def _reset_after_initial_check(payload):
+        nonlocal checks
+        checks += 1
+        result = original_check(payload)
+        if checks == 1:
+            runner.session_store._entries[session_key] = SimpleNamespace(
+                session_id="sess-new"
+            )
+        return result
+
+    monkeypatch.setattr(runner, "_is_stale_process_notification", _reset_after_initial_check)
+
+    await runner._run_process_watcher(watcher)
+
+    assert checks >= 2
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_run_process_watcher_drops_completion_for_reset_session_boundary(monkeypatch, tmp_path):
+    import tools.process_registry as pr_module
+
+    sessions = [SimpleNamespace(output_buffer="done\n", exited=True, exit_code=0, command="echo hi")]
+    monkeypatch.setattr(pr_module, "process_registry", _FakeRegistry(sessions))
+
+    async def _instant_sleep(*_a, **_kw):
+        pass
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    adapter = runner.adapters[Platform.TELEGRAM]
+    runner.session_store._entries["agent:main:telegram:group:-100:42"] = SimpleNamespace(
+        session_id="sess-new",
+    )
+
+    watcher = _watcher_dict(session_id="proc_done")
+    watcher.update({
+        "session_key": "agent:main:telegram:group:-100:42",
+        "notify_on_complete": True,
+        "conversation_session_id": "sess-old",
+    })
+
+    await runner._run_process_watcher(watcher)
+
+    adapter.handle_message.assert_not_awaited()
 
 
 def test_build_process_event_source_returns_none_for_empty_evt(monkeypatch, tmp_path):
@@ -524,6 +2208,17 @@ def test_parse_session_key_valid():
     assert result == {"platform": "telegram", "chat_type": "group", "chat_id": "-100"}
 
 
+def test_parse_session_key_named_profile():
+    result = _parse_session_key("agent:coder:telegram:dm:123:topic42")
+    assert result == {
+        "platform": "telegram",
+        "chat_type": "dm",
+        "chat_id": "123",
+        "profile": "coder",
+        "thread_id": "topic42",
+    }
+
+
 def test_parse_session_key_with_extra_parts():
     """6th part in a group key may be a user_id, not a thread_id — omit it."""
     result = _parse_session_key("agent:main:discord:group:chan123:thread456")
@@ -555,4 +2250,4 @@ def test_parse_session_key_too_short():
 
 def test_parse_session_key_wrong_prefix():
     assert _parse_session_key("cron:main:telegram:dm:123") is None
-    assert _parse_session_key("agent:cron:telegram:dm:123") is None
+    assert _parse_session_key("agent::telegram:dm:123") is None

--- a/tests/gateway/test_moa_one_shot_restore.py
+++ b/tests/gateway/test_moa_one_shot_restore.py
@@ -77,6 +77,40 @@ def test_no_restore_for_non_one_shot_turn():
     runner._evict_cached_agent.assert_not_called()
 
 
+def test_stop_invalidated_turn_restores_owned_moa_override():
+    """A /stop must not strand the one-shot MoA override after invalidation."""
+    runner = _make_runner()
+    key = "agent:main:telegram:dm:stop"
+    installed = {"provider": "moa", "model": "default"}
+    runner._session_model_overrides[key] = installed
+    event = _make_event(moa_disable=True, moa_restore=None)
+    event._moa_installed_override = installed
+
+    runner._restore_moa_one_shot(event, key)
+
+    assert key not in runner._session_model_overrides
+    runner._evict_cached_agent.assert_called_once_with(key)
+
+
+def test_new_replacement_override_wins_over_stale_moa_unwind():
+    """A late old finally cannot overwrite or evict replacement-session state."""
+    runner = _make_runner()
+    key = "agent:main:telegram:dm:replacement"
+    installed = {"provider": "moa", "model": "default"}
+    replacement = {"provider": "openrouter", "model": "new-model"}
+    runner._session_model_overrides[key] = replacement
+    event = _make_event(
+        moa_disable=True,
+        moa_restore={"provider": "old-provider", "model": "old-model"},
+    )
+    event._moa_installed_override = installed
+
+    runner._restore_moa_one_shot(event, key)
+
+    assert runner._session_model_overrides[key] is replacement
+    runner._evict_cached_agent.assert_not_called()
+
+
 def test_restore_runs_from_finally_even_when_turn_raises():
     """The whole point of the fix: a raising turn still reverts the override.
 

--- a/tests/gateway/test_model_picker_persist.py
+++ b/tests/gateway/test_model_picker_persist.py
@@ -19,6 +19,8 @@ closure the PR changed, against a real temp ``HERMES_HOME``.
 """
 
 import types
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import yaml
 import pytest
@@ -201,3 +203,32 @@ async def test_picker_tap_session_flag_does_not_persist(tmp_path, monkeypatch):
     written = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
     assert written["model"]["default"] == "old-model"
     assert written["model"]["provider"] == "openai-codex"
+
+
+@pytest.mark.asyncio
+async def test_picker_callback_uses_boundary_guarded_session_lookup(
+    tmp_path, monkeypatch
+):
+    adapter = _FakePickerAdapter()
+    _setup_isolated_home(
+        tmp_path,
+        monkeypatch,
+        {"default": "old-model", "provider": "openai-codex"},
+    )
+    runner = _make_runner(adapter)
+    event = _make_event("/model --session")
+    session_key = runner._session_key_for_source(event.source)
+    guarded_lookup = AsyncMock(
+        return_value=SimpleNamespace(session_id="sess-current")
+    )
+    runner._get_or_create_session_at_process_delivery_boundary = guarded_lookup
+    runner._session_db = SimpleNamespace(update_session_model=AsyncMock())
+    runner._async_session_store = SimpleNamespace(set_model_override=AsyncMock())
+
+    confirmation = await _drive_picker(runner, event)
+
+    assert confirmation is not None
+    guarded_lookup.assert_awaited_once_with(event.source, session_key)
+    runner._session_db.update_session_model.assert_awaited_once_with(
+        "sess-current", "gpt-5.5"
+    )

--- a/tests/gateway/test_multiplex_phase0.py
+++ b/tests/gateway/test_multiplex_phase0.py
@@ -10,7 +10,7 @@ Covers the three Phase 0 deliverables:
 """
 import pytest
 from datetime import datetime
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 import yaml
 
 from hermes_constants import reset_hermes_home_override, set_hermes_home_override
@@ -103,6 +103,27 @@ class TestSessionKeyNamespacedWhenOn:
         assert d[0] == n[0] == "agent"
         assert d[1] == "main" and n[1] == "coder"
         assert d[2:] == n[2:]  # everything after the namespace is identical
+
+    @pytest.mark.asyncio
+    async def test_adapter_internal_session_resolver_binds_profile(self):
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        entry = object()
+        runner._get_or_create_session_at_process_delivery_boundary = AsyncMock(
+            return_value=entry
+        )
+        resolver = runner._make_profile_session_resolver("coder")
+        source = _src(chat_id="99", chat_type="dm")
+
+        assert await resolver(source) is entry
+        assert source.profile == "coder"
+        resolved_source = (
+            runner._get_or_create_session_at_process_delivery_boundary.await_args.args[0]
+        )
+        assert build_session_key(
+            resolved_source, profile=resolved_source.profile
+        ) == "agent:coder:telegram:dm:99"
 
 
 class TestMultiplexConfigFlag:

--- a/tests/gateway/test_proxy_mode.py
+++ b/tests/gateway/test_proxy_mode.py
@@ -1,5 +1,6 @@
 """Tests for gateway proxy mode — forwarding messages to a remote API server."""
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -226,6 +227,213 @@ class TestRunAgentProxyDispatch:
 
 class TestRunAgentViaProxy:
     """Test the actual proxy HTTP forwarding logic."""
+
+    @pytest.mark.asyncio
+    async def test_stamped_process_proxy_run_exposes_interruptible_handle(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv("GATEWAY_PROXY_URL", "http://host:8642")
+        runner = _make_runner()
+        source = _make_source()
+        session_key = "agent:main:matrix:group:test"
+        generation = runner._begin_session_run_generation(session_key)
+        monkeypatch.setattr(
+            runner, "_is_stale_process_notification", lambda _payload: False
+        )
+
+        request_started = asyncio.Event()
+        hold_request = asyncio.Event()
+
+        class _BlockingResponse(_FakeSSEResponse):
+            async def __aenter__(self):
+                request_started.set()
+                await hold_request.wait()
+                return self
+
+        session = _FakeSession(_BlockingResponse())
+        with patch("gateway.run._load_gateway_config", return_value={}):
+            with _patch_aiohttp(session):
+                with patch("aiohttp.ClientTimeout"):
+                    task = asyncio.create_task(
+                        runner._run_agent_via_proxy(
+                            message="stale completion",
+                            context_prompt="",
+                            history=[],
+                            source=source,
+                            session_id="sess-old",
+                            session_key=session_key,
+                            run_generation=generation,
+                            expected_process_session_id="sess-old",
+                        )
+                    )
+                    await request_started.wait()
+                    handle = runner._running_agents[session_key]
+
+                    # Mirrors /new: invalidate before interrupting the concrete
+                    # execution handle, so no pending-sentinel gap remains.
+                    runner._invalidate_session_run_generation(
+                        session_key, reason="test-reset"
+                    )
+                    handle.interrupt("test reset")
+                    with pytest.raises(asyncio.CancelledError):
+                        await task
+
+        # Direct backend invocation has no outer gateway turn finalizer; emulate
+        # the explicit reset cleanup that owns the published identities.
+        runner._release_running_agent_state(session_key)
+        assert session_key not in runner._running_agents
+        assert session_key not in runner._stamped_process_running_agents
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("busy_mode", ["interrupt", "steer"])
+    async def test_foreground_input_does_not_interrupt_stamped_proxy_process_turn(
+        self, monkeypatch, busy_mode
+    ):
+        from types import SimpleNamespace
+
+        from gateway.platforms.base import MessageEvent, MessageType
+
+        monkeypatch.setenv("GATEWAY_PROXY_URL", "http://host:8642")
+        monkeypatch.delenv("GATEWAY_PROXY_KEY", raising=False)
+        monkeypatch.setenv("HERMES_GATEWAY_BUSY_ACK_ENABLED", "false")
+        runner = _make_runner()
+        runner._stamped_process_running_agents = {}
+        runner._draining = False
+        runner._busy_input_mode = busy_mode
+        runner._busy_text_mode = "interrupt"
+        monkeypatch.setattr(runner, "_is_user_authorized", lambda _source: True)
+        source = _make_source()
+        adapter = SimpleNamespace(_pending_messages={})
+        runner.adapters[source.platform] = adapter
+        session_key = "agent:main:matrix:group:!room:server.org:@user:server.org"
+        generation = runner._begin_session_run_generation(session_key)
+        monkeypatch.setattr(
+            runner, "_is_stale_process_notification", lambda _payload: False
+        )
+        request_started = asyncio.Event()
+        hold_request = asyncio.Event()
+
+        class _BlockingResponse(_FakeSSEResponse):
+            async def __aenter__(self):
+                request_started.set()
+                await hold_request.wait()
+                return self
+
+        session = _FakeSession(
+            _BlockingResponse(
+                sse_chunks=[b'data: {"choices":[{"delta":{"content":"ok"}}]}\n\n']
+            )
+        )
+        with patch("gateway.run._load_gateway_config", return_value={}):
+            with _patch_aiohttp(session):
+                with patch("aiohttp.ClientTimeout"):
+                    proxy_task = asyncio.create_task(
+                        runner._run_agent_via_proxy(
+                            message="stale completion",
+                            context_prompt="",
+                            history=[],
+                            source=source,
+                            session_id="sess-old",
+                            session_key=session_key,
+                            run_generation=generation,
+                            expected_process_session_id="sess-old",
+                        )
+                    )
+                    await request_started.wait()
+                    handle = runner._running_agents[session_key]
+                    assert runner._stamped_process_running_agents[session_key] is handle
+                    foreground = MessageEvent(
+                        text="real foreground request",
+                        message_type=MessageType.TEXT,
+                        source=source,
+                    )
+
+                    handled = await runner._handle_active_session_busy_message(
+                        foreground, session_key
+                    )
+
+                    assert handled is True
+                    assert not proxy_task.done()
+                    assert adapter._pending_messages[session_key] is foreground
+                    hold_request.set()
+                    result = await proxy_task
+
+        assert result["final_response"] == "ok"
+        # Backend completion is not the turn boundary: ownership remains visible
+        # until the outer gateway lifecycle releases the complete synthetic turn.
+        handle = runner._running_agents[session_key]
+        assert runner._stamped_process_running_agents[session_key] is handle
+        runner._release_running_agent_state(session_key)
+        assert session_key not in runner._running_agents
+        assert session_key not in runner._stamped_process_running_agents
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("busy_mode", ["interrupt", "steer"])
+    async def test_proxy_backend_completion_keeps_stamped_tail_owned(
+        self, monkeypatch, busy_mode
+    ):
+        from types import SimpleNamespace
+
+        from gateway.platforms.base import MessageEvent, MessageType
+
+        monkeypatch.setenv("GATEWAY_PROXY_URL", "http://host:8642")
+        monkeypatch.delenv("GATEWAY_PROXY_KEY", raising=False)
+        runner = _make_runner()
+        runner._stamped_process_running_agents = {}
+        runner._draining = False
+        runner._busy_input_mode = busy_mode
+        runner._busy_text_mode = "interrupt"
+        monkeypatch.setattr(runner, "_is_user_authorized", lambda _source: True)
+        source = _make_source()
+        adapter = SimpleNamespace(_pending_messages={})
+        runner.adapters[source.platform] = adapter
+        session_key = "agent:main:matrix:group:proxy-tail"
+        generation = runner._begin_session_run_generation(session_key)
+        monkeypatch.setattr(
+            runner, "_is_stale_process_notification", lambda _payload: False
+        )
+        session = _FakeSession(
+            _FakeSSEResponse(
+                sse_chunks=[b'data: {"choices":[{"delta":{"content":"ok"}}]}\n\n']
+            )
+        )
+
+        with patch("gateway.run._load_gateway_config", return_value={}):
+            with _patch_aiohttp(session):
+                with patch("aiohttp.ClientTimeout"):
+                    result = await runner._run_agent_via_proxy(
+                        message="stale completion",
+                        context_prompt="",
+                        history=[],
+                        source=source,
+                        session_id="sess-old",
+                        session_key=session_key,
+                        run_generation=generation,
+                        expected_process_session_id="sess-old",
+                    )
+
+        assert result["final_response"] == "ok"
+        handle = runner._running_agents[session_key]
+        assert runner._stamped_process_running_agents[session_key] is handle
+        handle.interrupt = MagicMock()
+        handle.steer = MagicMock(return_value=True)
+        tail_foreground = MessageEvent(
+            text="foreground during proxy postprocessing tail",
+            message_type=MessageType.TEXT,
+            source=source,
+        )
+
+        handled = await runner._handle_active_session_busy_message(
+            tail_foreground, session_key
+        )
+
+        assert handled is True
+        handle.interrupt.assert_not_called()
+        handle.steer.assert_not_called()
+        assert adapter._pending_messages[session_key] is tail_foreground
+        runner._release_running_agent_state(session_key)
+        assert session_key not in runner._running_agents
+        assert session_key not in runner._stamped_process_running_agents
 
     @pytest.mark.asyncio
     async def test_builds_correct_request(self, monkeypatch):

--- a/tests/gateway/test_session_state_cleanup.py
+++ b/tests/gateway/test_session_state_cleanup.py
@@ -231,51 +231,76 @@ class TestSessionDbCloseOnShutdown:
 
 
 class TestSessionResetZombieRace:
-    """Regression for #28686 — a session_reset racing the in-flight run's
-    guarded release must not leave a dead agent locking the slot forever.
-    """
+    """Reset owns stale-slot cleanup; old turns may only release their generation."""
 
-    def test_generation_guard_blocks_then_unconditional_release_evicts(self):
+    def test_reset_release_then_old_unwind_preserves_newer_generation(self):
         runner = _make_runner()
         runner._session_run_generation = {}
         key = "agent:main:telegram:private:1"
 
-        gen_n = runner._begin_session_run_generation(key)
-        dead_agent = MagicMock()
-        runner._running_agents[key] = dead_agent
+        old_generation = runner._begin_session_run_generation(key)
+        runner._running_agents[key] = MagicMock(name="old-agent")
         runner._running_agents_ts[key] = 1.0
         runner._busy_ack_ts[key] = 1.0
 
-        # session_reset bumps the generation while gen-N is still in flight.
+        # Reset invalidates first and explicitly clears the old slot.
         runner._invalidate_session_run_generation(key, reason="session_reset")
-
-        # gen-N's own guarded release is correctly blocked — slot would be a
-        # zombie if nothing else cleared it (the pre-fix behaviour).
-        assert runner._release_running_agent_state(key, run_generation=gen_n) is False
-        assert runner._running_agents.get(key) is dead_agent
-
-        # The fix: unconditional release (no run_generation) always clears it.
         assert runner._release_running_agent_state(key) is True
-        assert key not in runner._running_agents
-        assert key not in runner._running_agents_ts
-        assert key not in runner._busy_ack_ts
 
-    def test_normal_completion_is_not_evicted_by_outer_release(self):
-        """Guarded release with the current generation succeeds; the outer
-        unconditional release that follows is a harmless no-op.
-        """
+        # A replacement turn claims the same stable routing key.
+        new_generation = runner._begin_session_run_generation(key)
+        new_agent = MagicMock(name="new-agent")
+        runner._running_agents[key] = new_agent
+        runner._running_agents_ts[key] = 2.0
+        runner._busy_ack_ts[key] = 2.0
+
+        # The old handler's finally must not clear the replacement.
+        assert (
+            runner._release_running_agent_state(
+                key, run_generation=old_generation
+            )
+            is False
+        )
+        assert runner._is_session_run_current(key, new_generation)
+        assert runner._running_agents[key] is new_agent
+        assert runner._running_agents_ts[key] == 2.0
+        assert runner._busy_ack_ts[key] == 2.0
+
+    def test_normal_completion_guarded_release_clears_current_turn(self):
         runner = _make_runner()
         runner._session_run_generation = {}
         key = "agent:main:telegram:private:2"
 
-        gen = runner._begin_session_run_generation(key)
+        generation = runner._begin_session_run_generation(key)
         runner._running_agents[key] = MagicMock()
         runner._running_agents_ts[key] = 1.0
         runner._busy_ack_ts[key] = 1.0
 
-        assert runner._release_running_agent_state(key, run_generation=gen) is True
+        assert (
+            runner._release_running_agent_state(
+                key, run_generation=generation
+            )
+            is True
+        )
         assert key not in runner._running_agents
-        # Outer finally runs the unconditional release after — nothing stranded.
-        assert runner._release_running_agent_state(key) is True
         assert key not in runner._running_agents_ts
         assert key not in runner._busy_ack_ts
+
+
+class TestIdentityGuardedAgentCacheEviction:
+    def test_evicts_only_the_stale_agent_instance(self):
+        runner = _make_runner()
+        runner._agent_cache = {}
+        runner._agent_cache_lock = threading.Lock()
+        key = "agent:main:telegram:private:cache"
+        stale_agent = MagicMock(name="stale-agent")
+        newer_agent = MagicMock(name="newer-agent")
+
+        runner._agent_cache[key] = (stale_agent, "sig", 0, "sess-old")
+        assert runner._evict_cached_agent_if_identity(key, stale_agent) is True
+        assert key not in runner._agent_cache
+
+        # A newer turn may publish before the stale worker finishes unwinding.
+        runner._agent_cache[key] = (newer_agent, "sig", 0, "sess-new")
+        assert runner._evict_cached_agent_if_identity(key, stale_agent) is False
+        assert runner._agent_cache[key][0] is newer_agent

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -2943,6 +2943,10 @@ class TestAssistantThreadLifecycle:
     async def test_lifecycle_event_seeds_session_store(
         self, assistant_adapter, mock_session_store
     ):
+        assistant_adapter.set_session_resolver(AsyncMock(return_value=MagicMock()))
+        mock_session_store.get_or_create_session.side_effect = AssertionError(
+            "direct transition-capable lookup bypassed runner resolver"
+        )
         event = {
             "type": "assistant_thread_started",
             "team_id": "T_TEAM",
@@ -2960,8 +2964,10 @@ class TestAssistantThreadLifecycle:
             assistant_adapter._assistant_threads[("D123", "171.000")]["user_id"]
             == "U_USER"
         )
-        mock_session_store.get_or_create_session.assert_called_once()
-        source = mock_session_store.get_or_create_session.call_args[0][0]
+        mock_session_store.get_or_create_session.assert_not_called()
+        resolver = assistant_adapter._session_resolver
+        resolver.assert_awaited_once()
+        source = resolver.await_args.args[0]
         assert source.chat_id == "D123"
         assert source.chat_type == "dm"
         assert source.user_id == "U_USER"

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -191,6 +191,40 @@ def test_unmentioned_group_messages_can_be_observed_without_dispatching():
     asyncio.run(_run())
 
 
+def test_observed_group_message_uses_boundary_resolver():
+    async def _run():
+        adapter = _make_adapter(
+            require_mention=True,
+            allowed_chats=["-100"],
+            group_allowed_chats=["-100"],
+            observe_unmentioned_group_messages=True,
+        )
+        store = _FakeSessionStore()
+        store.get_or_create_session = Mock(
+            side_effect=AssertionError(
+                "direct transition-capable lookup bypassed runner resolver"
+            )
+        )
+        adapter._session_store = store
+        adapter._session_resolver = AsyncMock(return_value=_FakeSessionEntry())
+        update = SimpleNamespace(
+            update_id=1001,
+            message=_group_message("side chatter"),
+            effective_message=None,
+        )
+
+        await adapter._handle_text_message(update, SimpleNamespace())
+
+        store.get_or_create_session.assert_not_called()
+        adapter._session_resolver.assert_awaited_once()
+        resolved_source = adapter._session_resolver.await_args.args[0]
+        assert resolved_source.chat_id == "-100"
+        assert resolved_source.user_id is None
+        assert len(store.messages) == 1
+
+    asyncio.run(_run())
+
+
 def test_observed_group_context_uses_shared_source_and_prompt_for_later_mentions():
     async def _run():
         adapter = _make_adapter(

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -950,6 +950,7 @@ class TestCheckpoint:
             s.watcher_user_id = "u123"
             s.watcher_user_name = "alice"
             s.watcher_thread_id = "42"
+            s.conversation_session_id = "sess-old"
             s.watcher_interval = 60
             registry._running[s.id] = s
             registry._write_checkpoint()
@@ -961,7 +962,124 @@ class TestCheckpoint:
             assert data[0]["watcher_user_id"] == "u123"
             assert data[0]["watcher_user_name"] == "alice"
             assert data[0]["watcher_thread_id"] == "42"
+            assert data[0]["conversation_session_id"] == "sess-old"
             assert data[0]["watcher_interval"] == 60
+
+    def test_terminal_spawn_flushes_stamped_session_id_before_recovery(
+        self, monkeypatch, tmp_path
+    ):
+        """The post-spawn notification stamp must reach crash recovery storage."""
+        import shlex
+
+        import tools.process_registry as pr_module
+        import tools.terminal_tool as terminal_module
+        from gateway.session_context import clear_session_vars, set_session_vars
+
+        checkpoint = tmp_path / "procs.json"
+        live_registry = ProcessRegistry()
+        monkeypatch.setattr(pr_module, "CHECKPOINT_PATH", checkpoint)
+        monkeypatch.setattr(pr_module, "process_registry", live_registry)
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+
+        tokens = set_session_vars(
+            platform="telegram",
+            chat_id="123",
+            session_key="agent:main:telegram:dm:123",
+            session_id="physical-session-old",
+            async_delivery=True,
+        )
+        process_id = ""
+        try:
+            result = json.loads(
+                terminal_module.terminal_tool(
+                    command=(
+                        f"{shlex.quote(sys.executable)} -c "
+                        f"{shlex.quote('import time; time.sleep(30)')}"
+                    ),
+                    background=True,
+                    notify_on_complete=True,
+                    force=True,
+                    workdir=str(tmp_path),
+                )
+            )
+            process_id = result["session_id"]
+
+            saved = json.loads(checkpoint.read_text())
+            assert saved[0]["conversation_session_id"] == "physical-session-old"
+            assert saved[0]["notify_on_complete"] is True
+            assert saved[0]["watcher_interval"] == 5
+
+            recovered_registry = ProcessRegistry()
+            assert recovered_registry.recover_from_checkpoint() == 1
+            recovered = recovered_registry.get(process_id)
+            assert recovered is not None
+            assert recovered.conversation_session_id == "physical-session-old"
+            assert recovered.notify_on_complete is True
+            assert recovered_registry.pending_watchers[0][
+                "conversation_session_id"
+            ] == "physical-session-old"
+        finally:
+            clear_session_vars(tokens)
+            if process_id:
+                live_registry.kill_process(process_id)
+
+    def test_checkpoint_writes_cannot_regress_newer_notification_metadata(
+        self, registry, tmp_path
+    ):
+        checkpoint = tmp_path / "procs.json"
+        session = _make_session()
+        registry._running[session.id] = session
+
+        first_write_ready = threading.Event()
+        second_write_ready = threading.Event()
+        release_first_write = threading.Event()
+        fresh_writer_started = threading.Event()
+        call_lock = threading.Lock()
+        call_count = 0
+
+        def delayed_atomic_write(path, entries):
+            nonlocal call_count
+            with call_lock:
+                call_count += 1
+                this_call = call_count
+            if this_call == 1:
+                first_write_ready.set()
+                assert release_first_write.wait(timeout=2)
+            else:
+                second_write_ready.set()
+            path.write_text(json.dumps(entries))
+
+        def write_fresh_checkpoint():
+            fresh_writer_started.set()
+            registry._write_checkpoint()
+
+        with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint), patch(
+            "utils.atomic_json_write", side_effect=delayed_atomic_write
+        ):
+            stale_writer = threading.Thread(target=registry._write_checkpoint)
+            stale_writer.start()
+            assert first_write_ready.wait(timeout=2)
+
+            session.conversation_session_id = "physical-session-new"
+            session.notify_on_complete = True
+            session.watcher_interval = 5
+
+            fresh_writer = threading.Thread(target=write_fresh_checkpoint)
+            fresh_writer.start()
+            assert fresh_writer_started.wait(timeout=2)
+            assert not second_write_ready.wait(timeout=0.1)
+            release_first_write.set()
+
+            stale_writer.join(timeout=2)
+            fresh_writer.join(timeout=2)
+            assert not stale_writer.is_alive()
+            assert not fresh_writer.is_alive()
+
+        saved = json.loads(checkpoint.read_text())
+        assert saved[0]["conversation_session_id"] == "physical-session-new"
+        assert saved[0]["notify_on_complete"] is True
+        assert saved[0]["watcher_interval"] == 5
 
     def test_recover_enqueues_watchers(self, registry, tmp_path):
         checkpoint = tmp_path / "procs.json"
@@ -976,6 +1094,7 @@ class TestCheckpoint:
             "watcher_user_id": "u123",
             "watcher_user_name": "alice",
             "watcher_thread_id": "42",
+            "conversation_session_id": "sess-old",
             "watcher_interval": 60,
         }]))
         with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint):
@@ -989,6 +1108,7 @@ class TestCheckpoint:
             assert w["user_id"] == "u123"
             assert w["user_name"] == "alice"
             assert w["thread_id"] == "42"
+            assert w["conversation_session_id"] == "sess-old"
             assert w["check_interval"] == 60
 
     def test_recover_skips_watcher_when_no_interval(self, registry, tmp_path):

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -115,6 +115,7 @@ class ProcessSession:
     watcher_user_name: str = ""
     watcher_thread_id: str = ""
     watcher_message_id: str = ""                # Triggering message id — reply anchor for topic routing
+    conversation_session_id: str = ""           # Logical Hermes session_id when spawned
     watcher_interval: int = 0                   # 0 = no watcher configured
     notify_on_complete: bool = False             # Queue agent notification on exit
     # Watch patterns — trigger agent notification when output matches any pattern
@@ -161,6 +162,10 @@ class ProcessRegistry:
         self._running: Dict[str, ProcessSession] = {}
         self._finished: Dict[str, ProcessSession] = {}
         self._lock = threading.Lock()
+        # Serialize snapshot + atomic replacement as one checkpoint generation.
+        # Without this, an older snapshot can finish writing after a newer one
+        # and silently regress recently stamped watcher/session metadata.
+        self._checkpoint_lock = threading.Lock()
 
         # Side-channel for check_interval watchers (gateway reads after agent run)
         self.pending_watchers: List[Dict[str, Any]] = []
@@ -318,6 +323,7 @@ class ProcessRegistry:
                     "user_name": session.watcher_user_name,
                     "thread_id": session.watcher_thread_id,
                     "message_id": session.watcher_message_id,
+                    "conversation_session_id": session.conversation_session_id,
                     "message": (
                         f"Watch patterns disabled for process {session.id} — "
                         f"{WATCH_STRIKE_LIMIT} consecutive rate-limit windows triggered "
@@ -351,6 +357,7 @@ class ProcessRegistry:
             "user_name": session.watcher_user_name,
             "thread_id": session.watcher_thread_id,
             "message_id": session.watcher_message_id,
+            "conversation_session_id": session.conversation_session_id,
         })
 
     def _global_watch_admit(self, now: float) -> bool:
@@ -1091,6 +1098,7 @@ class ProcessRegistry:
                 "completion_reason": session.completion_reason,
                 "termination_source": session.termination_source,
                 "output": output_tail,
+                "conversation_session_id": session.conversation_session_id,
             })
 
     # ----- Query Methods -----
@@ -1791,17 +1799,18 @@ class ProcessRegistry:
 
     def _write_checkpoint(self):
         """Write running process metadata to checkpoint file atomically."""
-        try:
-            with self._lock:
-                entries = []
-                for s in self._running.values():
-                    if not s.exited:
-                        # Lazily backfill the kernel start time for host PIDs so
-                        # recovery after restart can detect PID recycling even
-                        # for sessions spawned before this field existed.
-                        if s.host_start_time is None and s.pid_scope == "host" and s.pid:
-                            s.host_start_time = self._safe_host_start_time(s.pid)
-                        entries.append({
+        with self._checkpoint_lock:
+            try:
+                with self._lock:
+                    entries = []
+                    for s in self._running.values():
+                        if not s.exited:
+                            # Lazily backfill the kernel start time for host PIDs so
+                            # recovery after restart can detect PID recycling even
+                            # for sessions spawned before this field existed.
+                            if s.host_start_time is None and s.pid_scope == "host" and s.pid:
+                                s.host_start_time = self._safe_host_start_time(s.pid)
+                            entries.append({
                             "session_id": s.id,
                             "command": s.command,
                             "pid": s.pid,
@@ -1817,16 +1826,18 @@ class ProcessRegistry:
                             "watcher_user_name": s.watcher_user_name,
                             "watcher_thread_id": s.watcher_thread_id,
                             "watcher_message_id": s.watcher_message_id,
+                            "conversation_session_id": s.conversation_session_id,
                             "watcher_interval": s.watcher_interval,
                             "notify_on_complete": s.notify_on_complete,
                             "watch_patterns": s.watch_patterns,
-                        })
-            
-            # Atomic write to avoid corruption on crash
-            from utils import atomic_json_write
-            atomic_json_write(CHECKPOINT_PATH, entries)
-        except Exception as e:
-            logger.debug("Failed to write checkpoint file: %s", e, exc_info=True)
+                            })
+
+                # Atomic write to avoid corruption on crash. Keep the generation
+                # lock through replacement so an older snapshot cannot land last.
+                from utils import atomic_json_write
+                atomic_json_write(CHECKPOINT_PATH, entries)
+            except Exception as e:
+                logger.debug("Failed to write checkpoint file: %s", e, exc_info=True)
 
     def recover_from_checkpoint(self) -> int:
         """
@@ -1895,6 +1906,7 @@ class ProcessRegistry:
                 watcher_user_name=entry.get("watcher_user_name", ""),
                 watcher_thread_id=entry.get("watcher_thread_id", ""),
                 watcher_message_id=entry.get("watcher_message_id", ""),
+                conversation_session_id=entry.get("conversation_session_id", ""),
                 watcher_interval=entry.get("watcher_interval", 0),
                 notify_on_complete=entry.get("notify_on_complete", False),
                 watch_patterns=entry.get("watch_patterns", []),
@@ -1916,6 +1928,7 @@ class ProcessRegistry:
                     "user_name": session.watcher_user_name,
                     "thread_id": session.watcher_thread_id,
                     "message_id": session.watcher_message_id,
+                    "conversation_session_id": session.conversation_session_id,
                     "notify_on_complete": session.notify_on_complete,
                 })
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2546,12 +2546,14 @@ def terminal_tool(
                             _gw_user_id = _gse("HERMES_SESSION_USER_ID", "")
                             _gw_user_name = _gse("HERMES_SESSION_USER_NAME", "")
                             _gw_message_id = _gse("HERMES_SESSION_MESSAGE_ID", "")
+                            _gw_session_id = _gse("HERMES_SESSION_ID", "")
                             proc_session.watcher_platform = _gw_platform
                             proc_session.watcher_chat_id = _gw_chat_id
                             proc_session.watcher_user_id = _gw_user_id
                             proc_session.watcher_user_name = _gw_user_name
                             proc_session.watcher_thread_id = _gw_thread_id
                             proc_session.watcher_message_id = _gw_message_id
+                            proc_session.conversation_session_id = _gw_session_id
 
                 # Mutual exclusion: if both notify_on_complete and watch_patterns
                 # are set, drop watch_patterns. The combination produces duplicate
@@ -2589,6 +2591,7 @@ def terminal_tool(
                             "user_name": proc_session.watcher_user_name,
                             "thread_id": proc_session.watcher_thread_id,
                             "message_id": proc_session.watcher_message_id,
+                            "conversation_session_id": proc_session.conversation_session_id,
                             "notify_on_complete": True,
                         })
 
@@ -2596,6 +2599,13 @@ def terminal_tool(
                 if watch_patterns and background:
                     proc_session.watch_patterns = list(watch_patterns)
                     result_data["watch_patterns"] = proc_session.watch_patterns
+
+                # spawn_local()/spawn_via_env() checkpoint before terminal_tool
+                # can stamp gateway routing and notification metadata. Persist the
+                # completed notification configuration so crash recovery keeps the
+                # physical conversation session boundary used by stale-event guards.
+                if background and (notify_on_complete or watch_patterns):
+                    process_registry._write_checkpoint()
 
                 return json.dumps(result_data, ensure_ascii=False)
             except Exception as e:


### PR DESCRIPTION
## Summary

- expose the active gateway physical `session_id` through session context as `HERMES_SESSION_ID`
- stamp background process watcher metadata with the conversation session id at spawn time
- persist/recover that metadata through process-registry checkpoints
- suppress stale background-process watch/completion notifications when a session key has moved to a different physical session, fail closed when stamped session ownership cannot be resolved, and revalidate through final routing and immediately before model/tool or text delivery
- keep notifications alive across normal compression continuations by comparing session ids through the compression-tip chain
- cover stale agent notifications, text-only watcher sends, compression continuations, and checkpoint recovery

## Why

Background process notifications can arrive after a user starts a fresh session. Routing by chat/thread alone is not enough: the event may belong to an older physical session while the session key now points at a new one.

Keeping the spawning `session_id` lets the gateway suppress stale synthetic turns and text-only watcher messages instead of injecting old process output into the new session. Compression continuations are handled separately so a process spawned before auto-compression can still notify the live continuation.

## Related Issue

No separate issue. Follow-up slice from closed broad host-support PR #13370; complementary to merged compression-boundary PR #16306.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `gateway/run.py`: drops stale or unverifiable stamped process notifications using `session_key` + captured `conversation_session_id`, preserves compression continuations, pins the expected process session into synthetic agent events, revalidates after Telegram topic-binding routing overrides and awaited pre-agent setup, and gives stamped process turns a narrow side-effect-free handler path: no inbound enrichment, lifecycle hooks, tool/status/notice/voice/progress/interim callbacks, streaming, generic stable-key postprocessing, goal continuation, or stale response handoff. Stamped notifications wait behind an active foreground turn without steering or interrupting it; while a stamped process agent is executing, ordinary foreground input is queued under both busy-entry paths rather than being steered into or used to interrupt the synthetic turn; dangerous-command approvals auto-deny without a platform prompt in a generation-owned approval namespace; and model-produced `MEDIA:` directives are intentionally suppressed because this synthetic narrow path is text-only and cannot deliver local files, images, voice, video, or documents. After executor completion, stamped turns return immediately through this narrow result path without heartbeat/inactivity sends, fallback persistence, pending-message dequeue, direct queued-response sends, or recursive foreground follow-up execution. Stamped final delivery runs directly through a per-session boundary lock shared with all session lookups that can auto-reset an expired session, explicit reset/resume/branch switching, and `/stop`/`/new` generation invalidation, closing the last check-to-`adapter.send()` race for agent and text-only notifications. Process watcher delivery reconstructs named-profile sources from multiplexed `agent:<profile>:...` keys and selects that profile's adapter credentials, while retaining default-adapter compatibility for legacy unstamped watchers. It defers model-backed transcript hygiene for synthetic process turns and gates local/proxy model startup on both physical ownership and run generation. Reset invalidates generation before reading the execution slot; process-triggered local/proxy runs expose a concrete interruptible handle plus an identity-owned stamped-process marker before their final execution-boundary check; both identities remain published through backend completion and surrounding synthetic-turn postprocessing, so ordinary foreground input stays behind the existing adapter guard until stamped release and is then drained exactly once instead of adapter hot-looping, steering, or interrupting; explicit `/stop` and `/new` can still cancel it, and both identities are generation/identity-CAS-published and identity-cleared together only at the true outer turn boundary. Stamped agent-cache publication is a generation-checked compare-and-set inside the cache lock, stale cleanup identity-evicts only its own cached agent, and stale process runs skip all postprocessing. Old process finalizers generation-guard slot release; one-shot MoA restoration uses exact installed-override ownership so `/stop` restores the temporary override while `/new` replacement state wins.
- `gateway/slash_commands.py`: routes session lookups (including auto-reset), delayed model-picker callback persistence and preflight-warning history reads, explicit reset, resume, and branch session-store mutations through the same process-delivery boundary lock.
- `hermes_cli/context_switch_guard.py`: makes gateway model-switch warning enrichment async and reads the resolved physical session history inside the runner-owned boundary instead of directly invoking the transition-capable synchronous store.
- `gateway/platforms/base.py`: exposes a runner-owned async session resolver so adapter middleware can perform transition-capable lookups through the same delivery boundary; secondary-profile adapters receive a profile-bound resolver before middleware runs so lookup and lock keys remain in `agent:<profile>`. When a foreground adapter task discovers an out-of-band stamped owner, it retains the adapter guard and pending-drain ownership until that stamped lifecycle releases it, then drains the retained foreground event exactly once instead of entering a recursive redispatch loop or exposing an ownerless replay gap.
- `gateway/platforms/yuanbao.py`: routes recall redaction/patching, observed-group transcript writes, quote-media lookup, and observed-media hydration through that boundary-aware resolver instead of direct synchronous store lookups.
- `plugins/platforms/slack/adapter.py`: makes Assistant thread session seeding async and boundary-resolved.
- `plugins/platforms/telegram/adapter.py`: makes unmentioned-group transcript observation async and boundary-resolved across text, location, and media handlers.
- `cron/scheduler.py`: seeds continuable thread/channel cron sessions through the live adapter's profile-bound resolver on the gateway loop and appends the seed transcript within the same delivery-boundary critical section, preventing cron auto-reset/profile races without adding a second unguarded mirror lookup.
- `tools/terminal_tool.py`: stamps background process metadata with the spawning conversation session id and flushes the completed notification configuration after spawn so crash recovery does not retain the earlier empty metadata.
- `tools/process_registry.py`: persists and recovers `conversation_session_id` for background watcher checkpoints/events and serializes complete checkpoint generations so an older concurrent snapshot cannot overwrite newer metadata.
- `tests/gateway/test_background_process_notifications.py`: adds stale-boundary, missing-owner/store-failure, compression-continuation, post-validation Telegram topic-rebind, barrier-based reset-during-pre-agent and cache-publication regressions, callback/streaming side-channel suppression checks, direct guarded agent-result delivery coverage, deliberate media-only suppression, proof that stamped turns cannot dequeue or recursively execute queued foreground messages, delivery-first/reset-first boundary-lock schedules, an auto-resetting session-lookup race, a real Yuanbao middleware lookup-versus-delivery schedule, a production busy-session non-interruption regression, a real `BasePlatformAdapter` regression proving one retained foreground dispatch and one post-release normal turn without recursive task churn, stale deferred-replay suppression, stale local-handle publication CAS preserving replacement ownership, both foreground busy-entry paths retaining input behind a stamped process agent, named-profile adapter selection across injected/completion/running rails, a cron-seed-versus-guarded-delivery lock schedule, a model-switch-warning lookup-versus-delivery lock schedule, queued stamped-event retry coverage, approval auto-denial without visible delivery, and replacement approval-state survival after stale process cleanup.
- `tests/gateway/test_proxy_mode.py`: proves a stamped process-triggered proxy request exposes a concrete interruptible task handle, publishes the matching stamped ownership marker, queues ordinary foreground input without cancellation in interrupt and steer modes, and cleans both identities after completion or explicit reset cancellation.
- `tests/gateway/test_session_state_cleanup.py`: proves reset-owned cleanup plus generation-guarded old-turn unwind preserves a newer execution slot, and identity cache eviction cannot remove a newer agent.
- `tests/gateway/test_moa_one_shot_restore.py`: proves ownership-based restoration removes the still-owned temporary MoA override after `/stop`, while stale unwind cannot restore old overrides or evict replacement-session cache state after `/new`.
- `tests/gateway/test_slack.py`, `tests/gateway/test_telegram_group_gating.py`, and `tests/gateway/test_multiplex_phase0.py`: prove adapter middleware awaits the injected resolver rather than the synchronous store and secondary-profile resolution uses the correct profile namespace.
- `tests/gateway/test_model_picker_persist.py`: proves the delayed picker callback uses the boundary-guarded session lookup before persisting its selected model.
- `tests/tools/test_process_registry.py`: asserts checkpoint write/recovery preserves `conversation_session_id`, including a real spawn → stamp → recover lifecycle regression and an ordered concurrent-writer regression.
- `tests/cron/test_scheduler.py`: covers resolver-based thread/channel seeding, exact reply-key compatibility, in-boundary transcript append, and standalone fallback behavior.

## How to Test

1. Start a background process with `notify_on_complete=True` from a gateway session.
2. Reset or resume that chat/thread so the same `session_key` points to a different physical session.
3. Let the old process finish: stale output should not be injected into the new session.
4. Repeat with auto-compression instead of reset: output should still notify the live compression continuation.

## Validation

- Rebased without conflicts onto `origin/main` `f813c7ddad6f7a4973f83737d36d5e11a5cbbe50`; no additional local post-rebase test cycle was run.
- Pre-rebase validation of the exact patch:
  - `python3 -m compileall -q gateway/run.py gateway/slash_commands.py gateway/platforms/base.py gateway/platforms/yuanbao.py hermes_cli/context_switch_guard.py cron/scheduler.py plugins/platforms/slack/adapter.py plugins/platforms/telegram/adapter.py tools/process_registry.py tools/terminal_tool.py tests/gateway/test_background_process_notifications.py tests/gateway/test_proxy_mode.py tests/gateway/test_model_picker_persist.py tests/gateway/test_multiplex_phase0.py tests/gateway/test_slack.py tests/gateway/test_telegram_group_gating.py tests/tools/test_process_registry.py tests/cron/test_scheduler.py`
  - `git diff --check`
  - `./scripts/run_tests.sh tests/gateway/test_background_process_notifications.py tests/gateway/test_proxy_mode.py tests/gateway/test_tool_response_drop_recovery.py tests/gateway/test_session_state_cleanup.py tests/gateway/test_moa_one_shot_restore.py tests/gateway/test_agent_cache.py tests/gateway/test_new_clears_last_resolved_model.py tests/gateway/test_session_model_reset.py tests/gateway/test_resume_command.py tests/gateway/test_35809_auto_reset_clean_context.py tests/gateway/test_10710_auto_reset_evicts_cached_agent.py tests/gateway/test_48031_model_switch_after_auto_reset.py tests/gateway/test_35994_reset_button_deadlock.py tests/tools/test_process_registry.py tests/tools/test_terminal_tool.py tests/tools/test_terminal_compound_background.py tests/gateway/test_session_store_runtime_stale_guard.py tests/hermes_state/test_resolve_resume_session_id.py tests/cli/test_moa_command.py tests/gateway/test_usage_command.py tests/gateway/test_title_command.py tests/gateway/test_status_command.py tests/gateway/test_model_command_custom_providers.py tests/gateway/test_undo_rewind_session.py tests/gateway/test_session_info.py tests/gateway/test_session_reset_notify.py tests/gateway/test_compress_command.py tests/gateway/test_model_picker_persist.py tests/gateway/test_model_command_async_offload.py tests/test_yuanbao_pipeline.py tests/test_yuanbao_integration.py tests/gateway/platforms/test_yuanbao_recall_db_only.py tests/gateway/test_yuanbao_media_ssrf.py tests/gateway/test_telegram_group_gating.py tests/gateway/test_slack.py tests/gateway/test_multiplex_phase0.py tests/gateway/test_multiplex_lifecycle.py tests/gateway/test_multiplex_adapter_registry.py tests/cron/test_scheduler.py tests/hermes_cli/test_context_switch_guard.py -q --tb=short` — 1,319 passed.
- `./scripts/run_tests.sh -q` was attempted against the refreshed branch; the 37k-test run reached 75% before the 10-minute local timeout. Ten failures had appeared outside the touched test files; all touched/focused files above passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing PRs/issues for duplicates and superseding fixes
- [x] My PR contains only changes related to this fix
- [ ] I've run the full suite to completion — the 37k-test run reached 75% before the 10-minute local timeout; focused validation above passes
- [x] I've added tests for my changes
- [x] I've tested on Ubuntu/Linux

### Documentation & Housekeeping

- [x] Documentation update N/A
- [x] `cli-config.yaml.example` update N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update N/A
- [x] Cross-platform impact considered
- [x] Tool descriptions/schemas update N/A

## Screenshots / Logs

N/A — gateway/process-routing behavior, covered by regression tests.
