### PR TITLE
fix(send_message): enable Feishu media attachments (images/video/docs)

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -557,18 +557,18 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         return last_result
 
     # --- Non-media platforms ---
-    if media_files and not message.strip():
+    if media_files and not message.strip() and platform not in (Platform.FEISHU,):
         return {
             "error": (
-                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal and yuanbao; "
+                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao and feishu; "
                 f"target {platform.value} had only media attachments"
             )
         }
     warning = None
-    if media_files:
+    if media_files and platform not in (Platform.TELEGRAM, Platform.DISCORD, Platform.MATRIX, Platform.WEIXIN, Platform.FEISHU, Platform.SIGNAL):
         warning = (
             f"MEDIA attachments were omitted for {platform.value}; "
-            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal and yuanbao"
+            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao and feishu"
         )
 
     last_result = None
@@ -592,7 +592,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         elif platform == Platform.DINGTALK:
             result = await _send_dingtalk(pconfig.extra, chat_id, chunk)
         elif platform == Platform.FEISHU:
-            result = await _send_feishu(pconfig, chat_id, chunk, thread_id=thread_id)
+            result = await _send_feishu(pconfig, chat_id, chunk, media_files=media_files, thread_id=thread_id)
         elif platform == Platform.WECOM:
             result = await _send_wecom(pconfig.extra, chat_id, chunk)
         elif platform == Platform.BLUEBUBBLES:


### PR DESCRIPTION
## Problem

The `_send_feishu` call was missing the `media_files` argument, causing all `MEDIA:path` attachments to be silently dropped for Feishu targets — despite `FeishuAdapter` fully supporting `send_image_file` / `send_document` / `send_video`.

Feishu was also missing from the supported-platforms list in the warning/error messages.

## Fix

1. Pass `media_files=media_files` to `_send_feishu` so image/document/video attachments actually reach the adapter.
2. Add Feishu to the supported-platforms list in the media-only error and warning messages.

## Testing

87 tests pass in `test_send_message_tool.py`. Live Feishu DM confirmed working.