### PR TITLE
fix(tui): copilot follow-ups for PR #16732

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -868,7 +868,7 @@ def _tui_need_npm_install(root: Path) -> bool:
     try:
         wanted = json.loads(lock.read_text(encoding="utf-8")).get("packages") or {}
         installed = json.loads(marker.read_text(encoding="utf-8")).get("packages") or {}
-    except (OSError, json.JSONDecodeError):
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
         return lock.stat().st_mtime > marker.stat().st_mtime
 
     def comparable(pkg: dict) -> dict:

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -638,14 +638,14 @@ export function TextInput({
 
   const moveCursor = (next: number, extend = false) => {
     const c = snapPos(vRef.current, next)
+    const anchor = selRef.current?.start ?? curRef.current
 
-    if (extend) {
-      const anchor = selRef.current?.start ?? curRef.current
+    if (!extend || anchor === c) {
+      clearSel()
+    } else {
       const nextSel = { end: c, start: anchor }
       selRef.current = nextSel
       setSel(nextSel)
-    } else {
-      clearSel()
     }
 
     setCur(c)


### PR DESCRIPTION
## Summary
Address the two actionable copilot comments left on the merged PR #16732.

- `moveCursor(extend=true)` now collapses to the bare cursor when the computed offset equals the anchor instead of leaving a zero-length \`selected\` range. Shift+Left at col 0 / Shift+Home when already at start no longer silently hides the hardware cursor without rendering a highlight.
- `_tui_need_npm_install` also catches `UnicodeDecodeError` so a corrupted / non-UTF8 lockfile falls back to the mtime path the docstring promises instead of crashing.

## Test plan
- [x] \`npm run type-check\`
- [x] \`npm test\` — 387/387 in \`ui-tui\`
- [x] \`pytest tests/hermes_cli/test_tui_npm_install.py\` — 9/9

Made with [Cursor](https://cursor.com)