### PR TITLE
fix(cli): avoid nesting system prompt during manual /compress

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7099,9 +7099,15 @@ class HermesCLI:
                 else:
                     print(f"🗜️  Compressing {original_count} messages (~{approx_tokens:,} tokens)...")
 
+                # Pass None as system_message so _compress_context rebuilds
+                # the system prompt from scratch via _build_system_prompt(None).
+                # Passing _cached_system_prompt caused duplication because
+                # _build_system_prompt appends system_message to prompt_parts
+                # which already contain the agent identity — resulting in the
+                # identity block appearing twice (issue #15281).
                 compressed, _ = self.agent._compress_context(
                     original_history,
-                    self.agent._cached_system_prompt or "",
+                    None,
                     approx_tokens=approx_tokens,
                     focus_topic=focus_topic or None,
                 )

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -44,6 +44,7 @@ AUTHOR_MAP = {
     "qiyin.zuo@pcitc.com": "qiyin-code",
     "teknium@nousresearch.com": "teknium1",
     "127238744+teknium1@users.noreply.github.com": "teknium1",
+    "revar@users.noreply.github.com": "revaraver",
     # Matrix parity salvage batch (April 2026)
     "sr@samirusani": "samrusani",
     "angelclaw@AngelMacBook.local": "angel12",

--- a/tests/test_cli_manual_compress.py
+++ b/tests/test_cli_manual_compress.py
@@ -1,0 +1,57 @@
+from contextlib import nullcontext
+
+from cli import HermesCLI
+
+
+class DummyAgent:
+    def __init__(self):
+        self.compression_enabled = True
+        self._cached_system_prompt = "FULL CACHED SYSTEM PROMPT SHOULD NOT BE NESTED"
+        self.session_id = "new-session"
+        self.calls = []
+
+    def _compress_context(self, messages, system_message, *, approx_tokens=None, focus_topic=None):
+        self.calls.append(
+            {
+                "messages": messages,
+                "system_message": system_message,
+                "approx_tokens": approx_tokens,
+                "focus_topic": focus_topic,
+            }
+        )
+        return ([{"role": "user", "content": "[CONTEXT SUMMARY]: compacted"}], "new system prompt")
+
+
+def test_manual_compress_does_not_pass_cached_system_prompt(monkeypatch):
+    """Manual /compress should rebuild the next prompt without nesting the old one."""
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.conversation_history = [
+        {"role": "user", "content": "one"},
+        {"role": "assistant", "content": "two"},
+        {"role": "user", "content": "three"},
+        {"role": "assistant", "content": "four"},
+    ]
+    cli.agent = DummyAgent()
+    cli.session_id = "old-session"
+    cli._pending_title = "old title"
+    cli._busy_command = lambda _message: nullcontext()
+
+    monkeypatch.setattr(
+        "agent.manual_compression_feedback.summarize_manual_compression",
+        lambda *args, **kwargs: {
+            "noop": False,
+            "headline": "compressed",
+            "token_line": "tokens reduced",
+            "note": "",
+        },
+    )
+
+    cli._manual_compress("/compress database schema")
+
+    assert len(cli.agent.calls) == 1
+    call = cli.agent.calls[0]
+    assert call["system_message"] is None
+    assert call["system_message"] != cli.agent._cached_system_prompt
+    assert call["focus_topic"] == "database schema"
+    assert cli.session_id == "new-session"
+    assert cli._pending_title is None


### PR DESCRIPTION
## Summary
Manual `/compress` stops linearly growing the cached system prompt across repeated compressions.

## Root cause
`cli._manual_compress` passed `self.agent._cached_system_prompt` into `_compress_context(..., system_message=...)`. `_compress_context` rebuilds the next session's prompt with `_build_system_prompt(system_message)`, which treats a non-None `system_message` as an additive overlay (run_agent.py:4627). Each manual compression re-wrapped the old full prompt inside the new one.

## Changes
- `cli.py`: pass `None` instead of `_cached_system_prompt` so `_build_system_prompt` rebuilds from canonical layers.
- `tests/test_cli_manual_compress.py`: regression test — asserts `system_message` is `None`, `/compress <topic>` forwards the focus string, CLI session_id rotates to the child session, pending title clears.
- `scripts/release.py`: AUTHOR_MAP entry for revar.

## Validation
`scripts/run_tests.sh tests/test_cli_manual_compress.py` → 1 passed.

## Credit
Salvages three duplicate PRs that identified and fixed the same bug:
- #15304 @ygd58 (first submitter, Apr 24) — cherry-picked as the fix commit; authorship preserved.
- #15452 @Tranquil-Flow (Apr 25) — same fix + unittest variant; thanks for the independent confirmation.
- #16759 @revaraver (Apr 28) — richer regression test (real `_manual_compress` invocation, asserts session_id + pending_title behavior); adopted as the test commit with authorship preserved.