### PR TITLE
Fix BOOT.md runtime provider resolution

### DIFF
--- a/gateway/builtin_hooks/boot_md.py
+++ b/gateway/builtin_hooks/boot_md.py
@@ -20,11 +20,52 @@ suppress delivery.
 import logging
 import threading
 
+from hermes_constants import get_hermes_home
+
 logger = logging.getLogger("hooks.boot-md")
 
-from hermes_constants import get_hermes_home
 HERMES_HOME = get_hermes_home()
 BOOT_FILE = HERMES_HOME / "BOOT.md"
+
+
+def _resolve_boot_agent_kwargs() -> dict:
+    """Use the configured gateway runtime for BOOT.md sessions."""
+    try:
+        from hermes_cli.config import load_config
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        config = load_config()
+        model_cfg = config.get("model")
+        model = ""
+        provider = None
+        if isinstance(model_cfg, dict):
+            model = str(model_cfg.get("default") or model_cfg.get("model") or "").strip()
+            provider = str(model_cfg.get("provider") or "").strip() or None
+        elif isinstance(model_cfg, str):
+            model = model_cfg.strip()
+
+        runtime = resolve_runtime_provider(
+            requested=provider,
+            target_model=model or None,
+        )
+        kwargs = {
+            "api_key": runtime.get("api_key"),
+            "base_url": runtime.get("base_url"),
+            "provider": runtime.get("provider"),
+            "api_mode": runtime.get("api_mode"),
+            "command": runtime.get("command"),
+            "args": list(runtime.get("args") or []),
+            "credential_pool": runtime.get("credential_pool"),
+            "fallback_model": (
+                config.get("fallback_providers") or config.get("fallback_model")
+            ),
+        }
+        if model:
+            kwargs["model"] = model
+        return kwargs
+    except Exception as e:
+        logger.warning("boot-md runtime config resolution failed: %s", e)
+        return {}
 
 
 def _build_boot_prompt(content: str) -> str:
@@ -49,6 +90,7 @@ def _run_boot_agent(content: str) -> None:
 
         prompt = _build_boot_prompt(content)
         agent = AIAgent(
+            **_resolve_boot_agent_kwargs(),
             quiet_mode=True,
             skip_context_files=True,
             skip_memory=True,

--- a/tests/gateway/test_boot_md.py
+++ b/tests/gateway/test_boot_md.py
@@ -1,0 +1,122 @@
+"""Tests for the built-in BOOT.md gateway hook."""
+
+import sys
+from types import SimpleNamespace
+
+from gateway.builtin_hooks import boot_md
+
+
+def test_resolve_boot_agent_kwargs_uses_config_runtime(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "model": {"default": "glm-5.1", "provider": "zai"},
+            "fallback_providers": [
+                {"provider": "openai-codex", "model": "gpt-5.5"},
+                {"provider": "minimax", "model": "MiniMax-M2.7"},
+            ],
+        },
+    )
+
+    def fake_resolve_runtime_provider(*, requested=None, target_model=None, **_kwargs):
+        calls.append({"requested": requested, "target_model": target_model})
+        return {
+            "api_key": "secret",
+            "base_url": "https://api.z.ai/api/coding/paas/v4",
+            "provider": "zai",
+            "api_mode": "chat_completions",
+            "command": "agent",
+            "args": ["run"],
+            "credential_pool": object(),
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        fake_resolve_runtime_provider,
+    )
+
+    kwargs = boot_md._resolve_boot_agent_kwargs()
+
+    assert calls == [{"requested": "zai", "target_model": "glm-5.1"}]
+    assert kwargs["model"] == "glm-5.1"
+    assert kwargs["provider"] == "zai"
+    assert kwargs["api_mode"] == "chat_completions"
+    assert kwargs["base_url"] == "https://api.z.ai/api/coding/paas/v4"
+    assert kwargs["command"] == "agent"
+    assert kwargs["args"] == ["run"]
+    assert kwargs["fallback_model"] == [
+        {"provider": "openai-codex", "model": "gpt-5.5"},
+        {"provider": "minimax", "model": "MiniMax-M2.7"},
+    ]
+
+
+def test_resolve_boot_agent_kwargs_supports_legacy_fallback_model(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "model": "anthropic/claude-sonnet-4.5",
+            "fallback_model": {"provider": "openrouter", "model": "openai/gpt-5.1"},
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **_kwargs: {"provider": "openrouter", "api_mode": "chat_completions"},
+    )
+
+    kwargs = boot_md._resolve_boot_agent_kwargs()
+
+    assert kwargs["model"] == "anthropic/claude-sonnet-4.5"
+    assert kwargs["fallback_model"] == {
+        "provider": "openrouter",
+        "model": "openai/gpt-5.1",
+    }
+
+
+def test_resolve_boot_agent_kwargs_falls_back_to_defaults_on_error(monkeypatch):
+    def fail_load_config():
+        raise RuntimeError("config unavailable")
+
+    monkeypatch.setattr("hermes_cli.config.load_config", fail_load_config)
+
+    assert boot_md._resolve_boot_agent_kwargs() == {}
+
+
+def test_run_boot_agent_passes_resolved_runtime_kwargs(monkeypatch):
+    captured = {}
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            captured["kwargs"] = kwargs
+
+        def run_conversation(self, prompt):
+            captured["prompt"] = prompt
+            return {"final_response": "[SILENT]"}
+
+    monkeypatch.setattr(
+        boot_md,
+        "_resolve_boot_agent_kwargs",
+        lambda: {
+            "model": "gpt-5.5",
+            "provider": "openai-codex",
+            "fallback_model": [{"provider": "minimax", "model": "MiniMax-M2.7"}],
+        },
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "run_agent",
+        SimpleNamespace(AIAgent=FakeAgent),
+    )
+
+    boot_md._run_boot_agent("Check the system.")
+
+    assert captured["kwargs"]["model"] == "gpt-5.5"
+    assert captured["kwargs"]["provider"] == "openai-codex"
+    assert captured["kwargs"]["fallback_model"] == [
+        {"provider": "minimax", "model": "MiniMax-M2.7"}
+    ]
+    assert captured["kwargs"]["quiet_mode"] is True
+    assert captured["kwargs"]["skip_context_files"] is True
+    assert captured["kwargs"]["skip_memory"] is True
+    assert "Check the system." in captured["prompt"]


### PR DESCRIPTION
## Summary
- resolve BOOT.md startup agents through the configured runtime provider
- pass configured model and fallback_providers/fallback_model into the boot AIAgent
- add focused gateway hook regression coverage

## Tests
- ./venv/bin/python -m ruff check gateway/builtin_hooks/boot_md.py tests/gateway/test_boot_md.py
- ./venv/bin/python -m py_compile gateway/builtin_hooks/boot_md.py tests/gateway/test_boot_md.py
- ./venv/bin/python -m pytest tests/gateway/test_boot_md.py tests/gateway/test_hooks.py -q