### PR TITLE
fix(auxiliary): custom provider URL rewrite + main_runtime model for title gen (widened)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1895,10 +1895,22 @@ def resolve_provider_client(
             entry_api_mode = (api_mode or custom_entry.get("api_mode") or "").strip()
             if custom_base:
                 final_model = _normalize_resolved_model(
-                    model or custom_entry.get("model") or _read_main_model() or "gpt-4o-mini",
+                    model
+                    or custom_entry.get("model")
+                    or (main_runtime.get("model") if main_runtime else None)
+                    or _read_main_model()
+                    or "gpt-4o-mini",
                     provider,
                 )
-                _clean_base2, _dq2 = _extract_url_query_params(custom_base)
+                # anthropic_messages talks to the /anthropic surface directly;
+                # OpenAI-wire paths (chat_completions / codex_responses) need the
+                # /v1 equivalent.  Rewrite only on the OpenAI-wire path so the
+                # Anthropic fallback SDK still sees the original URL.
+                if entry_api_mode == "anthropic_messages":
+                    openai_base = custom_base
+                else:
+                    openai_base = _to_openai_base_url(custom_base)
+                _clean_base2, _dq2 = _extract_url_query_params(openai_base)
                 _extra2 = {"default_query": _dq2} if _dq2 else {}
                 logger.debug(
                     "resolve_provider_client: named custom provider %r (%s, api_mode=%s)",
@@ -1917,7 +1929,12 @@ def resolve_provider_client(
                             "installed — falling back to OpenAI-wire.",
                             provider,
                         )
-                        client = OpenAI(api_key=custom_key, base_url=_clean_base2, **_extra2)
+                        # Fallback went OpenAI-wire after all — redo the query
+                        # extraction against the rewritten /v1 URL.
+                        _fallback_base = _to_openai_base_url(custom_base)
+                        _fb_clean, _fb_dq = _extract_url_query_params(_fallback_base)
+                        _fb_extra = {"default_query": _fb_dq} if _fb_dq else {}
+                        client = OpenAI(api_key=custom_key, base_url=_fb_clean, **_fb_extra)
                         return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                                 else (client, final_model))
                     sync_anthropic = AnthropicAuxiliaryClient(
@@ -1936,7 +1953,7 @@ def resolve_provider_client(
                 ):
                     client = CodexAuxiliaryClient(client, final_model)
                 else:
-                    client = _wrap_if_needed(client, final_model, custom_base)
+                    client = _wrap_if_needed(client, final_model, openai_base)
                 return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                         else (client, final_model))
             logger.warning(
@@ -2038,7 +2055,12 @@ def resolve_provider_client(
 
     if pconfig.auth_type == "external_process":
         creds = resolve_external_process_provider_credentials(provider)
-        final_model = _normalize_resolved_model(model or _read_main_model(), provider)
+        final_model = _normalize_resolved_model(
+            model
+            or (main_runtime.get("model") if main_runtime else None)
+            or _read_main_model(),
+            provider,
+        )
         if provider == "copilot-acp":
             api_key = str(creds.get("api_key", "")).strip()
             base_url = str(creds.get("base_url", "")).strip()

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1834,7 +1834,7 @@ def resolve_provider_client(
     # ── Custom endpoint (OPENAI_BASE_URL + OPENAI_API_KEY) ───────────
     if provider == "custom":
         if explicit_base_url:
-            custom_base = explicit_base_url.strip()
+            custom_base = _to_openai_base_url(explicit_base_url).strip()
             custom_key = (
                 (explicit_api_key or "").strip()
                 or os.getenv("OPENAI_API_KEY", "").strip()
@@ -1847,7 +1847,7 @@ def resolve_provider_client(
                 )
                 return None, None
             final_model = _normalize_resolved_model(
-                model or _read_main_model() or "gpt-4o-mini",
+                model or (main_runtime.get("model") if main_runtime else None) or "gpt-4o-mini",
                 provider,
             )
             extra = {}

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -30,10 +30,12 @@ def generate_title(
     assistant_response: str,
     timeout: float = 30.0,
     failure_callback: Optional[FailureCallback] = None,
+    main_runtime: dict = None,
 ) -> Optional[str]:
     """Generate a session title from the first exchange.
 
-    Uses the auxiliary LLM client (cheapest/fastest available model).
+    Uses the main runtime's model when available, falling back to the
+    auxiliary LLM client (cheapest/fastest available model).
     Returns the title string or None on failure.
 
     ``failure_callback`` is invoked with ``(task, exception)`` when the
@@ -57,6 +59,7 @@ def generate_title(
             max_tokens=500,
             temperature=0.3,
             timeout=timeout,
+            main_runtime=main_runtime,
         )
         title = (response.choices[0].message.content or "").strip()
         # Clean up: remove quotes, trailing punctuation, prefixes like "Title: "
@@ -86,6 +89,7 @@ def auto_title_session(
     user_message: str,
     assistant_response: str,
     failure_callback: Optional[FailureCallback] = None,
+    main_runtime: dict = None,
 ) -> None:
     """Generate and set a session title if one doesn't already exist.
 
@@ -107,7 +111,7 @@ def auto_title_session(
         return
 
     title = generate_title(
-        user_message, assistant_response, failure_callback=failure_callback
+        user_message, assistant_response, failure_callback=failure_callback, main_runtime=main_runtime
     )
     if not title:
         return
@@ -126,6 +130,7 @@ def maybe_auto_title(
     assistant_response: str,
     conversation_history: list,
     failure_callback: Optional[FailureCallback] = None,
+    main_runtime: dict = None,
 ) -> None:
     """Fire-and-forget title generation after the first exchange.
 
@@ -147,7 +152,7 @@ def maybe_auto_title(
     thread = threading.Thread(
         target=auto_title_session,
         args=(session_db, session_id, user_message, assistant_response),
-        kwargs={"failure_callback": failure_callback},
+        kwargs={"failure_callback": failure_callback, "main_runtime": main_runtime},
         daemon=True,
         name="auto-title",
     )

--- a/cli.py
+++ b/cli.py
@@ -8814,6 +8814,13 @@ class HermesCLI:
                         response,
                         self.conversation_history,
                         failure_callback=_title_failure_cb,
+                        main_runtime={
+                            "model": self.model,
+                            "provider": self.provider,
+                            "base_url": self.base_url,
+                            "api_key": self.api_key,
+                            "api_mode": self.api_mode,
+                        },
                     )
                 except Exception:
                     pass

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10700,6 +10700,13 @@ class GatewayRunner:
                         final_response,
                         all_msgs,
                         failure_callback=_title_failure_cb,
+                        main_runtime={
+                            "model": getattr(agent, "model", None),
+                            "provider": getattr(agent, "provider", None),
+                            "base_url": getattr(agent, "base_url", None),
+                            "api_key": getattr(agent, "api_key", None),
+                            "api_mode": getattr(agent, "api_mode", None),
+                        } if agent else None,
                     )
                 except Exception:
                     pass

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -182,7 +182,7 @@ class TestMaybeAutoTitle:
             import time
             time.sleep(0.3)
             mock_auto.assert_called_once_with(
-                db, "sess-1", "hello", "hi there", failure_callback=None
+                db, "sess-1", "hello", "hi there", failure_callback=None, main_runtime=None
             )
 
     def test_forwards_failure_callback_to_worker(self):
@@ -202,7 +202,7 @@ class TestMaybeAutoTitle:
             import time
             time.sleep(0.3)
             mock_auto.assert_called_once_with(
-                db, "sess-1", "hello", "hi there", failure_callback=_cb
+                db, "sess-1", "hello", "hi there", failure_callback=_cb, main_runtime=None
             )
 
     def test_skips_if_no_response(self):


### PR DESCRIPTION
Salvage of #16819 by @crayfish-ai, widened to cover the two sibling custom-endpoint fallback sites carrying the same bug class.

## Summary
Auxiliary client now consistently (a) rewrites `/anthropic` → `/v1` before handing a custom base_url to the OpenAI SDK on every OpenAI-wire custom-endpoint path, and (b) prefers the live agent's runtime model over the stale `config.yaml` `model.default` when filling the auxiliary-task fallback chain. Title generation plumbs `main_runtime` through so mid-session `/model` switches take effect.

## Changes
Commit 1 — @crayfish-ai (cherry-picked from #16819):
- `agent/auxiliary_client.py`: anonymous `custom` branch applies `_to_openai_base_url()` + falls back to `main_runtime.get('model')`.
- `agent/title_generator.py`: thread `main_runtime` through `generate_title → auto_title_session → maybe_auto_title`.
- `cli.py` / `gateway/run.py`: pass `main_runtime` dict (model, provider, base_url, api_key, api_mode) to `maybe_auto_title`.
- `tests/agent/test_title_generator.py`: update mock assertions.

Commit 2 — widening:
- Named custom provider branch (`providers:` / `custom_providers:` config): apply `_to_openai_base_url()` only on OpenAI-wire paths; `anthropic_messages` api_mode keeps `/anthropic` (the Anthropic SDK needs it). ImportError fallback redoes query-param extraction against the rewritten URL so the fallback OpenAI client hits `/v1`.
- External-process branch (`copilot-acp`): same `main_runtime.get('model')` fallback before `_read_main_model()`.

## Validation
- `agent/auxiliary_client.py` compiles clean (`py_compile`).
- `scripts/run_tests.sh tests/agent/test_title_generator.py tests/agent/test_auxiliary_client.py`: 115 pass, 1 pre-existing failure (`test_custom_endpoint_uses_codex_wrapper_when_runtime_requests_responses_api`) — reproduced on plain `origin/main`, not caused by this PR.
- E2E with real imports + isolated `HERMES_HOME`:
  | Scenario | base_url to OpenAI | Model |
  |---|---|---|
  | Anonymous custom, `/anthropic` | `/v1` ✓ | `main_runtime.model` ✓ |
  | Named custom, `/anthropic`, chat_completions | `/v1` ✓ | `main_runtime.model` ✓ |
  | Named custom, `/anthropic`, anthropic_messages | `/anthropic` preserved for Anthropic SDK ✓ | — |
  | Anonymous custom, already `/v1` | `/v1` passthrough ✓ | explicit model ✓ |

Closes #16819.