### PR TITLE
fix(tui): expose forceRedraw in Ink type shim

### DIFF
--- a/ui-tui/src/types/hermes-ink.d.ts
+++ b/ui-tui/src/types/hermes-ink.d.ts
@@ -131,6 +131,7 @@ declare module '@hermes/ink' {
   }
   export function evictInkCaches(level?: EvictLevel): InkCacheSizes
 
+  export function forceRedraw(stdout?: NodeJS.WriteStream): boolean
   export function render(node: React.ReactNode, options?: NodeJS.WriteStream | RenderOptions): Instance
 
   export function useApp(): { readonly exit: (error?: Error) => void }


### PR DESCRIPTION
## Summary
- Adds the missing `forceRedraw` declaration to the local `@hermes/ink` type shim used by `tsconfig.build.json`.
- Fixes the TUI build failure on main where `useInputHandlers.ts` imports `forceRedraw` but the aliased declaration file did not expose it.

## Test plan
- `npm run build` from `ui-tui/`
- `npm run type-check` from `ui-tui/`