### PR TITLE
test(dingtalk): stub optional SDK modules so card/handler tests pass without dingtalk-stream

### DIFF
--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -583,7 +583,7 @@ class TestShouldProcessMessage:
 
 @pytest.fixture
 def _stub_chatbot_message(monkeypatch):
-    """Stub ChatbotMessage when the dingtalk-stream SDK isn't installed.
+    """Stub ChatbotMessage only when the dingtalk-stream SDK isn't installed.
 
     Production ``_IncomingHandler.process`` calls ``ChatbotMessage.from_dict()``;
     when the optional dependency is absent the symbol is bound to ``None`` and
@@ -591,7 +591,15 @@ def _stub_chatbot_message(monkeypatch):
     the SDK's field-mapping logic — they exercise the adapter's own fallback
     that pulls ``sessionWebhook`` straight off the raw data dict — so a stub
     that returns an empty namespace is enough to drive every assertion.
+
+    When the real SDK is installed, leave ``ChatbotMessage`` in place so dev
+    runs still exercise the SDK's actual ``from_dict`` mapping.
     """
+    from gateway.platforms import dingtalk as dingtalk_module
+
+    if dingtalk_module.ChatbotMessage is not None:
+        return
+
     class _StubChatbotMessage:
         @classmethod
         def from_dict(cls, data):
@@ -785,18 +793,26 @@ class _StubSdkModule:
 
 @pytest.fixture
 def _stub_card_sdk_models(monkeypatch):
-    """Stub the alibabacloud SDK module-level imports when the optional
+    """Stub the alibabacloud SDK module-level imports only when the optional
     dependencies are absent.  Production card paths reference
     ``tea_util_models``, ``dingtalk_card_models``, and ``dingtalk_robot_models``
     purely to construct request/header objects forwarded to the card-SDK
     methods (which the tests mock as ``AsyncMock``).  Returning placeholder
     namespaces lets the production code path execute end-to-end without the
     real SDK installed.
+
+    When the SDK is installed, leave the real model modules in place so dev
+    runs can still catch mismatches against the installed SDK.
     """
+    import gateway.platforms.dingtalk as dingtalk_module
+
     stub = _StubSdkModule()
-    monkeypatch.setattr("gateway.platforms.dingtalk.tea_util_models", stub)
-    monkeypatch.setattr("gateway.platforms.dingtalk.dingtalk_card_models", stub)
-    monkeypatch.setattr("gateway.platforms.dingtalk.dingtalk_robot_models", stub)
+    if getattr(dingtalk_module, "tea_util_models", None) is None:
+        monkeypatch.setattr("gateway.platforms.dingtalk.tea_util_models", stub)
+    if getattr(dingtalk_module, "dingtalk_card_models", None) is None:
+        monkeypatch.setattr("gateway.platforms.dingtalk.dingtalk_card_models", stub)
+    if getattr(dingtalk_module, "dingtalk_robot_models", None) is None:
+        monkeypatch.setattr("gateway.platforms.dingtalk.dingtalk_robot_models", stub)
 
 
 class TestCardLifecycle:

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -581,13 +581,34 @@ class TestShouldProcessMessage:
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture
+def _stub_chatbot_message(monkeypatch):
+    """Stub ChatbotMessage when the dingtalk-stream SDK isn't installed.
+
+    Production ``_IncomingHandler.process`` calls ``ChatbotMessage.from_dict()``;
+    when the optional dependency is absent the symbol is bound to ``None`` and
+    the call raises ``AttributeError``.  Tests in this class don't care about
+    the SDK's field-mapping logic — they exercise the adapter's own fallback
+    that pulls ``sessionWebhook`` straight off the raw data dict — so a stub
+    that returns an empty namespace is enough to drive every assertion.
+    """
+    class _StubChatbotMessage:
+        @classmethod
+        def from_dict(cls, data):
+            return SimpleNamespace()
+
+    monkeypatch.setattr(
+        "gateway.platforms.dingtalk.ChatbotMessage", _StubChatbotMessage
+    )
+
+
 class TestIncomingHandlerProcess:
     """Verify that _IncomingHandler.process correctly converts callback data
     and dispatches message processing as a background task (fire-and-forget)
     so the SDK ACK is returned immediately."""
 
     @pytest.mark.asyncio
-    async def test_process_extracts_session_webhook(self):
+    async def test_process_extracts_session_webhook(self, _stub_chatbot_message):
         """session_webhook must be populated from callback data."""
         from gateway.platforms.dingtalk import _IncomingHandler, DingTalkAdapter
 
@@ -618,7 +639,9 @@ class TestIncomingHandlerProcess:
         assert chatbot_msg.session_webhook == "https://oapi.dingtalk.com/robot/sendBySession?session=abc"
 
     @pytest.mark.asyncio
-    async def test_process_fallback_session_webhook_when_from_dict_misses_it(self):
+    async def test_process_fallback_session_webhook_when_from_dict_misses_it(
+        self, _stub_chatbot_message
+    ):
         """If ChatbotMessage.from_dict does not map sessionWebhook (e.g. SDK
         version mismatch), the handler should fall back to extracting it
         directly from the raw data dict."""
@@ -647,7 +670,7 @@ class TestIncomingHandlerProcess:
         assert chatbot_msg.session_webhook == "https://oapi.dingtalk.com/robot/sendBySession?session=def"
 
     @pytest.mark.asyncio
-    async def test_process_returns_ack_immediately(self):
+    async def test_process_returns_ack_immediately(self, _stub_chatbot_message):
         """process() must not block on _on_message — it should return
         the ACK tuple before the message is fully processed."""
         from gateway.platforms.dingtalk import _IncomingHandler, DingTalkAdapter
@@ -748,10 +771,38 @@ class TestMessageContextIsolation:
 # ---------------------------------------------------------------------------
 
 
+class _StubSdkModule:
+    """Module-shaped stub that synthesises a SimpleNamespace factory for any
+    attribute access.  ``Stub.AnyClassName(foo=1, bar=2)`` returns
+    ``SimpleNamespace(foo=1, bar=2)`` — enough to satisfy production code
+    that builds SDK request/header objects purely to forward them to a
+    mocked ``_card_sdk`` method without inspecting the result.
+    """
+
+    def __getattr__(self, name):
+        return lambda **kwargs: SimpleNamespace(**kwargs)
+
+
+@pytest.fixture
+def _stub_card_sdk_models(monkeypatch):
+    """Stub the alibabacloud SDK module-level imports when the optional
+    dependencies are absent.  Production card paths reference
+    ``tea_util_models``, ``dingtalk_card_models``, and ``dingtalk_robot_models``
+    purely to construct request/header objects forwarded to the card-SDK
+    methods (which the tests mock as ``AsyncMock``).  Returning placeholder
+    namespaces lets the production code path execute end-to-end without the
+    real SDK installed.
+    """
+    stub = _StubSdkModule()
+    monkeypatch.setattr("gateway.platforms.dingtalk.tea_util_models", stub)
+    monkeypatch.setattr("gateway.platforms.dingtalk.dingtalk_card_models", stub)
+    monkeypatch.setattr("gateway.platforms.dingtalk.dingtalk_robot_models", stub)
+
+
 class TestCardLifecycle:
 
     @pytest.fixture
-    def adapter_with_card(self):
+    def adapter_with_card(self, _stub_card_sdk_models):
         from gateway.platforms.dingtalk import DingTalkAdapter
         a = DingTalkAdapter(PlatformConfig(
             enabled=True,
@@ -942,7 +993,10 @@ class TestDingTalkAdapterAICards:
         return msg
 
     @pytest.mark.asyncio
-    async def test_send_uses_ai_card_if_configured(self, config, mock_stream_client, mock_http_client, mock_message):
+    async def test_send_uses_ai_card_if_configured(
+        self, config, mock_stream_client, mock_http_client, mock_message,
+        _stub_card_sdk_models,
+    ):
         from gateway.platforms.dingtalk import DingTalkAdapter
 
         adapter = DingTalkAdapter(config)


### PR DESCRIPTION
## Summary
- Stubs out `ChatbotMessage`, `tea_util_models`, `dingtalk_card_models`, and `dingtalk_robot_models` so the DingTalk card-streaming and incoming-handler tests pass on CI runners that don't have the optional `dingtalk_stream` / `alibabacloud-*` SDKs installed.
- 10 → 0 baseline failures in `tests/gateway/test_dingtalk.py`. Test-only fix; production code is unchanged.

## The bug

`gateway/platforms/dingtalk.py` imports the dingtalk-stream + alibabacloud SDKs inside a `try`/`except ImportError` and binds the symbols to `None` when the deps are absent.  That's the right runtime contract — the adapter just isn't loaded if the SDK is missing.  But three test classes drive production code paths that dereference those symbols:

- **`TestIncomingHandlerProcess`** (3 tests) — `_IncomingHandler.process()` calls `ChatbotMessage.from_dict(data)`. With `ChatbotMessage = None` this raises `AttributeError`, the production try/except logs it, and `process()` returns `(STATUS_SYSTEM_EXCEPTION, "error")` — i.e. `(500, ...)` — instead of `200`.  All three tests then fail their `assert result[0] == 200`.
- **`TestCardLifecycle`** (6 tests) — the streaming-card lifecycle constructs `tea_util_models.RuntimeOptions()` and `dingtalk_card_models.*` request/header objects to forward to the (already mocked) `_card_sdk.*_with_options_async` methods.  With those modules `None`, every `send`/`edit_message` call raises and the assertions about `_streaming_cards` / `_card_sdk` call args never see a real call.
- **`TestDingTalkAdapterAICards::test_send_uses_ai_card_if_configured`** — same card-create/deliver/streaming path.

These were introduced by:
- 47a0dd102 — `fix(dingtalk): fire-and-forget message processing & session_webhook fallback` (added the 3 `TestIncomingHandlerProcess` tests).
- 4459913f4 — `feat(dingtalk): AI Cards streaming, emoji reactions, and media handling` (added the 6 `TestCardLifecycle` tests + the AI card test).

## The fix

Two narrow `monkeypatch` fixtures in the test file — production code is untouched:

- **`_stub_chatbot_message`** replaces `ChatbotMessage` with a tiny stub whose `from_dict()` returns `SimpleNamespace()`.  The tests already exercise the adapter's *own* `session_webhook` fallback (pulling the value from the raw data dict when `from_dict` doesn't set the attribute), so a no-op stub is the right shape.
- **`_stub_card_sdk_models`** swaps in a `_StubSdkModule` that uses `__getattr__` to synthesise a `SimpleNamespace` factory for any attribute access.  Production code only constructs these SDK request/header objects to hand them off to the mocked `_card_sdk` methods, never inspecting their internals — so any object that accepts kwargs works.  All call sites in `dingtalk.py` use kwargs (verified by grep), so `lambda **kwargs: SimpleNamespace(**kwargs)` is sufficient.

## Test plan
- [x] **Before** (clean `origin/main`): `10 failed, 52 passed` in `tests/gateway/test_dingtalk.py`.
- [x] **After** (this branch): `62 passed`.
- [x] **Regression guard**: stashed the test diff → reproduced the same 10 failures with the identical NoneType errors; restored → 0 failures.
- [x] **Direct repro**: `python3 -c "from gateway.platforms.dingtalk import tea_util_models, ChatbotMessage; tea_util_models.RuntimeOptions()"` → `AttributeError: 'NoneType' object has no attribute 'RuntimeOptions'` (matches the captured-log traceback).
- [x] **Adjacent suites unchanged**: full `tests/gateway/` run shows the same baseline failures in `test_discord_*`, `test_run_progress_topics`, `test_approve_deny_commands`, `test_matrix.py` that exist on clean `origin/main` — no new regressions.
- [x] **Python 3.9 compat**: `ast.parse(src, feature_version=(3, 9))` passes.

## Related
- The `TestDingTalkRequirements::test_returns_false_when_sdk_missing` path is preserved as-is — that test still patches `DINGTALK_STREAM_AVAILABLE` to `False` and verifies `check_dingtalk_requirements()` returns `False`, so the SDK-absent contract at the entry point is still enforced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)