### PR TITLE
fix(cron): preserve explicit thread_id in delivery target resolution (#16795)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -192,17 +192,20 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
             chat_id, thread_id = rest, None
 
         # Resolve human-friendly labels like "Alice (dm)" to real IDs.
-        try:
-            from gateway.channel_directory import resolve_channel_name
-            resolved = resolve_channel_name(platform_key, chat_id)
-            if resolved:
-                parsed_chat_id, parsed_thread_id, resolved_is_explicit = _parse_target_ref(platform_key, resolved)
-                if resolved_is_explicit:
-                    chat_id, thread_id = parsed_chat_id, parsed_thread_id
-                else:
-                    chat_id = resolved
-        except Exception:
-            pass
+        # Skip when the target was already explicit (had a chat_id:thread_id)
+        # — re-resolving would strip the thread_id (#16795).
+        if not is_explicit:
+            try:
+                from gateway.channel_directory import resolve_channel_name
+                resolved = resolve_channel_name(platform_key, chat_id)
+                if resolved:
+                    parsed_chat_id, parsed_thread_id, resolved_is_explicit = _parse_target_ref(platform_key, resolved)
+                    if resolved_is_explicit:
+                        chat_id, thread_id = parsed_chat_id, parsed_thread_id
+                    else:
+                        chat_id = resolved
+            except Exception:
+                pass
 
         return {
             "platform": platform_name,


### PR DESCRIPTION
## Summary

Cron delivery targets that explicitly include a Telegram forum topic (e.g. `telegram:-1003724596514:345`) lose the topic/thread ID during channel-directory resolution. Messages land in the General topic instead of the configured topic.

## Root Cause

`_resolve_single_delivery_target()` correctly parses `telegram:chat_id:thread_id` into `chat_id="-1003724596514"` and `thread_id="345"`. But then it runs `resolve_channel_name()` on the parsed `chat_id`. When the directory has an exact match for the group chat ID, it returns just the chat ID (without thread). The second `_parse_target_ref()` call on this result returns `thread_id=None`, which overwrites the previously parsed `"345"`.

## Fix

Skip channel-directory resolution when the original target was already explicit (`is_explicit=True`). Human-friendly label resolution (e.g. "Alice (dm)" → real ID) should only run for non-explicit targets.

**File changed:** `cron/scheduler.py` (+3 lines, 1 indentation change)

## Before/After

```python
# Before: thread_id dropped
_resolve_single_delivery_target(job, "telegram:-1003724596514:345")
# → {"platform": "telegram", "chat_id": "-1003724596514", "thread_id": None}

# After: thread_id preserved
_resolve_single_delivery_target(job, "telegram:-1003724596514:345")
# → {"platform": "telegram", "chat_id": "-1003724596514", "thread_id": "345"}
```

Fixes #16795
