### PR TITLE
fix: resolve model aliases during claw migrate (#16745)

### DIFF
--- a/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
+++ b/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
@@ -1391,6 +1391,22 @@ class Migrator:
 
         model_str = model_str.strip()
 
+        # Resolve model alias against the catalog.
+        # OpenClaw can store a display name (e.g. "Claude Opus 4.6") in
+        # agents.defaults.model.  The actual API ID lives in
+        # agents.defaults.models (plural) under the "id" field.
+        model_catalog = config.get("agents", {}).get("defaults", {}).get("models", {})
+        if isinstance(model_catalog, dict) and model_str in model_catalog:
+            entry = model_catalog[model_str]
+            if isinstance(entry, dict) and entry.get("id"):
+                resolved = entry["id"]
+                provider = entry.get("provider", "")
+                if provider and "/" not in resolved:
+                    resolved = f"{provider}/{resolved}"
+                model_str = resolved
+            elif isinstance(entry, str):
+                model_str = entry
+
         if yaml is None:
             self.record("model-config", source_path, destination, "error", "PyYAML is not available")
             return


### PR DESCRIPTION
## Summary

`hermes claw migrate` copies the OpenClaw model setting verbatim as a display alias (e.g. `"Claude Opus 4.6"`) into `~/.hermes/config.yaml`, instead of resolving it to the actual API model ID (e.g. `claude-opus-4-6`). Hermes then sends the alias as the model parameter to the Anthropic API, which responds with HTTP 404 model not found.

## Root Cause

`migrate_model_config()` in `openclaw_to_hermes.py` reads `agents.defaults.model` and copies it directly. It never consults `agents.defaults.models` (plural) — the alias catalog that maps display names to API IDs. The catalog is only archived for manual review, never used for resolution.

## Fix

After stripping the model string, look it up in the `agents.defaults.models` catalog:
- If found with an `"id"` field, use the resolved API ID (prepending provider prefix if needed)
- If found as a plain string, use that directly
- If not found (already an API ID), pass through unchanged

**File changed:** `optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py` (+16 lines)

## Example

OpenClaw config:
```json
{
  "agents": {
    "defaults": {
      "model": "Claude Opus 4.6",
      "models": {
        "Claude Opus 4.6": { "id": "claude-opus-4-6", "provider": "anthropic" }
      }
    }
  }
}
```

**Before:** Hermes config gets `model: "Claude Opus 4.6"` → API returns 404
**After:** Hermes config gets `model: "anthropic/claude-opus-4-6"` → works correctly

Fixes #16745
