### PR TITLE
feat: add current-turn memory recall router

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -28,7 +28,6 @@ Usage in run_agent.py:
 
 from __future__ import annotations
 
-import json
 import logging
 import re
 import inspect
@@ -191,6 +190,37 @@ class MemoryManager:
             except Exception as e:
                 logger.debug(
                     "Memory provider '%s' prefetch failed (non-fatal): %s",
+                    provider.name, e,
+                )
+        return "\n\n".join(parts)
+
+    def recall_now_all(
+        self,
+        query: str,
+        *,
+        session_id: str = "",
+        max_tokens: Optional[int] = None,
+    ) -> str:
+        """Collect synchronous current-turn recall context from providers.
+
+        This complements ``prefetch_all()``: prefetch is a warmed next-turn
+        cache, while recall-now is used sparingly by the memory router when the
+        current message itself clearly needs past context. Provider failures are
+        non-fatal, matching the rest of the memory layer.
+        """
+        parts = []
+        for provider in self._providers:
+            try:
+                result = provider.recall_now(
+                    query,
+                    session_id=session_id,
+                    max_tokens=max_tokens,
+                )
+                if result and result.strip():
+                    parts.append(result)
+            except Exception as e:
+                logger.debug(
+                    "Memory provider '%s' recall_now failed (non-fatal): %s",
                     provider.name, e,
                 )
         return "\n\n".join(parts)

--- a/agent/memory_provider.py
+++ b/agent/memory_provider.py
@@ -103,6 +103,22 @@ class MemoryProvider(ABC):
         """
         return ""
 
+    def recall_now(
+        self,
+        query: str,
+        *,
+        session_id: str = "",
+        max_tokens: Optional[int] = None,
+    ) -> str:
+        """Synchronously recall context for the CURRENT turn.
+
+        This is the bounded, best-effort path used when the router detects a
+        memory-sensitive first turn (for example a domain trigger or explicit
+        reference to prior discussion). Providers that only support background
+        prefetch can keep the default empty implementation.
+        """
+        return ""
+
     def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
         """Queue a background recall for the NEXT turn.
 

--- a/agent/memory_router.py
+++ b/agent/memory_router.py
@@ -1,0 +1,186 @@
+"""Lightweight routing for external memory recall.
+
+This module is deliberately pure and dependency-free: it decides whether a
+turn should use current-turn recall, reuse an active capsule, or skip memory.
+The actual retrieval remains owned by memory providers and ``AIAgent``.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Literal
+
+
+RouteAction = Literal[
+    "skip",
+    "reuse_active_capsule",
+    "domain_capsule",
+    "hindsight_now",
+]
+
+
+_NUTRITION_PATTERNS = (
+    r"(?<![0-9a-zа-яё_])завтрак[а-яё]*",
+    r"(?<![0-9a-zа-яё_])обед[а-яё]*",
+    r"(?<![0-9a-zа-яё_])ужин[а-яё]*",
+    r"(?<![0-9a-zа-яё_])перекус[а-яё]*",
+    r"(?<![0-9a-zа-яё_])съе(л|ла|ли|ден|дено|денный|денная|денные)[а-яё]*",
+    r"(?<![0-9a-zа-яё_])калор[а-яё]*",
+    r"(?<![0-9a-zа-яё_])ккал(?![0-9a-zа-яё_])",
+    r"(?<![0-9a-zа-яё_])бел(ок|ка|ки|ков|ком|ку|ке)(?![0-9a-zа-яё_])",
+    r"(?<![0-9a-zа-яё_])протеин[а-яё]*",
+    r"(?<![0-9a-zа-яё_])омлет[а-яё]*",
+    r"(?<![0-9a-zа-яё_])яйц[а-яё]*",
+    r"(?<![0-9a-zа-яё_])йогурт[а-яё]*",
+    r"(?<![0-9a-zа-яё_])творог[а-яё]*",
+)
+
+_NUTRITION_WORD_TRIGGERS = (
+    "ел",
+    "ела",
+)
+
+_WORD_BOUNDARY = r"(?<![0-9a-zа-яё_]){word}(?![0-9a-zа-яё_])"
+
+_PAST_REFERENCE_PATTERNS = (
+    r"(?<![0-9a-zа-яё_])помнишь(?![0-9a-zа-яё_])",
+    r"(?<![0-9a-zа-яё_])в прошлый раз(?![0-9a-zа-яё_])",
+    r"(?<![0-9a-zа-яё_])мы (?:это )?обсуждали с тобой(?![0-9a-zа-яё_])",
+    r"(?<![0-9a-zа-яё_])с тобой (?:это )?обсуждали(?![0-9a-zа-яё_])",
+    r"(?<![0-9a-zа-яё_])что (?:мы )?(?:это )?решили(?![0-9a-zа-яё_])",
+    r"(?<![0-9a-zа-яё_])как (?:мы )?(?:это )?решили(?![0-9a-zа-яё_])",
+    r"(?<![0-9a-zа-яё_])о ч[её]м говорили(?![0-9a-zа-яё_])",
+    r"(?<![0-9a-z_])last time(?![0-9a-z_])",
+    r"(?<![0-9a-z_])remember when(?![0-9a-z_])",
+    r"(?<![0-9a-z_])as we discussed(?![0-9a-z_])",
+    r"(?<![0-9a-z_])we discussed (?:this )?(?:before|last time|previously)(?![0-9a-z_])",
+)
+
+
+@dataclass(frozen=True)
+class MemoryRoute:
+    """Decision from the memory router for a single user turn."""
+
+    action: RouteAction
+    topic: str = ""
+    query: str = ""
+    reason: str = ""
+    max_tokens: int = 800
+    sources: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ActiveContextCapsule:
+    """Small, reusable memory context for the current topic."""
+
+    topic: str
+    text: str
+    sources: list[str] = field(default_factory=list)
+    created_turn: int = 0
+    last_used_turn: int = 0
+    ttl_turns: int = 5
+
+    def is_valid(self, *, current_turn: int) -> bool:
+        if not self.topic or not self.text.strip():
+            return False
+        # Keep capsules bounded from creation time rather than extending them on
+        # every reuse; otherwise a stale topic can live forever in a chatty thread.
+        return (current_turn - self.created_turn) <= self.ttl_turns
+
+
+class ActiveContextCapsuleCache:
+    """One active context capsule per agent/session.
+
+    A single active capsule is enough for the MVP: it captures the current topic
+    and avoids repeated recall across short follow-up turns. When the topic
+    changes, the new capsule replaces the old one.
+    """
+
+    def __init__(self, *, default_ttl_turns: int = 5) -> None:
+        self.default_ttl_turns = max(1, int(default_ttl_turns))
+        self._capsule: ActiveContextCapsule | None = None
+
+    def set(self, capsule: ActiveContextCapsule) -> None:
+        if capsule.ttl_turns <= 0:
+            capsule.ttl_turns = self.default_ttl_turns
+        if capsule.last_used_turn <= 0:
+            capsule.last_used_turn = capsule.created_turn
+        self._capsule = capsule
+
+    def get(self, topic: str, *, current_turn: int) -> str:
+        capsule = self._capsule
+        if capsule is None or capsule.topic != topic:
+            return ""
+        if not capsule.is_valid(current_turn=current_turn):
+            return ""
+        capsule.last_used_turn = current_turn
+        return capsule.text
+
+    def clear(self) -> None:
+        self._capsule = None
+
+    def active_topic(self, *, current_turn: int) -> str:
+        capsule = self._capsule
+        if capsule is None or not capsule.is_valid(current_turn=current_turn):
+            return ""
+        return capsule.topic
+
+
+class MemoryRouter:
+    """Cheap deterministic router for deciding whether to recall memory."""
+
+    def classify(self, message: str, *, active_topic: str = "") -> MemoryRoute:
+        raw = message or ""
+        text = raw.lower().strip()
+        if not text:
+            return MemoryRoute(action="skip", reason="empty")
+        nutrition_turn = self._is_nutrition_turn(text)
+
+        if self._matches_any_pattern(text, _PAST_REFERENCE_PATTERNS):
+            return MemoryRoute(
+                action="hindsight_now",
+                topic="nutrition" if nutrition_turn else "",
+                query=raw,
+                reason="explicit past-reference",
+                max_tokens=800,
+                sources=["external-memory"],
+            )
+
+        if nutrition_turn:
+            if active_topic == "nutrition":
+                return MemoryRoute(
+                    action="reuse_active_capsule",
+                    topic="nutrition",
+                    query=raw,
+                    reason="same nutrition topic",
+                )
+            return MemoryRoute(
+                action="domain_capsule",
+                topic="nutrition",
+                query=raw,
+                reason="nutrition trigger",
+                max_tokens=800,
+                sources=["external-memory"],
+            )
+
+        return MemoryRoute(action="skip", query=raw, reason="no memory trigger")
+
+    @staticmethod
+    def _contains_any(text: str, needles: tuple[str, ...]) -> bool:
+        return any(needle in text for needle in needles)
+
+    @classmethod
+    def _contains_whole_word(cls, text: str, words: tuple[str, ...]) -> bool:
+        return any(re.search(_WORD_BOUNDARY.format(word=re.escape(word)), text) for word in words)
+
+    @staticmethod
+    def _matches_any_pattern(text: str, patterns: tuple[str, ...]) -> bool:
+        return any(re.search(pattern, text) for pattern in patterns)
+
+    @classmethod
+    def _is_nutrition_turn(cls, text: str) -> bool:
+        return cls._matches_any_pattern(text, _NUTRITION_PATTERNS) or cls._contains_whole_word(
+            text,
+            _NUTRITION_WORD_TRIGGERS,
+        )

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1038,6 +1038,64 @@ class HindsightMemoryProvider(MemoryProvider):
             f"hindsight_retain to store facts."
         )
 
+    def _build_recall_kwargs(self, query: str, *, max_tokens: int | None = None) -> dict:
+        configured_cap = max(1, int(self._recall_max_tokens))
+        token_cap = configured_cap
+        if max_tokens is not None:
+            try:
+                token_cap = min(configured_cap, max(1, int(max_tokens)))
+            except (TypeError, ValueError):
+                token_cap = configured_cap
+        recall_kwargs: dict = {
+            "bank_id": self._bank_id,
+            "query": query,
+            "budget": self._budget,
+            "max_tokens": token_cap,
+        }
+        if self._recall_tags:
+            recall_kwargs["tags"] = self._recall_tags
+            recall_kwargs["tags_match"] = self._recall_tags_match
+        if self._recall_types:
+            recall_kwargs["types"] = self._recall_types
+        return recall_kwargs
+
+    def recall_now(
+        self,
+        query: str,
+        *,
+        session_id: str = "",
+        max_tokens: int | None = None,
+    ) -> str:
+        """Synchronously recall bounded context for the current user turn."""
+        if self._memory_mode == "tools":
+            logger.debug("Recall-now: skipped (tools-only mode)")
+            return ""
+        if not self._auto_recall:
+            logger.debug("Recall-now: skipped (auto_recall disabled)")
+            return ""
+        query = (query or "").strip()
+        if not query:
+            return ""
+        if session_id:
+            self._session_id = str(session_id).strip()
+        if self._recall_max_input_chars and len(query) > self._recall_max_input_chars:
+            query = query[:self._recall_max_input_chars]
+        try:
+            recall_kwargs = self._build_recall_kwargs(query, max_tokens=max_tokens)
+            logger.debug(
+                "Recall-now: calling recall (bank=%s, query_len=%d, budget=%s)",
+                self._bank_id,
+                len(query),
+                self._budget,
+            )
+            resp = self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))
+            if not getattr(resp, "results", None):
+                return ""
+            return "\n".join(f"- {r.text}" for r in resp.results if getattr(r, "text", ""))
+        except Exception as e:
+            logger.debug("Hindsight recall-now failed: %s", e, exc_info=True)
+            return ""
+
     def prefetch(self, query: str, *, session_id: str = "") -> str:
         if self._prefetch_thread and self._prefetch_thread.is_alive():
             logger.debug("Prefetch: waiting for background thread to complete")
@@ -1204,7 +1262,7 @@ class HindsightMemoryProvider(MemoryProvider):
 
         def _sync():
             try:
-                client = self._get_client()
+                self._get_client()
                 item = self._build_retain_kwargs(
                     content,
                     context=self._retain_context,

--- a/run_agent.py
+++ b/run_agent.py
@@ -81,6 +81,7 @@ from tools.browser_tool import cleanup_browser
 
 # Agent internals extracted to agent/ package for modularity
 from agent.memory_manager import build_memory_context_block, sanitize_context
+from agent.memory_router import ActiveContextCapsule, ActiveContextCapsuleCache, MemoryRouter
 from agent.retry_utils import jittered_backoff
 from agent.error_classifier import classify_api_error, FailoverReason
 from agent.prompt_builder import (
@@ -1959,6 +1960,8 @@ class AIAgent:
             working_dir=os.getenv("TERMINAL_CWD") or None,
         )
         self._user_turn_count = 0
+        self._memory_router = MemoryRouter()
+        self._active_memory_capsules = ActiveContextCapsuleCache()
 
         # Cumulative token usage for the session
         self.session_prompt_tokens = 0
@@ -2078,6 +2081,7 @@ class AIAgent:
         
         # Turn counter (added after reset_session_state was first written — #2635)
         self._user_turn_count = 0
+        self._active_memory_capsules = ActiveContextCapsuleCache()
 
         # Context engine reset (works for both built-in compressor and plugins)
         if hasattr(self, "context_compressor") and self.context_compressor:
@@ -4276,6 +4280,86 @@ class AIAgent:
             self._memory_manager.on_session_end(messages or [])
         except Exception:
             pass
+
+    def _prepare_external_memory_context_for_turn(self, original_user_message: Any) -> str:
+        """Prepare ephemeral external-memory context for the current turn.
+
+        Combines the existing warmed prefetch path with a lightweight router for
+        immediate recall. Returned text is injected into the current user message
+        at API-call time only; callers must not persist it.
+        """
+        memory_manager = getattr(self, "_memory_manager", None)
+        if not memory_manager or not isinstance(original_user_message, str):
+            return ""
+        query = original_user_message.strip()
+        if not query:
+            return ""
+
+        context_parts: list[str] = []
+
+        def _append_context(text: Any) -> None:
+            if not isinstance(text, str) or not text.strip():
+                return
+            if text not in context_parts:
+                context_parts.append(text)
+
+        route = None
+        capsules = None
+        current_turn = int(getattr(self, "_user_turn_count", 0) or 0)
+        try:
+            router = getattr(self, "_memory_router", None)
+            if router is None:
+                router = MemoryRouter()
+                self._memory_router = router
+            capsules = getattr(self, "_active_memory_capsules", None)
+            if capsules is None:
+                capsules = ActiveContextCapsuleCache()
+                self._active_memory_capsules = capsules
+            active_topic = capsules.active_topic(current_turn=current_turn)
+            route = router.classify(query, active_topic=active_topic)
+        except Exception:
+            route = None
+
+        # Warmed prefetch belongs to the next-turn fallback path. When the
+        # current message explicitly triggers fresh recall, suppress prefetch so
+        # stale context from a previous query cannot be mixed into this turn.
+        try:
+            if route is None or route.action in {"skip", "reuse_active_capsule"}:
+                _append_context(memory_manager.prefetch_all(query) or "")
+        except Exception:
+            pass
+
+        try:
+            if route is None:
+                return "\n\n".join(context_parts)
+            if route.action == "reuse_active_capsule" and route.topic and capsules is not None:
+                _append_context(capsules.get(route.topic, current_turn=current_turn))
+            elif route.action in {"domain_capsule", "hindsight_now"}:
+                if route.action == "hindsight_now" and not route.topic and capsules is not None:
+                    capsules.clear()
+                recall_text = memory_manager.recall_now_all(
+                    route.query or query,
+                    session_id=getattr(self, "session_id", "") or "",
+                    max_tokens=route.max_tokens,
+                ) or ""
+                context_text = recall_text
+                if not context_text:
+                    context_text = memory_manager.prefetch_all(query) or ""
+                _append_context(context_text)
+                if context_text and route.topic and capsules is not None:
+                    capsules.set(
+                        ActiveContextCapsule(
+                            topic=route.topic,
+                            text=context_text,
+                            sources=route.sources,
+                            created_turn=current_turn,
+                            last_used_turn=current_turn,
+                        )
+                    )
+        except Exception:
+            pass
+
+        return "\n\n".join(context_parts)
 
     def _sync_external_memory_for_turn(
         self,
@@ -9572,18 +9656,14 @@ class AIAgent:
             except Exception:
                 pass
 
-        # External memory provider: prefetch once before the tool loop.
+        # External memory provider: prepare once before the tool loop.
         # Reuse the cached result on every iteration to avoid re-calling
-        # prefetch_all() on each tool call (10 tool calls = 10x latency + cost).
+        # providers on each tool call (10 tool calls = 10x latency + cost).
         # Use original_user_message (clean input) — user_message may contain
         # injected skill content that bloats / breaks provider queries.
-        _ext_prefetch_cache = ""
-        if self._memory_manager:
-            try:
-                _query = original_user_message if isinstance(original_user_message, str) else ""
-                _ext_prefetch_cache = self._memory_manager.prefetch_all(_query) or ""
-            except Exception:
-                pass
+        _ext_prefetch_cache = self._prepare_external_memory_context_for_turn(
+            original_user_message
+        )
 
         while (api_call_count < self.max_iterations and self.iteration_budget.remaining > 0) or self._budget_grace_call:
             # Reset per-turn checkpoint dedup so each iteration can take one snapshot

--- a/tests/agent/test_memory_recall_now.py
+++ b/tests/agent/test_memory_recall_now.py
@@ -1,0 +1,63 @@
+"""Tests for current-turn external memory recall support."""
+
+from agent.memory_manager import MemoryManager
+from agent.memory_provider import MemoryProvider
+
+
+class RecallNowProvider(MemoryProvider):
+    def __init__(self, name="recall", result="", fail=False):
+        self._name = name
+        self.result = result
+        self.fail = fail
+        self.calls = []
+
+    @property
+    def name(self):
+        return self._name
+
+    def is_available(self):
+        return True
+
+    def initialize(self, session_id, **kwargs):
+        pass
+
+    def get_tool_schemas(self):
+        return []
+
+    def recall_now(self, query, *, session_id="", max_tokens=None):
+        self.calls.append((query, session_id, max_tokens))
+        if self.fail:
+            raise RuntimeError("boom")
+        return self.result
+
+
+def test_memory_provider_default_recall_now_is_empty():
+    provider = RecallNowProvider(result="ignored")
+    # Call through the base implementation explicitly to prove the optional
+    # hook defaults to a safe no-op for providers that do not override it.
+    assert MemoryProvider.recall_now(provider, "hello") == ""
+
+
+def test_memory_manager_recall_now_all_merges_provider_results():
+    mgr = MemoryManager()
+    first = RecallNowProvider("builtin", result="First memory")
+    second = RecallNowProvider("external", result="Second memory")
+    mgr.add_provider(first)
+    mgr.add_provider(second)
+
+    result = mgr.recall_now_all("what did we decide?", session_id="s1", max_tokens=321)
+
+    assert "First memory" in result
+    assert "Second memory" in result
+    assert first.calls == [("what did we decide?", "s1", 321)]
+    assert second.calls == [("what did we decide?", "s1", 321)]
+
+
+def test_memory_manager_recall_now_all_skips_empty_and_failure():
+    mgr = MemoryManager()
+    failing = RecallNowProvider("builtin", fail=True)
+    empty = RecallNowProvider("external", result="")
+    mgr.add_provider(failing)
+    mgr.add_provider(empty)
+
+    assert mgr.recall_now_all("query") == ""

--- a/tests/agent/test_memory_router.py
+++ b/tests/agent/test_memory_router.py
@@ -1,0 +1,104 @@
+"""Tests for lightweight memory routing and active context capsules."""
+
+from agent.memory_router import (
+    ActiveContextCapsule,
+    ActiveContextCapsuleCache,
+    MemoryRouter,
+)
+
+
+def test_router_detects_nutrition_first_turn():
+    route = MemoryRouter().classify("На завтрак был съеден омлет из 2 яиц")
+
+    assert route.action == "domain_capsule"
+    assert route.topic == "nutrition"
+    assert "nutrition" in route.reason
+
+
+def test_router_detects_standalone_ate_word():
+    route = MemoryRouter().classify("я ел омлет")
+
+    assert route.action == "domain_capsule"
+    assert route.topic == "nutrition"
+
+
+def test_router_does_not_match_ate_inside_other_words():
+    router = MemoryRouter()
+
+    for message in ("я хотел спросить про OpenClaw", "я видел ошибку", "смотрел логи"):
+        route = router.classify(message)
+        assert route.action == "skip", message
+
+
+def test_router_does_not_match_nutrition_stems_inside_other_words():
+    router = MemoryRouter()
+
+    for message in ("победа будет за нами", "мы победим", "белокурый персонаж"):
+        route = router.classify(message)
+        assert route.action == "skip", message
+
+
+def test_router_reuses_active_nutrition_topic():
+    route = MemoryRouter().classify("а йогурт можно?", active_topic="nutrition")
+
+    assert route.action == "reuse_active_capsule"
+    assert route.topic == "nutrition"
+
+
+def test_router_explicit_past_reference_overrides_active_topic_reuse():
+    route = MemoryRouter().classify(
+        "помнишь, какой йогурт мы обсуждали?",
+        active_topic="nutrition",
+    )
+
+    assert route.action == "hindsight_now"
+    assert route.topic == "nutrition"
+
+
+def test_router_does_not_match_past_reference_inside_other_words_or_plain_narrative():
+    router = MemoryRouter()
+
+    for message in (
+        "если вспомнишь потом, напиши",
+        "мы обсуждали это с командой вчера",
+        "please remove the word previously from the docs",
+    ):
+        route = router.classify(message)
+        assert route.action == "skip", message
+
+
+def test_router_detects_explicit_past_reference():
+    route = MemoryRouter().classify("помнишь, что мы обсуждали по OpenClaw?")
+
+    assert route.action == "hindsight_now"
+    assert route.reason == "explicit past-reference"
+
+
+def test_router_skips_empty_message():
+    route = MemoryRouter().classify("   ")
+
+    assert route.action == "skip"
+
+
+def test_active_capsule_cache_reuses_until_ttl():
+    cache = ActiveContextCapsuleCache(default_ttl_turns=2)
+    cache.set(
+        ActiveContextCapsule(
+            topic="nutrition",
+            text="User eats two meals per day.",
+            created_turn=1,
+            last_used_turn=1,
+            ttl_turns=2,
+        )
+    )
+
+    assert cache.active_topic(current_turn=2) == "nutrition"
+    assert cache.get("nutrition", current_turn=2) == "User eats two meals per day."
+    assert cache.get("nutrition", current_turn=4) == ""
+
+
+def test_active_capsule_cache_does_not_reuse_wrong_topic():
+    cache = ActiveContextCapsuleCache(default_ttl_turns=5)
+    cache.set(ActiveContextCapsule(topic="nutrition", text="Nutrition context", created_turn=1))
+
+    assert cache.get("bro-pm", current_turn=2) == ""

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -522,6 +522,60 @@ class TestToolHandlers:
 
 
 # ---------------------------------------------------------------------------
+# recall_now tests
+# ---------------------------------------------------------------------------
+
+
+class TestRecallNow:
+    def test_recall_now_returns_bounded_context(self, provider_with_config):
+        p = provider_with_config(
+            recall_tags=["t1"],
+            recall_tags_match="all",
+            recall_types=["experience"],
+            recall_max_tokens=2048,
+        )
+
+        result = p.recall_now("На завтрак омлет", session_id="s1", max_tokens=800)
+
+        assert "Memory 1" in result
+        assert "Memory 2" in result
+        call_kwargs = p._client.arecall.call_args.kwargs
+        assert call_kwargs["bank_id"] == "test-bank"
+        assert call_kwargs["query"] == "На завтрак омлет"
+        assert call_kwargs["budget"] == "mid"
+        assert call_kwargs["max_tokens"] == 800
+        assert call_kwargs["tags"] == ["t1"]
+        assert call_kwargs["tags_match"] == "all"
+        assert call_kwargs["types"] == ["experience"]
+
+    def test_recall_now_clamps_requested_max_tokens_to_configured_cap(self, provider_with_config):
+        p = provider_with_config(recall_max_tokens=256)
+
+        p.recall_now("На завтрак омлет", max_tokens=800)
+
+        assert p._client.arecall.call_args.kwargs["max_tokens"] == 256
+
+    def test_recall_now_skips_tools_mode(self, provider_with_config):
+        p = provider_with_config(memory_mode="tools")
+
+        assert p.recall_now("query") == ""
+        p._client.arecall.assert_not_called()
+
+    def test_recall_now_skips_when_auto_recall_disabled(self, provider_with_config):
+        p = provider_with_config(auto_recall=False)
+
+        assert p.recall_now("query") == ""
+        p._client.arecall.assert_not_called()
+
+    def test_recall_now_truncates_long_query(self, provider_with_config):
+        p = provider_with_config(recall_max_input_chars=5)
+
+        p.recall_now("abcdefghij")
+
+        assert p._client.arecall.call_args.kwargs["query"] == "abcde"
+
+
+# ---------------------------------------------------------------------------
 # Prefetch tests
 # ---------------------------------------------------------------------------
 

--- a/tests/run_agent/test_memory_router_injection.py
+++ b/tests/run_agent/test_memory_router_injection.py
@@ -1,0 +1,228 @@
+"""Tests for AIAgent current-turn memory context preparation."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+def _bare_agent():
+    from run_agent import AIAgent
+
+    agent = AIAgent.__new__(AIAgent)
+    agent._memory_manager = MagicMock()
+    agent._memory_manager.prefetch_all.return_value = ""
+    agent._memory_manager.recall_now_all.return_value = "Nutrition plan: 2 meals/day, high protein."
+    agent.session_id = "session-1"
+    agent._user_turn_count = 1
+    return agent
+
+
+def _make_tool_defs(*names: str) -> list:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"{name} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for name in names
+    ]
+
+
+def _mock_response(content="Final answer", finish_reason="stop"):
+    message = SimpleNamespace(content=content, tool_calls=None)
+    choice = SimpleNamespace(message=message, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], model="test/model", usage=None)
+
+
+def _real_agent():
+    from run_agent import AIAgent
+
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.tool_delay = 0
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    agent._memory_manager = MagicMock()
+    agent._memory_manager.prefetch_all.return_value = ""
+    agent._memory_manager.recall_now_all.return_value = "Nutrition plan: 2 meals/day, high protein."
+    return agent
+
+
+def test_first_nutrition_turn_uses_current_turn_recall_and_caches_capsule():
+    agent = _bare_agent()
+
+    context = agent._prepare_external_memory_context_for_turn(
+        "На завтрак был съеден омлет из 2 яиц с сыром"
+    )
+
+    assert "Nutrition plan" in context
+    agent._memory_manager.recall_now_all.assert_called_once_with(
+        "На завтрак был съеден омлет из 2 яиц с сыром",
+        session_id="session-1",
+        max_tokens=800,
+    )
+
+    agent._memory_manager.recall_now_all.reset_mock()
+    agent._memory_manager.prefetch_all.return_value = ""
+    agent._user_turn_count = 2
+
+    followup = agent._prepare_external_memory_context_for_turn("а йогурт можно?")
+
+    assert "Nutrition plan" in followup
+    agent._memory_manager.recall_now_all.assert_not_called()
+
+
+def test_explicit_same_topic_memory_request_bypasses_cached_capsule():
+    agent = _bare_agent()
+
+    agent._prepare_external_memory_context_for_turn("На завтрак был омлет")
+    agent._memory_manager.recall_now_all.reset_mock()
+    agent._memory_manager.prefetch_all.return_value = ""
+    agent._memory_manager.recall_now_all.return_value = "Fresh yogurt context"
+    agent._user_turn_count = 2
+
+    context = agent._prepare_external_memory_context_for_turn("помнишь, какой йогурт мы обсуждали?")
+
+    assert context == "Fresh yogurt context"
+    agent._memory_manager.recall_now_all.assert_called_once_with(
+        "помнишь, какой йогурт мы обсуждали?",
+        session_id="session-1",
+        max_tokens=800,
+    )
+
+    agent._memory_manager.recall_now_all.reset_mock()
+    agent._user_turn_count = 3
+
+    followup = agent._prepare_external_memory_context_for_turn("а сколько там белка?")
+
+    assert followup == "Fresh yogurt context"
+    agent._memory_manager.recall_now_all.assert_not_called()
+
+
+def test_fresh_current_turn_recall_suppresses_stale_warm_prefetch():
+    agent = _bare_agent()
+    agent._memory_manager.prefetch_all.return_value = "WARM PREFETCH FROM PREVIOUS TURN"
+    agent._memory_manager.recall_now_all.return_value = "FRESH RECALL FOR CURRENT QUERY"
+
+    context = agent._prepare_external_memory_context_for_turn("помнишь, что решили по памяти?")
+
+    assert context == "FRESH RECALL FOR CURRENT QUERY"
+    agent._memory_manager.prefetch_all.assert_not_called()
+
+
+def test_prefetch_only_provider_still_works_when_current_turn_recall_unavailable():
+    agent = _bare_agent()
+    agent._memory_manager.prefetch_all.return_value = "PREFETCH-ONLY MEMORY"
+    agent._memory_manager.recall_now_all.return_value = ""
+
+    context = agent._prepare_external_memory_context_for_turn("помнишь, что решили по памяти?")
+
+    assert context == "PREFETCH-ONLY MEMORY"
+    agent._memory_manager.prefetch_all.assert_called_once_with("помнишь, что решили по памяти?")
+
+
+def test_same_topic_hindsight_prefetch_fallback_refreshes_capsule():
+    agent = _bare_agent()
+    agent._memory_manager.recall_now_all.return_value = "OLD CAPSULE"
+    agent._prepare_external_memory_context_for_turn("На завтрак был йогурт")
+
+    agent._memory_manager.recall_now_all.reset_mock()
+    agent._memory_manager.prefetch_all.reset_mock()
+    agent._memory_manager.recall_now_all.return_value = ""
+    agent._memory_manager.prefetch_all.return_value = "NEW PREFETCH CONTEXT"
+    agent._user_turn_count = 2
+
+    context = agent._prepare_external_memory_context_for_turn("помнишь, какой йогурт мы обсуждали?")
+
+    assert context == "NEW PREFETCH CONTEXT"
+
+    agent._memory_manager.recall_now_all.reset_mock()
+    agent._memory_manager.prefetch_all.reset_mock()
+    agent._memory_manager.prefetch_all.return_value = ""
+    agent._user_turn_count = 3
+
+    followup = agent._prepare_external_memory_context_for_turn("а сколько там белка?")
+
+    assert followup == "NEW PREFETCH CONTEXT"
+    agent._memory_manager.recall_now_all.assert_not_called()
+
+
+def test_non_topic_hindsight_empty_recall_clears_prior_capsule():
+    agent = _bare_agent()
+    agent._memory_manager.recall_now_all.return_value = "OLD CAPSULE"
+    agent._prepare_external_memory_context_for_turn("На завтрак был йогурт")
+
+    agent._memory_manager.recall_now_all.reset_mock()
+    agent._memory_manager.prefetch_all.return_value = ""
+    agent._memory_manager.recall_now_all.return_value = ""
+    agent._user_turn_count = 2
+
+    assert agent._prepare_external_memory_context_for_turn("помнишь, что мы решили по проекту?") == ""
+
+    agent._memory_manager.recall_now_all.reset_mock()
+    agent._memory_manager.recall_now_all.return_value = "FRESH DOMAIN RECALL"
+    agent._user_turn_count = 3
+
+    followup = agent._prepare_external_memory_context_for_turn("а сколько там белка?")
+
+    assert followup == "FRESH DOMAIN RECALL"
+    agent._memory_manager.recall_now_all.assert_called_once()
+
+
+def test_warm_prefetch_still_included_without_immediate_recall():
+    agent = _bare_agent()
+    agent._memory_manager.recall_now_all.return_value = ""
+    agent._memory_manager.prefetch_all.return_value = "Warm cached memory"
+
+    context = agent._prepare_external_memory_context_for_turn("hello there")
+
+    assert context == "Warm cached memory"
+    agent._memory_manager.prefetch_all.assert_called_once_with("hello there")
+
+
+def test_no_memory_manager_returns_empty_context():
+    from run_agent import AIAgent
+
+    agent = AIAgent.__new__(AIAgent)
+    agent._memory_manager = None
+
+    assert agent._prepare_external_memory_context_for_turn("На завтрак омлет") == ""
+
+
+def test_run_conversation_injects_recall_context_without_persisting_it():
+    agent = _real_agent()
+    seen = {}
+
+    def _capture_api_call(api_kwargs):
+        seen["messages"] = api_kwargs["messages"]
+        return _mock_response("Logged")
+
+    user_text = "На завтрак был съеден омлет из 2 яиц с сыром"
+    with (
+        patch.object(agent, "_interruptible_api_call", side_effect=_capture_api_call),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation(user_text)
+
+    api_user_messages = [m for m in seen["messages"] if m.get("role") == "user"]
+    assert len(api_user_messages) == 1
+    assert api_user_messages[0]["content"].startswith(user_text)
+    assert "<memory-context>" in api_user_messages[0]["content"]
+    assert "Nutrition plan" in api_user_messages[0]["content"]
+    assert result["messages"][0]["content"] == user_text

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4786,22 +4786,24 @@ class TestMemoryContextSanitization:
 
 
 class TestMemoryProviderTurnStart:
-    """run_conversation() must call memory_manager.on_turn_start() before prefetch_all().
+    """run_conversation() must tick memory providers before preparing context.
 
     Without this call, providers like Honcho never update _turn_count, so cadence
     checks (contextCadence, dialecticCadence) are always satisfied — every turn
     fires both context refresh and dialectic, ignoring the configured cadence.
     """
 
-    def test_on_turn_start_called_before_prefetch(self):
-        """Source-level check: on_turn_start appears before prefetch_all in run_conversation."""
+    def test_on_turn_start_called_before_memory_context_preparation(self):
+        """Source-level check: on_turn_start appears before recall/prefetch preparation."""
         import inspect
         src = inspect.getsource(AIAgent.run_conversation)
         # Find the actual method calls, not comments
         idx_turn_start = src.index(".on_turn_start(")
-        idx_prefetch = src.index(".prefetch_all(")
-        assert idx_turn_start < idx_prefetch, (
-            "on_turn_start() must be called before prefetch_all() in run_conversation "
+        idx_prepare = src.index("._prepare_external_memory_context_for_turn(")
+        helper_src = inspect.getsource(AIAgent._prepare_external_memory_context_for_turn)
+        assert ".prefetch_all(" in helper_src
+        assert idx_turn_start < idx_prepare, (
+            "on_turn_start() must be called before external memory context is prepared "
             "so that memory providers have the correct turn count for cadence checks"
         )
 


### PR DESCRIPTION
## Summary
- Add a lightweight memory router and active context capsules for current-turn external memory recall.
- Add `recall_now` plumbing through memory providers and Hindsight with configured token caps.
- Keep injected memory ephemeral in `run_conversation`, preserve prefetch fallback for providers without current-turn recall, and harden capsule refresh/clearing semantics.
- Add regression tests for router false positives, explicit past-reference precedence, fallback behavior, and non-persistent injection.

## Test plan
- `python -m pytest tests/agent/test_memory_provider.py tests/agent/test_memory_router.py tests/agent/test_memory_recall_now.py tests/plugins/memory/test_hindsight_provider.py tests/run_agent/test_memory_router_injection.py tests/run_agent/test_memory_sync_interrupted.py tests/run_agent/test_memory_provider_init.py tests/run_agent/test_run_agent.py -q` → 490 passed
- `ruff check agent/memory_router.py agent/memory_provider.py agent/memory_manager.py plugins/memory/hindsight/__init__.py tests/agent/test_memory_router.py tests/agent/test_memory_recall_now.py tests/run_agent/test_memory_router_injection.py tests/plugins/memory/test_hindsight_provider.py` → passed
- `python -m py_compile run_agent.py agent/memory_router.py agent/memory_provider.py agent/memory_manager.py plugins/memory/hindsight/__init__.py` → passed
- `git diff --cached --check` and added-line static scan → passed

## Notes
- A broader local subset previously had unrelated/baseline/order-dependent failures; focused reruns isolated the relevant touched-area suite as green.
