### PR TITLE
fix(google_oauth): close TOCTOU window when saving credentials

### DIFF
--- a/agent/google_oauth.py
+++ b/agent/google_oauth.py
@@ -489,16 +489,29 @@ def save_credentials(creds: GoogleCredentials) -> Path:
     """Atomically write creds to disk with 0o600 permissions."""
     path = _credentials_path()
     path.parent.mkdir(parents=True, exist_ok=True)
+    # Tighten parent dir to 0o700 so siblings can't traverse to the creds file.
+    # On Windows this is a no-op (POSIX mode bits aren't enforced); ignore failures.
+    try:
+        os.chmod(path.parent, 0o700)
+    except OSError:
+        pass
     payload = json.dumps(creds.to_dict(), indent=2, sort_keys=True) + "\n"
 
     with _credentials_lock():
         tmp_path = path.with_suffix(f".tmp.{os.getpid()}.{secrets.token_hex(4)}")
         try:
-            with open(tmp_path, "w", encoding="utf-8") as fh:
+            # Create with 0o600 atomically to close the TOCTOU window where the
+            # default umask (often 0o644) would briefly expose tokens to other
+            # local users between open() and chmod().
+            fd = os.open(
+                str(tmp_path),
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                stat.S_IRUSR | stat.S_IWUSR,
+            )
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
                 fh.write(payload)
                 fh.flush()
                 os.fsync(fh.fileno())
-            os.chmod(tmp_path, stat.S_IRUSR | stat.S_IWUSR)
             os.replace(tmp_path, path)
         finally:
             try:


### PR DESCRIPTION
  ## Problem
save_credentials created the temp file via `open(tmp, "w")` and only chmodedd it to 0o600 afterward. Between the create and the chmod, the file existed on disk at the process umask (commonly 0o644 aka publicly readable). On a multi-user host or a container with a permissive umask, another local user could read the Google OAuth refresh and access tokens during the short write window. The lock file at line 181 already opens with `os.open(..., 0o600)`, so it makes sense for the credentials file to too.

## Fix
  - Replace `open(tmp, "w")` + later `os.chmod` with `os.open(tmp, O_WRONLY|O_CREAT|O_EXCL, 0o600)` wrapped in `os.fdopen`. The file never exists at any other mode.
  - Tighten the parent dir to 0o700 with `os.chmod(path.parent, 0o700)` after mkdir, so sibling users can't traverse into the creds dir. Wrapped in try/except for Windows where POSIX modes aren't enforced (no-op).

  ## Tests
- `uv run pytest tests/agent/test_gemini_cloudcode.py` 85/85 tests passed
- `hermes auth login google`, verify ~/.hermes/google_oauth_credentials.json is mode 0600 and the parent dir is 0700
- Confirm re-login overwrites cleanly