### PR TITLE
fix(weixin): treat ret=-2 as token-invalid for retry

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1515,9 +1515,14 @@ class WeixinAdapter(BasePlatformAdapter):
                     ret = resp.get("ret")
                     errcode = resp.get("errcode")
                     if (ret is not None and ret not in (0,)) or (errcode is not None and errcode not in (0,)):
+                        # Patch 006: widen token-invalid trigger to include ret=-2.
+                        # Observed in the wild: cron pushes fail with ret=-2 when the
+                        # cached context_token silently becomes stale. The tokenless
+                        # retry path below already handles this correctly.
+                        _TOKEN_INVALID_CODES = (SESSION_EXPIRED_ERRCODE, -2)
                         is_session_expired = (
-                            ret == SESSION_EXPIRED_ERRCODE
-                            or errcode == SESSION_EXPIRED_ERRCODE
+                            ret in _TOKEN_INVALID_CODES
+                            or errcode in _TOKEN_INVALID_CODES
                         )
                         # Session expired — strip token and retry once
                         if is_session_expired and not retried_without_token and context_token:


### PR DESCRIPTION
## Summary

The cached `context_token` in `WeixinAdapter` can silently become stale, after which the iLink endpoint rejects sends with `ret=-2` (`errcode=None`, `errmsg='unknown error'`) instead of the documented session-expired code (`SESSION_EXPIRED_ERRCODE`).

The existing tokenless-retry path already handles the case correctly — strip the cached token and retry once — but it only triggers when `ret`/`errcode` matches `SESSION_EXPIRED_ERRCODE`. As a result `ret=-2` falls straight through to a hard send failure.

This widens the trigger to include `ret=-2` so the existing recovery logic kicks in.

## Reproduction

Observed in production for ~3 days on cron deliveries: a previously-healthy DM target starts returning `ret=-2 errcode=None errmsg=unknown error` for every push. Restarting the gateway clears the bad token and recovery resumes — confirming the cached token was the cause.

Sample log entries:

```
ERROR gateway.platforms.weixin: [Weixin] send failed to=...: iLink sendmessage error: ret=-2 errcode=None errmsg=unknown error
ERROR cron.scheduler: Job '...': delivery error: Weixin send failed: ...
```

## Test plan

- [x] `python -m py_compile gateway/platforms/weixin.py` passes
- [x] Locally verified: forcing a stale-token scenario now triggers the existing tokenless retry path and succeeds on the retry
- [ ] Reviewer to confirm no other code paths assume `ret=-2` means a different failure mode