### PR TITLE
test(tui_gateway): accept include_ancestors kwarg in test_session_resume mock

### DIFF
--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -170,7 +170,7 @@ def test_session_resume_returns_hydrated_messages(server, monkeypatch):
         def reopen_session(self, _sid):
             return None
 
-        def get_messages_as_conversation(self, _sid):
+        def get_messages_as_conversation(self, _sid, include_ancestors=False):
             return [
                 {"role": "user", "content": "hello"},
                 {"role": "assistant", "content": "yo"},


### PR DESCRIPTION
## Summary
- The inline `_DB` stub in `test_session_resume_returns_hydrated_messages` only declared `get_messages_as_conversation(self, _sid)`, so when `tui_gateway/server.py` started calling it with `include_ancestors=True` (in `d4dde6b5f`), the call raised `TypeError`, the handler returned a JSON-RPC error, and the test failed on clean `origin/main`.
- This is purely a test stub fix — accept the new kwarg with a default of `False`, matching the sibling stub in `tests/test_tui_gateway_server.py`.

## The bug

`tui_gateway/server.py:1807` (added in [d4dde6b5f](https://github.com/NousResearch/hermes-agent/commit/d4dde6b5f) — \"fix(tui): restore resumed transcript lineage\") calls:

```python
display_history = db.get_messages_as_conversation(
    target, include_ancestors=True
)
```

But the test stub was still:

```python
def get_messages_as_conversation(self, _sid):
    return [...]
```

The handler wraps the body in `try: ... except Exception as e: return _err(rid, 5000, f\"resume failed: {e}\")`, which absorbed the `TypeError` and returned a JSON-RPC error envelope:

```
assert 'error' not in {'error': {'code': 5000,
  'message': "resume failed: ...get_messages_as_conversation()
  got an unexpected keyword argument 'include_ancestors'"}, ...}
```

So the test fails on `origin/main` (`ef41d3bd4`) for everyone.

## The fix

Add `include_ancestors=False` to the stub. The two production calls (`db.get_messages_as_conversation(target)` for the agent-init `history`, and `db.get_messages_as_conversation(target, include_ancestors=True)` for the display payload) both return the same canned list under the stub, which is exactly what the existing assertions expect — `message_count == 3` and the three filtered hydrated messages. No production change.

The sibling stub in [tests/test_tui_gateway_server.py:101](tests/test_tui_gateway_server.py:101) already uses the `include_ancestors=False` default — this just brings the protocol-level test stub in line.

## Test plan
- [x] Reproduced the failure on clean `origin/main` (`ef41d3bd4`):
  ```
  uv run --with pytest --with pytest-xdist python3 -m pytest tests/tui_gateway/test_protocol.py::test_session_resume_returns_hydrated_messages -v
  → 1 failed (assert 'error' not in {... 'unexpected keyword argument include_ancestors' ...})
  ```
- [x] With the fix applied, `tests/tui_gateway/test_protocol.py` runs **40 passed** (full file, including the previously failing test).
- [x] Regression guard: stashed the fix → reproduced the same `TypeError`-driven JSON-RPC error; popped the stash → green again.

## Related
- d4dde6b5f introduced the `include_ancestors=True` call without updating this stub.
- `tests/test_tui_gateway_server.py:101` already had the matching signature, so this just aligns the second mock.