### PR TITLE
fix(qqbot): surface non-image attachments to agent when download fails (#16979)

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1192,26 +1192,36 @@ class QQAdapter(BasePlatformAdapter):
                 # agent must always learn that *something* was sent, even when
                 # the QQ file CDN download fails — otherwise the file is
                 # silently dropped and the user sees no acknowledgement.
-                label = filename or ct or "file"
+                #
+                # Strip whitespace from filename so a name like "   " doesn't
+                # produce "[Attachment:  (download failed)]".  The QQ file CDN
+                # URLs carry signed query parameters (``sign=`` / ``sig=``);
+                # log only the hostname + path so signed tokens don't leak
+                # into production logs.
+                stripped_name = (filename or "").strip()
+                label = stripped_name or (ct or "").strip() or "file"
+                _parsed = urlparse(url or "")
+                _safe_url = f"{_parsed.hostname or '?'}{_parsed.path or ''}"
                 try:
                     cached_path = await self._download_and_cache(url, ct)
                     if cached_path:
                         other_attachments.append(f"[Attachment: {label}]")
                     else:
                         logger.warning(
-                            "[%s] Attachment download returned no payload: %s (%s)",
+                            "[%s] Attachment download failed (no cached path): %s (%s)",
                             self._log_tag,
                             label,
-                            url[:80],
+                            _safe_url,
                         )
                         other_attachments.append(
                             f"[Attachment: {label} (download failed)]"
                         )
                 except Exception as exc:
                     logger.warning(
-                        "[%s] Failed to cache attachment %s: %s",
+                        "[%s] Failed to cache attachment %s (%s): %s",
                         self._log_tag,
                         label,
+                        _safe_url,
                         exc,
                     )
                     other_attachments.append(

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1188,13 +1188,35 @@ class QQAdapter(BasePlatformAdapter):
                 except Exception as exc:
                     logger.debug("[%s] Failed to cache image: %s", self._log_tag, exc)
             else:
-                # Other attachments (video, file, etc.): record as text.
+                # Other attachments (video, file, etc.): record as text. The
+                # agent must always learn that *something* was sent, even when
+                # the QQ file CDN download fails — otherwise the file is
+                # silently dropped and the user sees no acknowledgement.
+                label = filename or ct or "file"
                 try:
                     cached_path = await self._download_and_cache(url, ct)
                     if cached_path:
-                        other_attachments.append(f"[Attachment: {filename or ct}]")
+                        other_attachments.append(f"[Attachment: {label}]")
+                    else:
+                        logger.warning(
+                            "[%s] Attachment download returned no payload: %s (%s)",
+                            self._log_tag,
+                            label,
+                            url[:80],
+                        )
+                        other_attachments.append(
+                            f"[Attachment: {label} (download failed)]"
+                        )
                 except Exception as exc:
-                    logger.debug("[%s] Failed to cache attachment: %s", self._log_tag, exc)
+                    logger.warning(
+                        "[%s] Failed to cache attachment %s: %s",
+                        self._log_tag,
+                        label,
+                        exc,
+                    )
+                    other_attachments.append(
+                        f"[Attachment: {label} (download failed)]"
+                    )
 
         attachment_info = "\n".join(other_attachments) if other_attachments else ""
         return {

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -191,6 +191,99 @@ class TestVoiceAttachmentSSRFProtection:
         assert kwargs.get("follow_redirects") is True
         assert kwargs.get("event_hooks", {}).get("response") == [_ssrf_redirect_guard]
 
+
+# ---------------------------------------------------------------------------
+# Non-image, non-voice attachment fallback (#16979)
+# ---------------------------------------------------------------------------
+
+class TestProcessAttachmentsFallback:
+    """File / video attachments must surface to the agent even when the QQ
+    file CDN download fails — otherwise the user sends a PDF and the agent
+    silently sees nothing."""
+
+    def _make_adapter(self, **extra):
+        from gateway.platforms.qqbot import QQAdapter
+        return QQAdapter(_make_config(app_id="a", client_secret="b", **extra))
+
+    def test_file_download_returns_none_emits_failure_marker(self):
+        adapter = self._make_adapter()
+        adapter._download_and_cache = mock.AsyncMock(return_value=None)
+
+        result = asyncio.run(
+            adapter._process_attachments(
+                [
+                    {
+                        "content_type": "application/pdf",
+                        "url": "https://grouptalk.c2c.qq.com/qqdownloadftnv5?sign=abc",
+                        "filename": "report.pdf",
+                    }
+                ]
+            )
+        )
+
+        assert "report.pdf" in result["attachment_info"]
+        assert "download failed" in result["attachment_info"]
+
+    def test_file_download_raises_emits_failure_marker(self):
+        adapter = self._make_adapter()
+        adapter._download_and_cache = mock.AsyncMock(
+            side_effect=ValueError("Blocked unsafe URL")
+        )
+
+        result = asyncio.run(
+            adapter._process_attachments(
+                [
+                    {
+                        "content_type": "application/pdf",
+                        "url": "http://127.0.0.1/private.pdf",
+                        "filename": "private.pdf",
+                    }
+                ]
+            )
+        )
+
+        assert "private.pdf" in result["attachment_info"]
+        assert "download failed" in result["attachment_info"]
+
+    def test_file_download_succeeds_omits_failure_marker(self):
+        adapter = self._make_adapter()
+        adapter._download_and_cache = mock.AsyncMock(return_value="/tmp/cached.pdf")
+
+        result = asyncio.run(
+            adapter._process_attachments(
+                [
+                    {
+                        "content_type": "application/pdf",
+                        "url": "https://grouptalk.c2c.qq.com/qqdownloadftnv5?sign=abc",
+                        "filename": "report.pdf",
+                    }
+                ]
+            )
+        )
+
+        assert "report.pdf" in result["attachment_info"]
+        assert "download failed" not in result["attachment_info"]
+
+    def test_file_failure_falls_back_to_content_type_when_filename_missing(self):
+        adapter = self._make_adapter()
+        adapter._download_and_cache = mock.AsyncMock(return_value=None)
+
+        result = asyncio.run(
+            adapter._process_attachments(
+                [
+                    {
+                        "content_type": "video/mp4",
+                        "url": "https://grouptalk.c2c.qq.com/qqdownloadftnv5?sign=abc",
+                        "filename": "",
+                    }
+                ]
+            )
+        )
+
+        assert "video/mp4" in result["attachment_info"]
+        assert "download failed" in result["attachment_info"]
+
+
 # ---------------------------------------------------------------------------
 # _strip_at_mention
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -283,6 +283,59 @@ class TestProcessAttachmentsFallback:
         assert "video/mp4" in result["attachment_info"]
         assert "download failed" in result["attachment_info"]
 
+    def test_whitespace_filename_falls_back_to_content_type(self):
+        # Regression for Copilot review on PR #16990: a whitespace-only
+        # filename slipped through ``filename or ct or "file"`` and produced
+        # ``[Attachment:  (download failed)]``.  The label must strip
+        # whitespace before the falsy-fallback chain.
+        adapter = self._make_adapter()
+        adapter._download_and_cache = mock.AsyncMock(return_value=None)
+
+        result = asyncio.run(
+            adapter._process_attachments(
+                [
+                    {
+                        "content_type": "application/pdf",
+                        "url": "https://grouptalk.c2c.qq.com/qqdownloadftnv5?sign=abc",
+                        "filename": "   ",
+                    }
+                ]
+            )
+        )
+
+        info = result["attachment_info"]
+        assert "application/pdf" in info
+        assert "download failed" in info
+        assert "Attachment:  " not in info  # no double-space label
+
+    def test_failure_log_does_not_leak_signed_query_params(self, caplog):
+        # Regression for Copilot review on PR #16990: warning logs included
+        # ``url[:80]`` which for QQ file CDN often contains ``sign=`` /
+        # ``sig=`` tokens.  The warning must log only host + path.
+        import logging
+        adapter = self._make_adapter()
+        adapter._download_and_cache = mock.AsyncMock(return_value=None)
+
+        with caplog.at_level(logging.WARNING):
+            asyncio.run(
+                adapter._process_attachments(
+                    [
+                        {
+                            "content_type": "application/pdf",
+                            "url": "https://grouptalk.c2c.qq.com/qqdownloadftnv5?sign=SECRETSIGNATURE&sig=OTHER",
+                            "filename": "report.pdf",
+                        }
+                    ]
+                )
+            )
+
+        log_text = "\n".join(rec.getMessage() for rec in caplog.records)
+        assert "SECRETSIGNATURE" not in log_text
+        assert "sign=" not in log_text
+        # but the host + path should still be present for debuggability
+        assert "grouptalk.c2c.qq.com" in log_text
+        assert "/qqdownloadftnv5" in log_text
+
 
 # ---------------------------------------------------------------------------
 # _strip_at_mention


### PR DESCRIPTION
## Summary

QQ Bot users uploading files (PDFs, documents, videos) saw the bot
silently do nothing whenever the QQ file CDN download failed: the
agent never learned that an attachment had been sent, no warning was
emitted at the production log level, and the user had no way to tell
the upload had been dropped.

## The bug

`_process_attachments()` in `gateway/platforms/qqbot/adapter.py`
appended `[Attachment: …]` only on the **success** branch of the
non-image / non-voice path:

```python
else:
    # Other attachments (video, file, etc.): record as text.
    try:
        cached_path = await self._download_and_cache(url, ct)
        if cached_path:
            other_attachments.append(f\"[Attachment: {filename or ct}]\")
        # ← no else: download returns None → attachment disappears
    except Exception as exc:
        logger.debug(\"[%s] Failed to cache attachment: %s\", ...)
        # ← no fallback append either
```

Two real failure paths reach this code:

1. `_download_and_cache` returns `None` — happens when `_http_client`
   is unset, the transport fails, or `resp.raise_for_status()` raises
   (the helper catches and returns `None`).
2. `_download_and_cache` raises `ValueError` from the
   `is_safe_url` guard.

Both failures silently dropped the attachment and logged at `DEBUG`,
which production deployments running at `INFO`/`WARNING` never see.

## The fix

Tightly scoped to the non-image / non-voice branch:

- Compute `label = filename or ct or \"file\"` once so the success and
  failure markers stay consistent and never collapse to an empty
  `[Attachment: ]`.
- When `cached_path` is `None`, append `[Attachment: <label> (download
  failed)]` and log at `WARNING` with the truncated URL.
- When the download raises, also append the same fallback marker and
  log the exception at `WARNING`.

The image and voice branches are intentionally left alone — voice
already has its own `[Voice] [语音识别失败]` fallback, and the image
branch is outside the issue's scope.

## Test plan

- [x] Focused regression: `tests/gateway/test_qqbot.py::TestProcessAttachmentsFallback`
      — 4 new tests cover (1) `_download_and_cache` returns None, (2)
      raises, (3) succeeds, (4) success/failure with missing filename
      falls back to content_type. All pass.
- [x] Adjacent suite: full `tests/gateway/test_qqbot.py` — 75 passed.
- [x] Regression guard: reverted `gateway/platforms/qqbot/adapter.py`,
      confirmed the 3 failure-path tests fail with empty
      `attachment_info`, restored fix, all 4 pass again.

## Related

- Fixes #16979