### PR TITLE
fix(gateway): propagate credential_pool through /model session overrides (#16678)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5295,12 +5295,19 @@ class HermesCLI:
 
         if self.agent is not None:
             try:
+                # Propagate resolved credential pool so 429/402 rotation
+                # survives the in-place swap; mirror it on the CLI so any
+                # later code that reads ``self._credential_pool`` (e.g. on
+                # next-turn re-resolution) sees the new pool.
+                if result.credential_pool is not None:
+                    self._credential_pool = result.credential_pool
                 self.agent.switch_model(
                     new_model=result.new_model,
                     new_provider=result.target_provider,
                     api_key=result.api_key,
                     base_url=result.base_url,
                     api_mode=result.api_mode,
+                    credential_pool=result.credential_pool,
                 )
             except Exception as exc:
                 _cprint(f"  ⚠ Agent swap failed ({exc}); change applied to next session.")
@@ -5516,12 +5523,19 @@ class HermesCLI:
         # Apply to running agent (in-place swap)
         if self.agent is not None:
             try:
+                # Propagate resolved credential pool so 429/402 rotation
+                # survives the in-place swap; mirror it on the CLI so any
+                # later code that reads ``self._credential_pool`` (e.g. on
+                # next-turn re-resolution) sees the new pool.
+                if result.credential_pool is not None:
+                    self._credential_pool = result.credential_pool
                 self.agent.switch_model(
                     new_model=result.new_model,
                     new_provider=result.target_provider,
                     api_key=result.api_key,
                     base_url=result.base_url,
                     api_mode=result.api_mode,
+                    credential_pool=result.credential_pool,
                 )
             except Exception as exc:
                 _cprint(f"  ⚠ Agent swap failed ({exc}); change applied to next session.")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -637,7 +637,10 @@ class GatewayRunner:
     _restart_detached: bool = False
     _restart_via_service: bool = False
     _stop_task: Optional[asyncio.Task] = None
-    _session_model_overrides: Dict[str, Dict[str, str]] = {}
+    # Values are mostly ``str`` (model/provider/api_key/base_url/api_mode)
+    # but ``credential_pool`` is a live ``CredentialPool`` instance, so the
+    # value type is widened to ``Any`` rather than ``str``.  See #16678.
+    _session_model_overrides: Dict[str, Dict[str, Any]] = {}
     _session_reasoning_overrides: Dict[str, Dict[str, Any]] = {}
     
     def __init__(self, config: Optional[GatewayConfig] = None):
@@ -710,8 +713,11 @@ class GatewayRunner:
         self._agent_cache_lock = _threading.Lock()
 
         # Per-session model overrides from /model command.
-        # Key: session_key, Value: dict with model/provider/api_key/base_url/api_mode
-        self._session_model_overrides: Dict[str, Dict[str, str]] = {}
+        # Key: session_key.  Value: dict with model/provider/api_key/base_url/api_mode
+        # (all str) plus an optional ``credential_pool`` carrying the live
+        # ``CredentialPool`` for the target provider so future-turn 429
+        # rotation runs against the right pool.  See #16678.
+        self._session_model_overrides: Dict[str, Dict[str, Any]] = {}
         # Per-session reasoning effort overrides from /reasoning.
         # Key: session_key, Value: parsed reasoning config dict.
         self._session_reasoning_overrides: Dict[str, Dict[str, Any]] = {}

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5991,6 +5991,10 @@ class GatewayRunner:
                             "api_key": result.api_key,
                             "base_url": result.base_url,
                             "api_mode": result.api_mode,
+                            # The new provider's credential pool — without
+                            # this, future-turn rotation on 429 stays bound
+                            # to the original provider's pool.  See #16678.
+                            "credential_pool": result.credential_pool,
                         }
 
                         # Evict cached agent so the next turn creates a fresh
@@ -6119,6 +6123,9 @@ class GatewayRunner:
             "api_key": result.api_key,
             "base_url": result.base_url,
             "api_mode": result.api_mode,
+            # Carry the new provider's credential pool so future-turn 429
+            # rotation runs against the right pool (see #16678).
+            "credential_pool": result.credential_pool,
         }
 
         # Evict cached agent so the next turn creates a fresh agent from the
@@ -8915,6 +8922,12 @@ class GatewayRunner:
         config.yaml defaults so the switched model is actually used for
         subsequent messages.  Fields with ``None`` values are skipped so
         partial overrides don't clobber valid config defaults.
+
+        ``credential_pool`` is the exception: a ``None`` override is a
+        legitimate "no pool for the new provider" signal, and leaving the
+        startup pool in place would let 429 rotation run against the
+        wrong provider's credentials (#16678).  When the override carries
+        the key at all, it always wins — even when its value is ``None``.
         """
         override = self._session_model_overrides.get(session_key)
         if not override:
@@ -8924,6 +8937,8 @@ class GatewayRunner:
             val = override.get(key)
             if val is not None:
                 runtime_kwargs[key] = val
+        if "credential_pool" in override:
+            runtime_kwargs["credential_pool"] = override["credential_pool"]
         return model, runtime_kwargs
 
     def _is_intentional_model_switch(self, session_key: str, agent_model: str) -> bool:

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -23,7 +23,13 @@ from __future__ import annotations
 import logging
 import re
 from dataclasses import dataclass
-from typing import Any, List, NamedTuple, Optional
+from typing import TYPE_CHECKING, Any, List, NamedTuple, Optional
+
+if TYPE_CHECKING:
+    # Imported only for type hints — keeps the runtime import graph
+    # asymmetric (agent.* depends on hermes_cli.*, not the other way
+    # round) so loading hermes_cli stays cheap.
+    from agent.credential_pool import CredentialPool
 
 from hermes_cli.providers import (
     custom_provider_slug,
@@ -247,7 +253,7 @@ class ModelSwitchResult:
     # after a /model switch — without it, a 429 on the new provider rotates
     # within the original provider's pool (or skips rotation entirely and
     # falls through to the configured fallback model).  See #16678.
-    credential_pool: Optional[Any] = None
+    credential_pool: Optional["CredentialPool"] = None
 
 
 @dataclass

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import logging
 import re
 from dataclasses import dataclass
-from typing import List, NamedTuple, Optional
+from typing import Any, List, NamedTuple, Optional
 
 from hermes_cli.providers import (
     custom_provider_slug,
@@ -241,6 +241,13 @@ class ModelSwitchResult:
     capabilities: Optional[ModelCapabilities] = None
     model_info: Optional[ModelInfo] = None
     is_global: bool = False
+    # CredentialPool for the resolved target provider, when one was loaded.
+    # Callers that maintain runtime kwargs (e.g. the gateway session-override
+    # store) must propagate this so per-provider rotation continues to work
+    # after a /model switch — without it, a 429 on the new provider rotates
+    # within the original provider's pool (or skips rotation entirely and
+    # falls through to the configured fallback model).  See #16678.
+    credential_pool: Optional[Any] = None
 
 
 @dataclass
@@ -811,6 +818,11 @@ def switch_model(
     api_key = current_api_key
     base_url = current_base_url
     api_mode = ""
+    # Track the credential pool resolved for the *target* provider so the
+    # caller can wire it into runtime_kwargs / session overrides.  Stays
+    # None if resolution fails or the provider has no pool — the caller
+    # treats that as "no rotation available", which is correct.
+    credential_pool: Optional[Any] = None
 
     if provider_changed or explicit_provider:
         try:
@@ -821,6 +833,7 @@ def switch_model(
             api_key = runtime.get("api_key", "")
             base_url = runtime.get("base_url", "")
             api_mode = runtime.get("api_mode", "")
+            credential_pool = runtime.get("credential_pool")
         except Exception as e:
             return ModelSwitchResult(
                 success=False,
@@ -846,6 +859,7 @@ def switch_model(
                 api_key = runtime.get("api_key", "")
                 base_url = runtime.get("base_url", "")
                 api_mode = runtime.get("api_mode", "")
+                credential_pool = runtime.get("credential_pool")
         except Exception:
             pass
 
@@ -966,6 +980,7 @@ def switch_model(
         capabilities=capabilities,
         model_info=model_info,
         is_global=is_global,
+        credential_pool=credential_pool,
     )
 
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -2094,7 +2094,7 @@ class AIAgent:
         if hasattr(self, "context_compressor") and self.context_compressor:
             self.context_compressor.on_session_reset()
     
-    def switch_model(self, new_model, new_provider, api_key='', base_url='', api_mode=''):
+    def switch_model(self, new_model, new_provider, api_key='', base_url='', api_mode='', credential_pool=None):
         """Switch the model/provider in-place for a live agent.
 
         Called by the /model command handlers (CLI and gateway) after
@@ -2102,6 +2102,14 @@ class AIAgent:
         validated the model.  This method performs the actual runtime
         swap: rebuilding clients, updating caching flags, and refreshing
         the context compressor.
+
+        ``credential_pool`` is the optional pool resolved by the /model
+        pipeline (e.g. when switching to a ``custom:<name>`` provider that
+        is backed by a CredentialPool).  When provided, the agent's
+        ``_credential_pool`` is swapped so 429/402 rotation continues to
+        work after a mid-session switch — without it, the new provider's
+        pool is silently dropped and the agent falls back to single-key
+        behaviour.
 
         The implementation mirrors ``_try_activate_fallback()`` for the
         client-swap logic but also updates ``_primary_runtime`` so the
@@ -2140,6 +2148,15 @@ class AIAgent:
             self._transport_cache.clear()
         if api_key:
             self.api_key = api_key
+
+        # ── Swap credential pool if provided ──
+        # The /model pipeline resolves pools via load_pool() and surfaces
+        # them on ModelSwitchResult.credential_pool.  Callers that pass it
+        # through here keep the agent's per-provider rotation working after
+        # an in-place swap; without this the new provider would lose its
+        # 429/402 rotation and fall back to single-key behaviour.
+        if credential_pool is not None:
+            self._credential_pool = credential_pool
 
         # ── Build new client ──
         if api_mode == "anthropic_messages":

--- a/tests/gateway/test_session_model_override_routing.py
+++ b/tests/gateway/test_session_model_override_routing.py
@@ -163,3 +163,118 @@ async def test_background_task_prefers_session_override_over_global_runtime(monk
     assert _CapturingAgent.last_init["base_url"] == "https://chatgpt.com/backend-api/codex"
     assert _CapturingAgent.last_init["api_key"] == "***"
     assert _CapturingAgent.last_init["reasoning_config"] == {"enabled": True, "effort": "high"}
+
+
+# ---------------------------------------------------------------------------
+# credential_pool propagation (#16678)
+#
+# Without the override carrying credential_pool, /model switching to a new
+# provider in the gateway leaves runtime_kwargs["credential_pool"] pointing
+# at the *original* provider's pool — so a 429 on the new provider rotates
+# (or fails to rotate) against the wrong provider's credentials, and the
+# session falls through to the configured fallback model instead of
+# rotating to the next credential on the new provider.
+# ---------------------------------------------------------------------------
+
+
+def test_apply_session_model_override_propagates_credential_pool():
+    """An override-supplied credential_pool overwrites the global one."""
+    runner = _make_runner()
+    session_key = "agent:main:local:dm"
+
+    new_pool = MagicMock(name="new_provider_pool")
+    runner._session_model_overrides[session_key] = {
+        "model": "gpt-5.4",
+        "provider": "openai-codex",
+        "api_key": "***",
+        "base_url": "https://chatgpt.com/backend-api/codex",
+        "api_mode": "codex_responses",
+        "credential_pool": new_pool,
+    }
+
+    old_pool = MagicMock(name="old_provider_pool")
+    runtime_kwargs = {
+        "api_key": "old-key",
+        "base_url": "https://api.old.example",
+        "provider": "anthropic",
+        "api_mode": "anthropic_messages",
+        "credential_pool": old_pool,
+    }
+
+    model, kwargs = gateway_run.GatewayRunner._apply_session_model_override(
+        runner, session_key, "claude-sonnet", runtime_kwargs
+    )
+
+    assert model == "gpt-5.4"
+    assert kwargs["provider"] == "openai-codex"
+    # Critical assertion — without the fix this would still be ``old_pool``.
+    assert kwargs["credential_pool"] is new_pool
+
+
+def test_apply_session_model_override_replaces_pool_with_none():
+    """An explicit ``credential_pool: None`` clears the prior pool.
+
+    A switched-to provider may legitimately have no pool (e.g. only an env
+    var key configured).  Skipping ``None`` would leave the original
+    provider's pool live and rotate against the wrong credentials on 429.
+    """
+    runner = _make_runner()
+    session_key = "agent:main:local:dm"
+
+    runner._session_model_overrides[session_key] = {
+        "model": "gpt-5.4",
+        "provider": "openai-codex",
+        "api_key": "***",
+        "base_url": "https://chatgpt.com/backend-api/codex",
+        "api_mode": "codex_responses",
+        "credential_pool": None,
+    }
+
+    runtime_kwargs = {
+        "api_key": "old-key",
+        "base_url": "https://api.old.example",
+        "provider": "anthropic",
+        "api_mode": "anthropic_messages",
+        "credential_pool": MagicMock(name="old_provider_pool"),
+    }
+
+    _model, kwargs = gateway_run.GatewayRunner._apply_session_model_override(
+        runner, session_key, "claude-sonnet", runtime_kwargs
+    )
+
+    assert kwargs["credential_pool"] is None
+
+
+def test_apply_session_model_override_omitting_pool_keeps_existing():
+    """A pre-fix override (no ``credential_pool`` key) is left alone.
+
+    Older callers (and persisted overrides, if any) may not carry the
+    new key at all.  Those should keep the existing runtime pool — not
+    blank it — so we don't regress sessions that never switched provider.
+    """
+    runner = _make_runner()
+    session_key = "agent:main:local:dm"
+
+    runner._session_model_overrides[session_key] = {
+        "model": "gpt-5.4",
+        "provider": "openai-codex",
+        "api_key": "***",
+        "base_url": "https://chatgpt.com/backend-api/codex",
+        "api_mode": "codex_responses",
+        # credential_pool intentionally omitted (legacy override shape)
+    }
+
+    existing_pool = MagicMock(name="existing_pool")
+    runtime_kwargs = {
+        "api_key": "old-key",
+        "base_url": "https://api.old.example",
+        "provider": "anthropic",
+        "api_mode": "anthropic_messages",
+        "credential_pool": existing_pool,
+    }
+
+    _model, kwargs = gateway_run.GatewayRunner._apply_session_model_override(
+        runner, session_key, "claude-sonnet", runtime_kwargs
+    )
+
+    assert kwargs["credential_pool"] is existing_pool

--- a/tests/hermes_cli/test_model_switch_credential_pool.py
+++ b/tests/hermes_cli/test_model_switch_credential_pool.py
@@ -1,0 +1,145 @@
+"""Regression tests for credential_pool propagation through switch_model.
+
+The shared /model pipeline (``hermes_cli.model_switch.switch_model``) calls
+``resolve_runtime_provider()`` for the target provider, which returns the
+provider's credential pool alongside ``api_key`` / ``base_url`` / ``api_mode``.
+Historically the pool was discarded, so the gateway's session-override
+machinery had nothing to propagate — leaving the original provider's pool
+live across a /model switch (#16678).
+
+These tests pin the contract: ``ModelSwitchResult.credential_pool`` carries
+the resolved pool for the target provider on both the explicit-provider
+path and the same-provider re-resolve path.
+"""
+
+from unittest.mock import MagicMock
+
+from hermes_cli.model_switch import switch_model
+
+
+_MOCK_VALIDATION = {
+    "accepted": True,
+    "persist": True,
+    "recognized": True,
+    "message": None,
+}
+
+
+def _stub_model_metadata(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.models.validate_requested_model",
+        lambda *a, **k: _MOCK_VALIDATION,
+    )
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_info", lambda *a, **k: None)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_capabilities", lambda *a, **k: None)
+
+
+def test_switch_model_returns_credential_pool_on_explicit_provider(monkeypatch):
+    """Explicit --provider switch must surface the new provider's pool.
+
+    Without this, a 429 on the new provider rotates against the original
+    provider's pool (or skips rotation entirely) — see #16678.
+    """
+    target_pool = MagicMock(name="codex_pool")
+
+    def _fake_resolve_runtime_provider(**kwargs):
+        assert kwargs["requested"] == "openai-codex"
+        return {
+            "api_key": "sk-codex",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "api_mode": "codex_responses",
+            "provider": "openai-codex",
+            "credential_pool": target_pool,
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        _fake_resolve_runtime_provider,
+    )
+    _stub_model_metadata(monkeypatch)
+
+    result = switch_model(
+        raw_input="gpt-5.4",
+        current_provider="anthropic",
+        current_model="claude-sonnet-4-6",
+        current_base_url="https://api.anthropic.com",
+        current_api_key="sk-ant-old",
+        explicit_provider="openai-codex",
+    )
+
+    assert result.success is True
+    assert result.target_provider == "openai-codex"
+    # Critical: the new provider's pool must round-trip through the result
+    # so the gateway can store it on the session override.
+    assert result.credential_pool is target_pool
+
+
+def test_switch_model_returns_credential_pool_on_same_provider_reresolve(monkeypatch):
+    """Same-provider switches still re-resolve runtime, including the pool.
+
+    Models that don't change provider still go through resolve_runtime_provider
+    so credential rotation / OpenCode base_url adjustments are picked up.
+    The pool returned by that call must surface in the result.
+    """
+    pool = MagicMock(name="anthropic_pool")
+
+    def _fake_resolve_runtime_provider(**kwargs):
+        assert kwargs["requested"] == "anthropic"
+        return {
+            "api_key": "sk-ant-rotated",
+            "base_url": "https://api.anthropic.com",
+            "api_mode": "anthropic_messages",
+            "provider": "anthropic",
+            "credential_pool": pool,
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        _fake_resolve_runtime_provider,
+    )
+    _stub_model_metadata(monkeypatch)
+
+    result = switch_model(
+        raw_input="claude-opus-4-7",
+        current_provider="anthropic",
+        current_model="claude-sonnet-4-6",
+        current_base_url="https://api.anthropic.com",
+        current_api_key="sk-ant-old",
+    )
+
+    assert result.success is True
+    assert result.target_provider == "anthropic"
+    assert result.credential_pool is pool
+
+
+def test_switch_model_default_credential_pool_is_none(monkeypatch):
+    """When runtime resolution yields no pool, the result carries None.
+
+    Some providers (single env-var key, custom local endpoints without a
+    saved pool) genuinely have no pool — the gateway override layer must
+    see ``None`` so it can clear the previous provider's pool rather than
+    leaving stale rotation in place.
+    """
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kwargs: {
+            "api_key": "sk-codex",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "api_mode": "codex_responses",
+            "provider": "openai-codex",
+            # No credential_pool key — older code paths sometimes omit it.
+        },
+    )
+    _stub_model_metadata(monkeypatch)
+
+    result = switch_model(
+        raw_input="gpt-5.4",
+        current_provider="anthropic",
+        current_model="claude-sonnet-4-6",
+        current_base_url="https://api.anthropic.com",
+        current_api_key="sk-ant-old",
+        explicit_provider="openai-codex",
+    )
+
+    assert result.success is True
+    assert result.credential_pool is None

--- a/tests/run_agent/test_switch_model_credential_pool.py
+++ b/tests/run_agent/test_switch_model_credential_pool.py
@@ -1,0 +1,134 @@
+"""Regression tests that ``AIAgent.switch_model`` swaps ``_credential_pool``.
+
+The /model pipeline now resolves a target-provider credential pool and
+surfaces it on ``ModelSwitchResult.credential_pool``.  Both the gateway's
+``_on_model_selected`` and the CLI's ``_apply_model_switch_result`` /
+``_handle_model_switch`` pass that pool through to ``agent.switch_model()``.
+
+Without these tests, a regression that drops the new ``credential_pool``
+kwarg from ``AIAgent.switch_model`` would silently strand the new
+provider's pool and break 429/402 rotation after a /model switch — the
+exact bug fixed in #16678.  Pin the contract.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+def _make_agent_minimal(initial_pool=None) -> AIAgent:
+    """Build a minimal AIAgent that can run ``switch_model`` end-to-end.
+
+    Skips ``__init__`` (which builds clients, fallback chain, prompt
+    cache, compressor, etc.) and seeds only the fields ``switch_model``
+    reads or writes.  Mirrors the pattern in ``test_switch_model_context.py``.
+    """
+    agent = AIAgent.__new__(AIAgent)
+
+    agent.model = "primary-model"
+    agent.provider = "openrouter"
+    agent.base_url = "https://openrouter.ai/api/v1"
+    agent.api_key = "sk-primary"
+    agent.api_mode = "chat_completions"
+    agent.client = MagicMock()
+    agent.quiet_mode = True
+
+    agent._credential_pool = initial_pool
+    agent._config_context_length = None
+    agent._primary_runtime = {}
+    agent._fallback_chain = []
+    agent._fallback_model = None
+    agent._fallback_activated = False
+    agent._fallback_index = 0
+    agent._cached_system_prompt = None
+    agent._use_prompt_caching = False
+    agent._use_native_cache_layout = False
+    agent._client_kwargs = {}
+    # No context_compressor attribute — switch_model guards on hasattr.
+
+    return agent
+
+
+@patch("agent.model_metadata.get_model_context_length", return_value=128_000)
+def test_switch_model_swaps_credential_pool(mock_ctx_len):
+    """Passing ``credential_pool`` updates ``self._credential_pool``.
+
+    Reproduces the in-place swap that the /model command performs after
+    resolving a new provider's pool — the CLI and gateway both call
+    ``agent.switch_model(..., credential_pool=result.credential_pool)``
+    and rely on the agent picking up the new pool for next-turn rotation.
+    """
+    old_pool = MagicMock(name="openrouter_pool")
+    new_pool = MagicMock(name="codex_pool")
+    agent = _make_agent_minimal(initial_pool=old_pool)
+
+    # Mock client builder so we don't hit the network on the real
+    # _create_openai_client path.
+    with patch.object(agent, "_create_openai_client", return_value=MagicMock()):
+        agent.switch_model(
+            "gpt-5.4",
+            "openai-codex",
+            api_key="sk-codex",
+            base_url="https://chatgpt.com/backend-api/codex",
+            api_mode="chat_completions",
+            credential_pool=new_pool,
+        )
+
+    # The new pool must replace the old one — without this, 429s on the
+    # new provider rotate against the wrong pool (or skip rotation).
+    assert agent._credential_pool is new_pool
+
+
+@patch("agent.model_metadata.get_model_context_length", return_value=128_000)
+def test_switch_model_without_credential_pool_preserves_existing(mock_ctx_len):
+    """Omitting ``credential_pool`` leaves the existing one in place.
+
+    Many switch paths legitimately have no pool (single-key custom
+    endpoints, providers without rotation).  The agent must NOT clobber
+    its existing pool to ``None`` in that case — only replace when a new
+    pool is explicitly supplied.  This matches the ``if credential_pool
+    is not None`` guard in switch_model and prevents stale callers (or
+    older code paths that don't yet pass the kwarg) from silently
+    disabling rotation.
+    """
+    existing_pool = MagicMock(name="existing_pool")
+    agent = _make_agent_minimal(initial_pool=existing_pool)
+
+    with patch.object(agent, "_create_openai_client", return_value=MagicMock()):
+        agent.switch_model(
+            "gpt-5.4",
+            "openai-codex",
+            api_key="sk-codex",
+            base_url="https://chatgpt.com/backend-api/codex",
+            api_mode="chat_completions",
+        )
+
+    assert agent._credential_pool is existing_pool
+
+
+@patch("agent.model_metadata.get_model_context_length", return_value=128_000)
+def test_switch_model_explicit_none_preserves_existing(mock_ctx_len):
+    """``credential_pool=None`` is treated as "no change", not "clear".
+
+    The CLI passes ``result.credential_pool`` directly; that field is
+    ``None`` for providers without a saved pool.  We deliberately do NOT
+    clear the agent's existing pool in that case — clearing on a switch
+    to a single-key provider would leave the agent rotation-less for the
+    rest of the session even if the user later switches back to a pooled
+    provider whose pool is then re-set on the next switch.  Matches the
+    ``if credential_pool is not None`` guard.
+    """
+    existing_pool = MagicMock(name="existing_pool")
+    agent = _make_agent_minimal(initial_pool=existing_pool)
+
+    with patch.object(agent, "_create_openai_client", return_value=MagicMock()):
+        agent.switch_model(
+            "gpt-5.4",
+            "openai-codex",
+            api_key="sk-codex",
+            base_url="https://chatgpt.com/backend-api/codex",
+            api_mode="chat_completions",
+            credential_pool=None,
+        )
+
+    assert agent._credential_pool is existing_pool


### PR DESCRIPTION
## Summary

When a gateway session uses `/model` to switch to a different provider, the new provider's `credential_pool` was dropped — leaving the *original* provider's pool live across the switch.  A 429 on the new provider then either rotated against the old provider's credentials (which don't apply to the new endpoint) or skipped pool rotation entirely and fell through to the configured fallback model.

Fixes #16678.

## The bug

`hermes_cli.runtime_provider.resolve_runtime_provider()` returns `credential_pool` alongside `api_key` / `base_url` / `api_mode` for the resolved provider.  Three layers conspired to drop it on `/model` switches:

1. `ModelSwitchResult` had no `credential_pool` field, so `switch_model()` discarded what `resolve_runtime_provider` returned for the target provider.
2. The gateway's two `/model` handlers (regular switch at `gateway/run.py:6116`, picker callback at `gateway/run.py:5988`) stored model/provider/api_key/base_url/api_mode on `_session_model_overrides[session_key]` — but not the pool.
3. `_apply_session_model_override` propagated everything except `credential_pool` into `runtime_kwargs`, so on the next turn the runtime still carried the startup-time pool from the original provider.

Net effect: `agent._credential_pool` (the rotation source for `_recover_with_credential_pool` at `run_agent.py:5761`) belonged to the *old* provider after a `/model` switch.

## The fix

- `hermes_cli/model_switch.py` — add `credential_pool` to `ModelSwitchResult`, capture it from the runtime in `switch_model()` on both the explicit-provider path and the same-provider re-resolve path.
- `gateway/run.py` — store `credential_pool` on `_session_model_overrides[session_key]` in both `/model` handler paths.
- `gateway/run.py` — `_apply_session_model_override` now also propagates `credential_pool`, with one deviation from the existing skip-if-`None` rule: an explicit `None` overrides the prior pool instead of being skipped.  A switched-to provider may legitimately have no pool (single env-var key, custom local endpoint), and leaving the old pool in place would rotate against the wrong provider's credentials.

The legacy override shape (no `credential_pool` key at all) is preserved by the `if \"credential_pool\" in override:` gate, so any pre-fix override sitting in memory keeps the existing runtime pool rather than getting silently blanked.

## Test plan

- [x] `tests/hermes_cli/test_model_switch_credential_pool.py` — `ModelSwitchResult.credential_pool` round-trips through explicit-provider switches, same-provider re-resolves, and the no-pool case.
- [x] `tests/gateway/test_session_model_override_routing.py` — three new cases verify `_apply_session_model_override` propagates the override pool, replaces an existing pool with `None` when explicitly cleared, and keeps the existing runtime pool when the override predates this field.
- [x] Regression guard: temporarily reverted the production change and confirmed all 5 new assertions fail on clean `origin/main` with the precise expected `AttributeError: 'ModelSwitchResult' object has no attribute 'credential_pool'` / pool-identity mismatch, then restored.
- [x] Adjacent suites: full `tests/hermes_cli/test_model_switch_*.py`, `tests/run_agent/test_switch_model_*.py`, and gateway session/model tests pass (101 + 18, all green).

## Related

Fixes #16678.

Adjacent prior work on the same surface, none of which addressed this gap:

- #15455 (merged) — exponential backoff on repeated pool exhaustion
- #15414 (merged) — route 429 \"overloaded\" to `FailoverReason.overloaded`
- #15787 (merged) — honor `custom_providers` `context_length` on `/model` switch