### PR TITLE
fix: harden dashboard plugin APIs and run handling

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2280,7 +2280,7 @@ class APIServerAdapter(BasePlatformAdapter):
             result = agent.run_conversation(
                 user_message=user_message,
                 conversation_history=conversation_history,
-                task_id="default",
+                task_id=session_id or f"api_{uuid.uuid4().hex}",
             )
             usage = {
                 "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
@@ -2297,6 +2297,28 @@ class APIServerAdapter(BasePlatformAdapter):
 
     _MAX_CONCURRENT_RUNS = 10  # Prevent unbounded resource allocation
     _RUN_STREAM_TTL = 300  # seconds before orphaned runs are swept
+    _RUN_STREAM_QUEUE_MAX = 1000  # Bound queued SSE events for slow/non-consuming clients
+
+    @staticmethod
+    def _put_run_event_nowait(q: "asyncio.Queue[Optional[Dict]]", event: Optional[Dict]) -> None:
+        """Put an event into a bounded run queue, dropping oldest queued events if full."""
+        try:
+            q.put_nowait(event)
+            return
+        except asyncio.QueueFull:
+            pass
+        try:
+            q.get_nowait()
+        except asyncio.QueueEmpty:
+            pass
+        try:
+            q.put_nowait(event)
+        except asyncio.QueueFull:
+            pass
+
+    def _schedule_run_event(self, loop: "asyncio.AbstractEventLoop", q: "asyncio.Queue[Optional[Dict]]", event: Optional[Dict]) -> None:
+        """Thread-safe wrapper around _put_run_event_nowait for run SSE queues."""
+        loop.call_soon_threadsafe(self._put_run_event_nowait, q, event)
 
     def _make_run_event_callback(self, run_id: str, loop: "asyncio.AbstractEventLoop"):
         """Return a tool_progress_callback that pushes structured events to the run's SSE queue."""
@@ -2305,7 +2327,7 @@ class APIServerAdapter(BasePlatformAdapter):
             if q is None:
                 return
             try:
-                loop.call_soon_threadsafe(q.put_nowait, event)
+                self._schedule_run_event(loop, q, event)
             except Exception:
                 pass
 
@@ -2367,7 +2389,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         run_id = f"run_{uuid.uuid4().hex}"
         loop = asyncio.get_running_loop()
-        q: "asyncio.Queue[Optional[Dict]]" = asyncio.Queue()
+        q: "asyncio.Queue[Optional[Dict]]" = asyncio.Queue(maxsize=self._RUN_STREAM_QUEUE_MAX)
         self._run_streams[run_id] = q
         self._run_streams_created[run_id] = time.time()
 
@@ -2378,7 +2400,7 @@ class APIServerAdapter(BasePlatformAdapter):
             if delta is None:
                 return
             try:
-                loop.call_soon_threadsafe(q.put_nowait, {
+                self._schedule_run_event(loop, q, {
                     "event": "message.delta",
                     "run_id": run_id,
                     "timestamp": time.time(),
@@ -2450,7 +2472,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     r = agent.run_conversation(
                         user_message=user_message,
                         conversation_history=conversation_history,
-                        task_id="default",
+                        task_id=session_id or run_id,
                     )
                     u = {
                         "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
@@ -2461,7 +2483,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
                 result, usage = await asyncio.get_running_loop().run_in_executor(None, _run_sync)
                 final_response = result.get("final_response", "") if isinstance(result, dict) else ""
-                q.put_nowait({
+                self._put_run_event_nowait(q, {
                     "event": "run.completed",
                     "run_id": run_id,
                     "timestamp": time.time(),
@@ -2471,7 +2493,7 @@ class APIServerAdapter(BasePlatformAdapter):
             except Exception as exc:
                 logger.exception("[api_server] run %s failed", run_id)
                 try:
-                    q.put_nowait({
+                    self._put_run_event_nowait(q, {
                         "event": "run.failed",
                         "run_id": run_id,
                         "timestamp": time.time(),
@@ -2482,7 +2504,7 @@ class APIServerAdapter(BasePlatformAdapter):
             finally:
                 # Sentinel: signal SSE stream to close
                 try:
-                    q.put_nowait(None)
+                    self._put_run_event_nowait(q, None)
                 except Exception:
                     pass
                 self._active_run_agents.pop(run_id, None)
@@ -2526,6 +2548,9 @@ class APIServerAdapter(BasePlatformAdapter):
             },
         )
         await response.prepare(request)
+        # A connected SSE client is consuming this run, so it is no longer an
+        # orphan candidate.  Keep _run_streams itself until the stream closes.
+        self._run_streams_created.pop(run_id, None)
 
         try:
             while True:
@@ -2598,10 +2623,22 @@ class APIServerAdapter(BasePlatformAdapter):
             ]
             for run_id in stale:
                 logger.debug("[api_server] sweeping orphaned run %s", run_id)
-                self._run_streams.pop(run_id, None)
+                agent = self._active_run_agents.pop(run_id, None)
+                if agent is not None:
+                    try:
+                        agent.interrupt("Run event stream was not consumed")
+                    except Exception:
+                        pass
+                task = self._active_run_tasks.pop(run_id, None)
+                if task is not None and not task.done():
+                    task.cancel()
+                q = self._run_streams.pop(run_id, None)
+                if q is not None:
+                    try:
+                        self._put_run_event_nowait(q, None)
+                    except Exception:
+                        pass
                 self._run_streams_created.pop(run_id, None)
-                self._active_run_agents.pop(run_id, None)
-                self._active_run_tasks.pop(run_id, None)
 
     # ------------------------------------------------------------------
     # BasePlatformAdapter interface

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6535,25 +6535,18 @@ def _cmd_update_impl(args, gateway_mode: bool):
             )
             if pull_result.returncode != 0:
                 # ff-only failed — local and remote have diverged (e.g. upstream
-                # force-pushed or rebase).  Since local changes are already
-                # stashed, reset to match the remote exactly.
-                print(
-                    "  ⚠ Fast-forward not possible (history diverged), resetting to match remote..."
-                )
-                reset_result = subprocess.run(
-                    git_cmd + ["reset", "--hard", f"origin/{branch}"],
-                    cwd=PROJECT_ROOT,
-                    capture_output=True,
-                    text=True,
-                )
-                if reset_result.returncode != 0:
-                    print(f"✗ Failed to reset to origin/{branch}.")
-                    if reset_result.stderr.strip():
-                        print(f"  {reset_result.stderr.strip()}")
-                    print(
-                        "  Try manually: git fetch origin && git reset --hard origin/main"
-                    )
-                    sys.exit(1)
+                # force-pushed or this checkout has local commits).  Do NOT
+                # auto-run `git reset --hard`: that can discard committed local
+                # work, not just stashed working-tree changes.  Leave the repo
+                # untouched after the failed fast-forward and ask the user to
+                # choose the right recovery strategy explicitly.
+                print("  ⚠ Fast-forward not possible (history diverged).")
+                if pull_result.stderr.strip():
+                    print(f"  {pull_result.stderr.strip()}")
+                print("  No destructive reset was performed.")
+                print("  Inspect with: git status && git log --oneline --graph --decorate --all -20")
+                print(f"  If you intentionally want upstream exactly, run: git reset --hard origin/{branch}")
+                sys.exit(1)
             update_succeeded = True
         finally:
             if auto_stash_ref is not None:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -224,7 +224,7 @@ async def host_header_middleware(request: Request, call_next):
 async def auth_middleware(request: Request, call_next):
     """Require the session token on all /api/ routes except the public list."""
     path = request.url.path
-    if path.startswith("/api/") and path not in _PUBLIC_API_PATHS and not path.startswith("/api/plugins/"):
+    if path.startswith("/api/") and path not in _PUBLIC_API_PATHS:
         if not _has_valid_session_token(request):
             return JSONResponse(
                 status_code=401,
@@ -3085,6 +3085,26 @@ async def serve_plugin_asset(plugin_name: str, file_path: str):
     return FileResponse(target, media_type=media_type)
 
 
+def _resolve_plugin_api_path(plugin: Dict[str, Any]) -> Optional[Path]:
+    """Return a plugin API path only when it stays inside the plugin directory."""
+    api_file_name = plugin.get("_api_file")
+    if not api_file_name:
+        return None
+    try:
+        base = Path(plugin["_dir"]).resolve()
+        api_path = (base / str(api_file_name)).resolve()
+    except Exception:
+        return None
+    if not api_path.is_relative_to(base):
+        _log.warning(
+            "Plugin %s declares api=%s outside plugin directory; ignoring",
+            plugin.get("name", "<unknown>"),
+            api_file_name,
+        )
+        return None
+    return api_path
+
+
 def _mount_plugin_api_routes():
     """Import and mount backend API routes from plugins that declare them.
 
@@ -3094,9 +3114,9 @@ def _mount_plugin_api_routes():
     """
     for plugin in _get_dashboard_plugins():
         api_file_name = plugin.get("_api_file")
-        if not api_file_name:
+        api_path = _resolve_plugin_api_path(plugin)
+        if not api_path:
             continue
-        api_path = Path(plugin["_dir"]) / api_file_name
         if not api_path.exists():
             _log.warning("Plugin %s declares api=%s but file not found", plugin["name"], api_file_name)
             continue

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -363,3 +363,111 @@ class TestStopRun:
                 body = await events_resp.text()
                 # Stream should have received run.failed and closed
                 assert "run.failed" in body or "stream closed" in body
+
+# ---------------------------------------------------------------------------
+# Regression tests: isolation and resource bounds
+# ---------------------------------------------------------------------------
+
+
+def test_run_event_queue_is_bounded_and_drops_oldest():
+    adapter = _make_adapter()
+    q = asyncio.Queue(maxsize=1)
+
+    adapter._put_run_event_nowait(q, {"event": "old"})
+    adapter._put_run_event_nowait(q, {"event": "new"})
+
+    assert q.qsize() == 1
+    assert q.get_nowait()["event"] == "new"
+
+
+@pytest.mark.asyncio
+async def test_run_agent_uses_session_task_id(monkeypatch):
+    adapter = _make_adapter()
+    seen = {}
+
+    class FakeAgent:
+        session_prompt_tokens = 0
+        session_completion_tokens = 0
+        session_total_tokens = 0
+
+        def run_conversation(self, user_message, conversation_history=None, task_id=None):
+            seen["task_id"] = task_id
+            return {"final_response": "ok"}
+
+    monkeypatch.setattr(adapter, "_create_agent", lambda **_: FakeAgent())
+
+    await adapter._run_agent("hi", [], session_id="session-123")
+
+    assert seen["task_id"] == "session-123"
+    assert seen["task_id"] != "default"
+
+
+@pytest.mark.asyncio
+async def test_orphan_sweep_interrupts_agent_and_cancels_task(monkeypatch):
+    adapter = _make_adapter()
+    adapter._RUN_STREAM_TTL = -1
+    q = asyncio.Queue(maxsize=1)
+    agent = MagicMock()
+    task = MagicMock()
+    task.done.return_value = False
+
+    adapter._run_streams["run_old"] = q
+    adapter._run_streams_created["run_old"] = 0
+    adapter._active_run_agents["run_old"] = agent
+    adapter._active_run_tasks["run_old"] = task
+
+    sleeps = 0
+
+    async def fake_sleep(_seconds):
+        nonlocal sleeps
+        sleeps += 1
+        if sleeps > 1:
+            raise asyncio.CancelledError()
+
+    monkeypatch.setattr("gateway.platforms.api_server.asyncio.sleep", fake_sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        await adapter._sweep_orphaned_runs()
+
+    agent.interrupt.assert_called_once_with("Run event stream was not consumed")
+    task.cancel.assert_called_once()
+    assert "run_old" not in adapter._run_streams
+    assert "run_old" not in adapter._run_streams_created
+    assert "run_old" not in adapter._active_run_agents
+    assert "run_old" not in adapter._active_run_tasks
+
+
+@pytest.mark.asyncio
+async def test_orphan_sweep_does_not_cancel_consumed_run(monkeypatch):
+    adapter = _make_adapter()
+    adapter._RUN_STREAM_TTL = -1
+    q = asyncio.Queue(maxsize=1)
+    agent = MagicMock()
+    task = MagicMock()
+    task.done.return_value = False
+
+    adapter._run_streams["run_connected"] = q
+    # No _run_streams_created entry: _handle_run_events removes it after a
+    # successful SSE subscription, so connected long-running streams are not
+    # considered orphaned.
+    adapter._active_run_agents["run_connected"] = agent
+    adapter._active_run_tasks["run_connected"] = task
+
+    sleeps = 0
+
+    async def fake_sleep(_seconds):
+        nonlocal sleeps
+        sleeps += 1
+        if sleeps > 1:
+            raise asyncio.CancelledError()
+
+    monkeypatch.setattr("gateway.platforms.api_server.asyncio.sleep", fake_sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        await adapter._sweep_orphaned_runs()
+
+    agent.interrupt.assert_not_called()
+    task.cancel.assert_not_called()
+    assert adapter._run_streams["run_connected"] is q
+    assert adapter._active_run_agents["run_connected"] is agent
+    assert adapter._active_run_tasks["run_connected"] is task

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -426,22 +426,24 @@ def _make_update_side_effect(
     return side_effect, recorded
 
 
-def test_cmd_update_falls_back_to_reset_when_ff_only_fails(monkeypatch, tmp_path, capsys):
-    """When --ff-only fails (diverged history), update resets to origin/{branch}."""
+def test_cmd_update_refuses_destructive_reset_when_ff_only_fails(monkeypatch, tmp_path, capsys):
+    """When --ff-only fails, update exits without reset --hard so local commits survive."""
     _setup_update_mocks(monkeypatch, tmp_path)
     monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
 
     side_effect, recorded = _make_update_side_effect(ff_only_fails=True)
     monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
 
-    hermes_main.cmd_update(SimpleNamespace())
+    with pytest.raises(SystemExit, match="1"):
+        hermes_main.cmd_update(SimpleNamespace())
 
     reset_calls = [c for c in recorded if "reset" in c and "--hard" in c]
-    assert len(reset_calls) == 1
-    assert reset_calls[0] == ["git", "reset", "--hard", "origin/main"]
+    assert reset_calls == []
 
     out = capsys.readouterr().out
     assert "Fast-forward not possible" in out
+    assert "No destructive reset was performed" in out
+    assert "git reset --hard origin/main" in out
 
 
 def test_cmd_update_no_reset_when_ff_only_succeeds(monkeypatch, tmp_path):
@@ -584,11 +586,11 @@ def test_cmd_update_auth_error_shows_friendly_message(monkeypatch, tmp_path, cap
 
 
 # ---------------------------------------------------------------------------
-# reset --hard failure — don't attempt stash restore
+# update divergence failure — don't reset and don't attempt stash restore
 # ---------------------------------------------------------------------------
 
-def test_cmd_update_skips_stash_restore_when_reset_fails(monkeypatch, tmp_path, capsys):
-    """When reset --hard fails, stash restore is skipped with a helpful message."""
+def test_cmd_update_skips_stash_restore_when_ff_only_fails(monkeypatch, tmp_path, capsys):
+    """When fast-forward fails, stash restore is skipped and no reset --hard runs."""
     _setup_update_mocks(monkeypatch, tmp_path)
     # Re-enable stash so it actually returns a ref
     monkeypatch.setattr(
@@ -601,14 +603,16 @@ def test_cmd_update_skips_stash_restore_when_reset_fails(monkeypatch, tmp_path, 
         lambda *a, **kw: restore_calls.append(1) or True,
     )
 
-    side_effect, _ = _make_update_side_effect(ff_only_fails=True, reset_fails=True)
+    side_effect, recorded = _make_update_side_effect(ff_only_fails=True, reset_fails=True)
     monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
 
     with pytest.raises(SystemExit, match="1"):
         hermes_main.cmd_update(SimpleNamespace())
 
-    # Stash restore should NOT have been called
+    # Stash restore should NOT have been called, and update should not reset.
     assert len(restore_calls) == 0
+    assert [c for c in recorded if "reset" in c and "--hard" in c] == []
 
     out = capsys.readouterr().out
     assert "preserved in stash" in out
+    assert "No destructive reset was performed" in out

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -257,6 +257,39 @@ class TestWebServerEndpoints:
         )
         assert resp.status_code == 401
 
+    def test_plugin_api_requires_session_token(self):
+        """Dashboard plugin backend APIs inherit the dashboard session-token gate."""
+        from starlette.testclient import TestClient
+        from hermes_cli.web_server import app
+
+        unauth_client = TestClient(app)
+        resp = unauth_client.get("/api/plugins/nonexistent/ping")
+        assert resp.status_code == 401
+
+    def test_plugin_api_path_traversal_rejected(self, tmp_path):
+        """A plugin manifest api path cannot escape the plugin dashboard directory."""
+        from hermes_cli.web_server import _resolve_plugin_api_path
+
+        dashboard_dir = tmp_path / "plugin" / "dashboard"
+        dashboard_dir.mkdir(parents=True)
+        outside = tmp_path / "plugin" / "evil.py"
+        outside.write_text("router = None\n", encoding="utf-8")
+        plugin = {"name": "bad", "_dir": str(dashboard_dir), "_api_file": "../evil.py"}
+
+        assert _resolve_plugin_api_path(plugin) is None
+
+    def test_plugin_api_path_inside_plugin_allowed(self, tmp_path):
+        """A plugin manifest api file inside the plugin dashboard directory is allowed."""
+        from hermes_cli.web_server import _resolve_plugin_api_path
+
+        dashboard_dir = tmp_path / "plugin" / "dashboard"
+        dashboard_dir.mkdir(parents=True)
+        api_file = dashboard_dir / "api.py"
+        api_file.write_text("router = None\n", encoding="utf-8")
+        plugin = {"name": "ok", "_dir": str(dashboard_dir), "_api_file": "api.py"}
+
+        assert _resolve_plugin_api_path(plugin) == api_file.resolve()
+
     def test_reveal_env_var_bad_token(self, tmp_path):
         """POST /api/env/reveal with wrong token should return 401."""
         from hermes_cli.config import save_env_value


### PR DESCRIPTION
## Summary
- Require normal dashboard session authentication for plugin API routes.
- Reject plugin API file paths that resolve outside the owning plugin directory before importing/mounting them.
- Bound `/v1/runs` SSE queues, use per-run/per-session task IDs, and cancel stale orphaned agents/tasks without cancelling connected consumers.
- Make updater divergence handling abort safely instead of falling back to `git reset --hard`.

## Test plan
- `/Users/bschmidy10/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_api_server_runs.py tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_plugin_api_requires_session_token tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_plugin_api_path_traversal_rejected tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_plugin_api_path_inside_plugin_allowed tests/hermes_cli/test_update_autostash.py tests/hermes_cli/test_update_gateway_restart.py -q -o 'addopts='`

Result: 86 passed, 15 warnings.
