### PR TITLE
fix: resolve NameError in rl_cli by moving import before usage

### DIFF
--- a/rl_cli.py
+++ b/rl_cli.py
@@ -29,6 +29,7 @@ import yaml
 
 # Load .env from ~/.hermes/.env first, then project root as dev fallback.
 # User-managed env files should override stale shell exports on restart.
+from hermes_constants import get_hermes_home, OPENROUTER_BASE_URL
 _hermes_home = get_hermes_home()
 _project_env = Path(__file__).parent / '.env'
 
@@ -59,9 +60,6 @@ from tools.rl_training_tool import get_missing_keys
 # ============================================================================
 # Config Loading
 # ============================================================================
-
-from hermes_constants import get_hermes_home, OPENROUTER_BASE_URL
-
 DEFAULT_MODEL = "anthropic/claude-opus-4.5"
 DEFAULT_BASE_URL = OPENROUTER_BASE_URL
 


### PR DESCRIPTION
## Summary

Resolves a `NameError` at module import time in `rl_cli.py`. The function `get_hermes_home()` was called on line 32, but its import from `hermes_constants` was not placed until line 63 — causing the module to crash immediately on any `import rl_cli` or `python rl_cli.py`.

## Fix

Moved `from hermes_constants import get_hermes_home, OPENROUTER_BASE_URL` to before the first usage at line 32. Removed the now-redundant duplicate import from the Config Loading section.

## Verification

- `python3 -c "import rl_cli"` now succeeds with no errors
- `ruff check rl_cli.py --select=F821` passes with no issues
- No changes to any other files in the codebase
