### PR TITLE
fix(file-safety): refuse read_file on credential paths (SSH keys, .env, …) (#16809)

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -90,6 +90,75 @@ def is_write_denied(path: str) -> bool:
     return False
 
 
+def build_read_denied_paths(home: str) -> set[str]:
+    """Return exact sensitive paths that must never be read.
+
+    Mirrors build_write_denied_paths plus shell history files. Pattern-based
+    output redaction (agent/redact.py) is best-effort and was made off by
+    default; this list is the access-control floor for high-value credential
+    files where leakage is unrecoverable (private keys, .env, history).
+    """
+    hermes_home = _hermes_home_path()
+    return {
+        os.path.realpath(p)
+        for p in [
+            os.path.join(home, ".ssh", "authorized_keys"),
+            os.path.join(home, ".ssh", "id_rsa"),
+            os.path.join(home, ".ssh", "id_ed25519"),
+            os.path.join(home, ".ssh", "id_ecdsa"),
+            os.path.join(home, ".ssh", "id_dsa"),
+            os.path.join(home, ".ssh", "config"),
+            str(hermes_home / ".env"),
+            os.path.join(home, ".netrc"),
+            os.path.join(home, ".pgpass"),
+            os.path.join(home, ".npmrc"),
+            os.path.join(home, ".pypirc"),
+            os.path.join(home, ".bash_history"),
+            os.path.join(home, ".zsh_history"),
+            os.path.join(home, ".psql_history"),
+        ]
+    }
+
+
+def build_read_denied_prefixes(home: str) -> list[str]:
+    """Return sensitive directory prefixes that must never be read.
+
+    Limited to credential-bearing directories under $HOME. System paths like
+    /etc/sudoers.d are excluded because their files are useful to read for
+    debugging and the sensitive ones (e.g. /etc/shadow) are already
+    unreadable to non-root callers.
+    """
+    return [
+        os.path.realpath(p) + os.sep
+        for p in [
+            os.path.join(home, ".ssh"),
+            os.path.join(home, ".aws"),
+            os.path.join(home, ".gnupg"),
+            os.path.join(home, ".kube"),
+            os.path.join(home, ".docker"),
+            os.path.join(home, ".azure"),
+            os.path.join(home, ".config", "gh"),
+        ]
+    ]
+
+
+def is_read_denied(path: str) -> bool:
+    """Return True if path is blocked by the read denylist."""
+    home = os.path.realpath(os.path.expanduser("~"))
+    try:
+        resolved = os.path.realpath(os.path.expanduser(str(path)))
+    except (OSError, ValueError):
+        resolved = os.path.expanduser(str(path))
+
+    if resolved in build_read_denied_paths(home):
+        return True
+    for prefix in build_read_denied_prefixes(home):
+        if resolved.startswith(prefix):
+            return True
+
+    return False
+
+
 def get_read_block_error(path: str) -> Optional[str]:
     """Return an error message when a read targets internal Hermes cache files."""
     resolved = Path(path).expanduser().resolve()

--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -93,10 +93,22 @@ def is_write_denied(path: str) -> bool:
 def build_read_denied_paths(home: str) -> set[str]:
     """Return exact sensitive paths that must never be read.
 
-    Mirrors build_write_denied_paths plus shell history files. Pattern-based
-    output redaction (agent/redact.py) is best-effort and was made off by
-    default; this list is the access-control floor for high-value credential
-    files where leakage is unrecoverable (private keys, .env, history).
+    The set is intentionally *not* symmetric with ``build_write_denied_paths``:
+
+    * It adds shell-history paths (``.bash_history``/``.zsh_history``/
+      ``.psql_history``) that the write-deny list omits — leaking past
+      history would expose tokens/passwords pasted on the command line.
+    * It includes additional SSH key types (``id_ecdsa``/``id_dsa``) so
+      the floor covers older key formats still in use.
+    * It deliberately omits ``/etc/*`` paths from the write-deny list:
+      those files are useful to read for debugging, and the truly
+      sensitive ones (e.g. ``/etc/shadow``) are already unreadable to a
+      non-root caller.
+
+    Pattern-based output redaction (``agent/redact.py``) is best-effort
+    and off by default, so this list is the access-control floor for
+    high-value credential files where leakage is unrecoverable (private
+    keys, .env, shell history).
     """
     hermes_home = _hermes_home_path()
     return {

--- a/tests/tools/test_read_deny.py
+++ b/tests/tools/test_read_deny.py
@@ -161,3 +161,39 @@ class TestReadFileToolDenialMessage:
         # deny message.
         deny_msg = "sensitive credential path"
         assert deny_msg not in parsed.get("error", "")
+
+    def test_task_relative_ssh_key_path_does_not_bypass_guard(self, tmp_path, monkeypatch):
+        """Regression for the #16809 follow-up Copilot finding.
+
+        The deny check in ``read_file_tool`` previously called
+        ``is_read_denied(path)`` with the *raw* string, which resolves
+        relative paths against the Python process cwd — NOT the
+        terminal cwd that ``_resolve_path_for_task`` uses.  An agent
+        whose terminal cwd was ``$HOME`` could therefore pass
+        ``".ssh/id_ed25519"`` and slip past the deny list.
+
+        The fix passes the already-resolved path (resolved against the
+        terminal cwd via ``_resolve_path_for_task``) to
+        ``is_read_denied``, closing the bypass.
+        """
+        monkeypatch.setenv("HOME", str(tmp_path))
+        # Force ``_resolve_path_for_task`` to use ``HOME`` as the
+        # terminal cwd via ``TERMINAL_CWD`` (the env-var fallback used
+        # when no live terminal is bound to the task_id).
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+
+        ssh_dir = tmp_path / ".ssh"
+        ssh_dir.mkdir()
+        key_path = ssh_dir / "id_ed25519"
+        secret = "-----BEGIN OPENSSH PRIVATE KEY-----\nSECRETMATERIAL\n"
+        key_path.write_text(secret)
+
+        # Pass a *task-relative* path — this is the bypass shape.  It
+        # must resolve to ``$HOME/.ssh/id_ed25519`` (a deny-list path)
+        # and hit the deny guard, not the file contents.
+        result = read_file_tool(".ssh/id_ed25519", task_id="test_relative_ssh")
+        parsed = json.loads(result)
+
+        assert "error" in parsed
+        assert "sensitive credential path" in parsed["error"]
+        assert "SECRETMATERIAL" not in result

--- a/tests/tools/test_read_deny.py
+++ b/tests/tools/test_read_deny.py
@@ -177,9 +177,16 @@ class TestReadFileToolDenialMessage:
         ``is_read_denied``, closing the bypass.
         """
         monkeypatch.setenv("HOME", str(tmp_path))
-        # Force ``_resolve_path_for_task`` to use ``HOME`` as the
-        # terminal cwd via ``TERMINAL_CWD`` (the env-var fallback used
-        # when no live terminal is bound to the task_id).
+
+        # Force ``_resolve_path_for_task`` down the predictable
+        # TERMINAL_CWD branch by stubbing the live-tracking lookup.
+        # Without this, an xdist worker that ran an earlier terminal-tool
+        # test can leave ``_file_ops_cache`` / ``_active_environments``
+        # populated under ``"default"``, and ``_resolve_container_task_id``
+        # will resolve our task_id back to that stale entry — making the
+        # test pass on a clean worker (local) and fail on a hot one (CI).
+        import tools.file_tools as ft
+        monkeypatch.setattr(ft, "_get_live_tracking_cwd", lambda task_id="default": None)
         monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
 
         ssh_dir = tmp_path / ".ssh"
@@ -191,7 +198,7 @@ class TestReadFileToolDenialMessage:
         # Pass a *task-relative* path — this is the bypass shape.  It
         # must resolve to ``$HOME/.ssh/id_ed25519`` (a deny-list path)
         # and hit the deny guard, not the file contents.
-        result = read_file_tool(".ssh/id_ed25519", task_id="test_relative_ssh")
+        result = read_file_tool(".ssh/id_ed25519", task_id="test_relative_ssh_deny_bypass")
         parsed = json.loads(result)
 
         assert "error" in parsed

--- a/tests/tools/test_read_deny.py
+++ b/tests/tools/test_read_deny.py
@@ -1,0 +1,163 @@
+"""Tests for is_read_denied() and the read_file_tool sensitive-path guard.
+
+Read-side counterpart to test_write_deny.py.  Verifies that
+agent/file_safety.py refuses reads of credential files (SSH keys, .env,
+shell history, ~/.aws, etc.) and that read_file_tool returns a structured
+error rather than the file contents when the path is denied.
+"""
+
+import json
+import os
+from pathlib import Path
+
+from agent.file_safety import is_read_denied
+from tools.file_tools import read_file_tool
+
+
+class TestReadDenyExactPaths:
+    def test_ssh_authorized_keys(self):
+        path = os.path.join(str(Path.home()), ".ssh", "authorized_keys")
+        assert is_read_denied(path) is True
+
+    def test_ssh_id_rsa(self):
+        path = os.path.join(str(Path.home()), ".ssh", "id_rsa")
+        assert is_read_denied(path) is True
+
+    def test_ssh_id_ed25519(self):
+        path = os.path.join(str(Path.home()), ".ssh", "id_ed25519")
+        assert is_read_denied(path) is True
+
+    def test_ssh_id_ecdsa(self):
+        path = os.path.join(str(Path.home()), ".ssh", "id_ecdsa")
+        assert is_read_denied(path) is True
+
+    def test_ssh_config(self):
+        path = os.path.join(str(Path.home()), ".ssh", "config")
+        assert is_read_denied(path) is True
+
+    def test_netrc(self):
+        path = os.path.join(str(Path.home()), ".netrc")
+        assert is_read_denied(path) is True
+
+    def test_pgpass(self):
+        path = os.path.join(str(Path.home()), ".pgpass")
+        assert is_read_denied(path) is True
+
+    def test_npmrc(self):
+        path = os.path.join(str(Path.home()), ".npmrc")
+        assert is_read_denied(path) is True
+
+    def test_pypirc(self):
+        path = os.path.join(str(Path.home()), ".pypirc")
+        assert is_read_denied(path) is True
+
+    def test_shell_history(self):
+        home = str(Path.home())
+        for name in [".bash_history", ".zsh_history", ".psql_history"]:
+            assert is_read_denied(os.path.join(home, name)) is True, f"{name} should be read-denied"
+
+    def test_hermes_env(self):
+        # ``.env`` under the active HERMES_HOME (profile-aware, not just
+        # ``~/.hermes``) must be read-denied.  The hermetic test conftest
+        # points HERMES_HOME at a tempdir — resolve via get_hermes_home()
+        # to match the denylist.
+        from hermes_constants import get_hermes_home
+        path = str(get_hermes_home() / ".env")
+        assert is_read_denied(path) is True
+
+    def test_tilde_expansion(self):
+        # The check must accept user-relative paths exactly the way the
+        # read_file_tool receives them from the model.
+        assert is_read_denied("~/.ssh/id_ed25519") is True
+
+
+class TestReadDenyPrefixes:
+    def test_ssh_prefix(self):
+        path = os.path.join(str(Path.home()), ".ssh", "some_other_key")
+        assert is_read_denied(path) is True
+
+    def test_aws_prefix(self):
+        path = os.path.join(str(Path.home()), ".aws", "credentials")
+        assert is_read_denied(path) is True
+
+    def test_gnupg_prefix(self):
+        path = os.path.join(str(Path.home()), ".gnupg", "secring.gpg")
+        assert is_read_denied(path) is True
+
+    def test_kube_prefix(self):
+        path = os.path.join(str(Path.home()), ".kube", "config")
+        assert is_read_denied(path) is True
+
+    def test_docker_prefix(self):
+        path = os.path.join(str(Path.home()), ".docker", "config.json")
+        assert is_read_denied(path) is True
+
+    def test_azure_prefix(self):
+        path = os.path.join(str(Path.home()), ".azure", "msal_token_cache.json")
+        assert is_read_denied(path) is True
+
+    def test_gh_config_prefix(self):
+        path = os.path.join(str(Path.home()), ".config", "gh", "hosts.yml")
+        assert is_read_denied(path) is True
+
+
+class TestReadAllowed:
+    def test_tmp_file(self):
+        assert is_read_denied("/tmp/safe_file.txt") is False
+
+    def test_project_file(self):
+        assert is_read_denied("/home/user/project/main.py") is False
+
+    def test_hermes_config_not_env(self):
+        path = os.path.join(str(Path.home()), ".hermes", "config.yaml")
+        assert is_read_denied(path) is False
+
+    def test_etc_passwd_not_blocked(self):
+        # /etc/passwd is world-readable user metadata, not a secret.  Block
+        # only credential dirs (.ssh, .aws, .gnupg, …) where leakage is
+        # unrecoverable; system metadata can fall through to normal reads.
+        assert is_read_denied("/etc/passwd") is False
+
+    def test_bashrc_not_blocked(self):
+        # .bashrc is symmetric in the write-deny set, but reading it is a
+        # legitimate debugging case (PATH issues, alias setup).  The
+        # redact_sensitive_text pass at the bottom of read_file_tool covers
+        # inline `export FOO=key` strings via pattern matching when
+        # security.redact_secrets is enabled.
+        path = os.path.join(str(Path.home()), ".bashrc")
+        assert is_read_denied(path) is False
+
+
+class TestReadFileToolDenialMessage:
+    def test_ssh_key_returns_error_not_content(self, tmp_path, monkeypatch):
+        # Point HOME at a tempdir, drop a fake "private key" at ~/.ssh/id_ed25519,
+        # and confirm read_file_tool returns the deny error instead of the contents.
+        monkeypatch.setenv("HOME", str(tmp_path))
+        ssh_dir = tmp_path / ".ssh"
+        ssh_dir.mkdir()
+        key_path = ssh_dir / "id_ed25519"
+        secret = "-----BEGIN OPENSSH PRIVATE KEY-----\nSECRETMATERIAL\n"
+        key_path.write_text(secret)
+
+        result = read_file_tool(str(key_path), task_id="test_ssh_deny")
+        parsed = json.loads(result)
+
+        assert "error" in parsed
+        assert "sensitive credential path" in parsed["error"]
+        assert "SECRETMATERIAL" not in result
+
+    def test_safe_path_passes_guard(self, tmp_path, monkeypatch):
+        # Sanity-check: the deny guard does not flag normal project files.
+        monkeypatch.setenv("HOME", str(tmp_path))
+        normal_path = tmp_path / "project" / "main.py"
+        normal_path.parent.mkdir()
+        normal_path.write_text("print('hello')\n")
+
+        result = read_file_tool(str(normal_path), task_id="test_safe_read")
+        parsed = json.loads(result)
+
+        # Should NOT be the deny error; either succeeds with content, or
+        # fails for some unrelated reason — but never with the credential
+        # deny message.
+        deny_msg = "sensitive credential path"
+        assert deny_msg not in parsed.get("error", "")

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -17,6 +17,7 @@ from tools.file_operations import (
     normalize_search_pagination,
 )
 from tools import file_state
+from agent.file_safety import is_read_denied
 from agent.redact import redact_sensitive_text
 
 logger = logging.getLogger(__name__)
@@ -477,6 +478,22 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
         block_error = get_read_block_error(path)
         if block_error:
             return json.dumps({"error": block_error})
+
+        # ── Sensitive-path read guard ─────────────────────────────────
+        # Block reads of credential files (SSH keys, .env, ~/.aws, etc.).
+        # Pattern-based output redaction is best-effort and off by default
+        # (see agent/redact.py); this is the access-control floor.  The
+        # `terminal` tool with explicit user approval remains the escape
+        # hatch for cases where reading a credential file is intentional.
+        if is_read_denied(path):
+            return json.dumps({
+                "error": (
+                    f"Refusing to read sensitive credential path: {path}\n"
+                    "If you need this file's contents, ask the user to "
+                    "provide them directly, or use the terminal tool "
+                    "(which gates on user approval)."
+                ),
+            })
 
         # ── Dedup check ───────────────────────────────────────────────
         # If we already read this exact (path, offset, limit) and the

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -9,7 +9,7 @@ import threading
 from pathlib import Path
 from typing import Optional
 
-from agent.file_safety import get_read_block_error
+from agent.file_safety import get_read_block_error, is_read_denied
 from tools.binary_extensions import has_binary_extension
 from tools.file_operations import (
     ShellFileOperations,
@@ -17,7 +17,6 @@ from tools.file_operations import (
     normalize_search_pagination,
 )
 from tools import file_state
-from agent.file_safety import is_read_denied
 from agent.redact import redact_sensitive_text
 
 logger = logging.getLogger(__name__)
@@ -485,7 +484,14 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
         # (see agent/redact.py); this is the access-control floor.  The
         # `terminal` tool with explicit user approval remains the escape
         # hatch for cases where reading a credential file is intentional.
-        if is_read_denied(path):
+        #
+        # Pass the already-resolved path (resolved against the *terminal's*
+        # cwd via ``_resolve_path_for_task``) rather than the raw ``path``.
+        # ``is_read_denied`` only knows about the Python process cwd, so a
+        # task-relative path like ``.ssh/id_ed25519`` issued while the
+        # terminal cwd is ``$HOME`` would otherwise resolve against the
+        # wrong base and slip past the deny list.
+        if is_read_denied(str(_resolved)):
             return json.dumps({
                 "error": (
                     f"Refusing to read sensitive credential path: {path}\n"


### PR DESCRIPTION
## Summary
- Add a read-side counterpart to `build_write_denied_paths()` in `agent/file_safety.py` and have `read_file_tool` consult it before performing the read.
- Blocks SSH private keys, the active HERMES_HOME `.env`, shell history, and credential directories (`.ssh`, `.aws`, `.gnupg`, `.kube`, `.docker`, `.azure`, `.config/gh`) from being read by the model.

## The bug
`read_file` had **no sensitive-path deny list**. The reproduction in #16809 — and on a fresh checkout of `main` — succeeds today:

```python
read_file("~/.ssh/id_ed25519")  # → full SSH private key
read_file("~/.hermes/.env")     # → full API keys
read_file("~/.zsh_history")     # → shell history
```

The only defense was pattern-based output redaction via `redact_sensitive_text()`, and that path was made **off by default** in `73753417` ("feat(security): make secret redaction off by default", #16794) and uses a module-level `_REDACT_ENABLED` snapshotted at import time — so config-driven opt-in is fragile, and well-known credential prefixes are the only thing recognised even when redaction is on.

Write-side protection exists (`build_write_denied_paths` + `_check_sensitive_path`) but has no read-side counterpart.

## The fix
Add an access-control floor for high-value credential files where leakage is unrecoverable.

**`agent/file_safety.py`** gains three new helpers:
- `build_read_denied_paths(home)` — exact paths: SSH keys (`id_rsa`/`id_ed25519`/`id_ecdsa`/`id_dsa`/`authorized_keys`/`config`), `.netrc`, `.pgpass`, `.npmrc`, `.pypirc`, the active `HERMES_HOME / .env` (resolved through `get_hermes_home()` so profile-aware), and shell history (`.bash_history`, `.zsh_history`, `.psql_history`).
- `build_read_denied_prefixes(home)` — directory prefixes: `~/.ssh`, `~/.aws`, `~/.gnupg`, `~/.kube`, `~/.docker`, `~/.azure`, `~/.config/gh`.
- `is_read_denied(path)` — symmetric helper. Resolves through `os.path.realpath` before checking, so symlink shims are caught.

**`tools/file_tools.py`** — `read_file_tool` calls `is_read_denied(path)` after the existing device / binary / Hermes-internal guards (so denied paths can't return cached content from the dedup tracker either) and returns a structured error message pointing the model at the `terminal` tool when a credential read is genuinely intentional.

**Intentional scope decisions**
- `/etc/passwd` is *not* blocked — world-readable user metadata, not a secret. `/etc/shadow` is already unreadable to non-root callers, so blocking it would be cosmetic.
- Shell config (`.bashrc`, `.zshrc`, `.profile`, …) is write-denied but **read-allowed**: debugging PATH issues / alias setup is a legitimate case, and inline `export FOO=key` strings remain covered by `redact_sensitive_text` when `security.redact_secrets` is on.
- The escape hatch for genuinely intentional reads (e.g. an agent that wants to inspect its own SSH config) is the existing `terminal` tool, which gates on user approval — exactly the layer this guard is designed to defer to.

## Test plan
- [x] **Focused** — `tests/tools/test_read_deny.py` (new): 26 tests covering exact paths, prefixes, allowed paths, and end-to-end `read_file_tool` denial. All pass.
- [x] **Adjacent** — `tests/tools/test_write_deny.py`, `tests/tools/test_file_read_guards.py`, `tests/tools/test_file_operations.py`, `tests/tools/test_read_loop_detection.py`, `tests/tools/test_file_write_safety.py`, `tests/agent/test_copilot_acp_client.py`. The 6 `test_file_read_guards.py::TestFileDedup`/`TestWriteInvalidatesDedup` failures and the 1 `test_copilot_acp_client.py::test_read_text_file_redacts_sensitive_content` failure reproduce on clean `origin/main` (8081425a1) — they're pre-existing macOS `/private/var` write-deny collision and the redaction-off-by-default regression respectively, unrelated to this change.
- [x] **Regression guard** — verified directly:
  ```
  Without guard, contents readable: True
  With guard, error returned: True
  With guard, secret leaked: False
  ```

## Related
- Fixes #16809.
- Companion to the read-side concerns surfaced in #7826 (v0.8.0 audit) and adjacent to the redaction work in #16794 / #16700 / #16843 / #16849 — those address output-side redaction; this is the access-control floor underneath.