### PR TITLE
fix(gateway): honour HERMES_INFERENCE_PROVIDER in _resolve_startup_runtime (#16857)

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -187,16 +187,34 @@ def test_startup_runtime_uses_tui_provider_env(monkeypatch):
     assert server._resolve_startup_runtime() == ("nous/hermes-test", "nous")
 
 
-def test_startup_runtime_does_not_treat_inference_provider_as_explicit(monkeypatch):
-    monkeypatch.setenv("HERMES_MODEL", "nous/hermes-test")
+def test_startup_runtime_honours_inference_provider_env(monkeypatch):
+    """HERMES_INFERENCE_PROVIDER set by /model must be honoured directly.
+
+    This prevents static-catalog detection from overriding the user's
+    explicit provider choice (e.g. custom:xuanji → native deepseek).
+    Fixes #16857.
+    """
+    monkeypatch.setenv("HERMES_MODEL", "deepseek-v4-pro")
     monkeypatch.delenv("HERMES_TUI_PROVIDER", raising=False)
-    monkeypatch.setenv("HERMES_INFERENCE_PROVIDER", "nous")
+    monkeypatch.setenv("HERMES_INFERENCE_PROVIDER", "custom:xuanji")
+    # static detection must NOT be called — early return should happen first
     monkeypatch.setattr(
         "hermes_cli.models.detect_static_provider_for_model",
-        lambda model, provider: None,
+        lambda model, provider: (_ for _ in ()).throw(
+            AssertionError("static detection should not run when HERMES_INFERENCE_PROVIDER is set")
+        ),
     )
 
-    assert server._resolve_startup_runtime() == ("nous/hermes-test", None)
+    assert server._resolve_startup_runtime() == ("deepseek-v4-pro", "custom:xuanji")
+
+
+def test_startup_runtime_inference_provider_does_not_override_tui_provider(monkeypatch):
+    """HERMES_TUI_PROVIDER takes precedence over HERMES_INFERENCE_PROVIDER."""
+    monkeypatch.setenv("HERMES_MODEL", "nous/hermes-test")
+    monkeypatch.setenv("HERMES_TUI_PROVIDER", "nous")
+    monkeypatch.setenv("HERMES_INFERENCE_PROVIDER", "custom:other")
+
+    assert server._resolve_startup_runtime() == ("nous/hermes-test", "nous")
 
 
 def test_startup_runtime_detects_provider_for_model_env(monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -631,6 +631,14 @@ def _resolve_startup_runtime() -> tuple[str, str | None]:
     if explicit_provider:
         return model, explicit_provider
 
+    # Honour HERMES_INFERENCE_PROVIDER when set by /model — it represents
+    # the user's explicit provider choice and must not be overridden by
+    # static-catalog detection (which can match native provider names by
+    # coincidence, e.g. "deepseek-v4-pro" → native deepseek).
+    inference_provider = os.environ.get("HERMES_INFERENCE_PROVIDER", "").strip()
+    if inference_provider:
+        return model, inference_provider
+
     explicit_model = (
         os.environ.get("HERMES_MODEL", "")
         or os.environ.get("HERMES_INFERENCE_MODEL", "")
@@ -648,7 +656,6 @@ def _resolve_startup_runtime() -> tuple[str, str | None]:
                 if isinstance(cfg, dict)
                 else ""
             )
-            or os.environ.get("HERMES_INFERENCE_PROVIDER", "").strip().lower()
             or "auto"
         )
         detected = detect_static_provider_for_model(explicit_model, current_provider)


### PR DESCRIPTION
## Summary

Fixes #16857 — `/new` after `/model` switch to a custom provider model fails with "no API key" when the model name also exists in a native provider catalog.

## Root Cause

In `_resolve_startup_runtime()`, `HERMES_INFERENCE_PROVIDER` (set by `/model`) was passed as a hint to `detect_static_provider_for_model()`, but custom providers have no static catalog. The function fell through to matching native catalogs by model name, overriding the explicit custom provider choice with the coincidentally-matching native provider.

**Example:** `/model deepseek-v4-pro` via `custom:xuanji` → `/new` → `detect_static_provider_for_model` matches native `deepseek` catalog → tries to use `DEEPSEEK_API_KEY` → 401.

## Fix

Check `HERMES_INFERENCE_PROVIDER` immediately after `HERMES_TUI_PROVIDER` and return early when set. This env var is written by `/model` and represents the user's explicit provider choice — static catalog detection must not override it.

Also removes the now-redundant `HERMES_INFERENCE_PROVIDER` read from the `current_provider` fallback chain (line 651 of the original), since the early return means it can never be reached.

## Changes

- `tui_gateway/server.py`: Early-return on `HERMES_INFERENCE_PROVIDER` before static detection
- `tests/test_tui_gateway_server.py`: Updated existing test + added 2 new tests

## Testing

```bash
python3 -m pytest tests/test_tui_gateway_server.py -k "startup_runtime" -x -q -o "addopts="
# 6 passed
```

**Test coverage:**
| Test | Verifies |
|------|----------|
| `test_startup_runtime_honours_inference_provider_env` | Custom provider is returned directly; static detection is NOT called |
| `test_startup_runtime_inference_provider_does_not_override_tui_provider` | `HERMES_TUI_PROVIDER` still takes precedence |
| Existing tests | No regression in alias resolution, static detection, TUI provider |

## How to verify manually

1. Configure a custom provider with a model name that overlaps a native catalog
2. `/model <overlapping-model-name>` → should switch to custom provider
3. `/new` → should start new session with the **custom provider**, not the native one