### PR TITLE
fix(gateway): replace bash restart watcher with fcntl file-lock based Python process

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2056,7 +2056,6 @@ class GatewayRunner:
             pass
 
     async def _launch_detached_restart_command(self) -> None:
-        import shutil
         import subprocess
 
         hermes_cmd = _resolve_hermes_bin()
@@ -2064,27 +2063,58 @@ class GatewayRunner:
             logger.error("Could not locate hermes binary for detached /restart")
             return
 
-        current_pid = os.getpid()
-        cmd = " ".join(shlex.quote(part) for part in hermes_cmd)
-        shell_cmd = (
-            f"while kill -0 {current_pid} 2>/dev/null; do sleep 0.2; done; "
-            f"{cmd} gateway restart"
-        )
-        setsid_bin = shutil.which("setsid")
-        if setsid_bin:
-            subprocess.Popen(
-                [setsid_bin, "bash", "-lc", shell_cmd],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-                start_new_session=True,
-            )
+        # Instead of a bash wrapper (fragile: zombie PID can block kill -0
+        # forever, and the bash cmdline matches _scan_gateway_pids patterns),
+        # spawn a minimal Python process that blocks on the existing
+        # gateway.lock file lock.  fcntl.flock(LOCK_EX) is released atomically
+        # by the OS when the owning process exits — no PID polling, no
+        # zombie edge-case, no cmdline collision.
+        #
+        # After acquiring the lock, try to acquire it again non-blocking.
+        # If the lock is CLAIMABLE (no one else holds it), we're safe to
+        # restart.  If someone else claimed it in the meantime (another
+        # /restart or a manual restart beat us to it), exit silently.
+        import fcntl
+        try:
+            from gateway.status import _get_gateway_lock_path
+        except ImportError:
+            # Fallback: derive path the same way status.py does
+            lock_path = get_hermes_home() / "gateway.lock"
         else:
-            subprocess.Popen(
-                ["bash", "-lc", shell_cmd],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-                start_new_session=True,
-            )
+            lock_path = _get_gateway_lock_path()
+
+        cmd_repr = repr([str(p) for p in hermes_cmd] + ["gateway", "restart"])
+        lock_path_repr = repr(str(lock_path))
+
+        watcher_code = (
+            "import fcntl, os, subprocess, sys\n"
+            f"lock_path = {lock_path_repr}\n"
+            "# Block until the old gateway releases the file lock.\n"
+            "# flock(LOCK_EX) waits indefinitely — no timeout, no polling.\n"
+            "# The lock is released by the kernel when the owner process\n"
+            "# dies (even if it becomes a zombie, the lock goes away).\n"
+            "fd = os.open(lock_path, os.O_RDONLY)\n"
+            "fcntl.flock(fd, fcntl.LOCK_EX)\n"
+            "# Old gateway is gone.  Check if someone else already restarted\n"
+            "# by trying the lock non-blocking.  If we can't get it, someone\n"
+            "# else is already running — skip.\n"
+            "try:\n"
+            "    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)\n"
+            "    fcntl.flock(fd, fcntl.LOCK_UN)\n"
+            "except BlockingIOError:\n"
+            "    sys.exit(0)  # another gateway already running\n"
+            "finally:\n"
+            "    os.close(fd)\n"
+            f"subprocess.run({cmd_repr})\n"
+        )
+
+        subprocess.Popen(
+            [sys.executable, "-c", watcher_code],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
 
     def request_restart(self, *, detached: bool = False, via_service: bool = False) -> bool:
         if self._restart_task_started:

--- a/tests/gateway/test_restart_watcher.py
+++ b/tests/gateway/test_restart_watcher.py
@@ -1,0 +1,122 @@
+"""Tests for PR #16621: gateway restart watcher using fcntl file-lock."""
+
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from gateway.run import GatewayRunner
+
+
+@pytest.mark.asyncio
+async def test_launch_detached_restart_spawns_python_not_bash():
+    """The restart watcher must use Python+fcntl, not bash+kill -0."""
+    runner = object.__new__(GatewayRunner)
+    runner._background_tasks = set()
+
+    with (
+        patch("gateway.run._resolve_hermes_bin", return_value=["/usr/bin/hermes"]),
+        patch("subprocess.Popen") as mock_popen,
+        patch("gateway.status._get_gateway_lock_path", return_value="/tmp/gateway.lock"),
+        patch("gateway.run.logger"),
+    ):
+        await runner._launch_detached_restart_command()
+
+    mock_popen.assert_called_once()
+    args, kwargs = mock_popen.call_args
+    popen_cmd = args[0] if args else kwargs.get("args", [])
+
+    # The command should be Python, NOT bash
+    assert popen_cmd[0] == sys.executable, (
+        f"Expected Python ({sys.executable}), got {popen_cmd[0]}"
+    )
+    assert popen_cmd[1] == "-c", "Expected '-c' to run inline code"
+
+    watcher_code = popen_cmd[2]
+
+    # Must use fcntl.flock, not kill -0 polling
+    assert "fcntl.flock" in watcher_code, (
+        "Watcher must use fcntl.flock for lock-based waiting"
+    )
+    assert "kill -0" not in watcher_code, (
+        "Old bash kill -0 pattern must not be present"
+    )
+
+    # Must handle duplicate restart via non-blocking lock
+    assert "BlockingIOError" in watcher_code, (
+        "Watcher must handle duplicate restart via BlockingIOError"
+    )
+    assert "LOCK_NB" in watcher_code, (
+        "Watcher must use non-blocking lock (LOCK_NB) for dedup"
+    )
+
+    # Must run in a new session (detached)
+    assert kwargs.get("start_new_session") is True, (
+        "Watcher must run in a detached session"
+    )
+
+
+@pytest.mark.asyncio
+async def test_launch_detached_restart_no_bash_invocation():
+    """Verify no bash or setsid is invoked in the new watcher."""
+    runner = object.__new__(GatewayRunner)
+    runner._background_tasks = set()
+
+    with (
+        patch("gateway.run._resolve_hermes_bin", return_value=["/usr/bin/hermes"]),
+        patch("subprocess.Popen") as mock_popen,
+        patch("gateway.status._get_gateway_lock_path", return_value="/tmp/gateway.lock"),
+        patch("gateway.run.logger"),
+    ):
+        await runner._launch_detached_restart_command()
+
+    mock_popen.assert_called_once()
+    args, _ = mock_popen.call_args
+    popen_cmd = args[0]
+
+    # No bash anywhere in the command
+    for part in popen_cmd:
+        assert "bash" not in str(part), (
+            f"bash should not appear in restart command, found: {part}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_launch_detached_restart_graceful_missing_binary():
+    """Should return silently (no crash) when hermes binary is not found."""
+    runner = object.__new__(GatewayRunner)
+    runner._background_tasks = set()
+
+    with (
+        patch("gateway.run._resolve_hermes_bin", return_value=None),
+        patch("subprocess.Popen") as mock_popen,
+        patch("gateway.run.logger"),
+    ):
+        await runner._launch_detached_restart_command()
+
+    # Must NOT call subprocess.Popen when no binary
+    mock_popen.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_watcher_code_is_valid_python():
+    """The generated watcher code must be syntactically valid Python."""
+    runner = object.__new__(GatewayRunner)
+    runner._background_tasks = set()
+
+    with (
+        patch("gateway.run._resolve_hermes_bin", return_value=["/usr/bin/hermes"]),
+        patch("subprocess.Popen") as mock_popen,
+        patch("gateway.status._get_gateway_lock_path", return_value="/tmp/gateway.lock"),
+        patch("gateway.run.logger"),
+    ):
+        await runner._launch_detached_restart_command()
+
+    args, _ = mock_popen.call_args
+    watcher_code = args[0][2]
+
+    # Must compile without syntax errors
+    try:
+        compile(watcher_code, "<watcher>", "exec")
+    except SyntaxError as e:
+        pytest.fail(f"Watcher code has syntax error: {e}")


### PR DESCRIPTION
## What does this PR do?

Fix a `/restart` race condition in the messaging gateway. The old implementation spawned a detached `bash -c 'while kill -0 <pid>...'` wrapper that had two bugs in container environments: (1) zombie processes block `kill -0` forever, preventing restart; (2) the bash command line matched `_scan_gateway_pids()` grep patterns, causing the gateway to kill its own restart watcher. The fix replaces the bash wrapper with a minimal Python process that uses `fcntl.flock(LOCK_EX)` on the existing `gateway.lock` file — the kernel releases the lock atomically when the owning process dies (including zombies), eliminating both race conditions.

## Related Issue

Fixes #17576

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py` — `_launch_detached_restart_command()`:
  - **Removed**: bash wrapper (`while kill -0 <pid>; do sleep 0.2; done; hermes gateway restart`) and `shutil.which("setsid")` import
  - **Added**: Python watcher process that:
    1. Opens `gateway.lock` and blocks on `fcntl.flock(LOCK_EX)` — wait for old gateway to die (lock released by kernel on process exit, including zombies)
    2. Tries non-blocking `fcntl.flock(LOCK_EX | LOCK_NB)` — if held by another process, exits silently (another restart already in progress)
    3. Runs `hermes gateway restart` to start new gateway instance
- `tests/gateway/test_restart_watcher.py` — new: 4 tests covering watcher code generation, bash absence, missing binary, and syntax validation

## How to Test

1. Start gateway → send `/restart` → old gateway exits → watcher blocks on lock → new gateway starts
2. Start gateway → send `/restart` → send second `/restart` while watcher waits → second watcher finds lock claimed → exits silently (no duplicate gateway)
3. Simulate zombie: kill gateway with SIGSTOP then SIGKILL child → gateway becomes zombie → OS releases lock → watcher triggers restart (no zombie wait)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian 13 (Docker)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — this is a bug fix, not a new skill.

## Screenshots / Logs

N/A — no UI changes