### PR TITLE
fix(cli): include custom_providers in list_available_providers for TUI /model picker

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1405,6 +1405,28 @@ def list_available_providers() -> list[dict[str, str]]:
             "aliases": alias_list,
             "authenticated": has_creds,
         })
+
+    # Append user-defined custom providers from config.yaml
+    try:
+        from hermes_cli.config import get_compatible_custom_providers
+        seen_ids = {entry["id"] for entry in result}
+        for cp in get_compatible_custom_providers():
+            cp_name = cp.get("name", "")
+            if not cp_name:
+                continue
+            cp_id = f"custom:{cp_name}"
+            if cp_id in seen_ids:
+                continue
+            seen_ids.add(cp_id)
+            result.append({
+                "id": cp_id,
+                "label": cp_name,
+                "aliases": [],
+                "authenticated": True,
+            })
+    except Exception:
+        pass
+
     return result
 
 

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -6,6 +6,7 @@ from hermes_cli.models import (
     OPENROUTER_MODELS, fetch_openrouter_models, model_ids, detect_provider_for_model,
     is_nous_free_tier, partition_nous_models_by_tier,
     check_nous_free_tier, _FREE_TIER_CACHE_TTL,
+    list_available_providers,
 )
 import hermes_cli.models as _models_mod
 
@@ -615,3 +616,54 @@ class TestNousRecommendedModels:
             patch("hermes_cli.models.check_nous_free_tier", side_effect=RuntimeError("boom")),
         ):
             assert get_nous_recommended_aux_model(vision=False) == "paid-model"
+
+
+class TestListAvailableProvidersCustom:
+    """list_available_providers includes user-defined custom providers from config."""
+
+    _FAKE_CUSTOM_PROVIDERS = [
+        {"name": "local-llama", "base_url": "http://localhost:11434/v1"},
+        {"name": "my-server", "base_url": "https://my.server.example/v1"},
+    ]
+
+    @patch("hermes_cli.config.get_compatible_custom_providers", return_value=[])
+    def test_no_custom_providers(self, _mock_gcp):
+        providers = list_available_providers()
+        ids = [p["id"] for p in providers]
+        assert "custom" in ids
+        assert not any(pid.startswith("custom:") for pid in ids)
+
+    @patch("hermes_cli.config.get_compatible_custom_providers")
+    def test_custom_providers_appended(self, mock_gcp):
+        mock_gcp.return_value = self._FAKE_CUSTOM_PROVIDERS
+        providers = list_available_providers()
+        ids = [p["id"] for p in providers]
+        assert "custom:local-llama" in ids
+        assert "custom:my-server" in ids
+
+    @patch("hermes_cli.config.get_compatible_custom_providers")
+    def test_custom_providers_marked_authenticated(self, mock_gcp):
+        mock_gcp.return_value = self._FAKE_CUSTOM_PROVIDERS
+        providers = list_available_providers()
+        by_id = {p["id"]: p for p in providers}
+        assert by_id["custom:local-llama"]["authenticated"] is True
+        assert by_id["custom:my-server"]["authenticated"] is True
+
+    @patch("hermes_cli.config.get_compatible_custom_providers")
+    def test_custom_providers_no_duplicates(self, mock_gcp):
+        mock_gcp.return_value = [
+            {"name": "dup", "base_url": "http://a.test/v1"},
+            {"name": "dup", "base_url": "http://b.test/v1"},
+        ]
+        providers = list_available_providers()
+        dup_count = sum(1 for p in providers if p["id"] == "custom:dup")
+        assert dup_count == 1
+
+    @patch(
+        "hermes_cli.config.get_compatible_custom_providers",
+        side_effect=RuntimeError("config broken"),
+    )
+    def test_config_error_does_not_crash(self, _mock_gcp):
+        providers = list_available_providers()
+        assert isinstance(providers, list)
+        assert len(providers) > 0


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where the TUI `/model` picker does not display user-defined `custom_providers` from `config.yaml`. Only built-in/canonical providers were shown because `list_available_providers()` only iterated over `CANONICAL_PROVIDERS`.

The fix appends custom providers (loaded via `get_compatible_custom_providers()`) to the provider list with a `custom:<name>` id scheme, with deduplication by name.

## Related Issue

Fixes #16438

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/models.py`: After building the canonical provider list, load user-defined custom providers from config and append them with `custom:<name>` ids, marked as authenticated
- `tests/hermes_cli/test_models.py`: Added 5 tests covering custom provider inclusion, deduplication, authentication marking, empty list, and config error resilience

## How to Test

1. Add `custom_providers` entries to `~/.hermes/config.yaml`
2. Launch `hermes --tui` and type `/model`
3. Custom providers should now appear in the picker
4. Run the targeted test: `pytest tests/hermes_cli/test_models.py -v`
5. Run full suite: `pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (Darwin 25.4.0, Apple Silicon), Python 3.11

### Documentation & Housekeeping

- [x] Updated relevant documentation — or N/A
- [x] Updated cli-config.yaml.example — or N/A
- [x] Updated contributing / agents docs — or N/A
- [x] Considered cross-platform impact — or N/A
- [x] Updated tool descriptions/schemas — or N/A
