### PR TITLE
fix(gemini): bridge reasoning_config into thinking_config for chat-completions routes

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -51,11 +51,17 @@ def _build_gemini_thinking_config(model: str, reasoning_config: dict | None) -> 
     if effort not in {"minimal", "low", "medium", "high", "xhigh"}:
         effort = "medium"
 
-    # Gemini 3 Flash supports the wider level set; Gemini 3 Pro is stricter,
-    # so collapse low-end efforts to ``low`` and high-end efforts to ``high``.
+    # Gemini 3 Flash documents low/medium/high thinking levels; Gemini 3 Pro
+    # is stricter (low/high). Clamp Hermes' wider effort set to what each
+    # family accepts so we never forward an undocumented level verbatim.
     if normalized_model.startswith(("gemini-3", "gemini-3.1")):
         if "flash" in normalized_model:
-            thinking_config["thinkingLevel"] = "high" if effort == "xhigh" else effort
+            if effort in {"minimal", "low"}:
+                thinking_config["thinkingLevel"] = "low"
+            elif effort in {"high", "xhigh"}:
+                thinking_config["thinkingLevel"] = "high"
+            else:
+                thinking_config["thinkingLevel"] = "medium"
         elif "pro" in normalized_model:
             thinking_config["thinkingLevel"] = (
                 "high" if effort in {"high", "xhigh"} else "low"

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -18,6 +18,52 @@ from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse, ToolCall, Usage
 
 
+def _build_gemini_thinking_config(model: str, reasoning_config: dict | None) -> dict | None:
+    """Translate Hermes/OpenRouter-style reasoning config to Gemini thinkingConfig.
+
+    Gemini native/cloud-code adapters do not read ``extra_body.reasoning``.
+    They only inspect ``extra_body.thinking_config`` / ``thinkingConfig`` and
+    then request thought parts with ``includeThoughts`` enabled.
+    """
+    if reasoning_config is None or not isinstance(reasoning_config, dict):
+        return None
+
+    if reasoning_config.get("enabled") is False:
+        # Gemini can hide thought parts even when internal thinking still
+        # happens; omit thinkingLevel to avoid model-specific validation quirks.
+        return {"includeThoughts": False}
+
+    effort = str(reasoning_config.get("effort", "medium") or "medium").strip().lower()
+    if effort == "none":
+        return {"includeThoughts": False}
+
+    thinking_config: Dict[str, Any] = {"includeThoughts": True}
+    normalized_model = (model or "").strip().lower()
+    if normalized_model.startswith("google/"):
+        normalized_model = normalized_model.split("/", 1)[1]
+
+    # Gemini 2.5 accepts thinkingBudget; don't guess a budget from Hermes'
+    # coarse effort levels. ``includeThoughts`` alone is enough to surface
+    # thought parts without risking request validation errors.
+    if normalized_model.startswith("gemini-2.5-"):
+        return thinking_config
+
+    if effort not in {"minimal", "low", "medium", "high", "xhigh"}:
+        effort = "medium"
+
+    # Gemini 3 Flash supports the wider level set; Gemini 3 Pro is stricter,
+    # so collapse low-end efforts to ``low`` and high-end efforts to ``high``.
+    if normalized_model.startswith(("gemini-3", "gemini-3.1")):
+        if "flash" in normalized_model:
+            thinking_config["thinkingLevel"] = "high" if effort == "xhigh" else effort
+        elif "pro" in normalized_model:
+            thinking_config["thinkingLevel"] = (
+                "high" if effort in {"high", "xhigh"} else "low"
+            )
+
+    return thinking_config
+
+
 class ChatCompletionsTransport(ProviderTransport):
     """Transport for api_mode='chat_completions'.
 
@@ -241,6 +287,7 @@ class ChatCompletionsTransport(ProviderTransport):
         is_openrouter = params.get("is_openrouter", False)
         is_nous = params.get("is_nous", False)
         is_github_models = params.get("is_github_models", False)
+        provider_name = str(params.get("provider_name") or "").strip().lower()
 
         provider_prefs = params.get("provider_preferences")
         if provider_prefs and is_openrouter:
@@ -292,6 +339,11 @@ class ChatCompletionsTransport(ProviderTransport):
 
         if is_qwen:
             extra_body["vl_high_resolution_images"] = True
+
+        if provider_name in {"gemini", "google-gemini-cli"}:
+            thinking_config = _build_gemini_thinking_config(model, reasoning_config)
+            if thinking_config:
+                extra_body["thinking_config"] = thinking_config
 
         # Merge any pre-built extra_body additions
         additions = params.get("extra_body_additions")

--- a/run_agent.py
+++ b/run_agent.py
@@ -8094,6 +8094,7 @@ class AIAgent:
             supports_reasoning=self._supports_reasoning_extra_body(),
             github_reasoning_extra=self._github_models_reasoning_extra_body() if _is_gh else None,
             anthropic_max_output=_ant_max,
+            provider_name=self.provider,
         )
 
     def _supports_reasoning_extra_body(self) -> bool:

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -191,6 +191,21 @@ class TestChatCompletionsBuildKwargs:
         )
         assert kw["extra_body"]["thinking_config"]["thinkingLevel"] == "high"
 
+    def test_gemini_flash_minimal_clamps_to_low(self, transport):
+        # Gemini 3 Flash documents low/medium/high; "minimal" isn't accepted,
+        # so clamp it down to "low" rather than forwarding it verbatim.
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gemini-3-flash-preview",
+            messages=msgs,
+            provider_name="gemini",
+            reasoning_config={"enabled": True, "effort": "minimal"},
+        )
+        assert kw["extra_body"]["thinking_config"] == {
+            "includeThoughts": True,
+            "thinkingLevel": "low",
+        }
+
     def test_max_tokens_with_fn(self, transport):
         msgs = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -4,7 +4,7 @@ import pytest
 from types import SimpleNamespace
 
 from agent.transports import get_transport
-from agent.transports.types import NormalizedResponse, ToolCall
+from agent.transports.types import NormalizedResponse
 
 
 @pytest.fixture
@@ -121,6 +121,75 @@ class TestChatCompletionsBuildKwargs:
             reasoning_config={"effort": "none"},
         )
         assert kw["extra_body"]["think"] is False
+
+    def test_gemini_without_explicit_reasoning_config_keeps_existing_behavior(self, transport):
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gemini-3-flash-preview",
+            messages=msgs,
+            provider_name="gemini",
+        )
+        assert "thinking_config" not in kw.get("extra_body", {})
+
+    def test_gemini_flash_reasoning_maps_to_thinking_config(self, transport):
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gemini-3-flash-preview",
+            messages=msgs,
+            provider_name="gemini",
+            reasoning_config={"enabled": True, "effort": "high"},
+        )
+        assert kw["extra_body"]["thinking_config"] == {
+            "includeThoughts": True,
+            "thinkingLevel": "high",
+        }
+
+    def test_gemini_25_reasoning_only_enables_visible_thoughts(self, transport):
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gemini-2.5-flash",
+            messages=msgs,
+            provider_name="gemini",
+            reasoning_config={"enabled": True, "effort": "high"},
+        )
+        assert kw["extra_body"]["thinking_config"] == {
+            "includeThoughts": True,
+        }
+
+    def test_gemini_pro_reasoning_clamps_to_supported_levels(self, transport):
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="google/gemini-3.1-pro-preview",
+            messages=msgs,
+            provider_name="gemini",
+            reasoning_config={"enabled": True, "effort": "medium"},
+        )
+        assert kw["extra_body"]["thinking_config"] == {
+            "includeThoughts": True,
+            "thinkingLevel": "low",
+        }
+
+    def test_gemini_disabled_reasoning_hides_thoughts(self, transport):
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gemini-3-flash-preview",
+            messages=msgs,
+            provider_name="gemini",
+            reasoning_config={"enabled": False},
+        )
+        assert kw["extra_body"]["thinking_config"] == {
+            "includeThoughts": False,
+        }
+
+    def test_gemini_xhigh_clamps_to_high(self, transport):
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gemini-3-flash-preview",
+            messages=msgs,
+            provider_name="gemini",
+            reasoning_config={"enabled": True, "effort": "xhigh"},
+        )
+        assert kw["extra_body"]["thinking_config"]["thinkingLevel"] == "high"
 
     def test_max_tokens_with_fn(self, transport):
         msgs = [{"role": "user", "content": "Hi"}]


### PR DESCRIPTION
## Summary
Bridges Hermes `reasoning_config` into Gemini `thinking_config` on the chat-completions transport so `provider: gemini` + `gemini-3-flash-preview` actually returns thought parts, restoring the Discord `💭 Reasoning:` block when `display.show_reasoning: true` + `agent.reasoning_effort: high` are set.

Salvage of #16945 onto current `main` (57 commits ahead) by @Nanako0129, with one small follow-up clamp.

## Root cause
`provider: gemini` resolves to `api_mode=chat_completions`, so the request is built by `ChatCompletionsTransport.build_kwargs()` and then handed to `GeminiNativeClient.chat.completions.create()` — which reads `extra_body["thinking_config"]`. Nothing upstream was populating that key, so the native client never asked Gemini to return thought parts, `last_reasoning` stayed empty, and the gateway had nothing to render.

## Changes
- `agent/transports/chat_completions.py` — new `_build_gemini_thinking_config(model, reasoning_config)` helper. Gated on `provider_name in {"gemini", "google-gemini-cli"}`. No-op when `reasoning_config` is absent. `enabled: false` / `effort: none` → `includeThoughts: false`. `gemini-2.5-*` → `includeThoughts: true` only (no `thinkingLevel`, since 2.5 uses `thinkingBudget`). `gemini-3*` / `gemini-3.1*` → `includeThoughts: true` plus a family-aware `thinkingLevel` clamp.
- `run_agent.py` — pass `provider_name=self.provider` through `_build_api_kwargs` so the transport can fork on provider.
- Follow-up clamp (on top of the salvaged commit): Flash documents `low`/`medium`/`high` only, so `minimal` → `low` on Flash (matches how Pro already clamps). Anything outside `{low, medium, high}` funnels to `medium` so we never forward an undocumented `thinkingLevel` verbatim.
- `tests/agent/transports/test_chat_completions.py` — regression coverage for no-config, Flash+high, 2.5+high, Pro+medium (clamped to `low`), disabled reasoning, `xhigh` clamp, and the new `minimal → low` clamp on Flash.

## Effort → thinkingLevel matrix

| effort | gemini-2.5-* | gemini-3-flash | gemini-3-pro |
|---|---|---|---|
| (none set) | unchanged | unchanged | unchanged |
| `enabled: false` | `includeThoughts=false` | `includeThoughts=false` | `includeThoughts=false` |
| `minimal` | `includeThoughts=true` | `low` | `low` |
| `low` | `includeThoughts=true` | `low` | `low` |
| `medium` | `includeThoughts=true` | `medium` | `low` |
| `high` | `includeThoughts=true` | `high` | `high` |
| `xhigh` | `includeThoughts=true` | `high` | `high` |

## Validation
- `scripts/run_tests.sh tests/agent/transports/test_chat_completions.py tests/agent/test_gemini_cloudcode.py tests/agent/test_gemini_native_adapter.py` → **144 passed**
- E2E: confirmed `build_kwargs` emits the expected `extra_body["thinking_config"]` for `provider="gemini"` / `"google-gemini-cli"` and leaves `provider="openai"` untouched; `build_gemini_request(thinking_config=...)` lands it in the Gemini request as `generationConfig.thinkingConfig`.

Closes #16941. Supersedes #16945 — original contributor @Nanako0129's authorship preserved via rebase-merge on the primary commit.
