### PR TITLE
Improve /model picker visibility and current-model ordering

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4696,6 +4696,7 @@ class HermesCLI:
             try:
                 providers = list_authenticated_providers(
                     current_provider=self.provider or "",
+                    current_model=self.model or "",
                     user_providers=user_provs,
                     custom_providers=custom_provs,
                     max_models=50,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4701,6 +4701,7 @@ class GatewayRunner:
                 try:
                     providers = list_authenticated_providers(
                         current_provider=current_provider,
+                        current_model=current_model,
                         user_providers=user_provs,
                         custom_providers=custom_provs,
                         max_models=50,
@@ -4812,6 +4813,7 @@ class GatewayRunner:
             try:
                 providers = list_authenticated_providers(
                     current_provider=current_provider,
+                    current_model=current_model,
                     user_providers=user_provs,
                     custom_providers=custom_provs,
                     max_models=5,

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -769,19 +769,20 @@ def list_authenticated_providers(
     custom_providers: list | None = None,
     max_models: int = 8,
 ) -> List[dict]:
-    """Detect which providers have credentials and list their curated models.
+    """Detect which providers have credentials and list their picker-visible models.
 
-    Uses the curated model lists from hermes_cli/models.py (OPENROUTER_MODELS,
-    _PROVIDER_MODELS) — NOT the full models.dev catalog.  These are hand-picked
-    agentic models that work well as agent backends.
+    Starts with the curated model lists from hermes_cli/models.py
+    (OPENROUTER_MODELS, _PROVIDER_MODELS), then appends extra agentic models
+    discovered via models.dev. This keeps high-signal defaults at the top while
+    still exposing additional available models in the picker.
 
     Returns a list of dicts, each with:
       - slug: str — the --provider value to use
       - name: str — display name
       - is_current: bool
       - is_user_defined: bool
-      - models: list[str] — curated model IDs (up to max_models)
-      - total_models: int — total curated count
+      - models: list[str] — picker-visible model IDs (up to max_models)
+      - total_models: int — total visible count before truncation
       - source: str — "built-in", "models.dev", "user-config"
 
     Only includes providers that have API keys set or are user-defined endpoints.
@@ -791,6 +792,7 @@ def list_authenticated_providers(
         PROVIDER_TO_MODELS_DEV,
         fetch_models_dev,
         get_provider_info as _mdev_pinfo,
+        list_agentic_models,
     )
     from hermes_cli.auth import PROVIDER_REGISTRY
     from hermes_cli.models import OPENROUTER_MODELS, _PROVIDER_MODELS
@@ -811,6 +813,28 @@ def list_authenticated_providers(
     if "ollama-cloud" not in curated:
         from hermes_cli.models import fetch_ollama_cloud_models
         curated["ollama-cloud"] = fetch_ollama_cloud_models()
+
+    def _merged_model_list(provider_slug: str, fallback_slug: str = "") -> list[str]:
+        """Return curated models first, then extra agentic models from models.dev."""
+        merged: list[str] = []
+        for slug in filter(None, [provider_slug, fallback_slug]):
+            for model_id in curated.get(slug, []) or []:
+                if model_id and model_id not in merged:
+                    merged.append(model_id)
+
+        dynamic_models: list[str] = []
+        for slug in filter(None, [provider_slug, fallback_slug]):
+            try:
+                dynamic_models = list_agentic_models(slug)
+            except Exception:
+                dynamic_models = []
+            if dynamic_models:
+                break
+
+        for model_id in dynamic_models:
+            if model_id and model_id not in merged:
+                merged.append(model_id)
+        return merged
 
     # --- 1. Check Hermes-mapped providers ---
     for hermes_id, mdev_id in PROVIDER_TO_MODELS_DEV.items():
@@ -839,8 +863,8 @@ def list_authenticated_providers(
         if not has_creds:
             continue
 
-        # Use curated list, falling back to models.dev if no curated list
-        model_ids = curated.get(hermes_id, [])
+        # Use curated list first, then append extra agentic models from models.dev
+        model_ids = _merged_model_list(hermes_id, mdev_id)
         total = len(model_ids)
         top = model_ids[:max_models]
 
@@ -942,8 +966,8 @@ def list_authenticated_providers(
         if not has_creds:
             continue
 
-        # Use curated list — look up by Hermes slug, fall back to overlay key
-        model_ids = curated.get(hermes_slug, []) or curated.get(pid, [])
+        # Use curated list first, then append extra agentic models from models.dev
+        model_ids = _merged_model_list(hermes_slug, pid)
         total = len(model_ids)
         top = model_ids[:max_models]
 
@@ -1003,7 +1027,7 @@ def list_authenticated_providers(
         if not _cp_has_creds:
             continue
 
-        _cp_model_ids = curated.get(_cp.slug, [])
+        _cp_model_ids = _merged_model_list(_cp.slug)
         _cp_total = len(_cp_model_ids)
         _cp_top = _cp_model_ids[:max_models]
 

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -765,6 +765,7 @@ def switch_model(
 
 def list_authenticated_providers(
     current_provider: str = "",
+    current_model: str = "",
     user_providers: dict = None,
     custom_providers: list | None = None,
     max_models: int = 8,
@@ -815,8 +816,12 @@ def list_authenticated_providers(
         curated["ollama-cloud"] = fetch_ollama_cloud_models()
 
     def _merged_model_list(provider_slug: str, fallback_slug: str = "") -> list[str]:
-        """Return curated models first, then extra agentic models from models.dev."""
+        """Return current model first, then curated models, then extra agentic models."""
         merged: list[str] = []
+
+        if current_model and provider_slug == current_provider:
+            merged.append(current_model)
+
         for slug in filter(None, [provider_slug, fallback_slug]):
             for model_id in curated.get(slug, []) or []:
                 if model_id and model_id not in merged:

--- a/tests/hermes_cli/test_opencode_go_in_model_list.py
+++ b/tests/hermes_cli/test_opencode_go_in_model_list.py
@@ -1,4 +1,4 @@
-"""Test that opencode-go appears in /model list when credentials are set."""
+"""Tests for opencode-go visibility and model expansion in /model lists."""
 
 import os
 from unittest.mock import patch
@@ -10,26 +10,56 @@ from hermes_cli.model_switch import list_authenticated_providers
 def test_opencode_go_appears_when_api_key_set():
     """opencode-go should appear in list_authenticated_providers when OPENCODE_GO_API_KEY is set."""
     providers = list_authenticated_providers(current_provider="openrouter")
-    
+
     # Find opencode-go in results
     opencode_go = next((p for p in providers if p["slug"] == "opencode-go"), None)
-    
+
     assert opencode_go is not None, "opencode-go should appear when OPENCODE_GO_API_KEY is set"
-    assert opencode_go["models"] == ["glm-5", "kimi-k2.5", "mimo-v2-pro", "mimo-v2-omni", "minimax-m2.7", "minimax-m2.5"]
+    assert opencode_go["models"][:6] == [
+        "glm-5",
+        "kimi-k2.5",
+        "mimo-v2-pro",
+        "mimo-v2-omni",
+        "minimax-m2.7",
+        "minimax-m2.5",
+    ]
+    assert opencode_go["total_models"] >= 6
     # opencode-go can appear as "built-in" (from PROVIDER_TO_MODELS_DEV when
     # models.dev is reachable) or "hermes" (from HERMES_OVERLAYS fallback when
     # the API is unavailable, e.g. in CI).
     assert opencode_go["source"] in ("built-in", "hermes")
 
 
+@patch("agent.models_dev.list_agentic_models", return_value=["glm-5", "extra-model", "another-model"])
+@patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "test-key"}, clear=False)
+def test_opencode_go_picker_includes_dynamic_agentic_models(_mock_dynamic_models):
+    """Picker should append additional available agentic models after curated ones."""
+    providers = list_authenticated_providers(current_provider="openrouter", max_models=50)
+
+    opencode_go = next((p for p in providers if p["slug"] == "opencode-go"), None)
+
+    assert opencode_go is not None
+    assert opencode_go["models"][:6] == [
+        "glm-5",
+        "kimi-k2.5",
+        "mimo-v2-pro",
+        "mimo-v2-omni",
+        "minimax-m2.7",
+        "minimax-m2.5",
+    ]
+    assert "extra-model" in opencode_go["models"]
+    assert "another-model" in opencode_go["models"]
+    assert opencode_go["total_models"] >= 8
+
+
 def test_opencode_go_not_appears_when_no_creds():
     """opencode-go should NOT appear when no credentials are set."""
     # Ensure OPENCODE_GO_API_KEY is not set
     env_without_key = {k: v for k, v in os.environ.items() if k != "OPENCODE_GO_API_KEY"}
-    
+
     with patch.dict(os.environ, env_without_key, clear=True):
         providers = list_authenticated_providers(current_provider="openrouter")
-        
+
         # opencode-go should not be in results
         opencode_go = next((p for p in providers if p["slug"] == "opencode-go"), None)
         assert opencode_go is None, "opencode-go should not appear without credentials"

--- a/tests/hermes_cli/test_opencode_go_in_model_list.py
+++ b/tests/hermes_cli/test_opencode_go_in_model_list.py
@@ -52,6 +52,30 @@ def test_opencode_go_picker_includes_dynamic_agentic_models(_mock_dynamic_models
     assert opencode_go["total_models"] >= 8
 
 
+@patch("agent.models_dev.list_agentic_models", return_value=["glm-5", "extra-model", "another-model"])
+@patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "test-key"}, clear=False)
+def test_current_model_is_pinned_first_within_provider(_mock_dynamic_models):
+    """Current model should appear first for its provider in the picker list."""
+    providers = list_authenticated_providers(
+        current_provider="opencode-go",
+        current_model="another-model",
+        max_models=50,
+    )
+
+    opencode_go = next((p for p in providers if p["slug"] == "opencode-go"), None)
+
+    assert opencode_go is not None
+    assert opencode_go["models"][0] == "another-model"
+    assert opencode_go["models"][1:7] == [
+        "glm-5",
+        "kimi-k2.5",
+        "mimo-v2-pro",
+        "mimo-v2-omni",
+        "minimax-m2.7",
+        "minimax-m2.5",
+    ]
+
+
 def test_opencode_go_not_appears_when_no_creds():
     """opencode-go should NOT appear when no credentials are set."""
     # Ensure OPENCODE_GO_API_KEY is not set


### PR DESCRIPTION
## Summary
- expand picker-visible models with additional agentic models from models.dev
- pin the current model to the top within the selected provider list
- thread current model context through CLI and Telegram gateway pickers

## Testing
- source venv/bin/activate && pytest tests/hermes_cli/test_opencode_go_in_model_list.py tests/hermes_cli/test_model_normalize.py tests/hermes_cli/test_codex_models.py -q