### PR TITLE
fix(discord): scale slash sync timeout to actual write count (#16713)

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -813,7 +813,18 @@ class DiscordAdapter(BasePlatformAdapter):
                 logger.info("[%s] Synced %d slash command(s) via bulk tree sync", self.name, len(synced))
                 return
 
-            summary = await asyncio.wait_for(self._safe_sync_slash_commands(), timeout=30)
+            # Plan first so we can size the execute timeout to the actual
+            # workload. Discord enforces ~5 command-management writes per
+            # 20-second window per app; large reconciles (mass prune +
+            # re-upsert) reliably blow a fixed 30 s budget under bucket
+            # pressure. (#16713)
+            plan = await asyncio.wait_for(
+                self._plan_slash_command_sync(), timeout=30
+            )
+            sync_budget = self._estimate_slash_sync_budget(plan["write_count"])
+            summary = await asyncio.wait_for(
+                self._execute_slash_command_sync(plan), timeout=sync_budget
+            )
             logger.info(
                 "[%s] Safely reconciled %d slash command(s): unchanged=%d updated=%d recreated=%d created=%d deleted=%d",
                 self.name,
@@ -825,7 +836,11 @@ class DiscordAdapter(BasePlatformAdapter):
                 summary["deleted"],
             )
         except asyncio.TimeoutError:
-            logger.warning("[%s] Slash command sync timed out after 30s", self.name)
+            logger.warning(
+                "[%s] Slash command sync timed out — Discord rate-limit bucket "
+                "may be saturated; will retry on next reconnect",
+                self.name,
+            )
         except asyncio.CancelledError:
             raise
         except Exception as e:  # pragma: no cover - defensive logging
@@ -934,17 +949,38 @@ class DiscordAdapter(BasePlatformAdapter):
             "options": canonical["options"],
         }
 
-    async def _safe_sync_slash_commands(self) -> Dict[str, int]:
-        """Diff existing global commands and only mutate the commands that changed."""
+    # Discord's per-app command-management bucket is ~5 writes / 20 s.
+    # Use ~5 s/write so mass-prune-plus-upsert bursts don't blow the budget
+    # while still capping the total wait. (#16713)
+    _SLASH_SYNC_BASE_BUDGET_SECONDS = 30
+    _SLASH_SYNC_PER_WRITE_SECONDS = 5
+    _SLASH_SYNC_MAX_BUDGET_SECONDS = 600
+
+    @classmethod
+    def _estimate_slash_sync_budget(cls, write_count: int) -> int:
+        if write_count <= 0:
+            return cls._SLASH_SYNC_BASE_BUDGET_SECONDS
+        budget = cls._SLASH_SYNC_BASE_BUDGET_SECONDS + (
+            write_count * cls._SLASH_SYNC_PER_WRITE_SECONDS
+        )
+        return min(cls._SLASH_SYNC_MAX_BUDGET_SECONDS, budget)
+
+    async def _plan_slash_command_sync(self) -> Dict[str, Any]:
+        """Diff desired vs existing global commands without mutating anything.
+
+        Splitting the read-only diff from the writes lets the caller size the
+        execute-phase timeout to the actual workload. (#16713)
+        """
+        empty: Dict[str, Any] = {
+            "app_id": None,
+            "actions": [],
+            "deletes": [],
+            "unchanged": 0,
+            "total": 0,
+            "write_count": 0,
+        }
         if not self._client:
-            return {
-                "total": 0,
-                "unchanged": 0,
-                "updated": 0,
-                "recreated": 0,
-                "created": 0,
-                "deleted": 0,
-            }
+            return empty
 
         tree = self._client.tree
         app_id = getattr(self._client, "application_id", None) or getattr(getattr(self._client, "user", None), "id", None)
@@ -965,18 +1001,14 @@ class DiscordAdapter(BasePlatformAdapter):
             for command in existing_commands
         }
 
+        # action: ("create", desired) | ("update", current, desired) |
+        #         ("recreate", current, desired)
+        actions: list = []
         unchanged = 0
-        updated = 0
-        recreated = 0
-        created = 0
-        deleted = 0
-        http = self._client.http
-
         for key, desired in desired_by_key.items():
             current = existing_by_key.pop(key, None)
             if current is None:
-                await http.upsert_global_command(app_id, desired)
-                created += 1
+                actions.append(("create", None, desired))
                 continue
 
             current_existing_payload = self._existing_command_to_payload(current)
@@ -987,26 +1019,80 @@ class DiscordAdapter(BasePlatformAdapter):
                 continue
 
             if self._patchable_app_command_payload(current_existing_payload) == self._patchable_app_command_payload(desired):
+                actions.append(("recreate", current, desired))
+                continue
+
+            actions.append(("update", current, desired))
+
+        deletes = list(existing_by_key.values())
+
+        # ``recreate`` issues two writes (delete + upsert); everything else is one.
+        write_count = sum(2 if a[0] == "recreate" else 1 for a in actions) + len(deletes)
+
+        return {
+            "app_id": app_id,
+            "actions": actions,
+            "deletes": deletes,
+            "unchanged": unchanged,
+            "total": len(desired_payloads),
+            "write_count": write_count,
+        }
+
+    async def _execute_slash_command_sync(self, plan: Dict[str, Any]) -> Dict[str, int]:
+        """Apply a plan produced by ``_plan_slash_command_sync``."""
+        if not self._client or plan.get("app_id") is None:
+            return {
+                "total": plan.get("total", 0),
+                "unchanged": plan.get("unchanged", 0),
+                "updated": 0,
+                "recreated": 0,
+                "created": 0,
+                "deleted": 0,
+            }
+
+        app_id = plan["app_id"]
+        http = self._client.http
+        unchanged = plan["unchanged"]
+        updated = recreated = created = deleted = 0
+
+        for action in plan["actions"]:
+            kind = action[0]
+            if kind == "create":
+                _, _, desired = action
+                await http.upsert_global_command(app_id, desired)
+                created += 1
+            elif kind == "recreate":
+                _, current, desired = action
                 await http.delete_global_command(app_id, current.id)
                 await http.upsert_global_command(app_id, desired)
                 recreated += 1
-                continue
+            elif kind == "update":
+                _, current, desired = action
+                await http.edit_global_command(app_id, current.id, desired)
+                updated += 1
 
-            await http.edit_global_command(app_id, current.id, desired)
-            updated += 1
-
-        for current in existing_by_key.values():
+        for current in plan["deletes"]:
             await http.delete_global_command(app_id, current.id)
             deleted += 1
 
         return {
-            "total": len(desired_payloads),
+            "total": plan["total"],
             "unchanged": unchanged,
             "updated": updated,
             "recreated": recreated,
             "created": created,
             "deleted": deleted,
         }
+
+    async def _safe_sync_slash_commands(self) -> Dict[str, int]:
+        """Diff existing global commands and only mutate the commands that changed.
+
+        Kept for callers/tests that want a single-shot reconcile; the
+        post-connect path uses ``_plan_slash_command_sync`` +
+        ``_execute_slash_command_sync`` directly so it can size the timeout.
+        """
+        plan = await self._plan_slash_command_sync()
+        return await self._execute_slash_command_sync(plan)
 
     async def _add_reaction(self, message: Any, emoji: str) -> bool:
         """Add an emoji reaction to a Discord message."""

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -655,3 +655,197 @@ async def test_safe_sync_detects_contexts_drift():
     fake_http.edit_global_command.assert_not_awaited()
     fake_http.delete_global_command.assert_awaited_once_with(999, 77)
     fake_http.upsert_global_command.assert_awaited_once_with(999, desired)
+
+
+# ---------------------------------------------------------------------------
+# Adaptive sync-budget regression coverage for #16713
+# ---------------------------------------------------------------------------
+
+
+def test_estimate_slash_sync_budget_scales_with_write_count():
+    """A mass-prune-plus-upsert reconcile (77 orphans + 30 desired) must get
+    a budget materially larger than the 30 s constant that blew up in
+    production. (#16713)"""
+    from gateway.platforms.discord import DiscordAdapter
+
+    # No work to do → just the base budget.
+    assert DiscordAdapter._estimate_slash_sync_budget(0) == DiscordAdapter._SLASH_SYNC_BASE_BUDGET_SECONDS
+
+    # Heavy reconcile reported in the bug — must exceed the old 30 s wall.
+    heavy = DiscordAdapter._estimate_slash_sync_budget(107)
+    assert heavy > 30, "old 30s constant blew up — adaptive budget must exceed it"
+    assert heavy <= DiscordAdapter._SLASH_SYNC_MAX_BUDGET_SECONDS
+
+
+def test_estimate_slash_sync_budget_caps_at_max():
+    from gateway.platforms.discord import DiscordAdapter
+
+    # Pathological case shouldn't lock the gateway forever.
+    assert (
+        DiscordAdapter._estimate_slash_sync_budget(10_000)
+        == DiscordAdapter._SLASH_SYNC_MAX_BUDGET_SECONDS
+    )
+
+
+def test_estimate_slash_sync_budget_is_monotonic():
+    from gateway.platforms.discord import DiscordAdapter
+
+    a = DiscordAdapter._estimate_slash_sync_budget(5)
+    b = DiscordAdapter._estimate_slash_sync_budget(50)
+    c = DiscordAdapter._estimate_slash_sync_budget(500)
+    assert a <= b <= c
+
+
+@pytest.mark.asyncio
+async def test_plan_slash_command_sync_counts_recreate_as_two_writes():
+    """``recreate`` issues delete + upsert, so its budget must reflect both
+    operations against Discord's per-app rate-limit bucket. (#16713)"""
+    from gateway.platforms.discord import DiscordAdapter
+
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+
+    class _DesiredCommand:
+        def __init__(self, payload):
+            self._payload = payload
+
+        def to_dict(self, tree):
+            assert tree is not None
+            return dict(self._payload)
+
+    class _ExistingCommand:
+        def __init__(self, command_id, payload):
+            self.id = command_id
+            self.name = payload["name"]
+            self.type = SimpleNamespace(value=payload["type"])
+            self._payload = payload
+
+        def to_dict(self):
+            return {"id": self.id, "application_id": 999, **self._payload}
+
+    # 1 recreate (contexts diff requires delete+upsert) + 1 orphan delete.
+    desired_recreate = {
+        "name": "ping",
+        "description": "Ping",
+        "type": 1,
+        "options": [],
+        "nsfw": False,
+        "dm_permission": True,
+        "default_member_permissions": None,
+        "contexts": [0, 1, 2],
+    }
+    existing_recreate = _ExistingCommand(
+        100,
+        {**desired_recreate, "contexts": [0]},
+    )
+    existing_orphan = _ExistingCommand(
+        101,
+        {
+            "name": "old",
+            "description": "to delete",
+            "type": 1,
+            "options": [],
+            "nsfw": False,
+            "dm_permission": True,
+            "default_member_permissions": None,
+        },
+    )
+
+    adapter._client = SimpleNamespace(
+        tree=SimpleNamespace(
+            get_commands=lambda: [_DesiredCommand(desired_recreate)],
+            fetch_commands=AsyncMock(
+                return_value=[existing_recreate, existing_orphan]
+            ),
+        ),
+        http=SimpleNamespace(
+            upsert_global_command=AsyncMock(),
+            edit_global_command=AsyncMock(),
+            delete_global_command=AsyncMock(),
+        ),
+        application_id=999,
+        user=SimpleNamespace(id=999),
+    )
+
+    plan = await adapter._plan_slash_command_sync()
+    # 1 recreate (= 2 writes) + 1 orphan delete (= 1 write) = 3 writes.
+    assert plan["write_count"] == 3
+    assert plan["total"] == 1
+    assert plan["unchanged"] == 0
+    assert len(plan["actions"]) == 1
+    assert plan["actions"][0][0] == "recreate"
+    assert len(plan["deletes"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_plan_then_execute_matches_safe_sync_summary():
+    """The plan + execute path must produce the same summary numbers as the
+    legacy single-shot ``_safe_sync_slash_commands`` so existing callers
+    that read the summary stay correct. (#16713)"""
+    from gateway.platforms.discord import DiscordAdapter
+
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+
+    class _DesiredCommand:
+        def __init__(self, payload):
+            self._payload = payload
+
+        def to_dict(self, tree):
+            return dict(self._payload)
+
+    class _ExistingCommand:
+        def __init__(self, command_id, payload):
+            self.id = command_id
+            self.name = payload["name"]
+            self.type = SimpleNamespace(value=payload["type"])
+            self._payload = payload
+
+        def to_dict(self):
+            return {"id": self.id, "application_id": 999, **self._payload}
+
+    desired = {
+        "name": "newcmd",
+        "description": "fresh",
+        "type": 1,
+        "options": [],
+        "nsfw": False,
+        "dm_permission": True,
+        "default_member_permissions": None,
+    }
+    orphan = _ExistingCommand(
+        201,
+        {
+            "name": "stale",
+            "description": "orphan",
+            "type": 1,
+            "options": [],
+            "nsfw": False,
+            "dm_permission": True,
+            "default_member_permissions": None,
+        },
+    )
+
+    adapter._client = SimpleNamespace(
+        tree=SimpleNamespace(
+            get_commands=lambda: [_DesiredCommand(desired)],
+            fetch_commands=AsyncMock(return_value=[orphan]),
+        ),
+        http=SimpleNamespace(
+            upsert_global_command=AsyncMock(),
+            edit_global_command=AsyncMock(),
+            delete_global_command=AsyncMock(),
+        ),
+        application_id=999,
+        user=SimpleNamespace(id=999),
+    )
+
+    plan = await adapter._plan_slash_command_sync()
+    summary_split = await adapter._execute_slash_command_sync(plan)
+
+    assert summary_split == {
+        "total": 1,
+        "unchanged": 0,
+        "updated": 0,
+        "recreated": 0,
+        "created": 1,
+        "deleted": 1,
+    }


### PR DESCRIPTION
## What does this PR do?

`_run_post_connect_initialization` in `gateway/platforms/discord.py` wraps the entire `_safe_sync_slash_commands` call in `asyncio.wait_for(..., 30)`. Discord's per-app command-management bucket allows roughly 5 writes / 20-second window, so a mass-prune-plus-upsert reconcile reliably blows the 30 s budget under back-pressure. The reported case had 77 orphans + 30 desired = 107 writes; two consecutive 30 s timeouts, then a clean 22 s sync only after the bucket fully recovered ~60 minutes later.

This PR splits the read-only diff from the writes and sizes the execute-phase timeout to the actual workload, so a heavy reconcile gets enough budget to finish under bucket pressure but pathological loads still get a hard cap.

## Related Issue

Fixes #16713

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/discord.py` — extracted two helpers from `_safe_sync_slash_commands`:
  - `_plan_slash_command_sync()` — read-only; diffs desired vs existing global commands, returns a list of typed actions (`create` / `update` / `recreate`) plus the orphan deletes and a `write_count`.
  - `_execute_slash_command_sync(plan)` — applies the plan, returns the existing summary dict.
  - `_safe_sync_slash_commands` is now a thin wrapper that calls plan + execute, preserving the single-shot signature for callers and existing tests.
- `gateway/platforms/discord.py:_run_post_connect_initialization` — now plans first under a 30 s budget, then computes a write-count-aware execute budget (`30 + 5 × write_count`, capped at 600 s) before running the plan. `recreate` actions count as two writes (delete + upsert) so the budget covers Discord's actual rate-limit math. Timeout log message updated to point at saturated rate-limit bucket as the cause instead of a flat "after 30 s".
- Three new module-level constants on the adapter (`_SLASH_SYNC_BASE_BUDGET_SECONDS`, `_SLASH_SYNC_PER_WRITE_SECONDS`, `_SLASH_SYNC_MAX_BUDGET_SECONDS`) and a static `_estimate_slash_sync_budget(write_count)` so the budget formula is testable and trivially tunable.
- `tests/gateway/test_discord_connect.py` — added five tests:
  - `_estimate_slash_sync_budget` scales with write count, is monotonic, caps at the maximum.
  - `_plan_slash_command_sync` counts a `recreate` as two writes plus an orphan delete (matches Discord's bucket math).
  - Plan + execute produces the same summary dict as the existing `_safe_sync_slash_commands` single-shot path (so callers/tests that read the summary stay correct).

## How to Test

Reproduction (matches the issue body): trigger a session that produces ≥ ~30 orphan slash commands (e.g., a command-registry refactor that drops or renames commands), restart the gateway, and watch the post-connect initialization. Before this fix, `wait_for(..., 30)` raised `asyncio.TimeoutError` and subsequent reconnects within the rate-limit cooldown also timed out. After this fix, the budget scales with the planned write count and the reconcile completes under bucket pressure.

Automated:
```
pytest tests/gateway/test_discord_connect.py -q
```

Result on macOS 15.6.1 / Python 3.14.2: `16 passed` (11 pre-existing + 5 new). All five new tests fail on `main` without the production change.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.6.1 (Python 3.14.2)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A *(new helpers carry inline docstrings explaining the bucket math)*
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A *(N/A — budget tuning lives on adapter class constants; not user-facing yaml)*
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A *(N/A)*
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A *(N/A — pure asyncio + discord.py HTTP calls, no platform-specific syscalls)*
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A *(N/A — gateway adapter, not a tool)*

## Screenshots / Logs

```
$ pytest tests/gateway/test_discord_connect.py -q
................                                                         [100%]
16 passed, 3 warnings in 3.17s
```
