### PR TITLE
fix(context): use Codex OAuth max context window

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1228,13 +1228,13 @@ def _query_anthropic_context_length(model: str, base_url: str, api_key: str) -> 
     return None
 
 
-# Known ChatGPT Codex OAuth context windows (observed via live
-# chatgpt.com/backend-api/codex/models probe, Apr 2026). These are the
-# `context_window` values, which are what Codex actually enforces — the
-# direct OpenAI API has larger limits for the same slugs, but Codex OAuth
-# caps lower (e.g. gpt-5.5 is 1.05M on the API, 272K on Codex).
+# Known ChatGPT Codex OAuth default context windows (observed via live
+# chatgpt.com/backend-api/codex/models probe, Apr 2026). These conservative
+# defaults are used only when the live probe fails (no token, network error).
 #
-# Used as a fallback when the live probe fails (no token, network error).
+# The live endpoint can also advertise a larger per-slug `max_context_window`
+# (for example gpt-5.4 can expose a 1M usable window). Prefer the live value
+# whenever an access token is available.
 # Longest keys first so substring match picks the most specific entry.
 _CODEX_OAUTH_CONTEXT_FALLBACK: Dict[str, int] = {
     "gpt-5.1-codex-max": 272_000,
@@ -1263,11 +1263,12 @@ _CODEX_OAUTH_CONTEXT_CACHE_TTL = 3600  # 1 hour
 def _fetch_codex_oauth_context_lengths(access_token: str) -> Dict[str, int]:
     """Probe the ChatGPT Codex /models endpoint for per-slug context windows.
 
-    Codex OAuth imposes its own context limits that differ from the direct
-    OpenAI API (e.g. gpt-5.5 is 1.05M on the API, 272K on Codex). The
-    `context_window` field in each model entry is the authoritative source.
+    Codex OAuth has provider-specific context limits that differ from the direct
+    OpenAI API. Prefer the live ``max_context_window`` when present (that is the
+    usable upper bound Codex advertises), then fall back to ``context_window``
+    for older entries.
 
-    Returns a ``{slug: context_window}`` dict. Empty on failure.
+    Returns a ``{slug: resolved_context_window}`` dict. Empty on failure.
     """
     global _codex_oauth_context_cache, _codex_oauth_context_cache_time
     now = time.time()
@@ -1301,7 +1302,9 @@ def _fetch_codex_oauth_context_lengths(access_token: str) -> Dict[str, int]:
         if not isinstance(item, dict):
             continue
         slug = item.get("slug")
-        ctx = item.get("context_window")
+        ctx = item.get("max_context_window")
+        if not isinstance(ctx, int) or ctx <= 0:
+            ctx = item.get("context_window")
         if isinstance(slug, str) and isinstance(ctx, int) and ctx > 0:
             result[slug.strip()] = ctx
 
@@ -1483,16 +1486,23 @@ def get_model_context_length(
     if base_url and provider != "lmstudio":
         cached = get_cached_context_length(model, base_url)
         if cached is not None:
-            # Invalidate stale Codex OAuth cache entries: pre-PR #14935 builds
-            # resolved gpt-5.x to the direct-API value (e.g. 1.05M) via
-            # models.dev and persisted it. Codex OAuth caps at 272K for every
-            # slug, so any cached Codex entry at or above 400K is a leftover
-            # from the old resolution path. Drop it and fall through to the
-            # live /models probe in step 5 below.
-            if provider == "openai-codex" and cached >= 400_000:
+            # Codex OAuth is account/model metadata and has changed over time
+            # (e.g. gpt-5.4 gained max_context_window=1M after 272K entries
+            # were already cached). If we have a token, prefer a fresh live
+            # probe over persistent cache; the live probe has its own in-memory
+            # TTL, and save_context_length() writes the refreshed value back.
+            # Without a token, fall back to reasonable cached values, while
+            # still dropping old pre-PR #14935 direct-API-sized entries.
+            if provider == "openai-codex" and api_key:
+                logger.info(
+                    "Refreshing Codex cache entry %s@%s -> %s via live /models probe",
+                    model, base_url, f"{cached:,}",
+                )
+                _invalidate_cached_context_length(model, base_url)
+            elif provider == "openai-codex" and cached >= 400_000:
                 logger.info(
                     "Dropping stale Codex cache entry %s@%s -> %s (pre-fix value); "
-                    "re-resolving via live /models probe",
+                    "re-resolving via fallback/live probe if possible",
                     model, base_url, f"{cached:,}",
                 )
                 _invalidate_cached_context_length(model, base_url)

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -260,11 +260,13 @@ class TestDefaultContextLengths:
 # =========================================================================
 
 class TestCodexOAuthContextLength:
-    """ChatGPT Codex OAuth imposes lower context limits than the direct
-    OpenAI API for the same slugs. Verified Apr 2026 via live probe of
-    chatgpt.com/backend-api/codex/models: most models return 272k, while
-    models.dev reports 1.05M for gpt-5.5/gpt-5.4 and 400k for the rest.
-    (Known exception: gpt-5.3-codex-spark is 128k.)
+    """ChatGPT Codex OAuth exposes provider-specific context limits that
+    differ from the direct OpenAI API for the same slugs. Verified Apr 2026
+    via live probe of chatgpt.com/backend-api/codex/models: default
+    context_window can be 272k while max_context_window may advertise a
+    larger usable window for selected models such as gpt-5.4. When the live
+    probe is unavailable, conservative fallback defaults are used (known
+    exception: gpt-5.3-codex-spark is 128k).
     """
 
     def setup_method(self):
@@ -274,7 +276,7 @@ class TestCodexOAuthContextLength:
 
     def test_fallback_table_used_without_token(self):
         """With no access token, the hardcoded Codex fallback table wins
-        over models.dev (which reports 1.05M for gpt-5.5 but Codex is 272k).
+        over models.dev (which reports larger direct-API values for GPT-5 slugs).
         """
         from agent.model_metadata import get_model_context_length
 
@@ -303,17 +305,18 @@ class TestCodexOAuthContextLength:
                     "(models.dev leakage?)"
                 )
 
-    def test_live_probe_overrides_fallback(self):
-        """When a token is provided, the live /models probe is preferred
-        and its context_window drives the result."""
+    def test_live_probe_prefers_max_context_window_when_available(self):
+        """When Codex advertises a larger max_context_window, Hermes should
+        use it as the provider-enforced usable window.
+        """
         from agent.model_metadata import get_model_context_length
 
         fake_response = MagicMock()
         fake_response.status_code = 200
         fake_response.json.return_value = {
             "models": [
-                {"slug": "gpt-5.5", "context_window": 300_000},
-                {"slug": "gpt-5.4", "context_window": 400_000},
+                {"slug": "gpt-5.5", "context_window": 272_000, "max_context_window": 272_000},
+                {"slug": "gpt-5.4", "context_window": 272_000, "max_context_window": 1_000_000},
             ]
         }
 
@@ -332,8 +335,31 @@ class TestCodexOAuthContextLength:
                 api_key="fake-token",
                 provider="openai-codex",
             )
-        assert ctx_55 == 300_000
-        assert ctx_54 == 400_000
+        assert ctx_55 == 272_000
+        assert ctx_54 == 1_000_000
+
+    def test_live_probe_falls_back_to_context_window_when_max_missing(self):
+        """Older Codex model entries without max_context_window still resolve
+        from context_window.
+        """
+        from agent.model_metadata import get_model_context_length
+
+        fake_response = MagicMock()
+        fake_response.status_code = 200
+        fake_response.json.return_value = {
+            "models": [{"slug": "gpt-5.4", "context_window": 400_000}]
+        }
+
+        with patch("agent.model_metadata.requests.get", return_value=fake_response), \
+             patch("agent.model_metadata.get_cached_context_length", return_value=None), \
+             patch("agent.model_metadata.save_context_length"):
+            ctx = get_model_context_length(
+                model="gpt-5.4",
+                base_url="https://chatgpt.com/backend-api/codex",
+                api_key="fake-token",
+                provider="openai-codex",
+            )
+        assert ctx == 400_000
 
     def test_probe_failure_falls_back_to_hardcoded(self):
         """If the probe fails (non-200 / network error), we still return
@@ -384,8 +410,8 @@ class TestCodexOAuthContextLength:
         """Pre-PR #14935 builds cached gpt-5.5 at 1.05M (from models.dev)
         before the Codex-aware branch existed. Upgrading users keep that
         stale entry on disk and the cache-first lookup returns it forever.
-        Codex OAuth caps at 272k for every slug, so any cached Codex
-        entry >= 400k must be dropped and re-resolved via the live probe.
+        Cached direct-API-sized Codex entries remain suspicious and must be
+        dropped and re-resolved via the live probe or conservative fallback.
         """
         from agent import model_metadata as mm
 
@@ -425,9 +451,50 @@ class TestCodexOAuthContextLength:
         assert stale_key not in remaining, "Stale entry was not invalidated from the cache file"
         assert remaining.get(other_key) == 128_000, "Unrelated cache entries must not be touched"
 
-    def test_fresh_codex_cache_under_400k_is_respected(self, tmp_path, monkeypatch):
-        """Codex entries at the correct 272k must NOT be invalidated —
-        only stale pre-fix values (>= 400k) get dropped."""
+    def test_stale_codex_272k_cache_is_refreshed_when_token_available(self, tmp_path, monkeypatch):
+        """Codex /models can raise a slug's usable max_context_window after a
+        272k value was cached. With an access token, prefer a fresh live probe
+        over stale persistent cache.
+        """
+        from agent import model_metadata as mm
+
+        cache_file = tmp_path / "context_length_cache.yaml"
+        monkeypatch.setattr(mm, "_get_context_cache_path", lambda: cache_file)
+
+        base_url = "https://chatgpt.com/backend-api/codex/"
+        stale_key = f"gpt-5.4@{base_url}"
+        other_key = "gpt-5.5@https://chatgpt.com/backend-api/codex/"
+        import yaml as _yaml
+        cache_file.write_text(_yaml.dump({"context_lengths": {
+            stale_key: 272_000,
+            other_key: 272_000,
+        }}))
+
+        fake_response = MagicMock()
+        fake_response.status_code = 200
+        fake_response.json.return_value = {
+            "models": [
+                {"slug": "gpt-5.4", "context_window": 272_000, "max_context_window": 1_000_000},
+                {"slug": "gpt-5.5", "context_window": 272_000, "max_context_window": 272_000},
+            ]
+        }
+
+        with patch("agent.model_metadata.requests.get", return_value=fake_response), \
+             patch("agent.model_metadata.save_context_length") as mock_save:
+            ctx = mm.get_model_context_length(
+                model="gpt-5.4",
+                base_url=base_url,
+                api_key="fake-token",
+                provider="openai-codex",
+            )
+
+        assert ctx == 1_000_000
+        mock_save.assert_called_with("gpt-5.4", base_url, 1_000_000)
+
+    def test_codex_cache_used_when_no_token_available(self, tmp_path, monkeypatch):
+        """Without an access token, Hermes cannot do a live Codex probe and
+        should still use a reasonable persistent cache entry.
+        """
         from agent import model_metadata as mm
 
         cache_file = tmp_path / "context_length_cache.yaml"
@@ -439,12 +506,11 @@ class TestCodexOAuthContextLength:
             f"gpt-5.5@{base_url}": 272_000,
         }}))
 
-        # If the invalidation incorrectly fired, this would be called; assert it isn't.
         with patch("agent.model_metadata.requests.get") as mock_get:
             ctx = mm.get_model_context_length(
                 model="gpt-5.5",
                 base_url=base_url,
-                api_key="fake-token",
+                api_key="",
                 provider="openai-codex",
             )
         assert ctx == 272_000


### PR DESCRIPTION
## What does this PR do?

This PR updates the OpenAI Codex OAuth context resolver to use `max_context_window` from `chatgpt.com/backend-api/codex/models` when that field is advertised, falling back to `context_window` for older model entries.

The Codex backend currently reports different values for selected GPT-5 models. For example, live metadata for `gpt-5.4` can advertise:

```text
context_window=272000
max_context_window=1000000
```

Hermes previously read only `context_window`, so it capped `openai-codex/gpt-5.4` at 272k even though the backend accepts larger requests up to the advertised max window.

This PR also refreshes persistent `openai-codex` cache entries when an access token is available. That prevents stale cached values such as `gpt-5.4@https://chatgpt.com/backend-api/codex: 272000` from blocking the fresh live `/models` probe. The hardcoded `_CODEX_OAUTH_CONTEXT_FALLBACK` remains conservative at 272k for no-token/network-failure cases.

## Related Issue

No linked issue.

Related context:
- #14935 changed Codex OAuth context resolution to the live `context_window` value.
- #15078 invalidated stale Codex OAuth cache entries that were too large.
- This PR handles the newer `max_context_window` field and stale 272k cache entries for models whose live usable window increased.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/model_metadata.py`
  - Prefer `max_context_window` from the Codex OAuth `/models` response when it is a positive integer.
  - Fall back to `context_window` when `max_context_window` is missing or invalid.
  - Refresh `openai-codex` persistent cache entries when an access token is available, relying on the in-memory live-probe TTL to avoid repeated network calls in-process.
  - Preserve the conservative `_CODEX_OAUTH_CONTEXT_FALLBACK` for no-token/network-failure paths.

- `tests/agent/test_model_metadata.py`
  - Adds coverage for `max_context_window` preference.
  - Adds coverage for fallback to `context_window` when `max_context_window` is absent.
  - Adds coverage for refreshing stale cached 272k Codex values when a token is available.
  - Keeps coverage that no-token flows can still use reasonable persistent cache values.

## How to Test

1. Run the focused Codex context tests:

```bash
python -m pytest tests/agent/test_model_metadata.py::TestCodexOAuthContextLength -q
```

2. Run adjacent model/context-display tests:

```bash
python -m pytest \
  tests/agent/test_model_metadata.py \
  tests/hermes_cli/test_model_switch_context_display.py \
  tests/hermes_cli/test_apply_model_switch_result_context.py \
  -q
```

3. Optional live smoke test with a Codex OAuth token:

```bash
python - <<'PY'
import json
from pathlib import Path
from agent.model_metadata import get_model_context_length

auth = json.loads((Path.home() / '.hermes/auth.json').read_text())
token = auth['credential_pool']['openai-codex'][0]['access_token']
base = 'https://chatgpt.com/backend-api/codex'
for model in ['gpt-5.4', 'gpt-5.5']:
    ctx = get_model_context_length(model, base_url=base, api_key=token, provider='openai-codex')
    print(f'{model}={ctx}')
PY
```

Expected current live result:

```text
gpt-5.4=1000000
gpt-5.5=272000
```

## Verification Performed

```text
python -m pytest tests/agent/test_model_metadata.py::TestCodexOAuthContextLength -q
9 passed in 0.66s
```

```text
python -m pytest tests/agent/test_model_metadata.py tests/hermes_cli/test_model_switch_context_display.py tests/hermes_cli/test_apply_model_switch_result_context.py -q
105 passed in 2.04s
```

```text
python -m py_compile agent/model_metadata.py
# passed
```

```text
git diff --check
# passed
```

Live smoke test from the PR worktree with an isolated cache:

```text
gpt-5.4=1000000
gpt-5.5=272000
```

Manual large-context validation performed with Hermes `openai-codex` OAuth before opening this PR:

```text
Hermes AIAgent + openai-codex + gpt-5.4 + context_length=1000000
~900k-token prompt -> completed OK
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
  - Not run locally; targeted/adjacent tests were run instead.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
  - N/A: internal resolver behavior; comments/docstrings updated in code.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
  - N/A: no config keys changed.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
  - N/A: no architecture or workflow changes.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
  - Low risk: pure Python metadata parsing/cache behavior, no OS-specific path or process changes.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
  - N/A: no tool behavior or schema changes.

## Screenshots / Logs

Not applicable.
