### PR TITLE
fix(weixin): avoid cross-loop send session reuse

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1128,6 +1128,7 @@ class WeixinAdapter(BasePlatformAdapter):
         self._typing_cache = TypingTicketCache()
         self._poll_session: Optional[aiohttp.ClientSession] = None
         self._send_session: Optional[aiohttp.ClientSession] = None
+        self._send_loop: Optional[asyncio.AbstractEventLoop] = None
         self._poll_task: Optional[asyncio.Task] = None
         self._dedup = MessageDeduplicator(ttl_seconds=MESSAGE_DEDUP_TTL_SECONDS)
 
@@ -1204,6 +1205,7 @@ class WeixinAdapter(BasePlatformAdapter):
 
         self._poll_session = aiohttp.ClientSession(trust_env=True, connector=_make_ssl_connector())
         self._send_session = aiohttp.ClientSession(trust_env=True, connector=_make_ssl_connector())
+        self._send_loop = asyncio.get_running_loop()
         self._token_store.restore(self._account_id)
         self._poll_task = asyncio.create_task(self._poll_loop(), name="weixin-poll")
         self._mark_connected()
@@ -1227,6 +1229,7 @@ class WeixinAdapter(BasePlatformAdapter):
         if self._send_session and not self._send_session.closed:
             await self._send_session.close()
         self._send_session = None
+        self._send_loop = None
         self._release_platform_lock()
         self._mark_disconnected()
         logger.info("[%s] Disconnected", self.name)
@@ -1982,7 +1985,21 @@ async def send_weixin_direct(
 
     live_adapter = _LIVE_ADAPTERS.get(resolved_token)
     send_session = getattr(live_adapter, '_send_session', None)
-    if live_adapter is not None and send_session is not None and not send_session.closed:
+    current_loop: Optional[asyncio.AbstractEventLoop]
+    try:
+        current_loop = asyncio.get_running_loop()
+    except RuntimeError:
+        current_loop = None
+    live_loop = getattr(live_adapter, '_send_loop', None)
+    same_loop_live_adapter = (
+        live_adapter is not None
+        and send_session is not None
+        and not send_session.closed
+        and live_loop is not None
+        and current_loop is live_loop
+        and not live_loop.is_closed()
+    )
+    if same_loop_live_adapter:
         last_result: Optional[SendResult] = None
         cleaned = live_adapter.format_message(message)
         if cleaned:
@@ -2006,6 +2023,11 @@ async def send_weixin_direct(
             "message_id": last_result.message_id if last_result else None,
             "context_token_used": bool(context_token),
         }
+    if live_adapter is not None and send_session is not None and not send_session.closed:
+        logger.debug(
+            "[Weixin] live adapter session exists for %s but is bound to a different event loop; using one-shot session fallback",
+            _safe_id(chat_id),
+        )
 
     async with aiohttp.ClientSession(trust_env=True, connector=_make_ssl_connector()) as session:
         adapter = WeixinAdapter(

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -308,6 +308,57 @@ class TestWeixinSendMessageIntegration:
             media_files=[("/tmp/demo.png", False)],
         )
 
+    def test_send_weixin_direct_skips_live_adapter_from_foreign_event_loop(self, monkeypatch, tmp_path):
+        class _FakeSessionContext:
+            async def __aenter__(self):
+                return object()
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        class _FakeAiohttp:
+            class ClientSession:
+                def __init__(self, *args, **kwargs):
+                    pass
+
+                async def __aenter__(self):
+                    return object()
+
+                async def __aexit__(self, exc_type, exc, tb):
+                    return False
+
+        foreign_loop = asyncio.new_event_loop()
+        live_adapter = type("LiveAdapter", (), {})()
+        live_adapter._send_session = type("SendSession", (), {"closed": False})()
+        live_adapter._send_loop = foreign_loop
+        live_adapter.format_message = lambda message: message
+        live_adapter.send = AsyncMock(side_effect=RuntimeError("Timeout context manager should be used inside a task"))
+
+        monkeypatch.setitem(weixin._LIVE_ADAPTERS, "bot-token", live_adapter)
+        monkeypatch.setattr(weixin, "aiohttp", _FakeAiohttp)
+        monkeypatch.setattr(weixin, "_make_ssl_connector", lambda: None)
+        monkeypatch.setattr(weixin, "get_hermes_home", lambda: tmp_path)
+        fallback_send = AsyncMock(return_value=SendResult(success=True, message_id="fallback-msg"))
+        monkeypatch.setattr(weixin.WeixinAdapter, "send", fallback_send)
+
+        try:
+            result = asyncio.run(
+                weixin.send_weixin_direct(
+                    extra={"account_id": "acct", "base_url": "https://weixin.example.com"},
+                    token="bot-token",
+                    chat_id="wxid_test123",
+                    message="hello",
+                )
+            )
+        finally:
+            weixin._LIVE_ADAPTERS.clear()
+            foreign_loop.close()
+
+        assert result["success"] is True
+        assert result["message_id"] == "fallback-msg"
+        live_adapter.send.assert_not_awaited()
+        fallback_send.assert_awaited_once()
+
 
 class TestWeixinChunkDelivery:
     def _connected_adapter(self) -> WeixinAdapter:


### PR DESCRIPTION
## Bug Description

Sending messages from Hermes to Weixin could fail intermittently when an async tool execution ran on a different event loop than the live Weixin adapter session.

## Root Cause

The live Weixin adapter kept a long-lived aiohttp send session, but `send_