### PR TITLE
fix(compression): show main + aux model and provider in feasibility warning

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2423,7 +2423,10 @@ class AIAgent:
         if not self.compression_enabled:
             return
         try:
-            from agent.auxiliary_client import get_text_auxiliary_client
+            from agent.auxiliary_client import (
+                _resolve_task_provider_model,
+                get_text_auxiliary_client,
+            )
             from agent.model_metadata import (
                 MINIMUM_CONTEXT_LENGTH,
                 get_model_context_length,
@@ -2433,6 +2436,14 @@ class AIAgent:
                 "compression",
                 main_runtime=self._current_main_runtime(),
             )
+            # Best-effort aux provider label for the warning message. The
+            # configured provider may be "auto", in which case we fall back
+            # to the client's base_url hostname so the user can still tell
+            # where the compression model is actually being called.
+            try:
+                _aux_cfg_provider, _, _, _, _ = _resolve_task_provider_model("compression")
+            except Exception:
+                _aux_cfg_provider = ""
             if client is None or not aux_model:
                 msg = (
                     "⚠ No auxiliary LLM provider configured — context "
@@ -2499,10 +2510,37 @@ class AIAgent:
                         new_threshold / main_ctx
                     )
                 safe_pct = int((aux_context / main_ctx) * 100) if main_ctx else 50
+                # Build human-readable "model (provider)" labels for both
+                # the main model and the compression model so users can
+                # tell at a glance which provider each side is actually
+                # using. When the configured provider is empty or "auto",
+                # fall back to the client's base_url hostname.
+                _main_model = getattr(self, "model", "") or "?"
+                _main_provider = getattr(self, "provider", "") or ""
+                _aux_provider_label = (
+                    _aux_cfg_provider
+                    if _aux_cfg_provider and _aux_cfg_provider != "auto"
+                    else ""
+                )
+                if not _aux_provider_label:
+                    try:
+                        from urllib.parse import urlparse
+                        _aux_provider_label = (
+                            urlparse(aux_base_url).hostname or aux_base_url
+                        )
+                    except Exception:
+                        _aux_provider_label = aux_base_url or "auto"
+                _main_label = (
+                    f"{_main_model} ({_main_provider})"
+                    if _main_provider
+                    else _main_model
+                )
+                _aux_label = f"{aux_model} ({_aux_provider_label})"
                 msg = (
-                    f"⚠ Compression model ({aux_model}) context is "
-                    f"{aux_context:,} tokens, but the main model's "
-                    f"compression threshold was {old_threshold:,} tokens. "
+                    f"⚠ Compression model {_aux_label} context is "
+                    f"{aux_context:,} tokens, but the main model "
+                    f"{_main_label}'s compression threshold was "
+                    f"{old_threshold:,} tokens. "
                     f"Auto-lowered this session's threshold to "
                     f"{new_threshold:,} tokens so compression can run.\n"
                     f"  To make this permanent, edit config.yaml — either:\n"


### PR DESCRIPTION
## Summary
Compression feasibility warning now names both the main model and the compression model with their providers, so users can actually debug context-length mismatches.

## What was wrong
Previously the message only said `Compression model (stepfun/step-3.5-flash) context is 262,144 tokens, but the main model's compression threshold was 891,289 tokens.` When a user configures the same model slug for both main and aux, this reads like the same model has two different context windows — impossible to triage without more info. The real cause is usually a resolution divergence (OpenRouter catalog value for aux vs. a `model.context_length` override for main, or two different providers serving the same slug).

## After
```
⚠ Compression model stepfun/step-3.5-flash (openrouter.ai) context is 262,144 tokens, but the main model stepfun/step-3.5-flash (openrouter)'s compression threshold was 891,289 tokens. Auto-lowered this session's threshold to 262,144 tokens so compression can run.
```

## Changes
- `run_agent.py` `_check_compression_model_feasibility()`: import `_resolve_task_provider_model` to read the configured aux provider; build `model (provider)` labels for both sides; fall back to the client's base_url hostname when aux provider is `auto` or empty.

## Validation
- py_compile: passes
- Offline formatting smoke test confirms output for auto-aux and explicit-aux cases.