### PR TITLE
fix(credential-pool): pool rotation should not count toward api_max_retries (#16830)

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -931,6 +931,30 @@ class CredentialPool:
         available = self._available_entries()
         return available[0] if available else None
 
+    def has_unexhausted_alternates(self) -> bool:
+        """Return True if the pool has at least one entry besides the current
+        that is either unexhausted or whose exhaustion cooldown has elapsed.
+
+        Read-only; does not clear cooldown state or trigger refreshes.  Used by
+        retry logic to decide whether to rotate immediately on a transient
+        per-credential failure (e.g. 429) instead of burning a retry slot
+        retrying the same credential.
+        """
+        with self._lock:
+            if not self._entries:
+                return False
+            current_id = self._current_id
+            now = time.time()
+            for entry in self._entries:
+                if entry.id == current_id:
+                    continue
+                if entry.last_status != STATUS_EXHAUSTED:
+                    return True
+                exhausted_until = _exhausted_until(entry)
+                if exhausted_until is None or now >= exhausted_until:
+                    return True
+            return False
+
     def mark_exhausted_and_rotate(
         self,
         *,

--- a/run_agent.py
+++ b/run_agent.py
@@ -6376,9 +6376,21 @@ class AIAgent:
             return False, has_retried_429
 
         if effective_reason == FailoverReason.rate_limit:
-            if not has_retried_429:
-                return False, True
             rotate_status = status_code if status_code is not None else 429
+            # If the pool has other unexhausted credentials, rotate immediately
+            # rather than burning a retry slot retrying the same key. The rate
+            # limit window won't clear in our backoff interval, but a different
+            # key in the pool likely has fresh quota. This makes pool walking
+            # transparent to api_max_retries — only once every credential is
+            # exhausted does retry_count start incrementing.
+            has_alternates = False
+            try:
+                has_alternates = bool(pool.has_unexhausted_alternates())
+            except AttributeError:
+                # Older / mock pools without the method: keep prior behavior.
+                has_alternates = False
+            if not has_retried_429 and not has_alternates:
+                return False, True
             next_entry = pool.mark_exhausted_and_rotate(status_code=rotate_status, error_context=error_context)
             if next_entry is not None:
                 logger.info(

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -1568,3 +1568,158 @@ def test_codex_exhausted_entry_stays_stuck_without_auth_store_update(tmp_path, m
     # still skips it.
     available = pool._available_entries(clear_expired=True, refresh=False)
     assert available == []
+
+
+
+def test_has_unexhausted_alternates_true_when_other_entry_ok(tmp_path, monkeypatch):
+    """Pool with two ok entries reports alternates available."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "anthropic": [
+                    {
+                        "id": "cred-1",
+                        "label": "primary",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "***",
+                        "last_status": "ok",
+                    },
+                    {
+                        "id": "cred-2",
+                        "label": "secondary",
+                        "auth_type": "api_key",
+                        "priority": 1,
+                        "source": "manual",
+                        "access_token": "***",
+                        "last_status": "ok",
+                    },
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("anthropic")
+    pool.select()  # bind cred-1 as current
+    assert pool.has_unexhausted_alternates() is True
+
+
+def test_has_unexhausted_alternates_false_for_single_credential_pool(tmp_path, monkeypatch):
+    """Pool with only one entry reports no alternates."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "anthropic": [
+                    {
+                        "id": "cred-1",
+                        "label": "only",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "***",
+                        "last_status": "ok",
+                    },
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("anthropic")
+    pool.select()
+    assert pool.has_unexhausted_alternates() is False
+
+
+def test_has_unexhausted_alternates_false_when_other_in_cooldown(tmp_path, monkeypatch):
+    """Recently-exhausted entry whose cooldown has not elapsed should not
+    count as an unexhausted alternate."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "anthropic": [
+                    {
+                        "id": "cred-1",
+                        "label": "primary",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "***",
+                        "last_status": "ok",
+                    },
+                    {
+                        "id": "cred-2",
+                        "label": "secondary",
+                        "auth_type": "api_key",
+                        "priority": 1,
+                        "source": "manual",
+                        "access_token": "***",
+                        "last_status": "exhausted",
+                        # Just exhausted, cooldown hasn't elapsed.
+                        "last_status_at": time.time(),
+                        "last_error_code": 429,
+                    },
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("anthropic")
+    pool.select()  # cred-1 (only ok one) becomes current
+    assert pool.has_unexhausted_alternates() is False
+
+
+def test_has_unexhausted_alternates_true_when_other_cooldown_elapsed(tmp_path, monkeypatch):
+    """Entry whose exhaustion cooldown has elapsed counts as alternate again."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "anthropic": [
+                    {
+                        "id": "cred-1",
+                        "label": "primary",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "***",
+                        "last_status": "ok",
+                    },
+                    {
+                        "id": "cred-2",
+                        "label": "secondary",
+                        "auth_type": "api_key",
+                        "priority": 1,
+                        "source": "manual",
+                        "access_token": "***",
+                        "last_status": "exhausted",
+                        # 25 hours ago — well past any TTL.
+                        "last_status_at": time.time() - 90000,
+                        "last_error_code": 402,
+                    },
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("anthropic")
+    pool.select()  # cred-1 current
+    assert pool.has_unexhausted_alternates() is True

--- a/tests/agent/test_credential_pool_routing.py
+++ b/tests/agent/test_credential_pool_routing.py
@@ -156,9 +156,14 @@ class TestPoolRotationCycle:
         pool = MagicMock()
         pool.has_credentials.return_value = True
 
-        # mark_exhausted_and_rotate returns next entry until exhausted
+        # Track how many credentials have been rotated through. The pool has
+        # alternates as long as we haven't reached the last entry.
         self._rotation_index = 0
+        pool.has_unexhausted_alternates = MagicMock(
+            side_effect=lambda: self._rotation_index < pool_entries - 1
+        )
 
+        # mark_exhausted_and_rotate returns next entry until exhausted
         def rotate(status_code=None, error_context=None):
             self._rotation_index += 1
             if self._rotation_index < pool_entries:
@@ -173,9 +178,26 @@ class TestPoolRotationCycle:
 
         return agent, pool, entries
 
-    def test_first_429_sets_retry_flag_no_rotation(self):
-        """First 429 should just set has_retried_429=True, no rotation."""
-        agent, pool, _ = self._make_agent_with_pool(3)
+    def test_first_429_with_alternates_rotates_immediately(self):
+        """When the pool has unexhausted alternates, the first 429 should
+        rotate immediately rather than burning a retry slot on the same key."""
+        agent, pool, entries = self._make_agent_with_pool(3)
+        recovered, has_retried = agent._recover_with_credential_pool(
+            status_code=429, has_retried_429=False
+        )
+        assert recovered is True
+        assert has_retried is False  # reset after rotation
+        pool.mark_exhausted_and_rotate.assert_called_once_with(
+            status_code=429, error_context=None
+        )
+        agent._swap_credential.assert_called_once_with(entries[1])
+
+    def test_first_429_no_alternates_retries_same_credential(self):
+        """Single-credential pool (no alternates) preserves the original
+        retry-same-then-rotate behavior so transient 429s don't waste the only
+        available key."""
+        agent, pool, _ = self._make_agent_with_pool(1)
+        # Single-entry pool: has_unexhausted_alternates returns False from the start.
         recovered, has_retried = agent._recover_with_credential_pool(
             status_code=429, has_retried_429=False
         )
@@ -197,7 +219,7 @@ class TestPoolRotationCycle:
     def test_pool_exhaustion_returns_false(self):
         """When all credentials exhausted, recovery should return False."""
         agent, pool, _ = self._make_agent_with_pool(1)
-        # First 429 sets flag
+        # First 429 sets flag (single-entry pool, no alternates)
         _, has_retried = agent._recover_with_credential_pool(
             status_code=429, has_retried_429=False
         )
@@ -232,3 +254,36 @@ class TestPoolRotationCycle:
         )
         assert recovered is False
         assert has_retried is False
+
+    def test_full_pool_walk_does_not_burn_retry_slots(self):
+        """Regression for #16830: a 10-credential pool should walk through every
+        key on consecutive 429s without ever returning ``recovered=False`` until
+        the pool is fully exhausted. A False return is what the outer retry
+        loop counts as a retry attempt — so as long as recovery returns True,
+        retry_count stays at zero."""
+        agent, pool, entries = self._make_agent_with_pool(10)
+
+        has_retried_429 = False
+        recovered_count = 0
+        unrecovered_count = 0
+        # Simulate up to 12 consecutive 429s. With a 10-key pool, the first 10
+        # iterations should each rotate (recovered=True). Only after the pool
+        # is fully exhausted should recovery start returning False.
+        for _ in range(12):
+            recovered, has_retried_429 = agent._recover_with_credential_pool(
+                status_code=429, has_retried_429=has_retried_429
+            )
+            if recovered:
+                recovered_count += 1
+            else:
+                unrecovered_count += 1
+
+        # Every credential in the pool should have been rotated through before
+        # we start failing recovery — proving retry_count would not be
+        # incremented during pool walking with default api_max_retries=3.
+        assert recovered_count >= 9, (
+            f"expected to rotate through ~all 10 credentials, "
+            f"only rotated {recovered_count} times before pool exhausted"
+        )
+        # Once the pool is exhausted, the remaining iterations cannot rotate.
+        assert unrecovered_count >= 1, "pool exhaustion should eventually surface"

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3493,11 +3493,16 @@ class TestCredentialPoolRecovery:
         agent._swap_credential.assert_called_once_with(next_entry)
 
     def test_recover_with_pool_retries_first_429_then_rotates(self, agent):
+        """Single-credential pool (no alternates) — original behavior:
+        first 429 retries same credential, second 429 attempts to rotate."""
         next_entry = SimpleNamespace(label="secondary")
 
         class _Pool:
             def current(self):
                 return SimpleNamespace(label="primary")
+
+            def has_unexhausted_alternates(self):
+                return False  # single credential — nothing else to try
 
             def mark_exhausted_and_rotate(self, *, status_code, error_context=None):
                 assert status_code == 429
@@ -3518,6 +3523,34 @@ class TestCredentialPoolRecovery:
         recovered, retry_same = agent._recover_with_credential_pool(
             status_code=429,
             has_retried_429=True,
+        )
+        assert recovered is True
+        assert retry_same is False
+        agent._swap_credential.assert_called_once_with(next_entry)
+
+    def test_recover_with_pool_rotates_immediately_when_alternates_available(self, agent):
+        """Multi-credential pool — first 429 rotates immediately rather than
+        burning a retry slot on the same key. Regression for issue #16830."""
+        next_entry = SimpleNamespace(label="secondary")
+
+        class _Pool:
+            def current(self):
+                return SimpleNamespace(label="primary")
+
+            def has_unexhausted_alternates(self):
+                return True  # alternates available — rotate now
+
+            def mark_exhausted_and_rotate(self, *, status_code, error_context=None):
+                assert status_code == 429
+                return next_entry
+
+        agent._credential_pool = _Pool()
+        agent._swap_credential = MagicMock()
+
+        # First 429 should rotate immediately, not return (False, True).
+        recovered, retry_same = agent._recover_with_credential_pool(
+            status_code=429,
+            has_retried_429=False,
         )
         assert recovered is True
         assert retry_same is False


### PR DESCRIPTION
## Summary

- 429 on a credential with multi-key pool now rotates immediately instead of first burning a retry slot retrying the same key.
- Single-credential pools keep the original retry-same-then-rotate behavior so a transient 429 on the only available key isn't doubly punished.
- Pool walking is transparent to `api_max_retries` — only once every credential is exhausted does `retry_count` start incrementing.

## The bug

Fixes #16830. With a 10-key credential pool and the default `api_max_retries: 3`, only 2-3 keys ever get tried before the agent gives up. The remaining 7+ keys go unused even though they would have served the request.

Tracing `_recover_with_credential_pool` (in `run_agent.py`):

```
Iter 1: 429 on key #1 → returns (False, True)              → retry_count=1
Iter 2: 429 on key #1 → rotates to key #2, returns (True,…) → retry_count=1
Iter 3: 429 on key #2 → returns (False, True)              → retry_count=2
Iter 4: 429 on key #2 → rotates to key #3, returns (True,…) → retry_count=2
Iter 5: 429 on key #3 → returns (False, True)              → retry_count=3 → exit
```

Each credential consumed at least one retry slot before being exchanged, because the first 429 returned `(False, True)` and the outer loop did `retry_count += 1` (line 11315) before the second attempt that actually rotates.

## The fix

`agent/credential_pool.py` — new `has_unexhausted_alternates()`: a read-only query (no `_persist`, no refresh) that reports whether the pool has at least one entry besides the current one that is either unexhausted or whose cooldown has elapsed.

`run_agent.py` — rate-limit branch of `_recover_with_credential_pool`:

```python
has_alternates = False
try:
    has_alternates = bool(pool.has_unexhausted_alternates())
except AttributeError:
    has_alternates = False  # older / hand-rolled mock pools
if not has_retried_429 and not has_alternates:
    return False, True  # single credential — keep original behavior
next_entry = pool.mark_exhausted_and_rotate(...)
...
```

Multi-credential pool: first 429 → rotate immediately (no retry_count cost, fresh key likely has fresh quota).
Single-credential pool: first 429 → retry once before counting, preserving the safety net for transient blips on a lone key.

The `AttributeError` guard keeps existing tests with hand-rolled fake pools working without modification.

## Test plan

- [x] `tests/agent/test_credential_pool_routing.py` — `TestPoolRotationCycle` updated:
  - `test_first_429_with_alternates_rotates_immediately` (NEW): multi-credential → rotation on first 429
  - `test_first_429_no_alternates_retries_same_credential` (NEW): single-credential → original behavior
  - `test_full_pool_walk_does_not_burn_retry_slots` (NEW): 10-credential pool walks ~all keys before recovery returns False
- [x] `tests/run_agent/test_run_agent.py::TestCredentialPoolRecovery::test_recover_with_pool_rotates_immediately_when_alternates_available` (NEW): direct repro of the issue scenario.
- [x] `tests/agent/test_credential_pool.py` — four new direct unit tests for `has_unexhausted_alternates`: two ok entries, single entry, other-in-cooldown, other-cooldown-elapsed.
- [x] Regression guard: reverted `run_agent.py` + `agent/credential_pool.py`, the 3 new behavior tests failed with `recovered=False` where they now expect `True`. Restored fix → all 60 tests in `tests/agent/test_credential_pool*` and `TestCredentialPoolRecovery` pass.
- [x] CI's pre-existing baseline failures in `test_anthropic_adapter.py`, `test_bedrock_adapter.py`, `test_copilot_acp_client.py` reproduce on clean `origin/main` (8269f9056) and are unrelated to this change.

## Related

- Fixes #16830