### PR TITLE
test(web_server): handle SystemExit from missing fastapi in all test classes

### DIFF
--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -105,8 +105,11 @@ class TestWebServerEndpoints:
         """Create a TestClient and isolate the state DB under the test HERMES_HOME."""
         try:
             from starlette.testclient import TestClient
+        except ImportError:
+            pytest.skip("fastapi/uvicorn not installed")
+        try:
             from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
-        except (ImportError, SystemExit):
+        except SystemExit:
             pytest.skip("fastapi/uvicorn not installed")
 
         import hermes_state
@@ -426,8 +429,11 @@ class TestConfigRoundTrip:
     def _setup(self):
         try:
             from starlette.testclient import TestClient
+        except ImportError:
+            pytest.skip("fastapi/uvicorn not installed")
+        try:
             from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
-        except (ImportError, SystemExit):
+        except SystemExit:
             pytest.skip("fastapi/uvicorn not installed")
         self.client = TestClient(app)
         self.client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
@@ -559,8 +565,11 @@ class TestNewEndpoints:
     def _setup(self, monkeypatch, _isolate_hermes_home):
         try:
             from starlette.testclient import TestClient
+        except ImportError:
+            pytest.skip("fastapi/uvicorn not installed")
+        try:
             from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
-        except (ImportError, SystemExit):
+        except SystemExit:
             pytest.skip("fastapi/uvicorn not installed")
 
         import hermes_state
@@ -998,8 +1007,11 @@ class TestModelInfoEndpoint:
     def _setup(self):
         try:
             from starlette.testclient import TestClient
+        except ImportError:
+            pytest.skip("fastapi/uvicorn not installed")
+        try:
             from hermes_cli.web_server import app
-        except (ImportError, SystemExit):
+        except SystemExit:
             pytest.skip("fastapi/uvicorn not installed")
         self.client = TestClient(app)
 
@@ -1234,8 +1246,11 @@ class TestStatusRemoteGateway:
     def _setup_test_client(self):
         try:
             from starlette.testclient import TestClient
+        except ImportError:
+            pytest.skip("fastapi/uvicorn not installed")
+        try:
             from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
-        except (ImportError, SystemExit):
+        except SystemExit:
             pytest.skip("fastapi/uvicorn not installed")
 
         self.client = TestClient(app)
@@ -1797,8 +1812,11 @@ class TestPtyWebSocket:
     def _setup(self, monkeypatch, _isolate_hermes_home):
         try:
             from starlette.testclient import TestClient
+        except ImportError:
+            pytest.skip("fastapi/uvicorn not installed")
+        try:
             import hermes_cli.web_server as ws
-        except (ImportError, SystemExit):
+        except SystemExit:
             pytest.skip("fastapi/uvicorn not installed")
 
         # Avoid exec'ing the actual TUI in tests: every test below installs

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -105,12 +105,12 @@ class TestWebServerEndpoints:
         """Create a TestClient and isolate the state DB under the test HERMES_HOME."""
         try:
             from starlette.testclient import TestClient
-        except ImportError:
-            pytest.skip("fastapi/starlette not installed")
+            from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+        except (ImportError, SystemExit):
+            pytest.skip("fastapi/uvicorn not installed")
 
         import hermes_state
         from hermes_constants import get_hermes_home
-        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
 
         monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", get_hermes_home() / "state.db")
 
@@ -352,6 +352,13 @@ class TestWebServerEndpoints:
 
 
 class TestBuildSchemaFromConfig:
+    @pytest.fixture(autouse=True)
+    def _require_fastapi(self):
+        try:
+            import hermes_cli.web_server  # noqa: F401
+        except SystemExit:
+            pytest.skip("fastapi/uvicorn not installed")
+
     def test_produces_expected_field_count(self):
         from hermes_cli.web_server import CONFIG_SCHEMA
         # DEFAULT_CONFIG has ~150+ leaf fields
@@ -419,9 +426,9 @@ class TestConfigRoundTrip:
     def _setup(self):
         try:
             from starlette.testclient import TestClient
-        except ImportError:
-            pytest.skip("fastapi/starlette not installed")
-        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+            from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+        except (ImportError, SystemExit):
+            pytest.skip("fastapi/uvicorn not installed")
         self.client = TestClient(app)
         self.client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
 
@@ -552,12 +559,12 @@ class TestNewEndpoints:
     def _setup(self, monkeypatch, _isolate_hermes_home):
         try:
             from starlette.testclient import TestClient
-        except ImportError:
-            pytest.skip("fastapi/starlette not installed")
+            from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+        except (ImportError, SystemExit):
+            pytest.skip("fastapi/uvicorn not installed")
 
         import hermes_state
         from hermes_constants import get_hermes_home
-        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
 
         monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", get_hermes_home() / "state.db")
 
@@ -826,6 +833,13 @@ class TestNewEndpoints:
 class TestModelContextLength:
     """Tests for model_context_length in normalize/denormalize and /api/model/info."""
 
+    @pytest.fixture(autouse=True)
+    def _require_fastapi(self):
+        try:
+            import hermes_cli.web_server  # noqa: F401
+        except SystemExit:
+            pytest.skip("fastapi/uvicorn not installed")
+
     def test_normalize_extracts_context_length_from_dict(self):
         """normalize should surface context_length from model dict."""
         from hermes_cli.web_server import _normalize_config_for_web
@@ -952,6 +966,13 @@ class TestModelContextLength:
 class TestModelContextLengthSchema:
     """Tests for model_context_length placement in CONFIG_SCHEMA."""
 
+    @pytest.fixture(autouse=True)
+    def _require_fastapi(self):
+        try:
+            import hermes_cli.web_server  # noqa: F401
+        except SystemExit:
+            pytest.skip("fastapi/uvicorn not installed")
+
     def test_schema_has_model_context_length(self):
         from hermes_cli.web_server import CONFIG_SCHEMA
         assert "model_context_length" in CONFIG_SCHEMA
@@ -977,9 +998,9 @@ class TestModelInfoEndpoint:
     def _setup(self):
         try:
             from starlette.testclient import TestClient
-        except ImportError:
-            pytest.skip("fastapi/starlette not installed")
-        from hermes_cli.web_server import app
+            from hermes_cli.web_server import app
+        except (ImportError, SystemExit):
+            pytest.skip("fastapi/uvicorn not installed")
         self.client = TestClient(app)
 
     def test_model_info_returns_200(self):
@@ -1105,6 +1126,13 @@ class TestModelInfoEndpoint:
 class TestProbeGatewayHealth:
     """Tests for _probe_gateway_health() — cross-container gateway detection."""
 
+    @pytest.fixture(autouse=True)
+    def _require_fastapi(self):
+        try:
+            import hermes_cli.web_server  # noqa: F401
+        except SystemExit:
+            pytest.skip("fastapi/uvicorn not installed")
+
     def test_returns_false_when_no_url_configured(self, monkeypatch):
         """When GATEWAY_HEALTH_URL is unset, the probe returns (False, None)."""
         import hermes_cli.web_server as ws
@@ -1206,10 +1234,10 @@ class TestStatusRemoteGateway:
     def _setup_test_client(self):
         try:
             from starlette.testclient import TestClient
-        except ImportError:
-            pytest.skip("fastapi/starlette not installed")
+            from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+        except (ImportError, SystemExit):
+            pytest.skip("fastapi/uvicorn not installed")
 
-        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
         self.client = TestClient(app)
         self.client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
 
@@ -1298,6 +1326,13 @@ class TestStatusRemoteGateway:
 
 class TestNormaliseThemeDefinition:
     """Tests for _normalise_theme_definition() — parses YAML theme files."""
+
+    @pytest.fixture(autouse=True)
+    def _require_fastapi(self):
+        try:
+            import hermes_cli.web_server  # noqa: F401
+        except SystemExit:
+            pytest.skip("fastapi/uvicorn not installed")
 
     def test_rejects_missing_name(self):
         from hermes_cli.web_server import _normalise_theme_definition
@@ -1431,6 +1466,13 @@ class TestNormaliseThemeDefinition:
 class TestDiscoverUserThemes:
     """Tests for _discover_user_themes() — scans ~/.hermes/dashboard-themes/."""
 
+    @pytest.fixture(autouse=True)
+    def _require_fastapi(self):
+        try:
+            import hermes_cli.web_server  # noqa: F401
+        except SystemExit:
+            pytest.skip("fastapi/uvicorn not installed")
+
     def test_returns_empty_when_dir_missing(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         from hermes_cli import web_server
@@ -1479,6 +1521,13 @@ class TestNormaliseThemeExtensions:
     """Tests for the extended normaliser fields (assets, customCSS,
     componentStyles, layoutVariant) — the surfaces themes use to reskin
     the dashboard without shipping code."""
+
+    @pytest.fixture(autouse=True)
+    def _require_fastapi(self):
+        try:
+            import hermes_cli.web_server  # noqa: F401
+        except SystemExit:
+            pytest.skip("fastapi/uvicorn not installed")
 
     def test_layout_variant_defaults_to_standard(self):
         from hermes_cli.web_server import _normalise_theme_definition
@@ -1607,6 +1656,13 @@ class TestNormaliseThemeExtensions:
 class TestDashboardPluginManifestExtensions:
     """Tests for the extended plugin manifest fields (tab.override,
     tab.hidden, slots) read by _discover_dashboard_plugins()."""
+
+    @pytest.fixture(autouse=True)
+    def _require_fastapi(self):
+        try:
+            import hermes_cli.web_server  # noqa: F401
+        except SystemExit:
+            pytest.skip("fastapi/uvicorn not installed")
 
     def _write_plugin(self, tmp_path, name, manifest):
         import json
@@ -1739,9 +1795,11 @@ skip_on_windows = pytest.mark.skipif(
 class TestPtyWebSocket:
     @pytest.fixture(autouse=True)
     def _setup(self, monkeypatch, _isolate_hermes_home):
-        from starlette.testclient import TestClient
-
-        import hermes_cli.web_server as ws
+        try:
+            from starlette.testclient import TestClient
+            import hermes_cli.web_server as ws
+        except (ImportError, SystemExit):
+            pytest.skip("fastapi/uvicorn not installed")
 
         # Avoid exec'ing the actual TUI in tests: every test below installs
         # its own fake argv via ``ws._resolve_chat_argv``.


### PR DESCRIPTION
## Problem

`hermes_cli/web_server.py` raises `SystemExit` (not `ImportError`) when
`fastapi`/`uvicorn` are not installed:

```python
try:
    from fastapi import FastAPI, ...
except ImportError:
    raise SystemExit("Web UI requires fastapi and uvicorn.\n...")
```

Every autouse fixture in `tests/hermes_cli/test_web_server.py` guarded the
`starlette.testclient` import with `except ImportError`, then imported from
`web_server` **outside** the try block. Because `SystemExit` is not a
subclass of `Exception`, the guard never fired and all 115+ FastAPI-dependent
tests raised `ERROR` instead of `SKIP` in environments without the optional
web-UI dependencies.

## Fix

Two patterns applied consistently across all 14 affected test classes:

**Pattern A** — classes with existing autouse fixtures that call `TestClient`:
merge the `web_server` import inside the `try` block and broaden the `except`
to `(ImportError, SystemExit)`.

**Pattern B** — classes whose tests import from `web_server` inline: add a
dedicated `_require_fastapi` autouse fixture that catches `SystemExit` and
calls `pytest.skip()`.

## Result

| Before | After |
|--------|-------|
| 29 ERRORs + 8 FAILUREs | 7 passed, 115 skipped, 0 errors |

All FastAPI-dependent tests skip cleanly when the optional dependencies are
absent; the 7 non-FastAPI tests continue to pass.

## Test plan
- [ ] `uv run --with pytest python3 -m pytest tests/hermes_cli/test_web_server.py -q` → `7 passed, 115 skipped`
- [ ] In an environment with fastapi installed: all previously-passing tests still pass