### PR TITLE
fix(gateway): coerce tool_progress_command as a real boolean

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7155,7 +7155,10 @@ class GatewayRunner:
             if config_path.exists():
                 with open(config_path, encoding="utf-8") as f:
                     user_config = yaml.safe_load(f) or {}
-            gate_enabled = user_config.get("display", {}).get("tool_progress_command", False)
+            gate_enabled = is_truthy_value(
+                user_config.get("display", {}).get("tool_progress_command"),
+                default=False,
+            )
         except Exception:
             gate_enabled = False
 
@@ -9593,7 +9596,10 @@ class GatewayRunner:
                             tool_progress_hint_gateway,
                         )
                         _cfg = _load_gateway_config()
-                        gate_on = bool(_cfg.get("display", {}).get("tool_progress_command", False))
+                        gate_on = is_truthy_value(
+                            _cfg.get("display", {}).get("tool_progress_command"),
+                            default=False,
+                        )
                         if gate_on and not is_seen(_cfg, TOOL_PROGRESS_FLAG):
                             long_tool_hint_fired[0] = True
                             progress_queue.put(tool_progress_hint_gateway())

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -19,6 +19,8 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from typing import Any
 
+from utils import is_truthy_value
+
 # prompt_toolkit is an optional CLI dependency — only needed for
 # SlashCommandCompleter and SlashCommandAutoSuggest.  Gateway and test
 # environments that lack it must still be able to import this module
@@ -353,7 +355,7 @@ def _resolve_config_gates() -> set[str]:
             else:
                 val = None
                 break
-        if val:
+        if is_truthy_value(val, default=False):
             result.add(cmd.name)
     return result
 

--- a/tests/gateway/test_verbose_command.py
+++ b/tests/gateway/test_verbose_command.py
@@ -86,6 +86,25 @@ class TestVerboseCommand:
         assert saved["display"]["platforms"]["telegram"]["tool_progress"] == "verbose"
 
     @pytest.mark.asyncio
+    async def test_quoted_false_keeps_command_disabled(self, tmp_path, monkeypatch):
+        """Quoted false must not enable the /verbose gateway command."""
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            'display:\n  tool_progress_command: "false"\n  tool_progress: all\n',
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+        runner = _make_runner()
+        result = await runner._handle_verbose_command(_make_event())
+
+        assert "not enabled" in result.lower()
+        assert "tool_progress_command" in result
+
+    @pytest.mark.asyncio
     async def test_cycles_through_all_modes(self, tmp_path, monkeypatch):
         """Calling /verbose repeatedly cycles through all four modes."""
         hermes_home = tmp_path / "hermes"

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -405,6 +405,21 @@ class TestGatewayConfigGate:
         joined = "\n".join(lines)
         assert "`/verbose" in joined
 
+    def test_config_gate_quoted_false_stays_disabled_everywhere(self, tmp_path, monkeypatch):
+        """Quoted false must not enable config-gated gateway commands."""
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text('display:\n  tool_progress_command: "false"\n')
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        lines = gateway_help_lines()
+        joined = "\n".join(lines)
+        names = {name for name, _ in telegram_bot_commands()}
+        mapping = slack_subcommand_map()
+
+        assert "`/verbose" not in joined
+        assert "verbose" not in names
+        assert "verbose" not in mapping
+
     def test_config_gate_excluded_from_telegram_when_off(self, tmp_path, monkeypatch):
         config_file = tmp_path / "config.yaml"
         config_file.write_text("display:\n  tool_progress_command: false\n")


### PR DESCRIPTION
Summary:
This fixes a config-gating bug where `display.tool_progress_command: "false"` could be treated as truthy in gateway-facing command paths.

What changed:
- switched config-gated command resolution to shared boolean coercion
- applied the same coercion in the gateway `/verbose` handler
- applied the same coercion to the tool-progress onboarding gate
- added regression coverage for quoted `"false"` values in both command-surface and runtime paths

Why this matters:
Quoted booleans can appear through manual YAML edits or env-expanded config values. Before this change, `"false"` could incorrectly enable `/verbose` in gateway help/menu surfaces and at runtime. This patch makes the gate behavior consistent with the intended boolean semantics.

Validation:
- 137 passed
