### PR TITLE
fix(opencode-go): normalize Kimi and MiMo runtime routing

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -318,7 +318,7 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         name="OpenCode Go",
         auth_type="api_key",
         # OpenCode Go mixes API surfaces by model:
-        # - GLM / Kimi use OpenAI-compatible chat completions under /v1
+        # - GLM / Kimi / MiMo use OpenAI-compatible chat completions under /v1
         # - MiniMax models use Anthropic Messages under /v1/messages
         # Keep the provider base at /v1 and select api_mode per-model.
         inference_base_url="https://opencode.ai/zen/go/v1",

--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -392,7 +392,7 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
     if provider in _AGGREGATOR_PROVIDERS:
         return _prepend_vendor(name)
 
-    # --- OpenCode Zen: Claude stays hyphenated; other models keep dots ---
+    # --- OpenCode: Claude on Zen stays hyphenated; Go and other Zen models keep dots ---
     if provider == "opencode-zen":
         bare = _strip_matching_provider_prefix(name, provider)
         if "/" in bare:
@@ -400,6 +400,9 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
         if bare.lower().startswith("claude-"):
             return _dots_to_hyphens(bare)
         return bare
+
+    if provider == "opencode-go":
+        return _strip_matching_provider_prefix(name, provider)
 
     # --- Anthropic: strip matching provider prefix, dots -> hyphens ---
     if provider in _DOT_TO_HYPHEN_PROVIDERS:

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -928,8 +928,8 @@ def switch_model(
 
     # OpenCode base URLs end with /v1 for OpenAI-compatible models, but the
     # Anthropic SDK prepends its own /v1/messages to the base_url.  Strip the
-    # trailing /v1 so the SDK constructs the correct path (e.g.
-    # https://opencode.ai/zen/go/v1/messages instead of .../v1/v1/messages).
+    # trailing /v1 for Anthropic-routed OpenCode models so the SDK constructs
+    # the correct path.
     # Mirrors the same logic in hermes_cli.runtime_provider.resolve_runtime_provider;
     # without it, /model switches into an anthropic_messages-routed OpenCode
     # model (e.g. `/model minimax-m2.7` on opencode-go, `/model claude-sonnet-4-6`

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -375,6 +375,8 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "kimi-k2.5",
         "glm-5.1",
         "glm-5",
+        "deepseek-v4-pro",
+        "deepseek-v4-flash",
         "mimo-v2.5-pro",
         "mimo-v2.5",
         "mimo-v2-pro",
@@ -2432,7 +2434,7 @@ def opencode_model_api_mode(provider_id: Optional[str], model_id: Optional[str])
     - GPT-5 / Codex models on Zen use ``/v1/responses``
     - Claude models on Zen use ``/v1/messages``
     - MiniMax models on Go use ``/v1/messages``
-    - GLM / Kimi on Go use ``/v1/chat/completions``
+    - GLM / Kimi / MiMo on Go use ``/v1/chat/completions``
     - Other Zen models (Gemini, GLM, Kimi, MiniMax, Qwen, etc.) use
       ``/v1/chat/completions``
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -272,7 +272,7 @@ def _resolve_runtime_from_pool_entry(
             api_mode = configured_mode
         else:
             # Auto-detect Anthropic-compatible endpoints (/anthropic suffix,
-            # Kimi /coding, api.openai.com → codex_responses, api.x.ai →
+            # Kimi /coding, api.openai.com -> codex_responses, api.x.ai ->
             # codex_responses).
             detected = _detect_api_mode_for_url(base_url)
             if detected:
@@ -280,8 +280,8 @@ def _resolve_runtime_from_pool_entry(
 
     # OpenCode base URLs end with /v1 for OpenAI-compatible models, but the
     # Anthropic SDK prepends its own /v1/messages to the base_url.  Strip the
-    # trailing /v1 so the SDK constructs the correct path (e.g.
-    # https://opencode.ai/zen/go/v1/messages instead of .../v1/v1/messages).
+    # trailing /v1 for Anthropic-routed OpenCode models so the SDK constructs
+    # the correct path.
     if api_mode == "anthropic_messages" and provider in ("opencode-zen", "opencode-go"):
         base_url = re.sub(r"/v1/?$", "", base_url)
 
@@ -1279,7 +1279,7 @@ def resolve_runtime_provider(
             else:
                 # Auto-detect Anthropic-compatible endpoints by URL convention
                 # (e.g. https://api.minimax.io/anthropic, https://dashscope.../anthropic)
-                # plus api.openai.com → codex_responses and api.x.ai → codex_responses.
+                # plus api.openai.com -> codex_responses and api.x.ai -> codex_responses.
                 detected = _detect_api_mode_for_url(base_url)
                 if detected:
                     api_mode = detected

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -103,7 +103,7 @@ _DEFAULT_PROVIDER_MODELS = {
     "ai-gateway": ["anthropic/claude-opus-4.6", "anthropic/claude-sonnet-4.6", "openai/gpt-5", "google/gemini-3-flash"],
     "kilocode": ["anthropic/claude-opus-4.6", "anthropic/claude-sonnet-4.6", "openai/gpt-5.4", "google/gemini-3-pro-preview", "google/gemini-3-flash-preview"],
     "opencode-zen": ["gpt-5.4", "gpt-5.3-codex", "claude-sonnet-4-6", "gemini-3-flash", "glm-5", "kimi-k2.5", "minimax-m2.7"],
-    "opencode-go": ["kimi-k2.6", "kimi-k2.5", "glm-5.1", "glm-5", "mimo-v2.5-pro", "mimo-v2.5", "mimo-v2-pro", "mimo-v2-omni", "minimax-m2.7", "minimax-m2.5", "qwen3.6-plus", "qwen3.5-plus"],
+    "opencode-go": ["kimi-k2.6", "kimi-k2.5", "glm-5.1", "glm-5", "deepseek-v4-pro", "deepseek-v4-flash", "mimo-v2.5-pro", "mimo-v2.5", "mimo-v2-pro", "mimo-v2-omni", "minimax-m2.5", "minimax-m2.7", "qwen3.6-plus", "qwen3.5-plus"],
     "huggingface": [
         "Qwen/Qwen3.5-397B-A17B", "Qwen/Qwen3-235B-A22B-Thinking-2507",
         "Qwen/Qwen3-Coder-480B-A35B-Instruct", "deepseek-ai/DeepSeek-R1-0528",

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -23,12 +23,19 @@ class TestIssue5211OpenCodeGoDotPreservation:
         ("minimax-m2.7", "minimax-m2.7"),
         ("minimax-m2.5", "minimax-m2.5"),
         ("glm-4.5", "glm-4.5"),
+        ("mimo-v2.5", "mimo-v2.5"),
+        ("mimo-v2.5-pro", "mimo-v2.5-pro"),
+        ("kimi-k2.6", "kimi-k2.6"),
         ("kimi-k2.5", "kimi-k2.5"),
         ("some-model-1.0.3", "some-model-1.0.3"),
     ])
     def test_opencode_go_preserves_dots(self, model, expected):
         result = normalize_model_for_provider(model, "opencode-go")
         assert result == expected, f"Expected {expected!r}, got {result!r}"
+
+    def test_opencode_go_strips_matching_provider_prefix(self):
+        result = normalize_model_for_provider("opencode-go/kimi-k2.6", "opencode-go")
+        assert result == "kimi-k2.6"
 
     def test_opencode_go_not_in_dot_to_hyphen_set(self):
         """opencode-go must NOT be in the dot-to-hyphen provider set."""

--- a/tests/hermes_cli/test_model_provider_persistence.py
+++ b/tests/hermes_cli/test_model_provider_persistence.py
@@ -19,9 +19,9 @@ def config_home(tmp_path, monkeypatch):
     home.mkdir()
     config_yaml = home / "config.yaml"
     # Start with model as a plain string — the format that triggered the bug
-    config_yaml.write_text("model: some-old-model\n")
+    config_yaml.write_text("model: some-old-model\n", encoding="utf-8")
     env_file = home / ".env"
-    env_file.write_text("")
+    env_file.write_text("", encoding="utf-8")
     monkeypatch.setenv("HERMES_HOME", str(home))
     # Clear env vars that could interfere
     monkeypatch.delenv("HERMES_MODEL", raising=False)
@@ -46,7 +46,7 @@ class TestSaveModelChoiceAlwaysDict:
         _save_model_choice("kimi-k2.5")
 
         import yaml
-        config = yaml.safe_load((config_home / "config.yaml").read_text()) or {}
+        config = yaml.safe_load((config_home / "config.yaml").read_text(encoding="utf-8")) or {}
         model = config.get("model")
         assert isinstance(model, dict), (
             f"Expected model to be a dict after save, got {type(model)}: {model}"
@@ -57,13 +57,14 @@ class TestSaveModelChoiceAlwaysDict:
         """When config.model is already a dict, _save_model_choice preserves it."""
         import yaml
         (config_home / "config.yaml").write_text(
-            "model:\n  default: old-model\n  provider: openrouter\n"
+            "model:\n  default: old-model\n  provider: openrouter\n",
+            encoding="utf-8",
         )
         from hermes_cli.auth import _save_model_choice
 
         _save_model_choice("new-model")
 
-        config = yaml.safe_load((config_home / "config.yaml").read_text()) or {}
+        config = yaml.safe_load((config_home / "config.yaml").read_text(encoding="utf-8")) or {}
         model = config.get("model")
         assert isinstance(model, dict)
         assert model["default"] == "new-model"
@@ -94,7 +95,7 @@ class TestProviderPersistsAfterModelSave:
             _model_flow_api_key_provider(load_config(), "kimi-coding", "old-model")
 
         import yaml
-        config = yaml.safe_load((config_home / "config.yaml").read_text()) or {}
+        config = yaml.safe_load((config_home / "config.yaml").read_text(encoding="utf-8")) or {}
         model = config.get("model")
         assert isinstance(model, dict), f"model should be dict, got {type(model)}"
         assert model.get("provider") == "kimi-coding", (
@@ -142,7 +143,7 @@ class TestProviderPersistsAfterModelSave:
 
         import yaml
 
-        config = yaml.safe_load((config_home / "config.yaml").read_text()) or {}
+        config = yaml.safe_load((config_home / "config.yaml").read_text(encoding="utf-8")) or {}
         model = config.get("model")
         assert isinstance(model, dict), f"model should be dict, got {type(model)}"
         assert model.get("provider") == "copilot"
@@ -205,7 +206,7 @@ class TestProviderPersistsAfterModelSave:
 
         import yaml
 
-        config = yaml.safe_load((config_home / "config.yaml").read_text()) or {}
+        config = yaml.safe_load((config_home / "config.yaml").read_text(encoding="utf-8")) or {}
         model = config.get("model")
         assert isinstance(model, dict), f"model should be dict, got {type(model)}"
         assert model.get("provider") == "copilot-acp"
@@ -226,7 +227,7 @@ class TestProviderPersistsAfterModelSave:
             _model_flow_api_key_provider(load_config(), "opencode-go", "opencode-go/kimi-k2.5")
 
         import yaml
-        config = yaml.safe_load((config_home / "config.yaml").read_text()) or {}
+        config = yaml.safe_load((config_home / "config.yaml").read_text(encoding="utf-8")) or {}
         model = config.get("model")
         assert isinstance(model, dict)
         assert model.get("provider") == "opencode-go"
@@ -243,7 +244,8 @@ class TestProviderPersistsAfterModelSave:
             "  default: kimi-k2.5\n"
             "  provider: opencode-go\n"
             "  base_url: https://opencode.ai/zen/go/v1\n"
-            "  api_mode: chat_completions\n"
+            "  api_mode: chat_completions\n",
+            encoding="utf-8",
         )
 
         with patch("hermes_cli.models.fetch_api_models", return_value=["opencode-go/kimi-k2.5", "opencode-go/minimax-m2.5"]), \
@@ -253,7 +255,7 @@ class TestProviderPersistsAfterModelSave:
             _model_flow_api_key_provider(load_config(), "opencode-go", "kimi-k2.5")
 
         import yaml
-        config = yaml.safe_load((config_home / "config.yaml").read_text()) or {}
+        config = yaml.safe_load((config_home / "config.yaml").read_text(encoding="utf-8")) or {}
         model = config.get("model")
         assert isinstance(model, dict)
         assert model.get("provider") == "opencode-go"
@@ -355,7 +357,7 @@ class TestBaseUrlValidation:
 
         import yaml
 
-        config = yaml.safe_load((config_home / "config.yaml").read_text()) or {}
+        config = yaml.safe_load((config_home / "config.yaml").read_text(encoding="utf-8")) or {}
         model = config.get("model")
         assert isinstance(model, dict)
         assert model.get("provider") == "stepfun"

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -410,7 +410,10 @@ class TestCopilotNormalization:
         assert opencode_model_api_mode("opencode-go", "glm-5") == "chat_completions"
         assert opencode_model_api_mode("opencode-go", "opencode-go/glm-5") == "chat_completions"
         assert opencode_model_api_mode("opencode-go", "kimi-k2.5") == "chat_completions"
+        assert opencode_model_api_mode("opencode-go", "kimi-k2.6") == "chat_completions"
         assert opencode_model_api_mode("opencode-go", "opencode-go/kimi-k2.5") == "chat_completions"
+        assert opencode_model_api_mode("opencode-go", "mimo-v2.5") == "chat_completions"
+        assert opencode_model_api_mode("opencode-go", "opencode-go/mimo-v2.5") == "chat_completions"
         assert opencode_model_api_mode("opencode-go", "minimax-m2.5") == "anthropic_messages"
         assert opencode_model_api_mode("opencode-go", "opencode-go/minimax-m2.5") == "anthropic_messages"
 

--- a/tests/hermes_cli/test_opencode_go_in_model_list.py
+++ b/tests/hermes_cli/test_opencode_go_in_model_list.py
@@ -15,6 +15,10 @@ _OPENCODE_GO_REQUIRED = {
     "kimi-k2.5",
     "glm-5.1",
     "glm-5",
+    "deepseek-v4-pro",
+    "deepseek-v4-flash",
+    "mimo-v2.5-pro",
+    "mimo-v2.5",
     "mimo-v2-pro",
     "mimo-v2-omni",
     "minimax-m2.7",
@@ -33,7 +37,7 @@ def test_opencode_go_appears_when_api_key_set():
     assert opencode_go is not None, "opencode-go should appear when OPENCODE_GO_API_KEY is set"
     # Behavior check: the curated floor must be present. The list may also
     # include extra models.dev entries (e.g. mimo-v2.5-pro) when the registry
-    # is reachable — that's the whole point of the models.dev-preferred merge
+    # is reachable - that's the whole point of the models.dev-preferred merge
     # introduced for opencode-go, so don't pin to an exact list here.
     present = set(opencode_go["models"])
     missing = _OPENCODE_GO_REQUIRED - present
@@ -41,6 +45,7 @@ def test_opencode_go_appears_when_api_key_set():
         f"opencode-go picker should include the curated floor; missing: {sorted(missing)}. "
         f"Got: {opencode_go['models']}"
     )
+    assert opencode_go["total_models"] >= 12
     # opencode-go can appear as "built-in" (from PROVIDER_TO_MODELS_DEV when
     # models.dev is reachable) or "hermes" (from HERMES_OVERLAYS fallback when
     # the API is unavailable, e.g. in CI).

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1179,7 +1179,7 @@ def test_opencode_go_model_derivation_beats_stale_persisted_api_mode(monkeypatch
 
     minimax-m2.5 is an Anthropic-routed model on opencode-go, so even when
     the config claims ``api_mode: chat_completions`` the runtime must pick
-    ``anthropic_messages`` — the model dictates the mode, not the stale
+    ``anthropic_messages`` - the model dictates the mode, not the stale
     persisted setting.
     """
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "opencode-go")
@@ -1199,6 +1199,28 @@ def test_opencode_go_model_derivation_beats_stale_persisted_api_mode(monkeypatch
 
     assert resolved["provider"] == "opencode-go"
     assert resolved["api_mode"] == "anthropic_messages"
+    assert resolved["base_url"] == "https://opencode.ai/zen/go"
+
+
+def test_opencode_go_ignores_stale_anthropic_api_mode_for_kimi(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "opencode-go")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "opencode-go",
+            "default": "kimi-k2.6",
+            "api_mode": "anthropic_messages",
+        },
+    )
+    monkeypatch.setenv("OPENCODE_GO_API_KEY", "test-opencode-go-key")
+    monkeypatch.delenv("OPENCODE_GO_BASE_URL", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="opencode-go")
+
+    assert resolved["provider"] == "opencode-go"
+    assert resolved["api_mode"] == "chat_completions"
+    assert resolved["base_url"] == "https://opencode.ai/zen/go/v1"
 
 
 def test_named_custom_provider_anthropic_api_mode(monkeypatch):


### PR DESCRIPTION
## Summary
- recompute OpenCode Zen/Go `api_mode` from the selected model instead of trusting stale persisted config
- strip matching `opencode-go/` model prefixes while preserving dotted model ids like `kimi-k2.6` and `mimo-v2.5`
- refresh the OpenCode Go fallback model list with current Kimi, MiMo, MiniMax, Qwen, and DeepSeek entries
- keep config-persistence tests explicit about UTF-8 reads/writes on Windows
- resolve conflicts with current `main`

fix #16875
## Testing
- `venv\Scripts\python.exe -m pytest tests\hermes_cli\test_model_validation.py::TestCopilotNormalization::test_opencode_go_api_modes_match_docs tests\hermes_cli\test_model_normalize.py::TestIssue5211OpenCodeGoDotPreservation tests\hermes_cli\test_runtime_provider_resolution.py::test_opencode_go_minimax_defaults_to_messages tests\hermes_cli\test_runtime_provider_resolution.py::test_opencode_go_glm_defaults_to_chat_completions tests\hermes_cli\test_runtime_provider_resolution.py::test_opencode_go_model_derivation_beats_stale_persisted_api_mode tests\hermes_cli\test_runtime_provider_resolution.py::test_opencode_go_ignores_stale_anthropic_api_mode_for_kimi -q -n 4`
- `venv\Scripts\python.exe -m pytest tests\hermes_cli\test_model_provider_persistence.py tests\hermes_cli\test_opencode_go_in_model_list.py -q -n 4`
- `venv\Scripts\python.exe -m py_compile hermes_cli\runtime_provider.py hermes_cli\models.py hermes_cli\model_normalize.py hermes_cli\auth.py hermes_cli\setup.py hermes_cli\model_switch.py`