### PR TITLE
fix(honcho): replace raw int() config parsing with safe helper

### DIFF
--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -110,6 +110,17 @@ def _parse_context_tokens(host_val, root_val) -> int | None:
     return None
 
 
+def _parse_int_config(host_val, root_val, default: int) -> int:
+    """Parse an integer config: host wins, then root, then default."""
+    for val in (host_val, root_val):
+        if val is not None:
+            try:
+                return int(val)
+            except (ValueError, TypeError):
+                pass
+    return default
+
+
 def _parse_dialectic_depth(host_val, root_val) -> int:
     """Parse dialecticDepth: host wins, then root, then 1. Clamped to 1-3."""
     for val in (host_val, root_val):
@@ -463,10 +474,10 @@ class HonchoClientConfig:
                 raw.get("dialecticDynamic"),
                 default=True,
             ),
-            dialectic_max_chars=int(
-                host_block.get("dialecticMaxChars")
-                or raw.get("dialecticMaxChars")
-                or 600
+            dialectic_max_chars=_parse_int_config(
+                host_block.get("dialecticMaxChars"),
+                raw.get("dialecticMaxChars"),
+                default=600,
             ),
             dialectic_depth=_parse_dialectic_depth(
                 host_block.get("dialecticDepth"),
@@ -487,15 +498,15 @@ class HonchoClientConfig:
                 or raw.get("reasoningLevelCap")
                 or "high"
             ),
-            message_max_chars=int(
-                host_block.get("messageMaxChars")
-                or raw.get("messageMaxChars")
-                or 25000
+            message_max_chars=_parse_int_config(
+                host_block.get("messageMaxChars"),
+                raw.get("messageMaxChars"),
+                default=25000,
             ),
-            dialectic_max_input_chars=int(
-                host_block.get("dialecticMaxInputChars")
-                or raw.get("dialecticMaxInputChars")
-                or 10000
+            dialectic_max_input_chars=_parse_int_config(
+                host_block.get("dialecticMaxInputChars"),
+                raw.get("dialecticMaxInputChars"),
+                default=10000,
             ),
             recall_mode=_normalize_recall_mode(
                 host_block.get("recallMode")


### PR DESCRIPTION
## What does this PR do?

Three `int()` calls in `HonchoClient.from_global_config()` parsed `dialecticMaxChars`, `messageMaxChars`, and `dialecticMaxInputChars` directly without error handling. A malformed value in `honcho.json` (e.g. `"dialecticMaxChars": "oops"`) would raise `ValueError` and abort Honcho provider initialization entirely.

## Type of Change
- [x] Bug fix

## Root Cause

Raw `int(host_block.get(...) or raw.get(...) or default)` calls have no guard. The file already uses safe helpers like `_parse_context_tokens()` and `_parse_dialectic_depth()` for similar fields — these three fields were missed.

## Changes Made

- Added `_parse_int_config(host_val, root_val, default)` helper following the existing `_parse_context_tokens()` pattern
- Replaced all three raw `int()` calls with `_parse_int_config()`:
  - `dialecticMaxChars` — default 600
  - `messageMaxChars` — default 25000
  - `dialecticMaxInputChars` — default 10000

## How to Test

1. Add `"dialecticMaxChars": "oops"` to `honcho.json`
2. Initialize Honcho memory provider
3. Before: `ValueError` aborts provider init
4. After: falls back to default 600 safely

## Checklist
- [x] Follows existing `_parse_context_tokens()` pattern already in the file
- [x] No new dependencies
- [x] Only touches `from_global_config()` and adds one helper function