### PR TITLE
fix(tui): prefer raw text over rendered ANSI in render-markdown mode

### DIFF
--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -474,4 +474,53 @@ describe('createGatewayEventHandler', () => {
 
     expect(getTurnState().activity).toMatchObject([{ text: 'boom', tone: 'error' }])
   })
+
+  // The gateway populates `payload.rendered` with Rich-generated ANSI when
+  // `final_response_markdown: render` is set. Ink's <Md> renderer cannot
+  // interpret those sequences and would display them as garbled output —
+  // overlapping text, color layering, escape artifacts. The TUI must prefer
+  // the raw `payload.text` so its own markdown renderer takes over.
+  it('prefers raw payload.text over rendered ANSI for the final assistant message', () => {
+    const appended: Msg[] = []
+    const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+    onEvent({ payload: {}, type: 'message.start' } as any)
+    onEvent({
+      payload: {
+        rendered: '\x1b[1mhello\x1b[0m\x1b[A\x1b[K', // Rich ANSI: bold + cursor moves
+        text: '**hello**'
+      },
+      type: 'message.complete'
+    } as any)
+
+    const final = appended.find(msg => msg.role === 'assistant')
+    expect(final?.text).toBe('**hello**')
+    expect(final?.text).not.toContain('\x1b[')
+  })
+
+  it('ignores rendered fragment in message.delta and accumulates raw text', () => {
+    const appended: Msg[] = []
+    const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+    onEvent({ payload: {}, type: 'message.start' } as any)
+
+    // Two delta ticks. `rendered` carries an *incomplete* Rich fragment on
+    // each tick — using it would replace the full accumulated buffer and
+    // drop prior content. Only `text` should accumulate.
+    onEvent({
+      payload: { rendered: '\x1b[1mhel', text: 'hel' },
+      type: 'message.delta'
+    } as any)
+    onEvent({
+      payload: { rendered: 'lo\x1b[0m', text: 'lo' },
+      type: 'message.delta'
+    } as any)
+    onEvent({
+      payload: { text: 'hello' }, // no rendered: confirms text path is canonical
+      type: 'message.complete'
+    } as any)
+
+    const final = appended.find(msg => msg.role === 'assistant')
+    expect(final?.text).toBe('hello')
+  })
 })

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -423,7 +423,12 @@ class TurnController {
   recordMessageComplete(payload: { rendered?: string; reasoning?: string; text?: string }) {
     this.closeReasoningSegment()
 
-    const rawText = (payload.rendered ?? payload.text ?? this.bufRef).trimStart()
+    // Prefer raw text over `rendered` — the gateway may populate `rendered`
+    // with Rich-generated ANSI (cursor moves, line clears, color codes) when
+    // `final_response_markdown: render` is set. Ink's <Md> renderer cannot
+    // interpret those sequences and will display them as garbled output. Fall
+    // back to `rendered` only if the gateway didn't send `text`.
+    const rawText = (payload.text ?? payload.rendered ?? this.bufRef).trimStart()
     const split = splitReasoning(rawText)
     const finalText = finalTail(split.text, this.segmentMessages)
     const existingReasoning = this.reasoningText.trim() || String(payload.reasoning ?? '').trim()
@@ -508,7 +513,7 @@ class TurnController {
     return { finalMessages, finalText, wasInterrupted }
   }
 
-  recordMessageDelta({ rendered, text }: { rendered?: string; text?: string }) {
+  recordMessageDelta({ text }: { rendered?: string; text?: string }) {
     this.pruneTransient()
     this.endReasoningPhase()
 
@@ -516,7 +521,10 @@ class TurnController {
       return
     }
 
-    this.bufRef = rendered ?? this.bufRef + text
+    // Ignore `rendered` during streaming. It carries an *incomplete* Rich
+    // ANSI fragment and using it would replace the whole accumulated buffer
+    // with that fragment on every delta, dropping prior content.
+    this.bufRef = this.bufRef + text
 
     if (getUiState().streaming) {
       this.scheduleStreaming()


### PR DESCRIPTION
## What does this PR do?

When `display.final_response_markdown: render` is set, the TUI gateway populates `payload.rendered` with Rich-generated ANSI (cursor moves like `\x1b[A`, line clears `\x1b[K`, color codes). Ink's `<Md>` renderer cannot interpret those sequences and displays them as garbled, overlapping output — color layering, misaligned columns, escape artifacts.

The TUI's `turnController` was prioritizing `rendered` over the raw markdown text in two places:

1. **`recordMessageComplete`** (`ui-tui/src/app/turnController.ts:426`) — used `payload.rendered ?? payload.text` for the final assistant message, so Ink got ANSI instead of raw markdown.
2. **`recordMessageDelta`** (`ui-tui/src/app/turnController.ts:519`) — `this.bufRef = rendered ?? this.bufRef + text`. Worse: `rendered` arrives as an *incomplete* Rich fragment on every streaming tick, so this replaced the full accumulated buffer with that fragment, dropping prior content.

The CLI and other gateway platforms (Telegram, Discord, …) feed `rendered` to real terminal emulators that interpret Rich ANSI correctly. Ink does not — it has its own markdown renderer in `ui-tui/src/components/markdown.tsx` and just needs the raw markdown.

## Related Issue

Fixes #16391

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `ui-tui/src/app/turnController.ts` — `recordMessageComplete` now prefers `payload.text`; `recordMessageDelta` ignores `rendered` and accumulates `text` only.
- `ui-tui/src/__tests__/createGatewayEventHandler.test.ts` — two new tests covering the complete and delta paths.

## How to Test

1. Set in `~/.hermes/config.yaml`:
   ```yaml
   display:
     final_response_markdown: render
   ```
2. Run `hermes --tui` and ask for a multi-paragraph reply (or one with tables/code blocks).
3. Before this PR: output is garbled with ANSI escape artifacts.
4. After this PR: markdown renders cleanly via Ink's `<Md>` component.

Automated:
```bash
cd ui-tui
npm test       # 368 passed (incl. 2 new)
npm run type-check
npx eslint src/app/turnController.ts src/__tests__/createGatewayEventHandler.test.ts
```

## Notes

This is the minimal targeted fix (Option A from the issue). Two follow-ups remain possible but are out of scope here:
- Option B — make rendered/text priority configurable via `display.tui_prefer_raw_text`.
- Option C — gateway-side: skip `rendered` population for TUI sessions entirely (`tui_gateway/server.py:2319` and `:2264`). That would also save the wasted Rich render work for TUI clients.