### PR TITLE
fix(gemini): route /model gemini to native /v1beta endpoint (#16484)

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -205,6 +205,40 @@ def _resolve_runtime_from_pool_entry(
     elif provider == "google-gemini-cli":
         api_mode = "chat_completions"
         base_url = base_url or "cloudcode-pa://google"
+    elif provider == "gemini":
+        # Google AI Studio (native Gemini API).  Default base URL is the
+        # native /v1beta endpoint which uses ``:generateContent`` paths and
+        # ``x-goog-api-key`` headers — handled at runtime by
+        # ``GeminiNativeClient`` (see ``agent/gemini_native_adapter.py``).
+        # The ``/openai`` suffix opts into Google's OpenAI-compatibility
+        # endpoint, in which case the default OpenAI SDK transport is used.
+        # Bug #16484: a stale base_url from a previous provider must not
+        # leak into this resolution and cause ``/chat/completions`` to be
+        # appended to ``/v1beta`` (which Google's native API rejects).
+        api_mode = "chat_completions"
+        cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
+        pconfig = PROVIDER_REGISTRY.get("gemini")
+        default_base = (
+            pconfig.inference_base_url.rstrip("/")
+            if pconfig
+            else "https://generativelanguage.googleapis.com/v1beta"
+        )
+        cfg_base_url = ""
+        if cfg_provider == "gemini":
+            cfg_base_url = str(model_cfg.get("base_url") or "").strip().rstrip("/")
+        # Honour env var override, then config, then pool entry, then default.
+        env_base_url = os.getenv("GEMINI_BASE_URL", "").strip().rstrip("/")
+        if env_base_url:
+            base_url = env_base_url
+        elif cfg_base_url:
+            base_url = cfg_base_url
+        else:
+            # If the pool entry has a stale non-Google base_url (e.g. from a
+            # previous /model switch on a different provider), fall back to
+            # the canonical Gemini default rather than appending
+            # ``/chat/completions`` to it at request time.
+            host_ok = "generativelanguage.googleapis.com" in base_url.lower()
+            base_url = base_url if (base_url and host_ok) else default_base
     elif provider == "anthropic":
         api_mode = "anthropic_messages"
         cfg_provider = str(model_cfg.get("provider") or "").strip().lower()

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -2285,3 +2285,113 @@ def test_minimax_oauth_runtime_uses_inference_base_url(monkeypatch):
     resolved = rp.resolve_runtime_provider(requested="minimax-oauth")
 
     assert MINIMAX_OAUTH_CN_INFERENCE.rstrip("/") in resolved["base_url"]
+
+# ---------------------------------------------------------------------------
+# Gemini provider (Google AI Studio native /v1beta) — issue #16484
+# ---------------------------------------------------------------------------
+def test_resolve_runtime_provider_gemini_default_v1beta(monkeypatch):
+    """When no base_url is configured, gemini provider routes to the canonical
+    /v1beta endpoint so GeminiNativeClient picks up the native generateContent
+    path instead of /chat/completions being appended."""
+
+    class _Entry:
+        access_token = "gemini-key"
+        source = "env:GEMINI_API_KEY"
+        base_url = ""
+
+    class _Pool:
+        def has_credentials(self):
+            return True
+
+        def select(self):
+            return _Entry()
+
+    monkeypatch.delenv("GEMINI_BASE_URL", raising=False)
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "gemini")
+    monkeypatch.setattr(rp, "load_pool", lambda provider: _Pool())
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {"provider": "gemini", "default": "gemini-2.5-pro"})
+
+    resolved = rp.resolve_runtime_provider(requested="gemini")
+
+    assert resolved["provider"] == "gemini"
+    assert resolved["base_url"] == "https://generativelanguage.googleapis.com/v1beta"
+    assert resolved["api_key"] == "gemini-key"
+
+
+def test_resolve_runtime_provider_gemini_recovers_stale_base_url(monkeypatch):
+    """Bug #16484: a stale non-Google base_url in the pool entry (e.g.
+    leftover from a previous /model switch) must not be used verbatim,
+    or /chat/completions gets appended to it for a Gemini request."""
+
+    class _Entry:
+        access_token = "gemini-key"
+        source = "stale-pool"
+        base_url = "https://api.openai.com/v1"  # stale!
+
+    class _Pool:
+        def has_credentials(self):
+            return True
+
+        def select(self):
+            return _Entry()
+
+    monkeypatch.delenv("GEMINI_BASE_URL", raising=False)
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "gemini")
+    monkeypatch.setattr(rp, "load_pool", lambda provider: _Pool())
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {"provider": "gemini", "default": "gemini-2.5-pro"})
+
+    resolved = rp.resolve_runtime_provider(requested="gemini")
+
+    # Stale URL was rejected; canonical /v1beta substituted.
+    assert resolved["base_url"] == "https://generativelanguage.googleapis.com/v1beta"
+
+
+def test_resolve_runtime_provider_gemini_respects_openai_compat_suffix(monkeypatch):
+    """When user explicitly configures the OpenAI-compatibility endpoint
+    (/v1beta/openai), keep it — that path DOES accept /chat/completions."""
+
+    class _Entry:
+        access_token = "gemini-key"
+        source = "config"
+        base_url = "https://generativelanguage.googleapis.com/v1beta/openai"
+
+    class _Pool:
+        def has_credentials(self):
+            return True
+
+        def select(self):
+            return _Entry()
+
+    monkeypatch.delenv("GEMINI_BASE_URL", raising=False)
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "gemini")
+    monkeypatch.setattr(rp, "load_pool", lambda provider: _Pool())
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {"provider": "gemini", "default": "gemini-2.5-pro"})
+
+    resolved = rp.resolve_runtime_provider(requested="gemini")
+
+    assert resolved["base_url"] == "https://generativelanguage.googleapis.com/v1beta/openai"
+
+
+def test_resolve_runtime_provider_gemini_env_var_overrides(monkeypatch):
+    """GEMINI_BASE_URL env var wins over pool entry and config."""
+
+    class _Entry:
+        access_token = "gemini-key"
+        source = "config"
+        base_url = "https://generativelanguage.googleapis.com/v1beta"
+
+    class _Pool:
+        def has_credentials(self):
+            return True
+
+        def select(self):
+            return _Entry()
+
+    monkeypatch.setenv("GEMINI_BASE_URL", "https://my-proxy.example.com/v1beta")
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "gemini")
+    monkeypatch.setattr(rp, "load_pool", lambda provider: _Pool())
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {"provider": "gemini", "default": "gemini-2.5-pro"})
+
+    resolved = rp.resolve_runtime_provider(requested="gemini")
+
+    assert resolved["base_url"] == "https://my-proxy.example.com/v1beta"


### PR DESCRIPTION
## What does this PR do?

The runtime provider resolver in `hermes_cli/runtime_provider.py` had no explicit branch for the `gemini` provider, so `/model` switches to a Gemini model would fall through to the generic OpenAI-style path. With `api_mode=chat_completions` and a possibly stale `base_url` left over from a previous provider, the OpenAI SDK would POST to `{base_url}/chat/completions` — which Google's native `/v1beta` API does not support (it speaks `:generateContent` + `x-goog-api-key` headers).

This adds a dedicated `gemini` branch that ensures `base_url` is always pointed at a Gemini-aware endpoint so `GeminiNativeClient` (already in `agent/gemini_native_adapter.py`) takes over and constructs the correct `:generateContent` URL itself.

## Related Issue

Fixes #16484

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/runtime_provider.py`: add explicit `elif provider == "gemini"` branch in `_apply_provider_runtime_kwargs` that
  - defaults `base_url` to `https://generativelanguage.googleapis.com/v1beta` (the canonical native endpoint)
  - honours `GEMINI_BASE_URL` env override
  - honours `model.base_url` from config when `provider: gemini`
  - preserves the `/v1beta/openai` OpenAI-compatibility suffix when explicitly configured (that path *does* accept `/chat/completions`)
  - recovers from a stale non-Google pool entry `base_url` (e.g. left over from a previous `/model` switch on a different provider) instead of appending `/chat/completions` to it
- `tests/hermes_cli/test_runtime_provider_resolution.py`: 4 new tests covering each of the above branches

## How to Test

1. Configure a Google AI Studio API key: `export GEMINI_API_KEY=...`
2. From a fresh hermes session on a non-gemini provider (e.g. anthropic), run `/model gemini gemini-2.5-pro`
3. Send a prompt — request now routes to `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:generateContent` (verifiable via DEBUG logs / network capture) instead of `…/v1beta/chat/completions` (404).
4. Run the test suite:
   ```bash
   pytest tests/hermes_cli/test_runtime_provider_resolution.py -k gemini -q
   ```

All 4 new tests pass; full file (88 tests) passes.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(gemini):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/hermes_cli/test_runtime_provider_resolution.py tests/hermes_cli/test_gemini_provider.py tests/agent/test_gemini_native_adapter.py -q` and all tests pass
- [x] I've added tests for my changes
