### PR TITLE
feat(memory): add HKTMemory provider plugin

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -749,7 +749,8 @@ DEFAULT_CONFIG = {
         "user_char_limit": 1375,     # ~500 tokens at 2.75 chars/token
         # External memory provider plugin (empty = built-in only).
         # Set to a provider name to activate: "openviking", "mem0",
-        # "hindsight", "holographic", "retaindb", "byterover".
+        # "hindsight", "holographic", "retaindb", "byterover",
+        # "honcho", "supermemory", "hktmemory".
         # Only ONE external provider is allowed at a time.
         "provider": "",
     },
@@ -1550,6 +1551,19 @@ OPTIONAL_ENV_VARS = {
         "description": "Base URL for self-hosted Honcho instances (no API key needed)",
         "prompt": "Honcho base URL (e.g. http://localhost:8000)",
         "category": "tool",
+    },
+
+    # ── HKTMemory ──
+    "HERMES_HKTMEMORY_DIR": {
+        "description": "Root directory for HKTMemory enterprise knowledge store",
+        "prompt": "HKTMemory data directory",
+        "category": "tool",
+    },
+    "HERMES_HKTMEMORY_NAMESPACE": {
+        "description": "Namespace for HKTMemory recall isolation",
+        "prompt": "HKTMemory namespace",
+        "category": "tool",
+        "advanced": True,
     },
 
     # ── Messaging platforms ──

--- a/plugins/memory/hktmemory/__init__.py
+++ b/plugins/memory/hktmemory/__init__.py
@@ -1,0 +1,206 @@
+"""HKTMemory enterprise knowledge recall plugin — MemoryProvider adapter.
+
+Phase 1 is read-only: prefetch returns fenced recall results from the
+HKTMemory vector store; sync_turn is a no-op that logs a skip reason.
+
+External package (hktmemory-provider-hermes) is lazily imported inside
+initialize() so the plugin loads cleanly when the package is absent.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import logging
+import os
+import shutil
+from pathlib import Path
+from typing import Any, Dict, List
+
+from agent.memory_provider import MemoryProvider
+
+logger = logging.getLogger(__name__)
+
+# Token budget: ~4 chars/token, so 2048 tokens ~ 8192 chars.
+_MAX_CONTEXT_CHARS = 8192
+
+
+class HKTMemoryProvider(MemoryProvider):
+    """Enterprise knowledge recall via HKTMemory vector store."""
+
+    def __init__(self) -> None:
+        self._provider = None  # HKTMemoryHermesProvider instance
+        self._available = False
+
+    @property
+    def name(self) -> str:
+        return "hktmemory"
+
+    # -- Availability ---------------------------------------------------------
+
+    def is_available(self) -> bool:
+        """True when configured, importable, and backed by CLI or vector_store.db."""
+        hkt_dir = os.getenv("HERMES_HKTMEMORY_DIR")
+        if not hkt_dir:
+            return False
+
+        if importlib.util.find_spec("hktmemory_provider_hermes") is None:
+            return False
+
+        # CLI on PATH (hermes-hktmemory or fallback hkt-memory)
+        if shutil.which("hermes-hktmemory") or shutil.which("hkt-memory"):
+            return True
+
+        # SQLite vector store exists
+        db_path = Path(hkt_dir).expanduser() / "vector_store.db"
+        if db_path.is_file():
+            return True
+
+        return False
+
+    # -- Lifecycle ------------------------------------------------------------
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        """Lazy-import HKTMemoryHermesProvider; mark unavailable on ImportError."""
+        try:
+            from hktmemory_provider_hermes import HKTMemoryHermesProvider
+        except ImportError:
+            logger.warning(
+                "hktmemory-provider-hermes package not installed — "
+                "HKTMemory plugin unavailable"
+            )
+            self._available = False
+            return
+
+        config = {
+            "memory_dir": os.getenv("HERMES_HKTMEMORY_DIR"),
+            "namespace": os.getenv("HERMES_HKTMEMORY_NAMESPACE", "ai_infra_enterprise_knowledge"),
+            "read_only": True,
+        }
+        self._provider = HKTMemoryHermesProvider(config=config)
+        self._provider.initialize()
+        self._available = True
+
+    def system_prompt_block(self) -> str:
+        return (
+            "# HKTMemory Enterprise Memory\n"
+            "Active (read-only recall). Relevant enterprise knowledge may be "
+            "injected in <enterprise-memory>...</enterprise-memory> blocks."
+        )
+
+    # -- Prefetch / recall ----------------------------------------------------
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        """Recall from HKTMemory, serialize as fenced text, truncate if over budget."""
+        if not self._available or not self._provider:
+            return ""
+
+        hkt_dir = os.getenv("HERMES_HKTMEMORY_DIR", "")
+        query_hash = hashlib.sha256(query.encode()).hexdigest()[:8]
+        logger.info("enterprise_memory.recall.start query_hash=%s dir=%s", query_hash, hkt_dir)
+
+        if not query:
+            return ""
+
+        try:
+            results = self._provider.prefetch(query)
+        except Exception as exc:
+            logger.warning("enterprise_memory.recall.done results=0 emitted=0 error=%s", exc)
+            return ""
+
+        if not results:
+            return ""
+
+        serialized, emitted = self._serialize_results(results)
+        truncated = len(serialized.encode()) > _MAX_CONTEXT_CHARS
+
+        if truncated:
+            serialized, emitted = self._truncate_serialized(serialized, results, emitted)
+            logger.info(
+                "enterprise_memory.recall.done results=%d emitted=%d truncated=true",
+                len(results), emitted,
+            )
+        else:
+            logger.info(
+                "enterprise_memory.recall.done results=%d emitted=%d truncated=false",
+                len(results), emitted,
+            )
+
+        return serialized
+
+    # -- Serialization --------------------------------------------------------
+
+    @staticmethod
+    def _format_result(index: int, result: Any) -> str:
+        source = getattr(result, "source", None) or ""
+        scope = getattr(result, "scope", None) or ""
+        confidence = getattr(result, "confidence", None)
+        conf_str = f"{confidence:.2f}" if isinstance(confidence, (int, float)) else str(confidence or "")
+        text = getattr(result, "text", "")
+        # Escape literal --- in text when it appears as a record delimiter.
+        text = text.replace("\n---", "\n\\---")
+        header = f"[{index}] source: {source} | scope: {scope} | confidence: {conf_str}"
+        return f"{header}\n{text}\n---\n"
+
+    @staticmethod
+    def _serialize_results(results: list) -> tuple[str, int]:
+        """Serialize RecallResult list to fenced string.
+
+        Returns (serialized_text, number_of_records_emitted).
+        Empty result list returns ("", 0).
+        """
+        if not results:
+            return "", 0
+
+        output = f"<enterprise-memory>\nRecall Results ({len(results)}):\n\n"
+        for i, result in enumerate(results, 1):
+            output += HKTMemoryProvider._format_result(i, result)
+        output += "</enterprise-memory>"
+        return output, len(results)
+
+    @staticmethod
+    def _truncate_serialized(serialized: str, results: list, total: int) -> tuple[str, int]:
+        """Truncate serialized output at the last complete record that fits."""
+        if not results:
+            return "", 0
+
+        prefix = f"<enterprise-memory>\nRecall Results ({total}):\n\n"
+        suffix = "\n... (truncated)\n</enterprise-memory>"
+        current = prefix
+        emitted = 0
+
+        for i, result in enumerate(results, 1):
+            record = HKTMemoryProvider._format_result(i, result)
+            candidate = current + record
+            if len((candidate.rstrip() + suffix).encode()) > _MAX_CONTEXT_CHARS:
+                break
+            current = candidate
+            emitted = i
+
+        if emitted == 0:
+            return "", 0
+
+        return current.rstrip() + suffix, emitted
+
+    # -- Sync (read-only) -----------------------------------------------------
+
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+        """Phase 1: read-only — log skip, do not raise."""
+        logger.info("enterprise_memory.capture.skipped reason=read_only")
+
+    # -- Tools (none in Phase 1) ----------------------------------------------
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        return []
+
+    def shutdown(self) -> None:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Plugin entry point
+# ---------------------------------------------------------------------------
+
+def register(ctx) -> None:
+    """Register HKTMemory as a memory provider plugin."""
+    ctx.register_memory_provider(HKTMemoryProvider())

--- a/plugins/memory/hktmemory/plugin.yaml
+++ b/plugins/memory/hktmemory/plugin.yaml
@@ -1,0 +1,4 @@
+name: hktmemory
+version: 0.1.0
+description: "Enterprise knowledge recall via HKTMemory vector store"
+pip_dependencies: []

--- a/tests/plugins/test_hktmemory_provider.py
+++ b/tests/plugins/test_hktmemory_provider.py
@@ -1,0 +1,319 @@
+"""Tests for the HKTMemory enterprise knowledge recall provider plugin.
+
+Covers: is_available logic, prefetch serialization, truncation, sync_turn
+skip logging, system_prompt_block, register entry point, import-error
+handling, and prefetch log verification.
+"""
+
+import logging
+import os
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from plugins.memory.hktmemory import HKTMemoryProvider, register
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeRecallResult:
+    """Mimics hktmemory_provider_hermes.RecallResult for unit tests."""
+
+    def __init__(self, text, source=None, scope=None, confidence=None,
+                 timestamp=None, metadata=None):
+        self.text = text
+        self.source = source
+        self.scope = scope
+        self.confidence = confidence
+        self.timestamp = timestamp
+        self.metadata = metadata
+
+
+class _ProviderCollector:
+    """Collects providers registered via ctx.register_memory_provider()."""
+
+    def __init__(self):
+        self.providers = []
+
+    def register_memory_provider(self, provider):
+        self.providers.append(provider)
+
+
+# ---------------------------------------------------------------------------
+# is_available
+# ---------------------------------------------------------------------------
+
+
+class TestIsAvailable:
+
+    def test_dir_set_cli_present(self, monkeypatch, tmp_path):
+        """Available when HERMES_HKTMEMORY_DIR set + hermes-hktmemory on PATH."""
+        monkeypatch.setenv("HERMES_HKTMEMORY_DIR", str(tmp_path))
+        monkeypatch.setattr(
+            "plugins.memory.hktmemory.importlib.util.find_spec",
+            lambda name: object() if name == "hktmemory_provider_hermes" else None,
+        )
+        monkeypatch.setattr(
+            "plugins.memory.hktmemory.shutil.which",
+            lambda name: "/usr/local/bin/hermes-hktmemory" if name == "hermes-hktmemory" else None,
+        )
+        p = HKTMemoryProvider()
+        assert p.is_available() is True
+
+    def test_dir_set_sqlite_only(self, monkeypatch, tmp_path):
+        """Available when HERMES_HKTMEMORY_DIR set, no CLI, but vector_store.db exists."""
+        db_path = tmp_path / "vector_store.db"
+        db_path.write_text("fake sqlite")
+        monkeypatch.setenv("HERMES_HKTMEMORY_DIR", str(tmp_path))
+        monkeypatch.setattr(
+            "plugins.memory.hktmemory.importlib.util.find_spec",
+            lambda name: object() if name == "hktmemory_provider_hermes" else None,
+        )
+        monkeypatch.setattr("plugins.memory.hktmemory.shutil.which", lambda name: None)
+        p = HKTMemoryProvider()
+        assert p.is_available() is True
+
+    def test_dir_missing(self, monkeypatch):
+        """Not available when HERMES_HKTMEMORY_DIR is not set."""
+        monkeypatch.delenv("HERMES_HKTMEMORY_DIR", raising=False)
+        p = HKTMemoryProvider()
+        assert p.is_available() is False
+
+    def test_dir_set_no_cli_no_db(self, monkeypatch, tmp_path):
+        """Not available when dir set but no CLI and no vector_store.db."""
+        monkeypatch.setenv("HERMES_HKTMEMORY_DIR", str(tmp_path))
+        monkeypatch.setattr(
+            "plugins.memory.hktmemory.importlib.util.find_spec",
+            lambda name: object() if name == "hktmemory_provider_hermes" else None,
+        )
+        monkeypatch.setattr("plugins.memory.hktmemory.shutil.which", lambda name: None)
+        p = HKTMemoryProvider()
+        assert p.is_available() is False
+
+    def test_package_missing(self, monkeypatch, tmp_path):
+        """Not available when the adapter package is not importable."""
+        monkeypatch.setenv("HERMES_HKTMEMORY_DIR", str(tmp_path))
+        monkeypatch.setattr("plugins.memory.hktmemory.importlib.util.find_spec", lambda name: None)
+        monkeypatch.setattr(
+            "plugins.memory.hktmemory.shutil.which",
+            lambda name: "/usr/local/bin/hermes-hktmemory" if name == "hermes-hktmemory" else None,
+        )
+        p = HKTMemoryProvider()
+        assert p.is_available() is False
+
+
+# ---------------------------------------------------------------------------
+# prefetch serialization
+# ---------------------------------------------------------------------------
+
+
+class TestPrefetch:
+
+    def _make_provider_with_mock(self, results):
+        """Create a provider with _available=True and mocked _provider."""
+        p = HKTMemoryProvider()
+        p._available = True
+        p._provider = MagicMock()
+        p._provider.prefetch.return_value = results
+        return p
+
+    def test_prefetch_serializes_results(self, monkeypatch):
+        """Fenced output format with source, scope, confidence, text."""
+        monkeypatch.setenv("HERMES_HKTMEMORY_DIR", "/data")
+        results = [
+            _FakeRecallResult(
+                text="AI infra deployment uses kustomize",
+                source="runbook",
+                scope="infra",
+                confidence=0.92,
+            ),
+        ]
+        p = self._make_provider_with_mock(results)
+        out = p.prefetch("AI infra deployment")
+
+        assert out.startswith("<enterprise-memory>")
+        assert out.endswith("</enterprise-memory>")
+        assert "source: runbook" in out
+        assert "scope: infra" in out
+        assert "0.92" in out
+        assert "AI infra deployment uses kustomize" in out
+        assert "---" in out
+
+    def test_prefetch_empty_query(self, monkeypatch):
+        """Empty query returns empty string."""
+        monkeypatch.setenv("HERMES_HKTMEMORY_DIR", "/data")
+        p = HKTMemoryProvider()
+        p._available = True
+        p._provider = MagicMock()
+        out = p.prefetch("")
+        assert out == ""
+
+    def test_prefetch_no_results(self, monkeypatch):
+        """Provider returns empty list → empty string."""
+        monkeypatch.setenv("HERMES_HKTMEMORY_DIR", "/data")
+        p = self._make_provider_with_mock([])
+        out = p.prefetch("anything")
+        assert out == ""
+
+    def test_prefetch_not_available(self, monkeypatch):
+        """Provider not available → empty string."""
+        monkeypatch.setenv("HERMES_HKTMEMORY_DIR", "/data")
+        p = HKTMemoryProvider()
+        p._available = False
+        out = p.prefetch("anything")
+        assert out == ""
+
+    def test_prefetch_truncates_over_budget(self, monkeypatch):
+        """Large result set is truncated at ~8000 chars boundary."""
+        monkeypatch.setenv("HERMES_HKTMEMORY_DIR", "/data")
+        # Create results that will exceed the 8192 char budget
+        big_text = "x" * 2000
+        results = [
+            _FakeRecallResult(text=big_text, source="s", scope="sc", confidence=0.5)
+            for _ in range(5)
+        ]
+        p = self._make_provider_with_mock(results)
+        out = p.prefetch("big query")
+
+        assert "... (truncated)" in out
+        assert len(out.encode()) <= 8192
+
+    def test_prefetch_escapes_triple_dash(self, monkeypatch):
+        """Literal --- in text is escaped as \\---."""
+        monkeypatch.setenv("HERMES_HKTMEMORY_DIR", "/data")
+        results = [
+            _FakeRecallResult(
+                text="some text\n---\nmore text",
+                source="doc",
+                scope="test",
+                confidence=0.8,
+            ),
+        ]
+        p = self._make_provider_with_mock(results)
+        out = p.prefetch("test")
+        assert "\\---" in out
+
+
+# ---------------------------------------------------------------------------
+# sync_turn (read-only)
+# ---------------------------------------------------------------------------
+
+
+class TestSyncTurn:
+
+    def test_sync_turn_skips_with_reason(self, caplog):
+        """sync_turn logs skip reason and does not raise."""
+        p = HKTMemoryProvider()
+        with caplog.at_level(logging.INFO, logger="plugins.memory.hktmemory"):
+            p.sync_turn("user msg", "assistant msg")
+        assert "enterprise_memory.capture.skipped" in caplog.text
+        assert "read_only" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# system_prompt_block
+# ---------------------------------------------------------------------------
+
+
+class TestSystemPromptBlock:
+
+    def test_returns_non_empty_fence(self):
+        p = HKTMemoryProvider()
+        block = p.system_prompt_block()
+        assert block
+        assert "enterprise-memory" in block
+
+
+# ---------------------------------------------------------------------------
+# register entry point
+# ---------------------------------------------------------------------------
+
+
+class TestRegister:
+
+    def test_register_entry_point(self):
+        ctx = _ProviderCollector()
+        register(ctx)
+        assert len(ctx.providers) == 1
+        assert isinstance(ctx.providers[0], HKTMemoryProvider)
+        assert ctx.providers[0].name == "hktmemory"
+
+
+# ---------------------------------------------------------------------------
+# initialize import error
+# ---------------------------------------------------------------------------
+
+
+class TestInitialize:
+
+    def test_initialize_import_error(self, monkeypatch):
+        """ImportError on hktmemory_provider_hermes sets _available = False."""
+        monkeypatch.setenv("HERMES_HKTMEMORY_DIR", "/data")
+        monkeypatch.setenv("HERMES_HKTMEMORY_NAMESPACE", "test")
+        p = HKTMemoryProvider()
+        # The package is not installed in test env, so this naturally fails
+        with patch.dict("sys.modules", {"hktmemory_provider_hermes": None}):
+            p.initialize("session-1")
+        assert p._available is False
+
+    def test_initialize_success(self, monkeypatch):
+        """Successful init sets _available = True."""
+        monkeypatch.setenv("HERMES_HKTMEMORY_DIR", "/data")
+        monkeypatch.setenv("HERMES_HKTMEMORY_NAMESPACE", "test")
+
+        mock_provider_cls = MagicMock()
+        mock_instance = MagicMock()
+        mock_provider_cls.return_value = mock_instance
+
+        p = HKTMemoryProvider()
+        with patch.dict("sys.modules", {"hktmemory_provider_hermes": MagicMock(HKTMemoryHermesProvider=mock_provider_cls)}):
+            p.initialize("session-1")
+
+        assert p._available is True
+        assert p._provider is mock_instance
+
+
+# ---------------------------------------------------------------------------
+# prefetch logging
+# ---------------------------------------------------------------------------
+
+
+class TestPrefetchLogging:
+
+    def test_prefetch_logs_done_count(self, caplog, monkeypatch):
+        """Verify enterprise_memory.recall.done log line includes result count."""
+        monkeypatch.setenv("HERMES_HKTMEMORY_DIR", "/data")
+        results = [
+            _FakeRecallResult(text="hello", source="s", scope="sc", confidence=0.9),
+        ]
+        p = HKTMemoryProvider()
+        p._available = True
+        p._provider = MagicMock()
+        p._provider.prefetch.return_value = results
+
+        with caplog.at_level(logging.INFO, logger="plugins.memory.hktmemory"):
+            p.prefetch("test query")
+
+        assert "enterprise_memory.recall.done" in caplog.text
+        assert "results=1" in caplog.text
+        assert "emitted=1" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# get_tool_schemas / shutdown
+# ---------------------------------------------------------------------------
+
+
+class TestToolSchemasAndShutdown:
+
+    def test_get_tool_schemas_empty(self):
+        p = HKTMemoryProvider()
+        assert p.get_tool_schemas() == []
+
+    def test_shutdown_noop(self):
+        p = HKTMemoryProvider()
+        p.shutdown()  # should not raise


### PR DESCRIPTION
## Summary

Adds an HKTMemory enterprise knowledge recall provider as a Hermes memory plugin.

When configured with `memory.provider: hktmemory`, Hermes loads `plugins/memory/hktmemory` through the existing MemoryProvider plugin system. The provider performs read-only per-turn enterprise memory recall via `hktmemory-provider-hermes`, serializes recall results into `<enterprise-memory>` context, and logs recall/capture trace events.

## Scope

Changed files:

- `plugins/memory/hktmemory/__init__.py`
- `plugins/memory/hktmemory/plugin.yaml`
- `hermes_cli/config.py`
- `tests/plugins/test_hktmemory_provider.py`

No changes to:

- `run_agent.py`
- `agent/memory_manager.py`
- `agent/memory_provider.py`
- `toolsets.py`

## Behavior

- Adds `HKTMemoryProvider(MemoryProvider)` with `register(ctx)` entrypoint.
- Uses lazy import for `hktmemory_provider_hermes` so plugin discovery degrades safely if package is absent.
- `is_available()` requires `HERMES_HKTMEMORY_DIR`, importable `hktmemory_provider_hermes`, and either `hermes-hktmemory`/`hkt-memory` on PATH or `vector_store.db` in the configured dir.
- `prefetch()` returns a bounded `<enterprise-memory>` fenced string with `source`, `scope`, `confidence`, and `text`.
- `sync_turn()` is read-only for Phase 1 and logs `enterprise_memory.capture.skipped reason=read_only`.
- Adds `HERMES_HKTMEMORY_DIR` and `HERMES_HKTMEMORY_NAMESPACE` to optional env var setup metadata.

## Verification

```bash
python3 -m pytest -q -o addopts='' tests/plugins/test_hktmemory_provider.py
# 19 passed

python3 -m compileall -q plugins/memory/hktmemory tests/plugins/test_hktmemory_provider.py hermes_cli/config.py
# pass

git diff --check -- hermes_cli/config.py plugins/memory/hktmemory tests/plugins/test_hktmemory_provider.py
# pass
```

## Related

- Tracks AI-Infra demand: wangrenzhu-ola/infra-hermes-core-skills#55

## Notes

This is Phase 1 read-only recall integration. Actual enterprise memory capture/write remains intentionally deferred; `sync_turn()` only logs a skipped reason.
