### PR TITLE
fix(compression): retry transient transport errors before fallback marker (#16670)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -25,6 +25,7 @@ from typing import Any, Dict, List, Optional
 
 from agent.auxiliary_client import call_llm, _is_connection_error
 from agent.context_engine import ContextEngine
+from agent.error_classifier import is_transient_transport_error
 from agent.model_metadata import (
     MINIMUM_CONTEXT_LENGTH,
     get_model_context_length,
@@ -74,6 +75,15 @@ _IMAGE_TOKEN_ESTIMATE = 1600
 # for tail-cut decisions.
 _IMAGE_CHAR_EQUIVALENT = _IMAGE_TOKEN_ESTIMATE * _CHARS_PER_TOKEN
 _SUMMARY_FAILURE_COOLDOWN_SECONDS = 600
+
+# Transient transport errors during compression (incomplete chunked read,
+# RemoteProtocolError, "peer closed connection", etc.) are common when the
+# auxiliary endpoint hiccups mid-stream. Without an in-call retry, every
+# such hiccup costs the user a real summary turn and inserts the fallback
+# context marker for the next 60 seconds. Two cheap retries with brief
+# backoff recover most of these cases. (#16670)
+_SUMMARY_TRANSIENT_MAX_RETRIES = 2
+_SUMMARY_TRANSIENT_BACKOFF_SECONDS = (1.0, 3.0)
 
 
 def _content_length_for_budget(raw_content: Any) -> int:
@@ -1069,7 +1079,36 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             }
             if self.summary_model:
                 call_kwargs["model"] = self.summary_model
-            response = call_llm(**call_kwargs)
+
+            # Retry transient transport errors (incomplete chunked read,
+            # peer-closed-connection, etc.) before falling through to the
+            # cooldown path. Without this, a single network hiccup costs the
+            # user a real summary and a 60-second pause. (#16670)
+            response = None
+            last_transient_err: Optional[Exception] = None
+            for _attempt in range(_SUMMARY_TRANSIENT_MAX_RETRIES + 1):
+                try:
+                    response = call_llm(**call_kwargs)
+                    break
+                except Exception as call_err:
+                    if not is_transient_transport_error(call_err):
+                        raise
+                    last_transient_err = call_err
+                    if _attempt >= _SUMMARY_TRANSIENT_MAX_RETRIES:
+                        raise
+                    backoff = _SUMMARY_TRANSIENT_BACKOFF_SECONDS[
+                        min(_attempt, len(_SUMMARY_TRANSIENT_BACKOFF_SECONDS) - 1)
+                    ]
+                    logging.info(
+                        "Context compression: transient transport error (%s); "
+                        "retrying in %.1fs (attempt %d/%d)",
+                        call_err,
+                        backoff,
+                        _attempt + 1,
+                        _SUMMARY_TRANSIENT_MAX_RETRIES,
+                    )
+                    time.sleep(backoff)
+            assert response is not None  # loop only exits via break or raise
             content = response.choices[0].message.content
             # Handle cases where content is not a string (e.g., dict from llama.cpp)
             if not isinstance(content, str):

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -385,6 +385,63 @@ _SSL_TRANSIENT_PATTERNS = [
 ]
 
 
+# Disconnect/protocol-class transport errors only — the subset where a
+# single immediate retry is genuinely cheap (failed mid-stream, fast-fail
+# reconnect). Excludes timeout-class types (ReadTimeout, ConnectTimeout,
+# PoolTimeout, APITimeoutError, TimeoutError) because retrying those costs
+# one full timeout window each — three back-to-back retries against a
+# 120 s compression timeout = ~6 minute stall before fallback.
+_DISCONNECT_TRANSPORT_TYPES = frozenset({
+    "ConnectError",
+    "RemoteProtocolError",
+    "ConnectionResetError",
+    "ConnectionAbortedError",
+    "BrokenPipeError",
+    "ReadError",
+    "ServerDisconnectedError",
+    "SSLError", "SSLZeroReturnError", "SSLWantReadError",
+    "SSLWantWriteError", "SSLEOFError", "SSLSyscallError",
+    "APIConnectionError",
+})
+
+
+def is_transient_transport_error(error: Exception) -> bool:
+    """True for fast-fail mid-stream transport errors that are worth one
+    cheap retry (incomplete chunked read, peer-closed connection, SSL
+    record-MAC mismatch).
+
+    Deliberately excludes timeout-class errors and explicit HTTP status
+    codes:
+    - Timeouts mean "the endpoint is genuinely slow / hung"; retrying
+      pays the full timeout window again and turns one missed compaction
+      into a multi-minute stall.
+    - HTTP-status errors are server-side decisions, not transport
+      hiccups, and have their own retry/fallback logic.
+
+    Used by callers (e.g. the auxiliary compressor) that want a bounded
+    in-call retry without the full ``classify_api_error`` machinery.
+    """
+    if error is None:
+        return False
+    if _extract_status_code(error) is not None:
+        return False
+    # ConnectionError (built-in) covers ConnectionResetError /
+    # ConnectionAbortedError / BrokenPipeError without dragging in
+    # TimeoutError. Importantly, isinstance(_, TimeoutError) is NOT
+    # checked here — see docstring.
+    if isinstance(error, ConnectionError):
+        return True
+    error_type = type(error).__name__
+    if error_type in _DISCONNECT_TRANSPORT_TYPES:
+        return True
+    msg = str(error).lower()
+    if any(pat in msg for pat in _SERVER_DISCONNECT_PATTERNS):
+        return True
+    if any(pat in msg for pat in _SSL_TRANSIENT_PATTERNS):
+        return True
+    return False
+
+
 # ── Classification pipeline ─────────────────────────────────────────────
 
 def classify_api_error(

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -1942,3 +1942,121 @@ class TestTruncateToolCallArgsJson:
         parsed = _json.loads(shrunk)
         assert parsed["path"] == "~/.hermes/skills/shopping/browser-setup-notes.md"
         assert parsed["content"].endswith("...[truncated]")
+
+
+class TestSummaryTransientRetry:
+    """Regression coverage for #16670 — auxiliary compression must retry
+    transient transport errors (incomplete chunked read, peer-closed-
+    connection) before giving up and inserting the fallback marker.
+    """
+
+    @staticmethod
+    def _make_response(text: str = "summary text"):
+        mock = MagicMock()
+        mock.choices = [MagicMock()]
+        mock.choices[0].message.content = text
+        return mock
+
+    @staticmethod
+    def _messages():
+        return [
+            {"role": "user", "content": "long input"},
+            {"role": "assistant", "content": "long output"},
+        ]
+
+    def test_retries_incomplete_chunked_read_then_succeeds(self):
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True)
+
+        success_response = self._make_response()
+        attempt_results = [
+            Exception("peer closed connection without sending complete message body (incomplete chunked read)"),
+            success_response,
+        ]
+
+        with patch("agent.context_compressor.call_llm", side_effect=attempt_results) as mock_call, \
+             patch("agent.context_compressor.time.sleep"):
+            result = c._generate_summary(self._messages())
+
+        assert result is not None, "must recover after a single transient retry"
+        assert mock_call.call_count == 2
+        # Cooldown must NOT be set after a successful retry — otherwise the
+        # next compaction would skip even though we have a working summary.
+        assert c._summary_failure_cooldown_until == 0.0
+        assert c._last_summary_error is None
+
+    def test_retries_remote_protocol_error_then_succeeds(self):
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True)
+
+        # httpx.RemoteProtocolError is the actual class name reported in #16670.
+        # Use a custom class with that name so ``type(e).__name__`` matches the
+        # transport-error registry without requiring httpx in the test env.
+        class RemoteProtocolError(Exception):
+            pass
+
+        success_response = self._make_response()
+        attempt_results = [
+            RemoteProtocolError("server disconnected mid-stream"),
+            RemoteProtocolError("server disconnected mid-stream"),
+            success_response,
+        ]
+
+        with patch("agent.context_compressor.call_llm", side_effect=attempt_results) as mock_call, \
+             patch("agent.context_compressor.time.sleep"):
+            result = c._generate_summary(self._messages())
+
+        assert result is not None
+        assert mock_call.call_count == 3  # 1 initial + 2 retries
+
+    def test_non_transient_error_is_not_retried(self):
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True)
+
+        # 401-style error carries an HTTP status — ``is_transient_transport_error``
+        # rejects these so they fall straight through to the cooldown path.
+        class _Auth(Exception):
+            status_code = 401
+
+        with patch("agent.context_compressor.call_llm", side_effect=_Auth("forbidden")) as mock_call, \
+             patch("agent.context_compressor.time.sleep") as mock_sleep:
+            result = c._generate_summary(self._messages())
+
+        assert result is None
+        assert mock_call.call_count == 1, "non-transient errors must not retry"
+        mock_sleep.assert_not_called()
+
+    def test_timeout_error_is_not_retried(self):
+        """Reviewer feedback on round-7 PR #16670: each retry pays the
+        full compression timeout window again. A 1+2 retry loop against
+        the 120 s default = ~6 min stalled compaction before fallback.
+        Keep timeouts on the existing cooldown path."""
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True)
+
+        with patch("agent.context_compressor.call_llm", side_effect=TimeoutError("upstream hung")) as mock_call, \
+             patch("agent.context_compressor.time.sleep") as mock_sleep:
+            result = c._generate_summary(self._messages())
+
+        assert result is None
+        assert mock_call.call_count == 1, "TimeoutError must not enter the retry loop"
+        mock_sleep.assert_not_called()
+        # Cooldown still set so subsequent compactions don't hammer the
+        # slow endpoint.
+        assert c._summary_failure_cooldown_until > 0.0
+
+    def test_retries_exhausted_falls_through_to_cooldown(self):
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True)
+
+        err = Exception("incomplete chunked read")
+
+        with patch("agent.context_compressor.call_llm", side_effect=err) as mock_call, \
+             patch("agent.context_compressor.time.sleep"):
+            result = c._generate_summary(self._messages())
+
+        assert result is None
+        # 1 initial attempt + 2 retries before giving up.
+        assert mock_call.call_count == 3
+        assert c._summary_failure_cooldown_until > 0.0
+        assert "incomplete chunked read" in (c._last_summary_error or "")

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -1378,3 +1378,81 @@ class TestMultimodalToolContentUnsupported:
         e = MockAPIError("bad request: missing field 'model'", status_code=400)
         result = classify_api_error(e, provider="openrouter", model="anthropic/claude-sonnet-4")
         assert result.reason != FailoverReason.multimodal_tool_content_unsupported
+class TestIsTransientTransportError:
+    """Coverage for the helper used by callers (e.g. context_compressor)
+    that retry network hiccups before giving up. (#16670)"""
+
+    def test_incomplete_chunked_read_is_transient(self):
+        from agent.error_classifier import is_transient_transport_error
+        assert is_transient_transport_error(
+            Exception("peer closed connection without sending complete message body (incomplete chunked read)")
+        )
+
+    def test_remote_protocol_error_class_name_matches_registry(self):
+        from agent.error_classifier import is_transient_transport_error
+        assert is_transient_transport_error(RemoteProtocolError("server disconnected"))
+
+    def test_connection_error_is_transient(self):
+        from agent.error_classifier import is_transient_transport_error
+        assert is_transient_transport_error(ConnectionError("refused"))
+
+    def test_typed_http_error_is_not_transient(self):
+        """4xx/5xx are server-side decisions, not transport hiccups —
+        retrying them at this layer just amplifies user-visible errors."""
+        from agent.error_classifier import is_transient_transport_error
+        assert not is_transient_transport_error(
+            MockAPIError("forbidden", status_code=403)
+        )
+        assert not is_transient_transport_error(
+            MockAPIError("rate limited", status_code=429)
+        )
+
+    def test_unrelated_runtime_error_is_not_transient(self):
+        from agent.error_classifier import is_transient_transport_error
+        assert not is_transient_transport_error(ValueError("bad config"))
+
+    def test_none_is_not_transient(self):
+        from agent.error_classifier import is_transient_transport_error
+        assert not is_transient_transport_error(None)  # type: ignore[arg-type]
+
+    def test_builtin_timeout_error_is_not_transient(self):
+        """Each retry pays the full timeout window; chaining 3 of them
+        against a 120s compression timeout would stall the user-visible
+        response for ~6 minutes before fallback. Reviewer feedback on
+        round-7 PR #16670 — keep timeouts on the cooldown path."""
+        from agent.error_classifier import is_transient_transport_error
+        assert not is_transient_transport_error(TimeoutError("hung"))
+
+    def test_read_timeout_class_name_is_not_transient(self):
+        from agent.error_classifier import is_transient_transport_error
+
+        class ReadTimeout(MockTransportError):
+            pass
+
+        assert not is_transient_transport_error(ReadTimeout("slow read"))
+
+    def test_api_timeout_error_class_name_is_not_transient(self):
+        from agent.error_classifier import is_transient_transport_error
+
+        class APITimeoutError(MockTransportError):
+            pass
+
+        assert not is_transient_transport_error(APITimeoutError("upstream slow"))
+
+    def test_pool_timeout_class_name_is_not_transient(self):
+        from agent.error_classifier import is_transient_transport_error
+
+        class PoolTimeout(MockTransportError):
+            pass
+
+        assert not is_transient_transport_error(PoolTimeout("pool exhausted"))
+
+    def test_connect_timeout_class_name_is_not_transient(self):
+        """ConnectTimeout *is* a timeout — keep it on the cooldown path
+        even though it's transport-flavoured."""
+        from agent.error_classifier import is_transient_transport_error
+
+        class ConnectTimeout(MockTransportError):
+            pass
+
+        assert not is_transient_transport_error(ConnectTimeout("connect timeout"))


### PR DESCRIPTION
## What does this PR do?

Auxiliary compression's `call_llm` request can hit `RemoteProtocolError` ("peer closed connection without sending complete message body (incomplete chunked read)") mid-stream when the auxiliary endpoint hiccups. `_generate_summary`'s generic `except` block in `agent/context_compressor.py` treated this like any other failure: 60-second cooldown, drop the selected turns, insert a fallback context marker, repeat on the next compaction. Long Telegram sessions surface this often enough that real context is permanently lost.

This PR adds a bounded in-call retry **only** for fast-fail mid-stream disconnect/protocol classes. Timeout-class errors are deliberately excluded (see Changes Made for why) so a genuinely slow endpoint can't stall a compaction for multiple timeout windows in a row.

## Related Issue

Fixes #16670

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/error_classifier.py` — new `is_transient_transport_error(error)` predicate plus a narrow `_DISCONNECT_TRANSPORT_TYPES` registry. Returns `True` only for fast-fail mid-stream disconnect/protocol classes (RemoteProtocolError, ConnectError, ServerDisconnectedError, ConnectionResetError, ConnectionAbortedError, BrokenPipeError, ReadError, APIConnectionError, the SSL transport types). Status-coded errors (4xx/5xx) and **all timeout classes** (TimeoutError, ReadTimeout, ConnectTimeout, PoolTimeout, APITimeoutError) are explicitly NOT transient — retrying a timeout pays the full timeout window again, and against the 120 s compression default that would turn one missed compaction into a ~6 minute stalled response. Timeouts continue to use the existing cooldown path.
- `agent/context_compressor.py` — wraps the single `call_llm` invocation in `_generate_summary` with a 1 + 2 retry loop (1 s / 3 s back-offs) gated on `is_transient_transport_error`. Non-transient errors fall straight through to the existing cooldown / model-fallback logic — 401/404/timeout handling is unchanged.
- `tests/agent/test_error_classifier.py` — added `TestIsTransientTransportError` covering disconnect strings (`incomplete chunked read`), `RemoteProtocolError`, `ConnectionError`, the HTTP-status rejection, and explicit non-retry coverage for `TimeoutError`, `ReadTimeout`, `APITimeoutError`, `ConnectTimeout`, `PoolTimeout`.
- `tests/agent/test_context_compressor.py` — added `TestSummaryTransientRetry` covering retry-then-succeed for both `incomplete chunked read` strings and `RemoteProtocolError`-named classes, retries-exhausted falling through to cooldown, non-transient HTTP errors not retrying, and `TimeoutError` not entering the retry loop (single call, cooldown still set).

## How to Test

Reproducing the original bug requires a flaky auxiliary endpoint, but the failure mode is identical to the issue's repro: the agent's compaction logs `Failed to generate context summary: peer closed connection without sending complete message body (incomplete chunked read). Further summary attempts paused for 60 seconds.` followed by `⚠ Compression summary failed: ...` user-visible warnings. After this PR, transient mid-stream disconnects retry up to two times before that warning fires.

Automated:
```
pytest tests/agent/test_context_compressor.py tests/agent/test_error_classifier.py -q
```

Result on macOS 15.6.1 / Python 3.14.2: `190 passed`. Reviewer also ran the same command in a separate checkout and reported `190 passed`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.6.1 (Python 3.14.2)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A *(docstring on the new helper documents the timeout-exclusion rationale)*
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A *(N/A — no config keys touched; retry budget tuned via existing module-level constants)*
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A *(N/A)*
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A *(no platform-specific syscalls; relies only on `time.sleep` and existing transport-error registries)*
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A *(N/A — internal compressor, not a tool)*

## Screenshots / Logs

```
$ pytest tests/agent/test_context_compressor.py tests/agent/test_error_classifier.py -q
........................................................................ [ 37%]
........................................................................ [ 75%]
...............................................                          [100%]
190 passed, 190 warnings in 15.26s
```
