### PR TITLE
feat(bedrock): native support for application-inference-profile ARNs

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1109,6 +1109,15 @@ def anthropic_prompt_cache_policy(
     model_lower = eff_model.lower()
     provider_lower = eff_provider.lower()
     is_claude = "claude" in model_lower
+    # AWS Bedrock application-inference-profile ARNs and bare profile IDs do
+    # not contain "claude" in the string. Resolve them via boto3 so ARN-backed
+    # Claude gets the same prompt-caching treatment as bare model IDs.
+    if not is_claude and provider_lower == "bedrock":
+        try:
+            from agent.bedrock_adapter import is_anthropic_bedrock_model
+            is_claude = is_anthropic_bedrock_model(eff_model)
+        except Exception:
+            pass
     is_openrouter = base_url_host_matches(eff_base_url, "openrouter.ai")
     # Nous Portal proxies to OpenRouter behind the scenes — identical
     # OpenAI-wire envelope cache_control semantics. Treat it as an

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3640,7 +3640,15 @@ def resolve_provider_client(
                          "no AWS credentials found")
             return None, None
 
-        region = resolve_bedrock_region()
+        # Region priority: config.yaml bedrock.region → AWS_REGION env →
+        # AWS_DEFAULT_REGION → us-east-1.  Mirrors runtime_provider.py so
+        # auxiliary calls hit the same region as the main agent path.
+        try:
+            from hermes_cli.config import load_config as _load_aux_cfg
+            _aux_bedrock_cfg = _load_aux_cfg().get("bedrock", {}) or {}
+            region = (_aux_bedrock_cfg.get("region") or "").strip() or resolve_bedrock_region()
+        except Exception:
+            region = resolve_bedrock_region()
         default_model = "anthropic.claude-haiku-4-5-20251001-v1:0"
         final_model = _normalize_resolved_model(model or default_model, provider)
         try:

--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -381,6 +381,62 @@ def _model_supports_tool_use(model_id: str) -> bool:
     return not any(pattern in model_lower for pattern in _NON_TOOL_CALLING_PATTERNS)
 
 
+_APPLICATION_PROFILE_FAMILY_CACHE: Dict[str, Optional[str]] = {}
+
+_APPLICATION_PROFILE_ARN_RE = re.compile(
+    r"^arn:aws:bedrock:(?P<region>[\w-]+):\d+:application-inference-profile/[\w-]+$",
+    re.IGNORECASE,
+)
+
+
+def _resolve_application_inference_profile_family(arn: str) -> Optional[str]:
+    """Resolve the foundation-model family (e.g. ``anthropic``) behind an
+    application-inference-profile ARN.
+
+    Application inference profiles are user-defined wrappers around a
+    foundation model (or another inference profile) used for cost allocation
+    and tagging. Their ARN does not contain the underlying model name, so we
+    look it up via ``bedrock.GetInferenceProfile`` and inspect the first
+    referenced ``modelArn``.
+
+    Results are cached in-process. On any failure (network, IAM, unknown
+    shape) we cache ``None`` so callers gracefully fall through to the
+    Converse API path.
+    """
+    if arn in _APPLICATION_PROFILE_FAMILY_CACHE:
+        return _APPLICATION_PROFILE_FAMILY_CACHE[arn]
+
+    match = _APPLICATION_PROFILE_ARN_RE.match(arn)
+    if not match:
+        _APPLICATION_PROFILE_FAMILY_CACHE[arn] = None
+        return None
+    region = match.group("region")
+
+    family: Optional[str] = None
+    try:
+        client = _get_bedrock_control_client(region)
+        resp = client.get_inference_profile(inferenceProfileIdentifier=arn)
+        for entry in resp.get("models", []):
+            model_arn = (entry.get("modelArn") or "").lower()
+            fm = re.search(r"foundation-model/([\w.:-]+)", model_arn)
+            if not fm:
+                continue
+            fm_id = fm.group(1)
+            family = fm_id.split(".", 1)[0] if "." in fm_id else fm_id
+            break
+    except Exception as exc:
+        logger.warning(
+            "Could not resolve application-inference-profile %s family via "
+            "GetInferenceProfile (%s); falling back to Converse path. "
+            "Grant 'bedrock:GetInferenceProfile' for full Anthropic SDK features.",
+            arn,
+            exc,
+        )
+
+    _APPLICATION_PROFILE_FAMILY_CACHE[arn] = family
+    return family
+
+
 def is_anthropic_bedrock_model(model_id: str) -> bool:
     """Return True if the model is an Anthropic Claude model on Bedrock.
 
@@ -393,9 +449,14 @@ def is_anthropic_bedrock_model(model_id: str) -> bool:
       - ``us.anthropic.claude-*`` (US inference profiles)
       - ``global.anthropic.claude-*`` (global inference profiles)
       - ``eu.anthropic.claude-*`` (EU inference profiles)
+      - ``arn:aws:bedrock:<region>:<acct>:application-inference-profile/<id>``
+        when the underlying foundation model belongs to the ``anthropic``
+        family (resolved once via GetInferenceProfile and cached).
     """
+    if _APPLICATION_PROFILE_ARN_RE.match(model_id):
+        return _resolve_application_inference_profile_family(model_id) == "anthropic"
+
     model_lower = model_id.lower()
-    # Strip regional prefix if present
     for prefix in ("us.", "global.", "eu.", "ap.", "jp."):
         if model_lower.startswith(prefix):
             model_lower = model_lower[len(prefix):]

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -589,6 +589,21 @@ def resolve_display_context_length(
     Prefer the provider-aware value; fall back to ``model_info.context_window``
     only if the resolver returns nothing.
     """
+    # User-declared per-alias context_length wins.  Allows opaque IDs like
+    # AWS Bedrock application-inference-profile ARNs (whose built-in
+    # heuristics return wrong defaults) to declare their true window in
+    # ``config.yaml model_aliases.<name>.context_length``.
+    try:
+        from hermes_cli.config import load_config as _load_alias_cfg
+        for _alias_entry in (_load_alias_cfg().get("model_aliases") or {}).values():
+            if not isinstance(_alias_entry, dict):
+                continue
+            if _alias_entry.get("model") == model:
+                _alias_ctx = _alias_entry.get("context_length")
+                if _alias_ctx and int(_alias_ctx) > 0:
+                    return int(_alias_ctx)
+    except Exception:
+        pass
     try:
         from agent.model_metadata import get_model_context_length
         ctx = get_model_context_length(

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3596,6 +3596,16 @@ def validate_requested_model(
     # Anthropic Messages API: many proxies don't implement /v1/models.
     # Try probing with correct auth; if it fails, accept with a warning.
     if api_mode == "anthropic_messages":
+        # AWS Bedrock runtime does not implement GET /v1/models — model id
+        # validation happens server-side at invoke time.  Skip the probe and
+        # the noisy "could not verify" notice for native bedrock provider.
+        if normalized == "bedrock":
+            return {
+                "accepted": True,
+                "persist": True,
+                "recognized": True,
+                "message": None,
+            }
         api_models = fetch_api_models(api_key, base_url, api_mode=api_mode)
         if api_models is not None:
             if requested_for_lookup in set(api_models):


### PR DESCRIPTION
## Summary

Hermes recognises Bedrock Claude models via string-prefix matching (e.g. `anthropic.claude-*`, `us.anthropic.claude-*`).  AWS [application-inference-profile](https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-application-create.html) ARNs (`arn:aws:bedrock:<region>:<acct>:application-inference-profile/<id>`) carry no model name in the string, so they were misidentified as non-Claude models and silently routed away from prompt caching, given wrong context-length defaults, validated against the wrong region, and probed against `/v1/models` that bedrock-runtime does not implement.

This PR teaches Hermes to recognise such ARNs as first-class Bedrock model identifiers across **five** touchpoints, all gated behind `provider == "bedrock"` so non-Bedrock paths are unaffected.

## Why

Application inference profiles are how AWS organisations attach **cost-allocation tags** and **per-team budgets** to model usage.  Treating them as opaque blobs costs users the entire prompt-caching feature (5x+ token bill on agent workflows), forces wrong context windows on `/model` switch, and can route auxiliary calls to the wrong region.  All five issues observed on a real account where `claude-sonnet-4-6` was wrapped by an application profile in `us-west-2`.

## Changes

| # | File | Function | Fix |
|---|---|---|---|
| 1 | `agent/bedrock_adapter.py` | `is_anthropic_bedrock_model()` | Resolves application-inference-profile ARNs via `bedrock.GetInferenceProfile`, looks at the underlying foundation-model family, and caches per-ARN results in-process |
| 2 | `run_agent.py` | `_anthropic_prompt_cache_policy()` | Calls `is_anthropic_bedrock_model()` for `provider == "bedrock"` so ARN-backed Claude gets `cache_control` markers injected (Bedrock supports it server-side; we just weren't asking) |
| 3 | `agent/auxiliary_client.py` | bedrock branch in `resolve_provider_client()` | Reads `config.yaml bedrock.region` first (mirrors `runtime_provider.py:1117`) instead of relying solely on `resolve_bedrock_region()` which only sees env vars and misses `~/.aws/config`'s default region |
| 4 | `hermes_cli/model_switch.py` | `resolve_display_context_length()` | Honours `model_aliases.<name>.context_length` first.  Lets users declare per-alias context windows for opaque IDs (like ARNs) that built-in heuristics can't introspect |
| 5 | `hermes_cli/models.py` | `validate_requested_model()` | Skips the `/v1/models` probe and the noisy "could not verify" warning when `provider == "bedrock"`.  bedrock-runtime simply does not implement the Anthropic Models API — model id validation happens at invoke time |

Net diff: **+102 / -2** lines across 5 files.  No new dependencies (boto3 already optional via `[bedrock]` extra); the ARN lookup only runs when an actual ARN is encountered and is cached afterwards.

## Test plan

Verified end-to-end on a live `application-inference-profile` ARN backed by Claude Sonnet 4.6 in `us-west-2`:

- [x] `is_anthropic_bedrock_model(arn)` returns `True` for ARN; non-ARN inputs unchanged
- [x] `_anthropic_prompt_cache_policy()` returns `(True, True)` for ARN under bedrock
- [x] Live `client.messages.create()` with same ARN + `cache_control: {type: ephemeral}` returns `cache_creation_input_tokens > 0` on call 1, `cache_read_input_tokens > 0` on call 2 — confirms Bedrock honours the marker
- [x] `hermes -z "..."` with `HERMES_DUMP_REQUESTS=1` shows `cache_control` markers in the request body via Bedrock to ARN
- [x] Auxiliary `title_generation` / `vision` / `compression` all land on the configured region instead of `us-east-1`
- [x] `/model opus` shows the alias-declared context window (1M for sonnet/opus, 200K for haiku) instead of `BEDROCK_DEFAULT_CONTEXT_LENGTH (128K)`
- [x] `/model bedrock` switch no longer prints "could not verify against this endpoint's model listing"
- [x] All existing Bedrock string-prefix paths still work (`anthropic.claude-*`, `us.anthropic.claude-*`, `global.anthropic.claude-*`)
- [x] Non-Anthropic Bedrock models unaffected (`amazon.nova-*`, `meta.llama-*`)

## IAM

Patch 1 calls `bedrock:GetInferenceProfile`.  This is included in `AmazonBedrockFullAccess` and most read-only Bedrock policies.  If the call fails (permission denied, throttled, etc.) the function gracefully falls back to the Converse API path with a warning logged — no hard failure, just no caching for that ARN.


Made with [Cursor](https://cursor.com)