### PR TITLE
fix(gateway): preserve thread metadata on reset notice

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -639,6 +639,22 @@ class GatewayRunner:
     _stop_task: Optional[asyncio.Task] = None
     _session_model_overrides: Dict[str, Dict[str, str]] = {}
     _session_reasoning_overrides: Dict[str, Dict[str, Any]] = {}
+
+    @staticmethod
+    def _send_metadata_for_source(event: MessageEvent, source: SessionSource) -> Optional[Dict[str, Any]]:
+        """Build platform send metadata while preserving the session thread.
+
+        Some gateway-originated notifications are sent while handling a
+        ``MessageEvent`` that may not carry platform metadata.  In threaded
+        platforms (Telegram forum topics, Discord threads, Slack threads), the
+        stable thread context lives on ``SessionSource.thread_id``.  Preserve any
+        incoming metadata, but derive ``thread_id`` from the session source when
+        available so notifications stay in the originating thread/topic.
+        """
+        metadata = getattr(event, "metadata", None) or {}
+        if getattr(source, "thread_id", None):
+            metadata = {**metadata, "thread_id": source.thread_id}
+        return metadata or None
     
     def __init__(self, config: Optional[GatewayConfig] = None):
         self.config = config or load_gateway_config()
@@ -4512,7 +4528,7 @@ class GatewayRunner:
                             pass
                         await adapter.send(
                             source.chat_id, notice,
-                            metadata=getattr(event, 'metadata', None),
+                            metadata=self._send_metadata_for_source(event, source),
                         )
             except Exception as e:
                 logger.debug("Auto-reset notification failed (non-fatal): %s", e)

--- a/tests/gateway/test_send_metadata_for_source.py
+++ b/tests/gateway/test_send_metadata_for_source.py
@@ -1,0 +1,45 @@
+from types import SimpleNamespace
+
+from gateway.platforms.base import Platform, SessionSource
+from gateway.run import GatewayRunner
+
+
+def _source(thread_id):
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="user-1",
+        chat_id="chat-1",
+        thread_id=thread_id,
+    )
+
+
+def test_send_metadata_for_source_preserves_source_thread_without_event_metadata():
+    event = SimpleNamespace()
+
+    metadata = GatewayRunner._send_metadata_for_source(event, _source("17585"))
+
+    assert metadata == {"thread_id": "17585"}
+
+
+def test_send_metadata_for_source_keeps_existing_metadata_and_overrides_thread():
+    event = SimpleNamespace(metadata={"thread_id": "stale", "parse_mode": "Markdown"})
+
+    metadata = GatewayRunner._send_metadata_for_source(event, _source("17585"))
+
+    assert metadata == {"thread_id": "17585", "parse_mode": "Markdown"}
+
+
+def test_send_metadata_for_source_preserves_existing_metadata_without_thread():
+    event = SimpleNamespace(metadata={"parse_mode": "Markdown"})
+
+    metadata = GatewayRunner._send_metadata_for_source(event, _source(None))
+
+    assert metadata == {"parse_mode": "Markdown"}
+
+
+def test_send_metadata_for_source_returns_none_without_metadata_or_thread():
+    event = SimpleNamespace()
+
+    metadata = GatewayRunner._send_metadata_for_source(event, _source(None))
+
+    assert metadata is None


### PR DESCRIPTION
## Summary
- Preserve session `thread_id` when sending gateway-originated reset notifications
- Keep existing send metadata while deriving thread context from `SessionSource`
- Add regression tests for metadata construction behavior

## Test Plan
- `python3 -m py_compile gateway/run.py tests/gateway/test_send_metadata_for_source.py`
- `python3 -m pytest tests/gateway/test_send_metadata_for_source.py -q`
