### PR TITLE
fix(usage_pricing): add minimax-cn billing route and regression tests

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -399,6 +399,8 @@ def resolve_billing_route(
         return BillingRoute(provider="anthropic", model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
     if provider_name == "openai":
         return BillingRoute(provider="openai", model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
+    if provider_name == "minimax-cn" or "minimaxi.com" in base:
+        return BillingRoute(provider="minimax-cn", model=model, base_url=base_url or "", billing_mode="subscription_included")
     if provider_name in {"custom", "local"} or (base and "localhost" in base):
         return BillingRoute(provider=provider_name or "custom", model=model, base_url=base_url or "", billing_mode="unknown")
     return BillingRoute(provider=provider_name or "unknown", model=model.split("/")[-1] if model else "", base_url=base_url or "", billing_mode="unknown")

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from types import SimpleNamespace
 
 from agent.usage_pricing import (
@@ -5,6 +6,7 @@ from agent.usage_pricing import (
     estimate_usage_cost,
     get_pricing_entry,
     normalize_usage,
+    resolve_billing_route,
 )
 
 
@@ -123,3 +125,19 @@ def test_custom_endpoint_models_api_pricing_is_supported(monkeypatch):
 
     assert float(entry.input_cost_per_million) == 0.5
     assert float(entry.output_cost_per_million) == 2.0
+
+
+def test_minimax_cn_route_resolves_to_subscription_included():
+    route = resolve_billing_route("MiniMax-M2.7", provider="minimax-cn",
+                                  base_url="https://api.minimaxi.com/anthropic")
+    assert route.provider == "minimax-cn"
+    assert route.billing_mode == "subscription_included"
+
+
+def test_minimax_cn_cost_result_is_included_not_unknown():
+    result = estimate_usage_cost("MiniMax-M2.7",
+                                 CanonicalUsage(input_tokens=10000, output_tokens=500),
+                                 provider="minimax-cn",
+                                 base_url="https://api.minimaxi.com/anthropic")
+    assert result.status == "included"
+    assert result.amount_usd == Decimal("0")


### PR DESCRIPTION
## Problem
When using MiniMax-M2.7 via the minimax-cn provider, all sessions are recorded in state.db with `estimated_cost_usd = 0.0` and `cost_status = 'unknown'`. The `/usage` command in both CLI and gateway also reports $0.0000.

## Root Cause
`resolve_billing_route()` in `agent/usage_pricing.py` had no branch for `minimax-cn`, causing it to fall through to the catch-all with `billing_mode="unknown"`.

## Solution
- Add a `minimax-cn` route in `resolve_billing_route()` that returns `billing_mode="subscription_included"` (MiniMax uses a request-quota subscription plan).
- Add regression tests in `tests/agent/test_usage_pricing.py`.

## Changes
- `agent/usage_pricing.py`: add minimax-cn billing route
- `tests/agent/test_usage_pricing.py`: add regression tests for minimax-cn route and cost estimation

Fixes #16825