### PR TITLE
feat(feishu): add default_require_mention for group messages

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -386,6 +386,7 @@ class FeishuAdapterSettings:
     ws_ping_timeout: Optional[int] = None
     admins: frozenset[str] = frozenset()
     default_group_policy: str = ""
+    default_require_mention: bool = True
     group_rules: Dict[str, FeishuGroupRule] = field(default_factory=dict)
 
 
@@ -396,6 +397,7 @@ class FeishuGroupRule:
     policy: str  # "open" | "allowlist" | "blacklist" | "admin_only" | "disabled"
     allowlist: set[str] = field(default_factory=set)
     blacklist: set[str] = field(default_factory=set)
+    require_mention: bool = True  # False = reply to all messages in this group
 
 
 @dataclass
@@ -1381,6 +1383,7 @@ class FeishuAdapter(BasePlatformAdapter):
                     policy=str(rule_cfg.get("policy", "open")).strip().lower(),
                     allowlist=set(str(u).strip() for u in rule_cfg.get("allowlist", []) if str(u).strip()),
                     blacklist=set(str(u).strip() for u in rule_cfg.get("blacklist", []) if str(u).strip()),
+                    require_mention=bool(rule_cfg.get("require_mention", True)),
                 )
 
         # Bot-level admins
@@ -1389,6 +1392,7 @@ class FeishuAdapter(BasePlatformAdapter):
 
         # Default group policy (for groups not in group_rules)
         default_group_policy = str(extra.get("default_group_policy", "")).strip().lower()
+        default_require_mention = bool(extra.get("default_require_mention", True))
 
         return FeishuAdapterSettings(
             app_id=str(extra.get("app_id") or os.getenv("FEISHU_APP_ID", "")).strip(),
@@ -1445,6 +1449,7 @@ class FeishuAdapter(BasePlatformAdapter):
             ws_ping_timeout=_coerce_int(extra.get("ws_ping_timeout"), default=None, min_value=1),
             admins=admins,
             default_group_policy=default_group_policy,
+            default_require_mention=default_require_mention,
             group_rules=group_rules,
         )
 
@@ -3629,6 +3634,13 @@ class FeishuAdapter(BasePlatformAdapter):
         """Require an explicit @mention before group messages enter the agent."""
         if not self._allow_group_message(sender_id, chat_id):
             return False
+        # Per-group rule: if require_mention is False, accept all messages
+        rule = self._group_rules.get(chat_id) if chat_id else None
+        if rule and not rule.require_mention:
+            return True
+        # Global default: if default_require_mention is False and no per-group rule, accept all
+        if not rule and not self._settings.default_require_mention:
+            return True
         # @_all is Feishu's @everyone placeholder — always route to the bot.
         raw_content = getattr(message, "content", "") or ""
         if "@_all" in raw_content:


### PR DESCRIPTION
## Summary

Allow configuring whether Feishu group messages require @mention via:

- **Global default**: `default_require_mention` in `platforms.feishu.extra`
- **Per-group override**: `require_mention` in per-group `group_rules`

Currently all group messages must @mention the bot. This PR adds opt-in config to disable that requirement, so the bot responds to every message in the group.

## Changes

1. **FeishuGroupRule**: Add `require_mention: bool = True` field
2. **FeishuAdapterSettings**: Add `default_require_mention: bool = True` field
3. **_load_settings**: Parse both from config `extra`
4. **_should_accept_group_message**: Check per-group rule first, then fall back to global default

## Config Example

```yaml
platforms:
  feishu:
    extra:
      default_require_mention: false  # all groups: no @ needed
      group_rules:
        "oc_xxx":
          policy: open
          require_mention: true  # this specific group: @ still required
```

## Backward Compatibility

All defaults are `True` (require @mention), so existing behavior is unchanged unless explicitly configured.