### PR TITLE
fix: add request_timeout_seconds and stale_timeout_seconds to _KNOWN_KEYS

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2188,6 +2188,7 @@ def _normalize_custom_provider_entry(
         "name", "api", "url", "base_url", "api_key", "key_env",
         "api_mode", "transport", "model", "default_model", "models",
         "context_length", "rate_limit_delay",
+        "request_timeout_seconds", "stale_timeout_seconds",
     }
     for camel, snake in _CAMEL_ALIASES.items():
         if camel in entry and snake not in entry:


### PR DESCRIPTION
## Summary

Adds `"request_timeout_seconds"` and `"stale_timeout_seconds"` to the `_KNOWN_KEYS` set in the provider config validator. These two keys are already accepted and read by the runtime at other locations in the config module, but were missing from the validator's allowlist — causing a spurious "unknown config key" warning when users set them in `~/.hermes/config.yaml`.

## Fix

Added the two missing string keys to the `_KNOWN_KEYS` set in `hermes_cli/config.py`. This is a one-line addition that eliminates the false-positive warning without changing any runtime behavior.

## Verification

- `python3 -m py_compile hermes_cli/config.py` passes with no errors
- `from hermes_cli import config` succeeds without errors
- Related provider resolution tests pass: `pytest tests/hermes_cli/test_runtime_provider_resolution.py tests/hermes_cli/test_resolve_last_session.py -q` → 90 passed
- No changes to any other files in the codebase
