### PR TITLE
fix(mcp-oauth): reuse cached redirect port for client registrations

### DIFF
--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -491,7 +491,42 @@ def test_configure_callback_port_uses_explicit_port():
     assert cfg["_resolved_port"] == 54321
 
 
-def test_build_oauth_auth_preserves_server_url_path():
+def test_build_oauth_auth_reuses_cached_registered_redirect_port(tmp_path, monkeypatch):
+    """A cached client registration keeps using its registered callback port."""
+    from tools import mcp_oauth
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    token_dir = tmp_path / "mcp-tokens"
+    token_dir.mkdir()
+    (token_dir / "supabase.client.json").write_text(json.dumps({
+        "client_id": "supabase-client",
+        "redirect_uris": ["http://127.0.0.1:58741/callback"],
+        "grant_types": ["authorization_code", "refresh_token"],
+        "response_types": ["code"],
+        "token_endpoint_auth_method": "none",
+    }))
+
+    captured: dict = {}
+
+    class _FakeProvider:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    with patch.object(mcp_oauth, "_OAUTH_AVAILABLE", True), \
+         patch.object(mcp_oauth, "OAuthClientProvider", _FakeProvider), \
+         patch.object(mcp_oauth, "_is_interactive", return_value=True), \
+         patch.object(mcp_oauth, "_maybe_preregister_client"):
+        build_oauth_auth(
+            server_name="supabase",
+            server_url="https://mcp.supabase.com/mcp?project_ref=abc123&read_only=true",
+            oauth_config={},
+        )
+
+    redirect_uri = str(captured["client_metadata"].redirect_uris[0])
+    assert redirect_uri == "http://127.0.0.1:58741/callback"
+
+
+def test_build_oauth_auth_preserves_server_url_path(tmp_path, monkeypatch):
     """server_url with path is forwarded to OAuthClientProvider unmodified.
 
     Regression for #16015: previously ``_parse_base_url`` stripped the path,
@@ -503,6 +538,7 @@ def test_build_oauth_auth_preserves_server_url_path():
     """
     from tools import mcp_oauth
 
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     captured: dict = {}
 
     class _FakeProvider:
@@ -512,9 +548,7 @@ def test_build_oauth_auth_preserves_server_url_path():
     with patch.object(mcp_oauth, "_OAUTH_AVAILABLE", True), \
          patch.object(mcp_oauth, "OAuthClientProvider", _FakeProvider), \
          patch.object(mcp_oauth, "_is_interactive", return_value=True), \
-         patch.object(mcp_oauth, "_maybe_preregister_client"), \
-         patch.object(mcp_oauth, "HermesTokenStorage") as mock_storage_cls:
-        mock_storage_cls.return_value = MagicMock(has_cached_tokens=lambda: True)
+         patch.object(mcp_oauth, "_maybe_preregister_client"):
         build_oauth_auth(
             server_name="notion",
             server_url="https://mcp.notion.com/mcp",

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -437,7 +437,33 @@ def remove_oauth_tokens(server_name: str) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _configure_callback_port(cfg: dict) -> int:
+def _get_registered_redirect_port(storage: "HermesTokenStorage | None") -> int | None:
+    """Return the cached loopback callback port from client registration."""
+    if storage is None:
+        return None
+
+    client_info = _read_json(storage._client_info_path())
+    if not client_info:
+        return None
+
+    redirect_uris = client_info.get("redirect_uris")
+    if not isinstance(redirect_uris, list) or not redirect_uris:
+        return None
+
+    redirect_uri = redirect_uris[0]
+    if not isinstance(redirect_uri, str):
+        return None
+
+    parsed = urlparse(redirect_uri)
+    if parsed.scheme != "http" or parsed.hostname not in {"127.0.0.1", "localhost"}:
+        return None
+    if parsed.path != "/callback" or parsed.port is None:
+        return None
+
+    return parsed.port
+
+
+def _configure_callback_port(cfg: dict, storage: "HermesTokenStorage | None" = None) -> int:
     """Pick or validate the OAuth callback port.
 
     Stores the resolved port into ``cfg['_resolved_port']`` so sibling
@@ -452,7 +478,11 @@ def _configure_callback_port(cfg: dict) -> int:
     """
     global _oauth_port
     requested = int(cfg.get("redirect_port", 0))
-    port = _find_free_port() if requested == 0 else requested
+    if requested == 0:
+        registered_port = _get_registered_redirect_port(storage)
+        port = registered_port if registered_port is not None else _find_free_port()
+    else:
+        port = requested
     cfg["_resolved_port"] = port
     _oauth_port = port  # legacy consumer: _wait_for_callback reads this
     return port
@@ -559,7 +589,7 @@ def build_oauth_auth(
             server_name,
         )
 
-    _configure_callback_port(cfg)
+    _configure_callback_port(cfg, storage)
     client_metadata = _build_client_metadata(cfg)
     _maybe_preregister_client(storage, cfg, client_metadata)
 

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -380,7 +380,7 @@ class MCPOAuthManager:
                 server_name,
             )
 
-        _configure_callback_port(cfg)
+        _configure_callback_port(cfg, storage)
         client_metadata = _build_client_metadata(cfg)
         _maybe_preregister_client(storage, cfg, client_metadata)
 


### PR DESCRIPTION
## Summary
- reuse the callback port from cached OAuth client registrations when `redirect_port` is left at the default `0`
- keep using an ephemeral free port when there is no cached loopback registration to reuse
- add a regression test covering cached client registration reuse

## Why
Supabase MCP OAuth exposed a generic bug in Hermes' MCP OAuth flow: once a provider has registered a confidential/public client for an exact loopback redirect URI, Hermes could later reuse the cached client registration while still picking a fresh ephemeral callback port. Strict OAuth providers reject that authorize request because the redirect URI no longer matches the registered client.

This patch makes the default `redirect_port=0` behavior stable across re-authentication when Hermes already has a cached loopback registration.

## Test Plan
- `python -m pytest tests/tools/test_mcp_oauth.py -v`
- manual local verification that cached Supabase client info resolves to the previously registered redirect URI

## Platforms Tested
- macOS 14.5 (arm64)

## Scope
This PR intentionally only covers redirect-port reuse for cached registrations. It does not change token endpoint auth method handling.