### PR TITLE
fix(install): probe /dev/tty by opening it, not bare existence (#16746)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1330,7 +1330,12 @@ run_setup_wizard() {
     # The setup wizard reads from /dev/tty, so it works even when the
     # install script itself is piped (curl | bash). Only skip if no
     # terminal is available at all (e.g. Docker build, CI).
-    if ! [ -e /dev/tty ]; then
+    #
+    # Probe by actually opening /dev/tty: a bare existence test passes
+    # in Docker builds where the device node is in the mount namespace
+    # but opening fails with ENXIO, so the wizard would proceed and
+    # then crash on `< /dev/tty` below.
+    if ! (: </dev/tty) 2>/dev/null; then
         log_info "Setup wizard skipped (no terminal available). Run 'hermes setup' after install."
         return 0
     fi

--- a/tests/test_install_sh_setup_wizard_tty_probe.py
+++ b/tests/test_install_sh_setup_wizard_tty_probe.py
@@ -1,0 +1,41 @@
+"""Regression for #16746: setup-wizard tty gate must actually open /dev/tty.
+
+In a Docker build, ``/dev/tty`` exists as a device node (so ``[ -e /dev/tty ]``
+returns true) but opening it fails with ``ENXIO: No such device or address``.
+Under the old gate the wizard proceeded past the "no terminal available" skip
+and then crashed on the ``< /dev/tty`` redirect a few lines later, aborting
+the entire image build. The fix replaces the bare existence check with an
+open-based probe so the skip kicks in correctly.
+"""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+
+def _extract_run_setup_wizard() -> str:
+    """Return the body of run_setup_wizard() as a single string."""
+    text = INSTALL_SH.read_text()
+    start = text.index("run_setup_wizard()")
+    # The next top-level function follows immediately; use it as the end marker.
+    end = text.index("\nmaybe_start_gateway()", start)
+    return text[start:end]
+
+
+def test_run_setup_wizard_does_not_use_bare_existence_check() -> None:
+    body = _extract_run_setup_wizard()
+    assert "[ -e /dev/tty ]" not in body, (
+        "run_setup_wizard guards on `[ -e /dev/tty ]`, which is true in Docker "
+        "builds where the device node exists but cannot be opened (ENXIO). "
+        "Use an open-based probe such as `(: </dev/tty) 2>/dev/null` so the "
+        "skip kicks in before the wizard tries to read from /dev/tty. See #16746."
+    )
+
+
+def test_run_setup_wizard_uses_open_based_tty_probe() -> None:
+    body = _extract_run_setup_wizard()
+    assert "(: </dev/tty)" in body, (
+        "run_setup_wizard must probe /dev/tty by actually opening it before "
+        "running the wizard. See #16746."
+    )

--- a/tests/test_install_sh_setup_wizard_tty_probe.py
+++ b/tests/test_install_sh_setup_wizard_tty_probe.py
@@ -1,13 +1,16 @@
 """Regression for #16746: setup-wizard tty gate must actually open /dev/tty.
 
-In a Docker build, ``/dev/tty`` exists as a device node (so ``[ -e /dev/tty ]``
-returns true) but opening it fails with ``ENXIO: No such device or address``.
-Under the old gate the wizard proceeded past the "no terminal available" skip
-and then crashed on the ``< /dev/tty`` redirect a few lines later, aborting
-the entire image build. The fix replaces the bare existence check with an
-open-based probe so the skip kicks in correctly.
+In a Docker build, ``/dev/tty`` exists as a device node (so a bare ``-e``
+existence test returns true) but opening it fails with ``ENXIO: No such
+device or address``. Under the old gate the wizard proceeded past the "no
+terminal available" skip and then crashed on the ``< /dev/tty`` redirect a
+few lines later, aborting the entire image build. The fix replaces the
+existence check with an open-based probe so the skip kicks in correctly.
 """
 
+from __future__ import annotations
+
+import re
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -15,27 +18,58 @@ INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
 
 
 def _extract_run_setup_wizard() -> str:
-    """Return the body of run_setup_wizard() as a single string."""
+    """Return the body of ``run_setup_wizard()`` as a single string.
+
+    Anchored to ``run_setup_wizard()`` and a top-of-line ``}`` so the helper
+    keeps working if neighbouring functions are renamed.
+    """
     text = INSTALL_SH.read_text()
-    start = text.index("run_setup_wizard()")
-    # The next top-level function follows immediately; use it as the end marker.
-    end = text.index("\nmaybe_start_gateway()", start)
-    return text[start:end]
+    match = re.search(
+        r"^run_setup_wizard\(\)\s*\{\s*\n(?P<body>.*?)^\}",
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert match is not None, "run_setup_wizard() not found in scripts/install.sh"
+    return match["body"]
 
 
-def test_run_setup_wizard_does_not_use_bare_existence_check() -> None:
+def test_run_setup_wizard_does_not_use_existence_only_tty_check() -> None:
+    """The bare ``-e`` test is the bug — no spelling of it should remain."""
     body = _extract_run_setup_wizard()
-    assert "[ -e /dev/tty ]" not in body, (
-        "run_setup_wizard guards on `[ -e /dev/tty ]`, which is true in Docker "
-        "builds where the device node exists but cannot be opened (ENXIO). "
-        "Use an open-based probe such as `(: </dev/tty) 2>/dev/null` so the "
-        "skip kicks in before the wizard tries to read from /dev/tty. See #16746."
+    # Cover ``[ -e /dev/tty ]``, ``[ -e "/dev/tty" ]``, ``test -e /dev/tty``
+    # and friends, with arbitrary surrounding whitespace.
+    pattern = re.compile(
+        r"""(
+            \[\s*-e\s+["']?/dev/tty["']?\s*\]
+            |
+            \btest\s+-e\s+["']?/dev/tty["']?
+        )""",
+        re.VERBOSE,
+    )
+    match = pattern.search(body)
+    assert match is None, (
+        "run_setup_wizard contains an existence-only check on /dev/tty "
+        f"({match.group(0)!r}). Bare `-e` tests pass in Docker builds "
+        "where the device node is in the mount namespace but cannot be "
+        "opened (ENXIO). Use an open-based probe (e.g. "
+        "`(: </dev/tty) 2>/dev/null` or `exec 3</dev/tty`) so the skip "
+        "kicks in before the wizard tries to read from /dev/tty. "
+        "See #16746."
     )
 
 
-def test_run_setup_wizard_uses_open_based_tty_probe() -> None:
+def test_run_setup_wizard_gates_on_open_based_tty_probe() -> None:
+    """The gate must actually attempt to open ``/dev/tty``.
+
+    Any ``if !`` (or ``if``) whose condition opens ``/dev/tty`` for input
+    counts: ``(: </dev/tty)``, ``exec 3</dev/tty``, ``{ exec 3</dev/tty; }``,
+    etc. Asserting the higher-level invariant rather than a specific spelling
+    so equivalent refactors stay green.
+    """
     body = _extract_run_setup_wizard()
-    assert "(: </dev/tty)" in body, (
-        "run_setup_wizard must probe /dev/tty by actually opening it before "
-        "running the wizard. See #16746."
+    gate = re.compile(r"^\s*if\s+!?\s+[^\n]*<\s*/dev/tty[^\n]*;\s*then", re.MULTILINE)
+    assert gate.search(body), (
+        "run_setup_wizard must gate on an open-based probe of /dev/tty "
+        "(an `if`/`if !` whose test redirects stdin from /dev/tty), not a "
+        "mere existence check. See #16746."
     )


### PR DESCRIPTION
## Summary
- Replace `[ -e /dev/tty ]` with an open-based probe in `run_setup_wizard()` so Docker / CI installs skip the wizard cleanly instead of crashing on the next `< /dev/tty` redirect.
- Add a static regression test that asserts the gate does not use the bare existence check and that the open-based probe is in place.

## The bug
On a Docker build, `/dev/tty` exists as a device node (so `[ -e /dev/tty ]` returns true), but opening it fails with `ENXIO: No such device or address`. The skip at the top of `run_setup_wizard()` never triggered, the wizard proceeded, and bash aborted a few lines later when it tried to redirect from `/dev/tty`:

```
/tmp/install.sh: line 1347: /dev/tty: No such device or address
```

The `--skip-setup` flag works around this, but the bare existence check was supposed to catch this case automatically.

## The fix
`(: </dev/tty) 2>/dev/null` runs the no-op `:` in a subshell with stdin redirected from `/dev/tty`. The subshell exits non-zero exactly when opening `/dev/tty` would fail (ENXIO in Docker, ENODEV in some CI sandboxes), and the existing skip path runs. On a real terminal — including the `curl | bash` flow the wizard targets — the open succeeds and the wizard runs as before. The subshell isolates the probe so we don't leave an inherited fd open in the script.

`scripts/install.sh` has two other `[ -e /dev/tty ]` sites (the apt sudo prompt fallback near line 732 and the gateway-install gate near line 1395). They have the same shape but are outside the reproduction path in #16746 and on a separate code path, so this PR keeps the diff scoped to the wizard gate the reporter actually hit. Happy to follow up with a second PR for those if maintainers prefer.

## Test plan
- [x] Focused regression test: `uv run --with pytest --with pytest-xdist python3 -m pytest tests/test_install_sh_setup_wizard_tty_probe.py -v` — both assertions pass on this branch.
- [x] Regression guard: same suite run with `scripts/install.sh` reverted to `origin/main` fails with the documented assertion message; restoring the fix passes.
- [x] Adjacent: `tests/hermes_cli/test_managed_installs.py` and `tests/hermes_cli/test_doctor_command_install.py` — only baseline failure is `test_windows_skips_check`, which reproduces on clean `origin/main` (it depends on `_winapi`, macOS lacks the module).
- [x] Manual probe behavior:
  - `bash -c '(: </dev/tty) 2>/dev/null && echo OK || echo FAIL' < /dev/null` → `FAIL` (matches Docker-build skip).
  - On a real interactive terminal the same probe returns `OK` — the wizard still runs as before.

## Related
- Fixes #16746.