### PR TITLE
feat(agent): add dispatch receipt contracts

### DIFF
--- a/agent/dispatch_contracts.py
+++ b/agent/dispatch_contracts.py
@@ -1,0 +1,240 @@
+"""Dispatch contract models for bounded worker orchestration.
+
+These contracts intentionally describe receipts and verification evidence only.
+They do not launch workers, choose providers, or alter model routing.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+SCHEMA_VERSION = "dispatch-contracts/v1"
+
+
+class TaskComplexity(StrEnum):
+    TRIVIAL = "trivial"
+    SIMPLE = "simple"
+    MODERATE = "moderate"
+    HARD = "hard"
+
+
+class Stakes(StrEnum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    IRREVERSIBLE = "irreversible"
+
+
+class Reversibility(StrEnum):
+    REVERSIBLE = "reversible"
+    PARTIALLY_REVERSIBLE = "partially_reversible"
+    IRREVERSIBLE = "irreversible"
+
+
+class ToolReach(StrEnum):
+    NONE = "none"
+    LOCAL_FILES = "local_files"
+    GITHUB = "github"
+    BROWSER = "browser"
+    WORKSPACE = "workspace"
+    EXTERNAL_ACCOUNT = "external_account"
+
+
+class MemoryDependency(StrEnum):
+    NONE = "none"
+    LOCAL_CONTEXT = "local_context"
+    PROJECT_MEMORY = "project_memory"
+    DURABLE_MEMORY_REQUIRED = "durable_memory_required"
+
+
+class VerificationNeed(StrEnum):
+    NONE = "none"
+    LIGHTWEIGHT = "lightweight"
+    DETERMINISTIC = "deterministic"
+    INDEPENDENT_REVIEW = "independent_review"
+
+
+class AttemptStatus(StrEnum):
+    PLANNED = "planned"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    BLOCKED = "blocked"
+    ESCALATED = "escalated"
+
+
+class VerificationStatus(StrEnum):
+    NOT_CHECKED = "not_checked"
+    CLAIMED = "claimed"
+    VERIFIED = "verified"
+    REJECTED = "rejected"
+    BLOCKED = "blocked"
+
+
+class EvidenceItemStatus(StrEnum):
+    CLAIMED = "claimed"
+    VERIFIED = "verified"
+    REJECTED = "rejected"
+
+
+class EvidenceKind(StrEnum):
+    FILE_READBACK = "file_readback"
+    FILE_DIFF = "file_diff"
+    GITHUB_READBACK = "github_readback"
+    SOURCE_URL = "source_url"
+    TEST_OUTPUT = "test_output"
+    COMMAND_OUTPUT = "command_output"
+    LOG_EXCERPT = "log_excerpt"
+    ARTIFACT = "artifact"
+
+
+class ContractModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", use_enum_values=True)
+
+
+class TaskClassification(ContractModel):
+    task_complexity: TaskComplexity
+    stakes: Stakes
+    reversibility: Reversibility
+    tool_reach: ToolReach
+    memory_dependency: MemoryDependency
+    verification_need: VerificationNeed
+
+
+class BudgetPolicy(ContractModel):
+    max_worker_sessions_per_issue: int = Field(ge=1)
+    max_parallel_workers_default: int = Field(ge=1)
+    max_worker_turns: int = Field(ge=1)
+    max_worker_runtime_minutes: int = Field(ge=1)
+    max_escalations_to_sota: int = Field(ge=0)
+    stop_after_failed_attempts: int = Field(ge=1)
+    require_ceo_approval_above_stakes: Literal["medium", "high"] = "high"
+
+    @model_validator(mode="after")
+    def _parallelism_cannot_exceed_total_sessions(self) -> BudgetPolicy:
+        if self.max_parallel_workers_default > self.max_worker_sessions_per_issue:
+            raise ValueError(
+                "max_parallel_workers_default cannot exceed max_worker_sessions_per_issue"
+            )
+        return self
+
+
+class WorkerAttemptMetadata(ContractModel):
+    work_order_id: str = Field(min_length=1)
+    attempt_id: str = Field(min_length=1)
+    worker_session_id: str = Field(min_length=1)
+    worker_role: str = Field(min_length=1)
+    harness: str = Field(min_length=1)
+    provider_model: str = Field(min_length=1)
+    profile_or_toolset: str | None = None
+    branch: str | None = None
+    worktree: str | None = None
+    assigned_scope: str = Field(min_length=1)
+    allowed_paths: list[str] = Field(default_factory=list)
+    allowed_tools: list[str] = Field(default_factory=list)
+    budget: dict[str, Any] = Field(default_factory=dict)
+    status: AttemptStatus
+    touched_files: list[str] = Field(default_factory=list)
+    commands_run: list[str] = Field(default_factory=list)
+    evidence_packet_path: str | None = None
+    verification_status: VerificationStatus = VerificationStatus.NOT_CHECKED
+    escalation_or_failure_reason: str | None = None
+    external_approval_id: str | None = None
+
+    @field_validator("allowed_paths", "allowed_tools", "touched_files", "commands_run")
+    @classmethod
+    def _dedupe_preserving_order(cls, values: list[str]) -> list[str]:
+        seen: set[str] = set()
+        deduped: list[str] = []
+        for value in values:
+            if not value:
+                raise ValueError("list entries must be non-empty strings")
+            if value not in seen:
+                seen.add(value)
+                deduped.append(value)
+        return deduped
+
+    @model_validator(mode="after")
+    def _fail_closed_metadata(self) -> WorkerAttemptMetadata:
+        if self.status == AttemptStatus.SUCCEEDED and not self.evidence_packet_path:
+            raise ValueError("evidence_packet_path is required when status is succeeded")
+        if self.status in {AttemptStatus.FAILED, AttemptStatus.BLOCKED, AttemptStatus.ESCALATED}:
+            if not self.escalation_or_failure_reason:
+                raise ValueError(
+                    "escalation_or_failure_reason is required for failed, blocked, or escalated attempts"
+                )
+        external_markers = {"external_account", "gmail", "gmail_send", "email", "slack", "x", "twitter"}
+        if any(tool in external_markers for tool in self.allowed_tools):
+            if not self.external_approval_id:
+                raise ValueError("external_approval_id is required for external account tools")
+        return self
+
+
+class EvidenceItem(ContractModel):
+    kind: EvidenceKind
+    reference: str = Field(min_length=1)
+    observed_at: str | None = None
+    status: EvidenceItemStatus
+    excerpt: str | None = None
+
+
+class ConductorVerification(ContractModel):
+    status: VerificationStatus
+    commands: list[str] = Field(default_factory=list)
+    notes: str | None = None
+
+
+class EvidencePacket(ContractModel):
+    summary: str = Field(min_length=1)
+    items: list[EvidenceItem] = Field(default_factory=list)
+    conductor_verification: ConductorVerification
+
+
+class DispatchReceipt(ContractModel):
+    schema_version: Literal["dispatch-contracts/v1"] = SCHEMA_VERSION
+    work_order_id: str = Field(min_length=1)
+    attempt_id: str = Field(min_length=1)
+    task_classification: TaskClassification
+    budget_policy: BudgetPolicy
+    worker_attempt: WorkerAttemptMetadata
+    evidence: EvidencePacket
+
+    @model_validator(mode="after")
+    def _receipt_integrity(self) -> DispatchReceipt:
+        if (
+            self.worker_attempt.work_order_id != self.work_order_id
+            or self.worker_attempt.attempt_id != self.attempt_id
+        ):
+            raise ValueError(
+                "receipt and worker_attempt must share the same work_order_id and attempt_id"
+            )
+        if self.worker_attempt.status == AttemptStatus.SUCCEEDED and not self.evidence.items:
+            raise ValueError("succeeded receipts require at least one evidence item")
+        if self.worker_attempt.verification_status == VerificationStatus.VERIFIED:
+            if self.evidence.conductor_verification.status != VerificationStatus.VERIFIED:
+                raise ValueError("verified attempts require verified conductor_verification")
+        evidence_refs = {item.reference for item in self.evidence.items}
+        for touched_file in self.worker_attempt.touched_files:
+            if touched_file not in evidence_refs:
+                raise ValueError(f"touched file {touched_file!r} is missing from evidence references")
+        return self
+
+
+def validate_dispatch_receipt(payload: dict[str, Any]) -> DispatchReceipt:
+    """Parse and validate a worker dispatch receipt with fail-closed semantics."""
+    return DispatchReceipt.model_validate(payload)
+
+
+def dispatch_contract_json_schemas() -> dict[str, dict[str, Any]]:
+    """Return machine-readable JSON schemas for the Slice 1 dispatch contracts."""
+    return {
+        "TaskClassification": TaskClassification.model_json_schema(),
+        "BudgetPolicy": BudgetPolicy.model_json_schema(),
+        "WorkerAttemptMetadata": WorkerAttemptMetadata.model_json_schema(),
+        "EvidencePacket": EvidencePacket.model_json_schema(),
+        "DispatchReceipt": DispatchReceipt.model_json_schema(),
+    }

--- a/tests/agent/test_dispatch_contracts.py
+++ b/tests/agent/test_dispatch_contracts.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from agent.dispatch_contracts import (
+    BudgetPolicy,
+    DispatchReceipt,
+    TaskClassification,
+    WorkerAttemptMetadata,
+    dispatch_contract_json_schemas,
+    validate_dispatch_receipt,
+)
+
+FIXTURES = Path(__file__).resolve().parents[1] / "fixtures" / "dispatch_contracts"
+
+
+def _load_fixture(name: str) -> dict:
+    return json.loads((FIXTURES / name).read_text())
+
+
+@pytest.mark.parametrize(
+    "fixture_name",
+    [
+        "local_file_task.json",
+        "github_ops_task.json",
+        "research_task.json",
+        "repo_code_task.json",
+    ],
+)
+def test_valid_dispatch_receipt_fixtures_parse(fixture_name: str):
+    receipt = validate_dispatch_receipt(_load_fixture(fixture_name))
+
+    assert isinstance(receipt, DispatchReceipt)
+    assert receipt.schema_version == "dispatch-contracts/v1"
+    assert receipt.worker_attempt.work_order_id == receipt.work_order_id
+    assert receipt.worker_attempt.attempt_id == receipt.attempt_id
+    assert receipt.evidence.items
+
+
+def test_contracts_export_machine_readable_json_schemas():
+    schemas = dispatch_contract_json_schemas()
+
+    assert set(schemas) == {
+        "TaskClassification",
+        "BudgetPolicy",
+        "WorkerAttemptMetadata",
+        "EvidencePacket",
+        "DispatchReceipt",
+    }
+    assert schemas["DispatchReceipt"]["type"] == "object"
+    assert "required" in schemas["WorkerAttemptMetadata"]
+
+
+def test_task_classification_rejects_unknown_policy_values():
+    with pytest.raises(ValidationError):
+        TaskClassification(
+            task_complexity="huge",
+            stakes="medium",
+            reversibility="reversible",
+            tool_reach="github",
+            memory_dependency="local_context",
+            verification_need="deterministic",
+        )
+
+
+def test_budget_policy_enforces_positive_bounds_and_approval_threshold():
+    with pytest.raises(ValidationError):
+        BudgetPolicy(
+            max_worker_sessions_per_issue=0,
+            max_parallel_workers_default=2,
+            max_worker_turns=4,
+            max_worker_runtime_minutes=30,
+            max_escalations_to_sota=1,
+            stop_after_failed_attempts=2,
+            require_ceo_approval_above_stakes="irreversible",
+        )
+
+    with pytest.raises(ValidationError):
+        BudgetPolicy(
+            max_worker_sessions_per_issue=3,
+            max_parallel_workers_default=4,
+            max_worker_turns=4,
+            max_worker_runtime_minutes=30,
+            max_escalations_to_sota=1,
+            stop_after_failed_attempts=2,
+            require_ceo_approval_above_stakes="high",
+        )
+
+
+def test_worker_attempt_rejects_completion_claim_without_evidence_path():
+    payload = _load_fixture("local_file_task.json")["worker_attempt"]
+    payload["status"] = "succeeded"
+    payload["evidence_packet_path"] = None
+
+    with pytest.raises(ValidationError, match="evidence_packet_path"):
+        WorkerAttemptMetadata(**payload)
+
+
+def test_worker_attempt_rejects_external_account_without_approval():
+    payload = _load_fixture("github_ops_task.json")["worker_attempt"]
+    payload["allowed_tools"] = ["browser", "gmail_send"]
+    payload["assigned_scope"] = "send an email to a third party"
+    payload["external_approval_id"] = None
+
+    with pytest.raises(ValidationError, match="external_approval_id"):
+        WorkerAttemptMetadata(**payload)
+
+
+def test_receipt_rejects_mismatched_attempt_ids():
+    payload = _load_fixture("repo_code_task.json")
+    payload["worker_attempt"]["attempt_id"] = "different-attempt"
+
+    with pytest.raises(ValidationError, match="same work_order_id and attempt_id"):
+        validate_dispatch_receipt(payload)
+
+
+def test_receipt_rejects_success_without_verification_items():
+    payload = _load_fixture("research_task.json")
+    payload["evidence"]["items"] = []
+
+    with pytest.raises(ValidationError, match="at least one evidence item"):
+        validate_dispatch_receipt(payload)
+
+
+def test_receipt_rejects_claimed_touched_files_not_listed_in_evidence():
+    payload = _load_fixture("local_file_task.json")
+    payload["worker_attempt"]["touched_files"] = ["/tmp/output.md", "/tmp/unverified.md"]
+
+    with pytest.raises(ValidationError, match="touched file"):
+        validate_dispatch_receipt(payload)

--- a/tests/fixtures/dispatch_contracts/github_ops_task.json
+++ b/tests/fixtures/dispatch_contracts/github_ops_task.json
@@ -1,0 +1,64 @@
+{
+  "schema_version": "dispatch-contracts/v1",
+  "work_order_id": "lifeos-bus-12-slice1-github-ops",
+  "attempt_id": "attempt-001",
+  "task_classification": {
+    "task_complexity": "simple",
+    "stakes": "medium",
+    "reversibility": "partially_reversible",
+    "tool_reach": "github",
+    "memory_dependency": "project_memory",
+    "verification_need": "deterministic"
+  },
+  "budget_policy": {
+    "max_worker_sessions_per_issue": 3,
+    "max_parallel_workers_default": 2,
+    "max_worker_turns": 4,
+    "max_worker_runtime_minutes": 30,
+    "max_escalations_to_sota": 1,
+    "stop_after_failed_attempts": 2,
+    "require_ceo_approval_above_stakes": "high"
+  },
+  "worker_attempt": {
+    "work_order_id": "lifeos-bus-12-slice1-github-ops",
+    "attempt_id": "attempt-001",
+    "worker_session_id": "github-ops-worker-12",
+    "worker_role": "github-ops-worker",
+    "harness": "github-cli",
+    "provider_model": "openai-codex:gpt-5.4-mini",
+    "profile_or_toolset": "github,terminal",
+    "branch": null,
+    "worktree": null,
+    "assigned_scope": "Read issue #12 and prepare a bounded status comment draft only.",
+    "allowed_paths": [],
+    "allowed_tools": ["gh", "terminal"],
+    "budget": {
+      "max_turns": 4,
+      "max_runtime_minutes": 30
+    },
+    "status": "succeeded",
+    "touched_files": [],
+    "commands_run": ["gh issue view 12 -R marcusglee11/lifeos-operational-bus --json number,title,state,url"],
+    "evidence_packet_path": "/tmp/receipt-github-ops.json",
+    "verification_status": "verified",
+    "escalation_or_failure_reason": null,
+    "external_approval_id": null
+  },
+  "evidence": {
+    "summary": "Worker read back issue #12 metadata without public writes.",
+    "items": [
+      {
+        "kind": "github_readback",
+        "reference": "https://github.com/marcusglee11/lifeos-operational-bus/issues/12",
+        "observed_at": "2026-04-28T10:31:00Z",
+        "status": "verified",
+        "excerpt": "OPEN: Build boss-harness dispatch for bounded cheap workers"
+      }
+    ],
+    "conductor_verification": {
+      "status": "verified",
+      "commands": ["gh issue view 12 -R marcusglee11/lifeos-operational-bus --json state"],
+      "notes": "GitHub API readback matched worker claim."
+    }
+  }
+}

--- a/tests/fixtures/dispatch_contracts/local_file_task.json
+++ b/tests/fixtures/dispatch_contracts/local_file_task.json
@@ -1,0 +1,64 @@
+{
+  "schema_version": "dispatch-contracts/v1",
+  "work_order_id": "lifeos-bus-12-slice1-local-file",
+  "attempt_id": "attempt-001",
+  "task_classification": {
+    "task_complexity": "simple",
+    "stakes": "low",
+    "reversibility": "reversible",
+    "tool_reach": "local_files",
+    "memory_dependency": "local_context",
+    "verification_need": "deterministic"
+  },
+  "budget_policy": {
+    "max_worker_sessions_per_issue": 3,
+    "max_parallel_workers_default": 2,
+    "max_worker_turns": 4,
+    "max_worker_runtime_minutes": 30,
+    "max_escalations_to_sota": 1,
+    "stop_after_failed_attempts": 2,
+    "require_ceo_approval_above_stakes": "high"
+  },
+  "worker_attempt": {
+    "work_order_id": "lifeos-bus-12-slice1-local-file",
+    "attempt_id": "attempt-001",
+    "worker_session_id": "hermes-local-file-worker",
+    "worker_role": "local-file-worker",
+    "harness": "hermes-worker",
+    "provider_model": "openai-codex:gpt-5.4-mini",
+    "profile_or_toolset": "file,terminal",
+    "branch": null,
+    "worktree": null,
+    "assigned_scope": "Create a bounded local artifact under /tmp/output.md",
+    "allowed_paths": ["/tmp/output.md"],
+    "allowed_tools": ["file", "terminal"],
+    "budget": {
+      "max_turns": 4,
+      "max_runtime_minutes": 30
+    },
+    "status": "succeeded",
+    "touched_files": ["/tmp/output.md"],
+    "commands_run": ["python -m pytest tests/agent/test_dispatch_contracts.py -q"],
+    "evidence_packet_path": "/tmp/receipt-local-file.json",
+    "verification_status": "verified",
+    "escalation_or_failure_reason": null,
+    "external_approval_id": null
+  },
+  "evidence": {
+    "summary": "Worker created /tmp/output.md and conductor verified file readback.",
+    "items": [
+      {
+        "kind": "file_readback",
+        "reference": "/tmp/output.md",
+        "observed_at": "2026-04-28T10:30:00Z",
+        "status": "verified",
+        "excerpt": "bounded local artifact"
+      }
+    ],
+    "conductor_verification": {
+      "status": "verified",
+      "commands": ["test -s /tmp/output.md"],
+      "notes": "File exists and is non-empty."
+    }
+  }
+}

--- a/tests/fixtures/dispatch_contracts/repo_code_task.json
+++ b/tests/fixtures/dispatch_contracts/repo_code_task.json
@@ -1,0 +1,78 @@
+{
+  "schema_version": "dispatch-contracts/v1",
+  "work_order_id": "lifeos-bus-12-slice1-repo-code",
+  "attempt_id": "attempt-001",
+  "task_classification": {
+    "task_complexity": "moderate",
+    "stakes": "medium",
+    "reversibility": "partially_reversible",
+    "tool_reach": "local_files",
+    "memory_dependency": "project_memory",
+    "verification_need": "deterministic"
+  },
+  "budget_policy": {
+    "max_worker_sessions_per_issue": 3,
+    "max_parallel_workers_default": 2,
+    "max_worker_turns": 4,
+    "max_worker_runtime_minutes": 30,
+    "max_escalations_to_sota": 1,
+    "stop_after_failed_attempts": 2,
+    "require_ceo_approval_above_stakes": "high"
+  },
+  "worker_attempt": {
+    "work_order_id": "lifeos-bus-12-slice1-repo-code",
+    "attempt_id": "attempt-001",
+    "worker_session_id": "repo-code-worker-12",
+    "worker_role": "repo-code-worker",
+    "harness": "codex-lane",
+    "provider_model": "openai-codex:gpt-5.4-mini",
+    "profile_or_toolset": "terminal,file",
+    "branch": "feat/dispatch-contracts-slice1",
+    "worktree": "/tmp/hermes-issue12-slice1",
+    "assigned_scope": "Implement dispatch contract schemas and focused tests only.",
+    "allowed_paths": ["agent/dispatch_contracts.py", "tests/agent/test_dispatch_contracts.py", "tests/fixtures/dispatch_contracts"],
+    "allowed_tools": ["file", "terminal"],
+    "budget": {
+      "max_turns": 4,
+      "max_runtime_minutes": 30
+    },
+    "status": "succeeded",
+    "touched_files": ["agent/dispatch_contracts.py", "tests/agent/test_dispatch_contracts.py"],
+    "commands_run": ["pytest tests/agent/test_dispatch_contracts.py -q"],
+    "evidence_packet_path": "/tmp/receipt-repo-code.json",
+    "verification_status": "verified",
+    "escalation_or_failure_reason": null,
+    "external_approval_id": null
+  },
+  "evidence": {
+    "summary": "Worker produced code and tests; conductor reran focused pytest.",
+    "items": [
+      {
+        "kind": "test_output",
+        "reference": "pytest tests/agent/test_dispatch_contracts.py -q",
+        "observed_at": "2026-04-28T10:33:00Z",
+        "status": "verified",
+        "excerpt": "10 passed"
+      },
+      {
+        "kind": "file_diff",
+        "reference": "agent/dispatch_contracts.py",
+        "observed_at": "2026-04-28T10:33:30Z",
+        "status": "verified",
+        "excerpt": "Dispatch contract models added."
+      },
+      {
+        "kind": "file_diff",
+        "reference": "tests/agent/test_dispatch_contracts.py",
+        "observed_at": "2026-04-28T10:34:00Z",
+        "status": "verified",
+        "excerpt": "Malformed receipt tests added."
+      }
+    ],
+    "conductor_verification": {
+      "status": "verified",
+      "commands": ["pytest tests/agent/test_dispatch_contracts.py -q", "git diff --check"],
+      "notes": "Focused tests and whitespace check passed."
+    }
+  }
+}

--- a/tests/fixtures/dispatch_contracts/research_task.json
+++ b/tests/fixtures/dispatch_contracts/research_task.json
@@ -1,0 +1,64 @@
+{
+  "schema_version": "dispatch-contracts/v1",
+  "work_order_id": "lifeos-bus-12-slice1-research",
+  "attempt_id": "attempt-001",
+  "task_classification": {
+    "task_complexity": "moderate",
+    "stakes": "low",
+    "reversibility": "reversible",
+    "tool_reach": "browser",
+    "memory_dependency": "local_context",
+    "verification_need": "lightweight"
+  },
+  "budget_policy": {
+    "max_worker_sessions_per_issue": 3,
+    "max_parallel_workers_default": 2,
+    "max_worker_turns": 4,
+    "max_worker_runtime_minutes": 30,
+    "max_escalations_to_sota": 1,
+    "stop_after_failed_attempts": 2,
+    "require_ceo_approval_above_stakes": "high"
+  },
+  "worker_attempt": {
+    "work_order_id": "lifeos-bus-12-slice1-research",
+    "attempt_id": "attempt-001",
+    "worker_session_id": "research-worker-12",
+    "worker_role": "browser-research-worker",
+    "harness": "hermes-worker",
+    "provider_model": "openai-codex:gpt-5.4-mini",
+    "profile_or_toolset": "web,browser",
+    "branch": null,
+    "worktree": null,
+    "assigned_scope": "Collect source links for overlapping Hermes dispatch issues.",
+    "allowed_paths": [],
+    "allowed_tools": ["web", "browser"],
+    "budget": {
+      "max_turns": 4,
+      "max_runtime_minutes": 30
+    },
+    "status": "succeeded",
+    "touched_files": [],
+    "commands_run": [],
+    "evidence_packet_path": "/tmp/receipt-research.json",
+    "verification_status": "verified",
+    "escalation_or_failure_reason": null,
+    "external_approval_id": null
+  },
+  "evidence": {
+    "summary": "Worker collected source URLs and conductor spot-checked one source.",
+    "items": [
+      {
+        "kind": "source_url",
+        "reference": "https://github.com/NousResearch/hermes-agent/issues/16211",
+        "observed_at": "2026-04-28T10:32:00Z",
+        "status": "verified",
+        "excerpt": "smart_model_routing config accepted but not implemented"
+      }
+    ],
+    "conductor_verification": {
+      "status": "verified",
+      "commands": ["gh issue view 16211 -R NousResearch/hermes-agent --json state,title"],
+      "notes": "One representative URL was verified through GitHub API readback."
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds contract-only Pydantic models for task classification, budget policy, worker attempt metadata, evidence packets, and dispatch receipts.
- Adds fail-closed receipt validation for mismatched attempts, missing evidence, unapproved external-account tools, and unverified touched files.
- Adds JSON fixtures/examples for local-file, GitHub-ops, research, and repo/code dispatch tasks plus focused tests.

## Test plan
- [x] pytest -o 'addopts=' tests/agent/test_dispatch_contracts.py -q
- [x] python3 -m py_compile agent/dispatch_contracts.py
- [x] python3 -m ruff check agent/dispatch_contracts.py tests/agent/test_dispatch_contracts.py
- [x] git diff --cached --check
- [x] Fresh-context Codex review: ACCEPT, no blockers

Refs marcusglee11/lifeos-operational-bus#12

🤖 Generated with [Claude Code](https://claude.com/claude-code)
