### PR TITLE
fix(cli): use correct legacy OAuth App client_id for Copilot auth

### DIFF
--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -29,8 +29,8 @@ from typing import Optional
 
 logger = logging.getLogger(__name__)
 
-# OAuth device code flow constants (same client ID as opencode/Copilot CLI)
-COPILOT_OAUTH_CLIENT_ID = "Ov23li8tweQw6odWQebz"
+# Legacy OAuth App client_id shared by VS Code, Copilot CLI, and opencode
+COPILOT_OAUTH_CLIENT_ID = "Iv1.b507a08c87ecfe98"
 # Token type prefixes
 _CLASSIC_PAT_PREFIX = "ghp_"
 _SUPPORTED_PREFIXES = ("gho_", "github_pat_", "ghu_")

--- a/tests/hermes_cli/test_copilot_auth.py
+++ b/tests/hermes_cli/test_copilot_auth.py
@@ -5,6 +5,14 @@ import pytest
 from unittest.mock import patch, MagicMock
 
 
+class TestOAuthClientId:
+    """Ensure the OAuth client_id matches the legacy OAuth App used by VS Code / Copilot CLI."""
+
+    def test_client_id_is_legacy_oauth_app(self):
+        from hermes_cli.copilot_auth import COPILOT_OAUTH_CLIENT_ID
+        assert COPILOT_OAUTH_CLIENT_ID == "Iv1.b507a08c87ecfe98"
+
+
 class TestTokenValidation:
     """Token type validation."""
 


### PR DESCRIPTION
## What does this PR do?

Fixes Copilot OAuth device-code flow using the wrong `client_id`. The current GitHub App client_id (`Ov23li...` prefix) cannot access `copilot_internal/v2/token`, causing HTTP 404 for all Copilot users and blocking live model discovery (including gpt-5.5 and other newer models).

Replaces it with the legacy OAuth App client_id (`Iv1.b507a08c87ecfe98`) used by VS Code, Copilot CLI, and opencode.

## Related Issue

Fixes #16551

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/copilot_auth.py`: Changed `COPILOT_OAUTH_CLIENT_ID` from GitHub App client_id to legacy OAuth App client_id (`Iv1.b507a08c87ecfe98`)
- `tests/hermes_cli/test_copilot_auth.py`: Added test verifying the client_id value

## How to Test

1. Run `hermes auth add copilot` with a GitHub account that has an active Copilot subscription
2. Complete the device-code authorization flow
3. Verify that `exchange_copilot_token()` succeeds (no HTTP 404)
4. Verify that `hermes model` shows the full live Copilot catalog including newer models
5. Run the targeted test: `pytest tests/hermes_cli/test_copilot_auth.py -v`
6. Run full suite: `pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (Darwin 25.4.0, Apple Silicon), Python 3.11

### Documentation & Housekeeping

- [x] Updated relevant documentation — or N/A
- [x] Updated cli-config.yaml.example — or N/A
- [x] Updated contributing / agents docs — or N/A
- [x] Considered cross-platform impact — or N/A
- [x] Updated tool descriptions/schemas — or N/A
