### PR TITLE
test(tui_gateway): assert target_model in resolve_runtime_provider call

### DIFF
--- a/tests/tui_gateway/test_make_agent_provider.py
+++ b/tests/tui_gateway/test_make_agent_provider.py
@@ -45,7 +45,9 @@ def test_make_agent_passes_resolved_provider():
 
         _make_agent("sid-1", "key-1")
 
-        mock_resolve.assert_called_once_with(requested=None)
+        mock_resolve.assert_called_once_with(
+            requested=None, target_model="claude-opus-4-6"
+        )
 
         call_kwargs = mock_agent.call_args
         assert call_kwargs.kwargs["provider"] == "anthropic"

--- a/tests/tui_gateway/test_make_agent_provider.py
+++ b/tests/tui_gateway/test_make_agent_provider.py
@@ -8,9 +8,18 @@ provider/base_url/api_key empty in AIAgent, causing HTTP 404.
 from unittest.mock import MagicMock, patch
 
 
-def test_make_agent_passes_resolved_provider():
+def test_make_agent_passes_resolved_provider(monkeypatch):
     """_make_agent forwards provider/base_url/api_key/api_mode from
     resolve_runtime_provider to AIAgent."""
+
+    # ``_resolve_model()`` consults ``HERMES_MODEL`` /
+    # ``HERMES_INFERENCE_MODEL`` *before* falling back to the patched
+    # ``_load_cfg`` value, so a developer running the suite with either
+    # env var set would see the resolved model — and therefore the
+    # ``target_model`` kwarg — diverge from the config default this test
+    # asserts on.  Clear them up front so the assertion is hermetic.
+    monkeypatch.delenv("HERMES_MODEL", raising=False)
+    monkeypatch.delenv("HERMES_INFERENCE_MODEL", raising=False)
 
     fake_runtime = {
         "provider": "anthropic",


### PR DESCRIPTION
## Summary
- `_make_agent` in `tui_gateway/server.py:1410-1413` was updated in [e9c47c704](https://github.com/NousResearch/hermes-agent/commit/e9c47c704) (\"fix(tui): honor launch model overrides\") to pass `target_model=model or None` to `resolve_runtime_provider`. The regression test in `tests/tui_gateway/test_make_agent_provider.py` still pinned the old shape with `assert_called_once_with(requested=None)`, so it fails on clean `origin/main`.
- Update the assertion to match — keeps the existing intent (AIAgent is built from the resolved runtime) and the test still proves the call to `resolve_runtime_provider` happens once with the right kwargs.

## The bug

Before e9c47c704, `_make_agent` called:
```python
runtime = resolve_runtime_provider(requested=requested_provider)
```

After e9c47c704, it threads the configured/launch model in:
```python
runtime = resolve_runtime_provider(
    requested=requested_provider,
    target_model=model or None,
)
```

The fake config used by this test (`fake_cfg = {\"model\": {\"default\": \"claude-opus-4-6\", ...}}`) makes `model = \"claude-opus-4-6\"`, so the production call now includes `target_model=\"claude-opus-4-6\"`. The strict `assert_called_once_with(requested=None)` raises:

```
AssertionError: expected call not found.
Expected: resolve_runtime_provider(requested=None)
  Actual: resolve_runtime_provider(requested=None, target_model='claude-opus-4-6')
```

This reproduces on `ef41d3bd4` (current `origin/main`) under `python3.11` and `python3.12`.

## The fix

Update the assertion to:
```python
mock_resolve.assert_called_once_with(
    requested=None, target_model=\"claude-opus-4-6\"
)
```

The test continues to verify the documented behavior described in its own docstring (\"_make_agent forwards provider/base_url/api_key/api_mode from resolve_runtime_provider to AIAgent\") via the four `call_kwargs.kwargs[...] == ...` assertions immediately below. Only the call-site shape was updated to reflect the new kwarg.

## Test plan
- [x] Reproduced on clean `origin/main` (`ef41d3bd4`):
  ```
  uv run --with pytest --with pytest-xdist python3 -m pytest tests/tui_gateway/test_make_agent_provider.py::test_make_agent_passes_resolved_provider -v
  → 1 failed (\"Expected: resolve_runtime_provider(requested=None) / Actual: ...target_model='claude-opus-4-6'\")
  ```
- [x] With the fix applied, full file is green: `tests/tui_gateway/test_make_agent_provider.py` → **6 passed**.
- [x] No production change.

## Related
- e9c47c704 introduced the new kwarg without updating this assertion.
- The other 5 tests in this file already account for `target_model` because they don't strictly pin the call signature — only this one was strict.