### PR TITLE
fix(delegate): detect /anthropic URL suffix for proxy endpoints (#7833)

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -724,6 +724,38 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertIsNone(creds["model"])
         self.assertIsNone(creds["provider"])
 
+    def test_direct_endpoint_anthropic_proxy_suffix_gets_anthropic_mode(self):
+        """delegation.base_url ending in /anthropic -> api_mode=anthropic_messages (#7833)."""
+        parent = _make_mock_parent(depth=0)
+        cfg = {
+            "base_url": "http://localhost:6655/anthropic",
+            "api_key": "proxy-key",
+        }
+        creds = _resolve_delegation_credentials(cfg, parent)
+        self.assertEqual(creds["api_mode"], "anthropic_messages")
+        self.assertEqual(creds["provider"], "custom")
+
+    def test_direct_endpoint_anthropic_proxy_trailing_slash(self):
+        """Trailing slash on /anthropic/ suffix still resolves correctly."""
+        parent = _make_mock_parent(depth=0)
+        cfg = {
+            "base_url": "http://localhost:6655/anthropic/",
+            "api_key": "proxy-key",
+        }
+        creds = _resolve_delegation_credentials(cfg, parent)
+        self.assertEqual(creds["api_mode"], "anthropic_messages")
+
+    def test_direct_endpoint_canonical_anthropic_com_gets_anthropic_provider(self):
+        """api.anthropic.com -> provider=anthropic, api_mode=anthropic_messages."""
+        parent = _make_mock_parent(depth=0)
+        cfg = {
+            "base_url": "https://api.anthropic.com",
+            "api_key": "sk-ant-xxx",
+        }
+        creds = _resolve_delegation_credentials(cfg, parent)
+        self.assertEqual(creds["provider"], "anthropic")
+        self.assertEqual(creds["api_mode"], "anthropic_messages")
+
 
 class TestDelegationProviderIntegration(unittest.TestCase):
     """Integration tests: delegation config → _run_single_child → AIAgent construction."""

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2215,6 +2215,10 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
         elif "api.kimi.com/coding" in base_lower:
             provider = "custom"
             api_mode = "anthropic_messages"
+        elif base_lower.rstrip("/").endswith("/anthropic"):
+            # Third-party Anthropic-compatible proxies (HAI, LiteLLM, MiniMax,
+            # DashScope) use a URL convention ending in /anthropic.
+            api_mode = "anthropic_messages"
 
         return {
             "model": configured_model,


### PR DESCRIPTION
## What does this PR do?

When `delegation.base_url` points to a third-party Anthropic-compatible proxy (e.g. `http://localhost:6655/anthropic`), `_resolve_delegation_credentials()` now correctly detects the `/anthropic` URL suffix and sets `api_mode="anthropic_messages"` instead of defaulting to `"chat_completions"`.

Without this fix, subagents spawned via `delegate_task` use the OpenAI SDK (`/chat/completions`) instead of the native Anthropic SDK (`/v1/messages`), causing HTTP 404 errors from proxy endpoints that only speak the Anthropic Messages API.

## Related Issue

Fixes #7833

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/delegate_tool.py`: Added `elif` branch in `_resolve_delegation_credentials()` (after the Kimi check) to detect URLs ending in `/anthropic` and set `api_mode="anthropic_messages"`. This matches the existing detection in `AIAgent.__init__()` (run_agent.py L993) and `_detect_api_mode_for_url()` (runtime_provider.py L82).
- `tests/tools/test_delegate.py`: Added 3 tests to `TestDelegationCredentialResolution`:
  - Proxy URL with `/anthropic` suffix -> `api_mode="anthropic_messages"`, `provider="custom"`
  - Trailing slash `/anthropic/` -> still resolves correctly
  - Canonical `api.anthropic.com` -> `provider="anthropic"`, `api_mode="anthropic_messages"` (regression guard)

## How to Test

1. Configure `delegation.base_url: http://localhost:6655/anthropic` (or any Anthropic-compatible proxy)
2. Call `delegate_task` -- subagent should use Anthropic SDK (`/v1/messages`) instead of OpenAI SDK (`/chat/completions`)
3. Run tests: `pytest tests/tools/test_delegate.py -v -k "test_direct_endpoint_anthropic"`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Apple Silicon)

### Documentation & Housekeeping

- [x] N/A -- no docs/config changes needed for this bugfix
