### PR TITLE
fix(approval): use per-process UUID as default session key to prevent cross-session state leaks

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -173,6 +173,116 @@ class TestSessionKeyContext:
         assert "reset_current_session_key" in called_names
 
 
+class TestCliSessionKeyIsolation:
+    """B5: CLI sessions without an explicit HERMES_SESSION_KEY must not share
+    approval state.
+
+    Before the fix, get_current_session_key() returned "" (or "default") when
+    no key was set, causing all keyless CLI sessions to share the same bucket
+    in _session_approved.  After the fix, a stable per-process UUID is used
+    so each process gets its own isolated bucket.
+    """
+
+    def test_default_key_is_nonempty(self):
+        """Without any env var or context var, the key must be a non-empty UUID."""
+        import tools.approval as am
+
+        # Simulate a CLI context: no context var set, no env var
+        token = am._approval_session_key.set("")
+        try:
+            with mock_patch.dict("os.environ", {}, clear=False):
+                # Remove HERMES_SESSION_KEY if present
+                env_copy = {k: v for k, v in __import__("os").environ.items()
+                            if k != "HERMES_SESSION_KEY"}
+                with mock_patch.dict("os.environ", env_copy, clear=True):
+                    key = am.get_current_session_key()
+        finally:
+            am._approval_session_key.reset(token)
+
+        assert key, "default session key must not be empty"
+        assert key != "default", "default session key must not be the literal string 'default'"
+
+    def test_default_key_is_not_empty_string(self):
+        """Callers passing default='' still receive the process UUID, not ''."""
+        import tools.approval as am
+
+        token = am._approval_session_key.set("")
+        try:
+            env_copy = {k: v for k, v in __import__("os").environ.items()
+                        if k != "HERMES_SESSION_KEY"}
+            with mock_patch.dict("os.environ", env_copy, clear=True):
+                key = am.get_current_session_key(default="")
+        finally:
+            am._approval_session_key.reset(token)
+
+        assert key != "", (
+            "get_current_session_key(default='') must return the process UUID, "
+            "not an empty string — empty string caused cross-session state leaks"
+        )
+
+    def test_two_cli_sessions_do_not_share_approvals(self):
+        """Simulates two separate CLI processes by patching _DEFAULT_CLI_SESSION_KEY.
+
+        Session 1 approves a dangerous pattern.  Session 2, with a different
+        process-unique key, must NOT inherit that approval.
+        """
+        import tools.approval as am
+
+        pattern_key = "recursive delete"
+
+        # Session 1: simulate one CLI process
+        session1_key = "cli-process-uuid-aaaa-1111"
+        am._session_approved.pop(session1_key, None)
+        am._session_approved.pop("cli-process-uuid-bbbb-2222", None)
+
+        # Approve a pattern in session 1
+        am.approve_session(session1_key, pattern_key)
+        assert am.is_approved(session1_key, pattern_key) is True, (
+            "session 1 should have the pattern approved"
+        )
+
+        # Session 2: simulate a different CLI process (different UUID)
+        session2_key = "cli-process-uuid-bbbb-2222"
+        assert am.is_approved(session2_key, pattern_key) is False, (
+            "session 2 must NOT inherit the approval from session 1 — "
+            "this was the cross-session state leak fixed in B5"
+        )
+
+        # Cleanup
+        am._session_approved.pop(session1_key, None)
+        am._session_approved.pop(session2_key, None)
+
+    def test_process_uuid_is_stable_within_process(self):
+        """The same process must always get the same default key."""
+        import tools.approval as am
+
+        token = am._approval_session_key.set("")
+        try:
+            env_copy = {k: v for k, v in __import__("os").environ.items()
+                        if k != "HERMES_SESSION_KEY"}
+            with mock_patch.dict("os.environ", env_copy, clear=True):
+                key1 = am.get_current_session_key()
+                key2 = am.get_current_session_key()
+        finally:
+            am._approval_session_key.reset(token)
+
+        assert key1 == key2, (
+            "the default session key must be stable within a process "
+            "(same UUID returned on repeated calls)"
+        )
+
+    def test_explicit_env_var_takes_precedence_over_uuid(self):
+        """When HERMES_SESSION_KEY is set, it overrides the process UUID."""
+        import tools.approval as am
+
+        token = am._approval_session_key.set("")
+        try:
+            with mock_patch.dict("os.environ", {"HERMES_SESSION_KEY": "explicit-key"}, clear=False):
+                key = am.get_current_session_key()
+        finally:
+            am._approval_session_key.reset(token)
+
+        assert key == "explicit-key"
 
 
 class TestRmFalsePositiveFix:

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -16,9 +16,19 @@ import sys
 import threading
 import time
 import unicodedata
+import uuid
 from typing import Optional
 
 logger = logging.getLogger(__name__)
+
+# Stable per-process UUID used as the default session key when no explicit
+# HERMES_SESSION_KEY is configured (e.g. plain CLI sessions). This ensures
+# that each independent CLI process gets its own isolated approval bucket in
+# _session_approved, preventing dangerous-command approvals from one process
+# from bleeding into a concurrently-running or subsequent CLI session that
+# also lacks an explicit key.  Gateway sessions always receive an explicit key
+# via set_current_session_key(), so this value is never used there.
+_DEFAULT_CLI_SESSION_KEY: str = str(uuid.uuid4())
 
 # Per-thread/per-task gateway session identity.
 # Gateway runs agent turns concurrently in executor threads, so reading a
@@ -40,19 +50,27 @@ def reset_current_session_key(token: contextvars.Token[str]) -> None:
     _approval_session_key.reset(token)
 
 
-def get_current_session_key(default: str = "default") -> str:
+def get_current_session_key(default: str = "") -> str:
     """Return the active session key, preferring context-local state.
 
     Resolution order:
     1. approval-specific contextvars (set by gateway before agent.run)
     2. session_context contextvars (set by _set_session_env)
-    3. os.environ fallback (CLI, cron, tests)
+    3. HERMES_SESSION_KEY env var (CLI, cron, tests)
+    4. *default* if non-empty, otherwise _DEFAULT_CLI_SESSION_KEY
+
+    Callers that explicitly pass ``default=""`` still receive the
+    process-unique key rather than an empty string, which prevents all
+    keyless CLI sessions from sharing the same ``""`` approval bucket.
     """
     session_key = _approval_session_key.get()
     if session_key:
         return session_key
     from gateway.session_context import get_session_env
-    return get_session_env("HERMES_SESSION_KEY", default)
+    key = get_session_env("HERMES_SESSION_KEY", "")
+    if key:
+        return key
+    return default if default else _DEFAULT_CLI_SESSION_KEY
 
 # Sensitive write targets that should trigger approval even when referenced
 # via shell expansions like $HOME or $HERMES_HOME.
@@ -442,7 +460,7 @@ def is_session_yolo_enabled(session_key: str) -> bool:
 
 def is_current_session_yolo_enabled() -> bool:
     """Return True when the active approval session has YOLO bypass enabled."""
-    return is_session_yolo_enabled(get_current_session_key(default=""))
+    return is_session_yolo_enabled(get_current_session_key())
 
 
 def is_approved(session_key: str, pattern_key: str) -> bool:


### PR DESCRIPTION
## Summary
- `get_current_session_key()` returned `""` (empty string) when `HERMES_SESSION_KEY` env var was not set — all CLI sessions without an explicit key shared the same `""` bucket in `_session_approved`, so dangerous command approvals from one session bled into unrelated sessions
- Fix: generate a stable `_DEFAULT_CLI_SESSION_KEY = str(uuid.uuid4())` at module import time; use it as the fallback instead of `""`
- Gateway sessions are unaffected (they always set an explicit key via `set_current_session_key()`)
- Clean up `is_current_session_yolo_enabled()` which was passing the now-redundant `default=""`

## Test plan
- [x] `tests/tools/test_approval.py` — 5 new tests in `TestCliSessionKeyIsolation`
- [x] 170 approval tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)