### PR TITLE
Preserve document follow up type when merging queued gateway events

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -955,6 +955,11 @@ def merge_pending_message_event(
                     existing.text = event.text
             if existing_is_photo or incoming_is_photo:
                 existing.message_type = MessageType.PHOTO
+            elif (
+                getattr(existing, "message_type", None) == MessageType.TEXT
+                and event.message_type != MessageType.TEXT
+            ):
+                existing.message_type = event.message_type
             return
 
         if (

--- a/tests/gateway/test_session_race_guard.py
+++ b/tests/gateway/test_session_race_guard.py
@@ -226,6 +226,39 @@ def test_merge_pending_message_event_merges_text_and_photo_followups():
     assert merged.media_types == ["image/png"]
 
 
+def test_merge_pending_message_event_promotes_document_followups_over_text():
+    pending = {}
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        user_id="u1",
+    )
+    session_key = build_session_key(source)
+
+    text_event = MessageEvent(
+        text="please review this",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+    document_event = MessageEvent(
+        text="",
+        message_type=MessageType.DOCUMENT,
+        source=source,
+        media_urls=["/tmp/report.pdf"],
+        media_types=["application/pdf"],
+    )
+
+    merge_pending_message_event(pending, session_key, text_event, merge_text=True)
+    merge_pending_message_event(pending, session_key, document_event, merge_text=True)
+
+    merged = pending[session_key]
+    assert merged.message_type == MessageType.DOCUMENT
+    assert merged.text == "please review this"
+    assert merged.media_urls == ["/tmp/report.pdf"]
+    assert merged.media_types == ["application/pdf"]
+
+
 @pytest.mark.asyncio
 async def test_recent_telegram_text_followup_is_queued_without_interrupt():
     runner = _make_runner()


### PR DESCRIPTION
## Summary

Preserve non-text media semantics when merging queued gateway follow-ups.

Previously, if a busy session queued a text follow-up and then received a document follow-up, the merged pending event could remain typed as `TEXT`. That caused downstream document-specific handling to be skipped, so the attachment was not treated as a document on the next turn.

## Root cause

`merge_pending_message_event()` only promoted merged events to `PHOTO`. For other media types, a queued `TEXT` event could keep its original type even after inheriting document media payloads.

## Fix

When merging into an existing queued event:
- keep the existing `PHOTO` precedence behavior unchanged
- if the existing pending event is `TEXT` and the incoming event is a non-text media type, promote the merged event to the incoming message type

This keeps the fix narrow and avoids broader refactoring of merge precedence.

## Testing

Added regression test:
- `tests/gateway/test_session_race_guard.py::test_merge_pending_message_event_promotes_document_followups_over_text`

Verified result:
- `1 passed` 
