### PR TITLE
feat(delegate): add side-effect manifest verification

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -8605,6 +8605,8 @@ class AIAgent:
             acp_command=function_args.get("acp_command"),
             acp_args=function_args.get("acp_args"),
             role=function_args.get("role"),
+            verify_side_effects=function_args.get("verify_side_effects"),
+            expected_side_effects=function_args.get("expected_side_effects"),
             parent_agent=self,
         )
 

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -33,6 +33,7 @@ from tools.delegate_tool import (
     _resolve_child_credential_pool,
     _resolve_delegation_credentials,
 )
+from tools.side_effects import get_registry as get_side_effect_registry
 
 
 def _make_mock_parent(depth=0):
@@ -69,6 +70,11 @@ class TestDelegateRequirements(unittest.TestCase):
         self.assertIn("tasks", props)
         self.assertIn("context", props)
         self.assertIn("toolsets", props)
+        self.assertIn("verify_side_effects", props)
+        self.assertIn("expected_side_effects", props)
+        task_props = props["tasks"]["items"]["properties"]
+        self.assertIn("verify_side_effects", task_props)
+        self.assertIn("expected_side_effects", task_props)
         # max_iterations is intentionally NOT exposed to the model — it's
         # config-authoritative via delegation.max_iterations so users get
         # predictable budgets.
@@ -408,6 +414,12 @@ class TestToolNamePreservation(unittest.TestCase):
 class TestDelegateObservability(unittest.TestCase):
     """Tests for enriched metadata returned by _run_single_child."""
 
+    def setUp(self):
+        get_side_effect_registry().clear()
+
+    def tearDown(self):
+        get_side_effect_registry().clear()
+
     def test_observability_fields_present(self):
         """Completed child should return tool_trace, tokens, model, exit_reason."""
         parent = _make_mock_parent(depth=0)
@@ -723,6 +735,626 @@ class TestSubagentCostRollup(unittest.TestCase):
         # Parent cost unchanged.
         self.assertEqual(parent.session_estimated_cost_usd, 0.10)
         self.assertEqual(len(result["results"]), 1)
+
+
+class TestDelegateSideEffectVerification(unittest.TestCase):
+    """Tests for opt-in structural side-effect verification."""
+
+    def setUp(self):
+        get_side_effect_registry().clear()
+
+    def tearDown(self):
+        get_side_effect_registry().clear()
+
+    def test_requested_verification_without_manifest_downgrades_success(self):
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "Uploaded successfully",
+                "completed": True,
+                "interrupted": False,
+                "api_calls": 1,
+                "messages": [],
+            }
+            MockAgent.return_value = mock_child
+
+            result = json.loads(
+                delegate_task(
+                    goal="Upload a page",
+                    verify_side_effects=True,
+                    parent_agent=parent,
+                )
+            )
+
+        entry = result["results"][0]
+        self.assertEqual(entry["status"], "completed_unverified")
+        verification = entry["side_effect_verification"]
+        self.assertEqual(verification["status"], "failed")
+        self.assertEqual(verification["recorded_count"], 0)
+        self.assertIn("No side effects were recorded", entry["summary"])
+
+    def test_record_side_effect_tool_records_manifest_for_task_id(self):
+        from tools.registry import registry
+
+        long_description = "x" * 10_000
+        result = json.loads(
+            registry.dispatch(
+                "record_side_effect",
+                {
+                    "kind": "file_write",
+                    "path": "/tmp/example.txt",
+                    "description": long_description,
+                },
+                task_id="sa-test",
+            )
+        )
+
+        self.assertTrue(result["ok"])
+        manifest = get_side_effect_registry().list("sa-test")
+        self.assertEqual(len(manifest), 1)
+        self.assertEqual(manifest[0]["kind"], "file_write")
+        self.assertEqual(manifest[0]["path"], "/tmp/example.txt")
+        self.assertLessEqual(len(manifest[0]["description"]), 2048)
+
+    def test_requested_verification_grants_recorder_toolset(self):
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "done",
+                "completed": True,
+                "interrupted": False,
+                "api_calls": 1,
+                "messages": [],
+            }
+            MockAgent.return_value = mock_child
+
+            delegate_task(
+                goal="Write a shared file",
+                verify_side_effects=True,
+                parent_agent=parent,
+            )
+
+        self.assertIn("side_effects", MockAgent.call_args[1]["enabled_toolsets"])
+
+    def test_file_write_side_effect_verifies_path_and_sha256(self):
+        parent = _make_mock_parent(depth=0)
+        import hashlib
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", delete=False) as tmp:
+            tmp.write("verified content\n")
+            path = tmp.name
+        digest = hashlib.sha256(b"verified content\n").hexdigest()
+
+        try:
+            with patch("run_agent.AIAgent") as MockAgent:
+                mock_child = MagicMock()
+
+                def _run(user_message, task_id):
+                    get_side_effect_registry().record(
+                        task_id,
+                        {"kind": "file_write", "path": path, "sha256": digest},
+                    )
+                    return {
+                        "final_response": "Wrote the file",
+                        "completed": True,
+                        "interrupted": False,
+                        "api_calls": 1,
+                        "messages": [],
+                    }
+
+                mock_child.run_conversation.side_effect = _run
+                MockAgent.return_value = mock_child
+
+                result = json.loads(
+                    delegate_task(
+                        goal="Write a file",
+                        verify_side_effects=True,
+                        parent_agent=parent,
+                    )
+                )
+        finally:
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+
+        entry = result["results"][0]
+        self.assertEqual(entry["status"], "completed")
+        self.assertEqual(entry["side_effect_verification"]["status"], "verified")
+        self.assertEqual(entry["side_effect_verification"]["verified_count"], 1)
+
+    def test_file_write_side_effect_fails_on_content_mismatch(self):
+        parent = _make_mock_parent(depth=0)
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", delete=False) as tmp:
+            tmp.write("actual content\n")
+            path = tmp.name
+
+        try:
+            with patch("run_agent.AIAgent") as MockAgent:
+                mock_child = MagicMock()
+
+                def _run(user_message, task_id):
+                    get_side_effect_registry().record(
+                        task_id,
+                        {
+                            "kind": "file_write",
+                            "path": path,
+                            "contains": "expected content",
+                        },
+                    )
+                    return {
+                        "final_response": "Wrote the expected content",
+                        "completed": True,
+                        "interrupted": False,
+                        "api_calls": 1,
+                        "messages": [],
+                    }
+
+                mock_child.run_conversation.side_effect = _run
+                MockAgent.return_value = mock_child
+
+                result = json.loads(
+                    delegate_task(
+                        goal="Write a file",
+                        verify_side_effects=True,
+                        parent_agent=parent,
+                    )
+                )
+        finally:
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+
+        entry = result["results"][0]
+        self.assertEqual(entry["status"], "completed_unverified")
+        self.assertEqual(entry["side_effect_verification"]["status"], "failed")
+        self.assertEqual(entry["side_effect_verification"]["failed_count"], 1)
+
+    def test_url_side_effect_fails_on_http_error_status(self):
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent, patch(
+            "tools.side_effects.is_safe_url", return_value=True
+        ), patch("tools.side_effects._open_verification_url") as mock_urlopen:
+            response = MagicMock()
+            response.__enter__.return_value = response
+            response.status = 400
+            response.read.return_value = b"bad request"
+            mock_urlopen.return_value = response
+
+            mock_child = MagicMock()
+
+            def _run(user_message, task_id):
+                get_side_effect_registry().record(
+                    task_id,
+                    {"kind": "url", "url": "https://example.com/result"},
+                )
+                return {
+                    "final_response": "Uploaded successfully",
+                    "completed": True,
+                    "interrupted": False,
+                    "api_calls": 1,
+                    "messages": [],
+                }
+
+            mock_child.run_conversation.side_effect = _run
+            MockAgent.return_value = mock_child
+
+            result = json.loads(
+                delegate_task(
+                    goal="Upload a page",
+                    verify_side_effects=True,
+                    parent_agent=parent,
+                )
+            )
+
+        entry = result["results"][0]
+        self.assertEqual(entry["status"], "completed_unverified")
+        self.assertEqual(entry["side_effect_verification"]["status"], "failed")
+        self.assertIn("HTTP 400", entry["side_effects"][0]["verification"]["reason"])
+
+    def test_url_side_effect_fails_when_expected_marker_missing(self):
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent, patch(
+            "tools.side_effects.is_safe_url", return_value=True
+        ), patch("tools.side_effects._open_verification_url") as mock_urlopen:
+            response = MagicMock()
+            response.__enter__.return_value = response
+            response.status = 200
+            response.read.return_value = b"only test"
+            mock_urlopen.return_value = response
+
+            mock_child = MagicMock()
+
+            def _run(user_message, task_id):
+                get_side_effect_registry().record(
+                    task_id,
+                    {
+                        "kind": "url",
+                        "url": "https://example.com/result",
+                        "contains": "expected upload",
+                    },
+                )
+                return {
+                    "final_response": "Uploaded expected upload",
+                    "completed": True,
+                    "interrupted": False,
+                    "api_calls": 1,
+                    "messages": [],
+                }
+
+            mock_child.run_conversation.side_effect = _run
+            MockAgent.return_value = mock_child
+
+            result = json.loads(
+                delegate_task(
+                    goal="Upload a page",
+                    verify_side_effects=True,
+                    parent_agent=parent,
+                )
+            )
+
+        entry = result["results"][0]
+        self.assertEqual(entry["status"], "completed_unverified")
+        self.assertEqual(entry["side_effect_verification"]["failed_count"], 1)
+        self.assertIn("expected marker", entry["side_effects"][0]["verification"]["reason"])
+
+    def test_url_side_effect_blocks_unsafe_redirect(self):
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent, patch(
+            "tools.side_effects.is_safe_url", side_effect=[True, False]
+        ), patch("tools.side_effects._URL_OPENER") as mock_opener:
+            from tools.side_effects import _SafeRedirectHandler
+
+            def _open(request, timeout=10):
+                handler = _SafeRedirectHandler()
+                handler.redirect_request(
+                    request,
+                    None,
+                    302,
+                    "Found",
+                    {},
+                    "http://169.254.169.254/latest/meta-data",
+                )
+
+            mock_opener.open.side_effect = _open
+            mock_child = MagicMock()
+
+            def _run(user_message, task_id):
+                get_side_effect_registry().record(
+                    task_id,
+                    {"kind": "url", "url": "https://example.com/result"},
+                )
+                return {
+                    "final_response": "Uploaded successfully",
+                    "completed": True,
+                    "interrupted": False,
+                    "api_calls": 1,
+                    "messages": [],
+                }
+
+            mock_child.run_conversation.side_effect = _run
+            MockAgent.return_value = mock_child
+
+            result = json.loads(
+                delegate_task(
+                    goal="Upload a page",
+                    verify_side_effects=True,
+                    parent_agent=parent,
+                )
+            )
+
+        entry = result["results"][0]
+        self.assertEqual(entry["status"], "completed_unverified")
+        self.assertEqual(entry["side_effect_verification"]["status"], "failed")
+        self.assertIn(
+            "Blocked redirect", entry["side_effects"][0]["verification"]["reason"]
+        )
+
+    def test_http_post_requires_verify_url_and_content_evidence(self):
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent, patch(
+            "tools.side_effects._open_verification_url"
+        ) as mock_urlopen:
+            mock_child = MagicMock()
+
+            def _run(user_message, task_id):
+                get_side_effect_registry().record(
+                    task_id,
+                    {
+                        "kind": "http_post",
+                        "url": "https://example.com/upload",
+                        "verify_url": "https://example.com/result",
+                        "status": 200,
+                    },
+                )
+                return {
+                    "final_response": "Uploaded successfully",
+                    "completed": True,
+                    "interrupted": False,
+                    "api_calls": 1,
+                    "messages": [],
+                }
+
+            mock_child.run_conversation.side_effect = _run
+            MockAgent.return_value = mock_child
+
+            result = json.loads(
+                delegate_task(
+                    goal="Upload a page",
+                    verify_side_effects=True,
+                    parent_agent=parent,
+                )
+            )
+
+        entry = result["results"][0]
+        self.assertEqual(entry["status"], "completed_unverified")
+        self.assertEqual(entry["side_effect_verification"]["status"], "unverified")
+        self.assertIn(
+            "content, size, or hash evidence",
+            entry["side_effects"][0]["verification"]["reason"],
+        )
+        mock_urlopen.assert_not_called()
+
+    def test_http_put_allows_explicit_zero_byte_evidence(self):
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent, patch(
+            "tools.side_effects.is_safe_url", return_value=True
+        ), patch("tools.side_effects._open_verification_url") as mock_urlopen:
+            response = MagicMock()
+            response.__enter__.return_value = response
+            response.status = 200
+            response.read.return_value = b""
+            mock_urlopen.return_value = response
+            mock_child = MagicMock()
+
+            def _run(user_message, task_id):
+                get_side_effect_registry().record(
+                    task_id,
+                    {
+                        "kind": "http_put",
+                        "url": "https://example.com/upload",
+                        "verify_url": "https://example.com/result",
+                        "status": 200,
+                        "bytes": 0,
+                    },
+                )
+                return {
+                    "final_response": "Uploaded successfully",
+                    "completed": True,
+                    "interrupted": False,
+                    "api_calls": 1,
+                    "messages": [],
+                }
+
+            mock_child.run_conversation.side_effect = _run
+            MockAgent.return_value = mock_child
+
+            result = json.loads(
+                delegate_task(
+                    goal="Upload a page",
+                    verify_side_effects=True,
+                    parent_agent=parent,
+                )
+            )
+
+        entry = result["results"][0]
+        self.assertEqual(entry["status"], "completed")
+        self.assertEqual(entry["side_effect_verification"]["status"], "verified")
+
+    def test_unsupported_side_effect_kind_is_reported_unverified(self):
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+
+            def _run(user_message, task_id):
+                get_side_effect_registry().record(
+                    task_id,
+                    {"kind": "deploy", "target": "production"},
+                )
+                return {
+                    "final_response": "Deploy succeeded",
+                    "completed": True,
+                    "interrupted": False,
+                    "api_calls": 1,
+                    "messages": [],
+                }
+
+            mock_child.run_conversation.side_effect = _run
+            MockAgent.return_value = mock_child
+
+            result = json.loads(
+                delegate_task(
+                    goal="Deploy",
+                    verify_side_effects=True,
+                    parent_agent=parent,
+                )
+            )
+
+        entry = result["results"][0]
+        self.assertEqual(entry["status"], "completed_unverified")
+        self.assertEqual(entry["side_effect_verification"]["status"], "unverified")
+        self.assertEqual(entry["side_effect_verification"]["unverified_count"], 1)
+
+    def test_missing_expected_side_effect_fails_verification(self):
+        parent = _make_mock_parent(depth=0)
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", delete=False) as recorded:
+            recorded.write("recorded\n")
+            recorded_path = recorded.name
+        with tempfile.NamedTemporaryFile("w", delete=False) as expected:
+            expected.write("expected\n")
+            expected_path = expected.name
+
+        try:
+            with patch("run_agent.AIAgent") as MockAgent:
+                mock_child = MagicMock()
+
+                def _run(user_message, task_id):
+                    get_side_effect_registry().record(
+                        task_id,
+                        {"kind": "file_write", "path": recorded_path},
+                    )
+                    return {
+                        "final_response": "Wrote a file",
+                        "completed": True,
+                        "interrupted": False,
+                        "api_calls": 1,
+                        "messages": [],
+                    }
+
+                mock_child.run_conversation.side_effect = _run
+                MockAgent.return_value = mock_child
+
+                result = json.loads(
+                    delegate_task(
+                        goal="Write the expected file",
+                        verify_side_effects=True,
+                        expected_side_effects=[
+                            {"kind": "file_write", "path": expected_path}
+                        ],
+                        parent_agent=parent,
+                    )
+                )
+        finally:
+            for path in (recorded_path, expected_path):
+                try:
+                    os.unlink(path)
+                except OSError:
+                    pass
+
+        entry = result["results"][0]
+        self.assertEqual(entry["status"], "completed_unverified")
+        self.assertEqual(entry["side_effect_verification"]["status"], "failed")
+        self.assertEqual(entry["side_effect_verification"]["missing_expected_count"], 1)
+
+    def test_expected_side_effect_constraints_are_verified(self):
+        parent = _make_mock_parent(depth=0)
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", delete=False) as tmp:
+            tmp.write("actual content\n")
+            path = tmp.name
+
+        try:
+            with patch("run_agent.AIAgent") as MockAgent:
+                mock_child = MagicMock()
+
+                def _run(user_message, task_id):
+                    get_side_effect_registry().record(
+                        task_id,
+                        {"kind": "file_write", "path": path},
+                    )
+                    return {
+                        "final_response": "Wrote the file",
+                        "completed": True,
+                        "interrupted": False,
+                        "api_calls": 1,
+                        "messages": [],
+                    }
+
+                mock_child.run_conversation.side_effect = _run
+                MockAgent.return_value = mock_child
+
+                result = json.loads(
+                    delegate_task(
+                        goal="Write constrained content",
+                        verify_side_effects=True,
+                        expected_side_effects=[
+                            {
+                                "kind": "file_write",
+                                "path": path,
+                                "contains": "expected content",
+                            }
+                        ],
+                        parent_agent=parent,
+                    )
+                )
+        finally:
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+
+        entry = result["results"][0]
+        self.assertEqual(entry["status"], "completed_unverified")
+        self.assertEqual(entry["side_effect_verification"]["status"], "failed")
+        self.assertEqual(entry["side_effect_verification"]["failed_count"], 1)
+
+    def test_batch_side_effect_manifests_are_isolated_per_child(self):
+        parent = _make_mock_parent(depth=0)
+        import tempfile
+
+        paths = []
+        for content in ("alpha\n", "beta\n"):
+            with tempfile.NamedTemporaryFile("w", delete=False) as tmp:
+                tmp.write(content)
+                paths.append(tmp.name)
+
+        try:
+            with patch("run_agent.AIAgent") as MockAgent:
+                children = []
+                for i, path in enumerate(paths):
+                    child = MagicMock()
+
+                    def _run(user_message, task_id, _path=path, _i=i):
+                        get_side_effect_registry().record(
+                            task_id,
+                            {
+                                "kind": "file_write",
+                                "path": _path,
+                                "contains": "alpha" if _i == 0 else "beta",
+                            },
+                        )
+                        return {
+                            "final_response": f"Wrote file {_i}",
+                            "completed": True,
+                            "interrupted": False,
+                            "api_calls": 1,
+                            "messages": [],
+                        }
+
+                    child.run_conversation.side_effect = _run
+                    children.append(child)
+                MockAgent.side_effect = children
+
+                result = json.loads(
+                    delegate_task(
+                        tasks=[
+                            {"goal": "Write alpha", "verify_side_effects": True},
+                            {"goal": "Write beta", "verify_side_effects": True},
+                        ],
+                        parent_agent=parent,
+                    )
+                )
+        finally:
+            for path in paths:
+                try:
+                    os.unlink(path)
+                except OSError:
+                    pass
+
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(
+            [entry["side_effect_verification"]["status"] for entry in result["results"]],
+            ["verified", "verified"],
+        )
+        self.assertEqual(result["results"][0]["side_effects"][0]["path"], paths[0])
+        self.assertEqual(result["results"][1]["side_effects"][0]["path"], paths[1])
 
 
 class TestBlockedTools(unittest.TestCase):

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -775,6 +775,29 @@ class TestDelegateSideEffectVerification(unittest.TestCase):
         self.assertEqual(verification["recorded_count"], 0)
         self.assertIn("No side effects were recorded", entry["summary"])
 
+    def test_requested_verification_on_child_error_still_reports_verification(self):
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.side_effect = RuntimeError("boom")
+            mock_child.get_activity_summary.return_value = {"api_call_count": 0}
+            MockAgent.return_value = mock_child
+
+            result = json.loads(
+                delegate_task(
+                    goal="Upload a page",
+                    verify_side_effects=True,
+                    parent_agent=parent,
+                )
+            )
+
+        entry = result["results"][0]
+        self.assertEqual(entry["status"], "error")
+        self.assertIn("side_effect_verification", entry)
+        self.assertEqual(entry["side_effect_verification"]["status"], "failed")
+        self.assertEqual(entry["side_effect_verification"]["recorded_count"], 0)
+
     def test_record_side_effect_tool_records_manifest_for_task_id(self):
         from tools.registry import registry
 
@@ -918,6 +941,126 @@ class TestDelegateSideEffectVerification(unittest.TestCase):
         self.assertEqual(entry["side_effect_verification"]["status"], "failed")
         self.assertEqual(entry["side_effect_verification"]["failed_count"], 1)
 
+    def test_expected_file_contains_is_not_weakened_by_recorded_claims(self):
+        parent = _make_mock_parent(depth=0)
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", delete=False) as tmp:
+            tmp.write("anything\n")
+            path = tmp.name
+
+        try:
+            with patch("run_agent.AIAgent") as MockAgent:
+                mock_child = MagicMock()
+
+                def _run(user_message, task_id):
+                    get_side_effect_registry().record(
+                        task_id,
+                        {
+                            "kind": "file_write",
+                            "path": path,
+                            "contains": "anything",
+                        },
+                    )
+                    return {
+                        "final_response": "Wrote the expected output",
+                        "completed": True,
+                        "interrupted": False,
+                        "api_calls": 1,
+                        "messages": [],
+                    }
+
+                mock_child.run_conversation.side_effect = _run
+                MockAgent.return_value = mock_child
+
+                result = json.loads(
+                    delegate_task(
+                        goal="Write a file",
+                        verify_side_effects=True,
+                        expected_side_effects=[
+                            {
+                                "kind": "file_write",
+                                "path": path,
+                                "contains": "expected output",
+                            }
+                        ],
+                        parent_agent=parent,
+                    )
+                )
+        finally:
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+
+        entry = result["results"][0]
+        self.assertEqual(entry["status"], "completed_unverified")
+        self.assertEqual(entry["side_effect_verification"]["status"], "failed")
+        self.assertEqual(entry["side_effect_verification"]["failed_count"], 1)
+        self.assertIn(
+            "expected marker", entry["side_effects"][0]["verification"]["reason"]
+        )
+
+    def test_expected_file_min_bytes_is_not_weakened_by_recorded_claims(self):
+        parent = _make_mock_parent(depth=0)
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", delete=False) as tmp:
+            tmp.write("anything\n")
+            path = tmp.name
+
+        try:
+            with patch("run_agent.AIAgent") as MockAgent:
+                mock_child = MagicMock()
+
+                def _run(user_message, task_id):
+                    get_side_effect_registry().record(
+                        task_id,
+                        {
+                            "kind": "file_write",
+                            "path": path,
+                            "min_bytes": 1,
+                        },
+                    )
+                    return {
+                        "final_response": "Wrote enough bytes",
+                        "completed": True,
+                        "interrupted": False,
+                        "api_calls": 1,
+                        "messages": [],
+                    }
+
+                mock_child.run_conversation.side_effect = _run
+                MockAgent.return_value = mock_child
+
+                result = json.loads(
+                    delegate_task(
+                        goal="Write a file",
+                        verify_side_effects=True,
+                        expected_side_effects=[
+                            {
+                                "kind": "file_write",
+                                "path": path,
+                                "min_bytes": 100,
+                            }
+                        ],
+                        parent_agent=parent,
+                    )
+                )
+        finally:
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+
+        entry = result["results"][0]
+        self.assertEqual(entry["status"], "completed_unverified")
+        self.assertEqual(entry["side_effect_verification"]["status"], "failed")
+        self.assertEqual(entry["side_effect_verification"]["failed_count"], 1)
+        self.assertIn(
+            "below expected minimum", entry["side_effects"][0]["verification"]["reason"]
+        )
+
     def test_url_side_effect_fails_on_http_error_status(self):
         parent = _make_mock_parent(depth=0)
 
@@ -960,6 +1103,59 @@ class TestDelegateSideEffectVerification(unittest.TestCase):
         self.assertEqual(entry["status"], "completed_unverified")
         self.assertEqual(entry["side_effect_verification"]["status"], "failed")
         self.assertIn("HTTP 400", entry["side_effects"][0]["verification"]["reason"])
+
+    def test_url_side_effect_allows_expected_not_found_status(self):
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent, patch(
+            "tools.side_effects.is_safe_url", return_value=True
+        ), patch("tools.side_effects._open_verification_url") as mock_urlopen:
+            response = MagicMock()
+            response.__enter__.return_value = response
+            response.status = 404
+            response.read.return_value = b"deleted"
+            mock_urlopen.return_value = response
+
+            mock_child = MagicMock()
+
+            def _run(user_message, task_id):
+                get_side_effect_registry().record(
+                    task_id,
+                    {
+                        "kind": "url",
+                        "url": "https://example.com/result",
+                        "status": 404,
+                    },
+                )
+                return {
+                    "final_response": "Deleted successfully",
+                    "completed": True,
+                    "interrupted": False,
+                    "api_calls": 1,
+                    "messages": [],
+                }
+
+            mock_child.run_conversation.side_effect = _run
+            MockAgent.return_value = mock_child
+
+            result = json.loads(
+                delegate_task(
+                    goal="Delete a resource",
+                    verify_side_effects=True,
+                    expected_side_effects=[
+                        {
+                            "kind": "url",
+                            "url": "https://example.com/result",
+                            "expected_status": 404,
+                        }
+                    ],
+                    parent_agent=parent,
+                )
+            )
+
+        entry = result["results"][0]
+        self.assertEqual(entry["status"], "completed")
+        self.assertEqual(entry["side_effect_verification"]["status"], "verified")
 
     def test_url_side_effect_fails_when_expected_marker_missing(self):
         parent = _make_mock_parent(depth=0)
@@ -1107,7 +1303,7 @@ class TestDelegateSideEffectVerification(unittest.TestCase):
         )
         mock_urlopen.assert_not_called()
 
-    def test_http_put_allows_explicit_zero_byte_evidence(self):
+    def test_http_post_uses_expected_content_evidence(self):
         parent = _make_mock_parent(depth=0)
 
         with patch("run_agent.AIAgent") as MockAgent, patch(
@@ -1116,7 +1312,7 @@ class TestDelegateSideEffectVerification(unittest.TestCase):
             response = MagicMock()
             response.__enter__.return_value = response
             response.status = 200
-            response.read.return_value = b""
+            response.read.return_value = b"published"
             mock_urlopen.return_value = response
             mock_child = MagicMock()
 
@@ -1124,11 +1320,10 @@ class TestDelegateSideEffectVerification(unittest.TestCase):
                 get_side_effect_registry().record(
                     task_id,
                     {
-                        "kind": "http_put",
+                        "kind": "http_post",
                         "url": "https://example.com/upload",
                         "verify_url": "https://example.com/result",
                         "status": 200,
-                        "bytes": 0,
                     },
                 )
                 return {
@@ -1146,6 +1341,13 @@ class TestDelegateSideEffectVerification(unittest.TestCase):
                 delegate_task(
                     goal="Upload a page",
                     verify_side_effects=True,
+                    expected_side_effects=[
+                        {
+                            "kind": "http_post",
+                            "url": "https://example.com/upload",
+                            "contains": "published",
+                        }
+                    ],
                     parent_agent=parent,
                 )
             )
@@ -1241,121 +1443,6 @@ class TestDelegateSideEffectVerification(unittest.TestCase):
         self.assertEqual(entry["status"], "completed_unverified")
         self.assertEqual(entry["side_effect_verification"]["status"], "failed")
         self.assertEqual(entry["side_effect_verification"]["missing_expected_count"], 1)
-
-    def test_expected_side_effect_constraints_are_verified(self):
-        parent = _make_mock_parent(depth=0)
-        import tempfile
-
-        with tempfile.NamedTemporaryFile("w", delete=False) as tmp:
-            tmp.write("actual content\n")
-            path = tmp.name
-
-        try:
-            with patch("run_agent.AIAgent") as MockAgent:
-                mock_child = MagicMock()
-
-                def _run(user_message, task_id):
-                    get_side_effect_registry().record(
-                        task_id,
-                        {"kind": "file_write", "path": path},
-                    )
-                    return {
-                        "final_response": "Wrote the file",
-                        "completed": True,
-                        "interrupted": False,
-                        "api_calls": 1,
-                        "messages": [],
-                    }
-
-                mock_child.run_conversation.side_effect = _run
-                MockAgent.return_value = mock_child
-
-                result = json.loads(
-                    delegate_task(
-                        goal="Write constrained content",
-                        verify_side_effects=True,
-                        expected_side_effects=[
-                            {
-                                "kind": "file_write",
-                                "path": path,
-                                "contains": "expected content",
-                            }
-                        ],
-                        parent_agent=parent,
-                    )
-                )
-        finally:
-            try:
-                os.unlink(path)
-            except OSError:
-                pass
-
-        entry = result["results"][0]
-        self.assertEqual(entry["status"], "completed_unverified")
-        self.assertEqual(entry["side_effect_verification"]["status"], "failed")
-        self.assertEqual(entry["side_effect_verification"]["failed_count"], 1)
-
-    def test_batch_side_effect_manifests_are_isolated_per_child(self):
-        parent = _make_mock_parent(depth=0)
-        import tempfile
-
-        paths = []
-        for content in ("alpha\n", "beta\n"):
-            with tempfile.NamedTemporaryFile("w", delete=False) as tmp:
-                tmp.write(content)
-                paths.append(tmp.name)
-
-        try:
-            with patch("run_agent.AIAgent") as MockAgent:
-                children = []
-                for i, path in enumerate(paths):
-                    child = MagicMock()
-
-                    def _run(user_message, task_id, _path=path, _i=i):
-                        get_side_effect_registry().record(
-                            task_id,
-                            {
-                                "kind": "file_write",
-                                "path": _path,
-                                "contains": "alpha" if _i == 0 else "beta",
-                            },
-                        )
-                        return {
-                            "final_response": f"Wrote file {_i}",
-                            "completed": True,
-                            "interrupted": False,
-                            "api_calls": 1,
-                            "messages": [],
-                        }
-
-                    child.run_conversation.side_effect = _run
-                    children.append(child)
-                MockAgent.side_effect = children
-
-                result = json.loads(
-                    delegate_task(
-                        tasks=[
-                            {"goal": "Write alpha", "verify_side_effects": True},
-                            {"goal": "Write beta", "verify_side_effects": True},
-                        ],
-                        parent_agent=parent,
-                    )
-                )
-        finally:
-            for path in paths:
-                try:
-                    os.unlink(path)
-                except OSError:
-                    pass
-
-        self.assertEqual(len(result["results"]), 2)
-        self.assertEqual(
-            [entry["side_effect_verification"]["status"] for entry in result["results"]],
-            ["verified", "verified"],
-        )
-        self.assertEqual(result["results"][0]["side_effects"][0]["path"], paths[0])
-        self.assertEqual(result["results"][1]["side_effects"][0]["path"], paths[1])
-
 
 class TestBlockedTools(unittest.TestCase):
     def test_blocked_tools_constant(self):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -32,7 +32,7 @@ from concurrent.futures import (
 from typing import Any, Dict, List, Optional
 
 from toolsets import TOOLSETS
-from tools import file_state
+from tools import file_state, side_effects
 from tools.terminal_tool import set_approval_callback as _set_subagent_approval_cb
 from utils import base_url_hostname, is_truthy_value
 
@@ -539,6 +539,8 @@ def _build_child_system_prompt(
     role: str = "leaf",
     max_spawn_depth: int = 2,
     child_depth: int = 1,
+    verify_side_effects: bool = False,
+    expected_side_effects: Optional[List[Dict[str, Any]]] = None,
 ) -> str:
     """Build a focused system prompt for a child agent.
 
@@ -560,6 +562,25 @@ def _build_child_system_prompt(
             "\nWORKSPACE PATH:\n"
             f"{workspace_path}\n"
             "Use this exact path for local repository/workdir operations unless the task explicitly says otherwise."
+        )
+    if verify_side_effects:
+        expected = expected_side_effects or []
+        expected_text = ""
+        if expected:
+            expected_text = (
+                "\nExpected side effects to match:\n"
+                f"{json.dumps(expected, ensure_ascii=False)}\n"
+            )
+        parts.append(
+            "\nSIDE-EFFECT VERIFICATION:\n"
+            "The parent requested structural verification for external effects. "
+            "Whenever you create or mutate an external resource (file_write, url, "
+            "http_post, remote_write), call `record_side_effect` with a concrete "
+            "handle such as an absolute path, public verification URL, status, "
+            "sha256, byte count, or expected marker. Do this before your final "
+            "summary, and do not claim the side effect succeeded unless the "
+            "recorded handle supports that claim."
+            f"{expected_text}"
         )
     parts.append(
         "\nComplete this task using the tools available to you. "
@@ -853,6 +874,8 @@ def _build_child_agent(
     # 'leaf' (default) cannot; 'orchestrator' retains the delegation
     # toolset subject to depth/kill-switch bounds applied below.
     role: str = "leaf",
+    verify_side_effects: bool = False,
+    expected_side_effects: Optional[List[Dict[str, Any]]] = None,
 ):
     """
     Build a child AIAgent on the main thread (thread-safe construction).
@@ -928,6 +951,8 @@ def _build_child_agent(
     # test_intersection_preserves_delegation_bound test for the design rationale.
     if effective_role == "orchestrator" and "delegation" not in child_toolsets:
         child_toolsets.append("delegation")
+    if verify_side_effects and "side_effects" not in child_toolsets:
+        child_toolsets.append("side_effects")
 
     workspace_hint = _resolve_workspace_hint(parent_agent)
     child_prompt = _build_child_system_prompt(
@@ -937,6 +962,8 @@ def _build_child_agent(
         role=effective_role,
         max_spawn_depth=max_spawn,
         child_depth=child_depth,
+        verify_side_effects=verify_side_effects,
+        expected_side_effects=expected_side_effects,
     )
     # Extract parent's API key so subagents inherit auth (e.g. Nous Portal).
     parent_api_key = getattr(parent_agent, "api_key", None)
@@ -1247,6 +1274,9 @@ def _run_single_child(
 
     # Get the progress callback from the child agent
     child_progress_cb = getattr(child, "tool_progress_callback", None)
+    verify_requested = is_truthy_value(_kwargs.get("verify_side_effects"), default=False)
+    expected_side_effects = _kwargs.get("expected_side_effects") or []
+    child_task_id: Optional[str] = None
 
     # Restore parent tool names using the value saved before child construction
     # mutated the global. This is the correct parent toolset, not the child's.
@@ -1633,6 +1663,27 @@ def _run_single_child(
         if status == "failed":
             entry["error"] = result.get("error", "Subagent did not produce a response.")
 
+        if verify_requested:
+            verification = side_effects.verify_side_effects(
+                child_task_id,
+                expected_side_effects,
+            )
+            checked_effects = verification.pop("side_effects")
+            entry["side_effects"] = checked_effects
+            entry["side_effect_verification"] = verification
+            verification_status = verification.get("status")
+            if entry.get("status") == "completed" and verification_status != "verified":
+                entry["status"] = "completed_unverified"
+            if verification_status != "verified":
+                note = (
+                    "\n\n[SIDE EFFECT VERIFICATION: "
+                    f"{verification_status}; {verification.get('message')}]"
+                )
+                if entry.get("summary"):
+                    entry["summary"] = entry["summary"] + note
+                else:
+                    entry["summary"] = note.strip()
+
         # Cross-agent file-state reminder.  If this subagent wrote any
         # files the parent had already read, surface it so the parent
         # knows to re-read before editing — the scenario that motivated
@@ -1770,6 +1821,9 @@ def _run_single_child(
             except Exception as exc:
                 logger.debug("Failed to release credential lease: %s", exc)
 
+        if verify_requested and child_task_id:
+            side_effects.get_registry().clear(child_task_id)
+
         # Restore the parent's tool names so the process-global is correct
         # for any subsequent execute_code calls or other consumers.
         import model_tools
@@ -1811,6 +1865,8 @@ def delegate_task(
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
     role: Optional[str] = None,
+    verify_side_effects: Optional[bool] = None,
+    expected_side_effects: Optional[List[Dict[str, Any]]] = None,
     parent_agent=None,
 ) -> str:
     """
@@ -1841,6 +1897,10 @@ def delegate_task(
 
     # Normalise the top-level role once; per-task overrides re-normalise.
     top_role = _normalize_role(role)
+    top_verify_side_effects = is_truthy_value(verify_side_effects, default=False)
+    top_expected_side_effects = (
+        expected_side_effects if isinstance(expected_side_effects, list) else []
+    )
 
     # Depth limit — configurable via delegation.max_spawn_depth,
     # default 2 for parity with the original MAX_DEPTH constant.
@@ -1898,7 +1958,14 @@ def delegate_task(
         task_list = tasks
     elif goal and isinstance(goal, str) and goal.strip():
         task_list = [
-            {"goal": goal, "context": context, "toolsets": toolsets, "role": top_role}
+            {
+                "goal": goal,
+                "context": context,
+                "toolsets": toolsets,
+                "role": top_role,
+                "verify_side_effects": top_verify_side_effects,
+                "expected_side_effects": top_expected_side_effects,
+            }
         ]
     else:
         return tool_error("Provide either 'goal' (single task) or 'tasks' (batch).")
@@ -1935,6 +2002,15 @@ def delegate_task(
             # Per-task role beats top-level; normalise again so unknown
             # per-task values warn and degrade to leaf uniformly.
             effective_role = _normalize_role(t.get("role") or top_role)
+            task_verify_side_effects = is_truthy_value(
+                t.get("verify_side_effects"),
+                default=top_verify_side_effects,
+            )
+            task_expected_side_effects = (
+                t.get("expected_side_effects")
+                if isinstance(t.get("expected_side_effects"), list)
+                else top_expected_side_effects
+            )
             child = _build_child_agent(
                 task_index=i,
                 goal=t["goal"],
@@ -1957,6 +2033,8 @@ def delegate_task(
                     else (acp_args if acp_args is not None else creds.get("args"))
                 ),
                 role=effective_role,
+                verify_side_effects=task_verify_side_effects,
+                expected_side_effects=task_expected_side_effects,
             )
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names
@@ -1968,7 +2046,21 @@ def delegate_task(
     if n_tasks == 1:
         # Single task -- run directly (no thread pool overhead)
         _i, _t, child = children[0]
-        result = _run_single_child(0, _t["goal"], child, parent_agent)
+        result = _run_single_child(
+            0,
+            _t["goal"],
+            child,
+            parent_agent,
+            verify_side_effects=is_truthy_value(
+                _t.get("verify_side_effects"),
+                default=top_verify_side_effects,
+            ),
+            expected_side_effects=(
+                _t.get("expected_side_effects")
+                if isinstance(_t.get("expected_side_effects"), list)
+                else top_expected_side_effects
+            ),
+        )
         results.append(result)
     else:
         # Batch -- run in parallel with per-task progress lines
@@ -1984,6 +2076,15 @@ def delegate_task(
                     goal=t["goal"],
                     child=child,
                     parent_agent=parent_agent,
+                    verify_side_effects=is_truthy_value(
+                        t.get("verify_side_effects"),
+                        default=top_verify_side_effects,
+                    ),
+                    expected_side_effects=(
+                        t.get("expected_side_effects")
+                        if isinstance(t.get("expected_side_effects"), list)
+                        else top_expected_side_effects
+                    ),
                 )
                 futures[future] = i
 
@@ -2417,6 +2518,39 @@ DELEGATE_TASK_SCHEMA = {
                     "['terminal', 'file', 'web'] for full-stack tasks."
                 ),
             },
+            "verify_side_effects": {
+                "type": "boolean",
+                "description": (
+                    "Opt in when the delegated task is expected to create or "
+                    "mutate external state (upload, publish, remote write, "
+                    "shared-path file write). The child receives a "
+                    "record_side_effect tool and delegate_task returns a "
+                    "side_effect_verification object with parent-side checks."
+                ),
+            },
+            "expected_side_effects": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "kind": {"type": "string"},
+                        "path": {"type": "string"},
+                        "url": {"type": "string"},
+                        "verify_url": {"type": "string"},
+                        "target": {"type": "string"},
+                        "bytes": {"type": "integer"},
+                        "min_bytes": {"type": "integer"},
+                        "sha256": {"type": "string"},
+                        "contains": {"type": "string"},
+                        "expected_status": {"type": "integer"},
+                    },
+                },
+                "description": (
+                    "Optional expected side effects the child should record "
+                    "for verification, e.g. {'kind':'file_write','path':'/abs/file'} "
+                    "or {'kind':'url','url':'https://...','contains':'done'}."
+                ),
+            },
             "tasks": {
                 "type": "array",
                 "items": {
@@ -2431,6 +2565,29 @@ DELEGATE_TASK_SCHEMA = {
                             "type": "array",
                             "items": {"type": "string"},
                             "description": f"Toolsets for this specific task. Available: {_TOOLSET_LIST_STR}. Use 'web' for network access, 'terminal' for shell, 'browser' for web interaction.",
+                        },
+                        "verify_side_effects": {
+                            "type": "boolean",
+                            "description": "Per-task override for opt-in side-effect verification.",
+                        },
+                        "expected_side_effects": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "kind": {"type": "string"},
+                                    "path": {"type": "string"},
+                                    "url": {"type": "string"},
+                                    "verify_url": {"type": "string"},
+                                    "target": {"type": "string"},
+                                    "bytes": {"type": "integer"},
+                                    "min_bytes": {"type": "integer"},
+                                    "sha256": {"type": "string"},
+                                    "contains": {"type": "string"},
+                                    "expected_status": {"type": "integer"},
+                                },
+                            },
+                            "description": "Per-task expected side effects to record and verify.",
                         },
                         "acp_command": {
                             "type": "string",
@@ -2510,6 +2667,8 @@ registry.register(
         acp_command=args.get("acp_command"),
         acp_args=args.get("acp_args"),
         role=args.get("role"),
+        verify_side_effects=args.get("verify_side_effects"),
+        expected_side_effects=args.get("expected_side_effects"),
         parent_agent=kw.get("parent_agent"),
     ),
     check_fn=check_delegate_requirements,

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1430,6 +1430,31 @@ def _run_single_child(
             list(file_state.known_reads(parent_task_id)) if parent_task_id else []
         )
 
+        def _attach_side_effect_verification(
+            entry: Dict[str, Any], annotate_summary: bool = True
+        ) -> None:
+            if not verify_requested:
+                return
+            verification = side_effects.verify_side_effects(
+                child_task_id,
+                expected_side_effects,
+            )
+            checked_effects = verification.pop("side_effects")
+            entry["side_effects"] = checked_effects
+            entry["side_effect_verification"] = verification
+            verification_status = verification.get("status")
+            if entry.get("status") == "completed" and verification_status != "verified":
+                entry["status"] = "completed_unverified"
+            if annotate_summary and verification_status != "verified":
+                note = (
+                    "\n\n[SIDE EFFECT VERIFICATION: "
+                    f"{verification_status}; {verification.get('message')}]"
+                )
+                if entry.get("summary"):
+                    entry["summary"] = entry["summary"] + note
+                else:
+                    entry["summary"] = note.strip()
+
         # Run child with a hard timeout to prevent indefinite blocking
         # when the child's API call or tool-level HTTP request hangs.
         child_timeout = _get_child_timeout()
@@ -1536,7 +1561,7 @@ def _run_single_child(
             else:
                 _err = str(_timeout_exc)
 
-            return {
+            entry = {
                 "task_index": task_index,
                 "status": "timeout" if is_timeout else "error",
                 "summary": None,
@@ -1547,6 +1572,8 @@ def _run_single_child(
                 "_child_role": getattr(child, "_delegate_role", None),
                 "diagnostic_path": diagnostic_path,
             }
+            _attach_side_effect_verification(entry, annotate_summary=False)
+            return entry
         finally:
             # Shut down executor without waiting — if the child thread
             # is stuck on blocking I/O, wait=True would hang forever.
@@ -1663,26 +1690,7 @@ def _run_single_child(
         if status == "failed":
             entry["error"] = result.get("error", "Subagent did not produce a response.")
 
-        if verify_requested:
-            verification = side_effects.verify_side_effects(
-                child_task_id,
-                expected_side_effects,
-            )
-            checked_effects = verification.pop("side_effects")
-            entry["side_effects"] = checked_effects
-            entry["side_effect_verification"] = verification
-            verification_status = verification.get("status")
-            if entry.get("status") == "completed" and verification_status != "verified":
-                entry["status"] = "completed_unverified"
-            if verification_status != "verified":
-                note = (
-                    "\n\n[SIDE EFFECT VERIFICATION: "
-                    f"{verification_status}; {verification.get('message')}]"
-                )
-                if entry.get("summary"):
-                    entry["summary"] = entry["summary"] + note
-                else:
-                    entry["summary"] = note.strip()
+        _attach_side_effect_verification(entry)
 
         # Cross-agent file-state reminder.  If this subagent wrote any
         # files the parent had already read, surface it so the parent

--- a/tools/side_effects.py
+++ b/tools/side_effects.py
@@ -1,0 +1,498 @@
+#!/usr/bin/env python3
+"""Side-effect manifest recording and verification for delegated subagents."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import threading
+import time
+import urllib.error
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+from urllib.parse import urljoin
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+from tools.registry import registry, tool_error
+from tools.url_safety import is_safe_url
+
+
+_MAX_EFFECTS_PER_TASK = 256
+_MAX_BODY_BYTES = 2_000_000
+_DEFAULT_FIELD_CHARS = 2_048
+_FIELD_LIMITS = {
+    "kind": 64,
+    "path": 4_096,
+    "url": 4_096,
+    "verify_url": 4_096,
+    "target": 2_048,
+    "sha256": 128,
+    "contains": 8_192,
+    "description": 2_048,
+}
+_SUPPORTED_FILE_KINDS = {"file_write"}
+_REMOTE_MUTATION_KINDS = {"http_post", "http_put", "remote_write"}
+_SUPPORTED_URL_KINDS = {"url", "http_resource"} | _REMOTE_MUTATION_KINDS
+_ALLOWED_FIELDS = {
+    "kind",
+    "path",
+    "url",
+    "verify_url",
+    "target",
+    "status",
+    "bytes",
+    "min_bytes",
+    "sha256",
+    "contains",
+    "expected_status",
+    "description",
+}
+
+
+class _UnsafeRedirectError(Exception):
+    """Raised when URL verification follows a redirect to an unsafe target."""
+
+
+class _SafeRedirectHandler(HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        redirect_url = urljoin(req.full_url, newurl)
+        if not redirect_url.startswith(("http://", "https://")):
+            raise _UnsafeRedirectError(
+                f"Blocked redirect to non-http(s) URL: {redirect_url}"
+            )
+        if not is_safe_url(redirect_url):
+            raise _UnsafeRedirectError(
+                f"Blocked redirect to private/internal address: {redirect_url}"
+            )
+        return super().redirect_request(req, fp, code, msg, headers, redirect_url)
+
+
+_URL_OPENER = build_opener(_SafeRedirectHandler)
+
+
+def _open_verification_url(request: Request, timeout: int = 10):
+    return _URL_OPENER.open(request, timeout=timeout)
+
+
+class SideEffectManifestRegistry:
+    """Process-wide manifest store keyed by subagent task_id."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._effects: Dict[str, List[Dict[str, Any]]] = {}
+
+    def record(self, task_id: str, effect: Dict[str, Any]) -> Dict[str, Any]:
+        normalized = _normalize_effect(effect)
+        normalized["recorded_at"] = time.time()
+        with self._lock:
+            items = self._effects.setdefault(task_id, [])
+            items.append(normalized)
+            if len(items) > _MAX_EFFECTS_PER_TASK:
+                del items[: len(items) - _MAX_EFFECTS_PER_TASK]
+        return dict(normalized)
+
+    def list(self, task_id: str) -> List[Dict[str, Any]]:
+        with self._lock:
+            return [dict(item) for item in self._effects.get(task_id, [])]
+
+    def clear(self, task_id: Optional[str] = None) -> None:
+        with self._lock:
+            if task_id is None:
+                self._effects.clear()
+            else:
+                self._effects.pop(task_id, None)
+
+
+_registry = SideEffectManifestRegistry()
+
+
+def get_registry() -> SideEffectManifestRegistry:
+    return _registry
+
+
+def record_side_effect(task_id: str, effect: Dict[str, Any]) -> Dict[str, Any]:
+    return _registry.record(task_id, effect)
+
+
+def verify_side_effects(
+    task_id: str,
+    expected_side_effects: Optional[Iterable[Dict[str, Any]]] = None,
+) -> Dict[str, Any]:
+    effects = _registry.list(task_id)
+    verified_effects: List[Dict[str, Any]] = []
+    counts = {"verified": 0, "failed": 0, "unverified": 0}
+
+    expected = [
+        _normalize_effect(e)
+        for e in (expected_side_effects or [])
+        if isinstance(e, dict)
+    ]
+
+    for effect in effects:
+        checked = dict(effect)
+        verification_input = dict(effect)
+        for expected_effect in expected:
+            if _matches_expected(effect, expected_effect):
+                for key in (
+                    "bytes",
+                    "min_bytes",
+                    "sha256",
+                    "contains",
+                    "expected_status",
+                ):
+                    if key in expected_effect and key not in verification_input:
+                        verification_input[key] = expected_effect[key]
+        verification = _verify_one(verification_input)
+        checked["verification"] = verification
+        counts[verification["status"]] += 1
+        verified_effects.append(checked)
+
+    missing = [
+        expected_effect
+        for expected_effect in expected
+        if not any(_matches_expected(recorded, expected_effect) for recorded in effects)
+    ]
+
+    if not effects:
+        status = "failed"
+        message = "No side effects were recorded by the subagent."
+    elif counts["failed"] or missing:
+        status = "failed"
+        message = _verification_message(counts, len(missing))
+    elif counts["unverified"]:
+        status = "unverified"
+        message = _verification_message(counts, 0)
+    else:
+        status = "verified"
+        message = _verification_message(counts, 0)
+
+    return {
+        "requested": True,
+        "status": status,
+        "message": message,
+        "recorded_count": len(effects),
+        "verified_count": counts["verified"],
+        "failed_count": counts["failed"],
+        "unverified_count": counts["unverified"],
+        "missing_expected_count": len(missing),
+        "missing_expected": missing,
+        "side_effects": verified_effects,
+    }
+
+
+def _normalize_effect(effect: Dict[str, Any]) -> Dict[str, Any]:
+    out: Dict[str, Any] = {}
+    for key, value in effect.items():
+        if key not in _ALLOWED_FIELDS or value is None:
+            continue
+        if isinstance(value, str):
+            limit = _FIELD_LIMITS.get(key, _DEFAULT_FIELD_CHARS)
+            out[key] = value[:limit]
+        elif isinstance(value, (int, float, bool)):
+            out[key] = value
+        else:
+            limit = _FIELD_LIMITS.get(key, _DEFAULT_FIELD_CHARS)
+            out[key] = str(value)[:limit]
+    kind = str(out.get("kind") or "").strip().lower()
+    out["kind"] = kind or "other"
+    for key in (
+        "path",
+        "url",
+        "verify_url",
+        "target",
+        "sha256",
+        "contains",
+        "description",
+    ):
+        if key in out and isinstance(out[key], str):
+            out[key] = out[key].strip()
+    return out
+
+
+def _verify_one(effect: Dict[str, Any]) -> Dict[str, str]:
+    kind = str(effect.get("kind") or "").lower()
+    if kind in _SUPPORTED_FILE_KINDS:
+        return _verify_file_write(effect)
+    if kind in _SUPPORTED_URL_KINDS:
+        return _verify_url_effect(effect)
+    return {
+        "status": "unverified",
+        "reason": f"Unsupported side-effect kind: {kind or 'unknown'}",
+    }
+
+
+def _verify_file_write(effect: Dict[str, Any]) -> Dict[str, str]:
+    path_value = str(effect.get("path") or "").strip()
+    if not path_value:
+        return {"status": "failed", "reason": "Missing file path."}
+
+    path = Path(path_value).expanduser()
+    try:
+        resolved = path.resolve()
+        stat = resolved.stat()
+    except OSError as exc:
+        return {"status": "failed", "reason": f"File is not readable: {exc}"}
+
+    exact_bytes = _as_int(effect.get("bytes"))
+    if exact_bytes is not None and stat.st_size != exact_bytes:
+        return {
+            "status": "failed",
+            "reason": f"File size {stat.st_size} did not match expected {exact_bytes}.",
+        }
+
+    min_bytes = _as_int(effect.get("min_bytes"))
+    if min_bytes is not None and stat.st_size < min_bytes:
+        return {
+            "status": "failed",
+            "reason": f"File size {stat.st_size} was below expected minimum {min_bytes}.",
+        }
+
+    digest = str(effect.get("sha256") or "").strip().lower()
+    marker = str(effect.get("contains") or "")
+    needs_content = bool(digest or marker)
+    data = b""
+    if needs_content:
+        try:
+            with resolved.open("rb") as f:
+                data = f.read(_MAX_BODY_BYTES + 1)
+        except OSError as exc:
+            return {"status": "failed", "reason": f"File could not be read: {exc}"}
+
+    if digest:
+        actual = hashlib.sha256(data).hexdigest()
+        if len(data) > _MAX_BODY_BYTES:
+            return {
+                "status": "failed",
+                "reason": "File was too large to verify sha256 safely.",
+            }
+        if actual != digest:
+            return {"status": "failed", "reason": "File sha256 did not match."}
+
+    if marker and marker not in data.decode("utf-8", errors="ignore"):
+        return {"status": "failed", "reason": "File did not contain expected marker."}
+
+    return {"status": "verified", "reason": "File side effect verified."}
+
+
+def _verify_url_effect(effect: Dict[str, Any]) -> Dict[str, str]:
+    kind = str(effect.get("kind") or "").lower()
+    recorded_status = _as_int(effect.get("status"))
+    if recorded_status is not None and not (200 <= recorded_status < 300):
+        return {
+            "status": "failed",
+            "reason": f"Recorded HTTP status {recorded_status} was not successful.",
+        }
+
+    url = str(effect.get("verify_url") or effect.get("url") or "").strip()
+    if kind in _REMOTE_MUTATION_KINDS:
+        if not str(effect.get("verify_url") or "").strip():
+            return {
+                "status": "unverified",
+                "reason": "Remote mutation verification requires a separate verify_url.",
+            }
+        if not any(
+            key in effect and effect.get(key) not in (None, "")
+            for key in ("bytes", "min_bytes", "sha256", "contains")
+        ):
+            return {
+                "status": "unverified",
+                "reason": "Remote mutation verification requires content, size, or hash evidence.",
+            }
+
+    if not url:
+        return {
+            "status": "unverified",
+            "reason": "No verification URL was recorded.",
+        }
+    if not url.startswith(("http://", "https://")):
+        return {"status": "failed", "reason": "Verification URL must be http(s)."}
+    if not is_safe_url(url):
+        return {
+            "status": "failed",
+            "reason": "Verification URL targets a private or internal address.",
+        }
+
+    request = Request(url, headers={"User-Agent": "hermes-side-effect-verifier/1.0"})
+    try:
+        with _open_verification_url(request, timeout=10) as response:
+            status_value = getattr(response, "status", None)
+            if status_value is None:
+                status_value = response.getcode()
+            status = int(status_value)
+            data = response.read(_MAX_BODY_BYTES + 1)
+    except urllib.error.HTTPError as exc:
+        status = int(exc.code)
+        data = exc.read(_MAX_BODY_BYTES + 1)
+    except Exception as exc:
+        return {"status": "failed", "reason": f"Verification request failed: {exc}"}
+
+    expected_status = _as_int(effect.get("expected_status"))
+    if expected_status is not None:
+        if status != expected_status:
+            return {
+                "status": "failed",
+                "reason": f"HTTP {status} did not match expected {expected_status}.",
+            }
+    elif not (200 <= status < 300):
+        return {"status": "failed", "reason": f"HTTP {status} was not successful."}
+
+    min_bytes = _as_int(effect.get("min_bytes"))
+    if min_bytes is not None and len(data) < min_bytes:
+        return {
+            "status": "failed",
+            "reason": f"Response size {len(data)} was below expected minimum {min_bytes}.",
+        }
+
+    exact_bytes = _as_int(effect.get("bytes"))
+    if exact_bytes is not None and len(data) != exact_bytes:
+        return {
+            "status": "failed",
+            "reason": f"Response size {len(data)} did not match expected {exact_bytes}.",
+        }
+
+    digest = str(effect.get("sha256") or "").strip().lower()
+    if digest:
+        if len(data) > _MAX_BODY_BYTES:
+            return {
+                "status": "failed",
+                "reason": "Response was too large to verify sha256 safely.",
+            }
+        if hashlib.sha256(data).hexdigest() != digest:
+            return {"status": "failed", "reason": "Response sha256 did not match."}
+
+    marker = str(effect.get("contains") or "")
+    if marker and marker not in data.decode("utf-8", errors="ignore"):
+        return {
+            "status": "failed",
+            "reason": "Response did not contain expected marker.",
+        }
+
+    return {"status": "verified", "reason": "URL side effect verified."}
+
+
+def _matches_expected(recorded: Dict[str, Any], expected: Dict[str, Any]) -> bool:
+    if recorded.get("kind") != expected.get("kind"):
+        return False
+    for key in ("path", "url", "verify_url", "target"):
+        expected_value = str(expected.get(key) or "").strip()
+        if not expected_value:
+            continue
+        recorded_value = str(recorded.get(key) or "").strip()
+        if key == "path":
+            recorded_value = _norm_path(recorded_value)
+            expected_value = _norm_path(expected_value)
+        if recorded_value != expected_value:
+            return False
+    return True
+
+
+def _norm_path(path: str) -> str:
+    return os.path.abspath(os.path.expanduser(path)) if path else ""
+
+
+def _as_int(value: Any) -> Optional[int]:
+    if value is None or value == "":
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _verification_message(counts: Dict[str, int], missing_expected: int) -> str:
+    parts = []
+    if counts["verified"]:
+        parts.append(f"{counts['verified']} verified")
+    if counts["failed"]:
+        parts.append(f"{counts['failed']} failed")
+    if counts["unverified"]:
+        parts.append(f"{counts['unverified']} unverified")
+    if missing_expected:
+        parts.append(f"{missing_expected} expected missing")
+    return ", ".join(parts) if parts else "No side effects were verified."
+
+
+RECORD_SIDE_EFFECT_SCHEMA = {
+    "name": "record_side_effect",
+    "description": (
+        "Record a typed external side effect performed by this subagent so "
+        "delegate_task can verify it before the parent trusts the final summary."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "kind": {
+                "type": "string",
+                "description": "Side-effect kind, e.g. file_write, url, http_post, remote_write.",
+            },
+            "path": {
+                "type": "string",
+                "description": "Absolute file path for file_write effects.",
+            },
+            "url": {
+                "type": "string",
+                "description": "Public result URL or resource URL to verify.",
+            },
+            "verify_url": {
+                "type": "string",
+                "description": "Safe GET URL that verifies the side effect.",
+            },
+            "target": {
+                "type": "string",
+                "description": "External target identifier when no URL/path applies.",
+            },
+            "status": {
+                "type": "integer",
+                "description": "HTTP status observed by the subagent, if any.",
+            },
+            "bytes": {
+                "type": "integer",
+                "description": "Exact expected byte length, if known.",
+            },
+            "min_bytes": {
+                "type": "integer",
+                "description": "Minimum expected byte length.",
+            },
+            "sha256": {
+                "type": "string",
+                "description": "Expected SHA-256 for file content.",
+            },
+            "contains": {
+                "type": "string",
+                "description": "Text that should appear in the verified resource.",
+            },
+            "expected_status": {
+                "type": "integer",
+                "description": "Expected HTTP status for URL verification.",
+            },
+            "description": {
+                "type": "string",
+                "description": "Short human-readable note about the effect.",
+            },
+        },
+        "required": ["kind"],
+    },
+}
+
+
+def _handle_record_side_effect(
+    args: Dict[str, Any], task_id: Optional[str] = None, **_kw
+) -> str:
+    if not task_id:
+        return tool_error("record_side_effect requires a task_id.")
+    try:
+        recorded = record_side_effect(task_id, args)
+    except Exception as exc:
+        return tool_error(f"Could not record side effect: {exc}")
+    return json.dumps({"ok": True, "side_effect": recorded}, ensure_ascii=False)
+
+
+registry.register(
+    name="record_side_effect",
+    toolset="side_effects",
+    schema=RECORD_SIDE_EFFECT_SCHEMA,
+    handler=_handle_record_side_effect,
+    emoji="",
+    max_result_size_chars=8_000,
+)

--- a/tools/side_effects.py
+++ b/tools/side_effects.py
@@ -34,6 +34,13 @@ _FIELD_LIMITS = {
 _SUPPORTED_FILE_KINDS = {"file_write"}
 _REMOTE_MUTATION_KINDS = {"http_post", "http_put", "remote_write"}
 _SUPPORTED_URL_KINDS = {"url", "http_resource"} | _REMOTE_MUTATION_KINDS
+_CONSTRAINT_FIELDS = (
+    "bytes",
+    "min_bytes",
+    "sha256",
+    "contains",
+    "expected_status",
+)
 _ALLOWED_FIELDS = {
     "kind",
     "path",
@@ -131,19 +138,12 @@ def verify_side_effects(
 
     for effect in effects:
         checked = dict(effect)
-        verification_input = dict(effect)
-        for expected_effect in expected:
-            if _matches_expected(effect, expected_effect):
-                for key in (
-                    "bytes",
-                    "min_bytes",
-                    "sha256",
-                    "contains",
-                    "expected_status",
-                ):
-                    if key in expected_effect and key not in verification_input:
-                        verification_input[key] = expected_effect[key]
-        verification = _verify_one(verification_input)
+        matching_expected = [
+            expected_effect
+            for expected_effect in expected
+            if _matches_expected(effect, expected_effect)
+        ]
+        verification = _verify_with_expected_constraints(effect, matching_expected)
         checked["verification"] = verification
         counts[verification["status"]] += 1
         verified_effects.append(checked)
@@ -222,6 +222,63 @@ def _verify_one(effect: Dict[str, Any]) -> Dict[str, str]:
     }
 
 
+def _verify_with_expected_constraints(
+    effect: Dict[str, Any], matching_expected: Iterable[Dict[str, Any]]
+) -> Dict[str, str]:
+    expected_items = list(matching_expected)
+    recorded_input = dict(effect)
+    for expected_effect in expected_items:
+        if (
+            "expected_status" in expected_effect
+            and "expected_status" not in recorded_input
+        ):
+            recorded_input["expected_status"] = expected_effect["expected_status"]
+            break
+
+    checks = [_verify_one(recorded_input)]
+    for expected_effect in expected_items:
+        expected_input = dict(effect)
+        for key in _CONSTRAINT_FIELDS:
+            if key in expected_effect:
+                expected_input[key] = expected_effect[key]
+        checks.append(_verify_one(expected_input))
+
+    return _combine_verification_results(checks)
+
+
+def _combine_verification_results(checks: List[Dict[str, str]]) -> Dict[str, str]:
+    for index, check in enumerate(checks):
+        if check.get("status") == "failed":
+            if index:
+                return {
+                    "status": "failed",
+                    "reason": f"Expected side-effect constraint failed: {check.get('reason')}",
+                }
+            return check
+    expected_checks = checks[1:]
+    if expected_checks:
+        for check in expected_checks:
+            if check.get("status") == "unverified":
+                return {
+                    "status": "unverified",
+                    "reason": f"Expected side-effect constraint unverified: {check.get('reason')}",
+                }
+        if all(check.get("status") == "verified" for check in expected_checks):
+            recorded = checks[0]
+            if recorded.get("status") == "unverified":
+                return expected_checks[0]
+            return recorded
+    for index, check in enumerate(checks):
+        if check.get("status") == "unverified":
+            if index:
+                return {
+                    "status": "unverified",
+                    "reason": f"Expected side-effect constraint unverified: {check.get('reason')}",
+                }
+            return check
+    return checks[0] if checks else {"status": "unverified", "reason": "No check ran."}
+
+
 def _verify_file_write(effect: Dict[str, Any]) -> Dict[str, str]:
     path_value = str(effect.get("path") or "").strip()
     if not path_value:
@@ -277,12 +334,20 @@ def _verify_file_write(effect: Dict[str, Any]) -> Dict[str, str]:
 
 def _verify_url_effect(effect: Dict[str, Any]) -> Dict[str, str]:
     kind = str(effect.get("kind") or "").lower()
+    expected_status = _as_int(effect.get("expected_status"))
     recorded_status = _as_int(effect.get("status"))
-    if recorded_status is not None and not (200 <= recorded_status < 300):
-        return {
-            "status": "failed",
-            "reason": f"Recorded HTTP status {recorded_status} was not successful.",
-        }
+    if recorded_status is not None:
+        if expected_status is not None:
+            if recorded_status != expected_status:
+                return {
+                    "status": "failed",
+                    "reason": f"Recorded HTTP status {recorded_status} did not match expected {expected_status}.",
+                }
+        elif not (200 <= recorded_status < 300):
+            return {
+                "status": "failed",
+                "reason": f"Recorded HTTP status {recorded_status} was not successful.",
+            }
 
     url = str(effect.get("verify_url") or effect.get("url") or "").strip()
     if kind in _REMOTE_MUTATION_KINDS:
@@ -327,7 +392,6 @@ def _verify_url_effect(effect: Dict[str, Any]) -> Dict[str, str]:
     except Exception as exc:
         return {"status": "failed", "reason": f"Verification request failed: {exc}"}
 
-    expected_status = _as_int(effect.get("expected_status"))
     if expected_status is not None:
         if status != expected_status:
             return {

--- a/toolsets.py
+++ b/toolsets.py
@@ -193,6 +193,12 @@ TOOLSETS = {
         "includes": []
     },
 
+    "side_effects": {
+        "description": "Record delegated side-effect manifests for parent verification",
+        "tools": ["record_side_effect"],
+        "includes": []
+    },
+
     # "honcho" toolset removed — Honcho is now a memory provider plugin.
     # Tools are injected via MemoryManager, not the toolset system.
 


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in structural side-effect verification path for delegated subagents. Instead of trusting a child agent’s final summary alone, `delegate_task` can now grant a `record_side_effect` tool, collect a typed manifest, and verify recorded file/URL side effects before reporting the task as fully completed.

The implementation downgrades unverifiable claims to `completed_unverified`, verifies expected side effects when provided, blocks unsafe URL redirects during verification, requires concrete evidence for remote mutation checks, and bounds recorded manifest fields to keep parent context controlled.

## Related Issue

Fixes #16357

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/side_effects.py`: adds the side-effect manifest registry, `record_side_effect` tool, file/URL verification, redirect safety checks, remote mutation evidence requirements, and manifest field limits.
- `tools/delegate_tool.py`: adds `verify_side_effects` and `expected_side_effects` support, grants the side-effect recorder only when requested, and returns verification metadata.
- `run_agent.py`: forwards verification fields through delegate dispatch.
- `toolsets.py`: registers the new `side_effects` toolset.
- `tests/tools/test_delegate.py`: adds regression coverage for missing manifests, verified file writes, URL failures, unsafe redirects, remote mutation evidence, expected side effects, schema support, and batch isolation.

## How to Test

1. `.venv/bin/python -m pytest -o "addopts=" -n 0 --ignore=tests/integration --ignore=tests/e2e -m "not integration" tests/tools/test_delegate.py::TestDelegateSideEffectVerification tests/tools/test_delegate.py::TestDelegateRequirements::test_schema_valid`
2. `scripts/run_tests.sh tests/tools/test_delegate.py tests/tools/test_file_state_registry.py`
3. `.venv/bin/python -m ruff check tools/side_effects.py`
4. `.venv/bin/python -m ruff format --check tools/side_effects.py`
5. `.venv/bin/python -m compileall -q tools/side_effects.py tools/delegate_tool.py run_agent.py toolsets.py tests/tools/test_delegate.py`
6. `git diff --check`

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux container, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted verification passed:

- `15 passed` for side-effect verification/schema tests
- `145 passed` for `tests/tools/test_delegate.py` and `tests/tools/test_file_state_registry.py`
