### PR TITLE
feat(backup): make backup excluded dirs extensible via HERMES_BACKUP_EXTRA_EXCLUDED_DIRS (#16988)

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -41,6 +41,26 @@ _EXCLUDED_DIRS = {
                         # session-hash-keyed so they don't port to another machine anyway
 }
 
+
+def _get_excluded_dirs() -> set[str]:
+    """Return the directory names skipped during backup.
+
+    Combines the built-in ``_EXCLUDED_DIRS`` with any extras supplied via the
+    ``HERMES_BACKUP_EXTRA_EXCLUDED_DIRS`` environment variable (comma- or
+    whitespace-separated). The env var lets users bolt their own
+    workflow-specific transient dirs onto the deny list (per-skill ``.venv``
+    folders, ``uv.lock`` build caches, etc.) without forking ``backup.py``.
+    Empty / unset env var preserves prior behaviour exactly. Requested in
+    issue #16988.
+    """
+    extra = os.environ.get("HERMES_BACKUP_EXTRA_EXCLUDED_DIRS", "")
+    if not extra:
+        return _EXCLUDED_DIRS
+    extras = {token for token in extra.replace(",", " ").split() if token}
+    if not extras:
+        return _EXCLUDED_DIRS
+    return _EXCLUDED_DIRS | extras
+
 # File-name suffixes to skip
 _EXCLUDED_SUFFIXES = (
     ".pyc",
@@ -67,8 +87,9 @@ def _should_exclude(rel_path: Path) -> bool:
     parts = rel_path.parts
 
     # Any path component matches an excluded dir name
+    excluded_dirs = _get_excluded_dirs()
     for part in parts:
-        if part in _EXCLUDED_DIRS:
+        if part in excluded_dirs:
             return True
 
     name = rel_path.name
@@ -153,6 +174,7 @@ def run_backup(args) -> None:
     files_to_add: list[tuple[Path, Path]] = []  # (absolute, relative)
     skipped_dirs = set()
 
+    excluded_dirs = _get_excluded_dirs()
     for dirpath, dirnames, filenames in os.walk(hermes_root, followlinks=False):
         dp = Path(dirpath)
         rel_dir = dp.relative_to(hermes_root)
@@ -161,7 +183,7 @@ def run_backup(args) -> None:
         orig_dirnames = dirnames[:]
         dirnames[:] = [
             d for d in dirnames
-            if d not in _EXCLUDED_DIRS
+            if d not in excluded_dirs
         ]
         for removed in set(orig_dirnames) - set(dirnames):
             skipped_dirs.add(str(rel_dir / removed))
@@ -709,10 +731,11 @@ def _write_full_zip_backup(out_path: Path, hermes_root: Path) -> Optional[Path]:
     """
     files_to_add: list[tuple[Path, Path]] = []
     try:
+        excluded_dirs = _get_excluded_dirs()
         for dirpath, dirnames, filenames in os.walk(hermes_root, followlinks=False):
             dp = Path(dirpath)
             # Prune excluded directories in-place so os.walk doesn't descend
-            dirnames[:] = [d for d in dirnames if d not in _EXCLUDED_DIRS]
+            dirnames[:] = [d for d in dirnames if d not in excluded_dirs]
 
             for fname in filenames:
                 fpath = dp / fname

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -140,6 +140,41 @@ class TestShouldExclude:
         assert not _should_exclude(Path("logs/agent.log"))
 
 
+class TestExtraExcludedDirsEnv:
+    """``HERMES_BACKUP_EXTRA_EXCLUDED_DIRS`` lets users add their own dirs (#16988)."""
+
+    def test_unset_env_preserves_default_set(self, monkeypatch):
+        from hermes_cli.backup import _EXCLUDED_DIRS, _get_excluded_dirs
+
+        monkeypatch.delenv("HERMES_BACKUP_EXTRA_EXCLUDED_DIRS", raising=False)
+        assert _get_excluded_dirs() == _EXCLUDED_DIRS
+
+    def test_empty_env_preserves_default_set(self, monkeypatch):
+        from hermes_cli.backup import _EXCLUDED_DIRS, _get_excluded_dirs
+
+        monkeypatch.setenv("HERMES_BACKUP_EXTRA_EXCLUDED_DIRS", "   ,  ")
+        assert _get_excluded_dirs() == _EXCLUDED_DIRS
+
+    def test_comma_separated_values_added(self, monkeypatch):
+        from hermes_cli.backup import _EXCLUDED_DIRS, _get_excluded_dirs
+
+        monkeypatch.setenv("HERMES_BACKUP_EXTRA_EXCLUDED_DIRS", ".venv, venv ,uv-build")
+        merged = _get_excluded_dirs()
+        assert {".venv", "venv", "uv-build"} <= merged
+        assert _EXCLUDED_DIRS <= merged
+        # Built-in defaults must not be lost when extras are added.
+        assert "hermes-agent" in merged
+
+    def test_should_exclude_honors_env_extras(self, monkeypatch):
+        from hermes_cli.backup import _should_exclude
+
+        monkeypatch.setenv("HERMES_BACKUP_EXTRA_EXCLUDED_DIRS", ".venv,uv-build")
+        assert _should_exclude(Path("skills/my-skill/.venv/bin/python"))
+        assert _should_exclude(Path("uv-build/some-cache.bin"))
+        # Names not in either set still pass through.
+        assert not _should_exclude(Path("skills/my-skill/SKILL.md"))
+
+
 # ---------------------------------------------------------------------------
 # Backup tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

\`hermes_cli/backup.py\` hard-coded the directory deny list as the module-level constant \`_EXCLUDED_DIRS\`. Users with workflow-specific transient dirs (per-skill \`.venv\` folders, \`uv-build\` caches, etc.) had to fork the file to keep those dirs out of every full snapshot.

This adds a small \`_get_excluded_dirs()\` helper that unions the built-in deny list with anything passed via the \`HERMES_BACKUP_EXTRA_EXCLUDED_DIRS\` environment variable (comma- or whitespace-separated dir names). The three call sites that previously closed over \`_EXCLUDED_DIRS\` directly — \`_should_exclude\`, \`run_backup\`, and \`_write_full_zip_backup\` — now consult the helper, so extras take effect at all stages (path filtering, \`os.walk\` pruning, and the shared full-zip helper used by pre-update / pre-migration auto-backups).

## Behaviour

| ENV value                                  | Result                                                  |
|--------------------------------------------|---------------------------------------------------------|
| unset                                       | identical to today (no behaviour change)                |
| \`\"\"\` / whitespace only                  | identical to today                                       |
| \`\".venv, venv, uv-build\"\`               | union of built-in defaults + \`{.venv, venv, uv-build}\` |

Defaults are preserved verbatim when extras are added — the user can only widen the deny list, never shrink it.

## Test plan

- [x] \`tests/hermes_cli/test_backup.py\` — 97 tests pass (93 existing + 4 new)
- [x] New \`TestExtraExcludedDirsEnv\` covers unset, empty/whitespace, comma-separated, and end-to-end \`_should_exclude\` paths.

Fixes #16988