### PR TITLE
fix(provider): tighten azure endpoint host detection

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -868,7 +868,7 @@ def resolve_runtime_provider(
     # return provider="custom" with chat_completions api_mode and no valid key).
     # Instead, use the Azure key directly with anthropic_messages api_mode.
     _eff_base = (explicit_base_url or "").strip()
-    if requested_provider == "anthropic" and "azure.com" in _eff_base:
+    if requested_provider == "anthropic" and base_url_host_matches(_eff_base, "azure.com"):
         _azure_key = (
             (explicit_api_key or "").strip()
             or os.getenv("AZURE_ANTHROPIC_KEY", "").strip()
@@ -1091,8 +1091,8 @@ def resolve_runtime_provider(
         # would find the Claude Code OAuth token first (priority 3) and return
         # that instead, causing 401s. Detect Azure endpoints and use the env
         # key directly to bypass the OAuth priority chain.
-        _is_azure_endpoint = "azure.com" in base_url.lower() or (
-            cfg_base_url and "azure.com" in cfg_base_url.lower()
+        _is_azure_endpoint = base_url_host_matches(base_url, "azure.com") or (
+            bool(cfg_base_url) and base_url_host_matches(cfg_base_url, "azure.com")
         )
         if _is_azure_endpoint:
             token = (

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1587,6 +1587,76 @@ class TestAzureFoundryResolution:
             "default": "gpt-4.1",
         }
 
+    def test_explicit_azure_base_url_path_injection_does_not_trigger_azure_short_circuit(self, monkeypatch):
+        """azure.com in the path must not trigger Azure key routing."""
+        import agent.anthropic_adapter as anthropic_adapter
+
+        monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "anthropic")
+        monkeypatch.setattr(rp, "_get_model_config", lambda: {"provider": "anthropic"})
+        monkeypatch.setattr(rp, "load_pool", lambda provider: None)
+        monkeypatch.setattr(rp, "_resolve_named_custom_runtime", lambda **kwargs: None)
+        monkeypatch.setattr(rp, "_resolve_explicit_runtime", lambda **kwargs: None)
+        monkeypatch.setattr(anthropic_adapter, "resolve_anthropic_token", lambda: "anthropic-token")
+        monkeypatch.setenv("AZURE_ANTHROPIC_KEY", "azure-secret-should-not-leak")
+
+        resolved = rp.resolve_runtime_provider(
+            requested="anthropic",
+            explicit_base_url="https://proxy.example.test/azure.com/v1",
+        )
+
+        assert resolved["provider"] == "anthropic"
+        assert resolved["api_key"] == "anthropic-token"
+        assert "azure-secret" not in resolved["api_key"]
+
+    def test_explicit_azure_lookalike_host_does_not_trigger_azure_short_circuit(self, monkeypatch):
+        """azure.com.attacker.test is not an Azure host."""
+        import agent.anthropic_adapter as anthropic_adapter
+
+        monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "anthropic")
+        monkeypatch.setattr(rp, "_get_model_config", lambda: {"provider": "anthropic"})
+        monkeypatch.setattr(rp, "load_pool", lambda provider: None)
+        monkeypatch.setattr(rp, "_resolve_named_custom_runtime", lambda **kwargs: None)
+        monkeypatch.setattr(rp, "_resolve_explicit_runtime", lambda **kwargs: None)
+        monkeypatch.setattr(anthropic_adapter, "resolve_anthropic_token", lambda: "anthropic-token")
+        monkeypatch.setenv("AZURE_ANTHROPIC_KEY", "azure-secret-should-not-leak")
+
+        resolved = rp.resolve_runtime_provider(
+            requested="anthropic",
+            explicit_base_url="https://azure.com.attacker.test/v1",
+        )
+
+        assert resolved["provider"] == "anthropic"
+        assert resolved["api_key"] == "anthropic-token"
+        assert "azure-secret" not in resolved["api_key"]
+
+    def test_explicit_genuine_azure_host_uses_azure_key(self, monkeypatch):
+        """Explicit azure.com host should still use Azure key routing."""
+        monkeypatch.setenv("AZURE_ANTHROPIC_KEY", "az-key")
+
+        resolved = rp.resolve_runtime_provider(
+            requested="anthropic",
+            explicit_base_url="https://azure.com/foundry/v1",
+        )
+
+        assert resolved["provider"] == "anthropic"
+        assert resolved["api_mode"] == "anthropic_messages"
+        assert resolved["base_url"] == "https://azure.com/foundry/v1"
+        assert resolved["api_key"] == "az-key"
+
+    def test_explicit_azure_subdomain_uses_azure_key(self, monkeypatch):
+        """services.ai.azure.com should still be treated as Azure."""
+        monkeypatch.setenv("AZURE_ANTHROPIC_KEY", "az-key")
+
+        resolved = rp.resolve_runtime_provider(
+            requested="anthropic",
+            explicit_base_url="https://my-resource.services.ai.azure.com/anthropic/v1",
+        )
+
+        assert resolved["provider"] == "anthropic"
+        assert resolved["api_mode"] == "anthropic_messages"
+        assert resolved["base_url"] == "https://my-resource.services.ai.azure.com/anthropic/v1"
+        assert resolved["api_key"] == "az-key"
+
     def test_azure_foundry_openai_style_explicit(self, monkeypatch):
         """OpenAI-style Azure Foundry → chat_completions, keeps base_url as-is."""
         monkeypatch.setenv("AZURE_FOUNDRY_API_KEY", "az-key-openai")


### PR DESCRIPTION
                                                                                                                                                     
  Use `base_url_host_matches` for Azure Anthropic routing so path injections and lookalike hosts do not trigger Azure key selection. Add regression   
  tests covering invalid path/host matches and valid Azure domains.                                                                                   
                                                                                                                                                      
  ## What does this PR do?                                                                                                                            
                                                                                                                                                      
  This PR fixes Azure Anthropic endpoint detection in the runtime provider resolver.                                                                  
                                                                                                                                                      
  Previously, Azure detection used a raw substring check for `"azure.com"` in the base URL. That was too permissive and could incorrectly classify    
  non-Azure endpoints such as:                                                                                                                        
                                                                                                                                                      
  - `https://proxy.example.test/azure.com/v1`                                                                                                         
  - `https://azure.com.attacker.test/v1`                                                                                                              
                                                                                                                                                      
  When that happened, Hermes could take the Azure-specific credential path and select `AZURE_ANTHROPIC_KEY` for a non-Azure endpoint.                 
                                                                                                                                                      
  This change replaces the substring check with `base_url_host_matches(...)`, which is already used elsewhere in the codebase for safe hostname       
  matching. That keeps behavior correct for real Azure domains and subdomains while rejecting path injection and lookalike hosts.                     
                                                                                                                                                      
  ## Related Issue                                                                                                                                    
                                                                                                                                                      
  Fixes #                                                                                                                                             
                                                                                                                                                      
  ## Type of Change                                                                                                                                   
                                                                                                                                                      
  - [x] 🐛 Bug fix (non-breaking change that fixes an issue)                                                                                          
  - [x] 🔒 Security fix                                                                                                                               
  - [x] ✅ Tests (adding or improving test coverage)                                                                                                  
  - [ ] ✨ New feature (non-breaking change that adds functionality)                                                                                  
  - [ ] 📝 Documentation update                                                                                                                       
  - [ ] ♻️ Refactor (no behavior change)                                                                                                              
  - [ ] 🎯 New skill (bundled or hub)                                                                                                                 
                                                                                                                                                      
  ## Changes Made                                                                                                                                     
                                                                                                                                                      
  - Updated Azure endpoint detection in `hermes_cli/runtime_provider.py` to use `base_url_host_matches(..., "azure.com")` instead of raw substring    
  matching                                                                                                                                            
  - Tightened both Azure Anthropic routing paths:                                                                                                     
    - the explicit Anthropic + Azure short-circuit path                                                                                               
    - the Anthropic provider credential selection path                                                                                                
  - Added regression tests in `tests/hermes_cli/test_runtime_provider_resolution.py` for:                                                             
    - path injection containing `azure.com`                                                                                                           
    - lookalike hosts such as `azure.com.attacker.test`                                                                                               
    - valid `azure.com` hosts                                                                                                                         
    - valid Azure subdomains such as `services.ai.azure.com`                                                                                          
                                                                                                                                                      
  ## How to Test                                                                                                                                      
                                                                                                                                                      
  1. Reproduce the bad-match cases by resolving Anthropic with explicit non-Azure URLs that contain `azure.com`, for example:                         
     - `https://proxy.example.test/azure.com/v1`                                                                                                      
     - `https://azure.com.attacker.test/v1`                                                                                                           
  2. Run:                                                                                                                                             
     - `venv/bin/pytest tests/hermes_cli/test_runtime_provider_resolution.py -q -k "azure or anthropic"`                                              
     - `venv/bin/pytest tests/test_base_url_hostname.py -q`                                                                                           
  3. Verify that:                                                                                                                                     
     - non-Azure path/lookalike hosts do **not** trigger Azure key routing                                                                            
     - real Azure hosts and Azure subdomains still resolve through the Azure path correctly                                                           
                                                                                                                                                      
  ## Checklist                                                                                                                                        
                                                                                                                                                      
  ### Code                                                                                                                                            
                                                                                                                                                      
  - [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)                                    
  - [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)                  
  - [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate                         
  - [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)                                                            
  - [ ] I've run `pytest tests/ -q` and all tests pass                                                                                                
  - [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)                                                    
  - [x] I've tested on my platform: macOS 15.x                                                                                                        
                                                                                                                                                      
  ### Documentation & Housekeeping                                                                                                                    
                                                                                                                                                      
  - [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A                                                                    
  - [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A                                                                
  - [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A                                                 
  - [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility                                                                 
  guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A                                
  - [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A                                                                    
                                                                                                                                                      
  ## Screenshots / Logs                                                                                                                               
                                                                                                                                                      
  Test output:                                                                                                                                        
                                                                                                                                                      
  ```bash                                                                                                                                             
  venv/bin/pytest tests/hermes_cli/test_runtime_provider_resolution.py -q -k "azure or anthropic"                                                     
  21 passed in 2.27s                                                                                                                                  
                                                                                                                                                      
  venv/bin/pytest tests/test_base_url_hostname.py -q    