### PR TITLE
fix(tui): drop stale stream events after ctrl-c interrupt

### DIFF
--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -548,6 +548,10 @@ describe('createGatewayEventHandler', () => {
         },
         type: 'tool.start'
       } as any)
+      // Late tool.generating must NOT push a 'drafting …' line into the trail.
+      const trailBefore = getTurnState().turnTrail.length
+      onEvent({ payload: { name: 'browser' }, type: 'tool.generating' } as any)
+      expect(getTurnState().turnTrail.length).toBe(trailBefore)
       onEvent({ payload: { name: 'browser', preview: 'loading' }, type: 'tool.progress' } as any)
       onEvent({ payload: { summary: 'done', tool_id: 't-2' }, type: 'tool.complete' } as any)
       onEvent({ payload: { text: 'late chunk' }, type: 'message.delta' } as any)
@@ -557,20 +561,20 @@ describe('createGatewayEventHandler', () => {
       expect(turnController.bufRef).toBe('')
       expect(getTurnState().streamPendingTools).toEqual([])
       expect(getTurnState().streamSegments).toEqual([])
-      // Stale todos must not have leaked through; pre-interrupt todos
-      // are also expected to be cleared by the interrupt cycle.
+      // Stale post-interrupt todos must not have leaked through.
+      // (This test does not assert that pre-interrupt todos are cleared —
+      // current interrupt path leaves them visible until the next message.)
       expect(getTurnState().todos.find(t => t.content === 'late ghost')).toBeUndefined()
 
       onEvent({ payload: {}, type: 'message.start' } as any)
       onEvent({ payload: { text: 'fresh' }, type: 'reasoning.delta' } as any)
 
       expect(turnController.reasoningText).toBe('fresh')
-
-      // Drain interrupt cooldown + any pending status timers before
-      // restoring real timers — otherwise vi complains about queued
-      // timers crossing the boundary.
-      vi.runAllTimers()
     } finally {
+      // Drain pending fake timers BEFORE restoring real timers so a mid-
+      // test assertion failure can't leak the interrupt-cooldown setTimeout
+      // across test files (the original Copilot concern).
+      vi.runAllTimers()
       vi.useRealTimers()
     }
   })

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -495,4 +495,42 @@ describe('createGatewayEventHandler', () => {
 
     expect(getTurnState().activity).toMatchObject([{ text: 'boom', tone: 'error' }])
   })
+
+  it('drops stale reasoning/tool events after ctrl-c until the next message starts', () => {
+    // Repro for the discord report: ctrl-c interrupts, but late reasoning/tool
+    // events from the still-winding-down agent loop kept populating the UI for
+    // ~1s, making it look like the interrupt had been ignored.
+    const appended: Msg[] = []
+    const ctx = buildCtx(appended)
+    ctx.gateway.gw.request = vi.fn(async () => ({ status: 'interrupted' }))
+    const onEvent = createGatewayEventHandler(ctx)
+
+    patchUiState({ sid: 'sess-1' })
+    onEvent({ payload: {}, type: 'message.start' } as any)
+    onEvent({ payload: { context: 'pre', name: 'search', tool_id: 't-1' }, type: 'tool.start' } as any)
+
+    turnController.interruptTurn({
+      appendMessage: (msg: Msg) => appended.push(msg),
+      gw: ctx.gateway.gw,
+      sid: 'sess-1',
+      sys: ctx.system.sys
+    })
+
+    onEvent({ payload: { text: 'still thinking…' }, type: 'reasoning.delta' } as any)
+    onEvent({ payload: { context: 'post', name: 'browser', tool_id: 't-2' }, type: 'tool.start' } as any)
+    onEvent({ payload: { name: 'browser', preview: 'loading' }, type: 'tool.progress' } as any)
+    onEvent({ payload: { summary: 'done', tool_id: 't-2' }, type: 'tool.complete' } as any)
+    onEvent({ payload: { text: 'late chunk' }, type: 'message.delta' } as any)
+
+    expect(getTurnState().tools).toEqual([])
+    expect(turnController.reasoningText).toBe('')
+    expect(turnController.bufRef).toBe('')
+    expect(getTurnState().streamPendingTools).toEqual([])
+    expect(getTurnState().streamSegments).toEqual([])
+
+    onEvent({ payload: {}, type: 'message.start' } as any)
+    onEvent({ payload: { text: 'fresh' }, type: 'reasoning.delta' } as any)
+
+    expect(turnController.reasoningText).toBe('fresh')
+  })
 })

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -496,41 +496,82 @@ describe('createGatewayEventHandler', () => {
     expect(getTurnState().activity).toMatchObject([{ text: 'boom', tone: 'error' }])
   })
 
-  it('drops stale reasoning/tool events after ctrl-c until the next message starts', () => {
+  it('drops stale reasoning/tool/todos events after ctrl-c until the next message starts', () => {
     // Repro for the discord report: ctrl-c interrupts, but late reasoning/tool
     // events from the still-winding-down agent loop kept populating the UI for
     // ~1s, making it look like the interrupt had been ignored.
-    const appended: Msg[] = []
-    const ctx = buildCtx(appended)
-    ctx.gateway.gw.request = vi.fn(async () => ({ status: 'interrupted' }))
-    const onEvent = createGatewayEventHandler(ctx)
+    //
+    // Fake timers because `interruptTurn` schedules a real setTimeout for
+    // its cooldown — without flushing it inside this test, the timeout
+    // can fire later and mutate uiStore/turnState during unrelated tests
+    // (cross-file flake).
+    vi.useFakeTimers()
 
-    patchUiState({ sid: 'sess-1' })
-    onEvent({ payload: {}, type: 'message.start' } as any)
-    onEvent({ payload: { context: 'pre', name: 'search', tool_id: 't-1' }, type: 'tool.start' } as any)
+    try {
+      const appended: Msg[] = []
+      const ctx = buildCtx(appended)
+      ctx.gateway.gw.request = vi.fn(async () => ({ status: 'interrupted' }))
+      const onEvent = createGatewayEventHandler(ctx)
 
-    turnController.interruptTurn({
-      appendMessage: (msg: Msg) => appended.push(msg),
-      gw: ctx.gateway.gw,
-      sid: 'sess-1',
-      sys: ctx.system.sys
-    })
+      patchUiState({ sid: 'sess-1' })
+      onEvent({ payload: {}, type: 'message.start' } as any)
+      onEvent({
+        payload: {
+          context: 'pre',
+          name: 'search',
+          todos: [{ content: 'pre-interrupt', id: 'todo-1', status: 'pending' }],
+          tool_id: 't-1'
+        },
+        type: 'tool.start'
+      } as any)
 
-    onEvent({ payload: { text: 'still thinking…' }, type: 'reasoning.delta' } as any)
-    onEvent({ payload: { context: 'post', name: 'browser', tool_id: 't-2' }, type: 'tool.start' } as any)
-    onEvent({ payload: { name: 'browser', preview: 'loading' }, type: 'tool.progress' } as any)
-    onEvent({ payload: { summary: 'done', tool_id: 't-2' }, type: 'tool.complete' } as any)
-    onEvent({ payload: { text: 'late chunk' }, type: 'message.delta' } as any)
+      // Pre-interrupt todos should land in turn state.
+      expect(getTurnState().todos).toEqual([
+        { content: 'pre-interrupt', id: 'todo-1', status: 'pending' }
+      ])
 
-    expect(getTurnState().tools).toEqual([])
-    expect(turnController.reasoningText).toBe('')
-    expect(turnController.bufRef).toBe('')
-    expect(getTurnState().streamPendingTools).toEqual([])
-    expect(getTurnState().streamSegments).toEqual([])
+      turnController.interruptTurn({
+        appendMessage: (msg: Msg) => appended.push(msg),
+        gw: ctx.gateway.gw,
+        sid: 'sess-1',
+        sys: ctx.system.sys
+      })
 
-    onEvent({ payload: {}, type: 'message.start' } as any)
-    onEvent({ payload: { text: 'fresh' }, type: 'reasoning.delta' } as any)
+      onEvent({ payload: { text: 'still thinking…' }, type: 'reasoning.delta' } as any)
+      // Post-interrupt tool.start with a todos payload — must NOT mutate todos.
+      onEvent({
+        payload: {
+          context: 'post',
+          name: 'browser',
+          todos: [{ content: 'late ghost', id: 'todo-ghost', status: 'pending' }],
+          tool_id: 't-2'
+        },
+        type: 'tool.start'
+      } as any)
+      onEvent({ payload: { name: 'browser', preview: 'loading' }, type: 'tool.progress' } as any)
+      onEvent({ payload: { summary: 'done', tool_id: 't-2' }, type: 'tool.complete' } as any)
+      onEvent({ payload: { text: 'late chunk' }, type: 'message.delta' } as any)
 
-    expect(turnController.reasoningText).toBe('fresh')
+      expect(getTurnState().tools).toEqual([])
+      expect(turnController.reasoningText).toBe('')
+      expect(turnController.bufRef).toBe('')
+      expect(getTurnState().streamPendingTools).toEqual([])
+      expect(getTurnState().streamSegments).toEqual([])
+      // Stale todos must not have leaked through; pre-interrupt todos
+      // are also expected to be cleared by the interrupt cycle.
+      expect(getTurnState().todos.find(t => t.content === 'late ghost')).toBeUndefined()
+
+      onEvent({ payload: {}, type: 'message.start' } as any)
+      onEvent({ payload: { text: 'fresh' }, type: 'reasoning.delta' } as any)
+
+      expect(turnController.reasoningText).toBe('fresh')
+
+      // Drain interrupt cooldown + any pending status timers before
+      // restoring real timers — otherwise vi complains about queued
+      // timers crossing the boundary.
+      vi.runAllTimers()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -509,12 +509,12 @@ class TurnController {
   }
 
   recordMessageDelta({ rendered, text }: { rendered?: string; text?: string }) {
-    this.pruneTransient()
-    this.endReasoningPhase()
-
-    if (!text || this.interrupted) {
+    if (this.interrupted || !text) {
       return
     }
+
+    this.pruneTransient()
+    this.endReasoningPhase()
 
     this.bufRef = rendered ?? this.bufRef + text
 
@@ -524,7 +524,7 @@ class TurnController {
   }
 
   recordReasoningAvailable(text: string) {
-    if (!getUiState().showReasoning) {
+    if (this.interrupted || !getUiState().showReasoning) {
       return
     }
 
@@ -542,7 +542,7 @@ class TurnController {
   }
 
   recordReasoningDelta(text: string) {
-    if (!getUiState().showReasoning) {
+    if (this.interrupted || !getUiState().showReasoning) {
       return
     }
 
@@ -570,6 +570,10 @@ class TurnController {
     duration?: number,
     todos?: unknown
   ) {
+    if (this.interrupted) {
+      return
+    }
+
     this.recordTodos(todos)
     const line = this.completeTool(toolId, fallbackName, error, summary, duration)
 
@@ -585,6 +589,10 @@ class TurnController {
     error?: string,
     duration?: number
   ) {
+    if (this.interrupted) {
+      return
+    }
+
     this.flushStreamingSegment()
     this.pushInlineDiffSegment(diffText, [this.completeTool(toolId, fallbackName, error, '', duration)])
     this.publishToolState()
@@ -626,6 +634,10 @@ class TurnController {
   }
 
   recordToolProgress(toolName: string, preview: string) {
+    if (this.interrupted) {
+      return
+    }
+
     const index = this.activeTools.findIndex(tool => tool.name === toolName)
 
     if (index < 0) {
@@ -645,6 +657,10 @@ class TurnController {
   }
 
   recordToolStart(toolId: string, name: string, context: string) {
+    if (this.interrupted) {
+      return
+    }
+
     this.flushStreamingSegment()
     this.closeReasoningSegment()
     this.pruneTransient()
@@ -716,6 +732,7 @@ class TurnController {
     this.reasoningSegmentIndex = null
     this.turnTools = []
     this.toolTokenAcc = 0
+    this.interrupted = false
     this.persistedToolLabels.clear()
     patchUiState({ busy: true })
     patchTurnState({ activity: [], outcome: '', subagents: [], toolTokens: 0, tools: [], turnTrail: [] })

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -401,6 +401,10 @@ class TurnController {
   }
 
   pushTrail(line: string) {
+    if (this.interrupted) {
+      return
+    }
+
     patchTurnState(state => {
       if (state.turnTrail.at(-1) === line) {
         return state

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -316,6 +316,10 @@ class TurnController {
   }
 
   recordTodos(value: unknown) {
+    if (this.interrupted) {
+      return
+    }
+
     const todos = parseTodos(value)
 
     if (todos !== null) {


### PR DESCRIPTION
## What

Once \`interruptTurn()\` sets \`this.interrupted = true\`, only
\`recordMessageDelta\` short-circuited.  \`recordReasoningDelta\` /
\`recordReasoningAvailable\` / \`recordToolStart\` / \`recordToolProgress\` /
\`recordToolComplete\` / \`recordInlineDiffToolComplete\` all kept
mutating \`turnState\` until python's next \`_interrupt_requested\`
check (~1s on busy turns).

User-visible symptom (per discord report): "ctrl-c kinda broke in TUI
— now if i ctrl-c it interrupts, but then keeps going a second later,
and i keep getting thinking and tool calls."

## Fix

- Add the same \`if (this.interrupted) return\` early-exit to every
  stream-side recorder.
- Clear \`this.interrupted\` in \`startMessage()\` so a brand-new turn
  isn't accidentally muted if the previous turn never delivered
  \`message.complete\`.

## Test

\`ui-tui/src/__tests__/createGatewayEventHandler.test.ts\` — drives the
event sequence \`message.start → tool.start → interruptTurn →
{reasoning,tool}.* → message.delta\` and asserts that all stream state
(\`reasoningText\`, \`bufRef\`, \`streamSegments\`, \`streamPendingTools\`,
\`tools\`) stays empty.  Then sends a fresh \`message.start\` +
\`reasoning.delta\` and confirms the new turn is not suppressed.

Verified the test fails on \`origin/main\` before the fix and passes
after.  All 385 ui-tui tests + tsc clean.