### PR TITLE
fix: validate FAL_KEY for corrupted bytes and improve error messages

### DIFF
--- a/tests/tools/test_image_generation_env.py
+++ b/tests/tools/test_image_generation_env.py
@@ -37,3 +37,29 @@ def test_fal_key_empty_is_unset(monkeypatch):
     )
 
     assert image_generation_tool.check_fal_api_key() is False
+
+
+def test_fal_key_control_chars_is_unset(monkeypatch):
+    # Keys containing non-printable / control characters (e.g. ESC bytes
+    # from a botched .env edit) must NOT register as configured.
+    monkeypatch.setenv("FAL_KEY", "\x1b\x1b")
+
+    from tools import image_generation_tool
+
+    monkeypatch.setattr(
+        image_generation_tool, "_resolve_managed_fal_gateway", lambda: None
+    )
+
+    assert image_generation_tool.check_fal_api_key() is False
+
+
+def test_fal_key_tab_only_is_unset(monkeypatch):
+    monkeypatch.setenv("FAL_KEY", "\t\t")
+
+    from tools import image_generation_tool
+
+    monkeypatch.setattr(
+        image_generation_tool, "_resolve_managed_fal_gateway", lambda: None
+    )
+
+    assert image_generation_tool.check_fal_api_key() is False

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -438,7 +438,22 @@ def _submit_fal_request(model: str, arguments: Dict[str, Any]):
     request_headers = {"x-idempotency-key": str(uuid.uuid4())}
     managed_gateway = _resolve_managed_fal_gateway()
     if managed_gateway is None:
-        return fal_client.submit(model, arguments=arguments, headers=request_headers)
+        try:
+            return fal_client.submit(model, arguments=arguments, headers=request_headers)
+        except Exception as exc:
+            # Check for auth-related errors (401/403) which typically mean
+            # the API key is invalid, expired, or corrupted.
+            status = _extract_http_status(exc)
+            if status in (401, 403):
+                raise ValueError(
+                    f"FAL API authentication failed (HTTP {status}). "
+                    f"Your FAL_KEY may be invalid, expired, or corrupted. "
+                    f"To fix:\n"
+                    f"  • Run `hermes setup` to reconfigure your FAL key, or\n"
+                    f"  • Get a new key at https://fal.ai/dashboard/keys and\n"
+                    f"    set it via `export FAL_KEY=<your-key>` or in ~/.hermes/.env"
+                ) from exc
+            raise
 
     managed_client = _get_managed_fal_client(managed_gateway)
     try:
@@ -750,13 +765,26 @@ def image_generate_tool(
 
     except Exception as e:
         generation_time = (datetime.datetime.now() - start_time).total_seconds()
-        error_msg = f"Error generating image: {str(e)}"
-        logger.error("%s", error_msg, exc_info=True)
+        error_msg = str(e) or repr(e) or f"Unknown {type(e).__name__}"
+        logger.error("Error generating image: %s", error_msg, exc_info=True)
+
+        # Provide actionable hint for common FAL HTTP errors
+        hint = ""
+        status = _extract_http_status(e)
+        if status in (401, 403):
+            hint = (
+                " — FAL_KEY appears invalid or expired. "
+                "Run `hermes setup` or visit https://fal.ai/dashboard/keys"
+            )
+        elif status == 429:
+            hint = " — FAL API rate limit exceeded. Wait a moment and retry."
+        elif status is not None and status >= 500:
+            hint = " — FAL server error. Try again later or pick a different model."
 
         response_data = {
             "success": False,
             "image": None,
-            "error": str(e),
+            "error": error_msg + hint,
             "error_type": type(e).__name__,
         }
 

--- a/tools/tool_backend_helpers.py
+++ b/tools/tool_backend_helpers.py
@@ -139,4 +139,11 @@ def fal_key_is_configured() -> bool:
             value = get_env_value("FAL_KEY")
         except Exception:
             value = None
-    return bool(value and value.strip())
+    if not value or not value.strip():
+        return False
+    # Reject keys that contain non-printable / control characters (e.g.
+    # accidental ESC bytes from a botched .env edit).  Valid FAL keys are
+    # hex strings or UUIDs — printable ASCII only.
+    if any(ord(ch) < 0x20 or ord(ch) == 0x7F for ch in value):
+        return False
+    return True


### PR DESCRIPTION
## Problem

When `FAL_KEY` in `~/.hermes/.env` contains corrupted bytes (e.g. ESC characters `0x1b` from a botched edit), the key passes the `fal_key_configured()` check but the FAL API rejects it with an unhelpful error:

```json
{
  "success": false,
  "error": "",
  "error_type": "FalClientHTTPError"
}
```

The empty error string gives users zero diagnostic information.

## Root Cause

1. `fal_key_configured()` only checks `bool(value and value.strip())` — control characters like `\x1b` are not whitespace, so corrupted keys pass validation.
2. Direct FAL API auth errors (401/403) are not caught with actionable messages (unlike the managed gateway path which already handles 4xx).
3. The main error handler uses `str(e)` which can be empty for some exception types.

## Fix (3 files)

### `tools/tool_backend_helpers.py`
- `fal_key_configured()` now rejects keys containing non-printable / control characters (`ord(ch) < 0x20` or `0x7F`)

### `tools/image_generation_tool.py`
- `_submit_fal_request()`: catches 401/403 from direct FAL API and raises `ValueError` with remediation steps (matching existing managed gateway pattern)
- Main error handler: falls back to `repr(e)` when `str(e)` is empty; appends contextual hints for 401/403 (invalid key), 429 (rate limit), 5xx (server error)

### `tests/tools/test_image_generation_env.py`
- Added `test_fal_key_control_chars_is_unset` — verifies ESC bytes are rejected
- Added `test_fal_key_tab_only_is_unset` — verifies tab-only values are rejected

## Testing

```
$ pytest tests/tools/test_image_generation_env.py -v
5 passed in 1.45s
```

All 5 tests pass including the 3 existing ones (whitespace, valid, empty) and 2 new ones.
