### PR TITLE
feat(telegram): expose inline_keyboard via metadata.buttons in send()

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -967,6 +967,35 @@ class TelegramAdapter(BasePlatformAdapter):
         else:  # "first" (default)
             return chunk_index == 0
 
+    @staticmethod
+    def _build_reply_markup(metadata):
+        """Build an InlineKeyboardMarkup from `metadata.buttons` if present.
+
+        Schema (in metadata):
+            buttons: [{text, callback_data | url}, ...]            # flat -> 1 row
+            buttons: [[{text, callback_data | url}, ...], ...]     # grid -> N rows
+
+        Returns None if no buttons key (skill didn't request keyboard).
+        """
+        if not isinstance(metadata, dict):
+            return None
+        spec = metadata.get("buttons")
+        if not spec:
+            return None
+        rows = spec if isinstance(spec[0], list) else [spec]
+        from telegram import InlineKeyboardMarkup, InlineKeyboardButton
+        grid = []
+        for row in rows:
+            grid.append([
+                InlineKeyboardButton(
+                    text=b["text"],
+                    callback_data=b.get("callback_data"),
+                    url=b.get("url"),
+                )
+                for b in row if "text" in b
+            ])
+        return InlineKeyboardMarkup(grid) if grid else None
+
     async def send(
         self,
         chat_id: str,
@@ -985,6 +1014,7 @@ class TelegramAdapter(BasePlatformAdapter):
         try:
             # Format and split message if needed
             formatted = self.format_message(content)
+            reply_markup = self._build_reply_markup(metadata)
             chunks = self.truncate_message(
                 formatted, self.MAX_MESSAGE_LENGTH, len_fn=utf16_len,
             )
@@ -1019,6 +1049,9 @@ class TelegramAdapter(BasePlatformAdapter):
                 should_thread = self._should_thread_reply(reply_to, i)
                 reply_to_id = int(reply_to) if should_thread else None
                 effective_thread_id = self._message_thread_id_for_send(thread_id)
+                # Buttons attach to the LAST chunk only (avoids orphaned
+                # buttons on chunks 1..N-1 of multi-chunk messages).
+                effective_reply_markup = reply_markup if i == len(chunks) - 1 else None
 
                 msg = None
                 for _send_attempt in range(3):
@@ -1029,6 +1062,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                 chat_id=int(chat_id),
                                 text=chunk,
                                 parse_mode=ParseMode.MARKDOWN_V2,
+                                reply_markup=effective_reply_markup,
                                 reply_to_message_id=reply_to_id,
                                 message_thread_id=effective_thread_id,
                                 **self._link_preview_kwargs(),
@@ -1042,6 +1076,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                     chat_id=int(chat_id),
                                     text=plain_chunk,
                                     parse_mode=None,
+                                    reply_markup=effective_reply_markup,
                                     reply_to_message_id=reply_to_id,
                                     message_thread_id=effective_thread_id,
                                     **self._link_preview_kwargs(),


### PR DESCRIPTION
## What

Expose Telegram inline keyboards (`reply_markup`) to skills via the existing `metadata` dict on `send()`. Skills can now return drafts with tappable buttons instead of plain-text slash-commands.

## Why

Hermes 0.11 builds `InlineKeyboardMarkup` in 4 internal UI flows only:

- `send_update_prompt`
- `send_exec_approval`
- `send_model_picker`
- `/menu` pagination

There is **no public surface** for a skill to attach `reply_markup` to its output. Skills produce text → `format_message` → `send_message(text)` — buttons are dropped on the floor.

Confirmed via `grep` on `gateway/platforms/telegram.py` (3155 lines, main branch) — `InlineKeyboardMarkup` appears only inside Hermes' own internal flows, never exposed.

Live-tested 2026-04-27: bot+token+chat fully support inline keyboards at the Telegram API layer. Raw `sendMessage` with `reply_markup` payload renders 2 tappable buttons. The gap is purely Hermes routing.

This blocks user-facing skills like content drafters that want to surface `Ship 1` / `Ship 2` / `Regen` / `Skip` style CTAs as actual tappable buttons rather than `/slash-command` autocomplete.

## How

Single `_build_reply_markup` helper extracts a `buttons` field from the `metadata` dict and constructs `InlineKeyboardMarkup`. Invoked once at the top of `send()`, then attached to the LAST chunk only (avoids orphaned buttons on chunks 1..N-1).

### Schema

**Flat** (single row):
```json
{
  "buttons": [
    {"text": "Ship 1", "callback_data": "ship:1"},
    {"text": "Skip", "callback_data": "skip"}
  ]
}
```

**Grid** (multiple rows):
```json
{
  "buttons": [
    [
      {"text": "Ship 1", "callback_data": "ship:1"},
      {"text": "Ship 2", "callback_data": "ship:2"}
    ],
    [
      {"text": "Regen", "callback_data": "regen"},
      {"text": "Skip", "callback_data": "skip"}
    ]
  ]
}
```

A `url` field is also supported (opens external link instead of firing callback): `{"text": "Docs", "url": "https://example.com"}`.

### Skill usage (after merge)

```js
// content-pipeline skill: surface drafts with tappable Ship/Regen/Skip
module.exports.run = async (ctx) => {
  return {
    text: "📝 Drafts ready\n\n*Option 1*\n...\n\n*Option 2*\n...",
    metadata: {
      buttons: [
        [
          { text: "Ship 1", callback_data: "ship:1" },
          { text: "Ship 2", callback_data: "ship:2" }
        ],
        [
          { text: "Regen", callback_data: "regen" },
          { text: "Skip", callback_data: "skip" }
        ]
      ]
    }
  };
};
```

## Why metadata, not a signature change

- **Backwards compatible** — no caller has to update. `send(chat_id, content)` works identically.
- **Already plumbed** — `metadata: Optional[Dict[str, Any]]` is in the existing `send()` signature.
- **Skill-friendly** — `SkillResult.metadata` already supports arbitrary fields. No new API surface.
- **Future-proof** — same pattern can carry other reply-time options (e.g. `disable_notification`, `protect_content`).

## Behavior

- **Multi-chunk messages**: buttons attach to the LAST chunk only.
- **MarkdownV2 fallback**: buttons preserved (telegram-bot-api handles `reply_markup` independently of `parse_mode`).
- **Internal UI flows**: unchanged. `send_exec_approval` etc. build their own `InlineKeyboardMarkup` directly. The new public path is additive.
- **No buttons in metadata**: behaves identically to current code (`reply_markup=None` is python-telegram-bot's default).

## Test plan

- [x] AST parse passes
- [x] Patch applies cleanly to main (5/5 anchor matches)
- [ ] Reviewer-verified: send a SkillResult with `metadata.buttons` → 2 tappable buttons render in Telegram
- [ ] Reviewer-verified: send a long message that splits into 2 chunks with buttons → buttons attach to chunk 2/2 only
- [ ] Reviewer-verified: send a message with intentionally bad MarkdownV2 → strip-fallback fires, buttons still attach

## Companion follow-up

`feat(skills): SkillResult.on_callback hook for CallbackQuery dispatch` — wires the user-tap event back to the skill that produced the buttons. Without it, callbacks fire but are dropped. This PR enables RENDERING; CALLBACK routing is the natural follow-up.

Until then, skills can use slash-commands (registered via `setMyCommands`) which the chat input pipeline already routes — but they don't render as buttons.

## Discovery context

Surfaced during a multi-agent audit of a personal Hermes deployment: protocol-cto SOUL instructed the model to emit `/ship 1` / `/ship 2` / `/regen` / `/skip` as "tappable" CTAs. They render as plain text. Source-checking `gateway/platforms/telegram.py` revealed the architectural gap that this PR closes.

Audit report (15-agent CCGM, finding `claude-telegram-02`): https://github.com/[user]/spawner/blob/main/.planning/audits/audit-2026-04-27-bot-stack-telegram-final.md (link will resolve once that repo is public).
