### PR TITLE
feat(gateway): add `deliver: auto` to webhook adapter

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -11,7 +11,12 @@ Each route defines:
   - secret: HMAC secret for signature validation (REQUIRED)
   - prompt: template string formatted with the webhook payload
   - skills: optional list of skills to load for the agent
-  - deliver: where to send the response (github_comment, telegram, etc.)
+  - deliver: where to send the response.  Accepts any platform name
+    (telegram, discord, slack, …), "github_comment", "log", or "auto".
+    "auto" resolves at delivery time to the first connected platform
+    that has a home channel configured — useful when the webhook sender
+    doesn't know (or shouldn't hardcode) which chat platform the user
+    prefers.  Defaults to "log" if no platform qualifies.
   - deliver_extra: additional delivery config (repo, pr_number, chat_id)
   - deliver_only: if true, skip the agent — the rendered prompt IS the
     message that gets delivered.  Use for external push notifications
@@ -136,7 +141,8 @@ class WebhookAdapter(BasePlatformAdapter):
                     raise ValueError(
                         f"[webhook] Route '{name}' has deliver_only=true but "
                         f"deliver is '{deliver}'. Direct delivery requires a "
-                        f"real target (telegram, discord, slack, github_comment, etc.)."
+                        f"real target (telegram, discord, slack, auto, "
+                        f"github_comment, etc.)."
                     )
 
         app = web.Application()
@@ -194,6 +200,9 @@ class WebhookAdapter(BasePlatformAdapter):
         """
         delivery = self._delivery_info.get(chat_id, {})
         deliver_type = delivery.get("deliver", "log")
+
+        if deliver_type == "auto":
+            deliver_type = self._resolve_auto_platform()
 
         if deliver_type == "log":
             logger.info("[webhook] Response for %s: %s", chat_id, content[:200])
@@ -647,6 +656,34 @@ class WebhookAdapter(BasePlatformAdapter):
     # Response delivery
     # ------------------------------------------------------------------
 
+    def _resolve_auto_platform(self) -> str:
+        """Pick the first connected platform that has a home channel.
+
+        Skips the webhook adapter itself to avoid self-delivery loops.
+        Returns the platform name (e.g. ``"telegram"``) or ``"log"`` if
+        no suitable platform is found.
+
+        Users who need a specific platform should use an explicit 
+        ``deliver: telegram`` (or ``discord``, ``slack``, etc.) instead of ``auto``.
+        """
+        if not self.gateway_runner:
+            return "log"
+        for platform in self.gateway_runner.adapters:
+            if platform == Platform.WEBHOOK:
+                continue
+            home = self.gateway_runner.config.get_home_channel(platform)
+            if home and home.chat_id:
+                logger.debug(
+                    "[webhook] auto-resolved delivery platform: %s",
+                    platform.value,
+                )
+                return platform.value
+        logger.warning(
+            "[webhook] deliver=auto but no connected platform has a home "
+            "channel — falling back to log"
+        )
+        return "log"
+
     async def _direct_deliver(
         self, content: str, delivery: dict
     ) -> SendResult:
@@ -656,9 +693,12 @@ class WebhookAdapter(BasePlatformAdapter):
         literal message body, and we dispatch to the same delivery helpers
         that the agent-mode ``send()`` flow uses.  All target types that
         work in agent mode work here — Telegram, Discord, Slack, GitHub
-        PR comments, etc.
+        PR comments, ``auto``, etc.
         """
         deliver_type = delivery.get("deliver", "log")
+
+        if deliver_type == "auto":
+            deliver_type = self._resolve_auto_platform()
 
         if deliver_type == "log":
             # Shouldn't reach here — startup validation rejects deliver_only

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -11,7 +11,13 @@ Each route defines:
   - secret: HMAC secret for signature validation (REQUIRED)
   - prompt: template string formatted with the webhook payload
   - skills: optional list of skills to load for the agent
-  - deliver: where to send the response (github_comment, telegram, etc.)
+  - deliver: where to send the response.  Accepts any platform name
+    (telegram, discord, slack, …), "github_comment", "log", or "auto".
+    "auto" resolves at delivery time to the first platform — in config
+    declaration order — that is currently connected and has a home
+    channel configured.  Useful when the webhook sender doesn't know
+    (or shouldn't hardcode) which chat platform the user prefers.
+    Falls back to "log" if no platform qualifies.
   - deliver_extra: additional delivery config (repo, pr_number, chat_id)
   - deliver_only: if true, skip the agent — the rendered prompt IS the
     message that gets delivered.  Use for external push notifications
@@ -280,7 +286,8 @@ class WebhookAdapter(BasePlatformAdapter):
                     raise ValueError(
                         f"[webhook] Route '{name}' has deliver_only=true but "
                         f"deliver is '{deliver}'. Direct delivery requires a "
-                        f"real target (telegram, discord, slack, github_comment, etc.)."
+                        f"real target (telegram, discord, slack, auto, "
+                        f"github_comment, etc.)."
                     )
 
         # client_max_size makes aiohttp enforce the cap on every read path,
@@ -376,6 +383,18 @@ class WebhookAdapter(BasePlatformAdapter):
 
         delivery = self._delivery_info.get(chat_id, {})
         deliver_type = delivery.get("deliver", "log")
+
+        if deliver_type == "auto":
+            deliver_type = self._resolve_auto_platform()
+            if deliver_type != "log":
+                # The resolver already guaranteed a connected adapter with a
+                # home channel — dispatch directly rather than re-entering
+                # the known-platform name gate below, which would reject
+                # valid targets missing from _BUILTIN_DELIVER_PLATFORMS
+                # (e.g. whatsapp_cloud).
+                return await self._deliver_cross_platform(
+                    deliver_type, content, delivery
+                )
 
         if deliver_type == "log":
             logger.info("[webhook] Response for %s: %s", chat_id, content[:200])
@@ -1316,6 +1335,47 @@ class WebhookAdapter(BasePlatformAdapter):
     # Response delivery
     # ------------------------------------------------------------------
 
+    def _resolve_auto_platform(self) -> str:
+        """Pick the first configured platform that can receive a delivery.
+
+        Iterates ``config.platforms`` in **config declaration order** —
+        NOT ``gateway_runner.adapters``, whose dict order shifts when a
+        failed adapter is popped and later reinserted on reconnect — and
+        returns the first platform that is currently connected AND has a
+        home channel configured.  This keeps the resolved target stable
+        across adapter failure/reconnect cycles.
+
+        Skips the webhook adapter itself to avoid self-delivery loops.
+        Returns the platform name (e.g. ``"telegram"``) or ``"log"`` if
+        no suitable platform is found.
+
+        Scope: resolution reads the default profile's config and adapter
+        map only.  Profile-scoped routes (``/p/<profile>/webhooks/…``)
+        that need a specific target should use an explicit platform name
+        — as should anyone who wants a guaranteed destination.
+        """
+        if not self.gateway_runner:
+            return "log"
+        adapters = getattr(self.gateway_runner, "adapters", None) or {}
+        platforms = getattr(self.gateway_runner.config, "platforms", None) or {}
+        for platform in platforms:
+            if platform == Platform.WEBHOOK:
+                continue
+            if platform not in adapters:
+                continue
+            home = self.gateway_runner.config.get_home_channel(platform)
+            if home and home.chat_id:
+                logger.debug(
+                    "[webhook] auto-resolved delivery platform: %s",
+                    platform.value,
+                )
+                return platform.value
+        logger.warning(
+            "[webhook] deliver=auto but no connected platform has a home "
+            "channel — falling back to log"
+        )
+        return "log"
+
     async def _direct_deliver(
         self, content: str, delivery: dict
     ) -> SendResult:
@@ -1325,13 +1385,17 @@ class WebhookAdapter(BasePlatformAdapter):
         literal message body, and we dispatch to the same delivery helpers
         that the agent-mode ``send()`` flow uses.  All target types that
         work in agent mode work here — Telegram, Discord, Slack, GitHub
-        PR comments, etc.
+        PR comments, ``auto``, etc.
         """
         deliver_type = delivery.get("deliver", "log")
 
+        if deliver_type == "auto":
+            deliver_type = self._resolve_auto_platform()
+
         if deliver_type == "log":
-            # Shouldn't reach here — startup validation rejects deliver_only
-            # with deliver=log — but guard defensively.
+            # Startup validation rejects deliver_only with deliver=log, but
+            # deliver=auto legitimately falls back here when no connected
+            # platform has a home channel.
             logger.info("[webhook] direct-deliver log-only: %s", content[:200])
             return SendResult(success=True)
 

--- a/tests/gateway/test_webhook_deliver_auto.py
+++ b/tests/gateway/test_webhook_deliver_auto.py
@@ -1,0 +1,352 @@
+"""Tests for the webhook adapter's ``deliver: auto`` delivery target.
+
+``deliver: auto`` resolves the delivery platform at send time: the first
+platform — in **config declaration order** — that is currently connected
+and has a home channel configured.  It exists so a single route config
+works for any chat platform the user has set up, without hardcoding
+``deliver: telegram`` / ``deliver: discord`` / etc.
+
+Covers:
+- Agent-mode ``send()`` resolution to the first declared platform
+- The ordering contract: config declaration order wins even when the
+  runner's adapter dict is ordered differently (reconnects reorder it)
+- Skipping platforms that are not connected or have no home channel
+- Skipping the webhook adapter itself (no self-delivery loops)
+- Fallback to ``log`` when nothing qualifies (agent mode + direct mode)
+- Delivery to a connected platform that is NOT in the builtin deliver
+  allow-list (auto bypasses the name gate by construction)
+- Direct-delivery (``deliver_only``) end-to-end via HTTP POST
+- Startup validation accepts ``deliver_only`` + ``deliver: auto``
+"""
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import HomeChannel, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, SendResult
+from gateway.platforms.webhook import (
+    WebhookAdapter,
+    _BUILTIN_DELIVER_PLATFORMS,
+    _INSECURE_NO_AUTH,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_adapter(routes) -> WebhookAdapter:
+    config = PlatformConfig(
+        enabled=True,
+        extra={"host": "127.0.0.1", "port": 0, "routes": routes},
+    )
+    return WebhookAdapter(config)
+
+
+def _auto_route(**overrides):
+    route = {
+        "secret": _INSECURE_NO_AUTH,
+        "deliver": "auto",
+        "prompt": "{message}",
+    }
+    route.update(overrides)
+    return route
+
+
+def _wire_runner(adapter, declared, connected, homes):
+    """Attach a gateway_runner shaped like the real one.
+
+    declared:  list[Platform] — config declaration order
+    connected: list[Platform] — which of them have live adapters, in
+               ADAPTER-DICT insertion order (deliberately independent of
+               ``declared`` so ordering tests can diverge the two)
+    homes:     dict[Platform, chat_id] — platforms with a home channel
+    """
+    adapters = {}
+    for platform in connected:
+        target = AsyncMock()
+        target.send = AsyncMock(return_value=SendResult(success=True))
+        adapters[platform] = target
+
+    config = SimpleNamespace(
+        platforms={p: PlatformConfig(enabled=True) for p in declared},
+        get_home_channel=lambda p: (
+            HomeChannel(platform=p, chat_id=homes[p], name="Home")
+            if p in homes
+            else None
+        ),
+    )
+    adapter.gateway_runner = SimpleNamespace(
+        adapters=adapters,
+        config=config,
+        _profile_adapters={},
+    )
+    return adapters
+
+
+def _seed_agent_delivery(adapter, chat_id="webhook:r:d-1"):
+    adapter._delivery_info[chat_id] = {"deliver": "auto", "deliver_extra": {}}
+    return chat_id
+
+
+# ===================================================================
+# Agent-mode send() resolution
+# ===================================================================
+
+class TestAutoResolutionAgentMode:
+
+    @pytest.mark.asyncio
+    async def test_resolves_first_declared_platform(self):
+        adapter = _make_adapter({})
+        adapters = _wire_runner(
+            adapter,
+            declared=[Platform.TELEGRAM, Platform.DISCORD],
+            connected=[Platform.TELEGRAM, Platform.DISCORD],
+            homes={Platform.TELEGRAM: "tg-home", Platform.DISCORD: "dc-home"},
+        )
+        chat_id = _seed_agent_delivery(adapter)
+
+        result = await adapter.send(chat_id, "hello")
+
+        assert result.success is True
+        adapters[Platform.TELEGRAM].send.assert_awaited_once()
+        assert adapters[Platform.TELEGRAM].send.await_args.args[0] == "tg-home"
+        adapters[Platform.DISCORD].send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_declaration_order_wins_over_adapter_dict_order(self):
+        """The regression the sweeper review asked for.
+
+        A fatal adapter failure pops the adapter from the runner's dict and
+        a reconnect appends it at the END — so adapter-dict order is
+        failure-history-dependent.  ``auto`` must follow config declaration
+        order instead, or one Telegram hiccup silently re-routes every
+        delivery to Discord for the life of the process.
+        """
+        adapter = _make_adapter({})
+        # Adapter dict has discord FIRST (telegram failed + reconnected);
+        # config declares telegram first.
+        adapters = _wire_runner(
+            adapter,
+            declared=[Platform.TELEGRAM, Platform.DISCORD],
+            connected=[Platform.DISCORD, Platform.TELEGRAM],
+            homes={Platform.TELEGRAM: "tg-home", Platform.DISCORD: "dc-home"},
+        )
+        chat_id = _seed_agent_delivery(adapter)
+
+        result = await adapter.send(chat_id, "hello")
+
+        assert result.success is True
+        adapters[Platform.TELEGRAM].send.assert_awaited_once()
+        adapters[Platform.DISCORD].send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_skips_platform_without_connected_adapter(self):
+        adapter = _make_adapter({})
+        adapters = _wire_runner(
+            adapter,
+            declared=[Platform.TELEGRAM, Platform.DISCORD],
+            connected=[Platform.DISCORD],  # telegram configured but down
+            homes={Platform.TELEGRAM: "tg-home", Platform.DISCORD: "dc-home"},
+        )
+        chat_id = _seed_agent_delivery(adapter)
+
+        result = await adapter.send(chat_id, "hello")
+
+        assert result.success is True
+        adapters[Platform.DISCORD].send.assert_awaited_once()
+        assert adapters[Platform.DISCORD].send.await_args.args[0] == "dc-home"
+
+    @pytest.mark.asyncio
+    async def test_skips_platform_without_home_channel(self):
+        adapter = _make_adapter({})
+        adapters = _wire_runner(
+            adapter,
+            declared=[Platform.TELEGRAM, Platform.DISCORD],
+            connected=[Platform.TELEGRAM, Platform.DISCORD],
+            homes={Platform.DISCORD: "dc-home"},  # telegram has no home
+        )
+        chat_id = _seed_agent_delivery(adapter)
+
+        result = await adapter.send(chat_id, "hello")
+
+        assert result.success is True
+        adapters[Platform.TELEGRAM].send.assert_not_awaited()
+        adapters[Platform.DISCORD].send.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_skips_webhook_platform_itself(self):
+        """Even a webhook entry with a (nonsensical) home channel is skipped."""
+        adapter = _make_adapter({})
+        adapters = _wire_runner(
+            adapter,
+            declared=[Platform.WEBHOOK, Platform.TELEGRAM],
+            connected=[Platform.WEBHOOK, Platform.TELEGRAM],
+            homes={Platform.WEBHOOK: "loop", Platform.TELEGRAM: "tg-home"},
+        )
+        chat_id = _seed_agent_delivery(adapter)
+
+        result = await adapter.send(chat_id, "hello")
+
+        assert result.success is True
+        adapters[Platform.WEBHOOK].send.assert_not_awaited()
+        adapters[Platform.TELEGRAM].send.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_log_when_nothing_qualifies(self):
+        adapter = _make_adapter({})
+        adapters = _wire_runner(
+            adapter,
+            declared=[Platform.TELEGRAM],
+            connected=[Platform.TELEGRAM],
+            homes={},  # connected, but no home channel anywhere
+        )
+        chat_id = _seed_agent_delivery(adapter)
+
+        result = await adapter.send(chat_id, "hello")
+
+        assert result.success is True
+        adapters[Platform.TELEGRAM].send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_gateway_runner_falls_back_to_log(self):
+        adapter = _make_adapter({})
+        adapter.gateway_runner = None
+        chat_id = _seed_agent_delivery(adapter)
+
+        result = await adapter.send(chat_id, "hello")
+
+        assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_delivers_to_platform_outside_builtin_allow_list(self):
+        """Auto-resolved targets must bypass the known-platform name gate.
+
+        ``send()`` gates explicit deliver names on _BUILTIN_DELIVER_PLATFORMS
+        (plus plugin registrations).  A platform like whatsapp_cloud supports
+        home channels but is absent from that set — the resolver already
+        proved the target is connected with a home, so the resolved name must
+        be dispatched directly, not re-validated against the gate.
+        """
+        assert Platform.WHATSAPP_CLOUD.value not in _BUILTIN_DELIVER_PLATFORMS
+        adapter = _make_adapter({})
+        adapters = _wire_runner(
+            adapter,
+            declared=[Platform.WHATSAPP_CLOUD],
+            connected=[Platform.WHATSAPP_CLOUD],
+            homes={Platform.WHATSAPP_CLOUD: "wa-home"},
+        )
+        chat_id = _seed_agent_delivery(adapter)
+
+        result = await adapter.send(chat_id, "hello")
+
+        assert result.success is True
+        adapters[Platform.WHATSAPP_CLOUD].send.assert_awaited_once()
+        assert (
+            adapters[Platform.WHATSAPP_CLOUD].send.await_args.args[0]
+            == "wa-home"
+        )
+
+
+# ===================================================================
+# Direct delivery (deliver_only) end-to-end
+# ===================================================================
+
+class TestAutoDirectDelivery:
+
+    def _app(self, adapter):
+        app = web.Application()
+        app.router.add_post("/webhooks/{route_name}", adapter._handle_webhook)
+        return app
+
+    @pytest.mark.asyncio
+    async def test_deliver_only_auto_resolves_and_delivers(self):
+        routes = {"notify": _auto_route(deliver_only=True)}
+        adapter = _make_adapter(routes)
+        adapters = _wire_runner(
+            adapter,
+            declared=[Platform.TELEGRAM, Platform.DISCORD],
+            connected=[Platform.TELEGRAM, Platform.DISCORD],
+            homes={Platform.TELEGRAM: "tg-home", Platform.DISCORD: "dc-home"},
+        )
+
+        handle_message_calls: list[MessageEvent] = []
+
+        async def _capture(event):
+            handle_message_calls.append(event)
+
+        adapter.handle_message = _capture
+
+        async with TestClient(TestServer(self._app(adapter))) as cli:
+            resp = await cli.post(
+                "/webhooks/notify",
+                data=json.dumps({"message": "deploy finished"}).encode(),
+                headers={
+                    "Content-Type": "application/json",
+                    "X-GitHub-Delivery": "d-auto-1",
+                },
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["status"] == "delivered"
+
+        await asyncio.sleep(0.05)
+        assert handle_message_calls == []
+        adapters[Platform.TELEGRAM].send.assert_awaited_once()
+        call = adapters[Platform.TELEGRAM].send.await_args
+        assert call.args[0] == "tg-home"
+        assert call.args[1] == "deploy finished"
+        adapters[Platform.DISCORD].send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_deliver_only_auto_falls_back_to_log(self):
+        """No qualifying platform → the direct path logs and returns 200."""
+        routes = {"notify": _auto_route(deliver_only=True)}
+        adapter = _make_adapter(routes)
+        adapters = _wire_runner(
+            adapter,
+            declared=[Platform.TELEGRAM],
+            connected=[Platform.TELEGRAM],
+            homes={},
+        )
+
+        async with TestClient(TestServer(self._app(adapter))) as cli:
+            resp = await cli.post(
+                "/webhooks/notify",
+                data=json.dumps({"message": "hi"}).encode(),
+                headers={
+                    "Content-Type": "application/json",
+                    "X-GitHub-Delivery": "d-auto-2",
+                },
+            )
+            assert resp.status == 200
+
+        adapters[Platform.TELEGRAM].send.assert_not_awaited()
+
+
+# ===================================================================
+# Startup validation
+# ===================================================================
+
+class TestAutoStartupValidation:
+
+    @pytest.mark.asyncio
+    async def test_deliver_only_with_auto_passes_validation(self):
+        """``auto`` is a real target — deliver_only must accept it."""
+        routes = {"notify": _auto_route(deliver_only=True)}
+        adapter = _make_adapter(routes)
+        # connect() does more than validation (binds a socket) — we just
+        # want to verify the validation doesn't raise.  Call it and tear
+        # down immediately.
+        try:
+            started = await adapter.connect()
+            if started:
+                await adapter.disconnect()
+        except ValueError:
+            pytest.fail("deliver_only + deliver=auto should pass validation")

--- a/website/docs/user-guide/messaging/webhooks.md
+++ b/website/docs/user-guide/messaging/webhooks.md
@@ -86,7 +86,7 @@ Routes define how different webhook sources are handled. Each route is a named e
 | `script` | No | Filter/transform script under `~/.hermes/scripts/`. The webhook payload is passed as JSON on stdin. JSON object stdout replaces the payload before templating; text stdout is exposed as `script_output`; empty stdout, `[SILENT]`, or a nonzero exit code ignores the webhook. |
 | `skills` | No | List of skill names to load for the agent run. |
 | `toolsets` | No | List of toolset keys (e.g. `["terminal", "file", "web"]`) that **replaces** the platform-level webhook toolset for runs triggered by this route only. Manual config edit only — not settable via `hermes webhook subscribe`, so agent-created subscriptions cannot self-grant elevated tools. Names are validated the same way as `platform_toolsets` entries (unknown or platform-restricted names are dropped). See [Per-route toolsets](#per-route-toolsets). |
-| `deliver` | No | Where to send the response: `github_comment`, `telegram`, `discord`, `slack`, `signal`, `sms`, `whatsapp`, `matrix`, `mattermost`, `homeassistant`, `email`, `dingtalk`, `feishu`, `wecom`, `weixin`, `bluebubbles`, `qqbot`, or `log` (default). |
+| `deliver` | No | Where to send the response: `github_comment`, `telegram`, `discord`, `slack`, `signal`, `sms`, `whatsapp`, `matrix`, `mattermost`, `homeassistant`, `email`, `dingtalk`, `feishu`, `wecom`, `weixin`, `bluebubbles`, `qqbot`, `auto` (first configured platform that is connected and has a home channel), or `log` (default). |
 | `deliver_extra` | No | Additional delivery config — keys depend on `deliver` type (e.g. `repo`, `pr_number`, `chat_id`). Values support the same `{dot.notation}` templates as `prompt`. |
 | `deliver_only` | No | If `true`, skip the agent entirely — the rendered `prompt` template becomes the literal message that gets delivered. Zero LLM cost, sub-second delivery. See [Direct Delivery Mode](#direct-delivery-mode) for use cases. Requires `deliver` to be a real target (not `log`). |
 
@@ -318,8 +318,11 @@ The `deliver` field controls where the agent's response goes after processing th
 | `wecom` | Routes the response to WeCom. Uses the home channel, or specify `chat_id` in `deliver_extra`. |
 | `weixin` | Routes the response to Weixin (WeChat). Uses the home channel, or specify `chat_id` in `deliver_extra`. |
 | `bluebubbles` | Routes the response to BlueBubbles (iMessage). Uses the home channel, or specify `chat_id` in `deliver_extra`. |
+| `auto` | Resolves the target at delivery time: the first platform — in config declaration order — that is currently connected and has a home channel configured. Falls back to `log` if no platform qualifies. Useful when a route config should work regardless of which chat platform the user has set up. Use an explicit platform name if you need a guaranteed destination. |
 
 For cross-platform delivery, the target platform must also be enabled and connected in the gateway. If no `chat_id` is provided in `deliver_extra`, the response is sent to that platform's configured home channel.
+
+`deliver: auto` normally delivers to the resolved platform's home channel. Avoid combining it with a `chat_id` in `deliver_extra` — the chat id would be applied to whichever platform happens to resolve, and a chat id from one platform is meaningless on another. If you need a specific chat, use an explicit platform name. `auto` also works with `deliver_only` routes.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `deliver: auto` as a new delivery target for webhook routes. At send time, it resolves to the first connected platform adapter that has a home channel configured.
- When multiple platforms have home channels, the first one in config declaration order wins. Falls back to `log` if none qualify.
- Also supported in `deliver_only` (direct-delivery) routes.

**Motivation:** External services that POST to webhook routes currently must hardcode a platform name (e.g. `deliver: telegram`). This forces every user to edit their route config to match their preferred chat platform. With `deliver: auto`, a single route config works for any platform the user has set up — Telegram, Discord, Slack, etc.

**Backward-compatible** — existing explicit `deliver: telegram` / `deliver: discord` / etc. configs are unaffected.

### Example config

```yaml
platforms:
  webhook:
    enabled: true
    extra:
      port: 8644
      routes:
        my-notifications:
          secret: "<hmac-secret>"
          deliver: auto
          prompt: "Notification from {source}: {message}"
```

## Test plan

- [x] Tested with a single connected platform (Telegram) — auto-resolves and delivers correctly
- [x] Verified `deliver: log` fallback when no platform has a home channel
- [x] Verified existing explicit `deliver: telegram` configs still work unchanged