### PR TITLE
fix: only set HERMES_INTERACTIVE when stdin/stdout are real terminals

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -11011,9 +11011,13 @@ def main(
     """
     global _active_worktree
 
-    # Signal to terminal_tool that we're in interactive mode
-    # This enables interactive sudo password prompts with timeout
-    os.environ["HERMES_INTERACTIVE"] = "1"
+    # Signal to terminal_tool that we're in interactive mode.
+    # Only set when both stdin and stdout are real terminals — not pipes
+    # used by automated callers (hermes chat -q, Paperclip heartbeats, cron, etc.).
+    # This prevents sudo password prompts and approval prompts in non-interactive
+    # contexts where no user is present to respond.
+    if sys.stdin.isatty() and sys.stdout.isatty():
+        os.environ["HERMES_INTERACTIVE"] = "1"
     
     # Handle gateway mode (messaging + cron)
     if gateway:

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -158,12 +158,16 @@ def load_hermes_dotenv(
     project_env_path = Path(project_env) if project_env else None
 
     # Fix corrupted .env files before python-dotenv parses them (#8908).
-    if user_env.exists():
+    try:
+        env_exists = user_env.exists()
+    except PermissionError:
+        env_exists = False
+    if env_exists:
         _sanitize_env_file_if_needed(user_env)
     if project_env_path and project_env_path.exists():
         _sanitize_env_file_if_needed(project_env_path)
 
-    if user_env.exists():
+    if env_exists:
         _load_dotenv_with_fallback(user_env, override=True)
         loaded.append(user_env)
 

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -87,3 +87,21 @@ def test_main_import_applies_user_env_over_shell_values(tmp_path, monkeypatch):
 
     assert os.getenv("OPENAI_BASE_URL") == "https://new.example/v1"
     assert os.getenv("HERMES_INFERENCE_PROVIDER") == "custom"
+
+
+def test_env_loader_permission_error_is_graceful(tmp_path):
+    """PermissionError when reading .hermes/ dir should not crash (container fix)."""
+    home = tmp_path / "hermes"
+    home.mkdir()
+    env_file = home / ".env"
+    env_file.write_text("OPENAI_API_KEY=test\n", encoding="utf-8")
+    # Simulate root-owned .hermes dir that non-root user can't read
+    # (common in container setups)
+    home.chmod(0o000)
+
+    try:
+        # Should not raise PermissionError
+        loaded = load_hermes_dotenv(hermes_home=home)
+        assert loaded == []
+    finally:
+        home.chmod(0o755)  # cleanup so tmp_path can be removed

--- a/tests/hermes_cli/test_interactive_detection.py
+++ b/tests/hermes_cli/test_interactive_detection.py
@@ -1,0 +1,67 @@
+"""Tests for PR #16529: HERMES_INTERACTIVE gated behind isatty() checks."""
+
+import os
+import sys
+
+import pytest
+
+
+def test_hermes_interactive_not_set_when_piped(monkeypatch):
+    """HERMES_INTERACTIVE must not be set when stdin/stdout are pipes."""
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: False)
+    os.environ.pop("HERMES_INTERACTIVE", None)
+
+    # Replicate the exact guard introduced in cli.py main()
+    if sys.stdin.isatty() and sys.stdout.isatty():
+        os.environ["HERMES_INTERACTIVE"] = "1"
+
+    assert os.environ.get("HERMES_INTERACTIVE") is None, (
+        "HERMES_INTERACTIVE should NOT be set when stdin/stdout are pipes"
+    )
+
+
+def test_hermes_interactive_set_when_tty(monkeypatch):
+    """HERMES_INTERACTIVE should still be set when stdin/stdout are real terminals."""
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+    os.environ.pop("HERMES_INTERACTIVE", None)
+
+    if sys.stdin.isatty() and sys.stdout.isatty():
+        os.environ["HERMES_INTERACTIVE"] = "1"
+
+    assert os.environ.get("HERMES_INTERACTIVE") == "1", (
+        "HERMES_INTERACTIVE should be set when stdin/stdout are real terminals"
+    )
+
+
+def test_hermes_interactive_not_set_when_stdin_piped_only(monkeypatch):
+    """Only stdin piped (stdout tty) — should still NOT set interactive."""
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+    os.environ.pop("HERMES_INTERACTIVE", None)
+
+    if sys.stdin.isatty() and sys.stdout.isatty():
+        os.environ["HERMES_INTERACTIVE"] = "1"
+
+    assert os.environ.get("HERMES_INTERACTIVE") is None, (
+        "HERMES_INTERACTIVE should NOT be set when only stdout is a TTY"
+    )
+
+
+@pytest.mark.parametrize("stdin_tty,stdout_tty,expected", [
+    (True, True, "1"),
+    (True, False, None),
+    (False, True, None),
+    (False, False, None),
+])
+def test_interactive_flag_matrix(monkeypatch, stdin_tty, stdout_tty, expected):
+    """Full truth table: HERMES_INTERACTIVE only when BOTH stdin and stdout are TTYs."""
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: stdin_tty)
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: stdout_tty)
+    os.environ.pop("HERMES_INTERACTIVE", None)
+
+    if sys.stdin.isatty() and sys.stdout.isatty():
+        os.environ["HERMES_INTERACTIVE"] = "1"
+
+    assert os.environ.get("HERMES_INTERACTIVE") == expected


### PR DESCRIPTION
## What does this PR do?

In containerized/automated contexts (Docker, Paperclip integrations, cron), Hermes Agent is invoked via `hermes chat -q` with piped stdin/stdout. The CLI unconditionally set `HERMES_INTERACTIVE=1`, which triggers sudo password prompts and approval prompts even when no user is present. Each prompt waits 45s before timing out, causing slow/failing automated runs. This PR gates `HERMES_INTERACTIVE=1` behind `sys.stdin.isatty() && sys.stdout.isatty()`, and adds PermissionError handling for `~/.hermes/.env` reads in non-root container setups.

## Related Issue

Fixes #17575

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cli.py` — `main()`:
  - `HERMES_INTERACTIVE=1` is now only set when both `sys.stdin.isatty()` and `sys.stdout.isatty()` return True
  - Piped/automated callers (e.g., `hermes chat -q`, Paperclip heartbeats, cron) no longer trigger interactive prompts
- `hermes_cli/env_loader.py` — `load_hermes_dotenv()`:
  - Wrapped `user_env.exists()` in try/except PermissionError to prevent crashes when `~/.hermes/.env` is unreadable (common in non-root container setups)
- `tests/hermes_cli/test_env_loader.py` — added `test_env_loader_permission_error_is_graceful`
- `tests/hermes_cli/test_interactive_detection.py` — new: 7 test cases covering isatty truth table

## How to Test

1. `echo 'hello' | hermes chat -q` — no approval/sudo prompts, runs to completion
2. `hermes` (interactive TTY) — prompts still work, HERMES_INTERACTIVE=1 is set
3. Run as non-root user with `~/.hermes/` having permissions 000 — no PermissionError crash
4. Run via Paperclip adapter heartbeat — no 45s timeout stalls

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian 13 (Docker)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — this is a bug fix, not a new skill.

## Screenshots / Logs

N/A — no UI changes