### PR TITLE
fix: honor agent.disabled_toolsets in gateway sessions

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -777,6 +777,16 @@ def _get_platform_tools(
     else:
         enabled_toolsets.update(explicit_mcp_servers)
 
+    # Honor agent.disabled_toolsets from config.yaml — allows users to
+    # globally suppress specific toolsets (e.g. "memory") across all
+    # platforms without per-platform toolset configuration.  This runs
+    # last so it overrides everything above.
+    agent_cfg = config.get("agent") or {}
+    disabled_toolsets = agent_cfg.get("disabled_toolsets") or []
+    if disabled_toolsets:
+        disabled_set = {str(ts) for ts in disabled_toolsets}
+        enabled_toolsets -= disabled_set
+
     return enabled_toolsets
 
 

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -17,6 +17,50 @@ from hermes_cli.tools_config import (
 )
 
 
+def test_agent_disabled_toolsets_suppresses_across_platforms():
+    """agent.disabled_toolsets in config.yaml should remove those toolsets
+    from the enabled set, regardless of platform defaults or explicit config.
+    """
+    config = {
+        "agent": {"disabled_toolsets": ["memory"]},
+    }
+
+    cli_enabled = _get_platform_tools(config, "cli")
+    discord_enabled = _get_platform_tools(config, "discord")
+
+    assert "memory" not in cli_enabled
+    assert "memory" not in discord_enabled
+
+
+def test_agent_disabled_toolsets_with_explicit_platform_config():
+    """agent.disabled_toolsets should still suppress even when the platform
+    has an explicit toolset list that includes the disabled toolset.
+    """
+    config = {
+        "agent": {"disabled_toolsets": ["memory"]},
+        "platform_toolsets": {"cli": ["web", "terminal", "memory"]},
+    }
+
+    enabled = _get_platform_tools(config, "cli")
+
+    assert "memory" not in enabled
+    assert "web" in enabled
+    assert "terminal" in enabled
+
+
+def test_agent_disabled_toolsets_empty_list_is_noop():
+    """Empty or missing disabled_toolsets should not change behavior."""
+    config_empty = {"agent": {"disabled_toolsets": []}}
+    config_none = {"agent": {}}
+    config_missing = {}
+
+    default = _get_platform_tools({}, "cli")
+
+    assert _get_platform_tools(config_empty, "cli") == default
+    assert _get_platform_tools(config_none, "cli") == default
+    assert _get_platform_tools(config_missing, "cli") == default
+
+
 def test_get_platform_tools_uses_default_when_platform_not_configured():
     config = {}
 


### PR DESCRIPTION
## Problem

`agent.disabled_toolsets` in config.yaml only worked for CLI mode (`run_agent.py --disabled_toolsets`). The gateway always passes `enabled_toolsets` (from `_get_platform_tools()`) to `AIAgent`, and `get_tool_definitions()` ignores `disabled_toolsets` when `enabled_toolsets` is set -- it is an `if/elif/else` chain where `enabled_toolsets` takes precedence.

This means setting `agent.disabled_toolsets: [memory]` in config.yaml has no effect on gateway sessions (Discord, Telegram, etc.). The tool still appears in the tool list and MEMORY_GUIDANCE is still injected into the system prompt.

## Fix

`_get_platform_tools()` in `hermes_cli/tools_config.py` now reads `agent.disabled_toolsets` from config and excludes those toolsets from the returned set. This runs last, overriding everything above.

## Changes

- **hermes_cli/tools_config.py**: Added 7 lines at the end of `_get_platform_tools()` to honor `agent.disabled_toolsets`
- **tests/hermes_cli/test_tools_config.py**: Added 3 tests:
  - Cross-platform suppression (CLI + Discord)
  - Explicit platform config override
  - Empty/missing config no-op

## Testing

All 53 tests in `tests/hermes_cli/test_tools_config.py` pass. No regressions in the broader test suite (2 pre-existing failures unrelated to this change).
