### PR TITLE
feat(alibaba): add qwen3.6-plus to supported models

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -350,6 +350,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     # to https://dashscope-intl.aliyuncs.com/compatible-mode/v1 (OpenAI-compat)
     # or https://dashscope-intl.aliyuncs.com/apps/anthropic (Anthropic-compat).
     "alibaba": [
+        "qwen3.6-plus",
         "kimi-k2.5",
         "qwen3.5-plus",
         "qwen3-coder-plus",


### PR DESCRIPTION
## Summary
- Add `qwen3.6-plus` to the Alibaba DashScope curated model list in `_PROVIDER_MODELS`
- This enables users to switch to qwen3.6-plus via `/model qwen3.6-plus` without the auto-correction warning (`Auto-corrected qwen3.6-plus → qwen3.5-plus`)

## Test Plan
- Model validation will now recognize `qwen3.6-plus` as a valid Alibaba model
- Users can switch to it mid-session without auto-correction

Closes: N/A (feature request from user)