### PR TITLE
fix(models): refresh stale xAI catalog + auto-derive from models.dev (#16699)

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -106,6 +106,51 @@ def _codex_curated_models() -> list[str]:
     return _add_forward_compat_models(list(DEFAULT_CODEX_MODELS))
 
 
+# Static fallback for xAI when the models.dev disk cache is empty (fresh
+# install, offline first run, etc.). Mirrors the xAI-direct model IDs from
+# $HERMES_HOME/models_dev_cache.json as of 2026-04-28. Whenever xAI renames
+# or retires a model, the disk cache picks it up on the next refresh and the
+# fallback here only matters until that refresh lands.
+_XAI_STATIC_FALLBACK: list[str] = [
+    "grok-4.20-0309-reasoning",
+    "grok-4.20-0309-non-reasoning",
+    "grok-4.20-multi-agent-0309",
+    "grok-4-1-fast",
+    "grok-4-1-fast-non-reasoning",
+    "grok-4-fast",
+    "grok-4-fast-non-reasoning",
+    "grok-4",
+    "grok-code-fast-1",
+]
+
+
+def _xai_curated_models() -> list[str]:
+    """Derive the xAI-direct curated list from models.dev disk cache.
+
+    Reads $HERMES_HOME/models_dev_cache.json directly (no network) so this
+    runs at import time without blocking. Falls back to ``_XAI_STATIC_FALLBACK``
+    when the cache is empty or unreadable. Hermes refreshes the cache from
+    https://models.dev/api.json on normal use, so this list self-heals as
+    xAI renames models.
+
+    Mirrors ``_codex_curated_models()``'s role for openai-codex.
+    """
+    try:
+        from agent.models_dev import _load_disk_cache
+        data = _load_disk_cache()
+        xai = data.get("xai") if isinstance(data, dict) else None
+        models = xai.get("models") if isinstance(xai, dict) else None
+        if isinstance(models, dict) and models:
+            ids = [mid for mid in models.keys() if isinstance(mid, str)]
+            if ids:
+                return sorted(ids)
+    except Exception:
+        # Any failure (missing file, malformed JSON, import error)
+        # falls through to the static list.
+        pass
+    return list(_XAI_STATIC_FALLBACK)
+
+
 _PROVIDER_MODELS: dict[str, list[str]] = {
     "nous": [
         "moonshotai/kimi-k2.6",
@@ -193,17 +238,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "glm-4.5",
         "glm-4.5-flash",
     ],
-    "xai": [
-        "grok-4.20-0309-reasoning",
-        "grok-4.20-0309-non-reasoning",
-        "grok-4.20-multi-agent-0309",
-        "grok-4-1-fast",
-        "grok-4-1-fast-non-reasoning",
-        "grok-4-fast",
-        "grok-4-fast-non-reasoning",
-        "grok-4",
-        "grok-code-fast-1",
-    ],
+    "xai": _xai_curated_models(),
     "nvidia": [
         # NVIDIA flagship reasoning models
         "nvidia/nemotron-3-super-120b-a12b",

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -194,8 +194,15 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "glm-4.5-flash",
     ],
     "xai": [
-        "grok-4.20-reasoning",
-        "grok-4-1-fast-reasoning",
+        "grok-4.20-0309-reasoning",
+        "grok-4.20-0309-non-reasoning",
+        "grok-4.20-multi-agent-0309",
+        "grok-4-1-fast",
+        "grok-4-1-fast-non-reasoning",
+        "grok-4-fast",
+        "grok-4-fast-non-reasoning",
+        "grok-4",
+        "grok-code-fast-1",
     ],
     "nvidia": [
         # NVIDIA flagship reasoning models


### PR DESCRIPTION
## Summary

The `/model` picker for xAI-direct now shows every current xAI model ID and self-heals when xAI renames models, instead of drifting until someone opens an issue.

Salvages #16818 (@vominh1919, credit preserved) with three name corrections, then adds the structural piece issue #16699 actually asked for.

## Root cause

`_PROVIDER_MODELS["xai"]` hardcoded two stale names (`grok-4.20-reasoning`, `grok-4-1-fast-reasoning`) → HTTP 400 "Unknown Model" on xAI-direct. Same drift pattern that hit openai-codex (#6595, fixed by #7844's `_codex_curated_models()`).

## Commits

### 1. `fix(models): update stale xAI model list (#16699)` — @vominh1919
Replaces the stale entries with xAI-direct's actual current catalog IDs.

PR #16818 as-submitted had three names that look right but don't exist on xAI-direct (`grok-4.20`, `grok-4.20-multi-agent`, `grok-4.1-fast` — those are OpenRouter/Vercel-gateway normalized aliases). This commit corrects to the IDs xAI-direct actually serves, verified against `~/.hermes/models_dev_cache.json`:

```
grok-4.20-0309-reasoning
grok-4.20-0309-non-reasoning
grok-4.20-multi-agent-0309
grok-4-1-fast
grok-4-1-fast-non-reasoning
grok-4-fast
grok-4-fast-non-reasoning
grok-4
grok-code-fast-1
```

### 2. `fix(models): auto-derive xAI model list from models.dev cache`
Replaces the static list with `_xai_curated_models()`, mirroring `_codex_curated_models()` from #7844. Reads `$HERMES_HOME/models_dev_cache.json` at import time (disk only, no network) and falls back to a small static snapshot when the cache is missing.

Hermes already refreshes this cache during normal operation, so the `/model` picker self-heals on the next refresh whenever xAI renames a model. Next time: no issue, no PR.

## Validation

E2E tested against four scenarios with isolated `HERMES_HOME`:

| Scenario | Result |
|---|---|
| Real populated cache (25 current xAI IDs) | ✓ picker shows all 25, including new grok-2/3/4 variants |
| Fresh install / no cache file | ✓ static fallback (9 IDs) |
| Malformed JSON | ✓ static fallback, no crash |
| `xai` present but empty models dict | ✓ static fallback |
| Import-time cost | 11 ms (disk read only, confirmed no HTTP) |

Targeted tests: `tests/hermes_cli/test_model_validation.py` (76 passed), `tests/hermes_cli/ -k models` (227 passed).

Fixes #16699
Closes #16818

Credit: @vominh1919 for the initial fix; extended with a models.dev-backed resolver as the issue requested.