### PR TITLE
fix(gateway): fall back to HERMES_HOME when ~/.local/state is unwritable

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -11,8 +11,10 @@ that will be useful when we add named profiles (multiple agents running
 concurrently under distinct configurations).
 """
 
+import functools
 import hashlib
 import json
+import logging
 import os
 import signal
 import subprocess
@@ -26,6 +28,8 @@ if sys.platform == "win32":
     import msvcrt
 else:
     import fcntl
+
+logger = logging.getLogger(__name__)
 
 _GATEWAY_KIND = "hermes-gateway"
 _RUNTIME_STATUS_FILE = "gateway_state.json"
@@ -56,12 +60,55 @@ def _get_runtime_status_path() -> Path:
 
 
 def _get_lock_dir() -> Path:
-    """Return the machine-local directory for token-scoped gateway locks."""
+    """Return the machine-local directory for token-scoped gateway locks.
+
+    Resolution order:
+
+    1. ``HERMES_GATEWAY_LOCK_DIR`` env var — explicit override.
+    2. ``XDG_STATE_HOME`` env var — XDG spec, honored verbatim.
+    3. ``~/.local/state/hermes/<locks>`` — XDG default, when writable.
+    4. ``HERMES_HOME/<locks>`` — fallback when ``$HOME`` is not writable.
+
+    The fallback exists for containers where ``$HOME`` resolves to the image
+    ``WORKDIR`` (e.g. ``/opt/hermes``) which the runtime user cannot write to
+    — common with ``podman`` ``UserNS=keep-id`` + ``User=$UID:$GID`` quadlets,
+    or any ``docker run -u <uid>`` against an image whose WORKDIR is owned by
+    a different UID. ``HERMES_HOME`` is always intended to be writable, so it
+    is the natural backstop.
+
+    The default-path probe is cached after the first successful resolve so
+    repeated lock acquires don't re-issue ``mkdir`` syscalls.
+    """
     override = os.getenv("HERMES_GATEWAY_LOCK_DIR")
     if override:
         return Path(override)
-    state_home = Path(os.getenv("XDG_STATE_HOME", Path.home() / ".local" / "state"))
-    return state_home / "hermes" / _LOCKS_DIRNAME
+
+    state_home_env = os.getenv("XDG_STATE_HOME")
+    if state_home_env:
+        return Path(state_home_env) / "hermes" / _LOCKS_DIRNAME
+
+    return _resolve_default_lock_dir()
+
+
+@functools.lru_cache(maxsize=1)
+def _resolve_default_lock_dir() -> Path:
+    """Probe ``~/.local/state`` and fall back to HERMES_HOME if unwritable.
+
+    Result is memoized — a single ``mkdir`` probe per process. Tests that
+    need to re-evaluate must call ``_resolve_default_lock_dir.cache_clear()``.
+    """
+    default = Path.home() / ".local" / "state" / "hermes" / _LOCKS_DIRNAME
+    try:
+        default.mkdir(parents=True, exist_ok=True)
+        return default
+    except (PermissionError, OSError) as exc:
+        fallback = get_hermes_home() / _LOCKS_DIRNAME
+        logger.warning(
+            "Default gateway lock dir %s is not writable (%s); using %s "
+            "instead. Set HERMES_GATEWAY_LOCK_DIR or XDG_STATE_HOME to override.",
+            default, exc, fallback,
+        )
+        return fallback
 
 
 def _utc_now_iso() -> str:

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -628,3 +628,92 @@ class TestTakeoverMarker:
 
         # We are not the target — must NOT consume as planned
         assert result is False
+
+
+class TestGetLockDir:
+    """Resolution order for ``_get_lock_dir`` — see the docstring there.
+
+    The default-path probe is memoized on ``_resolve_default_lock_dir``;
+    each test below clears that cache to force re-evaluation under its own
+    monkeypatched ``Path.home`` / env state.
+    """
+
+    def setup_method(self) -> None:
+        status._resolve_default_lock_dir.cache_clear()
+
+    def teardown_method(self) -> None:
+        status._resolve_default_lock_dir.cache_clear()
+
+    def test_explicit_override_takes_priority(self, tmp_path, monkeypatch):
+        explicit = tmp_path / "explicit-locks"
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(explicit))
+        # Even with XDG_STATE_HOME set and a writable HOME, override wins.
+        monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "xdg"))
+        monkeypatch.setattr(status.Path, "home", classmethod(lambda cls: tmp_path / "home"))
+
+        assert status._get_lock_dir() == explicit
+
+    def test_xdg_state_home_used_when_set(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("HERMES_GATEWAY_LOCK_DIR", raising=False)
+        xdg = tmp_path / "xdg-state"
+        monkeypatch.setenv("XDG_STATE_HOME", str(xdg))
+
+        assert status._get_lock_dir() == xdg / "hermes" / "gateway-locks"
+
+    def test_default_path_under_writable_home(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("HERMES_GATEWAY_LOCK_DIR", raising=False)
+        monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        monkeypatch.setattr(status.Path, "home", classmethod(lambda cls: fake_home))
+
+        result = status._get_lock_dir()
+
+        assert result == fake_home / ".local" / "state" / "hermes" / "gateway-locks"
+        # Probe also creates the directory tree.
+        assert result.exists()
+
+    def test_falls_back_to_hermes_home_when_default_unwritable(
+        self, tmp_path, monkeypatch
+    ):
+        """Container scenario: ``$HOME`` points at a read-only image dir
+        (e.g. ``/opt/hermes`` owned by root, runtime user is non-root).
+        """
+        monkeypatch.delenv("HERMES_GATEWAY_LOCK_DIR", raising=False)
+        monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+
+        readonly_home = tmp_path / "readonly-home"
+        readonly_home.mkdir()
+        readonly_home.chmod(0o500)  # r-x: cannot create children
+        monkeypatch.setattr(status.Path, "home", classmethod(lambda cls: readonly_home))
+
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        try:
+            result = status._get_lock_dir()
+        finally:
+            # Restore so pytest can clean up tmp_path.
+            readonly_home.chmod(0o700)
+
+        assert result == hermes_home / "gateway-locks"
+
+    def test_default_path_probe_is_memoized(self, tmp_path, monkeypatch):
+        """Repeated calls do not re-issue ``mkdir`` once the path resolves."""
+        monkeypatch.delenv("HERMES_GATEWAY_LOCK_DIR", raising=False)
+        monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        monkeypatch.setattr(status.Path, "home", classmethod(lambda cls: fake_home))
+
+        first = status._get_lock_dir()
+        # Remove the probed directory; if the function re-probed it would
+        # be re-created. The cache should short-circuit instead.
+        import shutil
+        shutil.rmtree(first)
+
+        second = status._get_lock_dir()
+
+        assert second == first
+        assert not second.exists()  # cache short-circuit, no re-probe


### PR DESCRIPTION
## What does this PR do?

In containers where the runtime user is non-root and the image \`WORKDIR\` (typically \`/opt/hermes\` under the Dockerfile) is owned by root, \`Path.home()\` resolves to a directory the process cannot write to. The gateway lock directory then fails to materialize:

\`\`\`
PermissionError: [Errno 13] Permission denied: '/opt/hermes/.local'
File \"/opt/hermes/gateway/status.py\", line 471, in acquire_scoped_lock
    lock_path.parent.mkdir(parents=True, exist_ok=True)
\`\`\`

The reproduction in the issue was a podman quadlet with \`UserNS=keep-id\` + \`User=%U:%G\`, where podman runs the container under the host UID without adjusting the container-side \`/etc/passwd\` entry, so \`\$HOME\` ends up at the \`WORKDIR\` rather than the \`hermes\` user's home.

This PR adds a fallback step to \`_get_lock_dir()\`:

| # | Source | When |
|---|--------|------|
| 1 | \`HERMES_GATEWAY_LOCK_DIR\` | explicit override (existing) |
| 2 | \`XDG_STATE_HOME/hermes/gateway-locks\` | XDG spec env (existing) |
| 3 | \`~/.local/state/hermes/gateway-locks\` | XDG default — **probed** |
| 4 | \`HERMES_HOME/gateway-locks\` | **new** fallback when (3) is unwritable |

\`HERMES_HOME\` is the documented runtime data root and is always intended to be writable (that's where the container volume mounts). It's the natural backstop for state files when \`\$HOME\` is locked down.

The probe result is memoized in \`_resolve_default_lock_dir\` so repeated \`acquire_scoped_lock\` calls don't re-issue \`mkdir\` syscalls.

## Related Issue

Fixes #16550

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- \`gateway/status.py\` — split \`_get_lock_dir()\`: env-driven branches stay un-cached for testability; the default-path probe lives in \`_resolve_default_lock_dir\` with \`functools.lru_cache(maxsize=1)\`. Probe failures fall back to \`HERMES_HOME / \"gateway-locks\"\` and emit a warning naming both \`HERMES_GATEWAY_LOCK_DIR\` and \`XDG_STATE_HOME\` as available overrides.
- \`tests/gateway/test_status.py\` — 5 new tests under \`TestGetLockDir\`: explicit override priority, XDG_STATE_HOME honor, default-path probe under writable HOME, fallback to HERMES_HOME under read-only HOME (the container scenario), and probe memoization.

## How to Test

Reproduce the original failure (no fix):

\`\`\`bash
docker run --rm -u 1000:1000 -e HERMES_HOME=/opt/data -v /tmp/data:/opt/data \\
  ghcr.io/nousresearch/hermes-agent gateway run
# → PermissionError: '/opt/hermes/.local'
\`\`\`

After this PR, the same command falls back to \`/opt/data/gateway-locks\` and logs a warning.

Automated:
\`\`\`bash
pytest tests/gateway/test_status.py
# 38 passed (5 new in TestGetLockDir)
\`\`\`

Wider \`tests/gateway/\` suite: 1006 passed (4 pre-existing flaky failures in Discord / approve-deny tests unrelated to this change — verified by running them on \`upstream/main\` without this PR).

## Notes

- Existing deployments with \`~/.local/state\` writable see no behavior change — the probe succeeds and returns the same path as before.
- Operators who want the lock directory in a specific location can still set \`HERMES_GATEWAY_LOCK_DIR\` or \`XDG_STATE_HOME\` explicitly; both short-circuit ahead of the probe.
- A complementary one-line fix in \`docker/entrypoint.sh\` (\`export HERMES_GATEWAY_LOCK_DIR=\"\$HERMES_HOME/gateway-locks\"\`) would make the explicit-override path active in the official image. Left out of this PR to keep the change purely fixing the runtime fallback; happy to follow up.