### PR TITLE
fix(claw-migrate): resolve model aliases against real OpenClaw catalog schema (salvage #16778)

### DIFF
--- a/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
+++ b/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
@@ -1671,6 +1671,29 @@ class Migrator:
 
         model_str = model_str.strip()
 
+        # Resolve a model alias against the OpenClaw model catalog.
+        # OpenClaw stores agents.defaults.model as either a bare string or
+        # {"primary": "<value>"}, and that value can be either:
+        #   - a full provider/model API ID (e.g. "anthropic/claude-opus-4-6"), or
+        #   - a display alias (e.g. "Claude Opus 4.6") that maps to one.
+        # The catalog at agents.defaults.models is keyed by the full
+        # provider/model API ID with an "alias" field on the value, e.g.:
+        #   {"anthropic/claude-opus-4-6": {"alias": "Claude Opus 4.6"}}
+        # If model_str matches an alias in the catalog, rewrite it to the
+        # catalog key (the real API ID).  If it's already an API ID or has
+        # no catalog match, leave it alone and let downstream pass it through.
+        model_catalog = config.get("agents", {}).get("defaults", {}).get("models", {})
+        if isinstance(model_catalog, dict) and model_str not in model_catalog:
+            for api_id, entry in model_catalog.items():
+                if not isinstance(api_id, str):
+                    continue
+                if isinstance(entry, dict) and entry.get("alias") == model_str:
+                    model_str = api_id
+                    break
+                if isinstance(entry, str) and entry == model_str:
+                    model_str = api_id
+                    break
+
         if yaml is None:
             self.record("model-config", source_path, destination, "error", "PyYAML is not available")
             return

--- a/tests/skills/test_openclaw_migration.py
+++ b/tests/skills/test_openclaw_migration.py
@@ -970,3 +970,140 @@ def test_migrate_soul_rebrands_content(tmp_path):
     result = (target_root / "SOUL.md").read_text(encoding="utf-8")
     assert "OpenClaw" not in result
     assert "You are Hermes" in result
+
+
+# ── migrate_model_config: alias resolution (issue #16745) ──────────────────
+
+def _run_model_migration(tmp_path: Path, openclaw_json: dict) -> dict:
+    """Helper: run just migrate_model_config on an openclaw.json and return
+    the parsed destination config.yaml."""
+    import yaml
+
+    mod = load_module()
+    source = tmp_path / ".openclaw"
+    target = tmp_path / ".hermes"
+    source.mkdir(parents=True)
+    target.mkdir(parents=True)
+    (source / "openclaw.json").write_text(json.dumps(openclaw_json), encoding="utf-8")
+
+    migrator = mod.Migrator(
+        source_root=source,
+        target_root=target,
+        execute=True,
+        workspace_target=None,
+        overwrite=True,
+        migrate_secrets=False,
+        output_dir=target / "migration-report",
+    )
+    migrator.migrate_model_config()
+
+    cfg_path = target / "config.yaml"
+    if not cfg_path.exists():
+        return {}
+    return yaml.safe_load(cfg_path.read_text(encoding="utf-8")) or {}
+
+
+def _extract_model(parsed: dict) -> str | None:
+    model = parsed.get("model")
+    if isinstance(model, dict):
+        return model.get("default")
+    return model
+
+
+def test_migrate_model_config_resolves_alias_against_real_openclaw_schema(tmp_path: Path):
+    """Regression for #16745 — OpenClaw's catalog is keyed by the full
+    provider/model API ID with an "alias" field on the value.  The migration
+    must reverse-lookup the alias to find the API ID."""
+    parsed = _run_model_migration(
+        tmp_path,
+        {
+            "agents": {
+                "defaults": {
+                    "model": {"primary": "Claude Opus 4.6"},
+                    "models": {
+                        "anthropic/claude-opus-4-6": {"alias": "Claude Opus 4.6"},
+                        "openai/gpt-5.2": {"alias": "GPT"},
+                    },
+                }
+            }
+        },
+    )
+    assert _extract_model(parsed) == "anthropic/claude-opus-4-6"
+
+
+def test_migrate_model_config_resolves_alias_with_bare_string_model(tmp_path: Path):
+    parsed = _run_model_migration(
+        tmp_path,
+        {
+            "agents": {
+                "defaults": {
+                    "model": "Sonnet",
+                    "models": {"anthropic/claude-sonnet-4-7": {"alias": "Sonnet"}},
+                }
+            }
+        },
+    )
+    assert _extract_model(parsed) == "anthropic/claude-sonnet-4-7"
+
+
+def test_migrate_model_config_passes_through_existing_api_id(tmp_path: Path):
+    """If the model value is already a provider/model API ID that appears as
+    a key in the catalog, it should be written verbatim — not double-rewritten."""
+    parsed = _run_model_migration(
+        tmp_path,
+        {
+            "agents": {
+                "defaults": {
+                    "model": "anthropic/claude-opus-4-6",
+                    "models": {
+                        "anthropic/claude-opus-4-6": {"alias": "Claude Opus 4.6"},
+                    },
+                }
+            }
+        },
+    )
+    assert _extract_model(parsed) == "anthropic/claude-opus-4-6"
+
+
+def test_migrate_model_config_passes_through_unknown_alias(tmp_path: Path):
+    """If the model value matches no catalog entry, leave it alone and let
+    downstream surface the mismatch."""
+    parsed = _run_model_migration(
+        tmp_path,
+        {
+            "agents": {
+                "defaults": {
+                    "model": "Totally Unknown Name",
+                    "models": {
+                        "anthropic/claude-opus-4-6": {"alias": "Claude Opus 4.6"},
+                    },
+                }
+            }
+        },
+    )
+    assert _extract_model(parsed) == "Totally Unknown Name"
+
+
+def test_migrate_model_config_handles_string_valued_catalog_entries(tmp_path: Path):
+    """Belt-and-suspenders: some catalogs store the alias as a plain string
+    value instead of a dict with an "alias" field."""
+    parsed = _run_model_migration(
+        tmp_path,
+        {
+            "agents": {
+                "defaults": {
+                    "model": "MyModel",
+                    "models": {"provider/some-id": "MyModel"},
+                }
+            }
+        },
+    )
+    assert _extract_model(parsed) == "provider/some-id"
+
+
+def test_migrate_model_config_no_catalog_leaves_value_alone(tmp_path: Path):
+    parsed = _run_model_migration(
+        tmp_path,
+        {"agents": {"defaults": {"model": "some-model-id"}}},
+    )
+    assert _extract_model(parsed) == "some-model-id"


### PR DESCRIPTION
Salvages @vominh1919's PR #16778 with corrected lookup direction.

## Summary

`claw migrate` now correctly resolves an OpenClaw model display-name alias to the real provider/model API ID before writing to `config.yaml`, so Hermes no longer sends `"Claude Opus 4.6"` to the Anthropic API and gets HTTP 404.

## Root cause

OpenClaw's `agents.defaults.models` catalog is keyed by the full provider/model API ID, with an `alias` field on the value:

```json
{ "anthropic/claude-opus-4-6": { "alias": "Claude Opus 4.6" } }
```

The original PR assumed the catalog was keyed by display name with `{"id": ..., "provider": ...}` as the value — the inverse shape. The forward lookup `if model_str in model_catalog` would have missed on every real OpenClaw config, including the exact catalog shown in issue #16745's repro.

## Fix

Do a reverse lookup: if `model_str` isn't already a catalog key, scan catalog items for one whose `alias` (or plain-string value) matches `model_str`, then use that entry's key as the resolved API ID. Leave `model_str` alone when it's already an API ID or has no match.

## Changes

- `optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py` (+23 / -0): reverse-lookup in `migrate_model_config`
- `tests/skills/test_openclaw_migration.py` (+137 / -0): 6 regression tests covering real schema, bare-string model value, already-an-API-ID passthrough, unknown-alias passthrough, string-valued entries, no catalog

## Validation

Targeted suite: 100/100 passing (`tests/skills/test_openclaw_migration*.py` + `tests/hermes_cli/test_setup_openclaw_migration.py`).

E2E: real OpenClaw schema from issue #16745 resolves `{"primary": "Claude Opus 4.6"}` → `anthropic/claude-opus-4-6` in the written `config.yaml`.

## Credit

Cherry-picked @vominh1919's commit (authorship preserved); lookup direction amended to match the real OpenClaw catalog shape, plus a follow-up commit adding regression tests. Closes #16778, fixes #16745.