### PR TITLE
fix(search): quote underscored terms in FTS5 query sanitization

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1355,9 +1355,9 @@ class SessionDB:
         # quotes.  FTS5's tokenizer splits on dots and hyphens, turning
         # ``chat-send`` into ``chat AND send`` and ``P2.2`` into ``p2 AND 2``.
         # Quoting preserves phrase semantics.  A single pass avoids the
-        # double-quoting bug that would occur if dotted and hyphenated
+        # double-quoting bug that would occur if dotted, hyphenated and underscored
         # patterns were applied sequentially (e.g. ``my-app.config``).
-        sanitized = re.sub(r"\b(\w+(?:[.-]\w+)+)\b", r'"\1"', sanitized)
+        sanitized = re.sub(r"\b(\w+(?:[._-]\w+)+)\b", r'"\1"', sanitized)
 
         # Step 6: Restore preserved quoted phrases
         for i, quoted in enumerate(_quoted_parts):

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -127,6 +127,7 @@ AUTHOR_MAP = {
     "70424851+insecurejezza@users.noreply.github.com": "insecurejezza",
     "254021826+dodo-reach@users.noreply.github.com": "dodo-reach",
     "259807879+Bartok9@users.noreply.github.com": "Bartok9",
+    "270082434+crayfish-ai@users.noreply.github.com": "crayfish-ai",
     "241404605+MestreY0d4-Uninter@users.noreply.github.com": "MestreY0d4-Uninter",
     "268667990+Roy-oss1@users.noreply.github.com": "Roy-oss1",
     "27917469+nosleepcassette@users.noreply.github.com": "nosleepcassette",

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -655,6 +655,30 @@ class TestFTS5Search:
         assert s('my-app.config') == '"my-app.config"'
         assert s('my-app.config.ts') == '"my-app.config.ts"'
 
+    def test_sanitize_fts5_quotes_underscored_terms(self):
+        """Underscored terms should be wrapped in quotes for exact matching.
+
+        FTS5 default tokenizer splits 'sp_new1' into tokens 'sp' and 'new1'.
+        Without quoting, a search for 'sp_new' becomes an AND query
+        ('sp AND new') that fails to match rows indexed as 'sp_new1'.
+        """
+        from hermes_state import SessionDB
+        s = SessionDB._sanitize_fts5_query
+        # Simple underscored term
+        assert s('sp_new') == '"sp_new"'
+        # Multiple underscores
+        assert s('a_b_c') == '"a_b_c"'
+        # Mixed underscores and hyphens/dots — single pass avoids double-quoting
+        assert s('sp_new1') == '"sp_new1"'
+        assert s('docker-compose_up') == '"docker-compose_up"'
+        assert s('my.app_config.ts') == '"my.app_config.ts"'
+        # Already-quoted — no double quoting
+        assert s('"sp_new"') == '"sp_new"'
+        # Mixed with other words
+        result = s('sp_new and 血管瘤')
+        assert '"sp_new"' in result
+        assert '血管瘤' in result
+
 
 # =========================================================================
 # CJK (Chinese/Japanese/Korean) LIKE fallback


### PR DESCRIPTION
Salvages #16827 from @crayfish-ai onto current main.

## Summary
FTS5 search now returns results for underscored terms like `sp_new`, which previously got tokenized as `sp AND new` and produced zero hits even when content matched.

## Changes
- `hermes_state.py`: Step 5 regex `[.-]` → `[._-]` in `_sanitize_fts5_query` (one-pass, avoids double-quoting).
- `tests/test_hermes_state.py`: 8 new cases covering simple/multi/mixed underscores, already-quoted passthrough, and hyphen+dot regression.
- `scripts/release.py`: AUTHOR_MAP entry for @crayfish-ai.

## Validation
- Reproduced bug on main: `search_messages('sp_new')` against messages containing `sp_new1` → 0 results.
- After fix: same query → 2 results.
- `scripts/run_tests.sh tests/test_hermes_state.py -k sanitize_fts5` → 5/5 passing.

Closes #16827. Credit to @crayfish-ai.