### PR TITLE
feat(approvals): add approvals.context for customizable smart-approval prompts

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -729,6 +729,9 @@ DEFAULT_CONFIG = {
     "approvals": {
         "mode": "manual",
         "timeout": 60,
+        # Optional agent-specific context injected into the smart-approval prompt.
+        # Use this to reduce false positives for specialized agents (e.g. HA admin).
+        "context": None,
     },
 
     # Permanently allowed dangerous command patterns (added via "always" approval)
@@ -777,7 +780,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 18,
+    "_config_version": 19,
 }
 
 # =============================================================================

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -2,11 +2,13 @@
 
 import ast
 from pathlib import Path
-from unittest.mock import patch as mock_patch
+from unittest.mock import MagicMock, patch as mock_patch
 
 import tools.approval as approval_module
 from tools.approval import (
+    _get_approval_context,
     _get_approval_mode,
+    _smart_approve,
     approve_session,
     detect_dangerous_command,
     is_approved,
@@ -819,5 +821,63 @@ class TestChmodExecuteCombo:
         cmd = "chmod +x script.sh"
         dangerous, _, _ = detect_dangerous_command(cmd)
         assert dangerous is False
+
+
+class TestApprovalContext:
+    """Reading approvals.context from config."""
+
+    def test_no_context_returns_none(self):
+        with mock_patch("hermes_cli.config.load_config", return_value={"approvals": {}}):
+            assert _get_approval_context() is None
+
+    def test_empty_string_returns_none(self):
+        with mock_patch("hermes_cli.config.load_config", return_value={"approvals": {"context": ""}}):
+            assert _get_approval_context() is None
+
+    def test_whitespace_string_returns_none(self):
+        with mock_patch("hermes_cli.config.load_config", return_value={"approvals": {"context": "   \n  "}}):
+            assert _get_approval_context() is None
+
+    def test_valid_context_returns_stripped_string(self):
+        ctx = "curl to 192.168.x.x is safe"
+        with mock_patch("hermes_cli.config.load_config", return_value={"approvals": {"context": ctx}}):
+            assert _get_approval_context() == ctx
+
+    def test_context_gets_injected_into_smart_approve_prompt(self):
+        """When approvals.context is set, _smart_approve appends it to the LLM prompt."""
+        ctx = "This agent manages Home Assistant. curl to local IPs is always safe."
+        fake_client = MagicMock()
+        fake_response = MagicMock()
+        fake_response.choices = [MagicMock(message=MagicMock(content="APPROVE"))]
+        fake_client.chat.completions.create.return_value = fake_response
+
+        with mock_patch("hermes_cli.config.load_config", return_value={"approvals": {"context": ctx}}), \
+             mock_patch("agent.auxiliary_client.get_text_auxiliary_client", return_value=(fake_client, "test-model")), \
+             mock_patch("agent.auxiliary_client.auxiliary_max_tokens_param", return_value={"max_tokens": 16}):
+            result = _smart_approve("curl http://192.168.0.10:8123", "network request")
+            assert result == "approve"
+
+            call_args = fake_client.chat.completions.create.call_args
+            prompt = call_args.kwargs["messages"][0]["content"]
+            assert "Additional context for this agent:" in prompt
+            assert ctx in prompt
+            assert "Respond with exactly one word: APPROVE, DENY, or ESCALATE" in prompt
+
+    def test_no_context_omits_context_block(self):
+        """When approvals.context is absent, the prompt does not contain the context block."""
+        fake_client = MagicMock()
+        fake_response = MagicMock()
+        fake_response.choices = [MagicMock(message=MagicMock(content="ESCALATE"))]
+        fake_client.chat.completions.create.return_value = fake_response
+
+        with mock_patch("hermes_cli.config.load_config", return_value={"approvals": {}}), \
+             mock_patch("agent.auxiliary_client.get_text_auxiliary_client", return_value=(fake_client, "test-model")), \
+             mock_patch("agent.auxiliary_client.auxiliary_max_tokens_param", return_value={"max_tokens": 16}):
+            result = _smart_approve("python3 -c 'print(1)'", "script execution via -c flag")
+            assert result == "escalate"
+
+            call_args = fake_client.chat.completions.create.call_args
+            prompt = call_args.kwargs["messages"][0]["content"]
+            assert "Additional context for this agent:" not in prompt
 
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -531,6 +531,19 @@ def _get_approval_timeout() -> int:
         return 60
 
 
+def _get_approval_context() -> str | None:
+    """Read the optional smart-approval context from config.
+
+    When `approvals.context` is set, its contents are appended to the
+    smart-approval prompt so users can inject agent-specific guidance
+    (e.g. "curl to local LAN addresses is always safe").
+    """
+    context = _get_approval_config().get("context")
+    if isinstance(context, str) and context.strip():
+        return context.strip()
+    return None
+
+
 def _smart_approve(command: str, description: str) -> str:
     """Use the auxiliary LLM to assess risk and decide approval.
 
@@ -548,6 +561,11 @@ def _smart_approve(command: str, description: str) -> str:
             logger.debug("Smart approvals: no aux client available, escalating")
             return "escalate"
 
+        context_block = ""
+        custom_context = _get_approval_context()
+        if custom_context:
+            context_block = f"\n\nAdditional context for this agent:\n{custom_context}\n"
+
         prompt = f"""You are a security reviewer for an AI coding agent. A terminal command was flagged by pattern matching as potentially dangerous.
 
 Command: {command}
@@ -558,7 +576,7 @@ Assess the ACTUAL risk of this command. Many flagged commands are false positive
 Rules:
 - APPROVE if the command is clearly safe (benign script execution, safe file operations, development tools, package installs, git operations, etc.)
 - DENY if the command could genuinely damage the system (recursive delete of important paths, overwriting system files, fork bombs, wiping disks, dropping databases, etc.)
-- ESCALATE if you're uncertain
+- ESCALATE if you're uncertain{context_block}
 
 Respond with exactly one word: APPROVE, DENY, or ESCALATE"""
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1219,6 +1219,8 @@ Control how Hermes handles potentially dangerous commands:
 ```yaml
 approvals:
   mode: manual   # manual | smart | off
+  timeout: 60    # seconds to wait for user response (default: 60)
+  context: null  # optional agent-specific context for smart mode (string or null)
 ```
 
 | Mode | Behavior |
@@ -1228,6 +1230,22 @@ approvals:
 | `off` | Skip all approval checks. Equivalent to `HERMES_YOLO_MODE=true`. **Use with caution.** |
 
 Smart mode is particularly useful for reducing approval fatigue — it lets the agent work more autonomously on safe operations while still catching genuinely destructive commands.
+
+### Smart Approval Context
+
+The optional `approvals.context` key lets you inject agent-specific guidance into the smart-approval prompt. This is useful for specialized agents that routinely run commands which would otherwise be flagged as dangerous:
+
+```yaml
+approvals:
+  mode: smart
+  context: |
+    This agent manages a Home Assistant instance. The following are always safe in this context:
+    - curl requests to homeassistant.local or local LAN addresses (192.168.x.x)
+    - python -c commands that read environment variables
+    - SSH commands to ha@192.168.x.x
+```
+
+When `context` is set, its contents are appended to the prompt sent to the auxiliary LLM, helping it make context-aware approve/deny/escalate decisions.
 
 :::warning
 Setting `approvals.mode: off` disables all safety checks for terminal commands. Only use this in trusted, sandboxed environments.

--- a/website/docs/user-guide/security.md
+++ b/website/docs/user-guide/security.md
@@ -40,6 +40,22 @@ approvals:
 | **smart** | Use an auxiliary LLM to assess risk. Low-risk commands (e.g., `python -c "print('hello')"`) are auto-approved. Genuinely dangerous commands are auto-denied. Uncertain cases escalate to a manual prompt. |
 | **off** | Disable all approval checks — equivalent to running with `--yolo`. All commands execute without prompts. |
 
+### Smart Approval Context
+
+When using `smart` mode, you can inject agent-specific context into the auxiliary LLM's assessment prompt. This reduces false positives for specialized agents that have legitimate but unusual command patterns:
+
+```yaml
+approvals:
+  mode: smart
+  context: |
+    This agent manages a Home Assistant instance. The following are always safe in this context:
+    - curl requests to homeassistant.local or local LAN addresses (192.168.x.x)
+    - python -c commands that read environment variables
+    - SSH commands to ha@192.168.x.x
+```
+
+The `context` field is optional. When set, its contents are appended to the smart-approval prompt so the LLM can make context-aware decisions.
+
 :::warning
 Setting `approvals.mode: off` disables all safety prompts. Use only in trusted environments (CI/CD, containers, etc.).
 :::


### PR DESCRIPTION
## Summary

Implements the **quick win** suggested in #16475: an optional `approvals.context` config key that lets users customize the smart-approval prompt with agent-specific guidance.

## Problem

The current `smart` approval mode uses a hardcoded, generic prompt in `_smart_approve()`. Specialized agents (e.g. a Home Assistant admin bot) routinely run commands that match dangerous patterns but are completely safe in context — `curl` to local IPs, `python -c` env introspection, etc. This causes constant false positives and approval fatigue.

## Solution

Add an `approvals.context` string field that gets appended to the auxiliary LLM's assessment prompt when `mode: smart` is active.

### Example config

```yaml
approvals:
  mode: smart
  context: |
    This agent manages a Home Assistant instance. The following are always safe in this context:
    - curl requests to homeassistant.local or local LAN addresses (192.168.x.x)
    - python -c commands that read environment variables
    - SSH commands to ha@192.168.x.x
```

## Changes

- **`tools/approval.py`** — add `_get_approval_context()` helper; inject context into `_smart_approve()` prompt when present
- **`hermes_cli/config.py`** — add `"context": None` to default `approvals` block; bump `_config_version` to 19
- **`tests/tools/test_approval.py`** — add tests for context reading, empty/whitespace handling, and prompt injection
- **`website/docs/user-guide/security.md`** — document `approvals.context`
- **`website/docs/user-guide/configuration.md`** — document `approvals.context`

## Why not the full pluggable hook?

The full custom hook handler from the original issue is a larger architectural change (new approval mode, subprocess execution, JSON protocol, gateway notification hooks). This PR ships the immediate value — customizable smart prompts — with a ~10-line code change, while leaving the door open for the hook system later.

Closes #16475 (quick win)
