### PR TITLE
fix(agent): normalize Anthropic MCP tool names

### DIFF
--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -10,6 +10,17 @@ from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse
 
 
+def _normalize_tool_name(name: str, *, strip_tool_prefix: bool = False) -> str:
+    """Map provider tool names back to the registered Hermes tool name."""
+    if not strip_tool_prefix or not name.startswith("mcp_"):
+        return name
+
+    stripped = name[4:]
+    if stripped and stripped[0].isupper():
+        stripped = stripped[0].lower() + stripped[1:]
+    return stripped
+
+
 class AnthropicTransport(ProviderTransport):
     """Transport for api_mode='anthropic_messages'.
 
@@ -102,7 +113,10 @@ class AnthropicTransport(ProviderTransport):
                 tool_calls.append(
                     ToolCall(
                         id=block.id,
-                        name=block.name,
+                        name=_normalize_tool_name(
+                            block.name,
+                            strip_tool_prefix=kwargs.get("strip_tool_prefix", False),
+                        ),
                         arguments=json.dumps(block.input),
                     )
                 )

--- a/tests/agent/test_anthropic_transport_mcp_tool_names.py
+++ b/tests/agent/test_anthropic_transport_mcp_tool_names.py
@@ -1,0 +1,33 @@
+from types import SimpleNamespace
+
+import pytest
+
+from agent.transports.anthropic import AnthropicTransport
+
+
+@pytest.mark.parametrize(
+    ("wire_name", "expected_name"),
+    [
+        ("mcp_terminal", "terminal"),
+        ("mcp_Terminal", "terminal"),
+    ],
+)
+def test_normalize_response_strips_mcp_prefix_from_tool_name(
+    wire_name,
+    expected_name,
+):
+    block = SimpleNamespace(
+        type="tool_use",
+        id="toolu_terminal",
+        name=wire_name,
+        input={"command": "printf OPUS_TOOL_OK"},
+    )
+    response = SimpleNamespace(content=[block], stop_reason="tool_use")
+
+    normalized = AnthropicTransport().normalize_response(
+        response,
+        strip_tool_prefix=True,
+    )
+
+    assert normalized.tool_calls is not None
+    assert normalized.tool_calls[0].name == expected_name


### PR DESCRIPTION
## Summary
- normalize Anthropic `mcp_` tool-use names back to registered Hermes tool names during response normalization
- handle Claude Code-shaped PascalCase names like `mcp_Terminal`
- add focused regression coverage for both lowercase and PascalCase MCP tool names

## Root cause
`AnthropicTransport.normalize_response()` was passing `tool_use.name` through unchanged. When Anthropic returned Claude Code-shaped names such as `mcp_Terminal`, Hermes kept the `mcp_` prefix and PascalCase spelling, so dispatch missed the registered `terminal` tool.

## Fix
- add a small `_normalize_tool_name()` helper in `agent/transports/anthropic.py`
- when `strip_tool_prefix=True`, strip the `mcp_` prefix and downcase the first remaining character if needed
- preserve existing non-MCP names unchanged

## Regression coverage
- new test file `tests/agent/test_anthropic_transport_mcp_tool_names.py`
- covers both `mcp_terminal -> terminal` and `mcp_Terminal -> terminal`
- re-ran nearby Anthropic message conversion tests to confirm no tool-call regression

## Testing
- `scripts/run_tests.sh tests/agent/test_anthropic_transport_mcp_tool_names.py`
- `scripts/run_tests.sh tests/agent/test_anthropic_transport_mcp_tool_names.py tests/agent/test_anthropic_adapter.py::TestConvertMessages::test_converts_tool_calls tests/agent/test_anthropic_adapter.py::TestConvertMessages::test_converts_tool_results tests/agent/test_anthropic_adapter.py::TestConvertMessages::test_merges_consecutive_tool_results tests/agent/test_anthropic_adapter.py::TestConvertMessages::test_strips_orphaned_tool_use tests/agent/test_anthropic_adapter.py::TestConvertMessages::test_strips_orphaned_tool_result`

Closes #16817
