### PR TITLE
fix(cli): refuse-or-drop privileges when launched as root in Docker (#16480)

### DIFF
--- a/hermes_cli/docker_guard.py
+++ b/hermes_cli/docker_guard.py
@@ -1,0 +1,202 @@
+"""
+Docker-root execution guard for the Hermes CLI.
+
+Background (issue #16480):
+    The Docker entrypoint normally starts as root, fixes ownership of
+    ``$HERMES_HOME``, and then drops privileges to the ``hermes`` user
+    (UID/GID controlled by ``HERMES_UID`` / ``HERMES_GID``) before running
+    the gateway.
+
+    However, when a user enters a running container with
+    ``docker exec -it ... bash`` and runs ``hermes`` interactively, the
+    privilege drop in the entrypoint is bypassed. The CLI then runs as
+    ``root`` and any files it creates or rewrites under ``$HERMES_HOME``
+    (``config.yaml``, logs, cache, state DBs, …) become root-owned. The
+    long-running gateway, which still runs as the ``hermes`` user, can
+    then no longer read or chown them.
+
+    This module guards against that case. When the CLI is invoked
+    inside a container as root **and** the container declares a non-root
+    runtime user via ``HERMES_UID`` / ``HERMES_GID``, we either:
+
+    1.  Re-execute the same command as that user via ``gosu`` / ``su-exec``
+        (preferred — transparent for the user), or
+    2.  Refuse to continue and print an instruction to re-launch as the
+        ``hermes`` user.
+
+The guard is deliberately conservative:
+    * It only triggers inside a container (``/.dockerenv`` present, or
+      ``/proc/1/cgroup`` mentions docker/containerd, or the standard
+      Hermes Docker env vars are present).
+    * It is a no-op on non-Linux hosts and for non-root users.
+    * It can be disabled with ``HERMES_DISABLE_DOCKER_ROOT_GUARD=1`` for
+      maintenance / debugging.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import sys
+from typing import Iterable, Optional
+
+logger = logging.getLogger(__name__)
+
+# Subcommands that legitimately need to keep running as the original
+# (possibly root) user. These typically *want* root to fix ownership
+# from inside the container during recovery.
+_BYPASS_SUBCOMMANDS = frozenset({"version", "--version", "-V", "help", "--help", "-h"})
+
+_DISABLE_ENV = "HERMES_DISABLE_DOCKER_ROOT_GUARD"
+
+
+def _is_linux() -> bool:
+    return sys.platform.startswith("linux")
+
+
+def _running_as_root() -> bool:
+    geteuid = getattr(os, "geteuid", None)
+    if geteuid is None:  # pragma: no cover - non-POSIX
+        return False
+    try:
+        return geteuid() == 0
+    except OSError:  # pragma: no cover - extremely unusual
+        return False
+
+
+def _in_container() -> bool:
+    """Best-effort container detection.
+
+    We treat any of the following as "inside a container":
+      * ``/.dockerenv`` exists (classic Docker marker).
+      * ``/run/.containerenv`` exists (Podman marker).
+      * ``/proc/1/cgroup`` mentions ``docker``, ``containerd``, ``kubepods``,
+        ``podman``, or ``crio``.
+      * ``HERMES_DOCKER`` env var is truthy (set by our official image).
+    """
+    if os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv"):
+        return True
+    if os.environ.get("HERMES_DOCKER", "").lower() in {"1", "true", "yes"}:
+        return True
+    try:
+        with open("/proc/1/cgroup", "r", encoding="utf-8", errors="replace") as fh:
+            content = fh.read()
+    except OSError:
+        return False
+    needles = ("docker", "containerd", "kubepods", "podman", "crio")
+    return any(n in content for n in needles)
+
+
+def _resolve_target_uid_gid() -> Optional[tuple[int, int]]:
+    """Return the (uid, gid) the CLI *should* run as, or ``None`` if
+    the container did not declare a non-root runtime identity.
+    """
+    raw_uid = os.environ.get("HERMES_UID")
+    if not raw_uid:
+        return None
+    try:
+        uid = int(raw_uid)
+    except ValueError:
+        logger.warning("Ignoring non-integer HERMES_UID=%r", raw_uid)
+        return None
+    if uid == 0:
+        # Operator explicitly opted into running as root; honour it.
+        return None
+    raw_gid = os.environ.get("HERMES_GID") or str(uid)
+    try:
+        gid = int(raw_gid)
+    except ValueError:
+        logger.warning("Ignoring non-integer HERMES_GID=%r", raw_gid)
+        gid = uid
+    return uid, gid
+
+
+def _find_dropper() -> Optional[list[str]]:
+    """Locate ``gosu`` or ``su-exec`` for transparent privilege drop."""
+    for name in ("gosu", "su-exec"):
+        path = shutil.which(name)
+        if path:
+            return [path]
+    return None
+
+
+def _argv_is_bypass(argv: Iterable[str]) -> bool:
+    args = list(argv)[1:]
+    if not args:
+        return False
+    return args[0] in _BYPASS_SUBCOMMANDS
+
+
+def enforce_docker_non_root(argv: Optional[list[str]] = None) -> None:
+    """Refuse-or-reexec when running as root inside a container.
+
+    Should be called as early as possible in :func:`hermes_cli.main.main`,
+    *before* any code path that might create or touch files under
+    ``$HERMES_HOME``.
+    """
+    if argv is None:
+        argv = sys.argv
+
+    if os.environ.get(_DISABLE_ENV, "").lower() in {"1", "true", "yes"}:
+        return
+    if not _is_linux():
+        return
+    if not _running_as_root():
+        return
+    if not _in_container():
+        return
+    if _argv_is_bypass(argv):
+        # ``hermes version`` / ``hermes --help`` don't write state.
+        return
+
+    target = _resolve_target_uid_gid()
+    if target is None:
+        return  # container did not declare a non-root identity
+    uid, gid = target
+
+    # Mark the re-exec so we don't loop forever if the dropped process
+    # somehow still appears to satisfy the trigger conditions.
+    if os.environ.get("HERMES_DOCKER_GUARD_REEXEC") == "1":
+        return
+
+    dropper = _find_dropper()
+    env = os.environ.copy()
+    env["HERMES_DOCKER_GUARD_REEXEC"] = "1"
+    # Ensure the dropped process has a sane HOME so config.yaml / .env
+    # land where the gateway expects them.
+    hermes_home = env.get("HERMES_HOME")
+    if hermes_home and not env.get("HOME"):
+        env["HOME"] = hermes_home
+
+    if dropper:
+        spec = f"{uid}:{gid}"
+        cmd = [*dropper, spec, *argv]
+        sys.stderr.write(
+            f"[hermes] Dropping privileges to uid={uid} gid={gid} via "
+            f"{os.path.basename(dropper[0])} (issue #16480 guard).\n"
+        )
+        sys.stderr.flush()
+        try:
+            os.execvpe(cmd[0], cmd, env)
+        except OSError as exc:  # pragma: no cover - exec failure is rare
+            logger.error("Privilege drop via %s failed: %s", dropper[0], exc)
+            # fall through to refuse path
+
+    # No dropper available (or exec failed) — refuse rather than poison
+    # ``$HERMES_HOME`` with root-owned files.
+    sys.stderr.write(
+        "ERROR: hermes refuses to run as root inside this container.\n"
+        f"       Files written under $HERMES_HOME would become root-owned and the\n"
+        f"       gateway running as uid={uid} would lose access to them.\n\n"
+        "       Re-launch as the hermes user, e.g.:\n"
+        f"         gosu {uid}:{gid} hermes {' '.join(argv[1:]) or 'chat'}\n"
+        "       or enter the container with:\n"
+        f"         docker exec -it -u {uid}:{gid} <container> bash\n\n"
+        f"       To override (NOT recommended), set {_DISABLE_ENV}=1.\n"
+    )
+    sys.stderr.flush()
+    sys.exit(1)
+
+
+__all__ = ["enforce_docker_non_root"]

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8131,6 +8131,17 @@ def cmd_logs(args):
 
 def main():
     """Main entry point for hermes CLI."""
+    # Issue #16480: refuse to run (or transparently drop privileges) when
+    # the CLI is launched as root inside a Docker container that declares
+    # a non-root runtime user. Must run before any code that could create
+    # files under $HERMES_HOME.
+    try:
+        from hermes_cli.docker_guard import enforce_docker_non_root
+
+        enforce_docker_non_root()
+    except Exception:  # pragma: no cover - guard must never break startup
+        pass
+
     from hermes_cli._parser import build_top_level_parser
 
     parser, subparsers, chat_parser = build_top_level_parser()

--- a/tests/hermes_cli/test_docker_guard.py
+++ b/tests/hermes_cli/test_docker_guard.py
@@ -1,0 +1,167 @@
+"""Tests for the Docker root-execution guard (issue #16480)."""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest import mock
+
+import pytest
+
+from hermes_cli import docker_guard
+
+
+@pytest.fixture(autouse=True)
+def _clear_disable_env(monkeypatch):
+    monkeypatch.delenv(docker_guard._DISABLE_ENV, raising=False)
+    monkeypatch.delenv("HERMES_DOCKER_GUARD_REEXEC", raising=False)
+    yield
+
+
+def _patch_env(monkeypatch, *, in_container=True, root=True, uid="10000", gid="10000"):
+    monkeypatch.setattr(docker_guard, "_is_linux", lambda: True)
+    monkeypatch.setattr(docker_guard, "_running_as_root", lambda: root)
+    monkeypatch.setattr(docker_guard, "_in_container", lambda: in_container)
+    if uid is None:
+        monkeypatch.delenv("HERMES_UID", raising=False)
+    else:
+        monkeypatch.setenv("HERMES_UID", uid)
+    if gid is None:
+        monkeypatch.delenv("HERMES_GID", raising=False)
+    else:
+        monkeypatch.setenv("HERMES_GID", gid)
+
+
+def test_noop_on_non_linux(monkeypatch):
+    monkeypatch.setattr(docker_guard, "_is_linux", lambda: False)
+    monkeypatch.setattr(docker_guard, "_running_as_root", lambda: True)
+    monkeypatch.setattr(docker_guard, "_in_container", lambda: True)
+    # Must not raise / exit / exec.
+    docker_guard.enforce_docker_non_root(["hermes", "chat"])
+
+
+def test_noop_when_not_root(monkeypatch):
+    _patch_env(monkeypatch, root=False)
+    docker_guard.enforce_docker_non_root(["hermes", "chat"])
+
+
+def test_noop_when_not_in_container(monkeypatch):
+    _patch_env(monkeypatch, in_container=False)
+    docker_guard.enforce_docker_non_root(["hermes", "chat"])
+
+
+def test_noop_when_no_target_uid(monkeypatch):
+    _patch_env(monkeypatch, uid=None)
+    docker_guard.enforce_docker_non_root(["hermes", "chat"])
+
+
+def test_noop_when_target_uid_is_root(monkeypatch):
+    _patch_env(monkeypatch, uid="0")
+    docker_guard.enforce_docker_non_root(["hermes", "chat"])
+
+
+def test_disable_env_skips_guard(monkeypatch):
+    _patch_env(monkeypatch)
+    monkeypatch.setenv(docker_guard._DISABLE_ENV, "1")
+    # Even though all conditions are met, env override skips the guard.
+    docker_guard.enforce_docker_non_root(["hermes", "chat"])
+
+
+def test_version_subcommand_bypasses(monkeypatch):
+    _patch_env(monkeypatch)
+    # version / help shouldn't trigger refuse-or-exec
+    docker_guard.enforce_docker_non_root(["hermes", "version"])
+    docker_guard.enforce_docker_non_root(["hermes", "--version"])
+    docker_guard.enforce_docker_non_root(["hermes", "--help"])
+
+
+def test_reexec_marker_breaks_loop(monkeypatch):
+    _patch_env(monkeypatch)
+    monkeypatch.setenv("HERMES_DOCKER_GUARD_REEXEC", "1")
+    # Should return without trying to exec or exit.
+    docker_guard.enforce_docker_non_root(["hermes", "chat"])
+
+
+def test_reexecs_via_gosu(monkeypatch):
+    _patch_env(monkeypatch)
+    monkeypatch.setattr(docker_guard, "_find_dropper", lambda: ["/usr/local/bin/gosu"])
+
+    captured: dict = {}
+
+    def fake_execvpe(prog, argv, env):
+        captured["prog"] = prog
+        captured["argv"] = argv
+        captured["env"] = env
+        raise SystemExit(0)  # simulate exec replacing the process
+
+    monkeypatch.setattr(docker_guard.os, "execvpe", fake_execvpe)
+
+    with pytest.raises(SystemExit) as exc:
+        docker_guard.enforce_docker_non_root(["hermes", "chat"])
+    assert exc.value.code == 0
+    assert captured["prog"] == "/usr/local/bin/gosu"
+    assert captured["argv"] == [
+        "/usr/local/bin/gosu",
+        "10000:10000",
+        "hermes",
+        "chat",
+    ]
+    assert captured["env"]["HERMES_DOCKER_GUARD_REEXEC"] == "1"
+
+
+def test_refuses_when_no_dropper(monkeypatch, capsys):
+    _patch_env(monkeypatch)
+    monkeypatch.setattr(docker_guard, "_find_dropper", lambda: None)
+
+    with pytest.raises(SystemExit) as exc:
+        docker_guard.enforce_docker_non_root(["hermes", "chat"])
+    assert exc.value.code == 1
+
+    err = capsys.readouterr().err
+    assert "refuses to run as root" in err
+    assert "10000:10000" in err
+    assert docker_guard._DISABLE_ENV in err
+
+
+def test_invalid_uid_is_ignored(monkeypatch):
+    _patch_env(monkeypatch, uid="not-an-int")
+    # Should not raise / exit even though we're root in a container.
+    docker_guard.enforce_docker_non_root(["hermes", "chat"])
+
+
+def test_invalid_gid_falls_back_to_uid(monkeypatch):
+    _patch_env(monkeypatch, uid="10000", gid="bogus")
+    monkeypatch.setattr(docker_guard, "_find_dropper", lambda: ["/usr/bin/gosu"])
+
+    captured: dict = {}
+
+    def fake_execvpe(prog, argv, env):
+        captured["argv"] = argv
+        raise SystemExit(0)
+
+    monkeypatch.setattr(docker_guard.os, "execvpe", fake_execvpe)
+
+    with pytest.raises(SystemExit):
+        docker_guard.enforce_docker_non_root(["hermes", "chat"])
+    # GID should have fallen back to UID.
+    assert captured["argv"][1] == "10000:10000"
+
+
+def test_in_container_detects_dockerenv(monkeypatch, tmp_path):
+    monkeypatch.setattr(os.path, "exists", lambda p: p == "/.dockerenv")
+    monkeypatch.delenv("HERMES_DOCKER", raising=False)
+    assert docker_guard._in_container() is True
+
+
+def test_in_container_detects_hermes_docker_env(monkeypatch):
+    monkeypatch.setattr(os.path, "exists", lambda p: False)
+    monkeypatch.setenv("HERMES_DOCKER", "1")
+    assert docker_guard._in_container() is True
+
+
+def test_in_container_false_on_bare_host(monkeypatch):
+    monkeypatch.setattr(os.path, "exists", lambda p: False)
+    monkeypatch.delenv("HERMES_DOCKER", raising=False)
+    fake_open = mock.mock_open(read_data="0::/user.slice/user-1000.slice")
+    with mock.patch("builtins.open", fake_open):
+        assert docker_guard._in_container() is False


### PR DESCRIPTION
## What does this PR do?

When a user enters a running Hermes container via `docker exec -it … bash` and launches `hermes` interactively, the Docker entrypoint's privilege drop is bypassed and the CLI runs as **root**. Any files it writes under `$HERMES_HOME` (`config.yaml`, logs, cache, state DBs, …) become root-owned, and the long-running gateway running as the `hermes` user later hits `Permission denied` / `Operation not permitted` errors — exactly the symptom in #16480 and the related #15865 / #16096.

This PR adds a small startup-time guard in the CLI that detects "running as root inside a container with a declared non-root runtime user" and either transparently drops privileges (re-execs via `gosu` / `su-exec`) or refuses with an actionable error. It is purely additive and a no-op outside that exact situation.

## Related Issue

Fixes #16480.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/docker_guard.py` — new module. Exposes `enforce_docker_non_root()`. Triggers **only** when **all** of the following hold:
  1. Running on Linux.
  2. `os.geteuid() == 0`.
  3. Inside a container — detected via `/.dockerenv`, `/run/.containerenv`, container hints in `/proc/1/cgroup` (`docker` / `containerd` / `kubepods` / `podman` / `crio`), or `HERMES_DOCKER=1`.
  4. The container declared a non-root runtime user via `HERMES_UID` (and optionally `HERMES_GID`).

  When triggered:
  - Transparently re-execs the same argv via `gosu` / `su-exec` as `HERMES_UID:HERMES_GID` (preferred — invisible to the user, same mechanism the entrypoint already uses).
  - Falls back to refusing with an actionable error if no privilege-dropper is installed, telling the user how to relaunch (`gosu …` / `docker exec -u …`).
  - `HERMES_DOCKER_GUARD_REEXEC=1` loop-guard prevents infinite re-exec.
  - `hermes version` / `--version` / `--help` are exempt because they don't write state.
  - Opt-out via `HERMES_DISABLE_DOCKER_ROOT_GUARD=1` for maintenance / debugging.

- `hermes_cli/main.py` — call `enforce_docker_non_root()` at the very top of `main()`, wrapped in a broad `try / except` so an unforeseen guard failure can never break CLI startup.

- `tests/hermes_cli/test_docker_guard.py` — 15 new tests.

## How to Test

Reproduce the original bug:

1. `docker compose -p hermes-agent-dev up -d --build`
2. `docker exec -it hermes-agent-dev bash` (lands you in the container as **root**).
3. `hermes` — before this PR: runs as root, can write root-owned files under `$HERMES_HOME`.
4. After this PR: the CLI either re-execs itself as `hermes` (UID 10000) via `gosu` and continues, or, if no `gosu` / `su-exec` is present, exits with a clear instruction to relaunch via `docker exec -u hermes …`.

Verify the guard's no-op cases:

- `HERMES_DISABLE_DOCKER_ROOT_GUARD=1 hermes` → no-op.
- `hermes --version` / `hermes --help` → no-op (writes no state).
- Non-Linux host, non-root user, outside container, or `HERMES_UID` unset → no-op.

Unit tests:

```
$ .venv/bin/python -m pytest tests/hermes_cli/test_docker_guard.py -q
...............  15 passed in 0.90s
```

Tests cover: no-op on non-Linux / non-root / non-container / missing `HERMES_UID` / `HERMES_UID=0`; disable env override; `version` / `--version` / `--help` bypass; re-exec loop marker breaks recursion; `gosu` re-exec argv shape (`/usr/local/bin/gosu`, `10000:10000`, `hermes`, `chat`) and env propagation; refuse path: exit code `1` + actionable stderr + mention of the disable env; malformed `HERMES_UID` ignored; malformed `HERMES_GID` falls back to `UID`; container detection via `/.dockerenv`, `HERMES_DOCKER=1`, and bare-host (cgroup) negative case.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(cli): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_docker_guard.py -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.5 (Apple Silicon) — Linux/Docker behaviour exercised via unit tests that simulate `geteuid`, `/.dockerenv`, `/proc/1/cgroup`, etc.

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (internal startup guard; behaviour is invisible in the success path and prints actionable guidance in the refuse path).
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys; opt-out via env var only).
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — guard short-circuits to no-op on non-Linux platforms; covered by tests.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A.

## Screenshots / Logs

```
$ .venv/bin/python -m pytest tests/hermes_cli/test_docker_guard.py -q
...............
15 passed in 0.90s
```

Refuse path stderr (when `gosu` / `su-exec` are absent):

```
hermes: refusing to run as root inside a Docker container.
Detected: euid=0, container=yes, HERMES_UID=10000.
Re-launch as the unprivileged user, e.g.:
    docker exec -u hermes <container> hermes
or install `gosu` / `su-exec` in the image so Hermes can drop privileges automatically.
To bypass this guard (not recommended), set HERMES_DISABLE_DOCKER_ROOT_GUARD=1.
```

---

### Risk / rollback

- The guard is wrapped in a broad `try / except` inside `main()` — even an unforeseen failure cannot break CLI startup.
- If a deployment ever needs the old behaviour, set `HERMES_DISABLE_DOCKER_ROOT_GUARD=1`.
