### PR TITLE
fix(error-classifier): add insufficient balance to billing patterns

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -91,6 +91,7 @@ class ClassifiedError:
 _BILLING_PATTERNS = [
     "insufficient credits",
     "insufficient_quota",
+    "insufficient balance",
     "credit balance",
     "credits have been exhausted",
     "top up your credits",


### PR DESCRIPTION
## Summary

DeepSeek API returns HTTP 400 with `"Insufficient Balance"` when account funds are depleted. This pattern was missing from `_BILLING_PATTERNS`, causing the error to be misclassified instead of triggering billing exhaustion handling (fallback to alternate provider, skip retry).

## Change

- Added `"insufficient balance"` to `_BILLING_PATTERNS` in `agent/error_classifier.py` (line 93)

## Context

Suggested by @teknium1 in review of #15586:
> insufficient balance billing pattern — this string is not yet in _BILLING_PATTERNS (agent/error_classifier.py line 90). A focused one-line PR or issue to add it would be welcome.