### PR TITLE
feat(slack): wrap and align GFM tables for proper rendering

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -14,6 +14,7 @@ import logging
 import os
 import re
 import time
+import unicodedata
 from dataclasses import dataclass, field
 from typing import Dict, Optional, Any, Tuple, List
 
@@ -251,6 +252,120 @@ def _resolve_slack_proxy_url() -> Optional[str]:
         return None
 
     return proxy_url
+
+
+
+# ── GFM markdown table preprocessing ──────────────────────────────────────
+# Slack mrkdwn does not render GFM-style pipe tables — they appear as literal
+# pipes. Wrapping in ``` fences makes them render as monospace preformatted
+# text, and padding cells to per-column max display width (with East-Asian
+# Wide / CJK awareness) keeps the columns aligned for the reader.
+
+_TABLE_SEPARATOR_RE = re.compile(
+    r"^\s*\|?\s*:?-+:?\s*(?:\|\s*:?-+:?\s*){1,}\|?\s*$"
+)
+
+
+def _is_table_row(line: str) -> bool:
+    """Return True if *line* could plausibly be a table data row."""
+    stripped = line.strip()
+    return bool(stripped) and "|" in stripped
+
+
+def _disp_width(s: str) -> int:
+    """Monospace display width: East-Asian Wide / Full-width chars count as 2."""
+    return sum(2 if unicodedata.east_asian_width(c) in "WF" else 1 for c in s)
+
+
+def _pad(cell: str, width: int) -> str:
+    """Right-pad *cell* with spaces until its display width equals *width*."""
+    delta = width - _disp_width(cell)
+    return cell + (" " * delta if delta > 0 else "")
+
+
+def _split_row(line: str) -> List[str]:
+    """Split a ``| a | b | c |`` row into trimmed cells (outer pipes optional)."""
+    s = line.strip()
+    if s.startswith("|"):
+        s = s[1:]
+    if s.endswith("|"):
+        s = s[:-1]
+    return [c.strip() for c in s.split("|")]
+
+
+def _align_table(rows: List[str]) -> List[str]:
+    """Re-emit a markdown table with cells padded to per-column max display width.
+
+    *rows[0]* is the header, *rows[1]* is the GFM separator (regenerated to
+    match new column widths), and *rows[2:]* are data rows. Cells are
+    normalized to a uniform column count (missing cells filled with empty
+    strings) before width calculation.
+    """
+    if len(rows) < 2:
+        return rows
+    parsed = [_split_row(r) for r in rows]
+    n_cols = max(len(r) for r in parsed)
+    for r in parsed:
+        while len(r) < n_cols:
+            r.append("")
+    sep_idx = 1
+    parsed[sep_idx] = ["---"] * n_cols  # placeholder; regenerated below
+    widths = [max(_disp_width(r[c]) for r in parsed) for c in range(n_cols)]
+    out: List[str] = []
+    for idx, row in enumerate(parsed):
+        if idx == sep_idx:
+            cells = ["-" * widths[c] for c in range(n_cols)]
+        else:
+            cells = [_pad(row[c], widths[c]) for c in range(n_cols)]
+        out.append("| " + " | ".join(cells) + " |")
+    return out
+
+
+def _wrap_markdown_tables(text: str) -> str:
+    """Wrap GFM pipe tables in ``` fences and align column widths.
+
+    Detected by a row containing ``|`` immediately followed by a delimiter row
+    matching :data:`_TABLE_SEPARATOR_RE`. Subsequent pipe-containing non-blank
+    lines are consumed as the table body. Tables already inside fenced code
+    blocks are left alone.
+    """
+    if not text or "|" not in text or "-" not in text:
+        return text
+
+    lines = text.split("\n")
+    out: List[str] = []
+    in_fence = False
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.lstrip()
+        if stripped.startswith("```"):
+            in_fence = not in_fence
+            out.append(line)
+            i += 1
+            continue
+        if in_fence:
+            out.append(line)
+            i += 1
+            continue
+        if (
+            "|" in line
+            and i + 1 < len(lines)
+            and _TABLE_SEPARATOR_RE.match(lines[i + 1])
+        ):
+            block = [line, lines[i + 1]]
+            j = i + 2
+            while j < len(lines) and _is_table_row(lines[j]):
+                block.append(lines[j])
+                j += 1
+            out.append("```")
+            out.extend(_align_table(block))
+            out.append("```")
+            i = j
+            continue
+        out.append(line)
+        i += 1
+    return "\n".join(out)
 
 
 class SlackAdapter(BasePlatformAdapter):
@@ -817,12 +932,17 @@ class SlackAdapter(BasePlatformAdapter):
     def format_message(self, content: str) -> str:
         """Convert standard markdown to Slack mrkdwn format.
 
-        Protected regions (code blocks, inline code) are extracted first so
-        their contents are never modified.  Standard markdown constructs
+        GFM-style pipe tables are first wrapped in ``` fences and column-
+        aligned (with CJK display-width awareness) so they render as monospace
+        preformatted text instead of literal-pipe noise. Then protected
+        regions (code blocks — including the table fences just emitted —
+        and inline code) are extracted, and standard markdown constructs
         (headers, bold, italic, links) are translated to mrkdwn syntax.
         """
         if not content:
             return content
+
+        content = _wrap_markdown_tables(content)
 
         placeholders: dict = {}
         counter = [0]

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -25,6 +25,7 @@ from gateway.platforms.base import (
 )
 
 
+
 # ---------------------------------------------------------------------------
 # Mock the slack-bolt package if it's not installed
 # ---------------------------------------------------------------------------
@@ -61,6 +62,12 @@ import gateway.platforms.slack as _slack_mod
 _slack_mod.SLACK_AVAILABLE = True
 
 from gateway.platforms.slack import SlackAdapter  # noqa: E402
+from gateway.platforms.slack import (  # noqa: E402
+    _wrap_markdown_tables,
+    _align_table,
+    _disp_width,
+    _is_table_row,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -2586,3 +2593,180 @@ class TestSlackReplyToText:
         assert msg_event.reply_to_text is None
         # Top-level message: reply_to_message_id must be falsy (None or empty).
         assert not msg_event.reply_to_message_id
+
+
+# =========================================================================
+# Markdown table preprocessing (Slack mrkdwn does not render GFM tables)
+# =========================================================================
+
+
+class TestWrapMarkdownTables:
+    """``_wrap_markdown_tables`` wraps GFM pipe tables in ``` fences AND
+    aligns columns by per-column max display width, so Slack monospace
+    code-block rendering shows readable, aligned columns even with CJK
+    content (mirrors the TUI rendering)."""
+
+    def test_basic_table_wrapped(self):
+        text = (
+            "Scores:\n\n"
+            "| Player | Score |\n"
+            "|--------|-------|\n"
+            "| Alice  | 150   |\n"
+            "| Bob    | 120   |\n"
+            "\nEnd."
+        )
+        out = _wrap_markdown_tables(text)
+        # Wrapped in fence
+        assert "```\n| Player" in out
+        assert out.count("```") == 2
+        # Surrounding prose preserved
+        assert out.startswith("Scores:")
+        assert out.endswith("End.")
+
+    def test_columns_aligned_after_wrap(self):
+        """All rows in the wrapped block should have identical character length."""
+        text = (
+            "| short | long_header_name |\n"
+            "|---|---|\n"
+            "| a | bbb |"
+        )
+        out = _wrap_markdown_tables(text)
+        body = [ln for ln in out.split("\n") if ln.startswith("|")]
+        widths = {len(ln) for ln in body}
+        assert len(widths) == 1, f"row widths drift: {widths}"
+
+    def test_cjk_columns_aligned(self):
+        """CJK characters count as 2 display columns; alignment must respect that."""
+        text = (
+            "| Workflow | 状态 |\n"
+            "|---|---|\n"
+            "| ci | active |\n"
+            "| dep | 7 成功 |"
+        )
+        out = _wrap_markdown_tables(text)
+        body = [ln for ln in out.split("\n") if ln.startswith("|")]
+        # Display widths (not raw char counts) should be uniform
+        display_widths = {_disp_width(ln) for ln in body}
+        assert len(display_widths) == 1, f"display widths drift: {display_widths}"
+
+    def test_no_table_returns_unchanged(self):
+        text = "Just a paragraph with | one pipe but no table."
+        assert _wrap_markdown_tables(text) == text
+
+    def test_table_inside_existing_fence_untouched(self):
+        text = (
+            "```\n"
+            "| inside | a fence |\n"
+            "|---|---|\n"
+            "| x | y |\n"
+            "```"
+        )
+        # Content already inside ``` should be passed through verbatim.
+        assert _wrap_markdown_tables(text) == text
+
+    def test_alignment_separators_supported(self):
+        """Separator rows with :--- / ---: / :---: alignment markers match."""
+        text = (
+            "| Name | Age | City |\n"
+            "|:-----|----:|:----:|\n"
+            "| Ada  |  30 | NYC  |"
+        )
+        out = _wrap_markdown_tables(text)
+        assert out.count("```") == 2
+
+    def test_two_consecutive_tables_wrapped_separately(self):
+        text = (
+            "| A | B |\n|---|---|\n| 1 | 2 |\n"
+            "\n"
+            "| C | D |\n|---|---|\n| 3 | 4 |"
+        )
+        out = _wrap_markdown_tables(text)
+        # Two separate fence pairs (4 ``` total)
+        assert out.count("```") == 4
+
+    def test_bare_pipe_table_wrapped(self):
+        """Tables without outer pipes (GFM allows this) are still detected."""
+        text = "head1 | head2\n--- | ---\na | b\nc | d"
+        out = _wrap_markdown_tables(text)
+        assert out.count("```") == 2
+        assert "head1" in out
+
+    def test_empty_input(self):
+        assert _wrap_markdown_tables("") == ""
+
+    def test_single_pipe_no_table(self):
+        text = "this | that"  # no separator row → not a table
+        assert _wrap_markdown_tables(text) == text
+
+
+class TestAlignTable:
+    def test_normalizes_column_count(self):
+        """Rows with mismatched column counts get padded to the max."""
+        rows = [
+            "| a | b |",
+            "|---|---|",
+            "| 1 |",            # short
+            "| 2 | 3 | extra |",  # long
+        ]
+        out = _align_table(rows)
+        # All rows should have same number of `|` chars after padding
+        pipe_counts = {ln.count("|") for ln in out}
+        assert len(pipe_counts) == 1
+
+    def test_pads_to_max_display_width(self):
+        rows = [
+            "| short | longer_header |",
+            "|---|---|",
+            "| a | b |",
+        ]
+        out = _align_table(rows)
+        # All output rows have same character length
+        assert len({len(ln) for ln in out}) == 1
+
+    def test_regenerates_separator_row(self):
+        """Separator row is regenerated to match the (wider) column widths."""
+        rows = [
+            "| short | longer_header |",
+            "|---|---|",
+            "| a | b |",
+        ]
+        out = _align_table(rows)
+        sep = out[1]
+        # Original separator was 6 dashes total; the new one must be longer
+        assert sep.count("-") > 6
+
+    def test_too_few_rows_returned_unchanged(self):
+        rows = ["| only header |"]
+        assert _align_table(rows) == rows
+
+
+class TestDispWidth:
+    def test_ascii_one_per_char(self):
+        assert _disp_width("hello") == 5
+
+    def test_empty_string(self):
+        assert _disp_width("") == 0
+
+    def test_cjk_two_per_char(self):
+        assert _disp_width("成功") == 4
+        assert _disp_width("过去") == 4
+
+    def test_mixed_ascii_and_cjk(self):
+        # "5 成功" = 1 + 1 + 2 + 2 = 6
+        assert _disp_width("5 成功") == 6
+
+    def test_full_width_punctuation(self):
+        # ， is U+FF0C (full-width comma), east_asian_width = F
+        assert _disp_width("a，b") == 4  # 1 + 2 + 1
+
+
+class TestIsTableRow:
+    def test_recognizes_pipe_row(self):
+        assert _is_table_row("| a | b |") is True
+
+    def test_rejects_blank(self):
+        assert _is_table_row("") is False
+        assert _is_table_row("   ") is False
+
+    def test_rejects_no_pipe(self):
+        assert _is_table_row("just text") is False


### PR DESCRIPTION
## What does this PR do?

Slack mrkdwn does not render GFM-style \`| ... |\` tables — they appear as
literal pipe characters with no column alignment. \`gateway/platforms/telegram.py\`
already handles this with \`_wrap_markdown_tables()\` that fences the table in
\` \`\`\` \` blocks so it renders as monospace preformatted text.

This PR ports that approach to \`slack.py\` and additionally aligns columns
to per-column max display width with **East-Asian Wide / CJK awareness**, so
tables render with aligned columns in Slack's monospace code-block (matching
the TUI rendering) even when they contain Chinese / Japanese / Korean
content.

The CJK alignment goes beyond what the telegram adapter does today; a
follow-up PR could extend \`_align_table\` to telegram for parity, but this
PR is scoped to Slack to keep the change focused.

## Related Issue

Related to #7532 (slack adapter format-bridging gaps) and #6218 (slack
mrkdwn config bridging issues). No specific issue was filed for table
rendering.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (CJK-aware column alignment is new capability beyond telegram's wrap-only behavior)

## Changes Made

- \`gateway/platforms/slack.py\`
  - Add \`import unicodedata\` (stdlib only — no new dependency)
  - Add helpers: \`_TABLE_SEPARATOR_RE\`, \`_is_table_row\`, \`_disp_width\`, \`_pad\`, \`_split_row\`, \`_align_table\`, \`_wrap_markdown_tables\`
  - Call \`_wrap_markdown_tables(content)\` at the top of \`SlackAdapter.format_message()\` so the existing fence-protection pass preserves the wrapped output verbatim
- \`tests/gateway/test_slack.py\`
  - Add \`TestWrapMarkdownTables\` (10 cases — basic wrap, alignment, CJK, fence preservation, edge cases)
  - Add \`TestAlignTable\` (4 cases — column normalization, padding, separator regeneration)
  - Add \`TestDispWidth\` (5 cases — ASCII, CJK, mixed, full-width punct)
  - Add \`TestIsTableRow\` (3 cases)

## How to Test

\`\`\`bash
# Run the new tests
pytest tests/gateway/test_slack.py -v -k 'TestWrapMarkdownTables or TestAlignTable or TestDispWidth or TestIsTableRow'

# Full Slack adapter test suite (no regression)
pytest tests/gateway/test_slack.py -q
\`\`\`

Manual: send a hermes Slack message containing a markdown table — it renders aligned and monospace inside a code-block, instead of raw pipes.

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (\`feat(slack):\`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [x] I've run \`pytest tests/gateway/test_slack.py -q\` and all 176 tests pass (22 new + 154 existing)
- [x] I've added tests for my changes (22 new cases)
- [x] I've tested on my platform: Linux (Ubuntu 24.04, Docker)

### Documentation & Housekeeping
- [x] N/A — no public-facing config/docs changed
- [x] N/A — no new config keys
- [x] N/A — no architecture/workflow change
- [x] N/A — pure-Python change, cross-platform-safe (uses stdlib \`unicodedata\`)