### PR TITLE
feat(credentials): resolve env/keychain/secret-tool refs in api_key fields

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -15,6 +15,10 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 
 from hermes_constants import OPENROUTER_BASE_URL
 from hermes_cli.config import get_env_value
+from agent.credential_resolver import (
+    CredentialResolveError,
+    resolve_credential_string,
+)
 import hermes_cli.auth as auth_mod
 from hermes_cli.auth import (
     CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
@@ -1377,6 +1381,16 @@ def _seed_custom_pool(pool_key: str, entries: List[PooledCredential]) -> Tuple[b
         base_url = str(cp_config.get("base_url") or "").strip().rstrip("/")
         name = str(cp_config.get("name") or "").strip()
         if api_key:
+            try:
+                api_key = resolve_credential_string(api_key)
+            except CredentialResolveError as exc:
+                logger.error(
+                    "custom_providers[%s].api_key reference failed: %s",
+                    name or pool_key,
+                    exc,
+                )
+                api_key = ""
+        if api_key:
             source = f"config:{name}"
             if not _is_suppressed(pool_key, source):
                 active_sources.add(source)
@@ -1406,6 +1420,12 @@ def _seed_custom_pool(pool_key: str, entries: List[PooledCredential]) -> Tuple[b
                 if isinstance(v, str) and v.strip():
                     model_api_key = v.strip()
                     break
+            if model_provider == "custom" and model_base_url and model_api_key:
+                try:
+                    model_api_key = resolve_credential_string(model_api_key)
+                except CredentialResolveError as exc:
+                    logger.error("model.api_key reference failed: %s", exc)
+                    model_api_key = ""
             if model_provider == "custom" and model_base_url and model_api_key:
                 # Check if this model's base_url matches our custom provider
                 matched_key = get_custom_provider_pool_key(model_base_url)

--- a/agent/credential_resolver.py
+++ b/agent/credential_resolver.py
@@ -1,0 +1,169 @@
+"""Resolve credential strings with optional schema prefixes.
+
+Background: Hermes reads API keys from several config fields as plain strings
+(`model.api_key`, `custom_providers[*].api_key`). For users who store secrets
+in OS keychains (macOS Keychain, GNOME Keyring) or environment variables, this
+module lets the same fields hold a *reference* to the secret instead of the
+secret itself.
+
+Recognised schemas (everything else is treated as a literal value):
+
+    env:VAR                          — read from os.environ[VAR]
+    keychain:service[@account]       — macOS Keychain via `security`
+    secret-tool:service[@account]    — Linux GNOME Keyring via `secret-tool`
+
+The optional ``@account`` suffix selects a specific keychain account.
+When omitted, the current user (``$USER`` / ``getpass.getuser()``) is used —
+which matches common conventions like ``security find-generic-password
+-a "$USER" -s "<service>"``. This means service names can contain slashes
+(e.g. ``keychain:ai-system/litellm-master-key``) without ambiguity.
+
+Resolution failures (missing env var, missing keychain item, missing CLI tool)
+raise CredentialResolveError with a clear message — Hermes should fail loudly
+rather than silently fall back to an empty key, because a user who wrote
+``keychain:...`` explicitly opted in to a strict secret source.
+
+Backwards compatibility: any string without a recognised prefix is returned
+unchanged, so existing plaintext configs continue to work.
+"""
+
+from __future__ import annotations
+
+import getpass
+import os
+import shutil
+import subprocess
+
+
+SCHEMA_PREFIXES = ("env:", "keychain:", "secret-tool:")
+
+
+class CredentialResolveError(RuntimeError):
+    """Raised when a credential reference cannot be resolved."""
+
+
+def resolve_credential_string(value: str) -> str:
+    """Resolve a config string to its actual secret value.
+
+    Returns the value unchanged when no recognised schema prefix is present.
+    """
+    if not isinstance(value, str):
+        return value
+    stripped = value.strip()
+    if not stripped:
+        return stripped
+    if not any(stripped.startswith(p) for p in SCHEMA_PREFIXES):
+        return stripped
+
+    schema, _, rest = stripped.partition(":")
+    rest = rest.strip()
+    if not rest:
+        raise CredentialResolveError(
+            f"Empty reference after schema '{schema}:' — expected '{schema}:<target>'"
+        )
+
+    if schema == "env":
+        try:
+            resolved = os.environ[rest]
+        except KeyError:
+            raise CredentialResolveError(
+                f"Environment variable '{rest}' is not set (referenced as 'env:{rest}')"
+            ) from None
+        if not resolved:
+            raise CredentialResolveError(
+                f"Environment variable '{rest}' is empty (referenced as 'env:{rest}')"
+            )
+        return resolved
+
+    if schema == "keychain":
+        return _lookup_macos_keychain(rest)
+
+    if schema == "secret-tool":
+        return _lookup_secret_tool(rest)
+
+    return stripped
+
+
+def _split_service_account(target: str, schema: str) -> tuple[str, str]:
+    """Parse 'service[@account]'. Account defaults to the current user.
+
+    Slashes in the service portion are allowed and preserved — the only
+    delimiter is the first ``@``, which separates an explicit account.
+    """
+    service, sep, account = target.partition("@")
+    service = service.strip()
+    if sep:
+        account = account.strip()
+        if not account:
+            raise CredentialResolveError(
+                f"Reference '{schema}:{target}' has empty account after '@'"
+            )
+    else:
+        try:
+            account = getpass.getuser()
+        except Exception:
+            account = os.environ.get("USER", "")
+    if not service:
+        raise CredentialResolveError(
+            f"Reference '{schema}:{target}' has empty service"
+        )
+    if not account:
+        raise CredentialResolveError(
+            f"Reference '{schema}:{target}' has no account and current user is unknown"
+        )
+    return service, account
+
+
+def _lookup_macos_keychain(target: str) -> str:
+    service, account = _split_service_account(target, "keychain")
+    if shutil.which("security") is None:
+        raise CredentialResolveError(
+            "macOS 'security' CLI not found — 'keychain:' references work only on macOS"
+        )
+    try:
+        result = subprocess.run(
+            ["security", "find-generic-password", "-w", "-a", account, "-s", service],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except subprocess.TimeoutExpired:
+        raise CredentialResolveError(
+            f"Keychain lookup timed out for service='{service}' account='{account}'"
+        ) from None
+    if result.returncode != 0:
+        raise CredentialResolveError(
+            f"Keychain item not found: service='{service}' account='{account}' "
+            f"(security exit {result.returncode}: {result.stderr.strip() or 'no output'})"
+        )
+    secret = result.stdout.rstrip("\n")
+    if not secret:
+        raise CredentialResolveError(
+            f"Keychain item is empty: service='{service}' account='{account}'"
+        )
+    return secret
+
+
+def _lookup_secret_tool(target: str) -> str:
+    service, account = _split_service_account(target, "secret-tool")
+    if shutil.which("secret-tool") is None:
+        raise CredentialResolveError(
+            "'secret-tool' CLI not found — install libsecret-tools (Linux/GNOME Keyring)"
+        )
+    try:
+        result = subprocess.run(
+            ["secret-tool", "lookup", "service", service, "account", account],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except subprocess.TimeoutExpired:
+        raise CredentialResolveError(
+            f"secret-tool lookup timed out for service='{service}' account='{account}'"
+        ) from None
+    if result.returncode != 0 or not result.stdout:
+        raise CredentialResolveError(
+            f"secret-tool item not found: service='{service}' account='{account}' "
+            f"(exit {result.returncode}: {result.stderr.strip() or 'no output'})"
+        )
+    return result.stdout.rstrip("\n")

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -11,6 +11,7 @@ logger = logging.getLogger(__name__)
 
 from hermes_cli import auth as auth_mod
 from agent.credential_pool import CredentialPool, PooledCredential, get_custom_provider_pool_key, load_pool
+from agent.credential_resolver import CredentialResolveError, resolve_credential_string
 from hermes_cli.auth import (
     AuthError,
     DEFAULT_CODEX_BASE_URL,
@@ -115,6 +116,15 @@ def _get_model_config() -> Dict[str, Any]:
         # Accept "model" as alias for "default" (users intuitively write model.model)
         if not cfg.get("default") and cfg.get("model"):
             cfg["default"] = cfg["model"]
+        # Resolve api_key references like 'env:VAR', 'keychain:svc/acct',
+        # 'secret-tool:svc/acct'. Plain literals pass through unchanged.
+        raw_key = cfg.get("api_key")
+        if isinstance(raw_key, str) and raw_key.strip():
+            try:
+                cfg["api_key"] = resolve_credential_string(raw_key)
+            except CredentialResolveError as exc:
+                logger.error("model.api_key reference failed: %s", exc)
+                cfg["api_key"] = ""
         default = (cfg.get("default") or "").strip()
         base_url = (cfg.get("base_url") or "").strip()
         is_local = "localhost" in base_url or "127.0.0.1" in base_url

--- a/tests/agent/test_credential_resolver.py
+++ b/tests/agent/test_credential_resolver.py
@@ -1,0 +1,176 @@
+"""Unit tests for ``agent.credential_resolver``.
+
+The resolver lets users put references like ``env:VAR`` or
+``keychain:service/account`` in config fields where Hermes previously
+expected a literal API key. These tests cover the four supported forms
+plus the failure modes.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.credential_resolver import (
+    CredentialResolveError,
+    resolve_credential_string,
+)
+
+
+# ─── plain pass-through ──────────────────────────────────────────────────
+
+
+def test_literal_value_returned_unchanged():
+    assert resolve_credential_string("sk-abc123") == "sk-abc123"
+
+
+def test_value_is_stripped():
+    assert resolve_credential_string("  sk-abc123  ") == "sk-abc123"
+
+
+def test_empty_string_returns_empty():
+    assert resolve_credential_string("") == ""
+    assert resolve_credential_string("   ") == ""
+
+
+def test_non_string_returned_unchanged():
+    assert resolve_credential_string(None) is None  # type: ignore[arg-type]
+    assert resolve_credential_string(123) == 123  # type: ignore[arg-type]
+
+
+def test_unknown_prefix_treated_as_literal():
+    # Anything not matching env:/keychain:/secret-tool: passes through.
+    assert resolve_credential_string("https://example/key") == "https://example/key"
+
+
+# ─── env: schema ─────────────────────────────────────────────────────────
+
+
+def test_env_schema_resolves_from_environment(monkeypatch):
+    monkeypatch.setenv("HERMES_TEST_KEY", "value-from-env")
+    assert resolve_credential_string("env:HERMES_TEST_KEY") == "value-from-env"
+
+
+def test_env_schema_missing_var_raises(monkeypatch):
+    monkeypatch.delenv("HERMES_TEST_KEY_MISSING", raising=False)
+    with pytest.raises(CredentialResolveError, match="HERMES_TEST_KEY_MISSING"):
+        resolve_credential_string("env:HERMES_TEST_KEY_MISSING")
+
+
+def test_env_schema_empty_var_raises(monkeypatch):
+    monkeypatch.setenv("HERMES_TEST_KEY_EMPTY", "")
+    with pytest.raises(CredentialResolveError, match="empty"):
+        resolve_credential_string("env:HERMES_TEST_KEY_EMPTY")
+
+
+def test_env_schema_empty_target_raises():
+    with pytest.raises(CredentialResolveError, match="Empty reference"):
+        resolve_credential_string("env:")
+
+
+# ─── keychain: schema ────────────────────────────────────────────────────
+
+
+def _make_subprocess_result(returncode: int, stdout: str = "", stderr: str = "") -> MagicMock:
+    result = MagicMock()
+    result.returncode = returncode
+    result.stdout = stdout
+    result.stderr = stderr
+    return result
+
+
+def test_keychain_resolves_via_security_cli():
+    """Explicit account form 'service@account'."""
+    with patch("agent.credential_resolver.shutil.which", return_value="/usr/bin/security"), \
+         patch("agent.credential_resolver.subprocess.run") as run:
+        run.return_value = _make_subprocess_result(0, stdout="secret-value\n")
+        assert resolve_credential_string("keychain:my-service@my-account") == "secret-value"
+        args = run.call_args.args[0]
+        assert args[0:3] == ["security", "find-generic-password", "-w"]
+        assert "-a" in args and args[args.index("-a") + 1] == "my-account"
+        assert "-s" in args and args[args.index("-s") + 1] == "my-service"
+
+
+def test_keychain_default_account_is_current_user():
+    """Without '@account', current user is used (mirrors common security-cli usage)."""
+    with patch("agent.credential_resolver.shutil.which", return_value="/usr/bin/security"), \
+         patch("agent.credential_resolver.subprocess.run") as run, \
+         patch("agent.credential_resolver.getpass.getuser", return_value="testuser"):
+        run.return_value = _make_subprocess_result(0, stdout="secret-value\n")
+        assert resolve_credential_string("keychain:ai-system/litellm-master-key") == "secret-value"
+        args = run.call_args.args[0]
+        # Service preserves slashes
+        assert args[args.index("-s") + 1] == "ai-system/litellm-master-key"
+        # Account defaults to current user
+        assert args[args.index("-a") + 1] == "testuser"
+
+
+def test_keychain_missing_security_cli_raises():
+    with patch("agent.credential_resolver.shutil.which", return_value=None):
+        with pytest.raises(CredentialResolveError, match="security"):
+            resolve_credential_string("keychain:foo/bar")
+
+
+def test_keychain_item_not_found_raises():
+    with patch("agent.credential_resolver.shutil.which", return_value="/usr/bin/security"), \
+         patch("agent.credential_resolver.subprocess.run") as run:
+        run.return_value = _make_subprocess_result(44, stderr="not found")
+        with pytest.raises(CredentialResolveError, match="not found"):
+            resolve_credential_string("keychain:foo/bar")
+
+
+def test_keychain_empty_value_raises():
+    with patch("agent.credential_resolver.shutil.which", return_value="/usr/bin/security"), \
+         patch("agent.credential_resolver.subprocess.run") as run:
+        run.return_value = _make_subprocess_result(0, stdout="\n")
+        with pytest.raises(CredentialResolveError, match="empty"):
+            resolve_credential_string("keychain:foo/bar")
+
+
+def test_keychain_timeout_raises():
+    with patch("agent.credential_resolver.shutil.which", return_value="/usr/bin/security"), \
+         patch(
+             "agent.credential_resolver.subprocess.run",
+             side_effect=subprocess.TimeoutExpired(cmd=["security"], timeout=5),
+         ):
+        with pytest.raises(CredentialResolveError, match="timed out"):
+            resolve_credential_string("keychain:foo/bar")
+
+
+def test_keychain_malformed_target_raises():
+    # Empty account explicitly given via '@'
+    with pytest.raises(CredentialResolveError, match="empty account"):
+        resolve_credential_string("keychain:svc@")
+    # Empty service before '@'
+    with pytest.raises(CredentialResolveError, match="empty service"):
+        resolve_credential_string("keychain:@account-only")
+
+
+# ─── secret-tool: schema ─────────────────────────────────────────────────
+
+
+def test_secret_tool_resolves_via_cli():
+    with patch("agent.credential_resolver.shutil.which", return_value="/usr/bin/secret-tool"), \
+         patch("agent.credential_resolver.subprocess.run") as run:
+        run.return_value = _make_subprocess_result(0, stdout="linux-secret\n")
+        assert resolve_credential_string("secret-tool:my-svc@my-acc") == "linux-secret"
+        args = run.call_args.args[0]
+        assert args[0:2] == ["secret-tool", "lookup"]
+        assert "service" in args and args[args.index("service") + 1] == "my-svc"
+        assert "account" in args and args[args.index("account") + 1] == "my-acc"
+
+
+def test_secret_tool_missing_cli_raises():
+    with patch("agent.credential_resolver.shutil.which", return_value=None):
+        with pytest.raises(CredentialResolveError, match="secret-tool"):
+            resolve_credential_string("secret-tool:foo/bar")
+
+
+def test_secret_tool_not_found_raises():
+    with patch("agent.credential_resolver.shutil.which", return_value="/usr/bin/secret-tool"), \
+         patch("agent.credential_resolver.subprocess.run") as run:
+        run.return_value = _make_subprocess_result(1, stdout="", stderr="No matching items")
+        with pytest.raises(CredentialResolveError, match="not found"):
+            resolve_credential_string("secret-tool:foo/bar")


### PR DESCRIPTION
## Motivation

Hermes currently expects `model.api_key` (and `custom_providers[*].api_key`) to be a plaintext string. For users who already keep secrets in an OS keychain or environment variable, the only options today are:

- copy the secret into the YAML file (which lands in backups, accidentally gets shared with `hermes dump`, and clashes with project policies that ban plaintext credentials in repo-tracked configs), or
- write a wrapper script that templates the config at startup.

This PR adds an opt-in schema layer so a config field can hold a *reference* to the secret instead of the secret itself.

## What changes

Recognised reference forms (everything else passes through unchanged):

| Form | Source |
|---|---|
| `env:VAR` | `os.environ[VAR]` |
| `keychain:service[@account]` | macOS Keychain via `security find-generic-password` |
| `secret-tool:service[@account]` | Linux GNOME Keyring via `secret-tool lookup` |

The optional `@account` suffix selects a specific keychain account. When omitted, the current user (`getpass.getuser()` / `$USER`) is used — which matches the common convention `security find-generic-password -a "$USER" -s "<service>"`. The `@` choice (rather than `/`) lets service names contain slashes (e.g. `keychain:ai-system/litellm-master-key`) without ambiguity.

## Touchpoints

- **`agent/credential_resolver.py`** — new module, ~140 LoC. Pure resolver, no Hermes-internal imports, easy to test in isolation.
- **`hermes_cli/runtime_provider.py`** — `_get_model_config()` resolves `model.api_key` once, so every downstream consumer (auxiliary client, runtime dict, OpenAI SDK) sees the resolved value. Single point of truth.
- **`agent/credential_pool.py`** — `_seed_custom_pool()` resolves `custom_providers[*].api_key` and the `model_config`-seeded api_key analogously. Belt-and-suspenders for the named-custom-provider path.

## Failure mode

Resolution failures (missing env var, missing keychain item, missing CLI tool, malformed reference, timeout) raise `CredentialResolveError` with a clear message. At each call site the error is logged and the key is cleared rather than letting Hermes silently send a half-valid `Bearer keychain:...` header to the upstream provider — that produced confusing 400s during development.

## Backwards compatibility

A string without one of the recognised prefixes (`env:`, `keychain:`, `secret-tool:`) is returned unchanged. Existing plaintext configs keep working as before. All 45 existing tests in `tests/agent/test_credential_pool*.py` still pass.

## Test plan

- [x] 19 new unit tests in `tests/agent/test_credential_resolver.py` cover:
  - plaintext pass-through (incl. stripping, empty, non-string, unknown prefix)
  - `env:` happy path, missing var, empty var, empty target
  - `keychain:` explicit `@account`, default account = current user, missing `security` CLI, exit code != 0, empty output, timeout, malformed targets
  - `secret-tool:` happy path, missing CLI, item not found
- [x] Subprocess calls are mocked — no real keychain/secret-tool needed in CI.
- [x] All existing `tests/agent/test_credential_pool.py` and `test_credential_pool_routing.py` tests pass unchanged.
- [x] Live verified end-to-end on macOS (M5): `~/.hermes/config.yaml` with `api_key: keychain:ai-system/litellm-master-key` produces a 200 OK against a local LiteLLM proxy. Broken reference produces a clear ERROR log line and a downstream 400 from the proxy (no silent fallback).

## Notes for reviewers

- The `@account` delimiter was chosen over a `/` split so service names matching real-world keychain conventions (`ai-system/litellm-master-key`, `org/team-name/key`) work without escaping.
- `CredentialResolveError` extends `RuntimeError` to keep the import surface flat — no new public exception hierarchy.
- The resolver imports only stdlib (`getpass`, `os`, `shutil`, `subprocess`). No new dependencies.