### PR TITLE
fix(bedrock): correct context lengths for Claude 4.x models to 1M tokens

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -1181,8 +1181,9 @@ def classify_bedrock_error(error_message: str) -> str:
 
 BEDROCK_CONTEXT_LENGTHS: Dict[str, int] = {
     # Anthropic Claude models on Bedrock
-    "anthropic.claude-opus-4-6":     200_000,
-    "anthropic.claude-sonnet-4-6":   200_000,
+    "anthropic.claude-opus-4-7":     1_000_000,
+    "anthropic.claude-opus-4-6":     1_000_000,
+    "anthropic.claude-sonnet-4-6":   1_000_000,
     "anthropic.claude-sonnet-4-5":   200_000,
     "anthropic.claude-haiku-4-5":    200_000,
     "anthropic.claude-opus-4":       200_000,


### PR DESCRIPTION
## Summary

`BEDROCK_CONTEXT_LENGTHS` in `agent/bedrock_adapter.py` had incorrect 200K context lengths for the Claude 4.x models that actually support 1M tokens on Bedrock. This causes context compression to trigger far too early (at ~100K tokens instead of ~500K), wasting the model's large context window.

## Changes

| Model | Before | After |
|---|---|---|
| `anthropic.claude-opus-4-7` | *(missing)* | 1,000,000 |
| `anthropic.claude-opus-4-6` | 200,000 | 1,000,000 |
| `anthropic.claude-sonnet-4-6` | 200,000 | 1,000,000 |

## Root Cause

The `BEDROCK_CONTEXT_LENGTHS` dict is checked early in the model context length resolution order (step 1b in `get_model_context_length()`), intercepting Bedrock providers before the correct values in `DEFAULT_CONTEXT_LENGTHS` are reached. The stale 200K values here override both the config and the model metadata table for any model using the Bedrock Converse transport.

## Testing

Verified manually on Bedrock with `claude-sonnet-4-6` — compression threshold now correctly reflects the 1M context window.