### PR TITLE
fix: clear acp_command when delegation.provider is configured

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -994,6 +994,13 @@ def _build_child_agent(
         else (getattr(parent_agent, "acp_args", []) or [])
     )
 
+    # When delegation.provider is explicitly configured, subagent must use
+    # direct API calls instead of inheriting the parent's ACP transport.
+    # This prevents copilot-acp from overriding the intended provider.
+    if override_provider:
+        effective_acp_command = None
+        effective_acp_args = []
+
     if override_acp_command:
         # If explicitly forcing an ACP transport override, the provider MUST be copilot-acp
         # so run_agent.py initializes the CopilotACPClient.


### PR DESCRIPTION
## Bug Description

When `delegation.provider` is configured in `config.yaml` (e.g., `minimax-cn`), subagents still inherit the parent's `acp_command` and use Copilot ACP transport instead of direct API calls. This causes subagents to use the wrong model and provider, bypassing the intended `delegation.provider` settings entirely.

## Steps to Reproduce

1. Configure `delegation.provider: minimax-cn` and `delegation.model: MiniMax-M2.7` in `config.yaml`
2. Start a lead agent that uses ACP transport (`hermes --acp --stdio` or similar)
3. Spawn a subagent via `delegate_task`
4. Observe the subagent's API calls — logs show `provider=copilot-acp model=qwen3.5-397b-a17b` instead of `provider=minimax-cn model=MiniMax-M2.7`

## Expected Behavior

When `delegation.provider` is configured, subagents should use direct API calls with the configured provider's credentials (model, base_url, api_key). The parent's `acp_command` should NOT be inherited when a delegation provider override is set.

## Actual Behavior

Subagent inherits the parent's `acp_command` unconditionally (`delegate_tool.py:988-990`):

```python
effective_acp_command = override_acp_command or getattr(
    parent_agent, "acp_command", None
)
```

This causes the subagent to use Copilot ACP transport (`provider=copilot-acp`), whose default model is `qwen3.5-397b-a17b` — entirely ignoring the `delegation.provider` and `delegation.model` config.

## Root Cause

In `_build_child_agent()`, the `effective_acp_command` is resolved from the parent before checking if `override_provider` is set. The existing comment in the code says:

> When override_* params are set... the child uses those credentials instead of inheriting from the parent.

But this logic was not applied to `acp_command`, causing the ACP transport to override the intended delegation provider.

## Fix

Clear `effective_acp_command` and `effective_acp_args` when `override_provider` is set. This ensures subagents use direct API calls when `delegation.provider` is configured.

## Debug Report

**Root cause location**: `hermes-agent/tools/delegate_tool.py`, lines 988-990

**Evidence from agent.log**:
```
provider=copilot-acp model=qwen3.5-397b-a17b
Loaded env from /home/yeahlo/.hermes/profiles/coder/.env
```