### PR TITLE
feat(security): default skills.guard_agent_created to true

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -848,7 +848,7 @@ DEFAULT_CONFIG = {
         # agent, which can retry with the flagged content removed.
         # External hub installs (trusted/community sources) are always
         # scanned regardless of this setting.
-        "guard_agent_created": False,
+        "guard_agent_created": True,
     },
 
     # Honcho AI-native memory -- reads ~/.honcho/config.json as single source of truth.


### PR DESCRIPTION
Closes #16461

---

## Problem

The `skills.guard_agent_created` config option defaults to `false`, meaning skills autonomously created by the agent's learning loop are saved to `~/.hermes/skills/` without any security scan. This is a defense-in-depth gap — agent-generated content should be treated as untrusted by default, since the agent may have been influenced by prompt injection during the session that created the skill.

## Changes

- **File**: `hermes_cli/config.py` (line 851)
- Changed `"guard_agent_created": False` to `"guard_agent_created": True`
- No other files modified — this is a single-line default value change

## Impact

- Agent-created skills now pass through `skills_guard.py` security scanner by default (checks for prompt injection, data exfiltration, destructive commands, obfuscation)
- Existing users who set `guard_agent_created: false` in config.yaml see no change — their override is respected
- New installs get the safer default immediately
- No breaking changes — existing skills are not re-scanned