### PR TITLE
fix(mcp): move discovery out of model_tools import side effect (#16856)

### DIFF
--- a/acp_adapter/entry.py
+++ b/acp_adapter/entry.py
@@ -112,6 +112,17 @@ def main() -> None:
     import acp
     from .server import HermesACPAgent
 
+    # MCP tool discovery from config.yaml — run before asyncio.run() so
+    # it's safe to use blocking waits.  (ACP also registers per-session
+    # MCP servers dynamically via asyncio.to_thread inside the event
+    # loop; that path is unaffected.)  Moved from model_tools.py module
+    # scope to avoid freezing the gateway's loop on lazy import (#16856).
+    try:
+        from tools.mcp_tool import discover_mcp_tools
+        discover_mcp_tools()
+    except Exception:
+        logger.debug("MCP tool discovery failed at ACP startup", exc_info=True)
+
     agent = HermesACPAgent()
     try:
         asyncio.run(acp.run_agent(agent, use_unstable_protocol=True))

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11671,6 +11671,19 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     atexit.register(remove_pid_file)
     atexit.register(release_gateway_runtime_lock)
 
+    # MCP tool discovery — run in an executor so the asyncio event loop
+    # stays responsive even when a configured MCP server is slow or
+    # unreachable.  discover_mcp_tools() uses a blocking 120s wait
+    # internally; calling it from the loop thread would freeze platform
+    # heartbeats (Discord shard, Telegram polling) until it returned.
+    # See #16856.
+    try:
+        from tools.mcp_tool import discover_mcp_tools
+        _loop = asyncio.get_running_loop()
+        await _loop.run_in_executor(None, discover_mcp_tools)
+    except Exception as e:
+        logger.debug("MCP tool discovery failed: %s", e)
+
     # Start the gateway
     success = await runner.start()
     if not success:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10102,6 +10102,17 @@ Examples:
                 "plugin discovery failed at CLI startup", exc_info=True,
             )
         try:
+            # MCP tool discovery — no event loop running in CLI/TUI startup,
+            # so inline is safe.  Moved here from model_tools.py module scope
+            # to avoid freezing the gateway's event loop on its first message
+            # via the same lazy import path (#16856).
+            from tools.mcp_tool import discover_mcp_tools
+            discover_mcp_tools()
+        except Exception:
+            logger.debug(
+                "MCP tool discovery failed at CLI startup", exc_info=True,
+            )
+        try:
             from hermes_cli.config import load_config
             from agent.shell_hooks import register_from_config
             register_from_config(load_config(), accept_hooks=_accept_hooks)

--- a/model_tools.py
+++ b/model_tools.py
@@ -138,12 +138,18 @@ def _run_async(coro):
 
 discover_builtin_tools()
 
-# MCP tool discovery (external MCP servers from config)
-try:
-    from tools.mcp_tool import discover_mcp_tools
-    discover_mcp_tools()
-except Exception as e:
-    logger.debug("MCP tool discovery failed: %s", e)
+# MCP tool discovery (external MCP servers from config) used to run here as
+# a module-level side effect.  It was removed because discover_mcp_tools()
+# internally uses a blocking future.result(timeout=120) wait, and the
+# gateway lazy-imports this module from inside the asyncio event loop on
+# the first user message — freezing Discord/Telegram heartbeats for up to
+# 120s whenever any configured MCP server was slow or unreachable (#16856).
+#
+# Each entry point now runs discovery explicitly at its own startup:
+#   - gateway/run.py            -> start_gateway() uses run_in_executor
+#   - cli.py, hermes_cli/*      -> inline on startup (no event loop)
+#   - tui_gateway/server.py     -> inline on startup (no event loop)
+#   - acp_adapter/server.py     -> asyncio.to_thread on session init
 
 # Plugin tool discovery (user/project/pip plugins)
 try:

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -105,6 +105,17 @@ def _log_exit(reason: str) -> None:
 def main():
     _install_sidecar_publisher()
 
+    # MCP tool discovery — inline is safe here: TUI entry is a plain
+    # sync loop with no asyncio event loop to block.  Previously ran as
+    # a model_tools.py module-level side effect; moved to explicit
+    # startup calls to avoid freezing the gateway's loop on lazy import
+    # (#16856).
+    try:
+        from tools.mcp_tool import discover_mcp_tools
+        discover_mcp_tools()
+    except Exception:
+        pass
+
     if not write_json({
         "jsonrpc": "2.0",
         "method": "event",


### PR DESCRIPTION
## Summary
Removes the module-level `discover_mcp_tools()` call in `model_tools.py` so lazy-importing this module from inside an asyncio event loop no longer blocks the loop for up to 120s when an MCP server is slow or unreachable. Closes #16856. Supersedes #16877 (same intent, cleaner fix per suggestion #1 in the issue — credit @Bartok9).

## Root cause
`model_tools.py` ran `discover_mcp_tools()` as an import-time side effect. The gateway lazy-imports `run_agent` (→ `model_tools`) on the first user message, which executes inside the asyncio event loop thread. `discover_mcp_tools()` uses `future.result(timeout=120)` internally, freezing Discord shard heartbeats and Telegram polling for up to 120s whenever a configured MCP server was unreachable.

## Changes
- `model_tools.py`: remove module-level `discover_mcp_tools()` call (keeps the symbol importable for explicit callers).
- `gateway/run.py`: run discovery via `loop.run_in_executor(None, discover_mcp_tools)` in `start_gateway()` before `runner.start()` — loop stays responsive, tools are ready before the first message arrives.
- `hermes_cli/main.py`: inline discovery in the agent-command startup path (no event loop running).
- `tui_gateway/entry.py`: inline discovery in `main()` (sync stdin loop).
- `acp_adapter/entry.py`: inline discovery before `asyncio.run()` (sync context).

## Why this instead of PR #16877
#16877 added event-loop detection inside `model_tools.py` and offloaded discovery to an executor when a loop was running. That worked, but the module-level call made the first gateway message race against discovery (first message could hit the model before MCP tool schemas were registered). Moving the call into each entry point's startup sequence avoids both problems: no import-time side effect, and gateway discovery completes **before** platforms accept traffic.

## Validation
| | Before | After |
|---|---|---|
| `import model_tools` triggers MCP discovery | yes | no (verified via subprocess probe) |
| Gateway first-message delay w/ dead MCP server | up to 120s | ~0s (runs at startup, not first message) |
| `tests/test_model_tools_async_bridge.py` | 11 passed | 11 passed |
| `tests/tools/test_mcp_tool.py` | 177 passed | 177 passed |

## How to verify manually
1. Configure an unreachable MCP server in `config.yaml`.
2. Start the gateway — discovery happens in the executor during startup, logs show "(1 failed)" after the retry window.
3. Send the first Discord/Telegram message.
4. Before this PR: first message hangs for ~120s, heartbeat warnings flood logs.
5. After this PR: first message responds promptly, no heartbeat warnings.