### PR TITLE
fix: resolve model.aliases from config.yaml in /model alias resolution

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -190,11 +190,18 @@ def _load_direct_aliases() -> dict[str, DirectAlias]:
             model: "minimax-m2.7"
             provider: custom
             base_url: "https://ollama.com/v1"
+
+    Also reads ``model.aliases`` (set by ``hermes config set model.aliases.xxx``)
+    and converts simple string entries (``ds-flash: deepseek/deepseek-v4-flash``)
+    into DirectAlias objects.  The provider is parsed from the ``provider/``
+    prefix in the value; if no slash, the current provider is used.
     """
     merged = dict(_BUILTIN_DIRECT_ALIASES)
     try:
         from hermes_cli.config import load_config
         cfg = load_config()
+
+        # --- model_aliases (dict-based format) ---
         user_aliases = cfg.get("model_aliases")
         if isinstance(user_aliases, dict):
             for name, entry in user_aliases.items():
@@ -206,6 +213,30 @@ def _load_direct_aliases() -> dict[str, DirectAlias]:
                 if model:
                     merged[name.strip().lower()] = DirectAlias(
                         model=model, provider=provider, base_url=base_url,
+                    )
+
+        # --- model.aliases (string-based format, from config set) ---
+        model_section = cfg.get("model", {})
+        if isinstance(model_section, dict):
+            simple_aliases = model_section.get("aliases")
+            if isinstance(simple_aliases, dict):
+                current_provider = model_section.get("provider", "")
+                for name, value in simple_aliases.items():
+                    if not isinstance(value, str) or not value.strip():
+                        continue
+                    key = name.strip().lower()
+                    if key in merged:
+                        continue  # don't override explicit model_aliases entries
+                    val = value.strip()
+                    if "/" in val:
+                        provider, model = val.split("/", 1)
+                    else:
+                        provider = current_provider
+                        model = val
+                    merged[key] = DirectAlias(
+                        model=model.strip(),
+                        provider=provider.strip() or current_provider,
+                        base_url="",
                     )
     except Exception:
         pass


### PR DESCRIPTION
## Problem

`hermes config set model.aliases.xxx "deepseek/deepseek-v4-flash"` writes to `model.aliases` (nested under `model:` in config.yaml), but the `/model` alias resolver in `_load_direct_aliases()` only reads from the top-level `model_aliases:` key. These are two completely separate config paths — aliases set via the CLI command were invisible to the slash command.

When a user typed `/model ds-flash`, the alias was never found, so `ds-flash` fell through to `normalize_model_for_provider()` → `_normalize_for_deepseek()`, which maps all unrecognized inputs to `deepseek-chat`. But `deepseek-chat` doesn't exist in the DeepSeek v4 provider catalog (only `deepseek-v4-flash` and `deepseek-v4-pro`), causing the error:

```
Error: Model deepseek-chat was not found in this provider's model listing.
  Similar models: deepseek-v4-flash, deepseek-v4-pro
```

## Fix

`_load_direct_aliases()` now reads `model.aliases` as a second pass. Simple string-value entries (`ds-flash: deepseek/deepseek-v4-flash`) are parsed into `DirectAlias` objects — the provider is extracted from the slash prefix. Entries from `model_aliases:` (dict format) take precedence over `model.aliases:` entries to avoid conflicts.

## Testing

- Unit: all 31 `test_ollama_cloud_auth.py` tests pass
- Unit: all 25 model-switch tests pass (`test_model_switch_variant_tags`, etc.)
- Manual: verified `resolve_alias("ds-flash", "deepseek")` → `("deepseek", "deepseek-v4-flash", "ds-flash")`
