### PR TITLE
fix(cli): warn about stale dashboard processes after hermes update

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5213,6 +5213,80 @@ def _build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
     return True
 
 
+def _warn_stale_dashboard_processes() -> None:
+    """Warn about running dashboard processes that still hold pre-update code.
+
+    ``hermes dashboard`` is a long-lived server process commonly started and
+    forgotten.  When ``hermes update`` replaces files on disk, the running
+    process keeps the old Python backend in memory while the JS bundle on
+    disk is updated, causing a silent frontend/backend mismatch (e.g. new
+    auth headers the old backend doesn't recognise → every API call 401s).
+
+    Unlike the gateway, the dashboard has no service manager (systemd /
+    launchd), so we can only warn — we don't auto-kill user-managed
+    background processes.
+    """
+    patterns = [
+        "hermes dashboard",
+        "hermes_cli.main dashboard",
+        "hermes_cli/main.py dashboard",
+    ]
+    self_pid = os.getpid()
+    dashboard_pids: list[int] = []
+
+    try:
+        if sys.platform == "win32":
+            result = subprocess.run(
+                ["wmic", "process", "get", "ProcessId,CommandLine",
+                 "/FORMAT:LIST"],
+                capture_output=True, text=True, timeout=10,
+            )
+            if result.returncode != 0:
+                return
+            current_cmd = ""
+            for line in result.stdout.split("\n"):
+                line = line.strip()
+                if line.startswith("CommandLine="):
+                    current_cmd = line[len("CommandLine="):]
+                elif line.startswith("ProcessId="):
+                    pid_str = line[len("ProcessId="):]
+                    if (any(p in current_cmd for p in patterns)
+                            and int(pid_str) != self_pid):
+                        try:
+                            dashboard_pids.append(int(pid_str))
+                        except ValueError:
+                            pass
+        else:
+            # Linux / macOS: scan /proc or fall back to ps.
+            result = subprocess.run(
+                ["pgrep", "-f", "hermes.*dashboard"],
+                capture_output=True, text=True, timeout=5,
+            )
+            if result.returncode == 0:
+                for line in result.stdout.strip().splitlines():
+                    try:
+                        pid = int(line.strip())
+                        if pid != self_pid:
+                            dashboard_pids.append(pid)
+                    except ValueError:
+                        pass
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return
+
+    if not dashboard_pids:
+        return
+
+    print()
+    print(f"⚠ {len(dashboard_pids)} dashboard process(es) still running "
+          f"with the previous version:")
+    for pid in dashboard_pids:
+        print(f"    PID {pid}")
+    print("  The running backend may not match the updated frontend,")
+    print("  causing silent auth failures or empty data.")
+    print("  Restart them to pick up the changes:")
+    print("    kill <pid> && hermes dashboard --port <port> ...")
+
+
 def _update_via_zip(args):
     """Update Hermes Agent by downloading a ZIP archive.
 
@@ -5347,6 +5421,7 @@ def _update_via_zip(args):
 
     print()
     print("✓ Update complete!")
+    _warn_stale_dashboard_processes()
 
 
 def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[str]:
@@ -7162,6 +7237,10 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 print("  (add `sudo` if any are in system scope)")
         except Exception as e:
             logger.debug("Legacy unit check during update failed: %s", e)
+
+        # Warn about stale dashboard processes — the dashboard has no
+        # service manager, so we can only tell the user to restart them.
+        _warn_stale_dashboard_processes()
 
         print()
         print("Tip: You can now select a provider and model:")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5257,19 +5257,32 @@ def _warn_stale_dashboard_processes() -> None:
                         except ValueError:
                             pass
         else:
-            # Linux / macOS: scan /proc or fall back to ps.
+            # Linux / macOS: scan the process table via ps and match against
+            # the same explicit patterns list used on Windows.  Using ps
+            # (rather than `pgrep -f "hermes.*dashboard"`) keeps us consistent
+            # with `hermes_cli.gateway._scan_gateway_pids` and avoids the
+            # greedy regex matching unrelated cmdlines that merely contain
+            # both words (e.g. a chat session discussing "dashboard").
             result = subprocess.run(
-                ["pgrep", "-f", "hermes.*dashboard"],
-                capture_output=True, text=True, timeout=5,
+                ["ps", "-A", "-o", "pid=,command="],
+                capture_output=True, text=True, timeout=10,
             )
             if result.returncode == 0:
-                for line in result.stdout.strip().splitlines():
+                for line in result.stdout.split("\n"):
+                    stripped = line.strip()
+                    if not stripped or "grep" in stripped:
+                        continue
+                    parts = stripped.split(None, 1)
+                    if len(parts) != 2:
+                        continue
                     try:
-                        pid = int(line.strip())
-                        if pid != self_pid:
-                            dashboard_pids.append(pid)
+                        pid = int(parts[0])
                     except ValueError:
-                        pass
+                        continue
+                    command = parts[1]
+                    if (any(p in command for p in patterns)
+                            and pid != self_pid):
+                        dashboard_pids.append(pid)
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
         return
 

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -1,0 +1,106 @@
+"""Tests for _warn_stale_dashboard_processes — stale dashboard detection.
+
+Ensures ``hermes update`` warns the user when dashboard processes from a
+previous version are still running after files on disk have been replaced.
+See #16872.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from hermes_cli.main import _warn_stale_dashboard_processes
+
+
+class TestWarnStaleDashboardProcesses:
+    """Unit tests for the stale dashboard process warning."""
+
+    def test_no_warning_when_no_dashboard_running(self, capsys):
+        """pgrep finds nothing — no warning should be printed."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=1, stdout="", stderr=""
+            )
+            _warn_stale_dashboard_processes()
+        output = capsys.readouterr().out
+        assert "dashboard process" not in output
+
+    def test_warning_printed_for_running_dashboard(self, capsys):
+        """pgrep finds a dashboard PID — warning with PID should appear."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout="12345\n", stderr=""
+            )
+            _warn_stale_dashboard_processes()
+        output = capsys.readouterr().out
+        assert "1 dashboard process" in output
+        assert "PID 12345" in output
+        assert "kill <pid>" in output
+
+    def test_multiple_dashboard_pids(self, capsys):
+        """Multiple dashboard processes — all PIDs listed."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout="12345\n12346\n12347\n", stderr=""
+            )
+            _warn_stale_dashboard_processes()
+        output = capsys.readouterr().out
+        assert "3 dashboard process" in output
+        assert "PID 12345" in output
+        assert "PID 12346" in output
+        assert "PID 12347" in output
+
+    def test_self_pid_excluded(self, capsys):
+        """The current process PID should not be reported."""
+        with patch("subprocess.run") as mock_run:
+            # Return the current process PID
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout=f"{os.getpid()}\n12345\n",
+                stderr="",
+            )
+            _warn_stale_dashboard_processes()
+        output = capsys.readouterr().out
+        assert str(os.getpid()) not in output
+        assert "PID 12345" in output
+
+    def test_pgrep_not_found_silently_ignored(self, capsys):
+        """If pgrep is missing (FileNotFoundError), no crash, no warning."""
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            _warn_stale_dashboard_processes()
+        output = capsys.readouterr().out
+        assert output == ""
+
+    def test_pgrep_timeout_silently_ignored(self, capsys):
+        """If pgrep times out, no crash, no warning."""
+        import subprocess as sp
+
+        with patch("subprocess.run", side_effect=sp.TimeoutExpired("pgrep", 5)):
+            _warn_stale_dashboard_processes()
+        output = capsys.readouterr().out
+        assert output == ""
+
+    def test_empty_pgrep_output_no_warning(self, capsys):
+        """pgrep returns 0 but empty stdout — no warning."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout="\n", stderr=""
+            )
+            _warn_stale_dashboard_processes()
+        output = capsys.readouterr().out
+        assert "dashboard process" not in output
+
+    def test_invalid_pid_lines_skipped(self, capsys):
+        """Non-numeric lines from pgrep should be skipped gracefully."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout="notapid\n12345\nalso_bad\n", stderr=""
+            )
+            _warn_stale_dashboard_processes()
+        output = capsys.readouterr().out
+        assert "PID 12345" in output
+        assert "1 dashboard process" in output

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -16,24 +16,36 @@ import pytest
 from hermes_cli.main import _warn_stale_dashboard_processes
 
 
+def _ps_line(pid: int, cmd: str) -> str:
+    """Format a line as it would appear in ``ps -A -o pid=,command=`` output."""
+    return f"{pid:>7} {cmd}"
+
+
 class TestWarnStaleDashboardProcesses:
     """Unit tests for the stale dashboard process warning."""
 
     def test_no_warning_when_no_dashboard_running(self, capsys):
-        """pgrep finds nothing — no warning should be printed."""
+        """ps returns no matching processes — no warning should be printed."""
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(
-                returncode=1, stdout="", stderr=""
+                returncode=0,
+                stdout=_ps_line(111, "/usr/bin/python3 -m some.other.module")
+                + "\n"
+                + _ps_line(222, "/usr/bin/bash")
+                + "\n",
+                stderr="",
             )
             _warn_stale_dashboard_processes()
         output = capsys.readouterr().out
         assert "dashboard process" not in output
 
     def test_warning_printed_for_running_dashboard(self, capsys):
-        """pgrep finds a dashboard PID — warning with PID should appear."""
+        """ps finds a dashboard PID — warning with PID should appear."""
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(
-                returncode=0, stdout="12345\n", stderr=""
+                returncode=0,
+                stdout=_ps_line(12345, "python3 -m hermes_cli.main dashboard --port 9119") + "\n",
+                stderr="",
             )
             _warn_stale_dashboard_processes()
         output = capsys.readouterr().out
@@ -45,7 +57,13 @@ class TestWarnStaleDashboardProcesses:
         """Multiple dashboard processes — all PIDs listed."""
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(
-                returncode=0, stdout="12345\n12346\n12347\n", stderr=""
+                returncode=0,
+                stdout="\n".join([
+                    _ps_line(12345, "python3 -m hermes_cli.main dashboard --port 9119"),
+                    _ps_line(12346, "hermes dashboard --port 9120 --no-open"),
+                    _ps_line(12347, "python /home/x/hermes_cli/main.py dashboard"),
+                ]) + "\n",
+                stderr="",
             )
             _warn_stale_dashboard_processes()
         output = capsys.readouterr().out
@@ -57,35 +75,39 @@ class TestWarnStaleDashboardProcesses:
     def test_self_pid_excluded(self, capsys):
         """The current process PID should not be reported."""
         with patch("subprocess.run") as mock_run:
-            # Return the current process PID
             mock_run.return_value = MagicMock(
                 returncode=0,
-                stdout=f"{os.getpid()}\n12345\n",
+                stdout="\n".join([
+                    _ps_line(os.getpid(), "python3 -m hermes_cli.main dashboard"),
+                    _ps_line(12345, "hermes dashboard --port 9119"),
+                ]) + "\n",
                 stderr="",
             )
             _warn_stale_dashboard_processes()
         output = capsys.readouterr().out
-        assert str(os.getpid()) not in output
+        # The self PID may still appear inside an unrelated context, so anchor
+        # the check to "PID <self>" which is how the warning prints.
+        assert f"PID {os.getpid()}" not in output
         assert "PID 12345" in output
 
-    def test_pgrep_not_found_silently_ignored(self, capsys):
-        """If pgrep is missing (FileNotFoundError), no crash, no warning."""
+    def test_ps_not_found_silently_ignored(self, capsys):
+        """If ps is missing (FileNotFoundError), no crash, no warning."""
         with patch("subprocess.run", side_effect=FileNotFoundError):
             _warn_stale_dashboard_processes()
         output = capsys.readouterr().out
         assert output == ""
 
-    def test_pgrep_timeout_silently_ignored(self, capsys):
-        """If pgrep times out, no crash, no warning."""
+    def test_ps_timeout_silently_ignored(self, capsys):
+        """If ps times out, no crash, no warning."""
         import subprocess as sp
 
-        with patch("subprocess.run", side_effect=sp.TimeoutExpired("pgrep", 5)):
+        with patch("subprocess.run", side_effect=sp.TimeoutExpired("ps", 10)):
             _warn_stale_dashboard_processes()
         output = capsys.readouterr().out
         assert output == ""
 
-    def test_empty_pgrep_output_no_warning(self, capsys):
-        """pgrep returns 0 but empty stdout — no warning."""
+    def test_empty_ps_output_no_warning(self, capsys):
+        """ps returns 0 but empty stdout — no warning."""
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(
                 returncode=0, stdout="\n", stderr=""
@@ -95,12 +117,61 @@ class TestWarnStaleDashboardProcesses:
         assert "dashboard process" not in output
 
     def test_invalid_pid_lines_skipped(self, capsys):
-        """Non-numeric lines from pgrep should be skipped gracefully."""
+        """Malformed ps lines should be skipped gracefully."""
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(
-                returncode=0, stdout="notapid\n12345\nalso_bad\n", stderr=""
+                returncode=0,
+                stdout="\n".join([
+                    "notapid hermes dashboard --bad",
+                    _ps_line(12345, "hermes dashboard --port 9119"),
+                    "   ",
+                ]) + "\n",
+                stderr="",
             )
             _warn_stale_dashboard_processes()
         output = capsys.readouterr().out
         assert "PID 12345" in output
         assert "1 dashboard process" in output
+
+    def test_unrelated_process_containing_word_dashboard_not_matched(self, capsys):
+        """A process whose cmdline contains 'dashboard' but isn't a hermes
+        dashboard process must NOT be flagged.  This guards against the old
+        ``pgrep -f "hermes.*dashboard"`` greedy regex that matched e.g. a
+        chat session argv containing both words.
+        """
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout="\n".join([
+                    # Legitimate dashboard — should match.
+                    _ps_line(12345, "python3 -m hermes_cli.main dashboard --port 9119"),
+                    # hermes running something else, with "dashboard" as a
+                    # substring of an unrelated arg — should NOT match.
+                    _ps_line(22222, "python3 -m hermes_cli.main chat -q 'rewrite my dashboard'"),
+                    # Completely unrelated process mentioning dashboard.
+                    _ps_line(33333, "node /opt/grafana/dashboard-server.js"),
+                ]) + "\n",
+                stderr="",
+            )
+            _warn_stale_dashboard_processes()
+        output = capsys.readouterr().out
+        assert "1 dashboard process" in output
+        assert "PID 12345" in output
+        assert "PID 22222" not in output
+        assert "PID 33333" not in output
+
+    def test_grep_lines_ignored(self, capsys):
+        """Lines containing 'grep' (from a pipe in ps output) are ignored."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout="\n".join([
+                    _ps_line(99999, "grep hermes dashboard"),
+                    _ps_line(12345, "hermes dashboard --port 9119"),
+                ]) + "\n",
+                stderr="",
+            )
+            _warn_stale_dashboard_processes()
+        output = capsys.readouterr().out
+        assert "PID 99999" not in output
+        assert "PID 12345" in output


### PR DESCRIPTION
Salvages #16881 (@Societus) with a follow-up tightening commit.

## What this PR does
After `hermes update` finishes (both git and zip paths), scans the process table for running `hermes dashboard` processes and prints a warning with PIDs + restart instructions.

## Why
v0.11.0 added `X-Hermes-Session-Token`. A dashboard process started before the update keeps the old Python backend in memory while the JS bundle on disk gets replaced — the new frontend sends headers the stale backend doesn't recognize, so every API call returns 401 with no visible error (HTML loads, all data empty). Fixes #16872.

The dashboard has no service manager (unlike the gateway, which systemd/launchd auto-restart), so we can only warn — not auto-kill.

## Changes
- **`hermes_cli/main.py`**: new `_warn_stale_dashboard_processes()` called from `_cmd_update_impl` (git path) and `_update_via_zip` (zip path). Cross-platform: `ps` on Linux/macOS, `wmic` on Windows. Excludes self-PID. Swallows `FileNotFoundError`/`TimeoutExpired`/`OSError`.
- **`tests/hermes_cli/test_update_stale_dashboard.py`**: 10 unit tests — warning fires/doesn't, multi-PID, self excluded, missing binary, timeout, malformed lines, grep-line filter, and a regression guard for the previously greedy pattern.

## Follow-up tightening (commit 63b71c52)
The original Linux branch used `pgrep -f "hermes.*dashboard"` — a greedy regex that matches any cmdline containing both words (e.g. a chat session discussing "dashboard" or an unrelated `grafana/dashboard-server`). Replaced with `ps -A -o pid=,command=` + the explicit patterns list already used on the Windows branch and in `hermes_cli.gateway._scan_gateway_pids`:
- `hermes dashboard`
- `hermes_cli.main dashboard`
- `hermes_cli/main.py dashboard`

## Validation
- 10/10 unit tests pass
- E2E: spawned fake `python3 -m hermes_cli.main dashboard --port 9119` via `exec -a`, confirmed detection. Also detected a real pre-existing dashboard on the same machine.

Closes #16881.
Fixes #16872.