### PR TITLE
fix(gateway): bridge WhatsApp-specific config keys into config.extra

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -610,6 +610,10 @@ def load_gateway_config() -> GatewayConfig:
                         bridged["channel_prompts"] = {str(k): v for k, v in channel_prompts.items()}
                     else:
                         bridged["channel_prompts"] = channel_prompts
+                if plat == Platform.WHATSAPP:
+                    for key in ("bridge_port", "bridge_script", "session_path", "free_response_chats"):
+                        if key in platform_cfg:
+                            bridged[key] = platform_cfg[key]
                 if not bridged:
                     continue
                 plat_data = platforms_data.setdefault(plat.value, {})


### PR DESCRIPTION
## Fixes NousResearch/hermes-agent#16521

### Problem
Setting `bridge_port` under the `whatsapp:` section in `config.yaml` has no effect. The value is never loaded into `config.extra`, so the WhatsApp adapter always falls back to the hardcoded default of 3000.

### Root Cause
The per-platform config bridging loop in `gateway/config.py` only forwards a hardcoded whitelist of generic keys (`unauthorized_dm_behavior`, `reply_prefix`, `require_mention`, etc.). WhatsApp-specific keys like `bridge_port`, `bridge_script`, `session_path`, and `free_response_chats` were not in the whitelist and were silently ignored.

### Fix
Added a WhatsApp-specific block in the config bridging loop that forwards `bridge_port`, `bridge_script`, `session_path`, and `free_response_chats` from the shorthand config section into `config.extra`.

The WhatsApp adapter (`gateway/platforms/whatsapp.py`) already correctly reads these from `config.extra` — only the config loading was broken.

### Files Changed
- `gateway/config.py` — 4 lines added (WhatsApp-specific key bridging)
