### PR TITLE
fix(transport): emit deepseek-v4 thinking.type and reasoning_effort on non-OpenRouter routes

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -188,7 +188,17 @@ class ChatCompletionsTransport(ProviderTransport):
         anthropic_max_out = params.get("anthropic_max_output")
         is_nvidia_nim = params.get("is_nvidia_nim", False)
         is_kimi = params.get("is_kimi", False)
+        _model_lower = params.get("model_lower") or (model or "").lower()
+        is_deepseek_v4 = _model_lower.startswith("deepseek-v4")
         reasoning_config = params.get("reasoning_config")
+        _ds_thinking_off = bool(
+            reasoning_config
+            and isinstance(reasoning_config, dict)
+            and (
+                reasoning_config.get("enabled") is False
+                or (reasoning_config.get("effort") or "").strip().lower() == "none"
+            )
+        )
 
         if ephemeral is not None and max_tokens_fn:
             api_kwargs.update(max_tokens_fn(ephemeral))
@@ -219,6 +229,16 @@ class ChatCompletionsTransport(ProviderTransport):
                         _kimi_effort = _e
                 api_kwargs["reasoning_effort"] = _kimi_effort
 
+        # DeepSeek V4: top-level reasoning_effort (xhigh→max, others→high)
+        if is_deepseek_v4:
+            if not _ds_thinking_off:
+                _ds_effort = "high"
+                if reasoning_config and isinstance(reasoning_config, dict):
+                    _e = (reasoning_config.get("effort") or "").strip().lower()
+                    if _e == "xhigh":
+                        _ds_effort = "max"
+                api_kwargs["reasoning_effort"] = _ds_effort
+
         # extra_body assembly
         extra_body: Dict[str, Any] = {}
 
@@ -240,8 +260,14 @@ class ChatCompletionsTransport(ProviderTransport):
                 "type": "enabled" if _kimi_thinking_enabled else "disabled",
             }
 
+        # DeepSeek V4: extra_body.thinking
+        if is_deepseek_v4:
+            extra_body["thinking"] = {
+                "type": "enabled" if not _ds_thinking_off else "disabled",
+            }
+
         # Reasoning
-        if params.get("supports_reasoning", False):
+        if params.get("supports_reasoning", False) and not is_deepseek_v4:
             if is_github_models:
                 gh_reasoning = params.get("github_reasoning_extra")
                 if gh_reasoning is not None:

--- a/run_agent.py
+++ b/run_agent.py
@@ -7854,6 +7854,10 @@ class AIAgent:
                 return bool(github_model_reasoning_efforts(self.model))
             except Exception:
                 return False
+        # DeepSeek V4 series: supports reasoning_effort + thinking via any route
+        if self.model and self.model.lower().startswith("deepseek-v4"):
+            return True
+
         if "openrouter" not in self._base_url_lower:
             return False
         if "api.mistral.ai" in self._base_url_lower:
@@ -9346,13 +9350,28 @@ class AIAgent:
             _summary_temperature = None if _omit_summary_temperature else _raw_summary_temp
             _is_nous = "nousresearch" in self._base_url_lower
             if self._supports_reasoning_extra_body():
-                if self.reasoning_config is not None:
-                    summary_extra_body["reasoning"] = self.reasoning_config
-                else:
-                    summary_extra_body["reasoning"] = {
-                        "enabled": True,
-                        "effort": "medium"
+                _model_lower = (self.model or "").lower()
+                if _model_lower.startswith("deepseek-v4"):
+                    # DeepSeek V4 uses thinking.type, not the generic reasoning object
+                    _ds_thinking_off = (
+                        self.reasoning_config is not None
+                        and isinstance(self.reasoning_config, dict)
+                        and (
+                            self.reasoning_config.get("enabled") is False
+                            or (self.reasoning_config.get("effort") or "").strip().lower() == "none"
+                        )
+                    )
+                    summary_extra_body["thinking"] = {
+                        "type": "enabled" if not _ds_thinking_off else "disabled",
                     }
+                else:
+                    if self.reasoning_config is not None:
+                        summary_extra_body["reasoning"] = self.reasoning_config
+                    else:
+                        summary_extra_body["reasoning"] = {
+                            "enabled": True,
+                            "effort": "medium"
+                        }
             if _is_nous:
                 summary_extra_body["tags"] = ["product=hermes-agent"]
 

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -241,6 +241,91 @@ class TestChatCompletionsKimi:
         )
         assert kw["extra_body"]["thinking"] == {"type": "disabled"}
 
+
+class TestChatCompletionsDeepSeek:
+    """DeepSeek V4 thinking mode — reasoning_effort + thinking.type support."""
+
+    def test_deepseek_v4_reasoning_effort_top_level(self, transport):
+        kw = transport.build_kwargs(
+            model="deepseek-v4-pro", messages=[{"role": "user", "content": "Hi"}],
+            model_lower="deepseek-v4-pro",
+            reasoning_config={"effort": "high"},
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        assert kw["reasoning_effort"] == "high"
+
+    def test_deepseek_v4_reasoning_effort_xhigh_maps_to_max(self, transport):
+        kw = transport.build_kwargs(
+            model="deepseek-v4-pro", messages=[{"role": "user", "content": "Hi"}],
+            model_lower="deepseek-v4-pro",
+            reasoning_config={"effort": "xhigh"},
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        assert kw["reasoning_effort"] == "max"
+
+    def test_deepseek_v4_reasoning_effort_omitted_when_thinking_disabled(self, transport):
+        kw = transport.build_kwargs(
+            model="deepseek-v4-pro", messages=[{"role": "user", "content": "Hi"}],
+            model_lower="deepseek-v4-pro",
+            reasoning_config={"enabled": False},
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        assert "reasoning_effort" not in kw
+
+    def test_deepseek_v4_thinking_enabled_extra_body(self, transport):
+        kw = transport.build_kwargs(
+            model="deepseek-v4-pro", messages=[{"role": "user", "content": "Hi"}],
+            model_lower="deepseek-v4-pro",
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        assert kw["extra_body"]["thinking"] == {"type": "enabled"}
+
+    def test_deepseek_v4_thinking_disabled_extra_body(self, transport):
+        kw = transport.build_kwargs(
+            model="deepseek-v4-pro", messages=[{"role": "user", "content": "Hi"}],
+            model_lower="deepseek-v4-pro",
+            reasoning_config={"enabled": False},
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        assert kw["extra_body"]["thinking"] == {"type": "disabled"}
+
+    def test_deepseek_v4_thinking_disabled_by_effort_none(self, transport):
+        """reasoning_config={'effort': 'none'} also disables thinking."""
+        kw = transport.build_kwargs(
+            model="deepseek-v4-pro", messages=[{"role": "user", "content": "Hi"}],
+            model_lower="deepseek-v4-pro",
+            reasoning_config={"effort": "none"},
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        assert "reasoning_effort" not in kw
+        assert kw["extra_body"]["thinking"] == {"type": "disabled"}
+
+    def test_deepseek_v4_no_generic_reasoning_extra_body(self, transport):
+        """DeepSeek V4 must NOT get extra_body.reasoning (uses thinking.type instead)."""
+        kw = transport.build_kwargs(
+            model="deepseek-v4-pro", messages=[{"role": "user", "content": "Hi"}],
+            model_lower="deepseek-v4-pro",
+            supports_reasoning=True,
+            reasoning_config={"effort": "high"},
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        assert "reasoning" not in kw.get("extra_body", {})
+
+    def test_deepseek_chat_not_affected(self, transport):
+        """deepseek-chat (V2/V3) must still get generic reasoning, not thinking.type."""
+        kw = transport.build_kwargs(
+            model="deepseek-chat", messages=[{"role": "user", "content": "Hi"}],
+            model_lower="deepseek-chat",
+            supports_reasoning=True,
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        assert "thinking" not in kw.get("extra_body", {})
+        assert kw["extra_body"]["reasoning"] == {"enabled": True, "effort": "medium"}
+
+
+class TestChatCompletionsKimi_Moonshot:
+    """Moonshot/Kimi tool sanitization tests."""
+
     def test_moonshot_tool_schemas_are_sanitized_by_model_name(self, transport):
         """Aggregator routes (Nous, OpenRouter) hit Moonshot by model name, not base URL."""
         tools = [


### PR DESCRIPTION
## What does this PR do?

Add DeepSeek V4 thinking mode support that works through **any route** (direct `api.deepseek.com`, opencode-go, or other OpenAI-compatible relays), not just OpenRouter.

Currently `_supports_reasoning_extra_body()` gates on base_url containing `"openrouter"`, which silently drops `reasoning_config` for direct DeepSeek connections and opencode-go. This PR makes `reasoning_effort` and `thinking.type` actually reach the API.

## Related Issue

Fixes #15717

Related to #14958, #15251 — those PRs correct the detection gate but stop at `run_agent.py`. This PR completes the pipeline end-to-end.

## Type of Change

- [x] 🐛 Bug fix (reasoning_effort was silently dropped for non-OpenRouter routes)
- [x] ✨ New feature (DeepSeek V4 thinking mode via any route)

## Changes Made

**`run_agent.py`** — `_supports_reasoning_extra_body()` (1 line)
- Detect DeepSeek V4 models by name prefix (`deepseek-v4`), so routes like opencode-go (`opencode.ai/zen/go/v1`) and any future relay can enable thinking.

**`agent/transports/chat_completions.py`** — `build_kwargs()` (28 lines)
- New `is_deepseek_v4` branch, modelled after the existing `is_kimi` handling
- Top-level `reasoning_effort` with effort mapping: `xhigh` → `max`, others → `high`
- `extra_body["thinking"] = {"type": "enabled"/"disabled"}` — DeepSeek-native format
- Exclude DeepSeek V4 from the generic `extra_body["reasoning"]` path to avoid format conflict

**`tests/agent/transports/test_chat_completions.py`** — 7 new tests
- `reasoning_effort` top-level (high, xhigh→max, disabled→omitted)
- `extra_body.thinking` enabled/disabled
- No stray `extra_body.reasoning` for V4
- `deepseek-chat` (V2/V3) untouched — regression guard

## How to Test

1. Configure a DeepSeek V4 model without OpenRouter (e.g. `provider: opencode-go`, `base_url: https://opencode.ai/zen/go/v1`, `reasoning_effort: xhigh`)
2. Start a session and ask a reasoning-intensive question
3. Verify the API request includes `reasoning_effort: "max"` and `extra_body: {"thinking": {"type": "enabled"}}`

Or run the transport-level unit tests:
```bash
python -m pytest tests/agent/transports/test_chat_completions.py -k "deepseek" -v
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs (#14958, #15251, #15577) — this PR takes a different approach (model-name gating + transport-level handling, no new config parameter)
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/agent/transports/test_chat_completions.py` — 48/48 passing (41 existing + 7 new)
- [x] I've added tests for my changes
- [x] I've tested on Arch Linux (Hyprland)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` — or N/A
- [x] I've considered cross-platform impact — or N/A

## Why this approach

Existing PRs (#14958, #15251) add `is_deepseek` detection in `run_agent.py` but don't touch `build_kwargs()` — so the transport still emits OpenRouter-style `extra_body["reasoning"]` format. #15577 introduces a unified `thinking_mode` parameter framework.

This PR takes the minimal path: 

- **No new config parameter** — reuses the existing `reasoning_config` flow
- **Model-name-based gating** — works for opencode-go, direct API, and any future relay
- **Scoped to V4 only** — `deepseek-v4*` prefix match; `deepseek-chat` / `deepseek-reasoner` (legacy) are untouched
- **Follows existing patterns** — the code structure mirrors `is_kimi` handling, keeping the transport predictable
