### PR TITLE
diagnostic(cli): log slow bracketed-paste handler (>500ms) for #16263

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9871,6 +9871,12 @@ class HermesCLI:
             placeholder while preserving any existing user text in the
             buffer.
             """
+            # Diagnostic canary: measure how long the paste handler blocks
+            # the prompt_toolkit event loop. If this exceeds ~500ms we log
+            # it so recurring "CLI freezes on paste" reports (issue #16263,
+            # macOS Tahoe 26 + iTerm2/Ghostty) arrive with data attached.
+            _paste_handler_start = time.perf_counter()
+            _paste_raw_size = len(event.data or "")
             pasted_text = event.data or ""
             # Normalise line endings — Windows \r\n and old Mac \r both become \n
             # so the 5-line collapse threshold and display are consistent.
@@ -9899,6 +9905,17 @@ class HermesCLI:
                     buf.insert_text(prefix + placeholder)
                 else:
                     buf.insert_text(pasted_text)
+            _paste_handler_elapsed_ms = (time.perf_counter() - _paste_handler_start) * 1000.0
+            if _paste_handler_elapsed_ms > 500.0:
+                logger.warning(
+                    "Slow bracketed-paste handler: %.1fms to process %d bytes "
+                    "(%d lines) on %s. If the input becomes unresponsive after "
+                    "this, attach this log line to the bug report.",
+                    _paste_handler_elapsed_ms,
+                    _paste_raw_size,
+                    pasted_text.count('\n') + 1 if pasted_text else 0,
+                    sys.platform,
+                )
 
         @kb.add('c-v')
         def handle_ctrl_v(event):


### PR DESCRIPTION
## Summary
Add a one-shot warning log when the BracketedPaste handler takes >500ms to run. Gives us concrete repro data for recurring "CLI freezes after paste on macOS" reports (#16263 and its sibling reports across other CLI tools against macOS Tahoe 26).

Diagnostic-only. No behavior change.

## Context
The paste-freeze symptom is not Hermes-specific — Claude Code hits the same thing on the same environment signature (macOS 26 + iTerm2), with a main-thread stack blocked in `kevent64`. Cursor's integrated terminal, Adobe Lightroom, and others have parallel reports. The root cause is almost certainly in the macOS 26 terminal/pty layer.

We can't fix that from our layer, but we can make sure next time someone reports a freeze they have data to attach. This log line tells us (a) whether our handler was the slow part, (b) the paste size/line count, and (c) the platform.

## Changes
- `cli.py`: wrap `handle_paste` body with `time.perf_counter()` bookends; emit `logger.warning()` when elapsed > 500ms. Log includes bytes, lines, and `sys.platform`.

## Validation
- `py_compile cli.py` → ok
- `scripts/run_tests.sh tests/cli/test_cli_bracketed_paste_sanitizer.py` → 11/11 pass (paste path still works)

## Related
- #16263 (CLI input freezes after paste — macOS 26 + iTerm2/Ghostty)
- anthropics/claude-code#13183 (same symptom signature, different stack)
- #16367 (merged — sanitizes `^[[200~` wrapper leak, a different but adjacent symptom)