### PR TITLE
fix(api_server): redact secrets from exception messages in HTTP responses and logs

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1014,7 +1014,8 @@ class APIServerAdapter(BasePlatformAdapter):
 
         final_response = result.get("final_response", "")
         if not final_response:
-            final_response = result.get("error", "(No response generated)")
+            raw_error = result.get("error", "")
+            final_response = redact_sensitive_text(raw_error) if raw_error else "(No response generated)"
 
         response_data = {
             "id": completion_id,
@@ -1543,7 +1544,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 if agent_final and not final_response_text:
                     final_response_text = agent_final
                 if isinstance(result, dict) and result.get("error") and not final_response_text:
-                    agent_error = result["error"]
+                    agent_error = redact_sensitive_text(str(result["error"]))
             except Exception as e:  # noqa: BLE001
                 logger.error("Error running agent for streaming responses: %s", redact_sensitive_text(str(e)), exc_info=True)
                 agent_error = "Internal server error"
@@ -1885,7 +1886,8 @@ class APIServerAdapter(BasePlatformAdapter):
 
         final_response = result.get("final_response", "")
         if not final_response:
-            final_response = result.get("error", "(No response generated)")
+            raw_error = result.get("error", "")
+            final_response = redact_sensitive_text(raw_error) if raw_error else "(No response generated)"
 
         response_id = f"resp_{uuid.uuid4().hex[:28]}"
         created_at = int(time.time())
@@ -2008,7 +2010,8 @@ class APIServerAdapter(BasePlatformAdapter):
             jobs = _cron_list(include_disabled=include_disabled)
             return web.json_response({"jobs": jobs})
         except Exception as e:
-            return web.json_response({"error": str(e)}, status=500)
+            logger.error("API handler error: %s", redact_sensitive_text(str(e)), exc_info=True)
+            return web.json_response({"error": "Internal server error"}, status=500)
 
     async def _handle_create_job(self, request: "web.Request") -> "web.Response":
         """POST /api/jobs — create a new cron job."""
@@ -2056,7 +2059,8 @@ class APIServerAdapter(BasePlatformAdapter):
             job = _cron_create(**kwargs)
             return web.json_response({"job": job})
         except Exception as e:
-            return web.json_response({"error": str(e)}, status=500)
+            logger.error("API handler error: %s", redact_sensitive_text(str(e)), exc_info=True)
+            return web.json_response({"error": "Internal server error"}, status=500)
 
     async def _handle_get_job(self, request: "web.Request") -> "web.Response":
         """GET /api/jobs/{job_id} — get a single cron job."""
@@ -2075,7 +2079,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 return web.json_response({"error": "Job not found"}, status=404)
             return web.json_response({"job": job})
         except Exception as e:
-            return web.json_response({"error": str(e)}, status=500)
+            logger.error("API handler error: %s", redact_sensitive_text(str(e)), exc_info=True)
+            return web.json_response({"error": "Internal server error"}, status=500)
 
     async def _handle_update_job(self, request: "web.Request") -> "web.Response":
         """PATCH /api/jobs/{job_id} — update a cron job."""
@@ -2108,7 +2113,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 return web.json_response({"error": "Job not found"}, status=404)
             return web.json_response({"job": job})
         except Exception as e:
-            return web.json_response({"error": str(e)}, status=500)
+            logger.error("API handler error: %s", redact_sensitive_text(str(e)), exc_info=True)
+            return web.json_response({"error": "Internal server error"}, status=500)
 
     async def _handle_delete_job(self, request: "web.Request") -> "web.Response":
         """DELETE /api/jobs/{job_id} — delete a cron job."""
@@ -2127,7 +2133,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 return web.json_response({"error": "Job not found"}, status=404)
             return web.json_response({"ok": True})
         except Exception as e:
-            return web.json_response({"error": str(e)}, status=500)
+            logger.error("API handler error: %s", redact_sensitive_text(str(e)), exc_info=True)
+            return web.json_response({"error": "Internal server error"}, status=500)
 
     async def _handle_pause_job(self, request: "web.Request") -> "web.Response":
         """POST /api/jobs/{job_id}/pause — pause a cron job."""
@@ -2146,7 +2153,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 return web.json_response({"error": "Job not found"}, status=404)
             return web.json_response({"job": job})
         except Exception as e:
-            return web.json_response({"error": str(e)}, status=500)
+            logger.error("API handler error: %s", redact_sensitive_text(str(e)), exc_info=True)
+            return web.json_response({"error": "Internal server error"}, status=500)
 
     async def _handle_resume_job(self, request: "web.Request") -> "web.Response":
         """POST /api/jobs/{job_id}/resume — resume a paused cron job."""
@@ -2165,7 +2173,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 return web.json_response({"error": "Job not found"}, status=404)
             return web.json_response({"job": job})
         except Exception as e:
-            return web.json_response({"error": str(e)}, status=500)
+            logger.error("API handler error: %s", redact_sensitive_text(str(e)), exc_info=True)
+            return web.json_response({"error": "Internal server error"}, status=500)
 
     async def _handle_run_job(self, request: "web.Request") -> "web.Response":
         """POST /api/jobs/{job_id}/run — trigger immediate execution."""
@@ -2184,7 +2193,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 return web.json_response({"error": "Job not found"}, status=404)
             return web.json_response({"job": job})
         except Exception as e:
-            return web.json_response({"error": str(e)}, status=500)
+            logger.error("API handler error: %s", redact_sensitive_text(str(e)), exc_info=True)
+            return web.json_response({"error": "Internal server error"}, status=500)
 
     # ------------------------------------------------------------------
     # Output extraction helper
@@ -2470,13 +2480,13 @@ class APIServerAdapter(BasePlatformAdapter):
                     "usage": usage,
                 })
             except Exception as exc:
-                logger.exception("[api_server] run %s failed", run_id)
+                logger.error("[api_server] run %s failed: %s", run_id, redact_sensitive_text(str(exc)), exc_info=True)
                 try:
                     q.put_nowait({
                         "event": "run.failed",
                         "run_id": run_id,
                         "timestamp": time.time(),
-                        "error": str(exc),
+                        "error": "Internal server error",
                     })
                 except Exception:
                     pass

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -899,7 +899,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 if db is not None:
                     history = db.get_messages_as_conversation(session_id)
             except Exception as e:
-                logger.warning("Failed to load session history for %s: %s", session_id, e)
+                logger.warning("Failed to load session history for %s: %s", session_id, redact_sensitive_text(str(e)))
                 history = []
         else:
             # Derive a stable session ID from the conversation fingerprint so

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -41,6 +41,7 @@ except ImportError:
     AIOHTTP_AVAILABLE = False
     web = None  # type: ignore[assignment]
 
+from agent.redact import redact_sensitive_text
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
     BasePlatformAdapter,
@@ -996,18 +997,18 @@ class APIServerAdapter(BasePlatformAdapter):
             try:
                 result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_completion)
             except Exception as e:
-                logger.error("Error running agent for chat completions: %s", e, exc_info=True)
+                logger.error("Error running agent for chat completions: %s", redact_sensitive_text(str(e)), exc_info=True)
                 return web.json_response(
-                    _openai_error(f"Internal server error: {e}", err_type="server_error"),
+                    _openai_error("Internal server error", err_type="server_error"),
                     status=500,
                 )
         else:
             try:
                 result, usage = await _compute_completion()
             except Exception as e:
-                logger.error("Error running agent for chat completions: %s", e, exc_info=True)
+                logger.error("Error running agent for chat completions: %s", redact_sensitive_text(str(e)), exc_info=True)
                 return web.json_response(
-                    _openai_error(f"Internal server error: {e}", err_type="server_error"),
+                    _openai_error("Internal server error", err_type="server_error"),
                     status=500,
                 )
 
@@ -1544,8 +1545,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 if isinstance(result, dict) and result.get("error") and not final_response_text:
                     agent_error = result["error"]
             except Exception as e:  # noqa: BLE001
-                logger.error("Error running agent for streaming responses: %s", e, exc_info=True)
-                agent_error = str(e)
+                logger.error("Error running agent for streaming responses: %s", redact_sensitive_text(str(e)), exc_info=True)
+                agent_error = "Internal server error"
 
             # Close the message item if it was opened
             final_response_text = "".join(final_text_parts) or final_response_text
@@ -1867,18 +1868,18 @@ class APIServerAdapter(BasePlatformAdapter):
             try:
                 result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_response)
             except Exception as e:
-                logger.error("Error running agent for responses: %s", e, exc_info=True)
+                logger.error("Error running agent for responses: %s", redact_sensitive_text(str(e)), exc_info=True)
                 return web.json_response(
-                    _openai_error(f"Internal server error: {e}", err_type="server_error"),
+                    _openai_error("Internal server error", err_type="server_error"),
                     status=500,
                 )
         else:
             try:
                 result, usage = await _compute_response()
             except Exception as e:
-                logger.error("Error running agent for responses: %s", e, exc_info=True)
+                logger.error("Error running agent for responses: %s", redact_sensitive_text(str(e)), exc_info=True)
                 return web.json_response(
-                    _openai_error(f"Internal server error: {e}", err_type="server_error"),
+                    _openai_error("Internal server error", err_type="server_error"),
                     status=500,
                 )
 

--- a/tests/gateway/test_api_server_secret_redact.py
+++ b/tests/gateway/test_api_server_secret_redact.py
@@ -1,0 +1,171 @@
+"""
+Tests verifying that exception messages containing secrets (API keys, tokens)
+are NOT leaked to HTTP clients via error responses.
+
+Covers Bug B1: exception messages in api_server.py were returned verbatim
+to callers and written to logs without redaction.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import (
+    APIServerAdapter,
+    cors_middleware,
+    security_headers_middleware,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# A realistic API key pattern that redact_sensitive_text will catch (sk- prefix)
+_SECRET_KEY = "sk-proj-abc123XYZsecrettoken9999"
+
+
+def _make_adapter() -> APIServerAdapter:
+    config = PlatformConfig(enabled=True)
+    return APIServerAdapter(config)
+
+
+def _create_app(adapter: APIServerAdapter) -> web.Application:
+    mws = [mw for mw in (cors_middleware, security_headers_middleware) if mw is not None]
+    app = web.Application(middlewares=mws)
+    app["api_server_adapter"] = adapter
+    app.router.add_post("/v1/chat/completions", adapter._handle_chat_completions)
+    app.router.add_post("/v1/responses", adapter._handle_responses)
+    return app
+
+
+# ---------------------------------------------------------------------------
+# /v1/chat/completions — secret must not appear in error response
+# ---------------------------------------------------------------------------
+
+
+class TestChatCompletionsSecretRedact:
+    @pytest.mark.asyncio
+    async def test_exception_with_api_key_not_in_response_body(self):
+        """When _run_agent raises with an API key in the message,
+        the HTTP response body must NOT contain that key."""
+        adapter = _make_adapter()
+        app = _create_app(adapter)
+
+        async def _raise_with_secret(**kwargs):
+            raise RuntimeError(
+                f"bad value for key='{_SECRET_KEY}' passed to upstream provider"
+            )
+
+        with patch.object(adapter, "_run_agent", side_effect=_raise_with_secret):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "hermes-agent",
+                        "messages": [{"role": "user", "content": "hello"}],
+                    },
+                )
+
+                assert resp.status == 500
+                raw = await resp.text()
+                assert _SECRET_KEY not in raw, (
+                    f"Secret key '{_SECRET_KEY}' must not appear in HTTP response body"
+                )
+
+    @pytest.mark.asyncio
+    async def test_exception_error_response_is_generic(self):
+        """The error message returned to the client must be a generic string,
+        not the raw exception message."""
+        adapter = _make_adapter()
+        app = _create_app(adapter)
+
+        async def _raise_with_secret(**kwargs):
+            raise RuntimeError(
+                f"upstream API rejected key={_SECRET_KEY}"
+            )
+
+        with patch.object(adapter, "_run_agent", side_effect=_raise_with_secret):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "hermes-agent",
+                        "messages": [{"role": "user", "content": "hello"}],
+                    },
+                )
+
+                assert resp.status == 500
+                data = await resp.json()
+                error_message = data.get("error", {}).get("message", "")
+                assert _SECRET_KEY not in error_message, (
+                    f"Secret key must not appear in error message: {error_message!r}"
+                )
+                assert "Internal server error" in error_message
+
+
+# ---------------------------------------------------------------------------
+# /v1/responses — secret must not appear in error response
+# ---------------------------------------------------------------------------
+
+
+class TestResponsesSecretRedact:
+    @pytest.mark.asyncio
+    async def test_exception_with_api_key_not_in_response_body(self):
+        """When _run_agent raises with an API key in the message,
+        the HTTP response body must NOT contain that key."""
+        adapter = _make_adapter()
+        app = _create_app(adapter)
+
+        async def _raise_with_secret(**kwargs):
+            raise RuntimeError(
+                f"provider error: invalid api_key={_SECRET_KEY}"
+            )
+
+        with patch.object(adapter, "_run_agent", side_effect=_raise_with_secret):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "hello",
+                    },
+                )
+
+                assert resp.status == 500
+                raw = await resp.text()
+                assert _SECRET_KEY not in raw, (
+                    f"Secret key '{_SECRET_KEY}' must not appear in HTTP response body"
+                )
+
+    @pytest.mark.asyncio
+    async def test_exception_error_response_is_generic(self):
+        """The error message returned to the client must be generic."""
+        adapter = _make_adapter()
+        app = _create_app(adapter)
+
+        async def _raise_with_secret(**kwargs):
+            raise ValueError(
+                f"token validation failed for {_SECRET_KEY}"
+            )
+
+        with patch.object(adapter, "_run_agent", side_effect=_raise_with_secret):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "hello",
+                    },
+                )
+
+                assert resp.status == 500
+                data = await resp.json()
+                error_message = data.get("error", {}).get("message", "")
+                assert _SECRET_KEY not in error_message, (
+                    f"Secret key must not appear in error message: {error_message!r}"
+                )
+                assert "Internal server error" in error_message


### PR DESCRIPTION
## Summary
- Apply `redact_sensitive_text()` to all exception messages before logging and before returning HTTP responses in `gateway/platforms/api_server.py`
- Return generic `"Internal server error"` to clients instead of raw `str(e)` — prevents API keys, connection strings, or file paths from leaking in 500 responses
- Covers 5 exception handler sites: chat completions, streaming responses, non-streaming responses, and session history load
- Adds 4 tests verifying no secret pattern (`sk-proj-*`) appears in HTTP response bodies

## Test plan
- [x] `tests/gateway/test_api_server_secret_redact.py` — 4 new tests, all pass
- [x] 256 pre-existing tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)