### PR TITLE
fix(onboarding): reword OpenClaw workspace detection tip to be neutral

### DIFF
--- a/agent/onboarding.py
+++ b/agent/onboarding.py
@@ -98,17 +98,17 @@ def tool_progress_hint_cli() -> str:
 def openclaw_residue_hint_cli() -> str:
     """Banner shown the first time Hermes starts and finds ``~/.openclaw/``.
 
-    OpenClaw-era config, memory, and skill paths in ``~/.openclaw/`` will
-    otherwise attract the agent (memory entries like ``~/.openclaw/config.yaml``
-    get carried forward and the agent dutifully reads them). ``hermes claw
-    cleanup`` renames the directory so the agent stops finding it.
+    A neutral, informational notice letting the user know that a legacy
+    OpenClaw directory exists and how to optionally migrate or archive it.
     """
     return (
-        "Heads up — an OpenClaw workspace was detected at ~/.openclaw/.\n"
-        "After migrating, the agent can still get confused and read that "
-        "directory's config/memory instead of Hermes's.\n"
-        "Run `hermes claw cleanup` to archive it (rename → .openclaw.pre-migration). "
-        "This tip only shows once; rerun it any time with `hermes claw cleanup`."
+        "A legacy OpenClaw directory was detected at ~/.openclaw/.\n"
+        "If you'd like to migrate your config and skills to Hermes, "
+        "run `hermes claw migrate`.\n"
+        "To archive the old directory, run `hermes claw cleanup` "
+        "(renames ~/.openclaw/ to ~/.openclaw.pre-migration/; "
+        "this will break OpenClaw if you still use it).\n"
+        "This tip only shows once."
     )
 
 


### PR DESCRIPTION
## Problem

The onboarding tip shown when Hermes detects `~/.openclaw/` uses unnecessarily hostile language that implies OpenClaw is a problem:

> "Heads up — an OpenClaw workspace was detected... the agent can still get confused and read that directory's config/memory instead of Hermes's."

Issues with the current wording:
1. **Hostile tone** — "can still get confused" and "instead of Hermes's" frames OpenClaw as a problem to eliminate rather than a legacy setup to optionally migrate.
2. **No migration guidance** — the tip jumps straight to `hermes claw cleanup` without mentioning `hermes claw migrate` first.
3. **Missing side-effect warning** — `hermes claw cleanup` renames `~/.openclaw/` to `~/.openclaw.pre-migration/`, which breaks OpenClaw for users who still use it. The tip doesn't warn about this.
4. **Confusing framing** — "the agent dutifully reads" (in the docstring) sounds like a bug report rather than a neutral notice.

## Fix

Reword the message to be factual and neutral:

**Before:**
```
Heads up — an OpenClaw workspace was detected at ~/.openclaw/.
After migrating, the agent can still get confused and read that directory's config/memory instead of Hermes's.
Run `hermes claw cleanup` to archive it (rename → .openclaw.pre-migration). This tip only shows once; rerun it any time with `hermes claw cleanup`.
```

**After:**
```
A legacy OpenClaw directory was detected at ~/.openclaw/.
If you'd like to migrate your config and skills to Hermes, run `hermes claw migrate`.
To archive the old directory, run `hermes claw cleanup` (renames ~/.openclaw/ to ~/.openclaw.pre-migration/; this will break OpenClaw if you still use it).
This tip only shows once.
```

Changes:
- "legacy" framing instead of "heads up"
- Recommend `hermes claw migrate` as the first option
- Clear warning that `hermes claw cleanup` will break OpenClaw
- Remove anthropomorphic language about the agent "getting confused"

Fixes #16629
