### PR TITLE
fix(gateway): preserve backslash before dot in Telegram MarkdownV2 cleanup

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -107,8 +107,11 @@ def _strip_mdv2(text: str) -> str:
     Also removes MarkdownV2 formatting markers so the fallback
     doesn't show stray syntax characters from format_message conversion.
     """
-    # Remove escape backslashes before special characters
-    cleaned = re.sub(r'\\([_*\[\]()~`>#\+\-=|{}.!\\])', r'\1', text)
+    # Remove escape backslashes before formatting characters.
+    # Note: '.' is intentionally excluded — it is not a MarkdownV2 formatting
+    # character, and including it would strip backslashes from Windows paths
+    # like D:\Projects\.ai\ → D:\Projects.ai\ (see hermes-agent#16458).
+    cleaned = re.sub(r'\\([_*\[\]()~`>#\+\-=|{}!\\])', r'\1', text)
     # Remove MarkdownV2 bold markers that format_message converted from **bold**
     cleaned = re.sub(r'\*([^*]+)\*', r'\1', cleaned)
     # Remove MarkdownV2 italic markers that format_message converted from *italic*


### PR DESCRIPTION
## Fixes NousResearch/hermes-agent#16458

### Problem
Windows paths containing `\.` (backslash before dot) are incorrectly stripped to just `.` in Telegram message rendering. For example, `D:\Projects\.ai\skills\` renders as `D:\Projects.ai\skills\`.

### Root Cause
The `_strip_md2_escapes` regex in `telegram.py` includes `.` in its character class for backslash-escape removal. Since `.` is not a MarkdownV2 formatting character (it doesn't produce any visible formatting), including it causes false matches on Windows paths.

### Fix
Removed `.` from the character class in the escape-stripping regex. This preserves backslash-dot sequences in Windows paths while still correctly stripping escapes for actual MarkdownV2 formatting characters (`_`, `*`, `[`, `]`, etc.).

### Files Changed
- `gateway/platforms/telegram.py` — 3 lines changed (regex character class + comment)
