### PR TITLE
fix(feishu): post into existing topic thread when reply_to is absent

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -4079,13 +4079,16 @@ class FeishuAdapter(BasePlatformAdapter):
             request = self._build_reply_message_request(reply_to, body)
             return await asyncio.to_thread(self._client.im.v1.message.reply, request)
 
+        thread_id = (metadata or {}).get("thread_id")
+        receive_id = thread_id or chat_id
+        receive_id_type = "thread_id" if thread_id else "chat_id"
         body = self._build_create_message_body(
-            receive_id=chat_id,
+            receive_id=receive_id,
             msg_type=msg_type,
             content=payload,
             uuid_value=str(uuid.uuid4()),
         )
-        request = self._build_create_message_request("chat_id", body)
+        request = self._build_create_message_request(receive_id_type, body)
         return await asyncio.to_thread(self._client.im.v1.message.create, request)
 
     @staticmethod

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1963,6 +1963,52 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertTrue(captured["request"].request_body.reply_in_thread)
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_send_uses_thread_id_receive_type_when_no_reply_to(self):
+        # When reply_to is absent but thread_id is in metadata (e.g. progress messages
+        # or approval cards dispatched without a specific reply anchor), messages must
+        # be sent to the thread directly via receive_id_type="thread_id" so they stay
+        # inside the existing topic rather than creating a new one.
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _MessageAPI:
+            def create(self, request):
+                captured["request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_thread_msg"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.send(
+                    chat_id="oc_chat",
+                    content="thinking…",
+                    reply_to=None,
+                    metadata={"thread_id": "omt-thread"},
+                )
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.message_id, "om_thread_msg")
+        self.assertEqual(captured["request"].receive_id_type, "thread_id")
+        self.assertEqual(captured["request"].request_body.receive_id, "omt-thread")
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_send_retries_transient_failure(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter


### PR DESCRIPTION
## What changed and why

When a user sends a message inside a Feishu **topic thread**, the inbound event carries a `thread_id`. Hermes stored it in metadata and used it correctly when `reply_to` was set (via `reply_in_thread=True` on the `message.reply` API). However, the **create path** — reached when `reply_to` is `None` (progress/thinking messages, approval cards, or after the withdrawn-message fallback) — called `message.create` with `receive_id_type="chat_id"`, completely ignoring `thread_id`. This caused every such message to start a brand-new topic instead of replying within the current one.

Fix in `_send_raw_message` (`gateway/platforms/feishu.py`):
- When `reply_to` is `None` **and** `thread_id` is present in metadata, use `receive_id_type="thread_id"` with `thread_id` as `receive_id`.
- The Feishu API accepts `thread_id` as a receive-id type and delivers the message inside the existing thread.
- This also covers the fallback path (withdrawn message → `active_reply_to = None`) since `metadata` is forwarded unchanged.

## How to test

1. Set up Hermes with a Feishu enterprise account and a **topic group**.
2. Open an existing topic thread and send a message to Hermes.
3. Verify that all Hermes responses (including intermediate thinking/progress messages and any approval cards) appear **inside the same topic thread**, not as new top-level topics.
4. Run the regression test: `pytest tests/gateway/test_feishu.py::FeishuAdapterSendTests::test_send_uses_thread_id_receive_type_when_no_reply_to -v`

## What platforms tested on

- macOS (unit tests only; Feishu enterprise tenant required for live verification)

Fixes #7734

<!-- autocontrib:worker-id=issue-followup-d7456195 kind=pr-open -->