### PR TITLE
fix(google-workspace): restore required_credential_files in SKILL.md (#16452)

### DIFF
--- a/skills/productivity/google-workspace/SKILL.md
+++ b/skills/productivity/google-workspace/SKILL.md
@@ -1,9 +1,14 @@
 ---
 name: google-workspace
 description: "Gmail, Calendar, Drive, Docs, Sheets via gws CLI or Python."
-version: 1.0.0
+version: 1.0.1
 author: Nous Research
 license: MIT
+required_credential_files:
+  - path: google_token.json
+    description: Google OAuth2 token (created by setup script)
+  - path: google_client_secret.json
+    description: Google OAuth2 client credentials (downloaded from Google Cloud Console)
 metadata:
   hermes:
     tags: [Google, Gmail, Calendar, Drive, Sheets, Docs, Contacts, Email, OAuth]

--- a/tests/skills/test_google_workspace_credential_files.py
+++ b/tests/skills/test_google_workspace_credential_files.py
@@ -1,0 +1,102 @@
+"""Regression test: google-workspace SKILL.md must declare required_credential_files.
+
+PR #9931 accidentally removed the required_credential_files header, which broke
+credential file mounting in Docker/Modal remote backends (#16452). This test
+prevents the regression from silently reappearing.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+SKILL_MD = (
+    Path(__file__).resolve().parents[2]
+    / "skills/productivity/google-workspace/SKILL.md"
+)
+
+_EXPECTED_PATHS = {"google_token.json", "google_client_secret.json"}
+
+
+def _parse_frontmatter(content: str) -> dict:
+    from agent.skill_utils import parse_frontmatter
+
+    fm, _ = parse_frontmatter(content)
+    return fm
+
+
+class TestGoogleWorkspaceCredentialFiles:
+    def test_required_credential_files_present_in_skill_md(self):
+        content = SKILL_MD.read_text(encoding="utf-8")
+        fm = _parse_frontmatter(content)
+        entries = fm.get("required_credential_files")
+        assert entries, "required_credential_files missing from google-workspace SKILL.md"
+        assert isinstance(entries, list), "required_credential_files must be a list"
+        paths = {
+            (e["path"] if isinstance(e, dict) else e)
+            for e in entries
+        }
+        assert _EXPECTED_PATHS <= paths, (
+            f"Missing entries in required_credential_files: {_EXPECTED_PATHS - paths}"
+        )
+
+    def test_entries_are_registered_when_files_exist(self, tmp_path):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "google_token.json").write_text("{}")
+        (hermes_home / "google_client_secret.json").write_text("{}")
+
+        from tools.credential_files import (
+            clear_credential_files,
+            get_credential_file_mounts,
+            register_credential_files,
+        )
+
+        clear_credential_files()
+        try:
+            content = SKILL_MD.read_text(encoding="utf-8")
+            fm = _parse_frontmatter(content)
+            entries = fm.get("required_credential_files", [])
+
+            with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
+                missing = register_credential_files(entries)
+
+            assert missing == [], f"Unexpected missing files: {missing}"
+            mounts = get_credential_file_mounts()
+            container_paths = {m["container_path"] for m in mounts}
+            assert "/root/.hermes/google_token.json" in container_paths
+            assert "/root/.hermes/google_client_secret.json" in container_paths
+        finally:
+            clear_credential_files()
+
+    def test_missing_token_is_reported(self, tmp_path):
+        """google_token.json absent (first-time setup) — reported as missing, client secret still mounts."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "google_client_secret.json").write_text("{}")
+
+        from tools.credential_files import (
+            clear_credential_files,
+            get_credential_file_mounts,
+            register_credential_files,
+        )
+
+        clear_credential_files()
+        try:
+            content = SKILL_MD.read_text(encoding="utf-8")
+            fm = _parse_frontmatter(content)
+            entries = fm.get("required_credential_files", [])
+
+            with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
+                missing = register_credential_files(entries)
+
+            assert "google_token.json" in missing
+            mounts = get_credential_file_mounts()
+            container_paths = {m["container_path"] for m in mounts}
+            assert "/root/.hermes/google_client_secret.json" in container_paths
+            assert "/root/.hermes/google_token.json" not in container_paths
+        finally:
+            clear_credential_files()

--- a/tests/skills/test_google_workspace_credential_files.py
+++ b/tests/skills/test_google_workspace_credential_files.py
@@ -11,8 +11,6 @@ import os
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
-
 SKILL_MD = (
     Path(__file__).resolve().parents[2]
     / "skills/productivity/google-workspace/SKILL.md"
@@ -36,8 +34,9 @@ class TestGoogleWorkspaceCredentialFiles:
         assert entries, "required_credential_files missing from google-workspace SKILL.md"
         assert isinstance(entries, list), "required_credential_files must be a list"
         paths = {
-            (e["path"] if isinstance(e, dict) else e)
+            (e.get("path") if isinstance(e, dict) else e)
             for e in entries
+            if (isinstance(e, dict) and e.get("path")) or isinstance(e, str)
         }
         assert _EXPECTED_PATHS <= paths, (
             f"Missing entries in required_credential_files: {_EXPECTED_PATHS - paths}"
@@ -49,6 +48,7 @@ class TestGoogleWorkspaceCredentialFiles:
         (hermes_home / "google_token.json").write_text("{}")
         (hermes_home / "google_client_secret.json").write_text("{}")
 
+        import tools.credential_files as _cf
         from tools.credential_files import (
             clear_credential_files,
             get_credential_file_mounts,
@@ -56,6 +56,8 @@ class TestGoogleWorkspaceCredentialFiles:
         )
 
         clear_credential_files()
+        saved_config_files = _cf._config_files
+        _cf._config_files = None
         try:
             content = SKILL_MD.read_text(encoding="utf-8")
             fm = _parse_frontmatter(content)
@@ -63,14 +65,15 @@ class TestGoogleWorkspaceCredentialFiles:
 
             with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
                 missing = register_credential_files(entries)
+                assert missing == [], f"Unexpected missing files: {missing}"
+                mounts = get_credential_file_mounts()
 
-            assert missing == [], f"Unexpected missing files: {missing}"
-            mounts = get_credential_file_mounts()
             container_paths = {m["container_path"] for m in mounts}
             assert "/root/.hermes/google_token.json" in container_paths
             assert "/root/.hermes/google_client_secret.json" in container_paths
         finally:
             clear_credential_files()
+            _cf._config_files = saved_config_files
 
     def test_missing_token_is_reported(self, tmp_path):
         """google_token.json absent (first-time setup) — reported as missing, client secret still mounts."""
@@ -78,6 +81,7 @@ class TestGoogleWorkspaceCredentialFiles:
         hermes_home.mkdir()
         (hermes_home / "google_client_secret.json").write_text("{}")
 
+        import tools.credential_files as _cf
         from tools.credential_files import (
             clear_credential_files,
             get_credential_file_mounts,
@@ -85,6 +89,8 @@ class TestGoogleWorkspaceCredentialFiles:
         )
 
         clear_credential_files()
+        saved_config_files = _cf._config_files
+        _cf._config_files = None
         try:
             content = SKILL_MD.read_text(encoding="utf-8")
             fm = _parse_frontmatter(content)
@@ -92,11 +98,12 @@ class TestGoogleWorkspaceCredentialFiles:
 
             with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
                 missing = register_credential_files(entries)
+                mounts = get_credential_file_mounts()
 
             assert "google_token.json" in missing
-            mounts = get_credential_file_mounts()
             container_paths = {m["container_path"] for m in mounts}
             assert "/root/.hermes/google_client_secret.json" in container_paths
             assert "/root/.hermes/google_token.json" not in container_paths
         finally:
             clear_credential_files()
+            _cf._config_files = saved_config_files


### PR DESCRIPTION
## Summary

- Restores the `required_credential_files` frontmatter block removed in #9931 from `skills/productivity/google-workspace/SKILL.md`
- Adds a regression test that prevents this field from being silently dropped again

## The bug

PR #9931 ("feat(google-workspace): add --from flag for custom sender display name") accidentally dropped the `required_credential_files` YAML header while reformatting the frontmatter. This header is the mechanism by which hermes registers `google_token.json` and `google_client_secret.json` for bind-mounting into Docker/Modal remote terminal backends at container creation time.

Without this header, `register_credential_files()` is never called for the skill, the session-scoped `ContextVar` is never populated, and `get_credential_file_mounts()` returns an empty list when `DockerEnvironment.__init__` builds the container's `-v` arguments. The OAuth credential files are therefore never visible inside the sandbox — `setup.py` fails to find them even though they exist on the host.

## The fix

Restores both `google_token.json` and `google_client_secret.json` to `required_credential_files`. The existing `register_credential_file()` implementation skips files that don't exist on the host (first-time setup, `google_token.json` absent) without error and adds them to the `missing_cred_files` list that drives `setup_needed = True`, so the setup prompt behaviour is correct.

## Test plan

- [x] **Before**: `required_credential_files` absent → `fm.get("required_credential_files")` returns `None` → `test_required_credential_files_present_in_skill_md` fails
- [x] **After**: all 3 new tests pass; 141/141 existing skills + credential-files tests unchanged
- [x] **Regression guard**: manually stripped field from parsed content → confirmed test assertion fires with `"required_credential_files missing from google-workspace SKILL.md"`

## Related

- Fixes #16452
- Original feature: #3671 (feat: mount skill credential files into remote terminal backends)
- Regression introduced by: #9931

🤖 Generated with [Claude Code](https://claude.com/claude-code)