### PR TITLE
fix: add missing RateLimitState import to resolve F821 lint error

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -106,6 +106,7 @@ from agent.model_metadata import (
 from agent.context_compressor import ContextCompressor
 from agent.subdirectory_hints import SubdirectoryHintTracker
 from agent.prompt_caching import apply_anthropic_cache_control
+from agent.rate_limit_tracker import RateLimitState
 from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt, build_environment_hints, load_soul_md, TOOL_USE_ENFORCEMENT_GUIDANCE, TOOL_USE_ENFORCEMENT_MODELS, GOOGLE_MODEL_OPERATIONAL_GUIDANCE, OPENAI_MODEL_EXECUTION_GUIDANCE
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
 from agent.codex_responses_adapter import (


### PR DESCRIPTION
## Summary

Resolves an F821 ("undefined name") lint error in `run_agent.py:1189`. The class `RateLimitState` was used in a string type annotation on the `_rate_limit_state` field but was never imported — only `parse_rate_limit_headers` was imported from `agent.rate_limit_tracker`. Ruff correctly flags this as F821.

## Fix

Added `from agent.rate_limit_tracker import RateLimitState` to the import block alongside other agent internals imports.

## Verification

- `ruff check run_agent.py --select=F821` passes with no issues
- `python3 -m py_compile run_agent.py` passes with no errors
- `from run_agent import AIAgent` succeeds without import errors
- No changes to any other files in the codebase
