### PR TITLE
feat(tui): show account limits in status bar

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -7,7 +7,7 @@ from typing import Any, Optional
 import httpx
 
 from agent.anthropic_adapter import _is_oauth_token, resolve_anthropic_token
-from hermes_cli.auth import _read_codex_tokens, resolve_codex_runtime_credentials
+from hermes_cli.auth import _decode_jwt_claims, resolve_codex_runtime_credentials
 from hermes_cli.runtime_provider import resolve_runtime_provider
 
 
@@ -113,6 +113,105 @@ def render_account_usage_lines(snapshot: Optional[AccountUsageSnapshot], *, mark
     return lines
 
 
+def _format_reset_compact(dt: Optional[datetime]) -> Optional[str]:
+    if not dt:
+        return None
+    total_seconds = int((dt - _utc_now()).total_seconds())
+    if total_seconds <= 0:
+        return "now"
+    minutes_total = max(1, total_seconds // 60)
+    hours_total, minutes = divmod(minutes_total, 60)
+    days, hours = divmod(hours_total, 24)
+    if days:
+        return f"{days}d {hours}h"
+    if hours:
+        return f"{hours}h {minutes}m"
+    return f"{minutes}m"
+
+
+def _provider_status_label(provider: str) -> str:
+    normalized = (provider or "").strip().lower()
+    if normalized == "openai-codex":
+        return "Codex"
+    if normalized == "openrouter":
+        return "OpenRouter"
+    if normalized == "anthropic":
+        return "Claude"
+    return normalized.replace("-", " ").title() or "Provider"
+
+
+def _window_status_label(label: str) -> str:
+    normalized = (label or "").strip().lower()
+    if not normalized:
+        return "limit"
+    if "session" in normalized:
+        # Codex/Claude subscription APIs both use this for the short window.
+        return "5h"
+    if "opus" in normalized and "week" in normalized:
+        return "opus wk"
+    if "sonnet" in normalized and "week" in normalized:
+        return "sonnet wk"
+    if "week" in normalized or "weekly" in normalized:
+        return "week"
+    if "quota" in normalized:
+        return "quota"
+    return normalized.split()[0][:10]
+
+
+def _limit_level(used_percent: float) -> str:
+    if used_percent >= 90:
+        return "critical"
+    if used_percent >= 80:
+        return "warn"
+    return "ok"
+
+
+def build_account_limit_status(
+    snapshot: Optional[AccountUsageSnapshot],
+    *,
+    max_windows: Optional[int] = None,
+) -> Optional[dict[str, Any]]:
+    """Compact account-limit payload for status bars.
+
+    This intentionally stays provider-agnostic: any provider-specific usage API
+    only needs to return AccountUsageSnapshot windows.
+    """
+    if not snapshot or snapshot.unavailable_reason:
+        return None
+
+    windows: list[dict[str, Any]] = []
+    for window in snapshot.windows:
+        if window.used_percent is None:
+            continue
+        used = max(0.0, min(100.0, float(window.used_percent)))
+        remaining = max(0.0, 100.0 - used)
+        windows.append(
+            {
+                "label": _window_status_label(window.label),
+                "full_label": window.label,
+                "used_percent": round(used),
+                "remaining_percent": round(remaining),
+                "reset": _format_reset_compact(window.reset_at),
+                "level": _limit_level(used),
+            }
+        )
+
+    if max_windows is not None:
+        windows = windows[:max(0, max_windows)]
+    if not windows:
+        return None
+
+    level_rank = {"ok": 0, "warn": 1, "critical": 2}
+    level = max((str(w.get("level") or "ok") for w in windows), key=lambda value: level_rank.get(value, 0))
+    return {
+        "provider": snapshot.provider,
+        "label": _provider_status_label(snapshot.provider),
+        "plan": snapshot.plan,
+        "level": level,
+        "windows": windows,
+    }
+
+
 def _resolve_codex_usage_url(base_url: str) -> str:
     normalized = (base_url or "").strip().rstrip("/")
     if not normalized:
@@ -124,20 +223,43 @@ def _resolve_codex_usage_url(base_url: str) -> str:
     return normalized + "/api/codex/usage"
 
 
-def _fetch_codex_account_usage() -> Optional[AccountUsageSnapshot]:
-    creds = resolve_codex_runtime_credentials(refresh_if_expiring=True)
-    token_data = _read_codex_tokens()
-    tokens = token_data.get("tokens") or {}
-    account_id = str(tokens.get("account_id", "") or "").strip() or None
+def _codex_account_id_from_access_token(access_token: str) -> Optional[str]:
+    claims = _decode_jwt_claims(access_token)
+    auth_claim = claims.get("https://api.openai.com/auth")
+    if not isinstance(auth_claim, dict):
+        return None
+    account_id = auth_claim.get("chatgpt_account_id")
+    if isinstance(account_id, str) and account_id.strip():
+        return account_id.strip()
+    return None
+
+
+def _fetch_codex_account_usage(
+    *,
+    base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
+    timeout: float = 15.0,
+) -> Optional[AccountUsageSnapshot]:
+    token = str(api_key or "").strip()
+    resolved_base_url = str(base_url or "").strip().rstrip("/")
+    if not token:
+        creds = resolve_codex_runtime_credentials(refresh_if_expiring=True)
+        token = str(creds.get("api_key", "") or "").strip()
+        if not resolved_base_url:
+            resolved_base_url = str(creds.get("base_url", "") or "").strip().rstrip("/")
+    if not token:
+        return None
+
+    account_id = _codex_account_id_from_access_token(token)
     headers = {
-        "Authorization": f"Bearer {creds['api_key']}",
+        "Authorization": f"Bearer {token}",
         "Accept": "application/json",
         "User-Agent": "codex-cli",
     }
     if account_id:
         headers["ChatGPT-Account-Id"] = account_id
-    with httpx.Client(timeout=15.0) as client:
-        response = client.get(_resolve_codex_usage_url(creds.get("base_url", "")), headers=headers)
+    with httpx.Client(timeout=timeout) as client:
+        response = client.get(_resolve_codex_usage_url(resolved_base_url), headers=headers)
         response.raise_for_status()
     payload = response.json() or {}
     rate_limit = payload.get("rate_limit") or {}
@@ -172,8 +294,12 @@ def _fetch_codex_account_usage() -> Optional[AccountUsageSnapshot]:
     )
 
 
-def _fetch_anthropic_account_usage() -> Optional[AccountUsageSnapshot]:
-    token = (resolve_anthropic_token() or "").strip()
+def _fetch_anthropic_account_usage(
+    *,
+    api_key: Optional[str] = None,
+    timeout: float = 15.0,
+) -> Optional[AccountUsageSnapshot]:
+    token = str(api_key or "").strip() or (resolve_anthropic_token() or "").strip()
     if not token:
         return None
     if not _is_oauth_token(token):
@@ -190,7 +316,7 @@ def _fetch_anthropic_account_usage() -> Optional[AccountUsageSnapshot]:
         "anthropic-beta": "oauth-2025-04-20",
         "User-Agent": "claude-code/2.1.0",
     }
-    with httpx.Client(timeout=15.0) as client:
+    with httpx.Client(timeout=timeout) as client:
         response = client.get("https://api.anthropic.com/api/oauth/usage", headers=headers)
         response.raise_for_status()
     payload = response.json() or {}
@@ -233,7 +359,11 @@ def _fetch_anthropic_account_usage() -> Optional[AccountUsageSnapshot]:
     )
 
 
-def _fetch_openrouter_account_usage(base_url: Optional[str], api_key: Optional[str]) -> Optional[AccountUsageSnapshot]:
+def _fetch_openrouter_account_usage(
+    base_url: Optional[str],
+    api_key: Optional[str],
+    timeout: float = 10.0,
+) -> Optional[AccountUsageSnapshot]:
     runtime = resolve_runtime_provider(
         requested="openrouter",
         explicit_base_url=base_url,
@@ -249,7 +379,7 @@ def _fetch_openrouter_account_usage(base_url: Optional[str], api_key: Optional[s
         "Authorization": f"Bearer {token}",
         "Accept": "application/json",
     }
-    with httpx.Client(timeout=10.0) as client:
+    with httpx.Client(timeout=timeout) as client:
         credits_resp = client.get(credits_url, headers=headers)
         credits_resp.raise_for_status()
         credits = (credits_resp.json() or {}).get("data") or {}
@@ -310,17 +440,22 @@ def fetch_account_usage(
     *,
     base_url: Optional[str] = None,
     api_key: Optional[str] = None,
+    timeout: Optional[float] = None,
 ) -> Optional[AccountUsageSnapshot]:
     normalized = str(provider or "").strip().lower()
     if normalized in {"", "auto", "custom"}:
         return None
     try:
         if normalized == "openai-codex":
-            return _fetch_codex_account_usage()
+            return _fetch_codex_account_usage(
+                base_url=base_url,
+                api_key=api_key,
+                timeout=timeout or 15.0,
+            )
         if normalized == "anthropic":
-            return _fetch_anthropic_account_usage()
+            return _fetch_anthropic_account_usage(api_key=api_key, timeout=timeout or 15.0)
         if normalized == "openrouter":
-            return _fetch_openrouter_account_usage(base_url, api_key)
+            return _fetch_openrouter_account_usage(base_url, api_key, timeout=timeout or 10.0)
     except Exception:
         return None
     return None

--- a/tests/test_account_usage.py
+++ b/tests/test_account_usage.py
@@ -1,8 +1,11 @@
+import base64
+import json
 from datetime import datetime, timezone
 
 from agent.account_usage import (
     AccountUsageSnapshot,
     AccountUsageWindow,
+    build_account_limit_status,
     fetch_account_usage,
     render_account_usage_lines,
 )
@@ -22,8 +25,9 @@ class _Response:
 
 
 class _Client:
-    def __init__(self, payload):
+    def __init__(self, payload, requests=None):
         self._payload = payload
+        self._requests = requests
 
     def __enter__(self):
         return self
@@ -32,35 +36,97 @@ class _Client:
         return False
 
     def get(self, url, headers=None):
+        if self._requests is not None:
+            self._requests.append((url, dict(headers or {})))
         return _Response(self._payload)
 
 
-class _RoutingClient:
-    def __init__(self, payloads):
-        self._payloads = payloads
+def _fake_jwt(claims):
+    def encode(payload):
+        raw = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
 
-    def __enter__(self):
-        return self
+    return f"{encode({'alg': 'none'})}.{encode(claims)}."
 
-    def __exit__(self, exc_type, exc, tb):
-        return False
 
-    def get(self, url, headers=None):
-        return _Response(self._payloads[url])
+def test_build_account_limit_status_compacts_provider_windows(monkeypatch):
+    now = datetime(2030, 1, 1, 12, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr("agent.account_usage._utc_now", lambda: now)
+    snapshot = AccountUsageSnapshot(
+        provider="openai-codex",
+        source="usage_api",
+        fetched_at=now,
+        plan="Pro",
+        windows=(
+            AccountUsageWindow(
+                label="Session",
+                used_percent=82.4,
+                reset_at=datetime(2030, 1, 1, 14, 30, tzinfo=timezone.utc),
+            ),
+            AccountUsageWindow(
+                label="Weekly",
+                used_percent=91.2,
+                reset_at=datetime(2030, 1, 4, 18, 0, tzinfo=timezone.utc),
+            ),
+            AccountUsageWindow(label="Ignored", used_percent=None),
+        ),
+    )
+
+    status = build_account_limit_status(snapshot)
+
+    assert status == {
+        "provider": "openai-codex",
+        "label": "Codex",
+        "plan": "Pro",
+        "level": "critical",
+        "windows": [
+            {
+                "label": "5h",
+                "full_label": "Session",
+                "used_percent": 82,
+                "remaining_percent": 18,
+                "reset": "2h 30m",
+                "level": "warn",
+            },
+            {
+                "label": "week",
+                "full_label": "Weekly",
+                "used_percent": 91,
+                "remaining_percent": 9,
+                "reset": "3d 6h",
+                "level": "critical",
+            },
+        ],
+    }
+
+
+def test_build_account_limit_status_returns_none_when_unavailable():
+    snapshot = AccountUsageSnapshot(
+        provider="anthropic",
+        source="oauth_usage_api",
+        fetched_at=datetime.now(timezone.utc),
+        unavailable_reason="not oauth",
+    )
+
+    assert build_account_limit_status(snapshot) is None
 
 
 def test_fetch_account_usage_codex(monkeypatch):
+    requests = []
+    token = _fake_jwt(
+        {
+            "https://api.openai.com/auth": {
+                "chatgpt_account_id": "acct_123",
+            }
+        }
+    )
     monkeypatch.setattr(
         "agent.account_usage.resolve_codex_runtime_credentials",
         lambda refresh_if_expiring=True: {
             "provider": "openai-codex",
             "base_url": "https://chatgpt.com/backend-api/codex",
-            "api_key": "access-token",
+            "api_key": token,
         },
-    )
-    monkeypatch.setattr(
-        "agent.account_usage._read_codex_tokens",
-        lambda: {"tokens": {"account_id": "acct_123"}},
     )
     monkeypatch.setattr(
         "agent.account_usage.httpx.Client",
@@ -80,7 +146,8 @@ def test_fetch_account_usage_codex(monkeypatch):
                     },
                 },
                 "credits": {"has_credits": True, "balance": 12.5},
-            }
+            },
+            requests=requests,
         ),
     )
 
@@ -93,6 +160,57 @@ def test_fetch_account_usage_codex(monkeypatch):
     assert snapshot.windows[0].used_percent == 15.0
     assert snapshot.windows[0].reset_at == datetime.fromtimestamp(1_900_000_000, tz=timezone.utc)
     assert "Credits balance: $12.50" in snapshot.details
+    assert requests[0][0] == "https://chatgpt.com/backend-api/wham/usage"
+    assert requests[0][1]["ChatGPT-Account-Id"] == "acct_123"
+
+
+def test_fetch_account_usage_codex_prefers_runtime_credentials(monkeypatch):
+    requests = []
+    runtime_token = _fake_jwt(
+        {
+            "https://api.openai.com/auth": {
+                "chatgpt_account_id": "acct_runtime",
+            }
+        }
+    )
+
+    def fail_resolve(refresh_if_expiring=True):
+        raise AssertionError("runtime api_key should be used before stored Codex auth state")
+
+    monkeypatch.setattr("agent.account_usage.resolve_codex_runtime_credentials", fail_resolve)
+    monkeypatch.setattr(
+        "agent.account_usage.httpx.Client",
+        lambda timeout=15.0: _Client(
+            {
+                "plan_type": "plus",
+                "rate_limit": {
+                    "primary_window": {"used_percent": 33},
+                },
+            },
+            requests=requests,
+        ),
+    )
+
+    snapshot = fetch_account_usage(
+        "openai-codex",
+        base_url="https://runtime.example/backend-api/codex",
+        api_key=runtime_token,
+    )
+
+    assert snapshot is not None
+    assert snapshot.plan == "Plus"
+    assert snapshot.windows[0].used_percent == 33.0
+    assert requests == [
+        (
+            "https://runtime.example/backend-api/wham/usage",
+            {
+                "Authorization": f"Bearer {runtime_token}",
+                "Accept": "application/json",
+                "User-Agent": "codex-cli",
+                "ChatGPT-Account-Id": "acct_runtime",
+            },
+        )
+    ]
 
 
 def test_render_account_usage_lines_includes_reset_and_provider():
@@ -116,6 +234,20 @@ def test_render_account_usage_lines_includes_reset_and_provider():
     assert "openai-codex (Pro)" in lines[1]
     assert "Session: 75% remaining (25% used)" in lines[2]
     assert "Credits balance: $9.99" in lines[3]
+
+
+class _RoutingClient:
+    def __init__(self, payloads):
+        self._payloads = payloads
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def get(self, url, headers=None):
+        return _Response(self._payloads[url])
 
 
 def test_fetch_account_usage_openrouter_uses_limit_remaining_and_ignores_deprecated_rate_limit(monkeypatch):

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1115,6 +1115,69 @@ def test_session_info_includes_mcp_servers(monkeypatch):
     assert info["mcp_servers"] == fake_status
 
 
+def test_session_info_includes_account_limit_status(monkeypatch):
+    payload = {
+        "provider": "openai-codex",
+        "label": "Codex",
+        "level": "warn",
+        "windows": [{"label": "5h", "used_percent": 82, "remaining_percent": 18, "level": "warn"}],
+    }
+    monkeypatch.setattr(server, "_get_account_limit_status", lambda _agent: payload)
+
+    info = server._session_info(types.SimpleNamespace(tools=[], model="gpt-5.5"))
+
+    assert info["account_limits"] == payload
+
+
+def test_get_account_limit_status_fetches_and_caches(monkeypatch):
+    from datetime import datetime, timezone
+
+    from agent.account_usage import AccountUsageSnapshot, AccountUsageWindow
+
+    calls = []
+
+    def fake_fetch(provider, *, base_url=None, api_key=None, timeout=None):
+        calls.append({"api_key": api_key, "base_url": base_url, "provider": provider, "timeout": timeout})
+        return AccountUsageSnapshot(
+            provider="openai-codex",
+            source="usage_api",
+            fetched_at=datetime.now(timezone.utc),
+            windows=(AccountUsageWindow(label="Session", used_percent=81),),
+        )
+
+    monkeypatch.setattr("agent.account_usage.fetch_account_usage", fake_fetch)
+    server._ACCOUNT_LIMIT_CACHE.clear()
+
+    class _Pool:
+        def current(self):
+            return types.SimpleNamespace(label="work-account-long")
+
+        def peek(self):
+            return None
+
+    agent = types.SimpleNamespace(
+        api_key="secret-one",
+        base_url="https://chatgpt.com/backend-api/codex",
+        provider="openai-codex",
+        _credential_pool=_Pool(),
+    )
+
+    first = server._get_account_limit_status(agent)
+    second = server._get_account_limit_status(agent)
+
+    assert first == second
+    assert first["label"] == "Codex"
+    assert first["credential_label"] == "work-account-long"
+    assert first["windows"][0]["label"] == "5h"
+    assert len(calls) == 1
+    assert calls[0] == {
+        "api_key": "secret-one",
+        "base_url": "https://chatgpt.com/backend-api/codex",
+        "provider": "openai-codex",
+        "timeout": server._ACCOUNT_LIMIT_FETCH_TIMEOUT_SECONDS,
+    }
+
+
 # ---------------------------------------------------------------------------
 # History-mutating commands must reject while session.running is True.
 # Without these guards, prompt.submit's post-run history write either

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2,6 +2,7 @@ import atexit
 import concurrent.futures
 import contextvars
 import copy
+import hashlib
 import json
 import logging
 import os
@@ -117,6 +118,11 @@ from tui_gateway.render import make_stream_renderer, render_diff, render_message
 _sessions: dict[str, dict] = {}
 _methods: dict[str, callable] = {}
 _pending: dict[str, tuple[str, threading.Event]] = {}
+
+_ACCOUNT_LIMIT_CACHE_TTL_SECONDS = 300
+_ACCOUNT_LIMIT_FETCH_TIMEOUT_SECONDS = 2.0
+_ACCOUNT_LIMIT_CACHE: dict[str, tuple[float, Optional[dict]]] = {}
+_ACCOUNT_LIMIT_CACHE_LOCK = threading.Lock()
 _answers: dict[str, str] = {}
 _db = None
 _db_error: str | None = None
@@ -826,6 +832,69 @@ def _compress_session_history(
     return len(history) - len(compressed), _get_usage(agent)
 
 
+def _account_limit_cache_key(agent) -> str:
+    provider = str(getattr(agent, "provider", "") or "").strip().lower()
+    if not provider:
+        return ""
+    base_url = str(getattr(agent, "base_url", "") or "").strip().rstrip("/")
+    api_key = str(getattr(agent, "api_key", "") or "")
+    api_key_hash = hashlib.sha256(api_key.encode("utf-8")).hexdigest()[:16] if api_key else ""
+    return f"{provider}\0{base_url}\0{api_key_hash}"
+
+
+def _active_credential_label(agent) -> Optional[str]:
+    """Return the active pooled credential label without exposing secrets."""
+    pool = getattr(agent, "_credential_pool", None)
+    if pool is None:
+        return None
+    try:
+        entry = pool.current() or pool.peek()
+    except Exception:
+        return None
+    label = str(getattr(entry, "label", "") or "").strip() if entry is not None else ""
+    return label or None
+
+
+def _get_account_limit_status(agent) -> Optional[dict]:
+    """Fetch compact provider quota status for the TUI status bar.
+
+    The display layer stays provider-agnostic.  Provider-specific work happens
+    in agent.account_usage and is cached here so session info/message.complete
+    cannot hammer usage APIs.
+    """
+    key = _account_limit_cache_key(agent)
+    if not key:
+        return None
+
+    now = time.time()
+    with _ACCOUNT_LIMIT_CACHE_LOCK:
+        cached = _ACCOUNT_LIMIT_CACHE.get(key)
+        if cached and cached[0] > now:
+            return copy.deepcopy(cached[1]) if cached[1] is not None else None
+
+    payload = None
+    try:
+        from agent.account_usage import build_account_limit_status, fetch_account_usage
+
+        snapshot = fetch_account_usage(
+            getattr(agent, "provider", None),
+            base_url=getattr(agent, "base_url", None),
+            api_key=getattr(agent, "api_key", None),
+            timeout=_ACCOUNT_LIMIT_FETCH_TIMEOUT_SECONDS,
+        )
+        payload = build_account_limit_status(snapshot, max_windows=4)
+        if payload:
+            credential_label = _active_credential_label(agent)
+            if credential_label:
+                payload["credential_label"] = credential_label
+    except Exception:
+        payload = None
+
+    with _ACCOUNT_LIMIT_CACHE_LOCK:
+        _ACCOUNT_LIMIT_CACHE[key] = (now + _ACCOUNT_LIMIT_CACHE_TTL_SECONDS, copy.deepcopy(payload))
+    return payload
+
+
 def _get_usage(agent) -> dict:
     g = lambda k, fb=None: getattr(agent, k, 0) or (getattr(agent, fb, 0) if fb else 0)
     usage = {
@@ -934,6 +1003,7 @@ def _session_info(agent) -> dict:
         "update_behind": None,
         "update_command": "",
         "usage": _get_usage(agent),
+        "account_limits": _get_account_limit_status(agent),
     }
     try:
         from hermes_cli import __version__, __release_date__
@@ -2382,7 +2452,12 @@ def _(rid, params: dict) -> dict:
                 raw = str(result)
                 status = "complete"
 
-            payload = {"text": raw, "usage": _get_usage(agent), "status": status}
+            payload = {
+                "text": raw,
+                "usage": _get_usage(agent),
+                "account_limits": _get_account_limit_status(agent),
+                "status": status,
+            }
             if last_reasoning:
                 payload["reasoning"] = last_reasoning
             if status_note:

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -4,7 +4,7 @@ import { createGatewayEventHandler } from '../app/createGatewayEventHandler.js'
 import { getOverlayState, resetOverlayState } from '../app/overlayStore.js'
 import { turnController } from '../app/turnController.js'
 import { getTurnState, resetTurnState } from '../app/turnStore.js'
-import { patchUiState, resetUiState } from '../app/uiStore.js'
+import { getUiState, patchUiState, resetUiState } from '../app/uiStore.js'
 import { estimateTokensRough } from '../lib/text.js'
 import type { Msg } from '../types.js'
 
@@ -57,6 +57,26 @@ describe('createGatewayEventHandler', () => {
     resetTurnState()
     turnController.fullReset()
     patchUiState({ showReasoning: true })
+  })
+
+  it('updates usage and account limits from message.complete payload', () => {
+    const appended: Msg[] = []
+    const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+    const accountLimits = {
+      credential_label: 'work-account-long',
+      label: 'Codex',
+      level: 'warn' as const,
+      provider: 'openai-codex',
+      windows: [{ label: '5h', level: 'warn' as const, remaining_percent: 18, used_percent: 82 }]
+    }
+
+    patchUiState({ info: { account_limits: null, model: 'gpt-5.5', skills: {}, tools: {} } })
+
+    onEvent({ payload: { account_limits: accountLimits, text: 'done', usage: { total: 42 } }, type: 'message.complete' } as any)
+
+    expect(getUiState().usage.total).toBe(42)
+    expect(getUiState().info?.account_limits).toEqual(accountLimits)
   })
 
   it('archives incomplete todos into transcript flow at end of turn so they scroll up', () => {

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -546,8 +546,12 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
         setStatus('ready')
 
-        if (ev.payload?.usage) {
-          patchUiState(state => ({ ...state, usage: { ...state.usage, ...ev.payload!.usage } }))
+        if (ev.payload?.usage || 'account_limits' in (ev.payload ?? {})) {
+          patchUiState(state => ({
+            ...state,
+            info: state.info ? { ...state.info, account_limits: ev.payload?.account_limits ?? null } : state.info,
+            usage: ev.payload?.usage ? { ...state.usage, ...ev.payload.usage } : state.usage
+          }))
         }
 
         return

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -12,7 +12,7 @@ import { buildSubagentTree, treeTotals, widthByDepth } from '../lib/subagentTree
 import { fmtK } from '../lib/text.js'
 import { useViewportSnapshot } from '../lib/viewportStore.js'
 import type { Theme } from '../theme.js'
-import type { Msg, Usage } from '../types.js'
+import type { AccountLimitStatus, Msg, Usage } from '../types.js'
 
 const FACE_TICK_MS = 2500
 const HEART_COLORS = ['#ff5fa2', '#ff4d6d']
@@ -63,6 +63,70 @@ function ctxBar(pct: number | undefined, w = 10) {
   const filled = Math.round((p / 100) * w)
 
   return '█'.repeat(filled) + '░'.repeat(w - filled)
+}
+
+function accountLimitColor(level: string | undefined, t: Theme) {
+  if (level === 'critical') {
+    return t.color.statusCritical
+  }
+
+  if (level === 'warn') {
+    return t.color.statusWarn
+  }
+
+  return t.color.statusGood
+}
+
+function accountLimitWindowLabel(label: string, fullLabel?: string) {
+  const normalized = (fullLabel || label).toLowerCase()
+
+  if (normalized.includes('week')) {
+    return 'weekly'
+  }
+
+  return label
+}
+
+function accountLimitCredentialLabel(label?: null | string) {
+  const normalized = String(label ?? '')
+    .trim()
+    .replace(/\s+/g, '-')
+
+  if (!normalized) {
+    return ''
+  }
+
+  const chars = Array.from(normalized)
+
+  return chars.length > 10 ? `${chars.slice(0, 9).join('')}…` : normalized
+}
+
+function AccountLimitHud({ accountLimits, t }: { accountLimits?: AccountLimitStatus | null; t: Theme }) {
+  if (!accountLimits?.windows?.length) {
+    return null
+  }
+
+  const providerLabel = accountLimits.label?.trim()
+  const credentialLabel = accountLimitCredentialLabel(accountLimits.credential_label)
+
+  return (
+    <Text color={t.color.dim}>
+      {' │ '}
+      {providerLabel ? <Text color={t.color.dim}>{providerLabel} </Text> : null}
+      {credentialLabel ? <Text color={t.color.dim}>{credentialLabel} </Text> : null}
+      {accountLimits.windows.slice(0, 4).map((window, index) => {
+        const color = accountLimitColor(window.level, t)
+        const label = accountLimitWindowLabel(window.label, window.full_label)
+
+        return (
+          <Text color={t.color.dim} key={`${window.label}-${window.full_label ?? ''}`}>
+            {index > 0 ? ' • ' : ''}
+            {label} <Text color={color}>{window.remaining_percent}%</Text>
+          </Text>
+        )
+      })}
+    </Text>
+  )
 }
 
 function SpawnHud({ t }: { t: Theme }) {
@@ -186,6 +250,7 @@ export function GoodVibesHeart({ tick, t }: { tick: number; t: Theme }) {
 }
 
 export function StatusRule({
+  accountLimits,
   cwdLabel,
   cols,
   busy,
@@ -232,6 +297,7 @@ export function StatusRule({
               <Text color={barColor}>[{bar}]</Text> <Text color={barColor}>{pct != null ? `${pct}%` : ''}</Text>
             </Text>
           ) : null}
+          <AccountLimitHud accountLimits={accountLimits} t={t} />
           {sessionStartedAt ? (
             <Text color={t.color.dim}>
               {' │ '}
@@ -355,6 +421,7 @@ export function TranscriptScrollbar({ scrollRef, t }: TranscriptScrollbarProps) 
 }
 
 interface StatusRuleProps {
+  accountLimits?: AccountLimitStatus | null
   bgCount: number
   busy: boolean
   cols: number

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -233,6 +233,7 @@ const StatusRulePane = memo(function StatusRulePane({
   return (
     <Box marginTop={at === 'top' ? 1 : 0}>
       <StatusRule
+        accountLimits={ui.info?.account_limits ?? null}
         bgCount={ui.bgTasks.size}
         busy={ui.busy}
         cols={composer.cols}

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -1,4 +1,4 @@
-import type { SessionInfo, SlashCategory, Usage } from './types.js'
+import type { AccountLimitStatus, SessionInfo, SlashCategory, Usage } from './types.js'
 
 export interface GatewaySkin {
   banner_hero?: string
@@ -414,7 +414,13 @@ export type GatewayEvent =
   | { payload: SubagentEventPayload; session_id?: string; type: 'subagent.complete' }
   | { payload: { rendered?: string; text?: string }; session_id?: string; type: 'message.delta' }
   | {
-      payload?: { reasoning?: string; rendered?: string; text?: string; usage?: Usage }
+      payload?: {
+        account_limits?: AccountLimitStatus | null
+        reasoning?: string
+        rendered?: string
+        text?: string
+        usage?: Usage
+      }
       session_id?: string
       type: 'message.complete'
     }

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -140,7 +140,28 @@ export interface McpServerStatus {
   transport: string
 }
 
+export type AccountLimitLevel = 'critical' | 'ok' | 'warn'
+
+export interface AccountLimitWindow {
+  full_label?: string
+  label: string
+  level: AccountLimitLevel
+  remaining_percent: number
+  reset?: null | string
+  used_percent: number
+}
+
+export interface AccountLimitStatus {
+  credential_label?: null | string
+  label: string
+  level: AccountLimitLevel
+  plan?: null | string
+  provider: string
+  windows: AccountLimitWindow[]
+}
+
 export interface SessionInfo {
+  account_limits?: AccountLimitStatus | null
   cwd?: string
   fast?: boolean
   mcp_servers?: McpServerStatus[]


### PR DESCRIPTION
## Summary

- add provider-agnostic account usage snapshots and compact account-limit summaries
- fetch OpenAI Codex session/weekly usage with the active runtime credential
- expose cached account limits through the TUI gateway session info and turn-complete events
- render compact remaining quota windows in the Ink status bar, including the safe pooled credential label

Closes #16643

## Test plan

- [x] `venv/bin/python -m pytest tests/test_account_usage.py tests/test_tui_gateway_server.py -q -o 'addopts='`
- [x] `npm exec eslint -- src/components/appChrome.tsx src/components/appLayout.tsx src/app/createGatewayEventHandler.ts src/__tests__/createGatewayEventHandler.test.ts src/gatewayTypes.ts src/types.ts`
- [x] `npm run type-check` from `ui-tui/`
- [x] `npm run test -- src/__tests__/createGatewayEventHandler.test.ts` from `ui-tui/`
- [x] `npm run build` from `ui-tui/`