### PR TITLE
fix(media): validate extracted MEDIA: paths with isfile() before delivery

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1591,30 +1591,43 @@ class BasePlatformAdapter(ABC):
             Tuple of (list of (path, is_voice) pairs, cleaned content with tags removed).
         """
         media = []
-        cleaned = content
-        
-        # Check for [[audio_as_voice]] directive
         has_voice_tag = "[[audio_as_voice]]" in content
-        cleaned = cleaned.replace("[[audio_as_voice]]", "")
-        
+
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
         media_pattern = re.compile(
             r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$)|\S+)[`"']?'''
         )
+        matched_spans: list = []
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()
             if len(path) >= 2 and path[0] == path[-1] and path[0] in "`\"'":
                 path = path[1:-1].strip()
-            path = path.lstrip("`\"'").rstrip("`\"',.;:)}]")
-            if path:
-                media.append((os.path.expanduser(path), has_voice_tag))
+            # The \S+ fallback can swallow trailing punctuation, stray
+            # backticks from un-paired LLM markdown, and other noise.
+            # Strip aggressively, then verify the path resolves to a real
+            # file before treating it as media — otherwise the warning
+            # log fills with spurious "File not found" entries.
+            path = path.lstrip("`\"'").rstrip("`\"',.;:)}]").strip("`\"'")
+            if not path:
+                continue
+            expanded = os.path.expanduser(path)
+            if not os.path.isfile(expanded):
+                continue
+            media.append((expanded, has_voice_tag))
+            matched_spans.append(match.span())
 
-        # Remove MEDIA tags from content (including surrounding quote/backtick wrappers)
-        if media:
-            cleaned = media_pattern.sub('', cleaned)
+        # Strip verified MEDIA tags by span on the original content so indices
+        # stay aligned, then apply the [[audio_as_voice]] directive strip.
+        # MEDIA-looking text without an actual file is preserved verbatim.
+        cleaned = content
+        if matched_spans:
+            for start, end in reversed(matched_spans):
+                cleaned = cleaned[:start] + cleaned[end:]
+        cleaned = cleaned.replace("[[audio_as_voice]]", "")
+        if matched_spans or has_voice_tag:
             cleaned = re.sub(r'\n{3,}', '\n\n', cleaned).strip()
-        
+
         return media, cleaned
 
     @staticmethod


### PR DESCRIPTION
## Summary
`BasePlatformAdapter.extract_media` uses a permissive `\S+` fallback in its MEDIA-tag regex which can capture trailing punctuation, un-paired LLM backticks, and other noise when the LLM emits markdown-formatted text adjacent to a `MEDIA:` directive. Without validation, every MEDIA-looking response that referenced a non-existent file produced a `File not found` warning at delivery time, e.g.

```
WARNING gateway.platforms.base: [Slack] Failed to send media (.md`):
  File not found: /tmp/example.md`
```

The text was also being mutilated — `media_pattern.sub('', cleaned)` indiscriminately stripped *any* MEDIA-looking substring from user-visible output, even when it didn't resolve to a real file (e.g. a code sample discussing the directive).

## Fix
- Add an `os.path.isfile()` guard before appending to the media list, mirroring the validation already used by `extract_local_files` (in the same file).
- Track matched spans explicitly and strip only verified MEDIA tags from the cleaned content, so MEDIA-looking text that does not resolve to a real file is preserved verbatim instead of being mutilated.
- Reorder the `[[audio_as_voice]]` strip to run after span-based cleanup so the match indices stay aligned with the original `content`.

## Test plan
- [x] Backticked, non-existent path inside markdown text → no match, original text preserved
- [x] Real MEDIA: tag with verified file → matched, path captured, text cleaned
- [x] `[[audio_as_voice]]` directive alone → directive stripped, content preserved
- [x] Voice + real MEDIA combined → both handled, ordering correct
- [x] MEDIA before `[[audio_as_voice]]` (indices alignment) → correct
- [x] MEDIA-looking text inline-quoted in markdown context → no false match
- [x] py_compile passes
- [x] Smoke-tested live in a Slack-only Hermes deployment (warning log noise eliminated, real media delivery unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)