### PR TITLE
feat(alibaba): add qwen3.6-plus to supported models

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -350,6 +350,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     # to https://dashscope-intl.aliyuncs.com/compatible-mode/v1 (OpenAI-compat)
     # or https://dashscope-intl.aliyuncs.com/apps/anthropic (Anthropic-compat).
     "alibaba": [
+        "qwen3.6-plus",
         "kimi-k2.5",
         "qwen3.5-plus",
         "qwen3-coder-plus",

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -41,6 +41,7 @@ PYPROJECT_FILE = REPO_ROOT / "pyproject.toml"
 AUTHOR_MAP = {
     # teknium (multiple emails)
     "teknium1@gmail.com": "teknium1",
+    "qiyin.zuo@pcitc.com": "qiyin-code",
     "teknium@nousresearch.com": "teknium1",
     "127238744+teknium1@users.noreply.github.com": "teknium1",
     # Matrix parity salvage batch (April 2026)


### PR DESCRIPTION
Salvage of #16869 by @qiyin-code onto current main.

## Summary
Adds `qwen3.6-plus` to the Alibaba DashScope curated model list so `/model qwen3.6-plus` no longer auto-corrects to `qwen3.5-plus`.

## Changes
- `hermes_cli/models.py`: +1 line in `_PROVIDER_MODELS["alibaba"]`
- `scripts/release.py`: AUTHOR_MAP entry for @qiyin-code

Closes #16869.