### PR TITLE
fix(api-server): emit chat tool completion progress

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -932,8 +932,38 @@ class APIServerAdapter(BasePlatformAdapter):
                 if delta is not None:
                     _stream_q.put(delta)
 
+            def _queue_tool_progress(
+                *,
+                tool_call_id: Optional[str] = None,
+                name: str,
+                status: str,
+                args=None,
+                label: Optional[str] = None,
+                output=None,
+            ) -> None:
+                if not name or name.startswith("_"):
+                    return
+                from agent.display import get_tool_emoji
+                emoji = get_tool_emoji(name)
+                tool_args = args if args is not None else {}
+                payload = {
+                    "tool": name,
+                    "name": name,
+                    "emoji": emoji,
+                    "label": label or name,
+                    "status": status,
+                    "input": tool_args,
+                    "args": tool_args,
+                }
+                if tool_call_id:
+                    payload["toolCallId"] = str(tool_call_id)
+                if status in {"completed", "failed", "cancelled"}:
+                    payload["output"] = output
+                    payload["result"] = output
+                _stream_q.put(("__tool_progress__", payload))
+
             def _on_tool_progress(event_type, name, preview, args, **kwargs):
-                """Send tool progress as a separate SSE event.
+                """Compatibility hook for legacy tool progress producers.
 
                 Previously, progress markers like ``⏰ list`` were injected
                 directly into ``delta.content``.  OpenAI-compatible frontends
@@ -949,19 +979,40 @@ class APIServerAdapter(BasePlatformAdapter):
                 can render for UX but will *not* persist into conversation
                 history.  Clients that don't understand the custom event type
                 silently ignore it per the SSE specification.
+
+                The main chat/completions stream uses the structured
+                tool_start_callback/tool_complete_callback path below so each
+                update carries the exact tool call id.  This fallback is kept
+                for callers that only emit tool_progress_callback events.
                 """
                 if event_type != "tool.started":
                     return
                 if name.startswith("_"):
                     return
-                from agent.display import get_tool_emoji
-                emoji = get_tool_emoji(name)
-                label = preview or name
-                _stream_q.put(("__tool_progress__", {
-                    "tool": name,
-                    "emoji": emoji,
-                    "label": label,
-                }))
+                _queue_tool_progress(
+                    tool_call_id=kwargs.get("tool_call_id") or kwargs.get("toolCallId"),
+                    name=name,
+                    status="running",
+                    args=args,
+                    label=preview or name,
+                )
+
+            def _on_tool_start(tool_call_id, function_name, function_args):
+                _queue_tool_progress(
+                    tool_call_id=tool_call_id,
+                    name=function_name,
+                    status="running",
+                    args=function_args,
+                )
+
+            def _on_tool_complete(tool_call_id, function_name, function_args, function_result):
+                _queue_tool_progress(
+                    tool_call_id=tool_call_id,
+                    name=function_name,
+                    status="completed",
+                    args=function_args,
+                    output=function_result,
+                )
 
             # Start agent in background.  agent_ref is a mutable container
             # so the SSE writer can interrupt the agent on client disconnect.
@@ -973,6 +1024,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 session_id=session_id,
                 stream_delta_callback=_on_delta,
                 tool_progress_callback=_on_tool_progress,
+                tool_start_callback=_on_tool_start,
+                tool_complete_callback=_on_tool_complete,
                 agent_ref=agent_ref,
             ))
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -647,17 +647,17 @@ class TestChatCompletionsEndpoint:
 
     @pytest.mark.asyncio
     async def test_stream_includes_tool_progress(self, adapter):
-        """tool_progress_callback fires → progress appears as custom SSE event, not in delta.content."""
+        """tool_start_callback fires → progress appears as custom SSE event, not in delta.content."""
         import asyncio
 
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
             async def _mock_run_agent(**kwargs):
                 cb = kwargs.get("stream_delta_callback")
-                tp_cb = kwargs.get("tool_progress_callback")
+                start_cb = kwargs.get("tool_start_callback")
                 # Simulate tool progress before streaming content
-                if tp_cb:
-                    tp_cb("tool.started", "terminal", "ls -la", {"command": "ls -la"})
+                if start_cb:
+                    start_cb("call_terminal_1", "terminal", {"command": "ls -la"})
                 if cb:
                     await asyncio.sleep(0.05)
                     cb("Here are the files.")
@@ -682,8 +682,10 @@ class TestChatCompletionsEndpoint:
                 # delta.content — prevents model from learning to imitate
                 # markers instead of calling tools (#6972).
                 assert "event: hermes.tool.progress" in body
+                assert '"toolCallId": "call_terminal_1"' in body
+                assert '"status": "running"' in body
                 assert '"tool": "terminal"' in body
-                assert '"label": "ls -la"' in body
+                assert '"label": "terminal"' in body
                 # The progress marker must NOT appear inside any
                 # chat.completion.chunk delta.content field.
                 import json as _json
@@ -702,6 +704,47 @@ class TestChatCompletionsEndpoint:
                 assert "Here are the files." in body
 
     @pytest.mark.asyncio
+    async def test_stream_emits_tool_completed_progress_with_call_id(self, adapter):
+        """chat/completions SSE should mark an exact tool call completed before the final answer ends."""
+        import asyncio
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                start_cb = kwargs.get("tool_start_callback")
+                complete_cb = kwargs.get("tool_complete_callback")
+                cb = kwargs.get("stream_delta_callback")
+                if start_cb:
+                    start_cb("call_terminal_1", "terminal", {"command": "pwd"})
+                await asyncio.sleep(0.01)
+                if complete_cb:
+                    complete_cb("call_terminal_1", "terminal", {"command": "pwd"}, "/workspace\n")
+                if cb:
+                    cb("Done.")
+                return (
+                    {"final_response": "Done.", "messages": [], "api_calls": 1},
+                    {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "pwd"}],
+                        "stream": True,
+                    },
+                )
+                assert resp.status == 200
+                body = await resp.text()
+                assert body.count("event: hermes.tool.progress") >= 2
+                assert '"toolCallId": "call_terminal_1"' in body
+                assert '"status": "running"' in body
+                assert '"status": "completed"' in body
+                assert '"output": "/workspace\\n"' in body
+                assert "Done." in body
+
+    @pytest.mark.asyncio
     async def test_stream_tool_progress_skips_internal_events(self, adapter):
         """Internal events (name starting with _) are not streamed."""
         import asyncio
@@ -710,10 +753,10 @@ class TestChatCompletionsEndpoint:
         async with TestClient(TestServer(app)) as cli:
             async def _mock_run_agent(**kwargs):
                 cb = kwargs.get("stream_delta_callback")
-                tp_cb = kwargs.get("tool_progress_callback")
-                if tp_cb:
-                    tp_cb("tool.started", "_thinking", "some internal state", {})
-                    tp_cb("tool.started", "web_search", "Python docs", {"query": "Python docs"})
+                start_cb = kwargs.get("tool_start_callback")
+                if start_cb:
+                    start_cb("call_internal_1", "_thinking", {"state": "some internal state"})
+                    start_cb("call_search_1", "web_search", {"query": "Python docs"})
                 if cb:
                     await asyncio.sleep(0.05)
                     cb("Found it.")
@@ -738,7 +781,7 @@ class TestChatCompletionsEndpoint:
                 # Real tool progress should appear as custom SSE event
                 assert "event: hermes.tool.progress" in body
                 assert '"tool": "web_search"' in body
-                assert '"label": "Python docs"' in body
+                assert '"label": "web_search"' in body
 
     @pytest.mark.asyncio
     async def test_no_user_message_returns_400(self, adapter):


### PR DESCRIPTION
## What does this PR do?

Emit structured `hermes.tool.progress` completion events from the OpenAI-compatible `/v1/chat/completions` streaming endpoint.

The Responses API path already receives exact tool lifecycle callbacks. The chat completions streaming path only forwarded legacy start-style progress, so API Server clients could show a tool as running until the final assistant response ended. This change wires `tool_start_callback` and `tool_complete_callback` into the chat stream and includes a stable `toolCallId` on both running and completed events.

## Related Issue

Fixes #16588

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/api_server.py`: adds a shared queue helper for chat-completion tool progress events and wires `tool_start_callback` / `tool_complete_callback` into `_run_agent`.
- `tests/gateway/test_api_server.py`: updates streaming tool-progress tests to assert `toolCallId` and running status, and adds coverage for completed progress with output before the final assistant content.

## How to Test

1. Run `scripts/run_tests.sh tests/gateway/test_api_server.py -k 'tool_progress or tool_completed_progress'`.
2. Run `scripts/run_tests.sh tests/gateway/test_api_server.py`.
3. Run `git diff --check HEAD~1..HEAD`.

Targeted verification on macOS 15 / Python 3.12.10:

- `scripts/run_tests.sh tests/gateway/test_api_server.py -k 'tool_progress or tool_completed_progress'`: 3 passed, 3 warnings.
- `scripts/run_tests.sh tests/gateway/test_api_server.py`: 120 passed, 78 warnings.
- `git diff --check HEAD~1..HEAD`: passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15, Python 3.12.10

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no platform-specific code added
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

N/A

## Screenshots / Logs

Not applicable. The behavior is covered by the streaming SSE assertions in `tests/gateway/test_api_server.py`.
