### PR TITLE
fix(config): add request_timeout_seconds and stale_timeout_seconds to provider _KNOWN_KEYS

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2196,6 +2196,7 @@ def _normalize_custom_provider_entry(
         "name", "api", "url", "base_url", "api_key", "key_env",
         "api_mode", "transport", "model", "default_model", "models",
         "context_length", "rate_limit_delay",
+        "request_timeout_seconds", "stale_timeout_seconds",
     }
     for camel, snake in _CAMEL_ALIASES.items():
         if camel in entry and snake not in entry:

--- a/tests/hermes_cli/test_provider_config_validation.py
+++ b/tests/hermes_cli/test_provider_config_validation.py
@@ -82,7 +82,7 @@ class TestNormalizeCustomProviderEntry:
         """Unknown config keys should produce a warning."""
         entry = {
             "base_url": "https://api.example.com/v1",
-            "api_key": "sk-test-key",
+            "api_key": "***",
             "unknownField": "value",
             "anotherBad": 42,
         }
@@ -90,6 +90,19 @@ class TestNormalizeCustomProviderEntry:
             result = _normalize_custom_provider_entry(entry, provider_key="test")
         assert result is not None
         assert any("unknown config keys" in r.message.lower() for r in caplog.records)
+
+    def test_timeout_keys_not_flagged_unknown(self, caplog):
+        """request_timeout_seconds and stale_timeout_seconds should not produce warnings."""
+        entry = {
+            "base_url": "https://api.example.com/v1",
+            "api_key": "***",
+            "request_timeout_seconds": 300,
+            "stale_timeout_seconds": 900,
+        }
+        with caplog.at_level(logging.WARNING):
+            result = _normalize_custom_provider_entry(entry, provider_key="test")
+        assert result is not None
+        assert not any("unknown config keys" in r.message.lower() for r in caplog.records)
 
     def test_camel_case_warning_logged(self, caplog):
         """camelCase alias mapping should produce a warning."""


### PR DESCRIPTION
## What

Add `request_timeout_seconds` and `stale_timeout_seconds` to the `_KNOWN_KEYS` set in `hermes_cli/config.py` so the provider-entry validator recognizes them as valid config keys.

## Why

Both keys are:
1. **Documented** in `cli-config.yaml.example` (lines 87–88, 90, 97)
2. **Read at runtime** by `hermes_cli/timeouts.py` — `get_provider_request_timeout()` (line 40) and `get_provider_stale_timeout()` (line 69)

But the validator's `_KNOWN_KEYS` set (line 2195) was missing them, so every CLI invocation logged a noisy warning for users who followed the documented config:

```
WARNING hermes_cli.config: providers.ollama-local: unknown config keys ignored: request_timeout_seconds, stale_timeout_seconds
```

## How

- **1-line fix**: Added `"request_timeout_seconds", "stale_timeout_seconds"` to the `_KNOWN_KEYS` frozenset.
- **1 new test**: `test_timeout_keys_not_flagged_unknown` verifies that these keys no longer trigger the warning.

## Before vs After

**Before:**
```
$ hermes
WARNING hermes_cli.config: providers.ollama-local: unknown config keys ignored: request_timeout_seconds, stale_timeout_seconds
```

**After:**
```
$ hermes
(no warning)
```

Fixes #16779