### PR TITLE
fix(nous): hold _auth_store_lock through HTTP refresh to prevent token reuse revocation

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -617,39 +617,51 @@ class CredentialPool:
                     last_refresh=refreshed.get("last_refresh"),
                 )
             elif self.provider == "nous":
-                synced = self._sync_nous_entry_from_auth_store(entry)
-                if synced is not entry:
-                    entry = synced
-                nous_state = {
-                    "access_token": entry.access_token,
-                    "refresh_token": entry.refresh_token,
-                    "client_id": entry.client_id,
-                    "portal_base_url": entry.portal_base_url,
-                    "inference_base_url": entry.inference_base_url,
-                    "token_type": entry.token_type,
-                    "scope": entry.scope,
-                    "obtained_at": entry.obtained_at,
-                    "expires_at": entry.expires_at,
-                    "agent_key": entry.agent_key,
-                    "agent_key_expires_at": entry.agent_key_expires_at,
-                    "tls": entry.tls,
-                }
-                refreshed = auth_mod.refresh_nous_oauth_from_state(
-                    nous_state,
-                    min_key_ttl_seconds=DEFAULT_AGENT_KEY_MIN_TTL_SECONDS,
-                    force_refresh=force,
-                    force_mint=force,
-                )
-                # Apply returned fields: dataclass fields via replace, extras via dict update
-                field_updates = {}
-                extra_updates = dict(entry.extra)
-                _field_names = {f.name for f in fields(entry)}
-                for k, v in refreshed.items():
-                    if k in _field_names:
-                        field_updates[k] = v
-                    elif k in _EXTRA_KEYS:
-                        extra_updates[k] = v
-                updated = replace(entry, extra=extra_updates, **field_updates)
+                # FIX(shagghiesuperstar): Hold _auth_store_lock across the entire
+                # sync+HTTP+apply sequence so no concurrent process can read and
+                # consume the same single-use refresh token simultaneously.
+                # _auth_store_lock() is re-entrant (_auth_lock_holder.depth in auth.py)
+                # so the nested acquire inside _sync_nous_entry_from_auth_store()
+                # does not deadlock. If another process already refreshed while we
+                # waited for the lock, _sync returns a new object and we adopt those
+                # tokens directly without a second HTTP call.
+                with _auth_store_lock():
+                    synced = self._sync_nous_entry_from_auth_store(entry)
+                    if synced is not entry:
+                        entry = synced
+                        field_updates: Dict[str, Any] = {}
+                        extra_updates = dict(entry.extra)
+                        updated = replace(entry, extra=extra_updates, **field_updates)
+                    else:
+                        nous_state = {
+                            "access_token": entry.access_token,
+                            "refresh_token": entry.refresh_token,
+                            "client_id": entry.client_id,
+                            "portal_base_url": entry.portal_base_url,
+                            "inference_base_url": entry.inference_base_url,
+                            "token_type": entry.token_type,
+                            "scope": entry.scope,
+                            "obtained_at": entry.obtained_at,
+                            "expires_at": entry.expires_at,
+                            "agent_key": entry.agent_key,
+                            "agent_key_expires_at": entry.agent_key_expires_at,
+                            "tls": entry.tls,
+                        }
+                        refreshed = auth_mod.refresh_nous_oauth_from_state(
+                            nous_state,
+                            min_key_ttl_seconds=DEFAULT_AGENT_KEY_MIN_TTL_SECONDS,
+                            force_refresh=force,
+                            force_mint=force,
+                        )
+                        field_updates = {}
+                        extra_updates = dict(entry.extra)
+                        _field_names = {f.name for f in fields(entry)}
+                        for k, v in refreshed.items():
+                            if k in _field_names:
+                                field_updates[k] = v
+                            elif k in _EXTRA_KEYS:
+                                extra_updates[k] = v
+                        updated = replace(entry, extra=extra_updates, **field_updates)
             else:
                 return entry
         except Exception as exc:


### PR DESCRIPTION
## Problem

When Hermes runs multiple processes simultaneously (e.g. a persistent gateway
alongside cron-scheduled agent runs), both processes can trigger a Nous OAuth
token refresh within the same window. Because `_refresh_entry()` released
`_auth_store_lock` after calling `_sync_nous_entry_from_auth_store()` but
*before* the HTTP call to `refresh_nous_oauth_from_state()`, both processes
would read the same `refresh_token` from `auth.json`, then both send it to
the Nous Portal in separate HTTP requests.

Nous Portal treats this as **refresh token reuse** (a security signal for
token theft), immediately revokes the entire session chain, and returns:

```
Error: Could not resolve credentials for provider 'Nous Portal':
Refresh session has been revoked
```

This forces a full device-code re-authentication every ~24h (whenever the
access token expires and both processes attempt refresh near-simultaneously).

## Root Cause

In `CredentialPool._refresh_entry()`, the `nous` branch:

```python
# BEFORE (race window between lock release and HTTP call)
synced = self._sync_nous_entry_from_auth_store(entry)  # acquires+releases lock
if synced is not entry:
    entry = synced
nous_state = { ... }
refreshed = auth_mod.refresh_nous_oauth_from_state(...)  # HTTP call — no lock
```

`_sync_nous_entry_from_auth_store` acquires and releases `_auth_store_lock`
internally. The HTTP call happens outside any lock, creating a TOCTOU window.

## Fix

Wrap the entire sync+HTTP+apply sequence in a single `_auth_store_lock()` context:

```python
# AFTER (exactly-once refresh semantics)
with _auth_store_lock():
    synced = self._sync_nous_entry_from_auth_store(entry)
    if synced is not entry:
        # Another process already refreshed — adopt tokens, skip HTTP call
        entry = synced
        updated = replace(entry, ...)
    else:
        # We hold the lock — fire HTTP refresh exclusively
        refreshed = auth_mod.refresh_nous_oauth_from_state(...)
        updated = replace(entry, ...)
```

`_auth_store_lock()` is re-entrant (see `_auth_lock_holder.depth` in `auth.py`),
so the nested acquire inside `_sync_nous_entry_from_auth_store()` does not
deadlock. The HTTP call takes 1–3 seconds; the lock timeout is 15 seconds —
no starvation risk under normal operating conditions.

## Result

- Only one process per machine can hold a Nous refresh token in flight at a time
- A concurrent waiter sees the rotated token via `_sync` and adopts it directly
- Zero "Refresh session has been revoked" errors on multi-process deployments
- Analogous to the existing Anthropic `_sync_anthropic_entry_from_credentials_file`
  retry pattern, applied proactively via the lock rather than reactively on error

## Testing

Reproduce by running two `hermes` processes simultaneously with `--provider nous`
and forcing a token refresh (`hermes auth refresh nous`). Without this patch,
one process reliably revokes the session. With this patch, the second process
adopts the first process's fresh tokens.

Tested on: macOS M5, Hermes v0.11, Python 3.12, Nous Portal device_code auth.

Additional validation performed for this PR:

- `python3 -m py_compile agent/credential_pool.py`
- `pytest -q -k "credential_pool or nous" --tb=short` → 257 passed, 2 skipped
