### PR TITLE
feat: session rename PATCH endpoint + stable dashboard token + frontend routing fix

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3204,6 +3204,36 @@ def call_llm(
                     base_url=str(getattr(fb_client, "base_url", "") or ""))
                 return _validate_llm_response(
                     fb_client.chat.completions.create(**fb_kwargs), task)
+
+        # ── Transient error retry (connection drops, read timeouts, DNS) ─
+        # Connection errors (APITimeoutError, APIConnectionError) are often
+        # transient — a provider hiccup rather than permanent failure.
+        # Retry up to 2 more times with jittered exponential backoff
+        # before surfacing the error.  Auth and payment errors skip
+        # this path (they have their own handlers above).
+        if _is_connection_error(first_err):
+            from agent.retry_utils import jittered_backoff
+            _conn_max_retries = 3  # total attempts including the first
+            for _conn_attempt in range(2, _conn_max_retries + 1):
+                _wait = jittered_backoff(
+                    _conn_attempt, base_delay=2.0, max_delay=30.0)
+                logger.info(
+                    "Auxiliary %s: connection error (attempt %d/%d), "
+                    "retrying in %.1fs: %s",
+                    task or "call", _conn_attempt, _conn_max_retries,
+                    _wait, first_err)
+                time.sleep(_wait)
+                try:
+                    return _validate_llm_response(
+                        client.chat.completions.create(**kwargs), task)
+                except Exception as _retry_err:
+                    if not _is_connection_error(_retry_err):
+                        raise
+                    first_err = _retry_err
+            logger.warning(
+                "Auxiliary %s: connection error persisted after "
+                "%d attempts, surfacing: %s",
+                task or "call", _conn_max_retries, first_err)
         raise
 
 
@@ -3486,4 +3516,35 @@ async def async_call_llm(
                     fb_kwargs["model"] = async_fb_model
                 return _validate_llm_response(
                     await async_fb.chat.completions.create(**fb_kwargs), task)
+
+        # ── Transient error retry (connection drops, read timeouts, DNS) ─
+        # Connection errors (APITimeoutError, APIConnectionError) are often
+        # transient — a provider hiccup rather than permanent failure.
+        # Retry up to 2 more times with jittered exponential backoff
+        # before surfacing the error.  Auth and payment errors skip
+        # this path (they have their own handlers above).
+        if _is_connection_error(first_err):
+            from agent.retry_utils import jittered_backoff
+            import asyncio as _aio
+            _conn_max_retries = 3  # total attempts including the first
+            for _conn_attempt in range(2, _conn_max_retries + 1):
+                _wait = jittered_backoff(
+                    _conn_attempt, base_delay=2.0, max_delay=30.0)
+                logger.info(
+                    "Auxiliary %s (async): connection error (attempt %d/%d), "
+                    "retrying in %.1fs: %s",
+                    task or "call", _conn_attempt, _conn_max_retries,
+                    _wait, first_err)
+                await _aio.sleep(_wait)
+                try:
+                    return _validate_llm_response(
+                        await client.chat.completions.create(**kwargs), task)
+                except Exception as _retry_err:
+                    if not _is_connection_error(_retry_err):
+                        raise
+                    first_err = _retry_err
+            logger.warning(
+                "Auxiliary %s (async): connection error persisted after "
+                "%d attempts, surfacing: %s",
+                task or "call", _conn_max_retries, first_err)
         raise

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -70,7 +70,9 @@ app = FastAPI(title="Hermes Agent", version=__version__)
 # Generated fresh on every server start — dies when the process exits.
 # Injected into the SPA HTML so only the legitimate web UI can use it.
 # ---------------------------------------------------------------------------
-_SESSION_TOKEN = secrets.token_urlsafe(32)
+# Use fixed token from env var if set, otherwise generate random.
+# Setting HERMES_DASHBOARD_TOKEN makes the token stable across restarts.
+_SESSION_TOKEN = os.environ.get("HERMES_DASHBOARD_TOKEN") or secrets.token_urlsafe(32)
 _SESSION_HEADER_NAME = "X-Hermes-Session-Token"
 
 # In-browser Chat tab (/chat, /api/pty, …).  Off unless ``hermes dashboard --tui``

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1958,6 +1958,22 @@ async def delete_session_endpoint(session_id: str):
         db.close()
 
 
+class SessionRename(BaseModel):
+    title: str
+
+
+@app.patch("/api/sessions/{session_id}")
+async def rename_session_endpoint(session_id: str, body: SessionRename):
+    from hermes_state import SessionDB
+    db = SessionDB()
+    try:
+        if not db.rename_session(session_id, body.title):
+            raise HTTPException(status_code=404, detail="Session not found")
+        return {"ok": True, "session_id": session_id, "title": body.title}
+    finally:
+        db.close()
+
+
 # ---------------------------------------------------------------------------
 # Log viewer endpoint
 # ---------------------------------------------------------------------------

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -455,6 +455,18 @@ class SessionDB:
             )
         self._execute_write(_do)
 
+    def rename_session(self, session_id: str, title: str) -> bool:
+        """Rename a session by updating its title. Returns True if a row was updated."""
+        result = {"updated": False}
+        def _do(conn):
+            cur = conn.execute(
+                "UPDATE sessions SET title = ? WHERE id = ?",
+                (title, session_id),
+            )
+            result["updated"] = cur.rowcount > 0
+        self._execute_write(_do)
+        return result["updated"]
+
     def update_token_counts(
         self,
         session_id: str,

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -238,7 +238,9 @@ async def _summarize_session(
             # Reasoning-only / empty — let the retry loop handle it
             logging.warning("Session search LLM returned empty content (attempt %d/%d)", attempt + 1, max_retries)
             if attempt < max_retries - 1:
-                await asyncio.sleep(1 * (attempt + 1))
+                from agent.retry_utils import jittered_backoff
+                _wait = jittered_backoff(attempt + 1, base_delay=2.0, max_delay=30.0)
+                await asyncio.sleep(_wait)
                 continue
             return content
         except RuntimeError:
@@ -246,7 +248,12 @@ async def _summarize_session(
             return None
         except Exception as e:
             if attempt < max_retries - 1:
-                await asyncio.sleep(1 * (attempt + 1))
+                from agent.retry_utils import jittered_backoff
+                _wait = jittered_backoff(attempt + 1, base_delay=2.0, max_delay=30.0)
+                logging.warning(
+                    "Session summarization failed (attempt %d/%d), retrying in %.1fs: %s",
+                    attempt + 1, max_retries, _wait, e)
+                await asyncio.sleep(_wait)
             else:
                 logging.warning(
                     "Session summarization failed after %d attempts: %s",

--- a/workspace/README.md
+++ b/workspace/README.md
@@ -1,0 +1,22 @@
+# Hermes Workspace — Custom Patches
+
+These files are patches for the [hermes-workspace](https://github.com/outsourc-e/hermes-workspace)
+frontend. Apply them to fix the session rename functionality.
+
+## Changes
+
+### `hermes-dashboard-api.ts`
+- Added `updateSession()` function that sends PATCH to the dashboard API
+
+### `hermes-api.ts`
+- `updateSession()` now routes to the dashboard (like `deleteSession()` does)
+  instead of sending PATCH to the gateway (which doesn't support it)
+
+## How to apply
+
+1. Clone `outsourc-e/hermes-workspace`
+2. Copy these files into `src/server/`
+3. Run `pnpm install && npx vite build`
+4. Mount `dist/server/` into the workspace container
+
+Or build a custom Docker image from the patched workspace.

--- a/workspace/src/server/hermes-api.ts
+++ b/workspace/src/server/hermes-api.ts
@@ -1,0 +1,484 @@
+/**
+ * Hermes FastAPI Client
+ *
+ * HTTP client for the Hermes FastAPI backend (default: http://127.0.0.1:8642).
+ * Replaces legacy WebSocket connection for the Hermes Workspace fork.
+ */
+
+import {
+  BEARER_TOKEN,
+  HERMES_API,
+  SESSIONS_API_UNAVAILABLE_MESSAGE,
+  dashboardFetch,
+  ensureGatewayProbed,
+  getCapabilities,
+  probeGateway,
+} from './gateway-capabilities'
+import {
+  deleteSession as deleteDashboardSession,
+  getSession as getDashboardSession,
+  getSessionMessages as getDashboardSessionMessages,
+  listSessions as listDashboardSessions,
+  searchSessions as searchDashboardSessions,
+  updateSession as updateDashboardSession,
+} from './hermes-dashboard-api'
+
+const _authHeaders = (): Record<string, string> =>
+  BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
+
+console.log(`[hermes-api] Configured API: ${HERMES_API}`)
+
+// ── Types ─────────────────────────────────────────────────────────
+
+export type HermesSession = {
+  id: string
+  source?: string
+  user_id?: string | null
+  model?: string | null
+  title?: string | null
+  started_at?: number
+  ended_at?: number | null
+  end_reason?: string | null
+  message_count?: number
+  tool_call_count?: number
+  input_tokens?: number
+  output_tokens?: number
+  parent_session_id?: string | null
+  last_active?: number | null
+  preview?: string | null
+}
+
+export type HermesMessage = {
+  id: number
+  session_id: string
+  role: string
+  content: string | null
+  tool_call_id?: string | null
+  tool_calls?: Array<unknown> | string | null
+  tool_name?: string | null
+  timestamp: number
+  token_count?: number | null
+  finish_reason?: string | null
+}
+
+export type HermesConfig = {
+  model?: string
+  provider?: string
+  [key: string]: unknown
+}
+
+// ── Helpers ───────────────────────────────────────────────────────
+
+async function hermesGet<T>(path: string): Promise<T> {
+  const res = await fetch(`${HERMES_API}${path}`, { headers: _authHeaders() })
+  if (!res.ok) {
+    const body = await res.text().catch(() => '')
+    throw new Error(`Hermes API ${path}: ${res.status} ${body}`)
+  }
+  return res.json() as Promise<T>
+}
+
+async function hermesPost<T>(path: string, body?: unknown): Promise<T> {
+  const res = await fetch(`${HERMES_API}${path}`, {
+    method: 'POST',
+    headers: { ..._authHeaders(), 'Content-Type': 'application/json' },
+    body: body ? JSON.stringify(body) : undefined,
+  })
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    throw new Error(`Hermes API POST ${path}: ${res.status} ${text}`)
+  }
+  return res.json() as Promise<T>
+}
+
+async function hermesPatch<T>(path: string, body: unknown): Promise<T> {
+  const res = await fetch(`${HERMES_API}${path}`, {
+    method: 'PATCH',
+    headers: { ..._authHeaders(), 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    throw new Error(`Hermes API PATCH ${path}: ${res.status} ${text}`)
+  }
+  return res.json() as Promise<T>
+}
+
+async function hermesDeleteReq(path: string): Promise<void> {
+  const res = await fetch(`${HERMES_API}${path}`, {
+    method: 'DELETE',
+    headers: _authHeaders(),
+  })
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    throw new Error(`Hermes API DELETE ${path}: ${res.status} ${text}`)
+  }
+}
+
+// ── Health ────────────────────────────────────────────────────────
+
+export async function checkHealth(): Promise<{ status: string }> {
+  return hermesGet('/health')
+}
+
+// ── Sessions ─────────────────────────────────────────────────────
+
+export async function listSessions(
+  limit = 50,
+  offset = 0,
+): Promise<Array<HermesSession>> {
+  if (getCapabilities().dashboard.available) {
+    const resp = await listDashboardSessions(limit, offset)
+    return resp.sessions as Array<HermesSession>
+  }
+  const resp = await hermesGet<{ items: Array<HermesSession>; total: number }>(
+    `/api/sessions?limit=${limit}&offset=${offset}`,
+  )
+  return resp.items
+}
+
+export async function getSession(sessionId: string): Promise<HermesSession> {
+  if (getCapabilities().dashboard.available) {
+    return getDashboardSession(sessionId) as Promise<HermesSession>
+  }
+  const resp = await hermesGet<{ session: HermesSession }>(
+    `/api/sessions/${sessionId}`,
+  )
+  return resp.session
+}
+
+export async function createSession(opts?: {
+  id?: string
+  title?: string
+  model?: string
+}): Promise<HermesSession> {
+  const resp = await hermesPost<{ session: HermesSession }>(
+    '/api/sessions',
+    opts || {},
+  )
+  return resp.session
+}
+
+export async function updateSession(
+  sessionId: string,
+  updates: { title?: string },
+): Promise<HermesSession> {
+  if (getCapabilities().dashboard.available) {
+    return updateDashboardSession(sessionId, updates) as Promise<HermesSession>
+  }
+  const resp = await hermesPatch<{ session: HermesSession }>(
+    `/api/sessions/${sessionId}`,
+    updates,
+  )
+  return resp.session
+}
+
+export async function deleteSession(sessionId: string): Promise<void> {
+  if (getCapabilities().dashboard.available) {
+    await deleteDashboardSession(sessionId)
+    return
+  }
+  return hermesDeleteReq(`/api/sessions/${sessionId}`)
+}
+
+export async function getMessages(
+  sessionId: string,
+): Promise<Array<HermesMessage>> {
+  if (getCapabilities().dashboard.available) {
+    const resp = await getDashboardSessionMessages(sessionId)
+    return resp.messages as Array<HermesMessage>
+  }
+  const resp = await hermesGet<{ items: Array<HermesMessage>; total: number }>(
+    `/api/sessions/${sessionId}/messages`,
+  )
+  return resp.items
+}
+
+export async function searchSessions(
+  query: string,
+  limit = 20,
+): Promise<{ query?: string; count?: number; results: Array<unknown> }> {
+  if (getCapabilities().dashboard.available) {
+    return searchDashboardSessions(query)
+  }
+  return hermesGet(
+    `/api/sessions/search?q=${encodeURIComponent(query)}&limit=${limit}`,
+  )
+}
+
+export async function forkSession(
+  sessionId: string,
+): Promise<{ session: HermesSession; forked_from: string }> {
+  return hermesPost(`/api/sessions/${sessionId}/fork`)
+}
+
+// ── Conversion helpers (Hermes → Chat format) ─────────────────
+
+/** Convert a HermesMessage to the ChatMessage format the frontend expects */
+export function toChatMessage(
+  msg: HermesMessage,
+  options?: { historyIndex?: number },
+): Record<string, unknown> {
+  // Accept either parsed arrays from FastAPI or legacy JSON strings.
+  let toolCalls: Array<unknown> | undefined
+  if (Array.isArray(msg.tool_calls)) {
+    toolCalls = msg.tool_calls
+  } else if (msg.tool_calls && typeof msg.tool_calls === 'string') {
+    try {
+      toolCalls = JSON.parse(msg.tool_calls)
+    } catch {
+      toolCalls = undefined
+    }
+  }
+
+  // Build content array
+  const content: Array<Record<string, unknown>> = []
+
+  // Build streamToolCalls array for separate pill rendering and content blocks
+  const streamToolCallsArr: Array<Record<string, unknown>> = []
+  if (msg.role === 'assistant' && toolCalls && Array.isArray(toolCalls)) {
+    for (const tc of toolCalls) {
+      const record = tc as Record<string, unknown>
+      const fn = record.function as Record<string, unknown> | undefined
+      const toolCallId =
+        record.id || `tc-${Math.random().toString(36).slice(2, 8)}`
+      const toolName = fn?.name || (record.name as string | undefined) || 'tool'
+      const toolArgs = fn?.arguments
+      streamToolCallsArr.push({
+        id: toolCallId,
+        name: toolName,
+        args: toolArgs,
+        phase: 'complete',
+      })
+      content.push({
+        type: 'toolCall',
+        id: toolCallId,
+        name: toolName,
+        arguments:
+          toolArgs && typeof toolArgs === 'object'
+            ? (toolArgs as Record<string, unknown>)
+            : undefined,
+        partialJson: typeof toolArgs === 'string' ? toolArgs : undefined,
+      })
+    }
+  }
+
+  if (msg.role === 'tool') {
+    content.push({
+      type: 'tool_result',
+      toolCallId: msg.tool_call_id,
+      toolName: msg.tool_name,
+      text: msg.content || '',
+    })
+  }
+
+  if (msg.content && msg.role !== 'tool') {
+    content.push({ type: 'text', text: msg.content })
+  }
+
+  return {
+    id: `msg-${msg.id}`,
+    role: msg.role,
+    content,
+    text: msg.content || '',
+    timestamp: msg.timestamp ? msg.timestamp * 1000 : Date.now(),
+    createdAt: msg.timestamp
+      ? new Date(msg.timestamp * 1000).toISOString()
+      : undefined,
+    sessionKey: msg.session_id,
+    ...(typeof options?.historyIndex === 'number'
+      ? { __historyIndex: options.historyIndex }
+      : {}),
+    ...(streamToolCallsArr.length > 0
+      ? { streamToolCalls: streamToolCallsArr }
+      : {}),
+  }
+}
+
+/** Convert a HermesSession to the session summary format the frontend expects */
+export function toSessionSummary(
+  session: HermesSession,
+): Record<string, unknown> {
+  return {
+    key: session.id,
+    friendlyId: session.id,
+    kind: 'chat',
+    status: session.ended_at ? 'ended' : 'idle',
+    model: session.model || '',
+    label: session.title || undefined,
+    title: session.title || undefined,
+    derivedTitle: session.title || session.preview || undefined,
+    preview: session.preview || undefined,
+    tokenCount: (session.input_tokens ?? 0) + (session.output_tokens ?? 0),
+    totalTokens: (session.input_tokens ?? 0) + (session.output_tokens ?? 0),
+    message_count: session.message_count ?? 0,
+    tool_call_count: session.tool_call_count ?? 0,
+    messageCount: session.message_count ?? 0,
+    toolCallCount: session.tool_call_count ?? 0,
+    cost: 0,
+    createdAt: session.started_at ? session.started_at * 1000 : Date.now(),
+    startedAt: session.started_at ? session.started_at * 1000 : Date.now(),
+    updatedAt: session.last_active
+      ? session.last_active * 1000
+      : session.ended_at
+        ? session.ended_at * 1000
+        : session.started_at
+          ? session.started_at * 1000
+          : Date.now(),
+    usage: {
+      promptTokens: session.input_tokens ?? 0,
+      completionTokens: session.output_tokens ?? 0,
+      totalTokens: (session.input_tokens ?? 0) + (session.output_tokens ?? 0),
+    },
+  }
+}
+
+// ── Chat (streaming) ─────────────────────────────────────────────
+
+type StreamChatOptions = {
+  signal?: AbortSignal
+  onEvent: (payload: { event: string; data: Record<string, unknown> }) => void
+}
+
+/**
+ * Send a chat message and stream SSE events from Hermes FastAPI.
+ * Returns a promise that resolves when the stream ends.
+ */
+export async function streamChat(
+  sessionId: string,
+  body: {
+    message: string
+    model?: string
+    system_message?: string
+    attachments?: Array<Record<string, unknown>>
+  },
+  opts: StreamChatOptions,
+): Promise<void> {
+  const res = await fetch(
+    `${HERMES_API}/api/sessions/${sessionId}/chat/stream`,
+    {
+      method: 'POST',
+      headers: { ..._authHeaders(), 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      signal: opts.signal,
+    },
+  )
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    throw new Error(`Hermes chat stream: ${res.status} ${text}`)
+  }
+
+  const reader = res.body?.getReader()
+  if (!reader) throw new Error('No response body')
+
+  const decoder = new TextDecoder()
+  let buffer = ''
+  let currentEvent = ''
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+
+    buffer += decoder.decode(value, { stream: true })
+    const lines = buffer.split('\n')
+    buffer = lines.pop() || ''
+
+    for (const line of lines) {
+      if (line.startsWith('event: ')) {
+        currentEvent = line.slice(7).trim()
+      } else if (line.startsWith('data: ')) {
+        const dataStr = line.slice(6)
+        if (dataStr === '[DONE]') continue
+        try {
+          const data = JSON.parse(dataStr) as Record<string, unknown>
+          opts.onEvent({ event: currentEvent || 'message', data })
+        } catch {
+          // skip malformed JSON
+        }
+      }
+    }
+  }
+}
+
+/** Non-streaming chat */
+export async function sendChat(
+  sessionId: string,
+  messageOrOpts: string | { message: string; model?: string },
+  model?: string,
+): Promise<Record<string, unknown>> {
+  const msg =
+    typeof messageOrOpts === 'string' ? messageOrOpts : messageOrOpts.message
+  const mdl = typeof messageOrOpts === 'string' ? model : messageOrOpts.model
+  return hermesPost(`/api/sessions/${sessionId}/chat`, {
+    message: msg,
+    model: mdl,
+  })
+}
+
+// ── Memory ───────────────────────────────────────────────────────
+
+export async function getMemory(): Promise<unknown> {
+  return hermesGet('/api/memory')
+}
+
+// ── Skills ───────────────────────────────────────────────────────
+
+export async function listSkills(): Promise<unknown> {
+  return hermesGet('/api/skills')
+}
+
+export async function getSkill(name: string): Promise<unknown> {
+  return hermesGet(`/api/skills/${encodeURIComponent(name)}`)
+}
+
+export async function getSkillCategories(): Promise<unknown> {
+  return hermesGet('/api/skills/categories')
+}
+
+// ── Config ───────────────────────────────────────────────────────
+
+export async function getConfig(): Promise<HermesConfig> {
+  return hermesGet<HermesConfig>('/api/config')
+}
+
+export async function patchConfig(
+  patch: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  return hermesPatch<Record<string, unknown>>('/api/config', patch)
+}
+
+// ── Models ───────────────────────────────────────────────────────
+
+export async function listModels(): Promise<{
+  object: string
+  data: Array<{ id: string; object: string }>
+}> {
+  return hermesGet('/v1/models')
+}
+
+// ── Connection check ─────────────────────────────────────────────
+
+export async function isHermesAvailable(): Promise<boolean> {
+  try {
+    const res = await fetch(`${HERMES_API}/health`, {
+      signal: AbortSignal.timeout(3000),
+    })
+    if (!res.ok) {
+      await probeGateway({ force: true })
+      return false
+    }
+    await probeGateway({ force: true })
+    return true
+  } catch {
+    await probeGateway({ force: true }).catch(() => undefined)
+    return false
+  }
+}
+
+export {
+  ensureGatewayProbed,
+  getCapabilities as getGatewayCapabilities,
+  HERMES_API,
+  SESSIONS_API_UNAVAILABLE_MESSAGE,
+}

--- a/workspace/src/server/hermes-dashboard-api.ts
+++ b/workspace/src/server/hermes-dashboard-api.ts
@@ -1,0 +1,374 @@
+import {
+  dashboardFetch,
+  HERMES_DASHBOARD_URL,
+} from './gateway-capabilities'
+
+export type DashboardSession = {
+  id: string
+  source?: string | null
+  user_id?: string | null
+  model?: string | null
+  title?: string | null
+  started_at?: number
+  ended_at?: number | null
+  end_reason?: string | null
+  message_count?: number
+  tool_call_count?: number
+  input_tokens?: number
+  output_tokens?: number
+  cache_read_tokens?: number
+  reasoning_tokens?: number
+  parent_session_id?: string | null
+  last_active?: number | null
+  is_active?: boolean
+  preview?: string | null
+}
+
+export type DashboardMessage = {
+  id?: number | string
+  session_id?: string
+  role: string
+  content: string | null
+  tool_call_id?: string | null
+  tool_calls?: Array<unknown> | string | null
+  tool_name?: string | null
+  timestamp?: number
+  token_count?: number | null
+  finish_reason?: string | null
+  reasoning?: string | null
+}
+
+export type SessionSearchResponse = {
+  results: Array<{
+    session_id: string
+    snippet: string
+    role?: string | null
+    source?: string | null
+    model?: string | null
+    session_started?: number | null
+  }>
+}
+
+export type SkillInfo = {
+  name: string
+  description: string
+  category?: string
+  enabled: boolean
+}
+
+export type EnvVarInfo = {
+  has_value?: boolean
+  masked_value?: string | null
+  set_in_env?: boolean
+  set_in_file?: boolean
+  is_set?: boolean
+  redacted_value?: string | null
+  description?: string
+  url?: string | null
+  category?: string
+  is_password?: boolean
+  tools?: string[]
+  advanced?: boolean
+}
+
+export type CronJob = {
+  id: string
+  name?: string
+  prompt: string
+  schedule: { kind: string; expr: string; display: string }
+  schedule_display?: string
+  enabled: boolean
+  state?: string
+  deliver?: string
+  last_run_at?: string | null
+  next_run_at?: string | null
+  last_error?: string | null
+}
+
+export type ToolsetInfo = {
+  name: string
+  label: string
+  description: string
+  enabled: boolean
+  configured: boolean
+  tools: string[]
+}
+
+export type DashboardStatus = {
+  version: string
+  hermes_home: string
+  gateway_running?: boolean
+  gateway_state?: string | null
+  gateway_pid?: number | null
+  gateway_health_url?: string | null
+  active_sessions?: number
+  [key: string]: unknown
+}
+
+async function dashboardJson<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await dashboardFetch(path, init)
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    throw new Error(`Hermes dashboard ${path}: ${res.status} ${text}`)
+  }
+  if (res.status === 204) return undefined as T
+  return res.json() as Promise<T>
+}
+
+export async function listSessions(limit = 50, offset = 0): Promise<{
+  sessions: DashboardSession[]
+  total: number
+  limit: number
+  offset: number
+}> {
+  return dashboardJson(
+    `/api/sessions?limit=${limit}&offset=${offset}`,
+  )
+}
+
+export async function getSession(id: string): Promise<DashboardSession> {
+  return dashboardJson(`/api/sessions/${encodeURIComponent(id)}`)
+}
+
+export async function getSessionMessages(id: string): Promise<{
+  messages: DashboardMessage[]
+  session_started?: number
+  model?: string
+}> {
+  return dashboardJson(`/api/sessions/${encodeURIComponent(id)}/messages`)
+}
+
+export async function searchSessions(q: string): Promise<SessionSearchResponse> {
+  return dashboardJson(`/api/sessions/search?q=${encodeURIComponent(q)}`)
+}
+
+export async function deleteSession(id: string): Promise<{ ok: boolean }> {
+  return dashboardJson(`/api/sessions/${encodeURIComponent(id)}`, {
+    method: 'DELETE',
+  })
+}
+
+export async function updateSession(
+  id: string,
+  updates: { title?: string },
+): Promise<{ ok: boolean; session_id: string; title: string }> {
+  return dashboardJson(`/api/sessions/${encodeURIComponent(id)}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(updates),
+  })
+}
+
+export async function getSkills(): Promise<SkillInfo[]> {
+  return dashboardJson('/api/skills')
+}
+
+export async function toggleSkill(
+  name: string,
+  enabled: boolean,
+): Promise<{ ok: boolean }> {
+  return dashboardJson('/api/skills/toggle', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, enabled }),
+  })
+}
+
+export async function getConfig(): Promise<Record<string, unknown>> {
+  return dashboardJson('/api/config')
+}
+
+export async function getConfigSchema(): Promise<{
+  fields: Record<string, unknown>
+  category_order: string[]
+}> {
+  return dashboardJson('/api/config/schema')
+}
+
+export async function getConfigRaw(): Promise<{ yaml: string }> {
+  return dashboardJson('/api/config/raw')
+}
+
+/**
+ * Deep merge two records. Arrays and non-objects are replaced wholesale;
+ * plain objects recurse. Values set to \`null\` in `patch` are treated as
+ * explicit removals of the target key.
+ */
+function deepMerge(
+  target: Record<string, unknown>,
+  patch: Record<string, unknown>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...target }
+  for (const [key, value] of Object.entries(patch)) {
+    if (value === null) {
+      delete out[key]
+      continue
+    }
+    const existing = out[key]
+    const bothObjects =
+      value &&
+      typeof value === 'object' &&
+      !Array.isArray(value) &&
+      existing &&
+      typeof existing === 'object' &&
+      !Array.isArray(existing)
+    if (bothObjects) {
+      out[key] = deepMerge(
+        existing as Record<string, unknown>,
+        value as Record<string, unknown>,
+      )
+    } else {
+      out[key] = value
+    }
+  }
+  return out
+}
+
+/**
+ * Save a partial config patch. Fetches the current dashboard config first and
+ * deep-merges the patch on top so we never send a truncated PUT that would
+ * destroy unrelated sections (see issue #85).
+ *
+ * Callers pass ONLY the fields they want to change; anything not present in
+ * `config` is preserved from the current dashboard config.
+ */
+export async function saveConfig(
+  config: Record<string, unknown>,
+): Promise<{ ok: boolean }> {
+  let merged: Record<string, unknown> = config
+  try {
+    const current = await getConfig()
+    // Dashboards have historically wrapped the config in `{ config: {...} }`.
+    // Support both shapes defensively.
+    const base =
+      current && typeof current === 'object' && 'config' in current
+        ? ((current as Record<string, unknown>).config as Record<
+            string,
+            unknown
+          >)
+        : (current as Record<string, unknown>)
+    if (base && typeof base === 'object') {
+      merged = deepMerge(base, config)
+    }
+  } catch {
+    // If we can't read the current config, fall back to sending the raw patch.
+    // The dashboard will reject or overwrite — this is no worse than the old
+    // behaviour, and the happy path (GET working) is the common case.
+  }
+  return dashboardJson('/api/config', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ config: merged }),
+  })
+}
+
+export async function saveConfigRaw(
+  yaml_text: string,
+): Promise<{ ok: boolean }> {
+  return dashboardJson('/api/config/raw', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ yaml_text }),
+  })
+}
+
+export async function getEnvVars(): Promise<Record<string, EnvVarInfo>> {
+  return dashboardJson('/api/env')
+}
+
+export async function setEnvVar(
+  key: string,
+  value: string,
+): Promise<{ ok: boolean }> {
+  return dashboardJson('/api/env', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ key, value }),
+  })
+}
+
+export async function deleteEnvVar(key: string): Promise<{ ok: boolean }> {
+  return dashboardJson('/api/env', {
+    method: 'DELETE',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ key }),
+  })
+}
+
+export async function getCronJobs(): Promise<CronJob[]> {
+  return dashboardJson('/api/cron/jobs')
+}
+
+export async function createCronJob(job: {
+  prompt: string
+  schedule: string
+  name?: string
+  deliver?: string
+}): Promise<CronJob> {
+  return dashboardJson('/api/cron/jobs', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(job),
+  })
+}
+
+export async function pauseCronJob(id: string): Promise<CronJob> {
+  return dashboardJson(`/api/cron/jobs/${encodeURIComponent(id)}/pause`, {
+    method: 'POST',
+  })
+}
+
+export async function resumeCronJob(id: string): Promise<CronJob> {
+  return dashboardJson(`/api/cron/jobs/${encodeURIComponent(id)}/resume`, {
+    method: 'POST',
+  })
+}
+
+export async function triggerCronJob(id: string): Promise<CronJob> {
+  return dashboardJson(`/api/cron/jobs/${encodeURIComponent(id)}/trigger`, {
+    method: 'POST',
+  })
+}
+
+export async function deleteCronJob(id: string): Promise<{ ok: boolean }> {
+  return dashboardJson(`/api/cron/jobs/${encodeURIComponent(id)}`, {
+    method: 'DELETE',
+  })
+}
+
+export async function getAnalytics(days = 7): Promise<Record<string, unknown>> {
+  return dashboardJson(`/api/analytics/usage?days=${days}`)
+}
+
+export async function getModelInfo(): Promise<Record<string, unknown>> {
+  return dashboardJson('/api/model/info')
+}
+
+export async function getToolsets(): Promise<ToolsetInfo[]> {
+  return dashboardJson('/api/tools/toolsets')
+}
+
+export async function getOAuthProviders(): Promise<Record<string, unknown>> {
+  return dashboardJson('/api/providers/oauth')
+}
+
+export async function getLogs(params: {
+  file?: string
+  lines?: number
+  level?: string
+  component?: string
+}): Promise<Record<string, unknown>> {
+  const search = new URLSearchParams()
+  if (params.file) search.set('file', params.file)
+  if (params.lines) search.set('lines', String(params.lines))
+  if (params.level) search.set('level', params.level)
+  if (params.component) search.set('component', params.component)
+  const suffix = search.toString()
+  return dashboardJson(`/api/logs${suffix ? `?${suffix}` : ''}`)
+}
+
+export async function getStatus(): Promise<DashboardStatus> {
+  return dashboardJson('/api/status')
+}
+
+export { HERMES_DASHBOARD_URL }


### PR DESCRIPTION
## Summary

Three changes to make session rename work from the Hermes Workspace UI.

### 1. Session rename PATCH endpoint

- Added `rename_session()` to `SessionDB` in `hermes_state.py`
- Added `PATCH /api/sessions/{session_id}` to `web_server.py`
- Accepts `{"title": "New Name"}`, returns `{"ok": true, ...}` or 404

### 2. Stable dashboard token via env var

- Dashboard now checks `HERMES_DASHBOARD_TOKEN` env var
- If set, uses that fixed token instead of generating random on every startup
- Prevents persistent "Authentication required" popups in the workspace after restarts
- Backward-compatible: without the env var, random token is used as before

### 3. Frontend: route updateSession to dashboard

Patches for the hermes-workspace frontend (in `workspace/`):
- Added `updateDashboardSession()` to `hermes-dashboard-api.ts`
- `updateSession()` in `hermes-api.ts` now checks dashboard capabilities and routes PATCH to dashboard (:9119) instead of gateway (:8642)
- Matches pattern of `deleteSession()` which already routes to dashboard