### PR TITLE
feat(gateway): notify user when context is auto-compressed

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4943,6 +4943,19 @@ class GatewayRunner:
             # session_entry so transcript writes below go to the right session.
             if agent_result.get("session_id") and agent_result["session_id"] != session_entry.session_id:
                 session_entry.session_id = agent_result["session_id"]
+                # Send compression notification if configured
+                _comp_cfg = _load_gateway_config().get("compression", {})
+                if _comp_cfg.get("notify", False):
+                    try:
+                        _notif_adapter = self.adapters.get(source.platform)
+                        if _notif_adapter:
+                            _notif_msg = _comp_cfg.get(
+                                "notify_message",
+                                "⚡ 上下文已自动压缩，对话历史已精简摘要，当前对话继续有效。",
+                            )
+                            await _notif_adapter.send(source.chat_id, _notif_msg)
+                    except Exception as _notif_err:
+                        logger.debug("Compression notification failed: %s", _notif_err)
 
             # Prepend reasoning/thinking if display is enabled (per-platform)
             try:


### PR DESCRIPTION
## Summary

When the agent's `context_compressor` cuts a long conversation and continues under a fresh `session_id`, the user has no signal that this happened — the next reply they receive is in a session whose history has been summarised, which can be confusing if they reference earlier turns.

This adds an opt-in notification: when `GatewayRunner` observes that an agent result returned a different `session_id` than the entry it was launched with (the existing trigger for switching the gateway's session pointer), it sends one small message to the originating chat informing the user that the context has been compressed.

## Behavior

- **Opt-in**: gated by `config.compression.notify` (default `false`).
- **Customisable**: `config.compression.notify_message` overrides the default text. The default included is intentionally short so it works on bandwidth-constrained channels (SMS, telegram).
- **Non-fatal**: send is wrapped in `try/except`; a failed notification logs at debug level and does not affect the agent reply that follows.

## Example config

```yaml
compression:
  enabled: true
  threshold: 0.5
  notify: true
  notify_message: "⚡ Context auto-compressed; conversation continues."
```

## Test plan

- [x] `python -m py_compile gateway/run.py` passes
- [x] With `notify: true`, exercising compression on a real chat sends one notification message before the next agent reply
- [x] With `notify: false` (default), behavior is identical to today
- [x] When the platform adapter for the source platform is missing/unhealthy, the notify failure is swallowed and the reply still goes through

## Notes

The compression event is detected the same way the surrounding code already detects it (the `agent_result["session_id"] != session_entry.session_id` comparison just above). No new state is introduced.