### PR TITLE
fix(error_classifier): purge stale tool_call_id on 400 to prevent cross-session reuse (#16472)

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import enum
 import logging
+import re
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional
 
@@ -49,6 +50,7 @@ class FailoverReason(enum.Enum):
 
     # Request format
     format_error = "format_error"        # 400 bad request — abort or strip + retry
+    invalid_tool_call_id = "invalid_tool_call_id"  # 400 with stale tool_call_id — purge + retry
 
     # Provider-specific
     thinking_signature = "thinking_signature"  # Anthropic thinking block sig invalid
@@ -77,6 +79,13 @@ class ClassifiedError:
     should_compress: bool = False
     should_rotate_credential: bool = False
     should_fallback: bool = False
+
+    # When set, the retry loop should purge the assistant tool_call message
+    # whose ``id`` equals this value (and any tool_result messages tied to
+    # it) from the messages list before retrying or persisting. Used to
+    # recover from providers that reject a stale / malformed ``tool_call_id``
+    # with HTTP 400 (see issue #16472 — MiniMax `tool_call_id: ... (2013)`).
+    purge_tool_call_id: Optional[str] = None
 
     @property
     def is_auth(self) -> bool:
@@ -138,6 +147,39 @@ _USAGE_LIMIT_TRANSIENT_SIGNALS = [
     "periodic",
     "window",
 ]
+
+# Patterns that signal a stale / malformed ``tool_call_id`` was rejected by
+# the provider with HTTP 400. Hermes carries tool_call_ids across messages
+# in the SQLite session log; once a provider rejects one (e.g. MiniMax's
+# `invalid function arguments json string, tool_call_id: call_function_X (2013)`)
+# any subsequent session that inherits the same conversation history will
+# keep replaying the same broken assistant turn. Detecting this lets the
+# retry loop purge the offending assistant tool_call before persisting.
+_INVALID_TOOL_CALL_ID_PATTERNS = [
+    "tool_call_id",
+    "invalid function arguments",
+    "invalid params, invalid function arguments",
+    "unknown tool_call_id",
+    "no tool call with id",
+    "tool_call_id not found",
+]
+
+# Compiled extractor for the offending id. Matches OpenAI / MiniMax style
+# tokens emitted in 400 error messages, e.g.::
+#
+#     tool_call_id: call_function_18464z1gskgy_1
+#     tool_call_id call_abc_123
+#     'tool_call_id': 'call_xyz'
+#     no tool call with id call_xyz_42 found
+#
+# The pattern is intentionally loose on punctuation/quoting/separators
+# because each provider phrases the body slightly differently. Returns
+# None when no id can be extracted (caller falls back to the generic
+# format_error path).
+_TOOL_CALL_ID_TOKEN = re.compile(
+    r"tool[_\-\s]*call[_\-\s]*(?:with[_\-\s]+)?id\s*[:=]?\s*['\"]?(?P<id>[A-Za-z0-9_-]{4,256})['\"]?",
+    re.IGNORECASE,
+)
 
 # Payload-too-large patterns detected from message text (no status_code attr).
 # Proxies and some backends embed the HTTP status in the error message.
@@ -391,6 +433,13 @@ def classify_api_error(
     if _metadata_msg and _metadata_msg not in _raw_msg and _metadata_msg not in _body_msg:
         parts.append(_metadata_msg)
     error_msg = " ".join(parts)
+    # Case-preserved companion used by extractors that need original
+    # casing (e.g. ``tool_call_id`` is case-sensitive on the wire).
+    _cased_parts = [str(error)]
+    _cased_companion = _build_cased_error_msg(body)
+    if _cased_companion and _cased_companion not in _cased_parts[0]:
+        _cased_parts.append(_cased_companion)
+    error_msg_cased = " ".join(p for p in _cased_parts if p)
     provider_lower = (provider or "").strip().lower()
     model_lower = (model or "").strip().lower()
 
@@ -443,6 +492,7 @@ def classify_api_error(
             approx_tokens=approx_tokens, context_length=context_length,
             num_messages=num_messages,
             result_fn=_result,
+            error_msg_cased=error_msg_cased,
         )
         if classified is not None:
             return classified
@@ -517,6 +567,7 @@ def _classify_by_status(
     context_length: int,
     num_messages: int = 0,
     result_fn,
+    error_msg_cased: str = "",
 ) -> Optional[ClassifiedError]:
     """Classify based on HTTP status code with message-aware refinement."""
 
@@ -605,6 +656,7 @@ def _classify_by_status(
             context_length=context_length,
             num_messages=num_messages,
             result_fn=result_fn,
+            error_msg_cased=error_msg_cased,
         )
 
     if status_code in (500, 502):
@@ -657,6 +709,54 @@ def _classify_402(error_msg: str, result_fn) -> ClassifiedError:
     )
 
 
+def _build_cased_error_msg(body: Any) -> str:
+    """Reconstruct a case-preserved error message from a parsed body.
+
+    The main pattern-matching pipeline lowercases everything to keep
+    pattern lists short, but a few fields (notably ``tool_call_id``) are
+    case-sensitive on the wire. This helper recovers the original casing
+    from the structured body when available; callers fall back to the
+    lowercased ``error_msg`` if the result is empty.
+    """
+    parts: list[str] = []
+    if isinstance(body, dict):
+        err_obj = body.get("error", {})
+        if isinstance(err_obj, dict):
+            cased_body = str(err_obj.get("message") or "")
+            if cased_body:
+                parts.append(cased_body)
+        cased_top = str(body.get("message") or "")
+        if cased_top and cased_top not in parts:
+            parts.append(cased_top)
+    return " ".join(parts)
+
+
+def extract_invalid_tool_call_id(error_msg: str) -> Optional[str]:
+    """Best-effort extraction of the offending ``tool_call_id`` from a 400.
+
+    Returns ``None`` when no plausible id token is found. Pass the raw
+    (case-preserved) error string when possible — most providers emit
+    case-sensitive ids and the lowercased form used for pattern matching
+    elsewhere in this module would fail to match the persisted id.
+
+    The caller is expected to first verify that the error matches
+    :data:`_INVALID_TOOL_CALL_ID_PATTERNS` so a generic 400 mentioning
+    ``tool_call_id`` in passing isn't misclassified.
+    """
+    if not error_msg:
+        return None
+    match = _TOOL_CALL_ID_TOKEN.search(error_msg)
+    if not match:
+        return None
+    candidate = match.group("id")
+    # Sanity-check: drop obvious noise tokens captured by the regex when the
+    # provider phrases the message awkwardly (e.g. "the tool_call_id field").
+    lowered = candidate.lower()
+    if lowered in {"field", "value", "missing", "present", "required"}:
+        return None
+    return candidate
+
+
 def _classify_400(
     error_msg: str,
     error_code: str,
@@ -668,8 +768,25 @@ def _classify_400(
     context_length: int,
     num_messages: int = 0,
     result_fn,
+    error_msg_cased: str = "",
 ) -> ClassifiedError:
     """Classify 400 Bad Request — context overflow, format error, or generic."""
+
+    # Stale / malformed tool_call_id rejected by the provider. Detect this
+    # before falling through to the generic format_error path so the retry
+    # loop can purge the offending assistant tool_call from the messages
+    # list and avoid persisting it into state.db (issue #16472).
+    if any(p in error_msg for p in _INVALID_TOOL_CALL_ID_PATTERNS):
+        # Prefer the case-preserved string for extraction — ids are
+        # case-sensitive but error_msg has been lowercased upstream.
+        purge_id = extract_invalid_tool_call_id(error_msg_cased or error_msg)
+        if purge_id:
+            return result_fn(
+                FailoverReason.invalid_tool_call_id,
+                retryable=True,
+                should_fallback=False,
+                purge_tool_call_id=purge_id,
+            )
 
     # Context overflow from 400
     if any(p in error_msg for p in _CONTEXT_OVERFLOW_PATTERNS):

--- a/run_agent.py
+++ b/run_agent.py
@@ -4724,6 +4724,77 @@ class AIAgent:
         return messages
 
     @staticmethod
+    def _purge_invalid_tool_call_id(
+        messages: List[Dict[str, Any]],
+        invalid_id: str,
+    ) -> int:
+        """Strip a stale ``tool_call_id`` from the message list in-place.
+
+        Walks ``messages`` and:
+
+        * Drops the matching ``tool_call`` entry from every ``assistant`` /
+          ``function`` message; if that empties the call list and the
+          message has no textual content, the whole message is dropped.
+        * Drops every ``role=='tool'`` message keyed to that id.
+
+        Returns the number of (message, call) sites that were touched. Used
+        by the retry loop on HTTP 400 errors that name a specific id (see
+        :class:`agent.error_classifier.ClassifiedError.purge_tool_call_id`
+        — issue #16472). Mutates ``messages`` in place; the caller should
+        re-assign the slot when needed.
+        """
+        if not invalid_id or not messages:
+            return 0
+
+        touched = 0
+        cleaned: List[Dict[str, Any]] = []
+        for msg in messages:
+            role = msg.get("role")
+            if role == "tool" and msg.get("tool_call_id") == invalid_id:
+                touched += 1
+                continue  # Drop the matching tool_result.
+
+            tool_calls = msg.get("tool_calls")
+            if isinstance(tool_calls, list) and tool_calls:
+                kept_calls = []
+                for tc in tool_calls:
+                    cid = AIAgent._get_tool_call_id_static(tc)
+                    if cid == invalid_id:
+                        touched += 1
+                        continue
+                    kept_calls.append(tc)
+                if len(kept_calls) != len(tool_calls):
+                    if kept_calls:
+                        # Mutate carefully — some message implementations
+                        # are dataclass-like, so prefer dict assignment.
+                        if isinstance(msg, dict):
+                            msg["tool_calls"] = kept_calls
+                        else:
+                            try:
+                                msg.tool_calls = kept_calls  # type: ignore[attr-defined]
+                            except Exception:
+                                # If the object is immutable, drop it whole
+                                # rather than keeping a stale call list.
+                                continue
+                    else:
+                        # All tool_calls on this message were the bad id.
+                        content = msg.get("content") if isinstance(msg, dict) else getattr(msg, "content", None)
+                        if not content:
+                            continue  # Drop the now-empty assistant turn.
+                        if isinstance(msg, dict):
+                            msg["tool_calls"] = []
+                        else:
+                            try:
+                                msg.tool_calls = []  # type: ignore[attr-defined]
+                            except Exception:
+                                continue
+            cleaned.append(msg)
+
+        if touched:
+            messages[:] = cleaned
+        return touched
+
+    @staticmethod
     def _cap_delegate_task_calls(tool_calls: list) -> list:
         """Truncate excess delegate_task calls to max_concurrent_children.
 
@@ -10812,6 +10883,47 @@ class AIAgent:
                     )
                     if recovered_with_pool:
                         continue
+
+                    # ── Stale tool_call_id rejected by provider (#16472) ──
+                    # MiniMax (and other providers) can 400 a request when an
+                    # assistant message in the history names a tool_call_id
+                    # the provider no longer recognises. Without intervention
+                    # we'd persist the broken assistant turn into state.db,
+                    # and every subsequent session inheriting the same
+                    # conversation_history would hit the same 400. Purge the
+                    # offending tool_call (and its paired tool_result, if
+                    # any) and retry without counting against retry_count.
+                    if (
+                        classified.reason == FailoverReason.invalid_tool_call_id
+                        and classified.purge_tool_call_id
+                    ):
+                        purged = self._purge_invalid_tool_call_id(
+                            messages, classified.purge_tool_call_id
+                        )
+                        # Also clean up the api_messages snapshot so this
+                        # retry doesn't re-send the same broken payload.
+                        if api_messages:
+                            self._purge_invalid_tool_call_id(
+                                api_messages, classified.purge_tool_call_id
+                            )
+                        if purged:
+                            self._vprint(
+                                f"{self.log_prefix}⚠️  Provider rejected "
+                                f"tool_call_id={classified.purge_tool_call_id!r}; "
+                                f"purged {purged} stale entr{'y' if purged == 1 else 'ies'} "
+                                f"from history and retrying.",
+                                force=True,
+                            )
+                            # Persist the cleaned history immediately so a
+                            # crash-restart cannot resurrect the bad id.
+                            try:
+                                self._persist_session(messages, conversation_history)
+                            except Exception:
+                                logger.exception(
+                                    "Failed to persist session after purging invalid tool_call_id"
+                                )
+                            continue
+
                     if (
                         self.api_mode == "codex_responses"
                         and self.provider == "openai-codex"

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -56,6 +56,7 @@ class TestFailoverReason:
             "overloaded", "server_error", "timeout",
             "context_overflow", "payload_too_large",
             "model_not_found", "format_error",
+            "invalid_tool_call_id",
             "provider_policy_blocked",
             "thinking_signature", "long_context_tier", "unknown",
         }
@@ -1128,3 +1129,121 @@ class TestRateLimitErrorWithoutStatusCode:
         e.status_code = None
         result = classify_api_error(e, provider="copilot", model="gpt-4o")
         assert result.reason != FailoverReason.rate_limit
+
+
+# ── Test: invalid tool_call_id (issue #16472) ──────────────────────────
+
+class TestInvalidToolCallId:
+    """Regression tests for #16472 — MiniMax-style 400 with stale tool_call_id.
+
+    The provider rejects a tool_call_id that Hermes persisted in state.db
+    from a prior session. Without classification, the retry loop persists
+    the bad assistant turn again and every new session inheriting the
+    conversation_history hits the same 400 indefinitely.
+    """
+
+    MINIMAX_400_BODY = {
+        "type": "error",
+        "error": {
+            "type": "bad_request_error",
+            "message": (
+                "invalid params, invalid function arguments json string, "
+                "tool_call_id: call_function_18464z1gskgy_1 (2013)"
+            ),
+            "http_code": "400",
+        },
+    }
+
+    def test_minimax_invalid_tool_call_id_is_classified(self):
+        e = MockAPIError(
+            "Error code: 400 - invalid params, invalid function arguments json string, "
+            "tool_call_id: call_function_18464z1gskgy_1 (2013)",
+            status_code=400,
+            body=self.MINIMAX_400_BODY,
+        )
+        result = classify_api_error(e, provider="minimax-cn", model="MiniMax-M2.7")
+        assert result.reason == FailoverReason.invalid_tool_call_id
+        assert result.retryable is True
+        assert result.should_fallback is False
+
+    def test_purge_id_is_extracted_with_original_casing(self):
+        """The id is case-sensitive but error_msg is lowercased upstream;
+        ensure the cased version reaches the extractor (regression for the
+        early version of this fix that lost mixed-case ids)."""
+        e = MockAPIError(
+            "Error code: 400",
+            status_code=400,
+            body={
+                "error": {
+                    "message": (
+                        "invalid params, invalid function arguments json string, "
+                        "tool_call_id: call_function_BgFD4kM3qNvm_1 (2013)"
+                    ),
+                },
+            },
+        )
+        result = classify_api_error(e, provider="minimax-cn", model="MiniMax-M2.7")
+        assert result.reason == FailoverReason.invalid_tool_call_id
+        assert result.purge_tool_call_id == "call_function_BgFD4kM3qNvm_1"
+
+    def test_unrelated_400_keeps_format_error(self):
+        """A generic format-error 400 must NOT be reclassified."""
+        e = MockAPIError(
+            "Error code: 400 - parameter 'temperature' out of range",
+            status_code=400,
+            body={"error": {"message": "parameter 'temperature' out of range"}},
+        )
+        result = classify_api_error(e, provider="openai", model="gpt-4o")
+        assert result.reason == FailoverReason.format_error
+        assert result.purge_tool_call_id is None
+
+    def test_pattern_match_without_extractable_id_falls_through(self):
+        """Pattern match alone is not enough — the id has to be extractable.
+        Otherwise a vague mention would purge nothing and we'd be stuck."""
+        e = MockAPIError(
+            "Error code: 400 - tool_call_id field missing",
+            status_code=400,
+            body={"error": {"message": "tool_call_id field missing"}},
+        )
+        result = classify_api_error(e, provider="openai", model="gpt-4o")
+        # "field" is in the noise blocklist so extraction returns None and
+        # we fall through to format_error.
+        assert result.reason == FailoverReason.format_error
+
+    def test_openai_unknown_tool_call_id_is_classified(self):
+        """OpenAI emits the same family of error ('No tool call with id'),
+        so the same fix has to cover it."""
+        e = MockAPIError(
+            "Error code: 400",
+            status_code=400,
+            body={
+                "error": {
+                    "message": "no tool call with id call_xyz_42 found in conversation history",
+                },
+            },
+        )
+        result = classify_api_error(e, provider="openai", model="gpt-4o")
+        assert result.reason == FailoverReason.invalid_tool_call_id
+        assert result.purge_tool_call_id == "call_xyz_42"
+
+    def test_invalid_tool_call_id_takes_priority_over_context_overflow(self):
+        """Context-overflow and invalid_tool_call_id can both look like 400s;
+        the tool_call_id branch must run first because the recovery is
+        cheaper (no compression, just purge + retry)."""
+        e = MockAPIError(
+            "Error code: 400 - tool_call_id: call_function_X_1 — also context length exceeded",
+            status_code=400,
+            body={
+                "error": {
+                    "message": (
+                        "tool_call_id: call_function_X_1 — also context length exceeded"
+                    ),
+                },
+            },
+        )
+        result = classify_api_error(
+            e, provider="minimax-cn", model="MiniMax-M2.7",
+            approx_tokens=200_000, context_length=128_000,
+        )
+        assert result.reason == FailoverReason.invalid_tool_call_id
+        assert result.purge_tool_call_id == "call_function_X_1"

--- a/tests/run_agent/test_agent_guardrails.py
+++ b/tests/run_agent/test_agent_guardrails.py
@@ -263,3 +263,110 @@ class TestGetToolCallIdStatic:
     def test_object_without_id_attr(self):
         tc = types.SimpleNamespace()
         assert AIAgent._get_tool_call_id_static(tc) == ""
+
+
+# ---------------------------------------------------------------------------
+# _purge_invalid_tool_call_id (issue #16472)
+# ---------------------------------------------------------------------------
+
+class TestPurgeInvalidToolCallId:
+
+    def _assistant(self, *, tool_calls=None, content=""):
+        msg = {"role": "assistant", "content": content}
+        if tool_calls is not None:
+            msg["tool_calls"] = tool_calls
+        return msg
+
+    def _tool_result(self, tool_call_id, content="result"):
+        return {"role": "tool", "tool_call_id": tool_call_id, "content": content}
+
+    def test_drops_matching_tool_result_message(self):
+        messages = [
+            self._assistant(tool_calls=[{"id": "good_1", "function": {"name": "f", "arguments": "{}"}}]),
+            self._tool_result("good_1", "ok"),
+            self._tool_result("bad_99", "stale"),
+        ]
+        touched = AIAgent._purge_invalid_tool_call_id(messages, "bad_99")
+        assert touched == 1
+        ids_left = [m.get("tool_call_id") for m in messages if m.get("role") == "tool"]
+        assert "bad_99" not in ids_left
+        assert "good_1" in ids_left
+
+    def test_strips_only_the_bad_call_when_assistant_has_multiple(self):
+        messages = [
+            self._assistant(tool_calls=[
+                {"id": "bad_99", "function": {"name": "f", "arguments": "{}"}},
+                {"id": "good_1", "function": {"name": "g", "arguments": "{}"}},
+            ], content="reasoning"),
+            self._tool_result("good_1", "ok"),
+        ]
+        touched = AIAgent._purge_invalid_tool_call_id(messages, "bad_99")
+        assert touched == 1
+        # Assistant survives with the surviving call.
+        assert messages[0]["role"] == "assistant"
+        assert [tc["id"] for tc in messages[0]["tool_calls"]] == ["good_1"]
+        # tool_result for the surviving call also survives.
+        assert messages[-1] == {"role": "tool", "tool_call_id": "good_1", "content": "ok"}
+
+    def test_drops_assistant_when_only_call_was_bad_and_no_content(self):
+        """Empty assistant turn (no content, no surviving calls) is dropped
+        outright so the next assistant message isn't preceded by a stub."""
+        messages = [
+            {"role": "user", "content": "hello"},
+            self._assistant(
+                tool_calls=[{"id": "bad_99", "function": {"name": "f", "arguments": "{}"}}],
+                content="",
+            ),
+            self._tool_result("bad_99", "stale"),
+        ]
+        touched = AIAgent._purge_invalid_tool_call_id(messages, "bad_99")
+        # 1 assistant tool_call removed + 1 tool_result removed = 2 sites
+        assert touched == 2
+        assert len(messages) == 1
+        assert messages[0]["role"] == "user"
+
+    def test_keeps_assistant_when_only_call_was_bad_but_has_content(self):
+        """If the assistant turn carried text alongside the bad call, keep
+        the text — losing the message would discard model-visible context."""
+        messages = [
+            self._assistant(
+                tool_calls=[{"id": "bad_99", "function": {"name": "f", "arguments": "{}"}}],
+                content="here is some reasoning",
+            ),
+            self._tool_result("bad_99", "stale"),
+        ]
+        touched = AIAgent._purge_invalid_tool_call_id(messages, "bad_99")
+        assert touched == 2
+        assert len(messages) == 1
+        assert messages[0]["content"] == "here is some reasoning"
+        assert messages[0]["tool_calls"] == []
+
+    def test_no_op_when_id_is_missing(self):
+        messages = [
+            self._assistant(tool_calls=[{"id": "good_1", "function": {"name": "f", "arguments": "{}"}}]),
+            self._tool_result("good_1", "ok"),
+        ]
+        original_len = len(messages)
+        touched = AIAgent._purge_invalid_tool_call_id(messages, "not_present_xx")
+        assert touched == 0
+        assert len(messages) == original_len
+
+    def test_handles_object_style_tool_calls(self):
+        """Some code paths build assistant messages with object-style tool
+        calls (Pydantic / SDK shapes). The purge has to mutate those too."""
+        tc_good = types.SimpleNamespace(id="good_1", function=types.SimpleNamespace(name="f", arguments="{}"))
+        tc_bad = types.SimpleNamespace(id="bad_99", function=types.SimpleNamespace(name="g", arguments="{}"))
+        messages = [
+            {"role": "assistant", "content": "x", "tool_calls": [tc_good, tc_bad]},
+            self._tool_result("bad_99"),
+            self._tool_result("good_1"),
+        ]
+        touched = AIAgent._purge_invalid_tool_call_id(messages, "bad_99")
+        assert touched == 2  # 1 tool_call entry + 1 tool_result
+        remaining_ids = [tc.id for tc in messages[0]["tool_calls"]]
+        assert remaining_ids == ["good_1"]
+
+    def test_empty_inputs_are_safe(self):
+        assert AIAgent._purge_invalid_tool_call_id([], "anything") == 0
+        assert AIAgent._purge_invalid_tool_call_id(None, "anything") == 0
+        assert AIAgent._purge_invalid_tool_call_id([{"role": "user", "content": "hi"}], "") == 0


### PR DESCRIPTION
## Summary

Fixes #16472 — when a provider rejects a `tool_call_id` with HTTP 400 (most often MiniMax `invalid params, invalid function arguments json string, tool_call_id: call_function_X_1 (2013)`), Hermes was persisting the broken assistant turn into `state.db` anyway. Every subsequent session that inherited the same `conversation_history` replayed the same id and hit the same 400 indefinitely — until the gateway was restarted.

## Root cause

`run_agent.py` (around `if status_code == 400 and (approx_tokens > 50000 or len(api_messages) > 80)`) only skips persistence when the 400 is a *context-overflow* shaped failure. A small-session 400 (which is exactly what an invalid `tool_call_id` produces — short payload, structured error) falls through to `_persist_session(messages, conversation_history)` and writes the broken assistant turn to `state.db`.

That turn — assistant message with `tool_calls=[{ id: "call_function_X_1", ... }]` — is then loaded by every new session that inherits the same conversation history, so the provider keeps seeing the same id and keeps 400-ing. Restarting the gateway is the only way out today.

Reporter evidence:

- 2026-04-26 → `call_function_18464z1gskgy_1` reused across ~5 sessions
- 2026-04-26 → `call_function_bgfd4km3qnvm_1` reused across ~3 sessions
- 2026-04-27 → `call_function_41ojma24zxdp_1` reused across 4+ sessions

## Fix

### 1. Classify the error

`agent/error_classifier.py`:

- New `FailoverReason.invalid_tool_call_id`.
- New `ClassifiedError.purge_tool_call_id: Optional[str]` carrying the offending id.
- New `_INVALID_TOOL_CALL_ID_PATTERNS` (covers MiniMax `invalid function arguments`, OpenAI `no tool call with id`, etc.) plus a tolerant regex extractor `extract_invalid_tool_call_id()` that handles the various formats providers use (`tool_call_id: X`, `tool_call_id X`, `'tool_call_id': 'X'`, `no tool call with id X found`).
- The branch runs **before** the generic `format_error` fallback inside `_classify_400`, so the cheaper recovery (purge + retry) wins over fallback to a different provider.
- A case-preserved companion to `error_msg` is built once at the top of `classify_api_error` and threaded through, so case-sensitive ids (e.g. `call_function_BgFD4kM3qNvm_1`) survive the lowercasing the rest of the classifier relies on.

### 2. Purge the stale call

`run_agent.py`:

- New static `AIAgent._purge_invalid_tool_call_id(messages, invalid_id)` walks the messages list and:
  - Drops every `role=='tool'` message whose `tool_call_id` matches.
  - Strips the matching entry from each assistant `tool_calls` list (handles both dict-style and SDK-object-style entries).
  - Drops an assistant turn outright when the bad call was its only call **and** it had no textual content; otherwise preserves the surviving content and surviving calls.

### 3. Retry without consuming retry_count

When `classified.reason == invalid_tool_call_id` and `classified.purge_tool_call_id` is set, the retry loop:

1. Purges the id from both `messages` and `api_messages`.
2. **Persists the cleaned history immediately** so a crash-restart cannot resurrect the bad id (this is the key step the original code missed).
3. `continue`s without consuming `retry_count`.

## Behavior

| Scenario | Before | After |
|---|---|---|
| 400 `invalid function arguments... tool_call_id: X` | Persist broken turn → next session 400s on same id | Strip id, persist clean state, retry succeeds |
| 400 context overflow | Compress + retry (unchanged) | Compress + retry (unchanged) |
| 400 generic format error | Abort / fallback (unchanged) | Abort / fallback (unchanged) |
| 400 mentions `tool_call_id field missing` (no id) | Generic format_error | Generic format_error (extractor returns None, falls through) |

## Tests

13 new tests, all green. Existing 2049 tests still pass; the 9 failures in `test_bedrock_adapter.py` and `test_anthropic_adapter.py` are pre-existing on `main` (unrelated to this PR — verified by `git stash`).

`tests/agent/test_error_classifier.py` — 6 new:
- MiniMax body shape is classified as `invalid_tool_call_id`
- Mixed-case id (`call_function_BgFD4kM3qNvm_1`) is extracted with original casing
- Unrelated 400 (e.g. `parameter 'temperature' out of range`) keeps `format_error`
- Pattern match without an extractable id falls through to `format_error` (so a vague mention doesn't cause an empty-purge spin)
- OpenAI `no tool call with id call_xyz_42 found` is classified the same way
- `invalid_tool_call_id` branch wins over `context_overflow` when the message could match both

`tests/run_agent/test_agent_guardrails.py` — 7 new:
- Drops matching `tool_result` message
- Strips only the bad call when assistant has multiple
- Drops assistant turn when the bad call was its only call and content is empty
- Keeps assistant turn when the bad call was its only call but content is present
- No-op when id is missing from history
- Handles SDK-object-style `tool_calls` (`SimpleNamespace(id=..., function=...)`)
- Empty / `None` inputs are safe

```
$ pytest tests/agent/test_error_classifier.py tests/run_agent/test_agent_guardrails.py -q
160 passed in 5.03s
```
