### PR TITLE
fix(gateway): detect stale lock files on macOS via `ps -o lstart=`

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -103,14 +103,60 @@ def _get_scope_lock_path(scope: str, identity: str) -> Path:
     return _get_lock_dir() / f"{scope}-{_scope_hash(identity)}.lock"
 
 
+def _get_process_start_time_via_ps(pid: int) -> Optional[int]:
+    """POSIX fallback using ``ps -o lstart=``.
+
+    Used on macOS where ``/proc/<pid>/stat`` does not exist. ``lstart`` is a
+    PID-recycle-stable absolute timestamp; we parse it into a Unix-epoch int
+    so callers keep doing the same equality comparison against the value
+    persisted in lock/PID metadata.
+    """
+    try:
+        result = subprocess.run(
+            ["ps", "-o", "lstart=", "-p", str(pid)],
+            capture_output=True,
+            text=True,
+            timeout=2.0,
+            check=False,
+            # Force C locale so %a/%b month/day-of-week names are parseable.
+            env={"LC_ALL": "C", "LANG": "C", "PATH": os.environ.get("PATH", "")},
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    # ps lstart on BSD/macOS prints e.g. "Mon Apr 27 10:09:49 2026" (with a
+    # space-padded day for single-digit dates). Re-joining split() collapses
+    # the variable spacing so a single strptime format covers both cases.
+    parts = result.stdout.split()
+    if len(parts) < 5:
+        return None
+    try:
+        dt = datetime.strptime(" ".join(parts[:5]), "%a %b %d %H:%M:%S %Y")
+    except (ValueError, TypeError):
+        return None
+    return int(dt.replace(tzinfo=timezone.utc).timestamp())
+
+
 def _get_process_start_time(pid: int) -> Optional[int]:
-    """Return the kernel start time for a process when available."""
+    """Return the kernel start time for a process when available.
+
+    Used to detect PID reuse: if a recorded ``start_time`` differs from the
+    live process's current start time, the PID belongs to an unrelated
+    process and the on-disk metadata is stale. The Linux fast path reads
+    ``/proc/<pid>/stat`` directly; macOS, which has no ``/proc``, falls back
+    to ``ps -o lstart=``. Returning ``None`` on Windows or when both paths
+    fail preserves existing callers, which all guard with ``is not None``.
+    """
     stat_path = Path(f"/proc/{pid}/stat")
     try:
         # Field 22 in /proc/<pid>/stat is process start time (clock ticks).
         return int(stat_path.read_text().split()[21])
     except (FileNotFoundError, IndexError, PermissionError, ValueError, OSError):
-        return None
+        pass
+    if sys.platform == "darwin":
+        return _get_process_start_time_via_ps(pid)
+    return None
 
 
 def get_process_start_time(pid: int) -> Optional[int]:

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -475,6 +475,128 @@ class TestScopedLocks:
         assert reused_pid_lock.exists()
 
 
+class TestGetProcessStartTime:
+    """Regression coverage for #16586.
+
+    On macOS ``/proc/<pid>/stat`` does not exist, so the original Linux-only
+    reader returned ``None`` for every PID. Every caller guards with
+    ``is not None`` and silently skips PID-recycle staleness detection,
+    which means a recycled PID owned by an unrelated OS process (e.g.
+    ``FamilyControlsAgent`` after the gateway crashed) keeps the lock file
+    "alive" forever and blocks every subsequent gateway start.
+    """
+
+    def test_falls_back_to_ps_on_darwin(self, monkeypatch):
+        """On macOS we must call ``ps -o lstart=`` and return a stable int."""
+        monkeypatch.setattr(status.sys, "platform", "darwin")
+
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            captured["kwargs"] = kwargs
+            return SimpleNamespace(returncode=0, stdout="Mon Apr 27 10:09:49 2026\n", stderr="")
+
+        monkeypatch.setattr(status.subprocess, "run", fake_run)
+
+        result = status._get_process_start_time(12345)
+
+        assert isinstance(result, int)
+        assert captured["cmd"][:3] == ["ps", "-o", "lstart="]
+        assert "12345" in captured["cmd"]
+        # C locale forced so %a/%b parse deterministically across systems.
+        assert captured["kwargs"].get("env", {}).get("LC_ALL") == "C"
+
+    def test_returns_none_when_ps_fails_on_darwin(self, monkeypatch):
+        """Missing PID → ps returns non-zero → we must yield ``None`` so the
+        existing ``current_start is not None`` guard short-circuits cleanly
+        instead of treating arbitrary text as a start time."""
+        monkeypatch.setattr(status.sys, "platform", "darwin")
+        monkeypatch.setattr(
+            status.subprocess,
+            "run",
+            lambda *a, **k: SimpleNamespace(returncode=1, stdout="", stderr="ps: no such process"),
+        )
+
+        assert status._get_process_start_time(99999) is None
+
+    def test_returns_none_when_ps_output_unparseable(self, monkeypatch):
+        """Garbled ps output (truncated, locale leak) must yield ``None``
+        rather than partially-parsed garbage that would later be compared
+        against the persisted ``start_time`` integer."""
+        monkeypatch.setattr(status.sys, "platform", "darwin")
+        monkeypatch.setattr(
+            status.subprocess,
+            "run",
+            lambda *a, **k: SimpleNamespace(returncode=0, stdout="weird\n", stderr=""),
+        )
+
+        assert status._get_process_start_time(99999) is None
+
+    def test_returns_none_when_ps_executable_missing(self, monkeypatch):
+        monkeypatch.setattr(status.sys, "platform", "darwin")
+
+        def boom(*args, **kwargs):
+            raise FileNotFoundError("ps not on PATH")
+
+        monkeypatch.setattr(status.subprocess, "run", boom)
+
+        assert status._get_process_start_time(1) is None
+
+    def test_distinct_ps_outputs_produce_distinct_ints(self, monkeypatch):
+        """A recycled PID has a different ``lstart`` than the original
+        process — the contract of this helper is that those map to different
+        integers so the equality check in ``acquire_scoped_lock`` flips
+        ``stale = True``."""
+        monkeypatch.setattr(status.sys, "platform", "darwin")
+
+        outputs = iter([
+            SimpleNamespace(returncode=0, stdout="Mon Apr 27 10:09:49 2026\n", stderr=""),
+            SimpleNamespace(returncode=0, stdout="Mon Apr 27 10:09:50 2026\n", stderr=""),
+        ])
+        monkeypatch.setattr(status.subprocess, "run", lambda *a, **k: next(outputs))
+
+        first = status._get_process_start_time(100)
+        second = status._get_process_start_time(100)
+
+        assert first is not None
+        assert second is not None
+        assert first != second
+
+    def test_acquire_scoped_lock_detects_pid_recycle_on_darwin(self, tmp_path, monkeypatch):
+        """End-to-end: a stale lock left by a crashed gateway whose PID has
+        been recycled to an unrelated live OS process must be reclaimed on
+        macOS, not block the next gateway start. This is the exact path the
+        issue reporter hit (PID 560 recycled to ``FamilyControlsAgent``)."""
+        monkeypatch.setattr(status.sys, "platform", "darwin")
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = tmp_path / "locks" / "slack-app-token-2bb80d537b1da3e3.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_text(json.dumps({
+            "pid": 560,
+            "start_time": 1700000000,  # original gateway's lstart epoch
+            "kind": "hermes-gateway",
+        }))
+
+        # PID 560 is alive (recycled to FamilyControlsAgent) — os.kill(pid, 0)
+        # succeeds. But its real lstart is now different, so ps reports a
+        # different timestamp.
+        monkeypatch.setattr(status.os, "kill", lambda pid, sig: None)
+        monkeypatch.setattr(
+            status.subprocess,
+            "run",
+            lambda *a, **k: SimpleNamespace(returncode=0, stdout="Tue Apr 28 09:00:00 2026\n", stderr=""),
+        )
+
+        acquired, _ = status.acquire_scoped_lock(
+            "slack-app-token", "secret", metadata={"platform": "slack"}
+        )
+
+        assert acquired is True
+        payload = json.loads(lock_path.read_text())
+        assert payload["pid"] == os.getpid()
+
+
 class TestTakeoverMarker:
     """Tests for the --replace takeover marker.
 


### PR DESCRIPTION
## Summary
- `_get_process_start_time()` was Linux-only (`/proc/<pid>/stat`), so on macOS PID-recycle staleness detection was silently disabled across `acquire_scoped_lock`, `get_running_pid`, the takeover marker, and `release_all_scoped_locks`.
- Add a `ps -o lstart=` fallback for `sys.platform == "darwin"`, parsed under forced C locale into a Unix-epoch int.
- Regression coverage in `tests/gateway/test_status.py::TestGetProcessStartTime` (6 tests; 3 fail without the production change).

## The bug

When a gateway crashes hard on macOS (kill -9, OOM, panic), the scoped lock file at `~/.local/state/hermes/gateway-locks/<scope>-<hash>.lock` keeps the dead gateway's PID. macOS later recycles that PID to an unrelated OS process (`FamilyControlsAgent` in the reporter's case for #16586). The next gateway start runs `acquire_scoped_lock`:

1. `os.kill(existing_pid, 0)` succeeds — the recycled PID is alive, just not Hermes.
2. The strong stale check needs a `start_time` mismatch. `_get_process_start_time(existing_pid)` reads `/proc/<pid>/stat`, which doesn't exist on macOS, so it returns `None`. The `current_start is not None` guard short-circuits and `stale` stays `False`.
3. The secondary "stopped process" check at `gateway/status.py:520-528` also reads `/proc/<pid>/status` and silently no-ops on macOS.
4. `acquire_scoped_lock` returns `(False, existing)` → the platform reports `slack-app-token_lock` / `feishu_app_lock` / etc. and never recovers without a manual `rm` of the lock file.

The same Linux-only assumption affects `get_running_pid` (line 784), `write_takeover_marker` (line 656), `consume_takeover_marker_for_self` (line 716), and `release_all_scoped_locks` — every code path that wants to defend against PID reuse on macOS.

## The fix

Extend `_get_process_start_time()` so that when the `/proc` read fails and we're on `darwin`, it falls back to `ps -o lstart= -p <pid>`. `lstart` is the absolute wall-clock start timestamp; recycling a PID to a new process changes it. The helper parses the timestamp under a forced `LC_ALL=C` / `LANG=C` environment so `%a` / `%b` are deterministic, then converts to a Unix-epoch int.

Why it's safe to mix units across platforms:
- Lock and PID-file metadata are written and read on the same machine, so the value never crosses an OS boundary.
- Every consumer does equality comparison only — the contract is "the same live process produces the same int; a recycled PID produces a different int". Linux clock-ticks-since-boot and macOS lstart-as-epoch both satisfy that.

Diff: 1 production file (~50 lines, including docstrings), 1 test file. Linux fast path is untouched; Windows still returns `None` exactly as before.

## Test plan
- [x] Focused: `tests/gateway/test_status.py::TestGetProcessStartTime` — 6 tests covering happy-path parsing, ps non-zero return, garbled output, `FileNotFoundError` (ps not on PATH), distinct-int contract, and end-to-end `acquire_scoped_lock` PID-recycle reclaim.
- [x] Adjacent: full `tests/gateway/test_status.py` (40 tests) and `tests/gateway/test_runner_startup_failures.py` — 48 passed locally.
- [x] Regression guard: reverted `gateway/status.py`, reran the new test class — 3 of 6 fail (the ones exercising the Darwin path); restored fix and all 6 pass.

## Contract Protected

`_get_process_start_time(pid)` returns a value `v` such that, while a process holds a given PID, `v` stays equal across calls; once the kernel hands that PID to an unrelated process, `v` changes. The helper is allowed to return `None` when the value can't be determined (existing contract; every caller guards `is not None`). The fix extends this contract from "Linux only" to "Linux + macOS".

Known-bad inputs covered by tests:
- ps returns non-zero (PID gone) → `None`.
- ps returns empty / non-`lstart`-shaped text → `None`.
- ps executable missing → `None` (caught as `OSError`).
- Two different lstart values → two different ints (PID-recycle detection).

## Related

- Closes #16586.
- Adjacent merged history in this area: #8995 (stale lock recovery on Linux), #11909 (legacy hermes.service detection), #14504 (Windows `OSError` handling). All assumed Linux/Windows; this PR fills the macOS gap.