### PR TITLE
fix(state): register atexit WAL checkpoint to prevent unbounded WAL growth

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -11079,6 +11079,13 @@ class HermesCLI:
                     self._session_db.end_session(self.agent.session_id, "cli_close")
                 except (Exception, KeyboardInterrupt) as e:
                     logger.debug("Could not close session in DB: %s", e)
+            # WAL checkpoint + connection close so the WAL file doesn't grow
+            # unbounded across long-lived CLI sessions.
+            if hasattr(self, '_session_db') and self._session_db:
+                try:
+                    self._session_db.close()
+                except Exception as e:
+                    logger.debug("Could not close SessionDB connection: %s", e)
             # Plugin hook: on_session_end — safety net for interrupted exits.
             # run_conversation() already fires this per-turn on normal completion,
             # so only fire here if the agent was mid-turn (_agent_running) when

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -14,6 +14,7 @@ Key design decisions:
 - Session source tagging ('cli', 'telegram', 'discord', etc.) for filtering
 """
 
+import atexit
 import json
 import logging
 import random
@@ -193,6 +194,10 @@ class SessionDB:
         self._conn.execute("PRAGMA journal_mode=WAL")
         self._conn.execute("PRAGMA foreign_keys=ON")
 
+        # Ensure WAL checkpoint runs on process exit even if close() is never
+        # called explicitly (e.g. CLI/gateway crash or missing shutdown path).
+        atexit.register(self.close)
+
         self._init_schema()
 
     # ── Core write helper ──
@@ -275,15 +280,36 @@ class SessionDB:
 
         Attempts a PASSIVE WAL checkpoint first so that exiting processes
         help keep the WAL file from growing unbounded.
+
+        Safe to call multiple times — subsequent calls are no-ops once the
+        connection has been closed.  Also registered via ``atexit`` in
+        ``__init__`` so it runs automatically on process exit.
         """
         with self._lock:
             if self._conn:
                 try:
                     self._conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
-                except Exception:
-                    pass
+                except Exception as exc:
+                    # Suppress ENOENT-like errors (DB file already removed) but
+                    # warn on anything unexpected so operators can investigate.
+                    msg = str(exc).lower()
+                    if "no such file" not in msg and "unable to open" not in msg:
+                        logger.warning(
+                            "WAL checkpoint failed during close (%s): %s",
+                            self.db_path,
+                            exc,
+                        )
                 self._conn.close()
                 self._conn = None
+
+    def __enter__(self) -> "SessionDB":
+        """Support use as a context manager: ``with SessionDB() as db:``."""
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        """Close the connection when exiting the context manager block."""
+        self.close()
+        return None
 
     def _init_schema(self):
         """Create tables and FTS if they don't exist, run migrations."""

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2128,3 +2128,98 @@ class TestAutoMaintenance:
         assert not (sessions_dir / "old.jsonl").exists()
         assert (sessions_dir / "active.jsonl").exists()
 
+
+# =========================================================================
+# WAL checkpoint on close — regression tests for B4
+# =========================================================================
+
+class TestWALCheckpointOnClose:
+    """Verify that close() runs a WAL checkpoint and that the WAL file is
+    flushed (or absent) after close.  Also covers atexit registration and
+    context-manager support added as part of the B4 fix."""
+
+    def test_close_checkpoints_wal(self, tmp_path):
+        """After writing data and calling close(), the WAL file should be
+        empty or absent — meaning the checkpoint transferred all WAL frames
+        back into the main DB file."""
+        db_path = tmp_path / "wal_test.db"
+        db = SessionDB(db_path=db_path)
+        db.create_session(session_id="s1", source="cli")
+        db.append_message(session_id="s1", role="user", content="hello WAL test")
+
+        # WAL file may or may not exist before close, but after close + checkpoint
+        # it should be empty (0 bytes) or absent entirely.
+        db.close()
+
+        wal_path = db_path.parent / (db_path.name + "-wal")
+        if wal_path.exists():
+            assert wal_path.stat().st_size == 0, (
+                f"WAL file should be empty after close(), got {wal_path.stat().st_size} bytes"
+            )
+
+    def test_close_is_idempotent(self, tmp_path):
+        """Calling close() multiple times must not raise."""
+        db_path = tmp_path / "idempotent.db"
+        db = SessionDB(db_path=db_path)
+        db.create_session(session_id="s1", source="cli")
+        db.close()
+        db.close()  # second call must be a no-op
+
+    def test_context_manager_closes_connection(self, tmp_path):
+        """Using SessionDB as a context manager must close the connection on exit."""
+        db_path = tmp_path / "ctx_mgr.db"
+        with SessionDB(db_path=db_path) as db:
+            db.create_session(session_id="s1", source="cli")
+            db.append_message(session_id="s1", role="user", content="context manager test")
+            assert db._conn is not None
+
+        # After __exit__, connection must be closed.
+        assert db._conn is None
+
+    def test_context_manager_closes_on_exception(self, tmp_path):
+        """Context manager must close the connection even when an exception is raised."""
+        db_path = tmp_path / "ctx_exc.db"
+        with pytest.raises(ValueError):
+            with SessionDB(db_path=db_path) as db:
+                db.create_session(session_id="s1", source="cli")
+                raise ValueError("simulated error")
+
+        assert db._conn is None
+
+    def test_atexit_registered(self, tmp_path):
+        """atexit.register(self.close) must be called during __init__."""
+        import atexit
+        import inspect
+        from hermes_state import SessionDB as _SessionDB
+        src = inspect.getsource(_SessionDB.__init__)
+        assert "atexit.register" in src, (
+            "SessionDB.__init__ must call atexit.register(self.close) "
+            "to ensure WAL checkpoint on process exit"
+        )
+
+    def test_wal_checkpoint_pragma_return_value(self, tmp_path):
+        """PRAGMA wal_checkpoint should report that pages were checkpointed.
+
+        Checks the return value (busy, log, checkpointed) directly so we
+        confirm SQLite itself considers the checkpoint successful.
+        """
+        import sqlite3
+        db_path = tmp_path / "pragma_test.db"
+        db = SessionDB(db_path=db_path)
+        db.create_session(session_id="s1", source="cli")
+        db.append_message(session_id="s1", role="user", content="pragma check")
+
+        # Run checkpoint manually before close to inspect the return value.
+        with db._lock:
+            result = db._conn.execute("PRAGMA wal_checkpoint(PASSIVE)").fetchone()
+        # result is (busy, log, checkpointed): busy==0 means no other readers
+        # blocked the checkpoint; log and checkpointed should be equal when
+        # the checkpoint fully drained the WAL.
+        assert result is not None, "PRAGMA wal_checkpoint returned nothing"
+        busy, log, checkpointed = result[0], result[1], result[2]
+        assert busy == 0, f"WAL checkpoint was blocked (busy={busy})"
+        assert log == checkpointed, (
+            f"Not all WAL pages were checkpointed: log={log}, checkpointed={checkpointed}"
+        )
+        db.close()
+


### PR DESCRIPTION
## Summary
- `SessionDB.close()` existed but was never called — SQLite WAL files grew unboundedly on long-running gateway processes (field reports: 100+ MB WAL files degrading read performance)
- Fix: register `atexit.register(self.close)` in `SessionDB.__init__()` so the WAL is always checkpointed on process exit
- Add `__enter__`/`__exit__` context manager support to `SessionDB`
- Add explicit `close()` call in CLI atexit cleanup path
- Improve `close()` error handling: log a warning for unexpected errors instead of silently swallowing all exceptions

## Test plan
- [x] `tests/test_hermes_state.py` — 6 new tests in `TestWALCheckpointOnClose` including PRAGMA return value verification
- [x] 189 state tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)