### PR TITLE
fix: honor agent.disabled_toolsets across CLI + gateway (salvage #16867)

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -777,6 +777,16 @@ def _get_platform_tools(
     else:
         enabled_toolsets.update(explicit_mcp_servers)
 
+    # Honor agent.disabled_toolsets from config.yaml — allows users to
+    # globally suppress specific toolsets (e.g. "memory") across all
+    # platforms without per-platform toolset configuration.  This runs
+    # last so it overrides everything above.
+    agent_cfg = config.get("agent") or {}
+    disabled_toolsets = agent_cfg.get("disabled_toolsets") or []
+    if disabled_toolsets:
+        disabled_set = {str(ts) for ts in disabled_toolsets}
+        enabled_toolsets -= disabled_set
+
     return enabled_toolsets
 
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -68,6 +68,7 @@ AUTHOR_MAP = {
     "itonov@proton.me": "Ito-69",
     "glesstech@gmail.com": "georgeglessner",
     "maxim.smetanin@gmail.com": "maxims-oss",
+    "nazirulhafiy@gmail.com": "nazirulhafiy",
     "CREWorx@users.noreply.github.com": "BadTechBandit",
     "yoimexex@gmail.com": "Yoimex",
     "6548898+romanornr@users.noreply.github.com": "romanornr",

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -17,6 +17,50 @@ from hermes_cli.tools_config import (
 )
 
 
+def test_agent_disabled_toolsets_suppresses_across_platforms():
+    """agent.disabled_toolsets in config.yaml should remove those toolsets
+    from the enabled set, regardless of platform defaults or explicit config.
+    """
+    config = {
+        "agent": {"disabled_toolsets": ["memory"]},
+    }
+
+    cli_enabled = _get_platform_tools(config, "cli")
+    discord_enabled = _get_platform_tools(config, "discord")
+
+    assert "memory" not in cli_enabled
+    assert "memory" not in discord_enabled
+
+
+def test_agent_disabled_toolsets_with_explicit_platform_config():
+    """agent.disabled_toolsets should still suppress even when the platform
+    has an explicit toolset list that includes the disabled toolset.
+    """
+    config = {
+        "agent": {"disabled_toolsets": ["memory"]},
+        "platform_toolsets": {"cli": ["web", "terminal", "memory"]},
+    }
+
+    enabled = _get_platform_tools(config, "cli")
+
+    assert "memory" not in enabled
+    assert "web" in enabled
+    assert "terminal" in enabled
+
+
+def test_agent_disabled_toolsets_empty_list_is_noop():
+    """Empty or missing disabled_toolsets should not change behavior."""
+    config_empty = {"agent": {"disabled_toolsets": []}}
+    config_none = {"agent": {}}
+    config_missing = {}
+
+    default = _get_platform_tools({}, "cli")
+
+    assert _get_platform_tools(config_empty, "cli") == default
+    assert _get_platform_tools(config_none, "cli") == default
+    assert _get_platform_tools(config_missing, "cli") == default
+
+
 def test_get_platform_tools_uses_default_when_platform_not_configured():
     config = {}
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -462,6 +462,26 @@ tool_output:
   max_lines: 500
 ```
 
+## Global Toolset Disable
+
+To suppress specific toolsets across the CLI and every gateway platform in one
+place, list their names under `agent.disabled_toolsets`:
+
+```yaml
+agent:
+  disabled_toolsets:
+    - memory       # hide memory tools + MEMORY_GUIDANCE injection
+    - web          # no web_search / web_extract anywhere
+```
+
+This applies **after** per-platform tool config (`platform_toolsets` written by
+`hermes tools`), so a toolset listed here is always removed — even if a
+platform's saved config still lists it. Use this when you want a single
+switch for "turn X off everywhere" rather than editing 15+ platform rows in
+the `hermes tools` UI.
+
+Leaving the list empty, or omitting the key, is a no-op.
+
 ## Git Worktree Isolation
 
 Enable isolated git worktrees for running multiple agents in parallel on the same repo:


### PR DESCRIPTION
## Summary
Add `agent.disabled_toolsets` — a single config key that suppresses named toolsets across the CLI and every gateway platform, overriding per-platform `platform_toolsets` configuration.

## Changes
- `hermes_cli/tools_config.py`: `_get_platform_tools()` reads `agent.disabled_toolsets` and subtracts from the result set as the final step (@nazirulhafiy's commit).
- `tests/hermes_cli/test_tools_config.py`: +3 tests — cross-platform suppression, explicit-platform override, empty/missing no-op.
- `website/docs/user-guide/configuration.md`: new "Global Toolset Disable" section documenting the key and its precedence.
- `scripts/release.py`: AUTHOR_MAP entry for nazirulhafiy@gmail.com so release-notes CI attributes the cherry-picked commit.

## Validation
All 53 tests in `tests/hermes_cli/test_tools_config.py` pass. E2E verified with real imports:

| Scenario | Result |
|---|---|
| No config → memory in cli/discord tool set | ✓ present |
| `agent.disabled_toolsets: [memory]` → cli | ✓ removed |
| `agent.disabled_toolsets: [memory]` → discord | ✓ removed |
| `agent.disabled_toolsets: [memory]` + explicit `platform_toolsets.discord: [web, terminal, memory]` | ✓ memory removed, web/terminal kept |

## Credit
Salvages #16867 by @nazirulhafiy — the fix commit is cherry-picked with original authorship preserved. Follow-up commit adds docs for the new config surface and the AUTHOR_MAP entry.
