### PR TITLE
fix(wecom): fix media file/image receiving issues

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -480,6 +480,17 @@ class WeComAdapter(BasePlatformAdapter):
         if not isinstance(body, dict):
             return
 
+        # Debug: log full message structure for media debugging
+        import json
+        msgtype = str(body.get("msgtype") or "").lower()
+        if msgtype in ("image", "file", "mixed"):
+            logger.info(
+                "[%s] Received %s message, full body: %s",
+                self.name,
+                msgtype,
+                json.dumps(body, ensure_ascii=False, indent=2),
+            )
+
         msg_id = str(body.get("msgid") or self._payload_req_id(payload) or uuid.uuid4().hex)
         if self._dedup.is_duplicate(msg_id):
             logger.debug("[%s] Duplicate message %s ignored", self.name, msg_id)
@@ -1010,6 +1021,8 @@ class WeComAdapter(BasePlatformAdapter):
         if not aes_key:
             raise ValueError("aes_key is required")
 
+        # WeCom doesn't pad base64 keys; add padding if needed
+        aes_key = aes_key + '=' * ((4 - len(aes_key) % 4) % 4)
         key = base64.b64decode(aes_key)
         if len(key) != 32:
             raise ValueError(f"Invalid WeCom AES key length: expected 32 bytes, got {len(key)}")

--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -61,6 +61,7 @@ _ALWAYS_BLOCKED_NETWORKS = (
 # to 198.18.0.0/15 behind local proxy/benchmark infrastructure.
 _TRUSTED_PRIVATE_IP_HOSTS = frozenset({
     "multimedia.nt.qq.com.cn",
+    "ww-aibot-img-1258476243.cos.ap-guangzhou.myqcloud.com",
 })
 
 # 100.64.0.0/10 (CGNAT / Shared Address Space, RFC 6598) is NOT covered by


### PR DESCRIPTION
## Fixes two WeCom media receiving issues:

### 1. AES key base64 padding missing issue
- **Problem**: WeCom doesn't pad base64 aeskey with '=', causing Python strict mode decode failure
- **Fix**: Add automatic padding: 

### 2. WeCom COS domain SSRF blocking issue
- **Problem**:  resolves to 198.18.x.x (IANA reserved range), which was being blocked by SSRF protection
- **Fix**: Add the WeCom COS domain to  whitelist

Both fixes have been tested and verified working on WeCom private chat.