### PR TITLE
fix(claw): handle missing dir in _scan_workspace_state

### DIFF
--- a/hermes_cli/claw.py
+++ b/hermes_cli/claw.py
@@ -235,6 +235,9 @@ def _scan_workspace_state(source_dir: Path) -> list[tuple[Path, str]]:
     """
     findings: list[tuple[Path, str]] = []
 
+    if not source_dir.exists():
+        return findings
+
     # Direct state files in the root
     for name in ("todo.json", "sessions", "logs"):
         candidate = source_dir / name
@@ -243,7 +246,12 @@ def _scan_workspace_state(source_dir: Path) -> list[tuple[Path, str]]:
             findings.append((candidate, f"Root {kind}: {name}"))
 
     # State files inside workspace directories
-    for child in sorted(source_dir.iterdir()):
+    try:
+        children = sorted(source_dir.iterdir())
+    except OSError:
+        return findings
+
+    for child in children:
         if not child.is_dir() or child.name.startswith("."):
             continue
         # Check for workspace-like subdirectories


### PR DESCRIPTION
# What does this PR do?

Fixes a `FileNotFoundError` crash in hermes claw cleanup when an OpenClaw directory no longer exists or becomes inaccessible between the detection phase and the scanning phase.

## Related Issue

Fixes # (no issue exists yet — this was discovered via user report)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/claw.py`: `_scan_workspace_state()` now returns early if `source_dir` doesn't exist, and wraps the `iterdir()` call in a try/except to gracefully handle concurrent deletion or permission errors.

## How to Test

1. **Create a phantom entry**: `mkdir ~/.clawdbot` then `rmdir ~/.clawdbot` (so the path briefly existed when detected).
2. **Run cleanup**: Run `hermes claw cleanup` — previously this crashed with `FileNotFoundError`; now it skips the missing directory cleanly.
3. **Alternative**: Run `touch /tmp/testscan && hermes claw cleanup --source /tmp/testscan` to trigger the scan on a non-existent path — verify it exits cleanly instead of crashing.

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(claw):`)
- [x] Searched for existing PRs,  no duplicate
- [x] My PR contains only this fix (no unrelated commits)
- [x] I've run `pytest tests/ -q` but tests for `claw.py` do not exist, but the fix is trivially defensive
- [x] I've tested on my platform: Linux (Ubuntu)

### Documentation & Housekeeping
- [x] N/A — no docs affected
- [x] N/A — no config changes
- [x] N/A — no architecture changes
- [x] N/A — no tool behavior changes

## Screenshots / Logs

<img width="1290" height="957" alt="image" src="https://github.com/user-attachments/assets/3421be0b-1bf4-45b6-a05a-fd3c5d438911" />