### PR TITLE
Fix setup local TTS provider detection

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -129,6 +129,12 @@ def _set_reasoning_effort(config: Dict[str, Any], effort: str) -> None:
     agent_cfg["reasoning_effort"] = effort
 
 
+def _is_module_available(module_name: str) -> bool:
+    """Return whether an optional Python module can be imported."""
+    try:
+        return importlib.util.find_spec(module_name) is not None
+    except Exception:
+        return False
 
 
 # Import config helpers
@@ -472,21 +478,12 @@ def _print_setup_summary(config: dict, hermes_home):
     elif tts_provider == "gemini" and (get_env_value("GEMINI_API_KEY") or get_env_value("GOOGLE_API_KEY")):
         tool_status.append(("Text-to-Speech (Google Gemini)", True, None))
     elif tts_provider == "neutts":
-        try:
-            neutts_ok = importlib.util.find_spec("neutts") is not None
-        except Exception:
-            neutts_ok = False
-        if neutts_ok:
+        if _is_module_available("neutts"):
             tool_status.append(("Text-to-Speech (NeuTTS local)", True, None))
         else:
             tool_status.append(("Text-to-Speech (NeuTTS — not installed)", False, "run 'hermes setup tts'"))
     elif tts_provider == "kittentts":
-        try:
-            import importlib.util
-            kittentts_ok = importlib.util.find_spec("kittentts") is not None
-        except Exception:
-            kittentts_ok = False
-        if kittentts_ok:
+        if _is_module_available("kittentts"):
             tool_status.append(("Text-to-Speech (KittenTTS local)", True, None))
         else:
             tool_status.append(("Text-to-Speech (KittenTTS — not installed)", False, "run 'hermes setup tts'"))
@@ -1142,10 +1139,7 @@ def _setup_tts_provider(config: dict):
 
     if selected == "neutts":
         # Check if already installed
-        try:
-            already_installed = importlib.util.find_spec("neutts") is not None
-        except Exception:
-            already_installed = False
+        already_installed = _is_module_available("neutts")
 
         if already_installed:
             print_success("NeuTTS is already installed")
@@ -1250,11 +1244,7 @@ def _setup_tts_provider(config: dict):
 
     elif selected == "kittentts":
         # Check if already installed
-        try:
-            import importlib.util
-            already_installed = importlib.util.find_spec("kittentts") is not None
-        except Exception:
-            already_installed = False
+        already_installed = _is_module_available("kittentts")
 
         if already_installed:
             print_success("KittenTTS is already installed")

--- a/tests/hermes_cli/test_setup_tts_provider.py
+++ b/tests/hermes_cli/test_setup_tts_provider.py
@@ -1,0 +1,85 @@
+"""Regression tests for setup wizard TTS provider handling."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from hermes_cli import setup as setup_mod
+from hermes_cli.config import load_config
+
+
+def _feature_state(**overrides):
+    values = {
+        "managed_by_nous": False,
+        "available": False,
+        "current_provider": "",
+        "direct_override": False,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _subscription_features():
+    return SimpleNamespace(
+        nous_auth_present=False,
+        web=_feature_state(),
+        browser=_feature_state(),
+        image_gen=_feature_state(available=True),
+        tts=_feature_state(),
+        modal=_feature_state(),
+    )
+
+
+def _patch_common_setup_state(monkeypatch):
+    monkeypatch.setattr(
+        setup_mod,
+        "get_nous_subscription_features",
+        lambda _config: _subscription_features(),
+    )
+    monkeypatch.setattr(setup_mod, "managed_nous_tools_enabled", lambda: False)
+    monkeypatch.setattr(setup_mod, "get_env_value", lambda _key: "")
+    monkeypatch.setattr("agent.auxiliary_client.get_available_vision_backends", lambda: [])
+
+
+def _patch_neutts_installed(monkeypatch):
+    def fake_find_spec(name, *args, **kwargs):
+        return object() if name == "neutts" else None
+
+    monkeypatch.setattr(setup_mod.importlib.util, "find_spec", fake_find_spec)
+
+
+def test_setup_summary_reports_installed_neutts(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _patch_common_setup_state(monkeypatch)
+    _patch_neutts_installed(monkeypatch)
+
+    setup_mod._print_setup_summary({"tts": {"provider": "neutts"}}, tmp_path)
+    output = capsys.readouterr().out
+
+    assert "Text-to-Speech (NeuTTS local)" in output
+    assert "not installed" not in output
+
+
+def test_setup_tts_provider_keeps_installed_neutts(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _patch_common_setup_state(monkeypatch)
+    _patch_neutts_installed(monkeypatch)
+
+    def choose_neutts(_question, choices, _default=0, _description=None):
+        return next(
+            index
+            for index, choice in enumerate(choices)
+            if choice.startswith("NeuTTS ")
+        )
+
+    def fail_install_prompt(*args, **kwargs):
+        raise AssertionError("installed NeuTTS should not prompt for installation")
+
+    monkeypatch.setattr(setup_mod, "prompt_choice", choose_neutts)
+    monkeypatch.setattr(setup_mod, "prompt_yes_no", fail_install_prompt)
+
+    config = load_config()
+    setup_mod._setup_tts_provider(config)
+
+    assert load_config()["tts"]["provider"] == "neutts"
+    assert "NeuTTS is already installed" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- Add a shared optional-module availability helper for setup wizard checks.
- Use it for all `hermes_cli/setup.py` module probes, including NeuTTS, KittenTTS, and the `hermes_cli` relaunch fallback.
- Add regression coverage for the installed NeuTTS path.

## Why
When the setup code checked NeuTTS before a later local `import importlib.util`, Python treated `importlib` as a local variable for the whole function. The NeuTTS branch could hit `UnboundLocalError`, catch it broadly, and report NeuTTS as missing even when the `neutts` package was installed.

## User impact
Users with local NeuTTS installed can now see it reported as available and keep it selected without being prompted to reinstall or falling back to Edge TTS.

## Testing
- `scripts/run_tests.sh tests/hermes_cli/test_setup_tts_provider.py tests/hermes_cli/test_setup.py -k 'resolve_hermes_chat_argv or offer_launch_chat'`
- `scripts/run_tests.sh tests/hermes_cli/test_setup_model_provider.py tests/hermes_cli/test_setup_openclaw_migration.py`
- `uvx ruff check hermes_cli/setup.py tests/hermes_cli/test_setup_tts_provider.py --select F821,F822,F823 --config 'exclude=[]'`
- `codex review --base origin/main`

## Platform tested
- macOS, Python 3.11.14


## Rebase / conflict refresh (2026-05-06)
- Rebased onto current `main` and resolved the setup helper conflict against the new `hermes_cli.relaunch` flow.
- Validation: `scripts/run_tests.sh tests/hermes_cli/test_setup_tts_provider.py tests/hermes_cli/test_setup.py -k 'offer_launch_chat or setup_tts_provider or setup_summary' -q` (`4 passed`).
- Local merge check: `git merge-tree --write-tree --name-only origin/main HEAD` completed without conflicts.
