### PR TITLE
fix(approval): close prompt_toolkit deadlock vectors (#15216)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3247,6 +3247,21 @@ class AIAgent:
 
         def _run_review():
             import contextlib
+            # Install a non-interactive approval callback on this worker
+            # thread so any dangerous-command guard the review agent trips
+            # resolves to "deny" instead of falling back to input() -- which
+            # deadlocks against the parent's prompt_toolkit TUI (#15216).
+            # Same pattern as _subagent_auto_deny in tools/delegate_tool.py.
+            def _bg_review_auto_deny(command, description, **kwargs):
+                logger.warning(
+                    "Background review auto-denied dangerous command: %s (%s)",
+                    command, description,
+                )
+                return "deny"
+            try:
+                _set_approval_callback(_bg_review_auto_deny)
+            except Exception:
+                pass
             review_agent = None
             try:
                 with open(os.devnull, "w") as _devnull, \
@@ -3328,6 +3343,12 @@ class AIAgent:
                         review_agent.close()
                     except Exception:
                         pass
+                # Clear the approval callback on this bg-review thread so a
+                # recycled thread-id doesn't inherit a stale reference.
+                try:
+                    _set_approval_callback(None)
+                except Exception:
+                    pass
 
         t = threading.Thread(target=_run_review, daemon=True, name="bg-review")
         t.start()

--- a/run_agent.py
+++ b/run_agent.py
@@ -74,6 +74,12 @@ from model_tools import (
     check_toolset_requirements,
 )
 from tools.terminal_tool import cleanup_vm, get_active_env, is_persistent_env
+from tools.terminal_tool import (
+    set_approval_callback as _set_approval_callback,
+    set_sudo_password_callback as _set_sudo_password_callback,
+    _get_approval_callback,
+    _get_sudo_password_callback,
+)
 from tools.tool_result_storage import maybe_persist_tool_result, enforce_turn_budget
 from tools.interrupt import set_interrupt as _set_interrupt
 from tools.browser_tool import cleanup_browser
@@ -8469,6 +8475,14 @@ class AIAgent:
         self._current_tool = tool_names_str
         self._touch_activity(f"executing {num_tools} tools concurrently: {tool_names_str}")
 
+        # Capture CLI callbacks from the agent thread so worker threads can
+        # register them locally.  Without this, _get_approval_callback() in
+        # terminal_tool returns None in ThreadPoolExecutor workers, causing
+        # the dangerous-command prompt to fall back to input() — which
+        # deadlocks against prompt_toolkit's raw terminal mode (#13617).
+        _parent_approval_cb = _get_approval_callback()
+        _parent_sudo_cb = _get_sudo_password_callback()
+
         def _run_tool(index, tool_call, function_name, function_args):
             """Worker function executed in a thread."""
             # Register this worker tid so the agent can fan out an interrupt
@@ -8495,6 +8509,18 @@ class AIAgent:
                 set_activity_callback(self._touch_activity)
             except Exception:
                 pass
+            # Propagate approval/sudo callbacks to this worker thread.
+            # Mirrors cli.py run_agent() pattern (GHSA-qg5c-hvr5-hjgr).
+            if _parent_approval_cb is not None:
+                try:
+                    _set_approval_callback(_parent_approval_cb)
+                except Exception:
+                    pass
+            if _parent_sudo_cb is not None:
+                try:
+                    _set_sudo_password_callback(_parent_sudo_cb)
+                except Exception:
+                    pass
             start = time.time()
             try:
                 result = self._invoke_tool(function_name, function_args, effective_task_id, tool_call.id, messages=messages)
@@ -8515,6 +8541,13 @@ class AIAgent:
                 self._tool_worker_threads.discard(_worker_tid)
             try:
                 _set_interrupt(False, _worker_tid)
+            except Exception:
+                pass
+            # Clear thread-local callbacks so a recycled worker thread
+            # doesn't hold stale references to a disposed CLI instance.
+            try:
+                _set_approval_callback(None)
+                _set_sudo_password_callback(None)
             except Exception:
                 pass
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -553,6 +553,7 @@ AUTHOR_MAP = {
     "chenzeshi@live.com": "chen1749144759",
     "mor.aleksandr@yahoo.com": "MorAlekss",
     "ash@users.noreply.github.com": "ash",
+    "andrewho.sf@gmail.com": "andrewhosf",
 }
 
 

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -71,3 +71,59 @@ def test_background_review_shuts_down_memory_provider_before_close(monkeypatch):
         "shutdown_memory_provider",
         "close",
     ]
+
+
+def test_background_review_installs_auto_deny_approval_callback(monkeypatch):
+    """Regression guard for #15216.
+
+    The background review thread must install a non-interactive approval
+    callback. If it doesn't, any dangerous-command guard the review agent
+    trips falls back to input() on a daemon thread, which deadlocks against
+    the parent's prompt_toolkit TUI.
+    """
+    import tools.terminal_tool as tt
+
+    observed: dict = {"during_run": "<unread>", "after_finally": "<unread>"}
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            self._session_messages = []
+
+        def run_conversation(self, **kwargs):
+            # Capture what the callback looks like mid-run. It must be
+            # a callable (the auto-deny) -- not None.
+            observed["during_run"] = tt._get_approval_callback()
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+
+    # Start from a clean slot.
+    tt.set_approval_callback(None)
+    agent = _bare_agent()
+
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=[{"role": "user", "content": "hello"}],
+        review_memory=True,
+    )
+
+    observed["after_finally"] = tt._get_approval_callback()
+
+    assert callable(observed["during_run"]), (
+        "Background review did not install an approval callback on its "
+        "worker thread; dangerous-command prompts will deadlock against "
+        "the parent TUI (#15216)."
+    )
+    # The installed callback must deny (it's a safety gate, not a prompt).
+    assert observed["during_run"]("rm -rf /", "test") == "deny"
+
+    assert observed["after_finally"] is None, (
+        "Background review leaked its approval callback into the worker "
+        "thread's TLS slot; a recycled thread-id could reuse it."
+    )

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -906,3 +906,62 @@ class TestChmodExecuteCombo:
         cmd = "chmod +x script.sh"
         dangerous, _, _ = detect_dangerous_command(cmd)
         assert dangerous is False
+
+
+class TestFailClosedUnderPromptToolkit:
+    """Regression guard for #15216.
+
+    When prompt_toolkit owns the terminal and no approval callback is
+    registered on the calling thread, prompt_dangerous_approval() must
+    deny fast instead of falling through to the input() fallback -- which
+    deadlocks because the user's keystrokes go to prompt_toolkit's raw-mode
+    stdin capture, not to input().
+    """
+
+    def test_denies_when_prompt_toolkit_active_and_no_callback(self):
+        import threading
+        import prompt_toolkit.application.current as ptc
+
+        orig = ptc.get_app_or_none
+        ptc.get_app_or_none = lambda: object()  # pretend a pt app is running
+        result = []
+        try:
+            def run():
+                result.append(
+                    prompt_dangerous_approval(
+                        "rm -rf /",
+                        "test danger",
+                        timeout_seconds=30,
+                        approval_callback=None,
+                    )
+                )
+
+            t = threading.Thread(target=run, daemon=True)
+            t.start()
+            t.join(timeout=3)
+            assert not t.is_alive(), (
+                "prompt_dangerous_approval deadlocked under prompt_toolkit "
+                "with no callback -- fail-closed guard is broken"
+            )
+            assert result == ["deny"]
+        finally:
+            ptc.get_app_or_none = orig
+
+    def test_callback_path_still_wins_over_guard(self):
+        """Guard must not short-circuit a valid callback."""
+        import prompt_toolkit.application.current as ptc
+
+        orig = ptc.get_app_or_none
+        ptc.get_app_or_none = lambda: object()
+        try:
+            def cb(command, description, **kwargs):
+                return "once"
+
+            result = prompt_dangerous_approval(
+                "rm -rf /",
+                "test danger",
+                approval_callback=cb,
+            )
+            assert result == "once"
+        finally:
+            ptc.get_app_or_none = orig

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -536,6 +536,33 @@ def prompt_dangerous_approval(command: str, description: str,
             logger.error("Approval callback failed: %s", e, exc_info=True)
             return "deny"
 
+    # Fail-closed guard: if prompt_toolkit owns the terminal (interactive
+    # CLI session) and no approval callback is registered on this thread,
+    # the input() fallback below would spawn a daemon thread whose read
+    # can never see Enter -- the user's keystrokes go to prompt_toolkit,
+    # not input(), producing an invisible 60s deadlock (issue #15216).
+    # Deny fast and log loudly instead so the caller can surface a real
+    # error to the agent. Any thread that needs interactive approval must
+    # install a callback via tools.terminal_tool.set_approval_callback()
+    # before reaching this point (see delegate_tool.py, run_agent.py
+    # _execute_tool_calls_concurrent / _spawn_background_review for the
+    # established pattern).
+    try:
+        from prompt_toolkit.application.current import get_app_or_none
+        if get_app_or_none() is not None:
+            logger.warning(
+                "Dangerous-command approval requested on a thread with no "
+                "approval callback while prompt_toolkit is active; denying "
+                "to avoid stdin deadlock. command=%r description=%r",
+                command, description,
+            )
+            return "deny"
+    except Exception:
+        # prompt_toolkit not installed, or detection failed -- fall through
+        # to the legacy input() path (safe in non-TUI contexts: scripts,
+        # tests, sshd, etc.).
+        pass
+
     os.environ["HERMES_SPINNER_PAUSE"] = "1"
     try:
         while True:


### PR DESCRIPTION
## Summary
Approval prompts no longer deadlock against prompt_toolkit. The fallback in `tools/approval.py` spawned a daemon thread calling `input()` whenever a thread reached it without an approval callback; under prompt_toolkit's raw-mode stdin capture that thread never sees Enter, producing an invisible 60s freeze (#15216).

Salvages @andrewhosf's #13734 (concurrent-tool-executor vector) and closes the two remaining vectors.

## Changes
- **run_agent.py** `_execute_tool_calls_concurrent` (from #13734, @andrewhosf): snapshot the parent thread's approval + sudo TLS callbacks and register them on each `ThreadPoolExecutor` worker; clear on exit.
- **run_agent.py** `_spawn_background_review`: install a `_bg_review_auto_deny` callback on the `bg-review` thread (mirrors `_subagent_auto_deny` from 023b1bff1 / #15491); clear in `finally`.
- **tools/approval.py** `prompt_dangerous_approval` fallback: when `prompt_toolkit.application.current.get_app_or_none()` is not None AND no callback is registered, deny fast with a logged warning instead of spawning the deadlocking `input()` thread. Fail-closed so future threads that forget to install a callback degrade gracefully.
- **scripts/release.py**: AUTHOR_MAP entry for @andrewhosf.
- **tests**: regression guards in `tests/run_agent/test_background_review.py` (bg-review installs + clears an auto-deny callback) and `tests/tools/test_approval.py::TestFailClosedUnderPromptToolkit` (denies fast under pt + callback still wins over guard).

## Validation
```
tests/tools/test_approval.py .................. 145 passed
tests/run_agent/test_background_review.py ....    (incl new)
tests/cli/test_cli_approval_ui.py .............
tests/tools/test_yolo_mode.py, test_delegate.py
tests/run_agent/test_concurrent_interrupt.py
tests/acp/test_approval_isolation.py, test_permissions.py
Total: 289 passed, 0 failed
```

E2E verification (real imports, no mocks):
- Callback path returns the callback's choice unchanged.
- With `get_app_or_none()` patched to return an app and callback=None, `prompt_dangerous_approval` returns `"deny"` within 5s instead of blocking on `input()`.

Closes #15216. Closes #15194 (duplicate, also closed by reporter).
Credits @andrewhosf (concurrent-tool vector, #13734) and @stillmuchtolearn (background-review vector, diagnosis in #15216 comments).