### PR TITLE
fix: persist structured session content

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -34,6 +34,8 @@ from pathlib import Path
 from datetime import datetime
 from typing import List, Dict, Any, Optional
 
+from hermes_message_content import content_to_text
+
 logger = logging.getLogger(__name__)
 
 # Suppress startup messages for clean CLI experience
@@ -4114,22 +4116,13 @@ class HermesCLI:
                 continue
 
             if role == "user":
-                text = "" if content is None else str(content)
-                # Handle multimodal content (list of dicts)
-                if isinstance(content, list):
-                    parts = []
-                    for part in content:
-                        if isinstance(part, dict) and part.get("type") == "text":
-                            parts.append(part.get("text", ""))
-                        elif isinstance(part, dict) and part.get("type") == "image_url":
-                            parts.append("[image]")
-                    text = " ".join(parts)
+                text = content_to_text(content, separator=" ", attachment_style="compact")
                 if len(text) > MAX_USER_LEN:
                     text = text[:MAX_USER_LEN] + "..."
                 entries.append(("user", text))
 
             elif role == "assistant":
-                text = "" if content is None else str(content)
+                text = content_to_text(content, separator=" ", attachment_style="compact")
                 text = _strip_reasoning_tags(text)
                 parts = []
                 full_parts = []  # un-truncated version
@@ -5175,7 +5168,7 @@ class HermesCLI:
             visible_index += 1
 
             content = msg.get("content")
-            content_text = "" if content is None else str(content)
+            content_text = content_to_text(content, separator=" ", attachment_style="compact")
 
             if role == "user":
                 print(f"\n  [You #{visible_index}]")
@@ -5624,8 +5617,9 @@ class HermesCLI:
         # Extract the message text and remove everything from that point forward
         last_message = self.conversation_history[last_user_idx].get("content", "")
         self.conversation_history = self.conversation_history[:last_user_idx]
-        
-        print(f"(^_^)b Retrying: \"{last_message[:60]}{'...' if len(last_message) > 60 else ''}\"")
+
+        preview = content_to_text(last_message, separator=" ", attachment_style="compact")
+        print(f"(^_^)b Retrying: \"{preview[:60]}{'...' if len(preview) > 60 else ''}\"")
         return last_message
     
     def undo_last(self):
@@ -5656,7 +5650,8 @@ class HermesCLI:
         # Truncate history to before the last user message
         self.conversation_history = self.conversation_history[:last_user_idx]
         
-        print(f"(^_^)b Undid {removed_count} message(s). Removed: \"{removed_msg[:60]}{'...' if len(removed_msg) > 60 else ''}\"")
+        preview = content_to_text(removed_msg, separator=" ", attachment_style="compact")
+        print(f"(^_^)b Undid {removed_count} message(s). Removed: \"{preview[:60]}{'...' if len(preview) > 60 else ''}\"")
         remaining = len(self.conversation_history)
         print(f"  {remaining} message(s) remaining in history.")
     

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -48,6 +48,7 @@ from hermes_cli.config import (
     redact_key,
 )
 from gateway.status import get_running_pid, read_runtime_status
+from hermes_message_content import content_to_text
 
 try:
     from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
@@ -2195,7 +2196,12 @@ async def get_session_messages(session_id: str):
         sid = db.resolve_session_id(session_id)
         if not sid:
             raise HTTPException(status_code=404, detail="Session not found")
-        messages = db.get_messages(sid)
+        messages = []
+        for msg in db.get_messages_for_display(sid):
+            item = dict(msg)
+            content = item.get("content")
+            item["content"] = None if content is None else content_to_text(content)
+            messages.append(item)
         return {"session_id": sid, "messages": messages}
     finally:
         db.close()

--- a/hermes_message_content.py
+++ b/hermes_message_content.py
@@ -1,0 +1,201 @@
+"""Helpers for storing, replaying, and displaying structured message content."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Optional
+
+from agent.memory_manager import sanitize_context
+
+STRUCTURED_CONTENT_FORMAT = "json"
+
+_SURROGATE_RE = re.compile(r"[\ud800-\udfff]")
+
+
+def sanitize_storage_text(text: str) -> str:
+    """Replace invalid UTF-8 surrogate code points before SQLite binding."""
+    if _SURROGATE_RE.search(text):
+        return _SURROGATE_RE.sub("\ufffd", text)
+    return text
+
+
+def sanitize_content_for_storage(content: Any) -> Any:
+    if isinstance(content, str):
+        return sanitize_storage_text(content)
+    if isinstance(content, list):
+        return [sanitize_content_for_storage(item) for item in content]
+    if isinstance(content, dict):
+        return {
+            (sanitize_storage_text(key) if isinstance(key, str) else key): sanitize_content_for_storage(value)
+            for key, value in content.items()
+        }
+    return content
+
+
+def content_to_text(
+    content: Any,
+    *,
+    separator: str = "\n",
+    attachment_style: str = "detailed",
+) -> str:
+    """Render structured content as text safe for previews, display, and FTS."""
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return sanitize_storage_text(content)
+    if isinstance(content, list):
+        parts = []
+        for part in content:
+            text = content_part_to_text(part, separator=separator, attachment_style=attachment_style)
+            if text:
+                parts.append(text)
+        return separator.join(parts)
+    if isinstance(content, dict):
+        return (
+            content_part_to_text(content, separator=separator, attachment_style=attachment_style)
+            or "[structured content]"
+        )
+    return str(content)
+
+
+def content_part_to_text(
+    part: Any,
+    *,
+    separator: str = "\n",
+    attachment_style: str = "detailed",
+) -> str:
+    if isinstance(part, str):
+        return sanitize_storage_text(part)
+    if not isinstance(part, dict):
+        return str(part) if part is not None else ""
+
+    ptype = str(part.get("type") or "").strip().lower()
+    if ptype in {"text", "input_text", "output_text"}:
+        return sanitize_storage_text(str(part.get("text") or ""))
+
+    if ptype in {"image_url", "input_image", "image"}:
+        if attachment_style == "compact":
+            return "[image]"
+        source = part.get("source")
+        if isinstance(source, dict) and source.get("data") is not None:
+            return "[image attachment]"
+        image_ref = part.get("image_url") or part.get("url") or part.get("image")
+        if not image_ref and isinstance(source, dict):
+            image_ref = source.get("url") or source.get("uri")
+        if isinstance(image_ref, dict):
+            image_ref = image_ref.get("url") or image_ref.get("uri") or ""
+        image_url = sanitize_storage_text(str(image_ref or "").strip())
+        if image_url.lower().startswith("data:"):
+            return "[image attachment]"
+        return f"[image: {image_url}]" if image_url else "[image attachment]"
+
+    if ptype in {"file", "input_file"}:
+        if attachment_style == "compact":
+            return "[file]"
+        file_data = part.get("file_data") or part.get("data")
+        file_ref = part.get("file_id") or part.get("filename")
+        file_obj = part.get("file")
+        if isinstance(file_obj, dict):
+            file_data = file_data or file_obj.get("file_data") or file_obj.get("data")
+            file_ref = (
+                file_ref
+                or file_obj.get("file_id")
+                or file_obj.get("id")
+                or file_obj.get("filename")
+                or file_obj.get("name")
+            )
+        elif file_obj:
+            file_ref = file_ref or file_obj
+        if file_data:
+            return "[file attachment]"
+        file_text = sanitize_storage_text(str(file_ref or "").strip())
+        return f"[file: {file_text}]" if file_text else "[file attachment]"
+
+    if ptype in {"input_audio", "audio"}:
+        return "[audio]" if attachment_style == "compact" else "[audio attachment]"
+
+    source = part.get("source")
+    if (
+        part.get("data") is not None
+        or part.get("file_data") is not None
+        or (
+            isinstance(source, dict)
+            and (
+                source.get("data") is not None
+                or source.get("file_data") is not None
+            )
+        )
+    ):
+        return "[attachment]"
+
+    fallback = part.get("text") or part.get("content")
+    if isinstance(fallback, (list, dict)):
+        return content_to_text(
+            fallback,
+            separator=separator,
+            attachment_style=attachment_style,
+        )
+    return sanitize_storage_text(str(fallback)) if fallback is not None else ""
+
+
+def serialize_message_content(content: Any) -> tuple[Any, Optional[str], Optional[str]]:
+    """Convert message content into indexed text plus optional replay payload."""
+    content = sanitize_content_for_storage(content)
+    if isinstance(content, (list, dict)):
+        return (
+            content_to_text(content),
+            STRUCTURED_CONTENT_FORMAT,
+            json.dumps(content, ensure_ascii=False),
+        )
+    return content, None, None
+
+
+def deserialize_message_content(
+    content: Any,
+    content_format: Optional[str] = None,
+    content_payload: Optional[str] = None,
+) -> Any:
+    """Restore content only when Hermes marked it as structured JSON."""
+    if content_format != STRUCTURED_CONTENT_FORMAT or not isinstance(content, str):
+        return content
+    try:
+        return json.loads(content_payload if content_payload is not None else content)
+    except (json.JSONDecodeError, TypeError):
+        return content
+
+
+def sanitize_replay_content(content: Any) -> Any:
+    """Strip transient memory context from text before replaying to models."""
+    if isinstance(content, str):
+        return sanitize_context(content).strip()
+    if isinstance(content, list):
+        return [sanitize_replay_content(item) for item in content]
+    if isinstance(content, dict):
+        return {
+            key: sanitize_replay_content(value)
+            for key, value in content.items()
+        }
+    return content
+
+
+def normalize_replay_content(content: Any) -> Any:
+    """Return provider-acceptable replay content."""
+    content = sanitize_replay_content(content)
+    if isinstance(content, dict):
+        if content.get("type"):
+            return [content]
+        return content_to_text(content)
+    return content
+
+
+def content_identity(content: Any) -> Optional[str]:
+    """Stable content key for replay duplicate detection."""
+    if content is None or content == "":
+        return None
+    if isinstance(content, (list, dict)):
+        try:
+            return json.dumps(content, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        except (TypeError, ValueError):
+            return str(content)
+    return str(content)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -23,8 +23,13 @@ import threading
 import time
 from pathlib import Path
 
-from agent.memory_manager import sanitize_context
 from hermes_constants import get_hermes_home
+from hermes_message_content import (
+    content_identity as _content_identity,
+    deserialize_message_content as _deserialize_message_content,
+    normalize_replay_content as _normalize_replay_content,
+    serialize_message_content as _serialize_message_content,
+)
 from typing import Any, Callable, Dict, List, Optional, TypeVar
 
 logger = logging.getLogger(__name__)
@@ -76,6 +81,8 @@ CREATE TABLE IF NOT EXISTS messages (
     session_id TEXT NOT NULL REFERENCES sessions(id),
     role TEXT NOT NULL,
     content TEXT,
+    content_format TEXT,
+    content_payload TEXT,
     tool_call_id TEXT,
     tool_calls TEXT,
     tool_name TEXT,
@@ -1223,30 +1230,26 @@ class SessionDB:
     _CONTENT_JSON_PREFIX = "\x00json:"
 
     @classmethod
-    def _encode_content(cls, content: Any) -> Any:
-        """Serialize structured (list/dict) message content for sqlite.
+    def _encode_content(cls, content: Any) -> tuple[Any, Optional[str], Optional[str]]:
+        """Serialize message content for sqlite storage.
 
-        sqlite3 can only bind ``str``, ``bytes``, ``int``, ``float``, and ``None``
-        to query parameters. Multimodal messages have ``content`` as a list of
-        parts (``[{"type": "text", ...}, {"type": "image_url", ...}]``), which
-        raises ``ProgrammingError: Error binding parameter N: type 'list' is
-        not supported`` when bound directly.
-
-        Returns the value unchanged when it's already a safe scalar, or a
-        sentinel-prefixed JSON string for lists/dicts. Paired with
-        :meth:`_decode_content` on read.
+        Returns indexed/display text plus optional structured replay payload.
+        Kept as a method so storage tests can monkeypatch serialization errors
+        and verify transaction rollback behavior.
         """
-        if content is None or isinstance(content, (str, bytes, int, float)):
-            return content
-        try:
-            return cls._CONTENT_JSON_PREFIX + json.dumps(content)
-        except (TypeError, ValueError):
-            # Last-resort fallback: stringify so persistence never fails.
-            return str(content)
+        return _serialize_message_content(content)
 
     @classmethod
-    def _decode_content(cls, content: Any) -> Any:
-        """Reverse :meth:`_encode_content`; returns scalars unchanged."""
+    def _decode_content(
+        cls,
+        content: Any,
+        content_format: Optional[str] = None,
+        content_payload: Optional[str] = None,
+    ) -> Any:
+        """Reverse :meth:`_encode_content`; also reads legacy prefixed rows."""
+        decoded = _deserialize_message_content(content, content_format, content_payload)
+        if decoded is not content:
+            return decoded
         if isinstance(content, str) and content.startswith(cls._CONTENT_JSON_PREFIX):
             try:
                 return json.loads(content[len(cls._CONTENT_JSON_PREFIX):])
@@ -1262,7 +1265,7 @@ class SessionDB:
         self,
         session_id: str,
         role: str,
-        content: str = None,
+        content: Any = None,
         tool_name: str = None,
         tool_calls: Any = None,
         tool_call_id: str = None,
@@ -1281,6 +1284,7 @@ class SessionDB:
         if role is 'tool' or tool_calls is present).
         """
         # Serialize structured fields to JSON before entering the write txn
+        content_text, content_format, content_payload = self._encode_content(content)
         reasoning_details_json = (
             json.dumps(reasoning_details)
             if reasoning_details else None
@@ -1294,10 +1298,6 @@ class SessionDB:
             if codex_message_items else None
         )
         tool_calls_json = json.dumps(tool_calls) if tool_calls else None
-        # Multimodal content (list of parts) must be JSON-encoded: sqlite3
-        # cannot bind list/dict parameters directly.
-        stored_content = self._encode_content(content)
-
         # Pre-compute tool call count
         num_tool_calls = 0
         if tool_calls is not None:
@@ -1305,15 +1305,17 @@ class SessionDB:
 
         def _do(conn):
             cursor = conn.execute(
-                """INSERT INTO messages (session_id, role, content, tool_call_id,
-                   tool_calls, tool_name, timestamp, token_count, finish_reason,
-                   reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
-                   codex_message_items)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                """INSERT INTO messages (session_id, role, content, content_format,
+                   content_payload, tool_call_id, tool_calls, tool_name, timestamp,
+                   token_count, finish_reason, reasoning, reasoning_content,
+                   reasoning_details, codex_reasoning_items, codex_message_items)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     role,
-                    stored_content,
+                    content_text,
+                    content_format,
+                    content_payload,
                     tool_call_id,
                     tool_calls_json,
                     tool_name,
@@ -1367,6 +1369,9 @@ class SessionDB:
             total_tool_calls = 0
             for msg in messages:
                 role = msg.get("role", "unknown")
+                content_text, content_format, content_payload = self._encode_content(
+                    msg.get("content")
+                )
                 tool_calls = msg.get("tool_calls")
                 reasoning_details = msg.get("reasoning_details") if role == "assistant" else None
                 codex_reasoning_items = (
@@ -1388,15 +1393,17 @@ class SessionDB:
                 tool_calls_json = json.dumps(tool_calls) if tool_calls else None
 
                 conn.execute(
-                    """INSERT INTO messages (session_id, role, content, tool_call_id,
-                       tool_calls, tool_name, timestamp, token_count, finish_reason,
-                       reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
-                       codex_message_items)
-                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    """INSERT INTO messages (session_id, role, content, content_format,
+                       content_payload, tool_call_id, tool_calls, tool_name, timestamp,
+                       token_count, finish_reason, reasoning, reasoning_content,
+                       reasoning_details, codex_reasoning_items, codex_message_items)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                     (
                         session_id,
                         role,
-                        self._encode_content(msg.get("content")),
+                        content_text,
+                        content_format,
+                        content_payload,
                         msg.get("tool_call_id"),
                         tool_calls_json,
                         msg.get("tool_name"),
@@ -1435,13 +1442,46 @@ class SessionDB:
         result = []
         for row in rows:
             msg = dict(row)
-            if "content" in msg:
-                msg["content"] = self._decode_content(msg["content"])
+            content_format = msg.pop("content_format", None)
+            content_payload = msg.pop("content_payload", None)
+            msg["content"] = self._decode_content(
+                msg.get("content"),
+                content_format,
+                content_payload,
+            )
             if msg.get("tool_calls"):
                 try:
                     msg["tool_calls"] = json.loads(msg["tool_calls"])
                 except (json.JSONDecodeError, TypeError):
                     logger.warning("Failed to deserialize tool_calls in get_messages, falling back to []")
+                    msg["tool_calls"] = []
+            result.append(msg)
+        return result
+
+    def get_messages_for_display(self, session_id: str) -> List[Dict[str, Any]]:
+        """Load display-safe message rows without deserializing structured payloads."""
+        with self._lock:
+            cursor = self._conn.execute(
+                """
+                SELECT id, session_id, role, content, tool_call_id, tool_calls,
+                       tool_name, timestamp, token_count, finish_reason,
+                       reasoning, reasoning_content, reasoning_details,
+                       codex_reasoning_items, codex_message_items
+                FROM messages
+                WHERE session_id = ?
+                ORDER BY timestamp, id
+                """,
+                (session_id,),
+            )
+            rows = cursor.fetchall()
+        result = []
+        for row in rows:
+            msg = dict(row)
+            if msg.get("tool_calls"):
+                try:
+                    msg["tool_calls"] = json.loads(msg["tool_calls"])
+                except (json.JSONDecodeError, TypeError):
+                    logger.warning("Failed to deserialize tool_calls in display messages, falling back to []")
                     msg["tool_calls"] = []
             result.append(msg)
         return result
@@ -1525,19 +1565,26 @@ class SessionDB:
         with self._lock:
             placeholders = ",".join("?" for _ in session_ids)
             rows = self._conn.execute(
-                "SELECT role, content, tool_call_id, tool_calls, tool_name, "
-                "finish_reason, reasoning, reasoning_content, reasoning_details, "
-                "codex_reasoning_items, codex_message_items "
+                "SELECT role, content, content_format, content_payload, tool_call_id, tool_calls, tool_name, "
+                "finish_reason, reasoning, reasoning_content, reasoning_details, codex_reasoning_items, "
+                "codex_message_items "
                 f"FROM messages WHERE session_id IN ({placeholders}) ORDER BY timestamp, id",
                 tuple(session_ids),
             ).fetchall()
 
         messages = []
         for row in rows:
-            content = self._decode_content(row["content"])
-            if row["role"] in {"user", "assistant"} and isinstance(content, str):
-                content = sanitize_context(content).strip()
-            msg = {"role": row["role"], "content": content}
+            content = self._decode_content(
+                row["content"],
+                row["content_format"],
+                row["content_payload"],
+            )
+            if row["role"] in {"user", "assistant"}:
+                content = _normalize_replay_content(content)
+            msg = {
+                "role": row["role"],
+                "content": content,
+            }
             if row["tool_call_id"]:
                 msg["tool_call_id"] = row["tool_call_id"]
             if row["tool_name"]:
@@ -1607,11 +1654,11 @@ class SessionDB:
     def _is_duplicate_replayed_user_message(messages: List[Dict[str, Any]], msg: Dict[str, Any]) -> bool:
         if msg.get("role") != "user":
             return False
-        content = msg.get("content")
-        if not isinstance(content, str) or not content:
+        content_key = _content_identity(msg.get("content"))
+        if not content_key:
             return False
         for prev in reversed(messages):
-            if prev.get("role") == "user" and prev.get("content") == content:
+            if prev.get("role") == "user" and _content_identity(prev.get("content")) == content_key:
                 return True
             if prev.get("role") == "assistant" and (prev.get("content") or prev.get("tool_calls")):
                 return False
@@ -2666,4 +2713,3 @@ class SessionDB:
             result["error"] = str(exc)
 
         return result
-

--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -40,6 +40,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional
 
+from hermes_message_content import content_to_text
+
 logger = logging.getLogger("hermes.mcp_serve")
 
 # ---------------------------------------------------------------------------
@@ -76,6 +78,14 @@ def _get_session_db():
     except Exception as e:
         logger.debug("SessionDB unavailable: %s", e)
         return None
+
+
+def _get_display_messages(db, session_id: str) -> List[dict]:
+    """Load display-safe messages without materializing structured payloads."""
+    display_getter = getattr(db, "get_messages_for_display", None)
+    if callable(display_getter):
+        return display_getter(session_id)
+    return db.get_messages(session_id)
 
 
 def _load_sessions_index() -> dict:
@@ -120,11 +130,13 @@ def _extract_message_content(msg: dict) -> str:
     content = msg.get("content", "")
     if isinstance(content, list):
         text_parts = [
-            p.get("text", "") for p in content
-            if isinstance(p, dict) and p.get("type") == "text"
+            content_to_text(part)
+            for part in content
+            if isinstance(part, dict)
+            and str(part.get("type") or "").strip().lower() in {"text", "input_text", "output_text"}
         ]
         return "\n".join(text_parts)
-    return str(content) if content else ""
+    return content_to_text(content)
 
 
 def _extract_attachments(msg: dict) -> List[dict]:
@@ -367,7 +379,7 @@ class EventBridge:
             last_seen = self._last_poll_timestamps.get(session_key, 0.0)
 
             try:
-                messages = db.get_messages(session_id)
+                messages = _get_display_messages(db, session_id)
             except Exception:
                 continue
 
@@ -566,7 +578,7 @@ def create_mcp_server(event_bridge: Optional[EventBridge] = None) -> "FastMCP":
             return json.dumps({"error": "Session database unavailable"})
 
         try:
-            all_messages = db.get_messages(session_id)
+            all_messages = _get_display_messages(db, session_id)
         except Exception as e:
             return json.dumps({"error": f"Failed to read messages: {e}"})
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,7 +135,7 @@ hermes-agent = "run_agent:main"
 hermes-acp = "acp_adapter.entry:main"
 
 [tool.setuptools]
-py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajectory_compressor", "toolset_distributions", "cli", "hermes_constants", "hermes_state", "hermes_time", "hermes_logging", "rl_cli", "utils"]
+py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajectory_compressor", "toolset_distributions", "cli", "hermes_constants", "hermes_message_content", "hermes_state", "hermes_time", "hermes_logging", "rl_cli", "utils"]
 
 [tool.setuptools.package-data]
 hermes_cli = ["web_dist/**/*"]

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -261,6 +261,36 @@ class TestHistoryDisplay:
         assert "/resume" in output
         assert "Current preview" not in output
 
+    def test_history_redacts_structured_attachment_payloads(self, capsys):
+        cli = _make_cli()
+        cli.conversation_history = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "look"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "DATA:image/png;base64,raw-image"},
+                    },
+                ],
+            },
+            {
+                "role": "assistant",
+                "content": {
+                    "type": "document",
+                    "source": {"type": "base64", "data": "raw-document"},
+                },
+            },
+        ]
+
+        cli.show_history()
+        output = capsys.readouterr().out
+
+        assert "look [image]" in output
+        assert "[attachment]" in output
+        assert "raw-image" not in output
+        assert "raw-document" not in output
+
     def test_resume_without_target_lists_recent_sessions(self, capsys):
         cli = _make_cli()
         cli.session_id = "current"

--- a/tests/cli/test_cli_retry.py
+++ b/tests/cli/test_cli_retry.py
@@ -29,6 +29,49 @@ def test_retry_last_truncates_history_before_requeueing_message():
     ]
 
 
+def test_retry_last_prints_redacted_structured_preview(capsys):
+    cli = _make_cli()
+    content = [
+        {"type": "text", "text": "look"},
+        {"type": "image_url", "image_url": {"url": "DATA:image/png;base64,raw-image"}},
+    ]
+    cli.conversation_history = [
+        {"role": "user", "content": content},
+        {"role": "assistant", "content": "old answer"},
+    ]
+
+    retry_msg = cli.retry_last()
+    output = capsys.readouterr().out
+
+    assert retry_msg == content
+    assert "[image]" in output
+    assert "raw-image" not in output
+
+
+def test_undo_last_prints_redacted_structured_preview(capsys):
+    cli = _make_cli()
+    cli.conversation_history = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "read this"},
+                {
+                    "type": "file",
+                    "file": {"filename": "notes.pdf", "file_data": "raw-file"},
+                },
+            ],
+        },
+        {"role": "assistant", "content": "old answer"},
+    ]
+
+    cli.undo_last()
+    output = capsys.readouterr().out
+
+    assert "[file]" in output
+    assert "raw-file" not in output
+    assert cli.conversation_history == []
+
+
 def test_process_command_retry_requeues_original_message_not_retry_command():
     cli = _make_cli()
     queued = []

--- a/tests/cli/test_resume_display.py
+++ b/tests/cli/test_resume_display.py
@@ -108,6 +108,11 @@ def _multimodal_history():
             "content": [
                 {"type": "text", "text": "What's in this image?"},
                 {"type": "image_url", "image_url": {"url": "https://example.com/cat.jpg"}},
+                {"type": "input_image", "image_url": "DATA:image/png;base64,raw-image"},
+                {
+                    "type": "file",
+                    "file": {"filename": "notes.pdf", "file_data": "raw-file"},
+                },
             ],
         },
         {"role": "assistant", "content": "I see a cat in the image."},
@@ -263,6 +268,9 @@ class TestDisplayResumedHistory:
 
         assert "What's in this image?" in output
         assert "[image]" in output
+        assert "[file]" in output
+        assert "raw-image" not in output
+        assert "raw-file" not in output
 
     def test_empty_history_no_output(self):
         cli = _make_cli()

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -125,6 +125,49 @@ class TestWebServerEndpoints:
         assert "hermes_home" in data
         assert "active_sessions" in data
 
+    def test_session_messages_stringify_structured_content(self, monkeypatch):
+        import hermes_state
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session("s1", "cli")
+            db.append_message(
+                "s1",
+                role="user",
+                content=[
+                    {"type": "text", "text": "look at this"},
+                    {"type": "image_url", "image_url": {"url": "DATA:image/png;base64,abc"}},
+                    {"type": "image", "source": {"type": "base64", "data": "raw-image"}},
+                    {"type": "input_image", "source": {"type": "base64", "data": "raw-input-image"}},
+                    {"type": "input_file", "filename": "notes.pdf", "file_data": "raw-file"},
+                    {
+                        "type": "file",
+                        "file": {"filename": "nested.pdf", "file_data": "raw-nested-file"},
+                    },
+                ],
+            )
+        finally:
+            db.close()
+
+        def _fail_deserialize(*_args, **_kwargs):
+            raise AssertionError("dashboard messages should not deserialize content_payload")
+
+        monkeypatch.setattr(hermes_state, "_deserialize_message_content", _fail_deserialize)
+
+        resp = self.client.get("/api/sessions/s1/messages")
+
+        assert resp.status_code == 200
+        messages = resp.json()["messages"]
+        assert messages[0]["content"] == (
+            "look at this\n[image attachment]\n[image attachment]\n"
+            "[image attachment]\n[file attachment]\n[file attachment]"
+        )
+        assert "raw-image" not in messages[0]["content"]
+        assert "raw-input-image" not in messages[0]["content"]
+        assert "raw-file" not in messages[0]["content"]
+        assert "raw-nested-file" not in messages[0]["content"]
+
     def test_get_status_filters_unconfigured_gateway_platforms(self, monkeypatch):
         import gateway.config as gateway_config
         import hermes_cli.web_server as web_server

--- a/tests/test_hermes_message_content.py
+++ b/tests/test_hermes_message_content.py
@@ -1,0 +1,72 @@
+from hermes_message_content import (
+    STRUCTURED_CONTENT_FORMAT,
+    content_to_text,
+    deserialize_message_content,
+    normalize_replay_content,
+    serialize_message_content,
+)
+
+
+def test_content_to_text_redacts_inline_attachment_payloads():
+    content = [
+        {"type": "text", "text": "look"},
+        {"type": "image_url", "image_url": {"url": "DATA:image/png;base64,raw-image"}},
+        {"type": "input_image", "source": {"type": "base64", "data": "raw-input-image"}},
+        {"type": "file", "file": {"filename": "notes.pdf", "file_data": "raw-file"}},
+        {"type": "document", "source": {"type": "base64", "data": "raw-document"}},
+    ]
+
+    text = content_to_text(content)
+
+    assert text == (
+        "look\n[image attachment]\n[image attachment]\n"
+        "[file attachment]\n[attachment]"
+    )
+    assert "raw-image" not in text
+    assert "raw-input-image" not in text
+    assert "raw-file" not in text
+    assert "raw-document" not in text
+
+
+def test_content_to_text_supports_compact_cli_style():
+    content = [
+        {"type": "text", "text": "look"},
+        {"type": "image_url", "image_url": {"url": "https://example.com/p.png"}},
+        {"type": "file", "file": {"filename": "notes.pdf"}},
+    ]
+
+    assert content_to_text(content, separator=" ", attachment_style="compact") == "look [image] [file]"
+
+
+def test_structured_content_serializes_display_text_and_replay_payload():
+    content = [
+        {"type": "text", "text": "look"},
+        {"type": "image_url", "image_url": {"url": "DATA:image/png;base64,raw-image"}},
+    ]
+
+    text, content_format, payload = serialize_message_content(content)
+
+    assert text == "look\n[image attachment]"
+    assert content_format == STRUCTURED_CONTENT_FORMAT
+    assert "raw-image" not in text
+    assert "raw-image" in payload
+    assert deserialize_message_content(text, content_format, payload) == content
+
+
+def test_normalize_replay_content_wraps_single_content_part():
+    content = {
+        "type": "document",
+        "source": {"type": "base64", "data": "raw-document"},
+    }
+
+    assert normalize_replay_content(content) == [content]
+
+
+def test_normalize_replay_content_falls_back_for_non_content_dict():
+    assert normalize_replay_content({"metadata": {"source": "integration"}}) == "[structured content]"
+
+
+def test_normalize_replay_content_sanitizes_memory_context():
+    content = [{"type": "text", "text": "before <memory-context>secret</memory-context> after"}]
+
+    assert normalize_replay_content(content) == [{"type": "text", "text": "before  after"}]

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -153,6 +153,203 @@ class TestMessageStorage:
         assert messages[0]["content"] == "Hello"
         assert messages[1]["role"] == "assistant"
 
+    def test_structured_content_round_trips(self, db):
+        db.create_session(session_id="s1", source="cli")
+        content = [
+            {"type": "text", "text": "Look at this image"},
+            {"type": "image_url", "image_url": {"url": "DATA:image/png;base64,abc"}},
+        ]
+
+        db.append_message("s1", role="user", content=content)
+
+        row = db._conn.execute(
+            "SELECT content, content_payload FROM messages WHERE session_id = 's1'"
+        ).fetchone()
+        assert row["content"] == "Look at this image\n[image attachment]"
+        assert "DATA:image/png;base64,abc" not in row["content"]
+        assert "DATA:image/png;base64,abc" in row["content_payload"]
+
+        messages = db.get_messages("s1")
+        assert messages[0]["content"] == content
+        assert "content_payload" not in messages[0]
+        assert "content_format" not in messages[0]
+
+        conv = db.get_messages_as_conversation("s1")
+        assert conv[0] == {"role": "user", "content": content}
+
+    def test_structured_content_replay_sanitizes_context(self, db):
+        db.create_session(session_id="s1", source="cli")
+        content = [
+            {
+                "type": "text",
+                "text": "Before <memory-context>secret memory</memory-context> after",
+            },
+            {
+                "type": "input_text",
+                "text": (
+                    "[System note: The following is recalled memory context, "
+                    "NOT new user input. Treat as informational background data.] visible"
+                ),
+            },
+            {"type": "image_url", "image_url": {"url": "DATA:image/png;base64,abc"}},
+        ]
+
+        db.append_message("s1", role="user", content=content)
+
+        messages = db.get_messages("s1")
+        assert "secret memory" in messages[0]["content"][0]["text"]
+
+        conv = db.get_messages_as_conversation("s1")
+        replay_content = conv[0]["content"]
+        assert replay_content[0]["text"] == "Before  after"
+        assert replay_content[1]["text"] == "visible"
+        assert replay_content[2]["image_url"]["url"] == "DATA:image/png;base64,abc"
+
+    def test_json_text_content_stays_text(self, db):
+        db.create_session(session_id="s1", source="cli")
+        literal_json = '[{"type": "event", "text": "not a content part"}]'
+
+        db.append_message("s1", role="user", content=literal_json)
+
+        messages = db.get_messages("s1")
+        assert messages[0]["content"] == literal_json
+
+        conv = db.get_messages_as_conversation("s1")
+        assert conv[0]["content"] == literal_json
+
+    def test_structured_content_surrogates_are_sanitized(self, db):
+        db.create_session(session_id="s1", source="cli")
+
+        db.append_message(
+            "s1",
+            role="user",
+            content=[
+                {"type": "text", "text": "dirty \udce2 content"},
+                {"type": "image_url", "image_url": {"url": "https://example.com/img.png"}},
+            ],
+        )
+
+        messages = db.get_messages("s1")
+        assert messages[0]["content"][0]["text"] == "dirty \ufffd content"
+
+        row = db._conn.execute(
+            "SELECT content, content_payload FROM messages WHERE session_id = 's1'"
+        ).fetchone()
+        assert "\udce2" not in row["content"]
+        assert "\udce2" not in row["content_payload"]
+        assert "\ufffd" in row["content"]
+        assert "\ufffd" in row["content_payload"]
+
+    def test_structured_attachment_payloads_are_redacted_from_index_text(self, db):
+        db.create_session(session_id="s1", source="cli")
+        content = [
+            {"type": "text", "text": "attachments"},
+            {
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": "image/png",
+                    "data": "raw-image-payload",
+                },
+            },
+            {
+                "type": "input_image",
+                "source": {
+                    "type": "base64",
+                    "media_type": "image/png",
+                    "data": "raw-input-image-payload",
+                },
+            },
+            {
+                "type": "input_file",
+                "filename": "notes.pdf",
+                "file_data": "data:application/pdf;base64,raw-file-payload",
+            },
+            {
+                "type": "file",
+                "file": {
+                    "filename": "nested.pdf",
+                    "file_data": "data:application/pdf;base64,nested-file-payload",
+                },
+            },
+        ]
+
+        db.append_message("s1", role="user", content=content)
+
+        row = db._conn.execute(
+            "SELECT content, content_payload FROM messages WHERE session_id = 's1'"
+        ).fetchone()
+        assert row["content"] == (
+            "attachments\n[image attachment]\n[image attachment]\n"
+            "[file attachment]\n[file attachment]"
+        )
+        assert "raw-image-payload" not in row["content"]
+        assert "raw-input-image-payload" not in row["content"]
+        assert "raw-file-payload" not in row["content"]
+        assert "nested-file-payload" not in row["content"]
+        assert "raw-image-payload" in row["content_payload"]
+        assert "raw-input-image-payload" in row["content_payload"]
+        assert "raw-file-payload" in row["content_payload"]
+        assert "nested-file-payload" in row["content_payload"]
+
+    def test_structured_single_dict_attachment_payload_is_redacted_from_index_text(self, db):
+        db.create_session(session_id="s1", source="cli")
+        content = {
+            "type": "document",
+            "title": "notes.pdf",
+            "source": {
+                "type": "base64",
+                "media_type": "application/pdf",
+                "data": "raw-document-payload",
+            },
+        }
+
+        db.append_message("s1", role="user", content=content)
+
+        row = db._conn.execute(
+            "SELECT content, content_payload FROM messages WHERE session_id = 's1'"
+        ).fetchone()
+        assert row["content"] == "[attachment]"
+        assert "raw-document-payload" not in row["content"]
+        assert "raw-document-payload" in row["content_payload"]
+
+        messages = db.get_messages("s1")
+        assert messages[0]["content"] == content
+
+        conv = db.get_messages_as_conversation("s1")
+        assert conv == [{"role": "user", "content": [content]}]
+
+    def test_structured_non_content_dict_replays_as_text(self, db):
+        db.create_session(session_id="s1", source="cli")
+        content = {"metadata": {"source": "integration"}}
+
+        db.append_message("s1", role="user", content=content)
+
+        messages = db.get_messages("s1")
+        assert messages[0]["content"] == content
+
+        conv = db.get_messages_as_conversation("s1")
+        assert conv == [{"role": "user", "content": "[structured content]"}]
+
+    def test_replace_messages_structured_content_round_trips(self, db):
+        db.create_session(session_id="s1", source="cli")
+        content = [
+            {"type": "text", "text": "Replacement image"},
+            {"type": "image_url", "image_url": {"url": "DATA:image/png;base64,abc"}},
+        ]
+
+        db.replace_messages("s1", [{"role": "user", "content": content}])
+
+        row = db._conn.execute(
+            "SELECT content, content_payload FROM messages WHERE session_id = 's1'"
+        ).fetchone()
+        assert row["content"] == "Replacement image\n[image attachment]"
+        assert "DATA:image/png;base64,abc" not in row["content"]
+        assert "DATA:image/png;base64,abc" in row["content_payload"]
+
+        conv = db.get_messages_as_conversation("s1")
+        assert conv == [{"role": "user", "content": content}]
+
     def test_message_increments_session_count(self, db):
         db.create_session(session_id="s1", source="cli")
         db.append_message("s1", role="user", content="Hello")
@@ -327,6 +524,22 @@ class TestMessageStorage:
         conv = db.get_messages_as_conversation("child", include_ancestors=True)
 
         assert [m["content"] for m in conv if m["role"] == "user"] == ["same prompt", "next prompt"]
+
+    def test_get_messages_as_conversation_deduplicates_structured_resume_prompts(self, db):
+        content = [
+            {"type": "text", "text": "same prompt"},
+                {"type": "image_url", "image_url": {"url": "DATA:image/png;base64,abc"}},
+        ]
+        db.create_session("root", "tui")
+        db.append_message("root", role="user", content=content)
+        db.append_message("root", role="user", content=content)
+        db.append_message("root", role="assistant", content="answer")
+        db.create_session("child", "tui", parent_session_id="root")
+        db.append_message("child", role="user", content="next prompt")
+
+        conv = db.get_messages_as_conversation("child", include_ancestors=True)
+
+        assert [m["content"] for m in conv if m["role"] == "user"] == [content, "next prompt"]
 
     def test_finish_reason_stored(self, db):
         db.create_session(session_id="s1", source="cli")
@@ -1658,6 +1871,13 @@ class TestSchemaInit:
         assert sessions[0]["preview"] == "first prompt"
         db.close()
 
+    def test_message_structured_content_columns_exist(self, db):
+        """Verify structured message content can be stored outside FTS text."""
+        cursor = db._conn.execute("PRAGMA table_info(messages)")
+        columns = {row[1] for row in cursor.fetchall()}
+        assert "content_format" in columns
+        assert "content_payload" in columns
+
     def test_migration_from_v2(self, tmp_path):
         """Simulate a v2 database and verify migration adds title column."""
         import sqlite3
@@ -1706,7 +1926,7 @@ class TestSchemaInit:
         conn.commit()
         conn.close()
 
-        # Open with SessionDB — should migrate to v9
+        # Open with SessionDB — should migrate to current schema
         migrated_db = SessionDB(db_path=db_path)
 
         # Verify migration
@@ -1717,6 +1937,12 @@ class TestSchemaInit:
         session = migrated_db.get_session("existing")
         assert session is not None
         assert session["title"] is None
+
+        # Verify structured content columns were added for safe replay.
+        cursor = migrated_db._conn.execute("PRAGMA table_info(messages)")
+        columns = {row[1] for row in cursor.fetchall()}
+        assert "content_format" in columns
+        assert "content_payload" in columns
 
         # Verify api_call_count column was added with default 0
         cursor = migrated_db._conn.execute(
@@ -2714,8 +2940,6 @@ class TestAutoMaintenance:
         assert count == 1
         assert not (sessions_dir / "old.jsonl").exists()
         assert (sessions_dir / "active.jsonl").exists()
-
-
 # =========================================================================
 # FTS5 indexing of tool_calls / tool_name (#16751)
 # =========================================================================
@@ -2909,4 +3133,3 @@ class TestFTS5ToolCallMigration:
             assert version == 11
         finally:
             session_db.close()
-

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -246,6 +246,30 @@ class TestHelpers:
         monkeypatch.setattr(mcp_serve, "_get_sessions_dir", lambda: sessions_dir)
         assert mcp_serve._load_sessions_index() == {}
 
+    def test_get_display_messages_prefers_display_fetcher(self):
+        import mcp_serve
+
+        class DB:
+            def __init__(self):
+                self.display_calls = 0
+                self.full_calls = 0
+
+            def get_messages_for_display(self, session_id):
+                self.display_calls += 1
+                return [{"content": "safe display text", "session_id": session_id}]
+
+            def get_messages(self, _session_id):
+                self.full_calls += 1
+                return [{"content": [{"type": "image_url", "image_url": {"url": "DATA:image/png;base64,raw"}}]}]
+
+        db = DB()
+
+        messages = mcp_serve._get_display_messages(db, "s1")
+
+        assert messages == [{"content": "safe display text", "session_id": "s1"}]
+        assert db.display_calls == 1
+        assert db.full_calls == 0
+
 
 class TestContentExtraction:
     def test_text(self):

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -451,6 +451,46 @@ def test_history_to_messages_preserves_tool_calls_for_resume_display():
     ]
 
 
+def test_history_to_messages_renders_structured_content_parts():
+    history = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "look at this"},
+                {"type": "image_url", "image_url": {"url": "https://example.com/p.png"}},
+                {"type": "input_image", "image_url": "DATA:image/png;base64,abc"},
+                {"type": "image", "source": {"type": "base64", "data": "raw-image"}},
+                {"type": "input_image", "source": {"type": "base64", "data": "raw-input-image"}},
+                {"type": "input_file", "filename": "notes.pdf", "file_data": "raw-file"},
+                {
+                    "type": "file",
+                    "file": {"filename": "nested.pdf", "file_data": "raw-nested-file"},
+                },
+                {
+                    "type": "document",
+                    "source": {"type": "base64", "data": "raw-document"},
+                },
+            ],
+        },
+        {
+            "role": "assistant",
+            "content": {"type": "output_text", "text": "I can see it."},
+        },
+    ]
+
+    assert server._history_to_messages(history) == [
+        {
+            "role": "user",
+            "text": (
+                "look at this\n[image: https://example.com/p.png]\n"
+                "[image attachment]\n[image attachment]\n[image attachment]\n"
+                "[file attachment]\n[file attachment]\n[attachment]"
+            ),
+        },
+        {"role": "assistant", "text": "I can see it."},
+    ]
+
+
 def test_session_resume_uses_parent_lineage_for_display(monkeypatch):
     captured = {}
 

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -110,6 +110,43 @@ class TestFormatConversation:
         assert "web_search" in result
         assert "terminal" in result
 
+    def test_structured_content_redacts_inline_image_payloads(self):
+        msgs = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "look"},
+                    {"type": "image_url", "image_url": {"url": "DATA:image/png;base64,abc"}},
+                    {"type": "input_image", "image_url": "https://example.com/p.png"},
+                    {"type": "image", "source": {"type": "base64", "data": "raw-image"}},
+                    {"type": "input_image", "source": {"type": "base64", "data": "raw-input-image"}},
+                    {"type": "input_file", "filename": "notes.pdf", "file_data": "raw-file"},
+                    {
+                        "type": "file",
+                        "file": {"filename": "nested.pdf", "file_data": "raw-nested-file"},
+                    },
+                    {
+                        "type": "document",
+                        "source": {"type": "base64", "data": "raw-document"},
+                    },
+                ],
+            },
+        ]
+
+        result = _format_conversation(msgs)
+
+        assert (
+            "[USER]: look\n[image attachment]\n[image: https://example.com/p.png]\n"
+            "[image attachment]\n[image attachment]\n"
+            "[file attachment]\n[file attachment]\n[attachment]"
+        ) in result
+        assert "DATA:image/png;base64,abc" not in result
+        assert "raw-image" not in result
+        assert "raw-input-image" not in result
+        assert "raw-file" not in result
+        assert "raw-nested-file" not in result
+        assert "raw-document" not in result
+
     def test_empty_messages(self):
         result = _format_conversation([])
         assert result == ""

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -25,6 +25,7 @@ import re
 from typing import Dict, Any, List, Optional, Union
 
 from agent.auxiliary_client import async_call_llm, extract_content_or_reasoning
+from hermes_message_content import content_to_text
 MAX_SESSION_CHARS = 100_000
 MAX_SUMMARY_TOKENS = 10000
 
@@ -81,7 +82,7 @@ def _format_conversation(messages: List[Dict[str, Any]]) -> str:
     parts = []
     for msg in messages:
         role = msg.get("role", "unknown").upper()
-        content = msg.get("content") or ""
+        content = content_to_text(msg.get("content"))
         tool_name = msg.get("tool_name")
 
         if role == "TOOL" and tool_name:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 from hermes_constants import get_hermes_home
+from hermes_message_content import content_to_text
 from hermes_cli.env_loader import load_hermes_dotenv
 from utils import is_truthy_value
 from tui_gateway.transport import (
@@ -2008,7 +2009,7 @@ def _history_to_messages(history: list[dict]) -> list[dict]:
                     except (json.JSONDecodeError, TypeError):
                         args = {}
                     tool_call_args[tc_id] = (fn["name"], args)
-            if not (m.get("content") or "").strip():
+            if not content_to_text(m.get("content")).strip():
                 continue
         if role == "tool":
             tc_id = m.get("tool_call_id", "")
@@ -2019,9 +2020,10 @@ def _history_to_messages(history: list[dict]) -> list[dict]:
                 {"role": "tool", "name": name, "context": _tool_ctx(name, args)}
             )
             continue
-        if not (m.get("content") or "").strip():
+        text = content_to_text(m.get("content"))
+        if not text.strip():
             continue
-        messages.append({"role": role, "text": m.get("content") or ""})
+        messages.append({"role": role, "text": text})
 
     return messages
 


### PR DESCRIPTION
## Summary

- Store structured/multimodal session content with a replayable JSON payload while keeping indexed/display text redacted.
- Centralize structured-content serialization, replay normalization, redaction, and display rendering in `hermes_message_content.py` so storage, CLI, dashboard, TUI, MCP, and session-search paths use the same rules.
- Restore structured content for session replay/resume and use stable structured identities for duplicate replay detection.

## Root Cause

`SessionDB.append_message()` assumed message `content` was always a SQLite-bindable scalar. That is not true for structured/multimodal message content, where callers can pass typed content parts such as text plus `image_url`. In that case, the session store tried to bind the Python list directly into SQLite and could fail with `sqlite3.ProgrammingError: type 'list' is not supported`.

The built-in OpenAI-compatible API server is the concrete current repro path because it accepts OpenAI/Responses-style multimodal parts, but the underlying issue is in the shared session persistence layer. The fix is therefore not limited to OpenAI auth, provider selection, or Codex OAuth; any Hermes path that passes structured content into session persistence now gets the same safe storage and replay behavior.

## User Impact

Structured turns can now be saved and replayed correctly instead of failing at persistence time. API-server clients such as Open WebUI, LibreChat, LobeChat, ChatBox, or OpenAI SDK integrations are the main built-in example today. Structured content remains available for replay, while session search and display views avoid indexing or showing raw inline base64 payloads.

## Validation

- `scripts/run_tests.sh tests/test_hermes_message_content.py tests/test_hermes_state.py tests/cli/test_cli_retry.py tests/cli/test_cli_init.py::TestHistoryDisplay tests/cli/test_resume_display.py::TestDisplayResumedHistory tests/test_tui_gateway_server.py::test_history_to_messages_renders_structured_content_parts tests/tui_gateway/test_protocol.py::test_session_resume_returns_hydrated_messages tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_session_messages_stringify_structured_content tests/tools/test_session_search.py tests/test_mcp_serve.py`
- `scripts/run_tests.sh tests/test_hermes_message_content.py tests/test_hermes_state.py::TestMessageStorage::test_structured_content_round_trips tests/test_mcp_serve.py::TestHelpers::test_get_display_messages_prefers_display_fetcher`
- `git diff --check origin/main`
- `codex review --base origin/main`


## Rebase / conflict refresh (2026-05-06)
- Rebased onto current `main` and resolved the state-store conflicts by preserving structured `content_format`/`content_payload` storage while keeping the newer atomic rewrite serialization hook behavior.
- Validation: `scripts/run_tests.sh tests/test_hermes_message_content.py -q` (`6 passed`); `scripts/run_tests.sh tests/test_hermes_state.py -q` (`220 passed`); downstream replay/display/search selection (`44 passed`).
- Local merge check: `git merge-tree --write-tree --name-only origin/main HEAD` completed without conflicts.
