### PR TITLE
fix(matrix): stop tagging the user on every reply

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2469,15 +2469,11 @@ class BasePlatformAdapter(ABC):
                 # Send the text portion
                 if text_content:
                     logger.info("[%s] Sending response (%d chars) to %s", self.name, len(text_content), event.source.chat_id)
-                    # Build send metadata: thread_id + mention target for platforms that need it
-                    send_metadata = dict(_thread_metadata) if _thread_metadata else {}
-                    if event.source.user_id:
-                        send_metadata["mention_user_id"] = event.source.user_id
                     result = await self._send_with_retry(
                         chat_id=event.source.chat_id,
                         content=text_content,
                         reply_to=event.message_id,
-                        metadata=send_metadata,
+                        metadata=_thread_metadata,
                     )
                     _record_delivery(result)
 

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -879,32 +879,12 @@ class MatrixAdapter(BasePlatformAdapter):
         if not content:
             return SendResult(success=True)
 
-        mention_user_id = (metadata or {}).get("mention_user_id")
-
         formatted = self.format_message(content)
         chunks = self.truncate_message(formatted, MAX_MESSAGE_LENGTH)
 
         last_event_id = None
         for i, chunk in enumerate(chunks):
             msg_content = self._build_text_message_content(chunk)
-
-            # Append @mention pill to the last chunk for push notifications
-            # in muted rooms (mention-only mode).
-            if mention_user_id and i == len(chunks) - 1:
-                mention_html = (
-                    f'<a href="https://matrix.to/#/{mention_user_id}">'
-                    f"{mention_user_id}</a>"
-                )
-                msg_content["body"] = chunk + f" @{mention_user_id}"
-                base_html = msg_content.get("formatted_body", chunk)
-                msg_content["format"] = "org.matrix.custom.html"
-                msg_content["formatted_body"] = base_html + " " + mention_html
-                # m.mentions for MSC3952 push reliability.
-                existing_mentions = msg_content.get("m.mentions", {}).get("user_ids", [])
-                if mention_user_id not in existing_mentions:
-                    msg_content["m.mentions"] = {
-                        "user_ids": existing_mentions + [mention_user_id]
-                    }
 
             # Reply-to support.
             if reply_to:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10033,7 +10033,7 @@ class GatewayRunner:
         # Bridge sync status_callback → async adapter.send for context pressure
         _status_adapter = self.adapters.get(source.platform)
         _status_chat_id = source.chat_id
-        _status_thread_metadata = {"thread_id": _progress_thread_id, "mention_user_id": source.user_id} if _progress_thread_id else {"mention_user_id": source.user_id}
+        _status_thread_metadata = {"thread_id": _progress_thread_id} if _progress_thread_id else None
 
         def _status_callback_sync(event_type: str, message: str) -> None:
             if not _status_adapter or not _run_still_current():


### PR DESCRIPTION
## Summary
Matrix bot stopped pinging the user on every reply. Reverts the always-on `mention_user_id` injection introduced in #38a6bada9 — it was shipped without any gate (DM, group, muted, unmuted — everything got a pill + `m.mentions` push notification).

Reported by Elkim on Discord: "Sigh what happened to Matrix in latest commits? Agent keeps tagging me in every message."

## Changes
- `gateway/platforms/base.py`: drop `send_metadata["mention_user_id"] = event.source.user_id` on every reply; restore `_thread_metadata` passthrough.
- `gateway/run.py`: drop `mention_user_id` from status-thread metadata.
- `gateway/platforms/matrix.py`: remove the mention-pill append block in `_send_text` that consumed the metadata.

Kept intact: reaction-based exec approval (the other half of #38a6bada9) and inbound/outbound `m.mentions` handling for explicit `@user:server` in text — those are unrelated to the per-reply ping.

## Validation
| | Before | After |
|---|---|---|
| Every Matrix reply | Appends `@user:server` pill + `m.mentions.user_ids` → push notify | No mention metadata unless agent explicitly writes `@user:server` |
| `tests/gateway/test_matrix_mention.py` + `test_matrix_exec_approval.py` | 54 pass | 54 pass |

If someone wants mute-room notifications back, add it properly gated behind a config flag (`matrix.mention_on_reply: false` default).

cc @nbot