### PR TITLE
fix: add minimax-cn billing route to resolve cost_status='unknown' (#16825)

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -99,7 +99,7 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         "claude-sonnet-4-20250514",
     ): PricingEntry(
         input_cost_per_million=Decimal("3.00"),
-        output_cost_per_million=Decimal("75.00"),
+        output_cost_per_million=Decimal("15.00"),
         cache_read_cost_per_million=Decimal("0.30"),
         cache_write_cost_per_million=Decimal("3.75"),
         source="official_docs_snapshot",

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -99,7 +99,7 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         "claude-sonnet-4-20250514",
     ): PricingEntry(
         input_cost_per_million=Decimal("3.00"),
-        output_cost_per_million=Decimal("15.00"),
+        output_cost_per_million=Decimal("75.00"),
         cache_read_cost_per_million=Decimal("0.30"),
         cache_write_cost_per_million=Decimal("3.75"),
         source="official_docs_snapshot",
@@ -400,6 +400,10 @@ def resolve_billing_route(
         return BillingRoute(provider="anthropic", model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
     if provider_name == "openai":
         return BillingRoute(provider="openai", model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
+    if provider_name == "minimax-cn" or base_url_host_matches(base_url or "", "minimaxi.com"):
+        # MiniMax's own API (api.minimaxi.com) uses a subscription request-quota plan,
+        # not per-token billing — treat the same as openai-codex (subscription_included).
+        return BillingRoute(provider="minimax-cn", model=model, base_url=base_url or "", billing_mode="subscription_included")
     if provider_name in {"custom", "local"} or (base and "localhost" in base):
         return BillingRoute(provider=provider_name or "custom", model=model, base_url=base_url or "", billing_mode="unknown")
     return BillingRoute(provider=provider_name or "unknown", model=model.split("/")[-1] if model else "", base_url=base_url or "", billing_mode="unknown")

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -285,6 +285,57 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         source_url="https://ai.google.dev/pricing",
         pricing_version="google-pricing-2026-03-16",
     ),
+    # MiniMax — pay-as-you-go pricing from platform.minimax.io/docs/guides/pricing-paygo
+    # We always apply these rates regardless of whether the user is on a Token Plan
+    # subscription, so they can see the token-equivalent cost of their usage.
+    (
+        "minimax-cn",
+        "minimax-m2.7",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.30"),
+        output_cost_per_million=Decimal("1.20"),
+        cache_read_cost_per_million=Decimal("0.06"),
+        cache_write_cost_per_million=Decimal("0.375"),
+        source="official_docs_snapshot",
+        source_url="https://platform.minimax.io/docs/guides/pricing-paygo",
+        pricing_version="minimax-pricing-2026-04",
+    ),
+    (
+        "minimax-cn",
+        "minimax-m2.7-highspeed",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.60"),
+        output_cost_per_million=Decimal("2.40"),
+        cache_read_cost_per_million=Decimal("0.06"),
+        cache_write_cost_per_million=Decimal("0.375"),
+        source="official_docs_snapshot",
+        source_url="https://platform.minimax.io/docs/guides/pricing-paygo",
+        pricing_version="minimax-pricing-2026-04",
+    ),
+    (
+        "minimax-cn",
+        "minimax-m2.5",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.30"),
+        output_cost_per_million=Decimal("1.20"),
+        cache_read_cost_per_million=Decimal("0.03"),
+        cache_write_cost_per_million=Decimal("0.375"),
+        source="official_docs_snapshot",
+        source_url="https://platform.minimax.io/docs/guides/pricing-paygo",
+        pricing_version="minimax-pricing-2026-04",
+    ),
+    (
+        "minimax-cn",
+        "minimax-m2.5-highspeed",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.60"),
+        output_cost_per_million=Decimal("2.40"),
+        cache_read_cost_per_million=Decimal("0.03"),
+        cache_write_cost_per_million=Decimal("0.375"),
+        source="official_docs_snapshot",
+        source_url="https://platform.minimax.io/docs/guides/pricing-paygo",
+        pricing_version="minimax-pricing-2026-04",
+    ),
     # AWS Bedrock — pricing per the Bedrock pricing page.
     # Bedrock charges the same per-token rates as the model provider but
     # through AWS billing.  These are the on-demand prices (no commitment).
@@ -401,9 +452,11 @@ def resolve_billing_route(
     if provider_name == "openai":
         return BillingRoute(provider="openai", model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
     if provider_name == "minimax-cn" or base_url_host_matches(base_url or "", "minimaxi.com"):
-        # MiniMax's own API (api.minimaxi.com) uses a subscription request-quota plan,
-        # not per-token billing — treat the same as openai-codex (subscription_included).
-        return BillingRoute(provider="minimax-cn", model=model, base_url=base_url or "", billing_mode="subscription_included")
+        # MiniMax's own API (api.minimaxi.com) offers both a subscription Token Plan
+        # and pay-as-you-go per-token pricing. We always use the official pay-as-you-go
+        # rates so users can see the token-equivalent cost regardless of their plan.
+        # Source: https://platform.minimax.io/docs/guides/pricing-paygo
+        return BillingRoute(provider="minimax-cn", model=model, base_url=base_url or "", billing_mode="official_docs_snapshot")
     if provider_name in {"custom", "local"} or (base and "localhost" in base):
         return BillingRoute(provider=provider_name or "custom", model=model, base_url=base_url or "", billing_mode="unknown")
     return BillingRoute(provider=provider_name or "unknown", model=model.split("/")[-1] if model else "", base_url=base_url or "", billing_mode="unknown")

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from types import SimpleNamespace
 
 from agent.usage_pricing import (
@@ -5,6 +6,7 @@ from agent.usage_pricing import (
     estimate_usage_cost,
     get_pricing_entry,
     normalize_usage,
+    resolve_billing_route,
 )
 
 
@@ -190,3 +192,47 @@ def test_custom_endpoint_models_api_pricing_is_supported(monkeypatch):
 
     assert float(entry.input_cost_per_million) == 0.5
     assert float(entry.output_cost_per_million) == 2.0
+
+
+def test_minimax_cn_route_resolves_to_subscription_included():
+    """Regression test for issue #16825: minimax-cn was falling through to
+    billing_mode='unknown' instead of 'subscription_included', causing all
+    MiniMax sessions to be stored with cost_status='unknown' and cost=0.
+    """
+    route = resolve_billing_route(
+        "MiniMax-M2.7",
+        provider="minimax-cn",
+        base_url="https://api.minimaxi.com/anthropic",
+    )
+
+    assert route.provider == "minimax-cn"
+    assert route.billing_mode == "subscription_included"
+
+
+def test_minimax_cn_cost_result_is_included_not_unknown():
+    """Regression test for issue #16825: estimate_usage_cost must return
+    status='included' (not 'unknown') for minimax-cn routes.
+    """
+    result = estimate_usage_cost(
+        "MiniMax-M2.7",
+        CanonicalUsage(input_tokens=10000, output_tokens=500, cache_read_tokens=5000),
+        provider="minimax-cn",
+        base_url="https://api.minimaxi.com/anthropic",
+    )
+
+    assert result.status == "included"
+    assert result.amount_usd == Decimal("0")
+
+
+def test_minimax_cn_detected_by_base_url_host():
+    """Regression test for issue #16825: minimax-cn should also be detected
+    via the base_url host (minimaxi.com) when provider is not explicitly set.
+    """
+    route = resolve_billing_route(
+        "MiniMax-M2.7",
+        provider=None,
+        base_url="https://api.minimaxi.com/anthropic",
+    )
+
+    assert route.provider == "minimax-cn"
+    assert route.billing_mode == "subscription_included"

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -194,10 +194,11 @@ def test_custom_endpoint_models_api_pricing_is_supported(monkeypatch):
     assert float(entry.output_cost_per_million) == 2.0
 
 
-def test_minimax_cn_route_resolves_to_subscription_included():
+def test_minimax_cn_route_resolves_to_official_docs_snapshot():
     """Regression test for issue #16825: minimax-cn was falling through to
-    billing_mode='unknown' instead of 'subscription_included', causing all
-    MiniMax sessions to be stored with cost_status='unknown' and cost=0.
+    billing_mode='unknown', causing all MiniMax sessions to show cost=0.
+    We use official_docs_snapshot so the official pay-as-you-go rates are
+    applied regardless of whether the user is on a Token Plan subscription.
     """
     route = resolve_billing_route(
         "MiniMax-M2.7",
@@ -206,12 +207,15 @@ def test_minimax_cn_route_resolves_to_subscription_included():
     )
 
     assert route.provider == "minimax-cn"
-    assert route.billing_mode == "subscription_included"
+    assert route.billing_mode == "official_docs_snapshot"
 
 
-def test_minimax_cn_cost_result_is_included_not_unknown():
+def test_minimax_cn_cost_result_is_estimated_with_official_rates():
     """Regression test for issue #16825: estimate_usage_cost must return
-    status='included' (not 'unknown') for minimax-cn routes.
+    status='estimated' with a non-zero amount for minimax-cn routes, using
+    the official pay-as-you-go rates from platform.minimax.io/docs/guides/pricing-paygo.
+    10000 input @ $0.30/M + 500 output @ $1.20/M + 5000 cache_read @ $0.06/M
+    = $0.003000 + $0.000600 + $0.000300 = $0.003900
     """
     result = estimate_usage_cost(
         "MiniMax-M2.7",
@@ -220,8 +224,8 @@ def test_minimax_cn_cost_result_is_included_not_unknown():
         base_url="https://api.minimaxi.com/anthropic",
     )
 
-    assert result.status == "included"
-    assert result.amount_usd == Decimal("0")
+    assert result.status == "estimated"
+    assert result.amount_usd == Decimal("0.003900")
 
 
 def test_minimax_cn_detected_by_base_url_host():
@@ -235,4 +239,22 @@ def test_minimax_cn_detected_by_base_url_host():
     )
 
     assert route.provider == "minimax-cn"
-    assert route.billing_mode == "subscription_included"
+    assert route.billing_mode == "official_docs_snapshot"
+
+
+def test_minimax_cn_pricing_entry_uses_official_paygo_rates():
+    """Regression test for issue #16825: get_pricing_entry must return the
+    official MiniMax pay-as-you-go rates from _OFFICIAL_DOCS_PRICING.
+    """
+    entry = get_pricing_entry(
+        "MiniMax-M2.7",
+        provider="minimax-cn",
+        base_url="https://api.minimaxi.com/anthropic",
+    )
+
+    assert entry is not None
+    assert float(entry.input_cost_per_million) == 0.30
+    assert float(entry.output_cost_per_million) == 1.20
+    assert float(entry.cache_read_cost_per_million) == 0.06
+    assert float(entry.cache_write_cost_per_million) == 0.375
+    assert entry.source == "official_docs_snapshot"


### PR DESCRIPTION
## Problem

Closes #16825

When using `MiniMax-M2.7` via the `minimax-cn` provider (`https://api.minimaxi.com/anthropic`), all sessions are stored in `state.db` with `cost_status='unknown'` and `estimated_cost_usd=0.0`. The `/usage` command shows `$0.0000` for every session.

**Root cause:** `resolve_billing_route()` had no branch for `minimax-cn`, so it fell through to the final catch-all and returned `billing_mode='unknown'`. This caused `estimate_usage_cost()` to return `CostResult(amount_usd=None, status='unknown')`.

## Fix

Add an explicit `minimax-cn` branch in `resolve_billing_route()` that returns `billing_mode='official_docs_snapshot'`, and add per-token pricing entries for all MiniMax models in `_OFFICIAL_DOCS_PRICING`.

MiniMax's API offers both a subscription Token Plan (requests/5hrs quota) and pay-as-you-go per-token pricing. We always apply the official pay-as-you-go rates so users can see the token-equivalent cost of their usage regardless of which plan they are on. This lets subscription users understand the savings they receive compared to pay-as-you-go.

Pricing sourced from: https://platform.minimax.io/docs/guides/pricing-paygo

| Model | Input | Output | Cache Read | Cache Write |
|---|---|---|---|---|
| MiniMax-M2.7 | $0.30/M | $1.20/M | $0.06/M | $0.375/M |
| MiniMax-M2.7-highspeed | $0.60/M | $2.40/M | $0.06/M | $0.375/M |
| MiniMax-M2.5 | $0.30/M | $1.20/M | $0.03/M | $0.375/M |
| MiniMax-M2.5-highspeed | $0.60/M | $2.40/M | $0.03/M | $0.375/M |

Detection works both by `provider="minimax-cn"` and by `base_url` host match on `minimaxi.com`.

## Changes

- **`agent/usage_pricing.py`** — add `minimax-cn` route in `resolve_billing_route()` with `billing_mode='official_docs_snapshot'`, and 4 pricing entries in `_OFFICIAL_DOCS_PRICING`
- **`tests/agent/test_usage_pricing.py`** — add 4 regression tests:
  - `test_minimax_cn_route_resolves_to_official_docs_snapshot`
  - `test_minimax_cn_cost_result_is_estimated_with_official_rates`
  - `test_minimax_cn_detected_by_base_url_host`
  - `test_minimax_cn_pricing_entry_uses_official_paygo_rates`

## Verification

```
13 passed in 4.96s
```

All existing tests pass; 4 new regression tests added and passing.