### PR TITLE
fix(cli): avoid nesting system prompt during manual compress

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7101,7 +7101,7 @@ class HermesCLI:
 
                 compressed, _ = self.agent._compress_context(
                     original_history,
-                    self.agent._cached_system_prompt or "",
+                    None,
                     approx_tokens=approx_tokens,
                     focus_topic=focus_topic or None,
                 )

--- a/tests/test_cli_manual_compress.py
+++ b/tests/test_cli_manual_compress.py
@@ -1,0 +1,57 @@
+from contextlib import nullcontext
+
+from cli import HermesCLI
+
+
+class DummyAgent:
+    def __init__(self):
+        self.compression_enabled = True
+        self._cached_system_prompt = "FULL CACHED SYSTEM PROMPT SHOULD NOT BE NESTED"
+        self.session_id = "new-session"
+        self.calls = []
+
+    def _compress_context(self, messages, system_message, *, approx_tokens=None, focus_topic=None):
+        self.calls.append(
+            {
+                "messages": messages,
+                "system_message": system_message,
+                "approx_tokens": approx_tokens,
+                "focus_topic": focus_topic,
+            }
+        )
+        return ([{"role": "user", "content": "[CONTEXT SUMMARY]: compacted"}], "new system prompt")
+
+
+def test_manual_compress_does_not_pass_cached_system_prompt(monkeypatch):
+    """Manual /compress should rebuild the next prompt without nesting the old one."""
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.conversation_history = [
+        {"role": "user", "content": "one"},
+        {"role": "assistant", "content": "two"},
+        {"role": "user", "content": "three"},
+        {"role": "assistant", "content": "four"},
+    ]
+    cli.agent = DummyAgent()
+    cli.session_id = "old-session"
+    cli._pending_title = "old title"
+    cli._busy_command = lambda _message: nullcontext()
+
+    monkeypatch.setattr(
+        "agent.manual_compression_feedback.summarize_manual_compression",
+        lambda *args, **kwargs: {
+            "noop": False,
+            "headline": "compressed",
+            "token_line": "tokens reduced",
+            "note": "",
+        },
+    )
+
+    cli._manual_compress("/compress database schema")
+
+    assert len(cli.agent.calls) == 1
+    call = cli.agent.calls[0]
+    assert call["system_message"] is None
+    assert call["system_message"] != cli.agent._cached_system_prompt
+    assert call["focus_topic"] == "database schema"
+    assert cli.session_id == "new-session"
+    assert cli._pending_title is None


### PR DESCRIPTION
## Summary

- Fix manual `/compress` so it does not pass the cached full system prompt back into `_compress_context()` as an extra system message.
- Add a regression test covering the CLI manual compression path and focus-topic forwarding.

## Problem

Manual `/compress` passed `self.agent._cached_system_prompt` into `_compress_context(..., system_message=...)`.

`_compress_context()` rebuilds the next session prompt with `_build_system_prompt(system_message)`, and `_build_system_prompt()` treats a non-`None` `system_message` as an additive overlay. That means each manual compression can nest the previous full system prompt inside the newly built prompt, causing repeated manual `/compress` calls to linearly grow `sessions.system_prompt`.

This increases token usage, makes later requests heavier, and can cause earlier or more frequent compression. It also affects plugins or gateway flows that dispatch the normal `/compress` command.

## Fix

Pass `None` for the extra `system_message` during manual compression. This lets `_compress_context()` rebuild the canonical system prompt from normal prompt layers without appending the previous full prompt snapshot.

## Test plan

- `python3 -m py_compile cli.py tests/test_cli_manual_compress.py`
- `python3 -m pytest -q tests/test_cli_manual_compress.py`
