### PR TITLE
docs(mcp): add Mistral AI example to MCP use cases

### DIFF
--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -374,6 +374,37 @@ Use it like:
 Inspect the project root and explain the directory layout.
 ```
 
+### Mistral AI server for OCR, audio, and Codestral FIM
+
+```yaml
+mcp_servers:
+  mistral:
+    command: "npx"
+    args: ["-y", "mistral-mcp"]
+    env:
+      MISTRAL_API_KEY: "***"
+    tools:
+      include:
+        - mistral_ocr
+        - voxtral_transcribe
+        - voxtral_speak
+        - codestral_fim
+        - mistral_moderate
+```
+
+Use it like:
+
+```text
+Extract the text from /tmp/contract-scan.pdf with mistral_ocr,
+then summarize the key terms.
+```
+
+This pattern is useful when you want Hermes to keep a primary reasoning model
+(via the regular provider config) but route document OCR, audio transcription,
+or fill-in-the-middle code completion to Mistral's specialized endpoints. The
+`tools.include` filter narrows the surface so Hermes does not see the full
+22-tool list of the upstream server.
+
 ## Troubleshooting
 
 ### MCP server not connecting


### PR DESCRIPTION
## Summary

Adds a fourth example to the **Example use cases** section of `website/docs/user-guide/features/mcp.md`, showing how to wire the community [`mistral-mcp`](https://github.com/Swih/mistral-mcp) server (npm: `mistral-mcp`, MIT) with a curated `tools.include` list.

The example covers a niche the current trio (GitHub / Stripe / Filesystem) does not: routing **document OCR**, **audio transcription**, and **fill-in-the-middle code completion** to a specialized provider while the primary model keeps doing the reasoning.

## Diff

- `website/docs/user-guide/features/mcp.md` — single section appended after the Filesystem example. ~31 lines, doc-only.
- No code, no build, no test impact.

The block mirrors the existing entries: YAML config, "Use it like" prose, short rationale paragraph.

## Why this is useful

`mcp_servers.tools.include` is already documented in the **Per-server filtering** section of the same page, but no example currently shows it being used to **narrow a multi-tool third-party server** down to a curated subset. This is exactly the pattern a Hermes user lands on when they install a server like `mistral-mcp` (22 tools) and only wants four or five surfaced. Showing it inline in the use-cases section saves a hop back to the filtering section.

## Disclosure

I am the maintainer of `mistral-mcp`. I am submitting this as a doc-only PR — no provider code, no dependency, no required user action. Happy to drop the rationale paragraph or tighten the example if it feels like too much surface for one third-party server. If you would prefer the example to live in a different file (e.g. `cli-config.yaml.example`) or a different doc section, say the word.

## Test plan

- [x] Diff is doc-only (`git diff --stat`).
- [x] Markdown renders in the GitHub preview.
- [x] YAML in the example is valid (parses with `python -c 'import yaml,sys; yaml.safe_load(open("..."))'`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)