### PR TITLE
perf(tui): lazily seed virtual history heights

### DIFF
--- a/ui-tui/src/__tests__/useVirtualHistoryHeights.test.ts
+++ b/ui-tui/src/__tests__/useVirtualHistoryHeights.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { ensureVirtualItemHeight } from '../hooks/useVirtualHistory.js'
+
+describe('ensureVirtualItemHeight', () => {
+  it('reuses cached heights without invoking the estimator', () => {
+    const heights = new Map([['a', 7]])
+    const estimateHeight = vi.fn(() => 99)
+
+    expect(ensureVirtualItemHeight(heights, 'a', 0, 4, estimateHeight)).toBe(7)
+    expect(estimateHeight).not.toHaveBeenCalled()
+    expect(heights.get('a')).toBe(7)
+  })
+
+  it('lazily seeds missing heights from the estimator', () => {
+    const heights = new Map<string, number>()
+    const estimateHeight = vi.fn((index: number) => 10 + index)
+
+    expect(ensureVirtualItemHeight(heights, 'b', 2, 4, estimateHeight)).toBe(12)
+    expect(estimateHeight).toHaveBeenCalledTimes(1)
+    expect(estimateHeight).toHaveBeenCalledWith(2, 'b')
+    expect(heights.get('b')).toBe(12)
+  })
+
+  it('falls back to the default estimate when no estimator is provided', () => {
+    const heights = new Map<string, number>()
+
+    expect(ensureVirtualItemHeight(heights, 'c', 0, 4)).toBe(4)
+    expect(heights.get('c')).toBe(4)
+  })
+
+  it('normalizes non-positive estimates to a minimum of one row', () => {
+    const heights = new Map<string, number>()
+    const estimateHeight = vi.fn(() => 0)
+
+    expect(ensureVirtualItemHeight(heights, 'd', 0, 0, estimateHeight)).toBe(1)
+    expect(heights.get('d')).toBe(1)
+  })
+})

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -218,23 +218,15 @@ export function useMainApp(gw: GatewayClient) {
     return cache
   }, [heightCacheKey])
 
-  const initialHeights = useMemo(() => {
-    const out = new Map<string, number>()
-
-    for (const row of virtualRows) {
-      out.set(
-        row.key,
-        heightCache.get(row.key) ??
-          estimatedMsgHeight(row.msg, cols, {
-            compact: ui.compact,
-            details: detailsVisible,
-            limitHistory: row.index < virtualRows.length - FULL_RENDER_TAIL_ITEMS
-          })
-      )
-    }
-
-    return out
-  }, [cols, detailsVisible, heightCache, ui.compact, virtualRows])
+  const estimateRowHeight = useCallback(
+    (index: number) =>
+      estimatedMsgHeight(virtualRows[index]!.msg, cols, {
+        compact: ui.compact,
+        details: detailsVisible,
+        limitHistory: index < virtualRows.length - FULL_RENDER_TAIL_ITEMS
+      }),
+    [cols, detailsVisible, ui.compact, virtualRows]
+  )
 
   const syncHeightCache = useCallback(
     (heights: ReadonlyMap<string, number>) => {
@@ -250,7 +242,8 @@ export function useMainApp(gw: GatewayClient) {
   )
 
   const virtualHistory = useVirtualHistory(scrollRef, virtualRows, cols, {
-    initialHeights,
+    estimateHeight: estimateRowHeight,
+    initialHeights: heightCache,
     liveTailActive: turnLiveTailActive,
     onHeightsChange: syncHeightCache
   })

--- a/ui-tui/src/hooks/useVirtualHistory.ts
+++ b/ui-tui/src/hooks/useVirtualHistory.ts
@@ -76,12 +76,32 @@ export const shouldSetVirtualClamp = ({
   viewportHeight: number
 }) => itemCount > 0 && viewportHeight > 0 && !sticky && !liveTailActive
 
+export const ensureVirtualItemHeight = (
+  heights: Map<string, number>,
+  key: string,
+  index: number,
+  estimate: number,
+  estimateHeight?: (index: number, key: string) => number
+) => {
+  const cached = heights.get(key)
+
+  if (cached !== undefined) {
+    return Math.max(1, Math.floor(cached))
+  }
+
+  const seeded = Math.max(1, Math.floor(estimateHeight?.(index, key) ?? estimate))
+  heights.set(key, seeded)
+
+  return seeded
+}
+
 export function useVirtualHistory(
   scrollRef: RefObject<ScrollBoxHandle | null>,
   items: readonly { key: string }[],
   columns: number,
   {
     estimate = ESTIMATE,
+    estimateHeight,
     initialHeights,
     liveTailActive = false,
     onHeightsChange,
@@ -208,7 +228,7 @@ export function useVirtualHistory(
     arr[0] = 0
 
     for (let i = 0; i < n; i++) {
-      arr[i + 1] = arr[i]! + Math.max(1, Math.floor(heights.current.get(items[i]!.key) ?? estimate))
+      arr[i + 1] = arr[i]! + ensureVirtualItemHeight(heights.current, items[i]!.key, i, estimate, estimateHeight)
     }
 
     offsetsCache.current = { arr, n, version: offsetVersion.current }
@@ -280,7 +300,7 @@ export function useVirtualHistory(
     let coverage = 0
 
     for (let i = start; i < end; i++) {
-      coverage += heights.current.get(items[i]!.key) ?? PESSIMISTIC
+      coverage += ensureVirtualItemHeight(heights.current, items[i]!.key, i, PESSIMISTIC, estimateHeight)
     }
 
     if (sticky) {
@@ -288,13 +308,13 @@ export function useVirtualHistory(
 
       while (start > minStart && coverage < needed) {
         start--
-        coverage += heights.current.get(items[start]!.key) ?? PESSIMISTIC
+        coverage += ensureVirtualItemHeight(heights.current, items[start]!.key, start, PESSIMISTIC, estimateHeight)
       }
     } else {
       const maxEnd = Math.min(n, start + maxMounted)
 
       while (end < maxEnd && coverage < needed) {
-        coverage += heights.current.get(items[end]!.key) ?? PESSIMISTIC
+        coverage += ensureVirtualItemHeight(heights.current, items[end]!.key, end, PESSIMISTIC, estimateHeight)
         end++
       }
     }
@@ -498,6 +518,7 @@ interface MeasuredNode {
 interface VirtualHistoryOptions {
   coldStartCount?: number
   estimate?: number
+  estimateHeight?: (index: number, key: string) => number
   initialHeights?: ReadonlyMap<string, number>
   liveTailActive?: boolean
   maxMounted?: number


### PR DESCRIPTION
## Summary
- stop rebuilding a full `initialHeights` `Map` for every transcript row on every `useMainApp()` render
- lazily seed missing virtual-history heights inside `useVirtualHistory()` from an estimate callback
- add focused tests for the new lazy-seeding helper

## Problem
The TUI already has transcript virtualization, markdown caching, and measured-height caching, but `useMainApp()` was still doing one avoidable O(n) allocation-heavy step on every render:

- build a fresh `Map<string, number>` covering **every** transcript row
- look up cached heights or recompute `estimatedMsgHeight()` for misses
- pass that freshly-built map straight into `useVirtualHistory()`

That work happened even though `useVirtualHistory()` already walks the full item list internally to build offsets. In long sessions, that meant each React render paid an extra full-transcript scan plus a large temporary `Map` allocation before the hook could do its own work.

## Root cause
We were materializing the full initial-height snapshot in `useMainApp()` instead of letting the virtualization layer seed missing heights on demand.

Concretely, the old path did this on every render:

- iterate `virtualRows`
- allocate a new `Map`
- fill every row entry from `heightCache` or `estimatedMsgHeight(...)`

The virtualization hook only needed:
- a stable cache bucket for known heights
- a way to estimate a height when an item is missing from that bucket

## What changed
### 1. `useMainApp()`
Replaced the eager `initialHeights` `useMemo()` map build with:
- the existing stable `heightCache` bucket passed directly as `initialHeights`
- a new `estimateRowHeight(index)` callback passed as `estimateHeight`

### 2. `useVirtualHistory()`
Added `ensureVirtualItemHeight()` and used it when:
- building offsets
- computing viewport coverage / overscan coverage

That helper:
- reuses cached heights when present
- lazily seeds a missing height from `estimateHeight(index, key)`
- falls back to the numeric default estimate when no callback is provided
- normalizes values to at least 1 row

## Why this is safe
This does **not** change the measured-height lifecycle:
- mounted rows still replace estimates with actual Yoga-measured heights
- `onHeightsChange` still syncs measured heights back into the per-session bucket
- width-bucket invalidation still works the same way
- the hook still owns offset construction and range coverage logic

This is a refactor of where missing estimates are materialized, not a behavior change to how row heights are ultimately measured.

## Validation
### Focused tests added
- `ui-tui/src/__tests__/useVirtualHistoryHeights.test.ts`
  - reuses cached heights without invoking the estimator
  - lazily seeds missing heights from the estimator
  - falls back to the default estimate
  - clamps non-positive estimates to a minimum of 1 row

### Full validation run
From `ui-tui/`:

```bash
npm test -- --run src/__tests__/useVirtualHistoryHeights.test.ts src/__tests__/virtualHistoryClamp.test.ts src/__tests__/virtualHeights.test.ts
npm run type-check
npm test
npm run build
```

Results:
- targeted vitest suite: passed
- `npm run type-check`: passed
- full `ui-tui` vitest suite: **45 files / 370 tests passed**
- production build: passed

### Synthetic microbenchmark
I also ran a small local Node microbenchmark to quantify the exact work removed: rebuilding a 10k-entry `initialHeights` map 200 times versus reusing the existing cache bucket.

Observed locally:

```json
{"label":"old-build-initial-heights-map","ms":238.15,"heapDeltaKB":355,"lastSize":10000}
{"label":"new-pass-existing-cache-only","ms":0.01,"heapDeltaKB":0,"lastSize":6666}
```

This benchmark is synthetic and intentionally narrow: it measures only the removed eager map-build/allocation step, not whole-app frame time. But it does confirm that the deleted work was non-trivial and allocation-heavy.

## Why this helps
For long transcripts, this removes a full-transcript allocation/scanning pass from the hot render path in `useMainApp()`. That should reduce:
- React-side render overhead during transcript updates
- temporary heap churn from large per-render `Map` allocations
- avoidable repeated `estimatedMsgHeight()` work for rows that never needed eager materialization

## Scope
Focused perf cleanup only:
- no UX/behavior changes intended
- no protocol changes
- no Python/gateway changes
- no markdown/rendering semantics changes
