### PR TITLE
fix(error-classifier): add insufficient balance to billing patterns

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -91,6 +91,7 @@ class ClassifiedError:
 _BILLING_PATTERNS = [
     "insufficient credits",
     "insufficient_quota",
+    "insufficient balance",
     "credit balance",
     "credits have been exhausted",
     "top up your credits",


### PR DESCRIPTION
Salvage of #16772 onto current main (preserves @zons-zhaozhy authorship).

## Summary
Adds `"insufficient balance"` to `_BILLING_PATTERNS` in `agent/error_classifier.py` so DeepSeek's HTTP 402 `{"error":{"message":"Insufficient Balance"}}` response is classified as billing exhaustion (triggers fallback provider, skips retry) instead of being misclassified.

## Validation
- DeepSeek docs and multiple upstream bug reports confirm the exact response string
- `classify_error()` lowercases before matching, so capitalization is handled
- AUTHOR_MAP already has `1243352777@qq.com -> zons-zhaozhy`

Closes #16772.