### PR TITLE
fix(memory): pass session transcript to shutdown_memory_provider on gateway + CLI (#15165)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -759,9 +759,17 @@ def _run_cleanup():
         pass
     try:
         if _active_agent_ref and hasattr(_active_agent_ref, 'shutdown_memory_provider'):
-            _active_agent_ref.shutdown_memory_provider(
-                getattr(_active_agent_ref, 'conversation_history', None) or []
-            )
+            # Forward the agent's own transcript so memory providers'
+            # ``on_session_end`` hooks see the real conversation instead of
+            # an empty list (#15165). ``_session_messages`` is set on
+            # ``AIAgent.__init__`` and refreshed every turn via
+            # ``_persist_session``. Fall back to no-arg on test stubs /
+            # partially-initialised agents where the attribute is missing.
+            _session_msgs = getattr(_active_agent_ref, '_session_messages', None)
+            if isinstance(_session_msgs, list):
+                _active_agent_ref.shutdown_memory_provider(_session_msgs)
+            else:
+                _active_agent_ref.shutdown_memory_provider()
     except Exception:
         pass
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1943,7 +1943,21 @@ class GatewayRunner:
             return
         try:
             if hasattr(agent, "shutdown_memory_provider"):
-                agent.shutdown_memory_provider()
+                # Pass the agent's own conversation transcript so memory
+                # providers' ``on_session_end`` hooks see the real messages
+                # instead of the empty default (#15165). ``_session_messages``
+                # is set on ``AIAgent`` (run_agent.py:1518) and refreshed at
+                # the end of every ``run_conversation`` turn via
+                # ``_persist_session``; on an agent built through
+                # ``object.__new__`` (test stubs) the attribute may be
+                # absent, so ``getattr`` with a ``None`` default keeps the
+                # call signature-compatible with the pre-fix behaviour
+                # (``shutdown_memory_provider(messages=None)``).
+                session_messages = getattr(agent, "_session_messages", None)
+                if isinstance(session_messages, list):
+                    agent.shutdown_memory_provider(session_messages)
+                else:
+                    agent.shutdown_memory_provider()
         except Exception:
             pass
         # Close tool resources (terminal sandboxes, browser daemons,

--- a/tests/cli/test_cli_shutdown_memory_messages.py
+++ b/tests/cli/test_cli_shutdown_memory_messages.py
@@ -1,0 +1,111 @@
+"""Regression tests for #15165 (CLI sibling site) — CLI exit cleanup must
+forward the agent's conversation transcript to ``shutdown_memory_provider``
+so memory providers' ``on_session_end`` hooks see the real messages.
+
+Before the fix, ``_run_cleanup`` called
+``shutdown_memory_provider(getattr(agent, 'conversation_history', None) or [])``.
+``AIAgent`` has no ``conversation_history`` attribute — so the ``or []``
+branch always fired and providers got an empty list on CLI exit. This
+mirrors the gateway bug fixed in the same commit (gateway/run.py uses
+``_session_messages``, which IS set on ``AIAgent``).
+
+The fix reads ``_session_messages`` (same attribute the gateway path uses)
+with an ``isinstance(..., list)`` guard so MagicMock-based agents in
+other tests keep their existing no-arg behaviour.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+
+@patch("hermes_cli.plugins.invoke_hook")
+def test_cleanup_forwards_session_messages(mock_invoke_hook):
+    """_run_cleanup forwards a populated ``_session_messages`` list."""
+    import cli as cli_mod
+
+    transcript = [
+        {"role": "user", "content": "remember my dog is named Biscuit"},
+        {"role": "assistant", "content": "Got it — Biscuit."},
+    ]
+
+    agent = MagicMock()
+    agent.session_id = "cli-session-id"
+    agent._session_messages = transcript
+
+    cli_mod._active_agent_ref = agent
+    cli_mod._cleanup_done = False
+    try:
+        cli_mod._run_cleanup()
+    finally:
+        cli_mod._active_agent_ref = None
+        cli_mod._cleanup_done = False
+
+    agent.shutdown_memory_provider.assert_called_once_with(transcript)
+
+
+@patch("hermes_cli.plugins.invoke_hook")
+def test_cleanup_empty_list_still_forwarded(mock_invoke_hook):
+    """An agent that initialised but ran no turns has an empty list.
+    Forwarding it (rather than falling through) matches the gateway-side
+    behaviour and is explicit to providers."""
+    import cli as cli_mod
+
+    agent = MagicMock()
+    agent.session_id = "cli-session-id"
+    agent._session_messages = []
+
+    cli_mod._active_agent_ref = agent
+    cli_mod._cleanup_done = False
+    try:
+        cli_mod._run_cleanup()
+    finally:
+        cli_mod._active_agent_ref = None
+        cli_mod._cleanup_done = False
+
+    agent.shutdown_memory_provider.assert_called_once_with([])
+
+
+@patch("hermes_cli.plugins.invoke_hook")
+def test_cleanup_non_list_attribute_falls_back_to_no_arg(mock_invoke_hook):
+    """A MagicMock agent auto-synthesises ``_session_messages`` as a
+    nested MagicMock. ``isinstance(mock, list)`` is False, so we fall
+    back to the no-arg path rather than passing a garbage value to
+    providers expecting ``List[Dict]``.  This keeps existing CLI test
+    suites that use bare ``MagicMock()`` agents green."""
+    import cli as cli_mod
+
+    agent = MagicMock()
+    agent.session_id = "cli-session-id"
+    # No explicit _session_messages — MagicMock synthesises one on access.
+
+    cli_mod._active_agent_ref = agent
+    cli_mod._cleanup_done = False
+    try:
+        cli_mod._run_cleanup()
+    finally:
+        cli_mod._active_agent_ref = None
+        cli_mod._cleanup_done = False
+
+    agent.shutdown_memory_provider.assert_called_once_with()
+
+
+@patch("hermes_cli.plugins.invoke_hook")
+def test_cleanup_provider_exception_is_swallowed(mock_invoke_hook):
+    """A raising ``shutdown_memory_provider`` must not crash CLI exit."""
+    import cli as cli_mod
+
+    agent = MagicMock()
+    agent.session_id = "cli-session-id"
+    agent._session_messages = [{"role": "user", "content": "x"}]
+    agent.shutdown_memory_provider.side_effect = RuntimeError("boom")
+
+    cli_mod._active_agent_ref = agent
+    cli_mod._cleanup_done = False
+    try:
+        cli_mod._run_cleanup()  # must not raise
+    finally:
+        cli_mod._active_agent_ref = None
+        cli_mod._cleanup_done = False
+
+    agent.shutdown_memory_provider.assert_called_once()

--- a/tests/gateway/test_shutdown_memory_provider_messages.py
+++ b/tests/gateway/test_shutdown_memory_provider_messages.py
@@ -1,0 +1,148 @@
+"""Regression tests for #15165 — gateway session shutdown must pass the
+agent's conversation transcript to ``shutdown_memory_provider`` so memory
+providers' ``on_session_end`` hooks see the real messages instead of an
+empty list.
+
+Before the fix, ``_cleanup_agent_resources`` called
+``agent.shutdown_memory_provider()`` with no arguments, which in turn
+invoked ``on_session_end([])`` on every memory provider. Providers with
+an empty-guard (Holographic, Hindsight, etc.) exited early and never
+persisted the session's facts, so the next gateway start-up surfaced no
+memories from the prior conversation.
+
+The fix reads ``agent._session_messages`` (set on ``AIAgent.__init__``
+and refreshed every turn via ``_persist_session``) and forwards it to
+``shutdown_memory_provider``. Test stubs built via ``object.__new__``
+or plain ``MagicMock()`` still exercise the legacy no-arg path, so the
+change is backward-compatible with existing suites.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _mock_dotenv(monkeypatch):
+    """gateway.run imports dotenv at module load; stub so tests run bare."""
+    fake = types.ModuleType("dotenv")
+    fake.load_dotenv = lambda *a, **kw: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake)
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    return runner
+
+
+# A lightweight stand-in for AIAgent so ``isinstance(..., list)`` correctly
+# discriminates between "attribute set to a list" and "attribute absent /
+# MagicMock auto-synthesised". Using MagicMock directly for the agent
+# would also work for the populated case, but attribute access on a
+# MagicMock always yields a child MagicMock — we want a real Python
+# object we can shape per-test.
+class _FakeAgent:
+    def __init__(self, session_messages=None, has_shutdown=True):
+        if session_messages is not None:
+            self._session_messages = session_messages
+        if has_shutdown:
+            self.shutdown_memory_provider = MagicMock()
+        self.close = MagicMock()
+
+
+class TestCleanupAgentResourcesPassesMessages:
+    """_cleanup_agent_resources forwards the agent's session messages."""
+
+    def test_populated_messages_forwarded(self):
+        """Real-world path: an agent that ran a turn has a populated
+        ``_session_messages`` list and the cleanup call forwards it."""
+        runner = _make_runner()
+        transcript = [
+            {"role": "user", "content": "remember my dog is named Biscuit"},
+            {"role": "assistant", "content": "Got it — Biscuit."},
+        ]
+        agent = _FakeAgent(session_messages=transcript)
+
+        runner._cleanup_agent_resources(agent)
+
+        # The fix must call shutdown_memory_provider with the exact list
+        # identity — providers iterate it to extract facts.
+        agent.shutdown_memory_provider.assert_called_once_with(transcript)
+
+    def test_empty_list_still_forwarded(self):
+        """An agent that initialised but ran no turns has an empty list
+        on ``_session_messages``. Forwarding it (rather than falling
+        through to the no-arg path) makes the absence of content
+        explicit to providers and matches the pre-fix observable
+        behaviour (``on_session_end([])``)."""
+        runner = _make_runner()
+        agent = _FakeAgent(session_messages=[])
+
+        runner._cleanup_agent_resources(agent)
+
+        agent.shutdown_memory_provider.assert_called_once_with([])
+
+    def test_missing_attribute_falls_back_to_no_arg(self):
+        """Test stubs built via ``object.__new__(AIAgent)`` skip
+        ``__init__`` and therefore have no ``_session_messages``
+        attribute. The fix must not explode — it falls back to the
+        legacy no-arg call so existing suites keep passing."""
+        runner = _make_runner()
+        agent = _FakeAgent(session_messages=None)  # attribute not set
+
+        runner._cleanup_agent_resources(agent)
+
+        agent.shutdown_memory_provider.assert_called_once_with()
+
+    def test_non_list_attribute_falls_back_to_no_arg(self):
+        """A MagicMock-based agent auto-synthesises ``_session_messages``
+        as a nested MagicMock. ``isinstance(mock, list)`` is False, so
+        we fall back to the no-arg path rather than passing a garbage
+        value to providers that expect ``List[Dict]``."""
+        runner = _make_runner()
+        agent = MagicMock()
+        # No explicit _session_messages assignment — MagicMock will
+        # synthesise one on access.
+
+        runner._cleanup_agent_resources(agent)
+
+        agent.shutdown_memory_provider.assert_called_once_with()
+
+    def test_provider_exception_is_swallowed(self):
+        """Provider teardown must be best-effort — a raising
+        ``shutdown_memory_provider`` must not prevent ``close()`` from
+        running (tool resource leak is worse than a missed memory
+        flush)."""
+        runner = _make_runner()
+        agent = _FakeAgent(session_messages=[{"role": "user", "content": "x"}])
+        agent.shutdown_memory_provider.side_effect = RuntimeError("boom")
+
+        # Must not raise.
+        runner._cleanup_agent_resources(agent)
+
+        # close() still invoked after the swallowed exception.
+        agent.close.assert_called_once()
+
+    def test_none_agent_is_noop(self):
+        """Defensive: None agent short-circuits (idle sweeps may
+        observe a None entry in the cache during eviction races)."""
+        runner = _make_runner()
+        # Must not raise.
+        runner._cleanup_agent_resources(None)
+
+    def test_agent_without_shutdown_method_is_tolerated(self):
+        """An agent without ``shutdown_memory_provider`` (old test
+        stub, partial mock) must still have ``close()`` called."""
+        runner = _make_runner()
+        agent = _FakeAgent(has_shutdown=False)
+        # No _session_messages either, to exercise the hasattr guard.
+
+        runner._cleanup_agent_resources(agent)
+
+        agent.close.assert_called_once()


### PR DESCRIPTION
## Summary
Memory providers' `on_session_end` hook now receives the real conversation transcript on both gateway session teardown and CLI exit, instead of an empty list.  Fixes #15165.

Salvaged from #15481 (@briandevans) with the CLI sibling site fixed in a follow-up commit.

## The bug
Both teardown paths called `shutdown_memory_provider` with an effectively-empty list:

- **Gateway** (`gateway/run.py`): `agent.shutdown_memory_provider()` — no args, so `on_session_end([])` fired on every provider.
- **CLI** (`cli.py`): `shutdown_memory_provider(getattr(agent, 'conversation_history', None) or [])` — `AIAgent` has no `conversation_history` attribute, so the `or []` branch always fired.

Providers that early-return on empty input (Holographic, Hindsight mid-batch) never persisted the session.  Hindsight specifically buffers turns and only flushes at `retain_every_n_turns` boundaries — any turns held below the modulus at restart/idle-expiry/exit were silently dropped.

## The fix
Both sites now forward `agent._session_messages` — the transcript `AIAgent` maintains and refreshes every turn in `_persist_session` (run_agent.py:3378) and several loop paths.

```python
session_messages = getattr(agent, "_session_messages", None)
if isinstance(session_messages, list):
    agent.shutdown_memory_provider(session_messages)
else:
    agent.shutdown_memory_provider()
```

The `isinstance(..., list)` guard is deliberate — it protects against MagicMock agents (whose attribute access auto-synthesises a child mock) falling through to providers that expect `List[Dict]`, keeping existing test suites green.

## Scope
**Part A of #15165 only** (plus the CLI sibling).  Part B (adding an `on_session_end` implementation to the Hindsight plugin) is a separate concern that benefits from this landing first — without Part A the hook would still receive `[]`.

## Commits
1. `fix(gateway): pass session messages to shutdown_memory_provider` — @briandevans, cherry-picked from #15481
2. `fix(cli): pass session messages to shutdown_memory_provider` — widens the same fix to the CLI exit path; #15481 was gateway-only

## Test plan
- `tests/gateway/test_shutdown_memory_provider_messages.py` (7 cases, from #15481) — populated list forwarded, empty list forwarded, missing attribute falls back, MagicMock falls back, provider exception swallowed, None agent no-op, agent without method tolerated.
- `tests/cli/test_cli_shutdown_memory_messages.py` (4 cases, new) — populated, empty, non-list fallback, provider exception swallowed.
- **Regression guard verified**: reverted the CLI fix → 3 of 4 new CLI tests fail with `Expected: mock([...]) / Actual: mock()`; restored → all pass.
- Related gateway suites green: `test_shutdown_cache_cleanup`, `test_compress_command`, `test_agent_cache`, `test_session_hygiene`, `test_background_command`, `test_compress_plugin_engine`, `test_session_boundary_hooks` (92 + 15 = 107 passing).

## Related
- Fixes #15165 (Part A)
- Supersedes #15481 (@briandevans's authorship preserved via rebase merge)
- #7759 (closed) — `/new` / `/reset` memory commit, different code path
- #14981 — `on_session_finalize` not fired on idle timeout (orthogonal)
- #15073 — Hindsight sync races interpreter shutdown (orthogonal)