### PR TITLE
fix(agent): include name field on every role:tool message for Gemini compatibility

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4647,6 +4647,23 @@ class AIAgent:
             return tc.get("id", "") or ""
         return getattr(tc, "id", "") or ""
 
+    @staticmethod
+    def _get_tool_call_name_static(tc) -> str:
+        """Extract function name from a tool_call entry (dict or object).
+
+        Gemini's OpenAI-compatibility endpoint requires every `role: tool`
+        message to carry the matching function name. OpenAI/Anthropic/ollama
+        tolerate its absence, so the field is best-effort: callers fall back
+        to "" and the message still works elsewhere.
+        """
+        if isinstance(tc, dict):
+            fn = tc.get("function")
+            if isinstance(fn, dict):
+                return fn.get("name", "") or ""
+            return ""
+        fn = getattr(tc, "function", None)
+        return getattr(fn, "name", "") or ""
+
     _VALID_API_ROLES = frozenset({"system", "user", "assistant", "tool", "function", "developer"})
 
     @staticmethod
@@ -4709,6 +4726,7 @@ class AIAgent:
                         if cid in missing_results:
                             patched.append({
                                 "role": "tool",
+                                "name": AIAgent._get_tool_call_name_static(tc),
                                 "content": "[Result unavailable — see context summary above]",
                                 "tool_call_id": cid,
                             })
@@ -8053,6 +8071,7 @@ class AIAgent:
                             insert_at,
                             {
                                 "role": "tool",
+                                "name": function_name if function_name != "?" else "",
                                 "tool_call_id": tool_call_id,
                                 "content": marker,
                             },
@@ -8375,6 +8394,7 @@ class AIAgent:
             for tc in tool_calls:
                 messages.append({
                     "role": "tool",
+                    "name": tc.function.name,
                     "content": f"[Tool execution cancelled — {tc.function.name} was skipped due to user interrupt]",
                     "tool_call_id": tc.id,
                 })
@@ -8640,6 +8660,7 @@ class AIAgent:
 
             tool_msg = {
                 "role": "tool",
+                "name": name,
                 "content": function_result,
                 "tool_call_id": tc.id,
             }
@@ -8677,6 +8698,7 @@ class AIAgent:
                     skipped_name = skipped_tc.function.name
                     skip_msg = {
                         "role": "tool",
+                        "name": skipped_name,
                         "content": f"[Tool execution cancelled — {skipped_name} was skipped due to user interrupt]",
                         "tool_call_id": skipped_tc.id,
                     }
@@ -9004,6 +9026,7 @@ class AIAgent:
 
             tool_msg = {
                 "role": "tool",
+                "name": function_name,
                 "content": function_result,
                 "tool_call_id": tool_call.id
             }
@@ -9030,6 +9053,7 @@ class AIAgent:
                     skipped_name = skipped_tc.function.name
                     skip_msg = {
                         "role": "tool",
+                        "name": skipped_name,
                         "content": f"[Tool execution skipped — {skipped_name} was not started. User sent a new message]",
                         "tool_call_id": skipped_tc.id
                     }
@@ -11835,6 +11859,7 @@ class AIAgent:
                                 content = "Skipped: another tool call in this turn used an invalid name. Please retry this tool call."
                             messages.append({
                                 "role": "tool",
+                                "name": tc.function.name,
                                 "tool_call_id": tc.id,
                                 "content": content,
                             })
@@ -11926,6 +11951,7 @@ class AIAgent:
                                     tool_result = "Skipped: other tool call in this response had invalid JSON."
                                 messages.append({
                                     "role": "tool",
+                                    "name": tc.function.name,
                                     "tool_call_id": tc.id,
                                     "content": tool_result,
                                 })
@@ -12411,6 +12437,7 @@ class AIAgent:
                             if tc["id"] not in answered_ids:
                                 err_msg = {
                                     "role": "tool",
+                                    "name": AIAgent._get_tool_call_name_static(tc),
                                     "tool_call_id": tc["id"],
                                     "content": f"Error executing tool: {error_msg}",
                                 }

--- a/tests/run_agent/test_agent_guardrails.py
+++ b/tests/run_agent/test_agent_guardrails.py
@@ -263,3 +263,34 @@ class TestGetToolCallIdStatic:
     def test_object_without_id_attr(self):
         tc = types.SimpleNamespace()
         assert AIAgent._get_tool_call_id_static(tc) == ""
+
+
+# ---------------------------------------------------------------------------
+# _get_tool_call_name_static
+# ---------------------------------------------------------------------------
+
+class TestGetToolCallNameStatic:
+
+    def test_dict_with_valid_name(self):
+        assert AIAgent._get_tool_call_name_static(
+            {"id": "call_1", "function": {"name": "terminal", "arguments": "{}"}}
+        ) == "terminal"
+
+    def test_dict_with_missing_function(self):
+        assert AIAgent._get_tool_call_name_static({"id": "call_1"}) == ""
+
+    def test_dict_with_none_function(self):
+        assert AIAgent._get_tool_call_name_static({"id": "call_1", "function": None}) == ""
+
+    def test_dict_with_none_name(self):
+        assert AIAgent._get_tool_call_name_static(
+            {"function": {"name": None, "arguments": "{}"}}
+        ) == ""
+
+    def test_object_with_valid_name(self):
+        tc = make_tc("read_file")
+        assert AIAgent._get_tool_call_name_static(tc) == "read_file"
+
+    def test_object_without_function_attr(self):
+        tc = types.SimpleNamespace(id="call_1")
+        assert AIAgent._get_tool_call_name_static(tc) == ""

--- a/tests/run_agent/test_tool_call_args_sanitizer.py
+++ b/tests/run_agent/test_tool_call_args_sanitizer.py
@@ -96,6 +96,7 @@ def test_marker_message_inserted_when_missing():
     assert repaired == 1
     assert messages[1] == {
         "role": "tool",
+        "name": "read_file",
         "tool_call_id": "call_1",
         "content": marker,
     }


### PR DESCRIPTION
## What does this PR do?

Gemini's OpenAI-compatibility endpoint strictly requires the \`name\` field on \`role: tool\` messages — it returns HTTP 400 (\"Request contains an invalid argument\") when the function name is missing. OpenAI/Anthropic/ollama tolerate the absence, so the gap stays invisible until the conversation accumulates a tool-result turn and the user routes it through Gemini (direct API or via ollama-cloud proxy).

This PR adds a \`_get_tool_call_name_static()\` helper alongside the existing \`_get_tool_call_id_static()\`, and populates \`name\` at every site in \`run_agent.py\` that constructs a \`role: tool\` message:

| # | Site | What it produces |
|---|------|------------------|
| 1 | Pre-call sanitizer stub (4711) | \"[Result unavailable]\" filler for missing tool result |
| 2 | tool-call args repair marker (8055) | corruption marker injection |
| 3 | Parallel exec — interrupt skip (8377) | per-tool cancellation skip |
| 4 | Parallel exec — tool result (8642) | normal tool result |
| 5 | Parallel exec — cross-call interrupt (8679) | post-cancel skip for remaining calls |
| 6 | Sequential exec — tool result (9006) | normal tool result |
| 7 | Sequential exec — cross-call interrupt (9032) | post-cancel skip for remaining calls |
| 8 | Invalid tool-name recovery (11837) | \"Tool 'X' does not exist\" |
| 9 | Invalid JSON-args recovery (11928) | \"Invalid JSON arguments\" |
| 10 | Exception fallback (12413) | synthetic error result for orphaned tool_calls |

Each call site was already in scope of the function name (\`function_name\`, \`skipped_name\`, \`name\`, or a dict tool_call), so the change is local — no new lookups, no behavior change for providers that already worked.

## Related Issue

Fixes #16478

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- \`run_agent.py\` — new \`_get_tool_call_name_static()\` helper + \`name\` field added to all 10 \`role: tool\` construction sites.
- \`tests/run_agent/test_agent_guardrails.py\` — 6 new helper tests (\`TestGetToolCallNameStatic\`).
- \`tests/run_agent/test_tool_call_args_sanitizer.py\` — updated \`test_marker_message_inserted_when_missing\` to assert the new \`name\` field.

## How to Test

1. Configure a Gemini model as primary or fallback (e.g. \`gemini-2.5-flash\` via direct Gemini API, or \`gemini-3-flash-preview\` via ollama-cloud).
2. Send a message that triggers a tool call (e.g. ask it to read a URL via \`web_extract\`).
3. Continue the conversation through several tool rounds.
4. Before this PR: \`Error code: 400 - Request contains an invalid argument\`. After: tool turns succeed.

Automated:
\`\`\`bash
pytest tests/run_agent/test_agent_guardrails.py tests/run_agent/test_tool_call_args_sanitizer.py
# 42 passed
\`\`\`
\`tests/run_agent/\` overall: 555 passed (one pre-existing flaky thread-timing failure unrelated to this change).

## Notes

The helper docstring spells out that \`name\` is best-effort: when the upstream tool_call genuinely has no \`function.name\` (corrupt history, dict without function key), the helper returns \`\"\"\` and OpenAI/Anthropic/ollama still accept it. Gemini will only reject when both the field is empty *and* the conversation is being replayed there — which is the same failure mode as today.

A future cleanup could push \`name\` injection into a single \`_make_tool_message()\` constructor, but the spread-out call sites were left alone here to keep the diff a one-line addition per site.