### PR TITLE
fix(gateway): pass session messages to context engine on /new and idle-expiry

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1875,12 +1875,28 @@ class GatewayRunner:
             self._cleanup_agent_resources(agent)
 
     def _cleanup_agent_resources(self, agent: Any) -> None:
-        """Best-effort cleanup for temporary or cached agent instances."""
+        """Best-effort cleanup for temporary or cached agent instances.
+
+        Loads the agent's session transcript from state.db so that
+        context engines (e.g. LCM) can persist messages via
+        ``on_session_end()`` before being torn down.  Without this,
+        ``/new`` and idle-expiry silently lose every session.
+        """
         if agent is None:
             return
         try:
             if hasattr(agent, "shutdown_memory_provider"):
-                agent.shutdown_memory_provider()
+                # Load transcript so context engines receive messages.
+                _sid = getattr(agent, "session_id", None)
+                _messages: list = []
+                if _sid:
+                    try:
+                        _messages = (
+                            self.session_store.load_transcript(_sid) or []
+                        )
+                    except Exception:
+                        pass
+                agent.shutdown_memory_provider(messages=_messages)
         except Exception:
             pass
         # Close tool resources (terminal sandboxes, browser daemons,


### PR DESCRIPTION
## Summary

`_cleanup_agent_resources()` in `gateway/run.py` currently calls `shutdown_memory_provider()` with no arguments, causing `on_session_end()` to receive an empty message list. This makes `_ingest_messages()` a no-op, silently dropping every session created via `/new`, `/reset`, or idle-expiry from the LCM index.

## Root Cause

When `/new` fires:
1. `_handle_reset_command()` calls `_cleanup_agent_resources(agent)`
2. Which calls `agent.shutdown_memory_provider()` with **no arguments**
3. Which cascades to `context_compressor.on_session_end(session_id, [])` — always empty
4. `_ingest_messages([])` is a no-op → entire session lost to LCM

## Fix

Load the agent's session transcript from `state.db` via `self.session_store.load_transcript(_sid)` before calling `shutdown_memory_provider(messages=_messages)`. This ensures context engines receive the full message history for proper finalization.

## Verification

Tested on a live fleet running commit `b16f9d43`:

| Check | Before fix | After fix |
|-------|-----------|-----------|
| `last_finalized_session_id` | NULL | ✅ Set correctly |
| Messages in LCM after `/new` | 0 (all lost) | ✅ All 64 recovered |
| Pre-patch control session | NULL | Still NULL (expected) |

Across 144 sessions / 13,637 messages before the fix, 18 sessions were completely missing from LCM and 8 had partial counts. Every session created via `/new` was affected.

## Scope

This single change covers all three cleanup paths that call `_cleanup_agent_resources()`:
- `/new` and `/reset` commands
- Idle session expiry
- Gateway shutdown

The fix is defensive — transcript loading is wrapped in try/except so failures fall back to the original behavior (empty list).