### PR TITLE
feat: add opt-in native Codex web search support

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -863,7 +863,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
                     getattr(agent, "log_prefix", ""), exc,
                 )
 
-        return _ct.build_kwargs(
+        api_kwargs = _ct.build_kwargs(
             model=agent.model,
             messages=_msgs_for_codex,
             tools=tools_for_api,
@@ -880,6 +880,8 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
                 getattr(agent, "_codex_reasoning_replay_enabled", True)
             ),
         )
+        _ra()._maybe_add_codex_native_web_search(agent, api_kwargs)
+        return api_kwargs
 
     # ── chat_completions (default) ─────────────────────────────────────
     _ct = agent._get_transport()

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -870,13 +870,14 @@ def _preflight_codex_api_kwargs(
             # them through the function-tool validation below (which would
             # otherwise reject them with "unsupported type").  See
             # agent/transports/codex.py for where xAI's native web_search is
-            # injected.
+            # injected.  This also covers the opt-in native Codex web_search
+            # declaration injected by run_agent.py.
             if tool_type in _RESPONSES_BUILTIN_TOOL_TYPES:
                 normalized_tools.append(dict(tool))
                 continue
 
             if tool_type != "function":
-                raise ValueError(f"Codex Responses tools[{idx}] has unsupported type {tool.get('type')!r}.")
+                raise ValueError(f"Codex Responses tools[{idx}] has unsupported type {tool_type!r}.")
 
             name = tool.get("name")
             parameters = tool.get("parameters")

--- a/run_agent.py
+++ b/run_agent.py
@@ -351,6 +351,65 @@ def _safe_session_filename_component(session_id: str) -> str:
     return f"{sanitized}_{digest}"
 
 
+def _codex_native_web_search_enabled() -> bool:
+    return os.getenv("HERMES_CODEX_NATIVE_WEB_SEARCH", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _codex_native_web_search_disable_managed_enabled() -> bool:
+    return os.getenv("HERMES_CODEX_NATIVE_WEB_SEARCH_DISABLE_MANAGED", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _is_managed_web_search_tool(tool: Any) -> bool:
+    if not isinstance(tool, dict) or tool.get("type") != "function":
+        return False
+
+    name = tool.get("name")
+    function = tool.get("function")
+    if name is None and isinstance(function, dict):
+        name = function.get("name")
+    return name == "web_search"
+
+
+def _maybe_add_codex_native_web_search(agent: Any, api_kwargs: Dict[str, Any]) -> None:
+    if not (
+        getattr(agent, "api_mode", None) == "codex_responses"
+        and (getattr(agent, "provider", None) or "").lower() == "openai-codex"
+        and _codex_native_web_search_enabled()
+    ):
+        return
+
+    tools = api_kwargs.get("tools")
+    if not isinstance(tools, list):
+        tools = []
+        api_kwargs["tools"] = tools
+
+    if _codex_native_web_search_disable_managed_enabled():
+        tools[:] = [tool for tool in tools if not _is_managed_web_search_tool(tool)]
+
+    if not any(
+        isinstance(tool, dict) and tool.get("type") in {"web_search", "web_search_preview"}
+        for tool in tools
+    ):
+        tools.append({"type": "web_search", "external_web_access": True})
+
+    includes = api_kwargs.get("include")
+    if not isinstance(includes, list):
+        includes = []
+    if "web_search_call.action.sources" not in includes:
+        includes.append("web_search_call.action.sources")
+    api_kwargs["include"] = includes
+
+
 class _StreamErrorEvent(Exception):
     """Synthesized provider error surfaced from a Responses ``error`` SSE frame.
 

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -57,6 +57,78 @@ def _build_agent(monkeypatch):
     return agent
 
 
+def _build_openai_codex_agent(monkeypatch, *, model="gpt-5-codex"):
+    _patch_agent_bootstrap(monkeypatch)
+
+    agent = run_agent.AIAgent(
+        model=model,
+        provider="openai-codex",
+        api_mode="codex_responses",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key="codex-token",
+        quiet_mode=True,
+        max_iterations=4,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent._cleanup_task_resources = lambda task_id: None
+    agent._persist_session = lambda messages, history=None: None
+    agent._save_trajectory = lambda messages, user_message, completed: None
+    agent._save_session_log = lambda messages: None
+    return agent
+
+
+def _build_openai_codex_agent_with_web_tools(monkeypatch, *, model="gpt-5-codex"):
+    monkeypatch.setattr(
+        run_agent,
+        "get_tool_definitions",
+        lambda **kwargs: [
+            {
+                "type": "function",
+                "function": {
+                    "name": "web_search",
+                    "description": "Search the web.",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "web_extract",
+                    "description": "Extract web pages.",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "terminal",
+                    "description": "Run shell commands.",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            },
+        ],
+    )
+    monkeypatch.setattr(run_agent, "check_toolset_requirements", lambda: {})
+
+    agent = run_agent.AIAgent(
+        model=model,
+        provider="openai-codex",
+        api_mode="codex_responses",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key="codex-token",
+        quiet_mode=True,
+        max_iterations=4,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent._cleanup_task_resources = lambda task_id: None
+    agent._persist_session = lambda messages, history=None: None
+    agent._save_trajectory = lambda messages, user_message, completed: None
+    agent._save_session_log = lambda messages: None
+    return agent
+
+
 def _build_copilot_agent(monkeypatch, *, model="gpt-5.4"):
     _patch_agent_bootstrap(monkeypatch)
 
@@ -365,6 +437,131 @@ def test_build_api_kwargs_codex(monkeypatch):
     assert kwargs["timeout"] > 0
     assert "max_tokens" not in kwargs
     assert "extra_body" not in kwargs
+
+
+def test_preflight_codex_api_kwargs_allows_native_web_search_tool():
+    from agent.codex_responses_adapter import _preflight_codex_api_kwargs
+
+    result = _preflight_codex_api_kwargs(
+        {
+            "model": "gpt-5-codex",
+            "instructions": "You are Hermes.",
+            "input": [{"role": "user", "content": "Ping"}],
+            "tools": [{"type": "web_search", "external_web_access": True}],
+            "store": False,
+        }
+    )
+
+    assert result["tools"][0]["type"] == "web_search"
+    assert result["tools"][0]["external_web_access"] is True
+
+
+def test_codex_native_web_search_default_off(monkeypatch):
+    monkeypatch.delenv("HERMES_CODEX_NATIVE_WEB_SEARCH", raising=False)
+    agent = _build_openai_codex_agent(monkeypatch)
+
+    assert agent.provider == "openai-codex"
+    assert agent.api_mode == "codex_responses"
+
+    kwargs = agent._build_api_kwargs([{"role": "user", "content": "Ping"}])
+
+    assert not any(
+        isinstance(tool, dict) and tool.get("type") == "web_search"
+        for tool in kwargs.get("tools", [])
+    )
+
+
+def test_codex_native_web_search_env_adds_tool_and_sources_include(monkeypatch):
+    monkeypatch.setenv("HERMES_CODEX_NATIVE_WEB_SEARCH", "1")
+    agent = _build_openai_codex_agent(monkeypatch)
+
+    assert agent.provider == "openai-codex"
+    assert agent.api_mode == "codex_responses"
+
+    kwargs = agent._build_api_kwargs([{"role": "user", "content": "Ping"}])
+
+    assert {"type": "web_search", "external_web_access": True} in kwargs.get("tools", [])
+    assert "web_search_call.action.sources" in kwargs.get("include", [])
+
+
+def test_codex_native_web_search_keeps_managed_web_search_by_default(monkeypatch):
+    monkeypatch.setenv("HERMES_CODEX_NATIVE_WEB_SEARCH", "1")
+    monkeypatch.delenv("HERMES_CODEX_NATIVE_WEB_SEARCH_DISABLE_MANAGED", raising=False)
+    agent = _build_openai_codex_agent_with_web_tools(monkeypatch)
+
+    kwargs = agent._build_api_kwargs([{"role": "user", "content": "Ping"}])
+    tools = kwargs.get("tools", [])
+
+    assert any(
+        isinstance(tool, dict)
+        and tool.get("type") == "function"
+        and tool.get("name") == "web_search"
+        for tool in tools
+    )
+    assert any(
+        isinstance(tool, dict)
+        and tool.get("type") == "function"
+        and tool.get("name") == "web_extract"
+        for tool in tools
+    )
+    assert {"type": "web_search", "external_web_access": True} in tools
+
+
+def test_codex_native_web_search_disable_managed_removes_only_function_web_search(monkeypatch):
+    monkeypatch.setenv("HERMES_CODEX_NATIVE_WEB_SEARCH", "1")
+    monkeypatch.setenv("HERMES_CODEX_NATIVE_WEB_SEARCH_DISABLE_MANAGED", "1")
+    agent = _build_openai_codex_agent_with_web_tools(monkeypatch)
+
+    kwargs = agent._build_api_kwargs([{"role": "user", "content": "Ping"}])
+    tools = kwargs.get("tools", [])
+
+    assert not any(
+        isinstance(tool, dict)
+        and tool.get("type") == "function"
+        and tool.get("name") == "web_search"
+        for tool in tools
+    )
+    assert any(
+        isinstance(tool, dict)
+        and tool.get("type") == "function"
+        and tool.get("name") == "web_extract"
+        for tool in tools
+    )
+    assert any(
+        isinstance(tool, dict)
+        and tool.get("type") == "function"
+        and tool.get("name") == "terminal"
+        for tool in tools
+    )
+    assert {"type": "web_search", "external_web_access": True} in tools
+    assert "web_search_call.action.sources" in kwargs.get("include", [])
+
+
+def test_codex_native_web_search_disable_managed_without_native_search_is_noop(monkeypatch):
+    monkeypatch.delenv("HERMES_CODEX_NATIVE_WEB_SEARCH", raising=False)
+    monkeypatch.setenv("HERMES_CODEX_NATIVE_WEB_SEARCH_DISABLE_MANAGED", "1")
+    agent = _build_openai_codex_agent_with_web_tools(monkeypatch)
+
+    kwargs = agent._build_api_kwargs([{"role": "user", "content": "Ping"}])
+    tools = kwargs.get("tools", [])
+
+    assert any(
+        isinstance(tool, dict)
+        and tool.get("type") == "function"
+        and tool.get("name") == "web_search"
+        for tool in tools
+    )
+    assert not any(
+        isinstance(tool, dict) and tool.get("type") == "web_search"
+        for tool in tools
+    )
+
+
+def test_codex_native_web_search_uses_explicit_helper_without_module_level_wrapper():
+    assert hasattr(run_agent, "_codex_native_web_search_enabled")
+    assert hasattr(run_agent, "_maybe_add_codex_native_web_search")
+    assert not hasattr(run_agent, "_ORIGINAL_BUILD_API_KWARGS_FOR_NATIVE_CODEX_WEB_SEARCH")
+    assert not hasattr(run_agent, "_build_api_kwargs_with_native_codex_web_search")
 
 
 def test_build_api_kwargs_codex_clamps_minimal_effort(monkeypatch):


### PR DESCRIPTION
## Summary
- adds opt-in experimental `web_search` / `web_search_preview` passthrough for Codex Responses native tools
- injects native Codex `web_search` only for `openai-codex` + `codex_responses` when `HERMES_CODEX_NATIVE_WEB_SEARCH=1`
- ports request injection to the extracted request builder in `agent/chat_completion_helpers.py`
- optionally removes only the managed Hermes function tool named `web_search` when `HERMES_CODEX_NATIVE_WEB_SEARCH_DISABLE_MANAGED=1` and native Codex web search is enabled
- covers default-off, env-on, preflight normalization, no monkey-patch behavior, and managed-web conflict handling in Codex Responses tests

## Notes
- This does not replace Hermes `web` / `browser` tools.
- The feature is disabled by default and only exposed through explicit environment switches.
- This PR does not write `.env`, change `config.yaml`, modify docs, or touch `web_tools.py`.
- Provider-native web search has weaker Hermes-side observability than Hermes tool calls.

## Latest main refresh
- Base: `355af2c20` (`origin/main`)
- Head: `5778f6faa3aaf459afdbe2db797949981afdb2c3`
- Rebuilt as one clean commit on latest main.
- Cherry-pick was clean; no conflict-resolution edits were needed.

## Test Plan
- `git diff --check`
- `/home/ubuntu/.hermes/hermes-agent/.venv/bin/python -m pytest -o addopts='' tests/run_agent/test_run_agent_codex_responses.py -q`

Focused result: `78 passed in 14.31s`.
