### PR TITLE
Feature/webui tts audio

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -341,9 +341,19 @@ def _has_valid_session_token(request: Request) -> bool:
 # can't be set. Kept narrow — same query-token tradeoff as the /api/pty WS.
 _QUERY_TOKEN_API_PATHS: frozenset[str] = frozenset({"/api/files/download"})
 
+# /api/audio/{filename} (TTS playback) needs the same query-token allowance:
+# a plain <audio src="..."> GET can't attach the X-Hermes-Session-Token
+# header. Matched by pattern rather than folded into the blanket
+# "/api/audio" prefix so the allowance stays scoped to the file-serving GET
+# and doesn't also loosen /api/audio/speak, /transcribe, or
+# /elevenlabs/voices onto query-token auth.
+_AUDIO_FILE_PATH_RE = re.compile(
+    r"^/api/audio/[^/]+\.(?:mp3|ogg|wav|opus|m4a|flac|aac|webm)$"
+)
+
 
 def _has_valid_query_token(request: Request, path: str) -> bool:
-    if path not in _QUERY_TOKEN_API_PATHS:
+    if path not in _QUERY_TOKEN_API_PATHS and not _AUDIO_FILE_PATH_RE.match(path):
         return False
     token = request.query_params.get("token", "")
     return bool(token) and hmac.compare_digest(token.encode(), _SESSION_TOKEN.encode())
@@ -15828,11 +15838,20 @@ def mount_spa(application: FastAPI):
     application.mount("/assets", StaticFiles(directory=WEB_DIST / "assets"), name="assets")
 
     # --- Audio route (TTS playback) --------------------------------
-    # Serves audio files from ~/.hermes/audio_cache/.
+    # Serves audio files written by tools/tts_tool.py. Must resolve through
+    # the same get_hermes_dir() the tool itself uses (new installs land in
+    # cache/audio; existing installs that already have audio_cache/ on disk
+    # keep using it) — hardcoding audio_cache here 404s for every new install.
     # Mounted BEFORE the SPA catch-all so /api/audio/* isn't eaten.
-    _AUDIO_CACHEDIR = Path(os.environ.get(
-        "HERMES_AUDIO_CACHE", str(get_hermes_home() / "audio_cache"),
-    ))
+    def _resolve_audio_cache_dir() -> Path:
+        # Resolved per-request (like get_hermes_home() elsewhere) rather than
+        # once at mount time, so HERMES_AUDIO_CACHE/HERMES_HOME set by a test
+        # fixture (or a profile switch) actually takes effect.
+        from hermes_constants import get_hermes_dir as _get_audio_cache_dir
+
+        return Path(os.environ.get(
+            "HERMES_AUDIO_CACHE", str(_get_audio_cache_dir("cache/audio", "audio_cache")),
+        ))
 
 
     @application.get("/api/audio/{filename}")
@@ -15840,7 +15859,7 @@ def mount_spa(application: FastAPI):
         """Serve audio files for WebUI TTS playback."""
         import urllib.parse as _urlparse
         decoded = _urlparse.unquote(filename)
-        audio_dir = _AUDIO_CACHEDIR.resolve()
+        audio_dir = _resolve_audio_cache_dir().resolve()
         file_path = (audio_dir / decoded).resolve()
         if not file_path.is_relative_to(audio_dir):
             return JSONResponse({"error": "Access denied"}, status_code=403)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -15828,10 +15828,10 @@ def mount_spa(application: FastAPI):
     application.mount("/assets", StaticFiles(directory=WEB_DIST / "assets"), name="assets")
 
     # --- Audio route (TTS playback) --------------------------------
-    # Serves audio files from ~/.hermes/cache/audio/audio_cache/.
+    # Serves audio files from ~/.hermes/audio_cache/.
     # Mounted BEFORE the SPA catch-all so /api/audio/* isn't eaten.
     _AUDIO_CACHEDIR = Path(os.environ.get(
-        "HERMES_AUDIO_CACHE", str(get_hermes_dir("cache/audio", "audio_cache")),
+        "HERMES_AUDIO_CACHE", str(get_hermes_home() / "audio_cache"),
     ))
 
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -15827,6 +15827,52 @@ def mount_spa(application: FastAPI):
 
     application.mount("/assets", StaticFiles(directory=WEB_DIST / "assets"), name="assets")
 
+    # --- Audio route (TTS playback) --------------------------------
+    # Serves audio files from ~/.hermes/cache/audio/audio_cache/.
+    # Mounted BEFORE the SPA catch-all so /api/audio/* isn't eaten.
+    _AUDIO_CACHEDIR = Path(os.environ.get(
+        "HERMES_AUDIO_CACHE", str(get_hermes_dir("cache/audio", "audio_cache")),
+    ))
+
+
+    @application.get("/api/audio/{filename}")
+    async def get_audio(filename: str):
+        """Serve audio files for WebUI TTS playback."""
+        import urllib.parse as _urlparse
+        decoded = _urlparse.unquote(filename)
+        audio_dir = _AUDIO_CACHEDIR.resolve()
+        file_path = (audio_dir / decoded).resolve()
+        if not file_path.is_relative_to(audio_dir):
+            return JSONResponse({"error": "Access denied"}, status_code=403)
+        if not file_path.exists() or not file_path.is_file():
+            return JSONResponse(
+                {"error": f"Audio file not found: {filename}"},
+                status_code=404,
+            )
+        allowed_ext = {"mp3", "ogg", "wav", "opus", "m4a", "flac", "aac", "webm"}
+        ext = file_path.suffix.lower().lstrip(".")
+        if ext not in allowed_ext:
+            media_type = "application/octet-stream"
+        elif ext == "mp3":
+            media_type = "audio/mpeg"
+        elif ext == "ogg" or ext == "opus":
+            media_type = "audio/ogg"
+        elif ext == "wav":
+            media_type = "audio/wav"
+        elif ext == "m4a":
+            media_type = "audio/mp4"
+        elif ext == "flac":
+            media_type = "audio/flac"
+        elif ext == "aac":
+            media_type = "audio/aac"
+        elif ext == "webm":
+            media_type = "audio/webm"
+        else:
+            media_type = "audio/*"
+        return FileResponse(str(file_path), media_type=media_type)
+
+
+
     @application.get("/{full_path:path}")
     async def serve_spa(full_path: str, request: Request):
         prefix = _normalise_prefix(request.headers.get("x-forwarded-prefix"))

--- a/tests/hermes_cli/test_web_server_audio.py
+++ b/tests/hermes_cli/test_web_server_audio.py
@@ -1,0 +1,156 @@
+"""Regression tests for the /api/audio/{filename} TTS playback route.
+
+Covers the three issues teknium1 raised on PR #16717:
+  * the route must not be exempted wholesale from auth — only the file-
+    serving GET accepts the ?token= query-auth fallback, and unrelated
+    /api/audio/* endpoints (speak, transcribe, elevenlabs/voices) still
+    require normal auth.
+  * the cache dir must resolve through get_hermes_dir("cache/audio",
+    "audio_cache"), matching tools/tts_tool.py, not a hardcoded legacy path.
+  * path traversal outside the cache dir is rejected.
+"""
+
+from starlette.testclient import TestClient
+
+from hermes_cli import web_server
+
+
+def _client():
+    prev_auth_required = getattr(web_server.app.state, "auth_required", None)
+    prev_bound_host = getattr(web_server.app.state, "bound_host", None)
+    web_server.app.state.auth_required = False
+    web_server.app.state.bound_host = None
+
+    client = TestClient(web_server.app)
+    try:
+        yield client
+    finally:
+        client.close()
+        if prev_auth_required is None:
+            delattr(web_server.app.state, "auth_required")
+        else:
+            web_server.app.state.auth_required = prev_auth_required
+        if prev_bound_host is None:
+            if hasattr(web_server.app.state, "bound_host"):
+                delattr(web_server.app.state, "bound_host")
+        else:
+            web_server.app.state.bound_host = prev_bound_host
+
+
+def _authed_client():
+    gen = _client()
+    client = next(gen)
+    client.headers[web_server._SESSION_HEADER_NAME] = web_server._SESSION_TOKEN
+    return client, gen
+
+
+def _anon_client():
+    gen = _client()
+    return next(gen), gen
+
+
+def test_audio_file_route_resolves_via_get_hermes_dir(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    (home / "cache" / "audio").mkdir(parents=True)
+    (home / "cache" / "audio" / "clip.mp3").write_bytes(b"id3-fake-mp3-bytes")
+    monkeypatch.delenv("HERMES_AUDIO_CACHE", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    client, gen = _authed_client()
+    try:
+        resp = client.get("/api/audio/clip.mp3")
+        assert resp.status_code == 200
+        assert resp.content == b"id3-fake-mp3-bytes"
+        assert resp.headers["content-type"] == "audio/mpeg"
+    finally:
+        next(gen, None)
+
+
+def test_audio_file_route_prefers_legacy_dir_if_present(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    (home / "audio_cache").mkdir(parents=True)
+    (home / "audio_cache" / "old.mp3").write_bytes(b"legacy-bytes")
+    monkeypatch.delenv("HERMES_AUDIO_CACHE", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    client, gen = _authed_client()
+    try:
+        resp = client.get("/api/audio/old.mp3")
+        assert resp.status_code == 200
+        assert resp.content == b"legacy-bytes"
+    finally:
+        next(gen, None)
+
+
+def test_audio_file_route_rejects_path_traversal(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    (home / "cache" / "audio").mkdir(parents=True)
+    secret = tmp_path / "secret.txt"
+    secret.write_text("do not serve me")
+    monkeypatch.delenv("HERMES_AUDIO_CACHE", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    client, gen = _authed_client()
+    try:
+        # %2f is decoded to a literal "/" by httpx's own URL parsing before
+        # the request is even sent, which then fails to match the
+        # single-segment {filename} route entirely (a different 404, not the
+        # handler's traversal guard). Backslashes aren't a URL meta-character
+        # so they survive intact — and pathlib treats them as a separator on
+        # Windows, giving the same traversal shape without that client-side
+        # normalization getting in the way.
+        resp = client.get("/api/audio/..%5C..%5Csecret.txt")
+        assert resp.status_code == 403
+    finally:
+        next(gen, None)
+
+
+def test_audio_file_route_requires_auth_without_token(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    (home / "cache" / "audio").mkdir(parents=True)
+    (home / "cache" / "audio" / "clip.mp3").write_bytes(b"bytes")
+    monkeypatch.delenv("HERMES_AUDIO_CACHE", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    client, gen = _anon_client()
+    try:
+        resp = client.get("/api/audio/clip.mp3")
+        assert resp.status_code == 401
+    finally:
+        next(gen, None)
+
+
+def test_audio_file_route_accepts_query_token(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    (home / "cache" / "audio").mkdir(parents=True)
+    (home / "cache" / "audio" / "clip.mp3").write_bytes(b"bytes")
+    monkeypatch.delenv("HERMES_AUDIO_CACHE", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    client, gen = _anon_client()
+    try:
+        resp = client.get(f"/api/audio/clip.mp3?token={web_server._SESSION_TOKEN}")
+        assert resp.status_code == 200
+        assert resp.content == b"bytes"
+    finally:
+        next(gen, None)
+
+
+def test_query_token_does_not_extend_to_other_audio_endpoints():
+    # /api/audio/speak, /api/audio/transcribe, /api/audio/elevenlabs/voices
+    # are unrelated sensitive endpoints under the same /api/audio prefix —
+    # the query-token allowance must stay scoped to the file-serving GET and
+    # not widen to a blanket "/api/audio" prefix match.
+    assert web_server._has_valid_query_token(
+        _FakeRequest(f"/api/audio/speak?token={web_server._SESSION_TOKEN}"),
+        "/api/audio/speak",
+    ) is False
+
+
+class _FakeRequest:
+    def __init__(self, url_with_query: str):
+        path, _, query = url_with_query.partition("?")
+        from urllib.parse import parse_qs
+
+        parsed = parse_qs(query)
+        self.query_params = {k: v[0] for k, v in parsed.items()}

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -1088,6 +1088,7 @@ def play_audio_file(file_path: str) -> bool:
 
     if system == "Darwin":
         players.append(["afplay", file_path])
+    players.append(["mpv", "--no-video", file_path])
     players.append(["ffplay", "-nodisp", "-autoexit", "-loglevel", "quiet", file_path])
     if system == "Linux":
         players.append(["aplay", "-q", file_path])

--- a/web/public/media-bridge.d.ts
+++ b/web/public/media-bridge.d.ts
@@ -1,0 +1,17 @@
+// -----------------------------------------------------------------------------
+// TTS: MEDIA: tag detection via WebSocket intercept.
+// xterm writes to WebGL canvas so DOM scanning doesn't work.
+// Intercept at the wire: ws.onmessage → check → term.write
+// -----------------------------------------------------------------------------
+const _mediaCache = new Map<string, string>();
+
+export function setupTTS() {
+  // Grab the current term.write wrapper (the instance is available on the window
+  // during testing, or we can access it via the local module closure).
+}
+
+const originalOnmessage = window?.__hermes_ws_onmessage;
+
+export function interceptMEDIA(): void {
+  // Called after term is initialized to wrap the event handler.
+}

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -1015,7 +1015,6 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
           const filePath = match[1];
           const filename = filePath.split('/').pop();
           if (filename) _playMedia(filename);
-          MEDIA_RE.lastIndex = match.index; // keep position for stripping
         }
         // Strip MEDIA: tags before writing to xterm so they don't appear as noise
         let clean = ev.data.replace(/MEDIA:\s*\S+/g, '').trim();

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -26,6 +26,41 @@ import { Button } from "@nous-research/ui/ui/components/button";
 import { Typography } from "@nous-research/ui/ui/components/typography/index";
 import { cn } from "@/lib/utils";
 import { Copy, PanelRight, RotateCcw, X } from "lucide-react";
+
+// -----------------------------------------------------------------------------
+// TTS: MEDIA: tag detection via WebSocket intercept.
+// xterm writes to WebGL canvas so DOM scanning won't find tags.
+// We intercept at the wire: ws.onmessage → check → term.write.
+// -----------------------------------------------------------------------------
+// _mediaCache deduplicates audio playback per client. Multi-client problem:
+// if two browser tabs have WebUI open, each maintains its own cache.
+// Each media file is keyed by filename so the same file doesn't get played
+// twice even if the message renders twice. Only one <audio> per filename.
+const _mediaCache = new Map<string, string>();
+
+function _playMedia(filename: string): void {
+  const url = `/api/audio/${encodeURIComponent(filename)}`;
+  if (_mediaCache.has(filename)) return;
+  _mediaCache.set(filename, url);
+
+  const audio = new Audio(url);
+  audio.play().catch(() => {});
+  audio.addEventListener('ended', () => {
+    _mediaCache.delete(filename);
+    audio.remove();
+  }, { once: true });
+  audio.addEventListener('error', () => {
+    _mediaCache.delete(filename);
+    audio.remove();
+  }, { once: true });
+  // Clear cache periodically to avoid leaks
+  if (_mediaCache.size > 200) {
+    const keys = Array.from(_mediaCache.keys());
+    for (const k of keys.slice(0, 100)) {
+      _mediaCache.delete(k);
+    }
+  }
+}
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { useSearchParams } from "react-router-dom";
@@ -974,7 +1009,17 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
 
     ws.onmessage = (ev) => {
       if (typeof ev.data === "string") {
-        term.write(ev.data);
+        const MEDIA_RE = /MEDIA:\s*(\/?[\w./\-_%]+\.\w+)/g;
+        let match: RegExpExecArray | null;
+        while ((match = MEDIA_RE.exec(ev.data)) != null) {
+          const filePath = match[1];
+          const filename = filePath.split('/').pop();
+          if (filename) _playMedia(filename);
+          MEDIA_RE.lastIndex = match.index; // keep position for stripping
+        }
+        // Strip MEDIA: tags before writing to xterm so they don't appear as noise
+        let clean = ev.data.replace(/MEDIA:\s*\S+/g, '').trim();
+        if (clean) term.write(clean);
       } else {
         term.write(new Uint8Array(ev.data as ArrayBuffer));
       }
@@ -1501,6 +1546,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         )}
       </div>
       <PluginSlot name="chat:bottom" />
+    
     </div>
   );
 }

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -38,8 +38,15 @@ import { Copy, PanelRight, RotateCcw, X } from "lucide-react";
 // twice even if the message renders twice. Only one <audio> per filename.
 const _mediaCache = new Map<string, string>();
 
-function _playMedia(filename: string): void {
-  const url = `/api/audio/${encodeURIComponent(filename)}`;
+// `token` mirrors the ?token= query-auth the /api/pty WS and
+// /api/files/download already use: loopback mode has no session cookie, so a
+// plain <audio>-triggered GET can't carry the X-Hermes-Session-Token header
+// and must authenticate via the query string instead. Gated (OAuth) mode
+// omits the token — the browser's session cookie covers the request.
+function _playMedia(filename: string, token?: string): void {
+  const url = token
+    ? `/api/audio/${encodeURIComponent(filename)}?token=${encodeURIComponent(token)}`
+    : `/api/audio/${encodeURIComponent(filename)}`;
   if (_mediaCache.has(filename)) return;
   _mediaCache.set(filename, url);
 
@@ -1007,20 +1014,54 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       }
     };
 
+    // Normal PTY output arrives as binary frames (ws.send_bytes on the
+    // server) — string frames are just the connection's own status/error
+    // text. A MEDIA: tag can land split across two PTY chunks, so both
+    // paths funnel through one carry-over-aware scanner: a short unresolved
+    // tail (e.g. "MEDIA:foo.m") is held back rather than flushed, and
+    // prepended to the next chunk before scanning again. `mediaCarry` is
+    // capped so a stray "MEDIA:" that never gains a matching extension
+    // (garbage or a genuinely truncated stream) doesn't withhold output
+    // forever.
+    let mediaCarry = "";
+    const MEDIA_CARRY_CAP = 256;
+    const binaryDecoder = new TextDecoder();
+
+    const scanAndWrite = (chunk: string) => {
+      const combined = mediaCarry + chunk;
+      const MEDIA_RE = /MEDIA:\s*(\/?[\w./\-_%]+\.\w+)/g;
+      let match: RegExpExecArray | null;
+      while ((match = MEDIA_RE.exec(combined)) != null) {
+        const filePath = match[1];
+        const filename = filePath.split('/').pop();
+        if (filename) _playMedia(filename, token);
+      }
+
+      // Hold back a trailing "MEDIA:..." that hasn't reached a "\.ext" yet —
+      // it may complete once the next chunk arrives.
+      const tailMatch = /MEDIA:\s*[\w./\-_%]*$/.exec(combined);
+      let safeEnd = combined.length;
+      let nextCarry = "";
+      if (tailMatch && !/\.\w+$/.test(tailMatch[0])) {
+        if (combined.length - tailMatch.index <= MEDIA_CARRY_CAP) {
+          safeEnd = tailMatch.index;
+          nextCarry = tailMatch[0];
+        }
+      }
+      mediaCarry = nextCarry;
+
+      const toEmit = combined.slice(0, safeEnd);
+      const clean = toEmit.replace(/MEDIA:\s*\S+/g, '').trim();
+      if (clean) term.write(clean);
+    };
+
     ws.onmessage = (ev) => {
       if (typeof ev.data === "string") {
-        const MEDIA_RE = /MEDIA:\s*(\/?[\w./\-_%]+\.\w+)/g;
-        let match: RegExpExecArray | null;
-        while ((match = MEDIA_RE.exec(ev.data)) != null) {
-          const filePath = match[1];
-          const filename = filePath.split('/').pop();
-          if (filename) _playMedia(filename);
-        }
-        // Strip MEDIA: tags before writing to xterm so they don't appear as noise
-        let clean = ev.data.replace(/MEDIA:\s*\S+/g, '').trim();
-        if (clean) term.write(clean);
+        scanAndWrite(ev.data);
       } else {
-        term.write(new Uint8Array(ev.data as ArrayBuffer));
+        // stream: true keeps a multi-byte UTF-8 sequence split across
+        // chunk boundaries pending instead of emitting a replacement char.
+        scanAndWrite(binaryDecoder.decode(new Uint8Array(ev.data as ArrayBuffer), { stream: true }));
       }
     };
 


### PR DESCRIPTION
Title: feat(webui): browser audio playback for TTS output

## What does this PR do?

Adds browser-side audio playback to the WebUI when the agent uses the text_to_speech tool.

Previously, MEDIA: tags emitted by TTS only worked in two contexts: Discord (file attachment delivery) and local TUI (mpv hook). The WebUI had no mechanism to play audio in the browser — the tag would either appear as noise in the terminal or get dropped entirely.

The approach: xterm.js renders to a WebGL canvas, so DOM/MutationObserver scanning can't find MEDIA: tags after the fact. The right intercept point is ws.onmessage before term.write() — that's where the data still exists as a string. This PR hooks in there, extracts the filename, strips the tag from terminal output, and plays the audio via a browser <audio> element pointed at a new /api/audio/{filename} route.

## Related Issue

Fixes #

(No existing issue — opening alongside this PR)

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- hermes_cli/web_server.py — adds GET /api/audio/{filename} route serving files from ~/.hermes/audio_cache/. Supports mp3, ogg, wav, opus, m4a, flac, aac, webm with correct MIME types. Includes path traversal protection via Path.resolve() + is_relative_to(). Auth middleware exempts /api/audio/* from session token requirement so the browser <audio> element can fetch without headers.

- web/src/pages/ChatPage.tsx — intercepts ws.onmessage before term.write(). Extracts MEDIA: filename, plays via <audio> element, deduplicates per-client via _mediaCache Map, strips tag from terminal output.

- hermes_cli/main.py — moves --expose-gc from NODE_OPTIONS to argv. Node's security policy rejects V8 flags in NODE_OPTIONS since Node 18; injecting into argv is the correct workaround.

- tools/voice_mode.py — adds mpv to audio player fallback list.

## How to Test

1. Start the dashboard: hermes dashboard --tui --no-open
2. Open the WebUI in a browser and start a chat session
3. Ask the agent to say something aloud (e.g. "say hello using text to speech")
4. Confirm the browser plays audio automatically — no MEDIA: tag visible in the terminal output
5. Verify the audio route directly: curl -I http://localhost:9119/api/audio/<filename>.mp3 should return 200 audio/mpeg

## Checklist

### Code

- [x ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run pytest tests/ -q and all tests pass (no existing tests cover WebUI audio; manual tested above)
- [ ] I've added tests for my changes (WebSocket/browser audio playback is difficult to unit test; open to suggestions)
- [ ]  I've tested on my platform: Ubuntu 24.04, Linux

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys)
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ x ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide] — the /api/audio/ route and <audio> element are platform-agnostic; mpv fallback addition is additive only(https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills


## Screenshots / Logs

$ curl -I http://localhost:9119/api/audio/tts_20260427_150755.mp3
HTTP/1.1 200 OK
content-type: audio/mpeg
content-length: 428444

