### PR TITLE
feat(providers): add Groq and Cerebras

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -163,6 +163,8 @@ _API_KEY_PROVIDER_AUX_MODELS: Dict[str, str] = {
     "opencode-go": "glm-5",
     "kilocode": "google/gemini-3-flash-preview",
     "ollama-cloud": "nemotron-3-nano:30b",
+    "groq": "llama-3.3-70b-versatile",
+    "cerebras": "llama3.1-8b",
 }
 
 # Vision-specific model overrides for direct providers.

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -51,6 +51,7 @@ _PROVIDER_PREFIXES: frozenset[str] = frozenset({
     "qwen-oauth",
     "xiaomi",
     "arcee",
+    "groq", "cerebras",
     "custom", "local",
     # Common aliases
     "google", "google-gemini", "google-ai-studio",
@@ -308,6 +309,8 @@ _URL_TO_PROVIDER: Dict[str, str] = {
     "api.xiaomimimo.com": "xiaomi",
     "xiaomimimo.com": "xiaomi",
     "ollama.com": "ollama-cloud",
+    "api.groq.com": "groq",
+    "api.cerebras.ai": "cerebras",
 }
 
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -364,6 +364,22 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("AZURE_FOUNDRY_API_KEY",),
         base_url_env_var="AZURE_FOUNDRY_BASE_URL",
     ),
+    "groq": ProviderConfig(
+        id="groq",
+        name="Groq",
+        auth_type="api_key",
+        inference_base_url="https://api.groq.com/openai/v1",
+        api_key_env_vars=("GROQ_API_KEY",),
+        base_url_env_var="GROQ_BASE_URL",
+    ),
+    "cerebras": ProviderConfig(
+        id="cerebras",
+        name="Cerebras",
+        auth_type="api_key",
+        inference_base_url="https://api.cerebras.ai/v1",
+        api_key_env_vars=("CEREBRAS_API_KEY",),
+        base_url_env_var="CEREBRAS_BASE_URL",
+    ),
 }
 
 


### PR DESCRIPTION
## Summary

- Adds Groq and Cerebras as OpenAI-compatible providers
- 21 lines across 3 files, no schema translation, follows the existing `ProviderConfig` template (lifted from the z.ai entry)
- Both providers expose `/v1/chat/completions` and `/v1/models` directly compatible with the existing OpenAI client path

## Files

- `hermes_cli/auth.py`: `ProviderConfig` entries with `auth_type=api_key`, base URLs, env vars (`GROQ_API_KEY`, `CEREBRAS_API_KEY`)
- `agent/model_metadata.py`: `api.groq.com` / `api.cerebras.ai` added to the URL -> provider reverse-lookup table
- `agent/auxiliary_client.py`: default aux-task models per provider (`llama-3.3-70b-versatile` for Groq, `llama3.1-8b` for Cerebras)

## Cerebras default model note

The Cerebras default uses `llama3.1-8b`, verified against `inference-docs.cerebras.ai/models/overview` and a live `GET /v1/models` against the public API. The marketing page at `cerebras.ai/inference` lists `llama-3.3-70b`, but that model is not served by the public inference API and returns HTTP 404 on call. Picking it as the default would have failed silently the moment the fallback chain routed an aux task to Cerebras.

## Verified free-tier rate limits (live x-ratelimit headers / `/v1/models`)

| provider | model | RPM | RPD |
|----------|-------|----:|----:|
| Groq | `llama-3.1-8b-instant` | 30 | 14,400 |
| Groq | `llama-3.3-70b-versatile` | 30 | 1,000 |
| Cerebras | `llama3.1-8b` | 30 | 14,400 |
| Cerebras | `gpt-oss-120b` | 30 | 14,400 |

## Test plan

- [x] `auxiliary_client` resolver returns the new providers' `OpenAI()` client + model id
- [x] live `/v1/chat/completions` against both providers returns HTTP 200 with the expected model id echoed back
- [x] `model_metadata._infer_provider_from_url` correctly maps both base URLs
- [ ] CI passes