### PR TITLE
fix(nix): deprecate extraPackages — does not reach terminal/skills

### DIFF
--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -455,7 +455,16 @@
       extraPackages = mkOption {
         type = types.listOf types.package;
         default = [ ];
-        description = "Extra packages available on PATH.";
+        description = ''
+          **Deprecated.** Extra packages on the systemd service PATH.
+
+          This option does NOT make packages available to terminal commands
+          or skills — the terminal backend's login shell rebuilds PATH from
+          NixOS system profiles, discarding the service PATH.
+
+          Use `environment.systemPackages` instead, which works everywhere:
+          service process, terminal commands, skills, cron jobs.
+        '';
       };
 
       extraPlugins = mkOption {
@@ -640,6 +649,23 @@
       }
 
       # ── Warnings ──────────────────────────────────────────────────────
+      (lib.mkIf (cfg.extraPackages != []) {
+        warnings = [
+          ''
+            services.hermes-agent: `extraPackages` is deprecated and will be removed in a future release.
+
+            Packages added via `extraPackages` are only visible to the systemd
+            service process itself. Terminal commands, skills, and cron jobs do
+            NOT see them because the terminal backend starts a login shell whose
+            PATH is rebuilt from NixOS system profiles, discarding the service PATH.
+
+            Migrate to `environment.systemPackages`, which works everywhere:
+
+              environment.systemPackages = [ ${lib.concatMapStringsSep " " (p: "pkgs.${p.pname or (lib.getName p)}") cfg.extraPackages} ];
+          ''
+        ];
+      })
+
       (lib.mkIf (cfg.container.enable && !cfg.addToSystemPackages && cfg.container.hostUsers != []) {
         warnings = [
           ''

--- a/website/docs/getting-started/nix-setup.md
+++ b/website/docs/getting-started/nix-setup.md
@@ -321,7 +321,7 @@ Quick reference for the most common things Nix users want to customize:
 | Pass GPU access to container | `container.extraOptions` | `[ "--gpus" "all" ]` |
 | Use Podman instead of Docker | `container.backend` | `"podman"` |
 | Share state between host CLI and container | `container.hostUsers` | `[ "sidbin" ]` |
-| Add tools to the service PATH (native only) | `extraPackages` | `[ pkgs.pandoc pkgs.imagemagick ]` |
+| Make extra tools available to the agent | `environment.systemPackages` (top-level NixOS) | `[ pkgs.pandoc pkgs.imagemagick ]` |
 | Use a custom base image | `container.image` | `"ubuntu:24.04"` |
 | Override the hermes package | `package` | `inputs.hermes-agent.packages.${system}.default.override { ... }` |
 | Change state directory | `stateDir` | `"/opt/hermes"` |
@@ -648,11 +648,14 @@ The package's `site-packages` is added to PYTHONPATH in the hermes wrapper. `imp
 A directory plugin with third-party Python dependencies needs both options:
 
 ```nix
+# Plugin config
 services.hermes-agent = {
   extraPlugins = [ my-plugin-src ];          # plugin source
   extraPythonPackages = [ pkgs.python312Packages.redis ];  # its Python dep
-  extraPackages = [ pkgs.redis ];            # system binary it needs
 };
+
+# System binaries the plugin needs — available to terminal, skills, cron
+environment.systemPackages = [ pkgs.redis ];
 ```
 
 ### Using the Overlay
@@ -807,7 +810,7 @@ nix build .#checks.x86_64-linux.config-roundtrip    # merge script preserves use
 | Option | Type | Default | Description |
 |---|---|---|---|
 | `extraArgs` | `listOf str` | `[]` | Extra args for `hermes gateway` |
-| `extraPackages` | `listOf package` | `[]` | Extra packages on service PATH (native mode only) |
+| `extraPackages` | `listOf package` | `[]` | **Deprecated.** Use `environment.systemPackages` instead. Only affects the systemd service process — terminal commands, skills, and cron jobs do not see these packages |
 | `extraPlugins` | `listOf package` | `[]` | Directory plugin packages to symlink into `$HERMES_HOME/plugins/`. Each must contain `plugin.yaml` |
 | `extraPythonPackages` | `listOf package` | `[]` | Python packages added to PYTHONPATH for entry-point plugin discovery. Build with `python312Packages` |
 | `restart` | `str` | `"always"` | systemd `Restart=` policy |
@@ -945,3 +948,4 @@ nix-store --query --roots $(docker exec hermes-agent readlink /data/current-pack
 | `nix-collect-garbage` removed hermes | GC root missing | Restart the service (preStart recreates the GC root) |
 | `no container with name or ID "hermes-agent"` (Podman) | Podman rootful container not visible to regular user | Add passwordless sudo for podman (see [Container-aware CLI](#container-aware-cli) section) |
 | `unable to find user hermes` | Container still starting (entrypoint hasn't created user yet) | Wait a few seconds and retry — the CLI retries automatically |
+| Tool added via `extraPackages` not found in terminal | `extraPackages` only sets the systemd service PATH, not the terminal backend's | Move to `environment.systemPackages` — see deprecation warning at build time |


### PR DESCRIPTION
## Problem

`extraPackages` promises "extra packages available on PATH" but only delivers for the systemd service process itself — not for the terminal commands the agent actually runs.

**The mechanism:**

1. NixOS `systemd.services.<name>.path` constructs a `PATH` from the listed packages' `/bin`/`/sbin` dirs
2. The hermes gateway process starts with `pandoc`, `poppler-utils`, etc. on its PATH ✓
3. The terminal backend does a login-shell snapshot (`bash -lc 'echo $PATH'`)
4. NixOS's `/etc/set-environment` replaces PATH with the system profile paths
5. The snapshot — which is what every `terminal()` call, skill, and cron job uses — **no longer has the extra packages** ✗

A user writing this:

```nix
services.hermes-agent = {
  enable = true;
  extraPackages = [ pkgs.pandoc pkgs.poppler_utils ];
};
```

…gets packages the agent *process* can see but the agent's *terminal commands* cannot. The fix is trivial on the user side — `environment.systemPackages` is the NixOS-native way to make tools available system-wide — but `extraPackages` as documented was misleading.

## Changes

### `nix/nixosModules.nix`
- **Option description** — marked as deprecated with explanation of why it doesn't work as expected
- **Runtime warning** — `mkIf (cfg.extraPackages != [])` emits a NixOS evaluation warning with:
  - Clear explanation of the mechanism (login shell rebuilds PATH, discarding service PATH)
  - Ready-to-paste `environment.systemPackages = [ ... ]` replacement, auto-generated from the user's current `extraPackages` list via `lib.concatMapStringsSep`
- **Non-breaking** — the option still appends to `path` (line 895) so existing configs keep working while users migrate

### `website/docs/getting-started/nix-setup.md`
- **Quick-reference table** — `extraPackages` row replaced with `environment.systemPackages (top-level NixOS)` to make clear this is a NixOS option, not a hermes-agent sub-option
- **Plugin "Combining Both" example** — split system binaries out to `environment.systemPackages` with comment explaining the scope
- **Options reference table** — marked deprecated with explanation
- **Common Issues table** — added row for "Tool added via `extraPackages` not found in terminal" with cause and fix

## Non-goals

This PR does **not** remove the option or change its runtime behavior. It's a deprecation notice only — users get a warning at `nixos-rebuild` time and clear migration instructions.

A future PR could either remove the option entirely or make it actually work by injecting the store paths into the terminal backend's PATH snapshot. The latter is more complex and arguably the wrong abstraction — `environment.systemPackages` is the idiomatic NixOS approach.
