### PR TITLE
fix(model-tools): reuse persistent async bridge loop

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1100,6 +1100,11 @@ def _run_cleanup(*, notify_session_finalize: bool = True):
         shutdown_cached_clients()
     except Exception:
         pass
+    try:
+        from model_tools import shutdown_async_bridge_loop
+        shutdown_async_bridge_loop()
+    except BaseException:
+        pass
     # Shut down memory provider (on_session_end + shutdown_all) at actual
     # session boundary — NOT per-turn inside run_conversation().
     if notify_session_finalize:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8422,6 +8422,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 shutdown_cached_clients()
             except Exception as _e:
                 logger.debug("shutdown_cached_clients error: %s", _e)
+            try:
+                from model_tools import shutdown_async_bridge_loop
+                shutdown_async_bridge_loop()
+            except Exception as _e:
+                logger.debug("shutdown_async_bridge_loop error: %s", _e)
 
             # Close SQLite session DBs so the WAL write lock is released.
             # Without this, --replace and similar restart flows leave the

--- a/model_tools.py
+++ b/model_tools.py
@@ -93,21 +93,49 @@ def _get_worker_loop():
 def _run_async_in_oneoff_thread(coro, timeout: float = _ASYNC_BRIDGE_TIMEOUT):
     """Run a coroutine on a temporary worker thread and event loop."""
     done = threading.Event()
+    cancel_requested = threading.Event()
+    state_lock = threading.Lock()
     result = {}
+    state = {"loop": None, "task": None}
 
     def _target():
         loop = asyncio.new_event_loop()
         try:
             asyncio.set_event_loop(loop)
-            result["value"] = loop.run_until_complete(coro)
+            task = loop.create_task(coro)
+            with state_lock:
+                state["loop"] = loop
+                state["task"] = task
+            if cancel_requested.is_set():
+                task.cancel()
+            result["value"] = loop.run_until_complete(task)
         except BaseException as exc:
             result["error"] = exc
         finally:
             try:
-                loop.close()
+                pending = [
+                    task
+                    for task in asyncio.all_tasks(loop)
+                    if not task.done()
+                ]
+                for task in pending:
+                    task.cancel()
+                if pending:
+                    loop.run_until_complete(
+                        asyncio.gather(*pending, return_exceptions=True)
+                    )
+                loop.run_until_complete(loop.shutdown_asyncgens())
             finally:
-                asyncio.set_event_loop(None)
-                done.set()
+                try:
+                    with state_lock:
+                        state["loop"] = None
+                        state["task"] = None
+                finally:
+                    asyncio.set_event_loop(None)
+                try:
+                    loop.close()
+                finally:
+                    done.set()
 
     thread = threading.Thread(
         target=_target,
@@ -116,6 +144,20 @@ def _run_async_in_oneoff_thread(coro, timeout: float = _ASYNC_BRIDGE_TIMEOUT):
     )
     thread.start()
     if not done.wait(timeout=timeout):
+        cancel_requested.set()
+        with state_lock:
+            loop = state["loop"]
+            task = state["task"]
+        if (
+            loop is not None
+            and task is not None
+            and not loop.is_closed()
+            and not task.done()
+        ):
+            try:
+                loop.call_soon_threadsafe(task.cancel)
+            except RuntimeError as exc:
+                logger.debug("One-off async bridge cancellation failed: %s", exc)
         raise TimeoutError()
     if "error" in result:
         raise result["error"]

--- a/model_tools.py
+++ b/model_tools.py
@@ -40,12 +40,15 @@ _WARNED_DISABLED_BUNDLES: set = set()
 
 
 # =============================================================================
-# Async Bridging  (single source of truth -- used by registry.dispatch too)
+# Async Bridging  (used by registry.dispatch for is_async=True tools)
 # =============================================================================
 
 _tool_loop = None          # persistent loop for the main (CLI) thread
 _tool_loop_lock = threading.Lock()
 _worker_thread_local = threading.local()  # per-worker-thread persistent loops
+_async_bridge_loop = None
+_async_bridge_thread = None
+_async_bridge_lock = threading.Lock()
 
 
 def _get_tool_loop():
@@ -85,13 +88,123 @@ def _get_worker_loop():
     return loop
 
 
+def _run_bridge_loop(loop: asyncio.AbstractEventLoop, ready: threading.Event) -> None:
+    """Run the async-context bridge loop forever on its dedicated thread."""
+    asyncio.set_event_loop(loop)
+    ready.set()
+    loop.run_forever()
+
+
+async def _shutdown_bridge_loop_tasks() -> None:
+    """Cancel pending bridge-loop tasks before the loop is stopped."""
+    current = asyncio.current_task()
+    pending = [
+        task
+        for task in asyncio.all_tasks()
+        if task is not current and not task.done()
+    ]
+    for task in pending:
+        task.cancel()
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
+    await asyncio.get_running_loop().shutdown_asyncgens()
+
+
+def shutdown_async_bridge_loop(timeout: float = 5.0) -> None:
+    """Stop and close the dedicated async-context bridge loop, if it exists."""
+    global _async_bridge_loop, _async_bridge_thread
+
+    with _async_bridge_lock:
+        loop = _async_bridge_loop
+        thread = _async_bridge_thread
+        _async_bridge_loop = None
+        _async_bridge_thread = None
+
+    if loop is None or loop.is_closed():
+        return
+
+    if thread is not None and thread is threading.current_thread():
+        logger.debug("Skipping synchronous async bridge shutdown from bridge thread")
+        loop.call_soon(loop.stop)
+        return
+
+    if thread is not None and thread.is_alive():
+        try:
+            future = asyncio.run_coroutine_threadsafe(_shutdown_bridge_loop_tasks(), loop)
+            future.result(timeout=timeout)
+        except Exception as exc:
+            logger.debug("Async bridge task cleanup failed: %s", exc)
+        try:
+            loop.call_soon_threadsafe(loop.stop)
+        except RuntimeError as exc:
+            logger.debug("Async bridge stop failed: %s", exc)
+        thread.join(timeout=timeout)
+
+    if thread is not None and thread.is_alive():
+        logger.warning("Async bridge loop thread did not stop within %.1fs", timeout)
+        return
+
+    try:
+        loop.close()
+    except RuntimeError as exc:
+        logger.debug("Async bridge loop close failed: %s", exc)
+
+
+def _get_async_bridge_loop():
+    """Return a persistent loop for callers already inside a running loop.
+
+    Gateway mode hits ``_run_async()`` from inside an active asyncio loop.
+    Spawning ``asyncio.run()`` in a throwaway worker thread per call creates a
+    fresh loop every time, which strands cached AsyncOpenAI/httpx clients on
+    dead loops and leaks descriptors over a long-lived gateway process.
+
+    Instead, reuse one dedicated background loop and submit coroutines to it via
+    ``asyncio.run_coroutine_threadsafe()``. This keeps async clients bound to a
+    stable loop and prevents per-call loop churn.
+    """
+    global _async_bridge_loop, _async_bridge_thread
+
+    with _async_bridge_lock:
+        loop = _async_bridge_loop
+        thread = _async_bridge_thread
+        if loop is not None and not loop.is_closed() and thread is not None and thread.is_alive():
+            return loop
+        if loop is not None and not loop.is_closed():
+            loop.close()
+
+        loop = asyncio.new_event_loop()
+        ready = threading.Event()
+        thread = threading.Thread(
+            target=_run_bridge_loop,
+            args=(loop, ready),
+            daemon=True,
+            name="model-tools-async-bridge",
+        )
+        thread.start()
+        ready_started = ready.wait(timeout=5)
+        if not ready_started or not thread.is_alive():
+            if thread.is_alive():
+                try:
+                    loop.call_soon_threadsafe(loop.stop)
+                except RuntimeError:
+                    pass
+                thread.join(timeout=1)
+            if not thread.is_alive() and not loop.is_closed():
+                loop.close()
+            _async_bridge_loop = None
+            _async_bridge_thread = None
+            raise RuntimeError("Failed to start model_tools async bridge loop")
+        _async_bridge_loop = loop
+        _async_bridge_thread = thread
+        return loop
+
+
 def _run_async(coro):
     """Run an async coroutine from a sync context.
 
     If the current thread already has a running event loop (e.g., inside
-    the gateway's async stack or Atropos's event loop), we spin up a
-    disposable thread so asyncio.run() can create its own loop without
-    conflicting.
+    the gateway's async stack or Atropos's event loop), we submit the work
+    to a dedicated long-lived background loop.
 
     For the common CLI path (no running loop), we use a persistent event
     loop so that cached async clients (httpx / AsyncOpenAI) remain bound
@@ -102,8 +215,12 @@ def _run_async(coro):
     thread's shared loop AND the "Event loop is closed" errors caused by
     asyncio.run()'s create-and-destroy lifecycle.
 
-    This is the single source of truth for sync->async bridging in tool
-    handlers. Each handler is self-protecting via this function.
+    This bridge is used by registry.dispatch for handlers registered with
+    is_async=True. Some sync tool modules keep local bridges when they expose
+    synchronous handlers around async internals. The RL paths (agent_loop.py,
+    tool_context.py) also provide outer thread-pool wrapping as
+    defense-in-depth, but each registry-dispatched async handler is
+    self-protecting via this function.
     """
     try:
         loop = asyncio.get_running_loop()
@@ -111,62 +228,13 @@ def _run_async(coro):
         loop = None
 
     if loop and loop.is_running():
-        # Inside an async context (gateway, RL env) — run in a fresh thread
-        # with its own event loop we own a reference to, so on timeout we
-        # can cancel the task inside that loop (ThreadPoolExecutor.cancel()
-        # only works on not-yet-started futures — it's a no-op on a running
-        # worker, which previously leaked the thread on every 300 s timeout).
-        import concurrent.futures
-
-        worker_loop: Optional[asyncio.AbstractEventLoop] = None
-        loop_ready = threading.Event()
-
-        def _run_in_worker():
-            nonlocal worker_loop
-            worker_loop = asyncio.new_event_loop()
-            loop_ready.set()
-            try:
-                asyncio.set_event_loop(worker_loop)
-                return worker_loop.run_until_complete(coro)
-            finally:
-                try:
-                    # Cancel anything still pending (e.g. task cancelled
-                    # externally via call_soon_threadsafe on timeout).
-                    pending = asyncio.all_tasks(worker_loop)
-                    for t in pending:
-                        t.cancel()
-                    if pending:
-                        worker_loop.run_until_complete(
-                            asyncio.gather(*pending, return_exceptions=True)
-                        )
-                except Exception:
-                    pass
-                worker_loop.close()
-
-        pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-        # Carry the active profile + approval/sudo callbacks into the worker so
-        # async tools resolve get_hermes_home() under the active profile.
-        from tools.thread_context import propagate_context_to_thread
-
-        future = pool.submit(propagate_context_to_thread(_run_in_worker))
+        bridge_loop = _get_async_bridge_loop()
+        future = asyncio.run_coroutine_threadsafe(coro, bridge_loop)
         try:
             return future.result(timeout=300)
-        except concurrent.futures.TimeoutError:
-            # Cancel the coroutine inside its own loop so the worker thread
-            # can wind down instead of running forever.
-            if loop_ready.wait(timeout=1.0) and worker_loop is not None:
-                try:
-                    for t in asyncio.all_tasks(worker_loop):
-                        worker_loop.call_soon_threadsafe(t.cancel)
-                except RuntimeError:
-                    # Loop already closed — nothing to cancel.
-                    pass
+        except TimeoutError:
+            future.cancel()
             raise
-        finally:
-            # wait=False: don't block the caller on a stuck coroutine. We've
-            # already requested cancellation above; the worker will exit
-            # once the coroutine observes it (usually at the next await).
-            pool.shutdown(wait=False)
 
     # If we're on a worker thread (e.g., parallel tool execution in
     # delegate_task), use a per-thread persistent loop.  This avoids

--- a/model_tools.py
+++ b/model_tools.py
@@ -50,6 +50,7 @@ _async_bridge_loop = None
 _async_bridge_thread = None
 _async_bridge_lock = threading.Lock()
 _ASYNC_BRIDGE_TIMEOUT = 300
+_ASYNC_BRIDGE_HEALTH_PROBE_TIMEOUT = 0.2
 
 
 def _get_tool_loop():
@@ -153,6 +154,24 @@ def _retire_async_bridge_loop(loop: asyncio.AbstractEventLoop) -> None:
         loop.close()
     except RuntimeError as exc:
         logger.debug("Async bridge retire close failed: %s", exc)
+
+
+def _async_bridge_loop_is_responsive(
+    loop: asyncio.AbstractEventLoop,
+    timeout: float = _ASYNC_BRIDGE_HEALTH_PROBE_TIMEOUT,
+) -> bool:
+    """Return whether the bridge loop can still process callbacks promptly."""
+    if loop.is_closed():
+        return False
+
+    probe_ran = threading.Event()
+    try:
+        loop.call_soon_threadsafe(probe_ran.set)
+    except RuntimeError as exc:
+        logger.debug("Async bridge health probe scheduling failed: %s", exc)
+        return False
+
+    return probe_ran.wait(timeout=timeout)
 
 
 async def _shutdown_bridge_loop_tasks() -> None:
@@ -297,7 +316,8 @@ def _run_async(coro):
             return future.result(timeout=_ASYNC_BRIDGE_TIMEOUT)
         except TimeoutError:
             future.cancel()
-            _retire_async_bridge_loop(bridge_loop)
+            if not _async_bridge_loop_is_responsive(bridge_loop):
+                _retire_async_bridge_loop(bridge_loop)
             raise
 
     # If we're on a worker thread (e.g., parallel tool execution in

--- a/model_tools.py
+++ b/model_tools.py
@@ -49,6 +49,7 @@ _worker_thread_local = threading.local()  # per-worker-thread persistent loops
 _async_bridge_loop = None
 _async_bridge_thread = None
 _async_bridge_lock = threading.Lock()
+_ASYNC_BRIDGE_TIMEOUT = 300
 
 
 def _get_tool_loop():
@@ -88,11 +89,70 @@ def _get_worker_loop():
     return loop
 
 
+def _run_async_in_oneoff_thread(coro, timeout: float = _ASYNC_BRIDGE_TIMEOUT):
+    """Run a coroutine on a temporary worker thread and event loop."""
+    done = threading.Event()
+    result = {}
+
+    def _target():
+        loop = asyncio.new_event_loop()
+        try:
+            asyncio.set_event_loop(loop)
+            result["value"] = loop.run_until_complete(coro)
+        except BaseException as exc:
+            result["error"] = exc
+        finally:
+            try:
+                loop.close()
+            finally:
+                asyncio.set_event_loop(None)
+                done.set()
+
+    thread = threading.Thread(
+        target=_target,
+        daemon=True,
+        name="model-tools-async-oneoff",
+    )
+    thread.start()
+    if not done.wait(timeout=timeout):
+        raise TimeoutError()
+    if "error" in result:
+        raise result["error"]
+    return result.get("value")
+
+
 def _run_bridge_loop(loop: asyncio.AbstractEventLoop, ready: threading.Event) -> None:
     """Run the async-context bridge loop forever on its dedicated thread."""
     asyncio.set_event_loop(loop)
     ready.set()
     loop.run_forever()
+
+
+def _retire_async_bridge_loop(loop: asyncio.AbstractEventLoop) -> None:
+    """Remove a timed-out bridge loop from future use without blocking on it."""
+    global _async_bridge_loop, _async_bridge_thread
+
+    with _async_bridge_lock:
+        if _async_bridge_loop is not loop:
+            return
+        thread = _async_bridge_thread
+        _async_bridge_loop = None
+        _async_bridge_thread = None
+
+    if loop.is_closed():
+        return
+
+    if thread is not None and thread.is_alive():
+        try:
+            loop.call_soon_threadsafe(loop.call_later, 0.1, loop.stop)
+        except RuntimeError as exc:
+            logger.debug("Async bridge retire stop scheduling failed: %s", exc)
+        return
+
+    try:
+        loop.close()
+    except RuntimeError as exc:
+        logger.debug("Async bridge retire close failed: %s", exc)
 
 
 async def _shutdown_bridge_loop_tasks() -> None:
@@ -228,12 +288,16 @@ def _run_async(coro):
         loop = None
 
     if loop and loop.is_running():
+        if loop is _async_bridge_loop:
+            return _run_async_in_oneoff_thread(coro, timeout=_ASYNC_BRIDGE_TIMEOUT)
+
         bridge_loop = _get_async_bridge_loop()
         future = asyncio.run_coroutine_threadsafe(coro, bridge_loop)
         try:
-            return future.result(timeout=300)
+            return future.result(timeout=_ASYNC_BRIDGE_TIMEOUT)
         except TimeoutError:
             future.cancel()
+            _retire_async_bridge_loop(bridge_loop)
             raise
 
     # If we're on a worker thread (e.g., parallel tool execution in

--- a/model_tools.py
+++ b/model_tools.py
@@ -137,8 +137,10 @@ def _run_async_in_oneoff_thread(coro, timeout: float = _ASYNC_BRIDGE_TIMEOUT):
                 finally:
                     done.set()
 
+    from tools.thread_context import propagate_context_to_thread
+
     thread = threading.Thread(
-        target=_target,
+        target=propagate_context_to_thread(_target),
         daemon=True,
         name="model-tools-async-oneoff",
     )
@@ -374,7 +376,10 @@ def _run_async(coro):
             return _run_async_in_oneoff_thread(coro, timeout=_ASYNC_BRIDGE_TIMEOUT)
 
         bridge_loop = _get_async_bridge_loop()
-        future = asyncio.run_coroutine_threadsafe(coro, bridge_loop)
+        from tools.thread_context import propagate_context_to_async_task
+
+        with propagate_context_to_async_task():
+            future = asyncio.run_coroutine_threadsafe(coro, bridge_loop)
         try:
             return future.result(timeout=_ASYNC_BRIDGE_TIMEOUT)
         except TimeoutError:

--- a/model_tools.py
+++ b/model_tools.py
@@ -166,9 +166,29 @@ def _run_async_in_oneoff_thread(coro, timeout: float = _ASYNC_BRIDGE_TIMEOUT):
 
 def _run_bridge_loop(loop: asyncio.AbstractEventLoop, ready: threading.Event) -> None:
     """Run the async-context bridge loop forever on its dedicated thread."""
-    asyncio.set_event_loop(loop)
-    ready.set()
-    loop.run_forever()
+    try:
+        asyncio.set_event_loop(loop)
+        ready.set()
+        loop.run_forever()
+    finally:
+        try:
+            if not loop.is_closed():
+                pending = [
+                    task
+                    for task in asyncio.all_tasks(loop)
+                    if not task.done()
+                ]
+                for task in pending:
+                    task.cancel()
+                if pending:
+                    loop.run_until_complete(
+                        asyncio.gather(*pending, return_exceptions=True)
+                    )
+                loop.run_until_complete(loop.shutdown_asyncgens())
+        finally:
+            asyncio.set_event_loop(None)
+            if not loop.is_closed():
+                loop.close()
 
 
 def _retire_async_bridge_loop(loop: asyncio.AbstractEventLoop) -> None:
@@ -265,10 +285,11 @@ def shutdown_async_bridge_loop(timeout: float = 5.0) -> None:
         logger.warning("Async bridge loop thread did not stop within %.1fs", timeout)
         return
 
-    try:
-        loop.close()
-    except RuntimeError as exc:
-        logger.debug("Async bridge loop close failed: %s", exc)
+    if thread is None and not loop.is_closed():
+        try:
+            loop.close()
+        except RuntimeError as exc:
+            logger.debug("Async bridge loop close failed: %s", exc)
 
 
 def _get_async_bridge_loop():

--- a/tests/cli/test_session_boundary_hooks.py
+++ b/tests/cli/test_session_boundary_hooks.py
@@ -37,7 +37,8 @@ def test_session_finalize_on_reset(mock_invoke_hook):
 
 
 @patch("hermes_cli.plugins.invoke_hook")
-def test_session_finalize_on_cleanup(mock_invoke_hook):
+@patch("model_tools.shutdown_async_bridge_loop")
+def test_session_finalize_on_cleanup(mock_shutdown_bridge, mock_invoke_hook):
     """Verify on_session_finalize fires during CLI exit cleanup."""
     import cli as cli_mod
 
@@ -55,6 +56,7 @@ def test_session_finalize_on_cleanup(mock_invoke_hook):
         and c.kwargs["reason"] == "shutdown"
         for c in mock_invoke_hook.call_args_list
     )
+    mock_shutdown_bridge.assert_called_once()
 
 
 @patch("hermes_cli.plugins.invoke_hook")

--- a/tests/gateway/test_gateway_shutdown.py
+++ b/tests/gateway/test_gateway_shutdown.py
@@ -556,3 +556,18 @@ def test_pid_exists_zombie_via_proc_fallback_returns_false(monkeypatch):
 
     assert status._pid_exists(4242) is False
     kill.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_gateway_stop_shuts_down_async_bridge_loop():
+    runner, adapter = make_restart_runner()
+    adapter.disconnect = AsyncMock()
+
+    with (
+        patch("gateway.status.remove_pid_file"),
+        patch("gateway.status.write_runtime_status"),
+        patch("model_tools.shutdown_async_bridge_loop") as mock_shutdown_bridge,
+    ):
+        await runner.stop()
+
+    mock_shutdown_bridge.assert_called_once()

--- a/tests/test_model_tools_async_bridge.py
+++ b/tests/test_model_tools_async_bridge.py
@@ -492,6 +492,48 @@ class TestRunAsyncWithRunningLoop:
         finally:
             shutdown_async_bridge_loop()
 
+    def test_nested_bridge_loop_timeout_cancels_oneoff_task(self, monkeypatch):
+        """Timed-out nested bridge-loop calls must cancel the one-off task."""
+        import model_tools
+
+        from model_tools import _run_async, shutdown_async_bridge_loop
+
+        cancel_observed = threading.Event()
+        release_uncancelled = threading.Event()
+        oneoff_finished = threading.Event()
+
+        async def _inner_waits_for_cancellation():
+            try:
+                await asyncio.to_thread(release_uncancelled.wait)
+            except asyncio.CancelledError:
+                cancel_observed.set()
+                raise
+            finally:
+                oneoff_finished.set()
+
+        async def _outer_runs_on_bridge_loop():
+            with pytest.raises(TimeoutError):
+                _run_async(_inner_waits_for_cancellation())
+            return cancel_observed.wait(timeout=1)
+
+        monkeypatch.setattr(model_tools, "_ASYNC_BRIDGE_TIMEOUT", 0.05)
+
+        try:
+            bridge_loop = model_tools._get_async_bridge_loop()
+            future = asyncio.run_coroutine_threadsafe(
+                _outer_runs_on_bridge_loop(),
+                bridge_loop,
+            )
+
+            assert future.result(timeout=2), (
+                "Nested one-off coroutine never received CancelledError after "
+                "the bridge-loop fallback timed out"
+            )
+        finally:
+            release_uncancelled.set()
+            oneoff_finished.wait(timeout=1)
+            shutdown_async_bridge_loop()
+
     def test_bridge_loop_startup_failure_closes_and_resets(self, monkeypatch):
         """A failed bridge-thread startup should not publish a dead loop."""
         import model_tools

--- a/tests/test_model_tools_async_bridge.py
+++ b/tests/test_model_tools_async_bridge.py
@@ -218,7 +218,14 @@ class TestRunAsyncWithRunningLoop:
         async def _never_finishes():
             await asyncio.sleep(999)
 
-        dummy_loop = object()
+        class DummyLoop:
+            def is_closed(self):
+                return False
+
+            def call_soon_threadsafe(self, callback, *args):
+                callback(*args)
+
+        dummy_loop = DummyLoop()
 
         def fake_run_coroutine_threadsafe(coro, loop):
             assert loop is dummy_loop
@@ -333,6 +340,107 @@ class TestRunAsyncWithRunningLoop:
                 and not stuck_loop.is_closed()
             ):
                 stuck_loop.close()
+
+    def test_timeout_does_not_stop_healthy_bridge_submission(self, monkeypatch):
+        """A timed-out call must not stop another in-flight bridge submission."""
+        import concurrent.futures as _cf
+        import model_tools
+
+        from model_tools import _run_async, shutdown_async_bridge_loop
+
+        real_result = _cf.Future.result
+        thread_timeouts = threading.local()
+
+        def per_thread_result(self, timeout=None):
+            return real_result(
+                self,
+                timeout=getattr(thread_timeouts, "timeout", timeout),
+            )
+
+        monkeypatch.setattr(_cf.Future, "result", per_thread_result)
+
+        slow_started = threading.Event()
+        healthy_started = threading.Event()
+        slow_done = threading.Event()
+        healthy_done = threading.Event()
+        results = {}
+        bridge_loop = None
+        bridge_thread = None
+
+        async def _slow():
+            slow_started.set()
+            await asyncio.sleep(60)
+
+        async def _healthy():
+            healthy_started.set()
+            await asyncio.sleep(0.2)
+            return "healthy-ok"
+
+        def _run_in_async_context(name, coro_factory, timeout):
+            thread_timeouts.timeout = timeout
+
+            async def _call_run_async():
+                return _run_async(coro_factory())
+
+            try:
+                results[name] = asyncio.run(_call_run_async())
+            except BaseException as exc:
+                results[name] = exc
+            finally:
+                if name == "slow":
+                    slow_done.set()
+                else:
+                    healthy_done.set()
+
+        slow_thread = threading.Thread(
+            target=_run_in_async_context,
+            args=("slow", _slow, 0.05),
+            daemon=True,
+            name="test-slow-bridge-caller",
+        )
+        healthy_thread = threading.Thread(
+            target=_run_in_async_context,
+            args=("healthy", _healthy, 0.4),
+            daemon=True,
+            name="test-healthy-bridge-caller",
+        )
+
+        try:
+            slow_thread.start()
+            assert slow_started.wait(timeout=1)
+
+            healthy_thread.start()
+            assert healthy_started.wait(timeout=1)
+            bridge_loop = model_tools._async_bridge_loop
+            bridge_thread = model_tools._async_bridge_thread
+
+            assert slow_done.wait(timeout=1)
+            assert isinstance(results["slow"], _cf.TimeoutError)
+
+            assert healthy_done.wait(timeout=1)
+            assert results["healthy"] == "healthy-ok"
+        finally:
+            slow_thread.join(timeout=1)
+            healthy_thread.join(timeout=1)
+            shutdown_async_bridge_loop(timeout=1)
+            if (
+                bridge_loop is not None
+                and bridge_loop is not model_tools._async_bridge_loop
+                and not bridge_loop.is_closed()
+            ):
+                try:
+                    bridge_loop.call_soon_threadsafe(bridge_loop.stop)
+                except RuntimeError:
+                    pass
+            if bridge_thread is not None:
+                bridge_thread.join(timeout=1)
+            if (
+                bridge_thread is not None
+                and not bridge_thread.is_alive()
+                and bridge_loop is not None
+                and not bridge_loop.is_closed()
+            ):
+                bridge_loop.close()
 
     @pytest.mark.asyncio
     async def test_async_context_reuses_persistent_bridge_loop(self):

--- a/tests/test_model_tools_async_bridge.py
+++ b/tests/test_model_tools_async_bridge.py
@@ -522,6 +522,157 @@ class TestRunAsyncWithRunningLoop:
             "async clients become orphaned and leak descriptors in gateway mode"
         )
 
+    def test_concurrent_submissions_isolate_profile_and_callbacks(self, tmp_path):
+        """Shared bridge tasks must retain each caller's profile and callbacks."""
+        from concurrent.futures import ThreadPoolExecutor
+
+        import model_tools
+        from hermes_constants import (
+            get_hermes_home,
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+        from tools.terminal_tool import (
+            _get_approval_callback,
+            _get_sudo_password_callback,
+            set_approval_callback,
+            set_sudo_password_callback,
+        )
+
+        profiles = {
+            "a": tmp_path / "profile-a",
+            "b": tmp_path / "profile-b",
+        }
+        callbacks = {
+            "a": (object(), object()),
+            "b": (object(), object()),
+        }
+        caller_barrier = threading.Barrier(2)
+        bridge_barrier = asyncio.Barrier(2)
+
+        async def _observe_context():
+            def _snapshot():
+                return (
+                    str(get_hermes_home()),
+                    _get_approval_callback(),
+                    _get_sudo_password_callback(),
+                    asyncio.get_running_loop(),
+                    threading.get_ident(),
+                )
+
+            before = _snapshot()
+            await asyncio.wait_for(bridge_barrier.wait(), timeout=2)
+            await asyncio.sleep(0)
+            return before, _snapshot()
+
+        async def _driver():
+            return model_tools._run_async(_observe_context())
+
+        def _submit(key):
+            approval_cb, sudo_cb = callbacks[key]
+            token = set_hermes_home_override(profiles[key])
+            set_approval_callback(approval_cb)
+            set_sudo_password_callback(sudo_cb)
+            try:
+                caller_barrier.wait(timeout=2)
+                observed = asyncio.run(_driver())
+                caller_callbacks = (
+                    _get_approval_callback(),
+                    _get_sudo_password_callback(),
+                )
+                return observed, caller_callbacks
+            finally:
+                set_approval_callback(None)
+                set_sudo_password_callback(None)
+                reset_hermes_home_override(token)
+
+        model_tools.shutdown_async_bridge_loop()
+        try:
+            with ThreadPoolExecutor(max_workers=2) as pool:
+                submitted = {key: pool.submit(_submit, key) for key in profiles}
+                results = {key: future.result(timeout=5) for key, future in submitted.items()}
+
+            bridge_loops = set()
+            bridge_threads = set()
+            for key, (observed, caller_callbacks) in results.items():
+                approval_cb, sudo_cb = callbacks[key]
+                expected = (str(profiles[key]), approval_cb, sudo_cb)
+                before, after = observed
+                assert before[:3] == expected
+                assert after[:3] == expected
+                assert caller_callbacks == (approval_cb, sudo_cb)
+                bridge_loops.add(id(before[3]))
+                bridge_threads.add(before[4])
+                assert before[3] is after[3]
+                assert before[4] == after[4]
+
+            assert len(bridge_loops) == 1
+            assert len(bridge_threads) == 1
+
+            previous_approval = _get_approval_callback()
+            previous_sudo = _get_sudo_password_callback()
+            set_approval_callback(None)
+            set_sudo_password_callback(None)
+
+            async def _read_unbound_callbacks():
+                return _get_approval_callback(), _get_sudo_password_callback()
+
+            async def _unbound_driver():
+                return model_tools._run_async(_read_unbound_callbacks())
+
+            try:
+                assert asyncio.run(_unbound_driver()) == (None, None)
+            finally:
+                set_approval_callback(previous_approval)
+                set_sudo_password_callback(previous_sudo)
+        finally:
+            model_tools.shutdown_async_bridge_loop()
+
+    def test_nested_bridge_fallback_preserves_profile_and_callbacks(self, tmp_path):
+        """The one-off nested fallback must inherit the bridge task's context."""
+        import model_tools
+        from hermes_constants import (
+            get_hermes_home,
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+        from tools.terminal_tool import (
+            _get_approval_callback,
+            _get_sudo_password_callback,
+            set_approval_callback,
+            set_sudo_password_callback,
+        )
+
+        profile = tmp_path / "nested-profile"
+        approval_cb = object()
+        sudo_cb = object()
+
+        async def _inner():
+            return (
+                str(get_hermes_home()),
+                _get_approval_callback(),
+                _get_sudo_password_callback(),
+            )
+
+        async def _outer():
+            return model_tools._run_async(_inner())
+
+        async def _driver():
+            return model_tools._run_async(_outer())
+
+        previous_approval = _get_approval_callback()
+        previous_sudo = _get_sudo_password_callback()
+        token = set_hermes_home_override(profile)
+        set_approval_callback(approval_cb)
+        set_sudo_password_callback(sudo_cb)
+        try:
+            assert asyncio.run(_driver()) == (str(profile), approval_cb, sudo_cb)
+        finally:
+            set_approval_callback(previous_approval)
+            set_sudo_password_callback(previous_sudo)
+            reset_hermes_home_override(token)
+            model_tools.shutdown_async_bridge_loop()
+
     def test_nested_call_from_bridge_loop_uses_worker_loop(self, monkeypatch):
         """Calling _run_async from the bridge loop itself must not deadlock."""
         import concurrent.futures as _cf

--- a/tests/test_model_tools_async_bridge.py
+++ b/tests/test_model_tools_async_bridge.py
@@ -280,6 +280,61 @@ class TestRunAsyncWithRunningLoop:
             shutdown_async_bridge_loop()
 
     @pytest.mark.asyncio
+    async def test_timeout_retires_stuck_bridge_loop_for_next_call(self, monkeypatch):
+        """After a stuck bridge call times out, later calls should use a fresh loop."""
+        import model_tools
+
+        from model_tools import _run_async, shutdown_async_bridge_loop
+
+        blocker = threading.Event()
+        started = threading.Event()
+        stuck_loop = None
+        stuck_thread = None
+
+        async def _blocks_bridge_loop():
+            nonlocal stuck_loop, stuck_thread
+            stuck_loop = asyncio.get_running_loop()
+            stuck_thread = threading.current_thread()
+            started.set()
+            blocker.wait()
+            return "unblocked"
+
+        async def _simple():
+            return "fresh-ok"
+
+        monkeypatch.setattr(model_tools, "_ASYNC_BRIDGE_TIMEOUT", 0.05)
+
+        try:
+            with pytest.raises(TimeoutError):
+                _run_async(_blocks_bridge_loop())
+
+            assert started.is_set()
+
+            assert _run_async(_simple()) == "fresh-ok"
+            assert model_tools._async_bridge_loop is not stuck_loop
+        finally:
+            blocker.set()
+            shutdown_async_bridge_loop()
+            if (
+                stuck_loop is not None
+                and stuck_loop is not model_tools._async_bridge_loop
+                and not stuck_loop.is_closed()
+            ):
+                try:
+                    stuck_loop.call_soon_threadsafe(stuck_loop.stop)
+                except RuntimeError:
+                    pass
+            if stuck_thread is not None:
+                stuck_thread.join(timeout=1)
+            if (
+                stuck_thread is not None
+                and not stuck_thread.is_alive()
+                and stuck_loop is not None
+                and not stuck_loop.is_closed()
+            ):
+                stuck_loop.close()
+
+    @pytest.mark.asyncio
     async def test_async_context_reuses_persistent_bridge_loop(self):
         """Direct calls from an already-running loop should reuse one bridge loop."""
         from model_tools import _run_async
@@ -295,6 +350,39 @@ class TestRunAsyncWithRunningLoop:
             "The async-context bridge loop was closed after returning — cached "
             "async clients become orphaned and leak descriptors in gateway mode"
         )
+
+    def test_nested_call_from_bridge_loop_uses_worker_loop(self, monkeypatch):
+        """Calling _run_async from the bridge loop itself must not deadlock."""
+        import concurrent.futures as _cf
+        import model_tools
+
+        from model_tools import _run_async, shutdown_async_bridge_loop
+
+        real_result = _cf.Future.result
+
+        def fast_bridge_thread_result(self, timeout=None):
+            if (
+                threading.current_thread().name == "model-tools-async-bridge"
+                and timeout == 300
+            ):
+                return real_result(self, timeout=0.05)
+            return real_result(self, timeout=timeout)
+
+        async def _inner():
+            return "nested-ok"
+
+        async def _outer():
+            return _run_async(_inner())
+
+        monkeypatch.setattr(_cf.Future, "result", fast_bridge_thread_result)
+
+        try:
+            bridge_loop = model_tools._get_async_bridge_loop()
+            future = asyncio.run_coroutine_threadsafe(_outer(), bridge_loop)
+
+            assert future.result(timeout=2) == "nested-ok"
+        finally:
+            shutdown_async_bridge_loop()
 
     def test_bridge_loop_startup_failure_closes_and_resets(self, monkeypatch):
         """A failed bridge-thread startup should not publish a dead loop."""

--- a/tests/test_model_tools_async_bridge.py
+++ b/tests/test_model_tools_async_bridge.py
@@ -180,7 +180,7 @@ class TestRunAsyncWorkerThread:
 
 
 class TestRunAsyncWithRunningLoop:
-    """When a loop is already running, _run_async falls back to a thread."""
+    """When a loop is already running, _run_async uses the bridge loop."""
 
     @pytest.mark.asyncio
     async def test_run_async_from_async_context(self):
@@ -191,29 +191,19 @@ class TestRunAsyncWithRunningLoop:
         async def _simple():
             return 42
 
-        result = await asyncio.get_event_loop().run_in_executor(
-            None, _run_async, _simple()
-        )
+        result = _run_async(_simple())
         assert result == 42
 
     @pytest.mark.asyncio
-    async def test_timeout_uses_nonblocking_executor_shutdown(self, monkeypatch):
-        """A timeout in the running-loop branch must not block the caller.
-
-        If shutdown ever waits for a stuck worker, a tool coroutine that
-        ignores (or can't observe) cancellation would hang the whole agent.
-        Guard: the caller must raise TimeoutError and pool.shutdown must be
-        called with wait=False. The worker's own event loop handles cleanup
-        (cancellation is scheduled via call_soon_threadsafe before the
-        caller returns).
-        """
+    async def test_timeout_cancels_bridge_future(self, monkeypatch):
+        """A timeout in the running-loop branch should cancel the bridge task."""
         import concurrent.futures
+        import model_tools
         from model_tools import _run_async
 
         events = {
+            "cancelled": False,
             "result_timeout": None,
-            "shutdown_calls": [],
-            "submitted_fn": None,
         }
 
         class TimeoutFuture:
@@ -222,81 +212,36 @@ class TestRunAsyncWithRunningLoop:
                 raise concurrent.futures.TimeoutError()
 
             def cancel(self):
+                events["cancelled"] = True
                 return True
-
-        class FakeExecutor:
-            def __init__(self, *args, **kwargs):
-                pass
-
-            def __enter__(self):
-                return self
-
-            def __exit__(self, exc_type, exc, tb):
-                self.shutdown(wait=True)
-                return False
-
-            def submit(self, fn, *args, **kwargs):
-                # Record which function got submitted -- should be the
-                # in-function worker wrapper, not bare asyncio.run, so we
-                # know _run_async is using a loop it owns and can cancel.
-                events["submitted_fn"] = getattr(fn, "__name__", repr(fn))
-                return TimeoutFuture()
-
-            def shutdown(self, wait=True, cancel_futures=False):
-                events["shutdown_calls"].append((wait, cancel_futures))
 
         async def _never_finishes():
             await asyncio.sleep(999)
 
-        monkeypatch.setattr(
-            concurrent.futures,
-            "ThreadPoolExecutor",
-            FakeExecutor,
-        )
+        dummy_loop = object()
+
+        def fake_run_coroutine_threadsafe(coro, loop):
+            assert loop is dummy_loop
+            coro.close()
+            return TimeoutFuture()
+
+        monkeypatch.setattr(model_tools, "_get_async_bridge_loop", lambda: dummy_loop)
+        monkeypatch.setattr(asyncio, "run_coroutine_threadsafe", fake_run_coroutine_threadsafe)
 
         with pytest.raises(concurrent.futures.TimeoutError):
             _run_async(_never_finishes())
 
         assert events["result_timeout"] == 300
-        # The worker wrapper creates its own event loop so _run_async can
-        # cancel the task on timeout — this must NOT be bare asyncio.run.
-        assert events["submitted_fn"] != "run", (
-            "_run_async submitted asyncio.run directly — it must submit a "
-            "worker wrapper that owns the event loop so timeouts can cancel "
-            "the task"
-        )
-        # Critical: shutdown must NOT wait. If wait=True, a stuck coroutine
-        # would freeze the caller (converts a thread leak into a hang).
-        assert events["shutdown_calls"], "shutdown was never called"
-        for wait, _cancel in events["shutdown_calls"]:
-            assert wait is False, (
-                f"shutdown called with wait={wait} — a stuck tool coroutine "
-                f"would hang the caller indefinitely"
-            )
+        assert events["cancelled"] is True
 
     @pytest.mark.asyncio
-    async def test_timeout_cancels_coroutine_in_worker_loop(self, monkeypatch):
-        """On timeout, the worker's event loop must receive a cancel request
-        so the coroutine stops and the thread exits — not leaked.
+    async def test_timeout_cancels_coroutine_in_bridge_loop(self, monkeypatch):
+        """On timeout, the bridge loop task must receive cancellation."""
+        from model_tools import _run_async, shutdown_async_bridge_loop
 
-        Before the fix, future.cancel() on a running ThreadPoolExecutor
-        future is a no-op, so the worker thread kept running the coroutine
-        to completion (leaking one thread per tool-timeout).
-        """
-        from model_tools import _run_async
-
-        # Shrink the 300s internal timeout by patching future.result.
-        # We do this surgically: let everything else run for real so the
-        # worker loop actually exists and can observe cancellation.
         import concurrent.futures as _cf
+        import time as _time
 
-        real_pool_cls = _cf.ThreadPoolExecutor
-
-        class FastTimeoutPool(real_pool_cls):
-            def __init__(self, *a, **kw):
-                super().__init__(*a, **kw)
-
-        # Patch future.result to time out after 1s instead of 300s.
         real_result = _cf.Future.result
 
         def fast_result(self, timeout=None):
@@ -313,27 +258,101 @@ class TestRunAsyncWithRunningLoop:
                 cancel_observed.set()
                 raise
 
-        import time as _time
         t0 = _time.time()
-        with pytest.raises(_cf.TimeoutError):
-            _run_async(_slow_cancellable())
-        elapsed = _time.time() - t0
+        try:
+            with pytest.raises(_cf.TimeoutError):
+                _run_async(_slow_cancellable())
+            elapsed = _time.time() - t0
 
-        # Caller must return fast (no hang waiting for the coro).
-        assert elapsed < 3.0, (
-            f"_run_async blocked caller for {elapsed:.1f}s — should return "
-            f"on timeout regardless of whether the coroutine has finished"
+            assert elapsed < 3.0, (
+                f"_run_async blocked caller for {elapsed:.1f}s — should return "
+                f"on timeout regardless of whether the coroutine has finished"
+            )
+
+            deadline = _time.time() + 5
+            while not cancel_observed.is_set() and _time.time() < deadline:
+                _time.sleep(0.05)
+            assert cancel_observed.is_set(), (
+                "Coroutine never received CancelledError — the bridge task "
+                "must be cancelled when future.result(timeout=...) expires"
+            )
+        finally:
+            shutdown_async_bridge_loop()
+
+    @pytest.mark.asyncio
+    async def test_async_context_reuses_persistent_bridge_loop(self):
+        """Direct calls from an already-running loop should reuse one bridge loop."""
+        from model_tools import _run_async
+
+        loop1 = _run_async(_get_current_loop())
+        loop2 = _run_async(_get_current_loop())
+
+        assert loop1 is loop2, (
+            "_run_async() created a new bridge loop for the second async-context "
+            "call — cached async clients will accumulate across gateway turns"
+        )
+        assert not loop1.is_closed(), (
+            "The async-context bridge loop was closed after returning — cached "
+            "async clients become orphaned and leak descriptors in gateway mode"
         )
 
-        # Worker thread must cancel the task (not leak).
-        deadline = _time.time() + 5
-        while not cancel_observed.is_set() and _time.time() < deadline:
-            _time.sleep(0.05)
-        assert cancel_observed.is_set(), (
-            "Coroutine never received CancelledError — worker thread leaked "
-            "(ThreadPoolExecutor.cancel() is a no-op on a running future; "
-            "_run_async must cancel the task inside its worker loop)"
-        )
+    def test_bridge_loop_startup_failure_closes_and_resets(self, monkeypatch):
+        """A failed bridge-thread startup should not publish a dead loop."""
+        import model_tools
+
+        class NeverReadyEvent:
+            def set(self):
+                pass
+
+            def wait(self, timeout=None):
+                return False
+
+        class NeverStartedThread:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def start(self):
+                pass
+
+            def is_alive(self):
+                return False
+
+        created_loops = []
+        original_new_event_loop = asyncio.new_event_loop
+
+        def fake_new_event_loop():
+            loop = original_new_event_loop()
+            created_loops.append(loop)
+            return loop
+
+        model_tools.shutdown_async_bridge_loop()
+        monkeypatch.setattr(model_tools, "_async_bridge_loop", None)
+        monkeypatch.setattr(model_tools, "_async_bridge_thread", None)
+        monkeypatch.setattr(threading, "Event", NeverReadyEvent)
+        monkeypatch.setattr(threading, "Thread", NeverStartedThread)
+        monkeypatch.setattr(asyncio, "new_event_loop", fake_new_event_loop)
+
+        with pytest.raises(RuntimeError, match="async bridge loop"):
+            model_tools._get_async_bridge_loop()
+
+        assert model_tools._async_bridge_loop is None
+        assert model_tools._async_bridge_thread is None
+        assert created_loops and created_loops[0].is_closed()
+
+    def test_shutdown_async_bridge_loop_stops_thread_and_closes_loop(self):
+        """The process cleanup path should stop and close the bridge loop."""
+        import model_tools
+
+        loop = model_tools._get_async_bridge_loop()
+        thread = model_tools._async_bridge_thread
+        assert thread is not None and thread.is_alive()
+
+        model_tools.shutdown_async_bridge_loop()
+
+        assert model_tools._async_bridge_loop is None
+        assert model_tools._async_bridge_thread is None
+        assert loop.is_closed()
+        assert not thread.is_alive()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_model_tools_async_bridge.py
+++ b/tests/test_model_tools_async_bridge.py
@@ -341,6 +341,69 @@ class TestRunAsyncWithRunningLoop:
             ):
                 stuck_loop.close()
 
+    @pytest.mark.asyncio
+    async def test_retired_bridge_loop_closes_after_thread_exits(self, monkeypatch):
+        """A retired unhealthy bridge loop should close when its thread exits."""
+        import time as _time
+        import model_tools
+
+        from model_tools import _run_async, shutdown_async_bridge_loop
+
+        blocker = threading.Event()
+        started = threading.Event()
+        stuck_loop = None
+        stuck_thread = None
+
+        async def _blocks_bridge_loop():
+            nonlocal stuck_loop, stuck_thread
+            stuck_loop = asyncio.get_running_loop()
+            stuck_thread = threading.current_thread()
+            started.set()
+            blocker.wait()
+
+        monkeypatch.setattr(model_tools, "_ASYNC_BRIDGE_TIMEOUT", 0.05)
+        monkeypatch.setattr(model_tools, "_ASYNC_BRIDGE_HEALTH_PROBE_TIMEOUT", 0.01)
+
+        try:
+            with pytest.raises(TimeoutError):
+                _run_async(_blocks_bridge_loop())
+
+            assert started.is_set()
+            assert stuck_loop is not None
+            assert stuck_thread is not None and stuck_thread.is_alive()
+            assert model_tools._async_bridge_loop is None
+
+            blocker.set()
+            deadline = _time.monotonic() + 2
+            while stuck_thread.is_alive() and _time.monotonic() < deadline:
+                stuck_thread.join(timeout=0.05)
+
+            assert not stuck_thread.is_alive()
+            assert stuck_loop.is_closed(), (
+                "Retired bridge loop thread exited but left its event loop open"
+            )
+        finally:
+            blocker.set()
+            shutdown_async_bridge_loop()
+            if (
+                stuck_thread is not None
+                and stuck_thread.is_alive()
+                and stuck_loop is not None
+                and not stuck_loop.is_closed()
+            ):
+                try:
+                    stuck_loop.call_soon_threadsafe(stuck_loop.stop)
+                except RuntimeError:
+                    pass
+                stuck_thread.join(timeout=1)
+            if (
+                stuck_thread is not None
+                and not stuck_thread.is_alive()
+                and stuck_loop is not None
+                and not stuck_loop.is_closed()
+            ):
+                stuck_loop.close()
+
     def test_timeout_does_not_stop_healthy_bridge_submission(self, monkeypatch):
         """A timed-out call must not stop another in-flight bridge submission."""
         import concurrent.futures as _cf

--- a/tests/test_profile_isolation_runtime.py
+++ b/tests/test_profile_isolation_runtime.py
@@ -200,7 +200,7 @@ class TestThreadContextPropagation:
             return str(get_hermes_home())
 
         async def driver():
-            # Inside a running loop, _run_async spawns a worker thread + loop.
+            # Inside a running loop, _run_async submits to its persistent bridge.
             return model_tools._run_async(reads_home())
 
         seen = _under_override(prof_b, lambda: asyncio.run(driver()))

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -31,6 +31,7 @@ Usage:
     result = terminal_tool("python server.py", background=True)
 """
 
+import contextvars
 import importlib.util
 import json
 import logging
@@ -171,14 +172,35 @@ _sudo_password_cache_lock = threading.Lock()
 # the per-session queue in tools.approval, not through these callbacks,
 # so it's unaffected.
 _callback_tls = threading.local()
+_CALLBACK_TASK_OVERRIDE_UNSET = object()
+_callback_task_override: contextvars.ContextVar[object] = contextvars.ContextVar(
+    "terminal_callback_task_override",
+    default=_CALLBACK_TASK_OVERRIDE_UNSET,
+)
 
 
 def _get_sudo_password_callback():
+    task_override = _callback_task_override.get()
+    if task_override is not _CALLBACK_TASK_OVERRIDE_UNSET:
+        return task_override[1]
     return getattr(_callback_tls, "sudo_password", None)
 
 
 def _get_approval_callback():
+    task_override = _callback_task_override.get()
+    if task_override is not _CALLBACK_TASK_OVERRIDE_UNSET:
+        return task_override[0]
     return getattr(_callback_tls, "approval", None)
+
+
+def _set_task_callback_override(approval_cb, sudo_cb):
+    """Bind callback lookups to the current async task context."""
+    return _callback_task_override.set((approval_cb, sudo_cb))
+
+
+def _reset_task_callback_override(token) -> None:
+    """Restore the callback lookup context that preceded *token*."""
+    _callback_task_override.reset(token)
 
 
 def set_sudo_password_callback(cb):

--- a/tools/thread_context.py
+++ b/tools/thread_context.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 import contextvars
 import logging
+from contextlib import contextmanager
 from typing import Callable
 
 logger = logging.getLogger(__name__)
@@ -59,6 +60,65 @@ def _callback_api():
         set_approval_callback,
         set_sudo_password_callback,
     )
+
+
+def _async_callback_api():
+    """Resolve callback APIs used while submitting work to another loop."""
+    from tools.terminal_tool import (
+        _get_approval_callback,
+        _get_sudo_password_callback,
+        _reset_task_callback_override,
+        _set_task_callback_override,
+    )
+
+    return (
+        _get_approval_callback,
+        _get_sudo_password_callback,
+        _set_task_callback_override,
+        _reset_task_callback_override,
+    )
+
+
+@contextmanager
+def propagate_context_to_async_task():
+    """Expose current thread-local callbacks to a newly submitted async task.
+
+    ``asyncio.run_coroutine_threadsafe()`` copies the caller's ContextVars when
+    it schedules its task on the target loop. Bind the current thread-local
+    approval/sudo callbacks to a temporary ContextVar override around that
+    submission so concurrent tasks on a shared bridge thread remain isolated.
+    """
+    parent_approval_cb = parent_sudo_cb = None
+    set_override = reset_override = None
+    try:
+        get_approval, get_sudo, set_override, reset_override = _async_callback_api()
+        parent_approval_cb = get_approval()
+        parent_sudo_cb = get_sudo()
+    except Exception:
+        logger.debug("Could not capture async-task approval/sudo callbacks", exc_info=True)
+
+    token = None
+    if set_override is not None:
+        try:
+            token = set_override(parent_approval_cb, parent_sudo_cb)
+        except Exception:
+            logger.debug(
+                "Failed to bind async-task approval/sudo callbacks; "
+                "dangerous-command approval will fail closed",
+                exc_info=True,
+            )
+
+    try:
+        yield
+    finally:
+        if token is not None and reset_override is not None:
+            try:
+                reset_override(token)
+            except Exception:
+                logger.debug(
+                    "Failed to reset async-task approval/sudo callbacks",
+                    exc_info=True,
+                )
 
 
 def propagate_context_to_thread(target: Callable) -> Callable:


### PR DESCRIPTION
## What and why

Fixes #16570.

When `model_tools._run_async()` is called from code that already owns an event loop, Hermes currently starts a new worker thread and a new event loop for every call. Cached async clients such as `AsyncOpenAI` and httpx can outlive those short-lived loops, leaving clients and transports tied to closed loops while the gateway keeps creating more threads and loops.

This PR changes only that running-loop path. Calls are submitted to a lazily started bridge loop with `asyncio.run_coroutine_threadsafe()`, while the existing main-thread and worker-thread paths keep their current behavior.

## Details

- Reuse one bridge loop instead of creating a disposable loop for every async-context tool call.
- Preserve the caller's profile and approval/sudo routing for each submitted task. Concurrent callers keep separate context even though they share the bridge thread.
- Keep the timeout cancellation behavior from #17428. A timed-out future is cancelled, and the bridge is retired only when a health check shows that it is no longer responsive.
- Handle startup failures, nested calls from the bridge itself, retired-loop cleanup, and repeated shutdown safely.
- Shut the bridge down from the existing CLI and gateway cleanup paths, after cached async clients have been closed.

The nested-call fallback still uses the existing `propagate_context_to_thread()` contract, so it does not lose profile or approval state when it has to move work to a one-off thread.

## Related

Refs #8043. This PR addresses the running-loop/gateway part of that issue, including timeout and shutdown lifecycle. Cleanup for the persistent main-thread and per-worker loops remains separate.

## Testing

### Before/after probe

I ran the same no-mock probe against current `main` (`10dc1571bc`) and this branch (`5f359bed3b`). It calls the real `_run_async()` path 20 times from inside an active asyncio loop and retains the returned loop objects.

| | Current main | This PR |
|---|---:|---:|
| Calls | 20 | 20 |
| Unique event loops | 20 | 1 |
| Loops closed after the calls | 20 | 0 |

### Regression suites

```text
scripts/run_tests.sh tests/test_model_tools_async_bridge.py tests/test_profile_isolation_runtime.py -q
32 passed
```

```text
scripts/run_tests.sh tests/acp/test_approval_isolation.py tests/tools/test_execute_code_approval_cluster.py tests/run_agent/test_tool_executor_contextvar_propagation.py tests/test_model_tools.py tests/cli/test_session_boundary_hooks.py tests/gateway/test_gateway_shutdown.py -q
98 passed
```

Also checked:

- Ruff on the changed Python files
- `python -m py_compile` on the bridge and context-propagation paths
- `git diff --check upstream/main...HEAD`
- `scripts/check-windows-footguns.py --diff upstream/main`

Tested on macOS with Python 3.13.12.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [ ] I've run the complete `pytest tests/ -q` suite
- [x] I've added regression tests for the changed behavior
- [x] I've considered cross-platform impact
- [x] No configuration keys, tool schemas, or user-facing documentation changed
