### PR TITLE
security(tui-gateway): fail-closed dangerous-command check in shell.exec / command.dispatch (#16560)

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -7,6 +7,8 @@ import types
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from tui_gateway import server
 
 
@@ -1567,6 +1569,85 @@ def test_command_dispatch_exec_nonzero_surfaces_error(monkeypatch):
 
     assert "error" in resp
     assert "failed" in resp["error"]["message"]
+
+
+def test_shell_exec_blocks_dangerous_command(monkeypatch):
+    """shell.exec must refuse commands the dangerous-command detector flags."""
+    monkeypatch.setattr(
+        "tools.approval.detect_dangerous_command",
+        lambda cmd: (True, "RM_RF_ROOT", "rm -rf /"),
+    )
+    # If the detector reports dangerous, no subprocess.run call should happen.
+    monkeypatch.setattr(
+        server.subprocess,
+        "run",
+        lambda *a, **kw: pytest.fail("subprocess.run must not run for blocked commands"),
+    )
+
+    resp = server.handle_request(
+        {"id": "1", "method": "shell.exec", "params": {"command": "rm -rf /"}}
+    )
+
+    assert "error" in resp
+    assert resp["error"]["code"] == 4005
+
+
+def test_shell_exec_fails_closed_when_safety_module_missing(monkeypatch):
+    """shell.exec must refuse to run when tools.approval is unimportable (#16560).
+
+    Previously the server caught ImportError and silently fell through to
+    ``subprocess.run(cmd, shell=True, ...)``, letting any caller bypass the
+    danger check by removing or shadowing the safety module. The fix surfaces
+    the failure as an error instead of executing the command unchecked.
+    """
+    real_import = __builtins__["__import__"] if isinstance(__builtins__, dict) else __builtins__.__import__
+
+    def _import_blocking_approval(name, *args, **kwargs):
+        if name == "tools.approval":
+            raise ImportError("tools.approval missing")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(
+        server.subprocess,
+        "run",
+        lambda *a, **kw: pytest.fail("subprocess.run must not run when safety module is missing"),
+    )
+    if isinstance(__builtins__, dict):
+        monkeypatch.setitem(__builtins__, "__import__", _import_blocking_approval)
+    else:
+        monkeypatch.setattr(__builtins__, "__import__", _import_blocking_approval)
+
+    resp = server.handle_request(
+        {"id": "1", "method": "shell.exec", "params": {"command": "echo hello"}}
+    )
+
+    assert "error" in resp
+    assert "safety module unavailable" in resp["error"]["message"]
+
+
+def test_command_dispatch_blocks_dangerous_quick_command(monkeypatch):
+    """quick_commands matched by command.dispatch must clear the danger check too."""
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {"quick_commands": {"wipe": {"type": "exec", "command": ":(){ :|:& };:"}}},
+    )
+    monkeypatch.setattr(
+        "tools.approval.detect_dangerous_command",
+        lambda cmd: (True, "FORK_BOMB", "fork bomb"),
+    )
+    monkeypatch.setattr(
+        server.subprocess,
+        "run",
+        lambda *a, **kw: pytest.fail("subprocess.run must not run for blocked quick commands"),
+    )
+
+    resp = server.handle_request(
+        {"id": "1", "method": "command.dispatch", "params": {"name": "wipe"}}
+    )
+
+    assert "error" in resp
+    assert resp["error"]["code"] == 4005
 
 
 def test_plugins_list_surfaces_loader_error(monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3544,6 +3544,26 @@ def _resolve_name(name: str) -> str:
         return name
 
 
+def _check_dangerous_shell_command(cmd: str):
+    """Run the shared dangerous-command detector and surface any failure.
+
+    Returns ``None`` when the command is safe to execute. Returns a tuple
+    ``(error_code, error_message)`` when execution must be refused — either
+    because the command matched a dangerous pattern or because the safety
+    module itself failed to load. Failing the import path closed avoids the
+    earlier ``except ImportError: pass`` which let raw user input run
+    unchecked when ``tools.approval`` was missing (#16560).
+    """
+    try:
+        from tools.approval import detect_dangerous_command
+    except ImportError as exc:
+        return (5023, f"command safety module unavailable, refusing to execute: {exc}")
+    is_dangerous, _, desc = detect_dangerous_command(cmd)
+    if is_dangerous:
+        return (4005, f"blocked: {desc}. Use the agent for dangerous commands.")
+    return None
+
+
 @method("command.dispatch")
 def _(rid, params: dict) -> dict:
     name, arg = params.get("name", "").lstrip("/"), params.get("arg", "")
@@ -3556,8 +3576,12 @@ def _(rid, params: dict) -> dict:
     if name in qcmds:
         qc = qcmds[name]
         if qc.get("type") == "exec":
+            cmd_str = qc.get("command", "")
+            block = _check_dangerous_shell_command(cmd_str)
+            if block is not None:
+                return _err(rid, block[0], block[1])
             r = subprocess.run(
-                qc.get("command", ""),
+                cmd_str,
                 shell=True,
                 capture_output=True,
                 text=True,
@@ -5020,16 +5044,9 @@ def _(rid, params: dict) -> dict:
     cmd = params.get("command", "")
     if not cmd:
         return _err(rid, 4004, "empty command")
-    try:
-        from tools.approval import detect_dangerous_command
-
-        is_dangerous, _, desc = detect_dangerous_command(cmd)
-        if is_dangerous:
-            return _err(
-                rid, 4005, f"blocked: {desc}. Use the agent for dangerous commands."
-            )
-    except ImportError:
-        pass
+    block = _check_dangerous_shell_command(cmd)
+    if block is not None:
+        return _err(rid, block[0], block[1])
     try:
         r = subprocess.run(
             cmd, shell=True, capture_output=True, text=True, timeout=30, cwd=os.getcwd()


### PR DESCRIPTION
## Summary

Two ``subprocess.run(..., shell=True)`` call sites in ``tui_gateway/server.py`` accept input that is not gated by the danger-pattern check:

- ``shell.exec`` (JSON-RPC method, ``cmd`` from request params) wrapped the ``detect_dangerous_command`` import in ``except ImportError: pass`` — any caller able to make ``tools.approval`` un-importable (deleted, shadowed, broken venv) bypassed the entire safety gate.
- ``command.dispatch`` for ``quick_commands`` ran the configured command via ``shell=True`` straight from ``_load_cfg()`` with no danger check at all.

## Fix

Hoist the danger check into ``_check_dangerous_shell_command()``, which treats both pattern matches and import failures as a refusal (returns a JSON-RPC error instead of executing). Both call sites now share the same fail-closed gate, so an environment that breaks the safety module fails loudly instead of silently dropping protection, and quick commands match the same standard as ``shell.exec``.

## Test plan

- [x] ``test_shell_exec_blocks_dangerous_command`` — flagged command is refused (existing pattern path).
- [x] ``test_shell_exec_fails_closed_when_safety_module_missing`` — ``ImportError`` no longer falls through to ``subprocess.run``.
- [x] ``test_command_dispatch_blocks_dangerous_quick_command`` — flagged ``quick_commands`` entry is refused.
- [x] ``test_command_dispatch_exec_nonzero_surfaces_error`` (existing) still passes — non-flagged quick commands run unchanged.

Fixes #16560