### PR TITLE
Fix CLI routing for user-defined providers (closes #16767)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7762,32 +7762,12 @@ For more help on a command:
     )
     chat_parser.add_argument(
         "--provider",
-        choices=[
-            "auto",
-            "openrouter",
-            "nous",
-            "openai-codex",
-            "copilot-acp",
-            "copilot",
-            "anthropic",
-            "gemini",
-            "xai",
-            "ollama-cloud",
-            "huggingface",
-            "zai",
-            "kimi-coding",
-            "kimi-coding-cn",
-            "stepfun",
-            "minimax",
-            "minimax-cn",
-            "kilocode",
-            "xiaomi",
-            "arcee",
-            "gmi",
-            "nvidia",
-        ],
+        # No `choices=` here: user-defined providers from config.yaml `providers:`
+        # are also valid values, and runtime resolution (resolve_runtime_provider)
+        # handles validation/error reporting consistently with the top-level
+        # `--provider` flag.
         default=None,
-        help="Inference provider (default: auto)",
+        help="Inference provider (default: auto). Built-in or a user-defined name from `providers:` in config.yaml.",
     )
     chat_parser.add_argument(
         "-v", "--verbose", action="store_true", help="Verbose output"

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -213,10 +213,15 @@ def _load_direct_aliases() -> dict[str, DirectAlias]:
 
 
 def _ensure_direct_aliases() -> None:
-    """Lazy-load direct aliases on first use."""
-    global DIRECT_ALIASES
+    """Lazy-load direct aliases on first use.
+
+    Mutates the existing DIRECT_ALIASES dict in place rather than rebinding
+    the module attribute. This keeps `from hermes_cli.model_switch import
+    DIRECT_ALIASES` references valid in callers — rebinding would leave them
+    pointing at a stale empty dict.
+    """
     if not DIRECT_ALIASES:
-        DIRECT_ALIASES = _load_direct_aliases()
+        DIRECT_ALIASES.update(_load_direct_aliases())
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -128,27 +128,44 @@ def _run_agent(
     # the user's configured default provider, which may not host the model
     # the caller just asked for.
     effective_provider = (provider or "").strip() or None
+    explicit_base_url_from_alias: Optional[str] = None
     if effective_provider is None and (model or env_model):
         # Only auto-detect when the model was explicitly requested via arg or
         # env var (not when it came from config — that's the "use my defaults"
         # path and the configured provider is already correct).
         explicit_model = (model or "").strip() or env_model
         if explicit_model:
-            cfg_provider = ""
-            if isinstance(model_cfg, dict):
-                cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
-            current_provider = (
-                cfg_provider
-                or os.getenv("HERMES_INFERENCE_PROVIDER", "").strip().lower()
-                or "auto"
-            )
-            detected = detect_provider_for_model(explicit_model, current_provider)
-            if detected:
-                effective_provider, effective_model = detected
+            # First check DIRECT_ALIASES populated from config.yaml `model_aliases:`.
+            # These map a user-defined alias to (model, provider, base_url) for
+            # endpoints not in any catalog (local servers, custom proxies, etc.).
+            try:
+                from hermes_cli import model_switch as _ms
+                _ms._ensure_direct_aliases()
+                direct = _ms.DIRECT_ALIASES.get(explicit_model.strip().lower())
+            except Exception:
+                direct = None
+            if direct is not None:
+                effective_model = direct.model
+                effective_provider = direct.provider
+                if direct.base_url:
+                    explicit_base_url_from_alias = direct.base_url.rstrip("/")
+            else:
+                cfg_provider = ""
+                if isinstance(model_cfg, dict):
+                    cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
+                current_provider = (
+                    cfg_provider
+                    or os.getenv("HERMES_INFERENCE_PROVIDER", "").strip().lower()
+                    or "auto"
+                )
+                detected = detect_provider_for_model(explicit_model, current_provider)
+                if detected:
+                    effective_provider, effective_model = detected
 
     runtime = resolve_runtime_provider(
         requested=effective_provider,
         target_model=effective_model or None,
+        explicit_base_url=explicit_base_url_from_alias,
     )
 
     # Pull in whatever toolsets the user has enabled for "cli".

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -464,6 +464,30 @@ def _resolve_named_custom_runtime(
     explicit_api_key: Optional[str] = None,
     explicit_base_url: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
+    # Bare `provider="custom"` with an explicit base_url (e.g. propagated
+    # from a `model_aliases:` direct-alias resolution) — build a runtime
+    # directly so the alias's base_url actually takes effect.
+    requested_norm = (requested_provider or "").strip().lower()
+    if requested_norm == "custom" and explicit_base_url:
+        base_url = explicit_base_url.strip().rstrip("/")
+        api_key_candidates = [
+            (explicit_api_key or "").strip(),
+            os.getenv("OPENAI_API_KEY", "").strip(),
+            os.getenv("OPENROUTER_API_KEY", "").strip(),
+        ]
+        api_key = next(
+            (c for c in api_key_candidates if has_usable_secret(c)),
+            "",
+        ) or "no-key-required"
+        return {
+            "provider": "custom",
+            "api_mode": _detect_api_mode_for_url(base_url) or "chat_completions",
+            "base_url": base_url,
+            "api_key": api_key,
+            "source": "direct-alias",
+            "requested_provider": requested_provider,
+        }
+
     custom_provider = _get_named_custom_provider(requested_provider)
     if not custom_provider:
         return None

--- a/tests/hermes_cli/test_regression_16767.py
+++ b/tests/hermes_cli/test_regression_16767.py
@@ -1,0 +1,58 @@
+import pytest
+import sys
+from unittest.mock import patch
+from pathlib import Path
+
+import hermes_cli.model_switch as ms
+from hermes_cli.model_switch import DirectAlias
+from hermes_cli.runtime_provider import _resolve_named_custom_runtime
+
+def test_ensure_direct_aliases_mutates_in_place(monkeypatch):
+    """_ensure_direct_aliases mutates DIRECT_ALIASES in place (guards against rebinding regression)."""
+    # Ensure we start with an empty but existing dict to check for mutation vs rebinding
+    ms.DIRECT_ALIASES.clear()
+    initial_id = id(ms.DIRECT_ALIASES)
+    
+    mock_data = {
+        "my-custom-alias": DirectAlias("custom-model:v1", "custom", "https://example.com/v1")
+    }
+    monkeypatch.setattr(ms, "_load_direct_aliases", lambda: mock_data)
+    
+    ms._ensure_direct_aliases()
+    
+    assert id(ms.DIRECT_ALIASES) == initial_id, f"DIRECT_ALIASES was rebound (ID changed from {initial_id} to {id(ms.DIRECT_ALIASES)})"
+    assert "my-custom-alias" in ms.DIRECT_ALIASES
+    assert ms.DIRECT_ALIASES["my-custom-alias"].model == "custom-model:v1"
+
+def test_chat_provider_argparse_acceptance(monkeypatch):
+    """chat --provider <user-defined> is accepted by argparse (guards against restrictive choices)."""
+    recorded: dict[str, str] = {}
+
+    # Mock cmd_chat to record the provider passed to it
+    def mock_cmd_chat(args):
+        recorded["provider"] = args.provider
+
+    monkeypatch.setattr("hermes_cli.main.cmd_chat", mock_cmd_chat)
+    monkeypatch.setattr(sys, "argv", ["hermes", "chat", "--provider", "my-custom-key"])
+
+    from hermes_cli.main import main
+    main()
+
+    assert recorded["provider"] == "my-custom-key"
+
+def test_resolve_named_custom_runtime_honors_explicit_base_url(monkeypatch):
+    """_resolve_named_custom_runtime honors (provider='custom', explicit_base_url=...)."""
+    # Mock has_usable_secret to recognize our test key
+    monkeypatch.setattr("hermes_cli.runtime_provider.has_usable_secret", lambda x: x == "test-api-key")
+    
+    result = _resolve_named_custom_runtime(
+        requested_provider="custom",
+        explicit_api_key="test-api-key",
+        explicit_base_url="http://example.test:1234/v1"
+    )
+    
+    assert result is not None
+    assert result["base_url"] == "http://example.test:1234/v1"
+    assert result["provider"] == "custom"
+    assert result["api_key"] == "test-api-key"
+    assert result["source"] == "direct-alias"


### PR DESCRIPTION
Closes #16767.

User-defined providers configured in `~/.hermes/config.yaml` (`providers:` dict + `model_aliases:`) were silently dropped by two CLI paths, so requests routed to the wrong endpoint. This PR fixes both paths and adds regression tests.

## Commits

- **`fix(cli): honor user-defined providers via chat --provider and -m <alias>`** (4 files, +65/−39):
  - `hermes_cli/model_switch.py` — root cause: `_ensure_direct_aliases()` rebound `DIRECT_ALIASES` to a freshly-loaded dict, leaving every `from … import DIRECT_ALIASES` caller stuck on the stale empty original. Switched to `.update()` so module attribute references stay valid.
  - `hermes_cli/main.py` — chat subcommand `--provider` had `choices=[…]` hardcoded to built-in providers, rejecting valid keys from user `providers:` config. Dropped the choices list; runtime resolution validates correctly downstream.
  - `hermes_cli/oneshot.py` — `-m <alias>` only resolved the model name; the alias's `base_url` was never propagated. Now consults `DIRECT_ALIASES` before falling through to `detect_provider_for_model`, and threads the alias's `base_url` to `resolve_runtime_provider(explicit_base_url=…)`.
  - `hermes_cli/runtime_provider.py` — `_resolve_named_custom_runtime` now honors `(provider="custom", explicit_base_url=…)` so a `base_url` propagated from a direct-alias resolution actually builds a runtime instead of falling through to provider-registry handlers that don't know about ad-hoc local endpoints.

- **`test(cli): regression coverage for user-provider routing fix (#16767)`** (1 file, +58):
  - `test_ensure_direct_aliases_mutates_in_place` — captures `id(DIRECT_ALIASES)` before/after `_ensure_direct_aliases()` and asserts it's unchanged. Catches the rebinding regression specifically.
  - `test_chat_provider_argparse_acceptance` — invokes `main()` with `chat --provider my-custom-key` and asserts no `SystemExit` plus the value propagates. Catches the choices-list regression.
  - `test_resolve_named_custom_runtime_honors_explicit_base_url` — calls the function with `provider="custom"` + an explicit base_url and asserts the returned dict has the right base_url and `source == "direct-alias"`.

## Test plan

- [x] `pytest -q tests/hermes_cli/test_regression_16767.py` passes on this branch (3/3 in ~1.4 s)
- [x] Same tests **fail** when only the four source files are reverted to `main` (test file kept) — produces the exact argparse error / staleness symptoms the bugs cause, confirming each test catches its target regression
- [x] Verified end-to-end live: `hermes chat --provider <user-defined-key> -m <model> -q "…"` and `hermes -m <user-alias> -z "…"` both reach the user-intended endpoint after the fix, observable via the target server's request log

## Notes

- No new dependencies, no schema changes, no upstream behavior change for any existing CLI invocation that already worked.
- The TUI `/model` command path is unaffected (it already worked correctly via a different code path).
- See the original issue #16767 for the reproducible setup and the per-bug root-cause analysis.
