### PR TITLE
fix: repair broken tool_call arguments at the recovery write site

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -11908,8 +11908,18 @@ class AIAgent:
                             self._vprint(f"{self.log_prefix}⚠️  Injecting recovery tool results for invalid JSON...")
                             self._invalid_json_retries = 0  # Reset for next attempt
                             
-                            # Append the assistant message with its (broken) tool_calls
+                            # Append the assistant message, repairing broken tool_call
+                            # arguments at write time so corrupted JSON never enters
+                            # the persistent message history.
                             recovery_assistant = self._build_assistant_message(assistant_message, finish_reason)
+                            for tc_dict in recovery_assistant.get("tool_calls") or []:
+                                raw = tc_dict.get("function", {}).get("arguments", "")
+                                try:
+                                    json.loads(raw)
+                                except (json.JSONDecodeError, TypeError):
+                                    tc_dict["function"]["arguments"] = _repair_tool_call_arguments(
+                                        raw, tc_dict.get("function", {}).get("name", "?"),
+                                    )
                             messages.append(recovery_assistant)
                             
                             # Respond with tool error results for each tool call


### PR DESCRIPTION
## Summary

Follow-up micro-improvement to #15348 (`7a192b12`), as suggested by @teknium1 in #14518:

> Your proposed approach of sanitizing at the write site is slightly cleaner as defense-in-depth. If you'd like to land that as a follow-up micro-improvement on top of the existing fix, a new PR narrowly scoped to the recovery append site at line 11711 would be a good candidate.

The loop-top `_sanitize_tool_call_arguments()` pass (added in #15348) repairs corrupted entries on the **next** iteration, but the recovery append site still writes broken JSON into `messages[]` first. This creates a one-iteration window where corrupted data exists in the list and can be persisted to session state.

This PR repairs arguments at the **write site** using the existing `_repair_tool_call_arguments()` helper, so corrupted JSON never enters the message history at all.

## Changes

- **1 file changed**, 11 insertions, 1 deletion
- Narrowly scoped to the recovery append site at `run_agent.py:11911`

Ref: #4662, #14518

cc @alt-glitch

🤖 Generated with [Claude Code](https://claude.com/claude-code)