### PR TITLE
fix(multimodal): bridge image history for chat models

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -133,8 +133,9 @@ def _normalize_multimodal_content(content: Any) -> Any:
     Returns a plain string when the content is text-only, or a list of
     ``{"type": "text"|"image_url", ...}`` parts when images are present.
     The output shape is the native OpenAI Chat Completions vision format,
-    which the agent pipeline accepts verbatim (OpenAI-wire providers) or
-    converts (``_preprocess_anthropic_content`` for Anthropic).
+    which the agent pipeline accepts verbatim, or converts at the API
+    boundary via ``_preprocess_multimodal_content_to_text`` when the active
+    provider/model cannot consume native image parts.
 
     Raises ``ValueError`` with an OpenAI-style code on invalid input:
       * ``unsupported_content_type`` — file/input_file/file_id parts, or

--- a/run_agent.py
+++ b/run_agent.py
@@ -1223,10 +1223,13 @@ class AIAgent:
         self._persist_user_message_idx = None
         self._persist_user_message_override = None
 
-        # Cache anthropic image-to-text fallbacks per image payload/URL so a
-        # single tool loop does not repeatedly re-run auxiliary vision on the
-        # same image history.
-        self._anthropic_image_fallback_cache: Dict[str, str] = {}
+        # Cache image-to-text bridge results per image payload/URL so a
+        # single tool loop does not repeatedly re-run auxiliary vision on
+        # the same image history.  Used by the multimodal-to-text bridge
+        # applied to api_messages before sending to providers that do not
+        # accept native image parts (or where the configured main model
+        # cannot consume vision content).
+        self._image_text_bridge_cache: Dict[str, str] = {}
 
         # Initialize LLM client via centralized provider router.
         # The router handles auth resolution, base URL, headers, and
@@ -7226,15 +7229,15 @@ class AIAgent:
             "image/jpeg": ".jpg",
             "image/jpg": ".jpg",
         }.get(mime, ".jpg")
-        tmp = tempfile.NamedTemporaryFile(prefix="anthropic_image_", suffix=suffix, delete=False)
+        tmp = tempfile.NamedTemporaryFile(prefix="multimodal_image_", suffix=suffix, delete=False)
         with tmp:
             tmp.write(base64.b64decode(data))
         path = Path(tmp.name)
         return str(path), path
 
-    def _describe_image_for_anthropic_fallback(self, image_url: str, role: str) -> str:
+    def _describe_image_for_text_bridge(self, image_url: str, role: str) -> str:
         cache_key = hashlib.sha256(str(image_url or "").encode("utf-8")).hexdigest()
-        cached = self._anthropic_image_fallback_cache.get(cache_key)
+        cached = self._image_text_bridge_cache.get(cache_key)
         if cached:
             return cached
 
@@ -7280,10 +7283,10 @@ class AIAgent:
                 f"\n[If you need a closer look, use vision_analyze with image_url: {vision_source}]"
             )
 
-        self._anthropic_image_fallback_cache[cache_key] = note
+        self._image_text_bridge_cache[cache_key] = note
         return note
 
-    def _preprocess_anthropic_content(self, content: Any, role: str) -> Any:
+    def _preprocess_multimodal_content_to_text(self, content: Any, role: str) -> Any:
         if not self._content_has_image_parts(content):
             return content
 
@@ -7308,7 +7311,7 @@ class AIAgent:
                 image_data = part.get("image_url", {})
                 image_url = image_data.get("url", "") if isinstance(image_data, dict) else str(image_data or "")
                 if image_url:
-                    image_notes.append(self._describe_image_for_anthropic_fallback(image_url, role))
+                    image_notes.append(self._describe_image_for_text_bridge(image_url, role))
                 else:
                     image_notes.append("[An image was attached but no image source was available.]")
                 continue
@@ -7325,7 +7328,7 @@ class AIAgent:
             return prefix
         if suffix:
             return suffix
-        return "[A multimodal message was converted to text for Anthropic compatibility.]"
+        return "[A multimodal message was converted to text for provider compatibility.]"
 
     def _get_transport(self, api_mode: str = None):
         """Return the cached transport for the given (or current) api_mode.
@@ -7345,7 +7348,19 @@ class AIAgent:
             cache[mode] = t
         return t
 
-    def _prepare_anthropic_messages_for_api(self, api_messages: list) -> list:
+    def _prepare_messages_with_text_bridge(self, api_messages: list) -> list:
+        """Convert any multimodal image parts in api_messages to text notes.
+
+        Operates on a deep copy so the agent's internal ``messages`` history
+        (which may legitimately contain ``image_url`` / ``input_image`` parts
+        for native-vision providers) is never mutated.  When no message in
+        ``api_messages`` carries image parts, returns the input unchanged.
+
+        Used by both the Anthropic and chat_completions branches of
+        ``_build_api_kwargs`` so historical image content survives multi-turn
+        conversations even when the active main model does not support
+        native vision input.
+        """
         if not any(
             isinstance(msg, dict) and self._content_has_image_parts(msg.get("content"))
             for msg in api_messages
@@ -7356,11 +7371,39 @@ class AIAgent:
         for msg in transformed:
             if not isinstance(msg, dict):
                 continue
-            msg["content"] = self._preprocess_anthropic_content(
+            msg["content"] = self._preprocess_multimodal_content_to_text(
                 msg.get("content"),
                 str(msg.get("role", "user") or "user"),
             )
         return transformed
+
+    def _chat_model_likely_supports_native_vision(self, model_name: str) -> bool:
+        """Heuristic gate for native image-part support in chat_completions.
+
+        This deliberately stays lightweight (no catalog lookup, no config
+        schema expansion).  If the active model family is known to be vision-
+        capable, keep native multimodal content blocks.  Otherwise, bridge
+        image parts to text for compatibility.
+        """
+        name = (model_name or "").strip().lower()
+        if not name:
+            return False
+        known_vision_tokens = (
+            "gpt-4o",
+            "gpt-4.1",
+            "gemini",
+            "qwen-vl",
+            "qvq",
+            "llava",
+            "pixtral",
+            "internvl",
+            "minicpm-v",
+            "moondream",
+            "kimi-vl",
+            "glm-4v",
+            "grok-vision",
+        )
+        return any(token in name for token in known_vision_tokens)
 
     def _anthropic_preserve_dots(self) -> bool:
         """True when using an anthropic-compatible endpoint that preserves dots in model names.
@@ -7462,7 +7505,7 @@ class AIAgent:
         """Build the keyword arguments dict for the active API mode."""
         if self.api_mode == "anthropic_messages":
             _transport = self._get_transport()
-            anthropic_messages = self._prepare_anthropic_messages_for_api(api_messages)
+            anthropic_messages = self._prepare_messages_with_text_bridge(api_messages)
             ctx_len = getattr(self, "context_compressor", None)
             ctx_len = ctx_len.context_length if ctx_len else None
             ephemeral_out = getattr(self, "_ephemeral_max_output_tokens", None)
@@ -7591,9 +7634,16 @@ class AIAgent:
         if _ephemeral_out is not None:
             self._ephemeral_max_output_tokens = None
 
+        # Bridge only when the active chat model is unlikely to accept native
+        # image parts.  Vision-capable families keep native multimodal blocks.
+        if self._chat_model_likely_supports_native_vision(self.model):
+            chat_messages = api_messages
+        else:
+            chat_messages = self._prepare_messages_with_text_bridge(api_messages)
+
         return _ct.build_kwargs(
             model=self.model,
-            messages=api_messages,
+            messages=chat_messages,
             tools=self.tools,
             timeout=self._resolved_api_call_timeout(),
             max_tokens=self.max_tokens,

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3757,6 +3757,178 @@ class TestAnthropicImageFallback:
         assert mock_vision.await_count == 1
 
 
+class TestChatCompletionsImageBridge:
+    """Multimodal text bridge for chat_completions providers.
+
+    Mirrors the Anthropic behavior so historical messages carrying
+    image_url / input_image parts survive multi-turn conversations even
+    when the active model does not consume native vision input.
+    """
+
+    def _captured_messages(self, agent, api_messages, vision_result):
+        """Run _build_api_kwargs through chat_completions and return the
+        message list seen by the transport.
+        """
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        with (
+            patch(
+                "tools.vision_tools.vision_analyze_tool",
+                new=AsyncMock(return_value=json.dumps(vision_result)),
+            ),
+            patch.object(
+                ChatCompletionsTransport, "build_kwargs", autospec=True
+            ) as mock_build,
+        ):
+            mock_build.return_value = {"model": agent.model, "messages": []}
+            agent._build_api_kwargs(api_messages)
+
+        captured = mock_build.call_args.kwargs.get("messages")
+        if captured is None:
+            captured = mock_build.call_args.args[2]
+        return captured
+
+    def test_multimodal_user_image_in_history_is_converted_to_text(self, agent):
+        agent.api_mode = "chat_completions"
+        api_messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Look at this screenshot."},
+                    {"type": "image_url", "image_url": {"url": "https://example.com/shot.png"}},
+                ],
+            },
+            {"role": "assistant", "content": "Got it."},
+            {"role": "user", "content": "What did the chart say again?"},
+        ]
+
+        captured = self._captured_messages(
+            agent,
+            api_messages,
+            {"success": True, "analysis": "A bar chart titled Q3 revenue."},
+        )
+
+        bridged_first = captured[0]["content"]
+        assert isinstance(bridged_first, str)
+        assert "A bar chart titled Q3 revenue." in bridged_first
+        assert "Look at this screenshot." in bridged_first
+        assert "vision_analyze with image_url: https://example.com/shot.png" in bridged_first
+        assert captured[1] == {"role": "assistant", "content": "Got it."}
+        assert captured[2] == {"role": "user", "content": "What did the chart say again?"}
+
+    def test_multi_turn_history_uses_cached_image_analysis(self, agent):
+        agent.api_mode = "chat_completions"
+        url = "https://example.com/shot.png"
+        api_messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "first turn"},
+                    {"type": "image_url", "image_url": {"url": url}},
+                ],
+            },
+            {"role": "assistant", "content": "ok"},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "second turn references the same image"},
+                    {"type": "image_url", "image_url": {"url": url}},
+                ],
+            },
+        ]
+
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        mock_vision = AsyncMock(
+            return_value=json.dumps({"success": True, "analysis": "Same image."})
+        )
+        with (
+            patch("tools.vision_tools.vision_analyze_tool", new=mock_vision),
+            patch.object(
+                ChatCompletionsTransport, "build_kwargs", autospec=True
+            ) as mock_build,
+        ):
+            mock_build.return_value = {"model": agent.model, "messages": []}
+            agent._build_api_kwargs(api_messages)
+
+        assert mock_vision.await_count == 1
+
+    def test_text_only_history_is_passed_through_unchanged(self, agent):
+        agent.api_mode = "chat_completions"
+        api_messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+        ]
+
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        with patch.object(
+            ChatCompletionsTransport, "build_kwargs", autospec=True
+        ) as mock_build:
+            mock_build.return_value = {"model": agent.model, "messages": []}
+            agent._build_api_kwargs(api_messages)
+
+        captured = mock_build.call_args.kwargs.get("messages")
+        if captured is None:
+            captured = mock_build.call_args.args[2]
+        assert captured is api_messages
+
+    def test_internal_history_is_not_mutated_by_bridge(self, agent):
+        """The agent's persisted messages must keep their original
+        multimodal content list — only the API-call-time copy is bridged.
+        """
+        agent.api_mode = "chat_completions"
+        original_part = {"type": "image_url", "image_url": {"url": "https://example.com/shot.png"}}
+        api_messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "preserve me"},
+                    original_part,
+                ],
+            },
+        ]
+
+        self._captured_messages(
+            agent,
+            api_messages,
+            {"success": True, "analysis": "Preserved."},
+        )
+
+        assert isinstance(api_messages[0]["content"], list)
+        assert api_messages[0]["content"][1] is original_part
+
+    def test_vision_capable_chat_model_keeps_native_image_parts(self, agent):
+        agent.api_mode = "chat_completions"
+        agent.model = "gpt-4o-mini"
+        api_messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "inspect this"},
+                    {"type": "image_url", "image_url": {"url": "https://example.com/vision.png"}},
+                ],
+            }
+        ]
+
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        with (
+            patch("tools.vision_tools.vision_analyze_tool", new=AsyncMock()) as mock_vision,
+            patch.object(
+                ChatCompletionsTransport, "build_kwargs", autospec=True
+            ) as mock_build,
+        ):
+            mock_build.return_value = {"model": agent.model, "messages": []}
+            agent._build_api_kwargs(api_messages)
+
+        captured = mock_build.call_args.kwargs.get("messages")
+        if captured is None:
+            captured = mock_build.call_args.args[2]
+        assert captured is api_messages
+        assert mock_vision.await_count == 0
+
+
 class TestFallbackAnthropicProvider:
     """Bug fix: _try_activate_fallback had no case for anthropic provider."""
 

--- a/tests/test_ctx_halving_fix.py
+++ b/tests/test_ctx_halving_fix.py
@@ -175,7 +175,7 @@ class TestEphemeralMaxOutputTokens:
         agent.context_compressor = compressor
 
         # Stub out the internal message-preparation helper
-        agent._prepare_anthropic_messages_for_api = MagicMock(
+        agent._prepare_messages_with_text_bridge = MagicMock(
             return_value=[{"role": "user", "content": "hi"}]
         )
         agent._anthropic_preserve_dots = MagicMock(return_value=False)
@@ -249,7 +249,7 @@ class TestContextNotHalvedOnOutputCapError:
         compressor.threshold_percent = 0.75
         agent.context_compressor = compressor
 
-        agent._prepare_anthropic_messages_for_api = MagicMock(
+        agent._prepare_messages_with_text_bridge = MagicMock(
             return_value=[{"role": "user", "content": "hi"}]
         )
         agent._anthropic_preserve_dots = MagicMock(return_value=False)


### PR DESCRIPTION
## What does this PR do?

This PR fixes a multi-turn multimodal compatibility issue where historical image parts in conversation history can cause failures for non-vision chat models.

It generalizes the existing Anthropic image-to-text fallback into a provider-neutral bridge at API-kwargs build time, then applies that bridge to chat-completions only when the active model is unlikely to support native vision input. Vision-capable chat model families keep native image parts unchanged.

## Related Issue

Fixes #N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `run_agent.py`
  - Generalized Anthropic-specific bridge helpers into provider-neutral multimodal text-bridge helpers.
  - Reused bridge in `anthropic_messages` API kwargs path.
  - Added lightweight chat-completions gating:
    - bridge for likely non-vision models,
    - preserve native multimodal image parts for likely vision-capable model families.
  - Renamed temporary image file prefix from `anthropic_image_` to `multimodal_image_`.
- `tests/run_agent/test_run_agent.py`
  - Added `TestChatCompletionsImageBridge` coverage:
    - history multimodal image conversion,
    - duplicate image cache reuse,
    - text-only passthrough,
    - non-mutation of original message history,
    - vision-capable chat model bypass behavior.
- `tests/test_ctx_halving_fix.py`
  - Updated helper mocks after bridge-helper rename.
- `gateway/platforms/api_server.py`
  - Updated docstring reference to new provider-neutral bridge helper.

## How to Test

1. `scripts/run_tests.sh tests/run_agent/test_run_agent.py -q`
2. `scripts/run_tests.sh tests/run_agent/test_run_agent.py -k "ImageBridge or ImageFallback or vision_capable_chat_model" -q`
3. `scripts/run_tests.sh tests/test_ctx_halving_fix.py -q`
4. (template requirement check) `scripts/run_tests.sh tests/ -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (darwin 25.3.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Focused regression tests passed:
  - `scripts/run_tests.sh tests/run_agent/test_run_agent.py -q`
  - `scripts/run_tests.sh tests/run_agent/test_run_agent.py -k "ImageBridge or ImageFallback or vision_capable_chat_model" -q`
  - `scripts/run_tests.sh tests/test_ctx_halving_fix.py -q`
- Full-suite run result:
  - `scripts/run_tests.sh tests/ -q` => `110 failed, 16228 passed, 128 skipped, 6 errors`
  - failures are repository-wide baseline failures outside this PR's touched files.