### PR TITLE
fix(tests): clean tirith background install noise

### DIFF
--- a/tests/tools/test_local_interrupt_cleanup.py
+++ b/tests/tools/test_local_interrupt_cleanup.py
@@ -13,7 +13,6 @@ died.  See commit message for full context.
 """
 import os
 import signal
-import subprocess
 import threading
 import time
 
@@ -47,6 +46,18 @@ def test_wait_for_process_kills_subprocess_on_keyboardinterrupt():
         started = threading.Event()
         raise_at = [None]  # set by the main thread to tell worker when
 
+        original_run_bash = env._run_bash
+
+        def tracking_run_bash(*args, **kwargs):
+            proc = original_run_bash(*args, **kwargs)
+            cmd_string = args[0] if args else kwargs.get("cmd_string", "")
+            if "sleep 30" in str(cmd_string):
+                proc_holder["proc"] = proc
+                started.set()
+            return proc
+
+        env._run_bash = tracking_run_bash
+
         # Drive execute() on a separate thread so we can SIGNAL-interrupt it
         # via a thread-targeted exception without killing our test process.
         def worker():
@@ -60,43 +71,17 @@ def test_wait_for_process_kills_subprocess_on_keyboardinterrupt():
 
         t = threading.Thread(target=worker, daemon=True)
         t.start()
-        # Wait until the subprocess actually exists.  LocalEnvironment.execute
-        # does init_session() (one spawn) before the real command, so we need
-        # to wait until a sleep 30 is visible.  Use pgrep-style lookup via
-        # /proc to find the bash process running our sleep.
-        deadline = time.monotonic() + 5.0
-        target_pid = None
-        while time.monotonic() < deadline:
-            # Walk our children and grand-children to find one running 'sleep 30'
-            try:
-                import psutil  # optional — fall back if absent
-                for p in psutil.Process(os.getpid()).children(recursive=True):
-                    try:
-                        if "sleep 30" in " ".join(p.cmdline()):
-                            target_pid = p.pid
-                            break
-                    except (psutil.NoSuchProcess, psutil.AccessDenied):
-                        continue
-            except ImportError:
-                # Fall back to ps
-                ps = subprocess.run(
-                    ["ps", "-eo", "pid,ppid,pgid,cmd"], capture_output=True, text=True,
-                )
-                for line in ps.stdout.splitlines():
-                    if "sleep 30" in line and "grep" not in line:
-                        parts = line.split()
-                        if parts and parts[0].isdigit():
-                            target_pid = int(parts[0])
-                            break
-            if target_pid:
-                break
-            time.sleep(0.1)
-
-        assert target_pid is not None, (
-            "test setup: couldn't find 'sleep 30' subprocess after 5 s"
+        # Wait until the subprocess actually exists.  Capture the Popen object
+        # from LocalEnvironment._run_bash instead of scraping process text:
+        # wrappers vary by shell/platform and can make `sleep 30` cmdline scans
+        # flaky even when the process group is alive.
+        assert started.wait(timeout=5.0), (
+            "test setup: LocalEnvironment did not spawn the 'sleep 30' wrapper within 5 s"
         )
-        pgid = os.getpgid(target_pid)
-        assert _pgid_still_alive(pgid), "sanity: subprocess should be alive"
+        proc = proc_holder.get("proc")
+        assert proc is not None and proc.poll() is None, "sanity: subprocess wrapper should be alive"
+        pgid = os.getpgid(proc.pid)
+        assert _pgid_still_alive(pgid), "sanity: subprocess group should be alive"
 
         # Now inject a KeyboardInterrupt into the worker thread the same
         # way CPython's signal machinery would.  We use ctypes.PyThreadState_SetAsyncExc

--- a/tests/tools/test_tirith_security.py
+++ b/tests/tools/test_tirith_security.py
@@ -692,11 +692,29 @@ class TestBackgroundInstall:
 
         _tirith_mod._resolved_path = None
 
+    def test_background_install_suppresses_closed_stdout_shutdown_noise(self):
+        """Background installer must not leak thread exceptions during stream teardown."""
+        _tirith_mod._resolved_path = None
+        _tirith_mod._install_failure_reason = ""
+
+        with patch("tools.tirith_security.shutil.which", return_value=None), \
+             patch("tools.tirith_security._hermes_bin_dir", return_value="/nonexistent"), \
+             patch("tools.tirith_security._install_tirith",
+                   side_effect=ValueError("I/O operation on closed file")), \
+             patch("tools.tirith_security._mark_install_failed") as mock_mark:
+            _tirith_mod._background_install(log_failures=False)
+
+        assert _tirith_mod._resolved_path is _tirith_mod._INSTALL_FAILED
+        assert _tirith_mod._install_failure_reason == "background_install_error"
+        mock_mark.assert_called_once_with("background_install_error")
+
+        _tirith_mod._resolved_path = None
+        _tirith_mod._install_failure_reason = ""
+
 
 # ---------------------------------------------------------------------------
 # Disk failure marker persistence (P2)
 # ---------------------------------------------------------------------------
-
 class TestDiskFailureMarker:
     def test_mark_and_check(self):
         """Writing then reading the marker should work."""

--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -511,7 +511,14 @@ def _background_install(*, log_failures: bool = True):
             _install_failure_reason = ""
             return
 
-        installed, reason = _install_tirith(log_failures=log_failures)
+        try:
+            installed, reason = _install_tirith(log_failures=log_failures)
+        except Exception as exc:
+            logger.debug("tirith background install failed: %s", exc)
+            _resolved_path = _INSTALL_FAILED
+            _install_failure_reason = "background_install_error"
+            _mark_install_failed(_install_failure_reason)
+            return
         if installed:
             _resolved_path = installed
             _install_failure_reason = ""


### PR DESCRIPTION
## Summary
- Suppress unexpected tirith background installer exceptions so shutdown/closed-stream noise does not leak from daemon threads.
- Stabilize local interrupt cleanup coverage by capturing the spawned Popen object instead of scraping process command lines.
- Keep the PR scoped to files still present on current origin/main; legacy RTK integration test was already removed upstream.

## Test Plan
- `git diff --check origin/main...HEAD`
- `python -m pytest -q tests/tools/test_tirith_security.py tests/tools/test_local_interrupt_cleanup.py tests/tools/test_interrupt.py -W error::pytest.PytestUnhandledThreadExceptionWarning`

## Review
- Independent reviewer passed: no security concerns or logic errors.
