### PR TITLE
fix(cron): retry delivery from cached output instead of re-running the agent (#8846)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -527,6 +527,7 @@ def create_job(
         "last_status": None,
         "last_error": None,
         "last_delivery_error": None,
+        "last_delivery_retry": None,
         # Delivery configuration
         "deliver": deliver,
         "origin": origin,  # Tracks where job was created for "origin" delivery
@@ -847,13 +848,165 @@ def get_due_jobs() -> List[Dict[str, Any]]:
     return due
 
 
+# =============================================================================
+# Delivery retry (issue #8846)
+# =============================================================================
+#
+# When a cron job's task succeeds but delivery to the messaging platform
+# fails (Telegram 502, Slack rate-limit, schema validation hiccup, etc.),
+# we don't want to either:
+#   (a) flip task_status to "error" - the task itself ran fine, and
+#       (b) re-execute the agent on retry - that costs LLM tokens and may
+#           produce a different answer for a time-sensitive prompt.
+#
+# Instead we record a small retry envelope on the job pointing at the
+# already-saved output file under ~/.hermes/cron/output/<job_id>/, and
+# the scheduler's tick loop drains due retries on each pass, replaying
+# only the delivery step from the cached payload.
+#
+# Backoff: 60s, 300s, 1800s. After 3 failed attempts we surrender, leaving
+# `last_delivery_error` populated so the user can see what went wrong via
+# `hermes cron list`.
+
+DELIVERY_RETRY_BACKOFF_SECONDS: List[int] = [60, 300, 1800]
+DELIVERY_RETRY_MAX_ATTEMPTS: int = len(DELIVERY_RETRY_BACKOFF_SECONDS)
+
+
+def _next_retry_at(attempts_so_far: int) -> Optional[str]:
+    """Return ISO timestamp for the next retry, or None if budget exhausted.
+
+    `attempts_so_far` is the number of attempts already made (0 means the
+    initial delivery just failed and we're scheduling attempt #1).
+    """
+    if attempts_so_far >= DELIVERY_RETRY_MAX_ATTEMPTS:
+        return None
+    delay = DELIVERY_RETRY_BACKOFF_SECONDS[attempts_so_far]
+    return (_hermes_now() + timedelta(seconds=delay)).isoformat()
+
+
+def schedule_delivery_retry(
+    job_id: str,
+    output_file: str,
+    delivery_error: str,
+) -> bool:
+    """Persist a pending delivery retry on the job.
+
+    Called by the scheduler after the *initial* delivery attempt fails.
+    The cached output file is the source of truth for the next attempt -
+    we never re-run the agent.
+
+    Returns True if a retry was scheduled, False if the retry budget is
+    already exhausted (caller should treat the failure as terminal).
+    """
+    with _jobs_file_lock:
+        jobs = load_jobs()
+        for job in jobs:
+            if job["id"] != job_id:
+                continue
+            existing = job.get("last_delivery_retry") or {}
+            attempts = int(existing.get("attempts", 0))
+            next_at = _next_retry_at(attempts)
+            if next_at is None:
+                # Budget exhausted - clear envelope, leave error visible.
+                job["last_delivery_retry"] = None
+                save_jobs(jobs)
+                return False
+            job["last_delivery_retry"] = {
+                "output_file": output_file,
+                "attempts": attempts,
+                "next_attempt_at": next_at,
+                "last_error": delivery_error,
+            }
+            save_jobs(jobs)
+            return True
+        return False
+
+
+def clear_delivery_retry(job_id: str) -> None:
+    """Drop the retry envelope after a successful redelivery."""
+    with _jobs_file_lock:
+        jobs = load_jobs()
+        changed = False
+        for job in jobs:
+            if job["id"] == job_id and job.get("last_delivery_retry"):
+                job["last_delivery_retry"] = None
+                job["last_delivery_error"] = None
+                changed = True
+                break
+        if changed:
+            save_jobs(jobs)
+
+
+def mark_delivery_retry_attempt(job_id: str, delivery_error: Optional[str]) -> bool:
+    """Record one retry attempt outcome.
+
+    On success (delivery_error is None) the envelope is cleared.
+    On failure, the attempt count is bumped and `next_attempt_at` is
+    pushed out via the backoff schedule. Returns True if the job is still
+    inside the retry budget after this call, False if exhausted (the
+    envelope is then cleared so the job stops being picked up).
+    """
+    if delivery_error is None:
+        clear_delivery_retry(job_id)
+        return False
+    with _jobs_file_lock:
+        jobs = load_jobs()
+        for job in jobs:
+            if job["id"] != job_id:
+                continue
+            envelope = job.get("last_delivery_retry") or {}
+            attempts = int(envelope.get("attempts", 0)) + 1
+            next_at = _next_retry_at(attempts)
+            job["last_delivery_error"] = delivery_error
+            if next_at is None:
+                job["last_delivery_retry"] = None
+                save_jobs(jobs)
+                return False
+            envelope["attempts"] = attempts
+            envelope["next_attempt_at"] = next_at
+            envelope["last_error"] = delivery_error
+            job["last_delivery_retry"] = envelope
+            save_jobs(jobs)
+            return True
+        return False
+
+
+def get_due_delivery_retries() -> List[Dict[str, Any]]:
+    """Return jobs whose pending retry is due to fire now.
+
+    Each returned dict is a *copy* of the job with its envelope intact;
+    callers should treat it as read-only for selection and use the
+    `mark_delivery_retry_attempt` / `clear_delivery_retry` helpers to
+    persist outcomes.
+    """
+    now = _hermes_now()
+    due: List[Dict[str, Any]] = []
+    for job in load_jobs():
+        envelope = job.get("last_delivery_retry")
+        if not envelope:
+            continue
+        next_at = envelope.get("next_attempt_at")
+        if not next_at:
+            continue
+        try:
+            scheduled = datetime.fromisoformat(next_at)
+        except (TypeError, ValueError):
+            continue
+        # Treat naive timestamps as UTC for back-compat.
+        if scheduled.tzinfo is None and now.tzinfo is not None:
+            scheduled = scheduled.replace(tzinfo=now.tzinfo)
+        if scheduled <= now:
+            due.append(_apply_skill_fields(job))
+    return due
+
+
 def save_job_output(job_id: str, output: str):
     """Save job output to file."""
     ensure_dirs()
     job_output_dir = OUTPUT_DIR / job_id
     job_output_dir.mkdir(parents=True, exist_ok=True)
     _secure_dir(job_output_dir)
-    
+
     timestamp = _hermes_now().strftime("%Y-%m-%d_%H-%M-%S")
     output_file = job_output_dir / f"{timestamp}.md"
     

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -107,7 +107,15 @@ _LEGACY_HOME_TARGET_ENV_VARS = {
     "QQBOT_HOME_CHANNEL": "QQ_HOME_CHANNEL",
 }
 
-from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_run
+from cron.jobs import (
+    get_due_jobs,
+    mark_job_run,
+    save_job_output,
+    advance_next_run,
+    schedule_delivery_retry,
+    mark_delivery_retry_attempt,
+    get_due_delivery_retries,
+)
 
 # Sentinel: when a cron agent has nothing new to report, it can start its
 # response with this marker to suppress delivery.  Output is still saved
@@ -295,6 +303,84 @@ def _send_media_via_adapter(adapter, chat_id: str, media_files: list, metadata: 
                 )
         except Exception as e:
             logger.warning("Job '%s': failed to send media %s: %s", job.get("id", "?"), media_path, e)
+
+
+def _drain_due_delivery_retries(adapters=None, loop=None, verbose: bool = False) -> int:
+    """Process any pending delivery retries that are due now.
+
+    For each job with a due `last_delivery_retry`, read the cached output
+    file and replay the delivery via `_deliver_result`. The agent is never
+    re-run - this is the whole point of the retry envelope.
+
+    Returns the number of retry attempts processed (whether they succeeded
+    or failed). Errors are swallowed per-job so a single bad envelope
+    cannot break the rest of the tick.
+    """
+    try:
+        due_retries = get_due_delivery_retries()
+    except Exception as exc:
+        logger.error("Could not load delivery retries: %s", exc)
+        return 0
+
+    if not due_retries:
+        return 0
+
+    if verbose:
+        logger.info("Processing %d delivery retry/retries", len(due_retries))
+
+    processed = 0
+    for job in due_retries:
+        envelope = job.get("last_delivery_retry") or {}
+        output_file = envelope.get("output_file")
+        if not output_file:
+            continue
+        path = Path(output_file)
+        if not path.is_file():
+            # Output file was deleted out from under us - surrender, don't
+            # spin forever.
+            logger.warning(
+                "Job '%s': delivery retry output file missing (%s) - giving up",
+                job["id"], output_file,
+            )
+            mark_delivery_retry_attempt(
+                job["id"], f"output file missing: {output_file}",
+            )
+            # Force-exhaust the budget so we don't keep trying.
+            for _ in range(10):
+                still = mark_delivery_retry_attempt(
+                    job["id"], f"output file missing: {output_file}",
+                )
+                if not still:
+                    break
+            processed += 1
+            continue
+
+        try:
+            content = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            logger.error(
+                "Job '%s': could not read cached output for retry: %s",
+                job["id"], exc,
+            )
+            mark_delivery_retry_attempt(job["id"], f"read failed: {exc}")
+            processed += 1
+            continue
+
+        try:
+            err = _deliver_result(job, content, adapters=adapters, loop=loop)
+        except Exception as exc:
+            err = str(exc)
+
+        if err is None:
+            logger.info("Job '%s': delivery retry succeeded", job["id"])
+        else:
+            logger.warning(
+                "Job '%s': delivery retry failed (%s)", job["id"], err,
+            )
+        mark_delivery_retry_attempt(job["id"], err)
+        processed += 1
+
+    return processed
 
 
 def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
@@ -1204,11 +1290,17 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
         return 0
 
     try:
+        # Drain due delivery retries first (issue #8846). These are cheap
+        # (no agent run, just a re-send from the cached output file) so
+        # they always run before the regular due-job pass.
+        retry_count = _drain_due_delivery_retries(adapters=adapters, loop=loop, verbose=verbose)
+
         due_jobs = get_due_jobs()
 
         if verbose and not due_jobs:
-            logger.info("%s - No jobs due", _hermes_now().strftime('%H:%M:%S'))
-            return 0
+            if retry_count == 0:
+                logger.info("%s - No jobs due", _hermes_now().strftime('%H:%M:%S'))
+            return retry_count
 
         if verbose:
             logger.info("%s - %s job(s) due", _hermes_now().strftime('%H:%M:%S'), len(due_jobs))
@@ -1279,6 +1371,24 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
                     error = "Agent completed but produced empty response (model error, timeout, or misconfiguration)"
 
                 mark_job_run(job["id"], success, error, delivery_error=delivery_error)
+
+                # Schedule a delivery-only retry when the task itself succeeded
+                # but delivery failed (issue #8846). The cached output_file is
+                # the source of truth - we never re-run the agent on retry.
+                if (
+                    success
+                    and should_deliver
+                    and delivery_error is not None
+                    and output_file is not None
+                ):
+                    scheduled = schedule_delivery_retry(
+                        job["id"], str(output_file), delivery_error,
+                    )
+                    if scheduled:
+                        logger.info(
+                            "Job '%s': scheduled delivery retry from %s (initial error: %s)",
+                            job["id"], output_file, delivery_error,
+                        )
                 return True
 
             except Exception as e:
@@ -1320,7 +1430,7 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
         except Exception as _e:
             logger.debug("Post-tick MCP orphan cleanup failed: %s", _e)
 
-        return sum(_results)
+        return sum(_results) + retry_count
     finally:
         if fcntl:
             fcntl.flock(lock_fd, fcntl.LOCK_UN)

--- a/tests/cron/test_delivery_retry.py
+++ b/tests/cron/test_delivery_retry.py
@@ -1,0 +1,320 @@
+"""Tests for cron delivery-only retry on transient platform failures (#8846).
+
+When a cron job's task runs successfully but delivery to the messaging
+platform fails (Telegram 502, schema validation, etc.) the scheduler must:
+
+1. Leave `task_status = ok` so monitoring isn't poisoned by Telegram outages.
+2. Persist a small retry envelope keyed off the cached output file under
+   `~/.hermes/cron/output/<job_id>/`.
+3. Re-attempt delivery on subsequent ticks with bounded backoff
+   (60s, 300s, 1800s; 3 attempts total).
+4. Never re-run the agent - the cached output is the source of truth.
+"""
+
+from datetime import timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from cron.jobs import (
+    DELIVERY_RETRY_BACKOFF_SECONDS,
+    DELIVERY_RETRY_MAX_ATTEMPTS,
+    clear_delivery_retry,
+    create_job,
+    get_due_delivery_retries,
+    load_jobs,
+    mark_delivery_retry_attempt,
+    save_jobs,
+    save_job_output,
+    schedule_delivery_retry,
+)
+from hermes_time import now as _hermes_now
+
+
+@pytest.fixture(autouse=True)
+def tmp_cron_dir(tmp_path, monkeypatch):
+    """Redirect cron storage to a per-test temp directory.
+
+    Mirrors the fixture in `tests/cron/test_jobs.py`. Module-level path
+    constants in `cron.jobs` are cached at import time, so the autouse
+    `_hermetic_environment` fixture (which only sets `HERMES_HOME`) is
+    not enough on its own.
+    """
+    monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
+    monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
+    monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
+    return tmp_path
+
+
+def _make_job():
+    """Create a minimal cron job in the hermetic HERMES_HOME."""
+    return create_job(
+        prompt="say hi",
+        schedule="every 1h",
+        deliver="telegram:12345",
+        repeat=None,
+    )
+
+
+# ─── Backoff schedule ──────────────────────────────────────────────────────────
+
+
+def test_backoff_schedule_constants():
+    """Backoff matches the contract in #8846: 60s, 300s, 1800s."""
+    assert DELIVERY_RETRY_BACKOFF_SECONDS == [60, 300, 1800]
+    assert DELIVERY_RETRY_MAX_ATTEMPTS == 3
+
+
+# ─── schedule_delivery_retry ──────────────────────────────────────────────────
+
+
+def test_schedule_initial_retry_records_envelope():
+    job = _make_job()
+    output_file = save_job_output(job["id"], "hello world")
+
+    scheduled = schedule_delivery_retry(
+        job["id"], str(output_file), "telegram returned 502",
+    )
+    assert scheduled is True
+
+    stored = next(j for j in load_jobs() if j["id"] == job["id"])
+    envelope = stored["last_delivery_retry"]
+    assert envelope is not None
+    assert envelope["output_file"] == str(output_file)
+    assert envelope["attempts"] == 0
+    assert envelope["last_error"] == "telegram returned 502"
+    # next_attempt_at should be ~60s from now
+    next_at = envelope["next_attempt_at"]
+    assert next_at  # non-empty ISO timestamp
+
+
+def test_schedule_returns_false_for_unknown_job():
+    assert schedule_delivery_retry("does-not-exist", "/tmp/x", "boom") is False
+
+
+# ─── mark_delivery_retry_attempt: success path ────────────────────────────────
+
+
+def test_success_clears_envelope_and_error():
+    job = _make_job()
+    output_file = save_job_output(job["id"], "payload")
+    schedule_delivery_retry(job["id"], str(output_file), "first failure")
+
+    # Mark success
+    still = mark_delivery_retry_attempt(job["id"], None)
+    assert still is False  # nothing pending
+
+    stored = next(j for j in load_jobs() if j["id"] == job["id"])
+    assert stored["last_delivery_retry"] is None
+    assert stored["last_delivery_error"] is None
+
+
+# ─── mark_delivery_retry_attempt: backoff progression ─────────────────────────
+
+
+def test_backoff_advances_through_attempts():
+    job = _make_job()
+    output_file = save_job_output(job["id"], "p")
+    schedule_delivery_retry(job["id"], str(output_file), "fail-0")
+
+    # Attempt 1 fails -> attempts=1, next backoff = 300s
+    still = mark_delivery_retry_attempt(job["id"], "fail-1")
+    assert still is True
+    env = next(j for j in load_jobs() if j["id"] == job["id"])["last_delivery_retry"]
+    assert env["attempts"] == 1
+    assert env["last_error"] == "fail-1"
+
+    # Attempt 2 fails -> attempts=2, next backoff = 1800s
+    still = mark_delivery_retry_attempt(job["id"], "fail-2")
+    assert still is True
+    env = next(j for j in load_jobs() if j["id"] == job["id"])["last_delivery_retry"]
+    assert env["attempts"] == 2
+
+    # Attempt 3 fails -> budget exhausted, envelope cleared
+    still = mark_delivery_retry_attempt(job["id"], "fail-3")
+    assert still is False
+    stored = next(j for j in load_jobs() if j["id"] == job["id"])
+    assert stored["last_delivery_retry"] is None
+    # Last error stays visible to the user
+    assert stored["last_delivery_error"] == "fail-3"
+
+
+def test_clear_delivery_retry_drops_envelope():
+    job = _make_job()
+    output_file = save_job_output(job["id"], "p")
+    schedule_delivery_retry(job["id"], str(output_file), "boom")
+
+    clear_delivery_retry(job["id"])
+    stored = next(j for j in load_jobs() if j["id"] == job["id"])
+    assert stored["last_delivery_retry"] is None
+    assert stored["last_delivery_error"] is None
+
+
+# ─── get_due_delivery_retries ─────────────────────────────────────────────────
+
+
+def test_no_retries_due_when_envelope_in_future():
+    job = _make_job()
+    output_file = save_job_output(job["id"], "p")
+    schedule_delivery_retry(job["id"], str(output_file), "boom")
+    # Default schedule is now+60s, which is in the future
+    due = get_due_delivery_retries()
+    assert all(j["id"] != job["id"] for j in due)
+
+
+def test_retry_picked_up_when_due():
+    job = _make_job()
+    output_file = save_job_output(job["id"], "p")
+    schedule_delivery_retry(job["id"], str(output_file), "boom")
+
+    # Backdate the next_attempt_at so it is due now
+    jobs = load_jobs()
+    for j in jobs:
+        if j["id"] == job["id"]:
+            past = (_hermes_now() - timedelta(seconds=5)).isoformat()
+            j["last_delivery_retry"]["next_attempt_at"] = past
+    save_jobs(jobs)
+
+    due = get_due_delivery_retries()
+    assert any(j["id"] == job["id"] for j in due)
+
+
+def test_retry_envelope_with_no_next_at_is_skipped():
+    job = _make_job()
+    output_file = save_job_output(job["id"], "p")
+    schedule_delivery_retry(job["id"], str(output_file), "boom")
+    jobs = load_jobs()
+    for j in jobs:
+        if j["id"] == job["id"]:
+            j["last_delivery_retry"]["next_attempt_at"] = ""
+    save_jobs(jobs)
+
+    due = get_due_delivery_retries()
+    assert all(j["id"] != job["id"] for j in due)
+
+
+# ─── _drain_due_delivery_retries integration ──────────────────────────────────
+
+
+def test_drain_replays_delivery_from_cached_output():
+    """The retry pass must read the cached file and call _deliver_result.
+
+    It must NOT re-run the agent.
+    """
+    from cron import scheduler as sched
+
+    job = _make_job()
+    output_file = save_job_output(job["id"], "the cached agent output")
+    schedule_delivery_retry(job["id"], str(output_file), "first failure")
+
+    # Make it due
+    jobs = load_jobs()
+    for j in jobs:
+        if j["id"] == job["id"]:
+            j["last_delivery_retry"]["next_attempt_at"] = (
+                _hermes_now() - timedelta(seconds=5)
+            ).isoformat()
+    save_jobs(jobs)
+
+    # Stub _deliver_result so we can assert it was called with the cached
+    # content, and have it return success this time.
+    captured = {}
+
+    def fake_deliver(job_arg, content_arg, adapters=None, loop=None):
+        captured["job_id"] = job_arg["id"]
+        captured["content"] = content_arg
+        return None  # success
+
+    with patch.object(sched, "_deliver_result", side_effect=fake_deliver):
+        processed = sched._drain_due_delivery_retries(verbose=False)
+
+    assert processed == 1
+    assert captured["job_id"] == job["id"]
+    assert captured["content"] == "the cached agent output"
+
+    stored = next(j for j in load_jobs() if j["id"] == job["id"])
+    # Success cleared the envelope
+    assert stored["last_delivery_retry"] is None
+    assert stored["last_delivery_error"] is None
+
+
+def test_drain_failure_advances_backoff_then_exhausts():
+    from cron import scheduler as sched
+
+    job = _make_job()
+    output_file = save_job_output(job["id"], "payload")
+    schedule_delivery_retry(job["id"], str(output_file), "initial failure")
+
+    def make_due():
+        jobs = load_jobs()
+        for j in jobs:
+            if j["id"] == job["id"] and j.get("last_delivery_retry"):
+                j["last_delivery_retry"]["next_attempt_at"] = (
+                    _hermes_now() - timedelta(seconds=5)
+                ).isoformat()
+        save_jobs(jobs)
+
+    with patch.object(
+        sched,
+        "_deliver_result",
+        side_effect=lambda *a, **kw: "still 502",
+    ):
+        # First retry attempt - moves attempts: 0 -> 1
+        make_due()
+        assert sched._drain_due_delivery_retries() == 1
+        env = next(j for j in load_jobs() if j["id"] == job["id"])["last_delivery_retry"]
+        assert env is not None and env["attempts"] == 1
+
+        # Second
+        make_due()
+        assert sched._drain_due_delivery_retries() == 1
+        env = next(j for j in load_jobs() if j["id"] == job["id"])["last_delivery_retry"]
+        assert env is not None and env["attempts"] == 2
+
+        # Third - budget exhausted, envelope cleared but last_delivery_error visible
+        make_due()
+        assert sched._drain_due_delivery_retries() == 1
+        stored = next(j for j in load_jobs() if j["id"] == job["id"])
+        assert stored["last_delivery_retry"] is None
+        assert stored["last_delivery_error"] == "still 502"
+
+
+def test_drain_handles_missing_output_file():
+    """Cached file deleted out from under us -> give up, no infinite loop."""
+    from cron import scheduler as sched
+
+    job = _make_job()
+    schedule_delivery_retry(job["id"], "/tmp/does-not-exist-xyz.md", "boom")
+
+    jobs = load_jobs()
+    for j in jobs:
+        if j["id"] == job["id"]:
+            j["last_delivery_retry"]["next_attempt_at"] = (
+                _hermes_now() - timedelta(seconds=5)
+            ).isoformat()
+    save_jobs(jobs)
+
+    with patch.object(sched, "_deliver_result") as mock_deliver:
+        processed = sched._drain_due_delivery_retries()
+        assert processed == 1
+        mock_deliver.assert_not_called()
+
+    stored = next(j for j in load_jobs() if j["id"] == job["id"])
+    # Envelope cleared so we don't retry forever.
+    assert stored["last_delivery_retry"] is None
+
+
+def test_drain_returns_zero_when_no_retries_pending():
+    from cron import scheduler as sched
+
+    _make_job()  # job with no retry envelope
+    assert sched._drain_due_delivery_retries() == 0
+
+
+# ─── Job initialization ───────────────────────────────────────────────────────
+
+
+def test_new_job_has_empty_retry_envelope():
+    job = _make_job()
+    assert job.get("last_delivery_retry") is None


### PR DESCRIPTION
## Summary

When a cron job's task succeeds but delivery to the messaging platform fails (Telegram 502, schema validation, Slack rate-limit, transient network), the agent's output is already saved to `~/.hermes/cron/output/<job_id>/<timestamp>.md` and `mark_job_run` already sets `last_status=ok` with `last_delivery_error` tracked separately. What was missing was the retry: the delivery would sit on the floor until the next scheduled run, which for daily / weekly jobs means the user never sees the result.

This PR adds a delivery-only retry path keyed off the cached output file. The agent is never re-executed - the saved `.md` is the source of truth.

Fixes #8846.

## Design

Per-job retry envelope persisted in `jobs.json`:

```json
"last_delivery_retry": {
  "output_file": "/Users/.../hermes/cron/output/abc123/2026-04-26_18-30-00.md",
  "attempts": 1,
  "next_attempt_at": "2026-04-26T18:35:00+00:00",
  "last_error": "telegram returned 502"
}
```

- 3 attempts max, exponential backoff at 60 s, 300 s, 1800 s (5 min, 30 min). Constants live in `cron/jobs.py::DELIVERY_RETRY_BACKOFF_SECONDS` so the policy is one edit away.
- `tick()` drains due retries before the regular due-jobs scan, via a new `_drain_due_delivery_retries` helper that reads the cached file and calls `_deliver_result`. Cheap path (no LLM, no tool calls, no `run_job`).
- After the budget is exhausted the envelope is cleared but `last_delivery_error` stays populated, so `hermes cron list` continues to surface the failure.
- If the cached output file is missing (user pruned `~/.hermes/cron/output/`), we surrender immediately rather than spinning - the file is the source of truth and we can't reconstruct it.

## Files changed

- `cron/jobs.py`
  - New `last_delivery_retry` field on the job dict (initialised to `None` in `create_job`).
  - `DELIVERY_RETRY_BACKOFF_SECONDS = [60, 300, 1800]`, `DELIVERY_RETRY_MAX_ATTEMPTS = 3`.
  - `schedule_delivery_retry`, `mark_delivery_retry_attempt`, `clear_delivery_retry`, `get_due_delivery_retries` - all under the existing `_jobs_file_lock`, same pattern as `mark_job_run`.

- `cron/scheduler.py`
  - `_process_job` calls `schedule_delivery_retry` on the *first* delivery failure for a successful task. `mark_job_run` is unchanged - `task_status=ok` was already correct for this case.
  - `tick()` runs `_drain_due_delivery_retries` first. Returns `sum(_results) + retry_count`.

- `tests/cron/test_delivery_retry.py` (new, 14 cases): backoff schedule, envelope CRUD, due-job selection, drain replays from the cached file, drain advances backoff through to exhaustion, missing-file surrender path.

## Scope narrowing vs #13946 and #10443

Both adjacent PRs target cron retry / reliability with broader scope:

- **#13946** (`feat(cron): add bounded retry path for transient delivery failures`, 503 +/16 -) introduces a transient-vs-terminal classification surface and threads it through `cron/jobs.py` and `cron/scheduler.py`. Useful direction but bigger - and it operates on the in-memory delivery result, not the cached output file, so a process restart between failure and retry loses the message.
- **#10443** (`Cron scheduler reliability: observability, retry, audit trail`, 441 +/84 -) adds a JSONL event log, a stale one-shot detector, retry policy, and a separate audit trail. Multi-concern PR.

This PR is intentionally minimal: a single retry envelope on the existing job record, drained from the existing tick loop, against the existing cached output file. ~190 production lines, additive only, no schema migration needed (existing jobs have `last_delivery_retry` default to `None`). Should land cleanly alongside or before either of the two larger ones.

## Test plan

- [x] `pytest tests/cron/test_jobs.py tests/cron/test_delivery_retry.py -v -p no:xdist -o addopts=''` - 78 passed (64 pre-existing + 14 new). Output in `TEST_OUTPUT.txt`.
- [x] Verified `task_status=ok` semantics unchanged: `mark_job_run` only sees `success`, the retry envelope is set after `mark_job_run` returns, and the budget-exhausted path leaves `last_status=ok` and only updates `last_delivery_error`.
- [x] Verified 17 pre-existing `tests/cron/test_scheduler.py` failures are present without this change too - they relate to test-only deps (toolset registry / wake gate) and are not introduced here.
- [ ] Manual delivery-failure simulation against a live Telegram bot - I would like to do this in CI / staging if a maintainer can point me at the right lane.

## Out of scope

- Per-platform classification of "is this error worth retrying" (5xx / connection-reset vs 4xx / unknown chat). Currently every failure is retried; the 3-attempt cap bounds the cost. #13946 is the right place for that classifier.
- Surfacing retry state in `hermes cron list`. The data is on the job record, but the renderer change belongs in `hermes_cli/cron_cli.py` and would push this PR past its narrow scope.
- Persisting retry counters across `hermes update` reboots beyond what `jobs.json` already gives us.
