### PR TITLE
fix(cli/tui): split MRU resume + actual exit session

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1057,9 +1057,10 @@ def _launch_tui(
     import tempfile
 
     env = os.environ.copy()
-    active_session_file = os.path.join(
-        tempfile.gettempdir(), f"hermes-tui-active-session-{os.getpid()}.json"
+    active_session_fd, active_session_file = tempfile.mkstemp(
+        prefix="hermes-tui-active-session-", suffix=".json"
     )
+    os.close(active_session_fd)
     env["HERMES_TUI_ACTIVE_SESSION_FILE"] = active_session_file
     env["HERMES_PYTHON_SRC_ROOT"] = os.environ.get(
         "HERMES_PYTHON_SRC_ROOT", str(PROJECT_ROOT)
@@ -1088,18 +1089,20 @@ def _launch_tui(
         env["HERMES_TUI_RESUME"] = resume_session_id
 
     argv, cwd = _make_tui_argv(tui_dir, tui_dev)
+    code: Optional[int] = None
     try:
-        code = subprocess.call(argv, cwd=str(cwd), env=env)
-    except KeyboardInterrupt:
-        code = 130
+        try:
+            code = subprocess.call(argv, cwd=str(cwd), env=env)
+        except KeyboardInterrupt:
+            code = 130
 
-    if code in (0, 130):
-        _print_tui_exit_summary(resume_session_id, active_session_file)
-
-    try:
-        os.unlink(active_session_file)
-    except OSError:
-        pass
+        if code in (0, 130):
+            _print_tui_exit_summary(resume_session_id, active_session_file)
+    finally:
+        try:
+            os.unlink(active_session_file)
+        except OSError:
+            pass
 
     sys.exit(code)
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -44,6 +44,7 @@ Usage:
 """
 
 import argparse
+import json
 import os
 import shutil
 import subprocess
@@ -759,9 +760,20 @@ def _resolve_session_by_name_or_id(name_or_id: str) -> Optional[str]:
     return None
 
 
-def _print_tui_exit_summary(session_id: Optional[str]) -> None:
+def _read_tui_active_session_file(path: Optional[str]) -> Optional[str]:
+    if not path:
+        return None
+    try:
+        data = json.loads(Path(path).read_text(encoding="utf-8"))
+        sid = str(data.get("session_id") or "").strip()
+        return sid or None
+    except Exception:
+        return None
+
+
+def _print_tui_exit_summary(session_id: Optional[str], active_session_file: Optional[str] = None) -> None:
     """Print a shell-visible epilogue after TUI exits."""
-    target = session_id or _resolve_last_session(source="tui")
+    target = _read_tui_active_session_file(active_session_file) or session_id or _resolve_last_session(source="tui")
     if not target:
         return
 
@@ -1036,7 +1048,13 @@ def _launch_tui(
     """Replace current process with the TUI."""
     tui_dir = PROJECT_ROOT / "ui-tui"
 
+    import tempfile
+
     env = os.environ.copy()
+    active_session_file = os.path.join(
+        tempfile.gettempdir(), f"hermes-tui-active-session-{os.getpid()}.json"
+    )
+    env["HERMES_TUI_ACTIVE_SESSION_FILE"] = active_session_file
     env["HERMES_PYTHON_SRC_ROOT"] = os.environ.get(
         "HERMES_PYTHON_SRC_ROOT", str(PROJECT_ROOT)
     )
@@ -1070,7 +1088,12 @@ def _launch_tui(
         code = 130
 
     if code in (0, 130):
-        _print_tui_exit_summary(resume_session_id)
+        _print_tui_exit_summary(resume_session_id, active_session_file)
+
+    try:
+        os.unlink(active_session_file)
+    except OSError:
+        pass
 
     sys.exit(code)
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -597,15 +597,21 @@ def _session_browse_picker(sessions: list) -> Optional[str]:
 
 def _resolve_last_session(source: str = "cli") -> Optional[str]:
     """Look up the most recently-used session ID for a source."""
+    db = None
     try:
         from hermes_state import SessionDB
 
         db = SessionDB()
         sessions = db.search_sessions(source=source, limit=1)
-        db.close()
         return sessions[0]["id"] if sessions else None
     except Exception:
         pass
+    finally:
+        if db is not None:
+            try:
+                db.close()
+            except Exception:
+                pass
     return None
 
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -595,15 +595,14 @@ def _session_browse_picker(sessions: list) -> Optional[str]:
 
 
 def _resolve_last_session(source: str = "cli") -> Optional[str]:
-    """Look up the most recent session ID for a source."""
+    """Look up the most recently-used session ID for a source."""
     try:
         from hermes_state import SessionDB
 
         db = SessionDB()
         sessions = db.search_sessions(source=source, limit=1)
         db.close()
-        if sessions:
-            return sessions[0]["id"]
+        return sessions[0]["id"] if sessions else None
     except Exception:
         pass
     return None

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1487,22 +1487,25 @@ class SessionDB:
         message timestamp for the session, falling back to ``started_at``),
         ordered by most-recently-used first.
         """
-        select_last_active = (
-            "COALESCE("
-            "(SELECT MAX(m.timestamp) FROM messages m WHERE m.session_id = s.id),"
-            " s.started_at"
-            ") AS last_active"
+        select_with_last_active = (
+            "SELECT s.*, COALESCE(m.last_active, s.started_at) AS last_active "
+            "FROM sessions s "
+            "LEFT JOIN ("
+            "SELECT session_id, MAX(timestamp) AS last_active "
+            "FROM messages GROUP BY session_id"
+            ") m ON m.session_id = s.id "
         )
         with self._lock:
             if source:
                 cursor = self._conn.execute(
-                    f"SELECT s.*, {select_last_active} FROM sessions s "
-                    "WHERE s.source = ? ORDER BY last_active DESC, s.started_at DESC, s.id DESC LIMIT ? OFFSET ?",
+                    f"{select_with_last_active}"
+                    "WHERE s.source = ? "
+                    "ORDER BY last_active DESC, s.started_at DESC, s.id DESC LIMIT ? OFFSET ?",
                     (source, limit, offset),
                 )
             else:
                 cursor = self._conn.execute(
-                    f"SELECT s.*, {select_last_active} FROM sessions s "
+                    f"{select_with_last_active}"
                     "ORDER BY last_active DESC, s.started_at DESC, s.id DESC LIMIT ? OFFSET ?",
                     (limit, offset),
                 )

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1481,16 +1481,29 @@ class SessionDB:
         limit: int = 20,
         offset: int = 0,
     ) -> List[Dict[str, Any]]:
-        """List sessions, optionally filtered by source."""
+        """List sessions, optionally filtered by source.
+
+        Returns rows enriched with a computed ``last_active`` column (latest
+        message timestamp for the session, falling back to ``started_at``),
+        ordered by most-recently-used first.
+        """
+        select_last_active = (
+            "COALESCE("
+            "(SELECT MAX(m.timestamp) FROM messages m WHERE m.session_id = s.id),"
+            " s.started_at"
+            ") AS last_active"
+        )
         with self._lock:
             if source:
                 cursor = self._conn.execute(
-                    "SELECT * FROM sessions WHERE source = ? ORDER BY started_at DESC LIMIT ? OFFSET ?",
+                    f"SELECT s.*, {select_last_active} FROM sessions s "
+                    "WHERE s.source = ? ORDER BY last_active DESC, s.started_at DESC, s.id DESC LIMIT ? OFFSET ?",
                     (source, limit, offset),
                 )
             else:
                 cursor = self._conn.execute(
-                    "SELECT * FROM sessions ORDER BY started_at DESC LIMIT ? OFFSET ?",
+                    f"SELECT s.*, {select_last_active} FROM sessions s "
+                    "ORDER BY last_active DESC, s.started_at DESC, s.id DESC LIMIT ? OFFSET ?",
                     (limit, offset),
                 )
             return [dict(row) for row in cursor.fetchall()]

--- a/tests/hermes_cli/test_resolve_last_session.py
+++ b/tests/hermes_cli/test_resolve_last_session.py
@@ -89,6 +89,24 @@ def test_resolve_last_session_returns_none_when_empty(monkeypatch):
     assert _resolve_last_session("cli") is None
 
 
+def test_resolve_last_session_closes_db_on_search_error(monkeypatch):
+    class _FailingDB:
+        def __init__(self):
+            self.closed = False
+
+        def search_sessions(self, source=None, limit=20, **_kw):
+            raise RuntimeError("boom")
+
+        def close(self):
+            self.closed = True
+
+    db = _FailingDB()
+    monkeypatch.setattr("hermes_state.SessionDB", lambda: db)
+
+    assert _resolve_last_session("cli") is None
+    assert db.closed is True
+
+
 def test_resolve_last_session_falls_back_to_started_at(monkeypatch):
     # When last_active is missing entirely (legacy row), fall back to
     # started_at so the helper still picks the newest session.

--- a/tests/hermes_cli/test_resolve_last_session.py
+++ b/tests/hermes_cli/test_resolve_last_session.py
@@ -1,0 +1,139 @@
+"""Verify `hermes -c` picks the session the user most recently used."""
+
+from __future__ import annotations
+
+from hermes_cli.main import _resolve_last_session
+
+
+class _FakeDB:
+    def __init__(self, rows):
+        self._rows = rows
+        self.closed = False
+
+    def search_sessions(self, source=None, limit=20, **_kw):
+        rows = [r for r in self._rows if r.get("source") == source] if source else list(self._rows)
+        rows.sort(
+            key=lambda r: float(r.get("last_active") or r.get("started_at") or 0),
+            reverse=True,
+        )
+        return rows[:limit]
+
+    def close(self):
+        self.closed = True
+
+
+def test_resolve_last_session_prefers_last_active_over_started_at(monkeypatch):
+    # `search_sessions` should return in MRU order, so -c can trust row 0.
+    rows = [
+        {
+            "id": "new_started_old_active",
+            "source": "cli",
+            "started_at": 1000.0,
+            "last_active": 100.0,
+        },
+        {
+            "id": "old_started_recently_active",
+            "source": "cli",
+            "started_at": 500.0,
+            "last_active": 999.0,
+        },
+    ]
+
+    fake_db = _FakeDB(rows)
+    monkeypatch.setattr("hermes_state.SessionDB", lambda: fake_db)
+
+    assert _resolve_last_session("cli") == "old_started_recently_active"
+    assert fake_db.closed
+
+
+def test_search_sessions_exposes_last_active_column(tmp_path, monkeypatch):
+    # End-to-end: SessionDB must surface last_active and order by MRU.
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
+    import hermes_state
+
+    from pathlib import Path
+
+    db = hermes_state.SessionDB(db_path=Path(tmp_path / "state.db"))
+    try:
+        db.create_session("s_started_later", source="cli")
+        db.create_session("s_active_later", source="cli")
+        # Force started_at ordering so the test is deterministic regardless
+        # of how quickly the two inserts land.
+        with db._lock:
+            db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (2000.0, "s_started_later"))
+            db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (1000.0, "s_active_later"))
+            db._conn.commit()
+
+        db.append_message("s_active_later", role="user", content="hi")
+        with db._lock:
+            db._conn.execute(
+                "UPDATE messages SET timestamp=? WHERE session_id=?",
+                (3000.0, "s_active_later"),
+            )
+            db._conn.commit()
+
+        rows = db.search_sessions(source="cli", limit=5)
+        ids = {r["id"]: r.get("last_active") for r in rows}
+
+        assert ids["s_started_later"] == 2000.0
+        assert ids["s_active_later"] == 3000.0
+        assert rows[0]["id"] == "s_active_later"
+    finally:
+        db.close()
+
+
+def test_resolve_last_session_returns_none_when_empty(monkeypatch):
+    monkeypatch.setattr("hermes_state.SessionDB", lambda: _FakeDB([]))
+    assert _resolve_last_session("cli") is None
+
+
+def test_resolve_last_session_falls_back_to_started_at(monkeypatch):
+    # When last_active is missing entirely (legacy row), fall back to
+    # started_at so the helper still picks the newest session.
+    rows = [
+        {"id": "older", "source": "cli", "started_at": 10.0},
+        {"id": "newer", "source": "cli", "started_at": 20.0},
+    ]
+    monkeypatch.setattr("hermes_state.SessionDB", lambda: _FakeDB(rows))
+    assert _resolve_last_session("cli") == "newer"
+
+
+def test_resolve_last_session_not_limited_to_newest_started_20(tmp_path, monkeypatch):
+    # Regression: when sampling by started_at, -c could miss the true MRU if
+    # it was older than the newest 20 started sessions.
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
+    import hermes_state
+
+    from pathlib import Path
+
+    state_db = Path(tmp_path / "state.db")
+    real_session_db = hermes_state.SessionDB
+    db = real_session_db(db_path=state_db)
+    try:
+        for i in range(25):
+            sid = f"s_{i:02d}"
+            db.create_session(sid, source="cli")
+            with db._lock:
+                db._conn.execute(
+                    "UPDATE sessions SET started_at=? WHERE id=?",
+                    (10_000.0 - i, sid),
+                )
+                db._conn.commit()
+
+        target = "s_24"
+        db.append_message(target, role="user", content="latest activity")
+        with db._lock:
+            db._conn.execute(
+                "UPDATE messages SET timestamp=? WHERE session_id=?",
+                (20_000.0, target),
+            )
+            db._conn.commit()
+    finally:
+        db.close()
+
+    monkeypatch.setattr("hermes_state.SessionDB", lambda: real_session_db(db_path=state_db))
+    assert _resolve_last_session("cli") == target

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -178,3 +178,38 @@ def test_print_tui_exit_summary_includes_resume_and_token_totals(monkeypatch, ca
     assert "hermes --tui --resume 20260409_000001_abc123" in out
     assert 'hermes --tui -c "demo title"' in out
     assert "Tokens:         21 (in 10, out 6, cache 4, reasoning 1)" in out
+
+
+def test_print_tui_exit_summary_prefers_actual_active_session_file(monkeypatch, capsys, tmp_path):
+    import hermes_cli.main as main_mod
+
+    seen = []
+
+    class _FakeDB:
+        def get_session(self, session_id):
+            seen.append(session_id)
+            return {
+                "message_count": 1,
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+                "reasoning_tokens": 0,
+            }
+
+        def get_session_title(self, _session_id):
+            return "actual"
+
+        def close(self):
+            return None
+
+    active = tmp_path / "active.json"
+    active.write_text('{"session_id":"actual_session"}', encoding="utf-8")
+    monkeypatch.setitem(sys.modules, "hermes_state", types.SimpleNamespace(SessionDB=lambda: _FakeDB()))
+
+    main_mod._print_tui_exit_summary("startup_resume", str(active))
+    out = capsys.readouterr().out
+
+    assert seen == ["actual_session"]
+    assert "hermes --tui --resume actual_session" in out
+    assert "startup_resume" not in out

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -145,6 +145,10 @@ def test_launch_tui_exports_model_and_provider(monkeypatch, main_mod):
     assert env["HERMES_INFERENCE_MODEL"] == "nous/hermes-test"
     assert env["HERMES_TUI_PROVIDER"] == "nous"
     assert env["HERMES_INFERENCE_PROVIDER"] == "nous"
+    active_path = Path(env["HERMES_TUI_ACTIVE_SESSION_FILE"])
+    assert active_path.name.startswith("hermes-tui-active-session-")
+    assert active_path.suffix == ".json"
+    assert not active_path.exists()
     assert env["NODE_ENV"] == "production"
 
 

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -124,6 +124,7 @@ def test_cmd_chat_tui_passes_model_and_provider(monkeypatch, main_mod):
 
 def test_launch_tui_exports_model_and_provider(monkeypatch, main_mod):
     captured = {}
+    active_path_during_call = None
 
     monkeypatch.setattr(
         main_mod,
@@ -132,7 +133,10 @@ def test_launch_tui_exports_model_and_provider(monkeypatch, main_mod):
     )
 
     def fake_call(argv, cwd=None, env=None):
+        nonlocal active_path_during_call
         captured.update({"argv": argv, "cwd": cwd, "env": env})
+        active_path_during_call = Path(env["HERMES_TUI_ACTIVE_SESSION_FILE"])
+        assert active_path_during_call.exists()
         return 1
 
     monkeypatch.setattr(main_mod.subprocess, "call", fake_call)
@@ -148,6 +152,7 @@ def test_launch_tui_exports_model_and_provider(monkeypatch, main_mod):
     active_path = Path(env["HERMES_TUI_ACTIVE_SESSION_FILE"])
     assert active_path.name.startswith("hermes-tui-active-session-")
     assert active_path.suffix == ".json"
+    assert active_path_during_call == active_path
     assert not active_path.exists()
     assert env["NODE_ENV"] == "production"
 

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -84,7 +84,9 @@ def test_cmd_chat_tui_resume_resolves_title_before_launch(monkeypatch, main_mod)
         captured["resume"] = resume_session_id
         raise SystemExit(0)
 
-    monkeypatch.setattr(main_mod, "_resolve_session_by_name_or_id", lambda val: "20260409_000000_aa11bb")
+    monkeypatch.setattr(
+        main_mod, "_resolve_session_by_name_or_id", lambda val: "20260409_000000_aa11bb"
+    )
     monkeypatch.setattr(main_mod, "_launch_tui", fake_launch)
 
     with pytest.raises(SystemExit):
@@ -178,7 +180,9 @@ def test_print_tui_exit_summary_includes_resume_and_token_totals(monkeypatch, ca
         def close(self):
             return None
 
-    monkeypatch.setitem(sys.modules, "hermes_state", types.SimpleNamespace(SessionDB=lambda: _FakeDB()))
+    monkeypatch.setitem(
+        sys.modules, "hermes_state", types.SimpleNamespace(SessionDB=lambda: _FakeDB())
+    )
 
     main_mod._print_tui_exit_summary("20260409_000001_abc123")
     out = capsys.readouterr().out
@@ -189,7 +193,9 @@ def test_print_tui_exit_summary_includes_resume_and_token_totals(monkeypatch, ca
     assert "Tokens:         21 (in 10, out 6, cache 4, reasoning 1)" in out
 
 
-def test_print_tui_exit_summary_prefers_actual_active_session_file(monkeypatch, capsys, tmp_path):
+def test_print_tui_exit_summary_prefers_actual_active_session_file(
+    monkeypatch, capsys, tmp_path
+):
     import hermes_cli.main as main_mod
 
     seen = []
@@ -214,7 +220,9 @@ def test_print_tui_exit_summary_prefers_actual_active_session_file(monkeypatch, 
 
     active = tmp_path / "active.json"
     active.write_text('{"session_id":"actual_session"}', encoding="utf-8")
-    monkeypatch.setitem(sys.modules, "hermes_state", types.SimpleNamespace(SessionDB=lambda: _FakeDB()))
+    monkeypatch.setitem(
+        sys.modules, "hermes_state", types.SimpleNamespace(SessionDB=lambda: _FakeDB())
+    )
 
     main_mod._print_tui_exit_summary("startup_resume", str(active))
     out = capsys.readouterr().out

--- a/ui-tui/src/__tests__/useSessionLifecycle.test.ts
+++ b/ui-tui/src/__tests__/useSessionLifecycle.test.ts
@@ -1,0 +1,27 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { writeActiveSessionFile } from '../app/useSessionLifecycle.js'
+
+describe('writeActiveSessionFile', () => {
+  let dir = ''
+
+  afterEach(() => {
+    if (dir) {
+      rmSync(dir, { force: true, recursive: true })
+      dir = ''
+    }
+  })
+
+  it('writes the actual resumed session id for the shell exit summary', () => {
+    dir = mkdtempSync(join(tmpdir(), 'hermes-tui-active-'))
+    const path = join(dir, 'active.json')
+
+    writeActiveSessionFile('actual_session', path)
+
+    expect(JSON.parse(readFileSync(path, 'utf8'))).toEqual({ session_id: 'actual_session' })
+  })
+})

--- a/ui-tui/src/app/useSessionLifecycle.ts
+++ b/ui-tui/src/app/useSessionLifecycle.ts
@@ -1,3 +1,5 @@
+import { writeFileSync } from 'node:fs'
+
 import type { ScrollBoxHandle } from '@hermes/ink'
 import { evictInkCaches } from '@hermes/ink'
 import { type RefObject, useCallback } from 'react'
@@ -22,6 +24,18 @@ import { patchTurnState } from './turnStore.js'
 import { getUiState, patchUiState } from './uiStore.js'
 
 const usageFrom = (info: null | SessionInfo): Usage => (info?.usage ? { ...ZERO, ...info.usage } : ZERO)
+
+export const writeActiveSessionFile = (sessionId: null | string, file = process.env.HERMES_TUI_ACTIVE_SESSION_FILE) => {
+  if (!file || !sessionId) {
+    return
+  }
+
+  try {
+    writeFileSync(file, JSON.stringify({ session_id: sessionId }), { mode: 0o600 })
+  } catch {
+    // Best-effort shell epilogue hint only; never break live session changes.
+  }
+}
 
 const trimTail = (items: Msg[]) => {
   const q = [...items]
@@ -131,6 +145,7 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
       resetSession()
       setSessionStartedAt(Date.now())
 
+      writeActiveSessionFile(r.session_id)
       patchUiState({
         info,
         sid: r.session_id,
@@ -188,6 +203,7 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
               const resumed = toTranscriptMessages(r.messages)
 
               setHistoryItems(r.info ? [introMsg(r.info), ...resumed] : resumed)
+              writeActiveSessionFile(r.resumed ?? r.session_id)
               patchUiState({
                 info: r.info ?? null,
                 sid: r.session_id,


### PR DESCRIPTION
Salvage of #16336 by @OutThisLife onto current main (her branch had a merge-commit so GitHub refused rebase-merge). All 6 of her commits cherry-picked individually with authorship preserved. One tiny merge conflict in a test assertion list (NODE_ENV + active-session file checks both kept).

## Summary
- `search_sessions()` now joins `MAX(messages.timestamp)` and orders by `last_active` → `hermes -c` picks true MRU, not newest-started.
- `_resolve_last_session` drops client-side sort, uses `limit=1`, closes DB in `finally`.
- TUI writes live session_id to a `mkstemp` JSON file (mode 0o600) via `HERMES_TUI_ACTIVE_SESSION_FILE`; Python reads it in `_print_tui_exit_summary`, cleaned up in `finally`.

## Test plan
- `scripts/run_tests.sh tests/hermes_cli/test_resolve_last_session.py tests/hermes_cli/test_tui_resume_flow.py` → 13/13 pass

Closes #16336.