### PR TITLE
fix(anthropic): strip top-level oneOf/allOf/anyOf from tool schemas

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1054,6 +1054,20 @@ def _sanitize_tool_id(tool_id: str) -> str:
     return sanitized or "tool_0"
 
 
+def _sanitize_input_schema(schema: Dict) -> Dict:
+    """Strip top-level oneOf/allOf/anyOf — Anthropic API rejects them."""
+    if not isinstance(schema, dict):
+        return {"type": "object", "properties": {}}
+    banned = {"oneOf", "allOf", "anyOf"}
+    if banned & schema.keys():
+        schema = {k: v for k, v in schema.items() if k not in banned}
+        if "type" not in schema:
+            schema["type"] = "object"
+        if schema.get("type") == "object" and "properties" not in schema:
+            schema["properties"] = {}
+    return schema
+
+
 def convert_tools_to_anthropic(tools: List[Dict]) -> List[Dict]:
     """Convert OpenAI tool definitions to Anthropic format."""
     if not tools:
@@ -1061,10 +1075,11 @@ def convert_tools_to_anthropic(tools: List[Dict]) -> List[Dict]:
     result = []
     for t in tools:
         fn = t.get("function", {})
+        schema = fn.get("parameters", {"type": "object", "properties": {}})
         result.append({
             "name": fn.get("name", ""),
             "description": fn.get("description", ""),
-            "input_schema": fn.get("parameters", {"type": "object", "properties": {}}),
+            "input_schema": _sanitize_input_schema(schema),
         })
     return result
 


### PR DESCRIPTION
## Summary

The Anthropic Messages API rejects tool `input_schema` definitions that contain JSON-Schema union keywords (`oneOf`, `allOf`, `anyOf`) at the top level, returning HTTP 400 with a generic validation error. Several upstream/plugin tools still emit OpenAI-style schemas that include these keywords, which causes every Anthropic request to fail before the model is ever invoked.

This adds a small `_sanitize_input_schema()` helper that strips those three keys from the top level of each tool schema as it is converted to Anthropic format. Nested `oneOf` inside `properties` is left alone (Anthropic accepts those).

## Effect

- Tools that previously caused hard 400s now reach the model with their top-level union constraint dropped.
- The LLM gets a flattened `{type: object, properties: ...}` schema instead of a union — strictly better than failing the entire turn.
- All other tools are unchanged (the sanitizer is a no-op when no banned keys are present).

## Why drop instead of translate

A real translation (e.g. picking one variant or merging schemas) is hard to do safely without changing tool semantics. A clean drop with a fallback to `{type: object, properties: {}}` is a conservative middle ground: it keeps the request alive, the tool gets called, and any downstream validation by the tool itself can still reject malformed args.

## Test plan

- [x] `python -m py_compile agent/anthropic_adapter.py` passes
- [x] Tools that previously triggered 400 now successfully convert
- [x] Existing tools without union keywords are byte-identical after conversion
- [ ] Reviewer to confirm there is no internal consumer of `input_schema` that depends on `oneOf` being preserved