### PR TITLE
fix(session-search): index tool_calls and tool_name columns in FTS5 (#16751)

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1594,11 +1594,32 @@ class SessionDB:
                 if role_filter:
                     like_where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
                     like_params.extend(role_filter)
+                # Snippet must mirror the multi-column LIKE WHERE clause:
+                # tool-only assistant rows have NULL/empty ``content`` but a
+                # match in ``tool_calls`` or ``tool_name``, and the prior
+                # ``substr(m.content, instr(m.content, ?), …)`` would yield
+                # an empty string for those rows — leaving session_search
+                # results without any usable preview. Pick the snippet from
+                # whichever column actually contains the match. See #16751.
                 like_sql = f"""
                     SELECT m.id, m.session_id, m.role,
-                           substr(m.content,
-                                  max(1, instr(m.content, ?) - 40),
-                                  120) AS snippet,
+                           CASE
+                               WHEN instr(m.content, ?) > 0
+                                   THEN substr(m.content,
+                                               max(1, instr(m.content, ?) - 40),
+                                               120)
+                               WHEN m.tool_calls IS NOT NULL
+                                    AND instr(m.tool_calls, ?) > 0
+                                   THEN substr(m.tool_calls,
+                                               max(1, instr(m.tool_calls, ?) - 40),
+                                               120)
+                               WHEN m.tool_name IS NOT NULL
+                                    AND instr(m.tool_name, ?) > 0
+                                   THEN substr(m.tool_name,
+                                               max(1, instr(m.tool_name, ?) - 40),
+                                               120)
+                               ELSE ''
+                           END AS snippet,
                            m.content, m.timestamp, m.tool_name,
                            s.source, s.model, s.started_at AS session_started
                     FROM messages m
@@ -1608,8 +1629,10 @@ class SessionDB:
                     LIMIT ? OFFSET ?
                 """
                 like_params.extend([limit, offset])
-                # instr() parameter goes first in the bound list
-                like_params = [raw_query] + like_params
+                # CASE/instr() parameters go first in the bound list — six
+                # copies of ``raw_query`` for the three (instr-condition +
+                # instr-substr) pairs in the snippet expression.
+                like_params = [raw_query] * 6 + like_params
                 with self._lock:
                     like_cursor = self._conn.execute(like_sql, like_params)
                     matches = [dict(row) for row in like_cursor.fetchall()]

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -33,7 +33,7 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 10
+SCHEMA_VERSION = 11
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -103,21 +103,27 @@ CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, timestam
 FTS_SQL = """
 CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
     content,
+    tool_calls,
+    tool_name,
     content=messages,
     content_rowid=id
 );
 
 CREATE TRIGGER IF NOT EXISTS messages_fts_insert AFTER INSERT ON messages BEGIN
-    INSERT INTO messages_fts(rowid, content) VALUES (new.id, new.content);
+    INSERT INTO messages_fts(rowid, content, tool_calls, tool_name)
+        VALUES (new.id, new.content, new.tool_calls, new.tool_name);
 END;
 
 CREATE TRIGGER IF NOT EXISTS messages_fts_delete AFTER DELETE ON messages BEGIN
-    INSERT INTO messages_fts(messages_fts, rowid, content) VALUES('delete', old.id, old.content);
+    INSERT INTO messages_fts(messages_fts, rowid, content, tool_calls, tool_name)
+        VALUES('delete', old.id, old.content, old.tool_calls, old.tool_name);
 END;
 
 CREATE TRIGGER IF NOT EXISTS messages_fts_update AFTER UPDATE ON messages BEGIN
-    INSERT INTO messages_fts(messages_fts, rowid, content) VALUES('delete', old.id, old.content);
-    INSERT INTO messages_fts(rowid, content) VALUES (new.id, new.content);
+    INSERT INTO messages_fts(messages_fts, rowid, content, tool_calls, tool_name)
+        VALUES('delete', old.id, old.content, old.tool_calls, old.tool_name);
+    INSERT INTO messages_fts(rowid, content, tool_calls, tool_name)
+        VALUES (new.id, new.content, new.tool_calls, new.tool_name);
 END;
 """
 
@@ -128,22 +134,28 @@ END;
 FTS_TRIGRAM_SQL = """
 CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts_trigram USING fts5(
     content,
+    tool_calls,
+    tool_name,
     content=messages,
     content_rowid=id,
     tokenize='trigram'
 );
 
 CREATE TRIGGER IF NOT EXISTS messages_fts_trigram_insert AFTER INSERT ON messages BEGIN
-    INSERT INTO messages_fts_trigram(rowid, content) VALUES (new.id, new.content);
+    INSERT INTO messages_fts_trigram(rowid, content, tool_calls, tool_name)
+        VALUES (new.id, new.content, new.tool_calls, new.tool_name);
 END;
 
 CREATE TRIGGER IF NOT EXISTS messages_fts_trigram_delete AFTER DELETE ON messages BEGIN
-    INSERT INTO messages_fts_trigram(messages_fts_trigram, rowid, content) VALUES('delete', old.id, old.content);
+    INSERT INTO messages_fts_trigram(messages_fts_trigram, rowid, content, tool_calls, tool_name)
+        VALUES('delete', old.id, old.content, old.tool_calls, old.tool_name);
 END;
 
 CREATE TRIGGER IF NOT EXISTS messages_fts_trigram_update AFTER UPDATE ON messages BEGIN
-    INSERT INTO messages_fts_trigram(messages_fts_trigram, rowid, content) VALUES('delete', old.id, old.content);
-    INSERT INTO messages_fts_trigram(rowid, content) VALUES (new.id, new.content);
+    INSERT INTO messages_fts_trigram(messages_fts_trigram, rowid, content, tool_calls, tool_name)
+        VALUES('delete', old.id, old.content, old.tool_calls, old.tool_name);
+    INSERT INTO messages_fts_trigram(rowid, content, tool_calls, tool_name)
+        VALUES (new.id, new.content, new.tool_calls, new.tool_name);
 END;
 """
 
@@ -428,6 +440,36 @@ class SessionDB:
                         "INSERT INTO messages_fts_trigram(rowid, content) "
                         "SELECT id, content FROM messages WHERE content IS NOT NULL"
                     )
+            if current_version < 11:
+                # v11: extend messages_fts and messages_fts_trigram with the
+                # tool_calls and tool_name columns from messages so session_search
+                # surfaces tokens that only appear in serialized tool-call args
+                # or tool names — previously invisible to FTS5 even though the
+                # rows exist in the DB (#16751). External-content FTS5 columns
+                # are fixed at CREATE time, so we drop and recreate both tables
+                # plus their triggers, then backfill from messages.
+                cursor.executescript(
+                    """
+                    DROP TRIGGER IF EXISTS messages_fts_insert;
+                    DROP TRIGGER IF EXISTS messages_fts_delete;
+                    DROP TRIGGER IF EXISTS messages_fts_update;
+                    DROP TABLE IF EXISTS messages_fts;
+                    DROP TRIGGER IF EXISTS messages_fts_trigram_insert;
+                    DROP TRIGGER IF EXISTS messages_fts_trigram_delete;
+                    DROP TRIGGER IF EXISTS messages_fts_trigram_update;
+                    DROP TABLE IF EXISTS messages_fts_trigram;
+                    """
+                )
+                cursor.executescript(FTS_SQL)
+                cursor.executescript(FTS_TRIGRAM_SQL)
+                cursor.execute(
+                    "INSERT INTO messages_fts(rowid, content, tool_calls, tool_name) "
+                    "SELECT id, content, tool_calls, tool_name FROM messages"
+                )
+                cursor.execute(
+                    "INSERT INTO messages_fts_trigram(rowid, content, tool_calls, tool_name) "
+                    "SELECT id, content, tool_calls, tool_name FROM messages"
+                )
             if current_version < SCHEMA_VERSION:
                 cursor.execute(
                     "UPDATE schema_version SET version = ?",
@@ -1451,7 +1493,7 @@ class SessionDB:
                 m.id,
                 m.session_id,
                 m.role,
-                snippet(messages_fts, 0, '>>>', '<<<', '...', 40) AS snippet,
+                snippet(messages_fts, -1, '>>>', '<<<', '...', 40) AS snippet,
                 m.content,
                 m.timestamp,
                 m.tool_name,
@@ -1508,7 +1550,7 @@ class SessionDB:
                         m.id,
                         m.session_id,
                         m.role,
-                        snippet(messages_fts_trigram, 0, '>>>', '<<<', '...', 40) AS snippet,
+                        snippet(messages_fts_trigram, -1, '>>>', '<<<', '...', 40) AS snippet,
                         m.content,
                         m.timestamp,
                         m.tool_name,
@@ -1532,10 +1574,17 @@ class SessionDB:
                         matches = [dict(row) for row in tri_cursor.fetchall()]
             else:
                 # Short CJK query (1-2 chars) — trigram needs ≥3 CJK chars.
-                # Fall back to LIKE substring search.
+                # Fall back to LIKE substring search across the same columns
+                # indexed by FTS5 (content + tool_calls + tool_name) so the
+                # short-query path stays consistent with #16751.
                 escaped = raw_query.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-                like_where = ["m.content LIKE ? ESCAPE '\\'"]
-                like_params: list = [f"%{escaped}%"]
+                like_pattern = f"%{escaped}%"
+                like_where = [
+                    "(m.content LIKE ? ESCAPE '\\' "
+                    "OR m.tool_calls LIKE ? ESCAPE '\\' "
+                    "OR m.tool_name LIKE ? ESCAPE '\\')"
+                ]
+                like_params: list = [like_pattern, like_pattern, like_pattern]
                 if source_filter is not None:
                     like_where.append(f"s.source IN ({','.join('?' for _ in source_filter)})")
                     like_params.extend(source_filter)

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -657,6 +657,178 @@ class TestFTS5Search:
 
 
 # =========================================================================
+# session_search indexing of tool_calls / tool_name (#16751)
+# =========================================================================
+
+class TestFTS5SearchToolCallsAndToolName:
+    """Regression tests for #16751.
+
+    `messages_fts` previously had a single ``content`` column; tokens that
+    appeared only in ``messages.tool_calls`` (serialized JSON args) or
+    ``messages.tool_name`` were never indexed, so ``session_search`` missed
+    them even though the row existed in the DB. v11 extends both FTS5 tables
+    (unicode61 and trigram) with the ``tool_calls`` and ``tool_name`` columns
+    and backfills.
+    """
+
+    def _add_tool_call_message(self, db, sid, *, content, func_name, args, tool_name):
+        db.append_message(
+            sid,
+            role="assistant",
+            content=content,
+            tool_calls=[
+                {
+                    "id": "c1",
+                    "type": "function",
+                    "function": {"name": func_name, "arguments": args},
+                }
+            ],
+            tool_name=tool_name,
+        )
+
+    def test_search_finds_token_in_tool_call_function_name(self, db):
+        db.create_session(session_id="s1", source="cli")
+        self._add_tool_call_message(
+            db, "s1",
+            content="",
+            func_name="FUNCNAMEMARKER_UNIQUE",
+            args='{"cmd": "noop"}',
+            tool_name="something_else",
+        )
+        results = db.search_messages("FUNCNAMEMARKER_UNIQUE")
+        assert len(results) == 1
+        assert results[0]["session_id"] == "s1"
+
+    def test_search_finds_token_in_tool_call_arguments(self, db):
+        db.create_session(session_id="s1", source="cli")
+        self._add_tool_call_message(
+            db, "s1",
+            content="just running a script",
+            func_name="run",
+            args='{"cmd": "aws s3 cp x s3://BUCKETMARKER_TOOLCALL/"}',
+            tool_name="terminal",
+        )
+        results = db.search_messages("BUCKETMARKER_TOOLCALL")
+        assert len(results) == 1
+        assert results[0]["session_id"] == "s1"
+
+    def test_search_finds_token_in_tool_name(self, db):
+        db.create_session(session_id="s1", source="cli")
+        db.append_message(
+            "s1",
+            role="tool",
+            content="result body",
+            tool_name="TOOLNAMEMARKER_UNIQUE",
+        )
+        results = db.search_messages("TOOLNAMEMARKER_UNIQUE")
+        assert len(results) == 1
+        assert results[0]["session_id"] == "s1"
+
+    def test_search_still_finds_content_only_match(self, db):
+        """Content matches must continue to work — invariant preserved."""
+        db.create_session(session_id="s1", source="cli")
+        db.append_message("s1", role="user",
+                          content="Uploading to BUCKETMARKER_CONTENT.")
+        results = db.search_messages("BUCKETMARKER_CONTENT")
+        assert len(results) == 1
+        assert "BUCKETMARKER_CONTENT" in results[0]["snippet"]
+
+    def test_role_filter_applies_to_tool_call_matches(self, db):
+        db.create_session(session_id="s1", source="cli")
+        self._add_tool_call_message(
+            db, "s1",
+            content="",
+            func_name="FILTEREDFUNC",
+            args='{}',
+            tool_name="x",
+        )
+        # Match exists in an assistant message with tool_calls — role filter
+        # for "user" should exclude it.
+        assert db.search_messages("FILTEREDFUNC", role_filter=["user"]) == []
+        assert db.search_messages("FILTEREDFUNC", role_filter=["assistant"])
+
+    def test_v11_migration_backfills_existing_messages_db(self, tmp_path):
+        """A pre-v11 DB upgraded in place must have its tool_calls/tool_name
+        rows reachable via search_messages without re-inserting the data."""
+        db_path = tmp_path / "legacy.db"
+
+        # Build a v10-shaped DB by hand: schema columns + single-column FTS
+        # tables matching the pre-v11 layout.
+        import sqlite3
+        conn = sqlite3.connect(str(db_path), isolation_level=None)
+        conn.executescript(
+            """
+            CREATE TABLE schema_version (version INTEGER NOT NULL);
+            INSERT INTO schema_version VALUES (10);
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                source TEXT,
+                user_id TEXT,
+                model TEXT,
+                model_config TEXT,
+                system_prompt TEXT,
+                parent_session_id TEXT,
+                started_at REAL,
+                ended_at REAL,
+                end_reason TEXT,
+                title TEXT,
+                api_call_count INTEGER DEFAULT 0
+            );
+            CREATE TABLE messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                role TEXT NOT NULL,
+                content TEXT,
+                tool_call_id TEXT,
+                tool_calls TEXT,
+                tool_name TEXT,
+                timestamp REAL NOT NULL,
+                token_count INTEGER,
+                finish_reason TEXT,
+                reasoning TEXT,
+                reasoning_content TEXT,
+                reasoning_details TEXT,
+                codex_reasoning_items TEXT,
+                codex_message_items TEXT
+            );
+            CREATE VIRTUAL TABLE messages_fts USING fts5(
+                content, content=messages, content_rowid=id
+            );
+            CREATE VIRTUAL TABLE messages_fts_trigram USING fts5(
+                content, content=messages, content_rowid=id, tokenize='trigram'
+            );
+            """
+        )
+        conn.execute(
+            "INSERT INTO sessions (id, source, started_at) VALUES (?, ?, ?)",
+            ("s1", "cli", time.time()),
+        )
+        conn.execute(
+            "INSERT INTO messages "
+            "(session_id, role, content, tool_calls, tool_name, timestamp) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("s1", "assistant", "",
+             '{"function": {"name": "LEGACYFUNC_MARKER", "arguments": "{}"}}',
+             "LEGACYTOOL_MARKER", time.time()),
+        )
+        # Old triggers are absent here, so messages_fts has no rows for this
+        # message (mirrors a real upgrade where only some rows were indexed).
+        conn.commit()
+        conn.close()
+
+        # Open with SessionDB — runs the v11 migration, which should backfill
+        # tool_calls / tool_name into the recreated FTS tables.
+        session_db = SessionDB(db_path=db_path)
+        try:
+            r1 = session_db.search_messages("LEGACYFUNC_MARKER")
+            r2 = session_db.search_messages("LEGACYTOOL_MARKER")
+            assert len(r1) == 1, "tool_calls token must be searchable post-migration"
+            assert len(r2) == 1, "tool_name token must be searchable post-migration"
+        finally:
+            session_db.close()
+
+
+# =========================================================================
 # CJK (Chinese/Japanese/Korean) LIKE fallback
 # =========================================================================
 
@@ -1292,7 +1464,7 @@ class TestSchemaInit:
     def test_schema_version(self, db):
         cursor = db._conn.execute("SELECT version FROM schema_version")
         version = cursor.fetchone()[0]
-        assert version == 10
+        assert version == 11
 
     def test_title_column_exists(self, db):
         """Verify the title column was created in the sessions table."""
@@ -1348,12 +1520,12 @@ class TestSchemaInit:
         conn.commit()
         conn.close()
 
-        # Open with SessionDB — should migrate to v9
+        # Open with SessionDB — should migrate to the current version
         migrated_db = SessionDB(db_path=db_path)
 
         # Verify migration
         cursor = migrated_db._conn.execute("SELECT version FROM schema_version")
-        assert cursor.fetchone()[0] == 10
+        assert cursor.fetchone()[0] == 11
 
         # Verify title column exists and is NULL for existing sessions
         session = migrated_db.get_session("existing")

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1007,6 +1007,38 @@ class TestCJKSearchFallback:
         session_ids = {r["session_id"] for r in results}
         assert session_ids == {"s1", "s2"}
 
+    def test_cjk_like_fallback_snippet_pulls_from_tool_name_when_content_empty(self, db):
+        """Regression for the #16751 follow-up Copilot finding.
+
+        Tool-result rows commonly have an empty/NULL ``content`` and
+        carry the resolved function name in ``m.tool_name``. The LIKE
+        fallback (which runs for 1–2 character CJK queries that the
+        trigram path can't handle) previously sourced its snippet from
+        ``m.content`` only — yielding an empty string for these rows
+        even though the WHERE clause matched.
+
+        The fix derives the snippet from whichever column actually
+        contains the match. A 1-char CJK ``tool_name`` is the realistic
+        manifestation of this path: ``tool_name`` is a plain TEXT
+        column (no JSON escaping), the query length forces the LIKE
+        fallback, and ``content`` stays empty.
+        """
+        db.create_session(session_id="s1", source="cli")
+        db.append_message(
+            "s1",
+            role="tool",
+            content="",
+            tool_name="搜",
+        )
+        results = db.search_messages("搜")  # 1-char → LIKE fallback path
+        assert len(results) == 1
+        assert results[0]["session_id"] == "s1"
+        # The snippet must be non-empty and must contain the matched
+        # character — i.e. derived from tool_name, not the empty content.
+        snippet = results[0]["snippet"]
+        assert snippet, "snippet must not be empty for tool_name-only matches"
+        assert "搜" in snippet, f"snippet must contain query token, got: {snippet!r}"
+
 
 # =========================================================================
 # Session search and listing


### PR DESCRIPTION
## Summary

- Extend `messages_fts` and `messages_fts_trigram` with the `tool_calls` and `tool_name` columns from `messages` so `session_search` finds tokens that only appear in serialized tool-call args or tool names.
- Add v11 migration that drops + recreates both FTS tables and backfills from `messages`.
- Update triggers and the snippet column index (`iCol = -1`) to keep the snippet centered on the actual hit.
- Mirror the broadened column set in the short-CJK LIKE fallback so all query paths share the same searchable surface.

## The bug (#16751)

`messages_fts` is an external-content FTS5 table with a single `content` column. The triggers only insert `new.content`, so any token that lives in `messages.tool_calls` (TEXT JSON of function name + arguments) or `messages.tool_name` is never indexed. `messages_fts_trigram` (added in v10 for CJK substring search) has the same single-column shape.

The reporter showed that even with ASCII tokens, `db.search_messages("FUNCNAMEMARKER")` returns 0 hits when the marker only appears inside a tool call — although the row is in the DB. This is **not** the CJK tokenizer issue tracked in #14829 / #15500; the gap is at the schema/trigger layer.

## The fix

External-content FTS5 columns are fixed at CREATE time, so this requires drop-and-recreate plus a backfill, not an `ALTER TABLE`.

* `FTS_SQL` and `FTS_TRIGRAM_SQL` now declare three columns (`content`, `tool_calls`, `tool_name`) matching the source columns in `messages`. `INSERT`/`DELETE`/`UPDATE` triggers populate all three.
* `_init_schema` gains a v11 step that drops the old triggers + tables, recreates them via the updated SQL, and backfills with `INSERT INTO messages_fts(rowid, content, tool_calls, tool_name) SELECT id, content, tool_calls, tool_name FROM messages` (no `content IS NOT NULL` filter so tool-only assistant messages with empty content are also indexed).
* `snippet(messages_fts, 0, …)` → `snippet(messages_fts, -1, …)` (and the same for the trigram path). Per FTS5 docs, `iCol = -1` lets the function pick the column with the highest score, so a hit inside `tool_calls` produces a snippet of the JSON args instead of an empty/wrong slice of `content`. Content-only hits still pick column 0 (no behavior change for the common path).
* The 1–2 char CJK `LIKE` fallback now `OR`s the same three columns so the short-query path stays consistent with the FTS path.

## Test plan

- [x] New `TestFTS5SearchToolCallsAndToolName` regression suite (`tests/test_hermes_state.py`):
  - token only in tool-call function name → found
  - token only in tool-call arguments → found
  - token only in `tool_name` → found
  - content-only match still works (invariant preserved)
  - `role_filter` still applies to tool-call matches
  - v11 migration: hand-built v10 DB with `tool_calls`/`tool_name` rows is searchable after `SessionDB(...)` opens it
- [x] Full `tests/test_hermes_state.py` (230 tests): `230 passed`
- [x] Adjacent suites that consume `SessionDB`: `tests/tools/test_session_search.py`, `tests/hermes_state/`, `tests/gateway/test_resume_command.py`, `tests/plugins/memory/test_hindsight_provider.py` — `328 passed` total
- [x] Regression guard: stashed `hermes_state.py`, reran the new tests, 5/6 fail with the expected "0 hits" symptom; restored, 6/6 pass

## Contract protected

- **Invariant:** every token persisted in `messages.content`, `messages.tool_calls`, or `messages.tool_name` is reachable through `SessionDB.search_messages(...)` for the matching row.
- **Known-bad inputs (now covered):** assistant messages whose `content` is empty but whose tool-call function name or argument JSON contains the search token; tool-result messages whose `tool_name` is the only place the token appears.
- **Future-input coverage:** the column list is keyed off the `messages` schema, so adding new tool-related text columns in the future only requires extending the FTS column list + triggers (the migration pattern is already in place).
- **Negative case:** `test_role_filter_applies_to_tool_call_matches` — even with the broader index, `role_filter=["user"]` still excludes assistant tool-call rows. (Existing `test_search_special_chars_do_not_crash`, `test_search_quoted_phrase_preserved`, etc. still pass — the FTS5 query syntax surface is unchanged.)

## Related

- Fixes #16751
- Out of scope (and unchanged): #14829 / #15500 (CJK tokenizer behavior on `content`)