### PR TITLE
fix(cli): refresh local @hermes/ink copy after tui builds

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -949,6 +949,23 @@ def _hermes_ink_bundle_stale(tui_dir: Path) -> bool:
     return False
 
 
+def _refresh_local_hermes_ink_dependency(npm: str, tui_dir: Path) -> Optional[subprocess.CompletedProcess]:
+    """Re-copy the local file: dependency after rebuilding packages/hermes-ink."""
+    ink_root = tui_dir / "packages" / "hermes-ink" / "package.json"
+    installed_ink = tui_dir / "node_modules" / "@hermes" / "ink"
+    if not ink_root.exists() or not installed_ink.exists():
+        return None
+    shutil.rmtree(installed_ink, ignore_errors=True)
+    return subprocess.run(
+        [npm, "install", "--silent", "--no-fund", "--no-audit", "--progress=false"],
+        cwd=str(tui_dir),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        text=True,
+        env={**os.environ, "CI": "1"},
+    )
+
+
 def _ensure_tui_node() -> None:
     """Make sure `node` + `npm` are on PATH for the TUI.
 
@@ -1065,6 +1082,14 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
                 if preview:
                     print(preview)
                 sys.exit(1)
+            refresh = _refresh_local_hermes_ink_dependency(npm, tui_dir)
+            if refresh and refresh.returncode != 0:
+                err = (refresh.stderr or "").strip()
+                preview = "\n".join(err.splitlines()[-30:])
+                print("Refreshing @hermes/ink failed.")
+                if preview:
+                    print(preview)
+                sys.exit(1)
         tsx = tui_dir / "node_modules" / ".bin" / "tsx"
         if tsx.exists():
             return [str(tsx), "src/entry.tsx"], tui_dir
@@ -1081,6 +1106,14 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
             combined = f"{result.stdout or ''}{result.stderr or ''}".strip()
             preview = "\n".join(combined.splitlines()[-30:])
             print("TUI build failed.")
+            if preview:
+                print(preview)
+            sys.exit(1)
+        refresh = _refresh_local_hermes_ink_dependency(npm, tui_dir)
+        if refresh and refresh.returncode != 0:
+            err = (refresh.stderr or "").strip()
+            preview = "\n".join(err.splitlines()[-30:])
+            print("Refreshing @hermes/ink failed.")
             if preview:
                 print(preview)
             sys.exit(1)
@@ -5996,6 +6029,26 @@ def _update_node_dependencies() -> None:
             extra_args=("--silent", "--no-fund", "--no-audit", "--progress=false"),
         )
         if result.returncode == 0:
+            if label == "ui-tui" and (path / "packages" / "hermes-ink" / "package.json").exists():
+                build = subprocess.run(
+                    [npm, "run", "build", "--prefix", "packages/hermes-ink"],
+                    cwd=str(path),
+                    capture_output=True,
+                    text=True,
+                )
+                if build.returncode != 0:
+                    print("  ⚠ @hermes/ink build failed in ui-tui")
+                    combined = f"{build.stdout or ''}{build.stderr or ''}".strip()
+                    if combined:
+                        print(f"    {combined.splitlines()[-1]}")
+                    continue
+                refresh = _refresh_local_hermes_ink_dependency(npm, path)
+                if refresh and refresh.returncode != 0:
+                    print("  ⚠ refreshing @hermes/ink copy failed in ui-tui")
+                    stderr = (refresh.stderr or "").strip()
+                    if stderr:
+                        print(f"    {stderr.splitlines()[-1]}")
+                    continue
             print(f"  ✓ {label}")
             continue
 

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -2,6 +2,7 @@
 
 import os
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -29,6 +30,12 @@ def _touch_ink_bundle(root: Path) -> None:
     bundle = root / "packages" / "hermes-ink" / "dist" / "ink-bundle.js"
     bundle.parent.mkdir(parents=True, exist_ok=True)
     bundle.write_text("export {}")
+
+
+def _touch_local_ink_package(root: Path) -> None:
+    pkg = root / "packages" / "hermes-ink" / "package.json"
+    pkg.parent.mkdir(parents=True, exist_ok=True)
+    pkg.write_text("{}")
 
 
 def test_need_install_when_ink_missing(tmp_path: Path, main_mod) -> None:
@@ -103,3 +110,62 @@ def test_build_not_needed_when_entry_and_ink_bundle_present(tmp_path: Path, main
     _touch_ink_bundle(tmp_path)
 
     assert main_mod._tui_build_needed(tmp_path) is False
+
+
+def test_make_tui_argv_refreshes_hermes_ink_after_build(tmp_path: Path, main_mod, monkeypatch) -> None:
+    _touch_tui_entry(tmp_path)
+    _touch_local_ink_package(tmp_path)
+    _touch_ink(tmp_path)
+    calls = []
+
+    monkeypatch.setattr(main_mod, "_ensure_tui_node", lambda: None)
+    monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda path: False)
+    monkeypatch.setattr(main_mod, "_tui_build_needed", lambda path: True)
+    monkeypatch.setattr(main_mod, "_find_bundled_tui", lambda path: path)
+    monkeypatch.setattr(main_mod.shutil, "which", lambda bin: f"/usr/bin/{bin}")
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(main_mod.subprocess, "run", fake_run)
+
+    argv, root = main_mod._make_tui_argv(tmp_path, tui_dev=False)
+
+    assert argv == ["/usr/bin/node", str(tmp_path / "dist" / "entry.js")]
+    assert root == tmp_path
+    assert calls == [
+        ["/usr/bin/npm", "run", "build"],
+        ["/usr/bin/npm", "install", "--silent", "--no-fund", "--no-audit", "--progress=false"],
+    ]
+
+
+def test_update_node_dependencies_rebuilds_and_refreshes_ui_tui(tmp_path: Path, main_mod, monkeypatch) -> None:
+    (tmp_path / "package.json").write_text("{}")
+    ui_tui = tmp_path / "ui-tui"
+    (ui_tui / "package.json").parent.mkdir(parents=True, exist_ok=True)
+    (ui_tui / "package.json").write_text("{}")
+    _touch_local_ink_package(ui_tui)
+    _touch_ink(ui_tui)
+    installs = []
+    builds = []
+
+    monkeypatch.setattr(main_mod, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(main_mod.shutil, "which", lambda bin: "/usr/bin/npm")
+
+    def fake_install(npm, path, extra_args=()):
+        installs.append((npm, path, extra_args))
+        return SimpleNamespace(returncode=0, stderr="")
+
+    def fake_run(cmd, **kwargs):
+        if cmd[:4] == ["/usr/bin/npm", "run", "build", "--prefix"]:
+            builds.append((cmd, kwargs.get("cwd")))
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(main_mod, "_run_npm_install_deterministic", fake_install)
+    monkeypatch.setattr(main_mod.subprocess, "run", fake_run)
+
+    main_mod._update_node_dependencies()
+
+    assert [path for _, path, _ in installs] == [tmp_path, ui_tui]
+    assert builds == [(["/usr/bin/npm", "run", "build", "--prefix", "packages/hermes-ink"], str(ui_tui))]


### PR DESCRIPTION
## What does this PR do?

- rebuild `packages/hermes-ink` during `hermes update` before re-copying the local `file:` dependency
- refresh `node_modules/@hermes/ink` after TUI builds so launch-time self-healing also fixes manual git-pull/update cases
- add regression coverage for both the TUI launch path and the update path

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A