### PR TITLE
fix(config): add request_timeout_seconds and stale_timeout_seconds to provider _KNOWN_KEYS (#16779)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2188,6 +2188,7 @@ def _normalize_custom_provider_entry(
         "name", "api", "url", "base_url", "api_key", "key_env",
         "api_mode", "transport", "model", "default_model", "models",
         "context_length", "rate_limit_delay",
+        "request_timeout_seconds", "stale_timeout_seconds",
     }
     for camel, snake in _CAMEL_ALIASES.items():
         if camel in entry and snake not in entry:


### PR DESCRIPTION
## Summary

The provider-entry validator in `hermes_cli/config.py` has a `_KNOWN_KEYS` set that's out of sync with both the documented config example and the runtime code. It warns on `request_timeout_seconds` and `stale_timeout_seconds` as "unknown config keys ignored" even though those are:

1. **Read at runtime** — `hermes_cli/timeouts.py:40` reads `provider_config.get("request_timeout_seconds")` and `:69` reads `provider_config.get("stale_timeout_seconds")`
2. **Documented** — `cli-config.yaml.example` shows both keys in the `providers:` section

## Fix

Add both keys to the `_KNOWN_KEYS` set (one-line change).

**File changed:** `hermes_cli/config.py` (+2 lines in set literal)

## Impact

Eliminates false warnings for users who configure per-provider timeouts as documented. No behavioral change — the keys already work; this just stops the spurious warning.

Fixes #16779
