### PR TITLE
feat(ollama): dynamic model capability detection via /api/show

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -945,6 +945,47 @@ def query_ollama_num_ctx(model: str, base_url: str, api_key: str = "") -> Option
     return None
 
 
+def query_ollama_capabilities(model: str, base_url: str, api_key: str = "") -> set:
+    """Query an Ollama server for the model's capabilities.
+
+    Returns a set of capability strings (e.g. ``{"tools", "vision", "thinking"}``)
+    from the ``/api/show`` endpoint's ``capabilities`` array.  Returns an empty
+    set if the server is unreachable, not Ollama, or the field is absent.
+
+    This enables dynamic capability detection so Hermes knows whether an
+    Ollama-hosted model supports tools, vision, thinking etc. without relying
+    on hardcoded model lists.
+    """
+    import httpx
+
+    bare_model = _strip_provider_prefix(model)
+    server_url = base_url.rstrip("/")
+    if server_url.endswith("/v1"):
+        server_url = server_url[:-3]
+
+    try:
+        server_type = detect_local_server_type(base_url, api_key=api_key)
+    except Exception:
+        return set()
+    if server_type != "ollama":
+        return set()
+
+    headers = _auth_headers(api_key)
+
+    try:
+        with httpx.Client(timeout=3.0, headers=headers) as client:
+            resp = client.post(f"{server_url}/api/show", json={"name": bare_model})
+            if resp.status_code != 200:
+                return set()
+            data = resp.json()
+            capabilities = data.get("capabilities")
+            if isinstance(capabilities, list):
+                return {str(c).lower() for c in capabilities if isinstance(c, str)}
+    except Exception:
+        pass
+    return set()
+
+
 def _query_local_context_length(model: str, base_url: str, api_key: str = "") -> Optional[int]:
     """Query a local server for the model's context length."""
     import httpx

--- a/run_agent.py
+++ b/run_agent.py
@@ -102,6 +102,7 @@ from agent.model_metadata import (
     parse_available_output_tokens_from_error,
     save_context_length, is_local_endpoint,
     query_ollama_num_ctx,
+    query_ollama_capabilities,
 )
 from agent.context_compressor import ContextCompressor
 from agent.subdirectory_hints import SubdirectoryHintTracker
@@ -2010,6 +2011,22 @@ class AIAgent:
             logger.info(
                 "Ollama num_ctx: will request %d tokens (model max from /api/show)",
                 self._ollama_num_ctx,
+            )
+
+        # Detect Ollama model capabilities (tools, vision, thinking) from the
+        # /api/show endpoint so Hermes can adapt behaviour without hardcoding.
+        self._ollama_capabilities: set = set()
+        if self.base_url and is_local_endpoint(self.base_url):
+            try:
+                _caps = query_ollama_capabilities(self.model, self.base_url, api_key=self.api_key or "")
+                if _caps:
+                    self._ollama_capabilities = _caps
+            except Exception as exc:
+                logger.debug("Ollama capabilities detection failed: %s", exc)
+        if self._ollama_capabilities and not self.quiet_mode:
+            logger.info(
+                "Ollama capabilities: %s",
+                ", ".join(sorted(self._ollama_capabilities)),
             )
 
         if not self.quiet_mode:
@@ -4607,6 +4624,11 @@ class AIAgent:
                 # "auto" or any unrecognised value — use hardcoded defaults
                 model_lower = (self.model or "").lower()
                 _inject = any(p in model_lower for p in TOOL_USE_ENFORCEMENT_MODELS)
+                # Also inject when the Ollama server reports tool capability
+                # (dynamic detection via /api/show — no hardcoding needed).
+                if not _inject and hasattr(self, "_ollama_capabilities"):
+                    if "tools" in self._ollama_capabilities:
+                        _inject = True
             if _inject:
                 prompt_parts.append(TOOL_USE_ENFORCEMENT_GUIDANCE)
                 _model_lower = (self.model or "").lower()


### PR DESCRIPTION
## Summary

Adds automatic Ollama model capability detection via the `/api/show` endpoint, matching the existing `query_ollama_num_ctx()` pattern already in the codebase.

## Problem

Currently, `TOOL_USE_ENFORCEMENT_MODELS` in `agent/prompt_builder.py` only covers `("gpt", "codex", "gemini", "gemma", "grok")`. All Ollama-hosted models (kimi-k2.6, glm-5, minimax-m2.7, deepseek-v4-pro, etc.) are excluded and require manual `agent.tool_use_enforcement` config overrides to get working tool-calling behaviour.

## Solution

- **New function** `query_ollama_capabilities()` in `agent/model_metadata.py` — identical pattern to the existing `query_ollama_num_ctx()`. Queries `/api/show`, reads the `capabilities` array, returns `{"tools", "vision", "thinking", ...}`.

- **Wire into `AIAgent.__init__()`** in `run_agent.py` — after the existing `num_ctx` detection, also detect capabilities and store them in `self._ollama_capabilities`.

- **Extend tool-use enforcement** — in the `"auto"` mode: if the Ollama server reports `"tools"` capability, inject enforcement guidance regardless of whether the model name matches the hardcoded list.

## Changes

| File | Lines | Change |
|------|-------|--------|
| `agent/model_metadata.py` | +41 | New `query_ollama_capabilities()` function |
| `run_agent.py` | +22 | Import, init detection, enforcement extension |

## Verified Against Real Ollama Server

```
kimi-k2.6:cloud    → {"tools", "thinking", "completion", "vision"}
glm-5:cloud        → {"tools", "thinking", "completion"}
minimax-m2.7:cloud → {"tools", "thinking", "completion"}
deepseek-v4-pro    → {"tools", "thinking", "completion"}
Non-Ollama models  → set()  (graceful no-op)
```

## Backwards Compatibility

- Pure additive change — no existing code paths modified.
- If `/api/show` fails (timeout, non-Ollama endpoint, etc.) → returns empty set → Hermes falls back to existing behaviour.
- `agent.tool_use_enforcement` config overrides still take precedence — dynamic detection is only additive in `"auto"` mode.
