### PR TITLE
fix(yuanbao) messaging platform entrance

### DIFF
--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -511,6 +511,7 @@ const sidebars: SidebarsConfig = {
         'user-guide/messaging/weixin',
         'user-guide/messaging/bluebubbles',
         'user-guide/messaging/qqbot',
+        'user-guide/messaging/yuanbao',
         'user-guide/messaging/open-webui',
         'user-guide/messaging/webhooks',
       ],


### PR DESCRIPTION
Adding `website/docs/user-guide/messaging/yuanbao.md` documentation and registering it in `website/sidebars.ts` so Yuanbao appears in the Messaging Platforms navigation alongside other Chinese platforms (DingTalk, Feishu, WeCom, Weixin, QQ Bot).