### PR TITLE
feat(backup): exclude SQLite WAL/SHM/journal sidecars

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -45,6 +45,14 @@ _EXCLUDED_DIRS = {
 _EXCLUDED_SUFFIXES = (
     ".pyc",
     ".pyo",
+    # SQLite sidecar files — the backup takes a consistent snapshot of ``*.db``
+    # via ``sqlite3.backup()``, so shipping the live WAL / shared-memory /
+    # rollback-journal alongside would pair a fresh snapshot with stale sidecar
+    # state and produce a torn restore on the next open. They're transient and
+    # regenerated on first connection anyway.
+    ".db-wal",
+    ".db-shm",
+    ".db-journal",
 )
 
 # File names to skip (runtime state that's meaningless on another machine)

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -103,6 +103,18 @@ class TestShouldExclude:
         from hermes_cli.backup import _should_exclude
         assert _should_exclude(Path("backups/pre-update-2026-04-27-063400.zip"))
 
+    def test_excludes_sqlite_sidecars(self):
+        """SQLite WAL/SHM/journal sidecars must not ship alongside the
+        safe-copied .db — pairing a fresh snapshot with stale sidecar state
+        produces a torn restore."""
+        from hermes_cli.backup import _should_exclude
+        assert _should_exclude(Path("state.db-wal"))
+        assert _should_exclude(Path("state.db-shm"))
+        assert _should_exclude(Path("state.db-journal"))
+        assert _should_exclude(Path("memory_store.db-wal"))
+        # The .db itself is still included (and safe-copied separately)
+        assert not _should_exclude(Path("state.db"))
+
     def test_includes_config(self):
         from hermes_cli.backup import _should_exclude
         assert not _should_exclude(Path("config.yaml"))


### PR DESCRIPTION
## Summary
`hermes backup` now skips `*.db-wal`, `*.db-shm`, and `*.db-journal` files. The backup already takes a consistent snapshot of each `*.db` via `sqlite3.backup()`; shipping the live sidecars alongside pairs a fresh snapshot with stale WAL state and produces a torn restore on first open.

## Changes
- `hermes_cli/backup.py`: `.db-wal`, `.db-shm`, `.db-journal` added to `_EXCLUDED_SUFFIXES` with a comment explaining why
- `tests/hermes_cli/test_backup.py`: new `test_excludes_sqlite_sidecars` confirming the sidecars are excluded but the parent `*.db` is still included

## Validation
| | Before | After |
|---|---|---|
| `state.db-wal` / `state.db-shm` in zip | included (stale, torn) | excluded |
| `state.db` | safe-copied, included | safe-copied, included (unchanged) |
| `tests/hermes_cli/test_backup.py` | 85 passed | 86 passed |