### PR TITLE
fix(models): update stale xAI model list (#16699)

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -194,8 +194,12 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "glm-4.5-flash",
     ],
     "xai": [
-        "grok-4.20-reasoning",
-        "grok-4-1-fast-reasoning",
+        "grok-4.20",
+        "grok-4.20-multi-agent",
+        "grok-4.1-fast",
+        "grok-4-fast",
+        "grok-4",
+        "grok-code-fast-1",
     ],
     "nvidia": [
         # NVIDIA flagship reasoning models


### PR DESCRIPTION
## Summary

The hardcoded `_PROVIDER_MODELS["xai"]` list in `hermes_cli/models.py` is stale. The previous entries (`grok-4.20-reasoning`, `grok-4-1-fast-reasoning`) no longer exist in xAI's catalog, causing HTTP 400 "Unknown Model" errors when users select them from the `/model` picker.

## Root Cause

xAI renamed their models. The old names (`grok-4.20-reasoning`, `grok-4-1-fast-reasoning`) are no longer accepted.

## Fix

Updated to current xAI model IDs (verified via OpenRouter catalog):

| Old | New | Context |
|-----|-----|---------|
| `grok-4.20-reasoning` | `grok-4.20` | 2M |
| `grok-4-1-fast-reasoning` | `grok-4.1-fast` | 2M |
| — | `grok-4.20-multi-agent` | 2M |
| — | `grok-4-fast` | 2M |
| — | `grok-4` | 256K |
| — | `grok-code-fast-1` | 256K |

**File changed:** `hermes_cli/models.py` (6 lines changed in `_PROVIDER_MODELS["xai"]`)

## Testing

Verified model IDs against OpenRouter's live catalog (`/api/v1/models`).

Fixes #16699
