### PR TITLE
fix: send data URI images as native files and block encoded blobs

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -6,6 +6,8 @@ and implement the required methods.
 """
 
 import asyncio
+import base64
+import binascii
 import inspect
 import ipaddress
 import logging
@@ -1088,6 +1090,7 @@ class BasePlatformAdapter(ABC):
     - Sending messages/responses
     - Handling media
     """
+    MAX_DATA_URI_IMAGE_BASE64_CHARS = 20_000_000
     
     def __init__(self, config: PlatformConfig, platform: Platform):
         self.config = config
@@ -1435,48 +1438,124 @@ class BasePlatformAdapter(ABC):
         return lower.endswith('.gif')
 
     @staticmethod
+    def _cache_data_uri_image(data_uri: str) -> str | None:
+        """Decode a data:image/*;base64 URI into the image cache.
+
+        Returns a local file path on success, otherwise None. Failures are
+        logged and the original data URI is later stripped from the outbound
+        text by extract_images(), preventing multi-megabyte base64 blobs from
+        being sent to chat platforms as plain text.
+        """
+        match = re.fullmatch(
+            r'data:image/(?P<mime>png|jpe?g|gif|webp);base64,(?P<data>[A-Za-z0-9+/=\s]+)',
+            data_uri,
+            re.IGNORECASE,
+        )
+        if not match:
+            return None
+
+        encoded = re.sub(r'\s+', '', match.group('data'))
+        if len(encoded) > BasePlatformAdapter.MAX_DATA_URI_IMAGE_BASE64_CHARS:
+            logger.warning(
+                "Refusing oversized data URI image (%d encoded chars)",
+                len(encoded),
+            )
+            return None
+
+        mime = match.group('mime').lower()
+        ext = '.jpg' if mime in {'jpg', 'jpeg'} else f'.{mime}'
+        try:
+            raw = base64.b64decode(encoded, validate=True)
+            return cache_image_from_bytes(raw, ext=ext)
+        except (binascii.Error, ValueError, OSError) as exc:
+            logger.warning("Failed to decode data URI image for native delivery: %s", exc)
+            return None
+
+    @staticmethod
+    def _is_supported_image_url(ref_lower: str) -> bool:
+        return ref_lower.startswith(('http://', 'https://')) and any(
+            ref_lower.endswith(ext) or ext in ref_lower
+            for ext in ['.png', '.jpg', '.jpeg', '.gif', '.webp', 'fal.media', 'fal-cdn', 'replicate.delivery']
+        )
+
+    @staticmethod
+    def _extract_html_alt_text(img_tag: str) -> str:
+        match = re.search(r'\balt\s*=\s*(["\'])(.*?)\1', img_tag, re.IGNORECASE | re.DOTALL)
+        return match.group(2) if match else ""
+
+    @staticmethod
+    def _add_image_ref(
+        images: List[Tuple[str, str]],
+        extracted_tokens: set,
+        ref: str,
+        alt_text: str,
+        *,
+        require_image_url: bool,
+    ) -> None:
+        ref_lower = ref.lower()
+        if ref_lower.startswith('data:image/'):
+            cached_path = BasePlatformAdapter._cache_data_uri_image(ref)
+            if cached_path:
+                images.append((cached_path, alt_text))
+            extracted_tokens.add(ref)
+            return
+        if ref_lower.startswith(('http://', 'https://')) and (
+            not require_image_url or BasePlatformAdapter._is_supported_image_url(ref_lower)
+        ):
+            images.append((ref, alt_text))
+            extracted_tokens.add(ref)
+
+    @staticmethod
     def extract_images(content: str) -> Tuple[List[Tuple[str, str]], str]:
         """
         Extract image URLs from markdown and HTML image tags in a response.
         
         Finds patterns like:
         - ![alt text](https://example.com/image.png)
+        - ![alt text](data:image/png;base64,...)
         - <img src="https://example.com/image.png">
+        - <img src="data:image/png;base64,...">
         - <img src="https://example.com/image.png"></img>
         
         Args:
             content: The response text to scan.
         
         Returns:
-            Tuple of (list of (url, alt_text) pairs, cleaned content with image tags removed).
+            Tuple of (list of (url_or_local_path, alt_text) pairs, cleaned content with image tags removed).
         """
         images = []
         cleaned = content
-        
-        # Match markdown images: ![alt](url)
-        md_pattern = r'!\[([^\]]*)\]\((https?://[^\s\)]+)\)'
+        extracted_tokens = set()
+
+        # Match markdown images: ![alt](url-or-data-uri)
+        md_pattern = r'!\[([^\]]*)\]\((data:image/[^;\s]+;base64,[A-Za-z0-9+/=\s]+|[^\s\)]+)\)'
         for match in re.finditer(md_pattern, content):
-            alt_text = match.group(1)
-            url = match.group(2)
-            # Only extract URLs that look like actual images
-            if any(url.lower().endswith(ext) or ext in url.lower() for ext in
-                   ['.png', '.jpg', '.jpeg', '.gif', '.webp', 'fal.media', 'fal-cdn', 'replicate.delivery']):
-                images.append((url, alt_text))
+            BasePlatformAdapter._add_image_ref(
+                images,
+                extracted_tokens,
+                match.group(2),
+                match.group(1),
+                require_image_url=True,
+            )
         
         # Match HTML img tags: <img src="url"> or <img src="url"></img> or <img src="url"/>
-        html_pattern = r'<img\s+src=["\']?(https?://[^\s"\'<>]+)["\']?\s*/?>\s*(?:</img>)?'
-        for match in re.finditer(html_pattern, content):
-            url = match.group(1)
-            images.append((url, ""))
+        html_pattern = r'<img\b[^>]*\bsrc\s*=\s*(["\']?)(data:image/[^;\s]+;base64,[A-Za-z0-9+/=\s]+|[^\s"\'<>]+)\1[^>]*>\s*(?:</img>)?'
+        for match in re.finditer(html_pattern, content, re.IGNORECASE):
+            BasePlatformAdapter._add_image_ref(
+                images,
+                extracted_tokens,
+                match.group(2),
+                BasePlatformAdapter._extract_html_alt_text(match.group(0)),
+                require_image_url=False,
+            )
         
         # Remove only the matched image tags from content (not all markdown images)
-        if images:
-            extracted_urls = {url for url, _ in images}
+        if extracted_tokens:
             def _remove_if_extracted(match):
-                url = match.group(2) if match.lastindex >= 2 else match.group(1)
-                return '' if url in extracted_urls else match.group(0)
+                ref = match.group(2) if match.lastindex >= 2 else match.group(1)
+                return '' if ref in extracted_tokens else match.group(0)
             cleaned = re.sub(md_pattern, _remove_if_extracted, cleaned)
-            cleaned = re.sub(html_pattern, _remove_if_extracted, cleaned)
+            cleaned = re.sub(html_pattern, _remove_if_extracted, cleaned, flags=re.IGNORECASE)
             # Clean up leftover blank lines
             cleaned = re.sub(r'\n{3,}', '\n\n', cleaned).strip()
         
@@ -2423,8 +2502,19 @@ class BasePlatformAdapter(ABC):
                             safe_url_for_log(image_url),
                             alt_text[:30] if alt_text else "",
                         )
+                        # Route cached local images (e.g. data URI images) through
+                        # the file-native path. send_image() is for remote URLs and
+                        # can degrade to leaking local cache paths as text on some
+                        # adapters.
+                        if os.path.isfile(image_url):
+                            img_result = await self.send_image_file(
+                                chat_id=event.source.chat_id,
+                                image_path=image_url,
+                                caption=alt_text if alt_text else None,
+                                metadata=_thread_metadata,
+                            )
                         # Route animated GIFs through send_animation for proper playback
-                        if self._is_animation_url(image_url):
+                        elif self._is_animation_url(image_url):
                             img_result = await self.send_animation(
                                 chat_id=event.source.chat_id,
                                 animation_url=image_url,

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1091,6 +1091,11 @@ class BasePlatformAdapter(ABC):
     - Handling media
     """
     MAX_DATA_URI_IMAGE_BASE64_CHARS = 20_000_000
+    MAX_OUTBOUND_ENCODED_BLOB_CHARS = 2_000
+    OUTBOUND_BLOB_BLOCKED_MESSAGE = (
+        "⚠️ Outbound message blocked: the response contained an oversized encoded data blob "
+        "and was not sent as text. Please regenerate the content as a file or native media attachment."
+    )
     
     def __init__(self, config: PlatformConfig, platform: Platform):
         self.config = config
@@ -1915,6 +1920,50 @@ class BasePlatformAdapter(ABC):
         lowered = error.lower()
         return "timed out" in lowered or "readtimeout" in lowered or "writetimeout" in lowered
 
+    @classmethod
+    def _contains_unsafe_outbound_blob(cls, content: str) -> bool:
+        """Return True when text contains an encoded blob unsafe for platform send()."""
+        if not content:
+            return False
+
+        threshold = cls.MAX_OUTBOUND_ENCODED_BLOB_CHARS
+        data_uri_pattern = r'data:[^\s,;]+(?:;[^\s,;]+)*;base64,(?P<data>[A-Za-z0-9+/=]+)'
+        for match in re.finditer(data_uri_pattern, content, re.IGNORECASE):
+            encoded = re.sub(r'\s+', '', match.group('data'))
+            if len(encoded) > threshold:
+                return True
+
+        blob_pattern = r'blob:[^\s<>()\[\]{}"\']+'
+        for match in re.finditer(blob_pattern, content, re.IGNORECASE):
+            if len(match.group(0)) > threshold:
+                return True
+
+        base64_pattern = r'(?<![A-Za-z0-9+/=])(?:[A-Za-z0-9+/]{4}){16,}(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?(?![A-Za-z0-9+/=])'
+        for match in re.finditer(base64_pattern, content):
+            token = match.group(0)
+            if len(token) > threshold:
+                try:
+                    base64.b64decode(token, validate=True)
+                    return True
+                except (binascii.Error, ValueError):
+                    continue
+
+        wrapped_base64_pattern = r'(?<![A-Za-z0-9+/=])(?:[A-Za-z0-9+/]{16,120}\s+){2,}[A-Za-z0-9+/]{16,120}={0,2}(?![A-Za-z0-9+/=])'
+        for match in re.finditer(wrapped_base64_pattern, content):
+            token = ''.join(re.split(r'\s+', match.group(0).strip()))
+            chunks = re.split(r'\s+', match.group(0).strip())
+            if len(chunks) < 3 or any(len(chunk) < 16 for chunk in chunks):
+                continue
+            padding_needed = (-len(token)) % 4
+            padded_token = token + ("=" * padding_needed)
+            if len(token) > threshold:
+                try:
+                    base64.b64decode(padded_token, validate=True)
+                    return True
+                except (binascii.Error, ValueError):
+                    continue
+        return False
+
     async def _send_with_retry(
         self,
         chat_id: str,
@@ -1932,6 +1981,19 @@ class BasePlatformAdapter(ABC):
         network errors, sends the user a brief delivery-failure notice so they
         know to retry rather than waiting indefinitely.
         """
+
+        if self._contains_unsafe_outbound_blob(content):
+            logger.error(
+                "[%s] Blocking outbound text with oversized encoded blob (%d chars)",
+                self.name,
+                len(content),
+            )
+            return await self.send(
+                chat_id=chat_id,
+                content=self.OUTBOUND_BLOB_BLOCKED_MESSAGE,
+                reply_to=reply_to,
+                metadata=metadata,
+            )
 
         result = await self.send(
             chat_id=chat_id,

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -1,6 +1,7 @@
 """Tests for gateway/platforms/base.py — MessageEvent, media extraction, message truncation."""
 
 import asyncio
+import base64
 import os
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
@@ -425,6 +426,165 @@ async def test_process_message_routes_data_uri_image_to_send_image_file():
     assert Path(image_path).is_file()
     assert image_call["caption"] == "generated"
     assert session_key not in adapter._active_sessions
+
+
+@pytest.mark.asyncio
+async def test_send_with_retry_blocks_explicit_data_uri_blob_as_text(monkeypatch):
+    monkeypatch.setattr(BasePlatformAdapter, "MAX_OUTBOUND_ENCODED_BLOB_CHARS", 64, raising=False)
+    adapter = _RecordingAdapter()
+    blob = "A" * 65
+
+    result = await adapter._send_with_retry(
+        "42", f"Do not send this: data:application/octet-stream;base64,{blob}"
+    )
+
+    assert result.success is True
+    assert len(adapter.sent_texts) == 1
+    sent = adapter.sent_texts[0]["content"]
+    assert "blocked" in sent.lower()
+    assert blob not in sent
+    assert "data:application" not in sent
+
+
+@pytest.mark.asyncio
+async def test_send_with_retry_blocks_bare_base64_blob_as_text(monkeypatch):
+    monkeypatch.setattr(BasePlatformAdapter, "MAX_OUTBOUND_ENCODED_BLOB_CHARS", 64, raising=False)
+    adapter = _RecordingAdapter()
+    blob = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/lHGwVw=="
+
+    result = await adapter._send_with_retry("42", f"Raw image bytes: {blob}")
+
+    assert result.success is True
+    sent = adapter.sent_texts[0]["content"]
+    assert "blocked" in sent.lower()
+    assert blob not in sent
+
+
+@pytest.mark.asyncio
+async def test_send_with_retry_blocks_wrapped_bare_base64_blob_as_text(monkeypatch):
+    monkeypatch.setattr(BasePlatformAdapter, "MAX_OUTBOUND_ENCODED_BLOB_CHARS", 64, raising=False)
+    adapter = _RecordingAdapter()
+    raw = b"x" * 96
+    wrapped = "\n".join(base64.b64encode(raw).decode()[i:i + 32] for i in range(0, 128, 32))
+
+    result = await adapter._send_with_retry("42", f"Raw wrapped image bytes:\n{wrapped}")
+
+    assert result.success is True
+    sent = adapter.sent_texts[0]["content"]
+    assert "blocked" in sent.lower()
+    assert wrapped not in sent
+
+
+@pytest.mark.asyncio
+async def test_send_with_retry_blocks_large_blob_url_as_text(monkeypatch):
+    monkeypatch.setattr(BasePlatformAdapter, "MAX_OUTBOUND_ENCODED_BLOB_CHARS", 64, raising=False)
+    adapter = _RecordingAdapter()
+    blob_url = "blob:" + ("x" * 65)
+
+    result = await adapter._send_with_retry("42", f"Leaked blob URL: {blob_url}")
+
+    assert result.success is True
+    sent = adapter.sent_texts[0]["content"]
+    assert "blocked" in sent.lower()
+    assert blob_url not in sent
+
+
+@pytest.mark.asyncio
+async def test_send_with_retry_allows_long_normal_text(monkeypatch):
+    monkeypatch.setattr(BasePlatformAdapter, "MAX_OUTBOUND_ENCODED_BLOB_CHARS", 64, raising=False)
+    adapter = _RecordingAdapter()
+    text = "普通文本，不是编码数据。" * 20
+
+    result = await adapter._send_with_retry("42", text)
+
+    assert result.success is True
+    assert adapter.sent_texts == [{"chat_id": "42", "content": text, "reply_to": None, "metadata": None}]
+
+
+@pytest.mark.asyncio
+async def test_send_with_retry_allows_long_english_text(monkeypatch):
+    monkeypatch.setattr(BasePlatformAdapter, "MAX_OUTBOUND_ENCODED_BLOB_CHARS", 64, raising=False)
+    adapter = _RecordingAdapter()
+    text = "Test " * 600
+
+    result = await adapter._send_with_retry("42", text)
+
+    assert result.success is True
+    assert adapter.sent_texts == [{"chat_id": "42", "content": text, "reply_to": None, "metadata": None}]
+
+
+@pytest.mark.asyncio
+async def test_send_with_retry_blocks_non_quad_wrapped_bare_base64_blob(monkeypatch):
+    monkeypatch.setattr(BasePlatformAdapter, "MAX_OUTBOUND_ENCODED_BLOB_CHARS", 64, raising=False)
+    adapter = _RecordingAdapter()
+    encoded = base64.b64encode(b"x" * 3000).decode()
+    wrapped = "\n".join(encoded[i:i + 70] for i in range(0, len(encoded), 70))
+
+    result = await adapter._send_with_retry("42", f"Raw wrapped image bytes:\n{wrapped}")
+
+    assert result.success is True
+    sent = adapter.sent_texts[0]["content"]
+    assert "blocked" in sent.lower()
+    assert wrapped not in sent
+
+
+@pytest.mark.asyncio
+async def test_send_with_retry_blocks_common_width_wrapped_bare_base64_blob(monkeypatch):
+    monkeypatch.setattr(BasePlatformAdapter, "MAX_OUTBOUND_ENCODED_BLOB_CHARS", 64, raising=False)
+    encoded = base64.b64encode(b"x" * 3000).decode()
+
+    for width in (65, 77, 80):
+        adapter = _RecordingAdapter()
+        wrapped = "\n".join(encoded[i:i + width] for i in range(0, len(encoded), width))
+
+        result = await adapter._send_with_retry("42", f"Raw wrapped image bytes:\n{wrapped}")
+
+        assert result.success is True
+        sent = adapter.sent_texts[0]["content"]
+        assert "blocked" in sent.lower(), f"width={width}"
+        assert wrapped not in sent
+
+
+@pytest.mark.asyncio
+async def test_send_with_retry_allows_small_data_uri_followed_by_long_text(monkeypatch):
+    monkeypatch.setattr(BasePlatformAdapter, "MAX_OUTBOUND_ENCODED_BLOB_CHARS", 64, raising=False)
+    adapter = _RecordingAdapter()
+    text = "data:text/plain;base64,SGVsbG8= " + ("Test " * 600)
+
+    result = await adapter._send_with_retry("42", text)
+
+    assert result.success is True
+    assert adapter.sent_texts == [{"chat_id": "42", "content": text, "reply_to": None, "metadata": None}]
+
+
+@pytest.mark.asyncio
+async def test_send_with_retry_blocks_space_wrapped_bare_base64_blob(monkeypatch):
+    monkeypatch.setattr(BasePlatformAdapter, "MAX_OUTBOUND_ENCODED_BLOB_CHARS", 64, raising=False)
+    adapter = _RecordingAdapter()
+    encoded = base64.b64encode(b"x" * 3000).decode()
+    wrapped = " ".join(encoded[i:i + 32] for i in range(0, len(encoded), 32))
+
+    result = await adapter._send_with_retry("42", f"Raw wrapped image bytes: {wrapped}")
+
+    assert result.success is True
+    sent = adapter.sent_texts[0]["content"]
+    assert "blocked" in sent.lower()
+    assert wrapped not in sent
+
+
+@pytest.mark.asyncio
+async def test_send_with_retry_blocks_tab_wrapped_bare_base64_blob(monkeypatch):
+    monkeypatch.setattr(BasePlatformAdapter, "MAX_OUTBOUND_ENCODED_BLOB_CHARS", 64, raising=False)
+    adapter = _RecordingAdapter()
+    encoded = base64.b64encode(b"x" * 3000).decode()
+    wrapped = "\t".join(encoded[i:i + 32] for i in range(0, len(encoded), 32))
+
+    result = await adapter._send_with_retry("42", f"Raw wrapped image bytes: {wrapped}")
+
+    assert result.success is True
+    sent = adapter.sent_texts[0]["content"]
+    assert "blocked" in sent.lower()
+    assert wrapped not in sent
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -1,17 +1,23 @@
 """Tests for gateway/platforms/base.py — MessageEvent, media extraction, message truncation."""
 
+import asyncio
 import os
-from unittest.mock import patch
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
 
+import pytest
+
+from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
     BasePlatformAdapter,
     GATEWAY_SECRET_CAPTURE_UNSUPPORTED_MESSAGE,
     MessageEvent,
-    MessageType,
+    SendResult,
     safe_url_for_log,
     utf16_len,
     _prefix_within_utf16_limit,
 )
+from gateway.session import SessionSource, build_session_key
 
 
 class TestSecretCaptureGuidance:
@@ -248,6 +254,177 @@ class TestExtractImages:
         assert images[0][0] == "https://fal.media/cat.png"
         # The PDF link must survive in cleaned content
         assert "![report](https://example.com/report.pdf)" in cleaned
+
+
+    def test_markdown_data_uri_image_is_cached_as_local_file(self):
+        """Regression: data URI images must not be sent as giant text blobs."""
+        png_b64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/lHGwVwAAAABJRU5ErkJggg=="
+        content = f"Here is the image: ![generated](data:image/png;base64,{png_b64})\nDone"
+
+        images, cleaned = BasePlatformAdapter.extract_images(content)
+
+        assert len(images) == 1
+        image_path, alt_text = images[0]
+        assert alt_text == "generated"
+        assert image_path.endswith(".png")
+        assert Path(image_path).is_file()
+        assert "data:image" not in cleaned
+        assert png_b64 not in cleaned
+        assert cleaned == "Here is the image: \nDone"
+
+    def test_markdown_wrapped_data_uri_image_is_cached_as_local_file(self):
+        """Data URI extraction must tolerate line-wrapped base64 output."""
+        png_b64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/lHGwVwAAAABJRU5ErkJggg=="
+        wrapped_b64 = f"{png_b64[:32]}\n{png_b64[32:]}"
+        content = f"Here is the image: ![generated](data:image/png;base64,{wrapped_b64})"
+
+        images, cleaned = BasePlatformAdapter.extract_images(content)
+
+        assert len(images) == 1
+        image_path, alt_text = images[0]
+        assert alt_text == "generated"
+        assert Path(image_path).is_file()
+        assert "data:image" not in cleaned
+        assert png_b64[:32] not in cleaned
+
+    def test_html_wrapped_data_uri_image_is_cached_as_local_file(self):
+        png_b64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/lHGwVwAAAABJRU5ErkJggg=="
+        wrapped_b64 = f"{png_b64[:32]}\n{png_b64[32:]}"
+        content = f'Before <img src="data:image/png;base64,{wrapped_b64}"> After'
+
+        images, cleaned = BasePlatformAdapter.extract_images(content)
+
+        assert len(images) == 1
+        image_path, alt_text = images[0]
+        assert alt_text == ""
+        assert Path(image_path).is_file()
+        assert "data:image" not in cleaned
+        assert png_b64[:32] not in cleaned
+        assert cleaned == "Before After"
+
+    def test_html_data_uri_image_is_cached_as_local_file(self):
+        png_b64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/lHGwVwAAAABJRU5ErkJggg=="
+        content = f'Before <img src="data:image/png;base64,{png_b64}"> After'
+
+        images, cleaned = BasePlatformAdapter.extract_images(content)
+
+        assert len(images) == 1
+        image_path, alt_text = images[0]
+        assert alt_text == ""
+        assert image_path.endswith(".png")
+        assert Path(image_path).is_file()
+        assert "data:image" not in cleaned
+        assert png_b64 not in cleaned
+        assert cleaned == "Before After"
+
+    def test_html_data_uri_image_with_attributes_after_src_is_cached_as_local_file(self):
+        png_b64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/lHGwVwAAAABJRU5ErkJggg=="
+        content = f'Before <img src="data:image/png;base64,{png_b64}" alt="generated"> After'
+
+        images, cleaned = BasePlatformAdapter.extract_images(content)
+
+        assert len(images) == 1
+        image_path, alt_text = images[0]
+        assert alt_text == "generated"
+        assert Path(image_path).is_file()
+        assert "data:image" not in cleaned
+        assert png_b64 not in cleaned
+        assert cleaned == "Before After"
+
+    def test_html_data_uri_image_with_attributes_before_src_is_cached_as_local_file(self):
+        png_b64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/lHGwVwAAAABJRU5ErkJggg=="
+        content = f'Before <img alt="generated" class="rounded" src="data:image/png;base64,{png_b64}"> After'
+
+        images, cleaned = BasePlatformAdapter.extract_images(content)
+
+        assert len(images) == 1
+        image_path, alt_text = images[0]
+        assert alt_text == "generated"
+        assert Path(image_path).is_file()
+        assert "data:image" not in cleaned
+        assert png_b64 not in cleaned
+        assert cleaned == "Before After"
+
+    def test_oversized_data_uri_is_stripped_without_decoding(self, monkeypatch):
+        monkeypatch.setattr(BasePlatformAdapter, "MAX_DATA_URI_IMAGE_BASE64_CHARS", 12)
+        payload = "A" * 13
+        content = f"Before ![huge](data:image/png;base64,{payload}) After"
+
+        images, cleaned = BasePlatformAdapter.extract_images(content)
+
+        assert images == []
+        assert "data:image" not in cleaned
+        assert payload not in cleaned
+        assert cleaned == "Before  After"
+
+
+
+
+class _RecordingAdapter(BasePlatformAdapter):
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="t"), Platform.TELEGRAM)
+        self.sent_texts = []
+        self.sent_image_urls = []
+        self.sent_image_files = []
+
+    async def connect(self):
+        pass
+
+    async def disconnect(self):
+        pass
+
+    async def send(self, chat_id: str, content: str, **kwargs):
+        self.sent_texts.append({"chat_id": chat_id, "content": content, **kwargs})
+        return SendResult(success=True)
+
+    async def send_image(self, chat_id: str, image_url: str, **kwargs):
+        self.sent_image_urls.append({"chat_id": chat_id, "image_url": image_url, **kwargs})
+        return SendResult(success=True)
+
+    async def send_image_file(self, chat_id: str, image_path: str, **kwargs):
+        self.sent_image_files.append({"chat_id": chat_id, "image_path": image_path, **kwargs})
+        return SendResult(success=True)
+
+    async def get_chat_info(self, chat_id):
+        return {}
+
+
+def _make_event(text="hi", chat_id="42"):
+    return MessageEvent(
+        text=text,
+        source=SessionSource(platform=Platform.TELEGRAM, chat_id=chat_id, chat_type="dm"),
+    )
+
+
+def _session_key(chat_id="42"):
+    return build_session_key(
+        SessionSource(platform=Platform.TELEGRAM, chat_id=chat_id, chat_type="dm")
+    )
+
+
+@pytest.mark.asyncio
+async def test_process_message_routes_data_uri_image_to_send_image_file():
+    """Regression: cached data URI images must not be sent as URL text/path fallback."""
+    png_b64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/lHGwVwAAAABJRU5ErkJggg=="
+    adapter = _RecordingAdapter()
+    adapter._message_handler = AsyncMock(
+        return_value=f"Caption\n![generated](data:image/png;base64,{png_b64})"
+    )
+    event = _make_event()
+    session_key = _session_key()
+    guard = asyncio.Event()
+    adapter._active_sessions[session_key] = guard
+
+    await adapter._process_message_background(event, session_key)
+
+    assert adapter.sent_texts == [{"chat_id": "42", "content": "Caption", "reply_to": None, "metadata": None}]
+    assert adapter.sent_image_urls == []
+    assert len(adapter.sent_image_files) == 1
+    image_call = adapter.sent_image_files[0]
+    image_path = image_call["image_path"]
+    assert Path(image_path).is_file()
+    assert image_call["caption"] == "generated"
+    assert session_key not in adapter._active_sessions
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Send `data:image/*;base64,...` image outputs as native image files instead of leaving the data URI in outbound text.
- Decode supported markdown/HTML data URI images into local cached files and route local images through `send_image_file()`.
- Add a final outbound text guard before platform `send()` to block oversized encoded blobs such as data URIs, blob URLs, bare base64, and wrapped base64.
- Avoid logging or forwarding the original encoded blob when the guard triggers.

## Why
Image-generation providers can return markdown image payloads with `data:image/...;base64,...`. Previously those were not extracted by the gateway image pipeline, so the base64 payload could be sent to messaging platforms as plain text instead of as an image. This PR fixes the native image path and adds a defensive fallback so future oversized encoded blobs are not leaked as chat text.

## Test Plan
- `python -m py_compile gateway/platforms/base.py`
- `git diff --check origin/main...HEAD`
- `python -m pytest tests/plugins/image_gen/test_openai_provider.py tests/tools/test_image_generation_plugin_dispatch.py tests/gateway/test_platform_base.py -q`

Result: `122 passed, 110 warnings`
