### PR TITLE
fix(auxiliary): avoid locking into custom path when api_key is empty

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2740,8 +2740,14 @@ def _resolve_task_provider_model(
 
     if task:
         # Config.yaml is the primary source for per-task overrides.
-        if cfg_base_url:
+        if cfg_base_url and cfg_api_key:
+            # Both base_url and api_key explicitly set → custom endpoint.
             return "custom", resolved_model, cfg_base_url, cfg_api_key, resolved_api_mode
+        if cfg_base_url and cfg_provider and cfg_provider != "auto":
+            # base_url set without api_key but with a known provider — use
+            # the provider so it can resolve credentials from env vars
+            # (e.g. OPENROUTER_API_KEY) instead of locking into "custom".
+            return cfg_provider, resolved_model, cfg_base_url, None, resolved_api_mode
         if cfg_provider and cfg_provider != "auto":
             return cfg_provider, resolved_model, None, None, resolved_api_mode
 


### PR DESCRIPTION
## Problem

When `auxiliary.<task>` config has `base_url` set but `api_key` is empty (common when user expects env var fallback), `_resolve_task_provider_model()` returns `provider="custom"` with `api_key=None`. This causes downstream client construction to make API calls without an `Authorization` header, resulting in HTTP 401 errors.

This affects any user whose config has the default-looking shape from `hermes setup`:

```yaml
auxiliary:
  title_generation:
    provider: openrouter
    model: minimax/minimax-m2.7
    base_url: https://openrouter.ai/api/v1
    api_key: ''    # empty — user expects OPENROUTER_API_KEY fallback
```

## Root Cause

In `_resolve_task_provider_model()` (`agent/auxiliary_client.py:2743`):

```python
if cfg_base_url:
    return "custom", resolved_model, cfg_base_url, cfg_api_key, resolved_api_mode
```

The `if cfg_base_url:` branch fires before the provider is considered. With `cfg_api_key=None` (empty string in YAML), the returned tuple drives `_get_cached_client("custom", ..., api_key=None)`, which builds an `OpenAI()` client with no auth.

## Fix

Only return the `"custom"` provider path when **both** `cfg_base_url` and `cfg_api_key` are non-empty. When `base_url` is set without `api_key` but with a known provider (e.g. `"openrouter"`), pass through to that provider so it can resolve credentials from environment variables.

### Before

```
auxiliary.title_generation: base_url=https://openrouter.ai/api/v1, provider=openrouter, api_key=''
→ Returns ("custom", model, base_url, None, ...) → HTTP 401
```

### After

```
auxiliary.title_generation: base_url=https://openrouter.ai/api/v1, provider=openrouter, api_key=''
→ Returns ("openrouter", model, base_url, None, ...) → resolves OPENROUTER_API_KEY from env → succeeds
```

Fixes #16829
