### PR TITLE
fix(dashboard): normalize session header lookup to lowercase

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -117,7 +117,7 @@ def _has_valid_session_token(request: Request) -> bool:
     accept the legacy Bearer path for backward compatibility with older
     dashboard bundles.
     """
-    session_header = request.headers.get(_SESSION_HEADER_NAME, "")
+    session_header = request.headers.get(_SESSION_HEADER_NAME.lower(), "")
     if session_header and hmac.compare_digest(
         session_header.encode(),
         _SESSION_TOKEN.encode(),

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -328,6 +328,23 @@ class TestWebServerEndpoints:
         resp = unauth_client.get("/api/status")
         assert resp.status_code == 200
 
+    def test_session_header_case_insensitive(self):
+        """Session token lookup must work regardless of header casing (#16726)."""
+        from starlette.testclient import TestClient
+        from hermes_cli.web_server import app, _SESSION_TOKEN
+
+        for header_name in (
+            "X-Hermes-Session-Token",
+            "x-hermes-session-token",
+            "X-HERMES-SESSION-TOKEN",
+        ):
+            client = TestClient(app)
+            client.headers[header_name] = _SESSION_TOKEN
+            resp = client.get("/api/env")
+            assert resp.status_code == 200, (
+                f"Header {header_name!r} should authenticate but got {resp.status_code}"
+            )
+
     def test_path_traversal_blocked(self):
         """Verify URL-encoded path traversal is blocked."""
         # %2e%2e = ..


### PR DESCRIPTION
## What does this PR do?

Fixes the dashboard session header lookup that silently fails due to HTTP header case normalization. Starlette (FastAPI's ASGI layer) lowercases all incoming header names, but the lookup used the mixed-case constant `X-Hermes-Session-Token`. The `.get()` call always returned an empty string, causing every `/api/` endpoint to return 401 Unauthorized — including `/api/skills`.

The fix normalizes the lookup key to lowercase so it matches the framework's internal representation.

## Related Issue

Fixes #16726

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server.py`: Changed `request.headers.get(_SESSION_HEADER_NAME, "")` to `request.headers.get(_SESSION_HEADER_NAME.lower(), "")` on line 120
- `tests/hermes_cli/test_web_server.py`: Added `test_session_header_case_insensitive` test that verifies authentication works with mixed-case, lowercase, and uppercase header names

## How to Test

1. Start the dashboard: `hermes dashboard --port 9119`
2. Open the Skills page in the web UI — it should now load skills instead of showing "No skills found"
3. Run the targeted test: `pytest tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_session_header_case_insensitive -v`
4. Run full suite: `pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (Darwin 25.4.0, Apple Silicon), Python 3.11

### Documentation & Housekeeping

- [x] Updated relevant documentation — or N/A
- [x] Updated cli-config.yaml.example — or N/A
- [x] Updated contributing / agents docs — or N/A
- [x] Considered cross-platform impact — or N/A
- [x] Updated tool descriptions/schemas — or N/A
