### PR TITLE
fix(gateway): treat yaml slack block without explicit enabled as opt-in (#16682)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -284,7 +284,7 @@ class PlatformConfig:
     token: Optional[str] = None  # Bot token (Telegram, Discord)
     api_key: Optional[str] = None  # API key if different from token
     home_channel: Optional[HomeChannel] = None
-    
+
     # Reply threading mode (Telegram/Slack)
     # - "off": Never thread replies to original message
     # - "first": Only first chunk threads to user's message (default)
@@ -300,6 +300,12 @@ class PlatformConfig:
 
     # Platform-specific settings
     extra: Dict[str, Any] = field(default_factory=dict)
+
+    # True iff yaml/dict had an explicit "enabled" key. Lets the env-override
+    # layer distinguish "user set enabled: false" from "user set channel_prompts
+    # but never touched enabled" — only the former should suppress env-token
+    # activation. See #16682.
+    _enabled_explicit: bool = field(default=False, repr=False, compare=False)
 
     def to_dict(self) -> Dict[str, Any]:
         result = {
@@ -338,6 +344,7 @@ class PlatformConfig:
             reply_to_mode=data.get("reply_to_mode", "first"),
             gateway_restart_notification=_coerce_bool(_grn, True),
             extra=data.get("extra", {}),
+            _enabled_explicit="enabled" in data,
         )
 
 
@@ -1291,22 +1298,22 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     # Slack
     slack_token = os.getenv("SLACK_BOT_TOKEN")
     if slack_token:
-        if Platform.SLACK not in config.platforms:
+        slack_pc = config.platforms.get(Platform.SLACK)
+        if slack_pc is None:
             # No yaml config for Slack — env-only setup, enable it
-            config.platforms[Platform.SLACK] = PlatformConfig()
-            config.platforms[Platform.SLACK].enabled = True
-        else:
-            slack_config = config.platforms[Platform.SLACK]
-            enabled_was_explicit = bool(slack_config.extra.pop("_enabled_explicit", False))
-            if not slack_config.enabled and not enabled_was_explicit:
-                # Top-level Slack settings such as channel prompts should not
-                # turn an env-token setup into a disabled platform. Only an
-                # explicit slack.enabled/platforms.slack.enabled false should.
-                slack_config.enabled = True
-        # If yaml config exists, respect its enabled flag (don't override
-        # explicit enabled: false). Token is still stored so skills that
-        # send Slack messages can use it without activating the gateway adapter.
-        config.platforms[Platform.SLACK].token = slack_token
+            slack_pc = PlatformConfig(enabled=True)
+            config.platforms[Platform.SLACK] = slack_pc
+        elif not slack_pc._enabled_explicit:
+            # yaml mentioned slack (e.g. channel_prompts, require_mention) but
+            # never set the `enabled` key. Pre-a01e767b behaviour was to enable
+            # the gateway whenever SLACK_BOT_TOKEN was present; preserve that
+            # for the no-explicit-enabled case so a yaml block of bridged keys
+            # alone doesn't silently disable Slack. (#16682)
+            slack_pc.enabled = True
+        # If yaml explicitly set enabled (true or false), respect it. Token is
+        # still stored so skills that send Slack messages can use it without
+        # activating the gateway adapter.
+        slack_pc.token = slack_token
     slack_home = os.getenv("SLACK_HOME_CHANNEL")
     if slack_home and Platform.SLACK in config.platforms:
         config.platforms[Platform.SLACK].home_channel = HomeChannel(

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -703,3 +703,91 @@ class TestHomeChannelEnvOverrides:
             home = config.platforms[platform].home_channel
             assert home is not None, f"{platform.value}: home_channel should not be None"
             assert (home.chat_id, home.name) == expected, platform.value
+
+
+class TestSlackEnvTokenActivation:
+    """Regression coverage for #16682.
+
+    The post-a01e767b code path uses ``Platform.SLACK in config.platforms``
+    as a proxy for "user explicitly set enabled". That's wrong — yaml-bridged
+    keys (channel_prompts, require_mention, channel_skill_bindings, …) put
+    Platform.SLACK into config.platforms without ever touching the enabled
+    flag. SLACK_BOT_TOKEN must still activate the adapter in that case.
+    """
+
+    def test_yaml_bridged_keys_without_enabled_still_activate_on_env_token(
+        self, tmp_path, monkeypatch
+    ):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "slack:\n"
+            "  channel_prompts:\n"
+            '    "C01ABC": Code review mode\n',
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-env-token")
+
+        config = load_gateway_config()
+
+        slack = config.platforms[Platform.SLACK]
+        assert slack.enabled is True, (
+            "yaml has bridged slack keys but no explicit enabled — env token "
+            "must enable the adapter to preserve pre-#16682 behaviour"
+        )
+        assert slack.token == "xoxb-env-token"
+        assert slack.extra["channel_prompts"] == {"C01ABC": "Code review mode"}
+
+    def test_yaml_explicit_enabled_false_is_respected_under_env_token(
+        self, tmp_path, monkeypatch
+    ):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "platforms:\n"
+            "  slack:\n"
+            "    enabled: false\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-env-token")
+
+        config = load_gateway_config()
+
+        slack = config.platforms[Platform.SLACK]
+        assert slack.enabled is False, "explicit enabled: false must be honoured"
+        assert slack.token == "xoxb-env-token", "token still stored for skill use"
+
+    def test_env_only_setup_without_yaml_block_enables_slack(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-env-only")
+
+        config = load_gateway_config()
+
+        slack = config.platforms[Platform.SLACK]
+        assert slack.enabled is True
+        assert slack.token == "xoxb-env-only"
+
+    def test_yaml_explicit_enabled_true_remains_enabled(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "platforms:\n"
+            "  slack:\n"
+            "    enabled: true\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-env")
+
+        config = load_gateway_config()
+
+        slack = config.platforms[Platform.SLACK]
+        assert slack.enabled is True
+        assert slack.token == "xoxb-env"


### PR DESCRIPTION
## What does this PR do?

Commit `a01e767b` (`fix(gateway): respect config.yaml slack.enabled when SLACK_BOT_TOKEN env var is set`) introduced a regression: any pre-existing setup with a top-level `slack:` block in `config.yaml` — even one with no `enabled` key — silently fails to start the Slack adapter. The gateway logs `running with N platform(s)` and Slack isn't in the list, with no warning or error.

The post-`a01e767b` env-override path uses `Platform.SLACK in config.platforms` as a proxy for "user explicitly set `enabled`". That proxy is wrong: the yaml-bridging loop in `gateway/config.py` adds `Platform.SLACK` to `config.platforms` whenever **any** bridged key is present (`channel_prompts`, `require_mention`, `channel_skill_bindings`, `free_response_channels`, `dm_policy`, `allow_from`, `group_policy`, …), regardless of whether the user touched the `enabled` field. Once the platform is in `config.platforms` with the dataclass default `enabled=False`, the env-override branch skips the activation step and the adapter is suppressed.

Fix: track whether `enabled` was actually present in the source dict and gate the env-override on that signal.

## Related Issue

Fixes #16682

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/config.py:PlatformConfig` — added a private `_enabled_explicit: bool` field (excluded from `repr` / `compare`, not serialized via `to_dict`). `from_dict` sets it iff the source dict actually contains an `"enabled"` key, so dataclass-default platforms are distinguishable from yaml-explicit ones at env-override time.
- `gateway/config.py:_apply_env_overrides` — Slack env-token branch now distinguishes three cases:
  1. `Platform.SLACK` not in `config.platforms` → create with `enabled=True` (env-only setup, unchanged behavior).
  2. `Platform.SLACK` present but `_enabled_explicit=False` → set `enabled=True` (yaml has bridged keys but never touched `enabled` — restores pre-`a01e767b` behavior).
  3. `Platform.SLACK` present with `_enabled_explicit=True` → respect whatever the yaml said (preserves the `a01e767b` fix for users who explicitly set `enabled: false`).

  In every case the env token is still stored on the `PlatformConfig`, so skills that send Slack messages can use it without activating the gateway adapter.
- `tests/gateway/test_config.py` — new `TestSlackEnvTokenActivation` covering the four shapes:
  1. yaml has bridged keys without `enabled` + env token → enabled (the actual `#16682` repro case)
  2. yaml has explicit `enabled: false` + env token → adapter disabled, token stored
  3. env-only setup (no yaml block) → enabled
  4. yaml has explicit `enabled: true` + env token → enabled

  Of these four, only case 1 fails on current `main` and passes after this fix; the other three exercise behavior the original `a01e767b` fix intentionally introduced and that this PR preserves.

## How to Test

Reproduction (matches the issue body):

1. Set `SLACK_BOT_TOKEN` and `SLACK_APP_TOKEN` in `~/.hermes/.env`.
2. In `~/.hermes/config.yaml`, add (only):
   ```yaml
   slack:
     channel_prompts: {}
   ```
3. Restart the gateway: `hermes gateway restart` (or `systemctl --user restart hermes-gateway.service`).
4. **Before this fix:** gateway log shows `running with N platform(s)` without Slack listed.
5. **After this fix:** Slack appears in the platform list and connects normally.

Automated:
```
pytest tests/gateway/test_config.py -q
```

Result on macOS 15.6.1 / Python 3.14.2: `37 passed`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.6.1 (Python 3.14.2)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A *(field has an inline docstring on `PlatformConfig` explaining when it's used)*
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A *(N/A — no new config keys; restores prior behavior for an existing one)*
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A *(N/A)*
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A *(N/A — pure dataclass / dict logic)*
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A *(N/A — gateway config, not a tool)*

## Screenshots / Logs

```
$ pytest tests/gateway/test_config.py -q
.....................................                                    [100%]
37 passed, 37 warnings in 3.38s
```
