### PR TITLE
fix(gateway): keep env-token Slack enabled

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6000,6 +6000,7 @@ class HermesCLI:
             platform_status = {
                 Platform.TELEGRAM: ("Telegram", "TELEGRAM_BOT_TOKEN"),
                 Platform.DISCORD: ("Discord", "DISCORD_BOT_TOKEN"),
+                Platform.SLACK: ("Slack", "SLACK_BOT_TOKEN"),
                 Platform.WHATSAPP: ("WhatsApp", "WHATSAPP_ENABLED"),
             }
             

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -566,6 +566,8 @@ def load_gateway_config() -> GatewayConfig:
                         existing = {}
                     # Deep-merge extra dicts so gateway.json defaults survive
                     merged_extra = {**existing.get("extra", {}), **plat_block.get("extra", {})}
+                    if plat_name == Platform.SLACK.value and "enabled" in plat_block:
+                        merged_extra["_enabled_explicit"] = True
                     merged = {**existing, **plat_block}
                     if merged_extra:
                         merged["extra"] = merged_extra
@@ -610,16 +612,21 @@ def load_gateway_config() -> GatewayConfig:
                         bridged["channel_prompts"] = {str(k): v for k, v in channel_prompts.items()}
                     else:
                         bridged["channel_prompts"] = channel_prompts
-                if not bridged:
+                enabled_was_explicit = "enabled" in platform_cfg
+                if not bridged and not enabled_was_explicit:
                     continue
                 plat_data = platforms_data.setdefault(plat.value, {})
                 if not isinstance(plat_data, dict):
                     plat_data = {}
                     platforms_data[plat.value] = plat_data
+                if enabled_was_explicit:
+                    plat_data["enabled"] = platform_cfg["enabled"]
                 extra = plat_data.setdefault("extra", {})
                 if not isinstance(extra, dict):
                     extra = {}
                     plat_data["extra"] = extra
+                if plat == Platform.SLACK and enabled_was_explicit:
+                    extra["_enabled_explicit"] = True
                 extra.update(bridged)
 
             # Slack settings → env vars (env vars take precedence)
@@ -941,6 +948,14 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             # No yaml config for Slack — env-only setup, enable it
             config.platforms[Platform.SLACK] = PlatformConfig()
             config.platforms[Platform.SLACK].enabled = True
+        else:
+            slack_config = config.platforms[Platform.SLACK]
+            enabled_was_explicit = bool(slack_config.extra.pop("_enabled_explicit", False))
+            if not slack_config.enabled and not enabled_was_explicit:
+                # Top-level Slack settings such as channel prompts should not
+                # turn an env-token setup into a disabled platform. Only an
+                # explicit slack.enabled/platforms.slack.enabled false should.
+                slack_config.enabled = True
         # If yaml config exists, respect its enabled flag (don't override
         # explicit enabled: false). Token is still stored so skills that
         # send Slack messages can use it without activating the gateway adapter.

--- a/tests/gateway/test_slack_mention.py
+++ b/tests/gateway/test_slack_mention.py
@@ -356,6 +356,81 @@ def test_config_bridges_slack_free_response_channels(monkeypatch, tmp_path):
     assert _os.environ["SLACK_FREE_RESPONSE_CHANNELS"] == "C0AQWDLHY9M,C9999999999"
 
 
+def test_top_level_slack_settings_do_not_disable_env_token_setup(monkeypatch, tmp_path):
+    from gateway.config import load_gateway_config
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "slack:\n"
+        "  require_mention: false\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-test")
+    monkeypatch.delenv("SLACK_REQUIRE_MENTION", raising=False)
+
+    config = load_gateway_config()
+
+    slack_config = config.platforms[Platform.SLACK]
+    assert slack_config.enabled is True
+    assert slack_config.token == "xoxb-test"
+    assert slack_config.extra.get("require_mention") is False
+    assert "_enabled_explicit" not in slack_config.extra
+
+
+def test_explicit_top_level_slack_enabled_false_wins_over_env_token(monkeypatch, tmp_path):
+    from gateway.config import load_gateway_config
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "slack:\n"
+        "  enabled: false\n"
+        "  require_mention: false\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-test")
+    monkeypatch.delenv("SLACK_REQUIRE_MENTION", raising=False)
+
+    config = load_gateway_config()
+
+    slack_config = config.platforms[Platform.SLACK]
+    assert slack_config.enabled is False
+    assert slack_config.token == "xoxb-test"
+    assert slack_config.extra.get("require_mention") is False
+    assert "_enabled_explicit" not in slack_config.extra
+
+
+def test_explicit_platforms_slack_enabled_false_wins_over_env_token(monkeypatch, tmp_path):
+    from gateway.config import load_gateway_config
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "platforms:\n"
+        "  slack:\n"
+        "    enabled: false\n"
+        "    extra:\n"
+        "      reply_in_thread: false\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-test")
+
+    config = load_gateway_config()
+
+    slack_config = config.platforms[Platform.SLACK]
+    assert slack_config.enabled is False
+    assert slack_config.token == "xoxb-test"
+    assert slack_config.extra.get("reply_in_thread") is False
+    assert "_enabled_explicit" not in slack_config.extra
+
+
 def test_config_bridges_slack_reply_in_thread(monkeypatch, tmp_path):
     from gateway.config import load_gateway_config
 


### PR DESCRIPTION
## What does this PR do?

Fixes a Slack gateway regression where a harmless top-level `slack:` config block could create a disabled Slack platform entry before environment overrides were applied. In that state, installs using `SLACK_BOT_TOKEN` from `.env` no longer auto-enabled Slack, so `hermes gateway run` reported no messaging platforms enabled.

The fix tracks whether Slack `enabled` was explicitly set in config. Env-token Slack setups are auto-enabled unless the user explicitly disabled Slack with `slack.enabled: false` or `platforms.slack.enabled: false`.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `gateway/config.py`: preserve explicit Slack enabled/disabled intent while allowing `SLACK_BOT_TOKEN` to enable env-token Slack setups created by top-level Slack settings.
- `cli.py`: show Slack in the classic `/gateway` platform status list.
- `tests/gateway/test_slack_mention.py`: add regressions for top-level Slack settings, explicit top-level disable, and explicit `platforms.slack` disable.

## How to Test

1. Put `SLACK_BOT_TOKEN` in `.env` and add a top-level `slack:` block such as `require_mention: false`.
2. Run `hermes gateway run` and confirm Slack is enabled.
3. Set `slack.enabled: false` or `platforms.slack.enabled: false` and confirm Slack remains disabled even with `SLACK_BOT_TOKEN` present.

Focused regression tests:

`timeout 120s .venv/bin/python -m pytest -n 4 tests/gateway/test_slack_mention.py tests/gateway/test_config.py::TestLoadGatewayConfig::test_bridges_quoted_false_platform_enabled_from_config_yaml -q`

Result:

`41 passed in 1.38s`

Full suite:

`timeout 1800s .venv/bin/python -m pytest -n 4 tests/ -q`

Result:

`77 failed, 16804 passed, 41 skipped, 211 warnings in 373.82s`

The targeted Slack/config regression coverage passes. The broad suite is currently red in pre-existing gateway/platform and CLI clusters; the gateway config test included above passes in the focused run but appears in the full-suite failure summary, which points at broader suite isolation/state pollution rather than this Slack patch.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run `pytest tests/ -q` and documented the result
- [x] I've added tests for my changes
- [x] I've tested on my platform: WSL/Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — config loader only, no platform-specific path changes
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

User-facing symptom:

`WARNING gateway.run: No messaging platforms enabled.`

Even though Slack tokens were configured and Slack had worked before update.