### PR TITLE
Fix gateway restart handling and config validation

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -222,12 +222,12 @@ DEFAULT_CONTEXT_LENGTHS = {
     "moonshotai/Kimi-K2.6": 262144,
     "moonshotai/Kimi-K2-Thinking": 262144,
     "MiniMaxAI/MiniMax-M2.5": 204800,
-    "XiaomiMiMo/MiMo-V2-Flash": 262144,
-    "mimo-v2-pro": 1048576,
-    "mimo-v2.5-pro": 1048576,
+    "XiaomiMiMo/MiMo-V2-Flash": 256000,
+    "mimo-v2-pro": 1000000,
+    "mimo-v2.5-pro": 1000000,
     "mimo-v2.5": 1048576,
-    "mimo-v2-omni": 262144,
-    "mimo-v2-flash": 262144,
+    "mimo-v2-omni": 256000,
+    "mimo-v2-flash": 256000,
     "zai-org/GLM-5": 202752,
 }
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -907,6 +907,41 @@ class MessageEvent:
         return args
 
 
+_PLAINTEXT_GATEWAY_RESTART_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"^(?:please\s+)?restart\s+(?:the\s+)?gateway[.!?\s]*$", re.IGNORECASE),
+    re.compile(r"^(?:please\s+)?restart\s+(?:the\s+)?hermes\s+gateway[.!?\s]*$", re.IGNORECASE),
+    re.compile(r"^(?:please\s+)?restart\s+hermes[.!?\s]*$", re.IGNORECASE),
+)
+
+
+def coerce_plaintext_gateway_command(event: "MessageEvent") -> None:
+    """Rewrite a tiny set of DM plaintext admin phrases into slash commands.
+
+    This keeps high-impact operational phrases like ``restart gateway`` out of
+    the LLM/tool path, where they can trigger a self-restart from inside the
+    currently running agent and leave the gateway stuck in ``draining`` while it
+    waits for that same agent to finish.
+
+    Scope is intentionally narrow: DM text messages only, exact restart-style
+    phrases only. Group chats keep natural-language semantics.
+    """
+    try:
+        if event is None or event.message_type != MessageType.TEXT:
+            return
+        text = (event.text or "").strip()
+        if not text or text.startswith("/"):
+            return
+        source = getattr(event, "source", None)
+        if getattr(source, "chat_type", None) != "dm":
+            return
+        for pattern in _PLAINTEXT_GATEWAY_RESTART_PATTERNS:
+            if pattern.match(text):
+                event.text = "/restart"
+                return
+    except Exception:
+        return
+
+
 @dataclass 
 class SendResult:
     """Result of sending a message."""
@@ -2193,6 +2228,8 @@ class BasePlatformAdapter(ABC):
         """
         if not self._message_handler:
             return
+
+        coerce_plaintext_gateway_command(event)
         
         session_key = build_session_key(
             event.source,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -289,6 +289,7 @@ from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
     MessageType,
+    coerce_plaintext_gateway_command,
     merge_pending_message_event,
 )
 from gateway.restart import (
@@ -3394,6 +3395,7 @@ class GatewayRunner:
         7. Return response
         """
         source = event.source
+        coerce_plaintext_gateway_command(event)
 
         # Internal events (e.g. background-process completion notifications)
         # are system-generated and must skip user authorization.
@@ -8469,9 +8471,32 @@ class GatewayRunner:
                 return
 
             metadata = {"thread_id": thread_id} if thread_id else None
+
+            service_state = "active"
+            gateway_state = "running"
+            telegram_state = None
+            try:
+                from gateway.status import read_runtime_status
+                runtime_status = read_runtime_status() or {}
+                gateway_state = str(runtime_status.get("gateway_state") or gateway_state)
+                platforms = runtime_status.get("platforms") or {}
+                telegram_info = platforms.get("telegram") or {}
+                if telegram_info.get("state"):
+                    telegram_state = str(telegram_info.get("state"))
+            except Exception as status_err:
+                logger.debug("Restart notification status read failed: %s", status_err)
+
+            message_parts = [
+                "[Hermes] Gateway recovered:",
+                f"service={service_state}",
+                f"gateway={gateway_state}",
+            ]
+            if telegram_state:
+                message_parts.append(f"telegram={telegram_state}")
+
             await adapter.send(
                 chat_id,
-                "♻ Gateway restarted successfully. Your session continues.",
+                " ".join(message_parts),
                 metadata=metadata,
             )
             logger.info(

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2523,10 +2523,32 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
                         "Add the API endpoint URL, e.g.: base_url: https://api.example.com/v1",
                     ))
 
-    # ── fallback_model must be a top-level dict with provider + model ────
+    # ── fallback_model: single dict OR list of dicts (chain) ─────────────
     fb = config.get("fallback_model")
     if fb is not None:
-        if not isinstance(fb, dict):
+        if isinstance(fb, list):
+            # Chain fallback — validate each entry
+            for i, entry in enumerate(fb):
+                if not isinstance(entry, dict):
+                    issues.append(ConfigIssue(
+                        "error",
+                        f"fallback_model[{i}] should be a dict, got {type(entry).__name__}",
+                        "Each entry needs provider + model",
+                    ))
+                else:
+                    if not entry.get("provider"):
+                        issues.append(ConfigIssue(
+                            "warning",
+                            f"fallback_model[{i}] is missing 'provider' field",
+                            "Add: provider: openrouter (or another provider)",
+                        ))
+                    if not entry.get("model"):
+                        issues.append(ConfigIssue(
+                            "warning",
+                            f"fallback_model[{i}] is missing 'model' field",
+                            "Add: model: <model-name>",
+                        ))
+        elif not isinstance(fb, dict):
             issues.append(ConfigIssue(
                 "error",
                 f"fallback_model should be a dict with 'provider' and 'model', got {type(fb).__name__}",
@@ -3458,7 +3480,12 @@ def save_config(config: Dict[str, Any]):
     if not sec or sec.get("redact_secrets") is None:
         parts.append(_SECURITY_COMMENT)
     fb = normalized.get("fallback_model", {})
-    if not fb or not isinstance(fb, dict) or not (fb.get("provider") and fb.get("model")):
+    fb_is_valid = False
+    if isinstance(fb, list):
+        fb_is_valid = any(isinstance(e, dict) and e.get("provider") and e.get("model") for e in fb)
+    elif isinstance(fb, dict):
+        fb_is_valid = bool(fb.get("provider") and fb.get("model"))
+    if not fb_is_valid:
         parts.append(_FALLBACK_COMMENT)
 
     atomic_yaml_write(

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1552,13 +1552,14 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
 Description={SERVICE_DESCRIPTION}
 After=network-online.target
 Wants=network-online.target
-StartLimitIntervalSec=600
-StartLimitBurst=5
+StartLimitIntervalSec=900
+StartLimitBurst=10
 
 [Service]
 Type=simple
 User={username}
 Group={group_name}
+ExecStartPre=/bin/rm -f {hermes_home}/gateway.pid
 ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run --replace
 WorkingDirectory={working_dir}
 Environment="HOME={home_dir}"
@@ -1589,11 +1590,12 @@ WantedBy=multi-user.target
     return f"""[Unit]
 Description={SERVICE_DESCRIPTION}
 After=network.target
-StartLimitIntervalSec=600
-StartLimitBurst=5
+StartLimitIntervalSec=900
+StartLimitBurst=10
 
 [Service]
 Type=simple
+ExecStartPre=/bin/rm -f {hermes_home}/gateway.pid
 ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run --replace
 WorkingDirectory={working_dir}
 Environment="PATH={sane_path}"

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -125,13 +125,13 @@ from gateway.platforms.slack import SlackAdapter  # noqa: E402
 
 # Platform-generic factories
 
-def make_source(platform: Platform, chat_id: str = "e2e-chat-1", user_id: str = "e2e-user-1") -> SessionSource:
+def make_source(platform: Platform, chat_id: str = "e2e-chat-1", user_id: str = "e2e-user-1", chat_type: str = "dm") -> SessionSource:
     return SessionSource(
         platform=platform,
         chat_id=chat_id,
         user_id=user_id,
         user_name="e2e_tester",
-        chat_type="dm",
+        chat_type=chat_type,
     )
 
 
@@ -147,10 +147,16 @@ def make_session_entry(platform: Platform, source: SessionSource = None) -> Sess
     )
 
 
-def make_event(platform: Platform, text: str = "/help", chat_id: str = "e2e-chat-1", user_id: str = "e2e-user-1") -> MessageEvent:
+def make_event(
+    platform: Platform,
+    text: str = "/help",
+    chat_id: str = "e2e-chat-1",
+    user_id: str = "e2e-user-1",
+    chat_type: str = "dm",
+) -> MessageEvent:
     return MessageEvent(
         text=text,
-        source=make_source(platform, chat_id, user_id),
+        source=make_source(platform, chat_id, user_id, chat_type),
         message_id=f"msg-{uuid.uuid4().hex[:8]}",
     )
 
@@ -185,6 +191,23 @@ def make_runner(platform: Platform, session_entry: SessionEntry = None) -> "Gate
     runner._running_agents = {}
     runner._pending_messages = {}
     runner._pending_approvals = {}
+    runner._shutdown_event = asyncio.Event()
+    runner._exit_reason = None
+    runner._exit_code = None
+    runner._background_tasks = set()
+    runner._draining = False
+    runner._restart_requested = False
+    runner._restart_task_started = False
+    runner._restart_detached = False
+    runner._restart_via_service = False
+    from gateway.restart import DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
+    runner._restart_drain_timeout = DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
+    runner._stop_task = None
+    runner._busy_input_mode = "interrupt"
+    runner._running_agents_ts = {}
+    runner._pending_model_notes = {}
+    runner._update_prompt_pending = {}
+    runner._voice_mode = {}
     runner._session_db = None
     runner._reasoning_config = None
     runner._provider_routing = {}
@@ -193,6 +216,7 @@ def make_runner(platform: Platform, session_entry: SessionEntry = None) -> "Gate
 
     runner._is_user_authorized = lambda _source: True
     runner._set_session_env = lambda _context: None
+    runner._handle_message_with_agent = AsyncMock(return_value="agent-handled-default")
     runner._should_send_voice_reply = lambda *_a, **_kw: False
     runner._send_voice_reply = AsyncMock()
     runner._capture_gateway_honcho_if_configured = lambda *a, **kw: None

--- a/tests/e2e/test_platform_commands.py
+++ b/tests/e2e/test_platform_commands.py
@@ -11,10 +11,11 @@ Tests are parametrized over platforms via the ``platform`` fixture in conftest.
 """
 
 import asyncio
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from gateway.config import Platform
 from gateway.platforms.base import SendResult
 from tests.e2e.conftest import make_event, send_and_capture
 
@@ -81,6 +82,37 @@ class TestSlashCommands:
         response_text = send.call_args[1].get("content") or send.call_args[0][1]
         # Either shows the mode cycle or tells user to enable it in config
         assert "verbose" in response_text.lower() or "tool_progress" in response_text
+
+    @pytest.mark.asyncio
+    async def test_plaintext_restart_gateway_routes_to_safe_restart_command(self, adapter, runner, platform, monkeypatch):
+        if platform != Platform.TELEGRAM:
+            pytest.skip("Plaintext restart shortcut is intentionally DM/Telegram-focused")
+
+        monkeypatch.setenv("INVOCATION_ID", "e2e-systemd")
+        runner.request_restart = MagicMock(return_value=True)
+
+        send = await send_and_capture(adapter, "restart gateway", platform)
+
+        send.assert_called_once()
+        response_text = send.call_args[1].get("content") or send.call_args[0][1]
+        assert "restart" in response_text.lower() or "draining" in response_text.lower()
+        runner.request_restart.assert_called_once_with(detached=False, via_service=True)
+
+    @pytest.mark.asyncio
+    async def test_plaintext_restart_gateway_in_group_stays_plain_text(self, adapter, runner, platform, monkeypatch):
+        if platform != Platform.TELEGRAM:
+            pytest.skip("Shortcut scope is only verified for Telegram here")
+
+        monkeypatch.setenv("INVOCATION_ID", "e2e-systemd")
+        runner.request_restart = MagicMock(return_value=True)
+        runner._handle_message_with_agent = AsyncMock(return_value="agent-handled")
+
+        send = await send_and_capture(adapter, "restart gateway", platform, chat_id="group-chat-1", user_id="u1", chat_type="group")
+
+        send.assert_called_once()
+        response_text = send.call_args[1].get("content") or send.call_args[0][1]
+        assert response_text == "agent-handled"
+        runner.request_restart.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_personality_lists_options(self, adapter, platform):

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -135,7 +135,7 @@ async def test_send_restart_notification_delivers_and_cleans_up(tmp_path, monkey
     adapter.send.assert_called_once()
     call_args = adapter.send.call_args
     assert call_args[0][0] == "42"  # chat_id
-    assert "restarted" in call_args[0][1].lower()
+    assert call_args[0][1] == "[Hermes] Gateway recovered: service=active gateway=running"
     assert call_args[1].get("metadata") is None  # no thread
     assert not notify_path.exists()
 
@@ -159,6 +159,36 @@ async def test_send_restart_notification_with_thread(tmp_path, monkeypatch):
 
     call_args = adapter.send.call_args
     assert call_args[1]["metadata"] == {"thread_id": "topic_7"}
+    assert not notify_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_includes_telegram_runtime_state(tmp_path, monkeypatch):
+    """When runtime status has Telegram info, it is included in the recovery message."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(json.dumps({
+        "platform": "telegram",
+        "chat_id": "42",
+    }))
+    (tmp_path / "gateway_state.json").write_text(json.dumps({
+        "gateway_state": "running",
+        "platforms": {
+            "telegram": {
+                "state": "connected",
+            }
+        },
+    }))
+
+    runner, adapter = make_restart_runner()
+    adapter.send = AsyncMock()
+
+    await runner._send_restart_notification()
+
+    call_args = adapter.send.call_args
+    assert call_args[0][1] == "[Hermes] Gateway recovered: service=active gateway=running telegram=connected"
     assert not notify_path.exists()
 
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -91,8 +91,12 @@ class TestGeneratedSystemdUnits:
     def test_user_unit_avoids_recursive_execstop_and_uses_extended_stop_timeout(self):
         unit = gateway_cli.generate_systemd_unit(system=False)
 
+        assert "StartLimitIntervalSec=900" in unit
+        assert "StartLimitBurst=10" in unit
         assert "ExecStart=" in unit
         assert "ExecStop=" not in unit
+        assert "ExecStartPre=/bin/rm -f " in unit
+        assert "/gateway.pid" in unit
         assert "ExecReload=/bin/kill -USR1 $MAINPID" in unit
         assert f"RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
         # TimeoutStopSec must exceed the default drain_timeout (60s) so
@@ -110,8 +114,12 @@ class TestGeneratedSystemdUnits:
     def test_system_unit_avoids_recursive_execstop_and_uses_extended_stop_timeout(self):
         unit = gateway_cli.generate_systemd_unit(system=True)
 
+        assert "StartLimitIntervalSec=900" in unit
+        assert "StartLimitBurst=10" in unit
         assert "ExecStart=" in unit
         assert "ExecStop=" not in unit
+        assert "ExecStartPre=/bin/rm -f " in unit
+        assert "/gateway.pid" in unit
         assert "ExecReload=/bin/kill -USR1 $MAINPID" in unit
         assert f"RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
         # TimeoutStopSec must exceed the default drain_timeout (60s) so


### PR DESCRIPTION
Summary
- Preserve gateway.pid cleanup during systemd restarts so the gateway can recover cleanly.
- Harden plaintext restart handling and restart notifications in the gateway.
- Update config validation/save logic to support fallback_model chains.
- Refresh Xiaomi model metadata/list entries to match the current model set.

Validation
- scripts/run_tests.sh tests/e2e/test_platform_commands.py tests/gateway/test_restart_notification.py tests/hermes_cli/test_config_validation.py tests/hermes_cli/test_xiaomi_provider.py tests/tools/test_browser_cdp_tool.py
- One-shot smoke test: hermes -z "Reply with exactly: ok" --provider openrouter --model openai/gpt-4.1-mini
