### PR TITLE
feat(skills): add pagination and compact mode to skills_list

### DIFF
--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -331,6 +331,65 @@ class TestSkillsList:
         assert result["categories"] == ["linked"]
         assert result["skills"][0]["name"] == "knowledge-brain"
 
+    def test_pagination_limit_and_offset(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "alpha")
+            _make_skill(tmp_path, "beta")
+            _make_skill(tmp_path, "gamma")
+            raw = skills_list(limit=2, offset=1)
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert result["count"] == 3
+        assert result["returned_count"] == 2
+        assert result["offset"] == 1
+        assert result["limit"] == 2
+        assert result["has_more"] is False
+        assert [s["name"] for s in result["skills"]] == ["beta", "gamma"]
+
+    def test_pagination_has_more_and_next_offset(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "alpha")
+            _make_skill(tmp_path, "beta")
+            _make_skill(tmp_path, "gamma")
+            raw = skills_list(limit=1, offset=1)
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert result["count"] == 3
+        assert result["returned_count"] == 1
+        assert result["has_more"] is True
+        assert result["next_offset"] == 2
+        assert [s["name"] for s in result["skills"]] == ["beta"]
+
+    def test_include_descriptions_false(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "alpha")
+            raw = skills_list(include_descriptions=False)
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert "description" not in result["skills"][0]
+        assert result["skills"][0]["name"] == "alpha"
+
+    def test_invalid_limit_returns_error(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "alpha")
+            raw = skills_list(limit=0)
+
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert "limit must be > 0" in result["error"]
+
+    def test_invalid_offset_returns_error(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "alpha")
+            raw = skills_list(offset=-1)
+
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert "offset must be >= 0" in result["error"]
+
 
 # ---------------------------------------------------------------------------
 # skill_view

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -668,19 +668,28 @@ def _load_category_description(category_dir: Path) -> Optional[str]:
         return None
 
 
-def skills_list(category: str = None, task_id: str = None) -> str:
+def skills_list(
+    category: str = None,
+    limit: int = None,
+    offset: int = 0,
+    include_descriptions: bool = True,
+    task_id: str = None,
+) -> str:
     """
-    List all available skills (progressive disclosure tier 1 - minimal metadata).
+    List available skills (progressive disclosure tier 1).
 
-    Returns only name + description to minimize token usage. Use skill_view() to
-    load full content, tags, related files, etc.
+    Supports optional pagination to prevent oversized payloads in large
+    installations.
 
     Args:
         category: Optional category filter (e.g., "mlops")
+        limit: Optional max number of skills to return
+        offset: Number of skills to skip before returning results
+        include_descriptions: Include description field in each skill result
         task_id: Optional task identifier used to probe the active backend
 
     Returns:
-        JSON string with minimal skill info: name, description, category
+        JSON string with minimal skill info and pagination metadata.
     """
     try:
         if not SKILLS_DIR.exists():
@@ -716,17 +725,49 @@ def skills_list(category: str = None, task_id: str = None) -> str:
         # Sort by category then name
         all_skills = _sort_skills(all_skills)
 
-        # Extract unique categories
-        categories = sorted(
-            set(s.get("category") for s in all_skills if s.get("category"))
-        )
+        # Extract unique categories from the filtered set
+        categories = sorted(set(s.get("category") for s in all_skills if s.get("category")))
+
+        # Validate pagination inputs
+        if offset is None:
+            offset = 0
+        if not isinstance(offset, int):
+            return tool_error("offset must be an integer >= 0", success=False)
+        if offset < 0:
+            return tool_error("offset must be >= 0", success=False)
+
+        if limit is not None:
+            if not isinstance(limit, int):
+                return tool_error("limit must be an integer > 0", success=False)
+            if limit <= 0:
+                return tool_error("limit must be > 0", success=False)
+
+        total_count = len(all_skills)
+        if limit is None:
+            paged_skills = all_skills[offset:]
+        else:
+            paged_skills = all_skills[offset : offset + limit]
+
+        if not include_descriptions:
+            paged_skills = [
+                {"name": s["name"], "category": s.get("category")} for s in paged_skills
+            ]
+
+        returned_count = len(paged_skills)
+        next_offset = offset + returned_count
+        has_more = next_offset < total_count
 
         return json.dumps(
             {
                 "success": True,
-                "skills": all_skills,
+                "skills": paged_skills,
                 "categories": categories,
-                "count": len(all_skills),
+                "count": total_count,
+                "returned_count": returned_count,
+                "offset": offset,
+                "limit": limit,
+                "has_more": has_more,
+                "next_offset": next_offset if has_more else None,
                 "hint": "Use skill_view(name) to see full content, tags, and linked files",
             },
             ensure_ascii=False,
@@ -1438,14 +1479,26 @@ if __name__ == "__main__":
 
 SKILLS_LIST_SCHEMA = {
     "name": "skills_list",
-    "description": "List available skills (name + description). Use skill_view(name) to load full content.",
+    "description": "List available skills (name + description by default). Supports pagination to avoid oversized payloads.",
     "parameters": {
         "type": "object",
         "properties": {
             "category": {
                 "type": "string",
                 "description": "Optional category filter to narrow results",
-            }
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum number of skills to return",
+            },
+            "offset": {
+                "type": "integer",
+                "description": "Skip the first N skills (for pagination)",
+            },
+            "include_descriptions": {
+                "type": "boolean",
+                "description": "When false, return only skill names and categories",
+            },
         },
         "required": [],
     },
@@ -1475,7 +1528,11 @@ registry.register(
     toolset="skills",
     schema=SKILLS_LIST_SCHEMA,
     handler=lambda args, **kw: skills_list(
-        category=args.get("category"), task_id=kw.get("task_id")
+        category=args.get("category"),
+        limit=args.get("limit"),
+        offset=args.get("offset", 0),
+        include_descriptions=args.get("include_descriptions", True),
+        task_id=kw.get("task_id"),
     ),
     check_fn=check_skills_requirements,
     emoji="📚",


### PR DESCRIPTION
## What does this PR do?

Adds pagination and compact-output support to `skills_list` so large skill catalogs can be listed in smaller, reviewer/tool-friendly chunks.

Before this change, `skills_list` returned the full list with descriptions every time. This PR adds optional paging controls and a compact mode while preserving backward-compatible defaults.

## Related Issue

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `tools/skills_tool.py`:
  - Extended `skills_list(...)` with optional `limit`, `offset`, and `include_descriptions` parameters.
  - Added validation:
    - `offset` must be an integer `>= 0`
    - `limit` must be an integer `> 0` when provided
  - Added response metadata fields:
    - `returned_count`, `offset`, `limit`, `has_more`, `next_offset`
  - Preserved existing behavior by default (`include_descriptions=True`, no pagination when `limit` is omitted).
- Updated tool schema and handler wiring in `tools/skills_tool.py` so these new arguments are available via the `skills_list` tool.
- Added tests in `tests/tools/test_skills_tool.py`:
  - `test_pagination_limit_and_offset`
  - `test_pagination_has_more_and_next_offset`
  - `test_include_descriptions_false`
  - `test_invalid_limit_returns_error`
  - `test_invalid_offset_returns_error`

## How to Test

1. Run targeted tests for this feature:
   - `venv/bin/pytest -q tests/tools/test_skills_tool.py -k 'pagination or include_descriptions_false or invalid_limit_returns_error or invalid_offset_returns_error'`
2. Run the touched test module:
   - `venv/bin/pytest -q tests/tools/test_skills_tool.py`
3. Optional/manual behavior check:
   - call `skills_list(limit=5, offset=0, include_descriptions=false)` and verify:
     - only `name` and `category` per item
     - pagination metadata is present and `next_offset` advances when `has_more=true`

Test results captured during PR prep:
- Targeted tests: 5 passed
- Full touched module (`tests/tools/test_skills_tool.py`): 84 passed
- Full repo suite (`venv/bin/pytest tests/ -q`) currently has unrelated baseline failures in this environment

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (Linux 6.17.0-1010-azure)

### Documentation and Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (N/A)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (N/A)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A (N/A)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted test run:

```text
.....                                                                    [100%]
5 passed in 1.68s
```

Full touched module run:

```text
84 passed
```
