### PR TITLE
fix(backup): floor pre-update backup_keep to 1 so the new backup survives

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -788,9 +788,17 @@ def _prune_pre_update_backups(backup_dir: Path, keep: int) -> int:
     Returns the number of files deleted.  Only touches files matching
     ``pre-update-*.zip`` so hand-made zips dropped in the same directory
     are never touched.
+
+    ``keep`` is floored to 1 because this helper is only called immediately
+    after a fresh backup is written: deleting that backup right after the
+    user paid the disk/CPU cost to create it would leave them worse off
+    than no backup at all (and the wrapper in ``main.py`` would still print
+    a misleading ``Saved: <path>`` line for a file that no longer exists).
+    Operators who genuinely don't want a backup should set
+    ``updates.pre_update_backup: false`` in config — that gates creation.
     """
-    if keep < 0:
-        keep = 0
+    if keep < 1:
+        keep = 1
     if not backup_dir.exists():
         return 0
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1274,7 +1274,10 @@ DEFAULT_CONFIG = {
         # for a single update run.
         "pre_update_backup": False,
         # How many pre-update backup zips to retain.  Older ones are pruned
-        # automatically after each successful backup.
+        # automatically after each successful backup.  Values below 1 are
+        # floored to 1 — the backup just created is always preserved.  To
+        # disable backups entirely, set ``pre_update_backup: false`` above
+        # rather than ``backup_keep: 0``.
         "backup_keep": 5,
     },
 

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -1348,6 +1348,53 @@ class TestPreUpdateBackup:
         from hermes_cli.backup import create_pre_update_backup
         assert create_pre_update_backup(hermes_home=tmp_path / "does-not-exist") is None
 
+    def test_keep_zero_does_not_delete_freshly_created_backup(self, hermes_home):
+        """Regression: ``backup_keep: 0`` previously triggered ``backups[0:]``
+        in the pruner — wiping the just-created zip and leaving the user
+        with no recovery point.  The floor (keep>=1) preserves the new file
+        regardless of misconfiguration; users who don't want backups should
+        set ``pre_update_backup: false`` instead.
+        """
+        from hermes_cli.backup import create_pre_update_backup
+        out = create_pre_update_backup(hermes_home=hermes_home, keep=0)
+        assert out is not None
+        assert out.exists(), (
+            "keep=0 silently deleted the freshly-created backup; floor "
+            "should preserve the just-written file."
+        )
+
+    def test_keep_negative_does_not_delete_freshly_created_backup(self, hermes_home):
+        """Mirror coverage: any value <1 should be floored, not literally
+        applied as a slice index."""
+        from hermes_cli.backup import create_pre_update_backup
+        out = create_pre_update_backup(hermes_home=hermes_home, keep=-3)
+        assert out is not None
+        assert out.exists()
+
+    def test_keep_zero_still_prunes_older_backups(self, hermes_home):
+        """The floor preserves the new backup but should NOT regress the
+        rotation behaviour for older zips: a third call with keep=0 must
+        still remove pre-existing backups beyond the (floored) limit of 1.
+        """
+        import time as _t
+        from hermes_cli.backup import create_pre_update_backup
+
+        first = create_pre_update_backup(hermes_home=hermes_home, keep=5)
+        _t.sleep(1.05)
+        second = create_pre_update_backup(hermes_home=hermes_home, keep=5)
+        _t.sleep(1.05)
+        third = create_pre_update_backup(hermes_home=hermes_home, keep=0)
+
+        remaining = {
+            p.name for p in (hermes_home / "backups").iterdir()
+            if p.name.startswith("pre-update-")
+        }
+        assert third.name in remaining, "Floor must preserve the new backup"
+        assert first.name not in remaining and second.name not in remaining, (
+            f"keep=0 floor of 1 should still prune older backups; "
+            f"remaining={remaining}"
+        )
+
 
 class TestRunPreUpdateBackup:
     """Tests for the ``_run_pre_update_backup`` wrapper in main.py —


### PR DESCRIPTION
## Summary

- `updates.backup_keep: 0` (or negative) silently deletes the freshly-created pre-update backup, leaving the user with no recovery point even though `Saved: <path>` was printed.
- Floor the `keep` parameter to a minimum of 1 inside `_prune_pre_update_backups` so the just-written zip is always preserved.
- Three regression tests + clarifying comment on the config default.

## The bug

`_prune_pre_update_backups(backup_dir, keep)` only clamps `keep < 0` up to 0:

```python
if keep < 0:
    keep = 0
...
backups = sorted(..., reverse=True)   # newest-first, includes the just-written zip
for p in backups[keep:]:               # backups[0:] = ALL of them
    p.unlink()
```

The function is called from `create_pre_update_backup()` immediately after the new zip is written. So with `keep=0`:

1. The zip is written to `<HERMES_HOME>/backups/pre-update-<ts>.zip`.
2. `_prune_pre_update_backups(..., keep=0)` lists every `pre-update-*.zip` (one entry — the new one) and deletes it.
3. The wrapper in [`main.py`](https://github.com/NousResearch/hermes-agent/blob/main/hermes_cli/main.py#L6188-L6231) calls `out_path.stat().st_size`, which raises `OSError` (file missing) — caught and silently degraded to `size_bytes = 0`.
4. The user sees `Saved:    ~/.hermes/backups/pre-update-….zip (0 B, 1.2s)` and believes they have a recovery point.

This is exactly the kind of footgun config systems trigger because some apps treat `0` as "unlimited" / "no rotation". Here it does the opposite — every backup is destroyed right after creation, with no warning.

Reproduced locally:

```python
>>> from hermes_cli.backup import create_pre_update_backup
>>> out = create_pre_update_backup(hermes_home=Path('/tmp/hh'), keep=0)
>>> out.exists()
False
```

## The fix

Clamp `keep` to a minimum of 1 inside `_prune_pre_update_backups`:

```python
if keep < 1:
    keep = 1
```

The pruner is only ever invoked immediately after a fresh backup is written, so the smallest sensible retention is 1 — anything below that means \"throw away the file we just paid disk + CPU to produce.\" Operators who genuinely want no backups should set `updates.pre_update_backup: false` (which gates creation entirely) rather than relying on `backup_keep: 0`. The config docstring is updated to spell this out.

The floor only protects the *just-created* backup; older zips are still rotated out as before. `test_keep_zero_still_prunes_older_backups` proves this.

## Test plan

- [x] **Before** (on `8ed599dc0`, the merge commit of #16539): the three new tests fail with `keep=0` deleting the freshly-created backup.
- [x] **After**: 9/9 `TestPreUpdateBackup` tests pass; full `tests/hermes_cli/test_backup.py` suite green (84 tests).
- [x] **Regression guard**: temporarily reverted `hermes_cli/backup.py` → 3 new tests fail with \"keep=0 silently deleted the freshly-created backup\" / \"Floor must preserve the new backup\". Restored → all pass.
- [x] Behavior for the existing default (`keep=5`) is unchanged.

Tests added (parametrized in spirit by covering both 0 and negative):

- `test_keep_zero_does_not_delete_freshly_created_backup`
- `test_keep_negative_does_not_delete_freshly_created_backup`
- `test_keep_zero_still_prunes_older_backups` — proves the floor doesn't regress rotation for older files

## Related

- Follow-up to #16539 (`feat(update): auto-backup HERMES_HOME before hermes update`) — the new auto-backup feature merged earlier today (8ed599dc0).
- No competing PRs found (`gh search prs ... pre_update_backup / backup_keep / _prune_pre_update_backups / create_pre_update_backup` all clean as of 2026-04-27 13:30Z).

🤖 Generated with [Claude Code](https://claude.com/claude-code)