### PR TITLE
fix(security): isolate interactive sudo password cache per session

### DIFF
--- a/tests/acp/test_approval_isolation.py
+++ b/tests/acp/test_approval_isolation.py
@@ -118,6 +118,29 @@ class TestThreadLocalApprovalCallback:
         assert worker_saw == [None]
         assert _get_sudo_password_callback() is cb_main
 
+    def test_sudo_password_cache_does_not_leak_across_threads(self):
+        """Interactive sudo cache must not bleed into another executor thread."""
+        from tools.terminal_tool import (
+            _get_cached_sudo_password,
+            _reset_cached_sudo_passwords,
+            _set_cached_sudo_password,
+        )
+
+        _reset_cached_sudo_passwords()
+        _set_cached_sudo_password("main-thread-password")
+
+        worker_saw = []
+
+        def worker():
+            worker_saw.append(_get_cached_sudo_password())
+
+        t = threading.Thread(target=worker)
+        t.start()
+        t.join()
+
+        assert worker_saw == [""]
+        assert _get_cached_sudo_password() == "main-thread-password"
+
 
 class TestAcpExecAskGate:
     """GHSA-96vc-wcxf-jjff: ACP's _run_agent must set HERMES_INTERACTIVE so

--- a/tests/tools/test_terminal_tool.py
+++ b/tests/tools/test_terminal_tool.py
@@ -4,11 +4,11 @@ import tools.terminal_tool as terminal_tool
 
 
 def setup_function():
-    terminal_tool._cached_sudo_password = ""
+    terminal_tool._reset_cached_sudo_passwords()
 
 
 def teardown_function():
-    terminal_tool._cached_sudo_password = ""
+    terminal_tool._reset_cached_sudo_passwords()
 
 
 def test_searching_for_sudo_does_not_trigger_rewrite(monkeypatch):
@@ -82,12 +82,26 @@ def test_explicit_empty_sudo_password_tries_empty_without_prompt(monkeypatch):
 def test_cached_sudo_password_is_used_when_env_is_unset(monkeypatch):
     monkeypatch.delenv("SUDO_PASSWORD", raising=False)
     monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
-    terminal_tool._cached_sudo_password = "cached-pass"
+    terminal_tool._set_cached_sudo_password("cached-pass")
 
     transformed, sudo_stdin = terminal_tool._transform_sudo_command("echo ok && sudo whoami")
 
     assert transformed == "echo ok && sudo -S -p '' whoami"
     assert sudo_stdin == "cached-pass\n"
+
+
+def test_cached_sudo_password_isolated_by_session_key(monkeypatch):
+    monkeypatch.delenv("SUDO_PASSWORD", raising=False)
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+
+    monkeypatch.setenv("HERMES_SESSION_KEY", "session-a")
+    terminal_tool._set_cached_sudo_password("alpha-pass")
+
+    monkeypatch.setenv("HERMES_SESSION_KEY", "session-b")
+    assert terminal_tool._get_cached_sudo_password() == ""
+
+    monkeypatch.setenv("HERMES_SESSION_KEY", "session-a")
+    assert terminal_tool._get_cached_sudo_password() == "alpha-pass"
 
 
 def test_validate_workdir_allows_windows_drive_paths():

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -145,8 +145,14 @@ def _check_disk_usage_warning():
         return False
 
 
-# Session-cached sudo password (persists until CLI exits)
-_cached_sudo_password: str = ""
+# Interactive sudo password cache.
+#
+# Scope the cache to the active session when a session key is available, then
+# fall back to callback identity (ACP / CLI interactive callbacks), then the
+# current thread. This prevents one interactive session from reusing another
+# session's cached sudo password inside the same long-lived process.
+_sudo_password_cache: dict[str, str] = {}
+_sudo_password_cache_lock = threading.Lock()
 
 # Optional UI callbacks for interactive prompts. When set, these are called
 # instead of the default /dev/tty or input() readers. The CLI registers these
@@ -189,6 +195,54 @@ def set_approval_callback(cb):
     GHSA-qg5c-hvr5-hjgr.
     """
     _callback_tls.approval = cb
+
+
+def _get_sudo_password_cache_scope() -> str:
+    """Return the cache scope for interactive sudo passwords."""
+    try:
+        from gateway.session_context import get_session_env
+
+        session_key = get_session_env("HERMES_SESSION_KEY", "")
+    except Exception:
+        session_key = os.getenv("HERMES_SESSION_KEY", "")
+    if session_key:
+        return f"session:{session_key}"
+
+    callback = _get_sudo_password_callback()
+    if callback is not None:
+        owner = getattr(callback, "__self__", None)
+        func = getattr(callback, "__func__", None)
+        if owner is not None and func is not None:
+            return f"callback-owner:{id(owner)}:{id(func)}"
+        return f"callback:{id(callback)}"
+
+    return f"thread:{threading.get_ident()}"
+
+
+def _get_cached_sudo_password() -> str:
+    """Return the cached sudo password for the current scope."""
+    scope = _get_sudo_password_cache_scope()
+    with _sudo_password_cache_lock:
+        return _sudo_password_cache.get(scope, "")
+
+
+def _set_cached_sudo_password(password: str) -> None:
+    """Persist a sudo password for the current scope."""
+    scope = _get_sudo_password_cache_scope()
+    with _sudo_password_cache_lock:
+        if password:
+            _sudo_password_cache[scope] = password
+        else:
+            _sudo_password_cache.pop(scope, None)
+
+
+def _reset_cached_sudo_passwords() -> None:
+    """Clear all cached sudo passwords.
+
+    Internal helper for tests and process teardown paths.
+    """
+    with _sudo_password_cache_lock:
+        _sudo_password_cache.clear()
 
 # =============================================================================
 # Dangerous Command Approval System
@@ -700,8 +754,6 @@ def _transform_sudo_command(command: str | None) -> tuple[str | None, str | None
     If SUDO_PASSWORD is not set and NOT interactive:
       Command runs as-is (fails gracefully with "sudo: a password is required").
     """
-    global _cached_sudo_password
-
     if command is None:
         return None, None
     transformed, has_real_sudo = _rewrite_real_sudo_invocations(command)
@@ -709,12 +761,16 @@ def _transform_sudo_command(command: str | None) -> tuple[str | None, str | None
         return command, None
 
     has_configured_password = "SUDO_PASSWORD" in os.environ
-    sudo_password = os.environ.get("SUDO_PASSWORD", "") if has_configured_password else _cached_sudo_password
+    sudo_password = (
+        os.environ.get("SUDO_PASSWORD", "")
+        if has_configured_password
+        else _get_cached_sudo_password()
+    )
 
     if not has_configured_password and not sudo_password and os.getenv("HERMES_INTERACTIVE"):
         sudo_password = _prompt_for_sudo_password(timeout_seconds=45)
         if sudo_password:
-            _cached_sudo_password = sudo_password
+            _set_cached_sudo_password(sudo_password)
 
     if has_configured_password or sudo_password:
         # Trailing newline is required: sudo -S reads one line for the password.


### PR DESCRIPTION
## Summary

This fixes a session-boundary leak in the interactive `sudo` path.

Previously, `tools/terminal_tool.py` stored prompted `sudo` passwords in a single process-global cache. In long-lived multi-session runtimes such as ACP, one interactive session could populate that cache and a later session in the same process could reuse the password without prompting again.

This change scopes the interactive `sudo` password cache to the active session when `HERMES_SESSION_KEY` is available, and otherwise falls back to callback identity and then thread identity. That preserves the intended convenience of reusing the password within the same interactive flow, while preventing reuse across unrelated sessions.

## Root Cause

`_transform_sudo_command()` had this behavior when `SUDO_PASSWORD` was not set:

- prompt once in interactive mode
- save the result into a module-global `_cached_sudo_password`
- reuse that cached value for later `sudo` invocations

That design was safe for a single local CLI session, but not for concurrent or sequential multi-session execution inside the same Python process. The cache boundary was the process, not the session.

## What Changed

### `tools/terminal_tool.py`

- replaced the single global `sudo` password string cache with a scoped cache
- introduced helpers to:
  - derive a cache scope from `HERMES_SESSION_KEY`
  - fall back to callback identity when no session key exists
  - finally fall back to thread identity
- updated `_transform_sudo_command()` to read/write through the scoped cache helpers
- added a small reset helper used by tests

### Tests

Added regression coverage for both the direct terminal path and ACP-style isolation:

- `tests/tools/test_terminal_tool.py`
  - updated existing cache test to use the new helper path
  - added a session-key isolation test to ensure cached passwords do not cross session boundaries
- `tests/acp/test_approval_isolation.py`
  - added a cross-thread isolation test to ensure one executor thread does not observe another thread's cached interactive `sudo` password

## Behavior Notes

This does **not** change the explicit `SUDO_PASSWORD` environment variable behavior.

If `SUDO_PASSWORD` is configured, it still takes precedence exactly as before.

This also does **not** remove same-session convenience caching. Within the same interactive session/scope, repeated `sudo` commands continue to avoid redundant prompts.

## Why This Is the Right Scope

This is intentionally a narrow fix:

- no approval-flow redesign
- no changes to command rewriting semantics
- no changes to non-interactive behavior
- no changes to gateway approval routing

The patch only tightens the boundary of the existing interactive cache.

## Validation

Ran targeted tests with the repo-standard runner:

```bash
scripts/run_tests.sh tests/tools/test_terminal_tool.py tests/acp/test_approval_isolation.py  

17passed
