### PR TITLE
fix: return effective session_id after context compression (#16938)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -835,7 +835,10 @@ class APIServerAdapter(BasePlatformAdapter):
             },
         }
 
-        return web.json_response(response_data, headers={"X-Hermes-Session-Id": session_id})
+        return web.json_response(
+            response_data,
+            headers={"X-Hermes-Session-Id": result.get("session_id", session_id)},
+        )
 
     async def _write_sse_chat_completion(
         self, request: "web.Request", completion_id: str, model: str,
@@ -2027,6 +2030,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 "output_tokens": getattr(agent, "session_completion_tokens", 0) or 0,
                 "total_tokens": getattr(agent, "session_total_tokens", 0) or 0,
             }
+            # Include the effective session ID in the result so callers
+            # (e.g. X-Hermes-Session-Id header) can track compression-
+            # triggered session rotations. (#16938)
+            result["session_id"] = getattr(agent, "session_id", session_id)
             return result, usage
 
         return await loop.run_in_executor(None, _run)


### PR DESCRIPTION
## Problem

When Hermes is used through the OpenAI-compatible API server (`POST /v1/chat/completions`) with session continuity via `X-Hermes-Session-Id`, context compression can rotate the internal `AIAgent.session_id` to a new child session.

However, the API server continues to return the stale parent session id in the `X-Hermes-Session-Id` response header. External clients that rely on this header keep sending the old session id, causing subsequent requests to reload the uncompressed parent history instead of the compressed continuation.

## Fix

`_run_agent()` now includes `result["session_id"] = agent.session_id` after `run_conversation()` completes, capturing the effective session id (which may differ from the input if compression occurred).

The non-streaming response path uses `result.get("session_id", session_id)` instead of the original `session_id` variable when setting the `X-Hermes-Session-Id` header.

## Before vs After

| Scenario | Before | After |
|----------|--------|-------|
| No compression | Returns original session_id | Returns original session_id (same) |
| Compression triggered | Returns stale parent session_id | Returns new child session_id |

## Notes

- The streaming path (`_write_sse_chat_completion`) sets the session header before the agent completes, so it still uses the original session_id. A follow-up could send the effective session_id as a custom SSE event at stream end.
- This is a minimal, backward-compatible change — no config changes required.

Fixes #16938
