### PR TITLE
fix(cli): sanitize bracketed paste markers during setup

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -14,6 +14,7 @@ Config files are stored in ~/.hermes/ for easy access.
 import importlib.util
 import logging
 import os
+import re
 import shutil
 import sys
 import copy
@@ -205,10 +206,21 @@ def prompt(question: str, default: str = None, password: bool = False) -> str:
         else:
             value = input(color(display, Colors.YELLOW))
 
-        return value.strip() or default or ""
+        cleaned = _sanitize_pasted_input(value)
+        return cleaned.strip() or default or ""
     except (KeyboardInterrupt, EOFError):
         print()
         sys.exit(1)
+
+
+_BRACKETED_PASTE_PATTERN = re.compile(r"\x1b\[\s*200~|\x1b\[\s*201~")
+
+
+def _sanitize_pasted_input(value: str) -> str:
+    """Strip terminal bracketed-paste control markers from pasted text."""
+    if not isinstance(value, str) or not value:
+        return value
+    return _BRACKETED_PASTE_PATTERN.sub("", value)
 
 
 def _curses_prompt_choice(question: str, choices: list, default: int = 0, description: str | None = None) -> int:

--- a/tests/hermes_cli/test_setup_prompt_menus.py
+++ b/tests/hermes_cli/test_setup_prompt_menus.py
@@ -1,6 +1,28 @@
 from hermes_cli import setup as setup_mod
 
 
+def test_prompt_strips_bracketed_paste_markers(monkeypatch):
+    monkeypatch.setattr(
+        "builtins.input",
+        lambda _prompt="": "\x1b[200~sk-ant-api-key\x1b[201~",
+    )
+
+    value = setup_mod.prompt("API key")
+
+    assert value == "sk-ant-api-key"
+
+
+def test_password_prompt_strips_bracketed_paste_markers(monkeypatch):
+    monkeypatch.setattr(
+        "getpass.getpass",
+        lambda _prompt="": "\x1b[200~secret-token\x1b[201~",
+    )
+
+    value = setup_mod.prompt("API key", password=True)
+
+    assert value == "secret-token"
+
+
 def test_prompt_choice_uses_curses_helper(monkeypatch):
     monkeypatch.setattr(setup_mod, "_curses_prompt_choice", lambda question, choices, default=0, description=None: 1)
 


### PR DESCRIPTION
﻿## What does this PR do?

Fixes a setup input parsing bug where terminal bracketed-paste control markers can be included in pasted API keys on Linux/WSL. The setup prompt now sanitizes those markers before persisting values, so pasted keys are accepted reliably in both normal and hidden/password prompts.

## Related Issue

Fixes #16491

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `hermes_cli/setup.py` to sanitize bracketed-paste markers (`ESC[200~` / `ESC[201~`) from user input in `prompt()`.
- Added `_sanitize_pasted_input()` helper and shared regex pattern for marker stripping.
- Added regression tests in `tests/hermes_cli/test_setup_prompt_menus.py` for both standard and password prompt paths.

## How to Test

1. Run `hermes setup` on Linux or WSL.
2. Paste an API key into setup prompts (including hidden/password API key prompts).
3. Confirm the saved value no longer includes bracketed-paste markers and setup completes normally.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10 (repo edit), target behavior validated by regression tests for Linux/WSL paste markers

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A (CLI setup input handling fix)
