### PR TITLE
fix(openrouter): treat xiaomi models as reasoning-capable

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -8131,6 +8131,7 @@ class AIAgent:
             "google/gemini-2",
             "qwen/qwen3",
             "tencent/hy3-preview",
+            "xiaomi/",
         )
         return any(model.startswith(prefix) for prefix in reasoning_model_prefixes)
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4826,6 +4826,28 @@ class TestDeadRetryCode:
         )
 
 
+class TestSupportsReasoningExtraBody:
+    def _make_agent(self):
+        agent = object.__new__(AIAgent)
+        agent.provider = "openrouter"
+        agent.base_url = "https://openrouter.ai/api/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.model = ""
+        return agent
+
+    def test_xiaomi_models_are_treated_as_reasoning_capable(self):
+        agent = self._make_agent()
+        for model in (
+            "xiaomi/mimo-v2.5-pro",
+            "xiaomi/mimo-v2.5",
+            "xiaomi/mimo-v2-omni",
+            "xiaomi/mimo-v2-pro",
+            "xiaomi/mimo-v2-flash",
+        ):
+            agent.model = model
+            assert agent._supports_reasoning_extra_body() is True, model
+
+
 class TestMemoryContextSanitization:
     """sanitize_context() helper correctness — used at provider boundaries."""
 


### PR DESCRIPTION
## What

Treat Xiaomi models on OpenRouter as reasoning-capable in `_supports_reasoning_extra_body()` by adding the `xiaomi/` prefix.

## Why

Today, Xiaomi models on OpenRouter are not included in the reasoning-capable prefix detection used by `_supports_reasoning_extra_body()`, so they do not receive the same reasoning extra-body handling as other supported model families.

I verified the current OpenRouter model catalog via the live API metadata. The currently published Xiaomi / MiMo models all advertise both `reasoning` and `include_reasoning` in `supported_parameters`, which is the capability signal this code path relies on.

Models confirmed from OpenRouter metadata:
- `xiaomi/mimo-v2.5-pro`
- `xiaomi/mimo-v2.5`
- `xiaomi/mimo-v2-omni`
- `xiaomi/mimo-v2-pro`
- `xiaomi/mimo-v2-flash`

Given the current published Xiaomi family on OpenRouter, prefix-based detection is appropriate here and avoids maintaining a per-model allowlist.

## Changes

- add `xiaomi/` to the OpenRouter reasoning-capable prefix list in `run_agent.py`
- add regression coverage for Xiaomi / MiMo reasoning-capable model detection

## Validation

Added / exercised tests in:
- `tests/run_agent/test_run_agent.py`

Result:
- `35 passed, 273 deselected`
