### PR TITLE
fix(api_server): reuse session_id for known conversation slug on cold-start (#16517)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -312,9 +312,20 @@ class ResponseStore:
         self._conn.execute(
             """CREATE TABLE IF NOT EXISTS conversations (
                 name TEXT PRIMARY KEY,
-                response_id TEXT NOT NULL
+                response_id TEXT NOT NULL,
+                session_id TEXT
             )"""
         )
+        # Idempotent migration: add session_id to pre-existing conversations
+        # tables (issue #16517 — keep slug → session continuity even after
+        # the response_id row is evicted from the LRU).
+        try:
+            self._conn.execute(
+                "ALTER TABLE conversations ADD COLUMN session_id TEXT"
+            )
+        except sqlite3.OperationalError:
+            # Column already exists; ALTER fails with "duplicate column".
+            pass
         self._conn.commit()
 
     def get(self, response_id: str) -> Optional[Dict[str, Any]]:
@@ -362,12 +373,45 @@ class ResponseStore:
         ).fetchone()
         return row[0] if row else None
 
-    def set_conversation(self, name: str, response_id: str) -> None:
-        """Map a conversation name to its latest response_id."""
-        self._conn.execute(
-            "INSERT OR REPLACE INTO conversations (name, response_id) VALUES (?, ?)",
-            (name, response_id),
-        )
+    def get_session_id_for_conversation(self, name: str) -> Optional[str]:
+        """Get the latest agent session_id for a conversation name.
+
+        Survives LRU eviction of the underlying ``responses`` row — the
+        session_id is stored on the ``conversations`` row directly so that
+        cold-start requests with ``conversation=<slug>`` continue the
+        existing state.db session instead of minting a fresh fork (issue
+        #16517).
+
+        Returns ``None`` when the conversation is unknown or was created
+        before this column existed (legacy rows pre-migration).
+        """
+        row = self._conn.execute(
+            "SELECT session_id FROM conversations WHERE name = ?", (name,)
+        ).fetchone()
+        return row[0] if row and row[0] else None
+
+    def set_conversation(
+        self,
+        name: str,
+        response_id: str,
+        session_id: Optional[str] = None,
+    ) -> None:
+        """Map a conversation name to its latest response_id and session.
+
+        ``session_id`` is optional for backwards compatibility, but callers
+        that have a session_id in hand should pass it so cold-start lookup
+        (issue #16517) works even after the responses LRU evicts the row.
+        """
+        if session_id is not None:
+            self._conn.execute(
+                "INSERT OR REPLACE INTO conversations (name, response_id, session_id) VALUES (?, ?, ?)",
+                (name, response_id, session_id),
+            )
+        else:
+            self._conn.execute(
+                "INSERT OR REPLACE INTO conversations (name, response_id) VALUES (?, ?)",
+                (name, response_id),
+            )
         self._conn.commit()
 
     def close(self) -> None:
@@ -1294,7 +1338,9 @@ class APIServerAdapter(BasePlatformAdapter):
                 "session_id": session_id,
             })
             if conversation:
-                self._response_store.set_conversation(conversation, response_id)
+                self._response_store.set_conversation(
+                    conversation, response_id, session_id=session_id
+                )
 
         def _persist_incomplete_if_needed() -> None:
             """Persist an ``incomplete`` snapshot if no terminal one was written.
@@ -1699,9 +1745,16 @@ class APIServerAdapter(BasePlatformAdapter):
         if conversation and previous_response_id:
             return web.json_response(_openai_error("Cannot use both 'conversation' and 'previous_response_id'"), status=400)
 
-        # Resolve conversation name to latest response_id
+        # Resolve conversation name to latest response_id, plus a stable
+        # slug → session_id fallback for the cold-start path where the
+        # response_id was evicted from the LRU but the conversation slug
+        # is still known (issue #16517).
+        slug_session_id_hint: Optional[str] = None
         if conversation:
             previous_response_id = self._response_store.get_conversation(conversation)
+            slug_session_id_hint = self._response_store.get_session_id_for_conversation(
+                conversation
+            )
             # No error if conversation doesn't exist yet — it's a new conversation
 
         # Normalize input to message list
@@ -1752,12 +1805,38 @@ class APIServerAdapter(BasePlatformAdapter):
         if not conversation_history and previous_response_id:
             stored = self._response_store.get(previous_response_id)
             if stored is None:
-                return web.json_response(_openai_error(f"Previous response not found: {previous_response_id}"), status=404)
-            conversation_history = list(stored.get("conversation_history", []))
-            stored_session_id = stored.get("session_id")
-            # If no instructions provided, carry forward from previous
-            if instructions is None:
-                instructions = stored.get("instructions")
+                # The response_id we held for this conversation has been
+                # evicted from the LRU (or the gateway restarted with a
+                # smaller responses cache). When the request was keyed by
+                # ``conversation``, fall back to the slug → session_id
+                # mapping that is persisted independently of the LRU
+                # (issue #16517) so the agent continues the existing
+                # state.db session instead of minting a brand-new
+                # fork. We cannot recover ``conversation_history`` in
+                # this case — the agent will load it lazily from the
+                # session store via ``session_id`` instead.
+                if conversation:
+                    fallback_session_id = (
+                        self._response_store.get_session_id_for_conversation(conversation)
+                    )
+                    if fallback_session_id:
+                        stored_session_id = fallback_session_id
+                        logger.info(
+                            "response_id %s evicted from LRU; reusing "
+                            "session_id %s for conversation %r via slug fallback (#16517)",
+                            previous_response_id, fallback_session_id, conversation,
+                        )
+                if stored_session_id is None:
+                    return web.json_response(
+                        _openai_error(f"Previous response not found: {previous_response_id}"),
+                        status=404,
+                    )
+            else:
+                conversation_history = list(stored.get("conversation_history", []))
+                stored_session_id = stored.get("session_id")
+                # If no instructions provided, carry forward from previous
+                if instructions is None:
+                    instructions = stored.get("instructions")
 
         # Append new input messages to history (all but the last become history)
         for msg in input_messages[:-1]:
@@ -1773,8 +1852,16 @@ class APIServerAdapter(BasePlatformAdapter):
             conversation_history = conversation_history[-100:]
 
         # Reuse session from previous_response_id chain so the dashboard
-        # groups the entire conversation under one session entry.
-        session_id = stored_session_id or str(uuid.uuid4())
+        # groups the entire conversation under one session entry. When the
+        # caller used ``conversation=<slug>`` and we have a slug-only
+        # mapping (response_id evicted, or the slug is known but the
+        # responses row was never written), continue THAT session instead
+        # of minting a fresh one (issue #16517).
+        session_id = (
+            stored_session_id
+            or slug_session_id_hint
+            or str(uuid.uuid4())
+        )
 
         stream = bool(body.get("stream", False))
         if stream:
@@ -1926,9 +2013,13 @@ class APIServerAdapter(BasePlatformAdapter):
                 "session_id": session_id,
             })
             # Update conversation mapping so the next request with the same
-            # conversation name automatically chains to this response
+            # conversation name automatically chains to this response.
+            # Passing session_id keeps the slug → session link alive even
+            # after the responses LRU evicts this row (issue #16517).
             if conversation:
-                self._response_store.set_conversation(conversation, response_id)
+                self._response_store.set_conversation(
+                    conversation, response_id, session_id=session_id
+                )
 
         return web.json_response(response_data)
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -105,6 +105,85 @@ class TestResponseStore:
         store = ResponseStore(max_size=10)
         assert store.delete("resp_missing") is False
 
+    # ── issue #16517: slug → session_id continuity ──
+
+    def test_set_conversation_persists_session_id(self):
+        """set_conversation(slug, response_id, session_id=...) keeps the
+        slug → session_id mapping retrievable independently of the
+        responses LRU."""
+        store = ResponseStore(max_size=10)
+        store.put("resp_1", {"session_id": "sess_abc"})
+        store.set_conversation("my-chat", "resp_1", session_id="sess_abc")
+        assert store.get_session_id_for_conversation("my-chat") == "sess_abc"
+
+    def test_session_id_survives_response_lru_eviction(self):
+        """Regression for #16517: even after the responses row is evicted,
+        the slug-keyed session_id is still queryable so cold-start /v1/responses
+        can continue the existing state.db session."""
+        store = ResponseStore(max_size=2)
+        store.put("resp_1", {"session_id": "sess_abc"})
+        store.set_conversation("my-chat", "resp_1", session_id="sess_abc")
+        # Force eviction of resp_1 from responses.
+        store.put("resp_2", {"session_id": "sess_xyz"})
+        store.put("resp_3", {"session_id": "sess_qrs"})
+        assert store.get("resp_1") is None  # responses row evicted
+        # But the slug → session_id mapping survives.
+        assert store.get_session_id_for_conversation("my-chat") == "sess_abc"
+
+    def test_get_session_id_returns_none_for_unknown_slug(self):
+        store = ResponseStore(max_size=10)
+        assert store.get_session_id_for_conversation("never-seen") is None
+
+    def test_set_conversation_without_session_id_remains_backwards_compatible(self):
+        """The old call signature (no session_id) still works for callers
+        that haven't been updated yet — they just won't get the new
+        cold-start fallback benefit."""
+        store = ResponseStore(max_size=10)
+        store.set_conversation("my-chat", "resp_1")
+        assert store.get_conversation("my-chat") == "resp_1"
+        # session_id stays None until somebody upgrades the row.
+        assert store.get_session_id_for_conversation("my-chat") is None
+
+    def test_set_conversation_overwrites_session_id_on_chain_advance(self):
+        """Each new turn should refresh both response_id and session_id
+        on the conversations row (session_id is stable across the chain,
+        but the column must be re-asserted when callers pass it again)."""
+        store = ResponseStore(max_size=10)
+        store.set_conversation("my-chat", "resp_1", session_id="sess_abc")
+        store.set_conversation("my-chat", "resp_2", session_id="sess_abc")
+        assert store.get_conversation("my-chat") == "resp_2"
+        assert store.get_session_id_for_conversation("my-chat") == "sess_abc"
+
+    def test_legacy_conversations_table_migrates_in_place(self):
+        """A pre-existing conversations table without the session_id
+        column must be migrated transparently when ResponseStore is
+        re-opened, not crash."""
+        import tempfile, os, sqlite3 as _sqlite3
+        with tempfile.TemporaryDirectory() as td:
+            db_path = os.path.join(td, "resp.db")
+            # Build the old (pre-#16517) schema.
+            conn = _sqlite3.connect(db_path)
+            conn.execute(
+                "CREATE TABLE responses (response_id TEXT PRIMARY KEY, data TEXT NOT NULL, accessed_at REAL NOT NULL)"
+            )
+            conn.execute(
+                "CREATE TABLE conversations (name TEXT PRIMARY KEY, response_id TEXT NOT NULL)"
+            )
+            conn.execute(
+                "INSERT INTO conversations (name, response_id) VALUES (?, ?)",
+                ("old-chat", "resp_old"),
+            )
+            conn.commit()
+            conn.close()
+
+            store = ResponseStore(max_size=10, db_path=db_path)
+            # Migration adds the column without dropping the row.
+            assert store.get_conversation("old-chat") == "resp_old"
+            assert store.get_session_id_for_conversation("old-chat") is None
+            # Subsequent writes can populate it.
+            store.set_conversation("old-chat", "resp_new", session_id="sess_zzz")
+            assert store.get_session_id_for_conversation("old-chat") == "sess_zzz"
+
 
 # ---------------------------------------------------------------------------
 # _IdempotencyCache
@@ -2208,6 +2287,129 @@ class TestConversationParameter:
                 assert resp.status == 200
                 # Conversation mapping should NOT be set since store=false
                 assert adapter._response_store.get_conversation("ephemeral-chat") is None
+
+    # ── issue #16517: cold-start with conversation= reuses existing session_id ──
+
+    @pytest.mark.asyncio
+    async def test_first_turn_persists_session_id_on_conversations_row(self, adapter):
+        """After the first turn the slug → session_id mapping must be
+        queryable via the new helper, not just the response_id mapping."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {"final_response": "hi", "messages": [], "api_calls": 1},
+                    {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+                )
+                resp = await cli.post("/v1/responses", json={
+                    "input": "hello",
+                    "conversation": "sticky-chat",
+                })
+                assert resp.status == 200
+                stored_sid = adapter._response_store.get_session_id_for_conversation("sticky-chat")
+                assert stored_sid is not None
+                # And it matches the session_id the agent was actually invoked with.
+                first_call = mock_run.call_args_list[0]
+                kwargs = first_call.kwargs
+                assert kwargs.get("session_id") == stored_sid
+
+    @pytest.mark.asyncio
+    async def test_second_turn_after_lru_eviction_reuses_session_id(self, adapter):
+        """Regression for #16517. When the responses LRU evicts the previous
+        response_id, a follow-up request keyed by the same conversation slug
+        must continue the *same* state.db session_id instead of minting a
+        fresh fork."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {"final_response": "first", "messages": [], "api_calls": 1},
+                    {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+                )
+                # First turn establishes the slug → session_id row.
+                resp1 = await cli.post("/v1/responses", json={
+                    "input": "hello",
+                    "conversation": "persistent-chat",
+                })
+                assert resp1.status == 200
+                first_session_id = mock_run.call_args_list[0].kwargs["session_id"]
+                first_response_id = (await resp1.json())["id"]
+
+                # Simulate LRU eviction (or gateway restart with a smaller
+                # cache) by manually deleting the responses row while
+                # leaving the conversations row intact.
+                adapter._response_store._conn.execute(
+                    "DELETE FROM responses WHERE response_id = ?", (first_response_id,)
+                )
+                adapter._response_store._conn.commit()
+                assert adapter._response_store.get(first_response_id) is None
+
+                # Second turn keyed by slug must continue the SAME session.
+                mock_run.return_value = (
+                    {"final_response": "second", "messages": [], "api_calls": 1},
+                    {"input_tokens": 20, "output_tokens": 10, "total_tokens": 30},
+                )
+                resp2 = await cli.post("/v1/responses", json={
+                    "input": "are you still there",
+                    "conversation": "persistent-chat",
+                })
+                assert resp2.status == 200, await resp2.text()
+                second_session_id = mock_run.call_args_list[1].kwargs["session_id"]
+                assert second_session_id == first_session_id
+
+    @pytest.mark.asyncio
+    async def test_unknown_slug_with_evicted_response_returns_404(self, adapter):
+        """If the response_id was evicted AND the slug has no session_id
+        mapping (legacy row from before this fix), preserve the existing
+        404 behavior — don't silently swallow the missing reference."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            # Seed a conversations row pointing to a never-existed response_id
+            # without a session_id (simulates pre-#16517 row).
+            adapter._response_store._conn.execute(
+                "INSERT INTO conversations (name, response_id, session_id) VALUES (?, ?, ?)",
+                ("legacy-chat", "resp_evicted_xyz", None),
+            )
+            adapter._response_store._conn.commit()
+            resp = await cli.post("/v1/responses", json={
+                "input": "hello",
+                "conversation": "legacy-chat",
+            })
+            assert resp.status == 404
+
+    @pytest.mark.asyncio
+    async def test_brand_new_slug_still_mints_fresh_session_id(self, adapter):
+        """A genuinely new conversation must still get a fresh session_id.
+        Regression guard: the slug fallback should only fire when there's
+        actually a stored session_id for the slug."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {"final_response": "hi", "messages": [], "api_calls": 1},
+                    {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+                )
+                resp = await cli.post("/v1/responses", json={
+                    "input": "first time here",
+                    "conversation": "brand-new-slug",
+                })
+                assert resp.status == 200
+                # Got a real UUID-shaped session_id, not None / empty.
+                sid = mock_run.call_args_list[0].kwargs["session_id"]
+                assert sid and len(sid) >= 8
+
+    @pytest.mark.asyncio
+    async def test_previous_response_id_path_still_404s_on_eviction(self, adapter):
+        """Direct previous_response_id (no conversation slug) still 404s
+        when the row is evicted — we don't have anywhere to look up the
+        session, so the original behavior is preserved."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/v1/responses", json={
+                "input": "hello",
+                "previous_response_id": "resp_does_not_exist_anywhere",
+            })
+            assert resp.status == 404
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #16517 — `POST /v1/responses` with `{conversation: <slug>, ...}` was minting a brand-new state.db `session_id` whenever the in-memory `_response_store` no longer held the previous `response_id` (gateway restart, LRU eviction, process recycle). Result: N independent root sessions per logical conversation, each carrying a slice of the messages, with no `parent_session_id` linking them.

This PR makes the conversation slug a first-class continuity key: the slug → `session_id` mapping is now persisted on the `conversations` table itself, so cold-start requests continue the existing session even after the LRU forgets the response_id.

## Decision: Option 1 (slug → session reuse) over Option 2 (parent_session_id linkage)

The issue offered three paths. Option 1 — "look up the latest session_id for `conversation=<slug>` via the conversations table and reuse it" — is the cleanest because:

- It preserves the invariant the issue actually wants: **one logical conversation = one row in `sessions`**.
- It avoids the cross-walking work for sidebar UIs / drawer dedup / search CTEs (those still keep their `parent_session_id` walkers for the compression-rotation case at `run_agent.py:7580`).
- The `conversations` table already exists; we just needed one more column. No new tables, no schema rework.

Option 2 (linking via `parent_session_id`) was tempting (cheaper at the call site) but it leaves the "N rows per conversation" pathology in place — clients still have to dedup. That's exactly the workaround the issue is trying to eliminate.

Option 3 (document as intentional) didn't fit: `run_agent.py:7580` already sets `parent_session_id` for the compression-rotation fork case, so the lack of linkage on cold-start is clearly an inconsistency, not a deliberate design.

## Root cause

```
conversations:  name → response_id
responses:      response_id → { ..., "session_id": "<sess>", ... }   ← LRU bounded
```

The `session_id` only lived inside `responses.data` (JSON blob). Once an LRU eviction (or restart with a smaller cache) dropped the `responses` row, the cold-start path at `gateway/platforms/api_server.py:1694` fell through to `session_id = stored_session_id or str(uuid.uuid4())` with `stored_session_id=None`, and a fresh fork was born.

## Fix

### Schema

`conversations` gains a `session_id TEXT` column. Existing databases are migrated transparently with an idempotent `ALTER TABLE ... ADD COLUMN session_id TEXT` that swallows the duplicate-column `OperationalError` on already-migrated DBs.

### `ResponseStore` API

```python
# New
def get_session_id_for_conversation(self, name: str) -> Optional[str]: ...

# Extended (old call signature remains valid)
def set_conversation(
    self,
    name: str,
    response_id: str,
    session_id: Optional[str] = None,
) -> None: ...
```

### `/v1/responses` handler

- Compute a `slug_session_id_hint` at the top of the handler (single query, costs nothing on slug-less requests).
- When `previous_response_id` is unresolvable AND the request was keyed by `conversation`, fall back to the slug-only `session_id` lookup instead of returning 404. Logged at `INFO` level so operators see when the fallback fires.
- When `previous_response_id` was provided directly (no slug), preserve the existing 404 — there's no slug to fall back to and silently swallowing it would mask client bugs.
- `session_id = stored_session_id or slug_session_id_hint or str(uuid.uuid4())` — a brand-new slug still gets a fresh UUID (no behavior change for first-time conversations).
- All `set_conversation(...)` call sites now pass `session_id=session_id` so the column gets populated on every chain advance.

### Behavior

| Scenario | Before | After |
|---|---|---|
| `conversation=foo`, first turn | Mint new session_id (unchanged) | Mint new session_id, **persist on conversations row** |
| `conversation=foo`, second turn, response_id intact | Reuse session_id via responses.data | Reuse via responses.data (unchanged) |
| `conversation=foo`, second turn, **response_id evicted** | 404 / new fork | **Reuse same session_id from conversations.session_id** |
| `previous_response_id=evicted_id` (no slug) | 404 | 404 (unchanged) |
| `conversation=foo`, legacy row from before this fix (no session_id column populated) | N/A | 404 (no fallback path; client falls back to a fresh slug) |
| Brand-new slug | New session_id | New session_id (unchanged) |

## Tests

11 new tests in `tests/gateway/test_api_server.py`, all green. **130/130 tests in the file pass** after the change.

`TestResponseStore` (6 new):
- `set_conversation` persists `session_id` on the row.
- `session_id` survives LRU eviction of the underlying responses row.
- `get_session_id_for_conversation` returns `None` for unknown slugs.
- The old 2-arg `set_conversation(name, response_id)` call signature still works (backwards compat).
- `set_conversation` overwrites `session_id` correctly on chain advance.
- A legacy `conversations` table without the `session_id` column migrates in place without crashing.

`TestConversationParameter` (5 new):
- First turn populates the new column.
- Second turn **after manually evicting the responses row** continues the same `session_id` (the regression).
- Legacy slug with no `session_id` mapping still 404s (no silent regression of the explicit error).
- Brand-new slug still mints a fresh `session_id`.
- Direct `previous_response_id` path with no slug still 404s on eviction.

```
$ pytest tests/gateway/test_api_server.py -q
130 passed, 79 warnings in 2.71s
```

## Migration / compatibility

- **Online databases**: the `ALTER TABLE` runs on every `ResponseStore.__init__()`. The first time it runs against an existing DB, the column is added; subsequent runs hit the duplicate-column branch and no-op. Zero downtime.
- **Legacy `conversations` rows** that pre-date the migration have `session_id = NULL`. Those rows fall back to the existing 404 — no silent recovery, no crash. Clients that hit one of those will simply get fresh sessions on their next request, which is the same outcome they get today.
- **Old call sites** that still pass `set_conversation(name, response_id)` without `session_id=` keep working. They just don't benefit from the new fallback.
