### PR TITLE
fix: support Slack thread targets in send_message

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -24,12 +24,12 @@ def _run_async_immediately(coro):
     return asyncio.run(coro)
 
 
-def _make_config():
-    telegram_cfg = SimpleNamespace(enabled=True, token="***", extra={})
+def _make_config(platform=Platform.TELEGRAM):
+    cfg = SimpleNamespace(enabled=True, token="***", extra={})
     return SimpleNamespace(
-        platforms={Platform.TELEGRAM: telegram_cfg},
+        platforms={platform: cfg},
         get_home_channel=lambda _platform: None,
-    ), telegram_cfg
+    ), cfg
 
 
 def _install_telegram_mock(monkeypatch, bot):
@@ -198,6 +198,85 @@ class TestSendMessageTool:
             source_label="telegram",
             thread_id=None,
             user_id="user-123",
+        )
+
+    def test_resolved_slack_root_channel_id_is_explicit_target(self):
+        config, slack_cfg = _make_config(Platform.SLACK)
+
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("gateway.mirror.mirror_to_session", return_value=True):
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "slack:C0AK908M3JS",
+                        "message": "hello",
+                    }
+                )
+            )
+
+        assert result["success"] is True
+        send_mock.assert_awaited_once_with(
+            Platform.SLACK,
+            slack_cfg,
+            "C0AK908M3JS",
+            "hello",
+            thread_id=None,
+            media_files=[],
+        )
+
+    def test_resolved_slack_topic_name_preserves_thread_id(self):
+        config, slack_cfg = _make_config(Platform.SLACK)
+
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("gateway.channel_directory.resolve_channel_name", return_value="C0AK908M3JS:1777357381.688839"), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("gateway.mirror.mirror_to_session", return_value=True):
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "slack:C0AK908M3JS / topic 1777357381.688839",
+                        "message": "hello",
+                    }
+                )
+            )
+
+        assert result["success"] is True
+        send_mock.assert_awaited_once_with(
+            Platform.SLACK,
+            slack_cfg,
+            "C0AK908M3JS",
+            "hello",
+            thread_id="1777357381.688839",
+            media_files=[],
+        )
+
+    def test_send_to_platform_passes_thread_id_to_slack_sender(self):
+        slack_cfg = SimpleNamespace(enabled=True, token="***", extra={})
+
+        with patch("tools.send_message_tool._send_slack", new=AsyncMock(return_value={"success": True})) as send_mock:
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.SLACK,
+                    slack_cfg,
+                    "C0AK908M3JS",
+                    "hello",
+                    thread_id="1777357381.688839",
+                )
+            )
+
+        assert result["success"] is True
+        send_mock.assert_awaited_once_with(
+            "***",
+            "C0AK908M3JS",
+            "hello",
+            thread_id="1777357381.688839",
         )
 
     def test_top_level_send_failure_redacts_query_token(self):

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -343,6 +343,8 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         match = _SLACK_THREAD_TARGET_RE.fullmatch(target_ref)
         if match:
             return match.group(1), match.group(2), True
+        if re.fullmatch(r"[A-Z0-9]+", target_ref.strip()):
+            return target_ref.strip(), None, True
     if platform_name == "weixin":
         match = _WEIXIN_TARGET_RE.fullmatch(target_ref)
         if match:

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -343,8 +343,6 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         match = _SLACK_THREAD_TARGET_RE.fullmatch(target_ref)
         if match:
             return match.group(1), match.group(2), True
-        if re.fullmatch(r"[A-Z0-9]+", target_ref.strip()):
-            return target_ref.strip(), None, True
     if platform_name == "weixin":
         match = _WEIXIN_TARGET_RE.fullmatch(target_ref)
         if match:

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -27,6 +27,7 @@ _FEISHU_TARGET_RE = re.compile(r"^\s*((?:oc|ou|on|chat|open)_[-A-Za-z0-9]+)(?::(
 # conversations.open to obtain a D... ID. Without this gate, Slack IDs fall
 # through to channel-name resolution, which only matches by name and fails.
 _SLACK_TARGET_RE = re.compile(r"^\s*([CGD][A-Z0-9]{8,})\s*$")
+_SLACK_THREAD_TARGET_RE = re.compile(r"^\s*([A-Z0-9]+):([0-9]+\.[0-9]+)\s*$")
 _WEIXIN_TARGET_RE = re.compile(r"^\s*((?:wxid|gh|v\d+|wm|wb)_[A-Za-z0-9_-]+|[A-Za-z0-9._-]+@chatroom|filehelper)\s*$")
 _YUANBAO_TARGET_RE = re.compile(r"^\s*((?:group|direct):[^:]+)\s*$")
 # Discord snowflake IDs are numeric, same regex pattern as Telegram topic targets.
@@ -128,7 +129,7 @@ SEND_MESSAGE_SCHEMA = {
             },
             "target": {
                 "type": "string",
-                "description": "Delivery target. Format: 'platform' (uses home channel), 'platform:#channel-name', 'platform:chat_id', or 'platform:chat_id:thread_id' for Telegram topics and Discord threads. Examples: 'telegram', 'telegram:-1001234567890:17585', 'discord:999888777:555444333', 'discord:#bot-home', 'slack:#engineering', 'signal:+155****4567', 'matrix:!roomid:server.org', 'matrix:@user:server.org', 'yuanbao:direct:<account_id>' (DM), 'yuanbao:group:<group_code>' (group chat)"
+                "description": "Delivery target. Format: 'platform' (uses home channel), 'platform:#channel-name', 'platform:chat_id', or 'platform:chat_id:thread_id' for Telegram topics, Discord threads, and Slack threads. Examples: 'telegram', 'telegram:-1001234567890:17585', 'discord:999888777:555444333', 'discord:#bot-home', 'slack:#engineering', 'slack:C0AK908M3JS', 'slack:C0AK908M3JS:1777357381.688839', 'signal:+155****4567', 'matrix:!roomid:server.org', 'matrix:@user:server.org', 'yuanbao:direct:<account_id>' (DM), 'yuanbao:group:<group_code>' (group chat)"
             },
             "message": {
                 "type": "string",
@@ -339,6 +340,9 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         match = _SLACK_TARGET_RE.fullmatch(target_ref)
         if match:
             return match.group(1), None, True
+        match = _SLACK_THREAD_TARGET_RE.fullmatch(target_ref)
+        if match:
+            return match.group(1), match.group(2), True
     if platform_name == "weixin":
         match = _WEIXIN_TARGET_RE.fullmatch(target_ref)
         if match:
@@ -574,7 +578,10 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     last_result = None
     for chunk in chunks:
         if platform == Platform.SLACK:
-            result = await _send_slack(pconfig.token, chat_id, chunk)
+            if thread_id is not None:
+                result = await _send_slack(pconfig.token, chat_id, chunk, thread_id=thread_id)
+            else:
+                result = await _send_slack(pconfig.token, chat_id, chunk)
         elif platform == Platform.WHATSAPP:
             result = await _send_whatsapp(pconfig.extra, chat_id, chunk)
         elif platform == Platform.SIGNAL:
@@ -963,7 +970,7 @@ async def _send_discord(token, chat_id, message, thread_id=None, media_files=Non
         return _error(f"Discord send failed: {e}")
 
 
-async def _send_slack(token, chat_id, message):
+async def _send_slack(token, chat_id, message, thread_id=None):
     """Send via Slack Web API."""
     try:
         import aiohttp
@@ -977,6 +984,8 @@ async def _send_slack(token, chat_id, message):
         headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30), **_sess_kw) as session:
             payload = {"channel": chat_id, "text": message, "mrkdwn": True}
+            if thread_id:
+                payload["thread_ts"] = thread_id
             async with session.post(url, headers=headers, json=payload, **_req_kw) as resp:
                 data = await resp.json()
                 if data.get("ok"):


### PR DESCRIPTION
## Summary
- parse Slack thread targets in `send_message` as `channel_id:thread_ts`
- accept Slack root channel targets like `slack:C0AK908M3JS` as explicit targets
- pass Slack thread ids through `_send_to_platform` into `_send_slack`
- include `thread_ts` in the Slack Web API payload when sending to a thread
- document Slack thread target support in the tool schema
- add regression tests for both Slack root-channel and threaded send behavior

## Reproduction
- `send_message(action='list')` can surface Slack topic targets like `slack:C0AK908M3JS / topic 1777357381.688839`
- on older code, sending to that target can fall back to the Slack home channel because the Slack path does not preserve `thread_id` and `_send_slack` never sends `thread_ts`
- sending to a root channel target like `slack:C0AK908M3JS` also failed because Slack only treated `channel_id:thread_ts` as explicit, and the channel directory on this host only contained topic entries rather than a root-channel entry

## Test Plan
- `source venv/bin/activate && pytest tests/tools/test_send_message_tool.py -q`
- `source venv/bin/activate && pytest tests/gateway/test_channel_directory.py -q`

## Notes
- this branch is rebased/cherry-picked onto the latest `upstream/main`
- this keeps the non-threaded Slack send path unchanged when no `thread_id` is provided
- after this change both of these forms work as explicit targets:
  - `slack:C0AK908M3JS`
  - `slack:C0AK908M3JS:1777357381.688839`
- supersedes the earlier branch if that branch shows conflicts against current main
