### PR TITLE
fix(aux): default Codex reasoning effort to medium when extra_body.reasoning.effort is falsy

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -489,7 +489,12 @@ class _CodexCompletionsAdapter:
                     # API allows it.
                     pass
                 else:
-                    effort = reasoning_cfg.get("effort", "medium")
+                    # Truthy-only check mirrors agent/transports/codex.py
+                    # build_kwargs(): falsy values (None, "", 0) fall back
+                    # to the default rather than being forwarded to the
+                    # Codex backend, which rejects e.g. {"effort": null}
+                    # with a 400.
+                    effort = reasoning_cfg.get("effort") or "medium"
                     # Codex backend rejects "minimal"; clamp to "low" to
                     # match the main-agent Codex transport behavior.
                     if effort == "minimal":

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1635,6 +1635,30 @@ class TestCodexAdapterReasoningTranslation:
         )
         assert "reasoning" not in captured
 
+    def test_reasoning_effort_null_falls_back_to_medium(self):
+        """Parity with agent/transports/codex.py::build_kwargs() — falsy
+        ``effort`` (None / empty / 0) keeps the default ``medium`` instead
+        of being forwarded to Codex.  Codex rejects ``{"effort": null}``
+        with HTTP 400 (Invalid value for parameter `reasoning.effort`)."""
+        adapter, captured = self._build_adapter()
+        adapter.create(
+            messages=[{"role": "user", "content": "hi"}],
+            extra_body={"reasoning": {"effort": None}},
+        )
+        assert captured.get("reasoning") == {"effort": "medium", "summary": "auto"}
+        assert captured.get("include") == ["reasoning.encrypted_content"]
+
+    def test_reasoning_effort_empty_string_falls_back_to_medium(self):
+        """Empty-string effort (e.g. ``effort: ""`` in YAML) is falsy in
+        the main-agent path's truthy check; mirror that here so the same
+        config produces the same result."""
+        adapter, captured = self._build_adapter()
+        adapter.create(
+            messages=[{"role": "user", "content": "hi"}],
+            extra_body={"reasoning": {"effort": ""}},
+        )
+        assert captured.get("reasoning") == {"effort": "medium", "summary": "auto"}
+        assert captured.get("include") == ["reasoning.encrypted_content"]
 
 
 class TestVisionAutoSkipsKimiCoding:

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1660,6 +1660,18 @@ class TestCodexAdapterReasoningTranslation:
         assert captured.get("reasoning") == {"effort": "medium", "summary": "auto"}
         assert captured.get("include") == ["reasoning.encrypted_content"]
 
+    def test_reasoning_effort_zero_falls_back_to_medium(self):
+        """Numeric ``0`` is also falsy — the docstring lists it explicitly,
+        so cover the contract.  Codex would reject ``{"effort": 0}`` the
+        same way it rejects ``null``."""
+        adapter, captured = self._build_adapter()
+        adapter.create(
+            messages=[{"role": "user", "content": "hi"}],
+            extra_body={"reasoning": {"effort": 0}},
+        )
+        assert captured.get("reasoning") == {"effort": "medium", "summary": "auto"}
+        assert captured.get("include") == ["reasoning.encrypted_content"]
+
 
 class TestVisionAutoSkipsKimiCoding:
     """_resolve_auto vision branch skips providers that have no vision on


### PR DESCRIPTION
## Summary
- Fall back to `"medium"` when `auxiliary.<task>.extra_body.reasoning.effort` is `null` / `""` / `0` instead of forwarding the falsy value to Codex (which 400s).
- Brings `_CodexCompletionsAdapter.create()` (PR #17004) into parity with `agent/transports/codex.py::build_kwargs()`, which the new adapter is explicitly documented to mirror.

## The bug
PR #17004 (391f1ca1f) wired `extra_body.reasoning` through to the Codex Responses API:

```python
# agent/auxiliary_client.py — current
effort = reasoning_cfg.get("effort", "medium")
if effort == "minimal":
    effort = "low"
resp_kwargs["reasoning"] = {"effort": effort, "summary": "auto"}
```

The two-arg `dict.get` only fills in the default when the key is **absent**. If the user has the key but with a falsy value — which is what `effort: ~` or `effort:` (no value) produces in YAML — `effort` is bound to `None` / `""` and goes out as:

```json
"reasoning": {"effort": null, "summary": "auto"}
```

The Codex Responses API rejects that with HTTP 400 (`Invalid value for parameter "reasoning.effort"`), so the auxiliary call fails on a config shape that the main agent accepts cleanly.

The main-agent path the new adapter is mirroring (`agent/transports/codex.py:79-90`) uses a truthy check:

```python
reasoning_effort = "medium"
...
elif reasoning_config.get("effort"):    # truthy — None/""/0 fall through
    reasoning_effort = reasoning_config["effort"]
```

so falsy values stay at the `"medium"` default. The same config that works for the main agent's `reasoning_config` should work for the auxiliary adapter's `extra_body.reasoning`.

## The fix
One-line change in `_CodexCompletionsAdapter.create()`:

```python
effort = reasoning_cfg.get("effort") or "medium"
```

The `or "medium"` mirrors the truthy check from the main-agent transport — `None`, `""`, `0` all coalesce to the default rather than getting forwarded to Codex. Truthy strings (`"low"`, `"medium"`, `"high"`, `"minimal"`, etc.) behave exactly as before, and the existing `minimal → low` clamp still runs after this.

## Test plan
- [x] Focused regression tests: two new cases in `TestCodexAdapterReasoningTranslation` cover `effort: None` and `effort: ""` and assert the outgoing request is `{"effort": "medium", "summary": "auto"}`.
- [x] Regression guard: with the production fix reverted, both new tests fail with `{'effort': None} != {'effort': 'medium'}` and `{'effort': ''} != {'effort': 'medium'}`. With the fix applied, all 11 tests in the class pass.
- [x] Adjacent suite: `tests/agent/test_auxiliary_client.py` — 108 passed.
- [x] Transport adjacency: `tests/agent/transports/test_codex_transport.py` + `test_chat_completions.py` — 73 passed.

## Related
- Follows on from #17004 (just merged in 391f1ca1f) — the new adapter explicitly documents that it "Mirrors agent/transports/codex.py::build_kwargs()", so any config-handling divergence is a real bug, not just a hypothetical edge.
- The 9 tests added in #17004 cover the fully-omitted, fully-disabled, and valid-effort cases; they don't exercise the falsy-but-present shape that this PR closes.