### PR TITLE
fix(weixin): skip live_adapter session reuse in send_weixin_direct

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1980,33 +1980,12 @@ async def send_weixin_direct(
     token_store.restore(account_id)
     context_token = token_store.get(account_id, chat_id)
 
-    live_adapter = _LIVE_ADAPTERS.get(resolved_token)
-    send_session = getattr(live_adapter, '_send_session', None)
-    if live_adapter is not None and send_session is not None and not send_session.closed:
-        last_result: Optional[SendResult] = None
-        cleaned = live_adapter.format_message(message)
-        if cleaned:
-            last_result = await live_adapter.send(chat_id, cleaned)
-            if not last_result.success:
-                return {"error": f"Weixin send failed: {last_result.error}"}
-
-        for media_path, _is_voice in media_files or []:
-            ext = Path(media_path).suffix.lower()
-            if ext in {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp"}:
-                last_result = await live_adapter.send_image_file(chat_id, media_path)
-            else:
-                last_result = await live_adapter.send_document(chat_id, media_path)
-            if not last_result.success:
-                return {"error": f"Weixin media send failed: {last_result.error}"}
-
-        return {
-            "success": True,
-            "platform": "weixin",
-            "chat_id": chat_id,
-            "message_id": last_result.message_id if last_result else None,
-            "context_token_used": bool(context_token),
-        }
-
+    # The live_adapter's _send_session is bound to the gateway's main event loop.
+    # When send_weixin_direct is called from a worker thread (e.g., via
+    # send_message tool's _run_async → ThreadPoolExecutor), reusing that session
+    # causes "Timeout context manager should be used inside a task" because aiohttp
+    # session operations are tied to the loop they were created on.
+    # Always create a fresh session here to ensure loop compatibility.
     async with aiohttp.ClientSession(trust_env=True, connector=_make_ssl_connector()) as session:
         adapter = WeixinAdapter(
             PlatformConfig(


### PR DESCRIPTION
## Problem

Sending files via the  tool to WeChat fails with:



This happens in  → .

## Root Cause

The  function tries to reuse the  cached
session (line 1983-2008 before this fix). That session was created in the
gateway's main event loop, but  tool calls it from a worker
thread via  → , which creates a separate
event loop. aiohttp session operations are tied to the loop they were created
on, causing the error when called from a mismatched loop.

## Fix

Skip the  session reuse path entirely and always create a fresh
 for each  call. This ensures loop
compatibility regardless of the caller's async context.

## Testing

- Text messages (no media): continue to work via the text chunk path in the same function
- File/image attachments: now use a freshly created session with correct loop affinity
- No functional changes to the gateway's own WeixinAdapter lifecycle (still uses its own session)

---
Fixes: WeChat file/document sending via  tool
