### PR TITLE
fix(feishu): prevent topic replies from spawning new threads

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2132,10 +2132,15 @@ class BasePlatformAdapter(ABC):
                 discard_pending=False,
             )
             if response:
+                _reply_anchor = (
+                    event.reply_to_message_id
+                    if event.source.platform == Platform.FEISHU and event.source.thread_id and event.reply_to_message_id
+                    else event.message_id
+                )
                 await self._send_with_retry(
                     chat_id=event.source.chat_id,
                     content=response,
-                    reply_to=event.message_id,
+                    reply_to=_reply_anchor,
                     metadata=thread_meta,
                 )
         except Exception:
@@ -2216,10 +2221,15 @@ class BasePlatformAdapter(ABC):
                     _thread_meta = {"thread_id": event.source.thread_id} if event.source.thread_id else None
                     response = await self._message_handler(event)
                     if response:
+                        _reply_anchor = (
+                            event.reply_to_message_id
+                            if event.source.platform == Platform.FEISHU and event.source.thread_id and event.reply_to_message_id
+                            else event.message_id
+                        )
                         await self._send_with_retry(
                             chat_id=event.source.chat_id,
                             content=response,
-                            reply_to=event.message_id,
+                            reply_to=_reply_anchor,
                             metadata=_thread_meta,
                         )
                 except Exception as e:
@@ -2399,10 +2409,15 @@ class BasePlatformAdapter(ABC):
                 # Send the text portion
                 if text_content:
                     logger.info("[%s] Sending response (%d chars) to %s", self.name, len(text_content), event.source.chat_id)
+                    _reply_anchor = (
+                        event.reply_to_message_id
+                        if event.source.platform == Platform.FEISHU and event.source.thread_id and event.reply_to_message_id
+                        else event.message_id
+                    )
                     result = await self._send_with_retry(
                         chat_id=event.source.chat_id,
                         content=text_content,
-                        reply_to=event.message_id,
+                        reply_to=_reply_anchor,
                         metadata=_thread_metadata,
                     )
                     _record_delivery(result)

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -2697,9 +2697,11 @@ class FeishuAdapter(BasePlatformAdapter):
             if hint:
                 text = f"{hint}\n\n{text}" if text else hint
 
+        thread_id = getattr(message, "thread_id", None) or getattr(message, "root_id", None) or None
         reply_to_message_id = (
             getattr(message, "parent_id", None)
             or getattr(message, "upper_message_id", None)
+            or getattr(message, "root_id", None)
             or None
         )
         reply_to_text = await self._fetch_message_text(reply_to_message_id) if reply_to_message_id else None
@@ -2723,7 +2725,7 @@ class FeishuAdapter(BasePlatformAdapter):
             chat_type=self._resolve_source_chat_type(chat_info=chat_info, event_chat_type=chat_type),
             user_id=sender_profile["user_id"],
             user_name=sender_profile["user_name"],
-            thread_id=getattr(message, "thread_id", None) or None,
+            thread_id=thread_id,
             user_id_alt=sender_profile["user_id_alt"],
         )
         normalized = MessageEvent(
@@ -4066,6 +4068,15 @@ class FeishuAdapter(BasePlatformAdapter):
                 if active_reply_to and not self._response_succeeded(response):
                     code = getattr(response, "code", None)
                     if code in _FEISHU_REPLY_FALLBACK_CODES:
+                        if (metadata or {}).get("thread_id"):
+                            logger.warning(
+                                "[Feishu] Reply to %s failed in thread %s (code %s — message withdrawn/missing); "
+                                "skipping top-level fallback to avoid creating a new topic",
+                                active_reply_to,
+                                (metadata or {}).get("thread_id"),
+                                code,
+                            )
+                            return response
                         logger.warning(
                             "[Feishu] Reply to %s failed (code %s — message withdrawn/missing); "
                             "falling back to new message in chat %s",


### PR DESCRIPTION
## Summary

When replying inside a **Feishu topic-enabled group chat**, the agent would create a new topic/thread instead of staying inside the current one. This breaks multi-agent workflows where several bots operate in parallel within the same group — replies "cross" into stray topics.

Two root causes:

1. **Inbound thread resolution** — `root_id` was not used as a fallback for `thread_id`. When Feishu didn't provide `thread_id` directly, thread context was silently lost.
2. **Reply failure fallback** — when a threaded reply failed (target withdrawn/deleted, API error codes `230011` / `231003`), the code fell back to `im.v1.message.create`. In topic-enabled groups this spawns a brand-new topic instead of staying in the thread.

## Changes

### `gateway/platforms/feishu.py` (+13 / −1)

- Resolve `thread_id` with `root_id` as fallback (`thread_id || root_id`)
- Add `root_id` to the `reply_to_message_id` fallback chain (`parent_id → upper_message_id → root_id`)
- **Guard the reply-to-create fallback**: when inside a thread (`metadata.thread_id` is set), skip the fallback and return the error response as-is — avoids spawning a new topic

### `gateway/platforms/base.py` (+21 / −3)

- In three outbound reply paths (command dispatch, inline bypass, main response delivery), prefer `event.reply_to_message_id` over `event.message_id` when:
  - Platform is Feishu **and**
  - Inside a thread (`event.source.thread_id`) **and**
  - `reply_to_message_id` is available
- This ensures the Feishu reply API targets the correct message within the topic card

## Test plan

- [ ] In a Feishu topic-enabled group, send a message inside an existing topic card — agent should reply **within the same topic**
- [ ] Send a longer request that takes minutes to process — agent should still reply within the topic
- [ ] Open multiple topics in parallel with different agents — replies should not cross into wrong topics
- [ ] Verify non-topic chats (DMs, non-topic groups) still work normally — the reply-to-create fallback should still apply there