### PR TITLE
feat(gateway): display model name and context usage in response footer

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6630,6 +6630,19 @@ class GatewayRunner:
                         logger.debug("trailing footer send failed: %s", _e)
                 return None
 
+            # --- Auto-append context usage footer (non-streaming only) ---
+            if response and not agent_result.get("failed"):
+                _ctx_toks = agent_result.get("last_prompt_tokens", 0)
+                _ctx_len = agent_result.get("context_length", 0)
+                if _ctx_toks:
+                    _ctx_pct = min(100, _ctx_toks / _ctx_len * 100) if _ctx_len else 0
+                    # Always show context usage + model name
+                    _model_name = agent_result.get("model", "unknown") or "unknown"
+                    _footer = f"\n\n---\n🤖 {_model_name}  |  📊 Context: {_ctx_toks:,} / {_ctx_len:,} ({_ctx_pct:.0f}%)"
+                    if _ctx_pct >= 70:
+                        _footer += " ⚠️ 建议 /new 开启新会话"
+                    response += _footer
+
             return response
             
         except Exception as e:
@@ -11972,6 +11985,8 @@ class GatewayRunner:
             "api_calls": 1,
             "tools": [],
             "history_offset": len(history),
+            "last_prompt_tokens": 0,
+            "context_length": 0,
             "session_id": session_id,
             "response_previewed": _stream_consumer is not None and bool(full_response),
         }
@@ -13049,7 +13064,9 @@ class GatewayRunner:
             _context_length = 0
             _agent = agent_holder[0]
             if _agent and hasattr(_agent, "context_compressor"):
-                _last_prompt_toks = getattr(_agent.context_compressor, "last_prompt_tokens", 0)
+                _cc = _agent.context_compressor
+                _last_prompt_toks = getattr(_cc, "last_prompt_tokens", 0)
+                _context_length = getattr(_cc, "context_length", 0)
                 _input_toks = getattr(_agent, "session_prompt_tokens", 0)
                 _output_toks = getattr(_agent, "session_completion_tokens", 0)
                 _context_length = getattr(_agent.context_compressor, "context_length", 0) or 0
@@ -13066,6 +13083,7 @@ class GatewayRunner:
                     "tools": tools_holder[0] or [],
                     "history_offset": len(agent_history),
                     "last_prompt_tokens": _last_prompt_toks,
+                    "context_length": _context_length,
                     "input_tokens": _input_toks,
                     "output_tokens": _output_toks,
                     "model": _resolved_model,
@@ -13171,6 +13189,7 @@ class GatewayRunner:
                 "tools": tools_holder[0] or [],
                 "history_offset": _effective_history_offset,
                 "last_prompt_tokens": _last_prompt_toks,
+                "context_length": _context_length,
                 "input_tokens": _input_toks,
                 "output_tokens": _output_toks,
                 "model": _resolved_model,


### PR DESCRIPTION
## 📊 Display Model Name & Context Usage

This PR adds an automatic context usage footer to non-streaming gateway responses, helping users monitor their context window usage in real-time.

### What it shows

Every non-streaming response now includes a footer like:

```
---
🤖 anthropic/claude-sonnet-4  |  📊 Context: 45,230 / 200,000 (23%)
```

When context usage reaches **70%+**, it also shows a warning:

```
---
🤖 anthropic/claude-sonnet-4  |  📊 Context: 148,500 / 200,000 (74%) ⚠️ 建议 /new 开启新会话
```

### Changes

- Add context usage footer to non-streaming responses
- Track `context_length` in agent result (previously only `last_prompt_tokens` was tracked)
- Warning shown when context usage exceeds 70%, suggesting user to start a new session

### Why this matters

- Users often lose track of context consumption in long conversations
- When context gets full, model behavior degrades (truncation, lost instructions)
- Gives users visibility and actionable guidance before hitting the wall
- Helps users choose appropriate models for their context needs