### PR TITLE
feat(tui): delete queued message while editing with ctrl-x / cancel with esc

### DIFF
--- a/ui-tui/src/__tests__/useQueue.test.ts
+++ b/ui-tui/src/__tests__/useQueue.test.ts
@@ -1,26 +1,26 @@
 import { describe, expect, it } from 'vitest'
 
-import { removeAt } from '../hooks/useQueue.js'
+import { removeAtInPlace } from '../hooks/useQueue.js'
 
-describe('removeAt', () => {
+describe('removeAtInPlace', () => {
   it('removes the item at the given index in place', () => {
     const arr = ['a', 'b', 'c']
 
-    removeAt(arr, 1)
+    removeAtInPlace(arr, 1)
     expect(arr).toEqual(['a', 'c'])
   })
 
   it('is a no-op when the index is out of bounds', () => {
     const arr = ['a', 'b']
 
-    removeAt(arr, -1)
-    removeAt(arr, 5)
+    removeAtInPlace(arr, -1)
+    removeAtInPlace(arr, 5)
     expect(arr).toEqual(['a', 'b'])
   })
 
   it('returns the same reference (mutates in place)', () => {
     const arr = ['x']
-    const same = removeAt(arr, 0)
+    const same = removeAtInPlace(arr, 0)
 
     expect(same).toBe(arr)
     expect(arr).toEqual([])

--- a/ui-tui/src/__tests__/useQueue.test.ts
+++ b/ui-tui/src/__tests__/useQueue.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+
+import { removeAt } from '../hooks/useQueue.js'
+
+describe('removeAt', () => {
+  it('removes the item at the given index in place', () => {
+    const arr = ['a', 'b', 'c']
+
+    removeAt(arr, 1)
+    expect(arr).toEqual(['a', 'c'])
+  })
+
+  it('is a no-op when the index is out of bounds', () => {
+    const arr = ['a', 'b']
+
+    removeAt(arr, -1)
+    removeAt(arr, 5)
+    expect(arr).toEqual(['a', 'b'])
+  })
+
+  it('returns the same reference (mutates in place)', () => {
+    const arr = ['x']
+    const same = removeAt(arr, 0)
+
+    expect(same).toBe(arr)
+    expect(arr).toEqual([])
+  })
+})

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -125,6 +125,7 @@ export interface ComposerActions {
   handleTextPaste: (event: PasteEvent) => MaybePromise<ComposerPasteResult | null>
   openEditor: () => Promise<void>
   pushHistory: (text: string) => void
+  removeQueue: (index: number) => void
   replaceQueue: (index: number, text: string) => void
   setCompIdx: StateSetter<number>
   setHistoryIdx: StateSetter<null | number>

--- a/ui-tui/src/app/useComposerState.ts
+++ b/ui-tui/src/app/useComposerState.ts
@@ -110,8 +110,18 @@ export function useComposerState({
   const isBlocked = useStore($isBlocked)
   const { querier } = useStdin() as { querier: Parameters<typeof readOsc52Clipboard>[0] }
 
-  const { queueRef, queueEditRef, queuedDisplay, queueEditIdx, enqueue, dequeue, replaceQ, setQueueEdit, syncQueue } =
-    useQueue()
+  const {
+    queueRef,
+    queueEditRef,
+    queuedDisplay,
+    queueEditIdx,
+    enqueue,
+    dequeue,
+    removeQ,
+    replaceQ,
+    setQueueEdit,
+    syncQueue
+  } = useQueue()
 
   const { historyRef, historyIdx, setHistoryIdx, historyDraftRef, pushHistory } = useInputHistory()
   const { completions, compIdx, setCompIdx, compReplace } = useCompletion(input, isBlocked, gw)
@@ -294,6 +304,7 @@ export function useComposerState({
       handleTextPaste,
       openEditor,
       pushHistory,
+      removeQueue: removeQ,
       replaceQueue: replaceQ,
       setCompIdx,
       setHistoryIdx,
@@ -310,6 +321,7 @@ export function useComposerState({
       handleTextPaste,
       openEditor,
       pushHistory,
+      removeQ,
       replaceQ,
       setCompIdx,
       setHistoryIdx,

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -307,12 +307,15 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
       return scrollTranscript(key.pageUp ? -step : step)
     }
 
-    if (key.escape && terminal.hasSelection) {
-      return clearSelection()
-    }
-
+    // Queue-edit cancel beats selection-clear: the queue header explicitly
+    // promises "Esc cancel", so honoring it takes priority over the implicit
+    // selection-dismissal convention. Without an active edit, fall through.
     if (key.escape && cState.queueEditIdx !== null) {
       return cActions.clearIn()
+    }
+
+    if (key.escape && terminal.hasSelection) {
+      return clearSelection()
     }
 
     if (key.upArrow && !cState.inputBuf.length) {

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -311,6 +311,10 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
       return clearSelection()
     }
 
+    if (key.escape && cState.queueEditIdx !== null) {
+      return cActions.clearIn()
+    }
+
     if (key.upArrow && !cState.inputBuf.length) {
       const inputSel = getInputSelection()
       const cursor = inputSel && inputSel.start === inputSel.end ? inputSel.start : null
@@ -355,6 +359,11 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
       if (isMac) {
         return
       }
+    }
+
+    if (isCtrl(key, ch, 'x') && cState.queueEditIdx !== null) {
+      cActions.removeQueue(cState.queueEditIdx)
+      return cActions.clearIn()
     }
 
     if (key.ctrl && ch.toLowerCase() === 'c') {

--- a/ui-tui/src/components/queuedMessages.tsx
+++ b/ui-tui/src/components/queuedMessages.tsx
@@ -24,8 +24,9 @@ export function QueuedMessages({ cols, queueEditIdx, queued, t }: QueuedMessages
   return (
     <Box flexDirection="column" marginTop={1}>
       <Text color={t.color.dim} dimColor>
-        queued ({queued.length})
-        {queueEditIdx !== null ? ` · editing ${queueEditIdx + 1} · ⌃X delete · esc cancel` : ''}
+        {`queued (${queued.length})${
+          queueEditIdx !== null ? ` · editing ${queueEditIdx + 1} · Ctrl+X delete · Esc cancel` : ''
+        }`}
       </Text>
 
       {q.showLead && (

--- a/ui-tui/src/components/queuedMessages.tsx
+++ b/ui-tui/src/components/queuedMessages.tsx
@@ -24,7 +24,8 @@ export function QueuedMessages({ cols, queueEditIdx, queued, t }: QueuedMessages
   return (
     <Box flexDirection="column" marginTop={1}>
       <Text color={t.color.dim} dimColor>
-        queued ({queued.length}){queueEditIdx !== null ? ` · editing ${queueEditIdx + 1}` : ''}
+        queued ({queued.length})
+        {queueEditIdx !== null ? ` · editing ${queueEditIdx + 1} · ⌃X delete · esc cancel` : ''}
       </Text>
 
       {q.showLead && (

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -684,13 +684,13 @@ export function TextInput({
         return
       }
 
-      // Ctrl+B is the documented voice-recording toggle (see platform.ts →
-      // isVoiceToggleKey). Pass it through so the app-level handler in
-      // useInputHandlers receives it instead of being swallowed here as
-      // either backward-word nav (line below) or a literal 'b' insertion.
+      // Ctrl chords claimed by useInputHandlers — pass through instead of
+      // letting them fall into readline-style nav or a literal char insert.
+      // Ctrl+B = voice toggle, Ctrl+X = delete queued message while editing.
       if (
         (k.ctrl && inp === 'c') ||
         (k.ctrl && inp === 'b') ||
+        (k.ctrl && inp === 'x') ||
         k.tab ||
         (k.shift && k.tab) ||
         k.pageUp ||

--- a/ui-tui/src/content/hotkeys.ts
+++ b/ui-tui/src/content/hotkeys.ts
@@ -23,7 +23,7 @@ export const HOTKEYS: [string, string][] = [
   [paste + '+V / /paste', 'paste text; /paste attaches clipboard image'],
   ['Tab', 'apply completion'],
   ['↑/↓', 'completions / queue edit / history'],
-  ['Ctrl+X', 'delete the queued message you’re editing (esc cancels edit)'],
+  ['Ctrl+X', 'delete the queued message you’re editing (Esc cancels edit)'],
   [action + '+A/E', 'home / end of line'],
   [action + '+Z / ' + action + '+Y', 'undo / redo input edits'],
   [action + '+W', 'delete word'],

--- a/ui-tui/src/content/hotkeys.ts
+++ b/ui-tui/src/content/hotkeys.ts
@@ -23,6 +23,7 @@ export const HOTKEYS: [string, string][] = [
   [paste + '+V / /paste', 'paste text; /paste attaches clipboard image'],
   ['Tab', 'apply completion'],
   ['↑/↓', 'completions / queue edit / history'],
+  ['Ctrl+X', 'delete the queued message you’re editing (esc cancels edit)'],
   [action + '+A/E', 'home / end of line'],
   [action + '+Z / ' + action + '+Y', 'undo / redo input edits'],
   [action + '+W', 'delete word'],

--- a/ui-tui/src/hooks/useQueue.ts
+++ b/ui-tui/src/hooks/useQueue.ts
@@ -1,6 +1,8 @@
 import { useCallback, useRef, useState } from 'react'
 
-export function removeAt<T>(arr: T[], i: number): T[] {
+// Mutates `arr` in place; returned reference is the same input array, kept
+// so callers can chain. Use `Array.prototype.toSpliced` if you need a copy.
+export function removeAtInPlace<T>(arr: T[], i: number): T[] {
   if (i < 0 || i >= arr.length) {
     return arr
   }
@@ -50,7 +52,7 @@ export function useQueue() {
     (i: number) => {
       const before = queueRef.current.length
 
-      removeAt(queueRef.current, i)
+      removeAtInPlace(queueRef.current, i)
 
       if (queueRef.current.length !== before) {
         syncQueue()

--- a/ui-tui/src/hooks/useQueue.ts
+++ b/ui-tui/src/hooks/useQueue.ts
@@ -1,5 +1,15 @@
 import { useCallback, useRef, useState } from 'react'
 
+export function removeAt<T>(arr: T[], i: number): T[] {
+  if (i < 0 || i >= arr.length) {
+    return arr
+  }
+
+  arr.splice(i, 1)
+
+  return arr
+}
+
 export function useQueue() {
   const queueRef = useRef<string[]>([])
   const [queuedDisplay, setQueuedDisplay] = useState<string[]>([])
@@ -36,6 +46,19 @@ export function useQueue() {
     [syncQueue]
   )
 
+  const removeQ = useCallback(
+    (i: number) => {
+      const before = queueRef.current.length
+
+      removeAt(queueRef.current, i)
+
+      if (queueRef.current.length !== before) {
+        syncQueue()
+      }
+    },
+    [syncQueue]
+  )
+
   return {
     dequeue,
     enqueue,
@@ -43,6 +66,7 @@ export function useQueue() {
     queueEditRef,
     queueRef,
     queuedDisplay,
+    removeQ,
     replaceQ,
     setQueueEdit,
     syncQueue


### PR DESCRIPTION
## Why

Discord context: ctrl-c got slightly weird in the live turn (fixed in
#16706), and that surfaced an adjacent gap — there's currently no way
to **remove** a queued message. \`↑\` loads it for edit, \`ctrl-K\`
dispatches the head, but a draft you no longer want stays put forever.

\`ctrl-C\` while editing today just clears the composer and exits edit
mode without touching the queue, which is the right behavior — but it
leaves the user with no way to actually drop the item.

## Two new bindings, both gated on \`queueEditIdx !== null\`

- **\`ctrl-X\`** — delete the queue item being edited, clear composer,
  exit edit mode. \"cut\" matches the mental model and doesn't collide
  with any existing binding.
- **\`esc\`** — cancel the edit (composer clears, item stays in queue).
  Mirrors \`ctrl-C\`'s existing behavior so muscle memory has two
  paths.

Header line now reads:

\`\`\`
queued (3) · editing 2 · ⌃X delete · esc cancel
\`\`\`

…when in edit mode, so the affordance is discoverable without
\`/help\`. The \`/help\` hotkey table also gets a \`Ctrl+X\` entry.

## What I deliberately *didn't* do

- **\`ctrl-C\` while editing → delete the item** (Brooklyn's first
  instinct). Rejected because \`ctrl-C\` should never destroy queued
  content; making one binding both \"cancel\" and \"destroy\" is
  surprising. Clean separation: \`esc\` / \`ctrl-C\` cancel,
  \`ctrl-X\` deletes.
- **Clickable \`[x]\` per row** — defer. Adds visual weight to the
  3-row peek and Ink mouse plumbing isn't wired here yet. Can come
  later if asked; keyboard story is right first.

## Test

- \`removeAt\` extracted as a pure helper; covered in
  \`__tests__/useQueue.test.ts\` (happy path, OOB no-ops, mutate-in-place).
- The \`useInput\` keyboard wiring isn't unit-testable without an
  ink-testing-library; verified by tsc + manual walk-through.
- All 387 ui-tui tests pass; tsc clean.