### PR TITLE
fix: defer watch notifications until post-delivery

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4724,20 +4724,34 @@ class GatewayRunner:
             # inject watch-type events here.
             try:
                 from tools.process_registry import process_registry as _pr
-                _watch_events = []
+                _watch_notifications = []
                 while not _pr.completion_queue.empty():
                     evt = _pr.completion_queue.get_nowait()
                     evt_type = evt.get("type", "completion")
                     if evt_type in ("watch_match", "watch_disabled"):
-                        _watch_events.append(evt)
+                        synth_text = _format_gateway_process_notification(evt)
+                        if synth_text:
+                            _watch_notifications.append((synth_text, evt))
                     # else: completion events are handled by the watcher task
-                for evt in _watch_events:
-                    synth_text = _format_gateway_process_notification(evt)
-                    if synth_text:
+                if _watch_notifications:
+                    _watch_adapter = self.adapters.get(source.platform)
+                    _deferred = False
+                    if _watch_adapter and session_key:
                         try:
-                            await self._inject_watch_notification(synth_text, evt)
+                            _deferred = self._register_deferred_watch_notifications(
+                                _watch_adapter,
+                                session_key,
+                                run_generation,
+                                _watch_notifications,
+                            )
                         except Exception as e2:
-                            logger.error("Watch notification injection error: %s", e2)
+                            logger.error("Watch notification deferral error: %s", e2)
+                    if not _deferred:
+                        for synth_text, evt in _watch_notifications:
+                            try:
+                                await self._inject_watch_notification(synth_text, evt)
+                            except Exception as e2:
+                                logger.error("Watch notification injection error: %s", e2)
             except Exception as e:
                 logger.debug("Watch queue drain error: %s", e)
 
@@ -8477,6 +8491,73 @@ class GatewayRunner:
             await adapter.handle_message(synth_event)
         except Exception as e:
             logger.error("Watch notification injection error: %s", e)
+
+    def _register_deferred_watch_notifications(
+        self,
+        adapter: Any,
+        session_key: str,
+        run_generation: int | None,
+        notifications: list[tuple[str, dict]],
+    ) -> bool:
+        """Deliver watch notifications after the main response for this run.
+
+        This avoids routing a synthetic internal message through the active-session
+        busy path while the foreground turn is still unwinding. If a post-delivery
+        callback is already registered for the same run (e.g. background-review
+        release), preserve it and run it first.
+        """
+        if not adapter or not session_key or not notifications:
+            return False
+
+        existing_callback = None
+        if getattr(type(adapter), "pop_post_delivery_callback", None) is not None:
+            existing_callback = adapter.pop_post_delivery_callback(
+                session_key,
+                generation=run_generation,
+            )
+        else:
+            _pdc = getattr(adapter, "_post_delivery_callbacks", None)
+            if isinstance(_pdc, dict):
+                entry = _pdc.get(session_key)
+                if isinstance(entry, tuple) and len(entry) == 2:
+                    entry_generation, callback = entry
+                    if run_generation is not None and int(entry_generation) != int(run_generation):
+                        return False
+                    _pdc.pop(session_key, None)
+                    existing_callback = callback if callable(callback) else None
+                elif run_generation is None:
+                    existing_callback = _pdc.pop(session_key, None)
+                else:
+                    return False
+
+        def _deliver_deferred_watch_notifications() -> None:
+            if callable(existing_callback):
+                try:
+                    existing_callback()
+                except Exception:
+                    pass
+            for synth_text, evt in notifications:
+                try:
+                    asyncio.create_task(self._inject_watch_notification(synth_text, evt))
+                except Exception as e:
+                    logger.debug("deferred watch notification scheduling error: %s", e)
+
+        if getattr(type(adapter), "register_post_delivery_callback", None) is not None:
+            adapter.register_post_delivery_callback(
+                session_key,
+                _deliver_deferred_watch_notifications,
+                generation=run_generation,
+            )
+            return True
+
+        _pdc = getattr(adapter, "_post_delivery_callbacks", None)
+        if isinstance(_pdc, dict):
+            if run_generation is None:
+                _pdc[session_key] = _deliver_deferred_watch_notifications
+            else:
+                _pdc[session_key] = (int(run_generation), _deliver_deferred_watch_notifications)
+            return True
+        return False
 
     async def _run_process_watcher(self, watcher: dict) -> None:
         """

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -373,6 +373,155 @@ def test_build_process_event_source_returns_none_for_short_session_key(monkeypat
     assert source is None
 
 
+@pytest.mark.asyncio
+async def test_register_deferred_watch_notifications_preserves_existing_callback(monkeypatch, tmp_path):
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    session_key = "agent:main:telegram:group:-100:42"
+    sequence = []
+
+    class _Adapter:
+        def __init__(self):
+            self.send = AsyncMock()
+            self.handle_message = AsyncMock()
+            self._post_delivery_callbacks = {}
+
+        def register_post_delivery_callback(self, session_key, callback, *, generation=None):
+            if generation is None:
+                self._post_delivery_callbacks[session_key] = callback
+            else:
+                self._post_delivery_callbacks[session_key] = (int(generation), callback)
+
+        def pop_post_delivery_callback(self, session_key, *, generation=None):
+            entry = self._post_delivery_callbacks.get(session_key)
+            if entry is None:
+                return None
+            if isinstance(entry, tuple):
+                entry_generation, callback = entry
+                if generation is not None and entry_generation != generation:
+                    return None
+                self._post_delivery_callbacks.pop(session_key, None)
+                return callback
+            if generation is not None:
+                return None
+            return self._post_delivery_callbacks.pop(session_key, None)
+
+    adapter = _Adapter()
+    runner.adapters[Platform.TELEGRAM] = adapter
+
+    def _existing_callback():
+        sequence.append("existing")
+
+    adapter.register_post_delivery_callback(session_key, _existing_callback, generation=7)
+
+    async def _record_injection(synth_text, evt):
+        sequence.append(("inject", synth_text, evt["session_id"]))
+
+    runner._inject_watch_notification = AsyncMock(side_effect=_record_injection)
+    notifications = [
+        (
+            "[SYSTEM: Background process matched]",
+            {"session_id": "proc_watch", "session_key": session_key},
+        )
+    ]
+
+    runner._register_deferred_watch_notifications(adapter, session_key, 7, notifications)
+
+    stored = adapter._post_delivery_callbacks[session_key]
+    assert isinstance(stored, tuple)
+    assert stored[0] == 7
+    assert sequence == []
+
+    callback = adapter.pop_post_delivery_callback(session_key, generation=7)
+    assert callable(callback)
+
+    callback()
+    await asyncio.sleep(0)
+
+    assert sequence == [
+        "existing",
+        ("inject", "[SYSTEM: Background process matched]", "proc_watch"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_register_deferred_watch_notifications_preserves_multi_watch_order(monkeypatch, tmp_path):
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    session_key = "agent:main:telegram:group:-100:42"
+    sequence = []
+    scheduled = []
+    original_create_task = asyncio.create_task
+
+    class _Adapter:
+        def __init__(self):
+            self.send = AsyncMock()
+            self.handle_message = AsyncMock()
+            self._post_delivery_callbacks = {}
+
+        def register_post_delivery_callback(self, session_key, callback, *, generation=None):
+            if generation is None:
+                self._post_delivery_callbacks[session_key] = callback
+            else:
+                self._post_delivery_callbacks[session_key] = (int(generation), callback)
+
+        def pop_post_delivery_callback(self, session_key, *, generation=None):
+            entry = self._post_delivery_callbacks.get(session_key)
+            if entry is None:
+                return None
+            if isinstance(entry, tuple):
+                entry_generation, callback = entry
+                if generation is not None and entry_generation != generation:
+                    return None
+                self._post_delivery_callbacks.pop(session_key, None)
+                return callback
+            if generation is not None:
+                return None
+            return self._post_delivery_callbacks.pop(session_key, None)
+
+    def _capture_task(coro):
+        task = original_create_task(coro)
+        scheduled.append(task)
+        return task
+
+    monkeypatch.setattr(asyncio, "create_task", _capture_task)
+
+    adapter = _Adapter()
+    runner.adapters[Platform.TELEGRAM] = adapter
+
+    def _existing_callback():
+        sequence.append("existing")
+
+    adapter.register_post_delivery_callback(session_key, _existing_callback, generation=9)
+
+    async def _record_injection(synth_text, evt):
+        sequence.append(("inject", synth_text, evt["session_id"]))
+
+    runner._inject_watch_notification = AsyncMock(side_effect=_record_injection)
+    notifications = [
+        (
+            "[SYSTEM: First watch match]",
+            {"session_id": "proc_watch_1", "session_key": session_key},
+        ),
+        (
+            "[SYSTEM: Second watch match]",
+            {"session_id": "proc_watch_2", "session_key": session_key},
+        ),
+    ]
+
+    runner._register_deferred_watch_notifications(adapter, session_key, 9, notifications)
+
+    callback = adapter.pop_post_delivery_callback(session_key, generation=9)
+    assert callable(callback)
+
+    callback()
+    await asyncio.gather(*scheduled)
+
+    assert sequence == [
+        "existing",
+        ("inject", "[SYSTEM: First watch match]", "proc_watch_1"),
+        ("inject", "[SYSTEM: Second watch match]", "proc_watch_2"),
+    ]
+
+
 # ---------------------------------------------------------------------------
 # _parse_session_key helper
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- defer watch-pattern notifications until post-delivery instead of injecting them inline while the session is still active
- preserve any existing generation-scoped post-delivery callback for the same run
- add regression coverage for callback chaining and multi-watch ordering

## Test Plan
- pytest -q tests/gateway/test_background_process_notifications.py tests/gateway/test_status_command.py::test_handle_message_stale_result_keeps_newer_generation_callback

## Context
This isolates the cached-agent stall path triggered by background watch-pattern notifications entering the busy-session path before the main response fully unwinds.