### PR TITLE
fix(weixin): split long messages (>2000 chars) into chunks to prevent truncation

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -89,6 +89,7 @@ MAX_CONSECUTIVE_FAILURES = 3
 RETRY_DELAY_SECONDS = 2
 BACKOFF_DELAY_SECONDS = 30
 SESSION_EXPIRED_ERRCODE = -14
+RATE_LIMIT_ERRCODE = -2  # iLink frequency limit — backoff and retry
 MESSAGE_DEDUP_TTL_SECONDS = 300
 
 MEDIA_IMAGE = 1
@@ -1113,7 +1114,7 @@ async def qr_login(
 class WeixinAdapter(BasePlatformAdapter):
     """Native Hermes adapter for Weixin personal accounts."""
 
-    MAX_MESSAGE_LENGTH = 4000
+    MAX_MESSAGE_LENGTH = 2000
 
     # WeChat does not support editing sent messages — streaming must use the
     # fallback "send-final-only" path so the cursor (▉) is never left visible.
@@ -1138,10 +1139,10 @@ class WeixinAdapter(BasePlatformAdapter):
             extra.get("cdn_base_url") or os.getenv("WEIXIN_CDN_BASE_URL", WEIXIN_CDN_BASE_URL)
         ).strip().rstrip("/")
         self._send_chunk_delay_seconds = float(
-            extra.get("send_chunk_delay_seconds") or os.getenv("WEIXIN_SEND_CHUNK_DELAY_SECONDS", "0.35")
+            extra.get("send_chunk_delay_seconds") or os.getenv("WEIXIN_SEND_CHUNK_DELAY_SECONDS", "1.5")
         )
         self._send_chunk_retries = int(
-            extra.get("send_chunk_retries") or os.getenv("WEIXIN_SEND_CHUNK_RETRIES", "2")
+            extra.get("send_chunk_retries") or os.getenv("WEIXIN_SEND_CHUNK_RETRIES", "4")
         )
         self._send_chunk_retry_delay_seconds = float(
             extra.get("send_chunk_retry_delay_seconds")
@@ -1530,6 +1531,19 @@ class WeixinAdapter(BasePlatformAdapter):
                                 "[%s] session expired for %s; retrying without context_token",
                                 self.name, _safe_id(chat_id),
                             )
+                            continue
+                        # Rate limit (-2) — backoff and retry
+                        is_rate_limited = (
+                            ret == RATE_LIMIT_ERRCODE
+                            or errcode == RATE_LIMIT_ERRCODE
+                        )
+                        if is_rate_limited:
+                            wait = self._send_chunk_retry_delay_seconds * 3  # 3s backoff for rate limit
+                            logger.warning(
+                                "[%s] rate limited for %s; backing off %.1fs before retry",
+                                self.name, _safe_id(chat_id), wait,
+                            )
+                            await asyncio.sleep(wait)
                             continue
                         errmsg = resp.get("errmsg") or resp.get("msg") or "unknown error"
                         raise RuntimeError(


### PR DESCRIPTION
## Summary

This PR fixes the Weixin long message truncation bug described in #16411.

## Changes

- MAX_MESSAGE_LENGTH: Reduced from 4000 to 2000 to match the Weixin iLink API's actual message size limit
- RATE_LIMIT_ERRCODE handling: Added -2 error code detection with 3x backoff retry logic in _send_text_chunk()
- Default chunk delay: Increased from 0.35s to 1.5s to avoid triggering rate limits between chunks
- Default retries: Increased from 2 to 4 for better reliability on transient failures
- Message chunking in send(): Long messages are now split using the existing _split_text() infrastructure before delivery, with configurable delay between chunks

## The bug

When sending text messages >2000 characters via the Weixin gateway, content beyond the limit was silently truncated. The recipient only received the first portion with no indication that part of the message was lost.

Additionally, when the iLink API returns error code -2 (rate limit / message too long), the retry logic did not handle this effectively.

## Test plan
- [x] Local testing confirms messages >2000 chars are split and delivered as multiple chunks
- [x] Rate limit -2 responses trigger backoff before retry
- [x] Chunk delay of 1.5s prevents rate limit hits during multi-chunk sends

## Related
- Fixes #16411
- Complements #16422 (fail-fast on permanent iLink error codes)