### PR TITLE
fix: isolate profile state in TUI sessions

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1117,6 +1117,22 @@ def _launch_tui(
     env.setdefault("HERMES_PYTHON", sys.executable)
     env.setdefault("HERMES_CWD", os.getcwd())
     env.setdefault("NODE_ENV", "development" if tui_dev else "production")
+
+    # The TUI is a subprocess tree (Python CLI → Node Ink app → Python
+    # tui_gateway → slash_worker).  HERMES_HOME is already profile-scoped by
+    # _apply_profile_override(), but HOME can be inherited from the launching
+    # shell or even from another Hermes profile's terminal sandbox.  If the
+    # selected profile has its own {HERMES_HOME}/home directory, pass that HOME
+    # to the TUI subprocess tree so Path.home()/~ fallbacks cannot bleed across
+    # profiles.
+    try:
+        from hermes_constants import get_subprocess_home
+
+        subprocess_home = get_subprocess_home()
+        if subprocess_home:
+            env["HOME"] = subprocess_home
+    except Exception:
+        pass
     if model:
         env["HERMES_MODEL"] = model
         env["HERMES_INFERENCE_MODEL"] = model

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -172,7 +172,12 @@ class SessionDB:
     _CHECKPOINT_EVERY_N_WRITES = 50
 
     def __init__(self, db_path: Path = None):
-        self.db_path = db_path or DEFAULT_DB_PATH
+        # Resolve the default path at construction time, not import time.
+        # Profile selection happens very early in most CLI entrypoints, but
+        # subprocess trees (TUI/gateway/slash workers/tests) can import this
+        # module before HERMES_HOME is finalized.  A module-level default would
+        # then pin every later SessionDB() to the wrong profile's state.db.
+        self.db_path = db_path or (get_hermes_home() / "state.db")
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
 
         self._lock = threading.Lock()

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -159,6 +159,33 @@ def test_launch_tui_exports_model_and_provider(monkeypatch, main_mod):
     assert env["NODE_ENV"] == "production"
 
 
+def test_launch_tui_uses_profile_subprocess_home(monkeypatch, tmp_path, main_mod):
+    captured = {}
+    profile_home = tmp_path / "profiles" / "ai-news-team"
+    subprocess_home = profile_home / "home"
+    subprocess_home.mkdir(parents=True)
+
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+    monkeypatch.setenv("HOME", str(tmp_path / "profiles" / "seojongho" / "home"))
+    monkeypatch.setattr(
+        main_mod,
+        "_make_tui_argv",
+        lambda tui_dir, tui_dev: (["node", "dist/entry.js"], Path(".")),
+    )
+
+    def fake_call(argv, cwd=None, env=None):
+        captured.update({"argv": argv, "cwd": cwd, "env": env})
+        return 1
+
+    monkeypatch.setattr(main_mod.subprocess, "call", fake_call)
+
+    with pytest.raises(SystemExit):
+        main_mod._launch_tui()
+
+    assert captured["env"]["HERMES_HOME"] == str(profile_home)
+    assert captured["env"]["HOME"] == str(subprocess_home)
+
+
 def test_print_tui_exit_summary_includes_resume_and_token_totals(monkeypatch, capsys):
     import hermes_cli.main as main_mod
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -17,6 +17,33 @@ def db(tmp_path):
 
 
 # =========================================================================
+# Profile/path isolation
+# =========================================================================
+
+
+def test_default_db_path_resolves_hermes_home_at_construction_time(monkeypatch, tmp_path):
+    """SessionDB() must follow the current profile even if the module was imported earlier."""
+    first_home = tmp_path / "profiles" / "seojongho"
+    second_home = tmp_path / "profiles" / "ai-news-team"
+    first_home.mkdir(parents=True)
+    second_home.mkdir(parents=True)
+
+    monkeypatch.setenv("HERMES_HOME", str(first_home))
+    first = SessionDB()
+    try:
+        assert first.db_path == first_home / "state.db"
+    finally:
+        first.close()
+
+    monkeypatch.setenv("HERMES_HOME", str(second_home))
+    second = SessionDB()
+    try:
+        assert second.db_path == second_home / "state.db"
+    finally:
+        second.close()
+
+
+# =========================================================================
 # Session lifecycle
 # =========================================================================
 


### PR DESCRIPTION
## Summary
- Resolve `SessionDB()` default path at construction time so profile changes after import do not pin state to the wrong profile
- Propagate selected profile HOME into the TUI subprocess tree to prevent `Path.home()` fallback bleed between profiles
- Add regression coverage for profile state DB isolation and TUI subprocess HOME propagation

## Test Plan
- `HERMES_HOME=/tmp/hermes-test-home HERMES_BASE_HOME=/tmp/hermes-test-base ./venv/bin/python -m pytest tests/test_hermes_state.py tests/hermes_cli/test_tui_resume_flow.py -q -o 'addopts='`
