### PR TITLE
fix(cli): show history after resume

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3708,9 +3708,12 @@ class HermesCLI:
                     if len(text) > MAX_ASST_LEN:
                         text = text[:MAX_ASST_LEN] + "..."
                     parts.append(text)
-                if tool_calls:
+                if tool_calls and text:
+                    # If the assistant also provided user-visible text, keep a
+                    # compact hint that tools were involved.  Pure tool-call
+                    # assistant messages are skipped below so resume panels
+                    # don't become a wall of implementation noise.
                     tc_count = len(tool_calls)
-                    # Extract tool names
                     names = []
                     for tc in tool_calls:
                         fn = tc.get("function", {})
@@ -3725,7 +3728,8 @@ class HermesCLI:
                     parts.append(tc_summary)
                     full_parts.append(tc_summary)
                 if not parts:
-                    # Skip pure-reasoning messages that have no visible output
+                    # Skip pure-reasoning messages and pure tool-call messages
+                    # that have no user-visible assistant text.
                     continue
                 entries.append(("assistant", " ".join(parts)))
                 _last_asst_idx = len(entries) - 1
@@ -4837,7 +4841,15 @@ class HermesCLI:
                 session_meta = resolved_meta
 
         if target_id == self.session_id:
+            # The user may be trying to re-display context after losing the
+            # visible terminal scrollback.  Reload history if needed and show
+            # the same recap panel used by startup resume.
+            if not self.conversation_history:
+                restored = self._session_db.get_messages_as_conversation(target_id)
+                restored = [m for m in (restored or []) if m.get("role") != "session_meta"]
+                self.conversation_history = restored
             _cprint("  Already on that session.")
+            self._display_resumed_history()
             return
 
         # End current session
@@ -4885,6 +4897,7 @@ class HermesCLI:
                 f" ({msg_count} user message{'s' if msg_count != 1 else ''},"
                 f" {len(self.conversation_history)} total)"
             )
+            self._display_resumed_history()
         else:
             _cprint(f"  ↻ Resumed session {target_id}{title_part} — no messages, starting fresh.")
 

--- a/cli.py
+++ b/cli.py
@@ -383,7 +383,7 @@ def load_cli_config() -> Dict[str, Any]:
 
         "display": {
             "compact": False,
-            "resume_display": "full",
+            "resume_display": "recent",
             "show_reasoning": False,
             "streaming": True,
             "busy_input_mode": "interrupt",
@@ -1629,9 +1629,12 @@ class ChatConsole:
         # Read terminal width at render time so panels adapt to current size
         self._inner.width = shutil.get_terminal_size((80, 24)).columns
         self._inner.print(*args, **kwargs)
-        output = self._buffer.getvalue()
-        for line in output.rstrip("\n").split("\n"):
-            _cprint(line)
+        output = self._buffer.getvalue().rstrip("\n")
+        if output:
+            # Emit one multiline prompt_toolkit render call instead of one call
+            # per line. Large resume/history panels otherwise visibly crawl
+            # down the terminal line-by-line inside the interactive chat loop.
+            _cprint(output)
 
     @contextmanager
     def status(self, *_args, **_kwargs):
@@ -1894,8 +1897,8 @@ class HermesCLI:
         # YAML 1.1 parses bare `off` as boolean False — normalise to string.
         _raw_tp = CLI_CONFIG["display"].get("tool_progress", "all")
         self.tool_progress_mode = "off" if _raw_tp is False else str(_raw_tp)
-        # resume_display: "full" (show history) | "minimal" (one-liner only)
-        self.resume_display = CLI_CONFIG["display"].get("resume_display", "full")
+        # resume_display: "recent" (recent full text), "full" (all user/assistant text), "compact" (recent truncated recap), or "minimal" (one-liner only)
+        self.resume_display = CLI_CONFIG["display"].get("resume_display", "recent")
         # bell_on_complete: play terminal bell (\a) when agent finishes a response
         self.bell_on_complete = CLI_CONFIG["display"].get("bell_on_complete", False)
         # show_reasoning: display model thinking/reasoning before the response
@@ -3647,24 +3650,29 @@ class HermesCLI:
         return True
 
     def _display_resumed_history(self):
-        """Render a compact recap of previous conversation messages.
+        """Render previous conversation messages on session resume.
 
-        Uses Rich markup with dim/muted styling so the recap is visually
-        distinct from the active conversation.  Caps the display at the
-        last ``MAX_DISPLAY_EXCHANGES`` user/assistant exchanges and shows
-        an indicator for earlier hidden messages.
+        ``display.resume_display`` controls verbosity:
+        - ``recent`` (default): show the most recent full user/assistant text messages.
+        - ``full``: show all user/assistant text messages.
+        - ``compact``: show the last few exchanges with per-message truncation.
+        - ``minimal``/``off``: suppress the history panel.
+        Tool result messages and pure tool-call assistant messages are hidden to
+        avoid flooding the terminal with implementation details.
         """
         if not self.conversation_history:
             return
 
         # Check config: resume_display setting
-        if self.resume_display == "minimal":
+        if self.resume_display in {"minimal", "off"}:
             return
 
-        MAX_DISPLAY_EXCHANGES = 10   # max user+assistant pairs to show
-        MAX_USER_LEN = 300           # truncate user messages
-        MAX_ASST_LEN = 200           # truncate assistant text
-        MAX_ASST_LINES = 3           # max lines of assistant text
+        compact_mode = self.resume_display == "compact"
+        recent_mode = self.resume_display in {"recent", "compact"}
+        MAX_DISPLAY_EXCHANGES = 4    # recent/compact mode: max user+assistant pairs
+        MAX_USER_LEN = 300           # compact mode: truncate user messages
+        MAX_ASST_LEN = 200           # compact mode: truncate assistant text
+        MAX_ASST_LINES = 3           # compact mode: max lines of assistant text
 
         # Collect displayable entries (skip system, tool-result messages)
         entries = []  # list of (role, display_text)
@@ -3691,42 +3699,43 @@ class HermesCLI:
                         elif isinstance(part, dict) and part.get("type") == "image_url":
                             parts.append("[image]")
                     text = " ".join(parts)
-                if len(text) > MAX_USER_LEN:
+                if text.startswith("[SYSTEM:"):
+                    continue
+                if text.startswith("[Note: model was just switched"):
+                    if "]\n\n" in text:
+                        text = text.split("]\n\n", 1)[1]
+                    elif "]\n" in text:
+                        text = text.split("]\n", 1)[1]
+                if compact_mode and len(text) > MAX_USER_LEN:
                     text = text[:MAX_USER_LEN] + "..."
                 entries.append(("user", text))
 
             elif role == "assistant":
                 text = "" if content is None else str(content)
                 text = _strip_reasoning_tags(text)
+                if text.startswith("[CONTEXT COMPACTION"):
+                    # Context compaction is a synthetic handoff inserted by the
+                    # runtime, not a user-visible assistant answer. It also
+                    # marks a display boundary: assistant text after the handoff
+                    # belongs to the resumed task, and must not be paired with
+                    # the user message that triggered compaction.
+                    entries.clear()
+                    _last_asst_idx = None
+                    _last_asst_full = None
+                    continue
                 parts = []
                 full_parts = []  # un-truncated version
                 if text:
                     full_parts.append(text)
-                    lines = text.splitlines()
-                    if len(lines) > MAX_ASST_LINES:
-                        text = "\n".join(lines[:MAX_ASST_LINES]) + " ..."
-                    if len(text) > MAX_ASST_LEN:
-                        text = text[:MAX_ASST_LEN] + "..."
+                    if compact_mode:
+                        lines = text.splitlines()
+                        if len(lines) > MAX_ASST_LINES:
+                            text = "\n".join(lines[:MAX_ASST_LINES]) + " ..."
+                        if len(text) > MAX_ASST_LEN:
+                            text = text[:MAX_ASST_LEN] + "..."
                     parts.append(text)
-                if tool_calls and text:
-                    # If the assistant also provided user-visible text, keep a
-                    # compact hint that tools were involved.  Pure tool-call
-                    # assistant messages are skipped below so resume panels
-                    # don't become a wall of implementation noise.
-                    tc_count = len(tool_calls)
-                    names = []
-                    for tc in tool_calls:
-                        fn = tc.get("function", {})
-                        name = fn.get("name", "unknown") if isinstance(fn, dict) else "unknown"
-                        if name not in names:
-                            names.append(name)
-                    names_str = ", ".join(names[:4])
-                    if len(names) > 4:
-                        names_str += ", ..."
-                    noun = "call" if tc_count == 1 else "calls"
-                    tc_summary = f"[{tc_count} tool {noun}: {names_str}]"
-                    parts.append(tc_summary)
-                    full_parts.append(tc_summary)
+                # Resume display should read like chat history, not execution
+                # logs: omit tool call metadata entirely.
                 if not parts:
                     # Skip pure-reasoning messages and pure tool-call messages
                     # that have no user-visible assistant text.
@@ -3738,18 +3747,37 @@ class HermesCLI:
         if not entries:
             return
 
-        # Determine if we need to truncate
+        # Determine if we need to truncate. In recent/compact modes, select
+        # complete user-led exchanges from the tail instead of slicing raw
+        # messages. Raw message slicing can start with an orphan assistant
+        # response, which makes the recap feel like a head/tail hybrid rather
+        # than "the last few conversations".
         skipped = 0
-        if len(entries) > MAX_DISPLAY_EXCHANGES * 2:
-            skipped = len(entries) - MAX_DISPLAY_EXCHANGES * 2
-            entries = entries[skipped:]
+        skipped_unit = "messages"
+        if recent_mode:
+            exchanges = []
+            current_exchange = None
+            for role, text in entries:
+                if role == "user":
+                    current_exchange = [(role, text)]
+                    exchanges.append(current_exchange)
+                elif role == "assistant" and current_exchange is not None:
+                    current_exchange.append((role, text))
 
-        # Replace last assistant entry with full (un-truncated) text
+            if len(exchanges) > MAX_DISPLAY_EXCHANGES:
+                skipped = len(exchanges) - MAX_DISPLAY_EXCHANGES
+                skipped_unit = "exchanges"
+                exchanges = exchanges[-MAX_DISPLAY_EXCHANGES:]
+
+            entries = [entry for exchange in exchanges for entry in exchange]
+
+        # Replace the last visible assistant entry with full (un-truncated) text
         # so the user can see where they left off without wasting tokens.
-        if _last_asst_idx is not None and _last_asst_full:
-            adj_idx = _last_asst_idx - skipped
-            if 0 <= adj_idx < len(entries):
-                entries[adj_idx] = ("assistant_last", _last_asst_full)
+        if _last_asst_full:
+            for idx in range(len(entries) - 1, -1, -1):
+                if entries[idx][0] == "assistant":
+                    entries[idx] = ("assistant_last", _last_asst_full)
+                    break
 
         # Build the display using Rich
         from rich.panel import Panel
@@ -3771,7 +3799,7 @@ class HermesCLI:
         lines = Text()
         if skipped:
             lines.append(
-                f"  ... {skipped} earlier messages ...\n\n",
+                f"  ... {skipped} earlier {skipped_unit} ...\n\n",
                 style="dim italic",
             )
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -639,7 +639,7 @@ DEFAULT_CONFIG = {
     "display": {
         "compact": False,
         "personality": "kawaii",
-        "resume_display": "full",
+        "resume_display": "recent",
         "busy_input_mode": "interrupt",  # interrupt | queue | steer
         "bell_on_complete": False,
         "show_reasoning": False,

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -282,7 +282,7 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
     "display.resume_display": {
         "type": "select",
         "description": "How resumed sessions display history",
-        "options": ["minimal", "full", "off"],
+        "options": ["minimal", "compact", "recent", "full", "off"],
     },
     "display.busy_input_mode": {
         "type": "select",

--- a/tests/cli/test_chat_console.py
+++ b/tests/cli/test_chat_console.py
@@ -1,0 +1,21 @@
+"""Tests for prompt-toolkit-safe Rich console rendering."""
+
+from unittest.mock import patch
+
+
+def test_chat_console_batches_multiline_output_to_one_render_call():
+    """Large panels should not be emitted one terminal line at a time."""
+    from rich.panel import Panel
+
+    from cli import ChatConsole
+
+    console = ChatConsole()
+    with patch("cli._cprint") as mock_cprint:
+        console.print(Panel("first line\nsecond line\nthird line", title="History"))
+
+    assert mock_cprint.call_count == 1
+    rendered = mock_cprint.call_args.args[0]
+    assert "first line" in rendered
+    assert "second line" in rendered
+    assert "third line" in rendered
+    assert "\n" in rendered

--- a/tests/cli/test_resume_display.py
+++ b/tests/cli/test_resume_display.py
@@ -26,7 +26,7 @@ def _make_cli(config_overrides=None, env_overrides=None, **kwargs):
             "base_url": "https://openrouter.ai/api/v1",
             "provider": "auto",
         },
-        "display": {"compact": False, "tool_progress": "all", "resume_display": "full"},
+        "display": {"compact": False, "tool_progress": "all", "resume_display": "recent"},
         "agent": {},
         "terminal": {"env_type": "local"},
     }
@@ -164,7 +164,7 @@ class TestDisplayResumedHistory:
         assert "Here are some great Python tutorials" in output
 
     def test_long_user_message_truncated(self):
-        cli = _make_cli()
+        cli = _make_cli(config_overrides={"display": {"resume_display": "compact"}})
         long_text = "A" * 500
         cli.conversation_history = [
             {"role": "user", "content": long_text},
@@ -182,7 +182,7 @@ class TestDisplayResumedHistory:
 
     def test_long_assistant_message_truncated(self):
         """Non-last assistant messages are still truncated."""
-        cli = _make_cli()
+        cli = _make_cli(config_overrides={"display": {"resume_display": "compact"}})
         long_text = "B" * 400
         cli.conversation_history = [
             {"role": "user", "content": "Tell me a lot."},
@@ -199,7 +199,7 @@ class TestDisplayResumedHistory:
 
     def test_multiline_assistant_truncated(self):
         """Non-last multiline assistant messages are truncated to 3 lines."""
-        cli = _make_cli()
+        cli = _make_cli(config_overrides={"display": {"resume_display": "compact"}})
         multi = "\n".join([f"Line {i}" for i in range(20)])
         cli.conversation_history = [
             {"role": "user", "content": "Show me lines."},
@@ -246,15 +246,56 @@ class TestDisplayResumedHistory:
         assert "Line 10" in output
         assert "Line 19" in output
 
-    def test_large_history_shows_truncation_indicator(self):
+    def test_compact_large_history_shows_truncation_indicator(self):
+        cli = _make_cli(config_overrides={"display": {"resume_display": "compact"}})
+        cli.conversation_history = _large_history(n_exchanges=15)
+        output = self._capture_display(cli)
+
+        # Compact mode should show "earlier exchanges" indicator.
+        assert "earlier exchanges" in output
+        # Last question should still be visible.
+        assert "Question #15" in output
+
+    def test_recent_large_history_shows_recent_complete_messages(self):
         cli = _make_cli()
         cli.conversation_history = _large_history(n_exchanges=15)
         output = self._capture_display(cli)
 
-        # Should show "earlier messages" indicator
-        assert "earlier messages" in output
-        # Last question should still be visible
+        assert "earlier exchanges" in output
+        assert "Question #1: What is item 1?" not in output
+        assert "Answer #1: Item 1 is great." not in output
+        assert "Question #11: What is item 11?" not in output
+        assert "Answer #11: Item 11 is great." not in output
+        assert "Question #12" in output
+        assert "Answer #12" in output
         assert "Question #15" in output
+        assert "Answer #15" in output
+
+    def test_full_large_history_shows_all_displayable_messages(self):
+        cli = _make_cli(config_overrides={"display": {"resume_display": "full"}})
+        cli.conversation_history = _large_history(n_exchanges=15)
+        output = self._capture_display(cli)
+
+        assert "earlier messages" not in output
+        assert "Question #1" in output
+        assert "Answer #1" in output
+        assert "Question #15" in output
+        assert "Answer #15" in output
+
+    def test_recent_mode_does_not_truncate_long_messages(self):
+        cli = _make_cli()
+        long_user = " ".join(f"user{i}" for i in range(80))
+        long_assistant = "\n".join(f"assistant line {i}" for i in range(20))
+        cli.conversation_history = [
+            {"role": "user", "content": long_user},
+            {"role": "assistant", "content": long_assistant},
+        ]
+        output = self._capture_display(cli)
+
+        assert "user0" in output
+        assert "user79" in output
+        assert "assistant line 0" in output
+        assert "assistant line 19" in output
 
     def test_multimodal_content_handled(self):
         cli = _make_cli()
@@ -279,6 +320,76 @@ class TestDisplayResumedHistory:
         output = self._capture_display(cli)
 
         assert output.strip() == ""
+
+    def test_off_config_suppresses_display(self):
+        cli = _make_cli(config_overrides={"display": {"resume_display": "off"}})
+        cli.conversation_history = _simple_history()
+        output = self._capture_display(cli)
+
+        assert output.strip() == ""
+
+    def test_system_like_user_messages_hidden(self):
+        cli = _make_cli()
+        cli.conversation_history = [
+            {"role": "user", "content": "[SYSTEM: internal instruction]"},
+            {"role": "user", "content": "Real question"},
+            {"role": "assistant", "content": "Real answer"},
+        ]
+        output = self._capture_display(cli)
+
+        assert "internal instruction" not in output
+        assert "Real question" in output
+        assert "Real answer" in output
+
+    def test_model_switch_note_stripped_from_user_message(self):
+        cli = _make_cli()
+        cli.conversation_history = [
+            {
+                "role": "user",
+                "content": "[Note: model was just switched from a to b.]\n\nActual question",
+            },
+            {"role": "assistant", "content": "Actual answer"},
+        ]
+        output = self._capture_display(cli)
+
+        assert "model was just switched" not in output
+        assert "Actual question" in output
+        assert "Actual answer" in output
+
+    def test_context_compaction_assistant_message_hidden(self):
+        cli = _make_cli()
+        cli.conversation_history = [
+            {"role": "assistant", "content": "[CONTEXT COMPACTION — REFERENCE ONLY] noisy summary"},
+            {"role": "user", "content": "Real question"},
+            {"role": "assistant", "content": "Real answer"},
+        ]
+        output = self._capture_display(cli)
+
+        assert "CONTEXT COMPACTION" not in output
+        assert "noisy summary" not in output
+        assert "Real question" in output
+        assert "Real answer" in output
+
+    def test_context_compaction_resets_display_pairing(self):
+        cli = _make_cli()
+        cli.conversation_history = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "Hi!"},
+            {"role": "user", "content": "Old question before compaction"},
+            {"role": "assistant", "content": "[CONTEXT COMPACTION — REFERENCE ONLY] handoff"},
+            {"role": "tool", "content": "internal tool result"},
+            {"role": "assistant", "content": "Post-compaction answer"},
+            {"role": "user", "content": "New question"},
+            {"role": "assistant", "content": "New answer"},
+        ]
+        output = self._capture_display(cli)
+
+        assert "CONTEXT COMPACTION" not in output
+        assert "Old question before compaction" not in output
+        assert "hi" not in output
+        assert "Post-compaction answer" not in output
+        assert "New question" in output
+        assert "New answer" in output
 
     def test_panel_has_title(self):
         cli = _make_cli()
@@ -486,8 +597,8 @@ class TestDisplayResumedHistory:
         output = self._capture_display(cli)
 
         assert "Let me search for that." in output
-        assert "1 tool call" in output
-        assert "terminal" in output
+        assert "1 tool call" not in output
+        assert "terminal" not in output
 
 
 # ── Tests for /resume command display ──────────────────────────────
@@ -673,7 +784,7 @@ class TestResumeDisplayConfig:
         from hermes_cli.config import DEFAULT_CONFIG
         display = DEFAULT_CONFIG.get("display", {})
         assert "resume_display" in display
-        assert display["resume_display"] == "full"
+        assert display["resume_display"] == "recent"
 
     def test_cli_defaults_have_resume_display(self):
         """cli.py load_cli_config defaults include resume_display."""
@@ -687,4 +798,4 @@ class TestResumeDisplayConfig:
             config = load_cli_config()
 
         display = config.get("display", {})
-        assert display.get("resume_display") == "full"
+        assert display.get("resume_display") == "recent"

--- a/tests/cli/test_resume_display.py
+++ b/tests/cli/test_resume_display.py
@@ -153,14 +153,15 @@ class TestDisplayResumedHistory:
         assert "Found 5 results" not in output
         assert "Page content" not in output
 
-    def test_tool_calls_shown_as_summary(self):
+    def test_pure_tool_call_assistant_messages_hidden(self):
         cli = _make_cli()
         cli.conversation_history = _tool_call_history()
         output = self._capture_display(cli)
 
-        assert "2 tool calls" in output
-        assert "web_search" in output
-        assert "web_extract" in output
+        assert "2 tool calls" not in output
+        assert "web_search" not in output
+        assert "web_extract" not in output
+        assert "Here are some great Python tutorials" in output
 
     def test_long_user_message_truncated(self):
         cli = _make_cli()
@@ -487,6 +488,48 @@ class TestDisplayResumedHistory:
         assert "Let me search for that." in output
         assert "1 tool call" in output
         assert "terminal" in output
+
+
+# ── Tests for /resume command display ──────────────────────────────
+
+
+class TestResumeCommandDisplay:
+    """Mid-session /resume should show the same recap users see on startup."""
+
+    def test_resume_other_session_displays_previous_conversation(self):
+        cli = _make_cli()
+        messages = _simple_history()
+        mock_db = MagicMock()
+        mock_db.get_session.return_value = {"id": "target_session", "title": "Target"}
+        mock_db.resolve_resume_session_id.return_value = "target_session"
+        mock_db.get_messages_as_conversation.return_value = messages
+        cli._session_db = mock_db
+
+        buf = StringIO()
+        cli.console.file = buf
+        cli._handle_resume_command("/resume target_session")
+
+        output = buf.getvalue()
+        assert "Previous Conversation" in output
+        assert "What is Python?" in output
+        assert "You can install Python from python.org." in output
+
+    def test_resume_current_session_replays_previous_conversation(self):
+        cli = _make_cli()
+        cli.session_id = "current_session"
+        cli.conversation_history = _simple_history()
+        mock_db = MagicMock()
+        mock_db.get_session.return_value = {"id": "current_session", "title": "Current"}
+        mock_db.resolve_resume_session_id.return_value = "current_session"
+        cli._session_db = mock_db
+
+        buf = StringIO()
+        cli.console.file = buf
+        cli._handle_resume_command("/resume current_session")
+
+        output = buf.getvalue()
+        assert "Previous Conversation" in output
+        assert "How do I install it?" in output
 
 
 # ── Tests for _preload_resumed_session ──────────────────────────────


### PR DESCRIPTION
## Summary
- show the Previous Conversation panel after using /resume mid-session
- replay the current session history when /resume targets the active session
- hide pure tool-call assistant messages from resume history recap while preserving assistant text with tool summaries

## Test Plan
- ./venv/bin/python -m pytest tests/cli/test_resume_display.py -q