### PR TITLE
fix(weixin): split long messages >2000 chars + harden rate-limit retry

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -89,6 +89,7 @@ MAX_CONSECUTIVE_FAILURES = 3
 RETRY_DELAY_SECONDS = 2
 BACKOFF_DELAY_SECONDS = 30
 SESSION_EXPIRED_ERRCODE = -14
+RATE_LIMIT_ERRCODE = -2  # iLink frequency limit — backoff and retry
 MESSAGE_DEDUP_TTL_SECONDS = 300
 
 MEDIA_IMAGE = 1
@@ -1113,7 +1114,7 @@ async def qr_login(
 class WeixinAdapter(BasePlatformAdapter):
     """Native Hermes adapter for Weixin personal accounts."""
 
-    MAX_MESSAGE_LENGTH = 4000
+    MAX_MESSAGE_LENGTH = 2000
 
     # WeChat does not support editing sent messages — streaming must use the
     # fallback "send-final-only" path so the cursor (▉) is never left visible.
@@ -1138,10 +1139,10 @@ class WeixinAdapter(BasePlatformAdapter):
             extra.get("cdn_base_url") or os.getenv("WEIXIN_CDN_BASE_URL", WEIXIN_CDN_BASE_URL)
         ).strip().rstrip("/")
         self._send_chunk_delay_seconds = float(
-            extra.get("send_chunk_delay_seconds") or os.getenv("WEIXIN_SEND_CHUNK_DELAY_SECONDS", "0.35")
+            extra.get("send_chunk_delay_seconds") or os.getenv("WEIXIN_SEND_CHUNK_DELAY_SECONDS", "1.5")
         )
         self._send_chunk_retries = int(
-            extra.get("send_chunk_retries") or os.getenv("WEIXIN_SEND_CHUNK_RETRIES", "2")
+            extra.get("send_chunk_retries") or os.getenv("WEIXIN_SEND_CHUNK_RETRIES", "4")
         )
         self._send_chunk_retry_delay_seconds = float(
             extra.get("send_chunk_retry_delay_seconds")
@@ -1530,6 +1531,19 @@ class WeixinAdapter(BasePlatformAdapter):
                                 "[%s] session expired for %s; retrying without context_token",
                                 self.name, _safe_id(chat_id),
                             )
+                            continue
+                        # Rate limit (-2) — backoff and retry
+                        is_rate_limited = (
+                            ret == RATE_LIMIT_ERRCODE
+                            or errcode == RATE_LIMIT_ERRCODE
+                        )
+                        if is_rate_limited:
+                            wait = self._send_chunk_retry_delay_seconds * 3  # 3s backoff for rate limit
+                            logger.warning(
+                                "[%s] rate limited for %s; backing off %.1fs before retry",
+                                self.name, _safe_id(chat_id), wait,
+                            )
+                            await asyncio.sleep(wait)
                             continue
                         errmsg = resp.get("errmsg") or resp.get("msg") or "unknown error"
                         raise RuntimeError(

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1538,7 +1538,16 @@ class WeixinAdapter(BasePlatformAdapter):
                             or errcode == RATE_LIMIT_ERRCODE
                         )
                         if is_rate_limited:
-                            wait = self._send_chunk_retry_delay_seconds * 3  # 3s backoff for rate limit
+                            errmsg = resp.get("errmsg") or resp.get("msg") or "rate limited"
+                            # Record the error so we raise a descriptive
+                            # RuntimeError (instead of AssertionError) if the
+                            # loop exhausts with the server still rate-limiting.
+                            last_error = RuntimeError(
+                                f"iLink sendmessage rate limited: ret={ret} errcode={errcode} errmsg={errmsg}"
+                            )
+                            if attempt >= self._send_chunk_retries:
+                                break
+                            wait = self._send_chunk_retry_delay_seconds * 3  # 3x backoff for rate limit
                             logger.warning(
                                 "[%s] rate limited for %s; backing off %.1fs before retry",
                                 self.name, _safe_id(chat_id), wait,

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -581,6 +581,7 @@ AUTHOR_MAP = {
     "hekaru.agent@gmail.com": "hekaru-agent",
     "jas9000@gmail.com": "twozle",
     "r.filgueiras@apheris.com": "rfilgueiras",
+    "leihaibo1992@gmail.com": "Leihb",
 }
 
 


### PR DESCRIPTION
Salvage of #16757 (@Leihb) with a follow-up fix on the rate-limit retry path.

## Summary
Messages >2000 chars on Weixin are no longer silently truncated, and iLink `-2` (rate limit) responses now trigger a 3× backoff AND raise a descriptive RuntimeError when retries exhaust (instead of an opaque AssertionError).

## Changes
- **gateway/platforms/weixin.py** (original PR, @Leihb):
  - `MAX_MESSAGE_LENGTH` 4000 → 2000 (matches iLink's real cap, so text between 2000–4000 chars now gets split instead of truncated by the server)
  - Add `RATE_LIMIT_ERRCODE = -2` constant
  - Add rate-limit branch in `_send_text_chunk` with `retry_delay_seconds * 3` backoff
  - Default `send_chunk_delay_seconds` 0.35 → 1.5, default retries 2 → 4
- **gateway/platforms/weixin.py** (follow-up):
  - Record `last_error = RuntimeError(...)` inside the rate-limit branch before `continue`, and `break` on the final attempt. Without this, persistent `-2` exhausted the loop with `last_error = None` and hit `assert last_error is not None` — raising `AssertionError` with no detail.
- **scripts/release.py**: AUTHOR_MAP entry for `leihaibo1992@gmail.com` → `Leihb`.

## Validation
| | Before | After |
|---|---|---|
| 2000–4000-char message | truncated by iLink, no split | split into chunks, all delivered |
| Transient `-2` then success | unhandled in branch, retried immediately with same payload | sleeps `retry_delay * 3`, then retries |
| Persistent `-2` after retries exhaust | `AssertionError` (no context) | `RuntimeError: iLink sendmessage rate limited: ret=-2 errcode=... errmsg=...` |
| Unit tests | — | `tests/gateway/test_weixin.py`: 42/42 pass |
| E2E (`_send_text_chunk` with mocked iLink) | — | 4/4 scenarios: transient -2 / persistent -2 / session-expired -14 / permanent error |

Closes #16411.
Original PR: #16757 — contributor commit preserved via rebase merge.