### PR TITLE
fix(agent): always persist reasoning_content on assistant turns

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -8089,16 +8089,23 @@ class AIAgent:
             "finish_reason": finish_reason,
         }
 
-        if hasattr(assistant_message, "reasoning_content"):
-            raw_reasoning_content = getattr(assistant_message, "reasoning_content", None)
-            if raw_reasoning_content is not None:
-                msg["reasoning_content"] = _sanitize_surrogates(raw_reasoning_content)
-            elif msg.get("tool_calls") and self._needs_deepseek_tool_reasoning():
-                # DeepSeek thinking mode requires reasoning_content on every
-                # assistant tool-call message. Without it, replaying the
-                # persisted message causes HTTP 400. Include empty string
-                # as a defensive compatibility fallback (refs #15250).
-                msg["reasoning_content"] = ""
+        # Always persist `reasoning_content` on assistant turns. Without this
+        # the persisted history is silently incompatible with DeepSeek/Kimi
+        # thinking-mode replay (HTTP 400: "The reasoning_content in the
+        # thinking mode must be passed back to the API.") whenever the user
+        # later switches model. Prefer the SDK-supplied value (may carry
+        # structured data); otherwise fall back to the already-sanitized
+        # `reasoning_text` we accumulated from streaming deltas; finally
+        # default to "" so non-thinking providers ignore it harmlessly while
+        # thinking providers see a valid (empty) field. Refs #16844 (write
+        # side) / #15213, #15250, #15353, #15741, #15748 (read-side patches).
+        sdk_reasoning_content = getattr(assistant_message, "reasoning_content", None)
+        if sdk_reasoning_content is not None:
+            msg["reasoning_content"] = _sanitize_surrogates(sdk_reasoning_content)
+        elif reasoning_text:
+            msg["reasoning_content"] = reasoning_text
+        else:
+            msg["reasoning_content"] = ""
 
         if hasattr(assistant_message, 'reasoning_details') and assistant_message.reasoning_details:
             # Pass reasoning_details back unmodified so providers (OpenRouter,


### PR DESCRIPTION
## What

`run_agent.py` persists assistant turns with the chain of thought under the internal field `reasoning` and only writes the protocol-standard `reasoning_content` when:

- the upstream SDK exposes `assistant_message.reasoning_content` as a top-level attribute, **or**
- the current provider is DeepSeek and the turn has `tool_calls` (existing narrow guard).

Streaming-only providers (`glm`, `MiniMax`, `gpt-5.x` via aigw, Anthropic via openai-compat shims, etc.) emit reasoning through `delta.reasoning_content` chunks that get accumulated into the local `reasoning_text` string — but never land on the assistant message object as an attribute, so the persisted message is missing `reasoning_content`.

The bug is silent until the user later replays that history through a DeepSeek‑v4 / Kimi thinking model, which strictly requires `reasoning_content` on every replayed assistant turn:

> `The reasoning_content in the thinking mode must be passed back to the API.`

Read-side patches (#15213, #15741, #15748, #15353) each fix one build path, but every new path that reads history from disk is a fresh place the same 400 can resurface.

## Fix

Normalize at write time. At the point where the assistant message dict is built (around `run_agent.py:8085`), always populate `reasoning_content`:

1. prefer the SDK-supplied `assistant_message.reasoning_content` when present (may carry structured data);
2. otherwise fall back to the already-sanitized `reasoning_text` that was accumulated from streaming deltas;
3. finally default to `""` so non-thinking providers ignore it harmlessly while DeepSeek/Kimi see a valid (empty) value.

The internal `reasoning` alias is preserved for backward compatibility with existing read paths and downstream consumers — this PR is purely additive on the wire format.

This makes the four landed read-side fixes redundant safety nets rather than mandatory promotion paths.

## Diff

```
run_agent.py | 27 +++++++++++++++++----------
1 file changed, 17 insertions(+), 10 deletions(-)
```

The change is local to the assistant-message persistence block; no behavioural change for currently-working DeepSeek paths (those already get `reasoning_content` from the SDK or from the existing tool-call guard).

## Not in scope

- Migration of existing poisoned session files under `~/.hermes/sessions/**` — happy to follow up in a separate PR if maintainers want it; the original issue author offered one as well.
- Removing the read-side `_copy_reasoning_content_for_api` promotion logic — leaving it in place as defense in depth.

Refs #16844