### PR TITLE
Make still-working notifications silent

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -84,7 +84,7 @@ from gateway.platforms.telegram_network import (
     discover_fallback_ips,
     parse_fallback_ip_env,
 )
-from utils import atomic_replace
+from utils import atomic_replace, is_truthy_value
 
 
 def check_telegram_requirements() -> bool:
@@ -1083,6 +1083,11 @@ class TelegramAdapter(BasePlatformAdapter):
             
             message_ids = []
             thread_id = self._metadata_thread_id(metadata)
+            disable_notification = False
+            if metadata:
+                disable_notification = is_truthy_value(
+                    metadata.get("disable_notification", metadata.get("silent", False))
+                )
             
             try:
                 from telegram.error import NetworkError as _NetErr
@@ -1115,6 +1120,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                 parse_mode=ParseMode.MARKDOWN_V2,
                                 reply_to_message_id=reply_to_id,
                                 message_thread_id=effective_thread_id,
+                                disable_notification=disable_notification,
                                 **self._link_preview_kwargs(),
                             )
                         except Exception as md_error:
@@ -1128,6 +1134,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                     parse_mode=None,
                                     reply_to_message_id=reply_to_id,
                                     message_thread_id=effective_thread_id,
+                                    disable_notification=disable_notification,
                                     **self._link_preview_kwargs(),
                                 )
                             else:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -368,6 +368,8 @@ if _config_path.exists():
                 os.environ["HERMES_AGENT_TIMEOUT_WARNING"] = str(_agent_cfg["gateway_timeout_warning"])
             if "gateway_notify_interval" in _agent_cfg and "HERMES_AGENT_NOTIFY_INTERVAL" not in os.environ:
                 os.environ["HERMES_AGENT_NOTIFY_INTERVAL"] = str(_agent_cfg["gateway_notify_interval"])
+            if "gateway_notify_silent" in _agent_cfg and "HERMES_AGENT_NOTIFY_SILENT" not in os.environ:
+                os.environ["HERMES_AGENT_NOTIFY_SILENT"] = str(_agent_cfg["gateway_notify_silent"])
             if "restart_drain_timeout" in _agent_cfg and "HERMES_RESTART_DRAIN_TIMEOUT" not in os.environ:
                 os.environ["HERMES_RESTART_DRAIN_TIMEOUT"] = str(_agent_cfg["restart_drain_timeout"])
             if (
@@ -11884,6 +11886,7 @@ class GatewayRunner:
         # 0 = disable notifications.
         _NOTIFY_INTERVAL_RAW = _float_env("HERMES_AGENT_NOTIFY_INTERVAL", 180)
         _NOTIFY_INTERVAL = _NOTIFY_INTERVAL_RAW if _NOTIFY_INTERVAL_RAW > 0 else None
+        _NOTIFY_SILENT = is_truthy_value(os.getenv("HERMES_AGENT_NOTIFY_SILENT", "true"))
         _notify_start = time.time()
 
         async def _notify_long_running():
@@ -11910,10 +11913,14 @@ class GatewayRunner:
                     except Exception:
                         pass
                 try:
+                    _notify_metadata = dict(_status_thread_metadata or {})
+                    if _NOTIFY_SILENT:
+                        _notify_metadata["silent"] = True
+                        _notify_metadata["disable_notification"] = True
                     await _notify_adapter.send(
                         source.chat_id,
                         f"⏳ Still working... ({_elapsed_mins} min elapsed{_status_detail})",
-                        metadata=_status_thread_metadata,
+                        metadata=_notify_metadata,
                     )
                 except Exception as _ne:
                     logger.debug("Long-running notification error: %s", _ne)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -429,6 +429,11 @@ DEFAULT_CONFIG = {
         # (60+ tool iterations with tiny output) before users assume the
         # bot is dead and /restart.
         "gateway_notify_interval": 180,
+        # Send periodic gateway "still working" notifications silently when
+        # the underlying platform supports notification suppression. Telegram
+        # maps this to Bot API disable_notification=true; other platforms may
+        # ignore it.
+        "gateway_notify_silent": True,
         # Freshness window for the gateway auto-continue note (seconds).
         # After a gateway crash/restart/SIGTERM mid-run, the next user
         # message gets a "[System note: your previous turn was

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -106,6 +106,7 @@ AUTHOR_MAP = {
     "foxion37@gmail.com": "foxion37",
     "bloodcarter@gmail.com": "bloodcarter",
     "scott@scotttrinh.com": "scotttrinh",
+    "auspic7@gmail.com": "auspic7",
     # contributors (from noreply pattern)
     "david.vv@icloud.com": "davidvv",
     "wangqiang@wangqiangdeMac-mini.local": "xiaoqiang243",

--- a/tests/gateway/test_silent_still_working_notifications.py
+++ b/tests/gateway/test_silent_still_working_notifications.py
@@ -1,0 +1,83 @@
+"""Tests for silent gateway progress notifications on Telegram."""
+
+import asyncio
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+from gateway.config import PlatformConfig
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _ensure_telegram_mock():
+    """Install mock telegram modules so TelegramAdapter can be imported."""
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+
+    telegram_mod = MagicMock()
+    telegram_mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    telegram_mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    telegram_mod.constants.ChatType.GROUP = "group"
+    telegram_mod.constants.ChatType.SUPERGROUP = "supergroup"
+    telegram_mod.constants.ChatType.CHANNEL = "channel"
+    telegram_mod.constants.ChatType.PRIVATE = "private"
+
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, telegram_mod)
+
+
+_ensure_telegram_mock()
+
+from gateway.platforms.telegram import TelegramAdapter  # noqa: E402
+from hermes_cli.config import DEFAULT_CONFIG  # noqa: E402
+
+
+def _make_adapter():
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="fake-token"))
+    adapter._bot = MagicMock()
+    msg = MagicMock()
+    msg.message_id = 42
+    adapter._bot.send_message = AsyncMock(return_value=msg)
+    return adapter
+
+
+def test_default_config_makes_gateway_notifications_silent():
+    assert DEFAULT_CONFIG["agent"]["gateway_notify_silent"] is True
+
+
+def test_telegram_send_maps_silent_metadata_to_disable_notification():
+    adapter = _make_adapter()
+
+    result = _run(adapter.send("12345", "Still working", metadata={"silent": True}))
+
+    assert result.success is True
+    kwargs = adapter._bot.send_message.await_args.kwargs
+    assert kwargs["disable_notification"] is True
+
+
+def test_telegram_send_maps_disable_notification_metadata():
+    adapter = _make_adapter()
+
+    result = _run(
+        adapter.send(
+            "12345",
+            "Still working",
+            metadata={"disable_notification": "true"},
+        )
+    )
+
+    assert result.success is True
+    kwargs = adapter._bot.send_message.await_args.kwargs
+    assert kwargs["disable_notification"] is True
+
+
+def test_telegram_send_defaults_to_audible_notifications():
+    adapter = _make_adapter()
+
+    result = _run(adapter.send("12345", "Normal reply"))
+
+    assert result.success is True
+    kwargs = adapter._bot.send_message.await_args.kwargs
+    assert kwargs["disable_notification"] is False


### PR DESCRIPTION
## Summary
- make periodic gateway `Still working...` notifications silent by default via `agent.gateway_notify_silent`
- pass silent progress metadata through the gateway runner
- map Telegram `metadata.silent` / `metadata.disable_notification` to Bot API `disable_notification=true`

## Upstream search
I checked existing PRs/issues before implementing. Related but not sufficient:
- #2596 adds `silent_tool_hints` for Telegram tool-hint messages only, not gateway `Still working...` heartbeats
- #8572 already merged configurability for `gateway_notify_interval`, but does not suppress notifications
- #7446 is another heartbeat configurability PR and does not implement Telegram `disable_notification` for still-working messages
- issues #10990/#11075 discuss stale/missing visible heartbeats, not silent delivery

## Tests
- `python -m pytest tests/gateway/test_silent_still_working_notifications.py -q`
- `python -m pytest tests/gateway/test_silent_still_working_notifications.py tests/test_ipv4_preference.py -q`
- `python -m pytest tests/gateway/test_silent_still_working_notifications.py tests/gateway/test_telegram_text_batching.py tests/gateway/test_telegram_reply_mode.py tests/gateway/test_telegram_thread_fallback.py -q`
- `python -m py_compile gateway/run.py gateway/platforms/telegram.py hermes_cli/config.py tests/gateway/test_silent_still_working_notifications.py`
- `git diff --check`
