### PR TITLE
fix: preserve telegram cron topic delivery

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -192,17 +192,21 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
             chat_id, thread_id = rest, None
 
         # Resolve human-friendly labels like "Alice (dm)" to real IDs.
-        try:
-            from gateway.channel_directory import resolve_channel_name
-            resolved = resolve_channel_name(platform_key, chat_id)
-            if resolved:
-                parsed_chat_id, parsed_thread_id, resolved_is_explicit = _parse_target_ref(platform_key, resolved)
-                if resolved_is_explicit:
-                    chat_id, thread_id = parsed_chat_id, parsed_thread_id
-                else:
-                    chat_id = resolved
-        except Exception:
-            pass
+        # Explicit platform IDs have already been parsed above. Re-resolving
+        # them through the channel directory can strip explicit topic/thread
+        # suffixes when the directory contains an exact chat-id match.
+        if not is_explicit:
+            try:
+                from gateway.channel_directory import resolve_channel_name
+                resolved = resolve_channel_name(platform_key, chat_id)
+                if resolved:
+                    parsed_chat_id, parsed_thread_id, resolved_is_explicit = _parse_target_ref(platform_key, resolved)
+                    if resolved_is_explicit:
+                        chat_id, thread_id = parsed_chat_id, parsed_thread_id
+                    else:
+                        chat_id = resolved
+            except Exception:
+                pass
 
         return {
             "platform": platform_name,

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -42,6 +42,7 @@ AUTHOR_MAP = {
     # teknium (multiple emails)
     "teknium1@gmail.com": "teknium1",
     "teknium@nousresearch.com": "teknium1",
+    "alex@thealexferrari.com": "alexferrari88",
     "127238744+teknium1@users.noreply.github.com": "teknium1",
     "274096618+hermes-agent-dhabibi@users.noreply.github.com": "dhabibi",
     "johnnncenaaa77@gmail.com": "johnncenae",

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -129,6 +129,21 @@ class TestResolveDeliveryTarget:
             "thread_id": "17",
         }
 
+    def test_explicit_telegram_topic_keeps_thread_when_directory_has_chat_id(self):
+        """Exact channel-directory chat-id matches must not strip explicit topic IDs."""
+        job = {"deliver": "telegram:-1003724596514:345"}
+        with patch(
+            "gateway.channel_directory.resolve_channel_name",
+            return_value="-1003724596514",
+        ) as resolve_mock:
+            result = _resolve_delivery_target(job)
+        resolve_mock.assert_not_called()
+        assert result == {
+            "platform": "telegram",
+            "chat_id": "-1003724596514",
+            "thread_id": "345",
+        }
+
     def test_explicit_telegram_chat_id_without_thread_id(self):
         """deliver: 'telegram:chat_id' sets thread_id to None."""
         job = {


### PR DESCRIPTION
## Summary

- Preserve explicit Telegram topic/thread ids in cron delivery targets like `telegram:-1003724596514:345`.
- Avoid re-resolving already-explicit platform IDs through the channel directory, which can strip topic suffixes when the directory has an exact chat-id match.
- Add a regression test for the exact failure mode.

Fixes #16795

## Test Plan

- [x] `/home/alex/.hermes/hermes-agent/venv/bin/python -m pytest tests/cron/test_scheduler.py::TestResolveDeliveryTarget::test_explicit_telegram_topic_target_with_thread_id tests/cron/test_scheduler.py::TestResolveDeliveryTarget::test_explicit_telegram_topic_keeps_thread_when_directory_has_chat_id tests/cron/test_scheduler.py::TestResolveDeliveryTarget::test_human_friendly_topic_label_preserves_thread_id -q -o 'addopts='`

## Notes

A full local `tests/cron/test_scheduler.py` run is affected on my live host by the running Hermes gateway holding the real cron tick lock; the targeted resolver tests pass and CI should not have that live-service lock.
