### PR TITLE
chore(logging): drop aiohttp unclosed-session noise from errors.log

### DIFF
--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -138,6 +138,30 @@ class _ComponentFilter(logging.Filter):
         return record.name.startswith(self._prefixes)
 
 
+class _DropAiohttpUnclosedFilter(logging.Filter):
+    """Drop ``asyncio: Unclosed client session`` records.
+
+    These are GC-time warnings from aiohttp when a ``ClientSession`` was
+    created without ``async with`` / ``close()``. They are benign (the
+    session is already gone) and, in Hermes, account for ~90% of
+    ``errors.log`` volume, drowning real signal. Attached only to the
+    ``errors.log`` handler so the records still appear in ``agent.log``
+    if someone really wants to hunt the source.
+
+    Opt out by setting ``HERMES_KEEP_AIOHTTP_UNCLOSED=1`` in the env.
+    """
+
+    _PATTERNS = ("Unclosed client session", "Unclosed connector")
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if os.getenv("HERMES_KEEP_AIOHTTP_UNCLOSED") == "1":
+            return True
+        if record.name != "asyncio":
+            return True
+        msg = record.getMessage()
+        return not any(p in msg for p in self._PATTERNS)
+
+
 # Logger name prefixes that belong to each component.
 # Used by _ComponentFilter and exposed for ``hermes logs --component``.
 COMPONENT_PREFIXES = {
@@ -223,6 +247,9 @@ def setup_logging(
     )
 
     # --- errors.log (WARNING+) — quick triage log --------------------------
+    # Filter out aiohttp unclosed-session noise unless explicitly opted in
+    # via HERMES_KEEP_AIOHTTP_UNCLOSED=1. These GC-time records were
+    # ~90% of errors.log volume and are post-hoc warnings, not actionable.
     _add_rotating_handler(
         root,
         log_dir / "errors.log",
@@ -230,6 +257,7 @@ def setup_logging(
         max_bytes=2 * 1024 * 1024,
         backup_count=2,
         formatter=RedactingFormatter(_LOG_FORMAT),
+        log_filter=_DropAiohttpUnclosedFilter(),
     )
 
     # --- gateway.log (INFO+, gateway component only) ------------------------


### PR DESCRIPTION
## Summary

Adds an opt-out filter on the `errors.log` handler that drops `asyncio: Unclosed client session` and `Unclosed connector` records — GC-time warnings emitted when an aiohttp `ClientSession` is constructed without `async with` / explicit `close()`.

These records are post-hoc (the session is already gone when the warning fires), and in long-running gateway processes they accumulate fast enough to drown real signal in `errors.log`. In one local profile they made up ~90% of `errors.log` volume.

## Why on errors.log only

The same records still flow into `agent.log`, so anyone hunting the source of an unclosed session can still find it there. `errors.log` is meant for quick triage — keeping noisy GC-time records out makes it usable.

## Opt-out

`HERMES_KEEP_AIOHTTP_UNCLOSED=1` keeps the records in `errors.log` (filter becomes a no-op).

## Test plan

- [x] `python -m py_compile hermes_logging.py` passes
- [x] Verified the same records still appear in `agent.log` after the change
- [x] Verified `HERMES_KEEP_AIOHTTP_UNCLOSED=1` re-enables the records in `errors.log`

The proper fix is of course to close the offending sessions — but that is a moving target across many call sites and plugins, while this filter is local and reversible.