### PR TITLE
fix(terminal): cd to configured cwd before shell snapshot capture

### DIFF
--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -334,8 +334,13 @@ class BaseEnvironment(ABC):
         ``_snapshot_ready = True`` so subsequent commands source the snapshot
         instead of running with ``bash -l``.
         """
+        # Start in the configured cwd so the snapshot captures the right directory.
+        quoted_cwd = (
+            shlex.quote(self.cwd) if self.cwd != "~" and not self.cwd.startswith("~/") else self.cwd
+        )
         # Full capture: env vars, functions (filtered), aliases, shell options.
         bootstrap = (
+            f"cd {quoted_cwd} 2>/dev/null || true\n"
             f"export -p > {self._snapshot_path}\n"
             f"declare -f | grep -vE '^_[^_]' >> {self._snapshot_path}\n"
             f"alias -p >> {self._snapshot_path}\n"


### PR DESCRIPTION
## Problem
When terminal tools create a shell session snapshot, they capture environment variables (including `PWD`) from the shell's default directory — often the systemd `WorkingDirectory` — rather than the configured `TERMINAL_CWD`. This causes subsequent commands to inherit incorrect cwd state.

## Solution
Add `cd {quoted_cwd}` before the snapshot capture commands, ensuring `export -p` and `pwd -P` record the correct directory.

## Changes
- `tools/environments/base.py`: Add cwd quoting and `cd` command to `init_session()` bootstrap

## Testing
- [ ] Verify `pwd` returns correct path after first terminal command in gateway mode
- [ ] Verify `echo $PWD` matches configured `terminal.cwd` in snapshot

## Related
- Complements #11029 (CWD source consolidation)
- Fixes edge case where snapshot captures wrong directory before first command