### PR TITLE
fix(feishu): unify outbound to post and degrade tables to text element

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -158,6 +158,16 @@ _MARKDOWN_FENCE_CLOSE_RE = re.compile(r"^```\s*$")
 _MENTION_RE = re.compile(r"@_user_\d+")
 _MULTISPACE_RE = re.compile(r"[ \t]{2,}")
 _POST_CONTENT_INVALID_RE = re.compile(r"content format of the post type is incorrect", re.IGNORECASE)
+# Feishu API error codes that mean "post payload is structurally invalid" and
+# are recoverable by falling back to a plain-text msg_type. Sourced from the
+# Feishu open-platform error reference and the lark_oapi.channel taxonomy:
+#   230001 — invalid message content
+#   230099 — invalid card content
+# These cover all locales (the code is structural) so no CN string matching
+# is required. _POST_CONTENT_INVALID_RE remains as a fallback for code paths
+# that only have an exception message (no response.code attached).
+_FEISHU_POST_FORMAT_ERROR_CODES = frozenset({230001, 230099})
+_TABLE_SEP_CELL_RE = re.compile(r"^\s*:?-+:?\s*$")
 # ---------------------------------------------------------------------------
 # Media type sets and upload constants
 # ---------------------------------------------------------------------------
@@ -505,6 +515,59 @@ def _coerce_required_int(value: Any, default: int, min_value: int = 0) -> int:
 # ---------------------------------------------------------------------------
 
 
+def _looks_like_gfm_table_row(line: str) -> bool:
+    """A GFM table row contains at least one inner pipe; outer pipes optional.
+
+    GFM allows tables both with outer pipes (``| a | b |``) and without
+    (``a | b``). The row check just needs to confirm at least one column
+    boundary is present after stripping any outer pipes.
+    """
+    stripped = line.strip()
+    if "|" not in stripped:
+        return False
+    return len(stripped.strip("|").split("|")) >= 2
+
+
+def _looks_like_gfm_table_separator(line: str) -> bool:
+    """A GFM table separator: every cell matches ``:?-+:?``.
+
+    Each cell must have at least one ``-``; alignment colons are optional.
+    Outer pipes are optional, matching the row form.
+    """
+    stripped = line.strip()
+    if "|" not in stripped:
+        return False
+    cells = stripped.strip("|").split("|")
+    if len(cells) < 2:
+        return False
+    return all(_TABLE_SEP_CELL_RE.match(cell) for cell in cells)
+
+
+def _contains_gfm_table(content: str) -> bool:
+    """Detect a GFM pipe table.
+
+    Strict: a row line whose next line is a separator (cells of ``:?-+:?``).
+    Outer pipes are optional per GFM. Lines inside fenced code blocks are
+    skipped so code samples that contain pipes are not mis-classified.
+    """
+    if not content or "|" not in content:
+        return False
+    lines = content.splitlines()
+    in_fence = False
+    for i in range(len(lines) - 1):
+        stripped = lines[i].strip()
+        if in_fence:
+            if _MARKDOWN_FENCE_CLOSE_RE.match(stripped):
+                in_fence = False
+            continue
+        if _MARKDOWN_FENCE_OPEN_RE.match(stripped):
+            in_fence = True
+            continue
+        if _looks_like_gfm_table_row(lines[i]) and _looks_like_gfm_table_separator(lines[i + 1]):
+            return True
+    return False
+
+
 def _build_markdown_post_payload(content: str) -> str:
     rows = _build_markdown_post_rows(content)
     return json.dumps(
@@ -524,9 +587,17 @@ def _build_markdown_post_rows(content: str) -> List[List[Dict[str, str]]]:
     appears inside one large markdown element. Split the reply at real fence
     lines so prose before/after the code block remains visible while code stays
     in a dedicated row.
+
+    GFM tables are unsupported by Feishu's `md` tag (renders as silent blank
+    or pipe literals). When a table is detected we emit one `text` row with the
+    plain-text projection of the whole content — column alignment is lost, but
+    the content stays visible.
     """
     if not content:
         return [[{"tag": "md", "text": ""}]]
+    if _contains_gfm_table(content):
+        plain = _strip_markdown_to_plain_text(content) or content
+        return [[{"tag": "text", "text": plain}]]
     if "```" not in content:
         return [[{"tag": "md", "text": content}]]
 
@@ -1631,6 +1702,45 @@ class FeishuAdapter(BasePlatformAdapter):
     # Outbound — send / edit / send_image / send_voice / …
     # =========================================================================
 
+    @staticmethod
+    def _is_post_format_error(*, response: Any = None, text: str = "") -> bool:
+        """Detect whether a Feishu post-message rejection is a format error.
+
+        Prefers the structured ``response.code`` field when a response object
+        is available — codes 230001 (invalid message content) and 230099
+        (invalid card content) are language-independent and the canonical
+        signal. Falls back to an English string match against the API error
+        template for code paths that only have an exception message
+        (raised exceptions cannot read ``response.code``).
+        """
+        if response is not None:
+            try:
+                code = int(getattr(response, "code", None))
+            except (TypeError, ValueError):
+                code = None
+            if code is not None and code in _FEISHU_POST_FORMAT_ERROR_CODES:
+                return True
+        return bool(text and _POST_CONTENT_INVALID_RE.search(text))
+
+    @staticmethod
+    def _log_post_fallback(*, where: str, content: str, detail: str) -> None:
+        """Log a post-format fallback. ``has_gfm_table`` is descriptive only.
+
+        The flag tells operators whether the rejected payload contained a
+        GFM table so they can correlate fallback events with the table
+        routing path. It is *not* a leak alarm: Feishu's silent-blank-bubble
+        failure mode for embedded tables returns ``success=True`` and never
+        reaches this code path. Use the flag for diagnostics; do not infer
+        a bug from it alone.
+        """
+        has_table = _contains_gfm_table(content)
+        logger.warning(
+            "[Feishu] Post fallback at %s. has_gfm_table=%s detail=%s",
+            where,
+            has_table,
+            detail[:200],
+        )
+
     async def send(
         self,
         chat_id: str,
@@ -1658,9 +1768,9 @@ class FeishuAdapter(BasePlatformAdapter):
                         metadata=metadata,
                     )
                 except Exception as exc:
-                    if msg_type != "post" or not _POST_CONTENT_INVALID_RE.search(str(exc)):
+                    if msg_type != "post" or not self._is_post_format_error(text=str(exc)):
                         raise
-                    logger.warning("[Feishu] Invalid post payload rejected by API; falling back to plain text")
+                    self._log_post_fallback(where="send.exception", content=chunk, detail=str(exc))
                     response = await self._feishu_send_with_retry(
                         chat_id=chat_id,
                         msg_type="text",
@@ -1671,9 +1781,16 @@ class FeishuAdapter(BasePlatformAdapter):
                 if (
                     msg_type == "post"
                     and not self._response_succeeded(response)
-                    and _POST_CONTENT_INVALID_RE.search(str(getattr(response, "msg", "") or ""))
+                    and self._is_post_format_error(
+                        response=response,
+                        text=str(getattr(response, "msg", "") or ""),
+                    )
                 ):
-                    logger.warning("[Feishu] Post payload rejected by API response; falling back to plain text")
+                    self._log_post_fallback(
+                        where="send.response",
+                        content=chunk,
+                        detail=str(getattr(response, "msg", "") or ""),
+                    )
                     response = await self._feishu_send_with_retry(
                         chat_id=chat_id,
                         msg_type="text",
@@ -1707,8 +1824,12 @@ class FeishuAdapter(BasePlatformAdapter):
             request = self._build_update_message_request(message_id=message_id, request_body=body)
             response = await asyncio.to_thread(self._client.im.v1.message.update, request)
             result = self._finalize_send_result(response, "update failed")
-            if not result.success and msg_type == "post" and _POST_CONTENT_INVALID_RE.search(result.error or ""):
-                logger.warning("[Feishu] Invalid post update payload rejected by API; falling back to plain text")
+            if (
+                not result.success
+                and msg_type == "post"
+                and self._is_post_format_error(response=response, text=result.error or "")
+            ):
+                self._log_post_fallback(where="edit.response", content=content, detail=result.error or "")
                 fallback_body = self._build_update_message_body(
                     msg_type="text",
                     content=json.dumps({"text": _strip_markdown_to_plain_text(content)}, ensure_ascii=False),
@@ -3829,10 +3950,11 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
-        if _MARKDOWN_HINT_RE.search(content):
-            return "post", _build_markdown_post_payload(content)
-        text_payload = {"text": content}
-        return "text", json.dumps(text_payload, ensure_ascii=False)
+        # Unified post: every outbound chunk goes out as `post` so streaming
+        # edits never cross msg_type. `_build_markdown_post_rows` decides
+        # whether to emit `md` rows or fall back to a `text` element row when
+        # the content contains a GFM table that Feishu's `md` tag cannot render.
+        return "post", _build_markdown_post_payload(content)
 
     async def _send_uploaded_file_message(
         self,
@@ -4084,7 +4206,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 return response
             except Exception as exc:
                 last_error = exc
-                if msg_type == "post" and _POST_CONTENT_INVALID_RE.search(str(exc)):
+                if msg_type == "post" and self._is_post_format_error(text=str(exc)):
                     raise
                 if attempt >= _FEISHU_SEND_ATTEMPTS - 1:
                     raise

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -364,10 +364,12 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
         self.assertTrue(result.success)
         self.assertEqual(result.message_id, "om_progress")
         self.assertEqual(captured["request"].message_id, "om_progress")
-        self.assertEqual(captured["request"].request_body.msg_type, "text")
+        # Outbound is unified to post so streaming edits never cross msg_type.
+        self.assertEqual(captured["request"].request_body.msg_type, "post")
+        payload = json.loads(captured["request"].request_body.content)
         self.assertEqual(
-            captured["request"].request_body.content,
-            json.dumps({"text": "📖 read_file: \"/tmp/image.png\""}, ensure_ascii=False),
+            payload["zh_cn"]["content"],
+            [[{"tag": "md", "text": "📖 read_file: \"/tmp/image.png\""}]],
         )
 
     @patch.dict(os.environ, {}, clear=True)
@@ -2663,6 +2665,164 @@ class TestAdapterBehavior(unittest.TestCase):
             rows,
             [[{"tag": "md", "text": "---\n1. 第一项\n<u>下划线</u>\n~~删除线~~"}]],
         )
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_build_post_payload_routes_gfm_table_to_text_element(self):
+        """GFM tables must drop to a `text` row. Feishu's `md` tag does
+        not render GFM tables — the bubble would otherwise appear blank.
+        Column alignment is expected to be lost; what matters is that
+        the content stays visible."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        content = "Intro line\n\n| col1 | col2 |\n| --- | --- |\n| a | b |\n\nClosing."
+        payload = json.loads(adapter._build_post_payload(content))
+        rows = payload["zh_cn"]["content"]
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0][0]["tag"], "text")
+        self.assertIn("col1", rows[0][0]["text"])
+        self.assertIn("a", rows[0][0]["text"])
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_build_post_payload_routes_no_outer_pipe_table_to_text_element(self):
+        """GFM allows tables without outer pipes (`a | b` / `--- | ---`).
+        The detector must catch this form too — it is a frequent shape
+        emitted by LLMs and previously triggered the silent-blank bug."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        content = "metric | value\n--- | ---\nQPS | 1200\nP95 | 80ms"
+        payload = json.loads(adapter._build_post_payload(content))
+        rows = payload["zh_cn"]["content"]
+        self.assertEqual(rows[0][0]["tag"], "text")
+        self.assertIn("metric", rows[0][0]["text"])
+        self.assertIn("QPS", rows[0][0]["text"])
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_build_post_payload_skips_pipe_inside_fenced_code_block(self):
+        """Pipe characters inside fenced code blocks must not trigger the
+        table heuristic — fenced code is rendered by the `md` element."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        content = "before\n```\n| col | col |\n| --- | --- |\n```\nafter"
+        payload = json.loads(adapter._build_post_payload(content))
+        rows = payload["zh_cn"]["content"]
+        self.assertTrue(all(row[0]["tag"] == "md" for row in rows))
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_build_post_payload_does_not_misclassify_setext_heading(self):
+        """A setext heading (`Title` followed by `---`) shares the trailing
+        dashes with a table separator, but has no pipes. Detector must not
+        false-positive on it."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        content = "Heading\n---\nbody text"
+        payload = json.loads(adapter._build_post_payload(content))
+        rows = payload["zh_cn"]["content"]
+        self.assertTrue(all(row[0]["tag"] == "md" for row in rows))
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_unifies_plain_text_to_post(self):
+        """Plain text (no markdown hints) still goes out as `post` with an
+        `md` row — the unified post path eliminates cross-type edits."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _MessageAPI:
+            def create(self, request):
+                captured["request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_plain"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(adapter.send(chat_id="oc_chat", content="hello world"))
+
+        self.assertTrue(result.success)
+        self.assertEqual(captured["request"].request_body.msg_type, "post")
+        payload = json.loads(captured["request"].request_body.content)
+        self.assertEqual(payload["zh_cn"]["content"], [[{"tag": "md", "text": "hello world"}]])
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_post_fallback_log_includes_gfm_table_flag(self):
+        """The post-fallback log line is descriptive: it records whether
+        the rejected payload contained a GFM table so operators can
+        correlate fallback events with the table routing path."""
+        import logging as _logging
+        from gateway.platforms.feishu import FeishuAdapter
+
+        with self.assertLogs("gateway.platforms.feishu", level=_logging.WARNING) as cm:
+            FeishuAdapter._log_post_fallback(
+                where="send.response",
+                content="| a | b |\n| --- | --- |\n| 1 | 2 |",
+                detail="content format of the post type is incorrect",
+            )
+        self.assertTrue(any("has_gfm_table=True" in line for line in cm.output))
+
+        with self.assertLogs("gateway.platforms.feishu", level=_logging.WARNING) as cm:
+            FeishuAdapter._log_post_fallback(
+                where="send.response",
+                content="just prose, no table here",
+                detail="content format of the post type is incorrect",
+            )
+        self.assertTrue(any("has_gfm_table=False" in line for line in cm.output))
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_is_post_format_error_uses_response_code(self):
+        """Detection prefers the structured `response.code` field — codes
+        230001 / 230099 are language-independent and the canonical signal."""
+        from gateway.platforms.feishu import FeishuAdapter
+
+        self.assertTrue(
+            FeishuAdapter._is_post_format_error(
+                response=SimpleNamespace(code=230001, msg=""),
+            )
+        )
+        self.assertTrue(
+            FeishuAdapter._is_post_format_error(
+                response=SimpleNamespace(code=230099, msg=""),
+            )
+        )
+        self.assertFalse(
+            FeishuAdapter._is_post_format_error(
+                response=SimpleNamespace(code=99991663, msg="invalid token"),
+            )
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_is_post_format_error_falls_back_to_english_template(self):
+        """When only an exception message is available (no response.code),
+        match against the canonical English error template."""
+        from gateway.platforms.feishu import FeishuAdapter
+
+        self.assertTrue(
+            FeishuAdapter._is_post_format_error(
+                text="content format of the post type is incorrect",
+            )
+        )
+        self.assertFalse(FeishuAdapter._is_post_format_error(text="rate limited"))
+        self.assertFalse(FeishuAdapter._is_post_format_error(text=""))
 
 
 @unittest.skipUnless(_HAS_LARK_OAPI, "lark-oapi not installed")


### PR DESCRIPTION
## What does this PR do?

Fixes two markdown-rendering bugs in the Feishu adapter for streaming AI replies. The fix unifies all outbound chunks onto `msg_type=post` — closing Bug 1 by removing the cross-type-edit possibility entirely — and adds a GFM table detector that routes table content to a `text` row inside the post payload, closing Bug 2 by avoiding Feishu's unsupported `md`-tag-with-table path.

### Bug 1 — cross-type edit during streaming

`_build_outbound_payload` re-decided `msg_type` for every chunk via `_MARKDOWN_HINT_RE`. The first plain-text frame went out as `msg_type=text`; once a later frame contained `##` or `**bold**` it flipped to `msg_type=post`. Feishu rejected the cross-type edit (or the fallback stripped markdown), so users saw literal markdown source (`## Heading` shown as plain text) or a bubble stuck on the first plain-text frame.

**Reproduces with**: any streaming reply that starts non-markdown and later contains markdown — common in agent traces (`📖 read_file: ...` first, then a structured summary).

### Bug 2 — silent blank bubble for content containing a GFM table

A post `md` element with a GFM pipe table renders as a **silently blank bubble** in the Feishu client — Feishu's `md` tag does not support GFM table syntax. The API returns `success=True` so no existing fallback path could recover. AI generates a report, hermes streams it, every API call succeeds, the user sees an empty message.

**Reproduces with**: any reply that contains a `| col | col |` / `| --- | --- |` table, or the no-outer-pipe form `col | col` / `--- | ---`.

## Related Issue

Fixes #9549 (Bug 2). No separate issue tracks Bug 1.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

`gateway/platforms/feishu.py`:
- `_build_outbound_payload` always returns `("post", ...)`. Committing to a single `msg_type` for every chunk eliminates Bug 1 structurally — streaming edits cannot cross types because there is only one type. Plain text wraps in one `{"tag":"md","text":"..."}` row, which renders identically to a native `text` message in the Feishu client.
- Add `_contains_gfm_table(content)` plus `_looks_like_gfm_table_row` / `_looks_like_gfm_table_separator` helpers. Detects GFM tables both with outer pipes (`| a | b |`) and without (`a | b`), rejects setext headings (`Title\n---`), and skips fenced code blocks to avoid false positives on code samples.
- `_build_markdown_post_rows`: when a GFM table is present, emit a single `{"tag":"text"}` row with the plain-text projection of the content.
- Add `_FEISHU_POST_FORMAT_ERROR_CODES = {230001, 230099}` (Feishu API codes for "invalid message content" and "invalid card content"). Format-error detection in `_is_post_format_error(*, response=None, text="")` prefers the structured `response.code` field — locale-independent and avoids string-matching brittleness. Falls back to a string match against the canonical English error template for paths that only have an exception message.
- New `_log_post_fallback` helper. Logs the fallback event and records whether the rejected payload contained a GFM table, for diagnostic correlation when grepping logs.

`tests/gateway/test_feishu.py`:
- Updated `test_edit_message_updates_existing_feishu_message` for the unified `post`/`md`-row behavior on plain text.
- Added 8 cases:
  - GFM table → text-row routing (with outer pipes).
  - GFM table → text-row routing (no outer pipes).
  - Setext heading is **not** misclassified as a table.
  - Fenced-code pipe is not misdetected.
  - Plain-text unification onto post.
  - Post-fallback log includes `has_gfm_table` (both True and False branches).
  - `_is_post_format_error` recognises codes 230001 / 230099 from `response.code`.
  - `_is_post_format_error` falls back to the English template when only a message string is available.

### Inbound parsing impact

`normalize_feishu_message` already handles `text` and `post` symmetrically, so unifying outbound to `post` does not affect inbound parsing, message echo handling, dedupe, or self-message filtering.

### Relation to existing PRs targeting #9549

Aware of open alternatives (#15956 / #16194 / #12114). They take different approaches (table-to-bullet conversion / interactive card with native table component). Defer to maintainer judgement on which to merge.

## How to Test

```bash
pytest tests/gateway/test_feishu.py -q -o addopts="-m 'not integration'" \
  --deselect tests/gateway/test_feishu.py::TestAdapterBehavior::test_webhook_request_uses_same_message_dispatch_path
```

(The deselected case fails on environments without `aiohttp` installed — unrelated to this PR.)

Cross-suite regression:

```bash
pytest tests/gateway/test_stream_consumer.py tests/gateway/test_stream_consumer_fresh_final.py \
       tests/gateway/test_feishu_onboard.py tests/gateway/test_feishu_approval_buttons.py \
       tests/gateway/test_feishu_comment.py tests/gateway/test_feishu_comment_rules.py -q
```

Manual repro (requires a Feishu app + test chat):

1. Bug 1 — send `Working...`, then `edit_message` to `Working...\n\n## Result\n- a`. Bubble should update in place with the markdown rendered. **Before**: literal `##` or stalled bubble.
2. Bug 2a — send a message containing `| col | col |\n| --- | --- |\n| 1 | 2 |`. Bubble should show table content as plain text. **Before**: empty bubble.
3. Bug 2b — send the no-outer-pipe form `metric | value\n--- | ---\nQPS | 1200`. Same expected behavior. **Before**: empty bubble.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Conventional Commits format
- [x] PR contains only changes related to this fix
- [x] Tests pass
- [x] Tests added
- [x] Tested on macOS 15.6 / Python 3.11

### Documentation & Housekeeping

- [ ] Documentation update — N/A (internal adapter behavior, no public API change)
- [ ] `cli-config.yaml.example` — N/A
- [ ] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered — pure-Python regex + JSON
- [ ] Tool descriptions/schemas — N/A
