### PR TITLE
feat(backup): exclude checkpoints/ from backups

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -37,6 +37,8 @@ _EXCLUDED_DIRS = {
     ".git",             # nested git dirs (profiles shouldn't have these, but safety)
     "node_modules",     # js deps if website/ somehow leaks in
     "backups",          # prior auto-backups — don't nest backups exponentially
+    "checkpoints",      # session-local trajectory caches — regenerated per-session,
+                        # session-hash-keyed so they don't port to another machine anyway
 }
 
 # File-name suffixes to skip

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -91,6 +91,18 @@ class TestShouldExclude:
         assert _should_exclude(Path("gateway.pid"))
         assert _should_exclude(Path("cron.pid"))
 
+    def test_excludes_checkpoints(self):
+        """checkpoints/ is session-local trajectory cache — hash-keyed,
+        regenerated per-session, won't port to another machine anyway."""
+        from hermes_cli.backup import _should_exclude
+        assert _should_exclude(Path("checkpoints/abc123/trajectory.json"))
+        assert _should_exclude(Path("checkpoints/deadbeef/step_0001.json"))
+
+    def test_excludes_backups_dir(self):
+        """backups/ is excluded so pre-update backups don't nest exponentially."""
+        from hermes_cli.backup import _should_exclude
+        assert _should_exclude(Path("backups/pre-update-2026-04-27-063400.zip"))
+
     def test_includes_config(self):
         from hermes_cli.backup import _should_exclude
         assert not _should_exclude(Path("config.yaml"))


### PR DESCRIPTION
## Summary
`hermes backup` and the pre-update backup hook now skip `<HERMES_HOME>/checkpoints/`. Checkpoints are session-local trajectory caches — hash-keyed, regenerated per session, and wouldn't port to another machine anyway. On a heavy install this was multi-GB of dead weight in every zip.

## Changes
- `hermes_cli/backup.py`: `checkpoints` added to `_EXCLUDED_DIRS` alongside `backups`, `.git`, `__pycache__`, `node_modules`, `hermes-agent`
- `tests/hermes_cli/test_backup.py`: new `test_excludes_checkpoints` + `test_excludes_backups_dir` regression test for the sibling exclusion

## Validation
| | Before | After |
|---|---|---|
| `checkpoints/<hash>/trajectory.json` in zip | included | excluded |
| `tests/hermes_cli/test_backup.py` | 83 passed | 85 passed |