### PR TITLE
fix(run_agent): use aux provider for compression context length lookup

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2659,7 +2659,10 @@ class AIAgent:
                 base_url=aux_base_url,
                 api_key=aux_api_key,
                 config_context_length=getattr(self, "_aux_compression_context_length_config", None),
-                provider=getattr(self, "provider", ""),
+                # Each model must be resolved with its own provider so that
+                # provider-specific paths (e.g. Bedrock static table, OpenRouter API)
+                # are invoked for the correct client, not inherited from the main model.
+                provider=(_aux_cfg_provider if _aux_cfg_provider and _aux_cfg_provider != "auto" else getattr(self, "provider", "")),
             )
 
             # Hard floor: the auxiliary compression model must have at least


### PR DESCRIPTION
## Problem

When the main model is configured with **AWS Bedrock** (`provider: bedrock`),
`self.provider == "bedrock"` was being passed unconditionally to
`get_model_context_length()` for the **auxiliary compression model**.

`get_model_context_length` has a hard-intercept at step 1b:

```python
if provider == "bedrock" or base_url.startswith("bedrock-runtime."):
    return get_bedrock_context_length(model)  # short-circuits all other resolution
```

A non-Bedrock aux model (e.g. `deepseek/deepseek-v4-flash` on OpenRouter) is
not in the Bedrock static table, so it falls back to
`BEDROCK_DEFAULT_CONTEXT_LENGTH = 128_000`. This triggers a false feasibility
warning **every session start**:

```
⚠ Compression model deepseek/deepseek-v4-flash (openrouter) context is 128,000 tokens,
  but the main model's compression threshold was 800,000 tokens.
  Auto-lowered this session's threshold to 128,000 tokens so compression can run.
```

…even though `deepseek/deepseek-v4-flash` natively supports **1,048,576** tokens.

## Root Cause

`_aux_cfg_provider` (the aux model's own provider, resolved via
`_resolve_task_provider_model("compression")`) was already being fetched just
above the call site — but never passed to `get_model_context_length()`. Instead,
the main model's `self.provider` was passed unconditionally.

The invariant that `provider` must belong to the model being queried — not the
caller's model — is not enforced at the call site today, which is why this leak
is silent.

## Fix

Pass `_aux_cfg_provider` when it is explicitly set (not empty or `"auto"`),
falling back to the main model's provider only when the aux provider is
unspecified.

```python
# Before
provider=getattr(self, "provider", ""),

# After
provider=(_aux_cfg_provider if _aux_cfg_provider and _aux_cfg_provider != "auto" else getattr(self, "provider", "")),
```

## Impact

The Bedrock hard-intercept is the most visible trigger, but the root cause is
general: any provider whose resolution path diverges at step 1b (Bedrock static
table) or later steps will produce wrong results when a foreign provider is
passed for an aux model.

Affected: main model = Bedrock + aux compression model on any non-Bedrock
provider (OpenRouter, OpenAI, Anthropic, etc.). Other combinations are not
affected today because non-Bedrock providers don't short-circuit at step 1b.

Functional impact is minor (threshold auto-corrects for the session), but the
warning is misleading, fires every session, and causes users to misconfigure
their setup to suppress it.

## Why This Is Not a Duplicate of #17460

PR **#17460** fixes `get_model_context_length()` to auto-load `custom_providers`
when the parameter is `None` — protecting callers that never passed the
argument. This PR fixes a **different parameter on the same call**: `provider`
is present at every call site but is being set to the wrong value.

The two fixes are complementary and non-overlapping:

| | #17460 | This PR (#16918) |
|---|---|---|
| **Parameter fixed** | `custom_providers=None` | `provider=self.provider` (wrong value) |
| **Root cause** | Missing argument threading | Provider ownership violation at call site |
| **Affected scenario** | `custom_providers` overrides ignored for aux models | Bedrock (and future diverging providers) intercepting aux model resolution |

Neither PR makes the other redundant. Both should land.

## Testing

All 16 existing compression feasibility tests pass unchanged.

Closes #12977
Related: #13807, #17460