### PR TITLE
fix(delegate): clear acp_command when override_provider is set

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -935,6 +935,14 @@ def _build_child_agent(
         else (getattr(parent_agent, "acp_args", []) or [])
     )
 
+    # When override_provider is set (e.g. delegation.provider: minimax-cn),
+    # the subagent must use direct API calls — not the parent's ACP transport.
+    # Inheriting acp_command unconditionally causes run_agent.py to initialize
+    # CopilotACPClient, bypassing override credentials entirely (issue #16816).
+    if override_provider and not override_acp_command:
+        effective_acp_command = None
+        effective_acp_args = []
+
     if override_acp_command:
         # If explicitly forcing an ACP transport override, the provider MUST be copilot-acp
         # so run_agent.py initializes the CopilotACPClient.


### PR DESCRIPTION
## Problem

When `delegation.provider` is configured (e.g. `minimax-cn`), subagents inherited the parent's `acp_command` unconditionally. This caused `run_agent.py` to initialize `CopilotACPClient`, bypassing override credentials entirely and using its own default model (`provider=copilot-acp model=qwen3.5-397b-a17b`) instead of the configured `delegation.provider` and `delegation.model`.

## Fix

When `override_provider` is set but `override_acp_command` is not explicitly provided, clear `effective_acp_command` and `effective_acp_args` so the child agent uses direct API calls with the configured provider credentials.

The existing `override_acp_command` path is unchanged — explicit ACP transport overrides still force `provider=copilot-acp` as before.

Fixes #16816