### PR TITLE
fix(file-tools): cap read_file result size to prevent context window overflow

### DIFF
--- a/tests/tools/test_tool_result_storage.py
+++ b/tests/tools/test_tool_result_storage.py
@@ -516,12 +516,25 @@ class TestPerToolThresholds:
         except ImportError:
             pytest.skip("terminal_tool not importable in test env")
 
-    def test_read_file_never_persisted(self):
+    def test_read_file_result_size_cap(self):
         from tools.registry import registry
         try:
             import tools.file_tools  # noqa: F401
             val = registry.get_max_result_size("read_file")
-            assert val == float("inf")
+            assert val == 100_000
+        except ImportError:
+            pytest.skip("file_tools not importable in test env")
+
+    def test_read_file_registry_cap_is_100k(self):
+        """Regression test: read_file must have a 100_000 char registry cap (Layer 2 safety net)."""
+        from tools.registry import registry
+        try:
+            import tools.file_tools  # noqa: F401
+            val = registry.get_max_result_size("read_file")
+            assert val == 100_000, (
+                f"read_file registry cap must be 100_000, got {val!r}. "
+                "float('inf') is not allowed — it disables the Layer 2 result-size guard."
+            )
         except ImportError:
             pytest.skip("file_tools not importable in test env")
 

--- a/tests/tools/test_tool_result_storage.py
+++ b/tests/tools/test_tool_result_storage.py
@@ -516,15 +516,6 @@ class TestPerToolThresholds:
         except ImportError:
             pytest.skip("terminal_tool not importable in test env")
 
-    def test_read_file_result_size_cap(self):
-        from tools.registry import registry
-        try:
-            import tools.file_tools  # noqa: F401
-            val = registry.get_max_result_size("read_file")
-            assert val == 100_000
-        except ImportError:
-            pytest.skip("file_tools not importable in test env")
-
     def test_read_file_registry_cap_is_100k(self):
         """Regression test: read_file must have a 100_000 char registry cap (Layer 2 safety net)."""
         from tools.registry import registry

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1115,7 +1115,7 @@ def _handle_search_files(args, **kw):
         output_mode=args.get("output_mode", "content"), context=args.get("context", 0), task_id=tid)
 
 
-registry.register(name="read_file", toolset="file", schema=READ_FILE_SCHEMA, handler=_handle_read_file, check_fn=_check_file_reqs, emoji="📖", max_result_size_chars=float('inf'))
+registry.register(name="read_file", toolset="file", schema=READ_FILE_SCHEMA, handler=_handle_read_file, check_fn=_check_file_reqs, emoji="📖", max_result_size_chars=100_000)
 registry.register(name="write_file", toolset="file", schema=WRITE_FILE_SCHEMA, handler=_handle_write_file, check_fn=_check_file_reqs, emoji="✍️", max_result_size_chars=100_000)
 registry.register(name="patch", toolset="file", schema=PATCH_SCHEMA, handler=_handle_patch, check_fn=_check_file_reqs, emoji="🔧", max_result_size_chars=100_000)
 registry.register(name="search_files", toolset="file", schema=SEARCH_FILES_SCHEMA, handler=_handle_search_files, check_fn=_check_file_reqs, emoji="🔎", max_result_size_chars=100_000)


### PR DESCRIPTION
## Summary
- Change `read_file` registry registration from `max_result_size_chars=float('inf')` to `max_result_size_chars=100_000`, matching every other file tool
- Closes the defense-in-depth gap at the registry/persistence layer — the internal 100K character guard in `read_file_tool` remains the primary protection; this adds Layer 2 safety via `tool_result_storage`
- Updates the existing `test_read_file_never_persisted` test (which asserted `float('inf')`) to assert `100_000`
- Adds a regression guard test to prevent re-introducing the unlimited cap

## Test plan
- [x] `tests/tools/test_tool_result_storage.py` — updated + 1 new regression test
- [x] 72 tool tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)