### PR TITLE
fix(security): isolate interactive sudo password cache per ACP session

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextvars
 import logging
 import os
 from collections import defaultdict, deque
@@ -574,6 +575,22 @@ class HermesACPAgent(acp.Agent):
 
         def _run_agent() -> dict:
             nonlocal previous_approval_cb, previous_interactive
+            # Bind HERMES_SESSION_KEY for this session so per-session caches
+            # (e.g. the interactive sudo password cache in tools.terminal_tool)
+            # scope to the ACP session rather than leaking across sessions
+            # that land on the same reused executor thread. This call runs
+            # inside a contextvars.copy_context() below, so the ContextVar
+            # write is isolated from other concurrent ACP sessions.
+            try:
+                from gateway.session_context import (
+                    clear_session_vars,
+                    set_session_vars,
+                )
+                session_tokens = set_session_vars(session_key=session_id)
+            except Exception:
+                session_tokens = None
+                clear_session_vars = None  # type: ignore[assignment]
+                logger.debug("Could not set ACP session context", exc_info=True)
             if approval_cb:
                 try:
                     from tools import terminal_tool as _terminal_tool
@@ -607,9 +624,19 @@ class HermesACPAgent(acp.Agent):
                         _terminal_tool.set_approval_callback(previous_approval_cb)
                     except Exception:
                         logger.debug("Could not restore approval callback", exc_info=True)
+                if session_tokens is not None and clear_session_vars is not None:
+                    try:
+                        clear_session_vars(session_tokens)
+                    except Exception:
+                        logger.debug("Could not clear ACP session context", exc_info=True)
 
         try:
-            result = await loop.run_in_executor(_executor, _run_agent)
+            # Wrap the executor call in a fresh copy of the current context so
+            # concurrent ACP sessions on the shared ThreadPoolExecutor don't
+            # stomp on each other's ContextVar writes (HERMES_SESSION_KEY in
+            # particular — used by the interactive sudo password cache scope).
+            ctx = contextvars.copy_context()
+            result = await loop.run_in_executor(_executor, ctx.run, _run_agent)
         except Exception:
             logger.exception("Executor error for session %s", session_id)
             return PromptResponse(stop_reason="end_turn")

--- a/tests/acp/test_approval_isolation.py
+++ b/tests/acp/test_approval_isolation.py
@@ -141,6 +141,59 @@ class TestThreadLocalApprovalCallback:
         assert worker_saw == [""]
         assert _get_cached_sudo_password() == "main-thread-password"
 
+    def test_sudo_password_cache_isolated_across_acp_sessions_on_same_pool_thread(self):
+        """ACP's ThreadPoolExecutor reuses threads. Two ACP sessions that land
+        on the same reused thread must not share the interactive sudo password
+        cache. The fix wraps each session in contextvars.copy_context() and
+        binds HERMES_SESSION_KEY per session, so the cache scope key differs
+        across sessions even when the underlying thread is identical.
+        """
+        import contextvars
+        from concurrent.futures import ThreadPoolExecutor
+
+        from gateway.session_context import (
+            clear_session_vars,
+            set_session_vars,
+        )
+        from tools.terminal_tool import (
+            _get_cached_sudo_password,
+            _reset_cached_sudo_passwords,
+            _set_cached_sudo_password,
+        )
+
+        _reset_cached_sudo_passwords()
+        executor = ThreadPoolExecutor(max_workers=1)  # force thread reuse
+
+        runs: list[tuple[str, str, str]] = []  # (session_id, before, after)
+
+        def _simulate_acp_session(session_id: str, write_password: str) -> None:
+            tokens = set_session_vars(session_key=session_id)
+            try:
+                observed_before = _get_cached_sudo_password()
+                _set_cached_sudo_password(write_password)
+                observed_after = _get_cached_sudo_password()
+                runs.append((session_id, observed_before, observed_after))
+            finally:
+                clear_session_vars(tokens)
+
+        def _run_in_fresh_context(session_id: str, pw: str) -> str:
+            ctx = contextvars.copy_context()
+            ctx.run(_simulate_acp_session, session_id, pw)
+            return session_id
+
+        try:
+            executor.submit(_run_in_fresh_context, "acp-session-A", "alpha-secret").result()
+            # Same thread. Without the fix B would see "alpha-secret".
+            executor.submit(_run_in_fresh_context, "acp-session-B", "bravo-secret").result()
+        finally:
+            executor.shutdown(wait=True)
+            _reset_cached_sudo_passwords()
+
+        assert runs[0] == ("acp-session-A", "", "alpha-secret")
+        # Core regression guard: B on the same reused thread must see an empty
+        # cache, not A's password.
+        assert runs[1] == ("acp-session-B", "", "bravo-secret")
+
 
 class TestAcpExecAskGate:
     """GHSA-96vc-wcxf-jjff: ACP's _run_agent must set HERMES_INTERACTIVE so

--- a/tests/acp/test_approval_isolation.py
+++ b/tests/acp/test_approval_isolation.py
@@ -118,6 +118,29 @@ class TestThreadLocalApprovalCallback:
         assert worker_saw == [None]
         assert _get_sudo_password_callback() is cb_main
 
+    def test_sudo_password_cache_does_not_leak_across_threads(self):
+        """Interactive sudo cache must not bleed into another executor thread."""
+        from tools.terminal_tool import (
+            _get_cached_sudo_password,
+            _reset_cached_sudo_passwords,
+            _set_cached_sudo_password,
+        )
+
+        _reset_cached_sudo_passwords()
+        _set_cached_sudo_password("main-thread-password")
+
+        worker_saw = []
+
+        def worker():
+            worker_saw.append(_get_cached_sudo_password())
+
+        t = threading.Thread(target=worker)
+        t.start()
+        t.join()
+
+        assert worker_saw == [""]
+        assert _get_cached_sudo_password() == "main-thread-password"
+
 
 class TestAcpExecAskGate:
     """GHSA-96vc-wcxf-jjff: ACP's _run_agent must set HERMES_INTERACTIVE so

--- a/tests/tools/test_terminal_tool.py
+++ b/tests/tools/test_terminal_tool.py
@@ -4,11 +4,11 @@ import tools.terminal_tool as terminal_tool
 
 
 def setup_function():
-    terminal_tool._cached_sudo_password = ""
+    terminal_tool._reset_cached_sudo_passwords()
 
 
 def teardown_function():
-    terminal_tool._cached_sudo_password = ""
+    terminal_tool._reset_cached_sudo_passwords()
 
 
 def test_searching_for_sudo_does_not_trigger_rewrite(monkeypatch):
@@ -82,12 +82,26 @@ def test_explicit_empty_sudo_password_tries_empty_without_prompt(monkeypatch):
 def test_cached_sudo_password_is_used_when_env_is_unset(monkeypatch):
     monkeypatch.delenv("SUDO_PASSWORD", raising=False)
     monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
-    terminal_tool._cached_sudo_password = "cached-pass"
+    terminal_tool._set_cached_sudo_password("cached-pass")
 
     transformed, sudo_stdin = terminal_tool._transform_sudo_command("echo ok && sudo whoami")
 
     assert transformed == "echo ok && sudo -S -p '' whoami"
     assert sudo_stdin == "cached-pass\n"
+
+
+def test_cached_sudo_password_isolated_by_session_key(monkeypatch):
+    monkeypatch.delenv("SUDO_PASSWORD", raising=False)
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+
+    monkeypatch.setenv("HERMES_SESSION_KEY", "session-a")
+    terminal_tool._set_cached_sudo_password("alpha-pass")
+
+    monkeypatch.setenv("HERMES_SESSION_KEY", "session-b")
+    assert terminal_tool._get_cached_sudo_password() == ""
+
+    monkeypatch.setenv("HERMES_SESSION_KEY", "session-a")
+    assert terminal_tool._get_cached_sudo_password() == "alpha-pass"
 
 
 def test_validate_workdir_allows_windows_drive_paths():

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -145,8 +145,14 @@ def _check_disk_usage_warning():
         return False
 
 
-# Session-cached sudo password (persists until CLI exits)
-_cached_sudo_password: str = ""
+# Interactive sudo password cache.
+#
+# Scope the cache to the active session when a session key is available, then
+# fall back to callback identity (ACP / CLI interactive callbacks), then the
+# current thread. This prevents one interactive session from reusing another
+# session's cached sudo password inside the same long-lived process.
+_sudo_password_cache: dict[str, str] = {}
+_sudo_password_cache_lock = threading.Lock()
 
 # Optional UI callbacks for interactive prompts. When set, these are called
 # instead of the default /dev/tty or input() readers. The CLI registers these
@@ -189,6 +195,54 @@ def set_approval_callback(cb):
     GHSA-qg5c-hvr5-hjgr.
     """
     _callback_tls.approval = cb
+
+
+def _get_sudo_password_cache_scope() -> str:
+    """Return the cache scope for interactive sudo passwords."""
+    try:
+        from gateway.session_context import get_session_env
+
+        session_key = get_session_env("HERMES_SESSION_KEY", "")
+    except Exception:
+        session_key = os.getenv("HERMES_SESSION_KEY", "")
+    if session_key:
+        return f"session:{session_key}"
+
+    callback = _get_sudo_password_callback()
+    if callback is not None:
+        owner = getattr(callback, "__self__", None)
+        func = getattr(callback, "__func__", None)
+        if owner is not None and func is not None:
+            return f"callback-owner:{id(owner)}:{id(func)}"
+        return f"callback:{id(callback)}"
+
+    return f"thread:{threading.get_ident()}"
+
+
+def _get_cached_sudo_password() -> str:
+    """Return the cached sudo password for the current scope."""
+    scope = _get_sudo_password_cache_scope()
+    with _sudo_password_cache_lock:
+        return _sudo_password_cache.get(scope, "")
+
+
+def _set_cached_sudo_password(password: str) -> None:
+    """Persist a sudo password for the current scope."""
+    scope = _get_sudo_password_cache_scope()
+    with _sudo_password_cache_lock:
+        if password:
+            _sudo_password_cache[scope] = password
+        else:
+            _sudo_password_cache.pop(scope, None)
+
+
+def _reset_cached_sudo_passwords() -> None:
+    """Clear all cached sudo passwords.
+
+    Internal helper for tests and process teardown paths.
+    """
+    with _sudo_password_cache_lock:
+        _sudo_password_cache.clear()
 
 # =============================================================================
 # Dangerous Command Approval System
@@ -700,8 +754,6 @@ def _transform_sudo_command(command: str | None) -> tuple[str | None, str | None
     If SUDO_PASSWORD is not set and NOT interactive:
       Command runs as-is (fails gracefully with "sudo: a password is required").
     """
-    global _cached_sudo_password
-
     if command is None:
         return None, None
     transformed, has_real_sudo = _rewrite_real_sudo_invocations(command)
@@ -709,12 +761,16 @@ def _transform_sudo_command(command: str | None) -> tuple[str | None, str | None
         return command, None
 
     has_configured_password = "SUDO_PASSWORD" in os.environ
-    sudo_password = os.environ.get("SUDO_PASSWORD", "") if has_configured_password else _cached_sudo_password
+    sudo_password = (
+        os.environ.get("SUDO_PASSWORD", "")
+        if has_configured_password
+        else _get_cached_sudo_password()
+    )
 
     if not has_configured_password and not sudo_password and os.getenv("HERMES_INTERACTIVE"):
         sudo_password = _prompt_for_sudo_password(timeout_seconds=45)
         if sudo_password:
-            _cached_sudo_password = sudo_password
+            _set_cached_sudo_password(sudo_password)
 
     if has_configured_password or sudo_password:
         # Trailing newline is required: sudo -S reads one line for the password.


### PR DESCRIPTION
Salvages #16858 (@hharry11) onto current main + finishes the ACP wiring the original PR implicitly assumed.

## Summary

The interactive sudo password cache in `tools/terminal_tool.py` is now scoped per ACP session, not per process. Two ACP sessions that land on the same reused `ThreadPoolExecutor` thread no longer share a cached sudo password.

## Why a follow-up commit was needed

#16858 scopes the cache by `HERMES_SESSION_KEY` → callback identity → thread identity. ACP's `_run_agent()` never sets `HERMES_SESSION_KEY` and never registers a sudo-password callback, so the resolver fell through to `thread:<ident>`. ACP's executor is `ThreadPoolExecutor(max_workers=4)` — sequential sessions on a reused thread still shared the cache. The exact scenario the PR headlined wasn't actually protected.

## Changes

**Commit 1** (@hharry11, cherry-picked from #16858):
- Replaces the process-global `_cached_sudo_password` string with a scope-keyed dict + helpers
- Adds session-key isolation test + a cross-thread isolation test

**Commit 2** (this repo):
- `acp_adapter/server.py`: binds `HERMES_SESSION_KEY=<session_id>` inside `_run_agent()` via `gateway.session_context.set_session_vars` and clears on exit
- Wraps `loop.run_in_executor(_executor, _run_agent)` in a fresh `contextvars.copy_context()` so concurrent ACP sessions on the shared pool don't stomp on each other's ContextVar writes (pool threads otherwise share a default context)
- Adds `test_sudo_password_cache_isolated_across_acp_sessions_on_same_pool_thread` — drives two sequential sessions through a 1-worker pool and asserts session B does not observe session A's cached password

## Validation

```
scripts/run_tests.sh tests/tools/test_terminal_tool.py tests/acp/test_approval_isolation.py
18 passed in 1.95s
```

Reproduced the pre-fix leak with a minimal harness to confirm the new regression test actually guards the bug (B observes A's password without the fix).

## Preserves

- `SUDO_PASSWORD` env var precedence (unchanged)
- Same-session convenience caching (unchanged)
- CLI single-thread behavior (unchanged)

Closes #16858.