### PR TITLE
fix(api_server): persist session_id on conversation slug to survive LRU eviction (#16517)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -312,9 +312,19 @@ class ResponseStore:
         self._conn.execute(
             """CREATE TABLE IF NOT EXISTS conversations (
                 name TEXT PRIMARY KEY,
-                response_id TEXT NOT NULL
+                response_id TEXT NOT NULL,
+                session_id TEXT
             )"""
         )
+        # Idempotent migration for installs created before session_id column
+        # existed.  ADD COLUMN raises sqlite3.OperationalError if the column
+        # is already present, so swallow that case.
+        try:
+            self._conn.execute(
+                "ALTER TABLE conversations ADD COLUMN session_id TEXT"
+            )
+        except sqlite3.OperationalError:
+            pass
         self._conn.commit()
 
     def get(self, response_id: str) -> Optional[Dict[str, Any]]:
@@ -362,11 +372,34 @@ class ResponseStore:
         ).fetchone()
         return row[0] if row else None
 
-    def set_conversation(self, name: str, response_id: str) -> None:
-        """Map a conversation name to its latest response_id."""
+    def get_conversation_session_id(self, name: str) -> Optional[str]:
+        """Return the persisted Hermes session_id for a conversation name.
+
+        Survives LRU eviction of the underlying response row, so cold-start
+        with ``conversation=<slug>`` can continue the same Hermes session
+        even after the chained ``response_id`` is gone.
+        """
+        row = self._conn.execute(
+            "SELECT session_id FROM conversations WHERE name = ?", (name,)
+        ).fetchone()
+        return row[0] if row and row[0] else None
+
+    def set_conversation(
+        self,
+        name: str,
+        response_id: str,
+        session_id: Optional[str] = None,
+    ) -> None:
+        """Map a conversation name to its latest response_id and session_id.
+
+        ``session_id`` is persisted alongside ``response_id`` so that even when
+        the underlying response row is later evicted by the LRU policy, the
+        Hermes session for this conversation can still be recovered.
+        """
         self._conn.execute(
-            "INSERT OR REPLACE INTO conversations (name, response_id) VALUES (?, ?)",
-            (name, response_id),
+            "INSERT OR REPLACE INTO conversations "
+            "(name, response_id, session_id) VALUES (?, ?, ?)",
+            (name, response_id, session_id),
         )
         self._conn.commit()
 
@@ -1294,7 +1327,9 @@ class APIServerAdapter(BasePlatformAdapter):
                 "session_id": session_id,
             })
             if conversation:
-                self._response_store.set_conversation(conversation, response_id)
+                self._response_store.set_conversation(
+                    conversation, response_id, session_id
+                )
 
         def _persist_incomplete_if_needed() -> None:
             """Persist an ``incomplete`` snapshot if no terminal one was written.
@@ -1752,12 +1787,37 @@ class APIServerAdapter(BasePlatformAdapter):
         if not conversation_history and previous_response_id:
             stored = self._response_store.get(previous_response_id)
             if stored is None:
-                return web.json_response(_openai_error(f"Previous response not found: {previous_response_id}"), status=404)
-            conversation_history = list(stored.get("conversation_history", []))
-            stored_session_id = stored.get("session_id")
-            # If no instructions provided, carry forward from previous
-            if instructions is None:
-                instructions = stored.get("instructions")
+                # When the request used ``conversation=<slug>`` and the slug
+                # mapping pointed at a now-evicted response, fall back to the
+                # session_id persisted alongside the slug so the conversation
+                # keeps writing into the same Hermes session.  Without this,
+                # cold-start (gateway restart + LRU eviction) would either
+                # 404 the client (when the slug only stored response_id) or
+                # mint a fresh session, breaking client-side conversation
+                # continuity (#16517).
+                if conversation:
+                    fallback_session_id = (
+                        self._response_store.get_conversation_session_id(conversation)
+                    )
+                    if fallback_session_id:
+                        stored_session_id = fallback_session_id
+                    # Either way, drop the stale previous_response_id and
+                    # let this turn proceed with an empty history rather
+                    # than 404'ing.  Clients that need full history can
+                    # supply ``conversation_history`` explicitly.
+                else:
+                    return web.json_response(
+                        _openai_error(
+                            f"Previous response not found: {previous_response_id}"
+                        ),
+                        status=404,
+                    )
+            else:
+                conversation_history = list(stored.get("conversation_history", []))
+                stored_session_id = stored.get("session_id")
+                # If no instructions provided, carry forward from previous
+                if instructions is None:
+                    instructions = stored.get("instructions")
 
         # Append new input messages to history (all but the last become history)
         for msg in input_messages[:-1]:
@@ -1926,9 +1986,14 @@ class APIServerAdapter(BasePlatformAdapter):
                 "session_id": session_id,
             })
             # Update conversation mapping so the next request with the same
-            # conversation name automatically chains to this response
+            # conversation name automatically chains to this response.  We
+            # persist session_id alongside response_id so that even if the
+            # response row is evicted later (LRU), the conversation slug can
+            # still recover the Hermes session.
             if conversation:
-                self._response_store.set_conversation(conversation, response_id)
+                self._response_store.set_conversation(
+                    conversation, response_id, session_id
+                )
 
         return web.json_response(response_data)
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -2209,6 +2209,105 @@ class TestConversationParameter:
                 # Conversation mapping should NOT be set since store=false
                 assert adapter._response_store.get_conversation("ephemeral-chat") is None
 
+    @pytest.mark.asyncio
+    async def test_conversation_session_persisted_on_set(self, adapter):
+        """``set_conversation`` persists session_id alongside response_id (#16517)."""
+        adapter._response_store.set_conversation(
+            "persisted-chat", "resp_abc123", "session-xyz"
+        )
+        # New helper exposes session_id even when nothing else is in the store
+        assert (
+            adapter._response_store.get_conversation_session_id("persisted-chat")
+            == "session-xyz"
+        )
+        # Backward-compatible API still returns the response_id
+        assert (
+            adapter._response_store.get_conversation("persisted-chat")
+            == "resp_abc123"
+        )
+
+    @pytest.mark.asyncio
+    async def test_conversation_continues_session_after_response_eviction(
+        self, adapter
+    ):
+        """Cold-start: when the chained response is LRU-evicted but the
+        ``conversation`` slug still resolves, the next turn must reuse the
+        persisted session_id instead of 404'ing or minting a new one (#16517).
+        """
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {"final_response": "Hello!", "messages": [], "api_calls": 1},
+                    {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+                )
+                # Turn 1 — establish the conversation slug → session_id mapping.
+                resp1 = await cli.post(
+                    "/v1/responses",
+                    json={"input": "hi", "conversation": "stable-conv"},
+                )
+                assert resp1.status == 200
+                first_call = mock_run.call_args_list[0]
+                first_session_id = first_call.kwargs.get("session_id")
+                assert first_session_id is not None
+
+                # Simulate LRU eviction of the underlying response data while
+                # leaving the conversation slug mapping intact (the exact
+                # divergence the bug describes).
+                stored_response_id = adapter._response_store.get_conversation(
+                    "stable-conv"
+                )
+                assert stored_response_id is not None
+                deleted = adapter._response_store.delete(stored_response_id)
+                assert deleted is True
+                assert adapter._response_store.get(stored_response_id) is None
+                # But session_id is still recoverable from the conversation row
+                assert (
+                    adapter._response_store.get_conversation_session_id(
+                        "stable-conv"
+                    )
+                    == first_session_id
+                )
+
+                # Turn 2 — same slug, no explicit history.  Must succeed and
+                # reuse the same session_id (no 404, no fresh uuid).
+                mock_run.reset_mock()
+                mock_run.return_value = (
+                    {
+                        "final_response": "still here",
+                        "messages": [],
+                        "api_calls": 1,
+                    },
+                    {"input_tokens": 5, "output_tokens": 3, "total_tokens": 8},
+                )
+                resp2 = await cli.post(
+                    "/v1/responses",
+                    json={"input": "still there?", "conversation": "stable-conv"},
+                )
+                assert resp2.status == 200
+                second_call = mock_run.call_args_list[0]
+                assert second_call.kwargs.get("session_id") == first_session_id
+
+    @pytest.mark.asyncio
+    async def test_previous_response_id_still_404s_without_conversation(
+        self, adapter
+    ):
+        """Negative case: without a ``conversation`` slug to recover from,
+        an unresolvable ``previous_response_id`` must still 404.  The fallback
+        only kicks in when there is a slug to carry session continuity."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/responses",
+                json={
+                    "input": "follow up",
+                    "previous_response_id": "resp_does_not_exist",
+                },
+            )
+            assert resp.status == 404
+            data = await resp.json()
+            assert "Previous response not found" in data["error"]["message"]
+
 
 # ---------------------------------------------------------------------------
 # X-Hermes-Session-Id header (session continuity)


### PR DESCRIPTION
## Summary
- `/v1/responses` with `conversation=<slug>` lost session continuity after the underlying response row was LRU-evicted.
- Persist `session_id` alongside `response_id` on the conversations row and recover it on the read side when the response is gone.
- Adds three tests covering the new column, the cold-start recovery flow, and the preserved 404 behavior when no slug exists.

## The bug
The `ResponseStore.conversations` table only stored `name -> response_id`. When a turn's response was later evicted by the LRU policy, `get_conversation(slug)` still returned the orphaned `response_id` but `get(response_id)` returned `None`. The resolver in `_handle_responses` then either:

1. 404'd the client with `Previous response not found: <id>`, or
2. Fell through to mint a fresh `session_id`, breaking client-side conversation continuity (the symptom called out in #16517 — N forked sessions per logical conversation, none of them linked).

The conversations table did not carry enough state to recover the Hermes session by slug alone.

## The fix
Structural fix at the persistence layer: store `session_id` on the conversations row, recover it when the response row is gone.

- `gateway/platforms/api_server.py`
  - Schema: add `session_id TEXT` to the `conversations` table. Existing installs are migrated via an idempotent `ALTER TABLE ADD COLUMN` that swallows `sqlite3.OperationalError` if the column already exists, so re-running on a populated DB is a no-op.
  - `set_conversation(name, response_id, session_id=None)` now writes session_id too. Both call sites in `_handle_responses` (snapshot persist + final persist) pass the running session_id.
  - New helper `get_conversation_session_id(name)` reads back just the session_id — independent of the responses row, which may have been evicted.
  - `_handle_responses`: when `_response_store.get(previous_response_id)` returns `None` *and* the request used `conversation=<slug>`, recover `session_id` via `get_conversation_session_id(slug)` and continue. Without a slug, the original 404 path is preserved — there is genuinely no recovery context.

## Contract Protected
- **Invariant:** for any conversation slug whose row was ever written, the latest associated `session_id` is recoverable independently of whether the chained response row still exists.
- **Known-bad inputs:** evicted response_id + intact slug, gateway-restart cycle that leaves the conversations row but loses the responses LRU contents.
- **Future-input coverage:** any new code path that writes the conversations row inherits the session_id requirement via the updated method signature.
- **Negative case:** `previous_response_id` with no slug still 404s — the fallback only fires when there is a slug to carry continuity.

## Test plan
- [x] Focused regression test: `tests/gateway/test_api_server.py::TestConversationParameter::test_conversation_continues_session_after_response_eviction` — turn 1 establishes the slug, the response row is then deleted (LRU proxy), turn 2 with the same slug reuses the same `session_id`.
- [x] New invariant test: `test_conversation_session_persisted_on_set` — `set_conversation` writes session_id, `get_conversation_session_id` reads it back, and `get_conversation` still returns the response_id (backward-compatible).
- [x] Negative test: `test_previous_response_id_still_404s_without_conversation` — raw `previous_response_id` with no slug still 404s.
- [x] Regression guard: with the production fix reverted, the new tests fail (`AttributeError: 'ResponseStore' object has no attribute 'get_conversation_session_id'` + session_id assertion mismatch). With the fix, all 122 tests in `tests/gateway/test_api_server.py` pass.

## Related
- Fixes #16517