### PR TITLE
fix(nix): make extraPackages actually work via per-user profile

### DIFF
--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -456,14 +456,13 @@
         type = types.listOf types.package;
         default = [ ];
         description = ''
-          **Deprecated.** Extra packages on the systemd service PATH.
+          Extra packages available to the agent — terminal commands, skills,
+          cron jobs, and the service process all see them.
 
-          This option does NOT make packages available to terminal commands
-          or skills — the terminal backend's login shell rebuilds PATH from
-          NixOS system profiles, discarding the service PATH.
-
-          Use `environment.systemPackages` instead, which works everywhere:
-          service process, terminal commands, skills, cron jobs.
+          Implemented via the hermes user's per-user profile
+          (`/etc/profiles/per-user/${cfg.user}/bin`), which NixOS includes
+          in PATH for login shells.  The packages are also added to the
+          systemd service PATH for direct process access.
         '';
       };
 
@@ -649,21 +648,12 @@
       }
 
       # ── Warnings ──────────────────────────────────────────────────────
+      # ── Per-user profile for extraPackages ───────────────────────────
+      # Wire extraPackages into the hermes user's per-user profile so the
+      # login-shell snapshot (which rebuilds PATH from NixOS profiles) sees
+      # them.  The systemd service PATH also includes them for direct access.
       (lib.mkIf (cfg.extraPackages != []) {
-        warnings = [
-          ''
-            services.hermes-agent: `extraPackages` is deprecated and will be removed in a future release.
-
-            Packages added via `extraPackages` are only visible to the systemd
-            service process itself. Terminal commands, skills, and cron jobs do
-            NOT see them because the terminal backend starts a login shell whose
-            PATH is rebuilt from NixOS system profiles, discarding the service PATH.
-
-            Migrate to `environment.systemPackages`, which works everywhere:
-
-              environment.systemPackages = [ ${lib.concatMapStringsSep " " (p: "pkgs.${p.pname or (lib.getName p)}") cfg.extraPackages} ];
-          ''
-        ];
+        users.users.${cfg.user}.packages = cfg.extraPackages;
       })
 
       (lib.mkIf (cfg.container.enable && !cfg.addToSystemPackages && cfg.container.hostUsers != []) {

--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -653,6 +653,9 @@
       # login-shell snapshot (which rebuilds PATH from NixOS profiles) sees
       # them.  The systemd service PATH also includes them for direct access.
       (lib.mkIf (cfg.extraPackages != []) {
+        # listOf options are merged by the NixOS module system — this appends to
+        # any packages the operator assigned to this user externally (e.g. when
+        # createUser = false and the user definition lives elsewhere in the config).
         users.users.${cfg.user}.packages = cfg.extraPackages;
       })
 

--- a/website/docs/getting-started/nix-setup.md
+++ b/website/docs/getting-started/nix-setup.md
@@ -321,7 +321,7 @@ Quick reference for the most common things Nix users want to customize:
 | Pass GPU access to container | `container.extraOptions` | `[ "--gpus" "all" ]` |
 | Use Podman instead of Docker | `container.backend` | `"podman"` |
 | Share state between host CLI and container | `container.hostUsers` | `[ "sidbin" ]` |
-| Make extra tools available to the agent | `environment.systemPackages` (top-level NixOS) | `[ pkgs.pandoc pkgs.imagemagick ]` |
+| Make extra tools available to the agent | `extraPackages` | `[ pkgs.pandoc pkgs.imagemagick ]` |
 | Use a custom base image | `container.image` | `"ubuntu:24.04"` |
 | Override the hermes package | `package` | `inputs.hermes-agent.packages.${system}.default.override { ... }` |
 | Change state directory | `stateDir` | `"/opt/hermes"` |
@@ -648,14 +648,11 @@ The package's `site-packages` is added to PYTHONPATH in the hermes wrapper. `imp
 A directory plugin with third-party Python dependencies needs both options:
 
 ```nix
-# Plugin config
 services.hermes-agent = {
   extraPlugins = [ my-plugin-src ];          # plugin source
   extraPythonPackages = [ pkgs.python312Packages.redis ];  # its Python dep
+  extraPackages = [ pkgs.redis ];            # system binary it needs
 };
-
-# System binaries the plugin needs — available to terminal, skills, cron
-environment.systemPackages = [ pkgs.redis ];
 ```
 
 ### Using the Overlay
@@ -810,7 +807,7 @@ nix build .#checks.x86_64-linux.config-roundtrip    # merge script preserves use
 | Option | Type | Default | Description |
 |---|---|---|---|
 | `extraArgs` | `listOf str` | `[]` | Extra args for `hermes gateway` |
-| `extraPackages` | `listOf package` | `[]` | **Deprecated.** Use `environment.systemPackages` instead. Only affects the systemd service process — terminal commands, skills, and cron jobs do not see these packages |
+| `extraPackages` | `listOf package` | `[]` | Extra packages available to the agent. Added to the hermes user's per-user profile so terminal commands, skills, and cron jobs all see them |
 | `extraPlugins` | `listOf package` | `[]` | Directory plugin packages to symlink into `$HERMES_HOME/plugins/`. Each must contain `plugin.yaml` |
 | `extraPythonPackages` | `listOf package` | `[]` | Python packages added to PYTHONPATH for entry-point plugin discovery. Build with `python312Packages` |
 | `restart` | `str` | `"always"` | systemd `Restart=` policy |
@@ -948,4 +945,4 @@ nix-store --query --roots $(docker exec hermes-agent readlink /data/current-pack
 | `nix-collect-garbage` removed hermes | GC root missing | Restart the service (preStart recreates the GC root) |
 | `no container with name or ID "hermes-agent"` (Podman) | Podman rootful container not visible to regular user | Add passwordless sudo for podman (see [Container-aware CLI](#container-aware-cli) section) |
 | `unable to find user hermes` | Container still starting (entrypoint hasn't created user yet) | Wait a few seconds and retry — the CLI retries automatically |
-| Tool added via `extraPackages` not found in terminal | `extraPackages` only sets the systemd service PATH, not the terminal backend's | Move to `environment.systemPackages` — see deprecation warning at build time |
+| Tool added via `extraPackages` not found in terminal | Requires `nixos-rebuild switch` to update the per-user profile | Rebuild and restart: `nixos-rebuild switch && systemctl restart hermes-agent` |


### PR DESCRIPTION
## Context

#17030 deprecated `extraPackages` because packages added to the systemd service PATH weren't visible to terminal commands, skills, or cron jobs — the terminal backend's login-shell snapshot rebuilds PATH from NixOS system profiles, discarding the service PATH.

The deprecation told users to switch to `environment.systemPackages`, which works but is a sledgehammer — it pollutes every user's shell on the system. If you only need pandoc for the hermes agent, you shouldn't have to put it in the global profile.

## The fix

Instead of deprecating, make `extraPackages` actually work. One line of logic:

```nix
(lib.mkIf (cfg.extraPackages != []) {
  users.users.${cfg.user}.packages = cfg.extraPackages;
})
```

This tells NixOS "the hermes user has these packages," which creates a per-user profile at `/etc/profiles/per-user/hermes/bin`. That path is already in the PATH that `/etc/set-environment` constructs:

```
PATH="$HOME/.nix-profile/bin:…:/etc/profiles/per-user/$USER/bin:…:/run/current-system/sw/bin"
```

The login-shell snapshot (`bash -l -c 'export -p'`) picks this up, so terminal commands, skills, and cron jobs all see the packages. The systemd `path` line still includes them too for direct process access.

## Why this works for system users

NixOS creates per-user profiles for **any** user with `packages != []` — there's no `isNormalUser` filter. From `nixos/modules/config/users-groups.nix`:

```nix
environment.etc = mapAttrs' (…)
  (filterAttrs (_: u: u.packages != [ ]) cfg.users);
```

## Verification

Tested in a NixOS VM (`nixos/lib` `runTest`):

```
✔ /etc/profiles/per-user/hermes/bin exists
✔ hello and jq binaries present in per-user profile
✔ su - hermes -c 'which hello' → /etc/profiles/per-user/hermes/bin/hello
✔ su - hermes -c 'hello' → "Hello, world!"
```

## Edge cases

- **`createUser = false`**: `users.users.<name>.packages` is additive — doesn't require the module to own the user definition. Works fine.
- **Container mode**: unaffected. `extraPackages` was always native-only (the systemd `path` line is inside `!cfg.container.enable`). The per-user profile lives on the host, not inside the container. No regression.

## Changes

### `nix/nixosModules.nix`
- Replace deprecation warning block with per-user profile wiring
- Update option description to reflect that it works everywhere now

### `website/docs/getting-started/nix-setup.md`
- Revert quick-reference table to `extraPackages` (was changed to `environment.systemPackages` in #17030)
- Restore plugin example using `extraPackages` for system binaries
- Update options reference description
