### PR TITLE
fix(acp): replay text history on session load

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -403,9 +403,28 @@ class HermesACPAgent(acp.Agent):
             logger.warning("load_session: session %s not found", session_id)
             return None
         await self._register_session_mcp_servers(state, mcp_servers)
+        await self._replay_session_history(state)
         logger.info("Loaded session %s", session_id)
         self._schedule_available_commands_update(session_id)
         return LoadSessionResponse(models=self._build_model_state(state))
+
+    async def _replay_session_history(self, state: SessionState) -> None:
+        """Replay text conversation history to the ACP client during session/load."""
+        if not self._conn:
+            return
+
+        for msg in state.history:
+            role = msg.get("role")
+            content = msg.get("content")
+            if not isinstance(content, str) or not content:
+                continue
+            if role == "user":
+                update = acp.update_user_message_text(content)
+            elif role == "assistant":
+                update = acp.update_agent_message_text(content)
+            else:
+                continue
+            await self._conn.session_update(session_id=state.session_id, update=update)
 
     async def resume_session(
         self,

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -225,6 +225,77 @@ class TestSessionOps:
         assert resp is None
 
     @pytest.mark.asyncio
+    async def test_load_session_replays_text_history_before_returning(self, agent):
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        new_resp = await agent.new_session(cwd="/tmp/project")
+        state = agent.session_manager.get_session(new_resp.session_id)
+        state.history.extend([
+            {"role": "user", "content": "What changed in the parser?"},
+            {"role": "assistant", "content": "The parser now accepts nested arrays."},
+        ])
+        agent.session_manager.save_session(new_resp.session_id)
+        mock_conn.session_update.reset_mock()
+
+        resp = await agent.load_session(cwd="/tmp/project", session_id=new_resp.session_id)
+
+        assert isinstance(resp, LoadSessionResponse)
+        assert mock_conn.session_update.await_count == 2
+        updates = [call.kwargs["update"] for call in mock_conn.session_update.await_args_list]
+        assert updates[0].session_update == "user_message_chunk"
+        assert updates[0].content.text == "What changed in the parser?"
+        assert updates[1].session_update == "agent_message_chunk"
+        assert updates[1].content.text == "The parser now accepts nested arrays."
+
+    @pytest.mark.asyncio
+    async def test_load_session_restores_history_for_next_prompt(self, tmp_path):
+        db = SessionDB(tmp_path / "state.db")
+        first_manager = SessionManager(agent_factory=lambda: MagicMock(name="FirstAgent"), db=db)
+        original = first_manager.create_session(cwd="/tmp/project")
+        original_history = [
+            {"role": "user", "content": "Yesterday I told you the parser accepts TOML."},
+            {"role": "assistant", "content": "I will remember that parser detail."},
+        ]
+        original.history.extend(original_history)
+        first_manager.save_session(original.session_id)
+
+        db.close()
+        restored_db = SessionDB(tmp_path / "state.db")
+        second_manager = SessionManager(agent_factory=lambda: MagicMock(name="RestoredAgent"), db=restored_db)
+        acp_agent = HermesACPAgent(session_manager=second_manager)
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        acp_agent._conn = mock_conn
+
+        resp = await acp_agent.load_session(cwd="/tmp/project", session_id=original.session_id)
+
+        assert isinstance(resp, LoadSessionResponse)
+        replayed = [call.kwargs["update"] for call in mock_conn.session_update.await_args_list]
+        assert [update.content.text for update in replayed] == [
+            "Yesterday I told you the parser accepts TOML.",
+            "I will remember that parser detail.",
+        ]
+
+        restored = second_manager.get_session(original.session_id)
+        assert restored.history == original_history
+        restored.agent.run_conversation = MagicMock(return_value={
+            "final_response": "You told me the parser accepts TOML.",
+            "messages": original_history + [
+                {"role": "user", "content": "Do you remember what I told you yesterday?"},
+                {"role": "assistant", "content": "You told me the parser accepts TOML."},
+            ],
+        })
+        mock_conn.session_update.reset_mock()
+
+        prompt = [TextContentBlock(type="text", text="Do you remember what I told you yesterday?")]
+        await acp_agent.prompt(prompt=prompt, session_id=original.session_id)
+
+        restored.agent.run_conversation.assert_called_once()
+        assert restored.agent.run_conversation.call_args.kwargs["conversation_history"] == original_history
+
+    @pytest.mark.asyncio
     async def test_resume_session_creates_new_if_missing(self, agent):
         resume_resp = await agent.resume_session(cwd="/tmp", session_id="nonexistent")
         assert isinstance(resume_resp, ResumeSessionResponse)


### PR DESCRIPTION
## Summary

This is a small, text-history-focused fix for #12285.

`session/load` already restores the server-side ACP session state, but it did not replay restored conversation history back to the ACP client. As a result, editor clients can load an existing session whose history is present in Hermes, while their UI still shows an empty thread.

This patch replays restored text `user` and `assistant` messages during `load_session` using ACP `session_update` notifications.

## Scope

This intentionally keeps the first fix minimal:

- Replay text-only `user` messages as `user_message_chunk`
- Replay text-only `assistant` messages as `agent_message_chunk`
- Skip empty, non-string, and unsupported roles/content
- Leave tool calls, thought/reasoning chunks, and multimodal/multipart content for follow-up work

There is a larger open PR, #14691, that aims to implement richer replay including tools/reasoning, but it is currently conflicting and broader in scope. This PR is intended as a smaller unblocker for the common text-history case.

## Tests

Added regression coverage for both the protocol replay and the follow-up prompt context path:

- `test_load_session_replays_text_history_before_returning`
  - verifies `load_session` emits `user_message_chunk` and `agent_message_chunk` for existing text history.
- `test_load_session_restores_history_for_next_prompt`
  - simulates a cold restore from `SessionDB`, loads the previous session, verifies ACP replay, then prompts with "Do you remember what I told you yesterday?" and asserts the restored history is passed as `conversation_history`.

Ran locally:

```bash
git diff --check
$HOME/.hermes/hermes-agent/venv/bin/python -m pytest \
  tests/acp/test_server.py::TestSessionOps::test_load_session_replays_text_history_before_returning \
  tests/acp/test_server.py::TestSessionOps::test_load_session_restores_history_for_next_prompt \
  -q -o 'addopts='
$HOME/.hermes/hermes-agent/venv/bin/python -m pytest \
  tests/acp/test_server.py::TestSessionOps \
  tests/acp/test_server.py::TestPrompt \
  tests/acp/test_session.py::TestPersistence \
  -q -o 'addopts='
```

Results:

```text
2 passed
36 passed
```

## Tested platform

- macOS
- Python from local Hermes development environment

Fixes #12285.
