### PR TITLE
fix(models): add xai to _MODELS_DEV_PREFERRED; refresh stale curated IDs (#16699)

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -193,9 +193,15 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "glm-4.5",
         "glm-4.5-flash",
     ],
+    # Curated fallback used when models.dev is unreachable. xAI is in
+    # _MODELS_DEV_PREFERRED below, so when models.dev is reachable the live
+    # catalog (filtered to tool_call=True) is merged on top of this list.
     "xai": [
-        "grok-4.20-reasoning",
-        "grok-4-1-fast-reasoning",
+        "grok-4.20-0309-reasoning",
+        "grok-4.20-0309-non-reasoning",
+        "grok-4-fast",
+        "grok-4-fast-non-reasoning",
+        "grok-code-fast-1",
     ],
     "nvidia": [
         # NVIDIA flagship reasoning models
@@ -1735,6 +1741,7 @@ _MODELS_DEV_PREFERRED: frozenset[str] = frozenset({
     "zai",
     "gemini",
     "google",
+    "xai",
 })
 
 

--- a/tests/hermes_cli/test_models_dev_preferred_merge.py
+++ b/tests/hermes_cli/test_models_dev_preferred_merge.py
@@ -98,6 +98,44 @@ class TestProviderModelIdsPreferred:
         assert "claude-opus-4-7" in out
         assert "kimi-k2.6" in out
 
+    def test_xai_is_preferred(self):
+        """xAI catalog drifts (e.g. grok-4.20-* date-suffixed renames upstream),
+        so the picker must merge fresh models.dev entries on top of curated.
+        Regression for #16699 — selecting picker entries returned HTTP 400
+        because curated names had no match in xAI's live catalog.
+        """
+        assert "xai" in _MODELS_DEV_PREFERRED
+
+    def test_xai_includes_fresh_models_dev_entries(self):
+        """provider_model_ids('xai') surfaces current xAI IDs from models.dev."""
+        mdev = [
+            "grok-4.20-0309-reasoning",
+            "grok-4.20-0309-non-reasoning",
+            "grok-4-fast",
+            "grok-code-fast-1",
+        ]
+        with patch("agent.models_dev.list_agentic_models", return_value=mdev):
+            out = provider_model_ids("xai")
+        # Fresh models surface (the picker bug from #16699 is fixed).
+        assert "grok-4.20-0309-reasoning" in out
+        assert "grok-4.20-0309-non-reasoning" in out
+        assert "grok-4-fast" in out
+        assert "grok-code-fast-1" in out
+
+    def test_xai_offline_falls_back_to_curated(self):
+        """Offline models.dev → curated-only list, no crash, current IDs only.
+
+        The curated fallback must be valid current IDs (not stale renamed
+        ones), since users on offline/restricted networks see this list.
+        """
+        with patch("agent.models_dev.list_agentic_models", return_value=[]):
+            out = provider_model_ids("xai")
+        # Curated floor must be real current xAI IDs.
+        assert "grok-4.20-0309-reasoning" in out
+        # Stale entries that returned HTTP 400 must be gone.
+        assert "grok-4.20-reasoning" not in out
+        assert "grok-4-1-fast-reasoning" not in out
+
 
 class TestOpenRouterAndNousUnchanged:
     """Per Teknium: openrouter and nous are NEVER merged with models.dev."""


### PR DESCRIPTION
## Summary
- Add `"xai"` to `_MODELS_DEV_PREFERRED` so the `/model` picker merges fresh `models.dev` entries on top of curated, matching the existing pattern for opencode-go, deepseek, zai, gemini, etc.
- Replace stale curated entries (`grok-4.20-reasoning`, `grok-4-1-fast-reasoning` — both 400 on selection) with current valid IDs taken from the live `models.dev` xai catalog (filtered to `tool_call=True`).
- Add regression tests against `provider_model_ids("xai")` for both the live-merge and offline-fallback paths.

## The bug

`_PROVIDER_MODELS["xai"]` in `hermes_cli/models.py` contains two slugs that no longer match xAI's catalog:

```python
"xai": [
    "grok-4.20-reasoning",       # ← xAI no longer accepts this name
    "grok-4-1-fast-reasoning",   # ← never existed in xAI's catalog
],
```

Reproduction (from the issue, verified against live xAI catalog):

1. Configure xAI provider via `XAI_API_KEY` and base `https://api.x.ai/v1`.
2. Run `hermes`, open `/model`, select xAI, pick either entry.
3. Result:

   ```
   HTTP 400: Unknown Model, please check the model code.
   ```

Verified against a fresh `https://models.dev/api.json` fetch — the xai provider's `tool_call=True` IDs are date-suffixed: `grok-4.20-0309-reasoning`, `grok-4.20-0309-non-reasoning`, plus `grok-4-fast`, `grok-4-fast-non-reasoning`, `grok-code-fast-1`, etc. None of those match the curated list.

## The fix

Two changes — each is incomplete on its own:

1. **Add `"xai"` to `_MODELS_DEV_PREFERRED`.** xAI's catalog drifts (the `grok-4.20` family was renamed to date-suffixed IDs upstream). Adding xai to the preferred set causes `provider_model_ids` and the gateway `/model` picker to merge fresh `models.dev` entries on top of the curated list — the exact pattern already in place for opencode-go, opencode-zen, deepseek, zai, gemini, etc. Without this, refreshing the curated list just locks us into another stale snapshot the next time xAI renames a model.

2. **Refresh the curated fallback to current valid IDs.** This list is the offline / restricted-network fallback (when `models.dev` is unreachable, this is the only catalog users see), so it has to contain real current IDs that don't 400 on selection. New entries are pulled from the live `models.dev` xai catalog filtered to `tool_call=True`:

   ```python
   "xai": [
       "grok-4.20-0309-reasoning",
       "grok-4.20-0309-non-reasoning",
       "grok-4-fast",
       "grok-4-fast-non-reasoning",
       "grok-code-fast-1",
   ],
   ```

xAI doesn't fit either documented exclusion (`openrouter` — too many models to dump; `nous` — Portal `/models` endpoint is the source of truth), so adding it is consistent with the existing block comment.

## Test plan
- [x] `tests/hermes_cli/test_models_dev_preferred_merge.py` — 14 passed (3 new):
  - `test_xai_is_preferred` — xai is in `_MODELS_DEV_PREFERRED`.
  - `test_xai_includes_fresh_models_dev_entries` — fresh models.dev entries surface (the picker bug from #16699).
  - `test_xai_offline_falls_back_to_curated` — curated floor contains current IDs, excludes the two stale ones.
- [x] Adjacent suite: `test_model_catalog`, `test_user_providers_model_switch`, `test_api_key_providers`, `test_model_validation`, `test_model_metadata` — 354 passed.
- [x] Regression guard: ran the 3 new tests against unmodified `hermes_cli/models.py` (only test file diffed) — all 3 fail with the exact reporter symptom:

  ```
  AssertionError: assert 'grok-4.20-0309-reasoning' in ['grok-4.20-reasoning', 'grok-4-1-fast-reasoning']
  ```

  After applying the source fix, all 3 pass.

## Notes
- Doc reference to `/model grok-4-1-fast-reasoning` in `website/docs/integrations/providers.md` and the test fixture in `tests/agent/test_model_metadata.py` (substring-matching context-length lookup) are intentionally **not** touched here — both are independent of the picker behaviour and would broaden scope. Worth a small follow-up.
- The `VERCEL_AI_GATEWAY_MODELS` and OpenRouter slug entries (`xai/grok-4.20-reasoning`, `x-ai/grok-4.20`) are gateway-specific aliases, not direct xAI API IDs, so they are left alone here.

## Related
- Fixes #16699
- Same shape as the closed `openai-codex` precedent #6595 → PR #7844.