### PR TITLE
fix: propagate WhatsApp reply context

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -1060,6 +1060,9 @@ class WhatsAppAdapter(BasePlatformAdapter):
                         except Exception as e:
                             print(f"[{self.name}] Failed to read document text: {e}", flush=True)
 
+            reply_to_message_id = data.get("quotedMessageId") or data.get("replyToMessageId") or data.get("reply_to_message_id")
+            reply_to_text = data.get("quotedText") or data.get("replyToText") or data.get("reply_to_text")
+
             return MessageEvent(
                 text=body,
                 message_type=msg_type,
@@ -1068,6 +1071,8 @@ class WhatsAppAdapter(BasePlatformAdapter):
                 message_id=data.get("messageId"),
                 media_urls=cached_urls,
                 media_types=media_types,
+                reply_to_message_id=reply_to_message_id,
+                reply_to_text=reply_to_text,
             )
         except Exception as e:
             print(f"[{self.name}] Error building event: {e}")

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -89,6 +89,20 @@ function getContextInfo(messageContent) {
   return {};
 }
 
+function extractTextFromMessageContent(messageContent) {
+  if (!messageContent || typeof messageContent !== 'object') return '';
+
+  if (messageContent.conversation) return messageContent.conversation;
+  if (messageContent.extendedTextMessage?.text) return messageContent.extendedTextMessage.text;
+  if (messageContent.imageMessage) return messageContent.imageMessage.caption || '[image received]';
+  if (messageContent.videoMessage) return messageContent.videoMessage.caption || '[video received]';
+  if (messageContent.documentMessage) return messageContent.documentMessage.caption || messageContent.documentMessage.fileName || '[document received]';
+  if (messageContent.audioMessage || messageContent.pttMessage) return '[audio received]';
+  if (messageContent.stickerMessage) return '[sticker received]';
+
+  return '';
+}
+
 mkdirSync(SESSION_DIR, { recursive: true });
 
 // Build LID → phone reverse map from session files (lid-mapping-{phone}.json)
@@ -244,6 +258,9 @@ async function startSocket() {
       const contextInfo = getContextInfo(messageContent);
       const mentionedIds = Array.from(new Set((contextInfo?.mentionedJid || []).map(normalizeWhatsAppId).filter(Boolean)));
       const quotedParticipant = normalizeWhatsAppId(contextInfo?.participant || contextInfo?.remoteJid || '');
+      const quotedMessageId = contextInfo?.stanzaId || contextInfo?.quotedMessageKey?.id || '';
+      const quotedMessageContent = contextInfo?.quotedMessage ? getMessageContent({ message: contextInfo.quotedMessage }) : null;
+      const quotedText = extractTextFromMessageContent(quotedMessageContent);
 
       // Extract message body
       let body = '';
@@ -356,6 +373,8 @@ async function startSocket() {
         mediaUrls,
         mentionedIds,
         quotedParticipant,
+        quotedMessageId,
+        quotedText,
         botIds,
         timestamp: msg.messageTimestamp,
       };

--- a/tests/gateway/test_whatsapp_reply_context.py
+++ b/tests/gateway/test_whatsapp_reply_context.py
@@ -1,0 +1,89 @@
+import pytest
+from unittest.mock import AsyncMock
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+def _make_adapter():
+    from gateway.platforms.whatsapp import WhatsAppAdapter
+
+    adapter = object.__new__(WhatsAppAdapter)
+    adapter.platform = Platform.WHATSAPP
+    adapter.config = PlatformConfig(enabled=True, extra={})
+    adapter._message_handler = AsyncMock()
+    adapter._dm_policy = "open"
+    adapter._allow_from = set()
+    adapter._group_policy = "open"
+    adapter._group_allow_from = set()
+    adapter._mention_patterns = []
+    return adapter
+
+
+def _make_runner() -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={
+            Platform.WHATSAPP: PlatformConfig(enabled=True, extra={}),
+        },
+    )
+    runner.adapters = {}
+    runner._model = "openai/gpt-4.1-mini"
+    runner._base_url = None
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_whatsapp_build_message_event_populates_reply_context_from_bridge_payload():
+    adapter = _make_adapter()
+
+    event = await adapter._build_message_event({
+        "messageId": "current-msg",
+        "chatId": "85294049323@s.whatsapp.net",
+        "senderId": "85294049323@s.whatsapp.net",
+        "senderName": "TK",
+        "chatName": "TK",
+        "isGroup": False,
+        "body": "我要你改嘅係personal.",
+        "hasMedia": False,
+        "mentionedIds": [],
+        "botIds": [],
+        "quotedMessageId": "quoted-msg",
+        "quotedText": "我想去返linkedin page 改動先。",
+    })
+
+    assert event is not None
+    assert event.message_type is MessageType.TEXT
+    assert event.message_id == "current-msg"
+    assert event.reply_to_message_id == "quoted-msg"
+    assert event.reply_to_text == "我想去返linkedin page 改動先。"
+
+
+@pytest.mark.asyncio
+async def test_prepare_inbound_message_text_injects_whatsapp_reply_context():
+    runner = _make_runner()
+    source = SessionSource(
+        platform=Platform.WHATSAPP,
+        chat_id="85294049323@s.whatsapp.net",
+        chat_name="TK",
+        chat_type="dm",
+        user_name="TK",
+    )
+    event = MessageEvent(
+        text="我要你改嘅係personal.",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="current-msg",
+        reply_to_message_id="quoted-msg",
+        reply_to_text="我想去返linkedin page 改動先。",
+    )
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert result == '[Replying to: "我想去返linkedin page 改動先。"]\n\n我要你改嘅係personal.'


### PR DESCRIPTION
## Summary
- extract quoted message id and text from Baileys `contextInfo` in the WhatsApp bridge
- pass quoted reply metadata through the WhatsApp adapter into `MessageEvent.reply_to_message_id` / `reply_to_text`
- add regression tests covering event construction and gateway reply-context injection

## Test Plan
- `/opt/homebrew/bin/node --check scripts/whatsapp-bridge/bridge.js`
- `pytest tests/gateway/test_whatsapp_reply_context.py tests/gateway/test_whatsapp_group_gating.py -q`
