### PR TITLE
fix: normalize Anthropic PascalCase MCP tool names

### DIFF
--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -105,6 +105,8 @@ class AnthropicTransport(ProviderTransport):
                 name = block.name
                 if strip_tool_prefix and name.startswith(_MCP_PREFIX):
                     name = name[len(_MCP_PREFIX):]
+                    if name and name[0].isupper():
+                        name = name[0].lower() + name[1:]
                 tool_calls.append(
                     ToolCall(
                         id=block.id,

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -24,6 +24,7 @@ from agent.anthropic_adapter import (
     run_oauth_setup_token,
 )
 from agent.transports import get_transport
+from agent.transports.anthropic import AnthropicTransport
 
 
 # ---------------------------------------------------------------------------
@@ -1747,3 +1748,19 @@ class TestResolveMessagesMaxTokens:
         result = _resolve_anthropic_messages_max_tokens(0.5, "claude-opus-4-6")
         assert result > 0
         assert result != 0
+
+
+class TestAnthropicTransportToolNormalization:
+    def test_pascalcase_mcp_tool_name_maps_back_to_registered_tool_name(self):
+        """Claude Code-shaped OAuth can return mcp_Terminal; Hermes tool is terminal."""
+        block = SimpleNamespace(
+            type="tool_use",
+            id="toolu_terminal",
+            name="mcp_Terminal",
+            input={"command": "printf OPUS_TOOL_OK"},
+        )
+        response = SimpleNamespace(content=[block], stop_reason="tool_use")
+
+        normalized = AnthropicTransport().normalize_response(response, strip_tool_prefix=True)
+
+        assert normalized.tool_calls[0].name == "terminal"


### PR DESCRIPTION
## Summary

Fixes Anthropic transport tool-name normalization for Claude Code-shaped MCP response names.

When an Anthropic/OAuth route returns a tool-use name like `mcp_Terminal`, Hermes strips the `mcp_` prefix but currently leaves `Terminal`, which does not match the registered Hermes tool name `terminal`.

This PR lowercases the first character after stripping `mcp_` when needed, preserving existing lowercase behavior while supporting Claude Code-shaped PascalCase tool names.

Fixes #16817

## Test Plan

- [x] `python -m py_compile agent/transports/anthropic.py tests/agent/test_anthropic_adapter.py`
- [x] `python -m pytest -q tests/agent/test_anthropic_adapter.py::TestAnthropicTransportToolNormalization tests/agent/test_anthropic_adapter.py::TestToolChoice`
- [x] Ran the full `tests/agent/test_anthropic_adapter.py` locally; it exposed pre-existing environment/config failures unrelated to this change (local macOS Claude keychain credentials leaking into tests and an existing beta-header expectation mismatch), while the new focused regression passed.

## Notes

This PR does not promote or install any admin/OAuth route. It only hardens response normalization for Claude Code-shaped `mcp_` tool names.