### PR TITLE
fix(tui): `/model` writes HERMES_TUI_PROVIDER unconditionally (#16857)

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1171,6 +1171,61 @@ def test_config_set_model_syncs_inference_provider_env(monkeypatch):
     assert os.environ["HERMES_INFERENCE_PROVIDER"] == "anthropic"
 
 
+def test_config_set_model_syncs_tui_provider_unconditionally(monkeypatch):
+    """Regression for #16857: /model must set HERMES_TUI_PROVIDER even when
+    it wasn't pre-set on launch, so a later /new (which re-runs
+    _resolve_startup_runtime) honours the user's explicit provider choice
+    instead of falling through to static-catalog detection and picking a
+    coincidentally-matching native provider.
+    """
+
+    class _Agent:
+        provider = "openrouter"
+        model = "old/model"
+        base_url = ""
+        api_key = "sk-or"
+
+        def switch_model(self, **_kwargs):
+            return None
+
+    result = types.SimpleNamespace(
+        success=True,
+        new_model="deepseek-v4-pro",
+        target_provider="custom:xuanji",
+        api_key="sk-xuanji",
+        base_url="https://xuanji.example/v1",
+        api_mode="chat_completions",
+        warning_message="",
+    )
+
+    server._sessions["sid"] = _session(agent=_Agent())
+    monkeypatch.delenv("HERMES_TUI_PROVIDER", raising=False)
+    monkeypatch.delenv("HERMES_INFERENCE_PROVIDER", raising=False)
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.switch_model", lambda **_kwargs: result
+    )
+    monkeypatch.setattr(server, "_restart_slash_worker", lambda session: None)
+    monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
+
+    server.handle_request(
+        {
+            "id": "1",
+            "method": "config.set",
+            "params": {
+                "session_id": "sid",
+                "key": "model",
+                "value": "deepseek-v4-pro --provider custom:xuanji",
+            },
+        }
+    )
+
+    # Both env vars must reflect the user's choice. HERMES_TUI_PROVIDER is
+    # the canonical explicit-this-process carrier consumed by
+    # _resolve_startup_runtime() on /new.
+    assert os.environ["HERMES_TUI_PROVIDER"] == "custom:xuanji"
+    assert os.environ["HERMES_INFERENCE_PROVIDER"] == "custom:xuanji"
+
+
 def test_config_set_model_syncs_tui_provider_env(monkeypatch):
     class Agent:
         model = "gpt-5.3-codex"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -843,14 +843,19 @@ def _apply_model_switch(sid: str, session: dict, raw_input: str) -> dict:
 
     os.environ["HERMES_MODEL"] = result.new_model
     os.environ["HERMES_INFERENCE_MODEL"] = result.new_model
-    # Keep the process-level provider env var in sync with the user's explicit
-    # choice so any ambient re-resolution (credential pool refresh, compressor
-    # rebuild, aux clients) resolves to the new provider instead of the
-    # original one persisted in config or env.
+    # Keep the process-level provider env vars in sync with the user's
+    # explicit choice so any ambient re-resolution (credential pool refresh,
+    # compressor rebuild, aux clients) and startup re-resolution on /new
+    # both pick up the new provider instead of the original one persisted
+    # in config or env.
+    #
+    # HERMES_TUI_PROVIDER is the canonical "explicit-this-process" carrier
+    # consumed by _resolve_startup_runtime() — set it unconditionally on
+    # /model so /new can't fall through to static-catalog detection and
+    # pick a coincidentally-matching native provider (fixes #16857).
     if result.target_provider:
         os.environ["HERMES_INFERENCE_PROVIDER"] = result.target_provider
-        if os.environ.get("HERMES_TUI_PROVIDER"):
-            os.environ["HERMES_TUI_PROVIDER"] = result.target_provider
+        os.environ["HERMES_TUI_PROVIDER"] = result.target_provider
     if persist_global:
         _persist_model_switch(result)
     return {"value": result.new_model, "warning": result.warning_message or ""}


### PR DESCRIPTION
## Summary
`/new` after `/model <custom-provider>:<model>` now honours the user's explicit provider choice instead of silently reverting to a native provider that coincidentally has the model in its static catalog (e.g. `deepseek-v4-pro` → native `deepseek` → 401).

## Root cause
In `_apply_model_switch` (tui_gateway/server.py:850-853), `/model` set `HERMES_INFERENCE_PROVIDER` unconditionally but mirrored to `HERMES_TUI_PROVIDER` **only if it was already set**. Sessions launched without `--provider` never have `HERMES_TUI_PROVIDER` set, so on `/new`, `_resolve_startup_runtime()` skipped the explicit-provider early return (which keys off `HERMES_TUI_PROVIDER`) and fell through to `detect_static_provider_for_model()`, which matched the model name against native catalogs.

## Why fix at the `/model` writeback site, not `_resolve_startup_runtime`
@Bartok9's original PR #16873 early-returned `HERMES_INFERENCE_PROVIDER` in `_resolve_startup_runtime`. That works for this bug but partially reverts #15755 (commit 57b43fd), which deliberately removed that early return because `HERMES_INFERENCE_PROVIDER` can be ambient (shell-inherited, .env, persisted from prior processes) and ambient values shouldn't short-circuit resolution.

Brooklyn's invariant from #15755:
- `HERMES_TUI_PROVIDER` = explicit-this-process (user chose it via `--provider` or `/model`)
- `HERMES_INFERENCE_PROVIDER` = ambient (may be stale)

The real bug was that `/model` wasn't writing to the canonical "explicit" carrier. Fixing at the writeback site preserves both invariants simultaneously.

## Changes
- `tui_gateway/server.py`: `/model` now sets `HERMES_TUI_PROVIDER = target_provider` unconditionally alongside `HERMES_INFERENCE_PROVIDER`.
- `tests/test_tui_gateway_server.py`: regression test `test_config_set_model_syncs_tui_provider_unconditionally` covers the #16857 scenario (no pre-set `HERMES_TUI_PROVIDER`, custom provider selection).

## Validation
| | Before | After |
|---|---|---|
| Targeted tests (8) | N/A | all pass (`syncs_tui_provider`, `syncs_inference_provider`, `startup_runtime`) |
| E2E `/model custom:xuanji` → `/new` | resolves to native `deepseek` → 401 | resolves to `custom:xuanji` |
| E2E ambient `HERMES_INFERENCE_PROVIDER` alone | falls through to static detection | falls through to static detection (unchanged; #15755 invariant preserved) |

## Credit
Bug report, diagnosis, and initial fix: @Bartok9 in #16857 and #16873. This salvage PR reapplies the fix at the writeback site to avoid reverting #15755.

Closes #16857
Supersedes #16873