### PR TITLE
fix(gateway): guard against None request_overrides in _build_api_kwargs

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1271,14 +1271,14 @@ class GatewayRunner:
 
         service_tier = getattr(self, "_service_tier", None)
         if not service_tier:
-            route["request_overrides"] = None
+            route["request_overrides"] = {}
             return route
 
         try:
             overrides = resolve_fast_mode_overrides(route["model"])
         except Exception:
             overrides = None
-        route["request_overrides"] = overrides
+        route["request_overrides"] = overrides or {}
         return route
 
     async def _handle_adapter_fatal_error(self, adapter: BasePlatformAdapter) -> None:
@@ -10476,7 +10476,7 @@ class GatewayRunner:
             agent.status_callback = _status_callback_sync
             agent.reasoning_config = reasoning_config
             agent.service_tier = self._service_tier
-            agent.request_overrides = turn_route.get("request_overrides")
+            agent.request_overrides = turn_route.get("request_overrides") or {}
 
             _bg_review_release = threading.Event()
             _bg_review_pending: list[str] = []

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -118,7 +118,7 @@ def test_turn_route_skips_priority_processing_for_unsupported_models():
 
     route = gateway_run.GatewayRunner._resolve_turn_agent_config(runner, "hi", "gpt-5.3-codex", runtime_kwargs)
 
-    assert route["request_overrides"] is None
+    assert route["request_overrides"] == {}
 
 
 @pytest.mark.asyncio

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -251,6 +251,14 @@ class TestBuildApiKwargsChatCompletionsServiceTier:
         kwargs = agent._build_api_kwargs(messages)
         assert "service_tier" not in kwargs
 
+    def test_no_crash_when_request_overrides_is_none(self, monkeypatch):
+        agent = _make_agent(monkeypatch, "openrouter")
+        agent.model = "gpt-4.1"
+        agent.request_overrides = None
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert "service_tier" not in kwargs
+
 
 class TestBuildApiKwargsKimiNoTemperatureOverride:
     def test_kimi_for_coding_omits_temperature(self, monkeypatch):


### PR DESCRIPTION
## Summary

Salvage of #7305 by @konsisumer — normalizes `request_overrides` from `None` to `{}` at the source in gateway/run.py so downstream code never encounters NoneType.

Closes #7215, closes #7259, closes #7277

### Background

Commit 970192f1 (fast mode support) introduced `request_overrides` plumbing in the gateway. Three sites in `_resolve_turn_agent_config` could produce `None`:
1. No service tier configured → `route["request_overrides"] = None`
2. `resolve_fast_mode_overrides()` raises → `overrides = None`
3. Cached agent path directly assigns `turn_route.get("request_overrides")` which can be `None`

This caused `AttributeError: 'NoneType' object has no attribute 'get'` on every gateway message for users without fast mode configured.

The acute crash was already mitigated by PR #7350 (added `or {}` at the access site in `_build_api_kwargs`). This PR fixes the **root cause** — the gateway now always produces `{}` instead of `None`, preventing any future consumer from hitting the same bug.

### Changes

- `gateway/run.py`: Three sites in `_resolve_turn_agent_config` normalized from `None` to `{}`
- `tests/gateway/test_fast_command.py`: Updated assertion from `is None` to `== {}`
- `tests/run_agent/test_provider_parity.py`: New test for `_build_api_kwargs` with `request_overrides = None`

All 4 targeted tests pass. Clean cherry-pick, no conflicts (only 19 commits behind main).
