### PR TITLE
docs(config): surface telegram.reactions in DEFAULT_CONFIG

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -932,6 +932,7 @@ DEFAULT_CONFIG = {
 
     # Telegram platform settings (gateway mode)
     "telegram": {
+        "reactions": False,            # Add 👀/✅/❌ reactions to messages during processing
         "channel_prompts": {},         # Per-chat/topic ephemeral system prompts (topics inherit from parent group)
     },
 


### PR DESCRIPTION
## Summary
Surface the existing `telegram.reactions` config key in `DEFAULT_CONFIG` so users can discover it. No behavior change — default stays `False`.

The key was already wired up (`gateway/config.py:706-707` bridges `telegram.reactions` → `TELEGRAM_REACTIONS` env var at gateway startup) but was missing from `DEFAULT_CONFIG`, so users had no way to find it without reading the source.

## Changes
- `hermes_cli/config.py`: add `"reactions": False` under the `telegram:` block in `DEFAULT_CONFIG`.

Users who want Telegram's 👀/✅/❌ processing-lifecycle reactions can now set `telegram.reactions: true` in `config.yaml`.
