### PR TITLE
fix(gateway): read context_length from custom_providers in session info header

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4892,6 +4892,7 @@ class GatewayRunner:
         provider = None
         base_url = None
         api_key = None
+        data = None
 
         try:
             cfg_path = _hermes_home / "config.yaml"
@@ -4911,6 +4912,41 @@ class GatewayRunner:
                     base_url = model_cfg.get("base_url") or None
         except Exception:
             pass
+
+        # Also check custom_providers for context_length when top-level model.context_length is not set
+        if config_context_length is None and data:
+            try:
+                custom_providers = data.get("custom_providers", [])
+                if custom_providers:
+                    for cp in custom_providers:
+                        if not isinstance(cp, dict):
+                            continue
+                        cp_model = cp.get("model") or ""
+                        cp_models = cp.get("models") or {}
+                        # Match provider model to current model
+                        if cp_model and cp_model == model:
+                            raw_cp_ctx = cp.get("context_length")
+                            if raw_cp_ctx is not None:
+                                try:
+                                    config_context_length = int(raw_cp_ctx)
+                                    break
+                                except (TypeError, ValueError):
+                                    pass
+                        # Also check per-model context_length
+                        if isinstance(cp_models, dict):
+                            model_entry = cp_models.get(model)
+                            if isinstance(model_entry, dict):
+                                model_ctx = model_entry.get("context_length")
+                            else:
+                                model_ctx = model_entry
+                            if model_ctx is not None and isinstance(model_ctx, (int, float)):
+                                try:
+                                    config_context_length = int(model_ctx)
+                                    break
+                                except (TypeError, ValueError):
+                                    pass
+            except Exception:
+                pass
 
         # Resolve runtime credentials for probing
         try:


### PR DESCRIPTION
## Problem

`_format_session_info()` in `gateway/run.py` only reads `context_length` from the top-level `model.context_length` in config.yaml. If a user configures context_length under `custom_providers` → specific provider → `models.<model>.context_length`, this is completely ignored, and the session header always shows "128K tokens (default — set model.context_length in config to override)".

## Fix

Added a scan of `custom_providers` entries when the top-level `model.context_length` is not set. The resolution order is now:

1. Top-level `model.context_length` (existing, highest priority)
2. `custom_providers` → matching provider → `models.<model>.context_length`
3. Fall through to the existing probe/default behavior

The fix is a ~35 line addition that iterates through custom_providers looking for context_length matching the current model. Also checks both `cp[context_length]` (provider-level) and `cp[models][model][context_length]` (per-model).

## Testing

- All 19 gateway-related tests pass
- 250 existing run_agent tests pass (3 pre-existing unrelated failures)