### PR TITLE
feat(gateway): make detached foreman the default swarm path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -137,6 +137,13 @@
 # Get at: https://fal.ai/
 # FAL_KEY=
 
+# Delegation env fallbacks (optional)
+# Prefer config.yaml for these; use env only when you need process-level overrides.
+# Maps to delegation.stall_threshold_seconds in config.yaml (default: 300, floor: 30)
+# DELEGATION_STALL_THRESHOLD_SECONDS=300
+# Maps to delegation.orchestrator_model in config.yaml (empty = inherit delegation.model / parent)
+# DELEGATION_ORCHESTRATOR_MODEL=openai/gpt-5-mini
+
 # Honcho - Cross-session AI-native user modeling (optional)
 # Builds a persistent understanding of the user across sessions and tools.
 # Get at: https://app.honcho.dev

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -793,8 +793,10 @@ delegation:
   # max_concurrent_children: 3                # Max parallel child agents (default: 3)
   # max_spawn_depth: 1                        # Tree depth cap (1-3, default: 1 = flat). Raise to 2 or 3 to allow orchestrator children to spawn their own workers.
   # orchestrator_enabled: true                # Kill switch for role="orchestrator" children (default: true).
+  # stall_threshold_seconds: 300              # Mark active subagents stalled after this many idle seconds (default: 300, floor: 30). Env fallback: DELEGATION_STALL_THRESHOLD_SECONDS
   # inherit_mcp_toolsets: true                # When explicit child toolsets are narrowed, also keep the parent's MCP toolsets (default: true). Set false for strict intersection.
   # model: "google/gemini-3-flash-preview"    # Override model for subagents (empty = inherit parent)
+  # orchestrator_model: "openai/gpt-5-mini"   # Override model only for effective role="orchestrator" children (empty = inherit delegation.model / parent). Env fallback: DELEGATION_ORCHESTRATOR_MODEL
   # provider: "openrouter"                    # Override provider for subagents (empty = inherit parent)
   #                                           # Resolves full credentials (base_url, api_key) automatically.
   #                                           # Supported: openrouter, nous, zai, kimi-coding, minimax

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3037,6 +3037,7 @@ class GatewayRunner:
             Platform.QQBOT: "QQ_ALLOWED_USERS",
         }
         platform_group_env_map = {
+            Platform.TELEGRAM: "TELEGRAM_ALLOWED_GROUP_CHATS",
             Platform.QQBOT: "QQ_GROUP_ALLOWED_USERS",
         }
         platform_allow_all_map = {
@@ -3518,6 +3519,11 @@ class GatewayRunner:
             if _cmd_def_inner and _cmd_def_inner.name == "agents":
                 return await self._handle_agents_command(event)
 
+            # /swarm is a detached control/launch surface and must not interrupt
+            # the current run.
+            if _cmd_def_inner and _cmd_def_inner.name == "swarm":
+                return await self._handle_swarm_command(event)
+
             # /background must bypass the running-agent guard — it starts a
             # parallel task and must never interrupt the active conversation.
             if _cmd_def_inner and _cmd_def_inner.name == "background":
@@ -3718,6 +3724,9 @@ class GatewayRunner:
 
         if canonical == "agents":
             return await self._handle_agents_command(event)
+
+        if canonical == "swarm":
+            return await self._handle_swarm_command(event)
 
         if canonical == "restart":
             return await self._handle_restart_command(event)
@@ -5295,6 +5304,297 @@ class GatewayRunner:
             lines.append("No active agents or running tasks.")
 
         return "\n".join(lines)
+
+    def _load_swarm_settings(self, user_config: Optional[dict[str, Any]] = None) -> dict[str, Any]:
+        cfg = dict((user_config or _load_gateway_config()).get("swarm") or {})
+
+        try:
+            max_workers = int(cfg.get("max_workers", 10))
+        except (TypeError, ValueError):
+            max_workers = 10
+        max_workers = max(1, min(10, max_workers))
+
+        try:
+            max_iterations = int(cfg.get("max_iterations", 120))
+        except (TypeError, ValueError):
+            max_iterations = 120
+        max_iterations = max(1, max_iterations)
+
+        return {
+            "default_mode": str(cfg.get("default_mode") or "detached_foreman").strip().lower() or "detached_foreman",
+            "max_workers": max_workers,
+            "max_iterations": max_iterations,
+            "enable_hermes_workers": is_truthy_value(cfg.get("enable_hermes_workers"), default=True),
+            "enable_claude_workers": is_truthy_value(cfg.get("enable_claude_workers"), default=True),
+            "enable_codex_workers": is_truthy_value(cfg.get("enable_codex_workers"), default=True),
+        }
+
+    def _build_swarm_foreman_prompt(self, settings: dict[str, Any]) -> str:
+        worker_modes: list[str] = []
+        if settings.get("enable_hermes_workers"):
+            worker_modes.append("Hermes subagents via delegate_task")
+        if settings.get("enable_claude_workers"):
+            worker_modes.append("Claude Code workers via terminal/process")
+        if settings.get("enable_codex_workers"):
+            worker_modes.append("Codex CLI workers via terminal/process")
+        if not worker_modes:
+            worker_modes.append("Hermes subagents via delegate_task")
+
+        worker_modes_text = ", ".join(worker_modes)
+        max_workers = settings.get("max_workers", 10)
+
+        return (
+            "You are Main Sub, a detached swarm foreman running in the background while the live user chat stays free. "
+            "You are not the primary conversational agent. Your job is to solve the assigned task by orchestrating a bounded worker team and then return a synthesized result.\n\n"
+            "Required operating pattern:\n"
+            f"- Direct worker-wave budget: up to {max_workers} workers across all worker types. Use fewer when the task is simple, and treat this as your default total budget unless you have a compelling reason to stay smaller.\n"
+            f"- Available worker modes: {worker_modes_text}.\n"
+            "- Immediately assess task complexity, make a plan with todo, and then load the skills you need. At minimum, load swarm-orchestration. "
+            "Load claude-code and codex before launching Claude/Codex workers. Load using-git-worktrees before parallel writer lanes or any long-lived code-editing lanes.\n"
+            "- Prefer Hermes subagents for read-only scouting, synthesis, QA, and bounded reasoning branches.\n"
+            "- Prefer Claude Code or Codex CLI workers for long coding loops, iterative repair, or autonomous implementation lanes.\n"
+            "- If more than one writing lane is active, isolate them in separate git worktrees before editing.\n"
+            "- Re-synthesize after each worker wave instead of blindly continuing to fan out.\n"
+            "- Do not ask the user clarifying questions. The parent chat is elsewhere. Make reasonable decisions and keep moving.\n"
+            "- Return a concise but complete final synthesis with what was done, evidence, risks, and next actions.\n"
+            "- If blocked, return a blocker report with the exact failing command, output, and the smallest next fix."
+        )
+
+    def _is_swarm_home_channel(self, source: SessionSource) -> bool:
+        """Return True when *source* is the configured home channel for its platform."""
+        platform = getattr(source, "platform", None)
+        if not platform:
+            return False
+        cfg = getattr(self, "config", None)
+        getter = getattr(cfg, "get_home_channel", None)
+        if not callable(getter):
+            return False
+        try:
+            home = getter(platform)
+        except Exception:
+            return False
+        if not home:
+            return False
+        return str(getattr(home, "chat_id", "") or "") == str(getattr(source, "chat_id", "") or "")
+
+    @staticmethod
+    def _swarm_row_matches_source(row: dict[str, Any], source: SessionSource) -> bool:
+        return (
+            str(row.get("kind") or "") == "detached_foreman"
+            and str(row.get("source_platform") or "") == str(source.platform.value if source.platform else "")
+            and str(row.get("source_chat_id") or "") == str(source.chat_id or "")
+            and str(row.get("source_thread_id") or "") == str(source.thread_id or "")
+        )
+
+    def _scoped_swarm_rows(self, rows: list[dict[str, Any]], source: SessionSource) -> list[dict[str, Any]]:
+        """Return only the foreman(s) for this chat/thread plus their descendants."""
+        visible_ids = {
+            str(row.get("subagent_id") or "")
+            for row in rows
+            if self._swarm_row_matches_source(row, source)
+        }
+        visible_ids.discard("")
+        if not visible_ids:
+            return []
+
+        changed = True
+        while changed:
+            changed = False
+            for row in rows:
+                sid = str(row.get("subagent_id") or "")
+                parent_id = str(row.get("parent_id") or "")
+                if sid and sid not in visible_ids and parent_id in visible_ids:
+                    visible_ids.add(sid)
+                    changed = True
+
+        return [row for row in rows if str(row.get("subagent_id") or "") in visible_ids]
+
+    async def _handle_swarm_command(self, event: MessageEvent) -> str:
+        """Handle /swarm command - launch or control detached swarm foremen."""
+        from tools.delegate_tool import (
+            _get_max_concurrent_children,
+            _get_max_spawn_depth,
+            interrupt_subagent,
+            is_spawn_paused,
+            list_active_subagents,
+            set_spawn_paused,
+        )
+
+        user_config = _load_gateway_config()
+        swarm_settings = self._load_swarm_settings(user_config)
+        args = (event.get_command_args() or "").strip()
+        normalized_args = args.lower()
+        parts = args.split(None, 1) if args else []
+        subcommand = parts[0].lower() if parts else "status"
+        remainder = parts[1].strip() if len(parts) > 1 else ""
+        reserved_prompt_hint = (
+            "If your prompt begins with a control word, use `/swarm start <prompt>`."
+        )
+        source = event.source
+
+        if not args or (subcommand == "status" and not remainder):
+            all_rows = list_active_subagents()
+            rows = self._scoped_swarm_rows(all_rows, source)
+            rows.sort(
+                key=lambda row: (
+                    0 if str(row.get("kind") or "") == "detached_foreman" else 1,
+                    int(row.get("depth", 0) or 0),
+                    str(row.get("subagent_id") or ""),
+                )
+            )
+
+            lines = [
+                "**Swarm Status**",
+                "",
+                f"**Paused:** {'Yes' if is_spawn_paused() else 'No'}",
+                f"**Default mode:** {swarm_settings['default_mode']}",
+                f"**Detached foreman worker cap:** {swarm_settings['max_workers']}",
+                f"**Max depth:** {_get_max_spawn_depth()}",
+                f"**Delegate batch max concurrency:** {_get_max_concurrent_children()}",
+                f"**Active swarm agents in this chat:** {len(rows)}",
+            ]
+
+            if self._is_swarm_home_channel(source):
+                hidden_rows = max(0, len(all_rows) - len(rows))
+                lines.append(f"**Other active swarm agents:** {hidden_rows}")
+
+            if rows:
+                for row in rows[:12]:
+                    sid = str(row.get("subagent_id") or "?")
+                    depth = int(row.get("depth", 0) or 0)
+                    kind = str(row.get("kind") or "")
+                    role_label = "foreman" if kind == "detached_foreman" else f"d{depth}"
+                    status = str(row.get("status") or "running")
+                    stalled = "yes" if row.get("stalled") else "no"
+                    idle = max(0, int(float(row.get("idle_seconds", 0) or 0)))
+                    model = str(row.get("model") or "-")
+                    goal = " ".join(str(row.get("goal") or "").split())
+                    if len(model) > 40:
+                        model = model[:37] + "..."
+                    if len(goal) > 72:
+                        goal = goal[:69] + "..."
+                    lines.append(
+                        f"- `{sid}` · {role_label} · {status} · stalled={stalled} "
+                        f"· idle={idle}s · `{model}` · {goal or '-'}"
+                    )
+                if len(rows) > 12:
+                    lines.append(f"... and {len(rows) - 12} more")
+            else:
+                lines.extend(
+                    [
+                        "",
+                        "No active detached swarms or subagents in this chat.",
+                        "Launch one with `/swarm start <prompt>` or `/swarm <prompt>`."
+                    ]
+                )
+
+            return "\n".join(lines)
+
+        if subcommand == "status" and remainder:
+            return f"Usage: /swarm status\n{reserved_prompt_hint}"
+
+        if subcommand == "pause":
+            if remainder:
+                return f"Usage: /swarm pause\n{reserved_prompt_hint}"
+            if not self._is_swarm_home_channel(source):
+                return (
+                    "Global `/swarm pause` is restricted to the platform home channel because it affects every chat. "
+                    "Use `/swarm stop` to stop the swarm for just this chat."
+                )
+            set_spawn_paused(True)
+            return (
+                "Swarm paused. Active subagents keep running; "
+                "new delegation spawns are blocked."
+            )
+
+        if subcommand == "resume":
+            if remainder:
+                return f"Usage: /swarm resume\n{reserved_prompt_hint}"
+            if not self._is_swarm_home_channel(source):
+                return (
+                    "Global `/swarm resume` is restricted to the platform home channel because it affects every chat."
+                )
+            set_spawn_paused(False)
+            return "Swarm resumed. New delegation spawns are allowed."
+
+        if subcommand == "stop":
+            stop_parts = remainder.split() if remainder else []
+            if len(stop_parts) > 1:
+                return f"Usage: /swarm stop <id>\n{reserved_prompt_hint}"
+            stop_target = stop_parts[0] if stop_parts else ""
+            rows = list_active_subagents()
+            matching_foremen = [
+                row for row in rows
+                if self._swarm_row_matches_source(row, source)
+            ]
+
+            if stop_target:
+                target_row = next((row for row in matching_foremen if str(row.get("subagent_id") or "") == stop_target), None)
+                if target_row is None:
+                    if any(str(row.get("subagent_id") or "") == stop_target for row in rows):
+                        return f"Swarm foreman `{stop_target}` belongs to a different chat."
+                    return f"No active swarm foreman found with id `{stop_target}` for this chat."
+                if interrupt_subagent(stop_target):
+                    return f"🛑 Swarm stop requested for `{stop_target}`."
+                if str(target_row.get("status") or "") in {"launching", "queued"}:
+                    return f"Swarm foreman `{stop_target}` is still launching; try `/swarm stop {stop_target}` again in a moment."
+                return "Swarm stop failed — the foreman is no longer interruptible."
+
+            if not matching_foremen:
+                return "No detached swarm foreman is active for this chat."
+            if len(matching_foremen) > 1:
+                return "Multiple detached swarms are active for this chat. Use `/swarm stop <id>` after checking `/swarm status`."
+
+            foreman_id = str(matching_foremen[0].get("subagent_id") or "")
+            if foreman_id and interrupt_subagent(foreman_id):
+                return f"🛑 Swarm stop requested for `{foreman_id}`."
+            if str(matching_foremen[0].get("status") or "") in {"launching", "queued"}:
+                return f"Swarm foreman `{foreman_id}` is still launching; try `/swarm stop {foreman_id}` again in a moment."
+            return "Swarm stop failed — the foreman is no longer interruptible."
+
+        prompt = remainder if subcommand == "start" and remainder else ("" if normalized_args == "start" else args)
+        if not prompt:
+            return (
+                "Usage: /swarm [status|pause|resume|start <prompt>|stop <id>|<prompt>]\n"
+                "Example: /swarm start Audit the auth subsystem and propose a patch plan\n\n"
+                "Launches a detached foreman swarm in a separate background session. "
+                "You can keep chatting while Main Sub runs the swarm."
+            )
+
+        source = event.source
+        active_foremen = [
+            row for row in list_active_subagents()
+            if self._swarm_row_matches_source(row, source)
+        ]
+        if active_foremen:
+            return "A detached swarm foreman is already active for this chat. Use `/swarm status` to inspect it or `/swarm stop` to interrupt it first."
+
+        task_id = f"swarm_{datetime.now().strftime('%H%M%S')}_{os.urandom(3).hex()}"
+        from tools.delegate_tool import _register_subagent
+        _register_subagent(
+            {
+                "subagent_id": task_id,
+                "parent_id": None,
+                "depth": 0,
+                "goal": prompt,
+                "status": "launching",
+                "kind": "detached_foreman",
+                "source_platform": source.platform.value if source.platform else None,
+                "source_chat_id": source.chat_id,
+                "source_thread_id": source.thread_id,
+            }
+        )
+        _task = asyncio.create_task(self._run_swarm_task(prompt, source, task_id))
+        self._background_tasks.add(_task)
+        _task.add_done_callback(self._background_tasks.discard)
+
+        preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
+        return (
+            f'🐝 Detached swarm started: "{preview}"\n'
+            f"Swarm ID: {task_id}\n"
+            f"Worker budget: up to {swarm_settings['max_workers']}\n"
+            "You can keep chatting — Main Sub is running in the background."
+        )
     
     async def _handle_stop_command(self, event: MessageEvent) -> str:
         """Handle /stop command - interrupt a running agent.
@@ -6676,6 +6976,204 @@ class GatewayRunner:
                 await adapter.send(
                     chat_id=source.chat_id,
                     content=f"❌ Background task {task_id} failed: {e}",
+                    metadata=_thread_metadata,
+                )
+            except Exception:
+                pass
+
+    async def _run_swarm_task(
+        self, prompt: str, source: "SessionSource", task_id: str
+    ) -> None:
+        """Execute a detached swarm foreman and deliver the result to the chat."""
+        from run_agent import AIAgent
+        from hermes_cli.tools_config import _get_platform_tools
+        from tools.delegate_tool import _mark_subagent_activity, _register_subagent, _unregister_subagent
+
+        adapter = self.adapters.get(source.platform)
+        if not adapter:
+            logger.warning("No adapter for platform %s in swarm task %s", source.platform, task_id)
+            _unregister_subagent(task_id)
+            return
+
+        _thread_metadata = {"thread_id": source.thread_id} if source.thread_id else None
+
+        try:
+            user_config = _load_gateway_config()
+            swarm_settings = self._load_swarm_settings(user_config)
+            model, runtime_kwargs = self._resolve_session_agent_runtime(
+                source=source,
+                user_config=user_config,
+            )
+            if not runtime_kwargs.get("api_key"):
+                await adapter.send(
+                    source.chat_id,
+                    f"❌ Swarm task {task_id} failed: no provider credentials configured.",
+                    metadata=_thread_metadata,
+                )
+                _unregister_subagent(task_id)
+                return
+
+            platform_key = _platform_config_key(source.platform)
+            enabled_toolsets = set(_get_platform_tools(user_config, platform_key))
+            enabled_toolsets.update({"delegation", "terminal", "file", "skills", "todo", "session_search", "web"})
+            disabled_toolsets = {"clarify", "cronjob", "messaging", "memory"}
+            enabled_toolsets = sorted(t for t in enabled_toolsets if t and t not in disabled_toolsets)
+            disabled_toolsets = sorted(disabled_toolsets)
+
+            pr = self._provider_routing
+            reasoning_config = self._load_reasoning_config()
+            self._reasoning_config = reasoning_config
+            self._service_tier = self._load_service_tier()
+            turn_route = self._resolve_turn_agent_config(prompt, model, runtime_kwargs)
+            foreman_prompt = self._build_swarm_foreman_prompt(swarm_settings)
+
+            parent_session_id = None
+            try:
+                session_entry = self.session_store.get_or_create_session(source)
+                parent_session_id = getattr(session_entry, "session_id", None)
+            except Exception:
+                parent_session_id = None
+
+            def _foreman_progress(tool_name: str, args_preview: str = "") -> None:
+                _mark_subagent_activity(
+                    task_id,
+                    "foreman.tool",
+                    status="running",
+                    last_tool=tool_name or "",
+                    last_preview=args_preview or "",
+                )
+
+            agent = AIAgent(
+                model=turn_route["model"],
+                **turn_route["runtime"],
+                max_iterations=swarm_settings["max_iterations"],
+                quiet_mode=True,
+                verbose_logging=False,
+                enabled_toolsets=enabled_toolsets,
+                disabled_toolsets=disabled_toolsets,
+                reasoning_config=reasoning_config,
+                service_tier=self._service_tier,
+                request_overrides=turn_route.get("request_overrides"),
+                providers_allowed=pr.get("only"),
+                providers_ignored=pr.get("ignore"),
+                providers_order=pr.get("order"),
+                provider_sort=pr.get("sort"),
+                provider_require_parameters=pr.get("require_parameters", False),
+                provider_data_collection=pr.get("data_collection"),
+                session_id=task_id,
+                platform=platform_key,
+                user_id=source.user_id,
+                user_name=source.user_name,
+                chat_id=source.chat_id,
+                chat_name=source.chat_name,
+                chat_type=source.chat_type,
+                thread_id=source.thread_id,
+                session_db=self._session_db,
+                parent_session_id=parent_session_id,
+                fallback_model=self._fallback_model,
+                ephemeral_system_prompt=foreman_prompt,
+                tool_progress_callback=_foreman_progress,
+            )
+            agent._delegate_max_concurrent_children_override = swarm_settings["max_workers"]
+            agent._delegate_depth = 0
+            agent._delegate_role = "orchestrator"
+            agent._subagent_id = task_id
+            agent._subagent_goal = prompt
+
+            _register_subagent(
+                {
+                    "subagent_id": task_id,
+                    "parent_id": None,
+                    "depth": 0,
+                    "goal": prompt,
+                    "model": turn_route["model"],
+                    "status": "queued",
+                    "kind": "detached_foreman",
+                    "source_platform": source.platform.value if source.platform else None,
+                    "source_chat_id": source.chat_id,
+                    "source_thread_id": source.thread_id,
+                    "agent": agent,
+                }
+            )
+
+            def run_sync():
+                _mark_subagent_activity(task_id, "foreman.started", status="running")
+                try:
+                    result = agent.run_conversation(
+                        user_message=prompt,
+                        task_id=task_id,
+                    )
+                    _mark_subagent_activity(task_id, "foreman.completed", status="completed")
+                    return result
+                except Exception:
+                    _mark_subagent_activity(task_id, "foreman.error", status="error")
+                    raise
+                finally:
+                    _unregister_subagent(task_id)
+                    self._cleanup_agent_resources(agent)
+
+            result = await self._run_in_executor_with_context(run_sync)
+
+            response = result.get("final_response", "") if result else ""
+            if not response and result and result.get("error"):
+                response = f"Error: {result['error']}"
+
+            if response:
+                media_files, response = adapter.extract_media(response)
+                images, text_content = adapter.extract_images(response)
+
+                preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
+                header = f'✅ Swarm task complete\nPrompt: "{preview}"\n\n'
+
+                if text_content:
+                    await adapter.send(
+                        chat_id=source.chat_id,
+                        content=header + text_content,
+                        metadata=_thread_metadata,
+                    )
+                elif not images and not media_files:
+                    await adapter.send(
+                        chat_id=source.chat_id,
+                        content=header + "(No response generated)",
+                        metadata=_thread_metadata,
+                    )
+
+                for image_url, alt_text in (images or []):
+                    try:
+                        await adapter.send_image(
+                            chat_id=source.chat_id,
+                            image_url=image_url,
+                            caption=alt_text,
+                        )
+                    except Exception:
+                        pass
+
+                for media_path, _is_voice in (media_files or []):
+                    try:
+                        await adapter.send_document(
+                            chat_id=source.chat_id,
+                            file_path=media_path,
+                        )
+                    except Exception:
+                        pass
+            else:
+                preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
+                await adapter.send(
+                    chat_id=source.chat_id,
+                    content=f'✅ Swarm task complete\nPrompt: "{preview}"\n\n(No response generated)',
+                    metadata=_thread_metadata,
+                )
+
+        except Exception as e:
+            logger.exception("Swarm task %s failed", task_id)
+            try:
+                _unregister_subagent(task_id)
+            except Exception:
+                pass
+            try:
+                await adapter.send(
+                    chat_id=source.chat_id,
+                    content=f"❌ Swarm task {task_id} failed: {e}",
                     metadata=_thread_metadata,
                 )
             except Exception:

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -89,6 +89,9 @@ COMMAND_REGISTRY: list[CommandDef] = [
                args_hint="<question>"),
     CommandDef("agents", "Show active agents and running tasks", "Session",
                aliases=("tasks",)),
+    CommandDef("swarm", "Launch or control a detached swarm foreman", "Session",
+               gateway_only=True, subcommands=("status", "pause", "resume", "start", "stop"),
+               args_hint="[status|pause|resume|start <prompt>|stop <id>|<prompt>]"),
     CommandDef("queue", "Queue a prompt for the next turn (doesn't interrupt)", "Session",
                aliases=("q",), args_hint="<prompt>"),
     CommandDef("steer", "Inject a message after the next tool call without interrupting", "Session",
@@ -299,6 +302,7 @@ ACTIVE_SESSION_BYPASS_COMMANDS: frozenset[str] = frozenset(
         "status",
         "steer",
         "stop",
+        "swarm",
         "update",
     }
 )

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -760,6 +760,7 @@ DEFAULT_CONFIG = {
     # configured providers (OpenRouter, Nous, Z.ai, Kimi, etc.) are supported.
     "delegation": {
         "model": "",       # e.g. "google/gemini-3-flash-preview" (empty = inherit parent model)
+        "orchestrator_model": "",  # optional model override for effective role="orchestrator" children only
         "provider": "",    # e.g. "openrouter" (empty = inherit parent provider + credentials)
         "base_url": "",    # direct OpenAI-compatible endpoint for subagents
         "api_key": "",     # API key for delegation.base_url (falls back to OPENAI_API_KEY)
@@ -775,6 +776,7 @@ DEFAULT_CONFIG = {
                                        # no ceiling). High-reasoning models on large tasks
                                        # (e.g. gpt-5.5 xhigh, opus-4.6) need generous budgets;
                                        # raise if children time out before producing output.
+        "stall_threshold_seconds": 300,  # mark active subagents stalled after this many idle seconds (floor 30)
         "reasoning_effort": "",  # reasoning effort for subagents: "xhigh", "high", "medium",
                                  # "low", "minimal", "none" (empty = inherit parent's level)
         "max_concurrent_children": 3,  # max parallel children per batch; floor of 1 enforced, no ceiling
@@ -783,6 +785,17 @@ DEFAULT_CONFIG = {
         # warning log if out of range.
         "max_spawn_depth": 1,        # depth cap (1 = flat [default], 2 = orchestrator→leaf, 3 = three-level)
         "orchestrator_enabled": True,  # kill switch for role="orchestrator"
+    },
+
+    # Detached swarm foreman mode — a background duplicate that can orchestrate
+    # Hermes subagents plus CLI workers while the main chat stays free.
+    "swarm": {
+        "default_mode": "detached_foreman",
+        "max_workers": 10,
+        "max_iterations": 120,
+        "enable_hermes_workers": True,
+        "enable_claude_workers": True,
+        "enable_codex_workers": True,
     },
 
     # Ephemeral prefill messages file — JSON list of {role, content} dicts
@@ -2225,7 +2238,7 @@ def check_config_version() -> Tuple[int, int]:
 _KNOWN_ROOT_KEYS = {
     "_config_version", "model", "providers", "fallback_model",
     "fallback_providers", "credential_pool_strategies", "toolsets",
-    "agent", "terminal", "display", "compression", "delegation",
+    "agent", "terminal", "display", "compression", "delegation", "swarm",
     "auxiliary", "custom_providers", "context", "memory", "gateway",
     "sessions",
 }

--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -284,7 +284,7 @@ TIPS = [
     "V4A patch format supports Add File, Delete File, and Move File directives — not just Update.",
     "MCP servers can request LLM completions back via sampling — the agent becomes a tool for the server.",
     "MCP servers send notifications/tools/list_changed to trigger automatic tool re-registration without restart.",
-    "delegate_task with acp_command: 'claude' spawns Claude Code as a child agent from any platform.",
+    "delegate_task runs Hermes/OpenAI-compatible subagents; use terminal `claude -p` for Claude Code on machines without Claude ACP support.",
     "Delegation has a heartbeat thread — child activity propagates to the parent, preventing gateway timeouts.",
     "When a provider returns HTTP 402 (payment required), the auxiliary client auto-falls back to the next one.",
     "agent.tool_use_enforcement steers models that describe actions instead of calling tools — auto for GPT/Codex.",

--- a/run_agent.py
+++ b/run_agent.py
@@ -4422,8 +4422,7 @@ class AIAgent:
             )
         return messages
 
-    @staticmethod
-    def _cap_delegate_task_calls(tool_calls: list) -> list:
+    def _cap_delegate_task_calls(self, tool_calls: list) -> list:
         """Truncate excess delegate_task calls to max_concurrent_children.
 
         The delegate_tool caps the task list inside a single call, but the
@@ -4433,7 +4432,7 @@ class AIAgent:
         Returns the original list if no truncation was needed.
         """
         from tools.delegate_tool import _get_max_concurrent_children
-        max_children = _get_max_concurrent_children()
+        max_children = _get_max_concurrent_children(self)
         delegate_count = sum(1 for tc in tool_calls if tc.function.name == "delegate_task")
         if delegate_count <= max_children:
             return tool_calls

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -95,10 +95,17 @@ echo "▶ running pytest with $WORKERS workers, hermetic env, in $REPO_ROOT"
 echo "  (TZ=UTC LANG=C.UTF-8 PYTHONHASHSEED=0; all credential env vars unset)"
 
 # -o "addopts=" clears pyproject.toml's `-n auto` so our -n wins.
-exec "$PYTHON" -m pytest \
-  -o "addopts=" \
-  -n "$WORKERS" \
-  --ignore=tests/integration \
-  --ignore=tests/e2e \
-  -m "not integration" \
-  "${ARGS[@]}"
+PYTEST_CMD=(
+  "$PYTHON" -m pytest
+  -o "addopts="
+  -n "$WORKERS"
+  --ignore=tests/integration
+  --ignore=tests/e2e
+  -m "not integration"
+)
+
+if [ "${#ARGS[@]}" -gt 0 ]; then
+  exec "${PYTEST_CMD[@]}" "${ARGS[@]}"
+fi
+
+exec "${PYTEST_CMD[@]}"

--- a/skills/autonomous-ai-agents/swarm-orchestration/SKILL.md
+++ b/skills/autonomous-ai-agents/swarm-orchestration/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: swarm-orchestration
+description: Use when a task is broad, long-running, high-stakes, or decomposes into independent workstreams. Coordinates delegate_task swarms with orchestrator subagents, scout/reviewer lanes, one-writer discipline, and bounded synthesis.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [swarm, delegation, orchestration, subagents, autonomy, review]
+    related_skills: [claude-code, codex, subagent-driven-development, dispatching-parallel-agents]
+---
+
+# Swarm Orchestration
+
+Use this skill when a task is large enough that one agent doing everything serially would be slow, brittle, or context-heavy.
+
+Agent rule: initiate this yourself when it fits. If a task is broad, long-running, high-stakes, or naturally parallel, load this skill without waiting for the user to say "swarm" or to issue `/swarm`. The `/swarm` command is only a status/control surface, not the activation path.
+
+## Trigger
+
+Use Swarm when any of these are true:
+
+- The task naturally splits into 3+ independent workstreams.
+- The work will likely take more than 10 minutes.
+- The task is high-stakes and benefits from independent review.
+- Codebase exploration, research, QA, or debugging can be done in parallel.
+- The parent agent needs to preserve context for synthesis instead of reading every intermediate result.
+
+Do not use Swarm for:
+
+- One or two direct tool calls.
+- A single-file edit or tight serial debugging loop.
+- Work where several agents would edit the same files without isolated worktrees.
+- A sequential pipeline where step B depends on step A.
+- Anything needing user interaction inside a child; subagents cannot clarify.
+
+## Operating Model
+
+Parent agent = controller.
+
+The controller decomposes, assigns, monitors, and synthesizes. It should avoid doing all the work itself when parallel workers can produce better evidence faster.
+
+Default topology:
+
+```text
+controller
+  ├─ scout / reviewer agents: read-only investigation, design critique, QA
+  ├─ writer agent: one implementation lane per branch/worktree
+  └─ synthesis: parent combines results and chooses the next slice
+```
+
+Use role="orchestrator" only when a child must further decompose its own domain:
+
+```text
+controller
+  └─ domain orchestrator, role="orchestrator"
+       ├─ leaf scout A
+       ├─ leaf scout B
+       └─ leaf reviewer C
+```
+
+Leaf children cannot delegate further. Orchestrator children may spawn their own workers if the profile's delegation depth allows it. All children remain barred from user interaction and shared side-effect tools such as clarify, memory, send_message, and execute_code.
+
+## How to Dispatch
+
+For independent first-level work, use batch delegation:
+
+```python
+delegate_task(tasks=[
+    {
+        "goal": "Inspect the auth subsystem for likely failure points.",
+        "context": "Repo path: /path/to/repo. Read-only. Return files inspected, findings, and confidence.",
+        "toolsets": ["terminal", "file"],
+        "role": "leaf",
+    },
+    {
+        "goal": "Review the current diff for security and regression risks.",
+        "context": "Repo path: /path/to/repo. Do not edit. Return critical/important/minor findings.",
+        "toolsets": ["terminal", "file"],
+        "role": "leaf",
+    },
+])
+```
+
+For a domain that needs its own fan-out, explicitly grant orchestrator role:
+
+```python
+delegate_task(
+    goal="Coordinate backend API investigation across routes, data layer, and tests.",
+    context="Repo path: /path/to/repo. Spawn leaves only for independent read-only investigation. Synthesize before reporting.",
+    toolsets=["terminal", "file"],
+    role="orchestrator",
+)
+```
+
+The context must be self-contained. Include repo path, branch/worktree, constraints, exact verification commands, files to avoid, and expected output format.
+
+## Coding Discipline
+
+Use one writer lane per branch or worktree.
+
+- Scouts and reviewers are read-only by policy. Hermes does not hard-enforce read-only lanes, so instruct those children not to edit and keep their tool/context scoped accordingly.
+- Writers own the actual edit path.
+- If two writers are needed, isolate them in separate git worktrees.
+- Reviewers check spec compliance first, then code quality/security.
+- Parent re-reads files changed by workers before editing.
+
+Preferred coding pattern:
+
+1. Scout agents inspect separate domains.
+2. Parent chooses the smallest executable slice.
+3. One writer implements with TDD where practical.
+4. Two independent reviewers inspect the diff.
+5. Parent runs verification and synthesizes next steps.
+
+## Cost and Fanout Guardrails
+
+- Start with 2-4 children. Use 6 only when workstreams are truly independent and the active profile's delegation.max_concurrent_children allows it.
+- Use role="orchestrator" sparingly; most children should be leaves.
+- Depth 2 is the normal ceiling when the active profile allows it. Many Hermes installs default lower, so check delegation.max_spawn_depth before assuming nested orchestration is available.
+- Do not re-delegate the whole task to one child. Decompose or do it yourself.
+- Prefer fast/cheap scouts for broad inspection and stronger models for synthesis/review when configured.
+- Stop spawning when evidence converges.
+
+## Output Contract for Workers
+
+Ask each child to return:
+
+- What it inspected or changed.
+- Findings, ranked by severity.
+- Exact files touched, if any.
+- Verification commands run and results.
+- Blockers or uncertainty.
+- A one-line recommendation.
+
+## Telegram / Long-Running Work
+
+For long work from Telegram:
+
+- Use Swarm when it materially reduces wall time or increases confidence.
+- Keep status terse.
+- If work continues beyond the current turn, make continuation durable with a background process or cron job.
+- Do not restart the active gateway mid-task just to apply config; defer restarts until progress is durable.
+- Nested orchestrator telemetry may be less complete than first-level child telemetry on some Hermes builds, so treat parent synthesis and explicit worker summaries as the source of truth.
+
+## Verification
+
+Before claiming completion:
+
+- Run the relevant tests or verification command yourself.
+- Do not trust worker summaries without checking git status/diff/tests.
+- Use independent Claude review for hardening/security when changing autonomy behavior.
+- Report actual evidence, not intent.

--- a/tests/cron/test_cronjob_tool_scope.py
+++ b/tests/cron/test_cronjob_tool_scope.py
@@ -1,0 +1,173 @@
+"""Tests for session-scoped cronjob tool visibility."""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure project root is importable
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+@pytest.fixture
+def cron_env(tmp_path, monkeypatch):
+    """Isolated cron environment with temp HERMES_HOME."""
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "cron").mkdir()
+    (hermes_home / "cron" / "output").mkdir()
+    (hermes_home / "scripts").mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    import cron.jobs as jobs_mod
+
+    monkeypatch.setattr(jobs_mod, "HERMES_DIR", hermes_home)
+    monkeypatch.setattr(jobs_mod, "CRON_DIR", hermes_home / "cron")
+    monkeypatch.setattr(jobs_mod, "JOBS_FILE", hermes_home / "cron" / "jobs.json")
+    monkeypatch.setattr(jobs_mod, "OUTPUT_DIR", hermes_home / "cron" / "output")
+
+    return hermes_home
+
+
+@pytest.fixture(autouse=True)
+def reset_session_context(monkeypatch):
+    """Keep gateway session env/context isolated between tests."""
+    session_env_names = [
+        "HERMES_SESSION_PLATFORM",
+        "HERMES_SESSION_CHAT_ID",
+        "HERMES_SESSION_CHAT_NAME",
+        "HERMES_SESSION_THREAD_ID",
+        "HERMES_SESSION_USER_ID",
+        "HERMES_SESSION_USER_NAME",
+        "HERMES_SESSION_KEY",
+    ]
+    for name in session_env_names:
+        monkeypatch.delenv(name, raising=False)
+    yield
+    from gateway.session_context import _UNSET, _VAR_MAP
+
+    for var in _VAR_MAP.values():
+        var.set(_UNSET)
+
+
+def _list_job_names():
+    from tools.cronjob_tools import cronjob
+
+    result = json.loads(cronjob(action="list"))
+    assert result["success"] is True
+    return [job["name"] for job in result["jobs"]]
+
+
+def test_cronjob_list_without_session_context_lists_all_jobs(cron_env):
+    from cron.jobs import create_job
+
+    create_job(
+        prompt="Other group job",
+        schedule="every 1h",
+        name="other group monitor",
+        origin={"platform": "telegram", "chat_id": "-1003956282046", "thread_id": None},
+    )
+    create_job(
+        prompt="ChatLFG job",
+        schedule="every 1h",
+        name="chatlfg monitor",
+        origin={"platform": "telegram", "chat_id": "-1001234567890", "thread_id": None},
+    )
+
+    assert _list_job_names() == ["other group monitor", "chatlfg monitor"]
+
+
+def test_cronjob_list_in_group_session_shows_only_current_chat_jobs(cron_env):
+    from cron.jobs import create_job
+    from gateway.session_context import clear_session_vars, set_session_vars
+
+    create_job(
+        prompt="Other group job",
+        schedule="every 1h",
+        name="other group monitor",
+        origin={"platform": "telegram", "chat_id": "-1003956282046", "thread_id": None},
+    )
+    create_job(
+        prompt="ChatLFG job",
+        schedule="every 1h",
+        name="chatlfg monitor",
+        origin={"platform": "telegram", "chat_id": "-1001234567890", "thread_id": None},
+    )
+
+    tokens = set_session_vars(platform="telegram", chat_id="-1001234567890")
+    try:
+        assert _list_job_names() == ["chatlfg monitor"]
+    finally:
+        clear_session_vars(tokens)
+
+
+def test_cronjob_list_in_group_session_hides_originless_jobs(cron_env):
+    from cron.jobs import create_job
+    from gateway.session_context import clear_session_vars, set_session_vars
+
+    create_job(
+        prompt="Legacy local job",
+        schedule="every 1h",
+        name="legacy local monitor",
+        origin=None,
+    )
+    create_job(
+        prompt="ChatLFG job",
+        schedule="every 1h",
+        name="chatlfg monitor",
+        origin={"platform": "telegram", "chat_id": "-1001234567890", "thread_id": None},
+    )
+
+    tokens = set_session_vars(platform="telegram", chat_id="-1001234567890")
+    try:
+        assert _list_job_names() == ["chatlfg monitor"]
+    finally:
+        clear_session_vars(tokens)
+
+
+def test_cronjob_list_in_thread_session_shows_only_current_thread_jobs(cron_env):
+    from cron.jobs import create_job
+    from gateway.session_context import clear_session_vars, set_session_vars
+
+    create_job(
+        prompt="Same chat different topic",
+        schedule="every 1h",
+        name="other topic monitor",
+        origin={"platform": "telegram", "chat_id": "-1001234567890", "thread_id": "111"},
+    )
+    create_job(
+        prompt="Same chat current topic",
+        schedule="every 1h",
+        name="current topic monitor",
+        origin={"platform": "telegram", "chat_id": "-1001234567890", "thread_id": "222"},
+    )
+
+    tokens = set_session_vars(platform="telegram", chat_id="-1001234567890", thread_id="222")
+    try:
+        assert _list_job_names() == ["current topic monitor"]
+    finally:
+        clear_session_vars(tokens)
+
+
+def test_cronjob_management_in_group_session_rejects_other_chat_job_ids(cron_env):
+    from cron.jobs import create_job, get_job
+    from gateway.session_context import clear_session_vars, set_session_vars
+    from tools.cronjob_tools import cronjob
+
+    other_chat_job = create_job(
+        prompt="Other group job",
+        schedule="every 1h",
+        name="other group monitor",
+        origin={"platform": "telegram", "chat_id": "-1003956282046", "thread_id": None},
+    )
+
+    tokens = set_session_vars(platform="telegram", chat_id="-1001234567890")
+    try:
+        result = json.loads(cronjob(action="pause", job_id=other_chat_job["id"]))
+    finally:
+        clear_session_vars(tokens)
+
+    assert result["success"] is False
+    assert "not found" in result["error"]
+    assert get_job(other_chat_job["id"])["enabled"] is True

--- a/tests/e2e/test_platform_commands.py
+++ b/tests/e2e/test_platform_commands.py
@@ -11,10 +11,11 @@ Tests are parametrized over platforms via the ``platform`` fixture in conftest.
 """
 
 import asyncio
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from gateway.config import HomeChannel
 from gateway.platforms.base import SendResult
 from tests.e2e.conftest import make_event, send_and_capture
 
@@ -105,6 +106,48 @@ class TestSlashCommands:
         send.assert_called_once()
         response_text = send.call_args[1].get("content") or send.call_args[0][1]
         assert "compress" in response_text.lower() or "context" in response_text.lower()
+
+    @pytest.mark.asyncio
+    async def test_swarm_start_runs_through_full_gateway_pipeline(self, adapter, runner, platform):
+        runner._background_tasks = set()
+        runner._run_swarm_task = AsyncMock(return_value=None)
+
+        with patch("gateway.run._load_gateway_config", return_value={"swarm": {"max_workers": 5}}), \
+             patch("tools.delegate_tool.list_active_subagents", return_value=[]):
+            send = await send_and_capture(adapter, "/swarm start investigate auth regressions", platform)
+
+        send.assert_called_once()
+        response_text = send.call_args[1].get("content") or send.call_args[0][1]
+        assert "Detached swarm started" in response_text
+        assert "Main Sub is running in the background" in response_text
+        assert "Worker budget: up to 5" in response_text
+        runner._run_swarm_task.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_swarm_stop_multiword_arg_returns_usage_through_full_pipeline(self, adapter, runner, platform):
+        runner._background_tasks = set()
+        runner._run_swarm_task = AsyncMock(return_value=None)
+
+        with patch("gateway.run._load_gateway_config", return_value={"swarm": {"max_workers": 5}}), \
+             patch("tools.delegate_tool.list_active_subagents", return_value=[]):
+            send = await send_and_capture(adapter, "/swarm stop the bleeding in auth", platform)
+
+        send.assert_called_once()
+        response_text = send.call_args[1].get("content") or send.call_args[0][1]
+        assert "Usage: /swarm stop <id>" in response_text
+        assert "use `/swarm start <prompt>`" in response_text
+        runner._run_swarm_task.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_swarm_pause_is_restricted_to_home_channel_through_full_pipeline(self, adapter, runner, platform):
+        runner.config.platforms[platform].home_channel = HomeChannel(platform=platform, chat_id="home-chat", name="Home")
+
+        with patch("gateway.run._load_gateway_config", return_value={"swarm": {"max_workers": 5}}):
+            send = await send_and_capture(adapter, "/swarm pause", platform)
+
+        send.assert_called_once()
+        response_text = send.call_args[1].get("content") or send.call_args[0][1]
+        assert "restricted to the platform home channel" in response_text
 
 
 class TestSessionLifecycle:

--- a/tests/gateway/test_command_bypass_active_session.py
+++ b/tests/gateway/test_command_bypass_active_session.py
@@ -173,6 +173,18 @@ class TestCommandBypassActiveSession:
         assert any("handled:agents" in r for r in adapter.sent_responses)
 
     @pytest.mark.asyncio
+    async def test_swarm_bypasses_guard(self):
+        """/swarm must bypass so swarm controls work mid-run."""
+        adapter = _make_adapter()
+        sk = _session_key()
+        adapter._active_sessions[sk] = asyncio.Event()
+
+        await adapter.handle_message(_make_event("/swarm status"))
+
+        assert sk not in adapter._pending_messages
+        assert any("handled:swarm" in r for r in adapter.sent_responses)
+
+    @pytest.mark.asyncio
     async def test_tasks_alias_bypasses_guard(self):
         """/tasks alias must bypass active-session guard too."""
         adapter = _make_adapter()

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.config import GatewayConfig, HomeChannel, Platform, PlatformConfig
 from gateway.platforms.base import MessageEvent
 from gateway.session import SessionEntry, SessionSource, build_session_key
 
@@ -35,7 +35,13 @@ def _make_runner(session_entry: SessionEntry):
 
     runner = object.__new__(GatewayRunner)
     runner.config = GatewayConfig(
-        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")}
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                enabled=True,
+                token="***",
+                home_channel=HomeChannel(platform=Platform.TELEGRAM, chat_id="c1", name="Home"),
+            )
+        }
     )
     adapter = MagicMock()
     adapter.send = AsyncMock()
@@ -180,6 +186,114 @@ async def test_tasks_alias_routes_to_agents_command(monkeypatch):
     result = await runner._handle_message(_make_event("/tasks"))
 
     assert "Active Agents & Tasks" in result
+
+
+@pytest.mark.asyncio
+async def test_swarm_status_reports_pause_caps_and_active_subagents(monkeypatch):
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        total_tokens=0,
+    )
+    runner = _make_runner(session_entry)
+
+    monkeypatch.setattr("tools.delegate_tool.is_spawn_paused", lambda: True)
+    monkeypatch.setattr("tools.delegate_tool._get_max_spawn_depth", lambda: 2)
+    monkeypatch.setattr("tools.delegate_tool._get_max_concurrent_children", lambda: 4)
+    monkeypatch.setattr(
+        "tools.delegate_tool.list_active_subagents",
+        lambda: [
+            {
+                "subagent_id": "sa-0-abcd1234",
+                "kind": "detached_foreman",
+                "depth": 0,
+                "status": "running",
+                "stalled": True,
+                "idle_seconds": 312.4,
+                "model": "openai/orch-model",
+                "goal": "Coordinate backend and tests",
+                "source_platform": "telegram",
+                "source_chat_id": "c1",
+                "source_thread_id": "",
+            }
+        ],
+    )
+
+    result = await runner._handle_message(_make_event("/swarm"))
+
+    assert "Swarm Status" in result
+    assert "**Paused:** Yes" in result
+    assert "**Max depth:** 2" in result
+    assert "**Delegate batch max concurrency:** 4" in result
+    assert "**Active swarm agents in this chat:** 1" in result
+    assert "**Other active swarm agents:** 0" in result
+    assert "sa-0-abcd1234" in result
+    assert "foreman" in result
+    assert "stalled=yes" in result
+    assert "idle=312s" in result
+    assert "Coordinate backend and tests" in result
+
+
+@pytest.mark.asyncio
+async def test_swarm_pause_bypasses_running_agent_and_does_not_interrupt(monkeypatch):
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        total_tokens=0,
+    )
+    runner = _make_runner(session_entry)
+    running_agent = MagicMock()
+    runner._running_agents[build_session_key(_make_source())] = running_agent
+
+    monkeypatch.setattr("tools.delegate_tool.set_spawn_paused", lambda paused: bool(paused))
+
+    result = await runner._handle_message(_make_event("/swarm pause"))
+
+    assert "Swarm paused" in result
+    running_agent.interrupt.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_swarm_pause_is_denied_outside_home_channel(monkeypatch):
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        total_tokens=0,
+    )
+    runner = _make_runner(session_entry)
+    running_agent = MagicMock()
+    runner._running_agents[build_session_key(_make_source())] = running_agent
+
+    monkeypatch.setattr("tools.delegate_tool.set_spawn_paused", lambda paused: bool(paused))
+
+    off_home_event = MessageEvent(
+        text="/swarm pause",
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="u1",
+            chat_id="not-home",
+            user_name="tester",
+            chat_type="dm",
+        ),
+        message_id="m2",
+    )
+
+    result = await runner._handle_message(off_home_event)
+
+    assert "restricted to the platform home channel" in result
+    running_agent.interrupt.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_swarm_command.py
+++ b/tests/gateway/test_swarm_command.py
@@ -1,0 +1,433 @@
+"""Tests for /swarm gateway slash command.
+
+Covers detached foreman launch/control behavior while the parent chat remains
+free to continue.
+"""
+
+import asyncio
+import threading
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import GatewayConfig, HomeChannel, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+def _make_event(text="/swarm", platform=Platform.TELEGRAM,
+                user_id="12345", chat_id="67890", thread_id=None):
+    source = SessionSource(
+        platform=platform,
+        user_id=user_id,
+        chat_id=chat_id,
+        user_name="testuser",
+        thread_id=thread_id,
+    )
+    return MessageEvent(text=text, source=source)
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                enabled=True,
+                token="***",
+                home_channel=HomeChannel(platform=Platform.TELEGRAM, chat_id="67890", name="Home"),
+            )
+        }
+    )
+    runner.adapters = {}
+    runner._voice_mode = {}
+    runner._session_db = None
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._running_agents = {}
+    runner._background_tasks = set()
+
+    mock_store = MagicMock()
+    mock_store.get_or_create_session.return_value = MagicMock(session_id="parent-session")
+    runner.session_store = mock_store
+
+    from gateway.hooks import HookRegistry
+    runner.hooks = HookRegistry()
+
+    return runner
+
+
+class TestHandleSwarmCommand:
+    @pytest.mark.asyncio
+    async def test_start_without_prompt_shows_usage(self):
+        runner = _make_runner()
+        event = _make_event(text="/swarm start")
+        result = await runner._handle_swarm_command(event)
+        assert "Usage:" in result
+        assert "start <prompt>" in result
+
+    @pytest.mark.asyncio
+    async def test_launch_starts_detached_task(self):
+        runner = _make_runner()
+        created_tasks = []
+
+        def capture_task(coro, *args, **kwargs):
+            coro.close()
+            mock_task = MagicMock()
+            created_tasks.append(mock_task)
+            return mock_task
+
+        with patch("gateway.run._load_gateway_config", return_value={"swarm": {"max_workers": 7}}), \
+             patch("gateway.run.asyncio.create_task", side_effect=capture_task):
+            event = _make_event(text="/swarm Investigate auth regressions")
+            result = await runner._handle_swarm_command(event)
+
+        assert "Detached swarm started" in result
+        assert "Main Sub is running in the background" in result
+        assert "Worker budget: up to 7" in result
+        assert "swarm_" in result
+        assert len(created_tasks) == 1
+
+    @pytest.mark.asyncio
+    async def test_stop_without_matching_foreman_reports_none(self):
+        runner = _make_runner()
+        with patch("tools.delegate_tool.list_active_subagents", return_value=[]):
+            result = await runner._handle_swarm_command(_make_event(text="/swarm stop"))
+        assert "No detached swarm foreman is active for this chat" in result
+
+    @pytest.mark.asyncio
+    async def test_stop_interrupts_single_matching_foreman(self):
+        runner = _make_runner()
+        rows = [{
+            "subagent_id": "swarm_123",
+            "kind": "detached_foreman",
+            "source_platform": "telegram",
+            "source_chat_id": "67890",
+            "source_thread_id": "",
+        }]
+        with patch("tools.delegate_tool.list_active_subagents", return_value=rows), \
+             patch("tools.delegate_tool.interrupt_subagent", return_value=True) as interrupt:
+            result = await runner._handle_swarm_command(_make_event(text="/swarm stop"))
+        interrupt.assert_called_once_with("swarm_123")
+        assert "Swarm stop requested" in result
+
+    @pytest.mark.asyncio
+    async def test_explicit_stop_target_is_used(self):
+        runner = _make_runner()
+        rows = [{
+            "subagent_id": "swarm_abc",
+            "kind": "detached_foreman",
+            "source_platform": "telegram",
+            "source_chat_id": "67890",
+            "source_thread_id": "",
+        }]
+        with patch("tools.delegate_tool.list_active_subagents", return_value=rows), \
+             patch("tools.delegate_tool.interrupt_subagent", return_value=True) as interrupt:
+            result = await runner._handle_swarm_command(_make_event(text="/swarm stop swarm_abc"))
+        interrupt.assert_called_once_with("swarm_abc")
+        assert "swarm_abc" in result
+
+    @pytest.mark.asyncio
+    async def test_explicit_stop_rejects_other_chat_foreman(self):
+        runner = _make_runner()
+        rows = [{
+            "subagent_id": "swarm_other",
+            "kind": "detached_foreman",
+            "source_platform": "telegram",
+            "source_chat_id": "different-chat",
+            "source_thread_id": "",
+        }]
+        with patch("tools.delegate_tool.list_active_subagents", return_value=rows):
+            result = await runner._handle_swarm_command(_make_event(text="/swarm stop swarm_other"))
+        assert "belongs to a different chat" in result
+
+    @pytest.mark.asyncio
+    async def test_stop_with_multiword_arg_shows_usage_and_does_not_launch(self):
+        runner = _make_runner()
+        created_tasks = []
+
+        def capture_task(coro, *args, **kwargs):
+            coro.close()
+            mock_task = MagicMock()
+            created_tasks.append(mock_task)
+            return mock_task
+
+        with patch("gateway.run._load_gateway_config", return_value={"swarm": {"max_workers": 5}}), \
+             patch("tools.delegate_tool.list_active_subagents", return_value=[]), \
+             patch("gateway.run.asyncio.create_task", side_effect=capture_task):
+            result = await runner._handle_swarm_command(_make_event(text="/swarm stop the bleeding in auth"))
+
+        assert "Usage: /swarm stop <id>" in result
+        assert "use `/swarm start <prompt>`" in result
+        assert len(created_tasks) == 0
+
+    @pytest.mark.asyncio
+    async def test_start_allows_prompt_beginning_with_stop_word(self):
+        runner = _make_runner()
+        created_tasks = []
+
+        def capture_task(coro, *args, **kwargs):
+            coro.close()
+            mock_task = MagicMock()
+            created_tasks.append(mock_task)
+            return mock_task
+
+        with patch("gateway.run._load_gateway_config", return_value={"swarm": {"max_workers": 5}}), \
+             patch("tools.delegate_tool.list_active_subagents", return_value=[]), \
+             patch("gateway.run.asyncio.create_task", side_effect=capture_task):
+            result = await runner._handle_swarm_command(_make_event(text="/swarm start stop the bleeding in auth"))
+
+        assert "Detached swarm started" in result
+        assert len(created_tasks) == 1
+
+    @pytest.mark.asyncio
+    async def test_launch_rejected_when_chat_already_has_active_foreman(self):
+        runner = _make_runner()
+        rows = [{
+            "subagent_id": "swarm_busy",
+            "kind": "detached_foreman",
+            "source_platform": "telegram",
+            "source_chat_id": "67890",
+            "source_thread_id": "",
+        }]
+        with patch("tools.delegate_tool.list_active_subagents", return_value=rows):
+            result = await runner._handle_swarm_command(_make_event(text="/swarm investigate auth"))
+        assert "already active for this chat" in result
+
+    @pytest.mark.asyncio
+    async def test_stop_with_multiple_matching_foremen_requires_explicit_id(self):
+        runner = _make_runner()
+        rows = [
+            {
+                "subagent_id": "swarm_1",
+                "kind": "detached_foreman",
+                "source_platform": "telegram",
+                "source_chat_id": "67890",
+                "source_thread_id": "",
+            },
+            {
+                "subagent_id": "swarm_2",
+                "kind": "detached_foreman",
+                "source_platform": "telegram",
+                "source_chat_id": "67890",
+                "source_thread_id": "",
+            },
+        ]
+        with patch("tools.delegate_tool.list_active_subagents", return_value=rows):
+            result = await runner._handle_swarm_command(_make_event(text="/swarm stop"))
+        assert "Multiple detached swarms" in result
+
+    @pytest.mark.asyncio
+    async def test_swarm_status_labels_detached_foreman_rows(self):
+        runner = _make_runner()
+        with patch("gateway.run._load_gateway_config", return_value={"swarm": {"max_workers": 6}}), \
+             patch("tools.delegate_tool.is_spawn_paused", return_value=False), \
+             patch("tools.delegate_tool._get_max_spawn_depth", return_value=1), \
+             patch("tools.delegate_tool._get_max_concurrent_children", return_value=3), \
+             patch("tools.delegate_tool.list_active_subagents", return_value=[{
+                 "subagent_id": "swarm_123",
+                 "kind": "detached_foreman",
+                 "depth": 0,
+                 "status": "running",
+                 "stalled": False,
+                 "idle_seconds": 12.0,
+                 "model": "gpt-5.4",
+                 "goal": "Orchestrate worker swarm",
+                 "source_platform": "telegram",
+                 "source_chat_id": "67890",
+                 "source_thread_id": "",
+             }]):
+            result = await runner._handle_swarm_command(_make_event(text="/swarm status"))
+        assert "foreman" in result
+        assert "Detached foreman worker cap:" in result
+        assert "Active swarm agents in this chat:" in result
+
+    @pytest.mark.asyncio
+    async def test_swarm_status_is_scoped_to_this_chat_and_descendants(self):
+        runner = _make_runner()
+        rows = [
+            {
+                "subagent_id": "swarm_here",
+                "kind": "detached_foreman",
+                "depth": 0,
+                "status": "running",
+                "stalled": False,
+                "idle_seconds": 5.0,
+                "model": "gpt-5.4",
+                "goal": "This chat goal",
+                "source_platform": "telegram",
+                "source_chat_id": "67890",
+                "source_thread_id": "",
+            },
+            {
+                "subagent_id": "sa-child",
+                "parent_id": "swarm_here",
+                "kind": "delegate_child",
+                "depth": 1,
+                "status": "running",
+                "stalled": False,
+                "idle_seconds": 2.0,
+                "model": "gpt-5.4-mini",
+                "goal": "Child worker goal",
+            },
+            {
+                "subagent_id": "swarm_elsewhere",
+                "kind": "detached_foreman",
+                "depth": 0,
+                "status": "running",
+                "stalled": False,
+                "idle_seconds": 8.0,
+                "model": "gpt-5.4",
+                "goal": "Other chat goal",
+                "source_platform": "telegram",
+                "source_chat_id": "different-chat",
+                "source_thread_id": "",
+            },
+        ]
+        with patch("gateway.run._load_gateway_config", return_value={"swarm": {"max_workers": 6}}), \
+             patch("tools.delegate_tool.is_spawn_paused", return_value=False), \
+             patch("tools.delegate_tool._get_max_spawn_depth", return_value=1), \
+             patch("tools.delegate_tool._get_max_concurrent_children", return_value=3), \
+             patch("tools.delegate_tool.list_active_subagents", return_value=rows):
+            result = await runner._handle_swarm_command(_make_event(text="/swarm status"))
+        assert "swarm_here" in result
+        assert "sa-child" in result
+        assert "Child worker goal" in result
+        assert "swarm_elsewhere" not in result
+        assert "Other chat goal" not in result
+        assert "**Other active swarm agents:** 1" in result
+
+    @pytest.mark.asyncio
+    async def test_swarm_pause_is_denied_outside_home_channel(self):
+        runner = _make_runner()
+        result = await runner._handle_swarm_command(_make_event(text="/swarm pause", chat_id="not-home"))
+        assert "restricted to the platform home channel" in result
+
+    @pytest.mark.asyncio
+    async def test_swarm_resume_is_denied_outside_home_channel(self):
+        runner = _make_runner()
+        result = await runner._handle_swarm_command(_make_event(text="/swarm resume", chat_id="not-home"))
+        assert "restricted to the platform home channel" in result
+
+    @pytest.mark.asyncio
+    async def test_run_swarm_task_registers_interruptible_foreman_and_filters_toolsets(self):
+        runner = _make_runner()
+        source = _make_event(text="/swarm test").source
+        mock_adapter = MagicMock()
+        mock_adapter.send = AsyncMock()
+        mock_adapter.send_image = AsyncMock()
+        mock_adapter.send_document = AsyncMock()
+        mock_adapter.extract_media = MagicMock(return_value=([], "Swarm done"))
+        mock_adapter.extract_images = MagicMock(return_value=([], "Swarm done"))
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+        runner._resolve_session_agent_runtime = MagicMock(return_value=("gpt-5.4", {"api_key": "key"}))
+        runner._load_reasoning_config = MagicMock(return_value=None)
+        runner._load_service_tier = MagicMock(return_value=None)
+        runner._resolve_turn_agent_config = MagicMock(return_value={
+            "model": "gpt-5.4",
+            "runtime": {"api_key": "key"},
+            "request_overrides": None,
+        })
+        runner._cleanup_agent_resources = MagicMock()
+
+        captured = {}
+        release = threading.Event()
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+                self.interrupt = MagicMock()
+            def run_conversation(self, user_message=None, task_id=None):
+                release.wait(timeout=2)
+                return {"final_response": "Swarm done"}
+
+        async def delayed_executor(fn):
+            return await asyncio.to_thread(fn)
+
+        runner._run_in_executor_with_context = AsyncMock(side_effect=delayed_executor)
+
+        with patch("gateway.run._load_gateway_config", return_value={"swarm": {"max_workers": 6}}), \
+             patch("hermes_cli.tools_config._get_platform_tools", return_value={"terminal", "messaging", "memory"}), \
+             patch("run_agent.AIAgent", FakeAgent):
+            task = asyncio.create_task(runner._run_swarm_task("Investigate auth", source, "swarm_test"))
+            await asyncio.sleep(0.05)
+            from tools.delegate_tool import interrupt_subagent
+            assert interrupt_subagent("swarm_test") is True
+            release.set()
+            await task
+
+        assert "delegation" in captured["enabled_toolsets"]
+        assert "terminal" in captured["enabled_toolsets"]
+        assert "skills" in captured["enabled_toolsets"]
+        assert "messaging" not in captured["enabled_toolsets"]
+        assert "memory" not in captured["enabled_toolsets"]
+        assert "messaging" in captured["disabled_toolsets"]
+        assert "memory" in captured["disabled_toolsets"]
+        mock_adapter.send.assert_called()
+        sent_content = mock_adapter.send.call_args.kwargs.get("content", "")
+        assert "Swarm task complete" in sent_content
+
+    @pytest.mark.asyncio
+    async def test_run_swarm_task_unregisters_launching_foreman_when_adapter_missing(self):
+        runner = _make_runner()
+        source = _make_event(text="/swarm test").source
+
+        from tools.delegate_tool import _register_subagent, _unregister_subagent, list_active_subagents
+
+        task_id = "swarm_missing_adapter"
+        _register_subagent(
+            {
+                "subagent_id": task_id,
+                "parent_id": None,
+                "depth": 0,
+                "goal": "Investigate auth",
+                "status": "launching",
+                "kind": "detached_foreman",
+                "source_platform": source.platform.value,
+                "source_chat_id": source.chat_id,
+                "source_thread_id": source.thread_id,
+            }
+        )
+
+        try:
+            await runner._run_swarm_task("Investigate auth", source, task_id)
+            assert not any(row["subagent_id"] == task_id for row in list_active_subagents())
+        finally:
+            _unregister_subagent(task_id)
+
+    @pytest.mark.asyncio
+    async def test_run_swarm_task_unregisters_launching_foreman_when_api_key_missing(self):
+        runner = _make_runner()
+        source = _make_event(text="/swarm test").source
+        mock_adapter = MagicMock()
+        mock_adapter.send = AsyncMock()
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+        runner._resolve_session_agent_runtime = MagicMock(return_value=("gpt-5.4", {}))
+
+        from tools.delegate_tool import _register_subagent, _unregister_subagent, list_active_subagents
+
+        task_id = "swarm_missing_api_key"
+        _register_subagent(
+            {
+                "subagent_id": task_id,
+                "parent_id": None,
+                "depth": 0,
+                "goal": "Investigate auth",
+                "status": "launching",
+                "kind": "detached_foreman",
+                "source_platform": source.platform.value,
+                "source_chat_id": source.chat_id,
+                "source_thread_id": source.thread_id,
+            }
+        )
+
+        try:
+            with patch("gateway.run._load_gateway_config", return_value={"swarm": {"max_workers": 6}}):
+                await runner._run_swarm_task("Investigate auth", source, task_id)
+
+            mock_adapter.send.assert_awaited_once()
+            assert not any(row["subagent_id"] == task_id for row in list_active_subagents())
+        finally:
+            _unregister_subagent(task_id)

--- a/tests/gateway/test_unauthorized_dm_behavior.py
+++ b/tests/gateway/test_unauthorized_dm_behavior.py
@@ -12,6 +12,7 @@ from gateway.session import SessionSource
 def _clear_auth_env(monkeypatch) -> None:
     for key in (
         "TELEGRAM_ALLOWED_USERS",
+        "TELEGRAM_ALLOWED_GROUP_CHATS",
         "DISCORD_ALLOWED_USERS",
         "WHATSAPP_ALLOWED_USERS",
         "SLACK_ALLOWED_USERS",
@@ -136,6 +137,46 @@ def test_star_wildcard_works_for_any_platform(monkeypatch):
         chat_type="dm",
     )
     assert runner._is_user_authorized(source) is True
+
+
+def test_telegram_group_allowlist_authorizes_group_chat_without_user_allowlist(monkeypatch):
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("TELEGRAM_ALLOWED_GROUP_CHATS", "-1001234567890")
+
+    runner, _adapter = _make_runner(
+        Platform.TELEGRAM,
+        GatewayConfig(platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="t")}),
+    )
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="421433470",
+        chat_id="-1001234567890",
+        user_name="group member",
+        chat_type="group",
+    )
+
+    assert runner._is_user_authorized(source) is True
+
+
+def test_telegram_group_allowlist_does_not_authorize_other_groups(monkeypatch):
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("TELEGRAM_ALLOWED_GROUP_CHATS", "-1001234567890")
+
+    runner, _adapter = _make_runner(
+        Platform.TELEGRAM,
+        GatewayConfig(platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="t")}),
+    )
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="421433470",
+        chat_id="-1009999999999",
+        user_name="group member",
+        chat_type="group",
+    )
+
+    assert runner._is_user_authorized(source) is False
 
 
 def test_qq_group_allowlist_authorizes_group_chat_without_user_allowlist(monkeypatch):

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -95,6 +95,7 @@ class TestResolveCommand:
         assert resolve_command("background").name == "background"
         assert resolve_command("copy").name == "copy"
         assert resolve_command("agents").name == "agents"
+        assert resolve_command("swarm").name == "swarm"
 
     def test_alias_resolves_to_canonical(self):
         assert resolve_command("bg").name == "background"
@@ -113,6 +114,12 @@ class TestResolveCommand:
     def test_unknown_returns_none(self):
         assert resolve_command("nonexistent") is None
         assert resolve_command("") is None
+
+    def test_swarm_has_expected_subcommands(self):
+        cmd = resolve_command("swarm")
+        assert cmd is not None
+        assert cmd.gateway_only is True
+        assert cmd.subcommands == ("status", "pause", "resume")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -22,6 +22,7 @@ from tools.delegate_tool import (
     DELEGATE_TASK_SCHEMA,
     DelegateEvent,
     _get_max_concurrent_children,
+    _get_stall_threshold_seconds,
     _LEGACY_EVENT_MAP,
     MAX_DEPTH,
     check_delegate_requirements,
@@ -307,6 +308,25 @@ class TestDelegateTask(unittest.TestCase):
         self.assertTrue(callable(mock_child.thinking_callback))
         mock_child.thinking_callback("deliberating...")
         parent.tool_progress_callback.assert_not_called()
+
+    def test_claude_acp_override_fails_fast_with_clear_guidance(self):
+        """Claude Code on this machine lacks --acp, so do not route it through ACP."""
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent"):
+            with self.assertRaisesRegex(ValueError, "Claude Code ACP delegation is not supported"):
+                _build_child_agent(
+                    task_index=0,
+                    goal="Do not spawn Claude through ACP",
+                    context=None,
+                    toolsets=None,
+                    model=None,
+                    max_iterations=10,
+                    parent_agent=parent,
+                    task_count=1,
+                    override_acp_command="claude",
+                    override_acp_args=["--acp", "--stdio"],
+                )
 
 
 class TestToolNamePreservation(unittest.TestCase):
@@ -1585,10 +1605,131 @@ class TestConcurrencyDefaults(unittest.TestCase):
         with patch.dict(os.environ, {"DELEGATION_MAX_CONCURRENT_CHILDREN": "12"}):
             self.assertEqual(_get_max_concurrent_children(), 12)
 
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_parent_override_honored(self, mock_cfg):
+        parent = MagicMock()
+        parent._delegate_max_concurrent_children_override = 9
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(_get_max_concurrent_children(parent), 9)
+
+    @patch("tools.delegate_tool._load_config", return_value={"max_concurrent_children": 6})
+    def test_parent_override_beats_config(self, mock_cfg):
+        parent = MagicMock()
+        parent._delegate_max_concurrent_children_override = 8
+        self.assertEqual(_get_max_concurrent_children(parent), 8)
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_invalid_parent_override_falls_back(self, mock_cfg):
+        parent = MagicMock()
+        parent._delegate_max_concurrent_children_override = "bad"
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(_get_max_concurrent_children(parent), 3)
+
     @patch("tools.delegate_tool._load_config",
            return_value={"max_concurrent_children": 6})
     def test_configured_value_returned(self, mock_cfg):
         self.assertEqual(_get_max_concurrent_children(), 6)
+
+
+# =========================================================================
+# stall_threshold_seconds helper + active subagent telemetry
+# =========================================================================
+
+
+class TestStallThresholdSeconds(unittest.TestCase):
+    """Tests for delegation.stall_threshold_seconds parsing and clamping."""
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_default_is_300_seconds(self, mock_cfg):
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(_get_stall_threshold_seconds(), 300.0)
+
+    @patch("tools.delegate_tool._load_config",
+           return_value={"stall_threshold_seconds": 45})
+    def test_configured_value_returned(self, mock_cfg):
+        self.assertEqual(_get_stall_threshold_seconds(), 45.0)
+
+    @patch("tools.delegate_tool._load_config",
+           return_value={"stall_threshold_seconds": 5})
+    def test_config_below_floor_clamps_and_warns(self, mock_cfg):
+        import logging
+        with self.assertLogs("tools.delegate_tool", level=logging.WARNING) as cm:
+            result = _get_stall_threshold_seconds()
+        self.assertEqual(result, 30.0)
+        self.assertTrue(any("clamping to 30" in m for m in cm.output))
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_env_fallback_honored(self, mock_cfg):
+        with patch.dict(os.environ, {"DELEGATION_STALL_THRESHOLD_SECONDS": "90"}):
+            self.assertEqual(_get_stall_threshold_seconds(), 90.0)
+
+
+class TestActiveSubagentTelemetry(unittest.TestCase):
+    """Tests for the live subagent registry telemetry snapshot."""
+
+    def test_list_active_subagents_includes_stall_fields(self):
+        from tools.delegate_tool import _register_subagent, _unregister_subagent, list_active_subagents
+
+        sid = "sa-test-stall"
+        now = time.time()
+        _register_subagent(
+            {
+                "subagent_id": sid,
+                "parent_id": None,
+                "depth": 0,
+                "goal": "Investigate slow tests",
+                "model": "openai/test-orchestrator",
+                "started_at": now - 320,
+                "last_activity_at": now - 310,
+                "last_activity_kind": "subagent.thinking",
+                "status": "running",
+                "tool_count": 2,
+                "agent": MagicMock(),
+            }
+        )
+        try:
+            with patch("tools.delegate_tool._get_stall_threshold_seconds", return_value=300.0):
+                rows = [r for r in list_active_subagents() if r["subagent_id"] == sid]
+            self.assertEqual(len(rows), 1)
+            row = rows[0]
+            self.assertEqual(row["last_activity_kind"], "subagent.thinking")
+            self.assertTrue(row["stalled"])
+            self.assertGreaterEqual(row["idle_seconds"], 300)
+            self.assertNotIn("agent", row)
+        finally:
+            _unregister_subagent(sid)
+
+    def test_completed_subagent_record_is_not_kept(self):
+        from tools.delegate_tool import _run_single_child, list_active_subagents
+
+        sid = "sa-test-complete"
+        child = MagicMock()
+        child._subagent_id = sid
+        child._delegate_depth = 1
+        child._parent_subagent_id = None
+        child._delegate_role = "leaf"
+        child.model = "openai/test-leaf"
+        child._credential_pool = None
+        child.session_prompt_tokens = 0
+        child.session_completion_tokens = 0
+        child.session_reasoning_tokens = 0
+        child.run_conversation.return_value = {
+            "final_response": "done",
+            "completed": True,
+            "api_calls": 1,
+            "messages": [],
+        }
+
+        _run_single_child(
+            task_index=0,
+            goal="Finish quickly",
+            child=child,
+            parent_agent=_make_mock_parent(),
+        )
+
+        self.assertFalse(
+            any(row["subagent_id"] == sid for row in list_active_subagents())
+        )
 
 
 # =========================================================================
@@ -1815,6 +1956,56 @@ class TestOrchestratorRoleBehavior(unittest.TestCase):
                 kwargs = MockAgent.call_args[1]
                 self.assertNotIn("delegation", kwargs["enabled_toolsets"])
                 self.assertEqual(mock_child._delegate_role, "leaf")
+
+    @patch("tools.delegate_tool._load_config",
+           return_value={"max_spawn_depth": 2, "orchestrator_model": "openai/orch-model"})
+    @patch("tools.delegate_tool._build_child_progress_callback")
+    @patch("run_agent.AIAgent")
+    def test_orchestrator_model_override_applies_only_to_orchestrators(
+        self, MockAgent, mock_progress_cb, mock_cfg
+    ):
+        """delegation.orchestrator_model overrides the general child model
+        only when the effective role is orchestrator, and the callback sees
+        the same effective model.
+        """
+        mock_progress_cb.return_value = None
+        MockAgent.return_value = _make_role_mock_child()
+        parent = _make_mock_parent(depth=0)
+        parent.enabled_toolsets = ["terminal", "file", "delegation"]
+
+        _build_child_agent(
+            task_index=0,
+            goal="Coordinate broad work",
+            context=None,
+            toolsets=None,
+            model="openai/general-model",
+            max_iterations=50,
+            task_count=1,
+            parent_agent=parent,
+            role="orchestrator",
+        )
+
+        orch_call = MockAgent.call_args_list[0].kwargs
+        orch_cb_call = mock_progress_cb.call_args_list[0].kwargs
+        self.assertEqual(orch_call["model"], "openai/orch-model")
+        self.assertEqual(orch_cb_call["model"], "openai/orch-model")
+
+        _build_child_agent(
+            task_index=1,
+            goal="Handle one leaf task",
+            context=None,
+            toolsets=None,
+            model="openai/general-model",
+            max_iterations=50,
+            task_count=1,
+            parent_agent=parent,
+            role="leaf",
+        )
+
+        leaf_call = MockAgent.call_args_list[1].kwargs
+        leaf_cb_call = mock_progress_cb.call_args_list[1].kwargs
+        self.assertEqual(leaf_call["model"], "openai/general-model")
+        self.assertEqual(leaf_cb_call["model"], "openai/general-model")
 
     # ── Role-aware system prompt ────────────────────────────────────────
 

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -68,24 +68,63 @@ def _scan_cron_prompt(prompt: str) -> str:
     return ""
 
 
+def _current_session_scope() -> Optional[Dict[str, Optional[str]]]:
+    """Return the current messaging session scope, if this tool is running in one."""
+    from gateway.session_context import get_session_env
+
+    platform = (get_session_env("HERMES_SESSION_PLATFORM") or "").strip()
+    chat_id = (get_session_env("HERMES_SESSION_CHAT_ID") or "").strip()
+    if not platform or not chat_id:
+        return None
+    thread_id = (get_session_env("HERMES_SESSION_THREAD_ID") or "").strip() or None
+    return {
+        "platform": platform,
+        "chat_id": chat_id,
+        "thread_id": thread_id,
+    }
+
+
 def _origin_from_env() -> Optional[Dict[str, str]]:
     from gateway.session_context import get_session_env
-    origin_platform = get_session_env("HERMES_SESSION_PLATFORM")
-    origin_chat_id = get_session_env("HERMES_SESSION_CHAT_ID")
-    if origin_platform and origin_chat_id:
-        thread_id = get_session_env("HERMES_SESSION_THREAD_ID") or None
+
+    scope = _current_session_scope()
+    if scope:
+        thread_id = scope.get("thread_id")
         if thread_id:
             logger.debug(
                 "Cron origin captured thread_id=%s for %s:%s",
-                thread_id, origin_platform, origin_chat_id,
+                thread_id, scope["platform"], scope["chat_id"],
             )
         return {
-            "platform": origin_platform,
-            "chat_id": origin_chat_id,
+            "platform": scope["platform"],
+            "chat_id": scope["chat_id"],
             "chat_name": get_session_env("HERMES_SESSION_CHAT_NAME") or None,
             "thread_id": thread_id,
         }
     return None
+
+
+def _job_matches_session_scope(job: Dict[str, Any], scope: Optional[Dict[str, Optional[str]]]) -> bool:
+    """Return True when a cron job belongs to the active messaging chat/topic.
+
+    No active session scope means CLI/admin behaviour: show all jobs.  When a
+    messaging chat is active, origin-less jobs and jobs from other chats/topics
+    must stay hidden so status/list operations don't leak cross-chat state.
+    """
+    if not scope:
+        return True
+
+    origin = job.get("origin") or {}
+    if not isinstance(origin, dict):
+        return False
+
+    if str(origin.get("platform") or "").strip() != scope["platform"]:
+        return False
+    if str(origin.get("chat_id") or "").strip() != scope["chat_id"]:
+        return False
+
+    origin_thread_id = str(origin.get("thread_id") or "").strip() or None
+    return origin_thread_id == scope.get("thread_id")
 
 
 def _repeat_display(job: Dict[str, Any]) -> str:
@@ -298,14 +337,20 @@ def cronjob(
             )
 
         if normalized == "list":
-            jobs = [_format_job(job) for job in list_jobs(include_disabled=include_disabled)]
+            scope = _current_session_scope()
+            visible_jobs = [
+                job for job in list_jobs(include_disabled=include_disabled)
+                if _job_matches_session_scope(job, scope)
+            ]
+            jobs = [_format_job(job) for job in visible_jobs]
             return json.dumps({"success": True, "count": len(jobs), "jobs": jobs}, indent=2)
 
         if not job_id:
             return tool_error(f"job_id is required for action '{normalized}'", success=False)
 
         job = get_job(job_id)
-        if not job:
+        scope = _current_session_scope()
+        if not job or not _job_matches_session_scope(job, scope):
             return json.dumps(
                 {"success": False, "error": f"Job with ID '{job_id}' not found. Use cronjob(action='list') to inspect jobs."},
                 indent=2,

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -113,6 +113,15 @@ def _register_subagent(record: Dict[str, Any]) -> None:
     sid = record.get("subagent_id")
     if not sid:
         return
+    started_at = record.get("started_at")
+    try:
+        started_at = float(started_at)
+    except (TypeError, ValueError):
+        started_at = time.time()
+    record["started_at"] = started_at
+    record.setdefault("last_activity_at", started_at)
+    record.setdefault("last_activity_kind", "registered")
+    record.setdefault("status", "starting")
     with _active_subagents_lock:
         _active_subagents[sid] = record
 
@@ -120,6 +129,30 @@ def _register_subagent(record: Dict[str, Any]) -> None:
 def _unregister_subagent(subagent_id: str) -> None:
     with _active_subagents_lock:
         _active_subagents.pop(subagent_id, None)
+
+
+def _mark_subagent_activity(
+    subagent_id: Optional[str],
+    kind: str,
+    *,
+    status: Optional[str] = None,
+    when: Optional[float] = None,
+    **fields,
+) -> None:
+    """Update live telemetry for a running subagent."""
+    if not subagent_id:
+        return
+    at = time.time() if when is None else when
+    with _active_subagents_lock:
+        record = _active_subagents.get(subagent_id)
+        if record is None:
+            return
+        record["last_activity_at"] = at
+        record["last_activity_kind"] = kind
+        if status:
+            record["status"] = status
+        if fields:
+            record.update(fields)
 
 
 def interrupt_subagent(subagent_id: str) -> bool:
@@ -148,14 +181,28 @@ def interrupt_subagent(subagent_id: str) -> bool:
 def list_active_subagents() -> List[Dict[str, Any]]:
     """Snapshot of the currently running subagent tree.
 
-    Each record: {subagent_id, parent_id, depth, goal, model, started_at,
-    tool_count, status}.  Safe to call from any thread — returns a copy.
+    Each record includes live telemetry derived from the running child:
+    ``last_activity_at``, ``last_activity_kind``, ``idle_seconds``, and
+    ``stalled``. Safe to call from any thread — returns copies only.
     """
+    now = time.time()
+    stall_threshold = _get_stall_threshold_seconds()
     with _active_subagents_lock:
-        return [
-            {k: v for k, v in r.items() if k != "agent"}
-            for r in _active_subagents.values()
-        ]
+        rows: List[Dict[str, Any]] = []
+        for r in _active_subagents.values():
+            row = {k: v for k, v in r.items() if k != "agent"}
+            last_activity_at = row.get("last_activity_at", row.get("started_at", now))
+            try:
+                last_activity_at = float(last_activity_at)
+            except (TypeError, ValueError):
+                last_activity_at = now
+            idle_seconds = max(0.0, now - last_activity_at)
+            row["last_activity_at"] = last_activity_at
+            row["last_activity_kind"] = str(row.get("last_activity_kind") or "unknown")
+            row["idle_seconds"] = round(idle_seconds, 1)
+            row["stalled"] = idle_seconds >= stall_threshold
+            rows.append(row)
+        return rows
 
 
 def _extract_output_tail(
@@ -263,15 +310,34 @@ def _normalize_role(r: Optional[str]) -> str:
     return "leaf"
 
 
-def _get_max_concurrent_children() -> int:
-    """Read delegation.max_concurrent_children from config, falling back to
-    DELEGATION_MAX_CONCURRENT_CHILDREN env var, then the default (3).
+def _get_max_concurrent_children(parent_agent=None) -> int:
+    """Read the effective parallel child budget.
+
+    Precedence:
+    1. Parent-agent override (`_delegate_max_concurrent_children_override`) when set.
+    2. delegation.max_concurrent_children in config.yaml.
+    3. DELEGATION_MAX_CONCURRENT_CHILDREN env var.
+    4. Default (3).
 
     Users can raise this as high as they want; only the floor (1) is enforced.
-
-    Uses the same ``_load_config()`` path that the rest of ``delegate_task``
-    uses, keeping config priority consistent (config.yaml > env > default).
     """
+    if parent_agent is not None:
+        override = None
+        try:
+            parent_dict = object.__getattribute__(parent_agent, "__dict__")
+        except Exception:
+            parent_dict = None
+        if isinstance(parent_dict, dict) and "_delegate_max_concurrent_children_override" in parent_dict:
+            override = parent_dict.get("_delegate_max_concurrent_children_override")
+        if override is not None:
+            try:
+                return max(1, int(override))
+            except (TypeError, ValueError):
+                logger.warning(
+                    "parent override _delegate_max_concurrent_children_override=%r is not a valid integer; ignoring",
+                    override,
+                )
+
     cfg = _load_config()
     val = cfg.get("max_concurrent_children")
     if val is not None:
@@ -410,6 +476,7 @@ def _preserve_parent_mcp_toolsets(
 
 DEFAULT_MAX_ITERATIONS = 50
 DEFAULT_CHILD_TIMEOUT = 600  # seconds before a child agent is considered stuck
+DEFAULT_STALL_THRESHOLD_SECONDS = 300  # seconds with no subagent activity before flagged stalled
 _HEARTBEAT_INTERVAL = 30  # seconds between parent activity heartbeats during delegation
 _HEARTBEAT_STALE_CYCLES = (
     5  # mark child stale after this many heartbeats with no iteration progress
@@ -615,6 +682,11 @@ def _build_child_progress_callback(
     _batch: List[str] = []
     _tool_count = [0]  # per-subagent running counter (list for closure mutation)
 
+    def _record(kind: str, *, status: Optional[str] = None, **fields) -> None:
+        if subagent_id is None:
+            return
+        _mark_subagent_activity(subagent_id, kind, status=status, **fields)
+
     def _identity_kwargs() -> Dict[str, Any]:
         kw: Dict[str, Any] = {
             "task_index": task_index,
@@ -652,6 +724,7 @@ def _build_child_progress_callback(
         # Lifecycle events emitted by the orchestrator itself — handled
         # before enum normalisation since they are not part of DelegateEvent.
         if event_type == "subagent.start":
+            _record("subagent.start", status="running")
             if spinner and goal_label:
                 short = (
                     (goal_label[:55] + "...") if len(goal_label) > 55 else goal_label
@@ -664,6 +737,10 @@ def _build_child_progress_callback(
             return
 
         if event_type == "subagent.complete":
+            _record(
+                "subagent.complete",
+                status=str(kwargs.get("status") or "completed"),
+            )
             _relay("subagent.complete", preview=preview, **kwargs)
             return
 
@@ -683,6 +760,7 @@ def _build_child_progress_callback(
 
         if event == DelegateEvent.TASK_THINKING:
             text = preview or tool_name or ""
+            _record("subagent.thinking", status="running")
             if spinner:
                 short = (text[:55] + "...") if len(text) > 55 else text
                 try:
@@ -696,6 +774,7 @@ def _build_child_progress_callback(
             return
 
         if event == DelegateEvent.TASK_PROGRESS:
+            _record("subagent.progress", status="running")
             # Pre-batched progress summary relayed from a nested
             # orchestrator's grandchild (upstream emits as
             # parent_cb("subagent_progress", summary_string) where the
@@ -719,11 +798,12 @@ def _build_child_progress_callback(
         # TASK_TOOL_STARTED — display and batch for parent relay
         _tool_count[0] += 1
         if subagent_id is not None:
-            with _active_subagents_lock:
-                rec = _active_subagents.get(subagent_id)
-                if rec is not None:
-                    rec["tool_count"] = _tool_count[0]
-                    rec["last_tool"] = tool_name or ""
+            _record(
+                "subagent.tool_started",
+                status="running",
+                tool_count=_tool_count[0],
+                last_tool=tool_name or "",
+            )
         if spinner:
             short = (
                 (preview[:35] + "...")
@@ -804,6 +884,11 @@ def _build_child_agent(
     max_spawn = _get_max_spawn_depth()
     orchestrator_ok = _get_orchestrator_enabled() and child_depth < max_spawn
     effective_role = role if (role == "orchestrator" and orchestrator_ok) else "leaf"
+    effective_child_model = model
+    if effective_role == "orchestrator":
+        orchestrator_model = _get_orchestrator_model()
+        if orchestrator_model:
+            effective_child_model = orchestrator_model
 
     # ── Subagent identity (stable across events, 0-indexed for TUI) ─────
     # subagent_id is generated here so the progress callback, the
@@ -872,7 +957,7 @@ def _build_child_agent(
         parent_api_key = parent_agent._client_kwargs.get("api_key")
 
     # Resolve the child's effective model early so it can ride on every event.
-    effective_model_for_cb = model or getattr(parent_agent, "model", None)
+    effective_model_for_cb = effective_child_model or getattr(parent_agent, "model", None)
 
     # Build progress callback to relay tool calls to parent display.
     # Identity kwargs thread the subagent_id through every emitted event so the
@@ -908,7 +993,7 @@ def _build_child_agent(
         child_thinking_cb = _child_thinking
 
     # Resolve effective credentials: config override > parent inherit
-    effective_model = model or parent_agent.model
+    effective_model = effective_child_model or parent_agent.model
     effective_provider = override_provider or getattr(parent_agent, "provider", None)
     effective_base_url = override_base_url or parent_agent.base_url
     effective_api_key = override_api_key or parent_api_key
@@ -923,6 +1008,13 @@ def _build_child_agent(
     )
 
     if override_acp_command:
+        _cmd_name = os.path.basename(str(override_acp_command).split()[0]).lower()
+        if _cmd_name == "claude":
+            raise ValueError(
+                "Claude Code ACP delegation is not supported on this machine: "
+                "`claude --acp --stdio` fails with 'unknown option --acp'. "
+                "Use terminal print mode instead: `claude -p ... --model claude-opus-4-6`."
+            )
         # If explicitly forcing an ACP transport override, the provider MUST be copilot-acp
         # so run_agent.py initializes the CopilotACPClient.
         effective_provider = "copilot-acp"
@@ -988,6 +1080,12 @@ def _build_child_agent(
     child._subagent_id = subagent_id
     child._parent_subagent_id = parent_subagent_id
     child._subagent_goal = goal
+    try:
+        parent_dict = object.__getattribute__(parent_agent, "__dict__")
+    except Exception:
+        parent_dict = None
+    if isinstance(parent_dict, dict) and "_delegate_max_concurrent_children_override" in parent_dict:
+        child._delegate_max_concurrent_children_override = parent_dict["_delegate_max_concurrent_children_override"]
 
     # Share a credential pool with the child when possible so subagents can
     # rotate credentials on rate limits instead of getting pinned to one key.
@@ -1282,6 +1380,7 @@ def _run_single_child(
                     else None
                 ),
                 "started_at": time.time(),
+                "last_activity_kind": "registered",
                 "status": "running",
                 "tool_count": 0,
                 "agent": child,
@@ -1289,6 +1388,7 @@ def _run_single_child(
         )
 
     try:
+        _mark_subagent_activity(_subagent_id, "subagent.start", status="running")
         if child_progress_cb:
             try:
                 child_progress_cb("subagent.start", preview=goal)
@@ -1373,6 +1473,11 @@ def _run_single_child(
 
             if child_progress_cb:
                 try:
+                    _mark_subagent_activity(
+                        _subagent_id,
+                        "subagent.complete",
+                        status="timeout" if is_timeout else "error",
+                    )
                     child_progress_cb(
                         "subagent.complete",
                         preview=(
@@ -1610,6 +1715,7 @@ def _run_single_child(
 
         if child_progress_cb:
             try:
+                _mark_subagent_activity(_subagent_id, "subagent.complete", status=status)
                 child_progress_cb("subagent.complete", **complete_kwargs)
             except Exception as e:
                 logger.debug("Progress callback completion failed: %s", e)
@@ -1621,6 +1727,7 @@ def _run_single_child(
         logging.exception(f"[subagent-{task_index}] failed")
         if child_progress_cb:
             try:
+                _mark_subagent_activity(_subagent_id, "subagent.complete", status="failed")
                 child_progress_cb(
                     "subagent.complete",
                     preview=str(exc),
@@ -1729,8 +1836,8 @@ def delegate_task(
     # Normalise the top-level role once; per-task overrides re-normalise.
     top_role = _normalize_role(role)
 
-    # Depth limit — configurable via delegation.max_spawn_depth,
-    # default 2 for parity with the original MAX_DEPTH constant.
+    # Depth limit — configurable via delegation.max_spawn_depth.
+    # Default is flat (MAX_DEPTH=1); profile configs can raise it deliberately.
     depth = getattr(parent_agent, "_delegate_depth", 0)
     max_spawn = _get_max_spawn_depth()
     if depth >= max_spawn:
@@ -1772,7 +1879,7 @@ def delegate_task(
         return tool_error(str(exc))
 
     # Normalize to task list
-    max_children = _get_max_concurrent_children()
+    max_children = _get_max_concurrent_children(parent_agent)
     if tasks and isinstance(tasks, list):
         if len(tasks) > max_children:
             return tool_error(
@@ -2190,6 +2297,64 @@ def _load_config() -> dict:
         return {}
 
 
+def _get_stall_threshold_seconds() -> float:
+    """Read delegation.stall_threshold_seconds with env fallback.
+
+    Default: 300 seconds. Floor: 30 seconds.
+    """
+
+    def _parse(raw: Any, *, label: str) -> Optional[float]:
+        try:
+            value = float(raw)
+        except (TypeError, ValueError):
+            logger.warning(
+                "%s=%r is not a valid number; using default %d",
+                label,
+                raw,
+                DEFAULT_STALL_THRESHOLD_SECONDS,
+            )
+            return None
+        if value < 30.0:
+            logger.warning(
+                "%s=%r out of range [30, inf); clamping to 30",
+                label,
+                raw,
+            )
+            return 30.0
+        return value
+
+    cfg = _load_config()
+    cfg_val = cfg.get("stall_threshold_seconds")
+    if cfg_val is not None:
+        parsed = _parse(cfg_val, label="delegation.stall_threshold_seconds")
+        return (
+            parsed
+            if parsed is not None
+            else float(DEFAULT_STALL_THRESHOLD_SECONDS)
+        )
+
+    env_val = os.getenv("DELEGATION_STALL_THRESHOLD_SECONDS")
+    if env_val:
+        parsed = _parse(env_val, label="DELEGATION_STALL_THRESHOLD_SECONDS")
+        return (
+            parsed
+            if parsed is not None
+            else float(DEFAULT_STALL_THRESHOLD_SECONDS)
+        )
+
+    return float(DEFAULT_STALL_THRESHOLD_SECONDS)
+
+
+def _get_orchestrator_model() -> Optional[str]:
+    """Read delegation.orchestrator_model with env fallback."""
+    cfg = _load_config()
+    cfg_val = str(cfg.get("orchestrator_model") or "").strip()
+    if cfg_val:
+        return cfg_val
+    env_val = str(os.getenv("DELEGATION_ORCHESTRATOR_MODEL") or "").strip()
+    return env_val or None
+
+
 # ---------------------------------------------------------------------------
 # OpenAI Function-Calling Schema
 # ---------------------------------------------------------------------------
@@ -2222,7 +2387,7 @@ DELEGATE_TASK_SCHEMA = {
         "delegate_task so they can spawn their own workers, but still "
         "cannot use clarify, memory, send_message, or execute_code. "
         "Orchestrators are bounded by delegation.max_spawn_depth "
-        "(default 2) and can be disabled globally via "
+        "(default 1) and can be disabled globally via "
         "delegation.orchestrator_enabled=false.\n"
         "- Each subagent gets its own terminal session (separate working directory and state).\n"
         "- Results are always returned as an array, one entry per task."
@@ -2275,12 +2440,16 @@ DELEGATE_TASK_SCHEMA = {
                         },
                         "acp_command": {
                             "type": "string",
-                            "description": "Per-task ACP command override (e.g. 'claude'). Overrides the top-level acp_command for this task only.",
+                            "description": (
+                                "Per-task ACP command override for supported ACP subprocess transports. "
+                                "Do not use this for Claude Code on this machine; installed Claude Code lacks "
+                                "`--acp --stdio`. Use terminal `claude -p ...` for Claude instead."
+                            ),
                         },
                         "acp_args": {
                             "type": "array",
                             "items": {"type": "string"},
-                            "description": "Per-task ACP args override.",
+                            "description": "Per-task ACP args override for supported ACP subprocess transports.",
                         },
                         "role": {
                             "type": "string",
@@ -2315,18 +2484,18 @@ DELEGATE_TASK_SCHEMA = {
             "acp_command": {
                 "type": "string",
                 "description": (
-                    "Override ACP command for child agents (e.g. 'claude', 'copilot'). "
-                    "When set, children use ACP subprocess transport instead of inheriting "
-                    "the parent's transport. Enables spawning Claude Code (claude --acp --stdio) "
-                    "or other ACP-capable agents from any parent, including Discord/Telegram/CLI."
+                    "Override ACP command for supported child-agent subprocess transports. "
+                    "Current implementation is wired through the Copilot ACP client path; "
+                    "do not use this for Claude Code on this machine because `claude --acp --stdio` "
+                    "is not supported. For Claude, call `claude -p ...` via terminal instead."
                 ),
             },
             "acp_args": {
                 "type": "array",
                 "items": {"type": "string"},
                 "description": (
-                    "Arguments for the ACP command (default: ['--acp', '--stdio']). "
-                    "Only used when acp_command is set. Example: ['--acp', '--stdio', '--model', 'claude-opus-4-6']"
+                    "Arguments for the ACP command. Only used when acp_command is set. "
+                    "Do not pass ['--acp', '--stdio'] to Claude Code here; use terminal print mode instead."
                 ),
             },
         },


### PR DESCRIPTION
## Summary
- make `/swarm` launch a detached background foreman by default so the parent chat stays free
- add detached foreman config, status, stop handling, and child-concurrency override plumbing
- harden lifecycle cleanup, command parsing, and full gateway-path regression coverage

## Key behavior
- `/swarm <prompt>` or `/swarm start <prompt>` launches Main Sub in the background
- one detached foreman per chat by default
- `/swarm status` shows detached foremen as `foreman` plus worker cap and swarm mode
- `/swarm stop` is scoped to the launching chat
- prompts beginning with reserved control words must use `/swarm start <prompt>`

## Verification
- `python -m py_compile gateway/run.py hermes_cli/commands.py hermes_cli/config.py run_agent.py tests/gateway/test_status_command.py tests/tools/test_delegate.py tests/gateway/test_swarm_command.py tools/delegate_tool.py`
- `pytest -q tests/gateway/test_swarm_command.py tests/gateway/test_status_command.py tests/tools/test_delegate.py tests/gateway/test_command_bypass_active_session.py tests/gateway/test_background_command.py tests/run_agent/test_steer.py tests/e2e/test_platform_commands.py`
- result: `274 passed in 5.64s`

## Notes
- fixed orphaned `launching` rows on early swarm-task failure paths
- added e2e coverage for the real adapter -> gateway -> `/swarm` message path