### PR TITLE
fix: prevent stale reasoning from being reused across turns

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -13105,11 +13105,15 @@ class AIAgent:
             except Exception as exc:
                 logger.warning("post_llm_call hook failed: %s", exc)
 
-        # Extract reasoning from the last assistant message (if any)
+        # Extract reasoning from the LAST assistant message only.
+        # Do NOT walk backwards through history matching on reasoning truthiness —
+        # when the current turn produced no reasoning (e.g. the API returned
+        # reasoning_content=null), showing a stale reasoning from an older
+        # assistant message is misleading to the user.
         last_reasoning = None
         for msg in reversed(messages):
-            if msg.get("role") == "assistant" and msg.get("reasoning"):
-                last_reasoning = msg["reasoning"]
+            if msg.get("role") == "assistant":
+                last_reasoning = msg.get("reasoning")
                 break
 
         # Build result with interrupt info if applicable


### PR DESCRIPTION
## Summary

Fixes #17052

The `last_reasoning` extraction loop walked backwards through the entire message history looking for any assistant message with a truthy `reasoning` field. When the current turn produced no reasoning (e.g. the model returned `reasoning_content=null` for a simple prompt), the loop would skip the current message and match an older assistant message, displaying its reasoning as if it belonged to the current response.

## Changes

**`run_agent.py`** — `run_conversation()` last_reasoning extraction:

```python
# Before (walks backwards until finding any reasoning)
for msg in reversed(messages):
    if msg.get("role") == "assistant" and msg.get("reasoning"):
        last_reasoning = msg["reasoning"]
        break

# After (stops at the last assistant message)
for msg in reversed(messages):
    if msg.get("role") == "assistant":
        last_reasoning = msg.get("reasoning")
        break
```

## Testing

- Confirmed on a live deployment using GLM-5 (which returns `reasoning_content: null` for simple prompts and actual reasoning for complex ones)
- Before fix: simple "hello" message displayed reasoning from a previous complex turn
- After fix: simple messages show no reasoning; complex messages show their own reasoning correctly

## Impact

- Affects models that occasionally return `reasoning_content: null` (GLM-5, some DeepSeek/Qwen configurations)
- No behavior change for models that always return reasoning or never return reasoning
- Minimal change: 2 lines modified, no new dependencies