### PR TITLE
fix(gateway/telegram): quoted-image vision, sender sidecars, reply prefix, multi-sender merge attribution

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -922,6 +922,8 @@ class MessageEvent:
     # Reply context
     reply_to_message_id: Optional[str] = None
     reply_to_text: Optional[str] = None  # Text of the replied-to message (for context injection)
+    reply_to_from_name: Optional[str] = None  # Sender name of the replied-to message
+    reply_to_date: Any = None  # Date of replied-to message (datetime or unix timestamp int)
     # Media attached to the *quoted* (replied-to) message — downloaded so the
     # agent can see images/videos/files that the user is implicitly referring
     # to via the reply pointer. Parallel to media_urls/media_types but for the

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -6,8 +6,10 @@ and implement the required methods.
 """
 
 import asyncio
+import datetime as _dt
 import inspect
 import ipaddress
+import json
 import logging
 import os
 import random
@@ -785,6 +787,64 @@ def cache_document_from_bytes(data: bytes, filename: str) -> str:
     return str(filepath)
 
 
+def write_media_sidecar(media_path: str, metadata: Dict[str, Any]) -> Optional[str]:
+    """Write a JSON sidecar file alongside a cached media file.
+
+    The sidecar is named ``<media_basename>.json`` and lives next to the media
+    in the same cache directory. It records who sent the media so the agent
+    can later answer "who sent that photo?" via search_files / read_file —
+    Telegram does not write any of this into the media bytes themselves and
+    our cache filename is just a random uuid hash.
+
+    Pass any JSON-serialisable dict; common fields:
+      - platform: "telegram" / "discord" / ...
+      - chat_id, chat_type, chat_title
+      - thread_id (Telegram topic id, if any)
+      - from_id, from_name, from_username
+      - message_id, date (ISO 8601 UTC), caption
+      - is_quoted_reply: bool — True when the media came from a reply_to_message
+      - quoted_from_id, quoted_from_name — sender of the quoted message
+
+    Returns the sidecar path on success, None on failure (failure is logged
+    but never raised — the media itself was already cached successfully).
+    """
+    if not media_path:
+        return None
+    try:
+        sidecar_path = f"{media_path}.json"
+        # Always stamp a "saved_at" so old entries can be aged out.
+        payload = dict(metadata)
+        payload.setdefault("saved_at", _dt.datetime.now(_dt.timezone.utc).isoformat())
+        Path(sidecar_path).write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2, default=str),
+            encoding="utf-8",
+        )
+        return sidecar_path
+    except Exception as e:  # noqa: BLE001
+        logging.getLogger(__name__).warning(
+            "Failed to write media sidecar for %s: %s", media_path, e,
+        )
+        return None
+
+
+def read_media_sidecar(media_path: str) -> Optional[Dict[str, Any]]:
+    """Read the JSON sidecar for a cached media file, or return None.
+
+    Convenience for tools that want to ask "who sent this image?" given a
+    path. Returns the parsed dict or None when no sidecar exists / parse
+    fails.
+    """
+    if not media_path:
+        return None
+    sidecar_path = Path(f"{media_path}.json")
+    if not sidecar_path.exists():
+        return None
+    try:
+        return json.loads(sidecar_path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+
 def cleanup_document_cache(max_age_hours: int = 24) -> int:
     """
     Delete cached documents older than *max_age_hours*.
@@ -862,6 +922,12 @@ class MessageEvent:
     # Reply context
     reply_to_message_id: Optional[str] = None
     reply_to_text: Optional[str] = None  # Text of the replied-to message (for context injection)
+    # Media attached to the *quoted* (replied-to) message — downloaded so the
+    # agent can see images/videos/files that the user is implicitly referring
+    # to via the reply pointer. Parallel to media_urls/media_types but for the
+    # quoted message, not the current one.
+    reply_to_media_urls: List[str] = field(default_factory=list)
+    reply_to_media_types: List[str] = field(default_factory=list)
     
     # Auto-loaded skill(s) for topic/channel bindings (e.g., Telegram DM Topics,
     # Discord channel_skill_bindings).  A single name or ordered list.

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -985,6 +985,67 @@ class SendResult:
     retryable: bool = False  # True for transient connection errors — base will retry automatically
 
 
+def _incoming_text_with_sender_marker(
+    existing: MessageEvent,
+    event: MessageEvent,
+) -> str:
+    """Return ``event.text`` annotated with a ``[<sender>]`` prefix when the
+    incoming sender differs from the LAST segment's sender in ``existing``.
+
+    This preserves per-segment attribution when a shared-session group queues
+    follow-up messages from multiple participants while the agent is busy.
+    Without this, downstream code applies a single sender prefix at the head
+    of the merged text (see ``_prepare_inbound_message_text`` in
+    ``gateway/run.py``) and any later participant's words get misattributed
+    to whoever sent the first queued message.
+
+    The "last sender" is tracked on the pending event via a transient
+    ``_last_sender_user_id`` attribute (initialised to the original sender's
+    user_id), so alternating senders (A → B → A) all get correct markers.
+
+    No-op if:
+      - ``event.text`` is empty (nothing to attribute).
+      - Either side lacks ``user_id`` (cannot decide if senders differ —
+        legacy / synthetic events).
+      - The incoming sender matches the last segment's sender.
+      - ``event.text`` already starts with the same ``[name]`` marker (avoid
+        double-prefixing if the caller pre-marked the text).
+    """
+    incoming_text = event.text or ""
+    if not incoming_text:
+        return incoming_text
+
+    last_user_id = getattr(existing, "_last_sender_user_id", None)
+    if last_user_id is None:
+        last_user_id = getattr(getattr(existing, "source", None), "user_id", None)
+    incoming_source = getattr(event, "source", None)
+    incoming_user_id = getattr(incoming_source, "user_id", None)
+    incoming_user_name = getattr(incoming_source, "user_name", None)
+
+    if not (last_user_id and incoming_user_id):
+        return incoming_text
+    if last_user_id == incoming_user_id:
+        return incoming_text
+    if not incoming_user_name:
+        return incoming_text
+
+    marker = f"[{incoming_user_name}] "
+    if incoming_text.startswith(marker):
+        return incoming_text
+    return marker + incoming_text
+
+
+def _record_last_sender(existing: MessageEvent, event: MessageEvent) -> None:
+    """Stamp ``existing._last_sender_user_id`` with the most recent segment's
+    sender so subsequent merges can detect alternation (A → B → A)."""
+    incoming_user_id = getattr(getattr(event, "source", None), "user_id", None)
+    if incoming_user_id:
+        try:
+            existing._last_sender_user_id = incoming_user_id  # type: ignore[attr-defined]
+        except Exception:
+            pass
+
+
 def merge_pending_message_event(
     pending_messages: Dict[str, MessageEvent],
     session_key: str,
@@ -1002,6 +1063,13 @@ def merge_pending_message_event(
     instead of replacing the pending turn. This is used for Telegram bursty
     follow-ups so a multi-part user thought is not silently truncated to only
     the last queued fragment.
+
+    Multi-sender attribution: in shared-session groups (multiple participants
+    sharing one session), each segment from a different sender is prefixed
+    with ``[<sender_name>]`` so the agent can tell who said what after the
+    merge. The downstream ``_prepare_inbound_message_text`` adds the FIRST
+    sender's prefix at the very top, and this function adds prefixes for any
+    SUBSEQUENT distinct senders inside the merged body.
     """
     existing = pending_messages.get(session_key)
     if existing:
@@ -1014,7 +1082,9 @@ def merge_pending_message_event(
             existing.media_urls.extend(event.media_urls)
             existing.media_types.extend(event.media_types)
             if event.text:
-                existing.text = BasePlatformAdapter._merge_caption(existing.text, event.text)
+                marked = _incoming_text_with_sender_marker(existing, event)
+                existing.text = BasePlatformAdapter._merge_caption(existing.text, marked)
+            _record_last_sender(existing, event)
             return
 
         if existing_has_media or incoming_has_media:
@@ -1022,12 +1092,14 @@ def merge_pending_message_event(
                 existing.media_urls.extend(event.media_urls)
                 existing.media_types.extend(event.media_types)
             if event.text:
+                marked = _incoming_text_with_sender_marker(existing, event)
                 if existing.text:
-                    existing.text = BasePlatformAdapter._merge_caption(existing.text, event.text)
+                    existing.text = BasePlatformAdapter._merge_caption(existing.text, marked)
                 else:
-                    existing.text = event.text
+                    existing.text = marked
             if existing_is_photo or incoming_is_photo:
                 existing.message_type = MessageType.PHOTO
+            _record_last_sender(existing, event)
             return
 
         if (
@@ -1036,7 +1108,9 @@ def merge_pending_message_event(
             and event.message_type == MessageType.TEXT
         ):
             if event.text:
-                existing.text = f"{existing.text}\n{event.text}" if existing.text else event.text
+                marked = _incoming_text_with_sender_marker(existing, event)
+                existing.text = f"{existing.text}\n{marked}" if existing.text else marked
+            _record_last_sender(existing, event)
             return
 
     pending_messages[session_key] = event

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -73,6 +73,7 @@ from gateway.platforms.base import (
     cache_audio_from_bytes,
     cache_video_from_bytes,
     cache_document_from_bytes,
+    write_media_sidecar,
     resolve_proxy_url,
     SUPPORTED_VIDEO_TYPES,
     SUPPORTED_DOCUMENT_TYPES,
@@ -2443,6 +2444,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
         event = self._build_message_event(update.message, MessageType.TEXT, update_id=update.update_id)
         event.text = self._clean_bot_trigger_text(event.text)
+        await self._attach_reply_media(event, update.message)
         self._enqueue_text_event(event)
     
     async def _handle_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -2453,6 +2455,7 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         
         event = self._build_message_event(update.message, MessageType.COMMAND, update_id=update.update_id)
+        await self._attach_reply_media(event, update.message)
         await self.handle_message(event)
     
     async def _handle_location_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -2490,6 +2493,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
         event = self._build_message_event(msg, MessageType.LOCATION, update_id=update.update_id)
         event.text = "\n".join(parts)
+        await self._attach_reply_media(event, msg)
         await self.handle_message(event)
 
     # ------------------------------------------------------------------
@@ -2640,6 +2644,7 @@ class TelegramAdapter(BasePlatformAdapter):
             msg_type = MessageType.DOCUMENT
         
         event = self._build_message_event(msg, msg_type, update_id=update.update_id)
+        await self._attach_reply_media(event, msg)
         
         # Add caption as text
         if msg.caption:
@@ -2672,6 +2677,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 event.media_urls = [cached_path]
                 event.media_types = [f"image/{ext.lstrip('.')}" ]
                 logger.info("[Telegram] Cached user photo at %s", cached_path)
+                self._record_media_sender(msg, cached_path)
                 media_group_id = getattr(msg, "media_group_id", None)
                 if media_group_id:
                     await self._queue_media_group_event(str(media_group_id), event)
@@ -2692,6 +2698,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 event.media_urls = [cached_path]
                 event.media_types = ["audio/ogg"]
                 logger.info("[Telegram] Cached user voice at %s", cached_path)
+                self._record_media_sender(msg, cached_path)
             except Exception as e:
                 logger.warning("[Telegram] Failed to cache voice: %s", e, exc_info=True)
         elif msg.audio:
@@ -2702,6 +2709,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 event.media_urls = [cached_path]
                 event.media_types = ["audio/mp3"]
                 logger.info("[Telegram] Cached user audio at %s", cached_path)
+                self._record_media_sender(msg, cached_path)
             except Exception as e:
                 logger.warning("[Telegram] Failed to cache audio: %s", e, exc_info=True)
 
@@ -2719,6 +2727,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 event.media_urls = [cached_path]
                 event.media_types = [SUPPORTED_VIDEO_TYPES.get(ext, "video/mp4")]
                 logger.info("[Telegram] Cached user video at %s", cached_path)
+                self._record_media_sender(msg, cached_path)
             except Exception as e:
                 logger.warning("[Telegram] Failed to cache video: %s", e, exc_info=True)
 
@@ -2750,6 +2759,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     event.media_types = [SUPPORTED_VIDEO_TYPES[ext]]
                     event.message_type = MessageType.VIDEO
                     logger.info("[Telegram] Cached user video document at %s", cached_path)
+                    self._record_media_sender(msg, cached_path)
                     await self.handle_message(event)
                     return
 
@@ -2784,6 +2794,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 event.media_urls = [cached_path]
                 event.media_types = [mime_type]
                 logger.info("[Telegram] Cached user document at %s", cached_path)
+                self._record_media_sender(msg, cached_path)
 
                 # For text files, inject content into event.text (capped at 100 KB)
                 MAX_TEXT_INJECT_BYTES = 100 * 1024
@@ -2889,6 +2900,7 @@ class TelegramAdapter(BasePlatformAdapter):
             image_bytes = await file_obj.download_as_bytearray()
             cached_path = cache_image_from_bytes(bytes(image_bytes), ext=".webp")
             logger.info("[Telegram] Analyzing sticker at %s", cached_path)
+            self._record_media_sender(msg, cached_path)
 
             from tools.vision_tools import vision_analyze_tool
             result_json = await vision_analyze_tool(
@@ -3007,6 +3019,180 @@ class TelegramAdapter(BasePlatformAdapter):
                 "[%s] Cached DM topic from message: %s -> thread_id=%s",
                 self.name, cache_key, thread_id,
             )
+
+    async def _download_reply_media(self, reply_msg: Message) -> tuple[list[str], list[str]]:
+        """Download media attached to a quoted (reply_to) Telegram message.
+
+        Telegram delivers reply_to_message with metadata only — the bot must
+        re-fetch any attached photo/video/voice/audio/document via the file_id
+        if it wants the bytes. This mirrors the cache logic in
+        ``_handle_media_message`` but writes nothing to the current event's
+        primary media slots; callers attach the result to
+        ``MessageEvent.reply_to_media_urls`` so the agent can distinguish the
+        quoted media from media in the current message.
+
+        Returns (paths, mime_types). Both empty on failure or no media.
+        """
+        if not reply_msg:
+            return [], []
+        paths: list[str] = []
+        mtypes: list[str] = []
+        try:
+            if getattr(reply_msg, "photo", None):
+                photo = reply_msg.photo[-1]
+                file_obj = await photo.get_file()
+                image_bytes = await file_obj.download_as_bytearray()
+                ext = ".jpg"
+                if file_obj.file_path:
+                    for candidate in [".png", ".webp", ".gif", ".jpeg", ".jpg"]:
+                        if file_obj.file_path.lower().endswith(candidate):
+                            ext = candidate
+                            break
+                cached_path = cache_image_from_bytes(bytes(image_bytes), ext=ext)
+                paths.append(cached_path)
+                mtypes.append(f"image/{ext.lstrip('.')}")
+                logger.info("[Telegram] Cached quoted reply photo at %s", cached_path)
+            elif getattr(reply_msg, "video", None):
+                file_obj = await reply_msg.video.get_file()
+                video_bytes = await file_obj.download_as_bytearray()
+                ext = ".mp4"
+                if getattr(file_obj, "file_path", None):
+                    for candidate in SUPPORTED_VIDEO_TYPES:
+                        if file_obj.file_path.lower().endswith(candidate):
+                            ext = candidate
+                            break
+                cached_path = cache_video_from_bytes(bytes(video_bytes), ext=ext)
+                paths.append(cached_path)
+                mtypes.append(SUPPORTED_VIDEO_TYPES.get(ext, "video/mp4"))
+                logger.info("[Telegram] Cached quoted reply video at %s", cached_path)
+            elif getattr(reply_msg, "voice", None):
+                file_obj = await reply_msg.voice.get_file()
+                audio_bytes = await file_obj.download_as_bytearray()
+                cached_path = cache_audio_from_bytes(bytes(audio_bytes), ext=".ogg")
+                paths.append(cached_path)
+                mtypes.append("audio/ogg")
+                logger.info("[Telegram] Cached quoted reply voice at %s", cached_path)
+            elif getattr(reply_msg, "audio", None):
+                file_obj = await reply_msg.audio.get_file()
+                audio_bytes = await file_obj.download_as_bytearray()
+                cached_path = cache_audio_from_bytes(bytes(audio_bytes), ext=".mp3")
+                paths.append(cached_path)
+                mtypes.append("audio/mp3")
+                logger.info("[Telegram] Cached quoted reply audio at %s", cached_path)
+            elif getattr(reply_msg, "document", None):
+                doc = reply_msg.document
+                ext = ""
+                original_filename = doc.file_name or ""
+                if original_filename:
+                    _, ext = os.path.splitext(original_filename)
+                    ext = ext.lower()
+                if not ext and doc.mime_type:
+                    mime_to_ext = {v: k for k, v in SUPPORTED_DOCUMENT_TYPES.items()}
+                    ext = mime_to_ext.get(doc.mime_type, "")
+                MAX_DOC_BYTES = 20 * 1024 * 1024
+                if doc.file_size and doc.file_size <= MAX_DOC_BYTES and ext in SUPPORTED_DOCUMENT_TYPES:
+                    file_obj = await doc.get_file()
+                    doc_bytes = await file_obj.download_as_bytearray()
+                    cached_path = cache_document_from_bytes(bytes(doc_bytes), original_filename or f"document{ext}")
+                    paths.append(cached_path)
+                    mtypes.append(SUPPORTED_DOCUMENT_TYPES[ext])
+                    logger.info("[Telegram] Cached quoted reply document at %s", cached_path)
+            elif getattr(reply_msg, "sticker", None):
+                # Stickers are images — fetch the static .webp representation.
+                sticker = reply_msg.sticker
+                file_obj = await sticker.get_file()
+                image_bytes = await file_obj.download_as_bytearray()
+                cached_path = cache_image_from_bytes(bytes(image_bytes), ext=".webp")
+                paths.append(cached_path)
+                mtypes.append("image/webp")
+                logger.info("[Telegram] Cached quoted reply sticker at %s", cached_path)
+        except Exception as e:
+            logger.warning("[Telegram] Failed to download reply-quoted media: %s", e, exc_info=True)
+        return paths, mtypes
+
+    async def _attach_reply_media(self, event: MessageEvent, message: Message) -> None:
+        """Populate ``event.reply_to_media_urls/types`` if the message replies
+        to one with attached media. Safe to call for every inbound event —
+        no-op when there's no reply or no media in the quoted message."""
+        reply_msg = getattr(message, "reply_to_message", None)
+        if not reply_msg:
+            return
+        # Skip if the quoted message has no media at all (cheap check).
+        if not any(getattr(reply_msg, attr, None) for attr in (
+            "photo", "video", "voice", "audio", "document", "sticker",
+        )):
+            return
+        paths, mtypes = await self._download_reply_media(reply_msg)
+        if paths:
+            event.reply_to_media_urls = paths
+            event.reply_to_media_types = mtypes
+            # Record sidecars for the quoted media too — this is the case
+            # that motivated the feature: the user replies to a previous
+            # photo and asks "who sent that?" and we want a definitive answer.
+            for p in paths:
+                self._record_media_sender(reply_msg, p, is_quoted_reply=True)
+
+    def _record_media_sender(
+        self,
+        message: "Message",
+        cached_path: str,
+        *,
+        is_quoted_reply: bool = False,
+    ) -> None:
+        """Write a JSON sidecar next to a cached media file recording who sent it.
+
+        Telegram does not write sender metadata into media bytes and our cache
+        filenames are random uuid hashes, so without this sidecar the agent
+        has no way to answer "who sent that photo?" after the fact. Best-effort:
+        any failure is swallowed (the media itself is already cached).
+        """
+        if not cached_path or not message:
+            return
+        try:
+            from_user = getattr(message, "from_user", None)
+            chat = getattr(message, "chat", None)
+            metadata: dict = {
+                "platform": "telegram",
+                "is_quoted_reply": is_quoted_reply,
+                "message_id": getattr(message, "message_id", None),
+            }
+            if from_user is not None:
+                metadata["from_id"] = str(getattr(from_user, "id", "") or "")
+                metadata["from_name"] = (
+                    getattr(from_user, "full_name", None)
+                    or getattr(from_user, "first_name", None)
+                    or ""
+                )
+                metadata["from_username"] = getattr(from_user, "username", None) or ""
+                metadata["from_is_bot"] = bool(getattr(from_user, "is_bot", False))
+            if chat is not None:
+                metadata["chat_id"] = str(getattr(chat, "id", "") or "")
+                metadata["chat_type"] = getattr(chat, "type", None) or ""
+                metadata["chat_title"] = (
+                    getattr(chat, "title", None)
+                    or getattr(chat, "username", None)
+                    or ""
+                )
+            thread_id = getattr(message, "message_thread_id", None)
+            if thread_id is not None:
+                metadata["thread_id"] = str(thread_id)
+            date = getattr(message, "date", None)
+            if date is not None:
+                try:
+                    metadata["date"] = date.isoformat()
+                except Exception:
+                    metadata["date"] = str(date)
+            caption = getattr(message, "caption", None)
+            if caption:
+                metadata["caption"] = caption[:500]
+            text = getattr(message, "text", None)
+            if text and is_quoted_reply:
+                # For a reply, the quoted message's plain text (if any) is also
+                # useful context — captures e.g. "here's lunch".
+                metadata["quoted_text"] = text[:500]
+            write_media_sidecar(cached_path, metadata)
+        except Exception as e:  # noqa: BLE001
+            logger.debug("[Telegram] _record_media_sender failed: %s", e)
 
     def _build_message_event(
         self,

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -3266,9 +3266,19 @@ class TelegramAdapter(BasePlatformAdapter):
         # Extract reply context if this message is a reply
         reply_to_id = None
         reply_to_text = None
+        reply_to_from_name = None
+        reply_to_date = None
         if message.reply_to_message:
             reply_to_id = str(message.reply_to_message.message_id)
             reply_to_text = message.reply_to_message.text or message.reply_to_message.caption or None
+            _ru = getattr(message.reply_to_message, "from_user", None)
+            if _ru is not None:
+                reply_to_from_name = (
+                    getattr(_ru, "full_name", None)
+                    or getattr(_ru, "first_name", None)
+                    or getattr(_ru, "username", None)
+                )
+            reply_to_date = getattr(message.reply_to_message, "date", None)
 
         # Per-channel/topic ephemeral prompt
         from gateway.platforms.base import resolve_channel_prompt
@@ -3288,6 +3298,8 @@ class TelegramAdapter(BasePlatformAdapter):
             platform_update_id=update_id,
             reply_to_message_id=reply_to_id,
             reply_to_text=reply_to_text,
+            reply_to_from_name=reply_to_from_name,
+            reply_to_date=reply_to_date,
             auto_skill=topic_skill,
             channel_prompt=_channel_prompt,
             timestamp=message.date,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -455,6 +455,88 @@ def _is_control_interrupt_message(message: Optional[str]) -> bool:
     return normalized in _CONTROL_INTERRUPT_MESSAGES
 
 
+# Pre-compiled patterns for stripping noise out of topic previews. We strip:
+#   - leading ``[Replying to message ... at HH:MM: "..."]\n\n`` blocks (and the
+#     legacy ``[Replying to: "..."]`` form), because these reflect the *quoted*
+#     message, not the user's new intent.
+#   - leading shared-session sender markers ``[<name>] `` so the preview
+#     focuses on what the user said, not who they are.
+_REPLY_PREFIX_RE = re.compile(
+    r'^\[Replying to[^\]]*\](?:\n+)?',
+    flags=re.DOTALL,
+)
+_SENDER_MARKER_RE = re.compile(r'^\[[^\]\n]{1,40}\]\s+')
+
+
+def topic_preview_for_progress(message: Optional[str], *, max_chars: int = 30) -> str:
+    """Return a short topic preview suitable for a progress-message header.
+
+    Strips leading ``[Replying to ...]`` blocks and ``[name] `` shared-session
+    markers, collapses whitespace, and truncates to ``max_chars`` codepoints
+    (with a trailing ellipsis when truncation actually drops content).
+
+    Designed to give 玉子燒-style shared-session groups a clear "the agent is
+    currently thinking about *this*" header so participants can see which
+    queued question the bot is working on, even when their own message hasn't
+    been picked up yet.
+    """
+    if not message:
+        return ""
+    text = str(message)
+    # Strip leading Replying-to block(s).
+    while True:
+        m = _REPLY_PREFIX_RE.match(text)
+        if not m:
+            break
+        text = text[m.end():]
+    # Strip leading sender marker.
+    text = _SENDER_MARKER_RE.sub("", text, count=1)
+    # Collapse whitespace and trim.
+    text = " ".join(text.split())
+    if not text:
+        return ""
+    if len(text) > max_chars:
+        return text[:max_chars] + "…"
+    return text
+
+
+def _build_progress_header(
+    source: "SessionSource",
+    message: Optional[str],
+    *,
+    group_sessions_per_user: bool = True,
+    thread_sessions_per_user: bool = False,
+) -> Optional[str]:
+    """Return a one-line topic header for the progress message, or None.
+
+    Only emitted when the session is shared across multiple participants
+    (``is_shared_multi_user_session(source) is True``). In DMs and per-user
+    isolated groups every progress message is unambiguously about the only
+    participant who can see it, so a header would just be noise.
+
+    Format::
+
+        ⏳ 玉青：米粉跟醬包各2
+
+    The ⏳ icon makes it visually distinct from regular progress lines (which
+    start with tool emoji like 🔍 / 📑). The sender name + topic snippet
+    answer "who's question is being processed?" at a glance.
+    """
+    if not is_shared_multi_user_session(
+        source,
+        group_sessions_per_user=group_sessions_per_user,
+        thread_sessions_per_user=thread_sessions_per_user,
+    ):
+        return None
+    name = (getattr(source, "user_name", None) or "").strip()
+    if not name:
+        return None
+    topic = topic_preview_for_progress(message, max_chars=30)
+    if topic:
+        return f"⏳ {name}：{topic}"
+    return f"⏳ {name}"
+
+
 def _check_unavailable_skill(command_name: str) -> str | None:
     """Check if a command matches a known-but-inactive skill.
 
@@ -1720,15 +1802,21 @@ class GatewayRunner:
             except Exception:
                 pass  # don't let interrupt failure block the ack
 
-        # Debounce: only send an acknowledgment once every 30 seconds per session
-        # to avoid spamming the user when they send multiple messages quickly
+        # Debounce: only send an acknowledgment once every 30 seconds per
+        # (session, sender) pair to avoid spamming a single user when they
+        # send several follow-ups in a row, while still letting a *different*
+        # participant in a shared-session group get their own ack within the
+        # window — silence on a second sender's first message looks like the
+        # bot ignored them entirely.
         _BUSY_ACK_COOLDOWN = 30
         now = time.time()
-        last_ack = self._busy_ack_ts.get(session_key, 0)
+        _ack_user_id = getattr(event.source, "user_id", None) or "_anon"
+        ack_key = (session_key, _ack_user_id)
+        last_ack = self._busy_ack_ts.get(ack_key, 0)
         if now - last_ack < _BUSY_ACK_COOLDOWN:
             return True  # interrupt sent (if not queue), ack already delivered recently
 
-        self._busy_ack_ts[session_key] = now
+        self._busy_ack_ts[ack_key] = now
 
         # Build a status-rich acknowledgment
         status_parts = []
@@ -9941,11 +10029,35 @@ class GatewayRunner:
                         break
                 return
 
+            # Shared-session header: in groups where multiple participants
+            # share one session, prefix the progress message with a one-line
+            # "⏳ <sender>：<topic>" so the chat at large can see *whose*
+            # question the agent is currently working on.  Always None in
+            # DMs and per-user-isolated groups.
+            _progress_header = _build_progress_header(
+                source,
+                message,
+                group_sessions_per_user=getattr(self.config, "group_sessions_per_user", True),
+                thread_sessions_per_user=getattr(self.config, "thread_sessions_per_user", False),
+            )
+            # When we have a header (multi-user shared session), reply the
+            # progress message to the originating user message so Telegram
+            # draws a connecting line — even better attribution than the
+            # header alone.  In DMs and per-user groups we leave reply_to
+            # off so the progress doesn't pile up references.
+            _progress_reply_to = event_message_id if _progress_header else None
+
             progress_lines = []      # Accumulated tool lines
             progress_msg_id = None   # ID of the progress message to edit
             can_edit = True          # False once an edit fails (platform doesn't support it)
             _last_edit_ts = 0.0      # Throttle edits to avoid Telegram flood control
             _PROGRESS_EDIT_INTERVAL = 1.5  # Minimum seconds between edits
+
+            def _render_progress_text() -> str:
+                lines = list(progress_lines)
+                if _progress_header:
+                    lines.insert(0, _progress_header)
+                return "\n".join(lines)
 
             while True:
                 try:
@@ -10003,7 +10115,7 @@ class GatewayRunner:
 
                     if can_edit and progress_msg_id is not None:
                         # Try to edit the existing progress message
-                        full_text = "\n".join(progress_lines)
+                        full_text = _render_progress_text()
                         result = await adapter.edit_message(
                             chat_id=source.chat_id,
                             message_id=progress_msg_id,
@@ -10024,8 +10136,13 @@ class GatewayRunner:
                     else:
                         if can_edit:
                             # First tool: send all accumulated text as new message
-                            full_text = "\n".join(progress_lines)
-                            result = await adapter.send(chat_id=source.chat_id, content=full_text, metadata=_progress_metadata)
+                            full_text = _render_progress_text()
+                            result = await adapter.send(
+                                chat_id=source.chat_id,
+                                content=full_text,
+                                reply_to=_progress_reply_to,
+                                metadata=_progress_metadata,
+                            )
                         else:
                             # Editing unsupported: send just this line
                             result = await adapter.send(chat_id=source.chat_id, content=msg, metadata=_progress_metadata)
@@ -10056,7 +10173,7 @@ class GatewayRunner:
                             break
                     # Final edit with all remaining tools (only if editing works)
                     if can_edit and progress_lines and progress_msg_id:
-                        full_text = "\n".join(progress_lines)
+                        full_text = _render_progress_text()
                         try:
                             await adapter.edit_message(
                                 chat_id=source.chat_id,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4365,7 +4365,31 @@ class GatewayRunner:
             # multiple times, and without an explicit pointer the agent has to
             # guess (or answer for both subjects). Token overhead is minimal.
             reply_snippet = event.reply_to_text[:500]
-            message_text = f'[Replying to: "{reply_snippet}"]\n\n{message_text}'
+            from_name = getattr(event, "reply_to_from_name", None)
+            date_val = getattr(event, "reply_to_date", None)
+            time_str: Optional[str] = None
+            if date_val is not None:
+                try:
+                    import datetime as _dt
+                    if isinstance(date_val, (int, float)):
+                        dt_obj = _dt.datetime.fromtimestamp(int(date_val))
+                    elif isinstance(date_val, _dt.datetime):
+                        dt_obj = date_val
+                    else:
+                        dt_obj = None
+                    if dt_obj is not None:
+                        time_str = dt_obj.strftime("%H:%M")
+                except Exception:
+                    time_str = None
+            if from_name and time_str:
+                prefix = f'[Replying to message from {from_name} at {time_str}: "{reply_snippet}"]'
+            elif from_name:
+                prefix = f'[Replying to {from_name}: "{reply_snippet}"]'
+            elif time_str:
+                prefix = f'[Replying to message at {time_str}: "{reply_snippet}"]'
+            else:
+                prefix = f'[Replying to: "{reply_snippet}"]'
+            message_text = f'{prefix}\n\n{message_text}'
 
         # If the quoted (replied-to) message had attached media, enrich the
         # prompt the same way we would for current-message media: vision-

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -28,7 +28,7 @@ import time
 from collections import OrderedDict
 from contextvars import copy_context
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, Optional, Any, List
 
 from agent.account_usage import fetch_account_usage, render_account_usage_lines
@@ -290,6 +290,7 @@ from gateway.platforms.base import (
     MessageEvent,
     MessageType,
     merge_pending_message_event,
+    read_media_sidecar,
 )
 from gateway.restart import (
     DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,
@@ -535,6 +536,88 @@ def _build_progress_header(
     if topic:
         return f"⏳ {name}：{topic}"
     return f"⏳ {name}"
+
+
+def _format_sidecar_time(raw: Any) -> str:
+    """Format a sidecar ``date`` value as ``HH:MM`` (local clock) or "".
+
+    Accepts ISO-8601 strings (with or without timezone), unix timestamps
+    (int / float), or ``datetime`` instances. Returns an empty string when
+    the value is missing or cannot be parsed.
+    """
+    if raw in (None, "", 0):
+        return ""
+    try:
+        if isinstance(raw, datetime):
+            dt = raw
+        elif isinstance(raw, (int, float)):
+            dt = datetime.fromtimestamp(float(raw), tz=timezone.utc)
+        elif isinstance(raw, str):
+            # Accept "...Z" suffix.
+            iso = raw.replace("Z", "+00:00") if raw.endswith("Z") else raw
+            try:
+                dt = datetime.fromisoformat(iso)
+            except ValueError:
+                # Try unix-timestamp-encoded-as-string.
+                dt = datetime.fromtimestamp(float(raw), tz=timezone.utc)
+        else:
+            return ""
+    except Exception:
+        return ""
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    # Convert to local for display.
+    try:
+        dt_local = dt.astimezone()
+    except Exception:
+        dt_local = dt
+    return dt_local.strftime("%H:%M")
+
+
+def _describe_media_origin(media_path: Optional[str]) -> str:
+    """Read the JSON sidecar next to ``media_path`` and return a short tag
+    describing who sent it and when, or an empty string when no sidecar
+    exists / it lacks attribution data.
+
+    Formats:
+      "(from 子家 at 14:04)"                    — both name and time
+      "(from 玉青)"                              — name only
+      "(at 14:04)"                              — time only
+      "(originally from 子家 at 14:04)"          — when is_quoted_reply=True
+      ""                                        — no sidecar / no data
+
+    Used by ``_enrich_message_with_vision`` and
+    ``_enrich_message_with_transcription`` to surface attribution into the
+    prompt the agent sees, so it can answer "who sent that image?" without
+    a separate tool call. The sidecar itself is written by Telegram's
+    ``_record_media_sender`` at cache time.
+    """
+    if not media_path:
+        return ""
+    try:
+        sc = read_media_sidecar(media_path)
+    except Exception:
+        return ""
+    if not sc:
+        return ""
+    name = (sc.get("from_name") or "").strip()
+    time_str = _format_sidecar_time(sc.get("date"))
+    is_quoted = bool(sc.get("is_quoted_reply"))
+    if not name and not time_str:
+        return ""
+    parts = []
+    if is_quoted:
+        parts.append("originally from")
+    else:
+        parts.append("from")
+    if name:
+        parts.append(name)
+    if time_str:
+        if name:
+            parts.append(f"at {time_str}")
+        else:
+            parts = ["at", time_str]
+    return "(" + " ".join(parts) + ")"
 
 
 def _check_unavailable_skill(command_name: str) -> str | None:
@@ -8729,6 +8812,8 @@ class GatewayRunner:
         for path in image_paths:
             try:
                 logger.debug("Auto-analyzing user image: %s", path)
+                origin_tag = _describe_media_origin(path)
+                origin_suffix = f" {origin_tag}" if origin_tag else ""
                 result_json = await vision_analyze_tool(
                     image_url=path,
                     user_prompt=analysis_prompt,
@@ -8738,20 +8823,22 @@ class GatewayRunner:
                     description = result.get("analysis", "")
                     description = sanitize_context(description)
                     enriched_parts.append(
-                        f"[The user sent an image~ Here's what I can see:\n{description}]\n"
+                        f"[The user sent an image{origin_suffix}~ Here's what I can see:\n{description}]\n"
                         f"[If you need a closer look, use vision_analyze with "
                         f"image_url: {path} ~]"
                     )
                 else:
                     enriched_parts.append(
-                        "[The user sent an image but I couldn't quite see it "
+                        f"[The user sent an image{origin_suffix} but I couldn't quite see it "
                         "this time (>_<) You can try looking at it yourself "
                         f"with vision_analyze using image_url: {path}]"
                     )
             except Exception as e:
                 logger.error("Vision auto-analysis error: %s", e)
+                origin_tag = _describe_media_origin(path)
+                origin_suffix = f" {origin_tag}" if origin_tag else ""
                 enriched_parts.append(
-                    f"[The user sent an image but something went wrong when I "
+                    f"[The user sent an image{origin_suffix} but something went wrong when I "
                     f"tried to look at it~ You can try examining it yourself "
                     f"with vision_analyze using image_url: {path}]"
                 )
@@ -8796,13 +8883,15 @@ class GatewayRunner:
 
         enriched_parts = []
         for path in audio_paths:
+            origin_tag = _describe_media_origin(path)
+            origin_suffix = f" {origin_tag}" if origin_tag else ""
             try:
                 logger.debug("Transcribing user voice: %s", path)
                 result = await asyncio.to_thread(transcribe_audio, path)
                 if result["success"]:
                     transcript = result["transcript"]
                     enriched_parts.append(
-                        f'[The user sent a voice message~ '
+                        f'[The user sent a voice message{origin_suffix}~ '
                         f'Here\'s what they said: "{transcript}"]'
                     )
                 else:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4367,6 +4367,51 @@ class GatewayRunner:
             reply_snippet = event.reply_to_text[:500]
             message_text = f'[Replying to: "{reply_snippet}"]\n\n{message_text}'
 
+        # If the quoted (replied-to) message had attached media, enrich the
+        # prompt the same way we would for current-message media: vision-
+        # describe images, transcribe audio, note documents. This is what
+        # makes "reply to a photo and ask about it" actually work — without
+        # this block, the agent only sees the quoted text snippet and is
+        # blind to the image the user is pointing at.
+        reply_media_urls = getattr(event, "reply_to_media_urls", None) or []
+        if reply_media_urls:
+            reply_media_types = getattr(event, "reply_to_media_types", None) or []
+            reply_image_paths: List[str] = []
+            reply_audio_paths: List[str] = []
+            reply_doc_paths: List[tuple[str, str]] = []  # (path, mime)
+            for i, path in enumerate(reply_media_urls):
+                mtype = reply_media_types[i] if i < len(reply_media_types) else ""
+                if mtype.startswith("image/"):
+                    reply_image_paths.append(path)
+                elif mtype.startswith("audio/"):
+                    reply_audio_paths.append(path)
+                elif mtype.startswith(("application/", "text/")) or mtype.startswith("video/"):
+                    reply_doc_paths.append((path, mtype))
+
+            if reply_image_paths:
+                # Reuse the same vision pipeline; tag output as "quoted" so
+                # the agent doesn't confuse it with current-message media.
+                vision_prefix = await self._enrich_message_with_vision("", reply_image_paths)
+                if vision_prefix:
+                    message_text = (
+                        "[The user is replying to a previous message that contained "
+                        f"an image. {vision_prefix}]\n\n{message_text}"
+                    )
+            if reply_audio_paths:
+                audio_prefix = await self._enrich_message_with_transcription("", reply_audio_paths)
+                if audio_prefix:
+                    message_text = (
+                        "[The user is replying to a previous voice/audio message. "
+                        f"{audio_prefix}]\n\n{message_text}"
+                    )
+            for path, mtype in reply_doc_paths:
+                kind = "video" if mtype.startswith("video/") else "document"
+                message_text = (
+                    f"[The user is replying to a previous message that attached a "
+                    f"{kind}. The file is saved at: {path} (mime: {mtype}).]\n\n"
+                    f"{message_text}"
+                )
+
         if "@" in message_text:
             try:
                 from agent.context_references import preprocess_context_references_async

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -341,8 +341,9 @@ class TestBusySessionAck:
         await runner._handle_active_session_busy_message(event, sk)
         assert adapter._send_with_retry.call_count == 1
 
-        # Fake that cooldown expired
-        runner._busy_ack_ts[sk] = time.time() - 31
+        # Fake that cooldown expired (key now includes user_id, see
+        # gateway.run debounce note).
+        runner._busy_ack_ts[(sk, event.source.user_id or "_anon")] = time.time() - 31
 
         # Second ack should go through
         await runner._handle_active_session_busy_message(event, sk)

--- a/tests/gateway/test_media_origin_attribution.py
+++ b/tests/gateway/test_media_origin_attribution.py
@@ -1,0 +1,170 @@
+"""Tests for sender-attribution injection into vision / transcription enrichment.
+
+When the gateway auto-describes a user image or transcribes a voice message,
+the resulting enrichment text now includes a "from <sender> at HH:MM" tag
+read from the JSON sidecar that lives next to the cached media. This lets
+the agent know *who* sent the image/voice in shared-session groups (and
+even in DMs, gives an unambiguous timestamp).
+
+The tag is read from the sidecar written by gateway/platforms/telegram.py's
+_record_media_sender at cache time.
+"""
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from gateway.run import _describe_media_origin
+
+
+def _write_image_with_sidecar(tmp_path: Path, *, basename: str, **sidecar_fields):
+    img_path = tmp_path / basename
+    img_path.write_bytes(b"\xff\xd8\xff\xe0fake-jpeg")
+    sidecar_path = tmp_path / f"{basename}.json"
+    sidecar_path.write_text(json.dumps(sidecar_fields, ensure_ascii=False))
+    return str(img_path)
+
+
+def test_describe_media_origin_returns_name_and_time(tmp_path):
+    """Reading a sidecar with from_name and date yields a "from X at HH:MM" tag."""
+    img = _write_image_with_sidecar(
+        tmp_path,
+        basename="img_abc.jpg",
+        from_name="子家",
+        from_id=8682281996,
+        date="2026-04-28T06:04:02+00:00",
+        platform="telegram",
+        chat_type="supergroup",
+    )
+
+    out = _describe_media_origin(img)
+    assert "子家" in out
+    # date should render as local/explicit HH:MM, not the raw ISO blob.
+    assert "T" not in out
+    # The original ISO must not leak verbatim.
+    assert "2026-04-28T06:04:02" not in out
+
+
+def test_describe_media_origin_handles_missing_sidecar(tmp_path):
+    """An image with no sidecar yields an empty string (not an exception)."""
+    img = tmp_path / "img_naked.jpg"
+    img.write_bytes(b"\xff\xd8\xffno-sidecar")
+    assert _describe_media_origin(str(img)) == ""
+
+
+def test_describe_media_origin_handles_only_name(tmp_path):
+    """If the sidecar only has from_name (no date), still attribute by name."""
+    img = _write_image_with_sidecar(
+        tmp_path,
+        basename="img_name_only.jpg",
+        from_name="玉青",
+    )
+    out = _describe_media_origin(img)
+    assert "玉青" in out
+
+
+def test_describe_media_origin_handles_only_date(tmp_path):
+    """If the sidecar only has date (no name), still attribute by time."""
+    img = _write_image_with_sidecar(
+        tmp_path,
+        basename="img_date_only.jpg",
+        date="2026-04-28T06:04:02+00:00",
+    )
+    out = _describe_media_origin(img)
+    # Some HH:MM-ish marker should appear.
+    assert ":" in out
+
+
+def test_describe_media_origin_handles_unix_timestamp_date(tmp_path):
+    """Sidecars sometimes store date as a unix timestamp (int/float)."""
+    img = _write_image_with_sidecar(
+        tmp_path,
+        basename="img_unix.jpg",
+        from_name="玉青",
+        date=1714286642,
+    )
+    out = _describe_media_origin(img)
+    assert "玉青" in out
+    assert ":" in out
+
+
+def test_describe_media_origin_handles_corrupt_sidecar(tmp_path):
+    """A corrupt JSON sidecar must not crash — return empty."""
+    img = tmp_path / "img_corrupt.jpg"
+    img.write_bytes(b"\xff\xd8\xfffake")
+    (tmp_path / "img_corrupt.jpg.json").write_text("{not valid json")
+    assert _describe_media_origin(str(img)) == ""
+
+
+def test_describe_media_origin_marks_quoted_reply(tmp_path):
+    """A sidecar with is_quoted_reply=True hints the image was the *original*
+    media being replied to, so the description should make that clear."""
+    img = _write_image_with_sidecar(
+        tmp_path,
+        basename="img_reply.jpg",
+        from_name="子家",
+        date="2026-04-28T06:04:02+00:00",
+        is_quoted_reply=True,
+    )
+    out = _describe_media_origin(img)
+    assert "子家" in out
+    # Originality hint: "originally" is the most natural English marker.
+    assert "originally" in out.lower() or "原" in out
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: enrichment functions surface origin tag into prompt
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_enrich_message_with_vision_includes_origin_tag(tmp_path, monkeypatch):
+    """The text the agent ultimately sees must mention the sender from the
+    sidecar, so it can answer "who sent this image?" without an extra tool
+    call."""
+    from gateway.run import GatewayRunner
+
+    img = _write_image_with_sidecar(
+        tmp_path,
+        basename="img_e2e.jpg",
+        from_name="玉青",
+        date="2026-04-28T06:04:02+00:00",
+        platform="telegram",
+    )
+
+    async def _fake_vision(image_url, user_prompt):
+        return json.dumps({"success": True, "analysis": "A bowl of rice noodles."})
+
+    monkeypatch.setattr("tools.vision_tools.vision_analyze_tool", _fake_vision)
+
+    runner = object.__new__(GatewayRunner)
+    out = await runner._enrich_message_with_vision("", [img])
+    assert "玉青" in out
+    assert "rice noodles" in out
+    # And the sender attribution should appear in the leading bracket, not
+    # buried somewhere inside the description.
+    head = out.split("\n", 1)[0]
+    assert "玉青" in head
+
+
+@pytest.mark.asyncio
+async def test_enrich_message_with_vision_works_without_sidecar(tmp_path, monkeypatch):
+    """Images without a sidecar (e.g. legacy cached images) must still go
+    through the vision pipeline, just without the origin tag."""
+    from gateway.run import GatewayRunner
+
+    img = tmp_path / "img_no_sidecar.jpg"
+    img.write_bytes(b"\xff\xd8\xfffake")
+
+    async def _fake_vision(image_url, user_prompt):
+        return json.dumps({"success": True, "analysis": "Some image."})
+
+    monkeypatch.setattr("tools.vision_tools.vision_analyze_tool", _fake_vision)
+
+    runner = object.__new__(GatewayRunner)
+    out = await runner._enrich_message_with_vision("", [str(img)])
+    assert "Some image" in out
+    # No "(from ...)" tag because there's no sidecar.
+    assert "(from " not in out

--- a/tests/gateway/test_media_sidecar.py
+++ b/tests/gateway/test_media_sidecar.py
@@ -1,0 +1,183 @@
+"""Tests for media sidecar JSON files.
+
+When the Telegram adapter caches a photo/voice/document, it writes a JSON
+sidecar next to the cached file recording who sent it. This lets the agent
+later answer "who sent that photo?" by reading the sidecar — Telegram does
+not write any sender metadata into the media bytes themselves and our cache
+filenames are random uuid hashes.
+"""
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+import tempfile
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.platforms.base import write_media_sidecar, read_media_sidecar
+
+
+# --- pure helpers ------------------------------------------------------------
+
+
+def test_write_and_read_sidecar_roundtrip(tmp_path):
+    media = tmp_path / "img_abc.jpg"
+    media.write_bytes(b"\xff\xd8\xff")  # not used by the helper, just realistic
+
+    sidecar = write_media_sidecar(
+        str(media),
+        {
+            "platform": "telegram",
+            "from_id": "8682281996",
+            "from_name": "TZ Chia Tseng",
+            "message_id": 42,
+            "chat_id": "-1003964576906",
+        },
+    )
+    assert sidecar == f"{media}.json"
+    assert os.path.exists(sidecar)
+
+    payload = read_media_sidecar(str(media))
+    assert payload is not None
+    assert payload["from_id"] == "8682281996"
+    assert payload["from_name"] == "TZ Chia Tseng"
+    assert payload["message_id"] == 42
+    assert payload["chat_id"] == "-1003964576906"
+    assert "saved_at" in payload  # auto-stamped
+
+
+def test_read_sidecar_returns_none_when_missing(tmp_path):
+    assert read_media_sidecar(str(tmp_path / "nonexistent.jpg")) is None
+
+
+def test_write_sidecar_handles_datetime_objects(tmp_path):
+    media = tmp_path / "img_x.jpg"
+    media.write_bytes(b"\xff\xd8\xff")
+    write_media_sidecar(
+        str(media),
+        {"date": dt.datetime(2026, 4, 27, 12, 51, tzinfo=dt.timezone.utc)},
+    )
+    payload = read_media_sidecar(str(media))
+    assert payload is not None
+    # default=str fallback handles non-serialisable types
+    assert "2026-04-27" in payload["date"]
+
+
+# --- integration: TelegramAdapter._record_media_sender -----------------------
+
+
+def _make_fake_message(
+    *,
+    msg_id=99,
+    user_id=8682281996,
+    user_name="TZ Chia Tseng",
+    username="tz_chia",
+    chat_id=-1003964576906,
+    chat_type="supergroup",
+    chat_title="玉子燒廚房",
+    thread_id=None,
+    caption=None,
+    text=None,
+    date=None,
+):
+    from_user = SimpleNamespace(
+        id=user_id,
+        full_name=user_name,
+        first_name=user_name.split()[0] if user_name else "",
+        username=username,
+        is_bot=False,
+    )
+    chat = SimpleNamespace(id=chat_id, type=chat_type, title=chat_title, username=None)
+    return SimpleNamespace(
+        message_id=msg_id,
+        from_user=from_user,
+        chat=chat,
+        message_thread_id=thread_id,
+        date=date or dt.datetime(2026, 4, 27, 12, 51, tzinfo=dt.timezone.utc),
+        caption=caption,
+        text=text,
+    )
+
+
+def _make_adapter():
+    """Build a TelegramAdapter without running its full __init__."""
+    from gateway.platforms.telegram import TelegramAdapter
+    return object.__new__(TelegramAdapter)
+
+
+def test_record_media_sender_writes_full_metadata(tmp_path):
+    adapter = _make_adapter()
+    media = tmp_path / "img_xyz.jpg"
+    media.write_bytes(b"\xff\xd8\xff")
+
+    message = _make_fake_message(caption="my bento")
+    adapter._record_media_sender(message, str(media))
+
+    payload = read_media_sidecar(str(media))
+    assert payload["platform"] == "telegram"
+    assert payload["from_id"] == "8682281996"
+    assert payload["from_name"] == "TZ Chia Tseng"
+    assert payload["from_username"] == "tz_chia"
+    assert payload["from_is_bot"] is False
+    assert payload["chat_id"] == "-1003964576906"
+    assert payload["chat_type"] == "supergroup"
+    assert payload["chat_title"] == "玉子燒廚房"
+    assert payload["message_id"] == 99
+    assert "2026-04-27" in payload["date"]
+    assert payload["caption"] == "my bento"
+    assert payload["is_quoted_reply"] is False
+
+
+def test_record_media_sender_marks_quoted_reply(tmp_path):
+    adapter = _make_adapter()
+    media = tmp_path / "img_q.jpg"
+    media.write_bytes(b"\xff\xd8\xff")
+
+    quoted_msg = _make_fake_message(
+        msg_id=42,
+        user_id=1285712441,
+        user_name="王玉青",
+        username="wang_yuching",
+        text="here's lunch",
+    )
+    adapter._record_media_sender(quoted_msg, str(media), is_quoted_reply=True)
+
+    payload = read_media_sidecar(str(media))
+    assert payload["is_quoted_reply"] is True
+    assert payload["from_id"] == "1285712441"
+    assert payload["from_name"] == "王玉青"
+    assert payload["quoted_text"] == "here's lunch"
+
+
+def test_record_media_sender_swallows_errors(tmp_path):
+    """No exception should escape even if the message has no usable fields."""
+    adapter = _make_adapter()
+    media = tmp_path / "img_e.jpg"
+    media.write_bytes(b"\xff\xd8\xff")
+
+    # Empty SimpleNamespace — most getattr() calls return None
+    bare_message = SimpleNamespace()
+    adapter._record_media_sender(bare_message, str(media))  # must not raise
+
+    payload = read_media_sidecar(str(media))
+    assert payload is not None
+    assert payload["platform"] == "telegram"
+
+
+def test_record_media_sender_noop_on_empty_path(tmp_path):
+    adapter = _make_adapter()
+    msg = _make_fake_message()
+    # Should not raise, should not write anything
+    adapter._record_media_sender(msg, "")
+    adapter._record_media_sender(msg, None)  # type: ignore[arg-type]
+
+
+def test_record_media_sender_noop_on_no_message(tmp_path):
+    adapter = _make_adapter()
+    media = tmp_path / "img_n.jpg"
+    media.write_bytes(b"\xff\xd8\xff")
+    adapter._record_media_sender(None, str(media))  # type: ignore[arg-type]
+    assert not (tmp_path / "img_n.jpg.json").exists()

--- a/tests/gateway/test_multi_sender_merge.py
+++ b/tests/gateway/test_multi_sender_merge.py
@@ -1,0 +1,166 @@
+"""Tests for multi-sender attribution in merge_pending_message_event.
+
+When the gateway is busy and queues messages for the next turn, multiple
+participants in a shared-session group can each contribute messages that get
+merged into a single follow-up turn. The merge MUST preserve sender
+attribution per segment, otherwise the agent will misattribute later messages
+to whoever sent the first one.
+
+These tests reproduce the bug described in the 玉子燒廚房 (Tamagoyaki Kitchen)
+scenario, where 玉青's nutrition logs and 子家's nutrition logs were getting
+merged into a single text and the agent could not tell who said what.
+"""
+
+from gateway.config import Platform
+from gateway.platforms.base import (
+    MessageEvent,
+    MessageType,
+    merge_pending_message_event,
+)
+from gateway.session import SessionSource, build_session_key
+
+
+def _src(user_id: str, user_name: str) -> SessionSource:
+    """Helper: shared group source (same chat, different participants)."""
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1003964576906",
+        chat_type="group",
+        user_id=user_id,
+        user_name=user_name,
+    )
+
+
+def _key() -> str:
+    # Shared session: same key regardless of user_id.
+    return build_session_key(
+        _src("anyone", "anyone"),
+        group_sessions_per_user=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Multi-sender TEXT merge
+# ---------------------------------------------------------------------------
+
+
+def test_text_merge_preserves_each_sender_when_senders_differ():
+    """玉青 sends, then 子家 sends: merged text must mark 子家's segment."""
+    pending = {}
+    yuqing = MessageEvent(
+        text="米粉跟醬包各2",
+        message_type=MessageType.TEXT,
+        source=_src("1285712441", "玉青"),
+    )
+    zijia = MessageEvent(
+        text="水煮蛋一顆",
+        message_type=MessageType.TEXT,
+        source=_src("8682281996", "子家"),
+    )
+
+    merge_pending_message_event(pending, _key(), yuqing, merge_text=True)
+    merge_pending_message_event(pending, _key(), zijia, merge_text=True)
+
+    merged = pending[_key()]
+    # 子家's segment must carry [子家] prefix so the agent does not mistake
+    # it for 玉青's message.
+    assert "[子家] 水煮蛋一顆" in merged.text
+    assert "米粉跟醬包各2" in merged.text
+
+
+def test_text_merge_does_not_double_prefix_same_sender():
+    """If the same sender sends two follow-ups, do not insert a sender prefix.
+
+    The shared-session prefix is added once at the top by
+    _prepare_inbound_message_text; merge should not add its own prefix when
+    sender is unchanged.
+    """
+    pending = {}
+    src = _src("1285712441", "玉青")
+    first = MessageEvent(text="A", message_type=MessageType.TEXT, source=src)
+    second = MessageEvent(text="B", message_type=MessageType.TEXT, source=src)
+
+    merge_pending_message_event(pending, _key(), first, merge_text=True)
+    merge_pending_message_event(pending, _key(), second, merge_text=True)
+
+    merged = pending[_key()]
+    # Same sender → plain newline join, no [玉青] prefix inserted by merge.
+    assert merged.text == "A\nB"
+
+
+def test_text_merge_three_alternating_senders():
+    """玉青, 子家, 玉青 again: each segment after the first carries its sender."""
+    pending = {}
+    a1 = MessageEvent(text="早餐燕麥", message_type=MessageType.TEXT, source=_src("1", "玉青"))
+    b = MessageEvent(text="咖啡一杯", message_type=MessageType.TEXT, source=_src("2", "子家"))
+    a2 = MessageEvent(text="加蘋果", message_type=MessageType.TEXT, source=_src("1", "玉青"))
+
+    merge_pending_message_event(pending, _key(), a1, merge_text=True)
+    merge_pending_message_event(pending, _key(), b, merge_text=True)
+    merge_pending_message_event(pending, _key(), a2, merge_text=True)
+
+    merged = pending[_key()]
+    assert "早餐燕麥" in merged.text
+    assert "[子家] 咖啡一杯" in merged.text
+    # When sender flips back, prefix again so it's clear who's talking.
+    assert "[玉青] 加蘋果" in merged.text
+
+
+# ---------------------------------------------------------------------------
+# Multi-sender PHOTO merge
+# ---------------------------------------------------------------------------
+
+
+def test_photo_burst_merge_with_different_senders_marks_caption():
+    """Photo from 玉青 then photo from 子家: caption must mark 子家's caption."""
+    pending = {}
+    yuqing_photo = MessageEvent(
+        text="便當1",
+        message_type=MessageType.PHOTO,
+        source=_src("1285712441", "玉青"),
+        media_urls=["/tmp/img_yuqing.jpg"],
+        media_types=["image/jpeg"],
+    )
+    zijia_photo = MessageEvent(
+        text="便當2",
+        message_type=MessageType.PHOTO,
+        source=_src("8682281996", "子家"),
+        media_urls=["/tmp/img_zijia.jpg"],
+        media_types=["image/jpeg"],
+    )
+
+    merge_pending_message_event(pending, _key(), yuqing_photo, merge_text=True)
+    merge_pending_message_event(pending, _key(), zijia_photo, merge_text=True)
+
+    merged = pending[_key()]
+    assert merged.message_type == MessageType.PHOTO
+    # Both images carried over.
+    assert "/tmp/img_yuqing.jpg" in merged.media_urls
+    assert "/tmp/img_zijia.jpg" in merged.media_urls
+    # 子家's caption must be marked.
+    assert "[子家] 便當2" in merged.text
+
+
+def test_text_then_photo_from_different_sender_marks_photo_caption():
+    """玉青 sends text, then 子家 sends a photo: photo caption must mark 子家."""
+    pending = {}
+    text_event = MessageEvent(
+        text="幫我看",
+        message_type=MessageType.TEXT,
+        source=_src("1285712441", "玉青"),
+    )
+    photo_event = MessageEvent(
+        text="這張",
+        message_type=MessageType.PHOTO,
+        source=_src("8682281996", "子家"),
+        media_urls=["/tmp/zijia.jpg"],
+        media_types=["image/jpeg"],
+    )
+
+    merge_pending_message_event(pending, _key(), text_event, merge_text=True)
+    merge_pending_message_event(pending, _key(), photo_event, merge_text=True)
+
+    merged = pending[_key()]
+    assert merged.message_type == MessageType.PHOTO
+    assert "幫我看" in merged.text
+    assert "[子家] 這張" in merged.text

--- a/tests/gateway/test_multi_sender_visibility.py
+++ b/tests/gateway/test_multi_sender_visibility.py
@@ -1,0 +1,323 @@
+"""Tests for multi-sender visibility in busy acknowledgments and progress.
+
+When a shared-session group has multiple participants, the busy/queue ack
+and the tool-progress message must be wired up so that:
+
+1. The ack message is a *reply* to the participant's own message — Telegram
+   then draws a connecting line so each participant sees the bot answering
+   *their* specific question.
+
+2. The 30-second per-session debounce on busy acks is keyed per-sender, so
+   when 玉青 just got an ack and 子家 sends a follow-up 5 seconds later,
+   子家 still gets an ack instead of silence.
+
+3. A topic-preview helper extracts a short summary from the user message,
+   stripping any leading ``[name] `` shared-session sender prefix so the
+   preview shows the real intent, not the marker.
+"""
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Stub telegram so gateway.run imports cleanly. (Same approach as
+# tests/gateway/test_busy_session_ack.py.)
+import sys
+import types
+
+_tg = types.ModuleType("telegram")
+_tg.constants = types.ModuleType("telegram.constants")
+_ct = MagicMock()
+_ct.SUPERGROUP = "supergroup"
+_ct.GROUP = "group"
+_ct.PRIVATE = "private"
+_tg.constants.ChatType = _ct
+sys.modules.setdefault("telegram", _tg)
+sys.modules.setdefault("telegram.constants", _tg.constants)
+sys.modules.setdefault("telegram.ext", types.ModuleType("telegram.ext"))
+
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionSource
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _shared_group_event(user_id, user_name, text, message_id):
+    from gateway.config import Platform
+    src = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1003964576906",
+        chat_type="group",
+        user_id=user_id,
+        user_name=user_name,
+    )
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=src,
+        message_id=message_id,
+    )
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner, _AGENT_PENDING_SENTINEL
+
+    runner = object.__new__(GatewayRunner)
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._busy_ack_ts = {}
+    runner._draining = False
+    runner.adapters = {}
+    runner.config = MagicMock()
+    runner.config.busy_input_mode = "queue"
+    runner.config.group_sessions_per_user = False
+    runner.config.thread_sessions_per_user = False
+    runner.session_store = None
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = True
+    runner._is_user_authorized = lambda _source: True
+    runner._busy_input_mode = "queue"
+    return runner, _AGENT_PENDING_SENTINEL
+
+
+def _make_adapter():
+    from gateway.config import Platform
+    adapter = MagicMock()
+    adapter._pending_messages = {}
+    adapter._send_with_retry = AsyncMock()
+    adapter.send = AsyncMock()
+    adapter.config = MagicMock()
+    adapter.config.extra = {}
+    adapter.platform = Platform.TELEGRAM
+    return adapter
+
+
+# ---------------------------------------------------------------------------
+# Topic preview helper
+# ---------------------------------------------------------------------------
+
+
+def test_topic_preview_strips_sender_marker_and_truncates():
+    """`topic_preview_for_progress` removes a leading [name] marker."""
+    from gateway.run import topic_preview_for_progress
+
+    raw = "[玉青] 米粉跟醬包各2，麻煩你幫我記一下今天的午餐熱量"
+    out = topic_preview_for_progress(raw, max_chars=30)
+    assert not out.startswith("[玉青]")
+    # Some prefix of the actual content should be present.
+    assert "米粉" in out
+    # Truncated to roughly max_chars (allowing for ellipsis).
+    assert len(out) <= 33
+
+
+def test_topic_preview_handles_text_without_marker():
+    from gateway.run import topic_preview_for_progress
+
+    out = topic_preview_for_progress("水煮蛋一顆", max_chars=30)
+    assert out == "水煮蛋一顆"
+
+
+def test_topic_preview_handles_empty():
+    from gateway.run import topic_preview_for_progress
+
+    assert topic_preview_for_progress("", max_chars=30) == ""
+    assert topic_preview_for_progress(None, max_chars=30) == ""
+
+
+def test_topic_preview_strips_reply_prefix_too():
+    """A reply prefix like '[Replying to ...]' followed by the real text
+    should be skipped over so the preview reflects the new intent."""
+    from gateway.run import topic_preview_for_progress
+
+    raw = '[Replying to message from 玉青 at 13:02: "便當"]\n\n[子家] 看起來怎樣'
+    out = topic_preview_for_progress(raw, max_chars=30)
+    assert "看起來怎樣" in out
+    assert "Replying" not in out
+    assert "玉青" not in out  # the [玉青] marker (from the body) is also stripped
+
+
+# ---------------------------------------------------------------------------
+# Per-sender busy-ack debounce
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_busy_ack_per_sender_debounce_lets_second_user_through():
+    """玉青 gets an ack, 子家 5s later in the same shared session must also
+    get an ack (not silenced by the 30s per-session debounce)."""
+    runner, sentinel = _make_runner()
+    adapter = _make_adapter()
+    from gateway.config import Platform
+    runner.adapters[Platform.TELEGRAM] = adapter
+
+    # Pretend an agent is running for this shared-session key.
+    session_key = "agent:main:telegram:group:-1003964576906"
+    running_agent = MagicMock()
+    running_agent.get_activity_summary = MagicMock(
+        return_value={"api_call_count": 1, "max_iterations": 90, "current_tool": None}
+    )
+    runner._running_agents[session_key] = running_agent
+    runner._running_agents_ts[session_key] = time.time()
+
+    yuqing = _shared_group_event("1285712441", "玉青", "米粉", message_id="m1")
+    zijia = _shared_group_event("8682281996", "子家", "水煮蛋", message_id="m2")
+
+    with patch("gateway.run._load_gateway_config", return_value={}):
+        await runner._handle_active_session_busy_message(yuqing, session_key)
+        # Now 子家 sends within the 30s window.
+        await runner._handle_active_session_busy_message(zijia, session_key)
+
+    # Both senders should have produced an outgoing ack.
+    assert adapter._send_with_retry.await_count >= 2, (
+        f"Expected at least 2 acks (one per sender), got "
+        f"{adapter._send_with_retry.await_count}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_busy_ack_same_sender_still_debounced():
+    """玉青 sends two messages within 30s — only the first ack should fire."""
+    runner, sentinel = _make_runner()
+    adapter = _make_adapter()
+    from gateway.config import Platform
+    runner.adapters[Platform.TELEGRAM] = adapter
+
+    session_key = "agent:main:telegram:group:-1003964576906"
+    running_agent = MagicMock()
+    running_agent.get_activity_summary = MagicMock(
+        return_value={"api_call_count": 1, "max_iterations": 90, "current_tool": None}
+    )
+    runner._running_agents[session_key] = running_agent
+    runner._running_agents_ts[session_key] = time.time()
+
+    first = _shared_group_event("1285712441", "玉青", "米粉", message_id="m1")
+    second = _shared_group_event("1285712441", "玉青", "再加蛋", message_id="m2")
+
+    with patch("gateway.run._load_gateway_config", return_value={}):
+        await runner._handle_active_session_busy_message(first, session_key)
+        await runner._handle_active_session_busy_message(second, session_key)
+
+    # Only the first should have produced an ack.
+    assert adapter._send_with_retry.await_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Busy-ack reply_to wiring
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_busy_ack_replies_to_origin_message_id():
+    """The ack message must reply to the originating message id so Telegram
+    visually links the ack to the correct sender's message."""
+    runner, sentinel = _make_runner()
+    adapter = _make_adapter()
+    from gateway.config import Platform
+    runner.adapters[Platform.TELEGRAM] = adapter
+
+    session_key = "agent:main:telegram:group:-1003964576906"
+    running_agent = MagicMock()
+    running_agent.get_activity_summary = MagicMock(
+        return_value={"api_call_count": 1, "max_iterations": 90, "current_tool": None}
+    )
+    runner._running_agents[session_key] = running_agent
+    runner._running_agents_ts[session_key] = time.time()
+
+    evt = _shared_group_event("8682281996", "子家", "幫我查股票", message_id="msg-42")
+
+    with patch("gateway.run._load_gateway_config", return_value={}):
+        await runner._handle_active_session_busy_message(evt, session_key)
+
+    assert adapter._send_with_retry.await_count == 1
+    call = adapter._send_with_retry.await_args
+    # Verify the call carried reply_to pointing at this sender's message.
+    sent_kwargs = call.kwargs
+    assert sent_kwargs.get("reply_to") == "msg-42"
+
+
+# ---------------------------------------------------------------------------
+# Progress header for shared-session multi-user groups
+# ---------------------------------------------------------------------------
+
+
+def test_build_progress_header_in_shared_session_marks_sender_and_topic():
+    """`_build_progress_header(source, message)` returns a one-line topic
+    header marking the sender and a short preview, used as the first line of
+    the progress message in shared-session groups."""
+    from gateway.config import Platform
+    from gateway.run import _build_progress_header
+
+    src = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1003964576906",
+        chat_type="group",
+        user_id="1285712441",
+        user_name="玉青",
+    )
+    out = _build_progress_header(
+        src,
+        "[玉青] 米粉跟醬包各2",
+        group_sessions_per_user=False,
+        thread_sessions_per_user=False,
+    )
+    assert out is not None
+    assert "玉青" in out
+    assert "米粉" in out
+    # It should be a single line — no embedded newline.
+    assert "\n" not in out
+
+
+def test_build_progress_header_dm_returns_none():
+    """In a DM (single sender), no header is needed — return None."""
+    from gateway.config import Platform
+    from gateway.run import _build_progress_header
+
+    src = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="8682281996",
+        chat_type="dm",
+        user_id="8682281996",
+        user_name="子家",
+    )
+    assert (
+        _build_progress_header(
+            src,
+            "幫我查股票",
+            group_sessions_per_user=False,
+            thread_sessions_per_user=False,
+        )
+        is None
+    )
+
+
+def test_build_progress_header_per_user_group_returns_none():
+    """Per-user-isolated groups don't need a sender header either: each
+    participant has their own session, so any progress message a user sees is
+    necessarily theirs."""
+    from gateway.config import Platform
+    from gateway.run import _build_progress_header
+
+    src = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1003964576906",
+        chat_type="group",
+        user_id="1285712441",
+        user_name="玉青",
+    )
+    assert (
+        _build_progress_header(
+            src,
+            "[玉青] 米粉",
+            group_sessions_per_user=True,
+            thread_sessions_per_user=False,
+        )
+        is None
+    )

--- a/tests/gateway/test_reply_to_injection.py
+++ b/tests/gateway/test_reply_to_injection.py
@@ -157,3 +157,64 @@ async def test_reply_snippet_truncated_to_500_chars():
     assert result is not None
     assert result.startswith('[Replying to: "' + "x" * 500 + '"]')
     assert "x" * 501 not in result
+
+
+@pytest.mark.asyncio
+async def test_reply_prefix_with_name_and_date():
+    from datetime import datetime
+    runner = _make_runner()
+    source = _source()
+    dt = datetime(2026, 4, 27, 21, 5, 0)
+    event = MessageEvent(
+        text="thanks!",
+        source=source,
+        reply_to_message_id="42",
+        reply_to_text="Here's the report.",
+        reply_to_from_name="Bob Smith",
+        reply_to_date=dt,
+    )
+
+    result = await runner._prepare_inbound_message_text(
+        event=event, source=source, history=[]
+    )
+    assert result is not None
+    assert result.startswith(
+        '[Replying to message from Bob Smith at 21:05: "Here\'s the report."]'
+    )
+
+
+@pytest.mark.asyncio
+async def test_reply_prefix_with_only_name():
+    runner = _make_runner()
+    source = _source()
+    event = MessageEvent(
+        text="ok",
+        source=source,
+        reply_to_message_id="42",
+        reply_to_text="hello",
+        reply_to_from_name="Carol",
+    )
+    result = await runner._prepare_inbound_message_text(
+        event=event, source=source, history=[]
+    )
+    assert result.startswith('[Replying to Carol: "hello"]')
+
+
+@pytest.mark.asyncio
+async def test_reply_prefix_with_only_unix_timestamp_date():
+    from datetime import datetime
+    runner = _make_runner()
+    source = _source()
+    ts = int(datetime(2026, 4, 27, 9, 30, 0).timestamp())
+    event = MessageEvent(
+        text="ok",
+        source=source,
+        reply_to_message_id="42",
+        reply_to_text="hi",
+        reply_to_date=ts,
+    )
+    result = await runner._prepare_inbound_message_text(
+        event=event, source=source, history=[]
+    )
+    assert result.startswith('[Replying to message at 09:30: "hi"]')
+

--- a/tests/gateway/test_reply_to_media.py
+++ b/tests/gateway/test_reply_to_media.py
@@ -1,0 +1,136 @@
+"""Tests for reply-to media injection.
+
+When a user replies to a message that had attached media (photo, voice, video,
+document), the gateway must surface that media to the agent — not just the
+quoted text snippet. Otherwise the user pointing at a previous photo and asking
+"what's in this?" lands as a content-free reply pointer.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+def _make_runner() -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake")},
+    )
+    runner.adapters = {}
+    runner._model = "openai/gpt-4.1-mini"
+    runner._base_url = None
+    return runner
+
+
+def _source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        chat_name="DM",
+        chat_type="private",
+        user_name="Alice",
+    )
+
+
+@pytest.mark.asyncio
+async def test_reply_image_triggers_vision_enrichment():
+    runner = _make_runner()
+    source = _source()
+    event = MessageEvent(
+        text="what's in this?",
+        source=source,
+        reply_to_message_id="42",
+        reply_to_text="here's lunch",
+        reply_to_media_urls=["/tmp/cached_photo.jpg"],
+        reply_to_media_types=["image/jpeg"],
+    )
+
+    async def fake_vision(_self, user_text, image_paths):
+        assert image_paths == ["/tmp/cached_photo.jpg"]
+        return "[I see a salad with chicken.]"
+
+    with patch.object(GatewayRunner, "_enrich_message_with_vision", new=fake_vision):
+        result = await runner._prepare_inbound_message_text(
+            event=event, source=source, history=[]
+        )
+
+    assert result is not None
+    assert "replying to a previous message that contained an image" in result
+    assert "I see a salad with chicken" in result
+    assert "what's in this?" in result
+    # Reply-to text pointer is also still present
+    assert '[Replying to: "here\'s lunch"]' in result
+
+
+@pytest.mark.asyncio
+async def test_reply_audio_triggers_transcription():
+    runner = _make_runner()
+    source = _source()
+    event = MessageEvent(
+        text="what did i say?",
+        source=source,
+        reply_to_message_id="42",
+        reply_to_text=None,
+        reply_to_media_urls=["/tmp/voice.ogg"],
+        reply_to_media_types=["audio/ogg"],
+    )
+
+    async def fake_transcribe(_self, user_text, audio_paths):
+        assert audio_paths == ["/tmp/voice.ogg"]
+        return '[Voice transcript: "remember to buy milk"]'
+
+    with patch.object(
+        GatewayRunner, "_enrich_message_with_transcription", new=fake_transcribe
+    ):
+        result = await runner._prepare_inbound_message_text(
+            event=event, source=source, history=[]
+        )
+
+    assert result is not None
+    assert "replying to a previous voice/audio message" in result
+    assert "remember to buy milk" in result
+
+
+@pytest.mark.asyncio
+async def test_reply_document_path_injected():
+    runner = _make_runner()
+    source = _source()
+    event = MessageEvent(
+        text="summarize",
+        source=source,
+        reply_to_message_id="42",
+        reply_to_text="report.pdf",
+        reply_to_media_urls=["/tmp/abc_report.pdf"],
+        reply_to_media_types=["application/pdf"],
+    )
+
+    result = await runner._prepare_inbound_message_text(
+        event=event, source=source, history=[]
+    )
+
+    assert result is not None
+    assert "/tmp/abc_report.pdf" in result
+    assert "application/pdf" in result
+    assert "summarize" in result
+
+
+@pytest.mark.asyncio
+async def test_no_reply_media_means_no_extra_injection():
+    runner = _make_runner()
+    source = _source()
+    event = MessageEvent(
+        text="hi",
+        source=source,
+    )
+
+    result = await runner._prepare_inbound_message_text(
+        event=event, source=source, history=[]
+    )
+
+    assert result == "hi"


### PR DESCRIPTION
## Summary

Three related fixes for the Telegram gateway, surfaced when running a small family group bot where multiple participants share one chat with the agent. Each fix addresses a specific case where the agent loses track of "who sent what".

The commits build on each other but are scoped independently and have isolated tests; happy to split into multiple PRs if preferred.

## 1. Quoted-image vision pipeline (commit 1)

**Problem.** When a user replies to an earlier message that had a photo, voice, video, or document, Telegram sends only a quoted-text snippet. The agent saw `[Replying to: "..."]` with no media handle, even though the user was clearly pointing at the previous image. Reply-driven visual context was effectively dead.

**Fix.** Re-fetch the quoted message's media via Telegram Bot API and run it through the same vision/transcription/document-tag enrichment pipeline as current-message media. Emit it as a separate prefixed segment so the model knows the image is from the *quoted* message, not the current one.

- `MessageEvent.reply_to_media_urls` / `reply_to_media_types`
- `telegram._download_reply_media` + `_attach_reply_media`
- `run._prepare_inbound_message_text` enriches reply media with prefix `[The user is replying to a previous message that contained ...]`

## 2. Media sender sidecars (commit 1)

**Problem.** Cached media filenames are random UUID hashes. Telegram doesn't write sender info into the bytes themselves. Once a media file lives in cache, the agent has no way to answer "who sent this photo?" — a recurring failure in shared-chat scenarios where the agent guesses wrong about attribution.

**Fix.** Write a JSON sidecar next to every cached media file recording `from_id`, `from_name`, `from_username`, `chat_id`, `chat_type`, `chat_title`, `thread_id`, `message_id`, `date`, `caption`, and `is_quoted_reply`.

- `base.write_media_sidecar` / `read_media_sidecar`
- `telegram._record_media_sender` invoked from every cache_* site (photo, voice, audio, video, video-document, document, sticker) plus all quoted-reply media

## 3. Reply prefix with sender name + timestamp (commit 2)

**Problem.** The legacy `[Replying to: "<text>"]` prefix told the agent the user was replying to *something*, but not *who* sent the something or *when* — so in a busy group chat the agent could not disambiguate a reply to "didn't get my point".

**Fix.** When `reply_to_from_name` / `reply_to_date` are populated by the Telegram adapter, emit `[Replying to message from <name> at HH:MM: "<snippet>"]`. Falls back to name-only or time-only if only one is set, and the legacy bare form when neither.

## 4. Multi-sender attribution in busy-queue merges (commit 3)

**Problem.** In shared-session groups (multiple participants sharing one session, `group_sessions_per_user: false`), the gateway's busy-queue merge collapsed text and photo follow-ups from different senders into a single body without any per-segment marker. The downstream `_prepare_inbound_message_text` adds a single sender prefix at the head of the merged text, so any segment from a *later* participant got silently misattributed to whoever sent the *first* queued message.

Concrete reproduction:
```
Yuqing (busy with the agent): "米粉跟醬包各2"
Zijia (queued):                "水煮蛋一顆"

Agent saw: '[玉青] 米粉跟醬包各2\n水煮蛋一顆'
                              ↑ Zijia's line attributed to Yuqing
```

**Fix.** Add `_incoming_text_with_sender_marker()` and `_record_last_sender()` helpers in `merge_pending_message_event`. When a merge happens, if the incoming sender's `user_id` differs from the last segment's `user_id` (tracked via a transient `_last_sender_user_id` attribute on the pending event), prefix the incoming text with `[<sender_name>] `. The "last" tracking handles A → B → A alternation correctly.

No-op when:
- Incoming text is empty
- Either side lacks `user_id` (legacy / synthetic events)
- Senders match (avoid noise within a single user's burst)
- Caller pre-marked the text with the same prefix

## Tests

All four areas have new tests; full new test count = 25.

| File | Tests | Covers |
|------|-------|--------|
| `tests/gateway/test_reply_to_media.py` | 4 | Reply-image triggers vision; reply-audio triggers transcription; reply-document path injected; no-reply means no extra injection |
| `tests/gateway/test_media_sidecar.py` | 8 | Sidecar roundtrip, datetime serialisation, quoted-reply marking, error tolerance, no-message case |
| `tests/gateway/test_reply_to_injection.py` | 8 | Name+date prefix, name-only, time-only, no-prefix-when-empty, snippet truncation, redundancy with history |
| `tests/gateway/test_multi_sender_merge.py` | 5 | Text merge attribution, photo-burst attribution, mixed text+photo, three-way alternating senders, same-sender no-op |

```
$ pytest tests/gateway/test_reply_to_media.py \
         tests/gateway/test_media_sidecar.py \
         tests/gateway/test_reply_to_injection.py \
         tests/gateway/test_multi_sender_merge.py
============================== 25 passed in 2.42s ==============================
```

Full `tests/gateway/` run shows no new regressions; 8 pre-existing failures (whatsapp / slack / shutdown / split_brain) reproduce on a clean checkout of `upstream/main` without these commits.

## Verification in production

Both commit 1+2 (vision & sidecars) and commit 3 (reply prefix) verified end-to-end on a live Telegram bot before being submitted: sidecar JSONs written with correct `is_quoted_reply` flag and `from_id`, vision descriptions injected into the user message with `image_cache` path hint, and `[Replying to message from <name> at HH:MM: "..."]` rendered correctly.

Commit 4 (multi-sender attribution) verified by unit tests covering the exact failing scenario; the config change `group_sessions_per_user: false` + `busy_input_mode: queue` was deployed to a private family-bot instance and is functioning as expected.

## Backwards compatibility

- Commits 1, 2, 3 add fields and behavior; pure additions, no existing semantics change.
- Commit 4 changes merge output for **shared-session groups only** (`group_sessions_per_user: false`). DMs and per-user-isolated groups are unchanged because senders never differ within a single session.
- The `[name] ` marker is no-op when sender info is missing (legacy events) and when the sender is unchanged.
