### PR TITLE
test(skill_utils): add regression tests for non-dict metadata in extract_skill_conditions

### DIFF
--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -1,0 +1,58 @@
+"""Tests for agent/skill_utils.py — extract_skill_conditions metadata handling."""
+
+from agent.skill_utils import extract_skill_conditions
+
+
+def test_metadata_as_dict_with_hermes():
+    """Normal case: metadata is a dict containing hermes keys."""
+    frontmatter = {
+        "metadata": {
+            "hermes": {
+                "fallback_for_toolsets": ["toolset_a"],
+                "requires_toolsets": ["toolset_b"],
+                "fallback_for_tools": ["tool_x"],
+                "requires_tools": ["tool_y"],
+            }
+        }
+    }
+    result = extract_skill_conditions(frontmatter)
+    assert result["fallback_for_toolsets"] == ["toolset_a"]
+    assert result["requires_toolsets"] == ["toolset_b"]
+    assert result["fallback_for_tools"] == ["tool_x"]
+    assert result["requires_tools"] == ["tool_y"]
+
+
+def test_metadata_as_string_does_not_crash():
+    """Bug case: metadata is a non-dict truthy value (e.g. a YAML string)."""
+    frontmatter = {"metadata": "some text"}
+    result = extract_skill_conditions(frontmatter)
+    assert result == {
+        "fallback_for_toolsets": [],
+        "requires_toolsets": [],
+        "fallback_for_tools": [],
+        "requires_tools": [],
+    }
+
+
+def test_metadata_as_none():
+    """metadata key is present but set to null/None."""
+    frontmatter = {"metadata": None}
+    result = extract_skill_conditions(frontmatter)
+    assert result == {
+        "fallback_for_toolsets": [],
+        "requires_toolsets": [],
+        "fallback_for_tools": [],
+        "requires_tools": [],
+    }
+
+
+def test_metadata_missing_entirely():
+    """metadata key is absent from frontmatter."""
+    frontmatter = {"name": "my-skill", "description": "Does stuff."}
+    result = extract_skill_conditions(frontmatter)
+    assert result == {
+        "fallback_for_toolsets": [],
+        "requires_toolsets": [],
+        "fallback_for_tools": [],
+        "requires_tools": [],
+    }


### PR DESCRIPTION
## What does this PR do?

Adds regression test coverage for the non-dict metadata bug in `extract_skill_conditions()` in `agent/skill_utils.py`.

The fix itself (isinstance guard) was already merged via commit `3ff9e010`, but test coverage was not included in that commit. This was suggested in the review of #4495.

## Type of Change
- [x] Tests

## Changes Made

Added `tests/agent/test_skill_utils.py` with 4 tests:
- `test_metadata_as_dict_with_hermes` — normal case, metadata is a dict with hermes keys
- `test_metadata_as_string_does_not_crash` — bug case, previously caused `AttributeError`
- `test_metadata_as_none` — None metadata returns empty conditions
- `test_metadata_missing_entirely` — missing metadata key returns empty conditions

## How to Test

```bash
python -m pytest tests/agent/test_skill_utils.py -v
```

All 4 tests pass against current main.

## Checklist
- [x] Tests pass (4/4)
- [x] No new dependencies
- [x] Only adds test file, no production code changes