### PR TITLE
fix(cli): clarify doctor memory diagnostics

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -9,6 +9,7 @@ import sys
 import subprocess
 import shutil
 import importlib.util
+from dataclasses import dataclass
 from pathlib import Path
 
 from hermes_cli.config import get_project_root, get_hermes_home, get_env_path
@@ -154,6 +155,122 @@ def check_fail(text: str, detail: str = ""):
 
 def check_info(text: str):
     print(f"    {color('→', Colors.CYAN)} {text}")
+
+
+@dataclass(frozen=True)
+class _MemoryFileStatus:
+    path: Path
+    description: str
+    store_name: str
+    exists: bool
+    readable: bool
+    char_count: int | None = None
+    error: str = ""
+
+    @property
+    def filename(self) -> str:
+        return self.path.name
+
+    @property
+    def populated(self) -> bool:
+        return self.readable and self.char_count is not None and self.char_count > 0
+
+    @property
+    def empty(self) -> bool:
+        return self.readable and self.char_count == 0
+
+
+def _memory_file_status(path: Path, description: str, store_name: str) -> _MemoryFileStatus:
+    if not path.exists():
+        return _MemoryFileStatus(
+            path=path,
+            description=description,
+            store_name=store_name,
+            exists=False,
+            readable=False,
+        )
+
+    try:
+        char_count = len(path.read_text(encoding="utf-8").strip())
+    except (OSError, UnicodeDecodeError) as exc:
+        return _MemoryFileStatus(
+            path=path,
+            description=description,
+            store_name=store_name,
+            exists=True,
+            readable=False,
+            error=f"{type(exc).__name__}: {exc}",
+        )
+
+    return _MemoryFileStatus(
+        path=path,
+        description=description,
+        store_name=store_name,
+        exists=True,
+        readable=True,
+        char_count=char_count,
+    )
+
+
+def _report_builtin_memory_files(memories_dir: Path, issues: list[str]) -> None:
+    statuses = [
+        _memory_file_status(
+            memories_dir / "MEMORY.md",
+            "agent personal notes",
+            "agent personal notes store",
+        ),
+        _memory_file_status(
+            memories_dir / "USER.md",
+            "user profile",
+            "user profile store",
+        ),
+    ]
+    populated_files = [status.filename for status in statuses if status.populated]
+    unreadable_files = [status for status in statuses if status.exists and not status.readable]
+
+    if populated_files:
+        check_ok(f"Built-in memory data present ({', '.join(populated_files)})")
+    elif unreadable_files:
+        check_warn(
+            "Built-in memory files exist but could not be read",
+            "(check permissions or file encoding)",
+        )
+    elif any(status.exists for status in statuses):
+        check_info(
+            "Built-in memory files exist but are empty; each file is populated only "
+            "after Hermes saves that kind of memory"
+        )
+    else:
+        check_info(
+            "Built-in memory files not created yet; each file is created only after "
+            "Hermes saves that kind of memory"
+        )
+
+    for status in statuses:
+        if status.populated or status.empty:
+            empty_suffix = "; empty" if status.empty else ""
+            check_ok(
+                f"{status.filename} exists "
+                f"({status.char_count} chars; {status.description}{empty_suffix})"
+            )
+        elif status.exists:
+            check_warn(f"{status.filename} exists but could not be read", f"({status.error})")
+            issues.append(f"{status.filename} could not be read — check permissions or encoding")
+        else:
+            other = next(
+                (candidate for candidate in statuses if candidate.filename != status.filename),
+                None,
+            )
+            if other and other.populated:
+                check_info(
+                    f"{status.filename} not created yet ({status.store_name}; "
+                    f"{other.filename} already contains {other.description})"
+                )
+            else:
+                check_info(
+                    f"{status.filename} not created yet "
+                    f"(created when Hermes saves {status.description})"
+                )
 
 
 def _check_gateway_service_linger(issues: list[str]) -> None:
@@ -753,18 +870,7 @@ def run_doctor(args):
     memories_dir = hermes_home / "memories"
     if memories_dir.exists():
         check_ok(f"{_DHH}/memories/ directory exists")
-        memory_file = memories_dir / "MEMORY.md"
-        user_file = memories_dir / "USER.md"
-        if memory_file.exists():
-            size = len(memory_file.read_text(encoding="utf-8").strip())
-            check_ok(f"MEMORY.md exists ({size} chars)")
-        else:
-            check_info("MEMORY.md not created yet (will be created when the agent first writes a memory)")
-        if user_file.exists():
-            size = len(user_file.read_text(encoding="utf-8").strip())
-            check_ok(f"USER.md exists ({size} chars)")
-        else:
-            check_info("USER.md not created yet (will be created when the agent first writes a memory)")
+        _report_builtin_memory_files(memories_dir, issues)
     else:
         check_warn(f"{_DHH}/memories/ not found", "(will be created on first use)")
         if should_fix:

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -300,9 +300,11 @@ class TestDoctorMemoryProviderSection:
         (home / "config.yaml").write_text(yaml.dump(config))
         return home
 
-    def _run_doctor_and_capture(self, monkeypatch, tmp_path, provider=""):
+    def _run_doctor_and_capture(self, monkeypatch, tmp_path, provider="", prepare_home=None):
         """Run doctor and capture stdout."""
         home = self._make_hermes_home(tmp_path, provider)
+        if prepare_home is not None:
+            prepare_home(home)
         monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
         monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
         monkeypatch.setattr(doctor_mod, "_DHH", str(home))
@@ -323,7 +325,6 @@ class TestDoctorMemoryProviderSection:
         except Exception:
             pass
 
-        import io, contextlib
         buf = io.StringIO()
         with contextlib.redirect_stdout(buf):
             doctor_mod.run_doctor(Namespace(fix=False))
@@ -336,6 +337,49 @@ class TestDoctorMemoryProviderSection:
         # Should NOT mention Honcho or Mem0 errors
         assert "Honcho API key" not in out
         assert "Mem0" not in out
+
+    def test_user_profile_memory_is_reported_separately(self, monkeypatch, tmp_path):
+        def prepare_home(home):
+            memories = home / "memories"
+            memories.mkdir()
+            (memories / "USER.md").write_text(
+                "User prefers concise answers",
+                encoding="utf-8",
+            )
+
+        out = self._run_doctor_and_capture(
+            monkeypatch,
+            tmp_path,
+            provider="",
+            prepare_home=prepare_home,
+        )
+
+        assert "Built-in memory data present (USER.md)" in out
+        assert "USER.md exists" in out
+        assert "user profile" in out
+        assert (
+            "MEMORY.md not created yet (agent personal notes store; "
+            "USER.md already contains user profile)"
+        ) in out
+        assert "will be created when the agent first writes a memory" not in out
+
+    def test_unreadable_builtin_memory_file_warns(self, monkeypatch, tmp_path):
+        def prepare_home(home):
+            memories = home / "memories"
+            memories.mkdir()
+            (memories / "MEMORY.md").write_bytes(b"\xff\xfe\xff")
+
+        out = self._run_doctor_and_capture(
+            monkeypatch,
+            tmp_path,
+            provider="",
+            prepare_home=prepare_home,
+        )
+
+        assert "Built-in memory files exist but could not be read" in out
+        assert "MEMORY.md exists but could not be read" in out
+        assert "UnicodeDecodeError" in out
+        assert "MEMORY.md could not be read" in out
 
     def test_honcho_provider_not_installed_shows_fail(self, monkeypatch, tmp_path):
         # Make honcho import fail


### PR DESCRIPTION
## What does this PR do?

Clarifies `hermes doctor` diagnostics for the built-in memory files under `~/.hermes/memories/`.

Root cause: `doctor` reported a missing `MEMORY.md` with generic wording that implied no memory had been written yet, even when Hermes had saved user profile data in `USER.md`. The two files represent different stores, so the diagnostic should distinguish them.

This PR:
- reports whether built-in memory data is present in `MEMORY.md`, `USER.md`, or both
- uses the documented definitions: `MEMORY.md` is agent personal notes, `USER.md` is the user profile
- distinguishes missing, empty, populated, and unreadable memory files
- warns and adds a doctor issue when a memory file exists but cannot be read
- adds regression tests for a populated `USER.md` with missing `MEMORY.md` and for invalid UTF-8 memory files

## Related Issue

No dedicated issue exists. This addresses diagnostic confusion seen while checking `hermes doctor` memory output.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/doctor.py`: extracts built-in memory-file status reporting and handles unreadable files explicitly.
- `tests/hermes_cli/test_doctor.py`: adds focused doctor regression coverage for `USER.md`-only memory and unreadable memory files.

## How to Test

1. Create `~/.hermes/memories/USER.md` without `MEMORY.md`.
2. Run `hermes doctor`.
3. Confirm doctor reports `USER.md` as the user profile and explains that `MEMORY.md` is the agent personal notes store.

Validation run locally:

```bash
TERMINAL_ENV=local scripts/run_tests.sh tests/hermes_cli/test_doctor.py -q
```

Result: 25 passed, 4 warnings (`discord.player` deprecation warning from dependency import).

Also run:

```bash
codex review --base origin/main
git diff --check
```

`codex review` found no actionable defects before the docs-wording alignment; the final wording-only update passed the focused doctor suite and `git diff --check`.

## Checklist

- [x] I have read the Contributing Guide
- [x] My commit message follows Conventional Commits: `fix(cli): clarify doctor memory diagnostics`
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix
- [x] I added tests for my changes
- [x] I tested on macOS
- [x] Documentation/config/tool-schema updates are N/A


## Rebase / conflict refresh (2026-05-06)
- Rebased onto current `main` and kept the `hermes doctor` memory-file diagnostics alongside the newer provider import checks.
- Validation: `scripts/run_tests.sh tests/hermes_cli/test_doctor.py -q` (`39 passed`, warnings from dependency imports only).
- Local merge check: `git merge-tree --write-tree --name-only origin/main HEAD` completed without conflicts.
