### PR TITLE
fix(install): probe /dev/tty by opening it, not bare existence (#16746)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1330,7 +1330,12 @@ run_setup_wizard() {
     # The setup wizard reads from /dev/tty, so it works even when the
     # install script itself is piped (curl | bash). Only skip if no
     # terminal is available at all (e.g. Docker build, CI).
-    if ! [ -e /dev/tty ]; then
+    #
+    # Probe by actually opening /dev/tty: a bare existence test passes
+    # in Docker builds where the device node is in the mount namespace
+    # but opening fails with ENXIO, so the wizard would proceed and
+    # then crash on `< /dev/tty` below.
+    if ! (: </dev/tty) 2>/dev/null; then
         log_info "Setup wizard skipped (no terminal available). Run 'hermes setup' after install."
         return 0
     fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -729,9 +729,12 @@ install_system_packages() {
                         return 0
                     fi
                 fi
-            elif [ -e /dev/tty ]; then
+            elif (: </dev/tty) 2>/dev/null; then
                 # Non-interactive (e.g. curl | bash) but a terminal is available.
                 # Read the prompt from /dev/tty (same approach the setup wizard uses).
+                # Probe by actually opening /dev/tty: a bare existence test passes
+                # in Docker builds where the device node is in the mount namespace
+                # but opening fails with ENXIO. See #16746.
                 echo ""
                 log_info "sudo is needed ONLY to install optional system packages (${pkgs[*]}) via your package manager."
                 log_info "Hermes Agent itself does not require or retain root access."
@@ -1397,7 +1400,10 @@ maybe_start_gateway() {
         fi
     fi
 
-    if ! [ -e /dev/tty ]; then
+    # Probe by actually opening /dev/tty: a bare existence test passes
+    # in Docker builds where the device node is in the mount namespace
+    # but opening fails with ENXIO. See #16746.
+    if ! (: </dev/tty) 2>/dev/null; then
         log_info "Gateway setup skipped (no terminal available). Run 'hermes gateway install' later."
         return 0
     fi

--- a/tests/test_install_sh_setup_wizard_tty_probe.py
+++ b/tests/test_install_sh_setup_wizard_tty_probe.py
@@ -1,0 +1,41 @@
+"""Regression for #16746: setup-wizard tty gate must actually open /dev/tty.
+
+In a Docker build, ``/dev/tty`` exists as a device node (so ``[ -e /dev/tty ]``
+returns true) but opening it fails with ``ENXIO: No such device or address``.
+Under the old gate the wizard proceeded past the "no terminal available" skip
+and then crashed on the ``< /dev/tty`` redirect a few lines later, aborting
+the entire image build. The fix replaces the bare existence check with an
+open-based probe so the skip kicks in correctly.
+"""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+
+def _extract_run_setup_wizard() -> str:
+    """Return the body of run_setup_wizard() as a single string."""
+    text = INSTALL_SH.read_text()
+    start = text.index("run_setup_wizard()")
+    # The next top-level function follows immediately; use it as the end marker.
+    end = text.index("\nmaybe_start_gateway()", start)
+    return text[start:end]
+
+
+def test_run_setup_wizard_does_not_use_bare_existence_check() -> None:
+    body = _extract_run_setup_wizard()
+    assert "[ -e /dev/tty ]" not in body, (
+        "run_setup_wizard guards on `[ -e /dev/tty ]`, which is true in Docker "
+        "builds where the device node exists but cannot be opened (ENXIO). "
+        "Use an open-based probe such as `(: </dev/tty) 2>/dev/null` so the "
+        "skip kicks in before the wizard tries to read from /dev/tty. See #16746."
+    )
+
+
+def test_run_setup_wizard_uses_open_based_tty_probe() -> None:
+    body = _extract_run_setup_wizard()
+    assert "(: </dev/tty)" in body, (
+        "run_setup_wizard must probe /dev/tty by actually opening it before "
+        "running the wizard. See #16746."
+    )

--- a/tests/test_install_sh_setup_wizard_tty_probe.py
+++ b/tests/test_install_sh_setup_wizard_tty_probe.py
@@ -1,11 +1,16 @@
-"""Regression for #16746: setup-wizard tty gate must actually open /dev/tty.
+"""Regression for #16746: install.sh /dev/tty gates must actually open /dev/tty.
 
 In a Docker build, ``/dev/tty`` exists as a device node (so a bare ``-e``
 existence test returns true) but opening it fails with ``ENXIO: No such
-device or address``. Under the old gate the wizard proceeded past the "no
+device or address``. Under the old gates the script proceeded past the "no
 terminal available" skip and then crashed on the ``< /dev/tty`` redirect a
-few lines later, aborting the entire image build. The fix replaces the
-existence check with an open-based probe so the skip kicks in correctly.
+few lines later, aborting the entire image build. The fix replaces every
+existence-based check that guards a subsequent ``< /dev/tty`` redirect with
+an open-based probe so the skip kicks in correctly.
+
+This module covers all three affected functions: ``run_setup_wizard()``
+(the reproducer in #16746), ``install_system_packages()`` (the apt sudo
+prompt fallback), and ``maybe_start_gateway()`` (the gateway-install gate).
 """
 
 from __future__ import annotations
@@ -13,29 +18,36 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
 
+# Every function in scripts/install.sh that previously gated on a bare
+# ``[ -e /dev/tty ]`` check before redirecting stdin from ``/dev/tty``.
+GATED_FUNCTIONS = ("run_setup_wizard", "install_system_packages", "maybe_start_gateway")
 
-def _extract_run_setup_wizard() -> str:
-    """Return the body of ``run_setup_wizard()`` as a single string.
 
-    Anchored to ``run_setup_wizard()`` and a top-of-line ``}`` so the helper
-    keeps working if neighbouring functions are renamed.
+def _extract_function_body(name: str) -> str:
+    """Return the body of ``<name>()`` as a single string.
+
+    Anchored to ``<name>()`` and a top-of-line ``}`` so the helper keeps
+    working if neighbouring functions are renamed.
     """
     text = INSTALL_SH.read_text()
     match = re.search(
-        r"^run_setup_wizard\(\)\s*\{\s*\n(?P<body>.*?)^\}",
+        rf"^{re.escape(name)}\(\)\s*\{{\s*\n(?P<body>.*?)^\}}",
         text,
         re.MULTILINE | re.DOTALL,
     )
-    assert match is not None, "run_setup_wizard() not found in scripts/install.sh"
+    assert match is not None, f"{name}() not found in scripts/install.sh"
     return match["body"]
 
 
-def test_run_setup_wizard_does_not_use_existence_only_tty_check() -> None:
+@pytest.mark.parametrize("fn_name", GATED_FUNCTIONS)
+def test_tty_gate_does_not_use_existence_only_check(fn_name: str) -> None:
     """The bare ``-e`` test is the bug — no spelling of it should remain."""
-    body = _extract_run_setup_wizard()
+    body = _extract_function_body(fn_name)
     # Cover ``[ -e /dev/tty ]``, ``[ -e "/dev/tty" ]``, ``test -e /dev/tty``
     # and friends, with arbitrary surrounding whitespace.
     pattern = re.compile(
@@ -48,28 +60,32 @@ def test_run_setup_wizard_does_not_use_existence_only_tty_check() -> None:
     )
     match = pattern.search(body)
     assert match is None, (
-        "run_setup_wizard contains an existence-only check on /dev/tty "
+        f"{fn_name} contains an existence-only check on /dev/tty "
         f"({match.group(0)!r}). Bare `-e` tests pass in Docker builds "
         "where the device node is in the mount namespace but cannot be "
         "opened (ENXIO). Use an open-based probe (e.g. "
         "`(: </dev/tty) 2>/dev/null` or `exec 3</dev/tty`) so the skip "
-        "kicks in before the wizard tries to read from /dev/tty. "
+        "kicks in before the function tries to read from /dev/tty. "
         "See #16746."
     )
 
 
-def test_run_setup_wizard_gates_on_open_based_tty_probe() -> None:
+@pytest.mark.parametrize("fn_name", GATED_FUNCTIONS)
+def test_tty_gate_uses_open_based_probe(fn_name: str) -> None:
     """The gate must actually attempt to open ``/dev/tty``.
 
-    Any ``if !`` (or ``if``) whose condition opens ``/dev/tty`` for input
-    counts: ``(: </dev/tty)``, ``exec 3</dev/tty``, ``{ exec 3</dev/tty; }``,
-    etc. Asserting the higher-level invariant rather than a specific spelling
-    so equivalent refactors stay green.
+    Any ``if``/``if !``/``elif`` whose condition opens ``/dev/tty`` for
+    input counts: ``(: </dev/tty)``, ``exec 3</dev/tty``,
+    ``{ exec 3</dev/tty; }``, etc. Asserting the higher-level invariant
+    rather than a specific spelling so equivalent refactors stay green.
     """
-    body = _extract_run_setup_wizard()
-    gate = re.compile(r"^\s*if\s+!?\s+[^\n]*<\s*/dev/tty[^\n]*;\s*then", re.MULTILINE)
+    body = _extract_function_body(fn_name)
+    gate = re.compile(
+        r"^\s*(?:if|elif)\s+!?\s*[^\n]*<\s*/dev/tty[^\n]*;\s*then",
+        re.MULTILINE,
+    )
     assert gate.search(body), (
-        "run_setup_wizard must gate on an open-based probe of /dev/tty "
-        "(an `if`/`if !` whose test redirects stdin from /dev/tty), not a "
-        "mere existence check. See #16746."
+        f"{fn_name} must gate on an open-based probe of /dev/tty "
+        "(an `if`/`if !`/`elif` whose test redirects stdin from /dev/tty), "
+        "not a mere existence check. See #16746."
     )

--- a/tests/test_install_sh_setup_wizard_tty_probe.py
+++ b/tests/test_install_sh_setup_wizard_tty_probe.py
@@ -1,13 +1,16 @@
 """Regression for #16746: setup-wizard tty gate must actually open /dev/tty.
 
-In a Docker build, ``/dev/tty`` exists as a device node (so ``[ -e /dev/tty ]``
-returns true) but opening it fails with ``ENXIO: No such device or address``.
-Under the old gate the wizard proceeded past the "no terminal available" skip
-and then crashed on the ``< /dev/tty`` redirect a few lines later, aborting
-the entire image build. The fix replaces the bare existence check with an
-open-based probe so the skip kicks in correctly.
+In a Docker build, ``/dev/tty`` exists as a device node (so a bare ``-e``
+existence test returns true) but opening it fails with ``ENXIO: No such
+device or address``. Under the old gate the wizard proceeded past the "no
+terminal available" skip and then crashed on the ``< /dev/tty`` redirect a
+few lines later, aborting the entire image build. The fix replaces the
+existence check with an open-based probe so the skip kicks in correctly.
 """
 
+from __future__ import annotations
+
+import re
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -15,27 +18,58 @@ INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
 
 
 def _extract_run_setup_wizard() -> str:
-    """Return the body of run_setup_wizard() as a single string."""
+    """Return the body of ``run_setup_wizard()`` as a single string.
+
+    Anchored to ``run_setup_wizard()`` and a top-of-line ``}`` so the helper
+    keeps working if neighbouring functions are renamed.
+    """
     text = INSTALL_SH.read_text()
-    start = text.index("run_setup_wizard()")
-    # The next top-level function follows immediately; use it as the end marker.
-    end = text.index("\nmaybe_start_gateway()", start)
-    return text[start:end]
+    match = re.search(
+        r"^run_setup_wizard\(\)\s*\{\s*\n(?P<body>.*?)^\}",
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert match is not None, "run_setup_wizard() not found in scripts/install.sh"
+    return match["body"]
 
 
-def test_run_setup_wizard_does_not_use_bare_existence_check() -> None:
+def test_run_setup_wizard_does_not_use_existence_only_tty_check() -> None:
+    """The bare ``-e`` test is the bug — no spelling of it should remain."""
     body = _extract_run_setup_wizard()
-    assert "[ -e /dev/tty ]" not in body, (
-        "run_setup_wizard guards on `[ -e /dev/tty ]`, which is true in Docker "
-        "builds where the device node exists but cannot be opened (ENXIO). "
-        "Use an open-based probe such as `(: </dev/tty) 2>/dev/null` so the "
-        "skip kicks in before the wizard tries to read from /dev/tty. See #16746."
+    # Cover ``[ -e /dev/tty ]``, ``[ -e "/dev/tty" ]``, ``test -e /dev/tty``
+    # and friends, with arbitrary surrounding whitespace.
+    pattern = re.compile(
+        r"""(
+            \[\s*-e\s+["']?/dev/tty["']?\s*\]
+            |
+            \btest\s+-e\s+["']?/dev/tty["']?
+        )""",
+        re.VERBOSE,
+    )
+    match = pattern.search(body)
+    assert match is None, (
+        "run_setup_wizard contains an existence-only check on /dev/tty "
+        f"({match.group(0)!r}). Bare `-e` tests pass in Docker builds "
+        "where the device node is in the mount namespace but cannot be "
+        "opened (ENXIO). Use an open-based probe (e.g. "
+        "`(: </dev/tty) 2>/dev/null` or `exec 3</dev/tty`) so the skip "
+        "kicks in before the wizard tries to read from /dev/tty. "
+        "See #16746."
     )
 
 
-def test_run_setup_wizard_uses_open_based_tty_probe() -> None:
+def test_run_setup_wizard_gates_on_open_based_tty_probe() -> None:
+    """The gate must actually attempt to open ``/dev/tty``.
+
+    Any ``if !`` (or ``if``) whose condition opens ``/dev/tty`` for input
+    counts: ``(: </dev/tty)``, ``exec 3</dev/tty``, ``{ exec 3</dev/tty; }``,
+    etc. Asserting the higher-level invariant rather than a specific spelling
+    so equivalent refactors stay green.
+    """
     body = _extract_run_setup_wizard()
-    assert "(: </dev/tty)" in body, (
-        "run_setup_wizard must probe /dev/tty by actually opening it before "
-        "running the wizard. See #16746."
+    gate = re.compile(r"^\s*if\s+!?\s+[^\n]*<\s*/dev/tty[^\n]*;\s*then", re.MULTILINE)
+    assert gate.search(body), (
+        "run_setup_wizard must gate on an open-based probe of /dev/tty "
+        "(an `if`/`if !` whose test redirects stdin from /dev/tty), not a "
+        "mere existence check. See #16746."
     )


### PR DESCRIPTION
Salvages #16750 by @briandevans and widens the fix to the two sibling gates the original PR punted.

## Summary
Replace every `[ -e /dev/tty ]` gate in `scripts/install.sh` that guards a subsequent `< /dev/tty` redirect with an open-based probe `(: </dev/tty) 2>/dev/null`. In Docker builds the device node exists in the mount namespace but opening it fails with ENXIO, so the bare existence test returned true and the redirect crashed the build a few lines later.

## Changes
- `scripts/install.sh` — three sites, same fix:
  - `run_setup_wizard()` line 1333 (briandevans' original — the reproducer in #16746)
  - `install_system_packages()` line 732 (apt sudo prompt fallback, `sudo ... < /dev/tty` would die with the same ENXIO)
  - `maybe_start_gateway()` line 1395 (gateway-install gate, same function path as the wizard reproducer)
- `tests/test_install_sh_setup_wizard_tty_probe.py` — parametrized over all three functions so any future regression is caught regardless of which site breaks.

## Validation
| | Before | After |
|---|---|---|
| Probe on `stdin=/dev/null` | `[ -e /dev/tty ]` passes → crash on `< /dev/tty` | `(: </dev/tty)` fails → skip runs |
| Probe on real tty | passes (unchanged) | passes (unchanged) |
| Regression test | n/a | 6 passed (3 functions × 2 assertions) |
| bash -n syntax | OK | OK |

## Related
- Fixes #16746
- Supersedes #16750 (briandevans' commits cherry-picked with authorship preserved)

## Credit
@briandevans wrote the wizard fix and the original regex-based regression test. This PR rebase-merges those commits and adds a widening commit for the two sibling sites plus test parametrization.