### PR TITLE
fix(agent): invalidate failed tool_call_id on MiniMax 400 errors

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3398,6 +3398,24 @@ class AIAgent:
             if isinstance(msg, dict) and msg.get("role") == "user":
                 msg["content"] = override
 
+    def _invalidate_failed_tool_calls(self, messages: List[Dict], error_msg: str, provider: str) -> None:
+        """Remove tool_call_id from tool messages when API returns 400 error.
+
+        Prevents failed tool_call_ids from being persisted and reused across sessions.
+        Only applies to MiniMax provider with 400 errors related to tool calls.
+        """
+        if provider != "minimax-cn":
+            return
+
+        error_lower = str(error_msg).lower()
+        if not ("tool_call_id" in error_lower or "invalid function arguments" in error_lower):
+            return
+
+        for msg in messages:
+            if isinstance(msg, dict) and msg.get("role") == "tool":
+                if "tool_call_id" in msg:
+                    del msg["tool_call_id"]
+
     def _persist_session(self, messages: List[Dict], conversation_history: List[Dict] = None):
         """Save session state to both JSON log and SQLite on any exit path.
 
@@ -11700,6 +11718,8 @@ class AIAgent:
                                 force=True,
                             )
                         else:
+                            if status_code == 400:
+                                self._invalidate_failed_tool_calls(messages, str(api_error), _provider)
                             self._persist_session(messages, conversation_history)
                         return {
                             "final_response": None,


### PR DESCRIPTION
Closes #16472

---

## Problem

When MiniMax API (`minimax-cn`) returns HTTP 400 for invalid tool call arguments, the failed `tool_call_id` (format: `call_function_XXXXX_1`) is persisted to the session database. Subsequent sessions inherit these messages with stale `tool_call_id`s, causing persistent failures until Hermes is restarted.

## Changes

- **File**: `run_agent.py`
- Added `_invalidate_failed_tool_calls()` helper method (lines 3401-3418)
  - Only activates for `minimax-cn` provider
  - Detects 400 errors containing `tool_call_id` or `invalid function arguments`
  - Removes `tool_call_id` fields from all tool-role messages before persistence
- Modified 400 error handling path (line 11721-11722)
  - Calls helper before `_persist_session()` when status code is 400
  - Prevents failed tool_call_ids from being saved to session database

## Impact

- Fixes cross-session tool_call_id pollution for MiniMax provider
- No impact on other providers or normal operation
- Minimal, focused change — only affects 400 error persistence path