### PR TITLE
fix(docker): materialize bundled TUI Ink package

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,7 +5,9 @@
 
 # Dependencies
 node_modules
+**/node_modules
 .venv
+**/.venv
 
 # CI/CD
 .github

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,8 +47,10 @@ COPY --chown=hermes:hermes . .
 RUN cd web && npm run build && \
     cd ../ui-tui && npm run build && \
     rm -rf node_modules/@hermes/ink && \
+    rm -rf packages/hermes-ink/node_modules && \
     cp -R packages/hermes-ink node_modules/@hermes/ink && \
-    node -e "import('@hermes/ink')"
+    npm install --omit=dev --prefer-offline --no-audit --prefix node_modules/@hermes/ink && \
+    node --input-type=module -e "await import('@hermes/ink')"
 
 # ---------- Permissions ----------
 # Make install dir world-readable so any HERMES_UID can read it at runtime.

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,10 @@ COPY --chown=hermes:hermes . .
 
 # Build browser dashboard and terminal UI assets.
 RUN cd web && npm run build && \
-    cd ../ui-tui && npm run build
+    cd ../ui-tui && npm run build && \
+    rm -rf node_modules/@hermes/ink && \
+    cp -R packages/hermes-ink node_modules/@hermes/ink && \
+    node -e "import('@hermes/ink')"
 
 # ---------- Permissions ----------
 # Make install dir world-readable so any HERMES_UID can read it at runtime.

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,8 @@ RUN cd web && npm run build && \
     rm -rf node_modules/@hermes/ink && \
     rm -rf packages/hermes-ink/node_modules && \
     cp -R packages/hermes-ink node_modules/@hermes/ink && \
-    npm install --omit=dev --prefer-offline --no-audit --prefix node_modules/@hermes/ink && \
+    npm ci --omit=dev --prefer-offline --no-audit --prefix node_modules/@hermes/ink && \
+    rm -rf packages/hermes-ink && \
     node --input-type=module -e "await import('@hermes/ink')"
 
 # ---------- Permissions ----------

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,6 @@ RUN cd web && npm run build && \
     rm -rf packages/hermes-ink/node_modules && \
     cp -R packages/hermes-ink node_modules/@hermes/ink && \
     npm install --omit=dev --prefer-offline --no-audit --prefix node_modules/@hermes/ink && \
-    rm -rf packages/hermes-ink && \
     node --input-type=module -e "await import('@hermes/ink')"
 
 # ---------- Permissions ----------

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/opt/hermes/.playwright
 # that would otherwise accumulate when hermes runs as PID 1. See #15012.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        build-essential nodejs npm python3 ripgrep ffmpeg gcc python3-dev libffi-dev procps git openssh-client docker-cli tini && \
+    build-essential nodejs npm python3 ripgrep ffmpeg gcc python3-dev libffi-dev procps git openssh-client docker-cli tini && \
     rm -rf /var/lib/apt/lists/*
 
 # Non-root user for runtime; UID can be overridden via HERMES_UID at runtime
@@ -50,6 +50,7 @@ RUN cd web && npm run build && \
     rm -rf packages/hermes-ink/node_modules && \
     cp -R packages/hermes-ink node_modules/@hermes/ink && \
     npm install --omit=dev --prefer-offline --no-audit --prefix node_modules/@hermes/ink && \
+    rm -rf node_modules/@hermes/ink/node_modules/react && \
     node --input-type=module -e "await import('@hermes/ink')"
 
 # ---------- Permissions ----------

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN cd web && npm run build && \
     rm -rf node_modules/@hermes/ink && \
     rm -rf packages/hermes-ink/node_modules && \
     cp -R packages/hermes-ink node_modules/@hermes/ink && \
-    npm ci --omit=dev --prefer-offline --no-audit --prefix node_modules/@hermes/ink && \
+    npm install --omit=dev --prefer-offline --no-audit --prefix node_modules/@hermes/ink && \
     rm -rf packages/hermes-ink && \
     node --input-type=module -e "await import('@hermes/ink')"
 

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -130,7 +130,7 @@ class TestCmdUpdateBranchFallback:
         #   3. web/       — install + "npm run build" for the web frontend
         full_flags = [
             "/usr/bin/npm",
-            "install",
+            "ci",
             "--silent",
             "--no-fund",
             "--no-audit",
@@ -139,7 +139,7 @@ class TestCmdUpdateBranchFallback:
         assert npm_calls == [
             (full_flags, PROJECT_ROOT),
             (full_flags, PROJECT_ROOT / "ui-tui"),
-            (["/usr/bin/npm", "install", "--silent"], PROJECT_ROOT / "web"),
+            (["/usr/bin/npm", "ci", "--silent"], PROJECT_ROOT / "web"),
             (["/usr/bin/npm", "run", "build"], PROJECT_ROOT / "web"),
         ]
 

--- a/tests/tools/test_dockerfile_pid1_reaping.py
+++ b/tests/tools/test_dockerfile_pid1_reaping.py
@@ -130,7 +130,9 @@ def test_dockerfile_materializes_local_tui_ink_package(dockerfile_text):
         "ui-tui" in step
         and "node_modules/@hermes/ink" in step
         and "packages/hermes-ink" in step
-        and "import('@hermes/ink')" in step
+        and "rm -rf packages/hermes-ink/node_modules" in step
+        and "--prefix node_modules/@hermes/ink" in step
+        and "await import('@hermes/ink')" in step
         for step in _run_steps(dockerfile_text)
     )
 

--- a/tests/tools/test_dockerfile_pid1_reaping.py
+++ b/tests/tools/test_dockerfile_pid1_reaping.py
@@ -122,3 +122,13 @@ def test_dockerfile_builds_tui_assets(dockerfile_text):
         and "run build" in step
         for step in _run_steps(dockerfile_text)
     )
+
+
+def test_dockerfile_materializes_local_tui_ink_package(dockerfile_text):
+    assert any(
+        "ui-tui" in step
+        and "node_modules/@hermes/ink" in step
+        and "packages/hermes-ink" in step
+        and "import('@hermes/ink')" in step
+        for step in _run_steps(dockerfile_text)
+    )

--- a/tests/tools/test_dockerfile_pid1_reaping.py
+++ b/tests/tools/test_dockerfile_pid1_reaping.py
@@ -138,6 +138,9 @@ def test_dockerfile_materializes_local_tui_ink_package(dockerfile_text):
 
 
 def test_dockerignore_excludes_nested_dependency_dirs():
+    if not DOCKERIGNORE.exists():
+        pytest.skip(".dockerignore not present in this checkout")
+
     text = DOCKERIGNORE.read_text()
 
     assert "**/node_modules" in text

--- a/tests/tools/test_dockerfile_pid1_reaping.py
+++ b/tests/tools/test_dockerfile_pid1_reaping.py
@@ -21,6 +21,7 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DOCKERFILE = REPO_ROOT / "Dockerfile"
+DOCKERIGNORE = REPO_ROOT / ".dockerignore"
 
 
 @pytest.fixture(scope="module")
@@ -132,3 +133,10 @@ def test_dockerfile_materializes_local_tui_ink_package(dockerfile_text):
         and "import('@hermes/ink')" in step
         for step in _run_steps(dockerfile_text)
     )
+
+
+def test_dockerignore_excludes_nested_dependency_dirs():
+    text = DOCKERIGNORE.read_text()
+
+    assert "**/node_modules" in text
+    assert "**/.venv" in text

--- a/tests/tools/test_dockerfile_pid1_reaping.py
+++ b/tests/tools/test_dockerfile_pid1_reaping.py
@@ -131,7 +131,9 @@ def test_dockerfile_materializes_local_tui_ink_package(dockerfile_text):
         and "node_modules/@hermes/ink" in step
         and "packages/hermes-ink" in step
         and "rm -rf packages/hermes-ink/node_modules" in step
+        and "npm ci --omit=dev" in step
         and "--prefix node_modules/@hermes/ink" in step
+        and "rm -rf packages/hermes-ink" in step
         and "await import('@hermes/ink')" in step
         for step in _run_steps(dockerfile_text)
     )

--- a/tests/tools/test_dockerfile_pid1_reaping.py
+++ b/tests/tools/test_dockerfile_pid1_reaping.py
@@ -109,18 +109,14 @@ def test_dockerfile_installs_tui_dependencies(dockerfile_text):
     assert "ui-tui/package.json" in dockerfile_text
     assert "ui-tui/packages/hermes-ink/package-lock.json" in dockerfile_text
     assert any(
-        "ui-tui" in step
-        and "npm" in step
-        and (" install" in step or " ci" in step)
+        "ui-tui" in step and "npm" in step and (" install" in step or " ci" in step)
         for step in _run_steps(dockerfile_text)
     )
 
 
 def test_dockerfile_builds_tui_assets(dockerfile_text):
     assert any(
-        "ui-tui" in step
-        and "npm" in step
-        and "run build" in step
+        "ui-tui" in step and "npm" in step and "run build" in step
         for step in _run_steps(dockerfile_text)
     )
 
@@ -133,6 +129,7 @@ def test_dockerfile_materializes_local_tui_ink_package(dockerfile_text):
         and "rm -rf packages/hermes-ink/node_modules" in step
         and "npm install --omit=dev" in step
         and "--prefix node_modules/@hermes/ink" in step
+        and "rm -rf node_modules/@hermes/ink/node_modules/react" in step
         and "await import('@hermes/ink')" in step
         for step in _run_steps(dockerfile_text)
     )

--- a/tests/tools/test_dockerfile_pid1_reaping.py
+++ b/tests/tools/test_dockerfile_pid1_reaping.py
@@ -133,7 +133,6 @@ def test_dockerfile_materializes_local_tui_ink_package(dockerfile_text):
         and "rm -rf packages/hermes-ink/node_modules" in step
         and "npm install --omit=dev" in step
         and "--prefix node_modules/@hermes/ink" in step
-        and "rm -rf packages/hermes-ink" in step
         and "await import('@hermes/ink')" in step
         for step in _run_steps(dockerfile_text)
     )

--- a/tests/tools/test_dockerfile_pid1_reaping.py
+++ b/tests/tools/test_dockerfile_pid1_reaping.py
@@ -131,7 +131,7 @@ def test_dockerfile_materializes_local_tui_ink_package(dockerfile_text):
         and "node_modules/@hermes/ink" in step
         and "packages/hermes-ink" in step
         and "rm -rf packages/hermes-ink/node_modules" in step
-        and "npm ci --omit=dev" in step
+        and "npm install --omit=dev" in step
         and "--prefix node_modules/@hermes/ink" in step
         and "rm -rf packages/hermes-ink" in step
         and "await import('@hermes/ink')" in step


### PR DESCRIPTION
## Summary
- Keep nested dependency directories out of Docker build context by ignoring `**/node_modules` and `**/.venv`.
- Materialize a clean `@hermes/ink` package into `ui-tui/node_modules/@hermes/ink` during image build, reinstalling only production deps for that package.
- Add a deterministic build-time smoke check with top-level await (`node --input-type=module -e \"await import('@hermes/ink')\"`) so bad TUI module resolution fails before image publish.
- Expand Docker contract tests to cover the new Dockerfile behavior and skip `.dockerignore` assertions in partial checkouts.

## Test plan
- `/home/bb/hermes-agent/.venv/bin/python -m pytest tests/tools/test_dockerfile_pid1_reaping.py -q -n 4`
- `docker build -t hermes-agent:tui-ink-fix .`
- `docker run --rm hermes-agent:tui-ink-fix bash -lc 'cd /opt/hermes/ui-tui && node --input-type=module -e "await import(\"@hermes/ink\"); console.log(\"ok\")"'`
- `docker save hermes-agent:tui-ink-fix | podman load`
- `podman run --rm docker.io/library/hermes-agent:tui-ink-fix bash -lc 'cd /opt/hermes/ui-tui && node --input-type=module -e "await import(\"@hermes/ink\"); console.log(\"ok\")"'`