### PR TITLE
fix(discord): widen slash-sync timeout to 600s under rate-limit pressure (#16713)

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -813,7 +813,14 @@ class DiscordAdapter(BasePlatformAdapter):
                 logger.info("[%s] Synced %d slash command(s) via bulk tree sync", self.name, len(synced))
                 return
 
-            summary = await asyncio.wait_for(self._safe_sync_slash_commands(), timeout=30)
+            # Discord's per-app command-management bucket is ~5 writes / 20 s,
+            # so a mass-prune-plus-upsert reconcile (e.g. 77 orphans + 30
+            # desired = 107 writes) takes several minutes of forced waits.
+            # A flat 30 s budget blew up reliably under bucket pressure and
+            # left slash commands broken for ~60 min until the bucket fully
+            # recovered. Use a wide ceiling; the cap still guards against a
+            # true hang. (#16713)
+            summary = await asyncio.wait_for(self._safe_sync_slash_commands(), timeout=600)
             logger.info(
                 "[%s] Safely reconciled %d slash command(s): unchanged=%d updated=%d recreated=%d created=%d deleted=%d",
                 self.name,
@@ -825,7 +832,11 @@ class DiscordAdapter(BasePlatformAdapter):
                 summary["deleted"],
             )
         except asyncio.TimeoutError:
-            logger.warning("[%s] Slash command sync timed out after 30s", self.name)
+            logger.warning(
+                "[%s] Slash command sync timed out — Discord rate-limit bucket "
+                "may be saturated; will retry on next reconnect",
+                self.name,
+            )
         except asyncio.CancelledError:
             raise
         except Exception as e:  # pragma: no cover - defensive logging


### PR DESCRIPTION
## Summary
Bumps the outer `asyncio.wait_for` around `_safe_sync_slash_commands` from 30 s to 600 s so mass-prune-plus-upsert reconciles drain under Discord's ~5-writes/20-s command-management bucket. The 600 s cap still guards against a true hang.

Root cause: flat 30 s budget. A 107-write reconcile (77 orphans + 30 desired, from the bug report) needs several minutes of forced rate-limit waits to finish; the old budget cancelled mid-loop, subsequent reconnects inside the cooldown also timed out, and slash commands stayed broken for ~60 min until the bucket fully recovered.

Simpler alternative to #16739's plan/execute split + write-count-derived budget — the 600 s ceiling is the only load-bearing number.

## Changes
- `gateway/platforms/discord.py` `_run_post_connect_initialization`: timeout 30 → 600, warning message updated to point at saturated bucket.

## Validation
| | Before | After |
|---|---|---|
| 107-write reconcile under bucket pressure | cancelled at 30 s, ~60 min outage | drains in ~7 min, no outage |
| True hang | detected at 30 s | detected at 600 s (still bounded) |
| `tests/gateway/test_discord_connect.py` | 11 passed | 11 passed |

Credit: @Tranquil-Flow (PR #16739) and @davidbordenwi (issue #16713 bucket-math diagnosis).

Closes #16713.