### PR TITLE
fix(gateway): ignore malformed custom delay env vars in natural mode

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2303,10 +2303,11 @@ class BasePlatformAdapter(ABC):
         mode = os.getenv("HERMES_HUMAN_DELAY_MODE", "off").lower()
         if mode == "off":
             return 0.0
-        min_ms = int(os.getenv("HERMES_HUMAN_DELAY_MIN_MS", "800"))
-        max_ms = int(os.getenv("HERMES_HUMAN_DELAY_MAX_MS", "2500"))
         if mode == "natural":
             min_ms, max_ms = 800, 2500
+            return random.uniform(min_ms / 1000.0, max_ms / 1000.0)
+        min_ms = int(os.getenv("HERMES_HUMAN_DELAY_MIN_MS", "800"))
+        max_ms = int(os.getenv("HERMES_HUMAN_DELAY_MAX_MS", "2500"))
         return random.uniform(min_ms / 1000.0, max_ms / 1000.0)
 
     async def _process_message_background(self, event: MessageEvent, session_key: str) -> None:

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -443,6 +443,16 @@ class TestGetHumanDelay:
             delay = BasePlatformAdapter._get_human_delay()
             assert 0.8 <= delay <= 2.5
 
+    def test_natural_mode_ignores_malformed_custom_env_vars(self):
+        env = {
+            "HERMES_HUMAN_DELAY_MODE": "natural",
+            "HERMES_HUMAN_DELAY_MIN_MS": "oops",
+            "HERMES_HUMAN_DELAY_MAX_MS": "still-bad",
+        }
+        with patch.dict(os.environ, env):
+            delay = BasePlatformAdapter._get_human_delay()
+            assert 0.8 <= delay <= 2.5
+
     def test_custom_mode_uses_env_vars(self):
         env = {
             "HERMES_HUMAN_DELAY_MODE": "custom",


### PR DESCRIPTION
## What does this PR do?

Fixes a gateway crash path in `BasePlatformAdapter._get_human_delay()`.

`HERMES_HUMAN_DELAY_MODE=natural` should use the built-in 800ms–2500ms range and should not depend on `HERMES_HUMAN_DELAY_MIN_MS` / `HERMES_HUMAN_DELAY_MAX_MS`. Before this change, the function parsed those custom-only env vars even in `natural` mode, so malformed values could raise `ValueError` and break message processing.

This change keeps the fix narrowly scoped by returning early for `natural` mode before parsing custom env values.

## Related Issue

Fixes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Updated `gateway/platforms/base.py` so `natural` human-delay mode returns using the built-in range without parsing custom delay env vars.
- Added a regression test in `tests/gateway/test_platform_base.py` covering malformed custom env vars while `HERMES_HUMAN_DELAY_MODE=natural`.
- No unrelated changes.

## How to Test

1. Set:
   - `HERMES_HUMAN_DELAY_MODE=natural`
   - `HERMES_HUMAN_DELAY_MIN_MS=oops`
   - `HERMES_HUMAN_DELAY_MAX_MS=still-bad`
2. Before the fix, calling `BasePlatformAdapter._get_human_delay()` raises `ValueError`.
3. After the fix, it returns a float in the `0.8` to `2.5` range.

Automated:
1. `scripts/run_tests.sh tests/gateway/test_platform_base.py -q`
2. `scripts/run_tests.sh tests/ -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

