### PR TITLE
fix(models): consolidate provider and model into /model command

### DIFF
--- a/ui-tui/package-lock.json
+++ b/ui-tui/package-lock.json
@@ -124,6 +124,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -499,31 +500,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1700,6 +1676,7 @@
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -1710,6 +1687,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1720,6 +1698,7 @@
       "integrity": "sha512-eSkwoemjo76bdXl2MYqtxg51HNwUSkWfODUOQ3PaTLZGh9uIWWFZIjyjaJnex7wXDu+TRx+ATsnSxdN9YWfRTQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.58.1",
@@ -1749,6 +1728,7 @@
       "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.1",
         "@typescript-eslint/types": "8.58.1",
@@ -2066,6 +2046,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2468,6 +2449,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3203,6 +3185,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3334,6 +3317,7 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -4242,6 +4226,7 @@
       "resolved": "https://registry.npmjs.org/ink-text-input/-/ink-text-input-6.0.0.tgz",
       "integrity": "sha512-Fw64n7Yha5deb1rHY137zHTAbSTNelUKuB5Kkk2HACXEtwIHBCf9OH2tP/LQ9fRYTl1F0dZgbW0zPnZk6FA9Lw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chalk": "^5.3.0",
         "type-fest": "^4.18.2"
@@ -5678,6 +5663,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5787,6 +5773,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6611,6 +6598,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -6737,6 +6725,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6846,6 +6835,7 @@
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -7261,6 +7251,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createSlashHandler } from '../app/createSlashHandler.js'
+import { TUI_SESSION_MODEL_FLAG } from '../domain/slash.js'
 import { getOverlayState, resetOverlayState } from '../app/overlayStore.js'
 import { getUiState, patchUiState, resetUiState } from '../app/uiStore.js'
 
@@ -55,7 +56,7 @@ describe('createSlashHandler', () => {
 
     expect(
       createSlashHandler(ctx)(
-        '/model anthropic/claude-sonnet-4.6 --provider openrouter --tui-session'
+        `/model anthropic/claude-sonnet-4.6 --provider openrouter ${TUI_SESSION_MODEL_FLAG}`
       )
     ).toBe(true)
     expect(ctx.gateway.rpc).toHaveBeenCalledWith('config.set', {

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -43,6 +43,28 @@ describe('createSlashHandler', () => {
     })
   })
 
+  it('honors TUI picker session scope without adding --global', async () => {
+    patchUiState({ sid: 'sid-abc' })
+
+    const ctx = buildCtx({
+      gateway: {
+        ...buildGateway(),
+        rpc: vi.fn(() => Promise.resolve({ value: 'anthropic/claude-sonnet-4.6' }))
+      }
+    })
+
+    expect(
+      createSlashHandler(ctx)(
+        '/model anthropic/claude-sonnet-4.6 --provider openrouter --tui-session'
+      )
+    ).toBe(true)
+    expect(ctx.gateway.rpc).toHaveBeenCalledWith('config.set', {
+      key: 'model',
+      session_id: 'sid-abc',
+      value: 'anthropic/claude-sonnet-4.6 --provider openrouter'
+    })
+  })
+
   it('does not duplicate --global for explicit persistent model switches', () => {
     patchUiState({ sid: 'sid-abc' })
     const ctx = buildCtx()

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -10,6 +10,7 @@ import type {
   VoiceToggleResponse
 } from '../../../gatewayTypes.js'
 import { fmtK } from '../../../lib/text.js'
+import { TUI_SESSION_MODEL_FLAG } from '../../../domain/slash.js'
 import type { PanelSection } from '../../../types.js'
 import { patchOverlayState } from '../../overlayStore.js'
 import { patchUiState } from '../../uiStore.js'
@@ -17,14 +18,17 @@ import type { SlashCommand } from '../types.js'
 
 const GLOBAL_MODEL_FLAG_RE = /(?:^|\s)--global(?:\s|$)/
 
-/** Stripped before `config.set`; TUI model picker uses this for session-scoped switches. */
-const TUI_SESSION_MODEL_RE = /(?:^|\s)--tui-session(?:\s|$)/
+const TUI_SESSION_MODEL_RE = new RegExp(`(?:^|\\s)${TUI_SESSION_MODEL_FLAG}(?:\\s|$)`)
+const TUI_SESSION_STRIP_RE = new RegExp(`\\s*${TUI_SESSION_MODEL_FLAG}\\b\\s*`, 'g')
 
 const persistedModelArg = (arg: string) => {
   const trimmed = arg.trim()
 
   return !trimmed || GLOBAL_MODEL_FLAG_RE.test(trimmed) ? trimmed : `${trimmed} --global`
 }
+
+const stripTuiSessionFlag = (trimmed: string) =>
+  trimmed.replace(TUI_SESSION_STRIP_RE, ' ').replace(/\s+/g, ' ').trim()
 
 const modelValueForConfigSet = (arg: string) => {
   const trimmed = arg.trim()
@@ -34,7 +38,7 @@ const modelValueForConfigSet = (arg: string) => {
   }
 
   if (TUI_SESSION_MODEL_RE.test(trimmed)) {
-    return trimmed.replace(/\s*--tui-session\b\s*/g, ' ').replace(/\s+/g, ' ').trim()
+    return stripTuiSessionFlag(trimmed)
   }
 
   return persistedModelArg(trimmed)

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -17,10 +17,27 @@ import type { SlashCommand } from '../types.js'
 
 const GLOBAL_MODEL_FLAG_RE = /(?:^|\s)--global(?:\s|$)/
 
+/** Stripped before `config.set`; TUI model picker uses this for session-scoped switches. */
+const TUI_SESSION_MODEL_RE = /(?:^|\s)--tui-session(?:\s|$)/
+
 const persistedModelArg = (arg: string) => {
   const trimmed = arg.trim()
 
   return !trimmed || GLOBAL_MODEL_FLAG_RE.test(trimmed) ? trimmed : `${trimmed} --global`
+}
+
+const modelValueForConfigSet = (arg: string) => {
+  const trimmed = arg.trim()
+
+  if (!trimmed) {
+    return trimmed
+  }
+
+  if (TUI_SESSION_MODEL_RE.test(trimmed)) {
+    return trimmed.replace(/\s*--tui-session\b\s*/g, ' ').replace(/\s+/g, ' ').trim()
+  }
+
+  return persistedModelArg(trimmed)
 }
 
 export const sessionCommands: SlashCommand[] = [
@@ -60,7 +77,7 @@ export const sessionCommands: SlashCommand[] = [
       }
 
       ctx.gateway
-        .rpc<ConfigSetResponse>('config.set', { key: 'model', session_id: ctx.sid, value: persistedModelArg(arg) })
+        .rpc<ConfigSetResponse>('config.set', { key: 'model', session_id: ctx.sid, value: modelValueForConfigSet(arg) })
         .then(
           ctx.guarded<ConfigSetResponse>(r => {
             if (!r.value) {

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -662,7 +662,7 @@ export function useMainApp(gw: GatewayClient) {
 
   const onModelSelect = useCallback((value: string) => {
     patchOverlayState({ modelPicker: false })
-    slashRef.current(`/model ${value} --global`)
+    slashRef.current(`/model ${value}`)
   }, [])
 
   const hasReasoning = useTurnSelector(state => Boolean(state.reasoning.trim()))

--- a/ui-tui/src/components/modelPicker.tsx
+++ b/ui-tui/src/components/modelPicker.tsx
@@ -2,6 +2,7 @@ import { Box, Text, useInput, useStdout } from '@hermes/ink'
 import { useEffect, useMemo, useState } from 'react'
 
 import { providerDisplayNames } from '../domain/providers.js'
+import { TUI_SESSION_MODEL_FLAG } from '../domain/slash.js'
 import type { GatewayClient } from '../gatewayClient.js'
 import type { ModelOptionProvider, ModelOptionsResponse } from '../gatewayTypes.js'
 import { asRpcResult, rpcErrorMessage } from '../lib/rpc.js'
@@ -112,7 +113,7 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
 
       if (provider && model) {
         onSelect(
-          `${model} --provider ${provider.slug}${persistGlobal ? ' --global' : ' --tui-session'}`
+          `${model} --provider ${provider.slug}${persistGlobal ? ' --global' : ` ${TUI_SESSION_MODEL_FLAG}`}`
         )
       } else {
         setStage('provider')
@@ -140,7 +141,7 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
         }
       } else if (provider && models[offset + n - 1]) {
         onSelect(
-          `${models[offset + n - 1]} --provider ${provider.slug}${persistGlobal ? ' --global' : ' --tui-session'}`
+          `${models[offset + n - 1]} --provider ${provider.slug}${persistGlobal ? ' --global' : ` ${TUI_SESSION_MODEL_FLAG}`}`
         )
       }
     }

--- a/ui-tui/src/components/modelPicker.tsx
+++ b/ui-tui/src/components/modelPicker.tsx
@@ -52,6 +52,7 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
           )
         )
         setModelIdx(0)
+        setStage('provider')
         setErr('')
         setLoading(false)
       })
@@ -110,7 +111,9 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
       const model = models[modelIdx]
 
       if (provider && model) {
-        onSelect(`${model} --provider ${provider.slug}${persistGlobal ? ' --global' : ''}`)
+        onSelect(
+          `${model} --provider ${provider.slug}${persistGlobal ? ' --global' : ' --tui-session'}`
+        )
       } else {
         setStage('provider')
       }
@@ -136,7 +139,9 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
           setProviderIdx(next)
         }
       } else if (provider && models[offset + n - 1]) {
-        onSelect(`${models[offset + n - 1]} --provider ${provider.slug}${persistGlobal ? ' --global' : ''}`)
+        onSelect(
+          `${models[offset + n - 1]} --provider ${provider.slug}${persistGlobal ? ' --global' : ' --tui-session'}`
+        )
       }
     }
   })
@@ -173,11 +178,15 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
     return (
       <Box flexDirection="column" width={width}>
         <Text bold color={t.color.amber} wrap="truncate-end">
-          Select Provider
+          Select provider (step 1/2)
         </Text>
 
         <Text color={t.color.dim} wrap="truncate-end">
-          Current model: {currentModel || '(unknown)'}
+          Full model IDs on the next step · Enter to continue
+        </Text>
+
+        <Text color={t.color.dim} wrap="truncate-end">
+          Current: {currentModel || '(unknown)'}
         </Text>
         <Text color={t.color.label} wrap="truncate-end">
           {provider?.warning ? `warning: ${provider.warning}` : ' '}
@@ -225,11 +234,11 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
   return (
     <Box flexDirection="column" width={width}>
       <Text bold color={t.color.amber} wrap="truncate-end">
-        Select Model
+        Select model (step 2/2)
       </Text>
 
       <Text color={t.color.dim} wrap="truncate-end">
-        {names[providerIdx] || '(unknown provider)'}
+        {names[providerIdx] || '(unknown provider)'} · Esc back
       </Text>
       <Text color={t.color.label} wrap="truncate-end">
         {provider?.warning ? `warning: ${provider.warning}` : ' '}
@@ -254,6 +263,8 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
           )
         }
 
+        const prefix = modelIdx === idx ? '▸ ' : row === currentModel ? '* ' : '  '
+
         return (
           <Text
             bold={modelIdx === idx}
@@ -262,7 +273,7 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
             key={`${provider?.slug ?? 'prov'}:${idx}:${row}`}
             wrap="truncate-end"
           >
-            {modelIdx === idx ? '▸ ' : '  '}
+            {prefix}
             {i + 1}. {row}
           </Text>
         )

--- a/ui-tui/src/domain/slash.ts
+++ b/ui-tui/src/domain/slash.ts
@@ -1,3 +1,6 @@
+/** Appended to `/model` args from the TUI picker for session scope; stripped in `session` slash before `config.set`. */
+export const TUI_SESSION_MODEL_FLAG = '--tui-session'
+
 export const looksLikeSlashCommand = (text: string) => /^\/[^\s/]*(?:\s|$)/.test(text)
 
 export const parseSlashCommand = (cmd: string) => {

--- a/ui-tui/src/hooks/useCompletion.ts
+++ b/ui-tui/src/hooks/useCompletion.ts
@@ -42,6 +42,14 @@ export function useCompletion(input: string, blocked: boolean, gw: GatewayClient
       return
     }
 
+    // `/model` / `/provider` use the two-step ModelPicker (real curated IDs).
+    // Slash completion here only showed short aliases + vendor/family meta.
+    if (isSlash && /^\/(?:model|provider)(?:\s|$)/.test(input)) {
+      clear()
+
+      return
+    }
+
     const pathReplace = input.length - (pathWord?.length ?? 0)
 
     const t = setTimeout(() => {


### PR DESCRIPTION
## What does this PR do?

Improves the TUI `/model` (and `/provider`) flow so users rely on the **two-step ModelPicker** (provider → real curated model IDs) instead of slash TAB completion, which only offered **short aliases** plus `vendor/family` meta (e.g. `claude` → `anthropic/claude`) and looked like real OpenRouter IDs.

Also fixes picker **session vs global**: the **`g`** toggle had no effect because `onModelSelect` always appended `--global`, and typed `/model` still forced `--global` via `persistedModelArg`. Session-only picks now send an internal **`--tui-session`** flag that is stripped before `config.set`, matching `parse_model_flags` (no `--global` → session scope).


## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes-agent/ui-tui/src/hooks/useCompletion.ts` — Skip `complete.slash` for `^/(?:model|provider)(?:\s|$)` so alias completions don’t compete with the picker.
- `hermes-agent/ui-tui/src/components/modelPicker.tsx` — Clearer step labels, current-model `*` marker, reset to provider step when `model.options` reloads, **`--tui-session`** when persistence is session-only.
- `hermes-agent/ui-tui/src/app/slash/commands/session.ts` — `modelValueForConfigSet()` strips `--tui-session` and avoids auto-`--global` for those args; typed `/model` behavior unchanged.
- `hermes-agent/ui-tui/src/app/useMainApp.ts` — `onModelSelect` calls `/model ${value}` only (no extra `--global`).
- `hermes-agent/ui-tui/src/__tests__/createSlashHandler.test.ts` — Asserts session picker value is passed to `config.set` without `--global`.

## How to Test

1. `cd hermes-agent/ui-tui && pnpm exec vitest run` — all tests pass (including new `--tui-session` case).
2. Run TUI, type `/model` and Enter — **no** completion dropdown of aliases; **Select provider (step 1/2)** → **Select model (step 2/2)** with full ids (e.g. `anthropic/claude-sonnet-4.6`).
3. In the picker, toggle **`g`**, choose a model, confirm — **global** vs **session** should match the toggle (inspect `config.set` payload or resulting default vs session model as you prefer).

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass _(Python suite unchanged; run if your branch touches Python)_
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

_(Delete / ignore — not applicable.)_

## Screenshots / Logs
<img width="1271" height="890" alt="image" src="https://github.com/user-attachments/assets/c2c22e60-4755-43bb-911d-b2c9a9b39bfa" />
<img width="1258" height="888" alt="image" src="https://github.com/user-attachments/assets/a7573f58-abab-4e47-8c40-6aa2d0940db4" />