### PR TITLE
ci: migrate remaining workflow pip installs to uv

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -47,8 +47,11 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
+
       - name: Install PyYAML for skill extraction
-        run: pip install pyyaml==6.0.2 httpx==0.28.1
+        run: uv pip install --system pyyaml==6.0.2 httpx==0.28.1
 
       - name: Extract skill metadata for dashboard
         run: python3 website/scripts/extract-skills.py

--- a/.github/workflows/docs-site-checks.yml
+++ b/.github/workflows/docs-site-checks.yml
@@ -30,8 +30,11 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
+
       - name: Install ascii-guard
-        run: python -m pip install ascii-guard==2.3.0 pyyaml==6.0.3
+        run: uv pip install --system ascii-guard==2.3.0 pyyaml==6.0.3
 
       - name: Extract skill metadata for dashboard
         run: python3 website/scripts/extract-skills.py

--- a/.github/workflows/skills-index.yml
+++ b/.github/workflows/skills-index.yml
@@ -26,8 +26,11 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
+
       - name: Install dependencies
-        run: pip install httpx==0.28.1 pyyaml==6.0.2
+        run: uv pip install --system httpx==0.28.1 pyyaml==6.0.2
 
       - name: Build skills index
         env:
@@ -70,8 +73,11 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
+
       - name: Install PyYAML for skill extraction
-        run: pip install pyyaml==6.0.2
+        run: uv pip install --system pyyaml==6.0.2
 
       - name: Extract skill metadata for dashboard
         run: python3 website/scripts/extract-skills.py

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -44,7 +44,14 @@ PYTHON="$VENV/bin/python"
 # ── Ensure pytest-split is installed (required for shard-equivalent runs) ──
 if ! "$PYTHON" -c "import pytest_split" 2>/dev/null; then
   echo "→ installing pytest-split into $VENV"
-  "$PYTHON" -m pip install --quiet "pytest-split>=0.9,<1"
+  if command -v uv >/dev/null 2>&1; then
+    if ! uv pip install --quiet --python "$PYTHON" "pytest-split>=0.9,<1"; then
+      echo "→ uv install failed, falling back to pip" >&2
+      "$PYTHON" -m pip install --quiet "pytest-split>=0.9,<1"
+    fi
+  else
+    "$PYTHON" -m pip install --quiet "pytest-split>=0.9,<1"
+  fi
 fi
 
 # ── Hermetic environment ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- switch remaining GitHub Actions Python dependency installs from `pip` to `uv pip --system`
- add pinned `astral-sh/setup-uv` step to docs-site, skills-index, and deploy-site workflows
- update `scripts/run_tests.sh` to prefer `uv` for `pytest-split` installs with a safe fallback to `pip`

## Why
- improves install speed and consistency by standardizing on `uv` in CI
- keeps existing Python/ML flows safe by preserving fallback behavior and leaving Termux-specific `pip` paths untouched

## Validation
- `bash -n scripts/run_tests.sh`
- YAML parse check for updated workflows via Python `yaml.safe_load`
