### PR TITLE
fix(gateway): keep DoH-confirmed Telegram IPs that match system DNS (#14520)

### DIFF
--- a/gateway/platforms/telegram_network.py
+++ b/gateway/platforms/telegram_network.py
@@ -185,10 +185,13 @@ async def _query_doh_provider(
 async def discover_fallback_ips() -> list[str]:
     """Auto-discover Telegram API IPs via DNS-over-HTTPS.
 
-    Resolves api.telegram.org through Google and Cloudflare DoH, collects all
-    unique IPs, and excludes the system-DNS-resolved IP (which is presumably
-    unreachable on this network).  Falls back to a hardcoded seed list when DoH
-    is also unavailable.
+    Resolves api.telegram.org through Google and Cloudflare DoH and returns all
+    unique A records.  IPs that match the local system resolver are kept rather
+    than excluded: in many networks the system-DNS IP is the most reliable path
+    to api.telegram.org and a transient primary-path failure should be retried
+    against the same address via the IP-rewrite path before the seed list is
+    consulted (#14520).  Falls back to a hardcoded seed list only when DoH
+    yields no usable answers.
     """
     async with httpx.AsyncClient(timeout=httpx.Timeout(_DOH_TIMEOUT)) as client:
         doh_tasks = [_query_doh_provider(client, p) for p in _DOH_PROVIDERS]
@@ -203,11 +206,11 @@ async def discover_fallback_ips() -> list[str]:
         if isinstance(r, list):
             doh_ips.extend(r)
 
-    # Deduplicate preserving order, exclude system-DNS IPs
+    # Deduplicate preserving order
     seen: set[str] = set()
     candidates: list[str] = []
     for ip in doh_ips:
-        if ip not in seen and ip not in system_ips:
+        if ip not in seen:
             seen.add(ip)
             candidates.append(ip)
 
@@ -219,7 +222,7 @@ async def discover_fallback_ips() -> list[str]:
         return validated
 
     logger.info(
-        "DoH discovery yielded no new IPs (system DNS: %s); using seed fallback IPs %s",
+        "DoH discovery yielded no usable IPs (system DNS: %s); using seed fallback IPs %s",
         ", ".join(system_ips) or "unknown",
         ", ".join(_SEED_FALLBACK_IPS),
     )

--- a/tests/gateway/test_telegram_network.py
+++ b/tests/gateway/test_telegram_network.py
@@ -534,15 +534,20 @@ class TestDiscoverFallbackIps:
         assert "149.154.167.221" in ips
 
     @pytest.mark.asyncio
-    async def test_system_dns_ip_excluded(self, monkeypatch):
-        """The IP from system DNS is the one that doesn't work — exclude it."""
+    async def test_system_dns_ip_kept_when_doh_confirms(self, monkeypatch):
+        """DoH-confirmed IPs are kept even when they match system DNS (#14520).
+
+        The system-DNS IP is often the most reliable path; including it as a
+        fallback lets the IP-rewrite retry recover from transient primary-path
+        failures instead of jumping straight to the hardcoded seed list.
+        """
         self._patch_doh(monkeypatch, {
             "https://dns.google": (200, _doh_answer("149.154.166.110", "149.154.167.220")),
             "https://cloudflare-dns.com": (200, _doh_answer("149.154.166.110")),
         }, system_dns_ips=["149.154.166.110"])
 
         ips = await tnet.discover_fallback_ips()
-        assert ips == ["149.154.167.220"]
+        assert ips == ["149.154.166.110", "149.154.167.220"]
 
     @pytest.mark.asyncio
     async def test_doh_results_deduplicated(self, monkeypatch):
@@ -607,15 +612,21 @@ class TestDiscoverFallbackIps:
         assert "149.154.167.220" in ips
 
     @pytest.mark.asyncio
-    async def test_all_doh_ips_same_as_system_dns_uses_seed(self, monkeypatch):
-        """DoH returns only the same blocked IP — seed list is the fallback."""
+    async def test_all_doh_ips_same_as_system_dns_kept(self, monkeypatch):
+        """DoH agrees with system DNS — keep that IP instead of seed list (#14520).
+
+        Previous behavior fell through to ``_SEED_FALLBACK_IPS`` here, but the
+        seed addresses are not routable on every network.  When DoH confirms
+        the system IP, that IP is the best candidate we have and should be
+        used as the fallback target.
+        """
         self._patch_doh(monkeypatch, {
             "https://dns.google": (200, _doh_answer("149.154.166.110")),
             "https://cloudflare-dns.com": (200, _doh_answer("149.154.166.110")),
         }, system_dns_ips=["149.154.166.110"])
 
         ips = await tnet.discover_fallback_ips()
-        assert ips == tnet._SEED_FALLBACK_IPS
+        assert ips == ["149.154.166.110"]
 
     @pytest.mark.asyncio
     async def test_cloudflare_gets_accept_header(self, monkeypatch):


### PR DESCRIPTION
## Summary

`discover_fallback_ips()` in `gateway/platforms/telegram_network.py` filtered out any DoH-resolved IP that also appeared in the local system resolver's answer set, on the assumption that the system IP was unreachable. When DoH and system DNS agreed (a common case), the function returned the hardcoded `_SEED_FALLBACK_IPS` list instead — and on networks where those seed addresses are not routable, the Telegram fallback transport had no usable retry target and polling failed.

This drops the `system_ips` exclusion so DoH-confirmed IPs are preserved regardless of system-DNS overlap. `TelegramFallbackTransport` already tries the primary path first (via system DNS), then falls through to the IP-rewrite path on connect failure; including the same IP in both lanes lets a transient primary failure recover via the explicit IP route instead of escalating to seed addresses that may not route.

The two existing tests that codified the old exclusion are updated to reflect the new inclusion-by-default behaviour and renamed for clarity.

Fixes #14520

## Behavior change

| Scenario | Before | After |
|---|---|---|
| DoH returns `[sys_ip, X]`, system resolves `[sys_ip]` | `[X]` | `[sys_ip, X]` |
| DoH returns `[sys_ip]`, system resolves `[sys_ip]` | `_SEED_FALLBACK_IPS` (e.g. `149.154.167.220`) | `[sys_ip]` |
| DoH returns `[X, Y]`, system resolves `[sys_ip]` | `[X, Y]` | `[X, Y]` (unchanged) |
| DoH unavailable | `_SEED_FALLBACK_IPS` (unchanged) | `_SEED_FALLBACK_IPS` (unchanged) |

The third and fourth rows are unchanged, so users on networks where the seed list is reachable retain the existing safety net.

## Test plan

- [x] `tests/gateway/test_telegram_network.py` — 46 tests pass (12 in `TestDiscoverFallbackIps`)
- [x] `tests/gateway/test_telegram_network_reconnect.py` — 9 tests pass
- [x] Two existing tests updated:
  - `test_system_dns_ip_excluded` → `test_system_dns_ip_kept_when_doh_confirms`
  - `test_all_doh_ips_same_as_system_dns_uses_seed` → `test_all_doh_ips_same_as_system_dns_kept`