### PR TITLE
fix(test): stub macOS Keychain in TestReadClaudeCodeCredentials

### DIFF
--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -186,6 +186,13 @@ class TestIsClaudeCodeTokenValid:
 
 
 class TestResolveAnthropicToken:
+    @pytest.fixture(autouse=True)
+    def _no_keychain(self, monkeypatch):
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
+            lambda: None,
+        )
+
     def test_prefers_oauth_token_over_api_key(self, monkeypatch, tmp_path):
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api03-mykey")
         monkeypatch.setenv("ANTHROPIC_TOKEN", "sk-ant-oat01-mytoken")
@@ -394,6 +401,13 @@ class TestResolveWithRefresh:
 
 
 class TestRunOauthSetupToken:
+    @pytest.fixture(autouse=True)
+    def _no_keychain(self, monkeypatch):
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
+            lambda: None,
+        )
+
     def test_raises_when_claude_not_installed(self, monkeypatch):
         monkeypatch.setattr("shutil.which", lambda _: None)
         with pytest.raises(FileNotFoundError, match="claude.*CLI.*not installed"):

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -117,6 +117,14 @@ class TestBuildAnthropicClient:
 
 
 class TestReadClaudeCodeCredentials:
+    @pytest.fixture(autouse=True)
+    def _no_keychain(self, monkeypatch):
+        """Stub out the macOS Keychain lookup so tests exercise the JSON file path."""
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
+            lambda: None,
+        )
+
     def test_reads_valid_credentials(self, tmp_path, monkeypatch):
         cred_file = tmp_path / ".claude" / ".credentials.json"
         cred_file.parent.mkdir(parents=True)


### PR DESCRIPTION
## Summary

- `read_claude_code_credentials()` checks the macOS Keychain before falling back to the JSON credentials file
- On any developer machine with Claude Code installed, the Keychain holds a live `sk-ant-oat01-*` token
- All 5 `TestReadClaudeCodeCredentials` tests fail on such machines: the 4 tests expecting `None` get the real credential, and the positive test reads the Keychain token instead of its fixture value
- Fix: add an `autouse` fixture to the class that stubs `_read_claude_code_credentials_from_keychain` to return `None`, keeping all tests isolated from the host environment

## Root cause

```python
def read_claude_code_credentials():
    kc_creds = _read_claude_code_credentials_from_keychain()  # ← returns real creds on macOS
    if kc_creds:
        return kc_creds  # ← never reaches Path.home() patch
    ...
```

The tests only patched `agent.anthropic_adapter.Path.home`; they did not account for the Keychain path that short-circuits first.

## Test plan

- [ ] `pytest tests/agent/test_anthropic_adapter.py::TestReadClaudeCodeCredentials` — all 5 pass (was 5 failures on macOS with Claude Code installed)
- [ ] Confirmed failures on unpatched `main` then green after fix
- [ ] No production code changed — test isolation fix only

🤖 Generated with [Claude Code](https://claude.com/claude-code)