### PR TITLE
feat(whatsapp): add soft-thread sessions

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -860,7 +860,10 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["group_allow_admin_from"] = platform_cfg["group_allow_admin_from"]
                 if "group_user_allowed_commands" in platform_cfg:
                     bridged["group_user_allowed_commands"] = platform_cfg["group_user_allowed_commands"]
-                if plat in {Platform.DISCORD, Platform.SLACK} and "channel_skill_bindings" in platform_cfg:
+                for key in ("enable_sessions", "session_idle_minutes", "session_max_live_per_chat"):
+                    if key in platform_cfg:
+                        bridged[key] = platform_cfg[key]
+                if plat in (Platform.DISCORD, Platform.SLACK) and "channel_skill_bindings" in platform_cfg:
                     bridged["channel_skill_bindings"] = platform_cfg["channel_skill_bindings"]
                 if "channel_prompts" in platform_cfg:
                     channel_prompts = platform_cfg["channel_prompts"]

--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -24,6 +24,9 @@ import re
 import shutil
 import signal
 import subprocess
+import time
+import uuid
+from dataclasses import dataclass, replace
 
 _IS_WINDOWS = platform.system() == "Windows"
 from pathlib import Path
@@ -191,6 +194,25 @@ from gateway.platforms.base import (
 )
 
 
+@dataclass
+class _WhatsAppSession:
+    session_id: str
+    chat_key: str
+    created_at: float
+    last_activity_at: float
+    title: str = ""
+    root_message_id: Optional[str] = None
+    status: str = "idle"
+
+
+@dataclass
+class _WhatsAppSessionRoute:
+    event: MessageEvent
+    session_id: Optional[str] = None
+    created_new: bool = False
+    had_existing_session: bool = False
+
+
 def check_whatsapp_requirements() -> bool:
     """
     Check if WhatsApp dependencies are available.
@@ -260,6 +282,25 @@ class WhatsAppAdapter(BasePlatformAdapter):
             get_hermes_dir("platforms/whatsapp/session", "whatsapp/session")
         ))
         self._reply_prefix: Optional[str] = config.extra.get("reply_prefix")
+        self._sessions_enabled = self._truthy_config(
+            "enable_sessions", env_name="WHATSAPP_ENABLE_SESSIONS", default=True
+        )
+        session_idle_minutes = config.extra.get(
+            "session_idle_minutes", os.getenv("WHATSAPP_SESSION_IDLE_MINUTES", "60")
+        )
+        self._session_idle_seconds = max(1, int(float(session_idle_minutes) * 60))
+        self._session_max_live_per_chat = max(
+            1,
+            int(
+                config.extra.get(
+                    "session_max_live_per_chat",
+                    os.getenv("WHATSAPP_SESSION_MAX_LIVE_PER_CHAT", "5"),
+                )
+            ),
+        )
+        self._whatsapp_sessions: Dict[str, _WhatsAppSession] = {}
+        self._whatsapp_message_sessions: Dict[str, str] = {}
+        self._whatsapp_chat_focus: Dict[str, str] = {}
         self._dm_policy = str(config.extra.get("dm_policy") or os.getenv("WHATSAPP_DM_POLICY", "open")).strip().lower()
         self._allow_from = self._coerce_allow_list(config.extra.get("allow_from") or config.extra.get("allowFrom"))
         self._group_policy = str(config.extra.get("group_policy") or os.getenv("WHATSAPP_GROUP_POLICY", "open")).strip().lower()
@@ -296,6 +337,273 @@ class WhatsAppAdapter(BasePlatformAdapter):
         # Keep enough space for truncate_message's pagination indicator and
         # code-fence repair even if a user configures a very long prefix.
         return max(1024, self.MAX_MESSAGE_LENGTH - prefix_len)
+
+    def _truthy_config(self, key: str, *, env_name: str, default: bool = False) -> bool:
+        raw = self.config.extra.get(key)
+        if raw is None:
+            raw = os.getenv(env_name)
+        if raw is None:
+            return default
+        if isinstance(raw, bool):
+            return raw
+        return str(raw).strip().lower() in {"1", "true", "yes", "on"}
+
+    @staticmethod
+    def _session_chat_key(source) -> str:
+        return f"{source.chat_type}:{source.chat_id}" if source else "unknown"
+
+    def _whatsapp_session_is_live(self, session_id: Optional[str], *, now: Optional[float] = None) -> bool:
+        if not session_id:
+            return False
+        session = self._whatsapp_sessions.get(session_id)
+        if session is None or session.status == "expired":
+            return False
+        if now is None:
+            now = time.time()
+        if (now - session.last_activity_at) > self._session_idle_seconds:
+            session.status = "expired"
+            return False
+        return True
+
+    def _create_whatsapp_session(
+        self,
+        chat_key: str,
+        *,
+        root_message_id: Optional[str] = None,
+        title: str = "",
+        now: Optional[float] = None,
+    ) -> str:
+        now = now if now is not None else time.time()
+        session_id = f"wa-session-{uuid.uuid4().hex[:10]}"
+        self._whatsapp_sessions[session_id] = _WhatsAppSession(
+            session_id=session_id,
+            chat_key=chat_key,
+            created_at=now,
+            last_activity_at=now,
+            root_message_id=root_message_id,
+            title=(title or "")[:80],
+        )
+        self._whatsapp_chat_focus[chat_key] = session_id
+        self._prune_whatsapp_sessions(chat_key, now=now)
+        return session_id
+
+    def _touch_whatsapp_session(self, session_id: str, *, now: Optional[float] = None) -> None:
+        session = self._whatsapp_sessions.get(session_id)
+        if session is None:
+            return
+        session.status = "idle"
+        session.last_activity_at = now if now is not None else time.time()
+        self._whatsapp_chat_focus[session.chat_key] = session_id
+
+    def _register_whatsapp_session_message(self, message_id: Optional[str], session_id: Optional[str]) -> None:
+        if message_id and session_id:
+            self._whatsapp_message_sessions[str(message_id)] = session_id
+
+    def _prune_whatsapp_sessions(self, chat_key: str, *, now: Optional[float] = None) -> None:
+        now = now if now is not None else time.time()
+        live_for_chat = [
+            session for session in self._whatsapp_sessions.values()
+            if session.chat_key == chat_key and self._whatsapp_session_is_live(session.session_id, now=now)
+        ]
+        live_for_chat.sort(key=lambda session: session.last_activity_at, reverse=True)
+        for session in live_for_chat[self._session_max_live_per_chat:]:
+            session.status = "expired"
+            for msg_id, mapped_session in list(self._whatsapp_message_sessions.items()):
+                if mapped_session == session.session_id:
+                    self._whatsapp_message_sessions.pop(msg_id, None)
+
+    def _resolve_whatsapp_session(self, event: MessageEvent) -> tuple[str, bool, bool]:
+        """Return ``(session_id, created_new, had_existing_session)`` for an inbound event."""
+        now = time.time()
+        chat_key = self._session_chat_key(event.source)
+        had_existing_session = any(session.chat_key == chat_key for session in self._whatsapp_sessions.values())
+        explicit_session = getattr(event.source, "thread_id", None)
+        if explicit_session and self._whatsapp_session_is_live(explicit_session, now=now):
+            session = self._whatsapp_sessions.get(explicit_session)
+            if session and session.chat_key == chat_key:
+                self._touch_whatsapp_session(explicit_session, now=now)
+                return explicit_session, False, had_existing_session
+        quoted_id = getattr(event, "reply_to_message_id", None)
+        quoted_text = getattr(event, "reply_to_text", None)
+        if quoted_id:
+            known_session = self._whatsapp_message_sessions.get(str(quoted_id))
+            if self._whatsapp_session_is_live(known_session, now=now):
+                session = self._whatsapp_sessions.get(known_session)
+                if session and session.chat_key == chat_key:
+                    self._touch_whatsapp_session(known_session, now=now)
+                    return known_session, False, had_existing_session
+            session_id = self._create_whatsapp_session(
+                chat_key,
+                root_message_id=str(quoted_id),
+                title=str(quoted_text or event.text or "quoted reply"),
+                now=now,
+            )
+            self._register_whatsapp_session_message(str(quoted_id), session_id)
+            return session_id, True, had_existing_session
+
+        focus_session = self._whatsapp_chat_focus.get(chat_key)
+        if self._whatsapp_session_is_live(focus_session, now=now):
+            self._touch_whatsapp_session(focus_session, now=now)
+            return focus_session, False, had_existing_session
+        session_id = self._create_whatsapp_session(chat_key, title=str(event.text or ""), now=now)
+        return session_id, True, had_existing_session
+
+    def _resolve_whatsapp_session_id(self, event: MessageEvent) -> str:
+        session_id, _, _ = self._resolve_whatsapp_session(event)
+        return session_id
+
+    def _live_whatsapp_sessions_for_chat(self, chat_key: str) -> list[_WhatsAppSession]:
+        now = time.time()
+        sessions = [
+            session for session in self._whatsapp_sessions.values()
+            if session.chat_key == chat_key and self._whatsapp_session_is_live(session.session_id, now=now)
+        ]
+        sessions.sort(key=lambda session: session.last_activity_at, reverse=True)
+        return sessions
+
+    def _format_whatsapp_session_list(self, source) -> str:
+        chat_key = self._session_chat_key(source)
+        sessions = self._live_whatsapp_sessions_for_chat(chat_key)
+        if not sessions:
+            return "No active WhatsApp sessions yet. Use /sessions new to start one."
+        focus_session = self._whatsapp_chat_focus.get(chat_key)
+        lines = ["Active WhatsApp sessions:"]
+        for idx, session in enumerate(sessions, start=1):
+            marker = " ← current" if session.session_id == focus_session else ""
+            title = session.title or session.root_message_id or session.session_id
+            lines.append(f"{idx}. {session.session_id} — {title}{marker}")
+        lines.append("Use /sessions new to start a fresh session, or /sessions <number> to switch focus.")
+        return "\n".join(lines)
+
+    async def _handle_whatsapp_session_command(self, event: MessageEvent) -> bool:
+        if not self._sessions_enabled or not event:
+            return False
+        if event.get_command() != "sessions":
+            return False
+        chat_key = self._session_chat_key(event.source)
+        args = event.get_command_args().strip()
+        reply_to = getattr(event, "message_id", None)
+        metadata = {"thread_id": event.source.thread_id} if event.source and event.source.thread_id else None
+
+        if not args:
+            await self.send(
+                event.source.chat_id,
+                self._format_whatsapp_session_list(event.source),
+                reply_to=reply_to,
+                metadata=metadata,
+            )
+            return True
+
+        first, _, rest = args.partition(" ")
+        first_lower = first.lower()
+        if first_lower in {"new", "fresh", "create"}:
+            session_id = self._create_whatsapp_session(
+                chat_key,
+                root_message_id=reply_to,
+                title=(rest or "new session"),
+            )
+            self._register_whatsapp_session_message(reply_to, session_id)
+            if rest.strip():
+                await self._send_whatsapp_session_notice(event, session_id, rest.strip())
+                source = replace(event.source, thread_id=session_id)
+                routed = replace(
+                    event,
+                    text=rest.strip(),
+                    message_type=MessageType.TEXT,
+                    source=source,
+                )
+                await super().handle_message(routed)
+            else:
+                await self.send(
+                    event.source.chat_id,
+                    f"New WhatsApp session created: {session_id}\nYour next unquoted message will use it.",
+                    reply_to=reply_to,
+                    metadata={"thread_id": session_id},
+                )
+            return True
+
+        if first_lower.isdigit():
+            sessions = self._live_whatsapp_sessions_for_chat(chat_key)
+            index = int(first_lower) - 1
+            if 0 <= index < len(sessions):
+                session = sessions[index]
+                self._touch_whatsapp_session(session.session_id)
+                self._register_whatsapp_session_message(reply_to, session.session_id)
+                await self.send(
+                    event.source.chat_id,
+                    f"Switched WhatsApp session to {index + 1}: {session.session_id}\nYour next unquoted message will use it.",
+                    reply_to=reply_to,
+                    metadata={"thread_id": session.session_id},
+                )
+            else:
+                await self.send(
+                    event.source.chat_id,
+                    self._format_whatsapp_session_list(event.source),
+                    reply_to=reply_to,
+                    metadata=metadata,
+                )
+            return True
+
+        await self.send(
+            event.source.chat_id,
+            "Usage: /sessions, /sessions new, /sessions new <message>, or /sessions <number>",
+            reply_to=reply_to,
+            metadata=metadata,
+        )
+        return True
+
+    def _route_event_to_session_info(self, event: MessageEvent) -> _WhatsAppSessionRoute:
+        """Attach WhatsApp soft-thread session metadata and return routing details."""
+        if not self._sessions_enabled or not event or not event.source:
+            return _WhatsAppSessionRoute(event=event)
+        session_id, created_new, had_existing_session = self._resolve_whatsapp_session(event)
+        source = replace(event.source, thread_id=session_id)
+        routed = replace(event, source=source)
+        self._register_whatsapp_session_message(getattr(event, "message_id", None), session_id)
+        return _WhatsAppSessionRoute(
+            event=routed,
+            session_id=session_id,
+            created_new=created_new,
+            had_existing_session=had_existing_session,
+        )
+
+    def _route_event_to_session(self, event: MessageEvent) -> MessageEvent:
+        """Attach WhatsApp soft-thread session metadata before BasePlatformAdapter routing.
+
+        WhatsApp sessions are represented as synthetic ``source.thread_id`` values so
+        the existing session key/session store machinery creates a separate
+        Hermes session for each active WhatsApp session.
+        """
+        return self._route_event_to_session_info(event).event
+
+    def _format_whatsapp_session_notice(self, session_id: str, text: Optional[str]) -> str:
+        preview = (text or "").strip().replace("\n", " ")
+        if len(preview) > 80:
+            preview = preview[:77] + "..."
+        if preview:
+            return f"🧵 New WhatsApp session started: {session_id}\nProcessing separately: '{preview}'"
+        return f"🧵 New WhatsApp session started: {session_id}\nProcessing separately."
+
+    async def _send_whatsapp_session_notice(self, event: MessageEvent, session_id: Optional[str], text: Optional[str]) -> None:
+        if not event or not event.source or not session_id:
+            return
+        try:
+            await self.send(
+                event.source.chat_id,
+                self._format_whatsapp_session_notice(session_id, text),
+                reply_to=getattr(event, "message_id", None),
+                metadata={"thread_id": session_id},
+            )
+        except Exception as exc:
+            logger.debug("[%s] WhatsApp session notice send failed: %s", self.name, exc)
+
+    async def handle_message(self, event: MessageEvent) -> None:
+        if await self._handle_whatsapp_session_command(event):
+            return
+        session_route = self._route_event_to_session_info(event)
+        if session_route.created_new and session_route.had_existing_session and session_route.event.message_type == MessageType.TEXT:
+            await self._send_whatsapp_session_notice(event, session_route.session_id, event.text)
+        await super().handle_message(session_route.event)
 
     def _whatsapp_require_mention(self) -> bool:
         configured = self.config.extra.get("require_mention")
@@ -911,6 +1219,12 @@ class WhatsAppAdapter(BasePlatformAdapter):
                     if resp.status == 200:
                         data = await resp.json()
                         last_message_id = data.get("messageId")
+                        session_id = (
+                            (metadata or {}).get("thread_id")
+                            if isinstance(metadata, dict)
+                            else None
+                        )
+                        self._register_whatsapp_session_message(last_message_id, session_id)
                     else:
                         error = await resp.text()
                         return SendResult(success=False, error=error)
@@ -1268,6 +1582,13 @@ class WhatsAppAdapter(BasePlatformAdapter):
                         except Exception as e:
                             print(f"[{self.name}] Failed to read document text: {e}", flush=True)
 
+            reply_to_message_id = data.get("quotedMessageId") or None
+            reply_to_text = data.get("quotedText") or None
+            if isinstance(reply_to_message_id, str) and not reply_to_message_id.strip():
+                reply_to_message_id = None
+            if isinstance(reply_to_text, str) and not reply_to_text.strip():
+                reply_to_text = None
+
             return MessageEvent(
                 text=body,
                 message_type=msg_type,
@@ -1276,6 +1597,8 @@ class WhatsAppAdapter(BasePlatformAdapter):
                 message_id=data.get("messageId"),
                 media_urls=cached_urls,
                 media_types=media_types,
+                reply_to_message_id=reply_to_message_id,
+                reply_to_text=reply_to_text,
             )
         except Exception as e:
             print(f"[{self.name}] Error building event: {e}")

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -995,7 +995,7 @@ class SessionStore:
         Unlike ``suspend_session()``, this preserves the existing
         ``session_id`` and the transcript.  The next call to
         ``get_or_create_session()`` for this key returns the same entry
-        so the user auto-resumes on the same conversation lane.
+        so the user auto-resumes the same conversation.
 
         Returns True if the session existed and was marked.
         """

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -146,6 +146,26 @@ function getContextInfo(messageContent) {
   return {};
 }
 
+function extractQuotedText(quotedMessage) {
+  if (!quotedMessage || typeof quotedMessage !== 'object') return '';
+
+  // quotedMessage is already a message-content object shape (not wrapped in {message:{...}})
+  // Support common cases (text + media captions).
+  if (quotedMessage.conversation) return String(quotedMessage.conversation);
+  if (quotedMessage.extendedTextMessage?.text) return String(quotedMessage.extendedTextMessage.text);
+  if (quotedMessage.imageMessage?.caption) return String(quotedMessage.imageMessage.caption);
+  if (quotedMessage.videoMessage?.caption) return String(quotedMessage.videoMessage.caption);
+  if (quotedMessage.documentMessage?.caption) return String(quotedMessage.documentMessage.caption);
+
+  // Some wrappers can appear nested.
+  if (quotedMessage.ephemeralMessage?.message) return extractQuotedText(quotedMessage.ephemeralMessage.message);
+  if (quotedMessage.viewOnceMessage?.message) return extractQuotedText(quotedMessage.viewOnceMessage.message);
+  if (quotedMessage.viewOnceMessageV2?.message) return extractQuotedText(quotedMessage.viewOnceMessageV2.message);
+  if (quotedMessage.documentWithCaptionMessage?.message) return extractQuotedText(quotedMessage.documentWithCaptionMessage.message);
+
+  return '';
+}
+
 mkdirSync(SESSION_DIR, { recursive: true });
 
 // Build LID → phone reverse map from session files (lid-mapping-{phone}.json)
@@ -317,10 +337,11 @@ async function startSocket() {
       const messageContent = getMessageContent(msg);
       const contextInfo = getContextInfo(messageContent);
       const mentionedIds = Array.from(new Set((contextInfo?.mentionedJid || []).map(normalizeWhatsAppId).filter(Boolean)));
-      const quotedMessageId = contextInfo?.stanzaId || null;
-      const quotedParticipant = normalizeWhatsAppId(contextInfo?.participant || '') || null;
+      const quotedMessageId = contextInfo?.stanzaId ? String(contextInfo.stanzaId) : '';
+      const quotedParticipant = normalizeWhatsAppId(contextInfo?.participant || contextInfo?.remoteJid || '') || null;
       const quotedRemoteJid = normalizeWhatsAppId(contextInfo?.remoteJid || '') || null;
       const hasQuotedMessage = !!contextInfo?.quotedMessage;
+      const quotedText = extractQuotedText(contextInfo?.quotedMessage);
 
       // Extract message body
       let body = '';
@@ -432,10 +453,11 @@ async function startSocket() {
         mediaType,
         mediaUrls,
         mentionedIds,
-        quotedMessageId,
         quotedParticipant,
-        quotedRemoteJid,
+        quotedMessageId: quotedMessageId || undefined,
+        quotedRemoteJid: quotedRemoteJid || undefined,
         hasQuotedMessage,
+        quotedText: quotedText || undefined,
         botIds,
         timestamp: msg.messageTimestamp,
       };

--- a/tests/gateway/test_whatsapp_group_gating.py
+++ b/tests/gateway/test_whatsapp_group_gating.py
@@ -129,6 +129,27 @@ def test_config_bridges_whatsapp_group_settings(monkeypatch, tmp_path):
     assert json.loads(__import__("os").environ["WHATSAPP_MENTION_PATTERNS"]) == [r"^\s*chompy\b"]
 
 
+def test_config_bridges_whatsapp_session_settings(monkeypatch, tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "whatsapp:\n"
+        "  enable_sessions: true\n"
+        "  session_idle_minutes: 30\n"
+        "  session_max_live_per_chat: 3\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    config = load_gateway_config()
+
+    extra = config.platforms[Platform.WHATSAPP].extra
+    assert extra["enable_sessions"] is True
+    assert extra["session_idle_minutes"] == 30
+    assert extra["session_max_live_per_chat"] == 3
+
+
 def test_free_response_chats_bypass_mention_gating():
     adapter = _make_adapter(
         require_mention=True,

--- a/tests/gateway/test_whatsapp_sessions.py
+++ b/tests/gateway/test_whatsapp_sessions.py
@@ -1,0 +1,389 @@
+"""Regression tests for WhatsApp soft-thread sessions.
+
+WhatsApp has a flat chat UI, but users can reply to older messages to fork or
+return to a topic. The WhatsApp adapter maps those reply relationships to
+synthetic ``source.thread_id`` values so the existing Hermes session-key
+machinery isolates each session without a new core session subsystem.
+"""
+
+import asyncio
+import time
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import build_session_key
+
+
+@pytest.mark.asyncio
+async def test_whatsapp_build_event_maps_quoted_fields_to_reply_context():
+    from gateway.platforms.whatsapp import WhatsAppAdapter
+
+    adapter = WhatsAppAdapter(PlatformConfig(enabled=True))
+    data = {
+        "messageId": "m2",
+        "chatId": "123@lid",
+        "senderId": "123@lid",
+        "senderName": "Seb",
+        "chatName": "Seb",
+        "isGroup": False,
+        "body": "yep",
+        "hasMedia": False,
+        "mediaUrls": [],
+        "quotedMessageId": "q1",
+        "quotedText": "the thing you said earlier",
+    }
+
+    event = await adapter._build_message_event(data)
+
+    assert event is not None
+    assert event.reply_to_message_id == "q1"
+    assert event.reply_to_text == "the thing you said earlier"
+
+
+def test_whatsapp_session_router_reuses_latest_visible_session_for_unquoted_messages():
+    from gateway.platforms.whatsapp import WhatsAppAdapter
+
+    adapter = WhatsAppAdapter(PlatformConfig(enabled=True, extra={"enable_sessions": True}))
+    src = adapter.build_source(chat_id="123@lid", chat_type="dm", user_id="123@lid", user_name="Seb")
+
+    first = MessageEvent(text="start topic", message_type=MessageType.TEXT, source=src, message_id="m1")
+    routed_first = adapter._route_event_to_session(first)
+    assert routed_first.source.thread_id
+
+    second = MessageEvent(text="follow up", message_type=MessageType.TEXT, source=src, message_id="m2")
+    routed_second = adapter._route_event_to_session(second)
+
+    assert routed_second.source.thread_id == routed_first.source.thread_id
+    assert build_session_key(routed_second.source).endswith(routed_first.source.thread_id)
+
+
+def test_whatsapp_session_router_creates_new_session_for_unknown_quoted_reply():
+    from gateway.platforms.whatsapp import WhatsAppAdapter
+
+    adapter = WhatsAppAdapter(PlatformConfig(enabled=True, extra={"enable_sessions": True}))
+    src = adapter.build_source(chat_id="123@lid", chat_type="dm", user_id="123@lid", user_name="Seb")
+    focused = adapter._route_event_to_session(
+        MessageEvent(text="current topic", message_type=MessageType.TEXT, source=src, message_id="current")
+    )
+
+    quoted = MessageEvent(
+        text="about that older thing",
+        message_type=MessageType.TEXT,
+        source=src,
+        message_id="m-quoted",
+        reply_to_message_id="unknown-old-message",
+        reply_to_text="old quoted text",
+    )
+    routed = adapter._route_event_to_session(quoted)
+
+    assert routed.source.thread_id != focused.source.thread_id
+    assert routed.reply_to_text == "old quoted text"
+    assert adapter._whatsapp_message_sessions["unknown-old-message"] == routed.source.thread_id
+
+
+def test_whatsapp_session_router_routes_known_quoted_reply_to_original_session():
+    from gateway.platforms.whatsapp import WhatsAppAdapter
+
+    adapter = WhatsAppAdapter(PlatformConfig(enabled=True, extra={"enable_sessions": True}))
+    src = adapter.build_source(chat_id="123@lid", chat_type="dm", user_id="123@lid", user_name="Seb")
+    session_a = adapter._route_event_to_session(
+        MessageEvent(text="topic a", message_type=MessageType.TEXT, source=src, message_id="a1")
+    ).source.thread_id
+    adapter._register_whatsapp_session_message("assistant-a", session_a)
+    session_b = adapter._route_event_to_session(
+        MessageEvent(
+            text="topic b",
+            message_type=MessageType.TEXT,
+            source=src,
+            message_id="b1",
+            reply_to_message_id="unknown-b",
+            reply_to_text="seed b",
+        )
+    ).source.thread_id
+    assert session_b != session_a
+
+    routed = adapter._route_event_to_session(
+        MessageEvent(
+            text="back to a",
+            message_type=MessageType.TEXT,
+            source=src,
+            message_id="a2",
+            reply_to_message_id="assistant-a",
+            reply_to_text="assistant answer in topic a",
+        )
+    )
+
+    assert routed.source.thread_id == session_a
+
+
+def test_whatsapp_session_router_preserves_explicit_thread_id_for_internal_events():
+    from gateway.platforms.whatsapp import WhatsAppAdapter
+
+    adapter = WhatsAppAdapter(PlatformConfig(enabled=True, extra={"enable_sessions": True}))
+    src = adapter.build_source(chat_id="123@lid", chat_type="dm", user_id="123@lid", user_name="Seb")
+    session_a = adapter._route_event_to_session(
+        MessageEvent(text="topic a", message_type=MessageType.TEXT, source=src, message_id="a1")
+    ).source.thread_id
+    session_b = adapter._route_event_to_session(
+        MessageEvent(
+            text="topic b",
+            message_type=MessageType.TEXT,
+            source=src,
+            message_id="b1",
+            reply_to_message_id="unknown-b",
+            reply_to_text="seed b",
+        )
+    ).source.thread_id
+    assert session_b != session_a
+
+    # Simulates a background-process completion/watch notification whose
+    # watcher stored the original session id. Routing must not silently retarget
+    # it to the currently focused session.
+    internal_src = adapter.build_source(
+        chat_id="123@lid",
+        chat_type="dm",
+        user_id="123@lid",
+        user_name="Seb",
+        thread_id=session_a,
+    )
+    routed = adapter._route_event_to_session(
+        MessageEvent(
+            text="[SYSTEM: Background process completed]",
+            message_type=MessageType.TEXT,
+            source=internal_src,
+            internal=True,
+        )
+    )
+
+    assert routed.source.thread_id == session_a
+
+
+def test_whatsapp_session_router_expires_idle_focus_session_for_unquoted_messages():
+    from gateway.platforms.whatsapp import WhatsAppAdapter
+
+    adapter = WhatsAppAdapter(PlatformConfig(enabled=True, extra={"enable_sessions": True, "session_idle_minutes": 60}))
+    src = adapter.build_source(chat_id="123@lid", chat_type="dm", user_id="123@lid", user_name="Seb")
+    first = adapter._route_event_to_session(
+        MessageEvent(text="old topic", message_type=MessageType.TEXT, source=src, message_id="old")
+    )
+    old_session = first.source.thread_id
+    adapter._whatsapp_sessions[old_session].last_activity_at = time.time() - (61 * 60)
+
+    routed = adapter._route_event_to_session(
+        MessageEvent(text="new after idle", message_type=MessageType.TEXT, source=src, message_id="new")
+    )
+
+    assert routed.source.thread_id != old_session
+
+
+def test_whatsapp_session_router_does_not_route_known_message_id_across_chats():
+    from gateway.platforms.whatsapp import WhatsAppAdapter
+
+    adapter = WhatsAppAdapter(PlatformConfig(enabled=True, extra={"enable_sessions": True}))
+    src_a = adapter.build_source(chat_id="chat-a@lid", chat_type="dm", user_id="chat-a@lid", user_name="A")
+    src_b = adapter.build_source(chat_id="chat-b@lid", chat_type="dm", user_id="chat-b@lid", user_name="B")
+    session_a = adapter._route_event_to_session(
+        MessageEvent(text="topic a", message_type=MessageType.TEXT, source=src_a, message_id="a1")
+    ).source.thread_id
+    adapter._register_whatsapp_session_message("shared-looking-id", session_a)
+
+    routed_b = adapter._route_event_to_session(
+        MessageEvent(
+            text="reply from another chat",
+            message_type=MessageType.TEXT,
+            source=src_b,
+            message_id="b1",
+            reply_to_message_id="shared-looking-id",
+            reply_to_text="cross-chat quote",
+        )
+    )
+
+    assert routed_b.source.thread_id != session_a
+    assert adapter._whatsapp_sessions[routed_b.source.thread_id].chat_key == "dm:chat-b@lid"
+
+
+@pytest.mark.asyncio
+async def test_whatsapp_sessions_command_lists_active_sessions_without_calling_agent():
+    from gateway.platforms.whatsapp import WhatsAppAdapter
+
+    adapter = WhatsAppAdapter(PlatformConfig(enabled=True, extra={"enable_sessions": True}))
+    adapter.set_message_handler(AsyncMock(return_value="should not run"))
+    adapter.send = AsyncMock(return_value=None)
+    src = adapter.build_source(chat_id="123@lid", chat_type="dm", user_id="123@lid", user_name="Seb")
+    session_a = adapter._route_event_to_session(
+        MessageEvent(text="first topic", message_type=MessageType.TEXT, source=src, message_id="a1")
+    ).source.thread_id
+    session_b = adapter._route_event_to_session(
+        MessageEvent(
+            text="second topic",
+            message_type=MessageType.TEXT,
+            source=src,
+            message_id="b1",
+            reply_to_message_id="unknown-b",
+            reply_to_text="second seed",
+        )
+    ).source.thread_id
+
+    await adapter.handle_message(MessageEvent(text="/sessions", message_type=MessageType.COMMAND, source=src, message_id="cmd-list"))
+
+    adapter._message_handler.assert_not_awaited()
+    sent = adapter.send.await_args.args[1]
+    assert "Active WhatsApp sessions" in sent
+    assert "1." in sent and "2." in sent
+    assert session_b in sent
+    assert session_a in sent
+
+
+@pytest.mark.asyncio
+async def test_whatsapp_sessions_command_lists_active_sessions_without_calling_agent_from_sessions_command():
+    from gateway.platforms.whatsapp import WhatsAppAdapter
+
+    adapter = WhatsAppAdapter(PlatformConfig(enabled=True, extra={"enable_sessions": True}))
+    adapter.set_message_handler(AsyncMock(return_value="should not run"))
+    adapter.send = AsyncMock(return_value=None)
+    src = adapter.build_source(chat_id="123@lid", chat_type="dm", user_id="123@lid", user_name="Seb")
+    adapter._route_event_to_session(
+        MessageEvent(text="first topic", message_type=MessageType.TEXT, source=src, message_id="a1")
+    )
+
+    await adapter.handle_message(MessageEvent(text="/sessions", message_type=MessageType.COMMAND, source=src, message_id="cmd-list"))
+
+    adapter._message_handler.assert_not_awaited()
+    assert "Active WhatsApp sessions" in adapter.send.await_args.args[1]
+
+
+@pytest.mark.asyncio
+async def test_whatsapp_session_new_command_moves_focus_without_calling_agent():
+    from gateway.platforms.whatsapp import WhatsAppAdapter
+
+    adapter = WhatsAppAdapter(PlatformConfig(enabled=True, extra={"enable_sessions": True}))
+    adapter.set_message_handler(AsyncMock(return_value="should not run"))
+    adapter.send = AsyncMock(return_value=None)
+    src = adapter.build_source(chat_id="123@lid", chat_type="dm", user_id="123@lid", user_name="Seb")
+    old_session = adapter._route_event_to_session(
+        MessageEvent(text="old topic", message_type=MessageType.TEXT, source=src, message_id="old")
+    ).source.thread_id
+
+    await adapter.handle_message(MessageEvent(text="/sessions new", message_type=MessageType.COMMAND, source=src, message_id="cmd-new"))
+    routed = adapter._route_event_to_session(
+        MessageEvent(text="now on forced new session", message_type=MessageType.TEXT, source=src, message_id="after-new")
+    )
+
+    adapter._message_handler.assert_not_awaited()
+    assert routed.source.thread_id != old_session
+    assert "New WhatsApp session" in adapter.send.await_args.args[1]
+
+
+@pytest.mark.asyncio
+async def test_whatsapp_session_new_command_with_message_sends_immediate_session_notice():
+    from gateway.platforms.whatsapp import WhatsAppAdapter
+
+    adapter = WhatsAppAdapter(PlatformConfig(enabled=True, extra={"enable_sessions": True}))
+    adapter.set_message_handler(AsyncMock(return_value="ok"))
+    adapter.send = AsyncMock(return_value=None)
+    src = adapter.build_source(chat_id="123@lid", chat_type="dm", user_id="123@lid", user_name="Seb")
+
+    await adapter.handle_message(
+        MessageEvent(text="/sessions new side quest", message_type=MessageType.COMMAND, source=src, message_id="cmd-new-msg")
+    )
+
+    adapter.send.assert_awaited_once()
+    sent = adapter.send.await_args.args[1]
+    assert "🧵 New WhatsApp session" in sent
+    assert "side quest" in sent
+
+
+@pytest.mark.asyncio
+async def test_whatsapp_auto_new_session_sends_immediate_session_notice_when_reply_starts_side_session():
+    from gateway.platforms.whatsapp import WhatsAppAdapter
+
+    adapter = WhatsAppAdapter(PlatformConfig(enabled=True, extra={"enable_sessions": True}))
+    adapter.set_message_handler(AsyncMock(return_value="ok"))
+    adapter.send = AsyncMock(return_value=None)
+    src = adapter.build_source(chat_id="123@lid", chat_type="dm", user_id="123@lid", user_name="Seb")
+    first = adapter._route_event_to_session(
+        MessageEvent(text="active topic", message_type=MessageType.TEXT, source=src, message_id="active-root")
+    )
+
+    await adapter.handle_message(
+        MessageEvent(
+            text="separate side topic",
+            message_type=MessageType.TEXT,
+            source=src,
+            message_id="side-root",
+            reply_to_message_id="unknown-side",
+            reply_to_text="old side seed",
+        )
+    )
+
+    adapter.send.assert_awaited_once()
+    sent = adapter.send.await_args.args[1]
+    assert "🧵 New WhatsApp session" in sent
+    assert "separate side topic" in sent
+    assert adapter.send.await_args.kwargs["reply_to"] == "side-root"
+    assert adapter.send.await_args.kwargs["metadata"]["thread_id"] != first.source.thread_id
+
+
+@pytest.mark.asyncio
+async def test_whatsapp_session_number_command_switches_focus_to_listed_session():
+    from gateway.platforms.whatsapp import WhatsAppAdapter
+
+    adapter = WhatsAppAdapter(PlatformConfig(enabled=True, extra={"enable_sessions": True}))
+    adapter.set_message_handler(AsyncMock(return_value="should not run"))
+    adapter.send = AsyncMock(return_value=None)
+    src = adapter.build_source(chat_id="123@lid", chat_type="dm", user_id="123@lid", user_name="Seb")
+    session_a = adapter._route_event_to_session(
+        MessageEvent(text="first topic", message_type=MessageType.TEXT, source=src, message_id="a1")
+    ).source.thread_id
+    session_b = adapter._route_event_to_session(
+        MessageEvent(
+            text="second topic",
+            message_type=MessageType.TEXT,
+            source=src,
+            message_id="b1",
+            reply_to_message_id="unknown-b",
+            reply_to_text="second seed",
+        )
+    ).source.thread_id
+    assert session_b != session_a
+
+    await adapter.handle_message(MessageEvent(text="/sessions 2", message_type=MessageType.COMMAND, source=src, message_id="cmd-switch"))
+    routed = adapter._route_event_to_session(
+        MessageEvent(text="back on selected session", message_type=MessageType.TEXT, source=src, message_id="after-switch")
+    )
+
+    adapter._message_handler.assert_not_awaited()
+    assert routed.source.thread_id == session_a
+    assert "Switched WhatsApp session" in adapter.send.await_args.args[1]
+
+
+@pytest.mark.asyncio
+async def test_whatsapp_handle_message_routes_different_session_without_interrupting_active_focus():
+    from gateway.platforms.whatsapp import WhatsAppAdapter
+
+    adapter = WhatsAppAdapter(PlatformConfig(enabled=True, extra={"enable_sessions": True}))
+    adapter.set_message_handler(AsyncMock(return_value="ok"))
+    adapter._send_with_retry = AsyncMock(return_value=None)
+    src = adapter.build_source(chat_id="123@lid", chat_type="dm", user_id="123@lid", user_name="Seb")
+    active = adapter._route_event_to_session(
+        MessageEvent(text="active topic", message_type=MessageType.TEXT, source=src, message_id="active-root")
+    )
+    active_key = build_session_key(active.source)
+    adapter._active_sessions[active_key] = asyncio.Event()
+
+    side = MessageEvent(
+        text="separate side topic",
+        message_type=MessageType.TEXT,
+        source=src,
+        message_id="side-root",
+        reply_to_message_id="unknown-side",
+        reply_to_text="old side seed",
+    )
+    await adapter.handle_message(side)
+
+    assert adapter._active_sessions[active_key].is_set() is False
+    assert "side-root" in adapter._whatsapp_message_sessions
+    assert adapter._whatsapp_message_sessions["side-root"] != active.source.thread_id

--- a/website/docs/user-guide/messaging/whatsapp.md
+++ b/website/docs/user-guide/messaging/whatsapp.md
@@ -120,6 +120,35 @@ whatsapp:
 - `unauthorized_dm_behavior: pair` is the global default. Unknown DM senders get a pairing code.
 - `whatsapp.unauthorized_dm_behavior: ignore` makes WhatsApp stay silent for unauthorized DMs, which is usually the better choice for a private number.
 
+### WhatsApp sessions
+
+WhatsApp chats are flat, so Hermes can expose Hermes sessions as lightweight WhatsApp workstreams by mapping replies to synthetic thread IDs. Each workstream is still a normal Hermes session; the WhatsApp adapter only decides which session an incoming message belongs to. This keeps side topics from contaminating the main chat context while reusing Hermes' existing per-thread session storage.
+
+Session routing behavior:
+
+- Unquoted messages continue in the current session.
+- Replying to a known Hermes message routes your reply back to that message's session.
+- Replying to an unknown older message starts a fresh session.
+- Internal updates, such as background-process notifications, preserve their originating session.
+
+Commands:
+
+```text
+/sessions              # list active WhatsApp sessions
+/sessions new          # make the next unquoted message use a fresh session
+/sessions new <message># create a fresh session and send <message> there now
+/sessions <number>     # switch the current unquoted-message focus
+```
+
+Optional session-routing settings:
+
+```yaml
+whatsapp:
+  enable_sessions: true            # default: true; enables WhatsApp session routing
+  session_idle_minutes: 60         # expire inactive WhatsApp session routes after this many minutes
+  session_max_live_per_chat: 5     # cap remembered WhatsApp session routes per chat
+```
+
 Then start the gateway:
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds WhatsApp soft-thread session routing for flat reply surfaces.
- Keeps each WhatsApp workstream as a normal Hermes session by assigning synthetic `thread_id` values in the adapter.
- Routes quoted/replied-to WhatsApp messages back to the session that produced the quoted message.
- Adds `/sessions` controls for listing, switching, and creating WhatsApp sessions.
- Passes bridge-side quoted/reply metadata through to the gateway.
- Documents WhatsApp session routing and adds gateway regression coverage.

## How it works
- WhatsApp chats are flat, so the adapter maintains a lightweight active-session map per chat/contact.
- Unquoted messages continue in the current active WhatsApp session.
- Replying to a Hermes WhatsApp message switches back to the session that produced that message, preserving the right context.
- `/sessions` lists the active WhatsApp sessions for the chat.
- `/sessions new` makes the next unquoted message use a fresh session.
- `/sessions new <message>` creates a fresh session and sends `<message>` into it immediately.
- `/sessions <number>` switches the current unquoted-message focus to one of the listed sessions.
- Group gating still applies; session routing is layered on top of the existing WhatsApp authorization/mention behavior.

## Current version
- Refreshed onto current `origin/main`.
- Current head: `02045915eac71eac57f9fa4684c18a6348cef6d7`.
- This version uses the `/sessions` UX and `enable_sessions` / `session_idle_minutes` / `session_max_live_per_chat` configuration names.

## Test Plan
- `git diff --check origin/main...HEAD`
- `scripts/run_tests.sh tests/gateway/test_whatsapp_sessions.py tests/gateway/test_whatsapp_group_gating.py -q` — 41 passed

<!-- hermes-refresh-status -->
## Refresh status
- Rebased/updated for merge-conflict-free merge against current `main`.
- Current head: `4fa28fc8b`.
- Mergeability verified via GitHub API: `mergeable: true`; `mergeable_state: unstable` because GitHub checks are pending/absent, not because of conflicts.
- Notes: Rebased soft-thread WhatsApp session slice onto current main. No merge conflicts remain.
- Test plan:
  - scripts/run_tests.sh tests/gateway/test_whatsapp_sessions.py tests/gateway/test_whatsapp_group_gating.py — 41 passed, 0 failed
