### PR TITLE
fix(openviking): don't send Account/User headers with User API Key

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -92,15 +92,21 @@ class _VikingClient:
             raise ImportError("httpx is required for OpenViking: pip install httpx")
 
     def _headers(self) -> dict:
-        h = {
+        # User API Key: OV server parses account/user from the key itself,
+        # rejecting X-OpenViking-Account / X-OpenViking-User overrides (403).
+        if self._api_key:
+            return {
+                "Content-Type": "application/json",
+                "X-API-Key": self._api_key,
+                "X-OpenViking-Agent": self._agent,
+            }
+        # Root key or no key: send all context headers.
+        return {
             "Content-Type": "application/json",
             "X-OpenViking-Account": self._account,
             "X-OpenViking-User": self._user,
             "X-OpenViking-Agent": self._agent,
         }
-        if self._api_key:
-            h["X-API-Key"] = self._api_key
-        return h
 
     def _url(self, path: str) -> str:
         return f"{self._endpoint}{path}"


### PR DESCRIPTION
## Problem

When authenticating with a User API Key, `_VikingClient._headers()` always sends `X-OpenViking-Account` and `X-OpenViking-User` headers. However, the OpenViking server parses account/user from the key itself and rejects these override headers with a **403**:

```
X-OpenViking-Account cannot override the account for ADMIN/USER API keys.
```

This is a regression from PR #4825 (2026-04-03), which considered the no-key / Root Key case but not the User API Key case.

## Fix

`_headers()` now branches on whether an API key is present:

- **User API Key present** → only send `X-API-Key` + `X-OpenViking-Agent` (no Account/User)
- **Root key / no key** → send all context headers (unchanged behavior)

## Verification

- `viking_search`, `viking_browse`, `viking_read` all confirmed working after fix
- No 403 errors observed
- Tested after gateway restart