### PR TITLE
fix(agent): add missing `name` field to tool messages for Gemini compatibility

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4711,10 +4711,12 @@ class AIAgent:
                     for tc in msg.get("tool_calls") or []:
                         cid = AIAgent._get_tool_call_id_static(tc)
                         if cid in missing_results:
+                            tc_name = tc.get("function", {}).get("name", "unknown") if isinstance(tc, dict) else getattr(getattr(tc, "function", None), "name", "unknown")
                             patched.append({
                                 "role": "tool",
                                 "content": "[Result unavailable — see context summary above]",
                                 "tool_call_id": cid,
+                                "name": tc_name,
                             })
             messages = patched
             logger.debug(
@@ -8244,6 +8246,7 @@ class AIAgent:
                                 "role": "tool",
                                 "tool_call_id": tool_call_id,
                                 "content": marker,
+                                "name": function_name,
                             },
                         )
                         insert_at += 1
@@ -8566,6 +8569,7 @@ class AIAgent:
                     "role": "tool",
                     "content": f"[Tool execution cancelled — {tc.function.name} was skipped due to user interrupt]",
                     "tool_call_id": tc.id,
+                    "name": tc.function.name,
                 })
             return
 
@@ -8831,6 +8835,7 @@ class AIAgent:
                 "role": "tool",
                 "content": function_result,
                 "tool_call_id": tc.id,
+                "name": name,
             }
             messages.append(tool_msg)
 
@@ -8868,6 +8873,7 @@ class AIAgent:
                         "role": "tool",
                         "content": f"[Tool execution cancelled — {skipped_name} was skipped due to user interrupt]",
                         "tool_call_id": skipped_tc.id,
+                        "name": skipped_name,
                     }
                     messages.append(skip_msg)
                 break
@@ -9194,7 +9200,8 @@ class AIAgent:
             tool_msg = {
                 "role": "tool",
                 "content": function_result,
-                "tool_call_id": tool_call.id
+                "tool_call_id": tool_call.id,
+                "name": function_name,
             }
             messages.append(tool_msg)
 
@@ -9220,7 +9227,8 @@ class AIAgent:
                     skip_msg = {
                         "role": "tool",
                         "content": f"[Tool execution skipped — {skipped_name} was not started. User sent a new message]",
-                        "tool_call_id": skipped_tc.id
+                        "tool_call_id": skipped_tc.id,
+                        "name": skipped_name,
                     }
                     messages.append(skip_msg)
                 break
@@ -12052,6 +12060,7 @@ class AIAgent:
                                 "role": "tool",
                                 "tool_call_id": tc.id,
                                 "content": content,
+                                "name": tc.function.name,
                             })
                         continue
                     # Reset retry counter on successful tool call validation
@@ -12143,6 +12152,7 @@ class AIAgent:
                                     "role": "tool",
                                     "tool_call_id": tc.id,
                                     "content": tool_result,
+                                    "name": tc.function.name,
                                 })
                             continue
                     


### PR DESCRIPTION
## Fixes NousResearch/hermes-agent#16478

### Problem
All tool result messages (`role: "tool"`) were missing the required `name` field. While OpenAI's API tolerates this, Gemini and other strict OpenAI-compatible providers return **HTTP 400** when `name` is absent.

### Root Cause
The tool message dicts in `run_agent.py` only included `role`, `content`, and `tool_call_id`, but omitted the `name` field that identifies which function the tool response belongs to.

### Fix
Added `"name": <function_name>` to all 9 tool message construction sites in `run_agent.py`:

1. **Context sanitizer stub** (line ~4716) — pre-call gap-filler
2. **Argument repair insertion** (line ~8248) — corrupted JSON repair
3. **Parallel pre-flight interrupt** (line ~8568) — user interrupt during parallel
4. **Parallel execution result** (line ~8834) — main parallel tool result
5. **Sequential interrupt mid-tool** (line ~8872) — user interrupt during sequential
6. **Sequential execution result** (line ~9199) — main sequential tool result
7. **Sequential interrupt after-tool** (line ~9227) — user interrupt after partial completion
8. **Invalid tool name error** (line ~12059) — unknown tool self-correction
9. **Invalid JSON args error** (line ~12151) — malformed arguments self-correction

### Testing
- All 10 `role: "tool"` messages now include the `name` field
- Syntax verified with `ast.parse()` on the full file
- No functional changes to tool execution logic — only message formatting
