### PR TITLE
feat(runtime): add state recovery foundations

### DIFF
--- a/agent/runtime/__init__.py
+++ b/agent/runtime/__init__.py
@@ -1,0 +1,29 @@
+"""Runtime state foundations for Hermes Agent.
+
+This package is intentionally additive. It defines serializable state primitives
+that future runtime, cron, and self-evolution features can opt into without
+changing the current Gateway or agent loop behavior.
+"""
+
+from .state import (
+    AgentRuntimeState,
+    ModelRuntimeState,
+    RuntimeMutation,
+    RuntimeMutationRisk,
+    RuntimeMutationType,
+    RuntimeSessionState,
+    ToolRuntimeState,
+)
+from .state_store import RuntimeStateCheckpoint, RuntimeStateStore
+
+__all__ = [
+    "AgentRuntimeState",
+    "ModelRuntimeState",
+    "RuntimeMutation",
+    "RuntimeMutationRisk",
+    "RuntimeMutationType",
+    "RuntimeSessionState",
+    "RuntimeStateCheckpoint",
+    "RuntimeStateStore",
+    "ToolRuntimeState",
+]

--- a/agent/runtime/state.py
+++ b/agent/runtime/state.py
@@ -1,0 +1,115 @@
+"""Serializable runtime state models for Hermes Agent.
+
+These models are minimal by design. They are not a replacement for SessionDB,
+Gateway sessions, or filesystem checkpoints. They provide a stable snapshot
+shape that future capability layers can use for recovery, comparison, handoff,
+and controlled self-improvement records.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+class RuntimeMutationType(StrEnum):
+    """Mutation categories for controlled self-improvement records."""
+
+    SKILL_PATCH = "skill_patch"
+    MEMORY_ENTRY = "memory_entry"
+    CRON_PROMPT_PATCH = "cron_prompt_patch"
+    CONFIG_PATCH = "config_patch"
+    IDENTITY_RULE_PATCH = "identity_rule_patch"
+    CODE_PATCH = "code_patch"
+
+
+class RuntimeMutationRisk(StrEnum):
+    """Coarse mutation risk level for future gate/eval layers."""
+
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+class ModelRuntimeState(BaseModel):
+    """Model/provider state captured for a runtime snapshot."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    provider: str
+    model: str
+    api_mode: str | None = None
+    fallback_model: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class ToolRuntimeState(BaseModel):
+    """Tool state captured for a runtime snapshot."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    toolset: str | None = None
+    enabled: bool = True
+    concurrency_safe: bool | None = None
+    risk: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class AgentRuntimeState(BaseModel):
+    """Agent identity/state subset needed to interpret a runtime snapshot."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    agent_id: str
+    display_name: str | None = None
+    platform: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class RuntimeMutation(BaseModel):
+    """Typed, auditable mutation proposal or applied change.
+
+    Phase 0 only records mutation intent and rollback metadata. It deliberately
+    does not implement gate hierarchy or automatic application; those should be
+    based on real mutation history, not premature abstraction.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    mutation_id: str
+    mutation_type: RuntimeMutationType
+    scope: str
+    rationale: str
+    risk: RuntimeMutationRisk = RuntimeMutationRisk.MEDIUM
+    validator: str | None = None
+    rollback_hint: str | None = None
+    payload: dict[str, Any] = Field(default_factory=dict)
+    created_at: datetime = Field(default_factory=_utc_now)
+
+
+class RuntimeSessionState(BaseModel):
+    """A minimal session snapshot for recovery, handoff, and comparison."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    session_id: str
+    agent: AgentRuntimeState
+    model: ModelRuntimeState
+    platform: str | None = None
+    thread_id: str | None = None
+    task_id: str | None = None
+    tools: list[ToolRuntimeState] = Field(default_factory=list)
+    messages: list[dict[str, Any]] = Field(default_factory=list)
+    memory_refs: list[str] = Field(default_factory=list)
+    mutations: list[RuntimeMutation] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    created_at: datetime = Field(default_factory=_utc_now)
+    updated_at: datetime = Field(default_factory=_utc_now)

--- a/agent/runtime/state_store.py
+++ b/agent/runtime/state_store.py
@@ -1,0 +1,116 @@
+"""Append-only runtime state store.
+
+RuntimeStateStore is a small, opt-in recovery primitive for future runtime and
+self-improvement layers. It complements existing SessionDB and shadow-git
+checkpoints instead of replacing them.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+from uuid import uuid4
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from agent.runtime.state import RuntimeSessionState
+from utils import atomic_json_write
+
+
+_STATE_LOG = "runtime-state.jsonl"
+_INDEX_FILE = "runtime-state.index.json"
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+class RuntimeStateCheckpoint(BaseModel):
+    """One persisted runtime state checkpoint."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    checkpoint_id: str = Field(default_factory=lambda: uuid4().hex)
+    step_id: str
+    reason: str
+    state: RuntimeSessionState
+    created_at: datetime = Field(default_factory=_utc_now)
+
+
+class RuntimeStateStore:
+    """Single-process JSONL store for runtime state checkpoints.
+
+    Consistency model:
+    - checkpoint records are append-only JSONL lines;
+    - `runtime-state.index.json` is atomically replaced after each append;
+    - readers use the index first, so a corrupt trailing JSONL line does not
+      hide the most recent fully indexed checkpoint.
+    """
+
+    def __init__(self, root: str | Path):
+        self.root = Path(root)
+        self.root.mkdir(parents=True, exist_ok=True)
+        self.log_path = self.root / _STATE_LOG
+        self.index_path = self.root / _INDEX_FILE
+
+    def append(self, state: RuntimeSessionState, *, step_id: str, reason: str) -> RuntimeStateCheckpoint:
+        checkpoint = RuntimeStateCheckpoint(step_id=step_id, reason=reason, state=state)
+        with self.log_path.open("a", encoding="utf-8") as handle:
+            handle.write(checkpoint.model_dump_json())
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        index = self._load_index()
+        index[checkpoint.checkpoint_id] = {
+            "checkpoint_id": checkpoint.checkpoint_id,
+            "step_id": checkpoint.step_id,
+            "reason": checkpoint.reason,
+            "created_at": checkpoint.created_at.isoformat(),
+        }
+        index["_latest"] = checkpoint.checkpoint_id
+        atomic_json_write(self.index_path, index)
+        return checkpoint
+
+    def list(self) -> list[RuntimeStateCheckpoint]:
+        return self._read_all()
+
+    def latest(self) -> RuntimeStateCheckpoint | None:
+        latest_id = self._load_index().get("_latest")
+        return self.read(latest_id) if latest_id else None
+
+    def read(self, checkpoint_id: str | None) -> RuntimeStateCheckpoint | None:
+        if not checkpoint_id:
+            return None
+        for checkpoint in self._read_all():
+            if checkpoint.checkpoint_id == checkpoint_id:
+                return checkpoint
+        return None
+
+    def _load_index(self) -> dict:
+        if not self.index_path.exists():
+            return {}
+        try:
+            with self.index_path.open("r", encoding="utf-8") as handle:
+                data = json.load(handle)
+                return data if isinstance(data, dict) else {}
+        except (OSError, json.JSONDecodeError):
+            return {}
+
+    def _read_all(self) -> list[RuntimeStateCheckpoint]:
+        if not self.log_path.exists():
+            return []
+        checkpoints: list[RuntimeStateCheckpoint] = []
+        with self.log_path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    checkpoints.append(RuntimeStateCheckpoint.model_validate_json(line))
+                except ValueError:
+                    # A crash during append can leave a corrupt trailing line.
+                    # Keep earlier complete checkpoints available.
+                    continue
+        return checkpoints

--- a/tests/agent/runtime/test_state_models.py
+++ b/tests/agent/runtime/test_state_models.py
@@ -1,0 +1,53 @@
+from datetime import UTC, datetime
+
+from agent.runtime.state import (
+    AgentRuntimeState,
+    ModelRuntimeState,
+    RuntimeMutation,
+    RuntimeMutationRisk,
+    RuntimeMutationType,
+    RuntimeSessionState,
+    ToolRuntimeState,
+)
+
+
+def test_runtime_session_state_round_trips_json():
+    state = RuntimeSessionState(
+        session_id="session-1",
+        platform="telegram",
+        agent=AgentRuntimeState(agent_id="moss", display_name="Moss"),
+        model=ModelRuntimeState(provider="openai-codex", model="gpt-5.5"),
+        tools=[ToolRuntimeState(name="read_file", toolset="file", enabled=True)],
+        messages=[{"role": "user", "content": "ping"}],
+        metadata={"task": "capability-runtime"},
+        created_at=datetime(2026, 4, 27, 11, 0, tzinfo=UTC),
+        updated_at=datetime(2026, 4, 27, 11, 1, tzinfo=UTC),
+    )
+
+    restored = RuntimeSessionState.model_validate_json(state.model_dump_json())
+
+    assert restored.session_id == "session-1"
+    assert restored.agent.agent_id == "moss"
+    assert restored.model.model == "gpt-5.5"
+    assert restored.tools[0].name == "read_file"
+    assert restored.metadata["task"] == "capability-runtime"
+
+
+def test_runtime_mutation_carries_validator_and_rollback_hint():
+    mutation = RuntimeMutation(
+        mutation_id="mut-1",
+        mutation_type=RuntimeMutationType.SKILL_PATCH,
+        scope="skills/devops/hermes-core-backup/SKILL.md",
+        rationale="Capture repeated backup-check failure mode.",
+        risk=RuntimeMutationRisk.LOW,
+        validator="skill_view hermes-core-backup succeeds",
+        rollback_hint="revert skill patch",
+        payload={"old": "x", "new": "y"},
+    )
+
+    restored = RuntimeMutation.model_validate_json(mutation.model_dump_json())
+
+    assert restored.mutation_type is RuntimeMutationType.SKILL_PATCH
+    assert restored.risk is RuntimeMutationRisk.LOW
+    assert restored.validator.startswith("skill_view")
+    assert restored.rollback_hint == "revert skill patch"

--- a/tests/agent/runtime/test_state_store.py
+++ b/tests/agent/runtime/test_state_store.py
@@ -1,0 +1,59 @@
+from datetime import UTC, datetime
+from pathlib import Path
+
+from agent.runtime.state import AgentRuntimeState, ModelRuntimeState, RuntimeSessionState
+from agent.runtime.state_store import RuntimeStateStore
+
+
+def _state(session_id: str) -> RuntimeSessionState:
+    return RuntimeSessionState(
+        session_id=session_id,
+        platform="telegram",
+        agent=AgentRuntimeState(agent_id="moss"),
+        model=ModelRuntimeState(provider="openai-codex", model="gpt-5.5"),
+        created_at=datetime(2026, 4, 27, 11, 0, tzinfo=UTC),
+        updated_at=datetime(2026, 4, 27, 11, 0, tzinfo=UTC),
+    )
+
+
+def test_runtime_state_store_appends_and_reads_latest(tmp_path: Path):
+    store = RuntimeStateStore(tmp_path)
+
+    first = store.append(_state("s1"), step_id="step-1", reason="initial")
+    second = store.append(_state("s2"), step_id="step-2", reason="updated")
+
+    assert first.checkpoint_id != second.checkpoint_id
+    assert store.latest().checkpoint_id == second.checkpoint_id
+    assert store.latest().state.session_id == "s2"
+    assert [item.step_id for item in store.list()] == ["step-1", "step-2"]
+
+
+def test_runtime_state_store_reads_checkpoint_by_id(tmp_path: Path):
+    store = RuntimeStateStore(tmp_path)
+    checkpoint = store.append(_state("s1"), step_id="step-1", reason="initial")
+
+    restored = store.read(checkpoint.checkpoint_id)
+
+    assert restored is not None
+    assert restored.checkpoint_id == checkpoint.checkpoint_id
+    assert restored.state.session_id == "s1"
+
+
+def test_runtime_state_store_index_survives_corrupt_trailing_jsonl_line(tmp_path: Path):
+    store = RuntimeStateStore(tmp_path)
+    checkpoint = store.append(_state("s1"), step_id="step-1", reason="initial")
+    (tmp_path / "runtime-state.jsonl").write_text(
+        (tmp_path / "runtime-state.jsonl").read_text(encoding="utf-8") + "{not-json\n",
+        encoding="utf-8",
+    )
+
+    assert store.latest().checkpoint_id == checkpoint.checkpoint_id
+    assert store.read(checkpoint.checkpoint_id).state.session_id == "s1"
+
+
+def test_runtime_state_store_returns_none_when_empty(tmp_path: Path):
+    store = RuntimeStateStore(tmp_path)
+
+    assert store.latest() is None
+    assert store.read("missing") is None
+    assert store.list() == []

--- a/tests/test_atomic_write_utils.py
+++ b/tests/test_atomic_write_utils.py
@@ -1,0 +1,57 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from utils import atomic_bytes_write, atomic_text_write
+
+
+def test_atomic_text_write_preserves_existing_file_mode(tmp_path: Path):
+    target = tmp_path / "state.txt"
+    target.write_text("old", encoding="utf-8")
+    target.chmod(0o644)
+
+    atomic_text_write(target, "new")
+
+    assert target.read_text(encoding="utf-8") == "new"
+    assert (target.stat().st_mode & 0o777) == 0o644
+
+
+def test_atomic_bytes_write_round_trips_binary_payload(tmp_path: Path):
+    target = tmp_path / "state.bin"
+    payload = b"\x00hermes\xff"
+
+    atomic_bytes_write(target, payload)
+
+    assert target.read_bytes() == payload
+
+
+def test_atomic_text_write_keeps_original_on_replace_failure(monkeypatch, tmp_path: Path):
+    target = tmp_path / "state.txt"
+    target.write_text("old", encoding="utf-8")
+
+    def fail_replace(src, dst):
+        raise OSError("simulated replace failure")
+
+    monkeypatch.setattr(os, "replace", fail_replace)
+
+    with pytest.raises(OSError, match="simulated replace failure"):
+        atomic_text_write(target, "new")
+
+    assert target.read_text(encoding="utf-8") == "old"
+
+
+def test_atomic_text_write_cleans_temp_file_on_failure(monkeypatch, tmp_path: Path):
+    target = tmp_path / "state.txt"
+    target.write_text("old", encoding="utf-8")
+
+    def fail_replace(src, dst):
+        raise OSError("simulated replace failure")
+
+    monkeypatch.setattr(os, "replace", fail_replace)
+
+    with pytest.raises(OSError):
+        atomic_text_write(target, "new")
+
+    leftovers = list(tmp_path.glob(".state_*.tmp"))
+    assert leftovers == []

--- a/utils.py
+++ b/utils.py
@@ -58,6 +58,56 @@ def _restore_file_mode(path: Path, mode: "int | None") -> None:
         pass
 
 
+def _atomic_write_with_writer(
+    path: Union[str, Path],
+    mode: str,
+    writer,
+    *,
+    encoding: str | None = "utf-8",
+) -> None:
+    """Write a file via temp file + fsync + os.replace.
+
+    This is the shared primitive for Hermes state-like files. It preserves the
+    previous target if writing or replacing fails, cleans temporary files on
+    BaseException, and restores an existing file's permission bits after the
+    replace.
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    original_mode = _preserve_file_mode(path)
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(path.parent),
+        prefix=f".{path.stem}_",
+        suffix=".tmp",
+    )
+    open_kwargs = {} if "b" in mode else {"encoding": encoding or "utf-8"}
+    try:
+        with os.fdopen(fd, mode, **open_kwargs) as f:
+            writer(f)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, path)
+        _restore_file_mode(path, original_mode)
+    except BaseException:
+        # Intentionally catch BaseException so temp-file cleanup still runs for
+        # KeyboardInterrupt/SystemExit before re-raising the original signal.
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def atomic_text_write(path: Union[str, Path], text: str, *, encoding: str = "utf-8") -> None:
+    """Write text to a file atomically, preserving existing permissions."""
+    _atomic_write_with_writer(path, "w", lambda handle: handle.write(text), encoding=encoding)
+
+
+def atomic_bytes_write(path: Union[str, Path], data: bytes) -> None:
+    """Write bytes to a file atomically, preserving existing permissions."""
+    _atomic_write_with_writer(path, "wb", lambda handle: handle.write(data))
+
+
 def atomic_json_write(
     path: Union[str, Path],
     data: Any,
@@ -78,37 +128,17 @@ def atomic_json_write(
         **dump_kwargs: Additional keyword args forwarded to json.dump(), such
             as default=str for non-native types.
     """
-    path = Path(path)
-    path.parent.mkdir(parents=True, exist_ok=True)
 
-    original_mode = _preserve_file_mode(path)
+    def _write(handle) -> None:
+        json.dump(
+            data,
+            handle,
+            indent=indent,
+            ensure_ascii=False,
+            **dump_kwargs,
+        )
 
-    fd, tmp_path = tempfile.mkstemp(
-        dir=str(path.parent),
-        prefix=f".{path.stem}_",
-        suffix=".tmp",
-    )
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            json.dump(
-                data,
-                f,
-                indent=indent,
-                ensure_ascii=False,
-                **dump_kwargs,
-            )
-            f.flush()
-            os.fsync(f.fileno())
-        os.replace(tmp_path, path)
-        _restore_file_mode(path, original_mode)
-    except BaseException:
-        # Intentionally catch BaseException so temp-file cleanup still runs for
-        # KeyboardInterrupt/SystemExit before re-raising the original signal.
-        try:
-            os.unlink(tmp_path)
-        except OSError:
-            pass
-        raise
+    _atomic_write_with_writer(path, "w", _write)
 
 
 def atomic_yaml_write(


### PR DESCRIPTION
## Summary

This is PR 1 from the split Phase 7 runtime capability foundation series.

It adds the minimal state recovery foundation only:

- new serializable runtime state models under `agent/runtime/state.py`
- an append-only `RuntimeStateStore` with an atomically replaced index
- shared atomic text/bytes write helpers in `utils.py`
- focused tests for state models, state persistence, and atomic write helpers

This PR intentionally does **not** include later Phase 7 layers such as analytics, event correlation, task graphs, session export, or controlled mutation trials. Those will be proposed as smaller follow-up PRs if this foundation is acceptable.

## Why

Hermes currently has several persistence surfaces, but future recovery/handoff/self-improvement features need a small, explicit runtime snapshot shape that can be validated independently and persisted safely without changing the current Gateway or agent loop behavior.

The checkpoint store is opt-in and additive:

- JSONL checkpoint records are append-only
- `runtime-state.index.json` is atomically replaced after append
- corrupt trailing JSONL lines are skipped when reading historical checkpoints
- no current runtime behavior is wired to this yet

## Test Plan

Local focused checks passed:

```text
python -m pytest \
  tests/agent/runtime/test_state_models.py \
  tests/agent/runtime/test_state_store.py \
  tests/test_atomic_write_utils.py

10 passed
```

Additional local verification:

```text
python -m py_compile \
  agent/runtime/__init__.py \
  agent/runtime/state.py \
  agent/runtime/state_store.py \
  tests/agent/runtime/test_state_models.py \
  tests/agent/runtime/test_state_store.py \
  tests/test_atomic_write_utils.py \
  utils.py
```

Import smoke test passed:

```text
from agent.runtime import AgentRuntimeState, RuntimeSessionState, RuntimeStateStore
from utils import atomic_text_write, atomic_bytes_write, atomic_json_write
```

Secret scan note:

- `gitleaks` was not installed locally
- staged diff was scanned for common API key/token/private-key patterns; no findings

## Follow-up PRs planned

If this PR is accepted, the remaining Phase 7 work will be split into smaller draft PRs:

1. analytics + event correlation
2. recoverable task graph primitives
3. session export checkpoint bundle
4. controlled mutation trials
5. final docs/overview PR
