### PR TITLE
fix(gateway): handle image data URLs in media delivery

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -6,6 +6,8 @@ and implement the required methods.
 """
 
 import asyncio
+import base64
+import binascii
 import inspect
 import ipaddress
 import logging
@@ -455,6 +457,15 @@ async def _ssrf_redirect_guard(response):
 # Default location: {HERMES_HOME}/cache/images/ (legacy: image_cache/)
 IMAGE_CACHE_DIR = get_hermes_dir("cache/images", "image_cache")
 
+_IMAGE_DATA_URL_EXTENSIONS = {
+    "image/png": ".png",
+    "image/jpeg": ".jpg",
+    "image/jpg": ".jpg",
+    "image/webp": ".webp",
+    "image/gif": ".gif",
+}
+_MAX_DATA_URL_IMAGE_BYTES = 20 * 1024 * 1024
+
 
 def get_image_cache_dir() -> Path:
     """Return the image cache directory, creating it if it doesn't exist."""
@@ -505,6 +516,89 @@ def cache_image_from_bytes(data: bytes, ext: str = ".jpg") -> str:
     filepath = cache_dir / filename
     filepath.write_bytes(data)
     return str(filepath)
+
+
+def _image_bytes_match_mime(data: bytes, mime_type: str) -> bool:
+    """Return whether decoded image bytes match the declared data URL MIME."""
+    if mime_type == "image/png":
+        return data.startswith(b"\x89PNG\r\n\x1a\n")
+    if mime_type in {"image/jpeg", "image/jpg"}:
+        return data.startswith(b"\xff\xd8")
+    if mime_type == "image/gif":
+        return data.startswith((b"GIF87a", b"GIF89a"))
+    if mime_type == "image/webp":
+        return len(data) >= 12 and data.startswith(b"RIFF") and data[8:12] == b"WEBP"
+    return False
+
+
+def _cache_image_from_data_url(data_url: str) -> str | None:
+    """Decode an explicit image data URL into the controlled image cache."""
+    header, separator, payload = data_url.partition(",")
+    if not separator:
+        return None
+
+    metadata = header[5:] if header.lower().startswith("data:") else header
+    parts = [part.strip().lower() for part in metadata.split(";") if part.strip()]
+    if not parts or "base64" not in parts[1:]:
+        return None
+
+    mime_type = parts[0]
+    ext = _IMAGE_DATA_URL_EXTENSIONS.get(mime_type)
+    if not ext:
+        return None
+
+    payload = payload.replace("\r", "").replace("\n", "")
+
+    # Avoid decoding arbitrarily large inline payloads.  Base64 expands bytes
+    # by roughly 4/3; this check is intentionally conservative.
+    if len(payload) > ((_MAX_DATA_URL_IMAGE_BYTES + 2) // 3) * 4 + 8:
+        logger.warning("Skipping oversized image data URL (%s, %d base64 chars)", mime_type, len(payload))
+        return None
+
+    try:
+        image_bytes = base64.b64decode(payload, validate=True)
+    except (binascii.Error, ValueError):
+        logger.warning("Skipping invalid image data URL payload (%s, %d base64 chars)", mime_type, len(payload))
+        return None
+
+    if len(image_bytes) > _MAX_DATA_URL_IMAGE_BYTES:
+        logger.warning("Skipping oversized decoded image data URL (%s, %d bytes)", mime_type, len(image_bytes))
+        return None
+
+    if not _image_bytes_match_mime(image_bytes, mime_type):
+        logger.warning("Skipping image data URL with mismatched MIME type (%s)", mime_type)
+        return None
+
+    try:
+        return cache_image_from_bytes(image_bytes, ext)
+    except ValueError as exc:
+        logger.warning("Skipping non-image data URL payload (%s): %s", mime_type, exc)
+        return None
+
+
+def _first_data_image_srcset_candidate(value: str) -> str | None:
+    """Return the first data:image candidate from an HTML srcset value."""
+    marker = "data:image/"
+    lower = value.lower()
+    idx = lower.find(marker)
+    if idx == -1:
+        return None
+    header_end = value.find(",", idx)
+    if header_end == -1:
+        return None
+    payload_start = header_end + 1
+    payload_end = len(value)
+    for comma_match in re.finditer(",", value[payload_start:]):
+        comma_idx = payload_start + comma_match.start()
+        if re.match(r'\s*(?:https?:|data:image/)', value[comma_idx + 1:], re.IGNORECASE):
+            payload_end = comma_idx
+            break
+    header = value[idx:header_end].strip()
+    payload_and_descriptor = value[payload_start:payload_end].strip()
+    payload = payload_and_descriptor.split()[0] if payload_and_descriptor else ""
+    if not payload:
+        return None
+    return f"{header},{payload}"
 
 
 async def cache_image_from_url(url: str, ext: str = ".jpg", retries: int = 2) -> str:
@@ -1441,44 +1535,173 @@ class BasePlatformAdapter(ABC):
         
         Finds patterns like:
         - ![alt text](https://example.com/image.png)
+        - ![alt text](data:image/png;base64,...)
         - <img src="https://example.com/image.png">
+        - <img src="data:image/png;base64,...">
         - <img src="https://example.com/image.png"></img>
         
         Args:
             content: The response text to scan.
         
         Returns:
-            Tuple of (list of (url, alt_text) pairs, cleaned content with image tags removed).
+            Tuple of (list of (url/path, alt_text) pairs, cleaned content with image tags removed).
         """
         images = []
         cleaned = content
+        tags_to_remove: list[tuple[int, int]] = []
         
-        # Match markdown images: ![alt](url)
+        # Match HTML img tags with a quote-aware scanner. A bare regex like
+        # ``[^>]*`` stops too early when another attribute contains a literal
+        # ``>`` inside quotes (for example: alt="x > y").
+        def _iter_html_img_tags(text: str):
+            pos = 0
+            while True:
+                match = re.search(r'<img\b', text[pos:], re.IGNORECASE)
+                if not match:
+                    break
+                start = pos + match.start()
+                idx = start
+                quote = None
+                while idx < len(text):
+                    ch = text[idx]
+                    if quote:
+                        if ch == quote:
+                            quote = None
+                    elif ch in {'"', "'"}:
+                        quote = ch
+                    elif ch == ">":
+                        end = idx + 1
+                        closing = re.match(r'\s*</img>', text[end:], re.IGNORECASE)
+                        if closing:
+                            end += closing.end()
+                        yield start, end, text[start:end]
+                        pos = end
+                        break
+                    idx += 1
+                else:
+                    break
+
+        html_img_tags = list(_iter_html_img_tags(content))
+        html_img_spans = [(start, end) for start, end, _ in html_img_tags]
+
+        def _inside_html_img_tag(position: int) -> bool:
+            return any(start <= position < end for start, end in html_img_spans)
+
+        # Match markdown images: ![alt](url). Markdown-looking text inside
+        # HTML <img> attributes is handled by the HTML path below, not this
+        # global regex.
         md_pattern = r'!\[([^\]]*)\]\((https?://[^\s\)]+)\)'
         for match in re.finditer(md_pattern, content):
+            if _inside_html_img_tag(match.start()):
+                continue
             alt_text = match.group(1)
             url = match.group(2)
             # Only extract URLs that look like actual images
             if any(url.lower().endswith(ext) or ext in url.lower() for ext in
                    ['.png', '.jpg', '.jpeg', '.gif', '.webp', 'fal.media', 'fal-cdn', 'replicate.delivery']):
                 images.append((url, alt_text))
+                tags_to_remove.append(match.span())
+
+        # Match markdown image data URLs. These are explicit inline image payloads,
+        # so remove them from displayed text even when the MIME type is not one
+        # we decode/cache. The whitelist is enforced inside
+        # _cache_image_from_data_url(). Markdown-like text inside HTML <img>
+        # attributes is handled by the HTML path below, not this global regex.
+        md_data_pattern = r'!\[([^\]]*)\]\(\s*<?\s*(data:image/[^,\)>\s]+(?:;[^,\)>\s]+)*,[^\)>]*?)\s*>?\s*\)'
+        for match in re.finditer(md_data_pattern, content, re.IGNORECASE | re.DOTALL):
+            if _inside_html_img_tag(match.start()):
+                continue
+            alt_text = match.group(1)
+            image_path = _cache_image_from_data_url(match.group(2).strip())
+            if image_path:
+                images.append((image_path, alt_text))
+            tags_to_remove.append(match.span())
+
+        def _html_img_attrs(tag: str) -> list[tuple[str, str]]:
+            attrs: list[tuple[str, str]] = []
+            match = re.match(r'\s*<img\b', tag, re.IGNORECASE)
+            idx = match.end() if match else 0
+            length = len(tag)
+            while idx < length:
+                while idx < length and tag[idx].isspace():
+                    idx += 1
+                if idx >= length or tag[idx] in ">/":
+                    break
+                name_start = idx
+                while idx < length and (tag[idx].isalnum() or tag[idx] in "_:-"):
+                    idx += 1
+                if idx == name_start:
+                    idx += 1
+                    continue
+                name = tag[name_start:idx].lower()
+                while idx < length and tag[idx].isspace():
+                    idx += 1
+                value = ""
+                if idx < length and tag[idx] == "=":
+                    idx += 1
+                    while idx < length and tag[idx].isspace():
+                        idx += 1
+                    if idx < length and tag[idx] in {'"', "'"}:
+                        quote = tag[idx]
+                        idx += 1
+                        value_start = idx
+                        while idx < length and tag[idx] != quote:
+                            idx += 1
+                        value = tag[value_start:idx]
+                        if idx < length:
+                            idx += 1
+                    else:
+                        value_start = idx
+                        while idx < length and not tag[idx].isspace() and tag[idx] != ">":
+                            idx += 1
+                        value = tag[value_start:idx].rstrip("/")
+                attrs.append((name, value))
+            return attrs
+
+        for start, end, tag in _iter_html_img_tags(content):
+            attrs = _html_img_attrs(tag)
+            src = next((value for name, value in attrs if name == "src"), "").strip()
+            src_lower = src.lower()
+            data_image_values = []
+            if src_lower.startswith("data:image/"):
+                data_image_values.append(src)
+            data_src = next((value for name, value in attrs if name == "data-src"), "").strip()
+            if data_src.lower().startswith("data:image/"):
+                data_image_values.append(data_src)
+            srcset = next((value for name, value in attrs if name == "srcset"), "").strip()
+            srcset_data_url = _first_data_image_srcset_candidate(srcset)
+            if srcset_data_url:
+                data_image_values.append(srcset_data_url)
+            if src_lower.startswith(("http://", "https://")) and not data_image_values:
+                images.append((src, ""))
+                tags_to_remove.append((start, end))
+            elif data_image_values:
+                image_path = None
+                for data_url in data_image_values:
+                    image_path = _cache_image_from_data_url(data_url)
+                    if image_path:
+                        break
+                if image_path:
+                    images.append((image_path, ""))
+                tags_to_remove.append((start, end))
+            elif "data:image/" in tag.lower():
+                tags_to_remove.append((start, end))
         
-        # Match HTML img tags: <img src="url"> or <img src="url"></img> or <img src="url"/>
-        html_pattern = r'<img\s+src=["\']?(https?://[^\s"\'<>]+)["\']?\s*/?>\s*(?:</img>)?'
-        for match in re.finditer(html_pattern, content):
-            url = match.group(1)
-            images.append((url, ""))
-        
-        # Remove only the matched image tags from content (not all markdown images)
-        if images:
-            extracted_urls = {url for url, _ in images}
-            def _remove_if_extracted(match):
-                url = match.group(2) if match.lastindex >= 2 else match.group(1)
-                return '' if url in extracted_urls else match.group(0)
-            cleaned = re.sub(md_pattern, _remove_if_extracted, cleaned)
-            cleaned = re.sub(html_pattern, _remove_if_extracted, cleaned)
+        if tags_to_remove:
+            pieces = []
+            last = 0
+            for start, end in sorted(tags_to_remove):
+                if start < last:
+                    continue
+                pieces.append(cleaned[last:start])
+                last = end
+            pieces.append(cleaned[last:])
+            cleaned = ''.join(pieces)
             # Clean up leftover blank lines
             cleaned = re.sub(r'\n{3,}', '\n\n', cleaned).strip()
+        bare_data_idx = cleaned.lower().find("data:image/")
+        if bare_data_idx != -1:
+            cleaned = cleaned[:bare_data_idx].strip()
         
         return images, cleaned
     
@@ -2410,6 +2633,11 @@ class BasePlatformAdapter(ABC):
                 # Human-like pacing delay between text and media
                 human_delay = self._get_human_delay()
 
+                # Send extracted media files — route by file type
+                _AUDIO_EXTS = {'.ogg', '.opus', '.mp3', '.wav', '.m4a'}
+                _VIDEO_EXTS = {'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'}
+                _IMAGE_EXTS = {'.jpg', '.jpeg', '.png', '.webp', '.gif'}
+
                 # Send extracted images as native attachments
                 if images:
                     logger.info("[%s] Extracted %d image(s) to send as attachments", self.name, len(images))
@@ -2423,8 +2651,21 @@ class BasePlatformAdapter(ABC):
                             safe_url_for_log(image_url),
                             alt_text[:30] if alt_text else "",
                         )
+                        image_ext = Path(image_url).suffix.lower()
+                        image_is_remote = bool(urlsplit(image_url).scheme)
+                        if (
+                            not image_is_remote
+                            and image_ext in _IMAGE_EXTS
+                            and os.path.isfile(os.path.expanduser(image_url))
+                        ):
+                            img_result = await self.send_image_file(
+                                chat_id=event.source.chat_id,
+                                image_path=os.path.expanduser(image_url),
+                                caption=alt_text if alt_text else None,
+                                metadata=_thread_metadata,
+                            )
                         # Route animated GIFs through send_animation for proper playback
-                        if self._is_animation_url(image_url):
+                        elif self._is_animation_url(image_url):
                             img_result = await self.send_animation(
                                 chat_id=event.source.chat_id,
                                 animation_url=image_url,
@@ -2442,11 +2683,6 @@ class BasePlatformAdapter(ABC):
                             logger.error("[%s] Failed to send image: %s", self.name, img_result.error)
                     except Exception as img_err:
                         logger.error("[%s] Error sending image: %s", self.name, img_err, exc_info=True)
-
-                # Send extracted media files — route by file type
-                _AUDIO_EXTS = {'.ogg', '.opus', '.mp3', '.wav', '.m4a'}
-                _VIDEO_EXTS = {'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'}
-                _IMAGE_EXTS = {'.jpg', '.jpeg', '.png', '.webp', '.gif'}
 
                 for media_path, is_voice in media_files:
                     if human_delay > 0:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -30,6 +30,7 @@ from contextvars import copy_context
 from pathlib import Path
 from datetime import datetime
 from typing import Dict, Optional, Any, List
+from urllib.parse import urlsplit
 
 from agent.account_usage import fetch_account_usage, render_account_usage_lines
 
@@ -6654,7 +6655,7 @@ class GatewayRunner:
 
         try:
             media_files, _ = adapter.extract_media(response)
-            _, cleaned = adapter.extract_images(response)
+            images, cleaned = adapter.extract_images(response)
             local_files, _ = adapter.extract_local_files(cleaned)
 
             _thread_meta = {"thread_id": event.source.thread_id} if event.source.thread_id else None
@@ -6662,6 +6663,26 @@ class GatewayRunner:
             _AUDIO_EXTS = {'.ogg', '.opus', '.mp3', '.wav', '.m4a'}
             _VIDEO_EXTS = {'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'}
             _IMAGE_EXTS = {'.jpg', '.jpeg', '.png', '.webp', '.gif'}
+
+            for image_url, alt_text in images:
+                try:
+                    ext = Path(image_url).suffix.lower()
+                    if urlsplit(str(image_url)).scheme:
+                        continue
+                    image_path = Path(os.path.expanduser(image_url))
+                    # Streaming display has already handled text. Only deliver
+                    # cached/local images here, which covers decoded data URL
+                    # images without duplicating remote HTTP markdown/HTML
+                    # images that may already have been visible in the stream.
+                    if ext in _IMAGE_EXTS and image_path.is_file():
+                        await adapter.send_image_file(
+                            chat_id=event.source.chat_id,
+                            image_path=str(image_path),
+                            caption=alt_text if alt_text else None,
+                            metadata=_thread_meta,
+                        )
+                except Exception as e:
+                    logger.warning("[%s] Post-stream image delivery failed: %s", adapter.name, e)
 
             for media_path, is_voice in media_files:
                 try:

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -123,6 +123,14 @@ class GatewayStreamConsumer:
             getattr(adapter, "REQUIRES_EDIT_FINALIZE", False) is True
         )
 
+        # Data URLs can be much larger than normal text, and streaming may
+        # deliver them in multiple chunks. Keep a small text prefix visible,
+        # but hold the image tag itself until it is complete so partial
+        # ``data:image/...;base64,...`` payloads are never sent as text.
+        self._pending_image_data_url = ""
+        self._pending_image_data_url_confirmed = False
+        self._data_url_prefix_buffer = ""
+
         # Think-block filter state (mirrors CLI's _stream_delta tag suppression)
         self._in_think_block = False
         self._think_buffer = ""
@@ -152,6 +160,9 @@ class GatewayStreamConsumer:
         self._message_id = None
         self._message_created_ts = None
         self._accumulated = ""
+        self._pending_image_data_url = ""
+        self._pending_image_data_url_confirmed = False
+        self._data_url_prefix_buffer = ""
         self._last_sent_text = ""
         self._fallback_final_send = False
         self._fallback_prefix = ""
@@ -278,6 +289,287 @@ class GatewayStreamConsumer:
             self._accumulated += self._think_buffer
             self._think_buffer = ""
 
+    @staticmethod
+    def _html_tag_end(text: str, start: int = 0) -> int:
+        """Return the exclusive end offset of an HTML tag, respecting quotes."""
+        quote = None
+        idx = start
+        while idx < len(text):
+            ch = text[idx]
+            if quote:
+                if ch == quote:
+                    quote = None
+            elif ch in {'"', "'"}:
+                quote = ch
+            elif ch == ">":
+                return idx + 1
+            idx += 1
+        return -1
+
+    @staticmethod
+    def _strip_html_image_data_urls(text: str) -> str:
+        """Remove explicit HTML image data URL tags with quote-aware parsing."""
+        lower = text.lower()
+        output: list[str] = []
+        pos = 0
+        while True:
+            start = lower.find("<img", pos)
+            if start == -1:
+                output.append(text[pos:])
+                break
+            output.append(text[pos:start])
+            end = GatewayStreamConsumer._html_tag_end(text, start)
+            if end == -1:
+                output.append(text[start:])
+                break
+            tag = text[start:end]
+            if GatewayStreamConsumer._html_img_has_data_image_attr(tag):
+                pos = end
+                closing = re.match(r'\s*</img>', text[pos:], re.IGNORECASE)
+                if closing:
+                    pos += closing.end()
+            else:
+                output.append(tag)
+                pos = end
+        return "".join(output)
+
+    @staticmethod
+    def _html_img_attrs(tag: str) -> list[tuple[str, str]]:
+        """Extract HTML attributes from an <img> tag without reading quoted text as markup."""
+        attrs: list[tuple[str, str]] = []
+        match = re.match(r'\s*<img\b', tag, re.IGNORECASE)
+        idx = match.end() if match else 0
+        length = len(tag)
+        while idx < length:
+            while idx < length and tag[idx].isspace():
+                idx += 1
+            if idx >= length or tag[idx] in ">/":
+                break
+            name_start = idx
+            while idx < length and (tag[idx].isalnum() or tag[idx] in "_:-"):
+                idx += 1
+            if idx == name_start:
+                idx += 1
+                continue
+            name = tag[name_start:idx].lower()
+            while idx < length and tag[idx].isspace():
+                idx += 1
+            value = ""
+            if idx < length and tag[idx] == "=":
+                idx += 1
+                while idx < length and tag[idx].isspace():
+                    idx += 1
+                if idx < length and tag[idx] in {'"', "'"}:
+                    quote = tag[idx]
+                    idx += 1
+                    value_start = idx
+                    while idx < length and tag[idx] != quote:
+                        idx += 1
+                    value = tag[value_start:idx]
+                    if idx < length:
+                        idx += 1
+                else:
+                    value_start = idx
+                    while idx < length and not tag[idx].isspace() and tag[idx] != ">":
+                        idx += 1
+                    value = tag[value_start:idx].rstrip("/")
+            attrs.append((name, value))
+        return attrs
+
+    @staticmethod
+    def _html_img_src(tag: str) -> str | None:
+        """Extract the real src attribute from a complete <img ...> tag fragment."""
+        for name, value in GatewayStreamConsumer._html_img_attrs(tag):
+            if name == "src":
+                return value
+        return None
+
+    @staticmethod
+    def _html_img_data_image_values(tag: str) -> list[str]:
+        """Return data:image values from URL-bearing img attributes only."""
+        values: list[str] = []
+        for name, value in GatewayStreamConsumer._html_img_attrs(tag):
+            lower_value = value.strip().lower()
+            stripped_value = value.strip()
+            if name in {"src", "data-src"} and lower_value.startswith("data:image/"):
+                values.append(stripped_value)
+            elif name == "srcset" and "data:image/" in lower_value:
+                values.append(stripped_value)
+        return values
+
+    @staticmethod
+    def _html_img_has_data_image_attr(tag: str) -> bool:
+        """Return True when a URL-bearing img attribute carries an image data URL."""
+        return bool(GatewayStreamConsumer._html_img_data_image_values(tag))
+
+    @staticmethod
+    def _partial_image_tag_start(text: str) -> tuple[int, str] | None:
+        """Return the start of a trailing partial Markdown/HTML image opener."""
+        lower = text.lower()
+        prefixes = ("![", "<im", "<i", "<")
+        for prefix in prefixes:
+            if lower.endswith(prefix):
+                return len(text) - len(prefix), prefix
+        return None
+
+    @staticmethod
+    def _pending_image_data_url_is_unsafe(text: str) -> bool:
+        """Return True when held-back text is an incomplete data URL payload."""
+        lower = text.lower()
+        if "data:image/" in lower or lower.lstrip().startswith("data:"):
+            return True
+        if re.search(r'!\[[^\]]*\]\(\s*<?\s*data:', lower, re.DOTALL):
+            return True
+        if lower.lstrip().startswith("<img"):
+            for name, value in GatewayStreamConsumer._html_img_attrs(text):
+                stripped = value.strip().lower()
+                if name in {"src", "data-src", "srcset"} and stripped.startswith("data:"):
+                    return True
+        return False
+
+    def _filter_image_data_urls(self, text: str, *, final: bool = False) -> str:
+        """Hold incomplete image data URL tags so streaming never leaks base64."""
+        marker = "data:image/"
+
+        if final:
+            # End-of-stream is the only point where an incomplete pending image
+            # tag is unrecoverable. Drop that tag instead of prepending it back
+            # into visible text and leaking a partial data URL. A short prefix
+            # buffer is only speculative (for example trailing "da"), so keep it.
+            if self._data_url_prefix_buffer:
+                text += self._data_url_prefix_buffer
+                self._data_url_prefix_buffer = ""
+            if self._pending_image_data_url and not self._pending_image_data_url_confirmed:
+                if not self._pending_image_data_url_is_unsafe(self._pending_image_data_url):
+                    text += self._pending_image_data_url
+            self._pending_image_data_url = ""
+            self._pending_image_data_url_confirmed = False
+        else:
+            if self._data_url_prefix_buffer:
+                text = self._data_url_prefix_buffer + text
+                self._data_url_prefix_buffer = ""
+            if self._pending_image_data_url:
+                text = self._pending_image_data_url + text
+                self._pending_image_data_url = ""
+                self._pending_image_data_url_confirmed = False
+
+        lower = text.lower()
+        idx = lower.find(marker)
+        if idx == -1:
+            if final:
+                return text
+
+            md_open = text.rfind("![")
+            html_open = lower.rfind("<img")
+            tag_start = max(md_open, html_open)
+            if tag_start != -1:
+                candidate = text[tag_start:]
+                is_html = lower.startswith("<img", tag_start)
+                tag_closed = self._html_tag_end(candidate) != -1 if is_html else ")" in candidate
+                if is_html and not tag_closed:
+                    self._pending_image_data_url = candidate
+                    self._pending_image_data_url_confirmed = "data:image/" in candidate.lower()
+                    return text[:tag_start]
+                if not tag_closed:
+                    markdown_url_pending = re.search(r'!\[[^\]]*\]\(\s*<?\s*$', candidate, re.IGNORECASE)
+                    if (
+                        marker.startswith(candidate.lower())
+                        or "data:" in candidate.lower()
+                        or markdown_url_pending
+                        or candidate.startswith("![")
+                    ):
+                        self._pending_image_data_url = candidate
+                        self._pending_image_data_url_confirmed = "data:image/" in candidate.lower()
+                        return text[:tag_start]
+
+            partial_start = self._partial_image_tag_start(text)
+            if partial_start is not None:
+                tag_start, _ = partial_start
+                self._pending_image_data_url = text[tag_start:]
+                self._pending_image_data_url_confirmed = False
+                return text[:tag_start]
+
+            max_prefix = min(len(marker) - 1, len(text))
+            hold = 0
+            for length in range(1, max_prefix + 1):
+                if marker.startswith(lower[-length:]):
+                    hold = length
+            if hold:
+                partial_start = len(text) - hold
+                md_tag_start = text.rfind("![", 0, partial_start + 1)
+                html_tag_start = lower.rfind("<img", 0, partial_start + 1)
+                tag_start = max(md_tag_start, html_tag_start)
+                if tag_start != -1:
+                    candidate = text[tag_start:]
+                    is_html = lower.startswith("<img", tag_start)
+                    tag_closed = self._html_tag_end(candidate) != -1 if is_html else ")" in candidate
+                    if not tag_closed:
+                        self._pending_image_data_url = candidate
+                        self._pending_image_data_url_confirmed = "data:image/" in candidate.lower()
+                        return text[:tag_start]
+                boundary_ok = (
+                    partial_start == 0
+                    or not (text[partial_start - 1].isalnum() or text[partial_start - 1] in "_-/.")
+                )
+                if boundary_ok:
+                    self._data_url_prefix_buffer = text[partial_start:]
+                    return text[:partial_start]
+            return text
+
+        tag_start = max(
+            text.rfind("![", 0, idx),
+            lower.rfind("<img", 0, idx),
+        )
+        if tag_start != -1 and text[tag_start:tag_start + 2] == "![":
+            prior_markdown_end = text.find(")", tag_start, idx)
+            if prior_markdown_end != -1:
+                tag_start = lower.rfind("<img", 0, idx)
+        if tag_start == -1:
+            # Unknown data URL shape. Hide the payload once detected rather
+            # than risk sending raw base64 as user-visible streaming text.
+            if final:
+                return text[:idx]
+            self._pending_image_data_url = text[idx:]
+            self._pending_image_data_url_confirmed = True
+            return text[:idx]
+
+        is_html = text[tag_start:tag_start + 4].lower() == "<img"
+        if is_html:
+            tag_end = self._html_tag_end(text, tag_start)
+            if tag_end == -1:
+                if final:
+                    return text[:tag_start]
+                self._pending_image_data_url = text[tag_start:]
+                self._pending_image_data_url_confirmed = "data:image/" in text[tag_start:].lower()
+                return text[:tag_start]
+            tag = text[tag_start:tag_end]
+            if marker not in tag.lower():
+                return text[:tag_end] + self._filter_image_data_urls(text[tag_end:], final=final)
+            closing = re.match(r'\s*</img>', text[tag_end:], re.IGNORECASE)
+            if closing:
+                tag_end += closing.end()
+        else:
+            tag_end = text.find(")", idx)
+            if tag_end == -1:
+                if final:
+                    return text[:tag_start]
+                self._pending_image_data_url = text[tag_start:]
+                self._pending_image_data_url_confirmed = "data:image/" in text[tag_start:].lower()
+                return text[:tag_start]
+            tag_end += 1
+            tag_body = text[tag_start:tag_end].lower()
+            if not tag_body.lstrip().startswith("![") or marker not in tag_body:
+                return text[:tag_end] + self._filter_image_data_urls(text[tag_end:], final=final)
+
+        return text[:tag_start] + self._filter_image_data_urls(text[tag_end:], final=final)
+
+    def _flush_image_data_url_buffer(self) -> None:
+        """Drop any incomplete buffered image data URL at stream end."""
+        if self._pending_image_data_url:
+            self._pending_image_data_url = ""
+        if self._data_url_prefix_buffer:
+            self._data_url_prefix_buffer = ""
+
     async def run(self) -> None:
         """Async task that drains the queue and edits the platform message."""
         # Platform message length limit — leave room for cursor + formatting
@@ -302,7 +594,14 @@ class GatewayStreamConsumer:
                         if isinstance(item, tuple) and len(item) == 2 and item[0] is _COMMENTARY:
                             commentary_text = item[1]
                             break
+                        before_len = len(self._accumulated)
                         self._filter_and_accumulate(item)
+                        suffix = self._accumulated[before_len:]
+                        if suffix or self._pending_image_data_url:
+                            self._accumulated = (
+                                self._accumulated[:before_len]
+                                + self._filter_image_data_urls(suffix)
+                            )
                     except queue.Empty:
                         break
 
@@ -311,6 +610,18 @@ class GatewayStreamConsumer:
                 # tag is not lost.
                 if got_done:
                     self._flush_think_buffer()
+                    self._accumulated = self._filter_image_data_urls(self._accumulated, final=True)
+                    self._flush_image_data_url_buffer()
+
+                if got_segment_break:
+                    if self._data_url_prefix_buffer and not self._pending_image_data_url:
+                        self._accumulated += self._data_url_prefix_buffer
+                        self._data_url_prefix_buffer = ""
+                    if self._pending_image_data_url and not self._pending_image_data_url_confirmed:
+                        if not self._pending_image_data_url_is_unsafe(self._pending_image_data_url):
+                            self._accumulated += self._pending_image_data_url
+                        self._pending_image_data_url = ""
+                        self._pending_image_data_url_confirmed = False
 
                 # Decide whether to flush an edit
                 now = time.monotonic()
@@ -328,6 +639,23 @@ class GatewayStreamConsumer:
                     )
 
                 current_update_visible = False
+                if (
+                    should_edit
+                    and self._accumulated
+                    and not got_done
+                    and not self._pending_image_data_url
+                    and not self._data_url_prefix_buffer
+                ):
+                    # Defence-in-depth for cross-chunk bare data URLs. Suffix-only
+                    # filtering can miss cases like previous text ending in
+                    # "xdata" followed by ":image/..."; clean the whole visible
+                    # buffer before any send/split so base64-only overflow chunks
+                    # cannot escape.
+                    self._accumulated = self._filter_image_data_urls(
+                        self._accumulated,
+                        final=got_segment_break,
+                    )
+
                 if should_edit and self._accumulated:
                     # Split overflow: if accumulated text exceeds the platform
                     # limit, split into properly sized chunks.
@@ -488,22 +816,43 @@ class GatewayStreamConsumer:
     # Matches the simple cleanup regex used by the non-streaming path in
     # gateway/platforms/base.py for post-processing.
     _MEDIA_RE = re.compile(r'''[`"']?MEDIA:\s*\S+[`"']?''')
+    _MARKDOWN_IMAGE_DATA_URL_RE = re.compile(
+        r'!\[[^\]]*\]\(\s*<?\s*data:image/[^,\)>\s]+(?:;[^,\)>\s]+)*,[^\)>]*?\s*>?\s*\)',
+        re.IGNORECASE | re.DOTALL,
+    )
+    @staticmethod
+    def _strip_image_data_urls(text: str) -> str:
+        """Remove explicit inline image data URL tags without guessing bare base64."""
+        if "data:image/" not in text.lower():
+            return text
+        text = GatewayStreamConsumer._MARKDOWN_IMAGE_DATA_URL_RE.sub("", text)
+        text = GatewayStreamConsumer._strip_html_image_data_urls(text)
+        idx = text.lower().find("data:image/")
+        if idx != -1:
+            text = text[:idx]
+        return text
 
     @staticmethod
     def _clean_for_display(text: str) -> str:
-        """Strip MEDIA: directives and internal markers from text before display.
+        """Strip MEDIA: directives, inline image data URLs, and internal markers from text before display.
 
         The streaming path delivers raw text chunks that may include
-        ``MEDIA:<path>`` tags and ``[[audio_as_voice]]`` directives meant for
-        the platform adapter's post-processing.  The actual media files are
-        delivered separately via ``_deliver_media_from_response()`` after the
-        stream finishes — we just need to hide the raw directives from the
-        user.
+        ``MEDIA:<path>`` tags, explicit image data URL tags, and
+        ``[[audio_as_voice]]`` directives meant for the platform adapter's
+        post-processing.  The actual media files are delivered separately via
+        ``_deliver_media_from_response()`` after the stream finishes — we just
+        need to hide raw directives/payloads from the user.
         """
-        if "MEDIA:" not in text and "[[audio_as_voice]]" not in text:
+        needs_cleanup = (
+            "MEDIA:" in text
+            or "[[audio_as_voice]]" in text
+            or "data:image/" in text.lower()
+        )
+        if not needs_cleanup:
             return text
         cleaned = text.replace("[[audio_as_voice]]", "")
         cleaned = GatewayStreamConsumer._MEDIA_RE.sub("", cleaned)
+        cleaned = GatewayStreamConsumer._strip_image_data_urls(cleaned)
         # Collapse excessive blank lines left behind by removed tags
         cleaned = re.sub(r'\n{3,}', '\n\n', cleaned)
         # Strip trailing whitespace/newlines but preserve leading content

--- a/tests/gateway/test_base_topic_sessions.py
+++ b/tests/gateway/test_base_topic_sessions.py
@@ -1,6 +1,7 @@
 """Tests for BasePlatformAdapter topic-aware session handling."""
 
 import asyncio
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -14,6 +15,8 @@ class DummyTelegramAdapter(BasePlatformAdapter):
     def __init__(self):
         super().__init__(PlatformConfig(enabled=True, token="fake-token"), Platform.TELEGRAM)
         self.sent = []
+        self.image_files = []
+        self.remote_images = []
         self.typing = []
         self.processing_hooks = []
 
@@ -33,6 +36,30 @@ class DummyTelegramAdapter(BasePlatformAdapter):
             }
         )
         return SendResult(success=True, message_id="1")
+
+    async def send_image_file(self, chat_id, image_path, caption=None, reply_to=None, **kwargs) -> SendResult:
+        self.image_files.append(
+            {
+                "chat_id": chat_id,
+                "image_path": image_path,
+                "caption": caption,
+                "reply_to": reply_to,
+                "metadata": kwargs.get("metadata"),
+            }
+        )
+        return SendResult(success=True, message_id="img1")
+
+    async def send_image(self, chat_id, image_url, caption=None, reply_to=None, metadata=None) -> SendResult:
+        self.remote_images.append(
+            {
+                "chat_id": chat_id,
+                "image_url": image_url,
+                "caption": caption,
+                "reply_to": reply_to,
+                "metadata": metadata,
+            }
+        )
+        return SendResult(success=True, message_id="remote-img1")
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         self.typing.append({"chat_id": chat_id, "metadata": metadata})
@@ -143,6 +170,87 @@ class TestBasePlatformTopicSessions:
         assert adapter.processing_hooks == [
             ("start", "1"),
             ("complete", "1", ProcessingOutcome.SUCCESS),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_process_message_background_routes_data_url_image_as_local_file(self, tmp_path, monkeypatch):
+        from gateway.platforms import base as base_module
+
+        monkeypatch.setattr(base_module, "IMAGE_CACHE_DIR", tmp_path)
+        adapter = DummyTelegramAdapter()
+        typing_calls = []
+        png_data_url = (
+            "data:image/png;base64,"
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ"
+            "AAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+        )
+
+        async def handler(_event):
+            await asyncio.sleep(0)
+            return f"Generated image:\n![tiny]({png_data_url})\nDone."
+
+        async def hold_typing(_chat_id, interval=2.0, metadata=None):
+            typing_calls.append({"chat_id": _chat_id, "metadata": metadata})
+            await asyncio.Event().wait()
+
+        adapter.set_message_handler(handler)
+        adapter._keep_typing = hold_typing
+
+        event = _make_event("-1001", "17585")
+        await adapter._process_message_background(event, build_session_key(event.source))
+
+        assert adapter.sent == [
+            {
+                "chat_id": "-1001",
+                "content": "Generated image:\n\nDone.",
+                "reply_to": "1",
+                "metadata": {"thread_id": "17585"},
+            }
+        ]
+        assert len(adapter.image_files) == 1
+        image_delivery = adapter.image_files[0]
+        assert image_delivery["chat_id"] == "-1001"
+        assert image_delivery["caption"] == "tiny"
+        assert image_delivery["metadata"] == {"thread_id": "17585"}
+        image_path = Path(image_delivery["image_path"])
+        assert image_path.suffix == ".png"
+        assert image_path.is_file()
+        assert image_path.parent == tmp_path
+        assert adapter.remote_images == []
+        assert "data:image" not in adapter.sent[0]["content"]
+        assert "base64" not in adapter.sent[0]["content"]
+
+    @pytest.mark.asyncio
+    async def test_process_message_background_never_treats_remote_url_as_local_file(self, tmp_path, monkeypatch):
+        """Remote image URLs must not be uploaded as local files even if a matching path exists."""
+        adapter = DummyTelegramAdapter()
+        matching_local = tmp_path / "https:" / "example.com"
+        matching_local.mkdir(parents=True)
+        (matching_local / "image.png").write_bytes(b"not the remote image")
+        monkeypatch.chdir(tmp_path)
+
+        async def handler(_event):
+            await asyncio.sleep(0)
+            return "Remote image:\n![remote](https://example.com/image.png)"
+
+        async def hold_typing(_chat_id, interval=2.0, metadata=None):
+            await asyncio.Event().wait()
+
+        adapter.set_message_handler(handler)
+        adapter._keep_typing = hold_typing
+
+        event = _make_event("-1001", "17585")
+        await adapter._process_message_background(event, build_session_key(event.source))
+
+        assert adapter.image_files == []
+        assert adapter.remote_images == [
+            {
+                "chat_id": "-1001",
+                "image_url": "https://example.com/image.png",
+                "caption": "remote",
+                "reply_to": None,
+                "metadata": {"thread_id": "17585"},
+            }
         ]
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -1,6 +1,7 @@
 """Tests for gateway/platforms/base.py — MessageEvent, media extraction, message truncation."""
 
 import os
+from pathlib import Path
 from unittest.mock import patch
 
 from gateway.platforms.base import (
@@ -248,6 +249,319 @@ class TestExtractImages:
         assert images[0][0] == "https://fal.media/cat.png"
         # The PDF link must survive in cleaned content
         assert "![report](https://example.com/report.pdf)" in cleaned
+
+
+    def test_markdown_data_url_image_is_cached_and_removed(self, tmp_path, monkeypatch):
+        """Explicit image data URLs should become local image files, not visible base64 text."""
+        from gateway.platforms import base as base_module
+
+        monkeypatch.setattr(base_module, "IMAGE_CACHE_DIR", tmp_path)
+        png_data_url = (
+            "data:image/png;base64,"
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ"
+            "AAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+        )
+        content = f"Here is the image:\n![tiny]({png_data_url})\nDone."
+
+        images, cleaned = BasePlatformAdapter.extract_images(content)
+
+        assert len(images) == 1
+        image_path, alt_text = images[0]
+        assert alt_text == "tiny"
+        assert image_path.endswith(".png")
+        assert Path(image_path).is_file()
+        assert Path(image_path).parent == tmp_path
+        assert "data:image" not in cleaned
+        assert "base64" not in cleaned
+        assert "Here is the image:" in cleaned
+        assert "Done." in cleaned
+
+    def test_markdown_data_url_image_with_whitespace_and_angle_destination_is_cached_and_removed(self, tmp_path, monkeypatch):
+        """Explicit Markdown data URL variants should not leak base64 text."""
+        from gateway.platforms import base as base_module
+
+        monkeypatch.setattr(base_module, "IMAGE_CACHE_DIR", tmp_path)
+        gif_data_url = "data:image/gif;base64,R0lGODlhAQABAAAAACw="
+        content = f"Before ![tiny]( <{gif_data_url}> ) After"
+
+        images, cleaned = BasePlatformAdapter.extract_images(content)
+
+        assert len(images) == 1
+        image_path, alt_text = images[0]
+        assert alt_text == "tiny"
+        assert image_path.endswith(".gif")
+        assert Path(image_path).is_file()
+        assert "data:image" not in cleaned
+        assert "base64" not in cleaned
+        assert "R0lGOD" not in cleaned
+        assert "Before" in cleaned
+        assert "After" in cleaned
+
+
+    def test_html_data_url_image_is_cached_and_removed(self, tmp_path, monkeypatch):
+        """HTML image data URLs should also be converted to cached local files."""
+        from gateway.platforms import base as base_module
+
+        monkeypatch.setattr(base_module, "IMAGE_CACHE_DIR", tmp_path)
+        gif_data_url = "data:image/gif;base64,R0lGODlhAQABAAAAACw="
+        content = f'Before <img alt="x" src = "{gif_data_url}"> After'
+
+        images, cleaned = BasePlatformAdapter.extract_images(content)
+
+        assert len(images) == 1
+        image_path, alt_text = images[0]
+        assert alt_text == ""
+        assert image_path.endswith(".gif")
+        assert Path(image_path).is_file()
+        assert "data:image" not in cleaned
+        assert "Before" in cleaned
+        assert "After" in cleaned
+
+    def test_html_data_url_with_gt_in_quoted_attribute_is_cached_and_removed(self, tmp_path, monkeypatch):
+        """Quote-aware HTML parsing should tolerate > inside attributes before src."""
+        from gateway.platforms import base as base_module
+
+        monkeypatch.setattr(base_module, "IMAGE_CACHE_DIR", tmp_path)
+        gif_data_url = "data:image/gif;base64,R0lGODlhAQABAAAAACw="
+        content = f'Before <img alt="x > y" src="{gif_data_url}"> After'
+
+        images, cleaned = BasePlatformAdapter.extract_images(content)
+
+        assert len(images) == 1
+        image_path, _ = images[0]
+        assert image_path.endswith(".gif")
+        assert Path(image_path).is_file()
+        assert "data:image" not in cleaned
+        assert "R0lGOD" not in cleaned
+        assert "Before" in cleaned
+        assert "After" in cleaned
+
+    def test_html_data_url_with_quoted_src_text_before_real_src_is_cached_and_removed(self, tmp_path, monkeypatch):
+        """src= text inside another quoted attribute must not mask the real src."""
+        from gateway.platforms import base as base_module
+
+        monkeypatch.setattr(base_module, "IMAGE_CACHE_DIR", tmp_path)
+        gif_data_url = "data:image/gif;base64,R0lGODlhAQABAAAAACw="
+        content = f'Before <img alt="src=https://example.com/x.png" src="{gif_data_url}"> After'
+
+        images, cleaned = BasePlatformAdapter.extract_images(content)
+
+        assert len(images) == 1
+        image_path, _ = images[0]
+        assert image_path.endswith(".gif")
+        assert Path(image_path).is_file()
+        assert "data:image" not in cleaned
+        assert "example.com" not in cleaned
+        assert "Before" in cleaned
+        assert "After" in cleaned
+
+    def test_html_data_url_with_data_src_before_real_src_is_cached_and_removed(self, tmp_path, monkeypatch):
+        """data-src/srcset attributes must not be mistaken for the real src."""
+        from gateway.platforms import base as base_module
+
+        monkeypatch.setattr(base_module, "IMAGE_CACHE_DIR", tmp_path)
+        gif_data_url = "data:image/gif;base64,R0lGODlhAQABAAAAACw="
+        content = (
+            'Before <img data-src="https://example.com/track.png" '
+            f'src="{gif_data_url}" srcset="https://example.com/other.png 2x"> After'
+        )
+
+        images, cleaned = BasePlatformAdapter.extract_images(content)
+
+        assert len(images) == 1
+        image_path, _ = images[0]
+        assert image_path.endswith(".gif")
+        assert Path(image_path).is_file()
+        assert "example.com" not in cleaned
+        assert "data:image" not in cleaned
+        assert "R0lGOD" not in cleaned
+        assert "Before" in cleaned
+        assert "After" in cleaned
+
+    def test_html_data_url_in_alt_text_does_not_remove_remote_image(self):
+        """Non URL-bearing attributes mentioning data:image should not hide remote images."""
+        content = (
+            'Before <img src="https://example.com/a.png" '
+            'alt="literal data:image/png;base64,iVBORw0KGgo"> After'
+        )
+
+        images, cleaned = BasePlatformAdapter.extract_images(content)
+
+        assert images == [("https://example.com/a.png", "")]
+        assert "Before" in cleaned
+        assert "After" in cleaned
+        assert "data:image" not in cleaned
+        assert "https://example.com/a.png" not in cleaned
+
+    def test_markdown_like_data_url_inside_html_alt_does_not_cache_or_strip_as_markdown(self):
+        """Markdown-looking data URLs inside HTML attributes are not body Markdown."""
+        content = (
+            'Before <img src="https://example.com/a.png" '
+            'alt="![x](data:image/gif;base64,R0lGODlhAQABAAAAACw=)"> After'
+        )
+
+        images, cleaned = BasePlatformAdapter.extract_images(content)
+
+        assert images == [("https://example.com/a.png", "")]
+        assert "Before" in cleaned
+        assert "After" in cleaned
+        assert "data:image" not in cleaned
+        assert "R0lGOD" not in cleaned
+        assert "https://example.com/a.png" not in cleaned
+
+    def test_markdown_like_remote_url_inside_html_alt_does_not_extract_or_strip_as_markdown(self):
+        """Markdown-looking remote URLs inside HTML attributes are not body Markdown."""
+        content = (
+            'Before <img src="https://example.com/a.png" '
+            'alt="![x](https://example.com/hidden.png)"> After'
+        )
+
+        images, cleaned = BasePlatformAdapter.extract_images(content)
+
+        assert images == [("https://example.com/a.png", "")]
+        assert "Before" in cleaned
+        assert "After" in cleaned
+        assert "hidden.png" not in cleaned
+        assert "https://example.com/a.png" not in cleaned
+
+    def test_html_data_url_src_with_leading_space_is_cached_and_removed(self, tmp_path, monkeypatch):
+        """Quoted URL-bearing attributes may contain incidental whitespace."""
+        from gateway.platforms import base as base_module
+
+        monkeypatch.setattr(base_module, "IMAGE_CACHE_DIR", tmp_path)
+        gif_data_url = "data:image/gif;base64,R0lGODlhAQABAAAAACw="
+        content = f'Before <img src="  {gif_data_url}  "> After'
+
+        images, cleaned = BasePlatformAdapter.extract_images(content)
+
+        assert len(images) == 1
+        image_path, _ = images[0]
+        assert image_path.endswith(".gif")
+        assert Path(image_path).is_file()
+        assert "data:image" not in cleaned
+        assert "R0lGOD" not in cleaned
+        assert "Before" in cleaned
+        assert "After" in cleaned
+
+    def test_html_srcset_data_url_candidate_is_cached_and_removed(self, tmp_path, monkeypatch):
+        """srcset descriptors should be parsed so a data URL candidate can be cached."""
+        from gateway.platforms import base as base_module
+
+        monkeypatch.setattr(base_module, "IMAGE_CACHE_DIR", tmp_path)
+        gif_data_url = "data:image/gif;base64,R0lGODlhAQABAAAAACw="
+        content = f'Before <img srcset="{gif_data_url} 1x"> After'
+
+        images, cleaned = BasePlatformAdapter.extract_images(content)
+
+        assert len(images) == 1
+        image_path, _ = images[0]
+        assert image_path.endswith(".gif")
+        assert Path(image_path).is_file()
+        assert "data:image" not in cleaned
+        assert "R0lGOD" not in cleaned
+        assert "Before" in cleaned
+        assert "After" in cleaned
+
+    def test_data_url_with_metadata_and_folded_payload_is_cached(self, tmp_path, monkeypatch):
+        """Valid data URL parameters and folded base64 should still be handled."""
+        from gateway.platforms import base as base_module
+
+        monkeypatch.setattr(base_module, "IMAGE_CACHE_DIR", tmp_path)
+        folded_png_data_url = (
+            "data:image/png;charset=utf-8;base64,"
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ\r\n"
+            "AAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+        )
+        content = f"Before ![tiny]({folded_png_data_url}) After"
+
+        images, cleaned = BasePlatformAdapter.extract_images(content)
+
+        assert len(images) == 1
+        image_path, alt_text = images[0]
+        assert alt_text == "tiny"
+        assert image_path.endswith(".png")
+        assert Path(image_path).is_file()
+        assert "data:image" not in cleaned
+        assert "base64" not in cleaned
+        assert "Before" in cleaned
+        assert "After" in cleaned
+
+    def test_data_url_mime_magic_mismatch_is_removed_not_cached(self, tmp_path, monkeypatch):
+        """Declared MIME must match decoded image bytes."""
+        from gateway.platforms import base as base_module
+
+        monkeypatch.setattr(base_module, "IMAGE_CACHE_DIR", tmp_path)
+        gif_bytes_declared_png = "data:image/png;base64,R0lGODlhAQABAAAAACw="
+        content = f"Mismatch ![bad]({gif_bytes_declared_png})"
+
+        images, cleaned = BasePlatformAdapter.extract_images(content)
+
+        assert images == []
+        assert "data:image" not in cleaned
+        assert "R0lGOD" not in cleaned
+
+    def test_unsupported_image_data_url_is_removed_not_cached(self, tmp_path, monkeypatch):
+        """Unsupported explicit image data URLs must not leak even when not decoded."""
+        from gateway.platforms import base as base_module
+
+        monkeypatch.setattr(base_module, "IMAGE_CACHE_DIR", tmp_path)
+        svg_data_url = "data:image/svg+xml;base64,PHN2ZyBvbmxvYWQ9YWxlcnQoMSk+PC9zdmc+"
+        content = f'Before ![svg]({svg_data_url}) and <img src="{svg_data_url}"> After'
+
+        images, cleaned = BasePlatformAdapter.extract_images(content)
+
+        assert images == []
+        assert "data:image" not in cleaned
+        assert "base64" not in cleaned
+        assert "PHN2" not in cleaned
+        assert "Before" in cleaned
+        assert "After" in cleaned
+
+    def test_invalid_data_url_image_is_removed_without_guessing_base64(self, tmp_path, monkeypatch):
+        """Bad explicit data URL image tags should not leak raw base64 text."""
+        from gateway.platforms import base as base_module
+
+        monkeypatch.setattr(base_module, "IMAGE_CACHE_DIR", tmp_path)
+        content = "Bad image: ![bad](data:image/png;base64,not-valid-base64@@@)"
+
+        images, cleaned = BasePlatformAdapter.extract_images(content)
+
+        assert images == []
+        assert "data:image" not in cleaned
+        assert "not-valid-base64" not in cleaned
+
+    def test_bare_data_image_url_is_hidden_not_cached(self):
+        """Bare data:image URLs fail closed in outgoing text without guessing images."""
+        content = "before data:image/png;base64,AAAA after"
+
+        images, cleaned = BasePlatformAdapter.extract_images(content)
+
+        assert images == []
+        assert cleaned == "before"
+        assert "data:image" not in cleaned
+        assert "base64" not in cleaned
+        assert "AAAA" not in cleaned
+
+    def test_html_alt_only_data_url_is_hidden_not_cached(self):
+        """An <img> tag with data:image only in non-source attrs should not leak payload."""
+        content = 'before <img alt="literal data:image/png;base64,AAAA"> after'
+
+        images, cleaned = BasePlatformAdapter.extract_images(content)
+
+        assert images == []
+        assert cleaned == "before  after"
+        assert "data:image" not in cleaned
+        assert "base64" not in cleaned
+        assert "AAAA" not in cleaned
+
+    def test_bare_base64_text_is_not_treated_as_image(self):
+        """Only explicit data:image URLs are handled; arbitrary base64 text is preserved."""
+        content = "raw text iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ"
+
+        images, cleaned = BasePlatformAdapter.extract_images(content)
+
+        assert images == []
+        assert cleaned == content
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_send_image_file.py
+++ b/tests/gateway/test_send_image_file.py
@@ -9,12 +9,15 @@ Covers: local image file sending, file-not-found handling, fallback on error,
 import asyncio
 import os
 import sys
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from gateway.config import PlatformConfig
-from gateway.platforms.base import BasePlatformAdapter, SendResult
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, SendResult
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
 
 
 def _run(coro):
@@ -435,3 +438,164 @@ class TestScreenshotCleanup:
         from tools.browser_tool import _cleanup_old_screenshots, _last_screenshot_cleanup_by_dir
         _last_screenshot_cleanup_by_dir.clear()
         _cleanup_old_screenshots(Path("/nonexistent/dir"), max_age_hours=24)  # Should not raise
+
+
+
+class TestPostStreamDataUrlImageDelivery:
+    @pytest.mark.asyncio
+    async def test_streaming_final_response_delivers_data_url_image_file(self, tmp_path, monkeypatch):
+        """Post-stream media delivery must cache data URL images and send them as files."""
+        from gateway import platforms as _platforms_pkg
+        import gateway.platforms.base as base_module
+
+        monkeypatch.setattr(base_module, "IMAGE_CACHE_DIR", tmp_path)
+
+        class Adapter(BasePlatformAdapter):
+            name = "test"
+
+            def __init__(self):
+                super().__init__(PlatformConfig(enabled=True), Platform.LOCAL)
+                self.sent_images = []
+                self.sent_remote_images = []
+                self.sent_documents = []
+
+            async def connect(self):
+                return True
+
+            async def disconnect(self):
+                pass
+
+            async def get_chat_info(self, chat_id):
+                return {"id": chat_id, "name": "Test"}
+
+            async def send(self, chat_id, content, reply_to=None, metadata=None):
+                return SendResult(success=True, message_id="msg-text")
+
+            async def send_image_file(self, chat_id, image_path, caption=None, reply_to=None, **kwargs):
+                self.sent_images.append((chat_id, image_path, kwargs.get("metadata")))
+                return SendResult(success=True, message_id="msg-image")
+
+            async def send_image(self, chat_id, image_url, caption=None, reply_to=None, metadata=None):
+                self.sent_remote_images.append((chat_id, image_url, metadata))
+                return SendResult(success=True, message_id="msg-remote-image")
+
+            async def send_document(self, chat_id, file_path, caption=None, reply_to=None, metadata=None):
+                self.sent_documents.append(file_path)
+                return SendResult(success=True, message_id="msg-doc")
+
+        adapter = Adapter()
+        runner = object.__new__(GatewayRunner)
+        event = MessageEvent(
+            text="draw",
+            source=SessionSource(platform=Platform.LOCAL, chat_id="chat_1", thread_id="thread_1"),
+            message_id="m1",
+        )
+        response = (
+            "Here is the image\n"
+            "![tiny](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ)"
+        )
+
+        await runner._deliver_media_from_response(response, event, adapter)
+
+        assert len(adapter.sent_images) == 1
+        chat_id, image_path, metadata = adapter.sent_images[0]
+        assert chat_id == "chat_1"
+        assert metadata == {"thread_id": "thread_1"}
+        cached = Path(image_path)
+        assert cached.suffix == ".png"
+        assert cached.parent == tmp_path
+        assert cached.is_file()
+        assert b"\x89PNG\r\n\x1a\n" in cached.read_bytes()
+        assert adapter.sent_documents == []
+
+    @pytest.mark.asyncio
+    async def test_post_stream_does_not_duplicate_remote_images(self, tmp_path, monkeypatch):
+        """Post-stream delivery should only send cached local data URL images."""
+        import gateway.platforms.base as base_module
+
+        monkeypatch.setattr(base_module, "IMAGE_CACHE_DIR", tmp_path)
+
+        class Adapter(BasePlatformAdapter):
+            name = "test"
+
+            def __init__(self):
+                super().__init__(PlatformConfig(enabled=True), Platform.LOCAL)
+                self.sent_images = []
+                self.sent_remote_images = []
+
+            async def connect(self):
+                return True
+
+            async def disconnect(self):
+                pass
+
+            async def get_chat_info(self, chat_id):
+                return {"id": chat_id, "name": "Test"}
+
+            async def send(self, chat_id, content, reply_to=None, metadata=None):
+                return SendResult(success=True, message_id="msg-text")
+
+            async def send_image_file(self, chat_id, image_path, caption=None, reply_to=None, **kwargs):
+                self.sent_images.append((chat_id, image_path, kwargs.get("metadata")))
+                return SendResult(success=True, message_id="msg-image")
+
+            async def send_image(self, chat_id, image_url, caption=None, reply_to=None, metadata=None):
+                self.sent_remote_images.append((chat_id, image_url, metadata))
+                return SendResult(success=True, message_id="msg-remote-image")
+
+        adapter = Adapter()
+        runner = object.__new__(GatewayRunner)
+        event = MessageEvent(
+            text="draw",
+            source=SessionSource(platform=Platform.LOCAL, chat_id="chat_1"),
+            message_id="m1",
+        )
+        response = "remote ![img](https://example.com/image.png)"
+
+        await runner._deliver_media_from_response(response, event, adapter)
+
+        assert adapter.sent_images == []
+        assert adapter.sent_remote_images == []
+
+    @pytest.mark.asyncio
+    async def test_post_stream_does_not_treat_url_as_local_path(self):
+        """Scheme-bearing URLs must be skipped even if a similar local path exists."""
+        class Adapter(BasePlatformAdapter):
+            name = "test"
+
+            def __init__(self):
+                super().__init__(PlatformConfig(enabled=True), Platform.LOCAL)
+                self.sent_images = []
+
+            async def connect(self):
+                return True
+
+            async def disconnect(self):
+                pass
+
+            async def get_chat_info(self, chat_id):
+                return {"id": chat_id, "name": "Test"}
+
+            async def send(self, chat_id, content, reply_to=None, metadata=None):
+                return SendResult(success=True, message_id="msg-text")
+
+            async def send_image_file(self, chat_id, image_path, caption=None, reply_to=None, **kwargs):
+                self.sent_images.append(image_path)
+                return SendResult(success=True, message_id="msg-image")
+
+        adapter = Adapter()
+        runner = object.__new__(GatewayRunner)
+        event = MessageEvent(
+            text="draw",
+            source=SessionSource(platform=Platform.LOCAL, chat_id="chat_1"),
+            message_id="m1",
+        )
+
+        with patch("gateway.run.Path") as mock_path:
+            mock_path.return_value.suffix.lower.return_value = ".png"
+            mock_path.return_value.is_file.return_value = True
+            await runner._deliver_media_from_response(
+                "remote ![img](https://example.com/image.png)", event, adapter
+            )
+
+        assert adapter.sent_images == []

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from gateway.platforms.base import BasePlatformAdapter
 from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
 
 
@@ -75,6 +76,900 @@ class TestCleanForDisplay:
         assert "MEDIA:" not in result
         assert "generated" in result
         assert "for you." in result
+
+    def test_markdown_data_url_image_stripped(self):
+        """Streaming display must not leak explicit image data URL payloads."""
+        text = (
+            "Here is the image\n"
+            "![tiny](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ)\n"
+            "Done"
+        )
+        result = GatewayStreamConsumer._clean_for_display(text)
+        assert "data:image" not in result
+        assert "base64" not in result
+        assert "iVBOR" not in result
+        assert "Here is the image" in result
+        assert "Done" in result
+
+    def test_html_data_url_image_stripped(self):
+        """Streaming display strips HTML data URL image tags too."""
+        text = 'Before <img src = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ"> After'
+        result = GatewayStreamConsumer._clean_for_display(text)
+        assert "data:image" not in result
+        assert "iVBOR" not in result
+        assert "Before" in result
+        assert "After" in result
+
+    def test_data_url_with_metadata_and_folded_payload_stripped(self):
+        """Streaming display handles valid data URL metadata and folded base64."""
+        text = (
+            "Before\n"
+            "![tiny](data:image/png;charset=utf-8;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ\r\n"
+            "AAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==)\n"
+            "After"
+        )
+        result = GatewayStreamConsumer._clean_for_display(text)
+        assert "data:image" not in result
+        assert "base64" not in result
+        assert "iVBOR" not in result
+        assert "Before" in result
+        assert "After" in result
+
+    def test_clean_for_display_strips_markdown_data_url_with_whitespace_and_angle_destination(self):
+        """Markdown data URL variants should be stripped from streaming cleanup."""
+        text = "before ![tiny]( <data:image/png;base64,iVBORw0KGgo> ) after"
+        result = GatewayStreamConsumer._clean_for_display(text)
+        assert result == "before  after"
+        assert "data:image" not in result
+        assert "iVBOR" not in result
+
+    @pytest.mark.asyncio
+    async def test_streaming_open_html_img_tag_is_held_until_complete(self):
+        """Do not send partial <img ...> tags split before src/data attrs."""
+        adapter = MagicMock()
+        adapter.REQUIRES_EDIT_FINALIZE = False
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_1",
+            StreamConsumerConfig(edit_interval=0, buffer_threshold=1, cursor=""),
+        )
+        task = asyncio.create_task(consumer.run())
+        for chunk in [
+            'HTML <img alt="x" ',
+            'src="',
+            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ",
+            '"> done',
+        ]:
+            consumer.on_delta(chunk)
+            await asyncio.sleep(0.1)
+        consumer.finish()
+        await task
+
+        visible_payloads = [call.kwargs.get("content", "") for call in adapter.send.await_args_list]
+        visible_payloads += [call.kwargs.get("content", "") for call in adapter.edit_message.await_args_list]
+        assert visible_payloads
+        assert all("<img" not in payload for payload in visible_payloads)
+        assert all("data:image" not in payload for payload in visible_payloads)
+        assert all("base64" not in payload for payload in visible_payloads)
+        assert all("iVBOR" not in payload for payload in visible_payloads)
+        assert visible_payloads[-1] == "HTML  done"
+
+    @pytest.mark.asyncio
+    async def test_streaming_open_html_img_srcset_data_url_is_held_until_complete(self):
+        """Hold split img tags even when the data URL is in srcset rather than src."""
+        adapter = MagicMock()
+        adapter.REQUIRES_EDIT_FINALIZE = False
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_1",
+            StreamConsumerConfig(edit_interval=0, buffer_threshold=1, cursor=""),
+        )
+        task = asyncio.create_task(consumer.run())
+        for chunk in [
+            'HTML <img alt="x" ',
+            'src="https://example.com/x.png" srcset="',
+            "data:image/png;base64,iVBORw0KGgo 1x",
+            '"> done',
+        ]:
+            consumer.on_delta(chunk)
+            await asyncio.sleep(0.1)
+        consumer.finish()
+        await task
+
+        visible_payloads = [call.kwargs.get("content", "") for call in adapter.send.await_args_list]
+        visible_payloads += [call.kwargs.get("content", "") for call in adapter.edit_message.await_args_list]
+        assert visible_payloads
+        assert all("<img" not in payload for payload in visible_payloads)
+        assert all("data:image" not in payload for payload in visible_payloads)
+        assert all("base64" not in payload for payload in visible_payloads)
+        assert visible_payloads[-1] == "HTML  done"
+
+    def test_bare_base64_text_not_stripped(self):
+        """Do not strip arbitrary base64-looking text outside explicit image data URLs."""
+        text = "raw text iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ"
+        assert GatewayStreamConsumer._clean_for_display(text) == text
+
+    @pytest.mark.asyncio
+    async def test_streaming_partial_markdown_data_url_is_not_sent_before_complete(self):
+        """Do not leak partial data URL/base64 chunks while the image tag is still streaming."""
+        adapter = MagicMock()
+        adapter.REQUIRES_EDIT_FINALIZE = False
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_1",
+            StreamConsumerConfig(edit_interval=0, buffer_threshold=1, cursor=""),
+        )
+        task = asyncio.create_task(consumer.run())
+        for chunk in [
+            "Here is the image\n![tiny](",
+            "data:",
+            "ima",
+            "ge/png;charset=utf-8;base64,iVBORw0KGgo",
+            "AAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ)\nDone",
+        ]:
+            consumer.on_delta(chunk)
+            await asyncio.sleep(0.1)
+        consumer.finish()
+        await task
+
+        visible_payloads = [call.kwargs.get("content", "") for call in adapter.send.await_args_list]
+        visible_payloads += [call.kwargs.get("content", "") for call in adapter.edit_message.await_args_list]
+        assert visible_payloads
+        assert all("data:" not in payload for payload in visible_payloads)
+        assert all("data:image" not in payload for payload in visible_payloads)
+        assert all("base64" not in payload for payload in visible_payloads)
+        assert all("iVBOR" not in payload for payload in visible_payloads)
+        assert visible_payloads[-1] == "Here is the image\n\nDone"
+
+    @pytest.mark.asyncio
+    async def test_streaming_partial_html_data_url_is_not_sent_before_complete(self):
+        """HTML data URLs split after src= must not leak during streaming."""
+        adapter = MagicMock()
+        adapter.REQUIRES_EDIT_FINALIZE = False
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_1",
+            StreamConsumerConfig(edit_interval=0, buffer_threshold=1, cursor=""),
+        )
+        task = asyncio.create_task(consumer.run())
+        for chunk in [
+            'HTML image <img alt="x" src = "',
+            "data:",
+            "image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ",
+            '"> done',
+        ]:
+            consumer.on_delta(chunk)
+            await asyncio.sleep(0.1)
+        consumer.finish()
+        await task
+
+        visible_payloads = [call.kwargs.get("content", "") for call in adapter.send.await_args_list]
+        visible_payloads += [call.kwargs.get("content", "") for call in adapter.edit_message.await_args_list]
+        assert visible_payloads
+        assert all("data:" not in payload for payload in visible_payloads)
+        assert all("data:image" not in payload for payload in visible_payloads)
+        assert all("base64" not in payload for payload in visible_payloads)
+        assert all("iVBOR" not in payload for payload in visible_payloads)
+        assert visible_payloads[-1] == "HTML image  done"
+
+    @pytest.mark.asyncio
+    async def test_streaming_incomplete_data_url_is_dropped_at_finish(self):
+        """If the stream ends mid data URL, do not flush the pending payload as text."""
+        adapter = MagicMock()
+        adapter.REQUIRES_EDIT_FINALIZE = False
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_1",
+            StreamConsumerConfig(edit_interval=0, buffer_threshold=1, cursor=""),
+        )
+        task = asyncio.create_task(consumer.run())
+        for chunk in ["Intro ![tiny](", "data:", "ima"]:
+            consumer.on_delta(chunk)
+            await asyncio.sleep(0.1)
+        consumer.finish()
+        await task
+
+        visible_payloads = [call.kwargs.get("content", "") for call in adapter.send.await_args_list]
+        visible_payloads += [call.kwargs.get("content", "") for call in adapter.edit_message.await_args_list]
+        assert visible_payloads
+        assert all("data:" not in payload for payload in visible_payloads)
+        assert all("data:image" not in payload for payload in visible_payloads)
+        assert all("![tiny]" not in payload for payload in visible_payloads)
+        assert visible_payloads[-1] == "Intro "
+
+    @pytest.mark.asyncio
+    async def test_streaming_html_data_url_with_gt_before_src_does_not_leak(self):
+        """Quote-aware HTML buffering must ignore > inside attributes before src."""
+        adapter = MagicMock()
+        adapter.REQUIRES_EDIT_FINALIZE = False
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_1",
+            StreamConsumerConfig(edit_interval=0, buffer_threshold=1, cursor=""),
+        )
+        task = asyncio.create_task(consumer.run())
+        for chunk in [
+            'HTML image <img alt="x > y" src="',
+            "data:",
+            "image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ",
+            '"> done',
+        ]:
+            consumer.on_delta(chunk)
+            await asyncio.sleep(0.1)
+        consumer.finish()
+        await task
+
+        visible_payloads = [call.kwargs.get("content", "") for call in adapter.send.await_args_list]
+        visible_payloads += [call.kwargs.get("content", "") for call in adapter.edit_message.await_args_list]
+        assert visible_payloads
+        assert all("data:" not in payload for payload in visible_payloads)
+        assert all("data:image" not in payload for payload in visible_payloads)
+        assert all("base64" not in payload for payload in visible_payloads)
+        assert all("iVBOR" not in payload for payload in visible_payloads)
+        assert visible_payloads[-1] == "HTML image  done"
+
+    @pytest.mark.asyncio
+    async def test_streaming_html_data_url_with_gt_after_src_does_not_leave_fragment(self):
+        """Quote-aware HTML cleanup must ignore > inside later attributes too."""
+        adapter = MagicMock()
+        adapter.REQUIRES_EDIT_FINALIZE = False
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_1",
+            StreamConsumerConfig(edit_interval=0, buffer_threshold=1, cursor=""),
+        )
+        task = asyncio.create_task(consumer.run())
+        for chunk in [
+            'HTML image <img src="',
+            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ",
+            '" alt="x > y"> done',
+        ]:
+            consumer.on_delta(chunk)
+            await asyncio.sleep(0.1)
+        consumer.finish()
+        await task
+
+        visible_payloads = [call.kwargs.get("content", "") for call in adapter.send.await_args_list]
+        visible_payloads += [call.kwargs.get("content", "") for call in adapter.edit_message.await_args_list]
+        assert visible_payloads
+        assert all("data:image" not in payload for payload in visible_payloads)
+        assert all("base64" not in payload for payload in visible_payloads)
+        assert all("alt=\"x" not in payload for payload in visible_payloads)
+        assert visible_payloads[-1] == "HTML image  done"
+
+    @pytest.mark.asyncio
+    async def test_streaming_later_html_data_url_uses_nearest_tag_opener(self):
+        """A prior markdown image opener must not cause later HTML data URL text to be dropped."""
+        adapter = MagicMock()
+        adapter.REQUIRES_EDIT_FINALIZE = False
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_1",
+            StreamConsumerConfig(edit_interval=0, buffer_threshold=1, cursor=""),
+        )
+        task = asyncio.create_task(consumer.run())
+        for chunk in [
+            "Keep ![remote](https://example.com/a.png) before ",
+            '<img src="',
+            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ",
+            '"> after',
+        ]:
+            consumer.on_delta(chunk)
+            await asyncio.sleep(0.1)
+        consumer.finish()
+        await task
+
+        visible_payloads = [call.kwargs.get("content", "") for call in adapter.send.await_args_list]
+        visible_payloads += [call.kwargs.get("content", "") for call in adapter.edit_message.await_args_list]
+        assert visible_payloads
+        assert all("data:image" not in payload for payload in visible_payloads)
+        assert all("base64" not in payload for payload in visible_payloads)
+        assert visible_payloads[-1] == "Keep ![remote](https://example.com/a.png) before  after"
+
+    def test_clean_for_display_removes_html_data_url_with_closing_tag(self):
+        """HTML data URL cleanup should remove optional closing </img> too."""
+        text = 'before <img src="data:image/png;base64,iVBORw0KGgo" alt="x"></img> after'
+        assert GatewayStreamConsumer._clean_for_display(text) == "before  after"
+
+    def test_clean_for_display_ignores_src_text_inside_quoted_attribute(self):
+        """Quoted attribute text containing src= must not mask the real data URL src."""
+        text = (
+            'before <img alt="src=https://example.com/x.png" '
+            'src="data:image/png;base64,iVBORw0KGgo"> after'
+        )
+        assert GatewayStreamConsumer._clean_for_display(text) == "before  after"
+
+    def test_clean_for_display_removes_html_tag_with_data_image_srcset(self):
+        """Explicit data:image payloads in img srcset should not remain visible."""
+        text = (
+            'before <img src="https://example.com/x.png" '
+            'srcset="data:image/png;base64,iVBORw0KGgo 1x"> after'
+        )
+        assert GatewayStreamConsumer._clean_for_display(text) == "before  after"
+
+    @pytest.mark.asyncio
+    async def test_segment_break_preserves_speculative_data_url_prefix_text(self):
+        """A segment break after ordinary trailing d must not drop that character."""
+        adapter = MagicMock()
+        adapter.REQUIRES_EDIT_FINALIZE = False
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_1",
+            StreamConsumerConfig(edit_interval=0, buffer_threshold=1, cursor=""),
+        )
+        task = asyncio.create_task(consumer.run())
+        consumer.on_delta("hello d")
+        await asyncio.sleep(0.1)
+        consumer.on_delta(None)
+        consumer.finish()
+        await task
+
+        visible_payloads = [call.kwargs.get("content", "") for call in adapter.send.await_args_list]
+        visible_payloads += [call.kwargs.get("content", "") for call in adapter.edit_message.await_args_list]
+        assert visible_payloads
+        assert visible_payloads[-1] == "hello d"
+
+    @pytest.mark.asyncio
+    async def test_segment_break_preserves_speculative_image_opener_text(self):
+        """A tool boundary after ordinary image-like prefixes must not drop text."""
+        adapter = MagicMock()
+        adapter.REQUIRES_EDIT_FINALIZE = False
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_1",
+            StreamConsumerConfig(edit_interval=0, buffer_threshold=1, cursor=""),
+        )
+        task = asyncio.create_task(consumer.run())
+        consumer.on_delta("literal ![not image")
+        await asyncio.sleep(0.1)
+        consumer.on_delta(None)
+        consumer.finish()
+        await task
+
+        visible_payloads = [call.kwargs.get("content", "") for call in adapter.send.await_args_list]
+        visible_payloads += [call.kwargs.get("content", "") for call in adapter.edit_message.await_args_list]
+        assert visible_payloads
+        assert visible_payloads[-1] == "literal ![not image"
+
+    def test_clean_for_display_closed_html_before_bare_data_url_hides_payload(self):
+        """Cleanup must not associate a bare data URL with an already closed HTML tag."""
+        text = '<img src="https://example.com/a.png"> before data:image/png;base64,iVBORw0KGgo'
+        result = GatewayStreamConsumer._clean_for_display(text)
+        assert result == '<img src="https://example.com/a.png"> before'
+        assert "data:image" not in result
+        assert "base64" not in result
+
+    def test_clean_for_display_closed_markdown_before_bare_data_url_hides_payload(self):
+        """Cleanup must preserve closed Markdown image text before hiding a later bare data URL."""
+        text = "Keep ![remote](https://example.com/a.png) before data:image/png;base64,iVBORw0KGgo)"
+        result = GatewayStreamConsumer._clean_for_display(text)
+        assert result == "Keep ![remote](https://example.com/a.png) before"
+        assert "data:image" not in result
+        assert "base64" not in result
+
+    @pytest.mark.asyncio
+    async def test_streaming_closed_html_before_bare_data_url_keeps_prefix_and_hides_payload(self):
+        """A closed HTML img before a bare data URL must not make the payload visible."""
+        adapter = MagicMock()
+        adapter.REQUIRES_EDIT_FINALIZE = False
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_1",
+            StreamConsumerConfig(edit_interval=0, buffer_threshold=1, cursor=""),
+        )
+        task = asyncio.create_task(consumer.run())
+        for chunk in [
+            '<img src="https://example.com/a.png"> before ',
+            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ",
+        ]:
+            consumer.on_delta(chunk)
+            await asyncio.sleep(0.1)
+        consumer.finish()
+        await task
+
+        visible_payloads = [call.kwargs.get("content", "") for call in adapter.send.await_args_list]
+        visible_payloads += [call.kwargs.get("content", "") for call in adapter.edit_message.await_args_list]
+        assert visible_payloads
+        assert all("data:image" not in payload for payload in visible_payloads)
+        assert all("base64" not in payload for payload in visible_payloads)
+        assert visible_payloads[-1] == '<img src="https://example.com/a.png"> before '
+
+    @pytest.mark.asyncio
+    async def test_streaming_overflow_after_closed_html_before_bare_data_url_does_not_leak_base64_tail(self):
+        """Filtering must remove bare data URL from accumulated text before overflow splitting."""
+        adapter = MagicMock()
+        adapter.REQUIRES_EDIT_FINALIZE = False
+        adapter.MAX_MESSAGE_LENGTH = 640
+        adapter.truncate_message = BasePlatformAdapter.truncate_message
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_1",
+            StreamConsumerConfig(edit_interval=0, buffer_threshold=1, cursor=""),
+        )
+        long_payload = "A" * 2400
+        task = asyncio.create_task(consumer.run())
+        consumer.on_delta(
+            '<img src="https://example.com/a.png"> before '
+            f"data:image/png;base64,{long_payload}"
+        )
+        await asyncio.sleep(0.1)
+        consumer.finish()
+        await task
+
+        visible_payloads = [call.kwargs.get("content", "") for call in adapter.send.await_args_list]
+        visible_payloads += [call.kwargs.get("content", "") for call in adapter.edit_message.await_args_list]
+        assert visible_payloads
+        assert all("data:image" not in payload for payload in visible_payloads)
+        assert all("base64" not in payload for payload in visible_payloads)
+        assert all("A" * 100 not in payload for payload in visible_payloads)
+        assert visible_payloads[-1] == '<img src="https://example.com/a.png"> before '
+
+    @pytest.mark.asyncio
+    async def test_streaming_html_data_url_src_with_leading_space_does_not_leak_on_overflow(self):
+        """Quoted HTML src values should be stripped before data URL detection."""
+        adapter = MagicMock()
+        adapter.REQUIRES_EDIT_FINALIZE = False
+        adapter.MAX_MESSAGE_LENGTH = 640
+        adapter.truncate_message = BasePlatformAdapter.truncate_message
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_1",
+            StreamConsumerConfig(edit_interval=0, buffer_threshold=1, cursor=""),
+        )
+        long_payload = "A" * 2400
+        task = asyncio.create_task(consumer.run())
+        consumer.on_delta(f'Before <img src=" data:image/png;base64,{long_payload}"> After')
+        await asyncio.sleep(0.1)
+        consumer.finish()
+        await task
+
+        visible_payloads = [call.kwargs.get("content", "") for call in adapter.send.await_args_list]
+        visible_payloads += [call.kwargs.get("content", "") for call in adapter.edit_message.await_args_list]
+        assert visible_payloads
+        assert all("data:image" not in payload for payload in visible_payloads)
+        assert all("base64" not in payload for payload in visible_payloads)
+        assert all("A" * 100 not in payload for payload in visible_payloads)
+        assert visible_payloads[-1] == "Before  After"
+
+    @pytest.mark.asyncio
+    async def test_streaming_markdown_image_opener_split_before_data_url_does_not_leak_or_drop_suffix(self):
+        """Markdown image openers split across chunks should be held until removed."""
+        adapter = MagicMock()
+        adapter.REQUIRES_EDIT_FINALIZE = False
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_1",
+            StreamConsumerConfig(edit_interval=0, buffer_threshold=1, cursor=""),
+        )
+        task = asyncio.create_task(consumer.run())
+        for chunk in ["Here ![", "alt](", "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ", ") Done"]:
+            consumer.on_delta(chunk)
+            await asyncio.sleep(0.1)
+        consumer.finish()
+        await task
+
+        visible_payloads = [call.kwargs.get("content", "") for call in adapter.send.await_args_list]
+        visible_payloads += [call.kwargs.get("content", "") for call in adapter.edit_message.await_args_list]
+        assert visible_payloads
+        assert all("data:image" not in payload for payload in visible_payloads)
+        assert all("base64" not in payload for payload in visible_payloads)
+        assert all("![" not in payload for payload in visible_payloads)
+        assert visible_payloads[-1] == "Here  Done"
+
+    @pytest.mark.asyncio
+    async def test_streaming_html_img_opener_split_before_data_url_does_not_leak_or_drop_suffix(self):
+        """HTML <img openers split across chunks should be held until removed."""
+        adapter = MagicMock()
+        adapter.REQUIRES_EDIT_FINALIZE = False
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_1",
+            StreamConsumerConfig(edit_interval=0, buffer_threshold=1, cursor=""),
+        )
+        task = asyncio.create_task(consumer.run())
+        for chunk in ["Here <i", "mg src=\"", "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ", "\"> Done"]:
+            consumer.on_delta(chunk)
+            await asyncio.sleep(0.1)
+        consumer.finish()
+        await task
+
+        visible_payloads = [call.kwargs.get("content", "") for call in adapter.send.await_args_list]
+        visible_payloads += [call.kwargs.get("content", "") for call in adapter.edit_message.await_args_list]
+        assert visible_payloads
+        assert all("data:image" not in payload for payload in visible_payloads)
+        assert all("base64" not in payload for payload in visible_payloads)
+        assert all("<img" not in payload for payload in visible_payloads)
+        assert visible_payloads[-1] == "Here  Done"
+
+    @pytest.mark.asyncio
+    async def test_streaming_html_data_url_in_alt_does_not_leak_on_overflow(self):
+        """Non URL-bearing attributes containing data:image must not leak across split chunks."""
+        adapter = MagicMock()
+        adapter.REQUIRES_EDIT_FINALIZE = False
+        adapter.MAX_MESSAGE_LENGTH = 640
+        adapter.truncate_message = BasePlatformAdapter.truncate_message
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_1",
+            StreamConsumerConfig(edit_interval=0, buffer_threshold=1, cursor=""),
+        )
+        long_payload = "A" * 2400
+        task = asyncio.create_task(consumer.run())
+        consumer.on_delta(
+            'Before <img src="https://example.com/a.png" '
+            f'alt="literal data:image/png;base64,{long_payload}"> After'
+        )
+        await asyncio.sleep(0.1)
+        consumer.finish()
+        await task
+
+        visible_payloads = [call.kwargs.get("content", "") for call in adapter.send.await_args_list]
+        visible_payloads += [call.kwargs.get("content", "") for call in adapter.edit_message.await_args_list]
+        assert visible_payloads
+        assert all("data:image" not in payload for payload in visible_payloads)
+        assert all("base64" not in payload for payload in visible_payloads)
+        assert all("A" * 100 not in payload for payload in visible_payloads)
+        assert visible_payloads[-1] == "Before  After"
+
+    @pytest.mark.asyncio
+    async def test_streaming_markdown_image_split_inside_alt_does_not_leak_or_show_partial(self):
+        """Markdown image tags split before ](data:image...) should be held, not streamed."""
+        adapter = MagicMock()
+        adapter.REQUIRES_EDIT_FINALIZE = False
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_1",
+            StreamConsumerConfig(edit_interval=0, buffer_threshold=1, cursor=""),
+        )
+        task = asyncio.create_task(consumer.run())
+        for chunk in [
+            "Here ![alt",
+            "](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ",
+            ") Done",
+        ]:
+            consumer.on_delta(chunk)
+            await asyncio.sleep(0.1)
+        consumer.finish()
+        await task
+
+        visible_payloads = [call.kwargs.get("content", "") for call in adapter.send.await_args_list]
+        visible_payloads += [call.kwargs.get("content", "") for call in adapter.edit_message.await_args_list]
+        assert visible_payloads
+        assert all("![alt" not in payload for payload in visible_payloads)
+        assert all("data:image" not in payload for payload in visible_payloads)
+        assert all("base64" not in payload for payload in visible_payloads)
+        assert visible_payloads[-1] == "Here  Done"
+
+    @pytest.mark.asyncio
+    async def test_streaming_same_chunk_closed_markdown_before_bare_data_url_preserves_markdown(self):
+        """Closed non-data Markdown image before a bare data URL must not be mis-associated."""
+        adapter = MagicMock()
+        adapter.REQUIRES_EDIT_FINALIZE = False
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_1",
+            StreamConsumerConfig(edit_interval=0, buffer_threshold=1, cursor=""),
+        )
+        task = asyncio.create_task(consumer.run())
+        consumer.on_delta(
+            "Keep ![remote](https://example.com/a.png) before "
+            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ"
+        )
+        await asyncio.sleep(0.1)
+        consumer.finish()
+        await task
+
+        visible_payloads = [call.kwargs.get("content", "") for call in adapter.send.await_args_list]
+        visible_payloads += [call.kwargs.get("content", "") for call in adapter.edit_message.await_args_list]
+        assert visible_payloads
+        assert all("data:image" not in payload for payload in visible_payloads)
+        assert all("base64" not in payload for payload in visible_payloads)
+        assert visible_payloads[-1] == "Keep ![remote](https://example.com/a.png) before "
+
+    @pytest.mark.asyncio
+    async def test_streaming_speculative_image_prefix_restored_on_final_when_plain_text(self):
+        """Held speculative image prefixes should be restored if no data URL arrives."""
+        adapter = MagicMock()
+        adapter.REQUIRES_EDIT_FINALIZE = False
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_1",
+            StreamConsumerConfig(edit_interval=0, buffer_threshold=1, cursor=""),
+        )
+        task = asyncio.create_task(consumer.run())
+        consumer.on_delta("literal <i")
+        await asyncio.sleep(0.1)
+        consumer.finish()
+        await task
+
+        visible_payloads = [call.kwargs.get("content", "") for call in adapter.send.await_args_list]
+        visible_payloads += [call.kwargs.get("content", "") for call in adapter.edit_message.await_args_list]
+        assert visible_payloads
+        assert visible_payloads[-1] == "literal <i"
+
+    @pytest.mark.asyncio
+    async def test_streaming_closed_markdown_before_bare_data_url_keeps_prefix_and_hides_payload(self):
+        """A closed Markdown image before a bare data URL must not be removed."""
+        adapter = MagicMock()
+        adapter.REQUIRES_EDIT_FINALIZE = False
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_1",
+            StreamConsumerConfig(edit_interval=0, buffer_threshold=1, cursor=""),
+        )
+        task = asyncio.create_task(consumer.run())
+        for chunk in [
+            "Keep ![remote](https://example.com/a.png) before ",
+            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ)",
+        ]:
+            consumer.on_delta(chunk)
+            await asyncio.sleep(0.1)
+        consumer.finish()
+        await task
+
+        visible_payloads = [call.kwargs.get("content", "") for call in adapter.send.await_args_list]
+        visible_payloads += [call.kwargs.get("content", "") for call in adapter.edit_message.await_args_list]
+        assert visible_payloads
+        assert all("data:image" not in payload for payload in visible_payloads)
+        assert all("base64" not in payload for payload in visible_payloads)
+        assert visible_payloads[-1] == "Keep ![remote](https://example.com/a.png) before "
+
+    @pytest.mark.asyncio
+    async def test_streaming_closed_markdown_before_unknown_data_url_keeps_prefix(self):
+        """A closed markdown image before a later raw data URL should not lose the prefix."""
+        adapter = MagicMock()
+        adapter.REQUIRES_EDIT_FINALIZE = False
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_1",
+            StreamConsumerConfig(edit_interval=0, buffer_threshold=1, cursor=""),
+        )
+        task = asyncio.create_task(consumer.run())
+        for chunk in [
+            "Keep ![remote](https://example.com/a.png) before ",
+            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ",
+        ]:
+            consumer.on_delta(chunk)
+            await asyncio.sleep(0.1)
+        consumer.finish()
+        await task
+
+        visible_payloads = [call.kwargs.get("content", "") for call in adapter.send.await_args_list]
+        visible_payloads += [call.kwargs.get("content", "") for call in adapter.edit_message.await_args_list]
+        assert visible_payloads
+        assert all("data:image" not in payload for payload in visible_payloads)
+        assert visible_payloads[-1] == "Keep ![remote](https://example.com/a.png) before "
+
+    @pytest.mark.asyncio
+    async def test_streaming_bare_data_image_split_after_word_char_does_not_leak(self):
+        """Even if a prior chunk ended with xdata, a following :image must be hidden."""
+        adapter = MagicMock()
+        adapter.REQUIRES_EDIT_FINALIZE = False
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_1",
+            StreamConsumerConfig(edit_interval=0, buffer_threshold=1, cursor=""),
+        )
+        task = asyncio.create_task(consumer.run())
+        for chunk in ["xdata", ":image/png;base64,QUJD"]:
+            consumer.on_delta(chunk)
+            await asyncio.sleep(0.1)
+        consumer.finish()
+        await task
+
+        visible_payloads = [call.kwargs.get("content", "") for call in adapter.send.await_args_list]
+        visible_payloads += [call.kwargs.get("content", "") for call in adapter.edit_message.await_args_list]
+        assert visible_payloads
+        assert all("data:image" not in payload for payload in visible_payloads)
+        assert all("base64" not in payload for payload in visible_payloads)
+        assert all("QUJD" not in payload for payload in visible_payloads)
+        assert visible_payloads[-1] == "x"
+
+    @pytest.mark.asyncio
+    async def test_streaming_bare_data_image_split_after_word_char_long_payload_no_overflow_leak(self):
+        """Long split bare data:image payloads must not leak base64-only overflow chunks."""
+        adapter = MagicMock()
+        adapter.REQUIRES_EDIT_FINALIZE = False
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.truncate_message = BasePlatformAdapter.truncate_message
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_1",
+            StreamConsumerConfig(edit_interval=0, buffer_threshold=1, cursor=""),
+        )
+        long_payload = "QUJD" * 1500
+        task = asyncio.create_task(consumer.run())
+        for chunk in ["xdata", f":image/png;base64,{long_payload}"]:
+            consumer.on_delta(chunk)
+            await asyncio.sleep(0.1)
+        consumer.finish()
+        await task
+
+        visible_payloads = [call.kwargs.get("content", "") for call in adapter.send.await_args_list]
+        visible_payloads += [call.kwargs.get("content", "") for call in adapter.edit_message.await_args_list]
+        assert visible_payloads
+        assert all("data:image" not in payload for payload in visible_payloads)
+        assert all("base64" not in payload for payload in visible_payloads)
+        assert all("QUJD" not in payload for payload in visible_payloads)
+        assert visible_payloads[-1] == "x"
+
+    @pytest.mark.asyncio
+    async def test_streaming_speculative_metadata_text_restored_on_final(self):
+        """Speculative image-open text with benign data: substring should be restored."""
+        adapter = MagicMock()
+        adapter.REQUIRES_EDIT_FINALIZE = False
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_1",
+            StreamConsumerConfig(edit_interval=0, buffer_threshold=1, cursor=""),
+        )
+        task = asyncio.create_task(consumer.run())
+        consumer.on_delta("literal ![metadata:")
+        await asyncio.sleep(0.1)
+        consumer.finish()
+        await task
+
+        visible_payloads = [call.kwargs.get("content", "") for call in adapter.send.await_args_list]
+        visible_payloads += [call.kwargs.get("content", "") for call in adapter.edit_message.await_args_list]
+        assert visible_payloads
+        assert visible_payloads[-1] == "literal ![metadata:"
+
+    @pytest.mark.asyncio
+    async def test_streaming_bare_data_image_split_across_chunks_does_not_leak(self):
+        """Bare data:image split as da + ta:image must fail closed during streaming."""
+        adapter = MagicMock()
+        adapter.REQUIRES_EDIT_FINALIZE = False
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_1",
+            StreamConsumerConfig(edit_interval=0, buffer_threshold=1, cursor=""),
+        )
+        task = asyncio.create_task(consumer.run())
+        for chunk in [
+            "prefix da",
+            "ta:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ)",
+        ]:
+            consumer.on_delta(chunk)
+            await asyncio.sleep(0.1)
+        consumer.finish()
+        await task
+
+        visible_payloads = [call.kwargs.get("content", "") for call in adapter.send.await_args_list]
+        visible_payloads += [call.kwargs.get("content", "") for call in adapter.edit_message.await_args_list]
+        assert visible_payloads
+        assert all("data:image" not in payload for payload in visible_payloads)
+        assert all("base64" not in payload for payload in visible_payloads)
+        assert all("iVBOR" not in payload for payload in visible_payloads)
+        assert visible_payloads[-1] == "prefix "
+
+    @pytest.mark.asyncio
+    async def test_streaming_html_data_src_before_real_data_src_does_not_leak(self):
+        """data-src must not be mistaken for src before a real data:image src."""
+        adapter = MagicMock()
+        adapter.REQUIRES_EDIT_FINALIZE = False
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True, message_id="m1"))
+
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_1",
+            StreamConsumerConfig(edit_interval=0, buffer_threshold=1, cursor=""),
+        )
+        task = asyncio.create_task(consumer.run())
+        for chunk in [
+            'HTML <img data-src="https://example.com/track.png" src="',
+            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ",
+            '"> done',
+        ]:
+            consumer.on_delta(chunk)
+            await asyncio.sleep(0.1)
+        consumer.finish()
+        await task
+
+        visible_payloads = [call.kwargs.get("content", "") for call in adapter.send.await_args_list]
+        visible_payloads += [call.kwargs.get("content", "") for call in adapter.edit_message.await_args_list]
+        assert visible_payloads
+        assert all("data:image" not in payload for payload in visible_payloads)
+        assert all("base64" not in payload for payload in visible_payloads)
+        assert all("iVBOR" not in payload for payload in visible_payloads)
+        assert visible_payloads[-1] == "HTML  done"
 
     def test_preserves_non_media_colons(self):
         """Normal colons and text with 'MEDIA' as a word aren't stripped."""


### PR DESCRIPTION
## What does this PR do?

Fixes gateway media delivery for assistant responses that contain explicit image `data:` URLs. Previously, Markdown/HTML image data URLs could be streamed or sent as raw base64 text instead of being delivered as images. This change decodes valid explicit image data URLs into the existing controlled image cache and reuses the normal local image delivery path, while fail-closing invalid payloads so raw base64 is not shown to users.

The fix is implemented in the shared gateway layer rather than in a Feishu/Lark-specific sender, so other platforms get the same protection.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/base.py`
  - Decode and cache valid explicit Markdown/HTML image data URLs.
  - Remove invalid, oversized, unsupported, or malformed explicit image data URLs from visible text without guessing arbitrary base64.
  - Parse HTML `<img>` tags quote-safely, including `src`, `data-src`, and `srcset` data URL variants.
  - Hide bare `data:image/...` text fail-closed while preserving arbitrary bare base64 text.
- `gateway/stream_consumer.py`
  - Prevent streaming leakage of image data URLs across chunk boundaries, incomplete tags, segment breaks, and overflow message splitting.
  - Preserve benign speculative text such as `hello d`, `![not image`, and `![metadata:` when it is not an image data URL.
- `gateway/run.py`
  - In post-stream media delivery, send only existing local cached image files and skip remote HTTP(S) image URLs to avoid duplicate sends.
- Tests
  - Added regression coverage for Markdown, HTML, `srcset`, invalid payloads, oversized payloads, MIME/magic-byte validation, non-source HTML attributes, bare data URLs, remote images, post-stream delivery, and streaming overflow/cross-chunk cases.

## How to Test

1. Run the focused gateway regression suite:
   ```bash
   /tmp/hermes-ci-py311/bin/python -m pytest \
     tests/gateway/test_platform_base.py \
     tests/gateway/test_stream_consumer.py \
     tests/gateway/test_base_topic_sessions.py \
     tests/gateway/test_send_image_file.py \
     -q -o 'addopts='
   ```
   Result: `240 passed in 12.33s`
2. Run whitespace/diff validation:
   ```bash
   git diff --check -- \
     gateway/platforms/base.py \
     gateway/stream_consumer.py \
     gateway/run.py \
     tests/gateway/test_platform_base.py \
     tests/gateway/test_stream_consumer.py \
     tests/gateway/test_base_topic_sessions.py \
     tests/gateway/test_send_image_file.py
   ```
   Result: `0` lines.
3. Added-line security scan result: `security_lines=0`.
4. Independent pre-commit review result: `passed:true` for platform extraction, streaming cleanup, delivery path, and final summary review.

Note: I also attempted `pytest tests/ -q -o 'addopts='` with the same Python 3.11 environment. It did not complete cleanly in this local environment due to broad unrelated existing/environmental failures outside this gateway change area: `90 failed, 5427 passed, 44 skipped, 11209 errors in 289.11s`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Focused gateway regression suite:

```text
240 passed in 12.33s
```

Independent review final verdict:

```json
{"passed":true,"blockers":[],"security_concerns":[],"logic_errors":[]}
```
