### PR TITLE
fix(runtime_provider): log local model auto-detect failures at debug level

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -103,7 +103,7 @@ def _auto_detect_local_model(base_url: str) -> str:
                 if model_id:
                     return model_id
     except Exception:
-        pass
+        logger.debug("Local model auto-detect failed; falling back to configured resolution", exc_info=True)
     return ""
 
 

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1,6 +1,21 @@
+import logging
+
 import pytest
 
 from hermes_cli import runtime_provider as rp
+
+
+def test_auto_detect_local_model_logs_debug_on_request_failure(monkeypatch, caplog):
+    def _raise_request_error(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("requests.get", _raise_request_error)
+
+    with caplog.at_level(logging.DEBUG, logger=rp.logger.name):
+        detected = rp._auto_detect_local_model("http://127.0.0.1:11434")
+
+    assert detected == ""
+    assert "Local model auto-detect failed; falling back to configured resolution" in caplog.text
 
 
 def test_resolve_runtime_provider_uses_credential_pool(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

This PR improves troubleshooting for local custom endpoints by logging auto-detect failures at debug level in `hermes_cli/runtime_provider.py`.

When `_auto_detect_local_model()` fails to fetch or parse `<base_url>/v1/models`, it now emits a debug log with exception stack information and then continues the existing fallback path unchanged. This keeps runtime behavior stable while making failure causes visible during debugging.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- add a debug log with `exc_info=True` in `hermes_cli/runtime_provider.py` when local model auto-detect fails
- keep `_auto_detect_local_model()` return values and fallback control flow unchanged
- add `test_auto_detect_local_model_logs_debug_on_request_failure` in `tests/hermes_cli/test_runtime_provider_resolution.py`
- verify that request failures still return `""` and emit the expected debug log

## How to Test

1. Run `venv/bin/pytest tests/hermes_cli/test_runtime_provider_resolution.py::test_auto_detect_local_model_logs_debug_on_request_failure -q -vv`
2. Run `venv/bin/pytest tests/hermes_cli/test_runtime_provider_resolution.py -q`
3. Confirm the new test passes and no other runtime provider resolution tests regress

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 / Darwin 24.6.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A
