### PR TITLE
[codex] add update tag target

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ hermes gateway      # Start the messaging gateway (Telegram, Discord, etc.)
 hermes setup        # Run the full setup wizard (configures everything at once)
 hermes claw migrate # Migrate from OpenClaw (if coming from OpenClaw)
 hermes update       # Update to the latest version
+hermes update --tag v2026.4.23  # Update to a specific git tag/ref
 hermes doctor       # Diagnose any issues
 ```
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8078,6 +8078,28 @@ class GatewayRunner:
         if is_managed():
             return f"✗ {format_managed_message('update Hermes Agent')}"
 
+        update_tag: Optional[str] = None
+        try:
+            parts = shlex.split(event.text or "")
+        except ValueError as exc:
+            return f"✗ Invalid /update arguments: {exc}"
+        i = 1
+        while i < len(parts):
+            part = parts[i]
+            if part == "--tag":
+                if i + 1 >= len(parts) or not parts[i + 1].strip():
+                    return "✗ Usage: /update [--tag <tag-or-ref>]"
+                update_tag = parts[i + 1].strip()
+                i += 2
+                continue
+            if part.startswith("--tag="):
+                update_tag = part.split("=", 1)[1].strip()
+                if not update_tag:
+                    return "✗ Usage: /update [--tag <tag-or-ref>]"
+                i += 1
+                continue
+            return f"✗ Unknown /update option: {part}\nUsage: /update [--tag <tag-or-ref>]"
+
         project_root = Path(__file__).parent.parent.resolve()
         git_dir = project_root / '.git'
 
@@ -8118,8 +8140,9 @@ class GatewayRunner:
         # PYTHONUNBUFFERED ensures output is flushed line-by-line so the
         # gateway can stream it to the messenger in near-real-time.
         hermes_cmd_str = " ".join(shlex.quote(part) for part in hermes_cmd)
+        tag_arg = f" --tag {shlex.quote(update_tag)}" if update_tag else ""
         update_cmd = (
-            f"PYTHONUNBUFFERED=1 {hermes_cmd_str} update --gateway"
+            f"PYTHONUNBUFFERED=1 {hermes_cmd_str} update --gateway{tag_arg}"
             f" > {shlex.quote(str(output_path))} 2>&1; "
             f"status=$?; printf '%s' \"$status\" > {shlex.quote(str(exit_code_path))}"
         )

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6141,6 +6141,53 @@ def _cmd_update_check():
         print(f"  Run '{recommended_update_command()}' to install.")
 
 
+def _normalize_update_tag(value) -> Optional[str]:
+    """Normalize the optional update target passed via ``hermes update --tag``."""
+    if value is None:
+        return None
+    tag = str(value).strip()
+    if not tag:
+        print("✗ --tag requires a non-empty tag or ref.")
+        sys.exit(1)
+    return tag
+
+
+def _resolve_update_tag_ref(
+    git_cmd: list[str], cwd: Path, tag: str
+) -> tuple[Optional[str], Optional[str]]:
+    """Resolve a user-provided update tag/ref to a checkout target and SHA."""
+    candidates: list[str] = []
+
+    def add(candidate: str) -> None:
+        if candidate and candidate not in candidates:
+            candidates.append(candidate)
+
+    if tag == "main":
+        add("origin/main")
+        add("main")
+    elif tag.startswith("refs/"):
+        if tag.startswith("refs/tags/"):
+            add(f"{tag}^{{}}")
+        add(tag)
+    else:
+        add(f"refs/tags/{tag}^{{}}")
+        add(f"refs/tags/{tag}")
+        add(f"origin/{tag}")
+        add(tag)
+
+    for candidate in candidates:
+        result = subprocess.run(
+            git_cmd + ["rev-parse", "--verify", candidate],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return candidate, result.stdout.strip()
+
+    return None, None
+
+
 def _ensure_fhs_path_guard() -> None:
     """Ensure /usr/local/bin is on PATH for RHEL-family root non-login shells.
 
@@ -6345,6 +6392,8 @@ def cmd_update(args):
 def _cmd_update_impl(args, gateway_mode: bool):
     """Body of ``cmd_update`` — kept separate so the wrapper can always
     restore stdio even on ``sys.exit``."""
+    update_tag = _normalize_update_tag(getattr(args, "tag", None))
+
     # In gateway mode, use file-based IPC for prompts instead of stdin
     gw_input_fn = (
         (lambda prompt, default="": _gateway_prompt(prompt, default))
@@ -6414,8 +6463,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
     try:
 
         print("→ Fetching updates...")
+        fetch_args = git_cmd + ["fetch", "origin"]
+        if update_tag:
+            fetch_args.append("--tags")
         fetch_result = subprocess.run(
-            git_cmd + ["fetch", "origin"],
+            fetch_args,
             cwd=PROJECT_ROOT,
             capture_output=True,
             text=True,
@@ -6447,42 +6499,67 @@ def _cmd_update_impl(args, gateway_mode: bool):
         )
         current_branch = result.stdout.strip()
 
-        # Always update against main
-        branch = "main"
+        tag_checkout_target = None
+        tag_target_sha = None
+        if update_tag:
+            tag_checkout_target, tag_target_sha = _resolve_update_tag_ref(
+                git_cmd, PROJECT_ROOT, update_tag
+            )
+            if not tag_checkout_target or not tag_target_sha:
+                print(f"✗ No git tag or ref found for --tag {update_tag!r}.")
+                print("  Try a release tag like v2026.4.23, or use --tag main for origin/main.")
+                sys.exit(1)
 
-        # If user is on a non-main branch or detached HEAD, switch to main
-        if current_branch != "main":
-            label = (
-                "detached HEAD"
-                if current_branch == "HEAD"
-                else f"branch '{current_branch}'"
-            )
-            print(f"  ⚠ Currently on {label} — switching to main for update...")
-            # Stash before checkout so uncommitted work isn't lost
+            print(f"→ Targeting {update_tag} ({tag_target_sha[:8]})")
             auto_stash_ref = _stash_local_changes_if_needed(git_cmd, PROJECT_ROOT)
-            subprocess.run(
-                git_cmd + ["checkout", "main"],
-                cwd=PROJECT_ROOT,
-                capture_output=True,
-                text=True,
-                check=True,
-            )
         else:
-            auto_stash_ref = _stash_local_changes_if_needed(git_cmd, PROJECT_ROOT)
+            # Always update against main
+            branch = "main"
+
+            # If user is on a non-main branch or detached HEAD, switch to main
+            if current_branch != "main":
+                label = (
+                    "detached HEAD"
+                    if current_branch == "HEAD"
+                    else f"branch '{current_branch}'"
+                )
+                print(f"  ⚠ Currently on {label} — switching to main for update...")
+                # Stash before checkout so uncommitted work isn't lost
+                auto_stash_ref = _stash_local_changes_if_needed(git_cmd, PROJECT_ROOT)
+                subprocess.run(
+                    git_cmd + ["checkout", "main"],
+                    cwd=PROJECT_ROOT,
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                )
+            else:
+                auto_stash_ref = _stash_local_changes_if_needed(git_cmd, PROJECT_ROOT)
 
         prompt_for_restore = auto_stash_ref is not None and (
             gateway_mode or (sys.stdin.isatty() and sys.stdout.isatty())
         )
 
-        # Check if there are updates
-        result = subprocess.run(
-            git_cmd + ["rev-list", f"HEAD..origin/{branch}", "--count"],
-            cwd=PROJECT_ROOT,
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        commit_count = int(result.stdout.strip())
+        if update_tag:
+            result = subprocess.run(
+                git_cmd + ["rev-parse", "HEAD"],
+                cwd=PROJECT_ROOT,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            current_sha = result.stdout.strip()
+            commit_count = 0 if current_sha == tag_target_sha else 1
+        else:
+            # Check if there are updates
+            result = subprocess.run(
+                git_cmd + ["rev-list", f"HEAD..origin/{branch}", "--count"],
+                cwd=PROJECT_ROOT,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            commit_count = int(result.stdout.strip())
 
         if commit_count == 0:
             _invalidate_update_cache()
@@ -6495,7 +6572,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     prompt_user=prompt_for_restore,
                     input_fn=gw_input_fn,
                 )
-            if current_branch not in ("main", "HEAD"):
+            if not update_tag and current_branch not in ("main", "HEAD"):
                 subprocess.run(
                     git_cmd + ["checkout", current_branch],
                     cwd=PROJECT_ROOT,
@@ -6503,10 +6580,16 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     text=True,
                     check=False,
                 )
-            print("✓ Already up to date!")
+            if update_tag:
+                print(f"✓ Already at {update_tag}.")
+            else:
+                print("✓ Already up to date!")
             return
 
-        print(f"→ Found {commit_count} new commit(s)")
+        if update_tag:
+            print(f"→ Checking out {update_tag}")
+        else:
+            print(f"→ Found {commit_count} new commit(s)")
 
         # Snapshot critical state (state.db, config, pairing JSONs, etc.)
         # before pulling so a user can recover if something goes wrong.
@@ -6524,36 +6607,50 @@ def _cmd_update_impl(args, gateway_mode: bool):
             # Never let a snapshot failure block an update.
             logger.debug("Pre-update snapshot failed: %s", exc)
 
-        print("→ Pulling updates...")
+        print("→ Applying update...")
         update_succeeded = False
         try:
-            pull_result = subprocess.run(
-                git_cmd + ["pull", "--ff-only", "origin", branch],
-                cwd=PROJECT_ROOT,
-                capture_output=True,
-                text=True,
-            )
-            if pull_result.returncode != 0:
-                # ff-only failed — local and remote have diverged (e.g. upstream
-                # force-pushed or rebase).  Since local changes are already
-                # stashed, reset to match the remote exactly.
-                print(
-                    "  ⚠ Fast-forward not possible (history diverged), resetting to match remote..."
-                )
-                reset_result = subprocess.run(
-                    git_cmd + ["reset", "--hard", f"origin/{branch}"],
+            if update_tag:
+                checkout_result = subprocess.run(
+                    git_cmd + ["checkout", "--detach", tag_checkout_target],
                     cwd=PROJECT_ROOT,
                     capture_output=True,
                     text=True,
                 )
-                if reset_result.returncode != 0:
-                    print(f"✗ Failed to reset to origin/{branch}.")
-                    if reset_result.stderr.strip():
-                        print(f"  {reset_result.stderr.strip()}")
-                    print(
-                        "  Try manually: git fetch origin && git reset --hard origin/main"
-                    )
+                if checkout_result.returncode != 0:
+                    print(f"✗ Failed to checkout {update_tag}.")
+                    stderr = checkout_result.stderr.strip()
+                    if stderr:
+                        print(f"  {stderr.splitlines()[0]}")
                     sys.exit(1)
+            else:
+                pull_result = subprocess.run(
+                    git_cmd + ["pull", "--ff-only", "origin", branch],
+                    cwd=PROJECT_ROOT,
+                    capture_output=True,
+                    text=True,
+                )
+                if pull_result.returncode != 0:
+                    # ff-only failed — local and remote have diverged (e.g. upstream
+                    # force-pushed or rebase).  Since local changes are already
+                    # stashed, reset to match the remote exactly.
+                    print(
+                        "  ⚠ Fast-forward not possible (history diverged), resetting to match remote..."
+                    )
+                    reset_result = subprocess.run(
+                        git_cmd + ["reset", "--hard", f"origin/{branch}"],
+                        cwd=PROJECT_ROOT,
+                        capture_output=True,
+                        text=True,
+                    )
+                    if reset_result.returncode != 0:
+                        print(f"✗ Failed to reset to origin/{branch}.")
+                        if reset_result.stderr.strip():
+                            print(f"  {reset_result.stderr.strip()}")
+                        print(
+                            "  Try manually: git fetch origin && git reset --hard origin/main"
+                        )
+                        sys.exit(1)
             update_succeeded = True
         finally:
             if auto_stash_ref is not None:
@@ -6585,7 +6682,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
             )
 
         # Fork upstream sync logic (only for main branch on forks)
-        if is_fork and branch == "main":
+        if is_fork and not update_tag:
             _sync_with_upstream_if_needed(git_cmd, PROJECT_ROOT)
 
         # Reinstall Python dependencies. Prefer .[all], but if one optional extra
@@ -9752,6 +9849,11 @@ Examples:
         action="store_true",
         default=False,
         help="Check whether an update is available without installing anything",
+    )
+    update_parser.add_argument(
+        "--tag",
+        metavar="<tag-or-ref>",
+        help="Update to a specific git tag or ref for this run (for example: v2026.4.23 or main)",
     )
     update_parser.add_argument(
         "--no-backup",

--- a/tests/gateway/test_update_command.py
+++ b/tests/gateway/test_update_command.py
@@ -244,6 +244,42 @@ class TestHandleUpdateCommand:
         assert "Starting Hermes update" in result
 
     @pytest.mark.asyncio
+    async def test_update_tag_is_forwarded_to_cli(self, tmp_path):
+        """Forwards /update --tag to the detached hermes update process."""
+        runner = _make_runner()
+        event = _make_event(text="/update --tag v2026.4.23")
+
+        fake_root = tmp_path / "project"
+        fake_root.mkdir()
+        (fake_root / ".git").mkdir()
+        (fake_root / "gateway").mkdir()
+        (fake_root / "gateway" / "run.py").touch()
+        fake_file = str(fake_root / "gateway" / "run.py")
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+
+        mock_popen = MagicMock()
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("gateway.run.__file__", fake_file), \
+             patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"), \
+             patch("subprocess.Popen", mock_popen):
+            result = await runner._handle_update_command(event)
+
+        call_args = mock_popen.call_args[0][0]
+        assert "--tag v2026.4.23" in call_args[-1]
+        assert "Starting Hermes update" in result
+
+    @pytest.mark.asyncio
+    async def test_update_unknown_option_is_rejected(self):
+        """Rejects unsupported /update options instead of silently updating."""
+        runner = _make_runner()
+        event = _make_event(text="/update --unknown")
+
+        result = await runner._handle_update_command(event)
+
+        assert "Unknown /update option" in result
+
+    @pytest.mark.asyncio
     async def test_fallback_when_no_setsid(self, tmp_path):
         """Falls back to start_new_session=True when setsid is not available."""
         runner = _make_runner()

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -130,7 +130,7 @@ class TestCmdUpdateBranchFallback:
         #   3. web/       — install + "npm run build" for the web frontend
         full_flags = [
             "/usr/bin/npm",
-            "install",
+            "ci",
             "--silent",
             "--no-fund",
             "--no-audit",
@@ -139,9 +139,44 @@ class TestCmdUpdateBranchFallback:
         assert npm_calls == [
             (full_flags, PROJECT_ROOT),
             (full_flags, PROJECT_ROOT / "ui-tui"),
-            (["/usr/bin/npm", "install", "--silent"], PROJECT_ROOT / "web"),
+            (["/usr/bin/npm", "ci", "--silent"], PROJECT_ROOT / "web"),
             (["/usr/bin/npm", "run", "build"], PROJECT_ROOT / "web"),
         ]
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_update_tag_fetches_tags_and_checks_out_target(
+        self, mock_run, _mock_which, capsys
+    ):
+        target_sha = "1234567890abcdef1234567890abcdef12345678"
+        current_sha = "abcdef1234567890abcdef1234567890abcdef12"
+
+        def side_effect(cmd, **kwargs):
+            joined = " ".join(str(c) for c in cmd)
+            if "remote get-url origin" in joined:
+                return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+            if "fetch origin --tags" in joined:
+                return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+            if "rev-parse --abbrev-ref HEAD" in joined:
+                return subprocess.CompletedProcess(cmd, 0, stdout="main\n", stderr="")
+            if "rev-parse --verify refs/tags/v2026.4.23^{}" in joined:
+                return subprocess.CompletedProcess(cmd, 0, stdout=f"{target_sha}\n", stderr="")
+            if joined.endswith("rev-parse HEAD"):
+                return subprocess.CompletedProcess(cmd, 0, stdout=f"{current_sha}\n", stderr="")
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        mock_run.side_effect = side_effect
+
+        cmd_update(SimpleNamespace(tag="v2026.4.23"))
+
+        commands = [" ".join(str(a) for a in c.args[0]) for c in mock_run.call_args_list]
+        assert any("fetch origin --tags" in c for c in commands)
+        assert any("checkout --detach refs/tags/v2026.4.23^{}" in c for c in commands)
+        assert not any("pull" in c for c in commands)
+        assert not any("rev-list HEAD..origin/main --count" in c for c in commands)
+
+        captured = capsys.readouterr()
+        assert "Targeting v2026.4.23" in captured.out
 
     def test_update_non_interactive_skips_migration_prompt(self, mock_args, capsys):
         """When stdin/stdout aren't TTYs, config migration prompt is skipped."""

--- a/website/docs/getting-started/updating.md
+++ b/website/docs/getting-started/updating.md
@@ -16,6 +16,15 @@ hermes update
 
 This pulls the latest code, updates dependencies, and prompts you to configure any new options that were added since your last update.
 
+To target a specific git tag or ref for one update:
+
+```bash
+hermes update --tag v2026.4.23
+hermes update --tag main
+```
+
+`--tag` is not persisted. A later `hermes update` without `--tag` goes back to the normal `main` update flow.
+
 :::tip
 `hermes update` automatically detects new configuration options and prompts you to add them. If you skipped that prompt, you can manually run `hermes config check` to see missing options, then `hermes config migrate` to interactively add them.
 :::
@@ -24,7 +33,7 @@ This pulls the latest code, updates dependencies, and prompts you to configure a
 
 When you run `hermes update`, the following steps occur:
 
-1. **Git pull** — pulls the latest code from the `main` branch and updates submodules
+1. **Git update** — pulls the latest code from `main`, or checks out the tag/ref passed with `--tag`
 2. **Dependency install** — runs `uv pip install -e ".[all]"` to pick up new or changed dependencies
 3. **Config migration** — detects new config options added since your version and prompts you to set them
 4. **Gateway auto-restart** — if the gateway service is running (systemd on Linux, launchd on macOS), it is **automatically restarted** after the update completes so the new code takes effect immediately

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -69,7 +69,7 @@ hermes [global-options] <command> [subcommand/options]
 | `hermes profile` | Manage profiles — multiple isolated Hermes instances. |
 | `hermes completion` | Print shell completion scripts (bash/zsh). |
 | `hermes version` | Show version information. |
-| `hermes update` | Pull latest code and reinstall dependencies. |
+| `hermes update [--tag <tag-or-ref>]` | Pull latest code, or checkout a specific tag/ref, and reinstall dependencies. |
 | `hermes uninstall` | Remove Hermes from the system. |
 
 ## `hermes chat`
@@ -911,7 +911,7 @@ hermes completion zsh >> ~/.zshrc
 | Command | Description |
 |---------|-------------|
 | `hermes version` | Print version information. |
-| `hermes update` | Pull latest changes and reinstall dependencies. |
+| `hermes update [--tag <tag-or-ref>]` | Pull latest changes, or checkout a specific tag/ref, and reinstall dependencies. |
 | `hermes uninstall [--full] [--yes]` | Remove Hermes, optionally deleting all config/data. |
 
 ## See also

--- a/website/docs/reference/faq.md
+++ b/website/docs/reference/faq.md
@@ -612,7 +612,7 @@ No. Each profile has its own memory store, session database, and skills director
 
 ### What happens when I run `hermes update`?
 
-`hermes update` pulls the latest code and reinstalls dependencies **once** (not per-profile). It then syncs updated skills to all profiles automatically. You only need to run `hermes update` once — it covers every profile on the machine.
+`hermes update` pulls the latest code and reinstalls dependencies **once** (not per-profile). `hermes update --tag <tag-or-ref>` does the same work after checking out that git tag/ref for this run. It then syncs updated skills to all profiles automatically. You only need to run `hermes update` once — it covers every profile on the machine.
 
 
 ### How many profiles can I run?


### PR DESCRIPTION
## Summary
- Add `hermes update --tag <tag-or-ref>` to target a specific git tag/ref for a single update run.
- Forward `/update --tag ...` from the gateway to the CLI update command.
- Document the new option and cover tag checkout behavior with CLI and gateway tests.

## Validation
- `git diff --check`
- `scripts/run_tests.sh tests/hermes_cli/test_cmd_update.py tests/gateway/test_update_command.py`
- Earlier full affected suite: `scripts/run_tests.sh tests/hermes_cli/test_cmd_update.py tests/gateway/test_update_command.py tests/gateway/test_update_streaming.py`