### PR TITLE
fix(cli): fall back on invalid HERMES_MAX_ITERATIONS

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2044,7 +2044,10 @@ class HermesCLI:
         elif CLI_CONFIG.get("max_turns"):  # Backwards compat: root-level max_turns
             self.max_turns = CLI_CONFIG["max_turns"]
         elif os.getenv("HERMES_MAX_ITERATIONS"):
-            self.max_turns = int(os.getenv("HERMES_MAX_ITERATIONS"))
+            try:
+                self.max_turns = int(os.getenv("HERMES_MAX_ITERATIONS", ""))
+            except (TypeError, ValueError):
+                self.max_turns = 90
         else:
             self.max_turns = 90
         

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -75,6 +75,11 @@ class TestMaxTurnsResolution:
         cli_obj = _make_cli(env_overrides={"HERMES_MAX_ITERATIONS": "42"})
         assert cli_obj.max_turns == 42
 
+    def test_invalid_env_var_max_turns_falls_back_to_default(self):
+        """Invalid env values should not crash CLI init."""
+        cli_obj = _make_cli(env_overrides={"HERMES_MAX_ITERATIONS": "not-a-number"})
+        assert cli_obj.max_turns == 90
+
     def test_legacy_root_max_turns_is_used_when_agent_key_exists_without_value(self):
         cli_obj = _make_cli(config_overrides={"agent": {}, "max_turns": 77})
         assert cli_obj.max_turns == 77


### PR DESCRIPTION
## What does this PR do?

Fixes a CLI initialization crash when `HERMES_MAX_ITERATIONS` is set to a non-numeric value.

Before this change, Hermes called `int(os.getenv("HERMES_MAX_ITERATIONS"))` directly during `HermesCLI` setup. If the env var contained an invalid value like `not-a-number`, CLI startup failed with `ValueError`.

This change keeps the existing precedence order intact and only hardens the env-var fallback path:
CLI arg > config file > env var > default.

When the env var is invalid, Hermes now falls back to the existing default of `90` instead of crashing.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Hardened `HERMES_MAX_ITERATIONS` parsing in `cli.py`
- Added a regression test in `tests/cli/test_cli_init.py`
- Kept the change focused to a single bugfix with no unrelated edits

## How to Test

1. Set `HERMES_MAX_ITERATIONS=not-a-number`
2. Start Hermes CLI or instantiate `HermesCLI`
3. Confirm it no longer crashes and uses the default `max_turns` value of `90`

Regression test:
- `py -3.12 -m pytest tests/cli/test_cli_init.py -v`

## Validation

- Target test file passed: `tests/cli/test_cli_init.py` (`27 passed`)
- Full Windows-local `tests/` run also completed, but unrelated failures were platform/dependency-specific and not caused by this change


## Notes

- No config schema changes
- No behavior changes for valid CLI args, config values, or valid env values
- No unrelated changes
