### PR TITLE
fix(agent): persist streamed reasoning_content on assistant turns (#16844)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -8100,6 +8100,31 @@ class AIAgent:
                 # as a defensive compatibility fallback (refs #15250).
                 msg["reasoning_content"] = ""
 
+        # Additive fallback (refs #16844, #16884). Streaming-only providers
+        # (glm, MiniMax, gpt-5.x via aigw, Anthropic via openai-compat shims)
+        # accumulate reasoning through ``delta.reasoning_content`` chunks
+        # but never land it on the message object as a top-level attribute,
+        # so neither branch above fires and the chain-of-thought is stored
+        # only under the internal ``reasoning`` key. When the user later
+        # replays that history through a DeepSeek-v4 / Kimi thinking model,
+        # the missing ``reasoning_content`` causes HTTP 400 ("The
+        # reasoning_content in the thinking mode must be passed back to the
+        # API.").
+        #
+        # Promote the already-sanitized streamed ``reasoning_text`` to
+        # ``reasoning_content`` at write time, but ONLY when no prior branch
+        # already set it AND we actually captured reasoning text. This
+        # preserves every existing behavior:
+        #   - SDK-exposed ``reasoning_content`` (OpenAI/Moonshot/DeepSeek SDK)
+        #     still wins.
+        #   - DeepSeek tool-call ""-pad (#15250) still fires.
+        #   - Non-thinking turns with no reasoning leave the field absent,
+        #     so ``_copy_reasoning_content_for_api``'s cross-provider leak
+        #     guard (#15748) and ``reasoning``→``reasoning_content``
+        #     promotion tiers still apply at replay time.
+        if "reasoning_content" not in msg and reasoning_text:
+            msg["reasoning_content"] = reasoning_text
+
         if hasattr(assistant_message, 'reasoning_details') and assistant_message.reasoning_details:
             # Pass reasoning_details back unmodified so providers (OpenRouter,
             # Anthropic, OpenAI) can maintain reasoning continuity across turns.

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1397,6 +1397,62 @@ class TestBuildAssistantMessage:
         result = agent._build_assistant_message(msg, "stop")
         assert result["content"] == ""
 
+    def test_streaming_only_reasoning_promoted_to_reasoning_content(self, agent):
+        """Refs #16844 / #16884. Streaming-only providers (glm, MiniMax,
+        gpt-5.x via aigw, Anthropic via openai-compat shims) accumulate
+        reasoning through delta chunks but never expose
+        ``reasoning_content`` as a top-level attribute on the finalized
+        message — only ``reasoning`` (or the internal accumulator).
+
+        Without write-side promotion, the persisted message stores the
+        chain-of-thought under the internal ``reasoning`` key and omits
+        ``reasoning_content``. When the user later replays that history
+        through a DeepSeek-v4 / Kimi thinking model, the missing field
+        causes HTTP 400 ("The reasoning_content in the thinking mode
+        must be passed back to the API.").
+
+        Fix: when ``reasoning_content`` wasn't written by an earlier
+        branch AND we captured reasoning text from streaming deltas,
+        promote it to ``reasoning_content`` at write time.
+        """
+        # SDK-style object that exposes ``reasoning`` but NOT
+        # ``reasoning_content`` — the streaming-only provider shape.
+        msg = _mock_assistant_msg(content="answer", reasoning="hidden thinking")
+        assert not hasattr(msg, "reasoning_content")
+
+        result = agent._build_assistant_message(msg, "stop")
+
+        assert result["reasoning"] == "hidden thinking"
+        assert result["reasoning_content"] == "hidden thinking"
+
+    def test_sdk_reasoning_content_still_wins_over_fallback(self, agent):
+        """Additive fallback must not override SDK-supplied reasoning_content.
+
+        When both ``reasoning`` and ``reasoning_content`` are present, the
+        SDK's own ``reasoning_content`` is authoritative (may carry
+        structured data the accumulator doesn't have).
+        """
+        msg = _mock_assistant_msg(
+            content="answer",
+            reasoning="summary only",
+            reasoning_content="structured provider scratchpad",
+        )
+        result = agent._build_assistant_message(msg, "stop")
+        assert result["reasoning_content"] == "structured provider scratchpad"
+
+    def test_no_reasoning_text_leaves_field_absent(self, agent):
+        """Non-thinking turns with no reasoning leave reasoning_content absent.
+
+        This preserves ``_copy_reasoning_content_for_api``'s downstream
+        tiers at replay time — cross-provider leak guard (#15748),
+        promote-from-``reasoning``, and DeepSeek/Kimi ""-pad — which
+        would all be bypassed if we eagerly wrote ``reasoning_content=""``
+        on every assistant turn regardless of provider.
+        """
+        msg = _mock_assistant_msg(content="plain answer")
+        result = agent._build_assistant_message(msg, "stop")
+        assert "reasoning_content" not in result
+
     def test_tool_call_extra_content_preserved(self, agent):
         """Gemini thinking models attach extra_content with thought_signature
         to tool calls. This must be preserved so subsequent API calls include it."""


### PR DESCRIPTION
Supersedes #16884 with a scoped rework that preserves existing read-side compensation.

## Summary
Streaming-only providers (glm, MiniMax, gpt-5.x via aigw, Anthropic via openai-compat shims) accumulate reasoning through `delta.reasoning_content` chunks but never expose it as a top-level attribute on the finalized SDK message. The existing `hasattr`-guarded block at `_build_assistant_message` therefore never wrote `reasoning_content` for those providers, so the chain-of-thought was persisted only under the internal `reasoning` key.

The poison is silent until the user later switches to a DeepSeek-v4 or Kimi thinking model, at which point replay 400s with "The reasoning_content in the thinking mode must be passed back to the API." Issue #16844 reports 4,031 poisoned messages across 1,101 session files on one install.

## Changes
- `run_agent.py` `_build_assistant_message`: additive fallback promotes the already-sanitized `reasoning_text` to `reasoning_content` when no earlier branch wrote it and reasoning text was actually captured. Existing SDK-attr branch and DeepSeek `""`-pad (#15250) are untouched.
- `tests/run_agent/test_run_agent.py`: 3 regression tests — streaming promotion path, SDK precedence, field-absent-when-no-reasoning invariant.

## Why not #16884 as-written
#16884 replaced the conditional with `msg["reasoning_content"] = ""` as a universal fallback, which would have:
1. Triggered the Anthropic adapter's `isinstance(reasoning_content, str)` branch to prepend an empty `{"type":"thinking","thinking":""}` block on every replayed assistant turn.
2. Sent `reasoning_content: ""` to every strict OpenAI-compatible provider (Mistral, Fireworks, stock OpenAI, GitHub Models).
3. Short-circuited `_copy_reasoning_content_for_api`'s step-1 string check on every turn, making tiers 2–4 dead code — including #15748's cross-provider reasoning-leak guard for DeepSeek/Kimi.

The layered approach here solves the write-side bug without changing the field's presence semantics for non-thinking sessions. Existing read-side ladder (cross-provider leak guard #15748, promote-from-`reasoning`, DeepSeek/Kimi thinking-pad) stays live as defense in depth.

## Validation
| | Before | After |
|---|---|---|
| Streaming reasoning persisted (glm, MiniMax, gpt-5.x via aigw) | missing `reasoning_content` → 400 on DeepSeek/Kimi replay | promoted at write time |
| SDK-exposed `reasoning_content` | preserved | preserved |
| DeepSeek tool-call `""`-pad (#15250) | fires | fires |
| Non-thinking turns (no reasoning) | field absent | field absent |
| `_copy_reasoning_content_for_api` tiers 2–4 | live | live |
| #15748 cross-provider leak guard | live | live |
| Targeted tests: `TestBuildAssistantMessage` + `test_deepseek_reasoning_content_echo` | n/a | 15 + 23 passing |

Credit @Sanjays2402 for the original diagnosis in #16884.

Refs #16844, #16884, #15250, #15353, #15748.