### PR TITLE
feat(wecom): add instant random acknowledgment for incoming messages

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -33,6 +33,7 @@ import asyncio
 import base64
 import hashlib
 import json
+import random
 import logging
 import mimetypes
 import os
@@ -506,6 +507,36 @@ class WeComAdapter(BasePlatformAdapter):
         # this chat can fall back to APP_CMD_RESPONSE (required for groups —
         # WeCom AI Bots cannot initiate APP_CMD_SEND in group chats).
         self._remember_chat_req_id(chat_id, self._payload_req_id(payload))
+
+        # Instant random acknowledgment — fire-and-forget, no response wait.
+        # Uses _send_json directly to avoid the deadlock with _read_events.
+        _acks = [
+            "收到，让我看看 👀",
+            "好嘞，稍等 🔍",
+            "收到收到，容我想想 💭",
+            "来了来了 🏃",
+            "嗯嗯，在查了 📡",
+            "等一下哦～ ⏳",
+            "收到！正在处理 ✨",
+            "嗨～我看看哈 🤔",
+        ]
+        ack_req_id = self._payload_req_id(payload)
+        if ack_req_id:
+            async def _send_ack():
+                try:
+                    await self._send_json({
+                        "cmd": "aibot_send_msg",
+                        "headers": {"req_id": f"ack-{uuid.uuid4().hex}"},
+                        "body": {
+                            "chatid": chat_id,
+                            "msgtype": "markdown",
+                            "markdown": {"content": random.choice(_acks)},
+                        },
+                    })
+                    logger.info("[%s] Ack sent to %s", self.name, chat_id)
+                except Exception as e:
+                    logger.error("[%s] Ack failed for %s: %s", self.name, chat_id, e)
+            asyncio.create_task(_send_ack())
 
         text, reply_text = self._extract_text(body)
         # Strip leading @mention in group chats so slash commands like


### PR DESCRIPTION
## Summary

WeCom WebSocket bot now sends a fire-and-forget acknowledgment immediately after receiving a message, before the agent processes it.

## Motivation

Users on slow queries (e.g., web_search-based weather queries that take 2+ minutes) think the bot is dead because there is no immediate feedback. This PR adds an instant randomized acknowledgment so users know the bot received their message.

## Changes

- `gateway/platforms/wecom.py`: added `import random` and a fire-and-forget ack block in `_on_message()`
- Uses `aibot_send_msg` (proactive send) rather than `aibot_response` to avoid WebSocket read-loop deadlock
- Sends via `_send_json` directly without awaiting a response
- Randomizes from a pool of 8 Chinese acknowledgment phrases
- Errors caught and logged without disrupting the message pipeline

## Test Plan

- [x] Tested on live WeCom bot: DM triggers instant ack, group @mention triggers instant ack
- [x] Both short messages (greetings) and long queries (weather) verified
- [x] No regression on existing WeCom message flow