### PR TITLE
fix(gateway): harden StreamingConfig bool and numeric coercion

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -36,6 +36,26 @@ def _coerce_bool(value: Any, default: bool = True) -> bool:
     return is_truthy_value(value, default=default)
 
 
+def _coerce_float(value: Any, default: float) -> float:
+    """Coerce numeric config values, falling back on malformed input."""
+    if value is None:
+        return default
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_int(value: Any, default: int) -> int:
+    """Coerce integer config values, falling back on malformed input."""
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
 def _normalize_unauthorized_dm_behavior(value: Any, default: str = "pair") -> str:
     """Normalize unauthorized DM behavior to a supported value."""
     if isinstance(value, str):
@@ -220,13 +240,13 @@ class StreamingConfig:
         if not data:
             return cls()
         return cls(
-            enabled=data.get("enabled", False),
+            enabled=_coerce_bool(data.get("enabled"), False),
             transport=data.get("transport", "edit"),
-            edit_interval=float(data.get("edit_interval", 1.0)),
-            buffer_threshold=int(data.get("buffer_threshold", 40)),
+            edit_interval=_coerce_float(data.get("edit_interval"), 1.0),
+            buffer_threshold=_coerce_int(data.get("buffer_threshold"), 40),
             cursor=data.get("cursor", " ▉"),
-            fresh_final_after_seconds=float(
-                data.get("fresh_final_after_seconds", 60.0)
+            fresh_final_after_seconds=_coerce_float(
+                data.get("fresh_final_after_seconds"), 60.0
             ),
         )
 

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -9,6 +9,7 @@ from gateway.config import (
     Platform,
     PlatformConfig,
     SessionResetPolicy,
+    StreamingConfig,
     _apply_env_overrides,
     load_gateway_config,
 )
@@ -147,6 +148,24 @@ class TestSessionResetPolicy:
     def test_from_dict_coerces_quoted_false_notify(self):
         restored = SessionResetPolicy.from_dict({"notify": "false"})
         assert restored.notify is False
+
+
+class TestStreamingConfig:
+    def test_from_dict_coerces_quoted_false_enabled(self):
+        restored = StreamingConfig.from_dict({"enabled": "false"})
+        assert restored.enabled is False
+
+    def test_from_dict_malformed_numeric_values_fall_back_to_defaults(self):
+        restored = StreamingConfig.from_dict(
+            {
+                "edit_interval": "oops",
+                "buffer_threshold": "oops",
+                "fresh_final_after_seconds": "oops",
+            }
+        )
+        assert restored.edit_interval == 1.0
+        assert restored.buffer_threshold == 40
+        assert restored.fresh_final_after_seconds == 60.0
 
 
 class TestGatewayConfigRoundtrip:


### PR DESCRIPTION
## What does this PR do?
This PR hardens gateway streaming config parsing so malformed or quoted config values do not silently change runtime behavior or crash config loading.

Before this change, `gateway.config.StreamingConfig.from_dict()` left `enabled` uncoerced and parsed numeric fields with direct `float()` / `int()` calls. That caused two concrete problems:
1. `streaming.enabled: "false"` could remain truthy instead of disabling streaming.
2. Invalid numeric values like `edit_interval: "oops"` could raise during config loading instead of falling back safely.

This approach is the right fix because it keeps the change narrowly scoped to the config parser, aligns `StreamingConfig` with the existing coercion patterns already used elsewhere in gateway config, and adds regression coverage for both failure modes.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made
- Updated `gateway/config.py`
- Added safe numeric coercion helpers for float and int config fields
- Changed `StreamingConfig.from_dict()` to:
  - coerce `enabled` via the existing bool-normalization path
  - safely parse `edit_interval`
  - safely parse `buffer_threshold`
  - safely parse `fresh_final_after_seconds`
- Added regression tests in `tests/gateway/test_config.py` for:
  - quoted `"false"` on `streaming.enabled`
  - malformed numeric values falling back to defaults

## How to Test
1. Set a config value like `streaming.enabled: "false"` and verify it is treated as disabled instead of truthy.
2. Set malformed numeric streaming config values such as `edit_interval: "oops"` and verify gateway config loading falls back to defaults instead of raising.
3. Run:
   ```bash
   scripts/run_tests.sh tests/gateway/test_config.py
   
Expected result: 35 passed

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (fix(scope):, feat(scope):, etc.)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run pytest tests/ -q and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)


### Documentation & Housekeeping
- [x] I've updated relevant documentation (README, docs/, docstrings) — or N/A
- [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A


