### PR TITLE
feat: add cron preview command

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -394,6 +394,131 @@ def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None
     return None
 
 
+def _validate_preview_count(count: int) -> int:
+    """Validate preview count bounds."""
+    if not 1 <= count <= 20:
+        raise ValueError("count must be between 1 and 20")
+    return count
+
+
+def _coerce_schedule(schedule: Any) -> Dict[str, Any]:
+    """Accept a raw schedule string or parsed schedule dict."""
+    if isinstance(schedule, str):
+        return parse_schedule(schedule)
+    if isinstance(schedule, dict):
+        return schedule
+    raise ValueError("schedule must be a string or parsed schedule dict")
+
+
+def _preview_recurring_runs(
+    schedule: Dict[str, Any],
+    *,
+    count: int,
+    first_run_at: Optional[str] = None,
+) -> List[str]:
+    """Return recurring occurrences without mutating scheduler state."""
+    kind = schedule.get("kind")
+    occurrences: List[str] = []
+
+    if kind == "interval":
+        minutes = schedule["minutes"]
+        current = (
+            _ensure_aware(datetime.fromisoformat(first_run_at))
+            if first_run_at
+            else _ensure_aware(datetime.fromisoformat(compute_next_run(schedule)))
+        )
+        for _ in range(count):
+            occurrences.append(current.isoformat())
+            current = current + timedelta(minutes=minutes)
+        return occurrences
+
+    if kind == "cron":
+        if not HAS_CRONITER:
+            raise ValueError("Cron previews require croniter")
+        if first_run_at:
+            current = _ensure_aware(datetime.fromisoformat(first_run_at))
+            occurrences.append(current.isoformat())
+            base = current
+        else:
+            base = _hermes_now()
+        cron = croniter(schedule["expr"], base)
+        while len(occurrences) < count:
+            occurrences.append(cron.get_next(datetime).isoformat())
+        return occurrences
+
+    raise ValueError(f"Schedule kind '{kind}' does not support recurring preview")
+
+
+def preview_schedule_runs(schedule: Any, count: int = 5) -> List[str]:
+    """Preview upcoming run times for a schedule."""
+    count = _validate_preview_count(count)
+    parsed = _coerce_schedule(schedule)
+    kind = parsed.get("kind")
+
+    if kind == "once":
+        run_at = _recoverable_oneshot_run_at(parsed, _hermes_now())
+        if not run_at:
+            return []
+        return [_ensure_aware(datetime.fromisoformat(run_at)).isoformat()]
+
+    if kind in ("interval", "cron"):
+        return _preview_recurring_runs(parsed, count=count)
+
+    return []
+
+
+def preview_job_runs(job: Dict[str, Any], count: int = 5) -> Dict[str, Any]:
+    """Preview future runs for a job without mutating stored state."""
+    count = _validate_preview_count(count)
+    preview_job = _apply_skill_fields(copy.deepcopy(job))
+
+    if preview_job.get("state") == "completed":
+        return {
+            "occurrences": [],
+            "message": "Job is completed. It has no future runs.",
+        }
+
+    if preview_job.get("state") == "paused" or (
+        not preview_job.get("enabled", True) and preview_job.get("state") == "paused"
+    ):
+        return {
+            "occurrences": [],
+            "message": "Job is paused. Resume it to preview future runs.",
+        }
+
+    schedule = preview_job.get("schedule", {})
+    kind = schedule.get("kind")
+    now = _hermes_now()
+
+    if kind == "once":
+        run_at = preview_job.get("next_run_at") or _recoverable_oneshot_run_at(
+            schedule,
+            now,
+            last_run_at=preview_job.get("last_run_at"),
+        )
+        occurrences = []
+        if run_at:
+            occurrences = [_ensure_aware(datetime.fromisoformat(run_at)).isoformat()]
+        return {"occurrences": occurrences, "message": None if occurrences else None}
+
+    next_run = preview_job.get("next_run_at")
+    if not next_run:
+        return {
+            "occurrences": [],
+            "message": preview_job.get("last_error") or "Job has no next_run_at to preview.",
+        }
+
+    next_run_dt = _ensure_aware(datetime.fromisoformat(next_run))
+    grace = _compute_grace_seconds(schedule)
+    if next_run_dt <= now and (now - next_run_dt).total_seconds() > grace:
+        next_run = compute_next_run(schedule, now.isoformat())
+        if not next_run:
+            return {"occurrences": [], "message": preview_job.get("last_error") or "Job has no future runs."}
+
+    occurrences = _preview_recurring_runs(schedule, count=count, first_run_at=next_run)
+    return {"occurrences": occurrences, "message": None}
+
+
 # =============================================================================
 # Job CRUD Operations
 # =============================================================================

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -259,6 +259,57 @@ def cron_edit(args):
     return 0
 
 
+def cron_preview(args):
+    from cron.jobs import get_job, preview_job_runs, preview_schedule_runs
+
+    schedule = getattr(args, "schedule", None)
+    job_id = getattr(args, "job_id", None)
+    count = getattr(args, "next", 5)
+
+    if bool(schedule) == bool(job_id):
+        print("Choose exactly one of --schedule or --job-id.")
+        return 1
+
+    if not 1 <= count <= 20:
+        print("--next must be between 1 and 20.")
+        return 1
+
+    if schedule:
+        try:
+            occurrences = preview_schedule_runs(schedule, count=count)
+        except ValueError as exc:
+            print(str(exc))
+            return 1
+
+        print(f"Preview for schedule: {schedule}")
+        if occurrences:
+            for index, occurrence in enumerate(occurrences, start=1):
+                print(f"{index}. {occurrence}")
+        else:
+            print("No future runs found for this schedule.")
+        return 0
+
+    job = get_job(job_id)
+    if not job:
+        print(color(f"Job not found: {job_id}", Colors.RED))
+        return 1
+
+    try:
+        result = preview_job_runs(job, count=count)
+    except ValueError as exc:
+        print(str(exc))
+        return 1
+
+    print(f"Preview for job: {job_id}")
+    occurrences = result.get("occurrences", [])
+    if occurrences:
+        for index, occurrence in enumerate(occurrences, start=1):
+            print(f"{index}. {occurrence}")
+    elif result.get("message"):
+        print(result["message"])
+    return 0
+
+
 def _job_action(action: str, job_id: str, success_verb: str) -> int:
     result = _cron_api(action=action, job_id=job_id)
     if not result.get("success"):
@@ -305,9 +356,12 @@ def cron_command(args):
     if subcmd == "run":
         return _job_action("run", args.job_id, "Triggered")
 
+    if subcmd == "preview":
+        return cron_preview(args)
+
     if subcmd in {"remove", "rm", "delete"}:
         return _job_action("remove", args.job_id, "Removed")
 
     print(f"Unknown cron command: {subcmd}")
-    print("Usage: hermes cron [list|create|edit|pause|resume|run|remove|status|tick]")
+    print("Usage: hermes cron [list|create|edit|pause|resume|run|preview|remove|status|tick]")
     sys.exit(1)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5358,7 +5358,7 @@ def cmd_cron(args):
     """Cron job management."""
     from hermes_cli.cron import cron_command
 
-    cron_command(args)
+    return cron_command(args)
 
 
 def cmd_webhook(args):
@@ -10222,6 +10222,18 @@ def main():
     cron_run.add_argument("job_id", help="Job ID to trigger")
     _add_accept_hooks_flag(cron_run)
 
+    cron_preview = cron_subparsers.add_parser(
+        "preview", help="Preview future runs for a schedule or job"
+    )
+    cron_preview.add_argument("--schedule", help="Schedule like 'every 1h' or '0 9 * * *'")
+    cron_preview.add_argument("--job-id", help="Existing job ID to preview")
+    cron_preview.add_argument(
+        "--next",
+        type=int,
+        default=5,
+        help="Number of future occurrences to show (1-20)",
+    )
+
     cron_remove = cron_subparsers.add_parser(
         "remove", aliases=["rm", "delete"], help="Remove a scheduled job"
     )
@@ -12208,7 +12220,9 @@ Examples:
 
     # Execute the command
     if hasattr(args, "func"):
-        args.func(args)
+        result = args.func(args)
+        if isinstance(result, int):
+            sys.exit(result)
     else:
         parser.print_help()
 

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -11,6 +11,8 @@ from cron.jobs import (
     parse_duration,
     parse_schedule,
     compute_next_run,
+    preview_schedule_runs,
+    preview_job_runs,
     create_job,
     load_jobs,
     save_jobs,
@@ -25,6 +27,43 @@ from cron.jobs import (
     get_due_jobs,
     save_job_output,
 )
+
+
+def _coerce_preview_dt(value):
+    if isinstance(value, datetime):
+        return value
+    return datetime.fromisoformat(value)
+
+
+def _base_job(*, job_id: str, schedule: dict, next_run_at, now: datetime, **overrides):
+    job = {
+        "id": job_id,
+        "name": overrides.pop("name", "Preview job"),
+        "prompt": overrides.pop("prompt", "Preview this job"),
+        "skills": overrides.pop("skills", []),
+        "skill": overrides.pop("skill", None),
+        "model": overrides.pop("model", None),
+        "provider": overrides.pop("provider", None),
+        "base_url": overrides.pop("base_url", None),
+        "script": overrides.pop("script", None),
+        "schedule": schedule,
+        "schedule_display": overrides.pop("schedule_display", schedule.get("display", "schedule")),
+        "repeat": overrides.pop("repeat", {"times": None, "completed": 0}),
+        "enabled": overrides.pop("enabled", True),
+        "state": overrides.pop("state", "scheduled"),
+        "paused_at": overrides.pop("paused_at", None),
+        "paused_reason": overrides.pop("paused_reason", None),
+        "created_at": overrides.pop("created_at", now.isoformat()),
+        "next_run_at": next_run_at,
+        "last_run_at": overrides.pop("last_run_at", None),
+        "last_status": overrides.pop("last_status", None),
+        "last_error": overrides.pop("last_error", None),
+        "last_delivery_error": overrides.pop("last_delivery_error", None),
+        "deliver": overrides.pop("deliver", "local"),
+        "origin": overrides.pop("origin", None),
+    }
+    job.update(overrides)
+    return job
 
 
 # =========================================================================
@@ -174,6 +213,192 @@ class TestComputeNextRun:
 
     def test_unknown_kind_returns_none(self):
         assert compute_next_run({"kind": "unknown"}) is None
+
+
+# =========================================================================
+# preview_schedule_runs
+# =========================================================================
+
+class TestPreviewScheduleRuns:
+    def test_duration_returns_single_timezone_aware_timestamp(self, monkeypatch):
+        now = datetime(2026, 4, 1, 9, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        runs = preview_schedule_runs("30m", count=5)
+
+        assert len(runs) == 1
+        assert _coerce_preview_dt(runs[0]).tzinfo is not None
+
+    def test_interval_returns_strictly_increasing_timestamps(self, monkeypatch):
+        now = datetime(2026, 4, 1, 9, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        runs = preview_schedule_runs("every 1h", count=3)
+
+        assert len(runs) == 3
+        parsed = [_coerce_preview_dt(run) for run in runs]
+        assert parsed == sorted(parsed)
+        assert parsed[0] < parsed[1] < parsed[2]
+
+    def test_past_iso_oneshot_returns_empty_list(self, monkeypatch):
+        now = datetime(2026, 4, 1, 9, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        assert preview_schedule_runs("2026-04-01T08:00:00+00:00", count=3) == []
+
+    def test_cron_expression_returns_next_daily_runs(self, monkeypatch):
+        pytest.importorskip("croniter")
+        now = datetime(2026, 4, 1, 8, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        runs = preview_schedule_runs("0 9 * * *", count=3)
+
+        assert [_coerce_preview_dt(run) for run in runs] == [
+            datetime(2026, 4, 1, 9, 0, 0, tzinfo=timezone.utc),
+            datetime(2026, 4, 2, 9, 0, 0, tzinfo=timezone.utc),
+            datetime(2026, 4, 3, 9, 0, 0, tzinfo=timezone.utc),
+        ]
+
+    def test_missing_croniter_raises_value_error(self, monkeypatch):
+        monkeypatch.setattr("cron.jobs.HAS_CRONITER", False)
+
+        with pytest.raises(ValueError, match="croniter"):
+            preview_schedule_runs("0 9 * * *", count=3)
+
+
+# =========================================================================
+# preview_job_runs
+# =========================================================================
+
+class TestPreviewJobRuns:
+    def test_active_recurring_job_uses_stored_next_run_at(self, monkeypatch):
+        now = datetime(2026, 4, 1, 9, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        first_run = "2026-04-01T10:00:00+00:00"
+        job = _base_job(
+            job_id="preview-active",
+            schedule={"kind": "interval", "minutes": 60, "display": "every 60m"},
+            next_run_at=first_run,
+            now=now,
+        )
+
+        result = preview_job_runs(job, count=3)
+
+        assert result["message"] is None
+        assert [_coerce_preview_dt(run) for run in result["occurrences"]] == [
+            datetime(2026, 4, 1, 10, 0, 0, tzinfo=timezone.utc),
+            datetime(2026, 4, 1, 11, 0, 0, tzinfo=timezone.utc),
+            datetime(2026, 4, 1, 12, 0, 0, tzinfo=timezone.utc),
+        ]
+
+    def test_stale_recurring_job_fast_forwards_to_future_run(self, monkeypatch):
+        now = datetime(2026, 4, 1, 9, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        job = _base_job(
+            job_id="preview-stale",
+            schedule={"kind": "interval", "minutes": 60, "display": "every 60m"},
+            next_run_at="2026-04-01T08:20:00+00:00",
+            now=now,
+        )
+
+        result = preview_job_runs(job, count=3)
+
+        assert result["message"] is None
+        assert [_coerce_preview_dt(run) for run in result["occurrences"]] == [
+            datetime(2026, 4, 1, 10, 0, 0, tzinfo=timezone.utc),
+            datetime(2026, 4, 1, 11, 0, 0, tzinfo=timezone.utc),
+            datetime(2026, 4, 1, 12, 0, 0, tzinfo=timezone.utc),
+        ]
+
+    def test_paused_job_returns_message_without_occurrences(self, monkeypatch):
+        now = datetime(2026, 4, 1, 9, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        job = _base_job(
+            job_id="preview-paused",
+            schedule={"kind": "interval", "minutes": 60, "display": "every 60m"},
+            next_run_at="2026-04-01T10:00:00+00:00",
+            now=now,
+            enabled=False,
+            state="paused",
+            paused_reason="user paused",
+        )
+
+        result = preview_job_runs(job, count=3)
+
+        assert result["occurrences"] == []
+        assert result["message"] == "Job is paused. Resume it to preview future runs."
+
+    def test_completed_oneshot_returns_message_without_occurrences(self, monkeypatch):
+        now = datetime(2026, 4, 1, 9, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        job = _base_job(
+            job_id="preview-complete",
+            schedule={"kind": "once", "run_at": "2026-04-01T08:00:00+00:00", "display": "once at 2026-04-01 08:00"},
+            next_run_at=None,
+            now=now,
+            enabled=False,
+            state="completed",
+            last_run_at="2026-04-01T08:00:00+00:00",
+        )
+
+        result = preview_job_runs(job, count=3)
+
+        assert result["occurrences"] == []
+        assert result["message"] == "Job is completed. It has no future runs."
+
+    def test_recent_oneshot_within_grace_returns_original_run_at(self, monkeypatch):
+        now = datetime(2026, 4, 1, 9, 1, 30, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        run_at = "2026-04-01T09:00:00+00:00"
+        job = _base_job(
+            job_id="preview-recent-oneshot",
+            schedule={"kind": "once", "run_at": run_at, "display": "once at 2026-04-01 09:00"},
+            next_run_at=run_at,
+            now=now,
+            repeat={"times": 1, "completed": 0},
+        )
+
+        result = preview_job_runs(job, count=5)
+
+        assert [_coerce_preview_dt(run) for run in result["occurrences"]] == [
+            datetime(2026, 4, 1, 9, 0, 0, tzinfo=timezone.utc)
+        ]
+        assert result["message"] is None
+
+    def test_recurring_error_state_without_next_run_surfaces_last_error(self, monkeypatch):
+        now = datetime(2026, 4, 1, 9, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        job = _base_job(
+            job_id="preview-error",
+            schedule={"kind": "interval", "minutes": 60, "display": "every 60m"},
+            next_run_at=None,
+            now=now,
+            enabled=True,
+            state="error",
+            last_status="error",
+            last_error="scheduler lost track of next_run_at",
+        )
+
+        result = preview_job_runs(job, count=3)
+
+        assert result["occurrences"] == []
+        assert result["message"] == "scheduler lost track of next_run_at"
+
+    def test_legacy_naive_next_run_at_returns_timezone_aware_timestamps(self, monkeypatch):
+        now = datetime(2026, 4, 1, 9, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        job = _base_job(
+            job_id="preview-naive",
+            schedule={"kind": "interval", "minutes": 60, "display": "every 60m"},
+            next_run_at="2026-04-01T10:00:00",
+            now=now,
+        )
+
+        result = preview_job_runs(job, count=2)
+
+        parsed = [_coerce_preview_dt(run) for run in result["occurrences"]]
+        assert len(parsed) == 2
+        assert all(run.tzinfo is not None for run in parsed)
 
 
 # =========================================================================

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -1,11 +1,18 @@
 """Tests for hermes_cli.cron command handling."""
 
+import subprocess
+import sys
 from argparse import Namespace
+from datetime import datetime, timezone
+from pathlib import Path
 
 import pytest
 
 from cron.jobs import create_job, get_job, list_jobs
 from hermes_cli.cron import cron_command
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
 
 @pytest.fixture()
@@ -105,3 +112,106 @@ class TestCronCommandLifecycle:
         assert len(jobs) == 1
         assert jobs[0]["skills"] == ["blogwatcher", "maps"]
         assert jobs[0]["name"] == "Skill combo"
+
+
+class TestCronPreview:
+    @staticmethod
+    def _run_cron_cli(*argv):
+        return subprocess.run(
+            [sys.executable, "-m", "hermes_cli.main", "cron", *argv],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            cwd=PROJECT_ROOT,
+        )
+
+    def test_schedule_preview_prints_future_occurrences(self, tmp_cron_dir, monkeypatch, capsys):
+        now = datetime(2026, 4, 1, 9, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        result = cron_command(Namespace(cron_command="preview", schedule="every 1h", job_id=None, next=5))
+
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "Preview for schedule: every 1h" in out
+        for index in range(1, 6):
+            assert f"{index}. 2026-04-01T" in out
+
+    def test_schedule_preview_reports_when_no_future_runs_exist(self, tmp_cron_dir, monkeypatch, capsys):
+        now = datetime(2026, 4, 1, 9, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        result = cron_command(
+            Namespace(
+                cron_command="preview",
+                schedule="2026-04-01T08:00:00+00:00",
+                job_id=None,
+                next=5,
+            )
+        )
+
+        assert result == 0
+        assert capsys.readouterr().out.strip() == (
+            "Preview for schedule: 2026-04-01T08:00:00+00:00\n"
+            "No future runs found for this schedule."
+        )
+
+    def test_job_preview_reports_paused_state(self, tmp_cron_dir, capsys):
+        job = create_job(prompt="Check server status", schedule="every 1h")
+        cron_command(Namespace(cron_command="pause", job_id=job["id"]))
+        capsys.readouterr()
+
+        result = cron_command(Namespace(cron_command="preview", schedule=None, job_id=job["id"], next=5))
+
+        assert result == 0
+        assert capsys.readouterr().out.strip() == (
+            f"Preview for job: {job['id']}\nJob is paused. Resume it to preview future runs."
+        )
+
+    @pytest.mark.parametrize(
+        "schedule,job_id",
+        [(None, None), ("every 1h", "job-123")],
+    )
+    def test_preview_requires_exactly_one_selector(self, tmp_cron_dir, capsys, schedule, job_id):
+        result = cron_command(Namespace(cron_command="preview", schedule=schedule, job_id=job_id, next=5))
+
+        assert result == 1
+        assert capsys.readouterr().out.strip() == "Choose exactly one of --schedule or --job-id."
+
+    @pytest.mark.parametrize("count", [0, 21])
+    def test_preview_rejects_out_of_range_next(self, tmp_cron_dir, capsys, count):
+        result = cron_command(Namespace(cron_command="preview", schedule="every 1h", job_id=None, next=count))
+
+        assert result == 1
+        assert capsys.readouterr().out.strip() == "--next must be between 1 and 20."
+
+    def test_preview_cli_exits_nonzero_for_out_of_range_next(self):
+        result = self._run_cron_cli("preview", "--schedule", "every 1h", "--next", "0")
+
+        assert result.returncode != 0
+        assert "--next must be between 1 and 20." in result.stdout
+
+    def test_preview_cli_exits_nonzero_for_conflicting_selectors(self):
+        result = self._run_cron_cli(
+            "preview",
+            "--schedule",
+            "every 1h",
+            "--job-id",
+            "job-123",
+        )
+
+        assert result.returncode != 0
+        assert "Choose exactly one of --schedule or --job-id." in result.stdout
+
+    def test_preview_cli_succeeds_for_valid_schedule(self):
+        result = self._run_cron_cli("preview", "--schedule", "every 1h", "--next", "1")
+
+        assert result.returncode == 0, result.stderr
+        assert "Preview for schedule: every 1h" in result.stdout
+        assert "1. " in result.stdout
+
+    def test_cron_help_includes_preview(self):
+        result = self._run_cron_cli("--help")
+
+        assert result.returncode == 0, result.stderr
+        assert "preview" in result.stdout

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -48,7 +48,7 @@ hermes [global-options] <command> [subcommand/options]
 | `hermes auth` | Manage credentials — add, list, remove, reset, set strategy. Handles OAuth flows for Codex/Nous/Anthropic. |
 | `hermes login` / `logout` | **Deprecated** — use `hermes auth` instead. |
 | `hermes status` | Show agent, auth, and platform status. |
-| `hermes cron` | Inspect and tick the cron scheduler. |
+| `hermes cron` | Inspect, preview, and tick the cron scheduler. |
 | `hermes kanban` | Multi-profile collaboration board (tasks, links, dispatcher). |
 | `hermes webhook` | Manage dynamic webhook subscriptions for event-driven activation. |
 | `hermes hooks` | Inspect, approve, or remove shell-script hooks declared in `config.yaml`. |
@@ -355,7 +355,7 @@ hermes status [--all] [--deep]
 ## `hermes cron`
 
 ```bash
-hermes cron <list|create|edit|pause|resume|run|remove|status|tick>
+hermes cron <list|create|edit|pause|resume|preview|run|remove|status|tick>
 ```
 
 | Subcommand | Description |
@@ -365,6 +365,7 @@ hermes cron <list|create|edit|pause|resume|run|remove|status|tick>
 | `edit` | Update a job's schedule, prompt, name, delivery, repeat count, or attached skills. Supports `--clear-skills`, `--add-skill`, and `--remove-skill`. |
 | `pause` | Pause a job without deleting it. |
 | `resume` | Resume a paused job and compute its next future run. |
+| `preview` | Preview upcoming run times for a raw schedule or existing job without mutating state; pass exactly one of `--schedule` or `--job-id`, with `--next` defaulting to 5 (range: 1-20). |
 | `run` | Trigger a job on the next scheduler tick. |
 | `remove` | Delete a scheduled job. |
 | `status` | Check whether the cron scheduler is running. |

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -186,6 +186,24 @@ What they do:
 - `run` — trigger the job on the next scheduler tick
 - `remove` — delete it entirely
 
+## Previewing future runs
+
+Use `preview` to inspect upcoming run times without creating, editing, or triggering anything.
+
+```bash
+hermes cron preview --schedule "0 9 * * *" --next 5
+hermes cron preview --job-id <job_id> --next 5
+```
+
+Notes:
+
+- pass exactly one of `--schedule` or `--job-id`
+- `--schedule` previews from the current time
+- `--job-id` previews from the persisted state of an existing job
+- `--next` defaults to `5` and accepts values from `1` to `20`
+- paused jobs report no future runs until resumed
+- preview is read-only
+
 ## How it works
 
 **Cron execution is handled by the gateway daemon.** The gateway ticks the scheduler every 60 seconds, running any due jobs in isolated agent sessions.


### PR DESCRIPTION
## Summary
- add read-only cron preview helpers that mirror Hermes scheduler behavior for raw schedules and persisted jobs
- wire a new `hermes cron preview` CLI with selector/count validation, real exit-code propagation, and focused subprocess coverage
- document the new preview workflow in the cron feature guide and CLI reference

## Behavior
`hermes cron preview` is read-only:
- it does not create jobs
- it does not edit jobs
- it does not trigger jobs

Selector rules:
- pass exactly one of `--schedule` or `--job-id`
- `--next` defaults to `5`
- `--next` accepts values from `1` to `20`

## Test Plan
- [x] `scripts/run_tests.sh tests/cron/test_jobs.py tests/hermes_cli/test_cron.py`
- [x] `$HOME/.hermes/hermes-agent/venv/bin/python -m hermes_cli.main cron preview --help`
- [x] `$HOME/.hermes/hermes-agent/venv/bin/python -m hermes_cli.main cron preview --schedule 'every 1h' --next 1`
- [x] `$HOME/.hermes/hermes-agent/venv/bin/python -m hermes_cli.main cron preview --schedule 'every 1h' --next 0`
