### PR TITLE
fix(gateway): skip MEDIA tags inside code blocks in extract_media

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1597,12 +1597,25 @@ class BasePlatformAdapter(ABC):
         has_voice_tag = "[[audio_as_voice]]" in content
         cleaned = cleaned.replace("[[audio_as_voice]]", "")
         
+        # Build spans covered by fenced code blocks and inline code
+        # so that MEDIA: examples inside code are not treated as real attachments.
+        code_spans: list = []
+        for m in re.finditer(r'```[^\n]*\n.*?```', content, re.DOTALL):
+            code_spans.append((m.start(), m.end()))
+        for m in re.finditer(r'`[^`\n]+`', content):
+            code_spans.append((m.start(), m.end()))
+
+        def _in_code(pos: int) -> bool:
+            return any(s <= pos < e for s, e in code_spans)
+
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
         media_pattern = re.compile(
             r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$)|\S+)[`"']?'''
         )
         for match in media_pattern.finditer(content):
+            if _in_code(match.start()):
+                continue
             path = match.group("path").strip()
             if len(path) >= 2 and path[0] == path[-1] and path[0] in "`\"'":
                 path = path[1:-1].strip()
@@ -1611,8 +1624,13 @@ class BasePlatformAdapter(ABC):
                 media.append((os.path.expanduser(path), has_voice_tag))
 
         # Remove MEDIA tags from content (including surrounding quote/backtick wrappers)
+        # Only remove those NOT inside code blocks
         if media:
-            cleaned = media_pattern.sub('', cleaned)
+            def _remove_if_real(m):
+                if _in_code(m.start()):
+                    return m.group(0)
+                return ''
+            cleaned = media_pattern.sub(_remove_if_real, cleaned)
             cleaned = re.sub(r'\n{3,}', '\n\n', cleaned).strip()
         
         return media, cleaned

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -503,7 +503,22 @@ class GatewayStreamConsumer:
         if "MEDIA:" not in text and "[[audio_as_voice]]" not in text:
             return text
         cleaned = text.replace("[[audio_as_voice]]", "")
-        cleaned = GatewayStreamConsumer._MEDIA_RE.sub("", cleaned)
+
+        # Build code spans to avoid stripping MEDIA: inside code blocks
+        code_spans: list = []
+        for m in re.finditer(r'```[^\n]*\n.*?```', cleaned, re.DOTALL):
+            code_spans.append((m.start(), m.end()))
+        for m in re.finditer(r'`[^`\n]+`', cleaned):
+            code_spans.append((m.start(), m.end()))
+
+        def _in_code(pos: int) -> bool:
+            return any(s <= pos < e for s, e in code_spans)
+
+        def _safe_sub(m):
+            if _in_code(m.start()):
+                return m.group(0)
+            return ''
+        cleaned = GatewayStreamConsumer._MEDIA_RE.sub(_safe_sub, cleaned)
         # Collapse excessive blank lines left behind by removed tags
         cleaned = re.sub(r'\n{3,}', '\n\n', cleaned)
         # Strip trailing whitespace/newlines but preserve leading content


### PR DESCRIPTION
## Fixes NousResearch/hermes-agent#16434

### Problem
When the agent's response contains `MEDIA:` tags inside fenced code blocks (` ``` ... ``` `) or inline code (`` `...` ``), the gateway incorrectly treats them as real attachment directives and tries to deliver the files. This also mangles code examples in streamed display.

### Root Cause
`extract_media()` in `base.py` and `_clean_for_display()` in `stream_consumer.py` use `finditer()` / `sub()` over raw content with **no code-block filtering**. Ironically, `extract_local_files()` in the same file already has this exact code-block awareness pattern.

### Fix
Applied the same code-block-aware pattern already used by `extract_local_files()`:

1. **`base.py` — `extract_media()`**: Build `code_spans` list from fenced/inline code blocks, skip matches inside those spans, and only remove non-code MEDIA tags from cleaned content.

2. **`stream_consumer.py` — `_clean_for_display()`**: Same pattern — build code spans, use `_safe_sub()` to preserve MEDIA tags inside code blocks.

### Files Changed
- `gateway/platforms/base.py` — 20 lines added (code-block filtering in `extract_media()`)
- `gateway/stream_consumer.py` — 15 lines added (code-block filtering in `_clean_for_display()`)
