### PR TITLE
fix(agent): propagate ContextVars to concurrent tool worker threads

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -23,6 +23,7 @@ Usage:
 import asyncio
 import base64
 import concurrent.futures
+import contextvars
 import copy
 import hashlib
 import json
@@ -8846,7 +8847,9 @@ class AIAgent:
             with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
                 futures = []
                 for i, (tc, name, args) in enumerate(parsed_calls):
-                    f = executor.submit(_run_tool, i, tc, name, args)
+                    # Propagate ContextVars (e.g. _approval_session_key); mirrors asyncio.to_thread.
+                    ctx = contextvars.copy_context()
+                    f = executor.submit(ctx.run, _run_tool, i, tc, name, args)
                     futures.append(f)
 
                 # Wait for all to complete with periodic heartbeats so the

--- a/tests/eval_018/conftest.py
+++ b/tests/eval_018/conftest.py
@@ -1,0 +1,27 @@
+"""Shared fixtures for the 018 eval tests.
+
+Each eval run is a fresh subprocess so AnchorStateManager state never
+crosses runs in practice; the autouse reset is defensive and cheap.
+"""
+
+import importlib
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_anchor_state_if_present() -> None:
+    """Reset anchor tracker if talaria's hash-anchored edit module is importable.
+
+    When 018 runs against the talaria agent the AnchorStateManager singleton
+    can carry per-task state across pytest invocations launched from the
+    same process. We never want that here.
+    """
+    try:
+        mod = importlib.import_module("talaria.tools._anchor_state")
+    except ModuleNotFoundError:
+        return None
+    mgr = getattr(mod, "AnchorStateManager", None)
+    if mgr is not None and hasattr(mgr, "reset"):
+        mgr.reset()
+    return None

--- a/tests/eval_018/test_cli_errors.py
+++ b/tests/eval_018/test_cli_errors.py
@@ -1,0 +1,34 @@
+"""Eval 018: cli.py defines and uses a CliError subclass."""
+
+import ast
+import inspect
+from pathlib import Path
+
+
+def test_cli_uses_clierror() -> None:
+    import cli
+
+    assert hasattr(cli, "CliError"), "CliError class is not defined in cli module"
+    assert isinstance(cli.CliError, type), "CliError must be a class"
+    assert issubclass(cli.CliError, Exception), (
+        "CliError must subclass Exception"
+    )
+
+    src_path = Path(inspect.getsourcefile(cli) or "")
+    tree = ast.parse(src_path.read_text())
+
+    raise_clierror_count = 0
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Raise) or node.exc is None:
+            continue
+        exc = node.exc
+        if isinstance(exc, ast.Call):
+            exc = exc.func
+        if isinstance(exc, ast.Name) and exc.id == "CliError":
+            raise_clierror_count += 1
+        elif isinstance(exc, ast.Attribute) and exc.attr == "CliError":
+            raise_clierror_count += 1
+
+    assert raise_clierror_count >= 3, (
+        f"Expected ≥3 `raise CliError(...)` sites in cli.py, found {raise_clierror_count}"
+    )

--- a/tests/eval_018/test_file_tools_typed.py
+++ b/tests/eval_018/test_file_tools_typed.py
@@ -1,0 +1,29 @@
+"""Eval 018: every public function in tools/file_tools.py has annotations."""
+
+import inspect
+
+import tools.file_tools as file_tools
+
+
+def test_public_functions_typed() -> None:
+    untyped: list[str] = []
+    for name, fn in inspect.getmembers(file_tools, inspect.isfunction):
+        if name.startswith("_"):
+            continue
+        if inspect.getmodule(fn) is not file_tools:
+            continue
+        sig = inspect.signature(fn)
+        if sig.return_annotation is inspect.Signature.empty:
+            untyped.append(f"{name}: missing return annotation")
+            continue
+        for pname, param in sig.parameters.items():
+            if pname == "self":
+                continue
+            if param.kind in (
+                inspect.Parameter.VAR_POSITIONAL,
+                inspect.Parameter.VAR_KEYWORD,
+            ):
+                continue
+            if param.annotation is inspect.Parameter.empty:
+                untyped.append(f"{name}({pname}): missing annotation")
+    assert not untyped, "\n".join(untyped)

--- a/tests/eval_018/test_rename_compactor.py
+++ b/tests/eval_018/test_rename_compactor.py
@@ -1,0 +1,37 @@
+"""Eval 018: ContextCompressor symbol fully renamed to ContextCompactor in agent/.
+
+Walks every .py file under agent/, asserts no `ContextCompressor` matches and
+that `ContextCompactor` appears in at least one file (i.e., the rename
+actually happened — empty files would otherwise trivially pass).
+"""
+
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+AGENT_DIR = REPO_ROOT / "agent"
+
+_OLD = re.compile(r"\bContextCompressor\b")
+_NEW = re.compile(r"\bContextCompactor\b")
+
+
+def _iter_agent_py_files() -> list[Path]:
+    return [p for p in AGENT_DIR.rglob("*.py") if "__pycache__" not in p.parts]
+
+
+def test_no_compressor_references() -> None:
+    offenders: list[str] = []
+    daedalus_count = 0
+    for py in _iter_agent_py_files():
+        text = py.read_text(encoding="utf-8", errors="replace")
+        if _OLD.search(text):
+            offenders.append(str(py.relative_to(REPO_ROOT)))
+        if _NEW.search(text):
+            daedalus_count += 1
+    assert not offenders, (
+        f"`ContextCompressor` still referenced in: {offenders}"
+    )
+    assert daedalus_count >= 1, (
+        "Rename did not introduce `ContextCompactor` anywhere in agent/"
+    )

--- a/tests/eval_018/test_title_timeout.py
+++ b/tests/eval_018/test_title_timeout.py
@@ -1,0 +1,16 @@
+"""Eval 018: agent.title_generator.generate_title has timeout default = 60.0."""
+
+import inspect
+
+from agent.title_generator import generate_title
+
+
+def test_generate_title_timeout_default() -> None:
+    sig = inspect.signature(generate_title)
+    assert "timeout" in sig.parameters, (
+        "generate_title is missing a `timeout` parameter"
+    )
+    default = sig.parameters["timeout"].default
+    assert default == 60.0, (
+        f"expected timeout default 60.0, got {default!r}"
+    )

--- a/tests/eval_018/test_usage_pricing_docstrings.py
+++ b/tests/eval_018/test_usage_pricing_docstrings.py
@@ -1,0 +1,35 @@
+"""Eval 018: every class defined in agent/usage_pricing.py has a docstring.
+
+We check via AST rather than ``inspect.getdoc`` because dataclasses
+auto-generate a __doc__ string from the signature; the prompt is asking
+the agent to add an explicit class-level docstring.
+"""
+
+import ast
+import inspect
+from pathlib import Path
+
+import agent.usage_pricing as usage_pricing
+
+
+def test_classes_have_docstrings() -> None:
+    src = Path(inspect.getsourcefile(usage_pricing) or "").read_text()
+    tree = ast.parse(src)
+    missing: list[str] = []
+    for node in tree.body:
+        if not isinstance(node, ast.ClassDef):
+            continue
+        if not node.body:
+            missing.append(node.name)
+            continue
+        first = node.body[0]
+        if not (
+            isinstance(first, ast.Expr)
+            and isinstance(first.value, ast.Constant)
+            and isinstance(first.value.value, str)
+            and first.value.value.strip()
+        ):
+            missing.append(node.name)
+    assert not missing, (
+        f"Classes without explicit docstrings in agent/usage_pricing.py: {missing}"
+    )


### PR DESCRIPTION
Companion to 0046d170 (threading.local callback propagation) and 603a68b9 (per-session ContextVar isolation).

`_execute_tool_calls_concurrent` submits tools via `executor.submit(_run_tool, ...)` without `copy_context().run`, so worker threads do not inherit the parent's ContextVar values — including `_approval_session_key` set by the gateway before `agent.run`. Worker tools fall through `tools/approval.py:get_current_session_key`'s resolution order to the `os.environ` fallback (`"default"` session key), silently collapsing per-session dispatch.

Fix: wrap `_run_tool` in `copy_context().run` at submit time, mirroring `asyncio.to_thread`. The existing threading.local callback propagation at `run_agent.py:8796-8806` (from 0046d170 / GHSA-qg5c-hvr5-hjgr) is preserved — it handles a different propagation surface that ContextVars cannot carry.