### PR TITLE
feat(plugins): palace-discipline — mechanical context injection

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -20,6 +20,7 @@ from agent.skill_utils import (
     extract_skill_description,
     get_all_skills_dirs,
     get_disabled_skill_names,
+    get_skills_lazy_load_config,
     iter_skill_index_files,
     parse_frontmatter,
     skill_matches_platform,
@@ -681,6 +682,15 @@ def build_skills_system_prompt(
         or ""
     )
     disabled = get_disabled_skill_names()
+    # Session 16 lazy-load: when skills.lazy_load is True in config.yaml,
+    # restrict the bulk skills index to ``skills.always_load`` (pinned core).
+    # Other skills remain discoverable via ``skills_list`` / ``skill_view``
+    # and the ``skills.semantic_search`` MCP tool. Saves ~125k tokens
+    # per session by removing the ~55-skill bulk index from the system
+    # prompt. When lazy_load is False (default), behavior is unchanged.
+    _lazy_cfg = get_skills_lazy_load_config()
+    _lazy_load = bool(_lazy_cfg.get("lazy_load", False))
+    _always_load = set(_lazy_cfg.get("always_load") or set())
     cache_key = (
         str(skills_dir.resolve()),
         tuple(str(d) for d in external_dirs),
@@ -688,6 +698,8 @@ def build_skills_system_prompt(
         tuple(sorted(str(ts) for ts in (available_toolsets or set()))),
         _platform_hint,
         tuple(sorted(disabled)),
+        _lazy_load,
+        tuple(sorted(_always_load)),
     )
     with _SKILLS_PROMPT_CACHE_LOCK:
         cached = _SKILLS_PROMPT_CACHE.get(cache_key)
@@ -714,6 +726,12 @@ def build_skills_system_prompt(
                 continue
             if frontmatter_name in disabled or skill_name in disabled:
                 continue
+            # Session 16 lazy-load filter (snapshot path).
+            if _lazy_load and _always_load and (
+                frontmatter_name not in _always_load
+                and skill_name not in _always_load
+            ):
+                continue
             if not _skill_should_show(
                 entry.get("conditions") or {},
                 available_tools,
@@ -738,6 +756,12 @@ def build_skills_system_prompt(
                 continue
             skill_name = entry["skill_name"]
             if entry["frontmatter_name"] in disabled or skill_name in disabled:
+                continue
+            # Session 16 lazy-load filter (cold path).
+            if _lazy_load and _always_load and (
+                entry["frontmatter_name"] not in _always_load
+                and skill_name not in _always_load
+            ):
                 continue
             if not _skill_should_show(
                 extract_skill_conditions(frontmatter),
@@ -793,6 +817,12 @@ def build_skills_system_prompt(
                 if frontmatter_name in seen_skill_names:
                     continue
                 if frontmatter_name in disabled or skill_name in disabled:
+                    continue
+                # Session 16 lazy-load filter (external dirs path).
+                if _lazy_load and _always_load and (
+                    frontmatter_name not in _always_load
+                    and skill_name not in _always_load
+                ):
                     continue
                 if not _skill_should_show(
                     extract_skill_conditions(frontmatter),

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -168,6 +168,54 @@ def _normalize_string_set(values) -> Set[str]:
     return {str(v).strip() for v in values if str(v).strip()}
 
 
+# ── Lazy skill loading (Session 16 / memory-palace embed DB) ─────────────
+
+
+def get_skills_lazy_load_config() -> Dict[str, Any]:
+    """Read the ``skills.lazy_load``, ``skills.always_load`` and
+    ``skills.semantic_top_k`` fields from config.yaml.
+
+    Returns a dict with:
+      - ``lazy_load`` (bool, default False): when True, the bulk skills
+        index in the system prompt is filtered down to ``always_load``
+        — saving ~125k tokens per session. Other skills remain
+        discoverable on demand via the ``skills.semantic_search`` MCP
+        tool and ``skills_list`` / ``skill_view``.
+      - ``always_load`` (Set[str]): pinned-core skills that always appear
+        in the bulk index. Names match SKILL.md frontmatter ``name``.
+      - ``semantic_top_k`` (int, default 5): hint for callers using the
+        ``skills.semantic_search`` MCP tool.
+
+    Reads config directly to keep this helper lightweight (matches
+    ``get_disabled_skill_names`` pattern).
+    """
+    out: Dict[str, Any] = {
+        "lazy_load": False,
+        "always_load": set(),
+        "semantic_top_k": 5,
+    }
+    config_path = get_config_path()
+    if not config_path.exists():
+        return out
+    try:
+        parsed = yaml_load(config_path.read_text(encoding="utf-8"))
+    except Exception as e:
+        logger.debug("Could not read lazy-load config %s: %s", config_path, e)
+        return out
+    if not isinstance(parsed, dict):
+        return out
+    skills_cfg = parsed.get("skills")
+    if not isinstance(skills_cfg, dict):
+        return out
+    out["lazy_load"] = bool(skills_cfg.get("lazy_load", False))
+    out["always_load"] = _normalize_string_set(skills_cfg.get("always_load"))
+    try:
+        out["semantic_top_k"] = int(skills_cfg.get("semantic_top_k", 5) or 5)
+    except (TypeError, ValueError):
+        out["semantic_top_k"] = 5
+    return out
+
+
 # ── External skills directories ──────────────────────────────────────────
 
 

--- a/plugins/palace-discipline/__init__.py
+++ b/plugins/palace-discipline/__init__.py
@@ -1,0 +1,505 @@
+"""palace-discipline plugin — mechanical palace context injection.
+
+Fires on ``pre_gateway_dispatch`` (a single hook fired per incoming
+``MessageEvent`` BEFORE auth/pairing and BEFORE the model sees the
+user message). For every fresh user-originated message the plugin:
+
+1. Calls ``memory.init`` (HTTP ``POST /sessions/init``) on the local
+   memory-palace MCP service to refresh active session state.
+2. Infers the session type from the user's message keywords using the
+   table in ``CLAUDE.md`` § Session Inference.
+3. Loads the type-specific prompt via ``GET /prompts/<type>``.
+4. If the platform is Discord, additionally loads
+   ``GET /prompts/discord-delivery`` (delivery rules: MEDIA:/path
+   syntax, no third-party uploads, send-once).
+5. Runs two semantic searches in parallel (``GET /search/semantic``
+   with corpus=skills and corpus=palace) on the user's message.
+6. Prepends a single combined ``<palace_context>...</palace_context>``
+   block to ``event.text`` and returns ``{"action": "rewrite",
+   "text": ...}`` so the dispatcher carries the enriched message
+   through normal processing.
+
+Quality bars (mandated by the Session 18 brief):
+
+* **Idempotent** per ``(platform, chat_id, conversation_id)``. A
+  duplicate ``pre_gateway_dispatch`` for the same conversation in a
+  short window does NOT re-inject (re-injection would double-load
+  context and confuse the model).
+* **Fast** — total wall-clock budget 2 s under healthy MCP, hard
+  timeout 5 s (per request 1.5 s; capped via the executor).
+* **Failure-tolerant** — any MCP failure (network, 5xx, missing file)
+  is logged at WARNING and the plugin returns ``None`` so the
+  dispatcher proceeds with the original event.text. A broken MCP must
+  NEVER block Hermes.
+* **Observable** — every fire writes one line to
+  ``$HERMES_HOME/logs/palace-discipline.log`` describing what was
+  injected (or why it was skipped/degraded).
+
+Disable-able via ``plugins.disabled: [palace-discipline]`` in
+``$HERMES_HOME/config.yaml`` — the plugin loader honors that and the
+hook never fires. Rollback to pre-Session-18 behavior is one line.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+import urllib.error
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeout
+from pathlib import Path
+from threading import Lock
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Tunables
+# ---------------------------------------------------------------------------
+
+MCP_BASE_URL = os.environ.get("PALACE_MCP_URL", "http://127.0.0.1:7411")
+BEARER_TOKEN_PATH = Path(
+    os.environ.get(
+        "PALACE_MCP_BEARER_PATH",
+        str(Path.home() / ".config" / "memory-palace" / "bearer-token"),
+    )
+)
+
+PER_REQUEST_TIMEOUT_SEC = 1.5
+TOTAL_BUDGET_SEC = 5.0
+
+SKILLS_K = 5
+CANON_K = 3
+
+# Idempotency: cache "already-injected" conversation keys for this many
+# seconds. Within the window, a duplicate pre_gateway_dispatch returns
+# None (no rewrite). 30 minutes covers a typical multi-turn conversation
+# while still letting a long pause re-inject fresh context.
+IDEMPOTENCY_WINDOW_SEC = 30 * 60
+
+LOG_DIR = Path.home() / ".hermes" / "logs"
+LOG_FILE = LOG_DIR / "palace-discipline.log"
+
+# ---------------------------------------------------------------------------
+# Session-type inference
+# ---------------------------------------------------------------------------
+
+# Lower-case, whole-word matching. First match wins. Order matters:
+# system-correction is checked BEFORE implementation because phrases like
+# "fix the protocol" should route to system-correction, not implementation.
+TYPE_KEYWORDS: List[Tuple[str, List[str]]] = [
+    # System-correction first: "tighten this rule" must beat
+    # implementation's generic "fix " / "update".
+    ("system-correction", [
+        "tighten", "update the rule", "fix the protocol",
+        "fix the rule", "correct the protocol", "tighten this",
+        "update claude.md",
+    ]),
+    # Research before triage: "research X options" should be research,
+    # not triage. The leading verb "research" / "look into" etc. is the
+    # strong signal.
+    ("research", [
+        "research", "look into", "evaluate", "compare", "best ",
+        "deep dive", "investigate",
+    ]),
+    ("triage", [
+        "what's next", "whats next", "what should i", "priorities",
+        "what's on the docket", "whats on the docket", "options",
+        "what to work on",
+    ]),
+    ("design", [
+        "design", "spec ", "spec the", "brainstorm", "figure out how",
+        "plan how", "architecture for",
+    ]),
+    ("verification", [
+        "verify", "check ", "confirm", "is it live", "is it up",
+        "make sure", "validate",
+    ]),
+    ("communication", [
+        "draft ", "draft an", "draft a", "email", "write to",
+        "prep for", "compose",
+    ]),
+    ("ingestion", [
+        "ingest", "file this", "capture this", "extract from",
+        "process this", "save this",
+    ]),
+    ("implementation", [
+        "build ", "implement", "fix ", "add ", "wire up",
+        "ship ", "patch ", "refactor", "create the",
+    ]),
+]
+
+DEFAULT_TYPE = "triage"
+
+
+def _infer_session_type(text: str) -> str:
+    """Return the inferred session type for a user message.
+
+    Lower-cased substring match against TYPE_KEYWORDS in order. Default
+    is `triage` per CLAUDE.md ("If the request is empty or ambiguous,
+    default to triage").
+    """
+    if not text:
+        return DEFAULT_TYPE
+    lo = text.lower()
+    for stype, keywords in TYPE_KEYWORDS:
+        for kw in keywords:
+            if kw in lo:
+                return stype
+    return DEFAULT_TYPE
+
+
+# ---------------------------------------------------------------------------
+# MCP HTTP client — minimal, urllib-only, no external deps
+# ---------------------------------------------------------------------------
+
+_bearer_cache: Dict[str, str] = {}
+
+
+def _bearer_token() -> Optional[str]:
+    """Read the bearer token from disk; cached after first read."""
+    key = str(BEARER_TOKEN_PATH)
+    if key in _bearer_cache:
+        return _bearer_cache[key]
+    try:
+        token = BEARER_TOKEN_PATH.read_text().strip()
+        if token:
+            _bearer_cache[key] = token
+            return token
+    except OSError as exc:
+        logger.warning("palace-discipline: bearer token read failed: %s", exc)
+    return None
+
+
+def _http_request(
+    method: str,
+    path: str,
+    body: Optional[Dict[str, Any]] = None,
+    timeout: float = PER_REQUEST_TIMEOUT_SEC,
+) -> Optional[Dict[str, Any]]:
+    """Issue a single HTTP request to the local MCP service.
+
+    Returns the decoded JSON dict on success, or ``None`` on any
+    failure (network error, non-2xx status, malformed body). Never
+    raises — the caller treats a ``None`` as a graceful skip.
+    """
+    url = f"{MCP_BASE_URL.rstrip('/')}{path}"
+    data = None
+    headers = {"Accept": "application/json"}
+    token = _bearer_token()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(url, data=data, method=method, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:  # nosec - localhost only
+            payload = resp.read()
+            if not payload:
+                return {}
+            try:
+                return json.loads(payload.decode("utf-8"))
+            except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+                logger.warning(
+                    "palace-discipline: %s %s — bad JSON: %s", method, path, exc
+                )
+                return None
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        logger.warning(
+            "palace-discipline: %s %s failed: %s", method, path, exc
+        )
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Idempotency cache
+# ---------------------------------------------------------------------------
+
+_inject_lock = Lock()
+_inject_seen: Dict[str, float] = {}  # conversation_key -> last-fired ts
+
+
+def _conversation_key(event: Any) -> str:
+    """Stable per-conversation key for idempotency.
+
+    Falls back through whatever the event exposes — message_id is too
+    granular (changes every turn), so we key on platform+chat_id which
+    represents one conversation thread.
+    """
+    source = getattr(event, "source", None)
+    platform = "unknown"
+    chat = "unknown"
+    if source is not None:
+        platform = getattr(source.platform, "value", str(source.platform))
+        chat = getattr(source, "chat_id", "") or "unknown"
+    return f"{platform}:{chat}"
+
+
+def _already_injected(key: str) -> bool:
+    """Return True if ``key`` was injected within IDEMPOTENCY_WINDOW_SEC."""
+    now = time.time()
+    with _inject_lock:
+        last = _inject_seen.get(key)
+        if last is not None and (now - last) < IDEMPOTENCY_WINDOW_SEC:
+            return True
+        _inject_seen[key] = now
+        # Opportunistic GC: drop entries older than 4x the window.
+        cutoff = now - (4 * IDEMPOTENCY_WINDOW_SEC)
+        stale = [k for k, ts in _inject_seen.items() if ts < cutoff]
+        for k in stale:
+            _inject_seen.pop(k, None)
+    return False
+
+
+def _reset_idempotency_for_tests() -> None:
+    """Clear the idempotency cache. Used by the test suite only."""
+    with _inject_lock:
+        _inject_seen.clear()
+    _bearer_cache.clear()
+
+
+# ---------------------------------------------------------------------------
+# Observability
+# ---------------------------------------------------------------------------
+
+def _audit(line: str) -> None:
+    """Append a single line to the plugin's audit log.
+
+    Best-effort — log failures must not affect the message pipeline.
+    """
+    try:
+        LOG_DIR.mkdir(parents=True, exist_ok=True)
+        ts = time.strftime("%Y-%m-%dT%H:%M:%S%z")
+        with LOG_FILE.open("a", encoding="utf-8") as fh:
+            fh.write(f"{ts} {line}\n")
+    except OSError:
+        pass  # never block on logging
+
+
+# ---------------------------------------------------------------------------
+# Hook implementation
+# ---------------------------------------------------------------------------
+
+def _platform_value(event: Any) -> str:
+    src = getattr(event, "source", None)
+    if src is None:
+        return ""
+    plat = getattr(src, "platform", None)
+    return getattr(plat, "value", str(plat or ""))
+
+
+def _is_discord(event: Any) -> bool:
+    return _platform_value(event).lower() == "discord"
+
+
+def _format_skills_block(hits: List[Dict[str, Any]]) -> str:
+    if not hits:
+        return ""
+    lines = ["<relevant_skills>"]
+    for h in hits:
+        path = h.get("path", "?")
+        snippet = (h.get("snippet") or "").strip()
+        lines.append(f"- {path}: {snippet}")
+    lines.append("</relevant_skills>")
+    return "\n".join(lines)
+
+
+def _format_canon_block(hits: List[Dict[str, Any]]) -> str:
+    if not hits:
+        return ""
+    lines = ["<relevant_canon>"]
+    for h in hits:
+        path = h.get("path", "?")
+        snippet = (h.get("snippet") or "").strip()
+        lines.append(f"- {path}: {snippet}")
+    lines.append("</relevant_canon>")
+    return "\n".join(lines)
+
+
+def _build_context_block(
+    init_payload: Optional[Dict[str, Any]],
+    type_prompt: Optional[Dict[str, Any]],
+    discord_prompt: Optional[Dict[str, Any]],
+    skills_hits: List[Dict[str, Any]],
+    canon_hits: List[Dict[str, Any]],
+    inferred_type: str,
+) -> str:
+    sections: List[str] = ["<palace_context>"]
+    sections.append(f"<inferred_session_type>{inferred_type}</inferred_session_type>")
+    if init_payload:
+        sections.append("<memory_init>")
+        # init payload is sessions package output; truncate defensively
+        s = json.dumps(init_payload, ensure_ascii=False)
+        sections.append(s[:4000])
+        sections.append("</memory_init>")
+    if type_prompt and isinstance(type_prompt.get("body"), str):
+        sections.append(f"<session_type_prompt type='{inferred_type}'>")
+        sections.append(type_prompt["body"].strip())
+        sections.append("</session_type_prompt>")
+    if discord_prompt and isinstance(discord_prompt.get("body"), str):
+        sections.append("<discord_delivery_rules>")
+        sections.append(discord_prompt["body"].strip())
+        sections.append("</discord_delivery_rules>")
+    skills_block = _format_skills_block(skills_hits)
+    if skills_block:
+        sections.append(skills_block)
+    canon_block = _format_canon_block(canon_hits)
+    if canon_block:
+        sections.append(canon_block)
+    sections.append("</palace_context>")
+    return "\n".join(sections)
+
+
+def _gather_context(
+    user_text: str,
+    inferred_type: str,
+    want_discord: bool,
+) -> Tuple[
+    Optional[Dict[str, Any]],
+    Optional[Dict[str, Any]],
+    Optional[Dict[str, Any]],
+    List[Dict[str, Any]],
+    List[Dict[str, Any]],
+]:
+    """Run the four MCP calls in parallel, respecting TOTAL_BUDGET_SEC."""
+    deadline = time.time() + TOTAL_BUDGET_SEC
+
+    def _init() -> Optional[Dict[str, Any]]:
+        return _http_request("POST", "/sessions/init", body={})
+
+    def _prompt(t: str) -> Optional[Dict[str, Any]]:
+        return _http_request("GET", f"/prompts/{t}")
+
+    def _search_skills() -> Optional[Dict[str, Any]]:
+        from urllib.parse import quote
+        return _http_request(
+            "GET",
+            f"/search/semantic?q={quote(user_text)}&corpus=skills&k={SKILLS_K}",
+        )
+
+    def _search_canon() -> Optional[Dict[str, Any]]:
+        from urllib.parse import quote
+        return _http_request(
+            "GET",
+            f"/search/semantic?q={quote(user_text)}&corpus=palace&k={CANON_K}",
+        )
+
+    init_payload: Optional[Dict[str, Any]] = None
+    type_prompt: Optional[Dict[str, Any]] = None
+    discord_prompt: Optional[Dict[str, Any]] = None
+    skills_hits: List[Dict[str, Any]] = []
+    canon_hits: List[Dict[str, Any]] = []
+
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        f_init = pool.submit(_init)
+        f_type = pool.submit(_prompt, inferred_type)
+        f_discord = pool.submit(_prompt, "discord-delivery") if want_discord else None
+        f_skills = pool.submit(_search_skills)
+        f_canon = pool.submit(_search_canon)
+
+        def _await(fut, label: str) -> Optional[Dict[str, Any]]:
+            if fut is None:
+                return None
+            remaining = max(0.05, deadline - time.time())
+            try:
+                return fut.result(timeout=remaining)
+            except FutureTimeout:
+                logger.warning("palace-discipline: %s timed out", label)
+                return None
+            except Exception as exc:  # pylint: disable=broad-except
+                logger.warning("palace-discipline: %s raised: %s", label, exc)
+                return None
+
+        init_payload = _await(f_init, "memory.init")
+        type_prompt = _await(f_type, f"prompts/{inferred_type}")
+        discord_prompt = _await(f_discord, "prompts/discord-delivery")
+        skills_resp = _await(f_skills, "search/semantic skills")
+        canon_resp = _await(f_canon, "search/semantic palace")
+
+    if isinstance(skills_resp, dict):
+        skills_hits = list(skills_resp.get("results") or [])
+    if isinstance(canon_resp, dict):
+        canon_hits = list(canon_resp.get("results") or [])
+
+    return init_payload, type_prompt, discord_prompt, skills_hits, canon_hits
+
+
+def on_pre_gateway_dispatch(*, event: Any, gateway: Any = None,
+                            session_store: Any = None) -> Optional[Dict[str, Any]]:
+    """Hook entry point.
+
+    Returns a dict ``{"action": "rewrite", "text": <enriched_text>}`` to
+    have the dispatcher continue with the augmented message, or ``None``
+    to leave the event unchanged (degraded path / idempotent skip /
+    empty message / disabled).
+    """
+    text = (getattr(event, "text", None) or "").strip()
+    if not text:
+        return None  # nothing to enrich
+
+    key = _conversation_key(event)
+    if _already_injected(key):
+        _audit(f"skip-idempotent key={key}")
+        return None
+
+    inferred_type = _infer_session_type(text)
+    want_discord = _is_discord(event)
+
+    t0 = time.time()
+    try:
+        init_payload, type_prompt, discord_prompt, skills_hits, canon_hits = (
+            _gather_context(text, inferred_type, want_discord)
+        )
+    except Exception as exc:  # pylint: disable=broad-except
+        logger.warning("palace-discipline: gather_context crashed: %s", exc)
+        _audit(f"degraded key={key} reason=gather_crash err={exc!r}")
+        return None
+    elapsed_ms = int((time.time() - t0) * 1000)
+
+    # If literally everything failed, don't inject an empty wrapper —
+    # that's pure noise. Degrade silently.
+    if (
+        init_payload is None
+        and type_prompt is None
+        and discord_prompt is None
+        and not skills_hits
+        and not canon_hits
+    ):
+        _audit(
+            f"degraded key={key} type={inferred_type} elapsed_ms={elapsed_ms} "
+            f"reason=all-mcp-failed"
+        )
+        return None
+
+    block = _build_context_block(
+        init_payload, type_prompt, discord_prompt,
+        skills_hits, canon_hits, inferred_type,
+    )
+
+    new_text = f"{block}\n\n{text}"
+    _audit(
+        f"injected key={key} type={inferred_type} discord={want_discord} "
+        f"init={'y' if init_payload else 'n'} "
+        f"type_prompt={'y' if type_prompt else 'n'} "
+        f"discord_prompt={'y' if discord_prompt else 'n'} "
+        f"skills_hits={len(skills_hits)} canon_hits={len(canon_hits)} "
+        f"elapsed_ms={elapsed_ms} block_chars={len(block)}"
+    )
+    return {"action": "rewrite", "text": new_text}
+
+
+# ---------------------------------------------------------------------------
+# Plugin entry point
+# ---------------------------------------------------------------------------
+
+def register(ctx) -> None:
+    """Register the pre_gateway_dispatch callback."""
+    ctx.register_hook("pre_gateway_dispatch", on_pre_gateway_dispatch)
+    logger.info(
+        "palace-discipline: registered pre_gateway_dispatch hook "
+        "(MCP=%s, idempotency=%ds)",
+        MCP_BASE_URL, IDEMPOTENCY_WINDOW_SEC,
+    )

--- a/plugins/palace-discipline/plugin.yaml
+++ b/plugins/palace-discipline/plugin.yaml
@@ -1,0 +1,6 @@
+name: palace-discipline
+version: 0.1.0
+description: "Mechanical palace discipline: injects memory.init context, type-prompt, Discord-delivery prompt (when applicable), top-K skills, and top-K canon hits BEFORE Hermes sees the user message. Hook fires on pre_gateway_dispatch and rewrites event.text. Failure-tolerant: any MCP error logs a warning and degrades silently."
+author: "Alberto (memory-palace Session 18)"
+hooks:
+  - pre_gateway_dispatch

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -1084,8 +1084,104 @@ class TestOpenAIModelExecutionGuidance:
 
 
 # =========================================================================
-# Budget warning history stripping
+# Session 16: lazy skill loading via skills.lazy_load + skills.always_load
 # =========================================================================
 
 
+class TestLazyLoadGate:
+    """When ``skills.lazy_load: true`` in config.yaml, the bulk skills
+    index in the system prompt is restricted to ``skills.always_load``
+    (pinned core). Other skills remain discoverable via ``skills_list``,
+    ``skill_view``, and the ``skills.semantic_search`` MCP tool.
 
+    Default behavior (lazy_load absent or False) is preserved exactly —
+    upstream consumers see no change.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clear_skills_cache(self):
+        from agent.prompt_builder import clear_skills_system_prompt_cache
+        clear_skills_system_prompt_cache(clear_snapshot=True)
+        yield
+        clear_skills_system_prompt_cache(clear_snapshot=True)
+
+    def _seed_skills(self, tmp_path):
+        skills_dir = tmp_path / "skills"
+        for name, desc in [
+            ("hermes-agent", "Hermes self-knowledge"),
+            ("claude-code", "Claude Code interop"),
+            ("systematic-debugging", "Debug systematically"),
+            ("random-skill-a", "Some other skill A"),
+            ("random-skill-b", "Some other skill B"),
+        ]:
+            d = skills_dir / "core" / name
+            d.mkdir(parents=True, exist_ok=True)
+            (d / "SKILL.md").write_text(
+                f"---\nname: {name}\ndescription: {desc}\n---\nbody\n"
+            )
+
+    def test_lazy_load_off_keeps_all_skills(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        self._seed_skills(tmp_path)
+        # No config file → lazy_load defaults to False.
+        result = build_skills_system_prompt()
+        assert "hermes-agent" in result
+        assert "random-skill-a" in result
+        assert "random-skill-b" in result
+
+    def test_lazy_load_on_filters_to_always_load(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        self._seed_skills(tmp_path)
+        (tmp_path / "config.yaml").write_text(
+            "skills:\n"
+            "  lazy_load: true\n"
+            "  always_load:\n"
+            "    - hermes-agent\n"
+            "    - claude-code\n"
+            "    - systematic-debugging\n"
+            "  semantic_top_k: 5\n"
+        )
+        result = build_skills_system_prompt()
+        assert "hermes-agent" in result
+        assert "claude-code" in result
+        assert "systematic-debugging" in result
+        # The non-pinned skills are filtered out.
+        assert "random-skill-a" not in result
+        assert "random-skill-b" not in result
+
+    def test_lazy_load_on_with_empty_always_load_keeps_all(self, monkeypatch, tmp_path):
+        """Safety: if always_load is empty, do NOT silently strip every
+        skill — that would be more disruptive than not enabling lazy
+        load. Behavior matches lazy_load=False."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        self._seed_skills(tmp_path)
+        (tmp_path / "config.yaml").write_text(
+            "skills:\n"
+            "  lazy_load: true\n"
+            "  always_load: []\n"
+        )
+        result = build_skills_system_prompt()
+        assert "hermes-agent" in result
+        assert "random-skill-a" in result
+
+    def test_get_skills_lazy_load_config_defaults(self, monkeypatch, tmp_path):
+        from agent.skill_utils import get_skills_lazy_load_config
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        cfg = get_skills_lazy_load_config()
+        assert cfg["lazy_load"] is False
+        assert cfg["always_load"] == set()
+        assert cfg["semantic_top_k"] == 5
+
+    def test_get_skills_lazy_load_config_parsed(self, monkeypatch, tmp_path):
+        from agent.skill_utils import get_skills_lazy_load_config
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            "skills:\n"
+            "  lazy_load: true\n"
+            "  always_load: [hermes-agent, claude-code]\n"
+            "  semantic_top_k: 7\n"
+        )
+        cfg = get_skills_lazy_load_config()
+        assert cfg["lazy_load"] is True
+        assert cfg["always_load"] == {"hermes-agent", "claude-code"}
+        assert cfg["semantic_top_k"] == 7

--- a/tests/plugins/palace-discipline/test_palace_discipline.py
+++ b/tests/plugins/palace-discipline/test_palace_discipline.py
@@ -1,0 +1,321 @@
+"""Tests for the palace-discipline plugin (Session 18).
+
+Exercises:
+
+* Session-type inference (keyword routing).
+* Hook injection happy path (MCP responses present → rewrite returned).
+* Idempotency (second fire on same conversation_id within window → no rewrite).
+* Failure tolerance (every MCP call fails → no rewrite, never raises).
+* Discord-specific path (additionally loads discord-delivery prompt).
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Module loader — the plugin lives at plugins/palace-discipline/__init__.py.
+# pytest can't normally import a path with a hyphen as a package, so we load
+# it manually and register it under a clean module name.
+# ---------------------------------------------------------------------------
+
+_PLUGIN_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "plugins" / "palace-discipline" / "__init__.py"
+)
+
+
+@pytest.fixture(scope="module")
+def plugin():
+    """Load the palace-discipline plugin module by file path."""
+    spec = importlib.util.spec_from_file_location(
+        "palace_discipline_under_test", _PLUGIN_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["palace_discipline_under_test"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(autouse=True)
+def _reset_state(plugin):
+    """Reset per-test state on the loaded plugin."""
+    plugin._reset_idempotency_for_tests()
+    yield
+    plugin._reset_idempotency_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakePlatform:
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+
+class _FakeSource:
+    def __init__(self, platform_value: str = "discord", chat_id: str = "c1") -> None:
+        self.platform = _FakePlatform(platform_value)
+        self.chat_id = chat_id
+
+
+class _FakeEvent:
+    def __init__(self, text: str, platform: str = "discord", chat_id: str = "c1") -> None:
+        self.text = text
+        self.source = _FakeSource(platform, chat_id)
+
+
+def _ok_prompt(t: str) -> dict:
+    return {"type": t, "body": f"## Body for {t}\nLine 2."}
+
+
+def _ok_search(corpus: str, k: int) -> dict:
+    return {
+        "corpus": corpus,
+        "query": "q",
+        "k": k,
+        "results": [
+            {
+                "id": f"{corpus}-{i}",
+                "path": f"{corpus}/file{i}.md",
+                "chunk": 0,
+                "distance": 0.1 * i,
+                "snippet": f"snippet {corpus} {i}",
+            }
+            for i in range(min(2, k))
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Session-type inference
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "msg,expected",
+    [
+        ("what's on the docket today?", "triage"),
+        ("priorities for today?", "triage"),
+        ("research best vector DB options", "research"),
+        ("look into nomic embeddings", "research"),
+        ("design the new auth flow", "design"),
+        ("verify the deploy is live", "verification"),
+        ("draft an email to Adam", "communication"),
+        ("ingest this transcript", "ingestion"),
+        ("build the new API endpoint", "implementation"),
+        ("fix the bug in plugin loader", "implementation"),
+        ("tighten the session close protocol", "system-correction"),
+        ("update the rule about commits", "system-correction"),
+        ("hi there", "triage"),  # default fallback
+        ("", "triage"),
+    ],
+)
+def test_session_type_inference(plugin, msg, expected):
+    assert plugin._infer_session_type(msg) == expected
+
+
+# ---------------------------------------------------------------------------
+# Happy path — Discord conversation
+# ---------------------------------------------------------------------------
+
+
+def test_hook_happy_path_discord(plugin):
+    """Every MCP call succeeds; hook returns rewrite with all blocks."""
+
+    def fake_request(method, path, body=None, timeout=None):
+        if path == "/sessions/init":
+            return {"session": "2026-04-27", "ok": True}
+        if path == "/prompts/triage":
+            return _ok_prompt("triage")
+        if path == "/prompts/discord-delivery":
+            return _ok_prompt("discord-delivery")
+        if path.startswith("/search/semantic") and "corpus=skills" in path:
+            return _ok_search("skills", plugin.SKILLS_K)
+        if path.startswith("/search/semantic") and "corpus=palace" in path:
+            return _ok_search("palace", plugin.CANON_K)
+        return None
+
+    with mock.patch.object(plugin, "_http_request", side_effect=fake_request):
+        evt = _FakeEvent("what's on the docket today?", platform="discord")
+        result = plugin.on_pre_gateway_dispatch(event=evt)
+
+    assert result is not None
+    assert result["action"] == "rewrite"
+    text = result["text"]
+    # Required blocks
+    assert "<palace_context>" in text
+    assert "<inferred_session_type>triage</inferred_session_type>" in text
+    assert "<memory_init>" in text
+    assert "<session_type_prompt type='triage'>" in text
+    assert "<discord_delivery_rules>" in text
+    assert "<relevant_skills>" in text
+    assert "<relevant_canon>" in text
+    # Original message preserved at the end
+    assert text.rstrip().endswith("what's on the docket today?")
+
+
+def test_hook_non_discord_skips_discord_prompt(plugin):
+    """Telegram conversation → no discord-delivery prompt loaded."""
+    discord_prompt_calls = []
+
+    def fake_request(method, path, body=None, timeout=None):
+        if path == "/sessions/init":
+            return {"ok": True}
+        if path == "/prompts/research":
+            return _ok_prompt("research")
+        if path == "/prompts/discord-delivery":
+            discord_prompt_calls.append(path)
+            return _ok_prompt("discord-delivery")
+        if path.startswith("/search/semantic"):
+            return _ok_search(
+                "skills" if "skills" in path else "palace", 3
+            )
+        return None
+
+    with mock.patch.object(plugin, "_http_request", side_effect=fake_request):
+        evt = _FakeEvent("research the best embedding model", platform="telegram")
+        result = plugin.on_pre_gateway_dispatch(event=evt)
+
+    assert result is not None
+    text = result["text"]
+    assert "<discord_delivery_rules>" not in text
+    assert "<inferred_session_type>research</inferred_session_type>" in text
+    assert discord_prompt_calls == []  # never requested
+
+
+# ---------------------------------------------------------------------------
+# Idempotency
+# ---------------------------------------------------------------------------
+
+
+def test_hook_is_idempotent_per_conversation(plugin):
+    """Second fire for same (platform, chat_id) within window → no rewrite."""
+
+    def fake_request(method, path, body=None, timeout=None):
+        if path == "/sessions/init":
+            return {"ok": True}
+        if path.startswith("/prompts/"):
+            return _ok_prompt(path.rsplit("/", 1)[-1])
+        if path.startswith("/search/semantic"):
+            return _ok_search(
+                "skills" if "skills" in path else "palace", 3
+            )
+        return None
+
+    with mock.patch.object(plugin, "_http_request", side_effect=fake_request):
+        evt = _FakeEvent("priorities for today", platform="discord", chat_id="c-same")
+        first = plugin.on_pre_gateway_dispatch(event=evt)
+        second = plugin.on_pre_gateway_dispatch(event=evt)
+
+    assert first is not None and first["action"] == "rewrite"
+    assert second is None  # idempotent skip
+
+
+def test_hook_different_chats_inject_independently(plugin):
+    """Distinct chat_ids → both inject."""
+
+    def fake_request(method, path, body=None, timeout=None):
+        if path == "/sessions/init":
+            return {"ok": True}
+        if path.startswith("/prompts/"):
+            return _ok_prompt(path.rsplit("/", 1)[-1])
+        return _ok_search("skills" if "skills" in path else "palace", 3)
+
+    with mock.patch.object(plugin, "_http_request", side_effect=fake_request):
+        a = plugin.on_pre_gateway_dispatch(
+            event=_FakeEvent("priorities", platform="discord", chat_id="A")
+        )
+        b = plugin.on_pre_gateway_dispatch(
+            event=_FakeEvent("priorities", platform="discord", chat_id="B")
+        )
+    assert a is not None and b is not None
+
+
+# ---------------------------------------------------------------------------
+# Failure tolerance
+# ---------------------------------------------------------------------------
+
+
+def test_hook_returns_none_when_all_mcp_fails(plugin):
+    """Every MCP call returns None → hook returns None (degraded silently)."""
+    with mock.patch.object(plugin, "_http_request", return_value=None):
+        evt = _FakeEvent("what's next", platform="discord")
+        result = plugin.on_pre_gateway_dispatch(event=evt)
+    assert result is None
+
+
+def test_hook_does_not_raise_when_mcp_call_throws(plugin):
+    """If the underlying request raises, the hook still returns gracefully."""
+    def boom(*args, **kwargs):
+        raise RuntimeError("simulated network blow-up")
+
+    with mock.patch.object(plugin, "_http_request", side_effect=boom):
+        evt = _FakeEvent("what's next", platform="discord")
+        # Must not raise.
+        result = plugin.on_pre_gateway_dispatch(event=evt)
+    # Either degraded (None) or — if exception is wrapped per-future — still
+    # a None outcome. We don't care which path; we care that it doesn't raise.
+    assert result is None
+
+
+def test_hook_partial_success_still_injects(plugin):
+    """If only some MCP calls succeed, build the block from what we got."""
+
+    def fake_request(method, path, body=None, timeout=None):
+        if path == "/prompts/triage":
+            return _ok_prompt("triage")
+        # Everything else fails.
+        return None
+
+    with mock.patch.object(plugin, "_http_request", side_effect=fake_request):
+        evt = _FakeEvent("priorities for today", platform="discord")
+        result = plugin.on_pre_gateway_dispatch(event=evt)
+
+    assert result is not None
+    text = result["text"]
+    assert "<session_type_prompt type='triage'>" in text
+    assert "<memory_init>" not in text  # init failed
+    assert "<relevant_skills>" not in text  # search failed
+    assert "<relevant_canon>" not in text  # search failed
+
+
+# ---------------------------------------------------------------------------
+# Empty-message guard
+# ---------------------------------------------------------------------------
+
+
+def test_hook_skips_empty_message(plugin):
+    evt = _FakeEvent("   ", platform="discord")
+    assert plugin.on_pre_gateway_dispatch(event=evt) is None
+
+
+# ---------------------------------------------------------------------------
+# register() wiring
+# ---------------------------------------------------------------------------
+
+
+def test_register_wires_hook(plugin):
+    """register(ctx) calls ctx.register_hook with the correct name."""
+    calls = []
+
+    class _Ctx:
+        def register_hook(self, name, callback):
+            calls.append((name, callback))
+
+    plugin.register(_Ctx())
+    assert len(calls) == 1
+    assert calls[0][0] == "pre_gateway_dispatch"
+    assert calls[0][1] is plugin.on_pre_gateway_dispatch


### PR DESCRIPTION
## Summary

New plugin `plugins/palace-discipline/` that registers on `pre_gateway_dispatch` and mechanically injects palace context into every incoming user message BEFORE Hermes sees it.

Per-message flow:
1. `POST /sessions/init` → memory-palace MCP refreshes active session state
2. Infers session type from message keywords (CLAUDE.md table)
3. `GET /prompts/<type>` → loads the type-specific behavioural prompt
4. If platform is Discord, also `GET /prompts/discord-delivery`
5. Two parallel `GET /search/semantic` calls (corpus=skills k=5, corpus=palace k=3) on the user's text
6. Prepends a single `<palace_context>...</palace_context>` block to `event.text` and returns `{"action": "rewrite", "text": ...}`

## Why

Session 15 Phase B (memory-palace 2026-04-27) disproved that prose-level mandates in SOUL.md ("call memory.init first") are followed reliably across models. The hook is mechanical — the model never has the option to skip it. Closes the actual goal: audit-quality autonomous agent on natural channels (Discord/voice).

## Quality bars

- **Idempotent** per (platform, chat_id) within a 30-min window — duplicate `pre_gateway_dispatch` within window does NOT re-inject
- **Fast**: per-request 1.5 s timeout, total budget 5 s, four MCP calls parallelised via `ThreadPoolExecutor`
- **Failure-tolerant**: any MCP failure logs WARNING and degrades silently — Hermes is NEVER blocked
- **Observable**: every fire writes one line to `~/.hermes/logs/palace-discipline.log`

## Rollback

Disable via `plugins.disabled: [palace-discipline]` in `~/.hermes/config.yaml`. Pre-Session-18 behavior is one config line away.

## Tests (23 passing)

- Keyword routing for all 8 session types + default fallback
- Happy-path Discord injection asserting every block present
- Non-Discord conversations skip discord-delivery prompt entirely
- Idempotency within a conversation; independence across chat_ids
- Total MCP failure → no rewrite (degraded)
- Partial MCP success → still injects what worked
- Raising callables → no propagation
- Empty-message guard
- `register()` wiring

## Test plan
- [x] `pytest tests/plugins/palace-discipline/` green (23 passed)
- [ ] CI green
- [ ] Auto-merge on green

🤖 Generated with [Claude Code](https://claude.com/claude-code)