### PR TITLE
fix(cli): respect model_catalog filtering in /model picker

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1009,10 +1009,22 @@ def list_authenticated_providers(
         get_provider_info as _mdev_pinfo,
     )
     from hermes_cli.auth import PROVIDER_REGISTRY
+    from hermes_cli.model_catalog import _load_catalog_config
     from hermes_cli.models import (
         OPENROUTER_MODELS, _PROVIDER_MODELS,
         _MODELS_DEV_PREFERRED, _merge_with_models_dev, provider_model_ids,
     )
+
+    catalog_cfg = _load_catalog_config()
+    catalog_providers_cfg = catalog_cfg.get("providers") or {}
+
+    def _catalog_allows_builtin(provider_slug: str, mdev_id: str | None = None) -> bool:
+        if not catalog_cfg.get("enabled", True):
+            return False
+        for key in (provider_slug, mdev_id):
+            if key and catalog_providers_cfg.get(key) is False:
+                return False
+        return True
 
     results: List[dict] = []
     seen_slugs: set = set()  # lowercase-normalized to catch case variants (#9545)
@@ -1037,6 +1049,8 @@ def list_authenticated_providers(
         # kimi-coding and kimi-coding-cn both → kimi-for-coding).
         # The first one with valid credentials wins (#10526).
         if mdev_id in seen_mdev_ids:
+            continue
+        if not _catalog_allows_builtin(hermes_id, mdev_id):
             continue
         pdata = data.get(mdev_id)
         if not isinstance(pdata, dict):
@@ -1112,6 +1126,8 @@ def list_authenticated_providers(
         # Resolve Hermes slug — e.g. "github-copilot" → "copilot"
         hermes_slug = _mdev_to_hermes.get(pid, pid)
         if hermes_slug.lower() in seen_slugs:
+            continue
+        if not _catalog_allows_builtin(hermes_slug, pid):
             continue
 
         # Check if credentials exist
@@ -1221,6 +1237,8 @@ def list_authenticated_providers(
 
     for _cp in _canon_provs:
         if _cp.slug.lower() in seen_slugs:
+            continue
+        if not _catalog_allows_builtin(_cp.slug):
             continue
 
         # Check credentials via PROVIDER_REGISTRY (auth.py)

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -5,6 +5,9 @@ shared slash-command pipeline (`/model` in CLI/gateway/Telegram) historically
 only looked at `providers:`.
 """
 
+from types import SimpleNamespace
+
+import hermes_cli.model_catalog as model_catalog
 import hermes_cli.providers as providers_mod
 from hermes_cli.model_switch import list_authenticated_providers, switch_model
 from hermes_cli.providers import resolve_provider_full
@@ -43,6 +46,45 @@ def test_list_authenticated_providers_includes_custom_providers(monkeypatch):
         and p["api_url"] == "http://127.0.0.1:4141/v1"
         for p in providers
     )
+
+
+def test_list_authenticated_providers_skips_builtins_when_model_catalog_disabled(monkeypatch):
+    """model_catalog.enabled=false should hide built-in providers from /model.
+
+    Regression: list_authenticated_providers historically ignored the
+    model_catalog block entirely, so built-in providers authenticated via env
+    vars still appeared alongside custom_providers.
+    """
+    monkeypatch.setenv("DASHSCOPE_API_KEY", "test-key")
+    monkeypatch.setattr(
+        "agent.models_dev.fetch_models_dev",
+        lambda: {"alibaba": {"env": ["DASHSCOPE_API_KEY"]}},
+    )
+    monkeypatch.setattr(
+        "agent.models_dev.get_provider_info",
+        lambda _provider_id: SimpleNamespace(name="Alibaba/DashScope"),
+    )
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    monkeypatch.setattr(
+        model_catalog,
+        "_load_catalog_config",
+        lambda: {"enabled": False, "providers": {}, "url": "", "ttl_hours": 24},
+    )
+
+    providers = list_authenticated_providers(
+        current_provider="",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "my-dashscope",
+                "base_url": "https://coding-intl.dashscope.aliyuncs.com/v1",
+                "model": "qwen3.6-plus",
+            }
+        ],
+        max_models=50,
+    )
+
+    assert [p["slug"] for p in providers] == ["custom:my-dashscope"]
 
 
 def test_resolve_provider_full_finds_named_custom_provider():


### PR DESCRIPTION
## Summary
- make `/model` respect `model_catalog.enabled` and per-provider catalog filtering when enumerating built-in providers
- keep custom providers visible when the built-in catalog is disabled
- add regression coverage for the `model_catalog.enabled: false` case

## Root cause
`list_authenticated_providers()` read credential sources for built-in providers from `PROVIDER_TO_MODELS_DEV`, `HERMES_OVERLAYS`, and `CANONICAL_PROVIDERS`, but it never loaded the `model_catalog` config block. As a result, `/model` still listed authenticated built-in providers even when `model_catalog.enabled: false` was meant to hide them.

## Fix
- load `model_catalog` config inside `list_authenticated_providers()`
- add a small helper that blocks built-in provider rows when the catalog is disabled or an individual provider is disabled in `model_catalog.providers`
- apply that filter consistently across the models.dev-mapped, Hermes overlay, and canonical-provider enumeration paths

## Regression coverage
- add a test that sets `DASHSCOPE_API_KEY`, disables `model_catalog`, and verifies `/model` only returns the configured custom provider row

## Testing
- `scripts/run_tests.sh tests/hermes_cli/test_model_switch_custom_providers.py -k model_catalog_disabled`
- `scripts/run_tests.sh tests/hermes_cli/test_model_switch_custom_providers.py tests/hermes_cli/test_opencode_go_in_model_list.py`

Closes #16970
