### PR TITLE
feat: show account limits in CLI and TUI status bars

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import base64
+import json
 import logging
 import math
 from dataclasses import dataclass
@@ -436,6 +438,32 @@ def _resolve_codex_usage_url(base_url: str) -> str:
     return normalized + "/api/codex/usage"
 
 
+def _codex_account_id_from_access_token(access_token: str) -> Optional[str]:
+    """Best-effort account ID from the already-selected Codex access token."""
+    if not isinstance(access_token, str):
+        return None
+    parts = access_token.strip().split(".")
+    if len(parts) != 3 or not all(parts):
+        return None
+    try:
+        header_part, payload_part, _signature = parts
+        header = json.loads(
+            base64.urlsafe_b64decode(header_part + "=" * (-len(header_part) % 4))
+        )
+        payload = json.loads(
+            base64.urlsafe_b64decode(payload_part + "=" * (-len(payload_part) % 4))
+        )
+        if not isinstance(header, dict) or not isinstance(payload, dict):
+            return None
+        auth_claims = payload.get("https://api.openai.com/auth")
+        if not isinstance(auth_claims, dict):
+            return None
+        account_id = auth_claims.get("chatgpt_account_id")
+        return str(account_id).strip() if isinstance(account_id, str) and account_id.strip() else None
+    except (ValueError, TypeError, json.JSONDecodeError):
+        return None
+
+
 def _resolve_codex_usage_credentials(
     base_url: Optional[str],
     api_key: Optional[str],
@@ -449,7 +477,11 @@ def _resolve_codex_usage_credentials(
     """
     explicit_key = str(api_key or "").strip()
     if explicit_key:
-        return explicit_key, str(base_url or "").strip(), None
+        return (
+            explicit_key,
+            str(base_url or "").strip(),
+            _codex_account_id_from_access_token(explicit_key),
+        )
 
     # Tier 2: the native runtime resolver. It ALREADY falls back to the
     # credential pool when the singleton is empty (see

--- a/cli.py
+++ b/cli.py
@@ -24,6 +24,7 @@ except ModuleNotFoundError:
     pass
 
 import logging
+import hashlib
 import os
 import shutil
 import sys
@@ -4496,6 +4497,197 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         return f"[{('█' * filled) + ('░' * max(0, width - filled))}]"
 
     @staticmethod
+    def _account_limit_provider_label(provider: Optional[str]) -> str:
+        normalized = str(provider or "").strip().lower()
+        return {
+            "openai-codex": "Codex",
+            "anthropic": "Claude",
+            "openrouter": "OpenRouter",
+        }.get(normalized, normalized.replace("_", "-").replace("-", " ").title().replace(" ", "") or "Account")
+
+    @staticmethod
+    def _compact_account_limit_credential_label(label: Optional[str], max_width: int = 10) -> str:
+        cleaned = re.sub(r"\s+", "-", str(label or "").strip())
+        cleaned = re.sub(r"[^A-Za-z0-9._@+-]+", "-", cleaned).strip("-")
+        return cleaned if len(cleaned) <= max_width else cleaned[: max(1, max_width - 1)] + "…"
+
+    def _account_limit_credential_label(self, agent, api_key: Optional[str] = None) -> str:
+        """Return a pool label only after an exact active-token match."""
+        active_key = str(
+            api_key
+            if api_key is not None
+            else getattr(agent, "api_key", None) or getattr(self, "api_key", None) or ""
+        )
+        pool = getattr(agent, "_credential_pool", None) or getattr(self, "_credential_pool", None)
+        if pool is None or not active_key:
+            return ""
+        candidates = []
+        try:
+            entries = getattr(pool, "entries", None)
+            if callable(entries):
+                candidates.extend(entries())
+        except Exception:
+            pass
+        candidates.extend(list(getattr(pool, "_entries", None) or []))
+        for method_name in ("current", "peek"):
+            try:
+                method = getattr(pool, method_name, None)
+                entry = method() if callable(method) else None
+                if entry is not None:
+                    candidates.append(entry)
+            except Exception:
+                pass
+        for entry in candidates:
+            entry_api_key = str(
+                getattr(entry, "runtime_api_key", None)
+                or getattr(entry, "access_token", None)
+                or getattr(entry, "api_key", None)
+                or ""
+            )
+            if entry_api_key == active_key:
+                label = getattr(entry, "label", None) or getattr(entry, "id", None)
+                return self._compact_account_limit_credential_label(label)
+        return ""
+
+    @staticmethod
+    def _account_limit_window_label(label: str) -> str:
+        normalized = str(label or "").strip().lower()
+        if "session" in normalized or "five hour" in normalized:
+            return "5h"
+        if "opus" in normalized and "week" in normalized:
+            return "opus wk"
+        if "sonnet" in normalized and "week" in normalized:
+            return "sonnet wk"
+        if "week" in normalized:
+            return "weekly"
+        if "quota" in normalized:
+            return "quota"
+        cleaned = re.sub(r"[^A-Za-z0-9]+", "-", normalized).strip("-")
+        return cleaned[:10] if cleaned else "limit"
+
+    @classmethod
+    def _format_account_limit_status(cls, snapshot, credential_label: Optional[str] = None) -> Optional[Dict[str, str]]:
+        if not snapshot or not getattr(snapshot, "windows", None):
+            return None
+        parts: list[str] = []
+        lowest_remaining: Optional[int] = None
+        for window in list(snapshot.windows)[:3]:
+            try:
+                remaining = max(0, min(100, round(100 - float(window.used_percent))))
+            except (AttributeError, TypeError, ValueError):
+                continue
+            lowest_remaining = remaining if lowest_remaining is None else min(lowest_remaining, remaining)
+            parts.append(f"{cls._account_limit_window_label(getattr(window, 'label', ''))} {remaining}%")
+        if not parts:
+            return None
+        level = "critical" if lowest_remaining is not None and lowest_remaining <= 10 else "warn" if lowest_remaining is not None and lowest_remaining <= 25 else "ok"
+        prefix = cls._account_limit_provider_label(getattr(snapshot, "provider", None))
+        label = cls._compact_account_limit_credential_label(credential_label)
+        if label:
+            prefix += f" {label}"
+        return {"text": f"{prefix} {' • '.join(parts)}", "level": level}
+
+    @staticmethod
+    def _status_bar_account_limit_style(level: Optional[str]) -> str:
+        if level == "critical":
+            return "class:status-bar-critical"
+        if level == "warn":
+            return "class:status-bar-warn"
+        return "class:status-bar-dim"
+
+    def _ensure_account_limit_status_state(self) -> None:
+        if not hasattr(self, "_account_limit_status_lock"):
+            self._account_limit_status_lock = threading.Lock()
+        if not isinstance(getattr(self, "_account_limit_status_cache", None), dict):
+            self._account_limit_status_cache = {}
+        if not hasattr(self, "_account_limit_status_refreshing"):
+            self._account_limit_status_refreshing = set()
+        if not hasattr(self, "_account_limit_status_ttl"):
+            self._account_limit_status_ttl = 300.0
+        if not hasattr(self, "_account_limit_status_retry"):
+            self._account_limit_status_retry = 60.0
+        if not hasattr(self, "_account_limit_status_enabled"):
+            self._account_limit_status_enabled = True
+
+    def _account_limit_status_request_snapshot(self, agent) -> Optional[tuple]:
+        provider = str(getattr(agent, "provider", None) or getattr(self, "provider", None) or "").strip().lower()
+        if provider in {"", "auto", "custom"}:
+            return None
+        base_url = str(getattr(agent, "base_url", None) or getattr(self, "base_url", None) or "").strip().rstrip("/")
+        api_key = str(getattr(agent, "api_key", None) or getattr(self, "api_key", None) or "")
+        fingerprint = hashlib.sha256(api_key.encode("utf-8")).hexdigest() if api_key else ""
+        key = (provider, base_url, fingerprint)
+        return key, provider, base_url, api_key, self._account_limit_credential_label(agent, api_key)
+
+    def _account_limit_status_cache_key(self, agent) -> Optional[tuple[str, str, str]]:
+        snapshot = self._account_limit_status_request_snapshot(agent)
+        return snapshot[0] if snapshot else None
+
+    def _refresh_account_limit_status(self, request: tuple) -> None:
+        key, provider, base_url, api_key, credential_label = request
+        formatted = None
+        try:
+            from agent.account_usage import fetch_account_usage
+
+            formatted = self._format_account_limit_status(
+                fetch_account_usage(provider, base_url=base_url, api_key=api_key or None),
+                credential_label=credential_label,
+            )
+        except Exception:
+            formatted = None
+        finally:
+            now = time.monotonic()
+            ttl = float(getattr(self, "_account_limit_status_ttl", 300.0) or 300.0)
+            retry = float(getattr(self, "_account_limit_status_retry", 60.0) or 60.0)
+            with self._account_limit_status_lock:
+                previous = self._account_limit_status_cache.get(key) or {}
+                if formatted is not None:
+                    self._account_limit_status_cache[key] = {
+                        "payload": dict(formatted),
+                        "fresh_until": now + ttl,
+                        "retry_after": now + ttl,
+                    }
+                else:
+                    self._account_limit_status_cache[key] = {
+                        "payload": previous.get("payload"),
+                        "fresh_until": float(previous.get("fresh_until") or 0.0),
+                        "retry_after": now + min(ttl, retry),
+                    }
+                self._account_limit_status_refreshing.discard(key)
+            self._invalidate()
+
+    def _get_account_limit_status_for_status_bar(self, agent):
+        if not agent:
+            return None
+        self._ensure_account_limit_status_state()
+        request = self._account_limit_status_request_snapshot(agent)
+        if not request:
+            return None
+        key = request[0]
+        now = time.monotonic()
+        with self._account_limit_status_lock:
+            cached = self._account_limit_status_cache.get(key) or {}
+            stale = cached.get("payload")
+            if float(cached.get("fresh_until") or 0.0) > now:
+                return stale
+            if float(cached.get("retry_after") or 0.0) > now:
+                return stale
+            if not self._account_limit_status_enabled or key in self._account_limit_status_refreshing:
+                return stale
+            self._account_limit_status_refreshing.add(key)
+        try:
+            threading.Thread(
+                target=self._refresh_account_limit_status,
+                args=(request,),
+                daemon=True,
+                name="cli-account-limits-refresh",
+            ).start()
+        except Exception:
+            with self._account_limit_status_lock:
+                self._account_limit_status_refreshing.discard(key)
+        return stale
+
+    @staticmethod
     def _format_prompt_elapsed(prompt_start_time: Optional[float], prompt_duration: float, live: bool = False) -> str:
         """Format per-prompt elapsed time for the status bar.
 
@@ -5124,6 +5316,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 parts.append(idle_since)
             if yolo_active:
                 parts.append("⚠ YOLO")
+            account_limit_status = self._get_account_limit_status_for_status_bar(getattr(self, "agent", None))
+            if account_limit_status and account_limit_status.get("text"):
+                parts.append(str(account_limit_status["text"]))
             return self._trim_status_bar_text(" │ ".join(parts), width)
         except Exception:
             return f"⚕ {self.model if getattr(self, 'model', None) else 'Hermes'}"
@@ -5239,6 +5434,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     if yolo_active:
                         frags.append(("class:status-bar-dim", " │ "))
                         frags.append(("class:status-bar-yolo", "⚠ YOLO"))
+                    account_limit_status = self._get_account_limit_status_for_status_bar(getattr(self, "agent", None))
+                    if account_limit_status and account_limit_status.get("text"):
+                        frags.append(("class:status-bar-dim", " │ "))
+                        frags.append((
+                            self._status_bar_account_limit_style(account_limit_status.get("level")),
+                            str(account_limit_status["text"]),
+                        ))
                     frags.append(("class:status-bar", " "))
 
             total_width = sum(self._status_bar_display_width(text) for _, text in frags)

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -533,6 +533,8 @@ def _resolve_runtime_from_pool_entry(
         "base_url": base_url,
         "api_key": api_key,
         "source": getattr(entry, "source", "pool"),
+        "credential_id": getattr(entry, "id", None),
+        "credential_label": getattr(entry, "label", None),
         "credential_pool": pool,
         "requested_provider": requested_provider,
     }
@@ -583,6 +585,8 @@ def _try_resolve_from_custom_pool(
             "base_url": base_url,
             "api_key": pool_api_key,
             "source": f"pool:{pool_key}",
+            "credential_id": getattr(entry, "id", None),
+            "credential_label": getattr(entry, "label", None),
             "credential_pool": pool,
         }
     except Exception:

--- a/run_agent.py
+++ b/run_agent.py
@@ -563,6 +563,39 @@ class AIAgent:
             checkpoint_max_file_size_mb=checkpoint_max_file_size_mb,
             pass_session_id=pass_session_id,
         )
+        self._pin_initial_credential_identity()
+
+    def _pin_initial_credential_identity(self) -> None:
+        """Pin non-secret metadata for the pool credential backing ``api_key``."""
+        self.credential_id = None
+        self.credential_label = None
+        pool = getattr(self, "_credential_pool", None)
+        active_key = str(getattr(self, "api_key", None) or "")
+        if pool is None or not active_key:
+            return
+
+        candidates = []
+        try:
+            current = pool.current()
+            if current is not None:
+                candidates.append(current)
+        except Exception:
+            pass
+        try:
+            candidates.extend(pool.entries())
+        except Exception:
+            candidates.extend(list(getattr(pool, "_entries", None) or []))
+
+        for entry in candidates:
+            entry_key = str(
+                getattr(entry, "runtime_api_key", None)
+                or getattr(entry, "access_token", None)
+                or ""
+            )
+            if entry_key == active_key:
+                self.credential_id = getattr(entry, "id", None)
+                self.credential_label = getattr(entry, "label", None)
+                return
 
     def _get_session_db_for_recall(self):
         """Return a SessionDB for recall, lazily creating it if an entrypoint forgot.
@@ -4516,32 +4549,39 @@ class AIAgent:
     def _swap_credential(self, entry) -> None:
         runtime_key = getattr(entry, "runtime_api_key", None) or getattr(entry, "access_token", "")
         runtime_base = getattr(entry, "runtime_base_url", None) or getattr(entry, "base_url", None) or self.base_url
+        credential_id = getattr(entry, "id", None)
+        credential_label = getattr(entry, "label", None)
 
-        if self.api_mode == "anthropic_messages":
-            from agent.anthropic_adapter import build_anthropic_client, _is_oauth_token
+        with self._client_lock:
+            if self.api_mode == "anthropic_messages":
+                from agent.anthropic_adapter import build_anthropic_client, _is_oauth_token
 
-            try:
-                self._anthropic_client.close()
-            except Exception:
-                pass
+                try:
+                    self._anthropic_client.close()
+                except Exception:
+                    pass
 
-            self._anthropic_api_key = runtime_key
-            self._anthropic_base_url = runtime_base
-            self._anthropic_client = build_anthropic_client(
-                runtime_key, runtime_base,
-                timeout=get_provider_request_timeout(self.provider, self.model),
-            )
-            self._is_anthropic_oauth = _is_oauth_token(runtime_key) if self.provider == "anthropic" else False
+                self._anthropic_api_key = runtime_key
+                self._anthropic_base_url = runtime_base
+                self._anthropic_client = build_anthropic_client(
+                    runtime_key, runtime_base,
+                    timeout=get_provider_request_timeout(self.provider, self.model),
+                )
+                self._is_anthropic_oauth = _is_oauth_token(runtime_key) if self.provider == "anthropic" else False
+                self.api_key = runtime_key
+                self.base_url = runtime_base
+                self.credential_id = credential_id
+                self.credential_label = credential_label
+                return
+
             self.api_key = runtime_key
-            self.base_url = runtime_base
-            return
-
-        self.api_key = runtime_key
-        self.base_url = runtime_base.rstrip("/") if isinstance(runtime_base, str) else runtime_base
-        self._client_kwargs["api_key"] = self.api_key
-        self._client_kwargs["base_url"] = self.base_url
-        self._apply_client_headers_for_base_url(self.base_url)
-        self._replace_primary_openai_client(reason="credential_rotation")
+            self.base_url = runtime_base.rstrip("/") if isinstance(runtime_base, str) else runtime_base
+            self.credential_id = credential_id
+            self.credential_label = credential_label
+            self._client_kwargs["api_key"] = self.api_key
+            self._client_kwargs["base_url"] = self.base_url
+            self._apply_client_headers_for_base_url(self.base_url)
+            self._replace_primary_openai_client(reason="credential_rotation")
 
     def _recover_with_credential_pool(
         self,

--- a/tests/agent/test_account_usage.py
+++ b/tests/agent/test_account_usage.py
@@ -1,3 +1,6 @@
+import base64
+import json
+import threading
 from types import SimpleNamespace
 
 import pytest
@@ -76,6 +79,60 @@ def test_codex_usage_prefers_explicit_live_agent_credentials(monkeypatch, codex_
     assert snapshot.windows[0].used_percent == 21
     assert calls[0]["url"] == "https://chatgpt.com/backend-api/wham/usage"
     assert calls[0]["headers"]["Authorization"] == "Bearer live-agent-token"
+
+
+def _codex_access_token(account_id):
+    header = base64.urlsafe_b64encode(b'{"alg":"none","typ":"JWT"}').decode().rstrip("=")
+    payload = base64.urlsafe_b64encode(
+        json.dumps(
+            {
+                "https://api.openai.com/auth": {
+                    "chatgpt_account_id": account_id,
+                }
+            }
+        ).encode()
+    ).decode().rstrip("=")
+    return f"{header}.{payload}.signature"
+
+
+def test_codex_usage_explicit_token_account_id_beats_singleton(monkeypatch, codex_usage_payload):
+    calls = []
+    monkeypatch.setattr(
+        account_usage.httpx,
+        "Client",
+        lambda timeout: _FakeClient(calls, codex_usage_payload),
+    )
+    monkeypatch.setattr(
+        account_usage,
+        "_read_codex_tokens",
+        lambda: {"tokens": {"account_id": "singleton-account"}},
+    )
+
+    account_usage.fetch_account_usage(
+        "openai-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key=_codex_access_token("active-account"),
+    )
+
+    assert calls[0]["headers"]["ChatGPT-Account-Id"] == "active-account"
+
+
+def test_codex_usage_malformed_explicit_token_omits_account_id(monkeypatch, codex_usage_payload):
+    calls = []
+    monkeypatch.setattr(
+        account_usage.httpx,
+        "Client",
+        lambda timeout: _FakeClient(calls, codex_usage_payload),
+    )
+
+    snapshot = account_usage.fetch_account_usage(
+        "openai-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key="not-a-jwt",
+    )
+
+    assert snapshot is not None
+    assert "ChatGPT-Account-Id" not in calls[0]["headers"]
 
 
 def test_codex_usage_falls_back_to_native_credential_pool(monkeypatch, codex_usage_payload):
@@ -192,6 +249,38 @@ def test_codex_usage_account_id_read_failure_keeps_singleton_token(monkeypatch, 
     assert calls[0]["headers"]["Authorization"] == "Bearer singleton-token"
     # account_id read failed → header omitted, but the singleton token is kept.
     assert "ChatGPT-Account-Id" not in calls[0]["headers"]
+
+
+def test_credential_rotation_updates_identity_with_runtime_credential():
+    from run_agent import AIAgent
+
+    agent = object.__new__(AIAgent)
+    agent.api_mode = "chat_completions"
+    agent.api_key = "old-token"
+    agent.base_url = "https://old.example/v1"
+    agent.credential_id = "old-id"
+    agent.credential_label = "old-label"
+    agent._client_lock = threading.RLock()
+    agent._client_kwargs = {}
+    agent._apply_client_headers_for_base_url = lambda _base_url: None
+    agent._replace_primary_openai_client = lambda **_kwargs: None
+    entry = SimpleNamespace(
+        runtime_api_key="new-token",
+        runtime_base_url="https://new.example/v1/",
+        id="new-id",
+        label="new-label",
+    )
+
+    agent._swap_credential(entry)
+
+    assert agent.api_key == "new-token"
+    assert agent.base_url == "https://new.example/v1"
+    assert agent.credential_id == "new-id"
+    assert agent.credential_label == "new-label"
+    assert agent._client_kwargs == {
+        "api_key": "new-token",
+        "base_url": "https://new.example/v1",
+    }
 
 
 def test_codex_usage_treats_wham_used_percent_as_used_not_remaining(monkeypatch):

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -1,3 +1,4 @@
+import threading
 import time
 from datetime import datetime, timedelta
 from types import SimpleNamespace
@@ -678,3 +679,116 @@ class TestIdleSinceLastTurn:
         cli_obj._prompt_duration = 7.0
         text = cli_obj._build_status_bar_text(width=160)
         assert "✓ 42s" in text
+
+
+class TestCLIAccountLimitBackgroundCache:
+    @staticmethod
+    def _cli():
+        cli_obj = _attach_agent(
+            _make_cli(model="gpt-test"),
+            prompt_tokens=100,
+            completion_tokens=20,
+            total_tokens=120,
+            api_calls=1,
+            context_tokens=120,
+            context_length=10_000,
+        )
+        cli_obj.agent.provider = "openai-codex"
+        cli_obj.agent.api_key = "dummy-a"
+        cli_obj.agent._credential_pool = SimpleNamespace(
+            current=lambda: SimpleNamespace(label="main", access_token="dummy-a"),
+            peek=lambda: SimpleNamespace(label="wrong", access_token="dummy-other"),
+        )
+        cli_obj._invalidate = lambda: None
+        return cli_obj
+
+    def test_cold_miss_is_nonblocking_single_flight_and_snapshot_is_immutable(self):
+        cli_obj = self._cli()
+        started = threading.Event()
+        release = threading.Event()
+        finished = threading.Event()
+        calls = []
+        snapshot = SimpleNamespace(
+            provider="openai-codex",
+            windows=(SimpleNamespace(label="Session", used_percent=2),),
+        )
+
+        def fake_fetch(provider, *, base_url=None, api_key=None):
+            calls.append((provider, base_url, api_key))
+            started.set()
+            assert release.wait(2)
+            return snapshot
+
+        original = cli_obj._refresh_account_limit_status
+
+        def tracked(request):
+            try:
+                original(request)
+            finally:
+                finished.set()
+
+        cli_obj._refresh_account_limit_status = tracked
+        with patch("agent.account_usage.fetch_account_usage", side_effect=fake_fetch):
+            assert cli_obj._get_account_limit_status_for_status_bar(cli_obj.agent) is None
+            assert started.wait(2)
+            assert cli_obj._get_account_limit_status_for_status_bar(cli_obj.agent) is None
+            assert len(calls) == 1
+            cli_obj.agent.api_key = "dummy-b"
+            release.set()
+            assert finished.wait(2)
+
+        assert calls == [("openai-codex", "", "dummy-a")]
+        assert "dummy-a" not in repr(cli_obj._account_limit_status_cache)
+
+    def test_cached_limits_render_wide_but_not_as_partial_narrow_fragment(self):
+        cli_obj = self._cli()
+        cli_obj._ensure_account_limit_status_state()
+        key = cli_obj._account_limit_status_cache_key(cli_obj.agent)
+        cli_obj._account_limit_status_cache[key] = {
+            "payload": {"text": "Codex main 5h 98% • weekly 43%", "level": "ok"},
+            "fresh_until": time.monotonic() + 100,
+            "retry_after": time.monotonic() + 100,
+        }
+
+        assert "Codex main 5h 98% • weekly 43%" in cli_obj._build_status_bar_text(width=180)
+        assert "Codex" not in cli_obj._build_status_bar_text(width=60)
+
+    def test_label_requires_exact_runtime_token_match(self):
+        cli_obj = self._cli()
+        assert cli_obj._account_limit_credential_label(cli_obj.agent) == "main"
+        cli_obj.agent.credential_label = "stale-metadata"
+        cli_obj.agent._credential_pool = SimpleNamespace(
+            current=lambda: SimpleNamespace(label="wrong", access_token="dummy-other"),
+            peek=lambda: None,
+        )
+        assert cli_obj._account_limit_credential_label(cli_obj.agent) == ""
+        cli_obj.agent._credential_pool = SimpleNamespace(
+            current=lambda: SimpleNamespace(label="current", access_token="dummy-a"),
+            peek=lambda: None,
+        )
+        assert cli_obj._account_limit_credential_label(cli_obj.agent) == "current"
+
+    def test_stale_failure_preserves_payload_and_uses_short_retry(self):
+        cli_obj = self._cli()
+        cli_obj._ensure_account_limit_status_state()
+        cli_obj._account_limit_status_ttl = 300.0
+        cli_obj._account_limit_status_retry = 7.0
+        key = cli_obj._account_limit_status_cache_key(cli_obj.agent)
+        stale = {"text": "Codex main 5h 50%", "level": "ok"}
+        cli_obj._account_limit_status_cache[key] = {
+            "payload": stale,
+            "fresh_until": 1.0,
+            "retry_after": 1.0,
+        }
+        request = cli_obj._account_limit_status_request_snapshot(cli_obj.agent)
+        with patch("agent.account_usage.fetch_account_usage", return_value=None), patch.object(
+            cli_mod.time, "monotonic", return_value=100.0
+        ):
+            cli_obj._account_limit_status_refreshing.add(key)
+            cli_obj._refresh_account_limit_status(request)
+
+        entry = cli_obj._account_limit_status_cache[key]
+        assert entry["payload"] == stale
+        assert entry["fresh_until"] == 1.0
+        assert entry["retry_after"] == 107.0
+        assert key not in cli_obj._account_limit_status_refreshing

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -64,6 +64,8 @@ def _fake_invoke_jwt(ttl_seconds=3600):
 
 def test_resolve_runtime_provider_uses_credential_pool(monkeypatch):
     class _Entry:
+        id = "codex-cred-1"
+        label = "work-codex"
         access_token = "pool-token"
         source = "manual"
         base_url = "https://chatgpt.com/backend-api/codex"
@@ -84,6 +86,8 @@ def test_resolve_runtime_provider_uses_credential_pool(monkeypatch):
     assert resolved["api_key"] == "pool-token"
     assert resolved["credential_pool"] is not None
     assert resolved["source"] == "manual"
+    assert resolved["credential_id"] == "codex-cred-1"
+    assert resolved["credential_label"] == "work-codex"
 
 
 def test_resolve_runtime_provider_nous_pool_uses_env_base_url_override(monkeypatch):

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -17,6 +17,24 @@ from hermes_cli.browser_connect import ChromeDebugLaunch
 from tui_gateway import server
 
 
+def _limit_agent(api_key="dummy-a", *, label=None):
+    return types.SimpleNamespace(
+        provider="openai-codex",
+        base_url="https://example.invalid/api/",
+        api_key=api_key,
+        credential_label=label,
+        tools=[],
+        model="gpt-test",
+    )
+
+
+def _limit_snapshot(used=20):
+    return types.SimpleNamespace(
+        provider="openai-codex",
+        windows=(types.SimpleNamespace(label="Session", used_percent=used, reset_at=None),),
+    )
+
+
 def test_session_create_rejects_at_active_session_limit(monkeypatch, tmp_path):
     home = tmp_path / ".hermes"
     home.mkdir()
@@ -8912,3 +8930,206 @@ def test_get_usage_clamps_post_compression_sentinel():
     usage = server._get_usage(agent)
     assert "context_used" not in usage
     assert "context_percent" not in usage
+
+
+class TestAccountLimitBackgroundCache:
+    def setup_method(self):
+        server._ACCOUNT_LIMIT_CACHE.clear()
+        server._ACCOUNT_LIMIT_REFRESHING.clear()
+
+    def teardown_method(self):
+        server._ACCOUNT_LIMIT_CACHE.clear()
+        server._ACCOUNT_LIMIT_REFRESHING.clear()
+
+    def test_cold_miss_is_nonblocking_single_flight_and_uses_immutable_snapshot(self, monkeypatch):
+        started = threading.Event()
+        release = threading.Event()
+        finished = threading.Event()
+        calls = []
+
+        def fake_fetch(provider, *, base_url=None, api_key=None):
+            calls.append((provider, base_url, api_key))
+            started.set()
+            assert release.wait(2)
+            return _limit_snapshot()
+
+        original = server._refresh_account_limit_status
+
+        def tracked(request):
+            try:
+                original(request)
+            finally:
+                finished.set()
+
+        monkeypatch.setattr("agent.account_usage.fetch_account_usage", fake_fetch)
+        monkeypatch.setattr(server, "_refresh_account_limit_status", tracked)
+        agent = _limit_agent("dummy-a", label="main")
+
+        assert server._get_account_limit_status(agent) is None
+        assert started.wait(2)
+        assert server._get_account_limit_status(agent) is None
+        assert len(calls) == 1
+        agent.api_key = "dummy-b"
+        release.set()
+        assert finished.wait(2)
+        assert calls == [("openai-codex", "https://example.invalid/api", "dummy-a")]
+        assert "dummy-a" not in repr(server._ACCOUNT_LIMIT_CACHE)
+
+    def test_fresh_hit_does_not_refresh(self, monkeypatch):
+        agent = _limit_agent()
+        key = server._account_limit_cache_key(agent)
+        payload = {"label": "Codex", "windows": []}
+        server._ACCOUNT_LIMIT_CACHE[key] = {
+            "payload": payload,
+            "fresh_until": time.monotonic() + 100,
+            "retry_after": time.monotonic() + 100,
+        }
+        monkeypatch.setattr(server.threading, "Thread", lambda *a, **k: pytest.fail("refresh started"))
+        assert server._get_account_limit_status(agent) == payload
+
+    def test_stale_hit_returns_immediately_and_refreshes(self, monkeypatch):
+        started = threading.Event()
+        release = threading.Event()
+        finished = threading.Event()
+        agent = _limit_agent()
+        key = server._account_limit_cache_key(agent)
+        stale = {"label": "stale", "windows": []}
+        server._ACCOUNT_LIMIT_CACHE[key] = {"payload": stale, "fresh_until": 0.0, "retry_after": 0.0}
+
+        def fake_fetch(*args, **kwargs):
+            started.set()
+            assert release.wait(2)
+            return _limit_snapshot(10)
+
+        original = server._refresh_account_limit_status
+
+        def tracked(request):
+            try:
+                original(request)
+            finally:
+                finished.set()
+
+        monkeypatch.setattr("agent.account_usage.fetch_account_usage", fake_fetch)
+        monkeypatch.setattr(server, "_refresh_account_limit_status", tracked)
+        assert server._get_account_limit_status(agent) == stale
+        assert started.wait(2)
+        assert server._get_account_limit_status(agent) == stale
+        release.set()
+        assert finished.wait(2)
+
+    def test_failure_preserves_stale_with_short_retry_and_clears_inflight(self, monkeypatch):
+        now = [1000.0]
+        finished = threading.Event()
+        agent = _limit_agent()
+        key = server._account_limit_cache_key(agent)
+        stale = {"label": "stale", "windows": []}
+        server._ACCOUNT_LIMIT_CACHE[key] = {"payload": stale, "fresh_until": 900.0, "retry_after": 900.0}
+        monkeypatch.setattr(server.time, "monotonic", lambda: now[0])
+        monkeypatch.setattr("agent.account_usage.fetch_account_usage", lambda *a, **k: None)
+        original = server._refresh_account_limit_status
+
+        def tracked(request):
+            try:
+                original(request)
+            finally:
+                finished.set()
+
+        monkeypatch.setattr(server, "_refresh_account_limit_status", tracked)
+        assert server._get_account_limit_status(agent) == stale
+        assert finished.wait(2)
+        entry = server._ACCOUNT_LIMIT_CACHE[key]
+        assert entry["payload"] == stale
+        assert entry["fresh_until"] == 900.0
+        assert entry["retry_after"] == now[0] + server._ACCOUNT_LIMIT_CACHE_RETRY_SECONDS
+        assert key not in server._ACCOUNT_LIMIT_REFRESHING
+
+    def test_thread_start_failure_clears_inflight(self, monkeypatch):
+        agent = _limit_agent()
+        key = server._account_limit_cache_key(agent)
+
+        class BrokenThread:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def start(self):
+                raise RuntimeError("start failed")
+
+        monkeypatch.setattr(server.threading, "Thread", BrokenThread)
+        assert server._get_account_limit_status(agent) is None
+        assert key not in server._ACCOUNT_LIMIT_REFRESHING
+
+    def test_credential_change_uses_distinct_key_without_stale_leak(self, monkeypatch):
+        agent = _limit_agent("dummy-a")
+        old_key = server._account_limit_cache_key(agent)
+        server._ACCOUNT_LIMIT_CACHE[old_key] = {
+            "payload": {"credential_label": "old", "windows": []},
+            "fresh_until": time.monotonic() + 100,
+            "retry_after": time.monotonic() + 100,
+        }
+
+        class DormantThread:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def start(self):
+                pass
+
+        monkeypatch.setattr(server.threading, "Thread", DormantThread)
+        agent.api_key = "dummy-b"
+        new_key = server._account_limit_cache_key(agent)
+        assert new_key != old_key
+        assert server._get_account_limit_status(agent) is None
+
+    def test_label_requires_exact_runtime_token_match(self):
+        agent = _limit_agent("dummy-a", label="stale-metadata")
+        agent._credential_pool = types.SimpleNamespace(
+            current=lambda: types.SimpleNamespace(label="wrong", access_token="dummy-other"),
+            peek=lambda: None,
+        )
+        assert server._active_credential_label(agent) is None
+
+        agent._credential_pool = types.SimpleNamespace(
+            current=lambda: types.SimpleNamespace(label="current", access_token="dummy-a"),
+            peek=lambda: None,
+        )
+        assert server._active_credential_label(agent) == "current"
+
+    def test_session_info_and_message_complete_use_cached_accessor_only(self, monkeypatch):
+        payload = {"label": "Codex", "windows": []}
+        monkeypatch.setattr(server, "_get_account_limit_status", lambda _agent: payload)
+        monkeypatch.setattr(
+            "agent.account_usage.fetch_account_usage",
+            lambda *a, **k: pytest.fail("hot path fetched provider usage"),
+        )
+        agent = _limit_agent()
+        assert server._session_info(agent)["account_limits"] == payload
+
+        class Agent:
+            def run_conversation(self, prompt, conversation_history=None, stream_callback=None):
+                return {"final_response": "reply", "messages": []}
+
+        class ImmediateThread:
+            def __init__(self, target=None, args=(), daemon=None, **kwargs):
+                self.target = target
+                self.args = args
+
+            def start(self):
+                self.target(*self.args)
+
+        emits = []
+        server._sessions["limit-sid"] = _session(agent=Agent())
+        try:
+            monkeypatch.setattr(server.threading, "Thread", ImmediateThread)
+            monkeypatch.setattr(server, "_get_usage", lambda _agent: {})
+            monkeypatch.setattr(server, "render_message", lambda *_args: "")
+            monkeypatch.setattr(server, "_emit", lambda *args: emits.append(args))
+            response = server.handle_request({
+                "id": "limits",
+                "method": "prompt.submit",
+                "params": {"session_id": "limit-sid", "text": "hi"},
+            })
+            assert "result" in response
+            complete = next(args[2] for args in emits if args[0] == "message.complete")
+            assert complete["account_limits"] == payload
+        finally:
+            server._sessions.pop("limit-sid", None)

--- a/tests/tui_gateway/test_make_agent_provider.py
+++ b/tests/tui_gateway/test_make_agent_provider.py
@@ -60,6 +60,55 @@ def test_make_agent_passes_resolved_provider():
         assert call_kwargs.kwargs["api_mode"] == "anthropic_messages"
 
 
+def test_make_agent_pins_selected_pool_credential_identity():
+    entry = MagicMock(
+        id="codex-cred-1",
+        label="work-codex",
+        runtime_api_key="pool-token",
+    )
+    pool = MagicMock()
+    pool.current.return_value = entry
+    pool.entries.return_value = [entry]
+    pool._entries = [entry]
+    fake_runtime = {
+        "provider": "openai-codex",
+        "base_url": "https://chatgpt.com/backend-api/codex",
+        "api_key": "pool-token",
+        "api_mode": "codex_responses",
+        "credential_pool": pool,
+        "credential_id": "codex-cred-1",
+        "credential_label": "work-codex",
+    }
+    fake_cfg = {
+        "model": {"default": "gpt-5.3-codex", "provider": "openai-codex"},
+        "agent": {"system_prompt": "test"},
+    }
+
+    def fake_init(agent, **kwargs):
+        agent.api_key = kwargs["api_key"]
+        agent.base_url = kwargs["base_url"]
+        agent._credential_pool = kwargs["credential_pool"]
+
+    with (
+        patch("tui_gateway.server._load_cfg", return_value=fake_cfg),
+        patch("tui_gateway.server._get_db", return_value=MagicMock()),
+        patch("tui_gateway.server._load_reasoning_config", return_value=None),
+        patch("tui_gateway.server._load_service_tier", return_value=None),
+        patch("tui_gateway.server._load_enabled_toolsets", return_value=None),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value=fake_runtime,
+        ),
+        patch("agent.agent_init.init_agent", side_effect=fake_init),
+    ):
+        from tui_gateway.server import _make_agent
+
+        agent = _make_agent("sid-identity", "key-identity")
+
+    assert agent.credential_id == "codex-cred-1"
+    assert agent.credential_label == "work-codex"
+
+
 def test_make_agent_forwards_provider_routing():
     """Parity with the messaging gateway + CLI: ``provider_routing`` in
     config.yaml must reach AIAgent so OpenRouter honors the user's sort /

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3,6 +3,7 @@ import concurrent.futures
 import contextlib
 import contextvars
 import copy
+import hashlib
 import inspect
 import json
 import logging
@@ -129,6 +130,11 @@ _sessions: dict[str, dict] = {}
 _methods: dict[str, callable] = {}
 _pending: dict[str, tuple[str, threading.Event]] = {}
 _pending_prompt_payloads: dict[str, tuple[str, dict]] = {}
+_ACCOUNT_LIMIT_CACHE_TTL_SECONDS = 300.0
+_ACCOUNT_LIMIT_CACHE_RETRY_SECONDS = 60.0
+_ACCOUNT_LIMIT_CACHE: dict[tuple[str, str, str], dict] = {}
+_ACCOUNT_LIMIT_REFRESHING: set[tuple[str, str, str]] = set()
+_ACCOUNT_LIMIT_CACHE_LOCK = threading.Lock()
 _answers: dict[str, str] = {}
 _db = None
 _db_error: str | None = None
@@ -3259,6 +3265,182 @@ def _get_usage(agent) -> dict:
     return usage
 
 
+def _account_limit_level(remaining: int) -> str:
+    return "critical" if remaining <= 10 else "warn" if remaining <= 25 else "ok"
+
+
+def _account_limit_provider_label(provider: Optional[str]) -> str:
+    normalized = str(provider or "").strip().lower()
+    return {"openai-codex": "Codex", "anthropic": "Claude", "openrouter": "OpenRouter"}.get(
+        normalized, normalized.replace("_", "-").replace("-", " ").title().replace(" ", "") or "Account"
+    )
+
+
+def _account_limit_window_label(label: str) -> str:
+    normalized = str(label or "").strip().lower()
+    if "session" in normalized or "five hour" in normalized:
+        return "5h"
+    if "opus" in normalized and "week" in normalized:
+        return "opus wk"
+    if "sonnet" in normalized and "week" in normalized:
+        return "sonnet wk"
+    if "week" in normalized:
+        return "weekly"
+    if "quota" in normalized:
+        return "quota"
+    return normalized[:10] or "limit"
+
+
+def _active_credential_label(agent, api_key: Optional[str] = None) -> Optional[str]:
+    """Return a pool label only after an exact active-token match."""
+    active_key = str(api_key if api_key is not None else getattr(agent, "api_key", None) or "")
+    pool = getattr(agent, "_credential_pool", None)
+    if pool is None or not active_key:
+        return None
+    candidates = []
+    try:
+        entries = getattr(pool, "entries", None)
+        if callable(entries):
+            candidates.extend(entries())
+    except Exception:
+        pass
+    candidates.extend(list(getattr(pool, "_entries", None) or []))
+    for method_name in ("current", "peek"):
+        try:
+            method = getattr(pool, method_name, None)
+            entry = method() if callable(method) else None
+            if entry is not None:
+                candidates.append(entry)
+        except Exception:
+            pass
+    for entry in candidates:
+        entry_key = str(
+            getattr(entry, "runtime_api_key", None)
+            or getattr(entry, "access_token", None)
+            or getattr(entry, "api_key", None)
+            or ""
+        )
+        if entry_key == active_key:
+            return str(
+                getattr(entry, "label", None) or getattr(entry, "id", None) or ""
+            ).strip() or None
+    return None
+
+
+def _account_limit_request_snapshot(agent) -> Optional[tuple]:
+    """Capture immutable cache/fetch inputs before a background thread starts."""
+    provider = str(getattr(agent, "provider", "") or "").strip().lower()
+    if provider in {"", "auto", "custom"}:
+        return None
+    base_url = str(getattr(agent, "base_url", "") or "").strip().rstrip("/")
+    api_key = str(getattr(agent, "api_key", "") or "")
+    fingerprint = hashlib.sha256(api_key.encode("utf-8")).hexdigest() if api_key else ""
+    key = (provider, base_url, fingerprint)
+    return key, provider, base_url, api_key, _active_credential_label(agent, api_key)
+
+
+def _account_limit_cache_key(agent) -> Optional[tuple[str, str, str]]:
+    snapshot = _account_limit_request_snapshot(agent)
+    return snapshot[0] if snapshot else None
+
+
+def _format_account_limit_status(snapshot, credential_label: Optional[str] = None) -> Optional[dict]:
+    if not snapshot or not getattr(snapshot, "windows", None):
+        return None
+    windows = []
+    lowest_remaining = 100
+    for window in list(snapshot.windows)[:4]:
+        try:
+            used = max(0, min(100, round(float(window.used_percent))))
+        except (AttributeError, TypeError, ValueError):
+            continue
+        remaining = max(0, min(100, round(100 - float(window.used_percent))))
+        lowest_remaining = min(lowest_remaining, remaining)
+        item = {
+            "label": _account_limit_window_label(getattr(window, "label", "")),
+            "full_label": str(getattr(window, "label", "") or ""),
+            "used_percent": used,
+            "remaining_percent": remaining,
+            "level": _account_limit_level(remaining),
+        }
+        reset_at = getattr(window, "reset_at", None)
+        if reset_at:
+            item["reset_at"] = reset_at.isoformat()
+        windows.append(item)
+    if not windows:
+        return None
+    payload = {
+        "provider": getattr(snapshot, "provider", "") or "",
+        "label": _account_limit_provider_label(getattr(snapshot, "provider", None)),
+        "level": _account_limit_level(lowest_remaining),
+        "windows": windows,
+    }
+    if credential_label:
+        payload["credential_label"] = credential_label
+    return payload
+
+
+def _refresh_account_limit_status(request: tuple) -> None:
+    key, provider, base_url, api_key, credential_label = request
+    payload = None
+    try:
+        from agent.account_usage import fetch_account_usage
+
+        payload = _format_account_limit_status(
+            fetch_account_usage(provider, base_url=base_url, api_key=api_key or None),
+            credential_label=credential_label,
+        )
+    except Exception:
+        payload = None
+    finally:
+        now = time.monotonic()
+        with _ACCOUNT_LIMIT_CACHE_LOCK:
+            previous = _ACCOUNT_LIMIT_CACHE.get(key) or {}
+            if payload is not None:
+                _ACCOUNT_LIMIT_CACHE[key] = {
+                    "payload": copy.deepcopy(payload),
+                    "fresh_until": now + _ACCOUNT_LIMIT_CACHE_TTL_SECONDS,
+                    "retry_after": now + _ACCOUNT_LIMIT_CACHE_TTL_SECONDS,
+                }
+            else:
+                _ACCOUNT_LIMIT_CACHE[key] = {
+                    "payload": copy.deepcopy(previous.get("payload")),
+                    "fresh_until": float(previous.get("fresh_until") or 0.0),
+                    "retry_after": now + _ACCOUNT_LIMIT_CACHE_RETRY_SECONDS,
+                }
+            _ACCOUNT_LIMIT_REFRESHING.discard(key)
+
+
+def _get_account_limit_status(agent) -> Optional[dict]:
+    """Return cached/stale limits immediately and refresh single-flight."""
+    request = _account_limit_request_snapshot(agent)
+    if not request:
+        return None
+    key = request[0]
+    now = time.monotonic()
+    with _ACCOUNT_LIMIT_CACHE_LOCK:
+        cached = _ACCOUNT_LIMIT_CACHE.get(key) or {}
+        stale = copy.deepcopy(cached.get("payload"))
+        if float(cached.get("fresh_until") or 0.0) > now:
+            return stale
+        if float(cached.get("retry_after") or 0.0) > now:
+            return stale
+        if key in _ACCOUNT_LIMIT_REFRESHING:
+            return stale
+        _ACCOUNT_LIMIT_REFRESHING.add(key)
+    try:
+        threading.Thread(
+            target=_refresh_account_limit_status,
+            args=(request,),
+            daemon=True,
+            name="tui-account-limits-refresh",
+        ).start()
+    except Exception:
+        with _ACCOUNT_LIMIT_CACHE_LOCK:
+            _ACCOUNT_LIMIT_REFRESHING.discard(key)
+    return stale
+
+
 def _probe_credentials(agent) -> str:
     """Light credential check at session creation — returns warning or ''."""
     try:
@@ -3386,6 +3568,7 @@ def _session_info(agent, session: dict | None = None) -> dict:
         "update_command": "",
         "usage": _get_usage(agent),
         "profile_name": _current_profile_name(),
+        "account_limits": _get_account_limit_status(agent),
     }
     try:
         from hermes_cli.config import (
@@ -9158,7 +9341,12 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                 raw = str(result)
                 status = "complete"
 
-            payload = {"text": raw, "usage": _get_usage(agent), "status": status}
+            payload = {
+                "text": raw,
+                "usage": _get_usage(agent),
+                "account_limits": _get_account_limit_status(agent),
+                "status": status,
+            }
             if last_reasoning:
                 payload["reasoning"] = last_reasoning
             if status_note:

--- a/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
+++ b/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
@@ -104,6 +104,63 @@ const baseProps = {
   voiceLabel: ''
 }
 
+const accountLimits = {
+  credential_label: 'work-account-with-a-very-long-credential-label',
+  label: 'OpenAI Codex',
+  level: 'warn' as const,
+  provider: 'openai-codex',
+  windows: [
+    {
+      full_label: 'five-hour window',
+      label: '5h',
+      level: 'warn' as const,
+      remaining_percent: 18,
+      used_percent: 82
+    },
+    {
+      full_label: 'weekly window',
+      label: 'weekly',
+      level: 'ok' as const,
+      remaining_percent: 64,
+      used_percent: 36
+    }
+  ]
+}
+
+describe('StatusRule account-limit segment', () => {
+  it('renders the provider, credential, and every compact window on a wide terminal', () => {
+    const rendered = textContent(StatusRule({ ...baseProps, accountLimits, cols: 240, cwdLabel: '' }))
+
+    expect(rendered).toContain('OpenAI Codex')
+    expect(rendered).toContain('work-account-with-a-very-long-credential-label')
+    expect(rendered).toContain('5h 18%')
+    expect(rendered).toContain('weekly 64%')
+    expect(rendered).not.toContain('five-hour window')
+    expect(rendered).not.toContain('weekly window')
+  })
+
+  it('keeps account limits ahead of lower-priority tail segments', () => {
+    const rendered = textContent(
+      StatusRule({ ...baseProps, accountLimits, cols: 140, cwdLabel: '', voiceLabel: 'voice available' })
+    )
+
+    expect(rendered).toContain('weekly 64%')
+    expect(rendered).not.toContain('voice available')
+  })
+
+  it('hides the whole segment on a narrow terminal while preserving essentials', () => {
+    const rendered = textContent(StatusRule({ ...baseProps, accountLimits, cols: 64, cwdLabel: '' }))
+
+    expect(rendered).toContain('ready')
+    expect(rendered).toContain('opus 4.8')
+    expect(rendered).toContain('50k tok')
+    expect(rendered).not.toContain('OpenAI Codex')
+    expect(rendered).not.toContain('work-account')
+    expect(rendered).not.toContain('5h 18%')
+    expect(rendered).not.toContain('weekly 64%')
+  })
+})
+
 describe('StatusRule background-subagent indicator', () => {
   it('renders ⛓ N on a wide terminal when subagents are running', () => {
     const element = StatusRule({

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -66,6 +66,53 @@ describe('createGatewayEventHandler', () => {
     patchUiState({ showReasoning: true })
   })
 
+  const accountLimits = {
+    credential_label: 'work-account-with-a-long-label',
+    label: 'OpenAI Codex',
+    level: 'warn' as const,
+    provider: 'openai-codex',
+    windows: [
+      { label: '5h', level: 'warn' as const, remaining_percent: 18, used_percent: 82 },
+      { label: 'weekly', level: 'ok' as const, remaining_percent: 64, used_percent: 36 }
+    ]
+  }
+
+  it('sets account limits from session.info', () => {
+    const onEvent = createGatewayEventHandler(buildCtx([]))
+
+    onEvent({
+      payload: { account_limits: accountLimits, model: 'gpt-5.5', skills: {}, tools: {} },
+      type: 'session.info'
+    })
+
+    expect(getUiState().info?.account_limits).toEqual(accountLimits)
+  })
+
+  it('updates account limits from message.complete when present', () => {
+    const onEvent = createGatewayEventHandler(buildCtx([]))
+
+    const updated = {
+      ...accountLimits,
+      level: 'critical' as const,
+      windows: [{ label: '5h', level: 'critical' as const, remaining_percent: 2, used_percent: 98 }]
+    }
+
+    patchUiState({ info: { account_limits: accountLimits, model: 'gpt-5.5', skills: {}, tools: {} } })
+    onEvent({ payload: { account_limits: updated, text: 'done' }, type: 'message.complete' })
+
+    expect(getUiState().info?.account_limits).toEqual(updated)
+  })
+
+  it('preserves account limits when message.complete omits the field', () => {
+    const onEvent = createGatewayEventHandler(buildCtx([]))
+
+    patchUiState({ info: { account_limits: accountLimits, model: 'gpt-5.5', skills: {}, tools: {} } })
+    onEvent({ payload: { text: 'done', usage: { total: 43 } }, type: 'message.complete' } as any)
+
+    expect(getUiState().usage.total).toBe(43)
+    expect(getUiState().info?.account_limits).toEqual(accountLimits)
+  })
+
   it('archives incomplete todos into transcript flow at end of turn so they scroll up', () => {
     const appended: Msg[] = []
 

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -957,8 +957,15 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
         setStatus('ready')
 
-        if (ev.payload?.usage) {
-          patchUiState(state => ({ ...state, usage: { ...state.usage, ...ev.payload!.usage } }))
+        if (ev.payload?.usage || ev.payload?.account_limits) {
+          patchUiState(state => ({
+            ...state,
+            info:
+              state.info && ev.payload?.account_limits
+                ? { ...state.info, account_limits: ev.payload.account_limits }
+                : state.info,
+            usage: ev.payload?.usage ? { ...state.usage, ...ev.payload.usage } : state.usage
+          }))
         }
 
         return

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -15,7 +15,7 @@ import { buildSubagentTree, treeTotals, widthByDepth } from '../lib/subagentTree
 import { fmtK } from '../lib/text.js'
 import { useScrollbarSnapshot, useViewportSnapshot } from '../lib/viewportStore.js'
 import type { Theme } from '../theme.js'
-import type { Msg, Usage } from '../types.js'
+import type { AccountLimitStatus, AccountLimitWindow, Msg, Usage } from '../types.js'
 
 const FACE_TICK_MS = 2500
 const HEART_COLORS = ['#ff5fa2', '#ff4d6d']
@@ -213,6 +213,55 @@ function ctxBar(pct: number | undefined, w = 10) {
   return '█'.repeat(filled) + '░'.repeat(w - filled)
 }
 
+function accountLimitColor(level: AccountLimitWindow['level'], t: Theme) {
+  if (level === 'critical') {
+    return t.color.statusCritical
+  }
+
+  if (level === 'warn') {
+    return t.color.statusWarn
+  }
+
+  return t.color.statusGood
+}
+
+const accountLimitWindowLabel = (window: AccountLimitWindow) => String(window.label).trim()
+
+export const formatAccountLimitHud = (accountLimits: AccountLimitStatus): string => {
+  const providerLabel = accountLimits.label.trim() || accountLimits.provider.trim()
+  const credentialLabel = String(accountLimits.credential_label ?? '').trim()
+  const prefix = [providerLabel, credentialLabel].filter(Boolean).join(' ')
+
+  const windows = accountLimits.windows
+    .map(window => `${accountLimitWindowLabel(window)} ${window.remaining_percent}%`)
+    .join(' • ')
+
+  return [prefix, windows].filter(Boolean).join(' ')
+}
+
+export function AccountLimitHud({ accountLimits, t }: { accountLimits: AccountLimitStatus; t: Theme }) {
+  const providerLabel = accountLimits.label.trim() || accountLimits.provider.trim()
+  const credentialLabel = String(accountLimits.credential_label ?? '').trim()
+
+  return (
+    <Box flexShrink={0}>
+      <Text color={t.color.muted}>
+        {' │ '}
+        {providerLabel}
+        {credentialLabel ? ` ${credentialLabel}` : ''}
+        {accountLimits.windows.length ? ' ' : ''}
+        {accountLimits.windows.map((window, index) => (
+          <Text color={t.color.muted} key={`${window.label}-${window.full_label ?? ''}-${index}`}>
+            {index > 0 ? ' • ' : ''}
+            {accountLimitWindowLabel(window)}{' '}
+            <Text color={accountLimitColor(window.level, t)}>{window.remaining_percent}%</Text>
+          </Text>
+        ))}
+      </Text>
+    </Box>
+  )
+}
+
 // `minLeftContent` is the display width of the high-priority left segments
 // (status indicator + model + context). Reserving it makes the cwd/branch
 // segment on the right yield FIRST on narrow terminals, instead of squeezing
@@ -403,6 +452,7 @@ export function GoodVibesHeart({ tick, t }: { tick: number; t: Theme }) {
 }
 
 export function StatusRule({
+  accountLimits,
   cwdLabel,
   cols,
   busy,
@@ -474,9 +524,8 @@ export function StatusRule({
 
   // Whole-segment progressive disclosure for the tail: a segment renders only
   // if it fits in the space left after the pinned essentials, evaluated in
-  // descending priority order — bar, duration, compressions, voice, session
-  // count, bg, cost. Lower-priority segments drop first and nothing truncates
-  // mid-segment, so status/model/context are never crushed.
+  // descending priority order — bar, account limits, duration, compressions,
+  // voice, session count, bg, subagents, resume hint, dev credits.
   const SEP = stringWidth(' │ ')
   let tailBudget = Math.max(0, leftWidth - essentialWidth)
 
@@ -503,6 +552,8 @@ export function StatusRule({
       : ''
 
   const showBar = !!bar && fits(SEP + stringWidth(`[${bar}] ${pct != null ? `${pct}%` : ''}`))
+  const accountLimitText = accountLimits?.windows.length ? formatAccountLimitHud(accountLimits) : ''
+  const showAccountLimits = !!accountLimits && !!accountLimitText && fits(SEP + stringWidth(accountLimitText))
   const showDuration = segs.duration && !!sessionStartedAt && fits(SEP + MAX_DURATION_WIDTH)
 
   // Idle clock — time since the last final agent response. Hidden while busy
@@ -596,6 +647,7 @@ export function StatusRule({
             <Text color={barColor}>[{bar}]</Text> <Text color={barColor}>{pct != null ? `${pct}%` : ''}</Text>
           </Text>
         ) : null}
+        {showAccountLimits ? AccountLimitHud({ accountLimits: accountLimits!, t }) : null}
         {showDuration ? (
           <Text color={t.color.muted} wrap="truncate-end">
             {' │ '}
@@ -770,6 +822,7 @@ export function TranscriptScrollbar({ scrollRef, t }: TranscriptScrollbarProps) 
 }
 
 interface StatusRuleProps {
+  accountLimits?: AccountLimitStatus
   bgCount: number
   lastTurnEndedAt?: null | number
   liveSessionCount: number

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -466,6 +466,7 @@ const StatusRulePane = memo(function StatusRulePane({
   return (
     <Box marginTop={at === 'top' ? 1 : 0}>
       <StatusRule
+        accountLimits={ui.info?.account_limits}
         bgCount={ui.bgTasks.size}
         busy={ui.busy}
         cols={composer.cols}

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -1,4 +1,4 @@
-import type { SessionInfo, SlashCategory, SubagentStatus, Usage } from './types.js'
+import type { AccountLimitStatus, SessionInfo, SlashCategory, SubagentStatus, Usage } from './types.js'
 
 export interface GatewaySkin {
   banner_hero?: string
@@ -709,7 +709,7 @@ export type GatewayEvent =
   | { payload: SubagentEventPayload; session_id?: string; type: 'subagent.complete' }
   | { payload: { rendered?: string; text?: string }; session_id?: string; type: 'message.delta' }
   | {
-      payload?: { reasoning?: string; rendered?: string; text?: string; usage?: Usage }
+      payload?: { account_limits?: AccountLimitStatus; reasoning?: string; rendered?: string; text?: string; usage?: Usage }
       session_id?: string
       type: 'message.complete'
     }

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -147,7 +147,27 @@ export interface McpServerStatus {
   transport: string
 }
 
+export type AccountLimitLevel = 'critical' | 'ok' | 'warn'
+
+export interface AccountLimitWindow {
+  full_label?: string
+  label: string
+  level: AccountLimitLevel
+  remaining_percent: number
+  reset_at?: string
+  used_percent: number
+}
+
+export interface AccountLimitStatus {
+  credential_label?: string
+  label: string
+  level: AccountLimitLevel
+  provider: string
+  windows: AccountLimitWindow[]
+}
+
 export interface SessionInfo {
+  account_limits?: AccountLimitStatus
   cwd?: string
   fast?: boolean
   install_warning?: string


### PR DESCRIPTION
## Summary
- Shows compact active-account limits in both the classic CLI and Ink TUI status bars.
- Refreshes provider usage only in background workers; `session.info`, `message.complete`, and status rendering return cached/stale data immediately.
- Uses single-flight stale-while-revalidate caches keyed to a non-secret fingerprint of the active runtime credential.
- Preserves current Codex credential-resolution safeguards and derives `ChatGPT-Account-Id` only from the already-selected live token.
- Displays a credential label only when the active token exactly matches its credential-pool entry.
- Budgets the Ink account-limit HUD as one optional tail segment, so status/model/context remain pinned and quota text is omitted whole on narrow terminals.

Example: `Codex main 5h 83% • weekly 37%`.

## Review fixes
Addresses the July 12 review:
- No synchronous provider usage fetches remain in TUI hot paths.
- Cold misses and stale entries schedule at most one background refresh per credential key.
- Failures preserve stale data and retry after a short backoff.
- Credential rotation cannot reuse another account's cached payload or label.
- `AccountLimitHud` participates in the existing `essentialWidth` / `fits()` width budget.
- Ink regression coverage includes a long credential label, multiple windows, wide rendering, and whole-segment omission on a narrow terminal.

## PR consolidation
This remains the combined CLI + TUI account-limit status PR and supersedes the earlier TUI-only draft #16644.

## Verification
Rebuilt from current `main` at `7b5ba2054721dde998ed47fd4a0f031955278e99`; replacement commit: `1b3d9b34c872908fab6d61bec85af3b5b7df9420`.

- Python targeted regression: 228 passed.
- Ink targeted render/event regression: 102 passed.
- TypeScript typecheck: passed.
- TUI production build: passed.
- Ruff: passed.
- ESLint: passed.
- `git diff --check`: passed.

## CI status
GitHub created [CI run 29208048955](https://github.com/NousResearch/hermes-agent/actions/runs/29208048955), but it is currently `action_required`: a repository maintainer/admin must approve the fork workflow before jobs can start.

Broader local-suite caveats are environment/baseline-only: the isolated gateway suite lacks a Chromium binary, while unrelated unchanged Ink tests include SSH-environment assertions and one existing timeout. All changed and newly added tests pass.

Closes #16643
