### PR TITLE
docs: add Security & Auditability section with PiQrypt

### DIFF
--- a/website/docs/integrations/index.md
+++ b/website/docs/integrations/index.md
@@ -95,6 +95,10 @@ See the [Messaging Gateway overview](/docs/user-guide/messaging) for the platfor
 - **[Plugin System](/docs/user-guide/features/plugins)** — Extend Hermes with custom tools, lifecycle hooks, and CLI commands without modifying core code. Plugins are discovered from `~/.hermes/plugins/`, project-local `.hermes/plugins/`, and pip-installed entry points.
 - **[Build a Plugin](/docs/guides/build-a-hermes-plugin)** — Step-by-step guide for creating Hermes plugins with tools, hooks, and CLI commands.
 
+## Security & Auditability
+
+- **[PiQrypt](/docs/integrations/piqrypt)** — Cryptographic audit trail for every Hermes tool call. Ed25519-signed, hash-chained, local-first. buid for EU AI Act Art. 12 .
+  
 ## Training & Evaluation
 
 - **[RL Training](/docs/user-guide/features/rl-training)** — Generate trajectory data from agent sessions for reinforcement learning and model fine-tuning. Supports Atropos environments with customizable reward functions.

--- a/website/docs/integrations/index.md
+++ b/website/docs/integrations/index.md
@@ -97,7 +97,7 @@ See the [Messaging Gateway overview](/docs/user-guide/messaging) for the platfor
 
 ## Security & Auditability
 
-- **[PiQrypt](/docs/integrations/piqrypt)** — Cryptographic audit trail for every Hermes tool call. Ed25519-signed, hash-chained, local-first. buid for EU AI Act Art. 12 .
+- **[PiQrypt](https://github.com/piqrypt/piqrypt/tree/main/bridges/hermes)** — Cryptographic audit trail for every Hermes tool call. Ed25519-signed, hash-chained, local-first. Uses `pre_tool_call`, `post_tool_call`, and `pre_llm_call` plugin hooks — no core changes required. EU AI Act Art. 12 compliant. Install: `pip install piqrypt` then `hermes plugins enable piqrypt-audit`.
   
 ## Training & Evaluation
 


### PR DESCRIPTION
What this adds

Adds a Security & Auditability section to the integrations index with piqrypt-hermes, a native Hermes plugin that stamps every tool call with an Ed25519 signature and links events into a tamper-evident hash chain stored locally.

How it works
The plugin uses Hermes' native hook system — no core changes required:

. on_session_start → agent_initialized + memory context injection
. pre_tool_call → tool_intent (params hashed, never stored raw)
. post_tool_call → tool_result (result hashed, chained to intent)
. pre_llm_call → injects recent signed event history into the LLM turn
. on_session_end → session_end with total event count

Install
bash
pip install piqrypt piqrypt-hermes
hermes plugins enable piqrypt-audit

Minimal example
bash
# Optional — set a persistent identity (ephemeral keypair used otherwise)
export PIQRYPT_AGENT_NAME=hermes

# Every bash, web_search, file_read call is now Ed25519-signed and hash-chained.
# Monitor in real time:
piqrypt vigil   # opens localhost:8421

Why it's relevant to Hermes users

Hermes executes autonomous tool calls (bash, file ops, web) — PiQrypt makes every action non-repudiable and auditable post-incident
Local-first: no server, no account, nothing leaves the machine
Supports EU AI Act Art. 12 inviolable logging requirements
Full test suite: pytest bridges/hermes/test_piqrypt_hermes.py -v

Source: [github.com/piqrypt/piqrypt](https://github.com/piqrypt/piqrypt) — bridges/hermes/