### PR TITLE
fix(config): accept request_timeout_seconds / stale_timeout_seconds in providers entries (#16779)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2188,6 +2188,7 @@ def _normalize_custom_provider_entry(
         "name", "api", "url", "base_url", "api_key", "key_env",
         "api_mode", "transport", "model", "default_model", "models",
         "context_length", "rate_limit_delay",
+        "request_timeout_seconds", "stale_timeout_seconds",
     }
     for camel, snake in _CAMEL_ALIASES.items():
         if camel in entry and snake not in entry:

--- a/tests/hermes_cli/test_provider_config_validation.py
+++ b/tests/hermes_cli/test_provider_config_validation.py
@@ -180,3 +180,26 @@ class TestNormalizeCustomProviderEntry:
         result = _normalize_custom_provider_entry(entry)
         assert result is not None
         assert "models" not in result
+
+    def test_timeout_keys_not_warned(self, caplog):
+        """request_timeout_seconds and stale_timeout_seconds are valid runtime
+        keys (read by hermes_cli/timeouts.py) and documented in
+        cli-config.yaml.example, so the validator must not flag them as
+        unknown. Regression for #16779."""
+        entry = {
+            "base_url": "https://api.example.com/v1",
+            "api_key": "sk-test-key",
+            "request_timeout_seconds": 600,
+            "stale_timeout_seconds": 900,
+        }
+        with caplog.at_level(logging.WARNING):
+            result = _normalize_custom_provider_entry(entry, provider_key="myhost")
+        assert result is not None
+        unknown_warnings = [
+            r for r in caplog.records
+            if "unknown config keys" in r.message.lower()
+        ]
+        assert unknown_warnings == [], (
+            f"timeout keys should not trigger 'unknown config keys' warning, "
+            f"got: {[r.message for r in unknown_warnings]}"
+        )


### PR DESCRIPTION
## Summary
- `_normalize_custom_provider_entry()`'s `_KNOWN_KEYS` set was missing `request_timeout_seconds` and `stale_timeout_seconds`, both of which are valid runtime keys and are documented in `cli-config.yaml.example`.
- Result: every CLI invocation that follows the documented example prints a spurious `unknown config keys ignored: request_timeout_seconds, stale_timeout_seconds` warning, even though `hermes_cli/timeouts.py` reads and applies both keys correctly.
- Fix: add the two keys to `_KNOWN_KEYS`. One-line addition, plus a regression test.

## The bug
`hermes_cli/config.py:2187-2191` (pre-fix):

```python
_KNOWN_KEYS = {
    "name", "api", "url", "base_url", "api_key", "key_env",
    "api_mode", "transport", "model", "default_model", "models",
    "context_length", "rate_limit_delay",
}
```

But `hermes_cli/timeouts.py` reads:

- `request_timeout_seconds` at line 40 (`get_provider_request_timeout`).
- `stale_timeout_seconds` at lines 65 and 69 (`get_provider_stale_timeout`).

And `cli-config.yaml.example` documents both keys under the top-level `providers:` block (`request_timeout_seconds: 300`, `stale_timeout_seconds: 900`, etc.).

So users following the documented example see the validator complain about keys it actually accepts. That's not just noise: a "validator" warning telling users a key is "ignored" trains them to delete keys that are in fact load-bearing for their endpoint behavior.

## The fix
Add both keys to the existing `_KNOWN_KEYS` set in `_normalize_custom_provider_entry()`. No other path needs changing — the runtime readers in `timeouts.py` already do the right thing.

## Test plan
- [x] Focused regression test: `test_timeout_keys_not_warned` in `tests/hermes_cli/test_provider_config_validation.py` — asserts a providers entry with both timeout keys produces zero `"unknown config keys"` warnings.
- [x] Adjacent suite: full `tests/hermes_cli/test_provider_config_validation.py` — 17 passed (16 existing + 1 new).
- [x] Regression guard: with only the test added (no `_KNOWN_KEYS` change), the test fails with `AssertionError: ... got: ['providers.myhost: unknown config keys ignored: request_timeout_seconds, stale_timeout_seconds']`. With the one-line fix applied, the test passes. So the test is genuinely guarding the runtime contract.

## Related
- Fixes #16779.
- The runtime support for these keys landed in #12652 (`request_timeout_seconds`) and #12891 (`stale_timeout_seconds`); only the validator was out of sync.