### PR TITLE
fix(cron): preserve Telegram topic delivery targets

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -198,7 +198,9 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
             if resolved:
                 parsed_chat_id, parsed_thread_id, resolved_is_explicit = _parse_target_ref(platform_key, resolved)
                 if resolved_is_explicit:
-                    chat_id, thread_id = parsed_chat_id, parsed_thread_id
+                    chat_id = parsed_chat_id
+                    if parsed_thread_id is not None:
+                        thread_id = parsed_thread_id
                 else:
                     chat_id = resolved
         except Exception:

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -129,6 +129,22 @@ class TestResolveDeliveryTarget:
             "thread_id": "17",
         }
 
+    def test_explicit_telegram_topic_thread_survives_bare_directory_match(self):
+        """Exact channel-directory matches must not erase an explicit topic id."""
+        job = {
+            "deliver": "telegram:-1003724596514:17",
+        }
+        with patch(
+            "gateway.channel_directory.resolve_channel_name",
+            return_value="-1003724596514",
+        ):
+            result = _resolve_delivery_target(job)
+        assert result == {
+            "platform": "telegram",
+            "chat_id": "-1003724596514",
+            "thread_id": "17",
+        }
+
     def test_explicit_telegram_chat_id_without_thread_id(self):
         """deliver: 'telegram:chat_id' sets thread_id to None."""
         job = {


### PR DESCRIPTION
## What does this PR do?

Fixes cron delivery for explicit Telegram forum topic targets such as `deliver: telegram:GROUP_ID:THREAD_ID`.

Cron delivery parsed the original `THREAD_ID` correctly, but then resolved the bare `GROUP_ID` through the channel directory. When the directory returned just the bare group id, `_resolve_single_delivery_target()` replaced both `chat_id` and `thread_id`, dropping the already-parsed topic id. Telegram then received no `message_thread_id` and delivered to the default topic.

This changes the merge so a resolved channel id updates `chat_id`, but only replaces `thread_id` when the resolved value actually includes a thread/topic id.

## Related Issue

Reported from Discord support: cron jobs using `deliver: telegram:GROUP_ID:THREAD_ID` landed in the group default topic when the bare group id existed in the channel directory.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `cron/scheduler.py`: preserve an explicit `thread_id` when channel-directory resolution returns a bare chat id.
- `tests/cron/test_scheduler.py`: add regression coverage for explicit Telegram topic delivery where the channel directory exact-id lookup returns the bare group id.

## How to Test

1. Configure a cron job with `deliver: telegram:GROUP_ID:THREAD_ID`.
2. Ensure `GROUP_ID` exists in the channel directory as a bare id.
3. Resolve or run the cron job and confirm the delivery target keeps `thread_id: THREAD_ID`.

## Checklist

### Code

- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I added tests for my changes
- [x] I tested on my platform: Ubuntu/WSL-style Linux checkout

### Documentation & Housekeeping

- [x] Documentation update: N/A
- [x] `cli-config.yaml.example`: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A
- [x] Cross-platform impact considered: resolver-only change, platform-neutral
- [x] Tool descriptions/schemas: N/A

## Validation

- `scripts/run_tests.sh tests/cron/test_scheduler.py` — 94 passed
- `scripts/run_tests.sh` — 34 failed, 16972 passed, 42 skipped. The failures were outside cron delivery and include existing unrelated areas such as DingTalk card mocks, gateway config expectations, Anthropic adapter beta headers, clipboard WSL detection, and TUI/session tests.

## Screenshots / Logs

Before this change, resolving `telegram:-1003724596514:17` while the channel directory returned `-1003724596514` produced:

```python
{"platform": "telegram", "chat_id": "-1003724596514", "thread_id": None}
```

After this change, the explicit topic id is preserved:

```python
{"platform": "telegram", "chat_id": "-1003724596514", "thread_id": "17"}
```
