### PR TITLE
test(web_server): skip host-header tests when fastapi/uvicorn absent

### DIFF
--- a/tests/hermes_cli/test_web_server_host_header.py
+++ b/tests/hermes_cli/test_web_server_host_header.py
@@ -14,17 +14,19 @@ from pathlib import Path
 
 import pytest
 
-_repo = str(Path(__file__).resolve().parents[1])
+_repo = str(Path(__file__).resolve().parents[2])
 if _repo not in sys.path:
     sys.path.insert(0, _repo)
 
-# hermes_cli.web_server raises SystemExit at import time when fastapi/uvicorn
-# are absent.  Catch it here so the collection phase doesn't abort; the
-# pytestmark below then skips every test in this module.
+# hermes_cli.web_server raises SystemExit at import time when fastapi is absent
+# (it converts the underlying ImportError into a SystemExit with an install hint).
+# Catch only SystemExit here so the collection phase doesn't abort on missing
+# soft deps; a real ImportError elsewhere in the import chain (e.g. a regression
+# in hermes_cli.config or gateway.status) should still propagate as a hard error.
 try:
     import hermes_cli.web_server  # noqa: F401
     _WEB_SERVER_AVAILABLE = True
-except (ImportError, SystemExit):
+except SystemExit:
     _WEB_SERVER_AVAILABLE = False
 
 pytestmark = pytest.mark.skipif(

--- a/tests/hermes_cli/test_web_server_host_header.py
+++ b/tests/hermes_cli/test_web_server_host_header.py
@@ -18,6 +18,20 @@ _repo = str(Path(__file__).resolve().parents[1])
 if _repo not in sys.path:
     sys.path.insert(0, _repo)
 
+# hermes_cli.web_server raises SystemExit at import time when fastapi/uvicorn
+# are absent.  Catch it here so the collection phase doesn't abort; the
+# pytestmark below then skips every test in this module.
+try:
+    import hermes_cli.web_server  # noqa: F401
+    _WEB_SERVER_AVAILABLE = True
+except (ImportError, SystemExit):
+    _WEB_SERVER_AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(
+    not _WEB_SERVER_AVAILABLE,
+    reason="fastapi/uvicorn not installed",
+)
+
 
 class TestHostHeaderValidator:
     """Unit test the _is_accepted_host helper directly — cheaper and


### PR DESCRIPTION
## Summary
- Adds a module-level import probe in \`test_web_server_host_header.py\`
- Uses \`pytestmark\` to skip all 8 tests when fastapi/uvicorn are absent (instead of failing with SystemExit)

## The bug
\`hermes_cli.web_server\` raises \`SystemExit\` at module import time when \`fastapi\`/\`uvicorn\` are not installed. \`test_web_server_host_header.py\` imports directly from the module inside each test method, so on installs without the optional deps all 8 tests fail with:

\`\`\`
SystemExit: Web UI requires fastapi and uvicorn.
Install with: ... -m pip install 'fastapi' 'uvicorn[standard]'
\`\`\`

This masks the real test result and inflates CI failure counts alongside the unrelated baseline failures.

## The fix
A module-level try/except wraps the import probe once. The resulting \`_WEB_SERVER_AVAILABLE\` flag drives a \`pytestmark = pytest.mark.skipif(...)\` that applies to both \`TestHostHeaderValidator\` and \`TestHostHeaderMiddleware\`, converting the 8 failures into 8 clean skips.

The guard pattern is identical to the one used in \`test_web_server.py\` (see also #16518).

## Test plan
- [x] **Before**: 8 \`FAILED\` with \`SystemExit\` on env without fastapi
- [x] **After**: 8 \`SKIPPED\` cleanly; no failures
- [x] **Regression guard**: removed the try/except → observed 8 failures with SystemExit; restored → 0 failures
- [x] Adjacent suites unchanged

## Related
- Companion to #16518 (same fix pattern, different test file)
- Introduced by 244ae6db1 which added \`test_web_server_host_header.py\` without a fastapi skip guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)