### PR TITLE
fix(agent): enable reasoning_content for Z.AI/GLM models

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -188,6 +188,7 @@ class ChatCompletionsTransport(ProviderTransport):
         anthropic_max_out = params.get("anthropic_max_output")
         is_nvidia_nim = params.get("is_nvidia_nim", False)
         is_kimi = params.get("is_kimi", False)
+        is_zai = params.get("is_zai", False)
         reasoning_config = params.get("reasoning_config")
 
         if ephemeral is not None and max_tokens_fn:
@@ -238,6 +239,16 @@ class ChatCompletionsTransport(ProviderTransport):
                     _kimi_thinking_enabled = False
             extra_body["thinking"] = {
                 "type": "enabled" if _kimi_thinking_enabled else "disabled",
+            }
+
+        # Z.AI (GLM) extra_body.thinking — same format as Kimi
+        if is_zai:
+            _zai_thinking_enabled = True
+            if reasoning_config and isinstance(reasoning_config, dict):
+                if reasoning_config.get("enabled") is False:
+                    _zai_thinking_enabled = False
+            extra_body["thinking"] = {
+                "type": "enabled" if _zai_thinking_enabled else "disabled",
             }
 
         # Reasoning

--- a/run_agent.py
+++ b/run_agent.py
@@ -7721,6 +7721,10 @@ class AIAgent:
             or base_url_host_matches(self.base_url, "moonshot.ai")
             or base_url_host_matches(self.base_url, "moonshot.cn")
         )
+        _is_zai = (
+            base_url_host_matches(self._base_url_lower, "z.ai")
+            or base_url_host_matches(self._base_url_lower, "open.bigmodel.cn")
+        )
 
         # Temperature: _fixed_temperature_for_model may return OMIT_TEMPERATURE
         # sentinel (temperature omitted entirely), a numeric override, or None.
@@ -7792,6 +7796,7 @@ class AIAgent:
             is_github_models=_is_gh,
             is_nvidia_nim=_is_nvidia,
             is_kimi=_is_kimi,
+            is_zai=_is_zai,
             is_custom_provider=self.provider == "custom",
             ollama_num_ctx=self._ollama_num_ctx,
             provider_preferences=_prefs or None,
@@ -7837,6 +7842,7 @@ class AIAgent:
             "anthropic/",
             "openai/",
             "x-ai/",
+            "z-ai/",
             "google/gemini-2",
             "qwen/qwen3",
         )


### PR DESCRIPTION
## Fixes NousResearch/hermes-agent#16533

### Problem
Z.AI/GLM models (glm-5.1, glm-4.7, etc.) never return `reasoning_content` — even on questions that clearly trigger chain-of-thought when the same model is hit directly via cURL.

### Root Cause
Z.AI's API uses the `thinking` parameter (same format as Kimi) to enable reasoning:
```python
extra_body["thinking"] = {"type": "enabled"}
```

But Hermes only injected the OpenRouter-style `reasoning` extra_body, which Z.AI silently ignores. There was no Z.AI-specific handling in the reasoning pipeline.

### Fix
Three changes across 2 files:

1. **`run_agent.py`** — Add `_is_zai` URL detection for `z.ai` and `open.bigmodel.cn` hosts, pass `is_zai` flag to transport
2. **`run_agent.py`** — Add `"z-ai/"` to OpenRouter `reasoning_model_prefixes` so Z.AI models get reasoning via OpenRouter
3. **`chat_completions.py`** — Add Z.AI `thinking` extra_body injection, mirroring the existing Kimi pattern

### Files Changed
- `run_agent.py` — 8 lines added (Z.AI detection + OpenRouter prefix)
- `agent/transports/chat_completions.py` — 11 lines added (thinking extra_body)
