### PR TITLE
feat: add Gemini TTS persona prompt support

### DIFF
--- a/tests/tools/test_tts_gemini.py
+++ b/tests/tools/test_tts_gemini.py
@@ -193,9 +193,9 @@ class TestGenerateGeminiTts:
         config = {
             "gemini": {
                 "persona": {
-                    "profile": "Athena: warm and lucid.",
-                    "scene": "A private Telegram voice note to MK.",
-                    "sample_context": "Trusted technical partner.",
+                    "profile": "Assistant: warm and lucid.",
+                    "scene": "A private voice note to the user.",
+                    "sample_context": "Helpful assistant response.",
                     "style": "Empathetic",
                     "pacing": "Natural",
                     "accent": "Neutral",
@@ -205,18 +205,18 @@ class TestGenerateGeminiTts:
         }
 
         with patch("requests.post", return_value=mock_gemini_response) as mock_post:
-            _generate_gemini_tts("Hello MK.", str(tmp_path / "test.wav"), config)
+            _generate_gemini_tts("Hello there.", str(tmp_path / "test.wav"), config)
 
         prompt = mock_post.call_args[1]["json"]["contents"][0]["parts"][0]["text"]
-        assert "Voice profile: Athena: warm and lucid." in prompt
-        assert "Scene: A private Telegram voice note to MK." in prompt
-        assert "Sample context: Trusted technical partner." in prompt
+        assert "Voice profile: Assistant: warm and lucid." in prompt
+        assert "Scene: A private voice note to the user." in prompt
+        assert "Sample context: Helpful assistant response." in prompt
         assert "Style: Empathetic" in prompt
         assert "Pacing: Natural" in prompt
         assert "Accent: Neutral" in prompt
         assert "Director notes: Do not sound like an announcer." in prompt
         assert "Speak this text exactly:" in prompt
-        assert prompt.rstrip().endswith("Hello MK.")
+        assert prompt.rstrip().endswith("Hello there.")
 
     def test_http_error_raises_runtime_error(self, tmp_path, monkeypatch):
         from tools.tts_tool import _generate_gemini_tts

--- a/tests/tools/test_tts_gemini.py
+++ b/tests/tools/test_tts_gemini.py
@@ -174,6 +174,50 @@ class TestGenerateGeminiTts:
         payload = mock_post.call_args[1]["json"]
         assert payload["generationConfig"]["responseModalities"] == ["AUDIO"]
 
+    def test_temperature_is_included_when_configured(self, tmp_path, monkeypatch, mock_gemini_response):
+        from tools.tts_tool import _generate_gemini_tts
+
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        config = {"gemini": {"temperature": 0.75}}
+
+        with patch("requests.post", return_value=mock_gemini_response) as mock_post:
+            _generate_gemini_tts("Hi", str(tmp_path / "test.wav"), config)
+
+        payload = mock_post.call_args[1]["json"]
+        assert payload["generationConfig"]["temperature"] == 0.75
+
+    def test_persona_fields_are_compiled_into_tts_prompt(self, tmp_path, monkeypatch, mock_gemini_response):
+        from tools.tts_tool import _generate_gemini_tts
+
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        config = {
+            "gemini": {
+                "persona": {
+                    "profile": "Athena: warm and lucid.",
+                    "scene": "A private Telegram voice note to MK.",
+                    "sample_context": "Trusted technical partner.",
+                    "style": "Empathetic",
+                    "pacing": "Natural",
+                    "accent": "Neutral",
+                    "director_notes": "Do not sound like an announcer.",
+                }
+            }
+        }
+
+        with patch("requests.post", return_value=mock_gemini_response) as mock_post:
+            _generate_gemini_tts("Hello MK.", str(tmp_path / "test.wav"), config)
+
+        prompt = mock_post.call_args[1]["json"]["contents"][0]["parts"][0]["text"]
+        assert "Voice profile: Athena: warm and lucid." in prompt
+        assert "Scene: A private Telegram voice note to MK." in prompt
+        assert "Sample context: Trusted technical partner." in prompt
+        assert "Style: Empathetic" in prompt
+        assert "Pacing: Natural" in prompt
+        assert "Accent: Neutral" in prompt
+        assert "Director notes: Do not sound like an announcer." in prompt
+        assert "Speak this text exactly:" in prompt
+        assert prompt.rstrip().endswith("Hello MK.")
+
     def test_http_error_raises_runtime_error(self, tmp_path, monkeypatch):
         from tools.tts_tool import _generate_gemini_tts
 

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -632,6 +632,43 @@ def _wrap_pcm_as_wav(
     return riff_header + fmt_chunk + data_chunk_header + pcm_bytes
 
 
+def _build_gemini_tts_prompt(text: str, gemini_config: Dict[str, Any]) -> str:
+    """Compile optional Gemini TTS persona config into a natural-language prompt."""
+    persona = gemini_config.get("persona") if isinstance(gemini_config, dict) else None
+    if not isinstance(persona, dict):
+        return text
+
+    field_labels = (
+        ("profile", "Voice profile"),
+        ("scene", "Scene"),
+        ("sample_context", "Sample context"),
+        ("style", "Style"),
+        ("pacing", "Pacing"),
+        ("pace", "Pacing"),
+        ("accent", "Accent"),
+        ("director_notes", "Director notes"),
+        ("constraints", "Constraints"),
+    )
+    lines = []
+    seen_labels = set()
+    for key, label in field_labels:
+        if label in seen_labels:
+            continue
+        value = persona.get(key)
+        if isinstance(value, (list, tuple)):
+            value = "; ".join(str(v).strip() for v in value if str(v).strip())
+        elif value is not None:
+            value = str(value).strip()
+        if value:
+            lines.append(f"{label}: {value}")
+            seen_labels.add(label)
+
+    if not lines:
+        return text
+
+    return "\n".join(lines) + "\n\nSpeak this text exactly:\n" + text
+
+
 def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
     """Generate audio using Google Gemini TTS.
 
@@ -660,6 +697,8 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
     gemini_config = tts_config.get("gemini", {})
     model = str(gemini_config.get("model", DEFAULT_GEMINI_TTS_MODEL)).strip() or DEFAULT_GEMINI_TTS_MODEL
     voice = str(gemini_config.get("voice", DEFAULT_GEMINI_TTS_VOICE)).strip() or DEFAULT_GEMINI_TTS_VOICE
+    temperature = gemini_config.get("temperature")
+    prompt_text = _build_gemini_tts_prompt(text, gemini_config)
     base_url = str(
         gemini_config.get("base_url")
         or os.getenv("GEMINI_BASE_URL")
@@ -667,7 +706,7 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
     ).strip().rstrip("/")
 
     payload: Dict[str, Any] = {
-        "contents": [{"parts": [{"text": text}]}],
+        "contents": [{"parts": [{"text": prompt_text}]}],
         "generationConfig": {
             "responseModalities": ["AUDIO"],
             "speechConfig": {
@@ -677,6 +716,12 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
             },
         },
     }
+
+    if temperature is not None:
+        try:
+            payload["generationConfig"]["temperature"] = float(temperature)
+        except (TypeError, ValueError):
+            logger.warning("Ignoring invalid Gemini TTS temperature: %r", temperature)
 
     endpoint = f"{base_url}/models/{model}:generateContent"
     response = requests.post(


### PR DESCRIPTION
## Summary
- Add config-driven Gemini TTS persona prompt assembly
- Support optional Gemini TTS `temperature` in `generationConfig`
- Add tests covering persona prompt compilation and temperature payload behavior

## Details
This lets `tts.gemini.persona` fields shape the text prompt sent to Gemini TTS, including:

- `profile`
- `scene`
- `sample_context`
- `style`
- `pacing` / `pace`
- `accent`
- `director_notes`
- `constraints`

## Test Plan
- `python -m pytest tests/tools/test_tts_gemini.py -q`
- Result: `17 passed`
