### PR TITLE
feat: add local Korean TTS providers and effects

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -743,9 +743,9 @@ DEFAULT_CONFIG = {
     # Each provider supports an optional `max_text_length:` override for the
     # per-request input-character cap. Omit it to use the provider's documented
     # limit (OpenAI 4096, xAI 15000, MiniMax 10000, ElevenLabs 5k-40k model-aware,
-    # Gemini 5000, Edge 5000, Mistral 4000, NeuTTS/KittenTTS 2000).
+    # Gemini 5000, Edge 5000, Mistral 4000, NeuTTS/KittenTTS/Piper/MeloTTS 2000).
     "tts": {
-        "provider": "edge",  # "edge" (free) | "elevenlabs" (premium) | "openai" | "xai" | "minimax" | "mistral" | "neutts" (local)
+        "provider": "edge",  # "edge" (free) | "elevenlabs" (premium) | "openai" | "xai" | "minimax" | "mistral" | "neutts" | "kittentts" | "piper" | "melotts"
         "edge": {
             "voice": "en-US-AriaNeural",
             # Popular: AriaNeural, JennyNeural, AndrewNeural, BrianNeural, SoniaNeural
@@ -757,7 +757,13 @@ DEFAULT_CONFIG = {
         "openai": {
             "model": "gpt-4o-mini-tts",
             "voice": "alloy",
-            # Voices: alloy, echo, fable, onyx, nova, shimmer
+            "instructions": "",  # Supported by gpt-4o-mini-tts for style/tone control
+            # Voices include alloy, ash, ballad, coral, echo, fable, nova, onyx,
+            # sage, shimmer, verse, marin, cedar. API/model decides support.
+        },
+        "postprocess": {
+            "enabled": False,
+            "preset": "none",  # none, clean, hybrid, dark, cyber_autotune
         },
         "xai": {
             "voice_id": "eve",
@@ -774,6 +780,19 @@ DEFAULT_CONFIG = {
             "ref_text": "",   # Path to reference voice transcript (empty = bundled default)
             "model": "neuphonic/neutts-air-q4-gguf",  # HuggingFace model repo
             "device": "cpu",  # cpu, cuda, or mps
+        },
+        "piper": {
+            "base_url": "http://127.0.0.1:5005",  # Local Piper HTTP server
+            "timeout": 60,
+            "health_timeout": 2,
+        },
+        "melotts": {
+            "python": "/home/ubuntu/melotts-venv/bin/python",  # Isolated MeloTTS venv
+            "language": "KR",
+            "speaker": "KR",
+            "device": "cpu",
+            "speed": 1.0,
+            "timeout": 180,
         },
     },
     

--- a/tests/cli/test_fast_command.py
+++ b/tests/cli/test_fast_command.py
@@ -149,6 +149,7 @@ class TestPriorityProcessingModels(unittest.TestCase):
     def test_vendor_prefix_stripped(self):
         from hermes_cli.models import model_supports_fast_mode
 
+        assert model_supports_fast_mode("openai/gpt-5.5") is True
         assert model_supports_fast_mode("openai/gpt-5.4") is True
         assert model_supports_fast_mode("openai/gpt-4.1") is True
         assert model_supports_fast_mode("openai/o3") is True
@@ -170,6 +171,9 @@ class TestPriorityProcessingModels(unittest.TestCase):
 
     def test_resolve_overrides_returns_service_tier(self):
         from hermes_cli.models import resolve_fast_mode_overrides
+
+        result = resolve_fast_mode_overrides("gpt-5.5")
+        assert result == {"service_tier": "priority"}
 
         result = resolve_fast_mode_overrides("gpt-5.4")
         assert result == {"service_tier": "priority"}

--- a/tests/tools/test_tts_max_text_length.py
+++ b/tests/tools/test_tts_max_text_length.py
@@ -114,7 +114,7 @@ class TestResolveMaxTextLength:
 
     def test_all_documented_providers_have_defaults(self):
         expected = {"edge", "openai", "xai", "minimax", "mistral",
-                    "gemini", "elevenlabs", "neutts", "kittentts"}
+                    "gemini", "elevenlabs", "neutts", "kittentts", "piper", "melotts"}
         assert expected.issubset(PROVIDER_MAX_TEXT_LENGTH.keys())
 
 

--- a/tests/tools/test_tts_melotts.py
+++ b/tests/tools/test_tts_melotts.py
@@ -1,0 +1,128 @@
+"""Tests for the local MeloTTS provider."""
+
+import json
+import os
+import subprocess
+
+
+def test_generate_melotts_invokes_external_python(monkeypatch, tmp_path):
+    from tools.tts_tool import _generate_melotts_tts
+
+    calls = []
+
+    def fake_run(cmd, check, timeout, env):
+        calls.append((cmd, check, timeout, env))
+        output_path = cmd[-1]
+        with open(output_path, "wb") as f:
+            f.write(b"RIFF\x24\x00\x00\x00WAVEfmt fake-wav")
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    output = tmp_path / "out.wav"
+    result = _generate_melotts_tts(
+        "안녕하세요",
+        str(output),
+        {
+            "melotts": {
+                "python": "/home/ubuntu/melotts-venv/bin/python",
+                "language": "KR",
+                "speaker": "KR",
+                "speed": 1.1,
+                "device": "cpu",
+                "timeout": 123,
+            }
+        },
+    )
+
+    assert result == str(output)
+    assert output.read_bytes().startswith(b"RIFF")
+    assert len(calls) == 1
+    cmd, check, timeout, env = calls[0]
+    assert cmd[0] == "/home/ubuntu/melotts-venv/bin/python"
+    assert cmd[1:3] == ["-m", "tools.melotts_runner"]
+    assert cmd[cmd.index("--language") + 1] == "KR"
+    assert cmd[cmd.index("--speaker") + 1] == "KR"
+    assert cmd[cmd.index("--speed") + 1] == "1.1"
+    assert cmd[cmd.index("--device") + 1] == "cpu"
+    assert cmd[cmd.index("--text") + 1] == "안녕하세요"
+    assert cmd[-1] == str(output)
+    assert check is True
+    assert timeout == 123
+    assert env["TOKENIZERS_PARALLELISM"] == "false"
+
+
+def test_melotts_missing_output_raises(monkeypatch, tmp_path):
+    from tools.tts_tool import _generate_melotts_tts
+
+    def fake_run(cmd, check, timeout, env):
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    try:
+        _generate_melotts_tts("안녕하세요", str(tmp_path / "missing.wav"), {"melotts": {}})
+    except FileNotFoundError as exc:
+        assert "produced no output" in str(exc)
+    else:
+        raise AssertionError("expected FileNotFoundError")
+
+
+def test_text_to_speech_dispatches_to_melotts(monkeypatch, tmp_path):
+    from tools import tts_tool as _tt
+
+    captured = {}
+
+    def fake_melotts(text, output_path, config):
+        captured["text"] = text
+        captured["output_path"] = output_path
+        Path = __import__("pathlib").Path
+        Path(output_path).write_bytes(b"RIFF\x24\x00\x00\x00WAVEfmt fake-wav")
+        return output_path
+
+    monkeypatch.setattr(_tt, "_load_tts_config", lambda: {"provider": "melotts"})
+    monkeypatch.setattr(_tt, "_generate_melotts_tts", fake_melotts)
+
+    result = json.loads(_tt.text_to_speech_tool("안녕하세요", str(tmp_path / "out.wav")))
+
+    assert result["success"] is True
+    assert result["provider"] == "melotts"
+    assert captured["text"] == "안녕하세요"
+
+
+def test_melotts_requested_ogg_is_converted_to_telegram_opus(monkeypatch, tmp_path):
+    from tools import tts_tool as _tt
+
+    requested_ogg = tmp_path / "out.ogg"
+    generated = {}
+
+    def fake_melotts(text, output_path, config):
+        generated["output_path"] = output_path
+        with open(output_path, "wb") as f:
+            f.write(b"RIFF\x24\x00\x00\x00WAVEfmt fake-wav")
+        return output_path
+
+    def fake_convert(path):
+        generated["convert_input"] = path
+        requested_ogg.write_bytes(b"OggS opus")
+        return str(requested_ogg)
+
+    monkeypatch.setattr(_tt, "_load_tts_config", lambda: {"provider": "melotts"})
+    monkeypatch.setattr(_tt, "_generate_melotts_tts", fake_melotts)
+    monkeypatch.setattr(_tt, "_convert_to_opus", fake_convert)
+
+    result = json.loads(_tt.text_to_speech_tool("안녕하세요", str(requested_ogg)))
+
+    assert result["success"] is True
+    assert result["file_path"] == str(requested_ogg)
+    assert result["voice_compatible"] is True
+    assert result["media_tag"].startswith("[[audio_as_voice]]")
+    assert generated["output_path"].endswith(".wav")
+    assert generated["convert_input"] == generated["output_path"]
+
+
+def test_melotts_has_default_text_limit():
+    from tools.tts_tool import PROVIDER_MAX_TEXT_LENGTH, _resolve_max_text_length
+
+    assert PROVIDER_MAX_TEXT_LENGTH["melotts"] == 2000
+    assert _resolve_max_text_length("melotts", {}) == 2000

--- a/tests/tools/test_tts_mistral.py
+++ b/tests/tools/test_tts_mistral.py
@@ -207,7 +207,9 @@ class TestCheckTtsRequirementsMistral:
         with patch("tools.tts_tool._import_edge_tts", side_effect=ImportError), \
              patch("tools.tts_tool._import_elevenlabs", side_effect=ImportError), \
              patch("tools.tts_tool._import_openai_client", side_effect=ImportError), \
-             patch("tools.tts_tool._check_neutts_available", return_value=False):
+             patch("tools.tts_tool._check_neutts_available", return_value=False), \
+             patch("tools.tts_tool._check_piper_available", return_value=False), \
+             patch("tools.tts_tool._check_melotts_available", return_value=False):
             assert check_tts_requirements() is True
 
     def test_mistral_key_missing_returns_false(self, mock_mistral_module):
@@ -216,5 +218,7 @@ class TestCheckTtsRequirementsMistral:
         with patch("tools.tts_tool._import_edge_tts", side_effect=ImportError), \
              patch("tools.tts_tool._import_elevenlabs", side_effect=ImportError), \
              patch("tools.tts_tool._import_openai_client", side_effect=ImportError), \
-             patch("tools.tts_tool._check_neutts_available", return_value=False):
+             patch("tools.tts_tool._check_neutts_available", return_value=False), \
+             patch("tools.tts_tool._check_piper_available", return_value=False), \
+             patch("tools.tts_tool._check_melotts_available", return_value=False):
             assert check_tts_requirements() is False

--- a/tests/tools/test_tts_piper.py
+++ b/tests/tools/test_tts_piper.py
@@ -1,0 +1,125 @@
+"""Tests for the local Piper HTTP TTS provider."""
+
+import json
+import urllib.request
+from unittest.mock import MagicMock
+
+
+class FakeUrlopenResponse:
+    def __init__(self, body: bytes):
+        self.body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self, *args):
+        return self.body
+
+
+def test_check_piper_available_uses_health_endpoint(monkeypatch):
+    from tools.tts_tool import _check_piper_available
+
+    calls = []
+
+    def fake_urlopen(request, timeout=None):
+        calls.append((request.full_url, timeout))
+        return FakeUrlopenResponse(b'{"ok": true}')
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    assert _check_piper_available({"piper": {"base_url": "http://127.0.0.1:5005"}}) is True
+    assert calls == [("http://127.0.0.1:5005/health", 2)]
+
+
+def test_generate_piper_posts_text_and_writes_wav(monkeypatch, tmp_path):
+    from tools.tts_tool import _generate_piper_tts
+
+    calls = []
+    wav_bytes = b"RIFF\x24\x00\x00\x00WAVEfmt fake-wav"
+
+    def fake_urlopen(request, timeout=None):
+        calls.append(request)
+        assert timeout == 12
+        return FakeUrlopenResponse(wav_bytes)
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    output = tmp_path / "out.wav"
+    result = _generate_piper_tts(
+        "안녕하세요",
+        str(output),
+        {"piper": {"base_url": "http://127.0.0.1:5005", "timeout": 12}},
+    )
+
+    assert result == str(output)
+    assert output.read_bytes() == wav_bytes
+    assert len(calls) == 1
+    request = calls[0]
+    assert request.full_url == "http://127.0.0.1:5005/tts"
+    assert json.loads(request.data.decode("utf-8")) == {"text": "안녕하세요"}
+    assert request.get_method() == "POST"
+    assert request.get_header("Content-type") == "application/json"
+
+
+def test_text_to_speech_dispatches_to_piper(monkeypatch, tmp_path):
+    from tools import tts_tool as _tt
+
+    captured = {}
+
+    def fake_piper(text, output_path, config):
+        captured["text"] = text
+        captured["output_path"] = output_path
+        captured["config"] = config
+        with open(output_path, "wb") as f:
+            f.write(b"RIFF\x24\x00\x00\x00WAVEfmt fake-wav")
+        return output_path
+
+    monkeypatch.setattr(_tt, "_load_tts_config", lambda: {"provider": "piper"})
+    monkeypatch.setattr(_tt, "_generate_piper_tts", fake_piper)
+
+    result = json.loads(_tt.text_to_speech_tool("안녕하세요", str(tmp_path / "out.wav")))
+
+    assert result["success"] is True
+    assert result["provider"] == "piper"
+    assert captured["text"] == "안녕하세요"
+
+
+def test_piper_requested_ogg_is_converted_to_telegram_opus(monkeypatch, tmp_path):
+    from tools import tts_tool as _tt
+
+    requested_ogg = tmp_path / "out.ogg"
+    generated = {}
+
+    def fake_piper(text, output_path, config):
+        generated["output_path"] = output_path
+        with open(output_path, "wb") as f:
+            f.write(b"RIFF\x24\x00\x00\x00WAVEfmt fake-wav")
+        return output_path
+
+    def fake_convert(path):
+        generated["convert_input"] = path
+        requested_ogg.write_bytes(b"OggS opus")
+        return str(requested_ogg)
+
+    monkeypatch.setattr(_tt, "_load_tts_config", lambda: {"provider": "piper"})
+    monkeypatch.setattr(_tt, "_generate_piper_tts", fake_piper)
+    monkeypatch.setattr(_tt, "_convert_to_opus", fake_convert)
+
+    result = json.loads(_tt.text_to_speech_tool("안녕하세요", str(requested_ogg)))
+
+    assert result["success"] is True
+    assert result["file_path"] == str(requested_ogg)
+    assert result["voice_compatible"] is True
+    assert result["media_tag"].startswith("[[audio_as_voice]]")
+    assert generated["output_path"].endswith(".wav")
+    assert generated["convert_input"] == generated["output_path"]
+
+
+def test_piper_has_default_text_limit():
+    from tools.tts_tool import PROVIDER_MAX_TEXT_LENGTH, _resolve_max_text_length
+
+    assert PROVIDER_MAX_TEXT_LENGTH["piper"] == 2000
+    assert _resolve_max_text_length("piper", {}) == 2000

--- a/tests/tools/test_tts_speed.py
+++ b/tests/tools/test_tts_speed.py
@@ -134,16 +134,17 @@ class TestTtsPostprocessPresets:
             assert "loudnorm" in filt
             assert "acrusher" in filt
 
-    def test_cyber_autotune_uses_jarvis_voice_chain_without_bitcrusher(self):
+    def test_cyber_autotune_uses_jarvis_voice_chain_without_bitcrusher_or_speedup(self):
         from tools.tts_tool import _tts_effect_filter
 
         filt = _tts_effect_filter("cyber_autotune")
         assert "asetrate=48000*1.05" in filt
+        assert "atempo=0.952" in filt  # compensates the pitch-style asetrate shift
         assert "flanger=delay=0:depth=2:regen=50:width=71:speed=0.5" in filt
         assert "aecho=0.8:0.88:15:0.5" in filt
         assert "highpass=f=200" in filt
         assert "treble=g=6" in filt
-        assert "atempo=1.25" in filt
+        assert "atempo=1.25" not in filt
         assert "loudnorm" in filt
         assert "acrusher" not in filt
 

--- a/tests/tools/test_tts_speed.py
+++ b/tests/tools/test_tts_speed.py
@@ -108,6 +108,56 @@ class TestOpenaiTtsSpeed:
         kwargs = create.call_args[1]
         assert kwargs["speed"] == 4.0
 
+    def test_instructions_passed_when_configured(self, tmp_path, monkeypatch):
+        """gpt-4o-mini-tts supports style instructions; pass them through."""
+        create = self._run({"openai": {"instructions": "Speak calmly."}}, tmp_path, monkeypatch)
+        kwargs = create.call_args[1]
+        assert kwargs["instructions"] == "Speak calmly."
+
+    def test_empty_instructions_not_passed(self, tmp_path, monkeypatch):
+        """Avoid sending blank instructions."""
+        create = self._run({"openai": {"instructions": "   "}}, tmp_path, monkeypatch)
+        kwargs = create.call_args[1]
+        assert "instructions" not in kwargs
+
+
+# ---------------------------------------------------------------------------
+# TTS postprocess presets
+# ---------------------------------------------------------------------------
+
+class TestTtsPostprocessPresets:
+    def test_known_presets_build_filters(self):
+        from tools.tts_tool import _tts_effect_filter
+
+        for preset in ("clean", "hybrid", "dark"):
+            filt = _tts_effect_filter(preset)
+            assert "loudnorm" in filt
+            assert "acrusher" in filt
+
+    def test_cyber_autotune_uses_jarvis_voice_chain_without_bitcrusher(self):
+        from tools.tts_tool import _tts_effect_filter
+
+        filt = _tts_effect_filter("cyber_autotune")
+        assert "asetrate=48000*1.05" in filt
+        assert "flanger=delay=0:depth=2:regen=50:width=71:speed=0.5" in filt
+        assert "aecho=0.8:0.88:15:0.5" in filt
+        assert "highpass=f=200" in filt
+        assert "treble=g=6" in filt
+        assert "atempo=1.25" in filt
+        assert "loudnorm" in filt
+        assert "acrusher" not in filt
+
+    def test_none_preset_has_no_filter(self):
+        from tools.tts_tool import _tts_effect_filter
+
+        assert _tts_effect_filter("none") is None
+
+    def test_unknown_preset_rejected(self):
+        from tools.tts_tool import _tts_effect_filter
+
+        with pytest.raises(ValueError):
+            _tts_effect_filter("explode")
+
 
 # ---------------------------------------------------------------------------
 # MiniMax TTS speed (global fallback wired)

--- a/tools/melotts_runner.py
+++ b/tools/melotts_runner.py
@@ -1,0 +1,44 @@
+"""Subprocess runner for MeloTTS synthesis.
+
+This module is intentionally tiny so Hermes can call a separate MeloTTS virtualenv
+without importing MeloTTS/Torch into the main Hermes process.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate speech with MeloTTS")
+    parser.add_argument("--text", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--language", default="KR")
+    parser.add_argument("--speaker", default="KR")
+    parser.add_argument("--speed", type=float, default=1.0)
+    parser.add_argument("--device", default="cpu")
+    args = parser.parse_args()
+
+    from melo.api import TTS
+
+    model = TTS(language=args.language, device=args.device)
+    speaker_ids = model.hps.data.spk2id
+    speaker = args.speaker or args.language
+    try:
+        speaker_id = speaker_ids[speaker]
+    except Exception as exc:
+        try:
+            available = ", ".join(sorted(speaker_ids.keys()))
+        except Exception:
+            available = str(speaker_ids)
+        raise SystemExit(f"Unknown MeloTTS speaker {speaker!r}; available: {available}") from exc
+
+    output = Path(args.output).expanduser()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    model.tts_to_file(args.text, speaker_id, str(output), speed=args.speed)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -10,6 +10,7 @@ Supports seven TTS providers:
 - Mistral (Voxtral TTS): Multilingual, native Opus, needs MISTRAL_API_KEY
 - Google Gemini TTS: Controllable, 30 prebuilt voices, needs GEMINI_API_KEY
 - NeuTTS (local, free, no API key): On-device TTS via neutts_cli, needs neutts installed
+- Piper HTTP (local, free, no API key): Local Piper server returning WAV bytes
 
 Output formats:
 - Opus (.ogg) for Telegram voice bubbles (requires ffmpeg for Edge TTS)
@@ -98,6 +99,9 @@ DEFAULT_KITTENTTS_MODEL = "KittenML/kitten-tts-nano-0.8-int8"  # 25MB
 DEFAULT_KITTENTTS_VOICE = "Jasper"
 DEFAULT_OPENAI_VOICE = "alloy"
 DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1"
+DEFAULT_TTS_POSTPROCESS_ENABLED = False
+DEFAULT_TTS_POSTPROCESS_PRESET = "none"
+TTS_POSTPROCESS_PRESETS = {"none", "clean", "hybrid", "dark", "cyber_autotune"}
 DEFAULT_MINIMAX_MODEL = "speech-2.8-hd"
 DEFAULT_MINIMAX_VOICE_ID = "English_Graceful_Lady"
 DEFAULT_MINIMAX_BASE_URL = "https://api.minimax.io/v1/t2a_v2"
@@ -111,6 +115,15 @@ DEFAULT_XAI_BASE_URL = "https://api.x.ai/v1"
 DEFAULT_GEMINI_TTS_MODEL = "gemini-2.5-flash-preview-tts"
 DEFAULT_GEMINI_TTS_VOICE = "Kore"
 DEFAULT_GEMINI_TTS_BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
+DEFAULT_PIPER_BASE_URL = "http://127.0.0.1:5005"
+DEFAULT_PIPER_TIMEOUT = 60
+DEFAULT_PIPER_HEALTH_TIMEOUT = 2
+DEFAULT_MELOTTS_PYTHON = "/home/ubuntu/melotts-venv/bin/python"
+DEFAULT_MELOTTS_LANGUAGE = "KR"
+DEFAULT_MELOTTS_SPEAKER = "KR"
+DEFAULT_MELOTTS_DEVICE = "cpu"
+DEFAULT_MELOTTS_SPEED = 1.0
+DEFAULT_MELOTTS_TIMEOUT = 180
 # PCM output specs for Gemini TTS (fixed by the API)
 GEMINI_TTS_SAMPLE_RATE = 24000
 GEMINI_TTS_CHANNELS = 1
@@ -139,6 +152,8 @@ PROVIDER_MAX_TEXT_LENGTH: Dict[str, int] = {
     "elevenlabs": 10000,  # fallback when model-aware lookup can't resolve (multilingual_v2)
     "neutts": 2000,       # local model, quality falls off on long text
     "kittentts": 2000,    # local 25MB model
+    "piper": 2000,        # local Piper server, Korean model quality falls off on long text
+    "melotts": 2000,      # local MeloTTS subprocess, keep latency bounded
 }
 
 # ElevenLabs caps vary by model_id. https://elevenlabs.io/docs/overview/models
@@ -267,6 +282,133 @@ def _convert_to_opus(mp3_path: str) -> Optional[str]:
     return None
 
 
+def _ffmpeg_has_filter(filter_name: str) -> bool:
+    """Return True if the local ffmpeg build exposes *filter_name*."""
+    if not _has_ffmpeg():
+        return False
+    try:
+        result = subprocess.run(
+            ["ffmpeg", "-hide_banner", "-filters"],
+            capture_output=True, text=True, timeout=10,
+        )
+    except Exception:
+        return False
+    return result.returncode == 0 and re.search(rf"\s{re.escape(filter_name)}\s", result.stdout) is not None
+
+
+def _tts_effect_filter(preset: str) -> Optional[str]:
+    """Build a conservative ffmpeg filter chain for lab-AI TTS effects."""
+    preset = (preset or "none").lower().strip()
+    if preset in ("", "none", "off", "false"):
+        return None
+    if preset not in TTS_POSTPROCESS_PRESETS:
+        raise ValueError(
+            f"Unknown TTS postprocess preset: {preset}. "
+            f"Expected one of: {', '.join(sorted(TTS_POSTPROCESS_PRESETS))}"
+        )
+
+    # On this host rubberband has previously produced near-silent output in
+    # some chains, so only use it when the user explicitly allows it.
+    use_rubberband = os.getenv("HERMES_TTS_USE_RUBBERBAND", "").lower() in {"1", "true", "yes"}
+    pitch = ""
+    if use_rubberband and _ffmpeg_has_filter("rubberband"):
+        pitch_by_preset = {"clean": "0.96", "hybrid": "0.90", "dark": "0.84", "cyber_autotune": "1.06"}
+        pitch = f"rubberband=pitch={pitch_by_preset[preset]}:formant=preserved:tempo=1.0,"
+
+    if preset == "cyber_autotune":
+        # Based on openclaw/skills globalcaos/jarvis-voice's metallic ffmpeg
+        # chain, adapted for Hermes/OpenAI's 48 kHz Opus path and Korean TTS.
+        # Keep bitcrusher/acrusher out; the Jarvis-style character comes from
+        # +5% asetrate pitch, strong flanger, short echo, highpass, and treble.
+        if not pitch:
+            pitch = "asetrate=48000*1.05,aresample=48000,atempo=0.952,"
+        body = (
+            "flanger=delay=0:depth=2:regen=50:width=71:speed=0.5,"
+            "aecho=0.8:0.88:15:0.5,"
+            "highpass=f=200,"
+            "treble=g=6,"
+            "atempo=1.25,"
+            "loudnorm=I=-16:TP=-1.5:LRA=6"
+        )
+    elif preset == "clean":
+        body = (
+            "highpass=f=120,lowpass=f=6500,"
+            "equalizer=f=900:t=q:w=1.2:g=1.5,"
+            "equalizer=f=2600:t=q:w=1.1:g=2.0,"
+            "flanger=delay=1.2:depth=1.5:regen=8:width=18:speed=0.12,"
+            "aecho=0.82:0.88:12:0.08,"
+            "acrusher=bits=12:samples=4:mix=0.04,"
+            "loudnorm=I=-16:TP=-1.5:LRA=8"
+        )
+    elif preset == "hybrid":
+        body = (
+            "highpass=f=140,lowpass=f=5400,"
+            "equalizer=f=850:t=q:w=1.2:g=2.5,"
+            "equalizer=f=2400:t=q:w=1.0:g=3.5,"
+            "equalizer=f=4200:t=q:w=1.5:g=1.5,"
+            "tremolo=f=34:d=0.055,"
+            "vibrato=f=2.2:d=0.035,"
+            "flanger=delay=1.8:depth=2.4:regen=14:width=32:speed=0.16,"
+            "aecho=0.80:0.88:9|19:0.12|0.06,"
+            "acrusher=bits=10:samples=8:mix=0.09,"
+            "loudnorm=I=-16:TP=-1.5:LRA=7"
+        )
+    else:  # dark
+        body = (
+            "highpass=f=160,lowpass=f=4600,"
+            "equalizer=f=700:t=q:w=1.0:g=3.0,"
+            "equalizer=f=1800:t=q:w=1.0:g=2.0,"
+            "equalizer=f=2900:t=q:w=1.0:g=4.5,"
+            "tremolo=f=48:d=0.12,"
+            "vibrato=f=3.1:d=0.055,"
+            "flanger=delay=2.4:depth=3.8:regen=24:width=48:speed=0.22,"
+            "aecho=0.78:0.90:6|13|27:0.18|0.10|0.05,"
+            "acrusher=bits=9:samples=12:mix=0.16,"
+            "loudnorm=I=-16:TP=-1.5:LRA=6"
+        )
+    return f"{pitch}{body}"
+
+
+def _apply_tts_postprocess(audio_path: str, tts_config: Dict[str, Any]) -> Optional[str]:
+    """Apply optional ffmpeg postprocessing before the file is delivered."""
+    post_cfg = tts_config.get("postprocess", {})
+    if not isinstance(post_cfg, dict):
+        return None
+    enabled = bool(post_cfg.get("enabled", DEFAULT_TTS_POSTPROCESS_ENABLED))
+    preset = str(post_cfg.get("preset", DEFAULT_TTS_POSTPROCESS_PRESET)).lower().strip()
+    if not enabled or preset in ("", "none", "off", "false"):
+        return None
+    if not _has_ffmpeg():
+        logger.warning("TTS postprocess requested but ffmpeg is not available")
+        return None
+
+    filter_chain = _tts_effect_filter(preset)
+    if not filter_chain:
+        return None
+
+    src = Path(audio_path)
+    out = src.with_name(f"{src.stem}_{preset}{src.suffix}")
+    cmd = [
+        "ffmpeg", "-hide_banner", "-y", "-i", str(src),
+        "-af", filter_chain, "-ar", "48000", "-ac", "1",
+    ]
+    if out.suffix.lower() == ".ogg":
+        cmd += ["-c:a", "libopus", "-b:a", "64k", "-vbr", "off"]
+    cmd.append(str(out))
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+    except subprocess.TimeoutExpired:
+        logger.warning("TTS postprocess preset %s timed out", preset)
+        return None
+    if result.returncode != 0:
+        logger.warning("TTS postprocess preset %s failed: %s", preset, result.stderr[-500:])
+        return None
+    if out.exists() and out.stat().st_size > 0:
+        return str(out)
+    return None
+
+
 # ===========================================================================
 # Provider: Edge TTS (free)
 # ===========================================================================
@@ -365,6 +507,7 @@ def _generate_openai_tts(text: str, output_path: str, tts_config: Dict[str, Any]
     voice = oai_config.get("voice", DEFAULT_OPENAI_VOICE)
     base_url = oai_config.get("base_url", base_url)
     speed = float(oai_config.get("speed", tts_config.get("speed", 1.0)))
+    instructions = str(oai_config.get("instructions", "")).strip()
 
     # Determine response format from extension
     if output_path.endswith(".ogg"):
@@ -384,6 +527,8 @@ def _generate_openai_tts(text: str, output_path: str, tts_config: Dict[str, Any]
         )
         if speed != 1.0:
             create_kwargs["speed"] = max(0.25, min(4.0, speed))
+        if instructions:
+            create_kwargs["instructions"] = instructions
         response = client.audio.speech.create(**create_kwargs)
 
         response.stream_to_file(output_path)
@@ -912,6 +1057,172 @@ def _generate_kittentts(text: str, output_path: str, tts_config: Dict[str, Any])
 
 
 # ===========================================================================
+# Provider: Piper HTTP (local server, e.g. piper-rs-server)
+# ===========================================================================
+def _get_piper_base_url(tts_config: Dict[str, Any]) -> str:
+    """Return the configured Piper HTTP base URL without a trailing slash."""
+    piper_config = tts_config.get("piper", {}) if isinstance(tts_config.get("piper"), dict) else {}
+    return str(piper_config.get("base_url") or DEFAULT_PIPER_BASE_URL).rstrip("/")
+
+
+def _check_piper_available(tts_config: Optional[Dict[str, Any]] = None) -> bool:
+    """Check whether the configured Piper HTTP server responds to /health."""
+    import urllib.request
+
+    config = tts_config or _load_tts_config()
+    piper_config = config.get("piper", {}) if isinstance(config.get("piper"), dict) else {}
+    base_url = _get_piper_base_url(config)
+    timeout = piper_config.get("health_timeout", DEFAULT_PIPER_HEALTH_TIMEOUT)
+    try:
+        timeout = float(timeout)
+    except (TypeError, ValueError):
+        timeout = DEFAULT_PIPER_HEALTH_TIMEOUT
+
+    try:
+        request = urllib.request.Request(f"{base_url}/health", method="GET")
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            body = response.read(4096)
+        return b"ok" in body.lower() or body.strip() in (b"true", b"1")
+    except Exception:
+        return False
+
+
+def _generate_piper_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+    """Generate speech by POSTing text to a local Piper HTTP server.
+
+    The server is expected to expose:
+      * GET /health -> JSON/text health signal
+      * POST /tts {"text": "..."} -> audio/wav bytes
+
+    If *output_path* is not .wav, ffmpeg converts the returned WAV to the
+    requested extension so the rest of the TTS pipeline can stay provider-agnostic.
+    """
+    import urllib.error
+    import urllib.request
+
+    piper_config = tts_config.get("piper", {}) if isinstance(tts_config.get("piper"), dict) else {}
+    base_url = _get_piper_base_url(tts_config)
+    timeout = piper_config.get("timeout", DEFAULT_PIPER_TIMEOUT)
+    try:
+        timeout = float(timeout)
+    except (TypeError, ValueError):
+        timeout = DEFAULT_PIPER_TIMEOUT
+
+    payload = json.dumps({"text": text}, ensure_ascii=False).encode("utf-8")
+    request = urllib.request.Request(
+        f"{base_url}/tts",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            wav_bytes = response.read()
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode("utf-8", errors="ignore")[:500]
+        raise ValueError(f"Piper TTS server returned HTTP {e.code}: {detail}") from e
+    except urllib.error.URLError as e:
+        raise FileNotFoundError(f"Piper TTS server not reachable at {base_url}: {e}") from e
+
+    if not wav_bytes:
+        raise ValueError("Piper TTS server returned an empty audio response")
+
+    wav_path = output_path
+    if not output_path.endswith(".wav"):
+        wav_path = output_path.rsplit(".", 1)[0] + ".wav"
+
+    with open(wav_path, "wb") as f:
+        f.write(wav_bytes)
+
+    if wav_path != output_path:
+        ffmpeg = shutil.which("ffmpeg")
+        if ffmpeg:
+            conv_cmd = [ffmpeg, "-i", wav_path, "-y", "-loglevel", "error", output_path]
+            subprocess.run(conv_cmd, check=True, timeout=30)
+            os.remove(wav_path)
+        else:
+            os.rename(wav_path, output_path)
+
+    return output_path
+
+
+# ===========================================================================
+# Provider: MeloTTS (local subprocess in an isolated virtualenv)
+# ===========================================================================
+def _get_melotts_config(tts_config: Dict[str, Any]) -> Dict[str, Any]:
+    """Return normalized MeloTTS provider config."""
+    raw = tts_config.get("melotts", {}) if isinstance(tts_config.get("melotts"), dict) else {}
+    return {
+        "python": str(raw.get("python") or raw.get("python_path") or DEFAULT_MELOTTS_PYTHON),
+        "language": str(raw.get("language") or DEFAULT_MELOTTS_LANGUAGE),
+        "speaker": str(raw.get("speaker") or DEFAULT_MELOTTS_SPEAKER),
+        "device": str(raw.get("device") or DEFAULT_MELOTTS_DEVICE),
+        "speed": raw.get("speed", DEFAULT_MELOTTS_SPEED),
+        "timeout": raw.get("timeout", DEFAULT_MELOTTS_TIMEOUT),
+    }
+
+
+def _check_melotts_available(tts_config: Optional[Dict[str, Any]] = None) -> bool:
+    """Check whether the configured MeloTTS Python executable exists."""
+    config = _get_melotts_config(tts_config or _load_tts_config())
+    py = config["python"]
+    return bool(py and os.path.exists(py) and os.access(py, os.X_OK))
+
+
+def _generate_melotts_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+    """Generate speech with MeloTTS via a separate Python environment.
+
+    MeloTTS pulls in Torch and older text-processing dependencies. Running it
+    in its own venv avoids contaminating the main Hermes runtime.
+    """
+    cfg = _get_melotts_config(tts_config)
+    try:
+        speed = float(cfg["speed"])
+    except (TypeError, ValueError):
+        speed = DEFAULT_MELOTTS_SPEED
+    try:
+        timeout = float(cfg["timeout"])
+    except (TypeError, ValueError):
+        timeout = DEFAULT_MELOTTS_TIMEOUT
+
+    py = cfg["python"]
+    if not os.path.exists(py):
+        raise FileNotFoundError(f"MeloTTS Python executable not found: {py}")
+
+    output = Path(output_path).expanduser()
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    env = os.environ.copy()
+    env.setdefault("TOKENIZERS_PARALLELISM", "false")
+    repo_root = Path(__file__).resolve().parents[1]
+    env["PYTHONPATH"] = f"{repo_root}{os.pathsep}{env.get('PYTHONPATH', '')}" if env.get("PYTHONPATH") else str(repo_root)
+
+    cmd = [
+        py,
+        "-m",
+        "tools.melotts_runner",
+        "--language",
+        cfg["language"],
+        "--speaker",
+        cfg["speaker"],
+        "--speed",
+        str(speed),
+        "--device",
+        cfg["device"],
+        "--text",
+        text,
+        "--output",
+        str(output),
+    ]
+    subprocess.run(cmd, check=True, timeout=timeout, env=env)
+
+    if not output.exists() or output.stat().st_size == 0:
+        raise FileNotFoundError(f"MeloTTS produced no output: {output}")
+    return str(output)
+
+
+# ===========================================================================
 # Main tool function
 # ===========================================================================
 def text_to_speech_tool(
@@ -1048,6 +1359,26 @@ def text_to_speech_tool(
             logger.info("Generating speech with KittenTTS (local, ~25MB)...")
             _generate_kittentts(text, file_str, tts_config)
 
+        elif provider == "piper":
+            logger.info("Generating speech with Piper HTTP TTS (local)...")
+            piper_output = file_str
+            # Piper returns WAV. If the caller requested .ogg, synthesize WAV first
+            # and let the shared Opus conversion path create Telegram voice audio.
+            if file_str.endswith(".ogg"):
+                piper_output = str(file_path.with_suffix(".wav"))
+            _generate_piper_tts(text, piper_output, tts_config)
+            file_str = piper_output
+
+        elif provider == "melotts":
+            logger.info("Generating speech with MeloTTS (local)...")
+            melotts_output = file_str
+            # MeloTTS returns WAV. If the caller requested .ogg, synthesize WAV first
+            # and let the shared Opus conversion path create Telegram voice audio.
+            if file_str.endswith(".ogg"):
+                melotts_output = str(file_path.with_suffix(".wav"))
+            _generate_melotts_tts(text, melotts_output, tts_config)
+            file_str = melotts_output
+
         else:
             # Default: Edge TTS (free), with NeuTTS as local fallback
             edge_available = True
@@ -1084,10 +1415,15 @@ def text_to_speech_tool(
                 "error": f"TTS generation produced no output (provider: {provider})"
             }, ensure_ascii=False)
 
+        postprocessed = _apply_tts_postprocess(file_str, tts_config)
+        if postprocessed:
+            file_str = postprocessed
+
         # Try Opus conversion for Telegram compatibility
-        # Edge TTS outputs MP3, NeuTTS/KittenTTS output WAV — all need ffmpeg conversion
+        # Edge TTS outputs MP3; NeuTTS/KittenTTS/Piper/MeloTTS output WAV; MiniMax/xAI
+        # output MP3. All need ffmpeg conversion for Telegram voice bubbles.
         voice_compatible = False
-        if provider in ("edge", "neutts", "minimax", "xai", "kittentts") and not file_str.endswith(".ogg"):
+        if provider in ("edge", "neutts", "minimax", "xai", "kittentts", "piper", "melotts") and not file_str.endswith(".ogg"):
             opus_path = _convert_to_opus(file_str)
             if opus_path:
                 file_str = opus_path
@@ -1173,6 +1509,10 @@ def check_tts_requirements() -> bool:
     if _check_neutts_available():
         return True
     if _check_kittentts_available():
+        return True
+    if _check_piper_available():
+        return True
+    if _check_melotts_available():
         return True
     return False
 
@@ -1461,6 +1801,8 @@ if __name__ == "__main__":
         except ImportError:
             return False
 
+    config = _load_tts_config()
+
     print("\nProvider availability:")
     print(f"  Edge TTS:   {'installed' if _check(_import_edge_tts, 'edge') else 'not installed (pip install edge-tts)'}")
     print(f"  ElevenLabs: {'installed' if _check(_import_elevenlabs, 'el') else 'not installed (pip install elevenlabs)'}")
@@ -1471,10 +1813,10 @@ if __name__ == "__main__":
         f"{'set' if resolve_openai_audio_api_key() else 'not set (VOICE_TOOLS_OPENAI_KEY or OPENAI_API_KEY)'}"
     )
     print(f"  MiniMax:    {'API key set' if os.getenv('MINIMAX_API_KEY') else 'not set (MINIMAX_API_KEY)'}")
+    print(f"  Piper HTTP: {'available' if _check_piper_available(config) else 'not reachable'}")
     print(f"  ffmpeg:     {'✅ found' if _has_ffmpeg() else '❌ not found (needed for Telegram Opus)'}")
     print(f"\n  Output dir: {DEFAULT_OUTPUT_DIR}")
 
-    config = _load_tts_config()
     provider = _get_provider(config)
     print(f"  Configured provider: {provider}")
 

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -320,6 +320,9 @@ def _tts_effect_filter(preset: str) -> Optional[str]:
         # chain, adapted for Hermes/OpenAI's 48 kHz Opus path and Korean TTS.
         # Keep bitcrusher/acrusher out; the Jarvis-style character comes from
         # +5% asetrate pitch, strong flanger, short echo, highpass, and treble.
+        # The pitch compensation keeps the playback duration near the original;
+        # do not add a separate speed-up here because it makes Korean voice
+        # replies sound unnaturally rushed in Telegram.
         if not pitch:
             pitch = "asetrate=48000*1.05,aresample=48000,atempo=0.952,"
         body = (
@@ -327,7 +330,6 @@ def _tts_effect_filter(preset: str) -> Optional[str]:
             "aecho=0.8:0.88:15:0.5,"
             "highpass=f=200,"
             "treble=g=6,"
-            "atempo=1.25,"
             "loudnorm=I=-16:TP=-1.5:LRA=6"
         )
     elif preset == "clean":


### PR DESCRIPTION
## Summary
- add Piper HTTP and MeloTTS subprocess TTS providers
- add Telegram Opus conversion handling for local WAV providers
- add OpenAI TTS style instructions and optional postprocess presets
- add provider text limits and focused tests
- mark gpt-5.5 as priority-processing capable

## Test Plan
- python -m pytest tests/tools/test_tts_piper.py tests/tools/test_tts_melotts.py tests/tools/test_tts_speed.py tests/tools/test_tts_max_text_length.py tests/tools/test_tts_mistral.py tests/cli/test_fast_command.py -q