### PR TITLE
fix(agent): retry transient compression summary transport errors

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -107,6 +107,47 @@ def _content_length_for_budget(raw_content: Any) -> int:
     return total
 
 
+def _is_transient_summary_transport_error(exc: Exception) -> bool:
+    """Return True for one-off transport failures worth retrying once."""
+    status = getattr(exc, "status_code", None) or getattr(
+        getattr(exc, "response", None), "status_code", None
+    )
+    if isinstance(status, int):
+        if status == 408 or 500 <= status < 600:
+            return True
+        # Do not retry other client errors such as malformed payloads or
+        # auth failures.
+        if 400 <= status < 500:
+            return False
+
+    err_text = f"{type(exc).__name__} {exc}".lower()
+    return any(
+        marker in err_text
+        for marker in (
+            "api connection error",
+            "api timeout error",
+            "apiconnectionerror",
+            "connection aborted",
+            "connection error",
+            "connection reset",
+            "connection refused",
+            "connecterror",
+            "incomplete chunked read",
+            "network is unreachable",
+            "no route to host",
+            "peer closed connection",
+            "protocol error",
+            "read error",
+            "readerror",
+            "remote protocol error",
+            "remoteprotocolerror",
+            "server disconnected",
+            "timed out",
+            "timeout",
+        )
+    )
+
+
 def _content_text_for_contains(content: Any) -> str:
     """Return a best-effort text view of message content.
 
@@ -867,7 +908,19 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             }
             if self.summary_model:
                 call_kwargs["model"] = self.summary_model
-            response = call_llm(**call_kwargs)
+            for attempt in range(2):
+                try:
+                    response = call_llm(**call_kwargs)
+                    break
+                except Exception as e:
+                    if attempt == 0 and _is_transient_summary_transport_error(e):
+                        logging.info(
+                            "Context compression summary transport error; "
+                            "retrying once before fallback: %s",
+                            e,
+                        )
+                        continue
+                    raise
             content = response.choices[0].message.content
             # Handle cases where content is not a string (e.g., dict from llama.cpp)
             if not isinstance(content, str):

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -241,6 +241,139 @@ class TestSummaryFailureCooldown:
         assert second is None
         assert mock_call.call_count == 1
 
+    def test_summary_generation_retries_incomplete_chunked_read_once(self):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "summary after retry"
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True)
+
+        messages = [
+            {"role": "user", "content": "do something"},
+            {"role": "assistant", "content": "ok"},
+        ]
+        transient = Exception(
+            "peer closed connection without sending complete message body "
+            "(incomplete chunked read)"
+        )
+
+        with patch(
+            "agent.context_compressor.call_llm",
+            side_effect=[transient, mock_response],
+        ) as mock_call:
+            summary = c._generate_summary(messages)
+
+        assert summary == f"{SUMMARY_PREFIX}\nsummary after retry"
+        assert mock_call.call_count == 2
+        assert c._last_summary_error is None
+
+    def test_summary_generation_retries_generic_api_connection_error_once(self):
+        class APIConnectionError(Exception):
+            pass
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "summary after retry"
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True)
+
+        messages = [
+            {"role": "user", "content": "do something"},
+            {"role": "assistant", "content": "ok"},
+        ]
+        transient = APIConnectionError("Connection error.")
+
+        with patch(
+            "agent.context_compressor.call_llm",
+            side_effect=[transient, mock_response],
+        ) as mock_call:
+            summary = c._generate_summary(messages)
+
+        assert summary == f"{SUMMARY_PREFIX}\nsummary after retry"
+        assert mock_call.call_count == 2
+        assert c._last_summary_error is None
+
+    @pytest.mark.parametrize(
+        ("status_code", "via_response"),
+        [(408, False), (500, False), (503, True)],
+    )
+    def test_summary_generation_retries_transient_status_codes_once(
+        self, status_code, via_response
+    ):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "summary after retry"
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True)
+
+        messages = [
+            {"role": "user", "content": "do something"},
+            {"role": "assistant", "content": "ok"},
+        ]
+        transient = Exception(f"HTTP {status_code}")
+        if via_response:
+            transient.response = MagicMock(status_code=status_code)
+        else:
+            transient.status_code = status_code
+
+        with patch(
+            "agent.context_compressor.call_llm",
+            side_effect=[transient, mock_response],
+        ) as mock_call:
+            summary = c._generate_summary(messages)
+
+        assert summary == f"{SUMMARY_PREFIX}\nsummary after retry"
+        assert mock_call.call_count == 2
+        assert c._last_summary_error is None
+
+    def test_summary_generation_does_not_retry_auth_errors(self):
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True)
+
+        messages = [
+            {"role": "user", "content": "do something"},
+            {"role": "assistant", "content": "ok"},
+        ]
+        auth_error = Exception("unauthorized")
+        auth_error.status_code = 401
+
+        with patch("agent.context_compressor.call_llm", side_effect=auth_error) as mock_call:
+            summary = c._generate_summary(messages)
+            second = c._generate_summary(messages)
+
+        assert summary is None
+        assert second is None
+        assert mock_call.call_count == 1
+        assert c._last_summary_error == "unauthorized"
+
+    def test_summary_generation_falls_back_after_second_transient_failure(self):
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True)
+
+        messages = [
+            {"role": "user", "content": "do something"},
+            {"role": "assistant", "content": "ok"},
+        ]
+        transient = Exception(
+            "peer closed connection without sending complete message body "
+            "(incomplete chunked read)"
+        )
+
+        with patch(
+            "agent.context_compressor.call_llm",
+            side_effect=[transient, transient],
+        ) as mock_call:
+            summary = c._generate_summary(messages)
+            second = c._generate_summary(messages)
+
+        assert summary is None
+        assert second is None
+        assert mock_call.call_count == 2
+        assert c._last_summary_error == str(transient)
+
 
 class TestSummaryFallbackToMainModel:
     """When ``summary_model`` differs from the main model and the summary LLM


### PR DESCRIPTION
## Summary

- Retry context compression summary generation once for transient auxiliary transport, stream, timeout, and 5xx failures before falling back.
- Preserve existing no-retry behavior for auth and other non-408 client 4xx errors.
- Add regression coverage for incomplete chunked reads, generic `APIConnectionError("Connection error.")`, transient HTTP status-code paths, auth/client no-retry, and second transient failure cooldown.

## Context

I hit a transient compression-summary failure where the auxiliary call reported `peer closed connection without sending complete message body (incomplete chunked read)`. Today that path goes straight to fallback/cooldown, even though a single retry is often enough for stream/transport disconnects.

This is intentionally narrower than the open Responses API `role=tool` replay work around #5709. It does not change message conversion or tool replay behavior.

Refresh note: I rebased this branch onto current `main`, checked for duplicate/superseding PRs or issues for this exact compressor retry path, and added direct coverage for the status-code branches.

## Test Plan

- [x] `python -m py_compile agent/context_compressor.py`
- [x] `python -m pytest tests/agent/test_context_compressor.py -q -o 'addopts='` — 73 passed
- [x] `git diff --check upstream/main...HEAD`
