### PR TITLE
fix(gateway): add cleanup_audio_cache() and wire it into the cron ticker

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -680,6 +680,27 @@ async def cache_audio_from_url(url: str, ext: str = ".ogg", retries: int = 2) ->
                 raise
 
 
+def cleanup_audio_cache(max_age_hours: int = 24) -> int:
+    """
+    Delete cached audio files older than *max_age_hours*.
+
+    Returns the number of files removed.
+    """
+    import time
+
+    cache_dir = get_audio_cache_dir()
+    cutoff = time.time() - (max_age_hours * 3600)
+    removed = 0
+    for f in cache_dir.iterdir():
+        if f.is_file() and f.stat().st_mtime < cutoff:
+            try:
+                f.unlink()
+                removed += 1
+            except OSError:
+                pass
+    return removed
+
+
 # ---------------------------------------------------------------------------
 # Video cache utilities
 #

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11157,7 +11157,7 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
     once per hour.
     """
     from cron.scheduler import tick as cron_tick
-    from gateway.platforms.base import cleanup_image_cache, cleanup_document_cache
+    from gateway.platforms.base import cleanup_image_cache, cleanup_audio_cache, cleanup_document_cache
     from hermes_cli.debug import _sweep_expired_pastes
 
     IMAGE_CACHE_EVERY = 60   # ticks — once per hour at default 60s interval
@@ -11196,6 +11196,12 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
                     logger.info("Image cache cleanup: removed %d stale file(s)", removed)
             except Exception as e:
                 logger.debug("Image cache cleanup error: %s", e)
+            try:
+                removed = cleanup_audio_cache(max_age_hours=24)
+                if removed:
+                    logger.info("Audio cache cleanup: removed %d stale file(s)", removed)
+            except Exception as e:
+                logger.debug("Audio cache cleanup error: %s", e)
             try:
                 removed = cleanup_document_cache(max_age_hours=24)
                 if removed:

--- a/tests/gateway/test_audio_cache.py
+++ b/tests/gateway/test_audio_cache.py
@@ -1,0 +1,120 @@
+"""
+Tests for audio cache utilities in gateway/platforms/base.py.
+
+Covers: get_audio_cache_dir, cache_audio_from_bytes, cleanup_audio_cache.
+"""
+
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from gateway.platforms.base import (
+    cache_audio_from_bytes,
+    cleanup_audio_cache,
+    get_audio_cache_dir,
+)
+
+# ---------------------------------------------------------------------------
+# Fixture: redirect AUDIO_CACHE_DIR to a temp directory for every test
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _redirect_cache(tmp_path, monkeypatch):
+    """Point the module-level AUDIO_CACHE_DIR to a fresh tmp_path."""
+    monkeypatch.setattr(
+        "gateway.platforms.base.AUDIO_CACHE_DIR", tmp_path / "audio_cache"
+    )
+
+
+# ---------------------------------------------------------------------------
+# TestGetAudioCacheDir
+# ---------------------------------------------------------------------------
+
+class TestGetAudioCacheDir:
+    def test_creates_directory(self, tmp_path):
+        cache_dir = get_audio_cache_dir()
+        assert cache_dir.exists()
+        assert cache_dir.is_dir()
+
+    def test_returns_existing_directory(self):
+        first = get_audio_cache_dir()
+        second = get_audio_cache_dir()
+        assert first == second
+        assert first.exists()
+
+
+# ---------------------------------------------------------------------------
+# TestCacheAudioFromBytes
+# ---------------------------------------------------------------------------
+
+class TestCacheAudioFromBytes:
+    def test_basic_caching(self):
+        data = b"fake ogg audio bytes"
+        path = cache_audio_from_bytes(data, ".ogg")
+        assert os.path.exists(path)
+        assert Path(path).read_bytes() == data
+
+    def test_default_extension_is_ogg(self):
+        path = cache_audio_from_bytes(b"audio")
+        assert path.endswith(".ogg")
+
+    def test_mp3_extension(self):
+        path = cache_audio_from_bytes(b"audio", ".mp3")
+        assert path.endswith(".mp3")
+
+    def test_unique_filenames(self):
+        p1 = cache_audio_from_bytes(b"a")
+        p2 = cache_audio_from_bytes(b"b")
+        assert p1 != p2
+
+
+# ---------------------------------------------------------------------------
+# TestCleanupAudioCache
+# ---------------------------------------------------------------------------
+
+class TestCleanupAudioCache:
+    def test_removes_old_files(self, tmp_path):
+        cache_dir = get_audio_cache_dir()
+        old_file = cache_dir / "old.ogg"
+        old_file.write_bytes(b"old audio")
+        old_mtime = time.time() - 48 * 3600
+        os.utime(old_file, (old_mtime, old_mtime))
+
+        removed = cleanup_audio_cache(max_age_hours=24)
+        assert removed == 1
+        assert not old_file.exists()
+
+    def test_keeps_recent_files(self):
+        cache_dir = get_audio_cache_dir()
+        recent = cache_dir / "recent.ogg"
+        recent.write_bytes(b"fresh audio")
+
+        removed = cleanup_audio_cache(max_age_hours=24)
+        assert removed == 0
+        assert recent.exists()
+
+    def test_returns_removed_count(self):
+        cache_dir = get_audio_cache_dir()
+        old_time = time.time() - 48 * 3600
+        for i in range(3):
+            f = cache_dir / f"old_{i}.ogg"
+            f.write_bytes(b"x")
+            os.utime(f, (old_time, old_time))
+
+        assert cleanup_audio_cache(max_age_hours=24) == 3
+
+    def test_empty_cache_dir(self):
+        assert cleanup_audio_cache(max_age_hours=24) == 0
+
+    def test_skips_subdirectories(self):
+        cache_dir = get_audio_cache_dir()
+        subdir = cache_dir / "subdir"
+        subdir.mkdir()
+        old_time = time.time() - 48 * 3600
+        os.utime(subdir, (old_time, old_time))
+
+        removed = cleanup_audio_cache(max_age_hours=24)
+        assert removed == 0
+        assert subdir.exists()


### PR DESCRIPTION
## What does this PR do?

The gateway's cron ticker prunes the image and document caches once per hour via `cleanup_image_cache()` and `cleanup_document_cache()`. The audio cache (`cache/audio/`) follows the same pattern — voice messages from Telegram, Signal, WhatsApp, and Matrix are downloaded there for STT transcription — but no cleanup function existed, so audio files accumulated indefinitely.

The ticker's own docstring already described the operation as sweeping the "image/audio/document cache", but the audio half was never implemented.

This PR adds `cleanup_audio_cache()` to `gateway/platforms/base.py`, mirroring `cleanup_image_cache()` and `cleanup_document_cache()` exactly, and wires it into `_start_cron_ticker()` alongside the existing sweeps.

## Related Issue

No separate issue — proactive parity fix. The missing function is called out by the ticker's own docstring (`"image/audio/document cache"`).

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made
- `gateway/platforms/base.py`: add `cleanup_audio_cache(max_age_hours: int = 24) -> int` after `cache_audio_from_url()`, symmetric with `cleanup_image_cache()` and `cleanup_document_cache()`
- `gateway/run.py`: add `cleanup_audio_cache` to the `_start_cron_ticker()` import and sweep it inside the `IMAGE_CACHE_EVERY` block alongside image and document cleanup
- `tests/gateway/test_audio_cache.py` (new, 11 tests): mirrors `tests/gateway/test_document_cache.py` — covers `get_audio_cache_dir`, `cache_audio_from_bytes`, and `cleanup_audio_cache` (removes old, keeps recent, counts removed, handles empty dir, skips subdirectories)

## How to Test
```bash
python3.11 -m pytest tests/gateway/test_audio_cache.py -v --override-ini="addopts="
# 11 passed
```

## Checklist
### Code
- [x] Contributing Guide read
- [x] Conventional Commits
- [x] No duplicate PR
- [x] This fix only
- [x] pytest passed — 11 passed
- [x] Tests added
- [x] Platform: macOS

### Documentation & Housekeeping
- [x] Docs updated — N/A
- [x] cli-config.yaml.example — N/A
- [x] CONTRIBUTING.md/AGENTS.md — N/A
- [x] Cross-platform impact — N/A
- [x] Tool descriptions — N/A