### PR TITLE
feat(cli): default busy_input_mode to steer instead of interrupt

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -385,7 +385,7 @@ def load_cli_config() -> Dict[str, Any]:
             "resume_display": "full",
             "show_reasoning": False,
             "streaming": True,
-            "busy_input_mode": "interrupt",
+            "busy_input_mode": "steer",
 
             "skin": "default",
         },

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -626,7 +626,7 @@ DEFAULT_CONFIG = {
         "compact": False,
         "personality": "kawaii",
         "resume_display": "full",
-        "busy_input_mode": "interrupt",
+        "busy_input_mode": "steer",
         "bell_on_complete": False,
         "show_reasoning": False,
         "streaming": False,

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -101,6 +101,13 @@ class TestBusyInputMode:
         cli = _make_cli()
         assert cli.busy_input_mode == "interrupt"
 
+    def test_module_default_busy_input_mode_is_steer(self):
+        import hermes_cli.config as hermes_config
+        import cli as cli_mod
+
+        assert hermes_config.DEFAULT_CONFIG["display"]["busy_input_mode"] == "steer"
+        assert cli_mod.CLI_CONFIG["display"]["busy_input_mode"] == "steer"
+
     def test_busy_input_mode_queue_is_honored(self):
         cli = _make_cli(config_overrides={"display": {"busy_input_mode": "queue"}})
         assert cli.busy_input_mode == "queue"

--- a/website/docs/user-guide/cli.md
+++ b/website/docs/user-guide/cli.md
@@ -223,16 +223,16 @@ The `display.busy_input_mode` config key controls what happens when you press En
 
 | Mode | Behavior |
 |------|----------|
-| `"interrupt"` (default) | Your message interrupts the current operation and is processed immediately |
+| `"steer"` (default) | Your message interrupts the current operation and is processed immediately |
 | `"queue"` | Your message is silently queued and sent as the next turn after the agent finishes |
 
 ```yaml
 # ~/.hermes/config.yaml
 display:
-  busy_input_mode: "queue"   # or "interrupt" (default)
+  busy_input_mode: "queue"   # or "steer" (default)
 ```
 
-Queue mode is useful when you want to prepare follow-up messages without accidentally canceling in-flight work. Unknown values fall back to `"interrupt"`.
+Queue mode is useful when you want to prepare follow-up messages without accidentally canceling in-flight work. `"steer"` and `"interrupt"` behave the same; unknown values fall back to steer semantics.
 
 You can also change it inside the CLI:
 


### PR DESCRIPTION
Changes the default `busy_input_mode` from `"interrupt"` to `"steer"` in both the runtime CLI config and the default config.\n\n- Update `cli.py` default display config\n- Update `hermes_cli/config.py` DEFAULT_CONFIG\n- Add test asserting default is `"steer"`\n- Update docs accordingly