### PR TITLE
fix(anthropic): append stub text when final content block is thinking

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1310,6 +1310,19 @@ def convert_messages_to_anthropic(
             effective = blocks or content
             if not effective or effective == "":
                 effective = [{"type": "text", "text": "(empty)"}]
+            # Anthropic rejects assistant messages whose final block is a
+            # thinking/redacted_thinking block (HTTP 400: "The final block in
+            # an assistant message cannot be `thinking`").  This happens when
+            # a thinking-only response (empty content, non-empty reasoning_details)
+            # is replayed on the next turn.  Append a stub text block to satisfy
+            # the constraint.
+            if (
+                isinstance(effective, list)
+                and effective
+                and isinstance(effective[-1], dict)
+                and effective[-1].get("type") in ("thinking", "redacted_thinking")
+            ):
+                effective = list(effective) + [{"type": "text", "text": "(continued)"}]
             result.append({"role": "assistant", "content": effective})
             continue
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -75,6 +75,7 @@ AUTHOR_MAP = {
     "6548898+romanornr@users.noreply.github.com": "romanornr",
     "foxion37@gmail.com": "foxion37",
     "bloodcarter@gmail.com": "bloodcarter",
+    "richardhojunjang@gmail.com": "RichardHojunJang",
     # contributors (from noreply pattern)
     "david.vv@icloud.com": "davidvv",
     "wangqiang@wangqiangdeMac-mini.local": "xiaoqiang243",

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1539,6 +1539,47 @@ class TestThinkingBlockSignatureManagement:
         assert len(thinking) == 1
         assert thinking[0]["thinking"] == "First thought."
 
+    def test_trailing_thinking_block_gets_stub_text_appended(self):
+        """Assistant message whose final block is thinking gets a stub text appended.
+
+        Anthropic's API rejects messages with HTTP 400 if the last content block
+        is a thinking/redacted_thinking block ("The final block in an assistant
+        message cannot be `thinking`").  This happens on thinking-prefill paths
+        where the model produced reasoning but no visible text before a tool call.
+        """
+        messages = [
+            {
+                "role": "assistant",
+                "content": "",
+                # thinking-only turn (no text), with a valid signature
+                "reasoning_details": [
+                    {"type": "thinking", "thinking": "Let me reason.", "signature": "sig_abc"},
+                ],
+            },
+            {"role": "tool", "tool_call_id": "tc_x", "content": "result"},
+        ]
+        # We need a tool_call so the orphan-stripping logic keeps it; simulate it
+        messages[0]["tool_calls"] = [
+            {"id": "tc_x", "function": {"name": "my_tool", "arguments": "{}"}}
+        ]
+        _, result = convert_messages_to_anthropic(messages)
+        assistant = next(m for m in result if m["role"] == "assistant")
+        blocks = assistant["content"]
+        assert isinstance(blocks, list)
+        last = blocks[-1]
+        # The last block must NOT be thinking — a text stub must follow it
+        assert last.get("type") != "thinking", (
+            f"Last block is still 'thinking'; Anthropic would reject this: {blocks}"
+        )
+        assert last.get("type") != "redacted_thinking", (
+            f"Last block is still 'redacted_thinking'; Anthropic would reject this: {blocks}"
+        )
+        # There should still be a thinking block earlier in the list
+        assert any(b.get("type") == "thinking" for b in blocks)
+        # The stub text block should be non-empty (Anthropic rejects empty text blocks)
+        if last.get("type") == "text":
+            assert last.get("text"), "Stub text block must not be empty string"
+
     def test_empty_content_after_strip_gets_placeholder(self):
         """If stripping thinking leaves an empty message, a placeholder is added."""
         messages = [


### PR DESCRIPTION
Salvage of #13010 by @RichardHojunJang — cherry-picked onto current main with authorship preserved.

## Summary
Anthropic rejects assistant messages whose final content block is `thinking` / `redacted_thinking` (HTTP 400: "The final block in an assistant message cannot be \`thinking\`"). This happens on thinking-prefill paths where the model produced reasoning but no visible text before a tool call. Append a `(continued)` stub text block in `convert_messages_to_anthropic()` so the turn ends on a valid block.

## Changes
- `agent/anthropic_adapter.py`: +13 LOC — stub-text append at first-pass assistant assembly
- `tests/agent/test_anthropic_adapter.py`: +41 LOC — regression test
- `scripts/release.py`: AUTHOR_MAP entry for @RichardHojunJang

## Validation
| | Before | After |
|---|---|---|
| `tests/agent/test_anthropic_adapter.py -k thinking` | 14 passed | 15 passed |
| New test `test_trailing_thinking_block_gets_stub_text_appended` | n/a | pass |

## Supersedes
- #16842 (@ygd58): 3-guard defense-in-depth. Guard 1 crashes at runtime — `_THINKING_TYPES` is a local var defined further down the function. 10 thinking tests fail on that PR.
- #11098 (@c0nSpIc0uS7uRk3r): 1 guard at a different (final-pass) site, no regression test.

#13010 is the cleanest of the three — single guard at the correct site, inline literal (no scoping bug), ships its own regression test.

Fixes #16823