### PR TITLE
fix(feishu): include audio duration in voice message payload (#16524)

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -185,6 +185,64 @@ _FEISHU_DOC_UPLOAD_TYPES = {
     ".ppt": "ppt",
     ".pptx": "ppt",
 }
+
+# Feishu audio messages render as voice bubbles only when the payload includes
+# a positive ``duration`` in milliseconds. Without it the client falls back to
+# a generic file attachment with a music-note icon. (#16524)
+_FEISHU_AUDIO_DURATION_FALLBACK_MS = 1000  # 1s — minimum positive value
+# Approx bytes-per-second for the size-based heuristic when no metadata reader
+# is available. Mirrors discord.py's voice-message fallback (16 kbps Opus).
+_FEISHU_AUDIO_BYTES_PER_SECOND_HEURISTIC = 2000
+
+
+def _get_audio_duration_ms(file_path: str) -> int:
+    """Best-effort duration probe for Feishu voice messages.
+
+    Tries mutagen (transitive dep via ``discord.py[voice]``) first, then
+    falls back to ``ffprobe`` if it's on PATH, then to a size-based heuristic.
+    Always returns a positive integer so the caller can populate the audio
+    payload's required ``duration`` field. Returns
+    ``_FEISHU_AUDIO_DURATION_FALLBACK_MS`` if every probe fails.
+    """
+    try:
+        import mutagen  # type: ignore[import-not-found]
+
+        mf = mutagen.File(file_path)  # type: ignore[attr-defined]
+        length = getattr(getattr(mf, "info", None), "length", None) if mf else None
+        if length and length > 0:
+            return max(1, int(round(float(length) * 1000)))
+    except Exception:  # pragma: no cover - mutagen optional
+        pass
+
+    try:
+        import shutil
+        import subprocess
+
+        if shutil.which("ffprobe"):
+            result = subprocess.run(
+                [
+                    "ffprobe", "-v", "error",
+                    "-show_entries", "format=duration",
+                    "-of", "default=noprint_wrappers=1:nokey=1",
+                    file_path,
+                ],
+                capture_output=True, text=True, timeout=10,
+            )
+            stdout = (result.stdout or "").strip()
+            if stdout:
+                return max(1, int(round(float(stdout) * 1000)))
+    except Exception:  # pragma: no cover - ffprobe optional
+        pass
+
+    try:
+        size = os.path.getsize(file_path)
+        if size > 0:
+            estimate_secs = max(1.0, size / _FEISHU_AUDIO_BYTES_PER_SECOND_HEURISTIC)
+            return int(round(estimate_secs * 1000))
+    except Exception:  # pragma: no cover - filesystem error
+        pass
+
+    return _FEISHU_AUDIO_DURATION_FALLBACK_MS
 # ---------------------------------------------------------------------------
 # Connection, retry and batching tuning
 # ---------------------------------------------------------------------------
@@ -4589,10 +4647,18 @@ class FeishuAdapter(BasePlatformAdapter):
                     metadata=metadata,
                 )
             else:
+                message_payload: Dict[str, Any] = {"file_key": file_key}
+                # Audio messages need a ``duration`` field (ms) to render as a
+                # voice bubble; without it Feishu shows a generic file
+                # attachment with a music-note icon. (#16524)
+                if resolved_message_type == "audio":
+                    message_payload["duration"] = await asyncio.to_thread(
+                        _get_audio_duration_ms, file_path,
+                    )
                 message_response = await self._feishu_send_with_retry(
                     chat_id=chat_id,
                     msg_type=resolved_message_type,
-                    payload=json.dumps({"file_key": file_key}, ensure_ascii=False),
+                    payload=json.dumps(message_payload, ensure_ascii=False),
                     reply_to=reply_to,
                     metadata=metadata,
                 )

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2641,7 +2641,63 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertTrue(result.success)
         self.assertEqual(captured["upload_request"].request_body.file_type, "opus")
         self.assertEqual(captured["message_request"].request_body.msg_type, "audio")
-        self.assertEqual(captured["message_request"].request_body.content, '{"file_key": "file_audio_123"}')
+        # Voice messages must include a positive ``duration`` (ms) — without
+        # it Feishu renders the audio as a file attachment instead of a
+        # voice bubble. (#16524)
+        audio_payload = json.loads(captured["message_request"].request_body.content)
+        self.assertEqual(audio_payload["file_key"], "file_audio_123")
+        self.assertIn("duration", audio_payload)
+        self.assertIsInstance(audio_payload["duration"], int)
+        self.assertGreater(audio_payload["duration"], 0)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_video_does_not_inject_audio_duration_field(self):
+        """Video messages route through ``_send_uploaded_file_message`` too;
+        only the audio branch should add ``duration``. (#16524)"""
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _FileAPI:
+            def create(self, request):
+                captured["upload_request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(file_key="file_video_xyz"),
+                )
+
+        class _MessageAPI:
+            def create(self, request):
+                captured["message_request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_video_msg"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(file=_FileAPI(), message=_MessageAPI())
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with tempfile.NamedTemporaryFile("wb", suffix=".mp4", delete=False) as tmp:
+            tmp.write(b"\x00\x00\x00\x18ftypmp42")
+            video_path = tmp.name
+
+        try:
+            with patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct):
+                result = asyncio.run(adapter.send_video(chat_id="oc_chat", video_path=video_path))
+        finally:
+            os.unlink(video_path)
+
+        self.assertTrue(result.success)
+        body = json.loads(captured["message_request"].request_body.content)
+        self.assertEqual(body, {"file_key": "file_video_xyz"})
 
     @patch.dict(os.environ, {}, clear=True)
     def test_build_post_payload_extracts_title_and_links(self):
@@ -5120,3 +5176,72 @@ class TestChatLockEviction(unittest.TestCase):
                 held.release()
 
         asyncio.run(_run())
+
+
+class TestFeishuAudioDurationProbe(unittest.TestCase):
+    """Regression coverage for #16524.
+
+    Audio messages must include a positive ``duration`` (ms) so Feishu
+    renders them as voice bubbles. The probe must be best-effort and never
+    raise — falling back to a size-based heuristic and finally a fixed
+    minimum so the field is always populated.
+    """
+
+    def test_returns_positive_int_for_real_audio_file(self):
+        from plugins.platforms.feishu.adapter import _get_audio_duration_ms
+
+        with tempfile.NamedTemporaryFile("wb", suffix=".opus", delete=False) as tmp:
+            # 8 KB → ~4s under the 2000 B/s heuristic
+            tmp.write(b"\x00" * 8000)
+            path = tmp.name
+
+        try:
+            ms = _get_audio_duration_ms(path)
+        finally:
+            os.unlink(path)
+
+        self.assertIsInstance(ms, int)
+        self.assertGreater(ms, 0)
+
+    def test_falls_back_to_minimum_when_file_is_missing(self):
+        from plugins.platforms.feishu.adapter import (
+            _FEISHU_AUDIO_DURATION_FALLBACK_MS,
+            _get_audio_duration_ms,
+        )
+
+        ms = _get_audio_duration_ms("/nonexistent/path/voice.opus")
+        # Either heuristic-from-zero-size or fallback returns a positive int.
+        self.assertIsInstance(ms, int)
+        self.assertGreaterEqual(ms, _FEISHU_AUDIO_DURATION_FALLBACK_MS)
+
+    def test_size_heuristic_scales_with_file_bytes(self):
+        from plugins.platforms.feishu.adapter import _get_audio_duration_ms
+
+        # Force the size-heuristic branch by making mutagen + ffprobe both
+        # unavailable. ``builtins.__import__`` blocks mutagen; PATH-stripping
+        # blocks ffprobe.
+        original_import = __builtins__["__import__"] if isinstance(__builtins__, dict) else __builtins__.__import__
+
+        def _block_mutagen(name, *args, **kwargs):
+            if name == "mutagen" or name.startswith("mutagen."):
+                raise ImportError("blocked for test")
+            return original_import(name, *args, **kwargs)
+
+        with tempfile.NamedTemporaryFile("wb", suffix=".opus", delete=False) as small:
+            small.write(b"\x00" * 2000)
+            small_path = small.name
+        with tempfile.NamedTemporaryFile("wb", suffix=".opus", delete=False) as large:
+            large.write(b"\x00" * 20000)
+            large_path = large.name
+
+        try:
+            with patch("builtins.__import__", side_effect=_block_mutagen), \
+                 patch("shutil.which", return_value=None):
+                small_ms = _get_audio_duration_ms(small_path)
+                large_ms = _get_audio_duration_ms(large_path)
+        finally:
+            os.unlink(small_path)
+            os.unlink(large_path)
+
+        # Larger file → larger duration estimate under the heuristic.
+        self.assertGreater(large_ms, small_ms)


### PR DESCRIPTION
## What does this PR do?

Feishu's audio message API requires a positive `duration` field (in milliseconds) for uploaded audio to render as a playable voice bubble with a pre-play length indicator. Without it, the client falls back to a generic file attachment with a green music-note icon.

`_send_uploaded_file_message` in `gateway/platforms/feishu.py` was sending only `{"file_key": ...}` for the audio routing branch, so every voice message — TTS output, `MEDIA:/path/to/audio.opus` deliveries — landed as a plain file attachment.

This PR adds a best-effort duration probe that runs only on the audio branch, leaving image/video/document payloads unchanged.

## Related Issue

Fixes #16524

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/feishu.py` — new `_get_audio_duration_ms()` helper that probes mutagen (transitive dep via `discord.py[voice]`), then `ffprobe` on PATH, then a size-based heuristic, with a fixed minimum fallback so the field is always populated. Mirrors the mutagen+heuristic pattern already used for Discord native voice messages (`gateway/platforms/discord.py:1396-1402`).
- `gateway/platforms/feishu.py:_send_uploaded_file_message` — only the `audio` routing branch now adds `"duration"` to the payload. Video, document, and image payloads are unchanged.
- `tests/gateway/test_feishu.py` — updated `test_send_voice_uploads_opus_and_sends_audio_message` to assert a positive integer `duration` field; added `test_send_video_does_not_inject_audio_duration_field` regression for the video branch; added `TestFeishuAudioDurationProbe` covering real-file, missing-file, and size-heuristic monotonicity branches (the heuristic test forces both mutagen and ffprobe unavailable so the heuristic branch is actually exercised).

## How to Test

1. Configure a Feishu adapter with TTS enabled (`auxiliary.tts` resolved to ElevenLabs / Azure / etc., or via `text_to_speech` tool).
2. Trigger a voice reply: ask a Feishu chat anything that produces audio output, or send `MEDIA:/path/to/audio.opus`.
3. **Before this fix:** message renders in Feishu as a generic file attachment with a music-note icon; clicking is required to see duration.
4. **After this fix:** message renders as a voice bubble with the duration displayed before play.

Automated:
```
pytest tests/gateway/test_feishu.py -q
```

Result on macOS 15.6.1 / Python 3.14.2: `156 passed, 37 skipped`. The 37 skips are pre-existing (lark_oapi optional dep gating) and unaffected by this PR.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.6.1 (Python 3.14.2)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A *(N/A — internal helper, behaviour-only fix)*
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A *(N/A — no config keys touched)*
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A *(N/A)*
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A *(every probe is in a `try/except`; mutagen and ffprobe are both optional and the size-heuristic / fixed-minimum fallbacks always succeed; no platform-specific syscalls used)*
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A *(N/A — gateway adapter, not a tool)*

## Screenshots / Logs

```
$ pytest tests/gateway/test_feishu.py -q
.................................................................s..s.ss [ 37%]
.s..s....ssss.ssss.ss.s.sss....sssss.sssss......ss.ss..s......s....s.... [ 74%]
.................................................                        [100%]
156 passed, 37 skipped, 193 warnings in 3.32s
```
