### PR TITLE
fix(web): preserve dashboard content casing

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -310,7 +310,7 @@ export default function App() {
   return (
     <div
       data-layout-variant={layoutVariant}
-      className="font-mondwest flex h-dvh max-h-dvh min-h-0 flex-col overflow-hidden bg-black uppercase text-midground antialiased"
+      className="font-mondwest flex h-dvh max-h-dvh min-h-0 flex-col overflow-hidden bg-black text-midground antialiased"
     >
       <SelectionSwitcher />
       <Backdrop />
@@ -435,7 +435,7 @@ export default function App() {
                           cn(
                             "group relative flex items-center gap-3",
                             "px-5 py-2.5",
-                            "font-mondwest text-[0.8rem] tracking-[0.12em]",
+                            "font-mondwest text-[0.8rem] tracking-[0.12em] uppercase",
                             "whitespace-nowrap transition-colors cursor-pointer",
                             "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-midground",
                             isActive
@@ -599,7 +599,7 @@ function SidebarSystemActions({ onNavigate }: { onNavigate: () => void }) {
                 className={cn(
                   "group relative flex w-full items-center gap-3",
                   "px-5 py-1.5",
-                  "font-mondwest text-[0.75rem] tracking-[0.1em]",
+                  "font-mondwest text-[0.75rem] tracking-[0.1em] uppercase",
                   "text-left whitespace-nowrap transition-opacity cursor-pointer",
                   "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-midground",
                   busy

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -604,8 +604,8 @@ export default function ChatPage() {
   //     model badge, tool-call list, model picker. Best-effort: if the
   //     sidecar fails to connect the terminal pane keeps working.
   //
-  // `normal-case` opts out of the dashboard's global `uppercase` rule on
-  // the root `<div>` in App.tsx — terminal output must preserve case.
+  // `normal-case` remains here as a local guard for terminal output; the
+  // dashboard shell itself preserves content casing.
   //
   // Mobile model/tools sheet is portaled to `document.body` so it stacks
   // above the app sidebar (`z-50`) and mobile chrome (`z-40`).  The main


### PR DESCRIPTION
## Summary
- remove the inherited uppercase transform from the dashboard shell so normal content keeps its original casing
- keep intentional uppercase styling on sidebar navigation and system action labels
- update the embedded chat comment now that shell casing is preserved globally

Fixes #16416

## Verification
- npm ci
- npx tsc -b
- npx vite build

Note: npm run build is blocked on Windows by the existing Unix-style prebuild asset script (rm/cp). npm run lint is currently blocked by unrelated pre-existing dashboard lint errors.