### PR TITLE
fix(config): add request_timeout_seconds and stale_timeout_seconds to provider _KNOWN_KEYS

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2205,6 +2205,7 @@ def _normalize_custom_provider_entry(
         "name", "api", "url", "base_url", "api_key", "key_env",
         "api_mode", "transport", "model", "default_model", "models",
         "context_length", "rate_limit_delay",
+        "request_timeout_seconds", "stale_timeout_seconds",
     }
     for camel, snake in _CAMEL_ALIASES.items():
         if camel in entry and snake not in entry:

--- a/tests/hermes_cli/test_provider_config_validation.py
+++ b/tests/hermes_cli/test_provider_config_validation.py
@@ -82,7 +82,7 @@ class TestNormalizeCustomProviderEntry:
         """Unknown config keys should produce a warning."""
         entry = {
             "base_url": "https://api.example.com/v1",
-            "api_key": "sk-test-key",
+            "api_key": "***",
             "unknownField": "value",
             "anotherBad": 42,
         }
@@ -90,6 +90,19 @@ class TestNormalizeCustomProviderEntry:
             result = _normalize_custom_provider_entry(entry, provider_key="test")
         assert result is not None
         assert any("unknown config keys" in r.message.lower() for r in caplog.records)
+
+    def test_timeout_keys_not_flagged_unknown(self, caplog):
+        """request_timeout_seconds and stale_timeout_seconds should not produce warnings."""
+        entry = {
+            "base_url": "https://api.example.com/v1",
+            "api_key": "***",
+            "request_timeout_seconds": 300,
+            "stale_timeout_seconds": 900,
+        }
+        with caplog.at_level(logging.WARNING):
+            result = _normalize_custom_provider_entry(entry, provider_key="test")
+        assert result is not None
+        assert not any("unknown config keys" in r.message.lower() for r in caplog.records)
 
     def test_camel_case_warning_logged(self, caplog):
         """camelCase alias mapping should produce a warning."""


### PR DESCRIPTION
Salvage of #16853 — cherry-picked onto current main.

## Summary
Provider-entry validator no longer warns about `request_timeout_seconds` / `stale_timeout_seconds`, which are documented in `cli-config.yaml.example` and read at runtime by `hermes_cli/timeouts.py`.

## Changes
- `hermes_cli/config.py`: add both keys to `_KNOWN_KEYS` frozenset
- `tests/hermes_cli/test_provider_config_validation.py`: positive test that the keys no longer trigger the unknown-key warning

## Validation
- Targeted: `tests/hermes_cli/test_provider_config_validation.py` — 17/17 pass
- E2E: calling `_normalize_custom_provider_entry({..., request_timeout_seconds: 300, stale_timeout_seconds: 900})` emits no warning; truly unknown keys still warn.

Credit: @vominh1919 (authorship preserved via cherry-pick). Closes #16853.