### PR TITLE
fix(delegate): clear acp_command when override_provider is set

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -994,6 +994,14 @@ def _build_child_agent(
         else (getattr(parent_agent, "acp_args", []) or [])
     )
 
+    # When override_provider is set (e.g. delegation.provider: minimax-cn),
+    # the subagent must use direct API calls — not the parent's ACP transport.
+    # Inheriting acp_command unconditionally causes run_agent.py to initialize
+    # CopilotACPClient, bypassing override credentials entirely (issue #16816).
+    if override_provider and not override_acp_command:
+        effective_acp_command = None
+        effective_acp_args = []
+
     if override_acp_command:
         # If explicitly forcing an ACP transport override, the provider MUST be copilot-acp
         # so run_agent.py initializes the CopilotACPClient.


### PR DESCRIPTION
Subagents now use direct API calls when `delegation.provider` is configured, instead of inheriting the parent's Copilot ACP transport.

Salvaged from #16839 by @ygd58 (buray). Duplicate PR #16882 by @YeahloYip fixed the same bug 2h18m later with a weaker guard that would nuke caller-supplied `acp_command` overrides; #16839's version correctly guards on `not override_acp_command`.

## Changes
- tools/delegate_tool.py: clear `effective_acp_command` / `effective_acp_args` when `override_provider` is set and no explicit `override_acp_command` was passed. Existing explicit ACP-override path is unchanged.

## Validation
- tests/tools/test_delegate.py: 120/120 passed
- E2E resolution simulation covering four paths (delegation.provider only, no-override ACP parent, explicit ACP-override + provider, non-ACP parent) all behave as expected.

Fixes #16816.