### PR TITLE
fix(windows): prevent _update_cwd() from overwriting self.cwd with Git Bash POSIX path

### DIFF
--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -389,6 +389,15 @@ class LocalEnvironment(BaseEnvironment):
 
     def _update_cwd(self, result: dict):
         """Read CWD from temp file (local-only, no round-trip needed)."""
+        if _IS_WINDOWS:
+            # Windows: Git Bash pwd -P outputs POSIX paths (/c/Users/msn)
+            # that are invalid for subprocess.Popen(cwd=...). Strip the
+            # marker from output without overwriting self.cwd.
+            saved = self.cwd
+            self._extract_cwd_from_output(result)
+            self.cwd = saved
+            return
+
         try:
             cwd_path = open(self._cwd_file).read().strip()
             if cwd_path:


### PR DESCRIPTION
Fixes the WinError 267 "The directory name is invalid" error on Windows/Git Bash `terminal.backend: local`.

## Root Cause

`LocalEnvironment._update_cwd()` (local.py:390) reads the cwd from a temp file written by Git Bash's `pwd -P` command. Git Bash always outputs POSIX-style paths (e.g. `/c/Users/user/project`), which are invalid for `subprocess.Popen(cwd=...)` on Windows.

The failure sequence:

1. `TERMINAL_CWD` or `os.getcwd()` sets `self.cwd` to a valid Windows path (e.g. `D:\project`)
2. After the first successful command, `_update_cwd()` reads `_cwd_file` (which contains the POSIX path from Git Bash's `pwd -P`)
3. It **overwrites** `self.cwd` with `/c/Users/user/project` (POSIX format)
4. Next `subprocess.Popen(cwd=self.cwd)` -> **WinError 267** (The directory name is invalid)
5. All subsequent terminal commands fail silently

This affects all Windows users with `terminal.backend: local` using native Git Bash without WSL2. The initial cwd from TERMINAL_CWD is correct but gets immediately overwritten by the POSIX path from `_update_cwd()`.

## Fix

Guard `_update_cwd()` on Windows so the cwd file read (which always contains POSIX paths from Git Bash) cannot overwrite the already-correct `self.cwd`. The marker stripping (`_extract_cwd_from_output()`) still runs to keep output clean, but `self.cwd` is restored to its saved value afterward.

The `_IS_WINDOWS` variable is already defined at module level and used throughout the file in `_find_bash()`, `_kill_process()`, and `_run_bash()`.

**No non-Windows code paths are touched.**

## Relationship to existing work

- **Commit `4c136288`** ("fix(local): respect configured cwd in init_session()") added `cwd=self.cwd` to `subprocess.Popen()`, which correctly fixes the `init_session()` startup directory. This PR **complements** it by also protecting against `_update_cwd()` overwriting `self.cwd` on subsequent commands after the first one succeeds.

- **PR #14644** addresses the broader "exit 126 with empty output" issue on Windows (select.select, get_temp_dir, path conversion). This PR takes a simpler, complementary approach focused solely on the POSIX path overwrite in `_update_cwd()`.

## Tested

On Windows 11 + Git for Windows 2.42.0:
- `echo hello` -> `{output: "hello", exit_code: 0}`
- `pwd` -> `{output: "/c/Users/user/project", exit_code: 0}` (POSIX visible to user, but self.cwd stays valid for subsequent Popen)
- `cd /tmp && pwd` -> cwd persists correctly
- 10+ consecutive terminal commands all succeed, no WinError 267
- `TERMINAL_CWD=D:\project` in .env preserved across all commands

Ref: #14644