### PR TITLE
fix(opencode): re-derive api_mode per target model on /model switch

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -260,11 +260,16 @@ def _resolve_runtime_from_pool_entry(
             if cfg_base_url:
                 base_url = cfg_base_url
         configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
-        if configured_mode and _provider_supports_explicit_api_mode(provider, configured_provider):
-            api_mode = configured_mode
-        elif provider in ("opencode-zen", "opencode-go"):
+        if provider in ("opencode-zen", "opencode-go"):
+            # Re-derive api_mode from the effective model rather than the
+            # persisted api_mode: the opencode providers serve both
+            # anthropic_messages and chat_completions models, so the previous
+            # session's mode must not leak across /model switches.
+            # Refs #16878.
             from hermes_cli.models import opencode_model_api_mode
             api_mode = opencode_model_api_mode(provider, effective_model)
+        elif configured_mode and _provider_supports_explicit_api_mode(provider, configured_provider):
+            api_mode = configured_mode
         else:
             # Auto-detect Anthropic-compatible endpoints (/anthropic suffix,
             # Kimi /coding, api.openai.com → codex_responses, api.x.ai →
@@ -1212,15 +1217,20 @@ def resolve_runtime_provider(
             configured_provider = str(model_cfg.get("provider") or "").strip().lower()
             # Only honor persisted api_mode when it belongs to the same provider family.
             configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
-            if configured_mode and _provider_supports_explicit_api_mode(provider, configured_provider):
-                api_mode = configured_mode
-            elif provider in ("opencode-zen", "opencode-go"):
+            if provider in ("opencode-zen", "opencode-go"):
+                # opencode-zen/go must always re-derive api_mode from the
+                # target model (not the stale persisted api_mode), because
+                # the same provider serves both anthropic_messages
+                # (e.g. minimax-m2.7) and chat_completions (e.g.
+                # deepseek-v4-flash) and switching models via /model would
+                # otherwise carry the previous mode forward, stripping /v1
+                # from base_url for chat_completions models and 404'ing.
+                # Refs #16878.
                 from hermes_cli.models import opencode_model_api_mode
-                # Prefer the target_model from the caller (explicit mid-session
-                # switch) over the stale model.default; see _resolve_runtime_from_pool_entry
-                # for the same rationale.
                 _effective = target_model or model_cfg.get("default", "")
                 api_mode = opencode_model_api_mode(provider, _effective)
+            elif configured_mode and _provider_supports_explicit_api_mode(provider, configured_provider):
+                api_mode = configured_mode
             else:
                 # Auto-detect Anthropic-compatible endpoints by URL convention
                 # (e.g. https://api.minimax.io/anthropic, https://dashscope.../anthropic)

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1170,7 +1170,18 @@ def test_opencode_go_glm_defaults_to_chat_completions(monkeypatch):
     assert resolved["base_url"] == "https://opencode.ai/zen/go/v1"
 
 
-def test_opencode_go_configured_api_mode_still_overrides_default(monkeypatch):
+def test_opencode_go_model_derivation_beats_stale_persisted_api_mode(monkeypatch):
+    """opencode-zen/go re-derive api_mode from the effective model on every
+    resolve, ignoring any persisted ``api_mode`` in config. Refs #16878 /
+    PR #16888: the persisted mode from the previous default model must not
+    leak across /model switches (a stale ``anthropic_messages`` on a
+    chat_completions target would strip /v1 from base_url and 404).
+
+    minimax-m2.5 is an Anthropic-routed model on opencode-go, so even when
+    the config claims ``api_mode: chat_completions`` the runtime must pick
+    ``anthropic_messages`` — the model dictates the mode, not the stale
+    persisted setting.
+    """
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "opencode-go")
     monkeypatch.setattr(
         rp,
@@ -1187,7 +1198,7 @@ def test_opencode_go_configured_api_mode_still_overrides_default(monkeypatch):
     resolved = rp.resolve_runtime_provider(requested="opencode-go")
 
     assert resolved["provider"] == "opencode-go"
-    assert resolved["api_mode"] == "chat_completions"
+    assert resolved["api_mode"] == "anthropic_messages"
 
 
 def test_named_custom_provider_anthropic_api_mode(monkeypatch):


### PR DESCRIPTION
Salvages PR #16888 (opencode fix only — the second stacked reasoning_content commit from that PR is dropped; it is a separate concern tracked under #16844 and will be evaluated on its own).

## Summary
`/model deepseek-v4-flash` from a `minimax-m2.7` default on `opencode-go` / `opencode-zen` 404'd. The api_mode resolver honoured the persisted `api_mode: anthropic_messages` (set when minimax was default) before the opencode model registry, so the deepseek turn inherited `anthropic_messages`, stripped `/v1` from `base_url`, and went to `https://opencode.ai/zen/go/messages` instead of `.../v1/chat/completions`.

Fixes #16878.

## Changes
- `hermes_cli/runtime_provider.py` — promote the opencode-zen/go branch above the `configured_mode` check in both api_mode resolution paths (`_resolve_runtime_from_pool_entry` and the API-key fallback in `resolve_runtime_provider`). opencode always re-derives mode from the effective target_model; other providers keep existing precedence (persisted api_mode > URL detection).
- `tests/hermes_cli/test_runtime_provider_resolution.py` — rename + invert `test_opencode_go_configured_api_mode_still_overrides_default` (added in #4508) to lock in the new precedence. A persisted `chat_completions` on a minimax model no longer wins — the model dictates the mode. Escape-hatch for opencode is intentionally removed; the model name is the unambiguous signal.

## Validation
|  | Before | After |
|---|---|---|
| minimax default → `/model deepseek-v4-flash` | api_mode=anthropic_messages, base_url=`.../zen/go` (404) | api_mode=chat_completions, base_url=`.../zen/go/v1` |
| deepseek default → `/model minimax-m2.7` | api_mode=anthropic_messages, base_url=`.../zen/go` | unchanged |
| no target_model (legacy callers) | unchanged | unchanged |

Suites: `tests/hermes_cli/test_runtime_provider_resolution.py`, `test_model_switch_opencode_anthropic.py`, `test_model_switch_custom_providers.py` — 109/109 pass. E2E verified against origin/main with a real config.yaml and isolated HERMES_HOME.

Credit: @Sanjays2402 for the original fix (#16888).