### PR TITLE
fix(mcp-oauth): persist refresh identity instead of redirect URIs

### DIFF
--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -50,22 +50,56 @@ class TestHermesTokenStorage:
         data = json.loads(token_path.read_text())
         assert data["access_token"] == "abc123"
 
-    def test_roundtrip_client_info(self, tmp_path, monkeypatch):
+    def test_roundtrip_client_info_persists_refresh_identity_only(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         storage = HermesTokenStorage("test-server")
         import asyncio
+        from mcp.shared.auth import OAuthClientInformationFull
+        from pydantic import AnyUrl
 
         assert asyncio.run(storage.get_client_info()) is None
 
-        mock_client = MagicMock()
-        mock_client.model_dump.return_value = {
-            "client_id": "hermes-123",
-            "client_secret": "secret",
-        }
-        asyncio.run(storage.set_client_info(mock_client))
+        client_info = OAuthClientInformationFull(
+            client_id="hermes-123",
+            client_secret="secret",
+            redirect_uris=[AnyUrl("http://127.0.0.1:43111/callback")],
+            grant_types=["authorization_code", "refresh_token"],
+            response_types=["code"],
+            token_endpoint_auth_method="client_secret_post",
+        )
+        asyncio.run(storage.set_client_info(client_info))
 
         client_path = tmp_path / "mcp-tokens" / "test-server.client.json"
         assert client_path.exists()
+        data = json.loads(client_path.read_text())
+        assert data["client_id"] == "hermes-123"
+        assert data["client_secret"] == "secret"
+        assert data["token_endpoint_auth_method"] == "client_secret_post"
+        assert "redirect_uris" not in data
+
+    def test_get_client_identity_migrates_legacy_registration(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("legacy-server")
+        import asyncio
+
+        d = tmp_path / "mcp-tokens"
+        d.mkdir(parents=True)
+        (d / "legacy-server.client.json").write_text(json.dumps({
+            "client_id": "legacy-client",
+            "client_secret": "legacy-secret",
+            "redirect_uris": ["http://127.0.0.1:58741/callback"],
+            "grant_types": ["authorization_code", "refresh_token"],
+            "response_types": ["code"],
+            "token_endpoint_auth_method": "client_secret_post",
+            "scope": "projects:read",
+        }))
+
+        identity = asyncio.run(storage.get_client_identity())
+        assert identity is not None
+        assert identity.client_id == "legacy-client"
+        assert identity.client_secret == "legacy-secret"
+        assert identity.token_endpoint_auth_method == "client_secret_post"
+        assert identity.scope == "projects:read"
 
     def test_remove_cleans_up(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))

--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -143,10 +143,12 @@ class TestHermesTokenStorage:
         d = tmp_path / "mcp-tokens"
         d.mkdir(parents=True)
         (d / "test-server.json").write_text("{}")
+        (d / "test-server.identity.json").write_text("{}")
         (d / "test-server.client.json").write_text("{}")
 
         storage.remove()
         assert not (d / "test-server.json").exists()
+        assert not (d / "test-server.identity.json").exists()
         assert not (d / "test-server.client.json").exists()
 
     def test_has_cached_tokens(self, tmp_path, monkeypatch):

--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -69,9 +69,9 @@ class TestHermesTokenStorage:
         )
         asyncio.run(storage.set_client_info(client_info))
 
-        client_path = tmp_path / "mcp-tokens" / "test-server.client.json"
-        assert client_path.exists()
-        data = json.loads(client_path.read_text())
+        identity_path = tmp_path / "mcp-tokens" / "test-server.identity.json"
+        assert identity_path.exists()
+        data = json.loads(identity_path.read_text())
         assert data["client_id"] == "hermes-123"
         assert data["client_secret"] == "secret"
         assert data["token_endpoint_auth_method"] == "client_secret_post"
@@ -84,7 +84,8 @@ class TestHermesTokenStorage:
 
         d = tmp_path / "mcp-tokens"
         d.mkdir(parents=True)
-        (d / "legacy-server.client.json").write_text(json.dumps({
+        legacy_path = d / "legacy-server.client.json"
+        legacy_path.write_text(json.dumps({
             "client_id": "legacy-client",
             "client_secret": "legacy-secret",
             "redirect_uris": ["http://127.0.0.1:58741/callback"],
@@ -100,6 +101,39 @@ class TestHermesTokenStorage:
         assert identity.client_secret == "legacy-secret"
         assert identity.token_endpoint_auth_method == "client_secret_post"
         assert identity.scope == "projects:read"
+        assert legacy_path.exists()
+        identity_path = d / "legacy-server.identity.json"
+        assert identity_path.exists()
+
+    def test_legacy_confidential_registration_backfills_post_auth_method(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("legacy-server")
+        import asyncio
+
+        d = tmp_path / "mcp-tokens"
+        d.mkdir(parents=True)
+        (d / "legacy-server.client.json").write_text(json.dumps({
+            "client_id": "legacy-client",
+            "client_secret": "legacy-secret",
+            "redirect_uris": ["http://127.0.0.1:58741/callback"],
+            "grant_types": ["authorization_code", "refresh_token"],
+            "response_types": ["code"],
+        }))
+
+        identity = asyncio.run(storage.get_client_identity())
+        assert identity is not None
+        assert identity.token_endpoint_auth_method == "client_secret_post"
+
+    def test_refresh_identity_defaults_confidential_auth_to_basic(self):
+        from tools.mcp_oauth import HermesOAuthClientIdentity
+
+        identity = HermesOAuthClientIdentity(
+            client_id="client-123",
+            client_secret="secret",
+        )
+
+        client_info = identity.to_client_info("http://127.0.0.1:54321/callback")
+        assert client_info.token_endpoint_auth_method == "client_secret_basic"
 
     def test_remove_cleans_up(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -184,9 +218,9 @@ class TestBuildOAuthAuth:
             "scope": "channels:read",
         })
 
-        client_path = tmp_path / "mcp-tokens" / "slack.client.json"
-        assert client_path.exists()
-        data = json.loads(client_path.read_text())
+        identity_path = tmp_path / "mcp-tokens" / "slack.identity.json"
+        assert identity_path.exists()
+        data = json.loads(identity_path.read_text())
         assert data["client_id"] == "my-app-id"
         assert data["client_secret"] == "my-secret"
 

--- a/tests/tools/test_mcp_oauth_bidirectional.py
+++ b/tests/tools/test_mcp_oauth_bidirectional.py
@@ -198,6 +198,65 @@ async def test_hermes_provider_forwards_401_triggers_refresh(tmp_path, monkeypat
     await flow.aclose()
 
 
+@pytest.mark.asyncio
+async def test_provider_initializes_refresh_identity_with_current_redirect_uri(tmp_path, monkeypatch):
+    """Restart bootstrap should synthesize client_info from current metadata, not a legacy redirect URI."""
+    import httpx
+    from mcp.shared.auth import OAuthClientMetadata, OAuthToken
+    from pydantic import AnyUrl
+
+    from tools.mcp_oauth import HermesTokenStorage
+    from tools.mcp_oauth_manager import _HERMES_PROVIDER_CLS, reset_manager_for_tests
+
+    assert _HERMES_PROVIDER_CLS is not None
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    reset_manager_for_tests()
+
+    storage = HermesTokenStorage("srv")
+    await storage.set_tokens(
+        OAuthToken(
+            access_token="cached-access",
+            token_type="Bearer",
+            expires_in=3600,
+            refresh_token="cached-refresh",
+        )
+    )
+
+    token_dir = tmp_path / "mcp-tokens"
+    token_dir.mkdir(parents=True, exist_ok=True)
+    (token_dir / "srv.client.json").write_text(
+        '{"client_id": "test-client", "client_secret": "test-secret", '
+        '"redirect_uris": ["http://127.0.0.1:11111/callback"], '
+        '"grant_types": ["authorization_code", "refresh_token"], '
+        '"response_types": ["code"], '
+        '"token_endpoint_auth_method": "client_secret_post"}'
+    )
+
+    metadata = OAuthClientMetadata(
+        redirect_uris=[AnyUrl("http://127.0.0.1:54321/callback")],
+        client_name="Hermes Agent",
+    )
+    provider = _HERMES_PROVIDER_CLS(
+        server_name="srv",
+        server_url="https://example.com/mcp",
+        client_metadata=metadata,
+        storage=storage,
+        redirect_handler=_noop_redirect,
+        callback_handler=_noop_callback,
+    )
+
+    req = httpx.Request("POST", "https://example.com/mcp")
+    flow = provider.async_auth_flow(req)
+    outbound = await flow.__anext__()
+
+    assert provider.context.client_info is not None
+    assert str(provider.context.client_info.redirect_uris[0]) == "http://127.0.0.1:54321/callback"
+    assert provider.context.client_info.client_id == "test-client"
+
+    await flow.aclose()
+
+
 async def _noop_redirect(_url: str) -> None:
     """Redirect handler that does nothing (won't be invoked in these tests)."""
     return None

--- a/tests/tools/test_mcp_oauth_bidirectional.py
+++ b/tests/tools/test_mcp_oauth_bidirectional.py
@@ -257,8 +257,150 @@ async def test_provider_initializes_refresh_identity_with_current_redirect_uri(t
     await flow.aclose()
 
 
+@pytest.mark.asyncio
+async def test_expired_token_refreshes_before_any_browser_redirect(tmp_path, monkeypatch):
+    """Cold-start with an expired token should refresh before interactive auth."""
+    import httpx
+    from mcp.shared.auth import OAuthClientMetadata
+    from pydantic import AnyUrl
+
+    from tools.mcp_oauth import HermesTokenStorage, _get_token_dir
+    from tools.mcp_oauth_manager import _HERMES_PROVIDER_CLS, reset_manager_for_tests
+
+    assert _HERMES_PROVIDER_CLS is not None
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    reset_manager_for_tests()
+
+    token_dir = _get_token_dir()
+    token_dir.mkdir(parents=True, exist_ok=True)
+    (token_dir / "srv.json").write_text(
+        '{"access_token": "stale-access", "token_type": "Bearer", '
+        '"expires_in": 3600, "expires_at": 0, "refresh_token": "refresh-token"}'
+    )
+
+    storage = HermesTokenStorage("srv")
+    (token_dir / "srv.client.json").write_text(
+        '{"client_id": "test-client", "token_endpoint_auth_method": "none"}'
+    )
+
+    redirect_calls: list[str] = []
+
+    async def _record_redirect(url: str) -> None:
+        redirect_calls.append(url)
+
+    metadata = OAuthClientMetadata(
+        redirect_uris=[AnyUrl("http://127.0.0.1:54321/callback")],
+        client_name="Hermes Agent",
+    )
+    provider = _HERMES_PROVIDER_CLS(
+        server_name="srv",
+        server_url="https://example.com/mcp",
+        client_metadata=metadata,
+        storage=storage,
+        redirect_handler=_record_redirect,
+        callback_handler=_noop_callback,
+    )
+    provider._prefetch_oauth_metadata = _noop_prefetch  # type: ignore[attr-defined]
+
+    req = httpx.Request("POST", "https://example.com/mcp")
+    flow = provider.async_auth_flow(req)
+    refresh_request = await flow.__anext__()
+
+    assert refresh_request.method == "POST"
+    assert refresh_request.url.path == "/token"
+    assert redirect_calls == []
+
+    refresh_response = httpx.Response(
+        200,
+        request=refresh_request,
+        json={
+            "access_token": "fresh-access",
+            "refresh_token": "fresh-refresh",
+            "expires_in": 3600,
+            "token_type": "Bearer",
+        },
+    )
+    outbound = await flow.asend(refresh_response)
+    assert outbound.headers["Authorization"] == "Bearer fresh-access"
+
+    with pytest.raises(StopAsyncIteration):
+        await flow.asend(httpx.Response(200, request=outbound))
+
+    assert redirect_calls == []
+
+
+@pytest.mark.asyncio
+async def test_refresh_identity_uses_oauth_metadata_auth_method_hint(tmp_path, monkeypatch):
+    """Missing auth method should be resolved from OAuth metadata when available."""
+    import httpx
+    from mcp.shared.auth import OAuthClientMetadata, OAuthToken, OAuthMetadata
+    from pydantic import AnyUrl
+
+    from tools.mcp_oauth import HermesTokenStorage
+    from tools.mcp_oauth_manager import _HERMES_PROVIDER_CLS, reset_manager_for_tests
+
+    assert _HERMES_PROVIDER_CLS is not None
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    reset_manager_for_tests()
+
+    storage = HermesTokenStorage("srv")
+    await storage.set_tokens(
+        OAuthToken(
+            access_token="cached-access",
+            token_type="Bearer",
+            expires_in=3600,
+            refresh_token="cached-refresh",
+        )
+    )
+
+    token_dir = tmp_path / "mcp-tokens"
+    token_dir.mkdir(parents=True, exist_ok=True)
+    (token_dir / "srv.identity.json").write_text(
+        '{"client_id": "test-client", "client_secret": "test-secret"}'
+    )
+
+    metadata = OAuthClientMetadata(
+        redirect_uris=[AnyUrl("http://127.0.0.1:54321/callback")],
+        client_name="Hermes Agent",
+    )
+    provider = _HERMES_PROVIDER_CLS(
+        server_name="srv",
+        server_url="https://example.com/mcp",
+        client_metadata=metadata,
+        storage=storage,
+        redirect_handler=_noop_redirect,
+        callback_handler=_noop_callback,
+    )
+
+    async def _prefetch_with_post_only() -> None:
+        provider.context.oauth_metadata = OAuthMetadata(
+            issuer="https://auth.example.com",
+            authorization_endpoint="https://auth.example.com/authorize",
+            token_endpoint="https://auth.example.com/token",
+            token_endpoint_auth_methods_supported=["client_secret_post"],
+        )
+
+    provider._prefetch_oauth_metadata = _prefetch_with_post_only  # type: ignore[attr-defined]
+
+    req = httpx.Request("POST", "https://example.com/mcp")
+    flow = provider.async_auth_flow(req)
+    outbound = await flow.__anext__()
+
+    assert provider.context.client_info is not None
+    assert provider.context.client_info.token_endpoint_auth_method == "client_secret_post"
+
+    await flow.aclose()
+
+
 async def _noop_redirect(_url: str) -> None:
     """Redirect handler that does nothing (won't be invoked in these tests)."""
+    return None
+
+
+async def _noop_prefetch() -> None:
+    """Prefetch stub used when a test should not touch the network."""
     return None
 
 

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1403,6 +1403,37 @@ class TestReconnection:
 
         asyncio.run(_test())
 
+    def test_no_initial_retries_on_auth_failure(self):
+        """Interactive auth failures should not reopen the browser in a retry loop."""
+        from tools.mcp_oauth import OAuthNonInteractiveError
+        from tools.mcp_tool import MCPServerTask
+
+        run_count = 0
+        target_server = None
+
+        original_run_stdio = MCPServerTask._run_stdio
+
+        async def patched_run_stdio(self_srv, config):
+            nonlocal run_count, target_server
+            run_count += 1
+            if target_server is not self_srv:
+                return await original_run_stdio(self_srv, config)
+            raise OAuthNonInteractiveError("oauth callback timed out")
+
+        async def _test():
+            nonlocal target_server
+            server = MCPServerTask("test_srv")
+            target_server = server
+
+            with patch.object(MCPServerTask, "_run_stdio", patched_run_stdio), \
+                 patch("asyncio.sleep", new_callable=AsyncMock):
+                await server.run({"command": "test"})
+
+            assert run_count == 1
+            assert isinstance(server._error, OAuthNonInteractiveError)
+
+        asyncio.run(_test())
+
 
 # ---------------------------------------------------------------------------
 # Configurable timeouts

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -11,8 +11,8 @@ which handles discovery, dynamic client registration, PKCE, token exchange,
 refresh, and step-up authorization automatically.
 
 This module provides the glue:
-    - ``HermesTokenStorage``: persists tokens/client-info to disk so they
-      survive across process restarts.
+    - ``HermesTokenStorage``: persists tokens and refresh identity to disk so
+      they survive across process restarts.
     - Callback server: ephemeral localhost HTTP server to capture the OAuth
       redirect with the authorization code.
     - ``build_oauth_auth()``: entry point called by ``mcp_tool.py`` that wires
@@ -277,12 +277,13 @@ class HermesOAuthClientIdentity:
 
 
 class HermesTokenStorage:
-    """Persist OAuth tokens and client registration to JSON files.
+    """Persist OAuth tokens and refresh identity to JSON files.
 
     File layout::
 
-        HERMES_HOME/mcp-tokens/<server_name>.json         -- tokens
-        HERMES_HOME/mcp-tokens/<server_name>.client.json   -- client info
+        HERMES_HOME/mcp-tokens/<server_name>.json           -- tokens
+        HERMES_HOME/mcp-tokens/<server_name>.identity.json  -- refresh identity
+        HERMES_HOME/mcp-tokens/<server_name>.client.json    -- legacy registration cache (migration input only)
     """
 
     def __init__(self, server_name: str):

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -42,6 +42,7 @@ import sys
 import threading
 import time
 import webbrowser
+from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from typing import Any
@@ -168,6 +169,79 @@ def _write_json(path: Path, data: dict) -> None:
         raise
 
 
+@dataclass(frozen=True)
+class HermesOAuthClientIdentity:
+    """Minimal durable client state needed for token refresh across restarts."""
+
+    client_id: str
+    client_secret: str | None = None
+    token_endpoint_auth_method: str | None = None
+    scope: str | None = None
+
+    @classmethod
+    def from_data(cls, data: dict) -> "HermesOAuthClientIdentity":
+        client_id = data.get("client_id")
+        if not isinstance(client_id, str) or not client_id:
+            raise ValueError("client_id missing from stored OAuth client identity")
+        client_secret = data.get("client_secret")
+        token_endpoint_auth_method = data.get("token_endpoint_auth_method")
+        scope = data.get("scope")
+        return cls(
+            client_id=client_id,
+            client_secret=client_secret if isinstance(client_secret, str) else None,
+            token_endpoint_auth_method=(
+                token_endpoint_auth_method
+                if isinstance(token_endpoint_auth_method, str)
+                else None
+            ),
+            scope=scope if isinstance(scope, str) else None,
+        )
+
+    @classmethod
+    def from_client_info(
+        cls,
+        client_info: "OAuthClientInformationFull",
+    ) -> "HermesOAuthClientIdentity":
+        return cls(
+            client_id=client_info.client_id or "",
+            client_secret=client_info.client_secret,
+            token_endpoint_auth_method=client_info.token_endpoint_auth_method,
+            scope=client_info.scope,
+        )
+
+    def normalized_auth_method(self) -> str:
+        if self.token_endpoint_auth_method:
+            return self.token_endpoint_auth_method
+        if self.client_secret:
+            return "client_secret_post"
+        return "none"
+
+    def to_storage_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {"client_id": self.client_id}
+        if self.client_secret:
+            payload["client_secret"] = self.client_secret
+        auth_method = self.normalized_auth_method()
+        if auth_method:
+            payload["token_endpoint_auth_method"] = auth_method
+        if self.scope:
+            payload["scope"] = self.scope
+        return payload
+
+    def to_client_info(self, redirect_uri: str) -> "OAuthClientInformationFull":
+        payload: dict[str, Any] = {
+            "client_id": self.client_id,
+            "redirect_uris": [redirect_uri],
+            "grant_types": ["authorization_code", "refresh_token"],
+            "response_types": ["code"],
+            "token_endpoint_auth_method": self.normalized_auth_method(),
+        }
+        if self.client_secret:
+            payload["client_secret"] = self.client_secret
+        if self.scope:
+            payload["scope"] = self.scope
+        return OAuthClientInformationFull.model_validate(payload)
+
+
 # ---------------------------------------------------------------------------
 # HermesTokenStorage -- persistent token/client-info on disk
 # ---------------------------------------------------------------------------
@@ -254,18 +328,29 @@ class HermesTokenStorage:
 
     # -- client info -------------------------------------------------------
 
-    async def get_client_info(self) -> "OAuthClientInformationFull | None":
+    async def get_client_identity(self) -> "HermesOAuthClientIdentity | None":
         data = _read_json(self._client_info_path())
         if data is None:
             return None
         try:
-            return OAuthClientInformationFull.model_validate(data)
+            return HermesOAuthClientIdentity.from_data(data)
+        except (ValueError, TypeError, KeyError) as exc:
+            logger.warning("Corrupt client info at %s -- ignoring: %s", self._client_info_path(), exc)
+            return None
+
+    async def get_client_info(self) -> "OAuthClientInformationFull | None":
+        identity = await self.get_client_identity()
+        if identity is None:
+            return None
+        try:
+            return identity.to_client_info("http://127.0.0.1/callback")
         except (ValueError, TypeError, KeyError) as exc:
             logger.warning("Corrupt client info at %s -- ignoring: %s", self._client_info_path(), exc)
             return None
 
     async def set_client_info(self, client_info: "OAuthClientInformationFull") -> None:
-        _write_json(self._client_info_path(), client_info.model_dump(mode="json", exclude_none=True))
+        identity = HermesOAuthClientIdentity.from_client_info(client_info)
+        _write_json(self._client_info_path(), identity.to_storage_dict())
         logger.debug("OAuth client info saved for %s", self._server_name)
 
     # -- cleanup -----------------------------------------------------------
@@ -515,7 +600,8 @@ def _maybe_preregister_client(
         info_dict["scope"] = cfg["scope"]
 
     client_info = OAuthClientInformationFull.model_validate(info_dict)
-    _write_json(storage._client_info_path(), client_info.model_dump(mode="json", exclude_none=True))
+    identity = HermesOAuthClientIdentity.from_client_info(client_info)
+    _write_json(storage._client_info_path(), identity.to_storage_dict())
     logger.debug("Pre-registered client_id=%s for '%s'", client_id, storage._server_name)
 
 

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -45,7 +45,7 @@ import webbrowser
 from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
-from typing import Any
+from typing import Any, Sequence
 from urllib.parse import parse_qs, urlparse
 
 logger = logging.getLogger(__name__)
@@ -198,6 +198,18 @@ class HermesOAuthClientIdentity:
         )
 
     @classmethod
+    def from_legacy_client_info_data(cls, data: dict) -> "HermesOAuthClientIdentity":
+        identity = cls.from_data(data)
+        if identity.client_secret and not identity.token_endpoint_auth_method:
+            identity = cls(
+                client_id=identity.client_id,
+                client_secret=identity.client_secret,
+                token_endpoint_auth_method="client_secret_post",
+                scope=identity.scope,
+            )
+        return identity
+
+    @classmethod
     def from_client_info(
         cls,
         client_info: "OAuthClientInformationFull",
@@ -209,31 +221,48 @@ class HermesOAuthClientIdentity:
             scope=client_info.scope,
         )
 
-    def normalized_auth_method(self) -> str:
+    def resolved_auth_method(
+        self,
+        oauth_metadata: Any | None = None,
+    ) -> str:
         if self.token_endpoint_auth_method:
             return self.token_endpoint_auth_method
-        if self.client_secret:
-            return "client_secret_post"
-        return "none"
+        if not self.client_secret:
+            return "none"
+
+        supported = getattr(oauth_metadata, "token_endpoint_auth_methods_supported", None)
+        if isinstance(supported, Sequence):
+            supported_set = {item for item in supported if isinstance(item, str)}
+            if "client_secret_basic" in supported_set and "client_secret_post" not in supported_set:
+                return "client_secret_basic"
+            if "client_secret_post" in supported_set and "client_secret_basic" not in supported_set:
+                return "client_secret_post"
+            if "client_secret_basic" in supported_set and "client_secret_post" in supported_set:
+                return "client_secret_basic"
+
+        return "client_secret_basic"
 
     def to_storage_dict(self) -> dict[str, Any]:
         payload: dict[str, Any] = {"client_id": self.client_id}
         if self.client_secret:
             payload["client_secret"] = self.client_secret
-        auth_method = self.normalized_auth_method()
-        if auth_method:
-            payload["token_endpoint_auth_method"] = auth_method
+        if self.token_endpoint_auth_method:
+            payload["token_endpoint_auth_method"] = self.token_endpoint_auth_method
         if self.scope:
             payload["scope"] = self.scope
         return payload
 
-    def to_client_info(self, redirect_uri: str) -> "OAuthClientInformationFull":
+    def to_client_info(
+        self,
+        redirect_uri: str,
+        oauth_metadata: Any | None = None,
+    ) -> "OAuthClientInformationFull":
         payload: dict[str, Any] = {
             "client_id": self.client_id,
             "redirect_uris": [redirect_uri],
             "grant_types": ["authorization_code", "refresh_token"],
             "response_types": ["code"],
-            "token_endpoint_auth_method": self.normalized_auth_method(),
+            "token_endpoint_auth_method": self.resolved_auth_method(oauth_metadata),
         }
         if self.client_secret:
             payload["client_secret"] = self.client_secret
@@ -261,6 +290,9 @@ class HermesTokenStorage:
 
     def _tokens_path(self) -> Path:
         return _get_token_dir() / f"{self._server_name}.json"
+
+    def _client_identity_path(self) -> Path:
+        return _get_token_dir() / f"{self._server_name}.identity.json"
 
     def _client_info_path(self) -> Path:
         return _get_token_dir() / f"{self._server_name}.client.json"
@@ -329,11 +361,21 @@ class HermesTokenStorage:
     # -- client info -------------------------------------------------------
 
     async def get_client_identity(self) -> "HermesOAuthClientIdentity | None":
-        data = _read_json(self._client_info_path())
-        if data is None:
+        data = _read_json(self._client_identity_path())
+        if data is not None:
+            try:
+                return HermesOAuthClientIdentity.from_data(data)
+            except (ValueError, TypeError, KeyError) as exc:
+                logger.warning("Corrupt client identity at %s -- ignoring: %s", self._client_identity_path(), exc)
+                return None
+
+        legacy_data = _read_json(self._client_info_path())
+        if legacy_data is None:
             return None
         try:
-            return HermesOAuthClientIdentity.from_data(data)
+            identity = HermesOAuthClientIdentity.from_legacy_client_info_data(legacy_data)
+            _write_json(self._client_identity_path(), identity.to_storage_dict())
+            return identity
         except (ValueError, TypeError, KeyError) as exc:
             logger.warning("Corrupt client info at %s -- ignoring: %s", self._client_info_path(), exc)
             return None
@@ -350,14 +392,14 @@ class HermesTokenStorage:
 
     async def set_client_info(self, client_info: "OAuthClientInformationFull") -> None:
         identity = HermesOAuthClientIdentity.from_client_info(client_info)
-        _write_json(self._client_info_path(), identity.to_storage_dict())
+        _write_json(self._client_identity_path(), identity.to_storage_dict())
         logger.debug("OAuth client info saved for %s", self._server_name)
 
     # -- cleanup -----------------------------------------------------------
 
     def remove(self) -> None:
         """Delete all stored OAuth state for this server."""
-        for p in (self._tokens_path(), self._client_info_path()):
+        for p in (self._tokens_path(), self._client_identity_path(), self._client_info_path()):
             p.unlink(missing_ok=True)
 
     def has_cached_tokens(self) -> bool:
@@ -601,7 +643,7 @@ def _maybe_preregister_client(
 
     client_info = OAuthClientInformationFull.model_validate(info_dict)
     identity = HermesOAuthClientIdentity.from_client_info(client_info)
-    _write_json(storage._client_info_path(), identity.to_storage_dict())
+    _write_json(storage._client_identity_path(), identity.to_storage_dict())
     logger.debug("Pre-registered client_id=%s for '%s'", client_id, storage._server_name)
 
 

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -110,41 +110,33 @@ def _make_hermes_provider_class() -> Optional[type]:
         def __init__(self, *args: Any, server_name: str = "", **kwargs: Any):
             super().__init__(*args, **kwargs)
             self._hermes_server_name = server_name
+            self._hermes_uses_refresh_identity = False
 
         async def _initialize(self) -> None:
-            """Load stored tokens + client info AND seed token_expiry_time.
+            """Load stored tokens and synthesize refresh-only client identity.
 
-            Also eagerly fetches OAuth authorization-server metadata (PRM +
-            ASM) when we have stored tokens but no cached metadata, so the
-            SDK's ``_refresh_token`` can build the correct token_endpoint
-            URL on the preemptive-refresh path. Without this, the SDK
-            falls back to ``{mcp_server_url}/token`` (wrong for providers
-            whose AS is a different origin — BetterStack's MCP lives at
-            ``https://mcp.betterstack.com`` but its token endpoint is at
-            ``https://betterstack.com/oauth/token``), the refresh 404s, and
-            we drop through to full browser reauth.
-
-            The SDK's base ``_initialize`` populates ``current_tokens`` but
-            does NOT call ``update_token_expiry``, so ``token_expiry_time``
-            stays ``None`` and ``is_token_valid()`` returns True for any
-            loaded token regardless of actual age. After a process restart
-            this ships stale Bearer tokens to the server; some providers
-            return HTTP 401 (caught by the 401 handler), others return 200
-            with an app-level auth error (invisible to the transport layer,
-            e.g. BetterStack returning "No teams found. Please check your
-            authentication.").
-
-            Seeding ``token_expiry_time`` from the reloaded token fixes that:
-            ``is_token_valid()`` correctly reports False for expired tokens,
-            ``async_auth_flow`` takes the ``can_refresh_token()`` branch,
-            and the SDK quietly refreshes before the first real request.
-
-            Paired with :class:`HermesTokenStorage` persisting an absolute
-            ``expires_at`` timestamp (``mcp_oauth.py:set_tokens``) so the
-            remaining TTL we compute here reflects real wall-clock age.
+            Hermes persists token refresh identity separately from any
+            redirect-uri-bound client registration. On cold start we rebuild a
+            minimal ``client_info`` only when we have a refresh token to use,
+            and we synthesize its redirect URI from the CURRENT client metadata
+            rather than any legacy on-disk redirect URI.
             """
-            await super()._initialize()
+            storage = self.context.storage
+            self.context.current_tokens = await storage.get_tokens()
+            self.context.client_info = None
+            self._hermes_uses_refresh_identity = False
+            self._initialized = True
+
             tokens = self.context.current_tokens
+            if tokens is not None and tokens.refresh_token:
+                get_identity = getattr(storage, "get_client_identity", None)
+                if callable(get_identity):
+                    identity = await get_identity()
+                    if identity is not None:
+                        redirect_uri = str(self.context.client_metadata.redirect_uris[0])
+                        self.context.client_info = identity.to_client_info(redirect_uri)
+                        self._hermes_uses_refresh_identity = True
+
             if tokens is not None and tokens.expires_in is not None:
                 self.context.update_token_expiry(tokens)
 
@@ -236,6 +228,13 @@ def _make_hermes_provider_class() -> Optional[type]:
                         )
                         break
 
+        async def _handle_refresh_response(self, response):  # type: ignore[override]
+            ok = await super()._handle_refresh_response(response)
+            if not ok and self._hermes_uses_refresh_identity:
+                self.context.client_info = None
+                self._hermes_uses_refresh_identity = False
+            return ok
+
         async def async_auth_flow(self, request):  # type: ignore[override]
             # Pre-flow hook: ask the manager to refresh from disk if needed.
             # Any failure here is non-fatal — we just log and proceed with
@@ -269,6 +268,13 @@ def _make_hermes_provider_class() -> Optional[type]:
                 outgoing = await inner.__anext__()
                 while True:
                     incoming = yield outgoing
+                    if (
+                        incoming is not None
+                        and getattr(incoming, "status_code", None) == 401
+                        and self._hermes_uses_refresh_identity
+                    ):
+                        self.context.client_info = None
+                        self._hermes_uses_refresh_identity = False
                     outgoing = await inner.asend(incoming)
             except StopAsyncIteration:
                 return

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -128,23 +128,9 @@ def _make_hermes_provider_class() -> Optional[type]:
             self._initialized = True
 
             tokens = self.context.current_tokens
-            if tokens is not None and tokens.refresh_token:
-                get_identity = getattr(storage, "get_client_identity", None)
-                if callable(get_identity):
-                    identity = await get_identity()
-                    if identity is not None:
-                        redirect_uri = str(self.context.client_metadata.redirect_uris[0])
-                        self.context.client_info = identity.to_client_info(redirect_uri)
-                        self._hermes_uses_refresh_identity = True
-
             if tokens is not None and tokens.expires_in is not None:
                 self.context.update_token_expiry(tokens)
 
-            # Pre-flight OAuth AS discovery so ``_refresh_token`` has a
-            # correct ``token_endpoint`` before the first refresh attempt.
-            # Only runs when we have tokens on cold-load but no cached
-            # metadata — i.e. the exact scenario where the SDK's built-in
-            # 401-branch discovery hasn't had a chance to run yet.
             if (
                 tokens is not None
                 and self.context.oauth_metadata is None
@@ -152,13 +138,23 @@ def _make_hermes_provider_class() -> Optional[type]:
                 try:
                     await self._prefetch_oauth_metadata()
                 except Exception as exc:  # pragma: no cover — defensive
-                    # Non-fatal: if discovery fails, the SDK's normal 401-
-                    # branch discovery will run on the next request.
                     logger.debug(
                         "MCP OAuth '%s': pre-flight metadata discovery "
                         "failed (non-fatal): %s",
                         self._hermes_server_name, exc,
                     )
+
+            if tokens is not None and tokens.refresh_token:
+                get_identity = getattr(storage, "get_client_identity", None)
+                if callable(get_identity):
+                    identity = await get_identity()
+                    if identity is not None:
+                        redirect_uri = str(self.context.client_metadata.redirect_uris[0])
+                        self.context.client_info = identity.to_client_info(
+                            redirect_uri,
+                            self.context.oauth_metadata,
+                        )
+                        self._hermes_uses_refresh_identity = True
 
         async def _prefetch_oauth_metadata(self) -> None:
             """Fetch PRM + ASM from the well-known endpoints, cache on context.
@@ -227,6 +223,30 @@ def _make_hermes_provider_class() -> Optional[type]:
                             self._hermes_server_name, asm.token_endpoint,
                         )
                         break
+
+        async def _handle_token_response(self, response):  # type: ignore[override]
+            await super()._handle_token_response(response)
+            if self.context.client_info is not None:
+                try:
+                    from tools.mcp_oauth import HermesOAuthClientIdentity
+
+                    identity = HermesOAuthClientIdentity.from_client_info(
+                        self.context.client_info
+                    )
+                    resolved_method = identity.resolved_auth_method(
+                        self.context.oauth_metadata,
+                    )
+                    if resolved_method != self.context.client_info.token_endpoint_auth_method:
+                        self.context.client_info = self.context.client_info.model_copy(
+                            update={"token_endpoint_auth_method": resolved_method}
+                        )
+                    await self.context.storage.set_client_info(self.context.client_info)
+                except Exception as exc:  # pragma: no cover — defensive
+                    logger.debug(
+                        "MCP OAuth '%s': failed to persist client identity after token response: %s",
+                        self._hermes_server_name,
+                        exc,
+                    )
 
         async def _handle_refresh_response(self, response):  # type: ignore[override]
             ok = await super()._handle_refresh_response(response)

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1273,6 +1273,15 @@ class MCPServerTask:
                 # should not permanently kill the server.
                 # (Ported from Kilo Code's MCP resilience fix.)
                 if not self._ready.is_set():
+                    if _is_auth_error(exc):
+                        logger.warning(
+                            "MCP server '%s' initial auth failed; not retrying: %s",
+                            self.name, exc,
+                        )
+                        self._error = exc
+                        self._ready.set()
+                        return
+
                     initial_retries += 1
                     if initial_retries > _MAX_INITIAL_CONNECT_RETRIES:
                         logger.warning(


### PR DESCRIPTION
## What does this PR do?

Fixes MCP OAuth flows that persist redirect-bound client registrations and then fail when the callback URI changes on a later run.

Instead of caching the full client registration, Hermes now persists only the refresh identity needed to refresh tokens and reconstructs client info from current callback metadata at runtime. This keeps refreshes working across restarts without trusting stale `redirect_uris`, and it avoids repeated browser-open loops when initial interactive auth fails.

This approach was inspired by how Codex handles MCP OAuth: it persists token state plus the refresh identity needed to reuse it, then rebuilds runtime OAuth state from current server metadata when a full login is needed.

Direct Codex references:
- [`codex-rs/rmcp-client/src/oauth.rs#L56-L64`](https://github.com/openai/codex/blob/main/codex-rs/rmcp-client/src/oauth.rs#L56-L64) defines `StoredOAuthTokens` as `server_name`, `url`, `client_id`, `token_response`, and `expires_at`
- [`codex-rs/rmcp-client/src/oauth.rs#L79-L95`](https://github.com/openai/codex/blob/main/codex-rs/rmcp-client/src/oauth.rs#L79-L95) and [`#L155-L172`](https://github.com/openai/codex/blob/main/codex-rs/rmcp-client/src/oauth.rs#L155-L172) load/save only that token state
- [`codex-rs/rmcp-client/src/perform_oauth_login.rs#L430-L447`](https://github.com/openai/codex/blob/main/codex-rs/rmcp-client/src/perform_oauth_login.rs#L430-L447) starts a fresh OAuth authorization flow from `OAuthState::new(server_url, ...)` with the current redirect URI
- [`codex-rs/rmcp-client/src/perform_oauth_login.rs#L506-L527`](https://github.com/openai/codex/blob/main/codex-rs/rmcp-client/src/perform_oauth_login.rs#L506-L527) saves the resulting `client_id` and token response after callback completion
- [`codex-rs/rmcp-client/src/rmcp_client.rs#L938-L988`](https://github.com/openai/codex/blob/main/codex-rs/rmcp-client/src/rmcp_client.rs#L938-L988) restores runtime OAuth state from stored `client_id` + token response via `oauth_state.set_credentials(...)`
- [`codex-rs/rmcp-client/src/oauth.rs#L290-L368`](https://github.com/openai/codex/blob/main/codex-rs/rmcp-client/src/oauth.rs#L290-L368) refreshes persisted tokens before reauth when possible

Hermes follows that same broad persistence model in its Python MCP OAuth implementation.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `HermesOAuthClientIdentity` and persist it in `<server>.identity.json`
- Treat legacy `<server>.client.json` files as migration input only, rebuilding client info from current callback metadata instead of stale cached redirect URIs
- Preserve legacy confidential-client registrations by backfilling `client_secret_post` during migration while defaulting new confidential identities to metadata-informed auth methods or RFC-style `client_secret_basic`
- Stop retrying initial interactive auth failures in the MCP server startup loop so repeated failures do not reopen the browser over and over
- Add targeted MCP OAuth tests covering migration, cleanup, redirect synthesis, metadata hints, refresh-before-browser behavior, and initial auth failure handling

## How to Test

1. `source venv/bin/activate`
2. `export HERMES_HOME=$(mktemp -d)`
3. `python -m pytest tests/tools/test_mcp_oauth.py tests/tools/test_mcp_oauth_manager.py tests/tools/test_mcp_oauth_bidirectional.py tests/tools/test_mcp_oauth_cold_load_expiry.py tests/tools/test_mcp_tool.py tests/tools/test_mcp_tool_401_handling.py tests/tools/test_mcp_tool_session_expired.py -q -o addopts=''`
4. Optional manual verification: `export HERMES_HOME=~/.hermes && python -m hermes_cli.main mcp test supabase`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 14.5 arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted affected-area suite passed locally:

```text
262 passed in 15.01s
```

I left the full `pytest tests/ -q` checkbox unchecked because the repo's default pytest/xdist config currently triggers unrelated live MCP OAuth discovery against real profiles before fixture isolation kicks in. This PR's touched surface is covered by the targeted MCP OAuth/tool suites above, and I also manually verified `python -m hermes_cli.main mcp test supabase` on macOS with a real cached Supabase state.
