### PR TITLE
feat(code): adiciona control plane P0 ao Code Mode

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4578,24 +4578,36 @@ class HermesCLI:
             "\n".join([
                 "Code Mode Approvals",
                 "",
-                "Base Code Mode has no approval queue yet.",
-                "Approval-gated execution policy is deferred to the later P0 port.",
+                "P0 execution policy is available.",
+                "Risk classes include safe_readonly, network, git_write, secret_sensitive, destructive.",
+                "Use /code for backend status; policy assessments are exposed via /api/code/policy/assess-command.",
             ]),
             highlight=False,
             markup=False,
         )
 
     def _handle_skills_code_command(self, _cmd: str):
-        self._console_print(
-            "\n".join([
-                "Code Mode Skills",
-                "",
-                f"Installed slash skills visible to this CLI: {len(_skill_commands)}",
-                "SKILL.md repository discovery is deferred to the later P0 port.",
-            ]),
-            highlight=False,
-            markup=False,
-        )
+        discovered = []
+        workspace_skills = 0
+        workspace_path = Path(os.getenv("TERMINAL_CWD", os.getcwd()))
+        try:
+            from hermes_cli.code.skill_discovery import SkillDiscoveryService
+
+            service = SkillDiscoveryService()
+            discovered = service.list_skills(workspace_path=workspace_path)
+            workspace_skills = sum(1 for s in discovered if str(s.get("source", "")).startswith("workspace:"))
+        except Exception:
+            discovered = []
+
+        lines = [
+            "Code Mode Skills",
+            "",
+            f"Installed slash skills visible to this CLI: {len(_skill_commands)}",
+            f"Discovered skills (builtin/global/workspace): {len(discovered)}",
+            f"Workspace-local SKILL.md skills: {workspace_skills}",
+            "Skill folders supported: SKILL.md, scripts/, resources/",
+        ]
+        self._console_print("\n".join(lines), highlight=False, markup=False)
     
     def _fast_command_available(self) -> bool:
         try:

--- a/cli.py
+++ b/cli.py
@@ -4412,6 +4412,190 @@ class HermesCLI:
             f"Agent Running: {'Yes' if is_running else 'No'}",
         ])
         self._console_print("\n".join(lines), highlight=False, markup=False)
+
+    def _code_mode_dashboard_url(self) -> str:
+        dashboard = self.config.get("dashboard", {}) if isinstance(self.config, dict) else {}
+        host = str(dashboard.get("host") or "127.0.0.1")
+        port = int(dashboard.get("port") or 9119)
+        return f"http://{host}:{port}"
+
+    def _code_mode_backend_probe(self) -> tuple[str, dict[str, Any] | None]:
+        url = f"{self._code_mode_dashboard_url()}/api/code/status"
+        try:
+            import urllib.request
+            req = urllib.request.Request(url, method="GET")
+            with urllib.request.urlopen(req, timeout=0.75) as resp:
+                if resp.status == 200:
+                    return "online", json.loads(resp.read().decode("utf-8"))
+                return f"http {resp.status}", None
+        except Exception:
+            return "offline", None
+
+    def _code_mode_git_branch(self, cwd: str) -> str:
+        try:
+            result = subprocess.run(
+                ["git", "branch", "--show-current"],
+                cwd=cwd,
+                capture_output=True,
+                text=True,
+                timeout=2,
+            )
+            branch = result.stdout.strip()
+            return branch or "(detached or unavailable)"
+        except Exception:
+            return "(not a git repo)"
+
+    def _code_mode_state_status(self) -> dict[str, Any]:
+        if self._session_db:
+            try:
+                return self._session_db.code_mode_status()
+            except Exception as exc:
+                return {"mode": "unavailable", "error": str(exc)}
+        return {"mode": "unavailable", "error": "state database not available"}
+
+    def _handle_code_command(self, _cmd: str):
+        """Show the current Code Mode console summary."""
+        from hermes_cli.profiles import get_active_profile_name
+
+        cwd = os.getenv("TERMINAL_CWD", os.getcwd())
+        backend_status, backend_payload = self._code_mode_backend_probe()
+        state_status = (backend_payload or {}).get("state") if backend_payload else self._code_mode_state_status()
+        if not isinstance(state_status, dict):
+            state_status = self._code_mode_state_status()
+        schema_version = state_status.get("schema_version", "(unknown)")
+        counts = state_status.get("counts") or {}
+
+        lines = [
+            "Hermes Code Mode",
+            "",
+            f"Provider: {getattr(self, 'provider', None) or 'unknown'}",
+            f"Model: {getattr(self, 'model', None) or '(unknown)'}",
+            f"Profile: {get_active_profile_name()}",
+            f"Workspace: {cwd}",
+            f"Git Branch: {self._code_mode_git_branch(cwd)}",
+            f"Backend: {backend_status}",
+            f"Web/Cockpit: {self._code_mode_dashboard_url()}",
+            f"Schema: {schema_version}",
+            (
+                "State: "
+                f"{counts.get('code_workspaces', 0)} workspace(s), "
+                f"{counts.get('code_sessions', 0)} session(s), "
+                f"{counts.get('code_events', 0)} event(s)"
+            ),
+            "",
+            "Commands: /workspace, /session, /web, /approvals, /skills-code",
+        ]
+        if state_status.get("error"):
+            lines.insert(-2, f"State Note: {state_status['error']}")
+        self._console_print("\n".join(lines), highlight=False, markup=False)
+
+    def _handle_web_command(self, _cmd: str):
+        """Show dashboard launch hints for Code Mode."""
+        backend_status, _payload = self._code_mode_backend_probe()
+        url = self._code_mode_dashboard_url()
+        lines = [
+            "Hermes Web / Code Cockpit",
+            "",
+            f"URL: {url}",
+            f"Backend: {backend_status}",
+            "",
+            "Launch: python -m hermes_cli.main dashboard --port 9119",
+            "Note: hermesWeb is not present in this checkout; UI expansion is deferred.",
+        ]
+        self._console_print("\n".join(lines), highlight=False, markup=False)
+
+    def _handle_workspace_command(self, cmd: str):
+        """List known Code Mode workspaces, falling back to current cwd."""
+        query = ""
+        parts = cmd.strip().split(maxsplit=1)
+        if len(parts) > 1:
+            query = parts[1].strip()
+
+        workspaces = []
+        if self._session_db:
+            try:
+                workspaces = self._session_db.list_code_workspaces(q=query, limit=20)
+            except Exception:
+                workspaces = []
+
+        if not workspaces:
+            cwd = os.getenv("TERMINAL_CWD", os.getcwd())
+            lines = [
+                "Code Mode Workspaces",
+                "",
+                "No stored Code Mode workspaces found.",
+                f"Current Path: {cwd}",
+                f"Git Branch: {self._code_mode_git_branch(cwd)}",
+            ]
+            self._console_print("\n".join(lines), highlight=False, markup=False)
+            return
+
+        lines = ["Code Mode Workspaces", ""]
+        for workspace in workspaces:
+            name = workspace.get("name") or workspace.get("id") or "(unnamed)"
+            repo = workspace.get("repo_url") or workspace.get("git_remote") or workspace.get("repo") or ""
+            path = workspace.get("path") or ""
+            lines.append(f"- {name}")
+            if repo:
+                lines.append(f"  Repo: {repo}")
+            if path:
+                lines.append(f"  Path: {path}")
+        self._console_print("\n".join(lines), highlight=False, markup=False)
+
+    def _handle_code_session_command(self, cmd: str):
+        """List known Code Mode sessions."""
+        workspace_id = None
+        parts = cmd.strip().split(maxsplit=1)
+        if len(parts) > 1:
+            workspace_id = parts[1].strip() or None
+
+        sessions = []
+        if self._session_db:
+            try:
+                sessions = self._session_db.list_code_sessions(workspace_id=workspace_id, limit=20)
+            except Exception:
+                sessions = []
+
+        if not sessions:
+            self._console_print(
+                "Code Mode Sessions\n\nNo stored Code Mode sessions found.",
+                highlight=False,
+                markup=False,
+            )
+            return
+
+        lines = ["Code Mode Sessions", ""]
+        for session in sessions:
+            sid = session.get("id") or "(unknown)"
+            status = session.get("status") or "(unknown)"
+            workspace = session.get("workspace_id") or "(none)"
+            branch = session.get("branch") or "(unknown)"
+            lines.append(f"- {sid}: {status} workspace={workspace} branch={branch}")
+        self._console_print("\n".join(lines), highlight=False, markup=False)
+
+    def _handle_code_approvals_command(self, _cmd: str):
+        self._console_print(
+            "\n".join([
+                "Code Mode Approvals",
+                "",
+                "Base Code Mode has no approval queue yet.",
+                "Approval-gated execution policy is deferred to the later P0 port.",
+            ]),
+            highlight=False,
+            markup=False,
+        )
+
+    def _handle_skills_code_command(self, _cmd: str):
+        self._console_print(
+            "\n".join([
+                "Code Mode Skills",
+                "",
+                f"Installed slash skills visible to this CLI: {len(_skill_commands)}",
+                "SKILL.md repository discovery is deferred to the later P0 port.",
+            ]),
+            highlight=False,
+            markup=False,
+        )
     
     def _fast_command_available(self) -> bool:
         try:
@@ -6226,6 +6410,18 @@ class HermesCLI:
             self._show_gateway_status()
         elif canonical == "status":
             self._show_session_status()
+        elif canonical == "code":
+            self._handle_code_command(cmd_original)
+        elif canonical == "web":
+            self._handle_web_command(cmd_original)
+        elif canonical == "workspace":
+            self._handle_workspace_command(cmd_original)
+        elif canonical == "session":
+            self._handle_code_session_command(cmd_original)
+        elif canonical == "approvals":
+            self._handle_code_approvals_command(cmd_original)
+        elif canonical == "skills-code":
+            self._handle_skills_code_command(cmd_original)
         elif canonical == "statusbar":
             self._status_bar_visible = not self._status_bar_visible
             state = "visible" if self._status_bar_visible else "hidden"

--- a/docs/HERMES_CODE_MODE.md
+++ b/docs/HERMES_CODE_MODE.md
@@ -1,0 +1,94 @@
+# Hermes Code Mode
+
+Hermes Code Mode is the base coding-console foundation for Hermes Agent. This
+port keeps the feature aligned with the current `origin/main` architecture and
+intentionally does not include the later P0 Engineering Control Plane or P1
+GitHub integration.
+
+## What Is Included
+
+- CLI status console through `/code`.
+- Code Mode slash commands:
+  - `/code`
+  - `/web`
+  - `/workspace`
+  - `/session`
+  - `/approvals`
+  - `/skills-code`
+- Minimal backend API endpoints under `/api/code/*`.
+- SQLite state support for Code Mode workspace, session, and event metadata.
+- Graceful degraded behavior when the backend, state database, or Git metadata
+  is unavailable.
+
+## CLI Commands
+
+`/code` shows the active provider, model, profile, workspace path, Git branch,
+backend reachability, dashboard URL, schema version, and Code Mode state counts.
+
+`/web` shows the local dashboard URL and launch command. In this checkout,
+`hermesWeb/` is not present, so richer Code Cockpit UI work is deferred.
+
+`/workspace` lists stored Code Mode workspaces from state when available, and
+falls back to the current working directory and Git branch.
+
+`/session` lists stored Code Mode sessions from state when available.
+
+`/approvals` reports that approval orchestration is deferred to the P0 port.
+
+`/skills-code` reports installed slash skill visibility and notes that
+repository `SKILL.md` discovery is deferred to the P0 port.
+
+## Backend API
+
+The current base port exposes:
+
+- `GET /api/code/status`
+- `GET /api/code/workspaces`
+- `GET /api/code/sessions`
+- `GET /api/code/events`
+
+`/api/code/status` is public and read-only so the CLI can detect whether the
+dashboard backend is online. Other `/api/code/*` endpoints use the existing
+dashboard session-token middleware.
+
+## State
+
+Code Mode state lives in `state.db` with schema version `12`.
+
+Tables:
+
+- `code_workspaces`
+- `code_sessions`
+- `code_events`
+
+Fresh databases create these tables directly. Existing databases migrate through
+the normal declarative reconciliation path and the v12 migration step.
+
+## Startup
+
+Start the dashboard backend with:
+
+```bash
+python -m hermes_cli.main dashboard --port 9119
+```
+
+Then run `/code` or `/web` in the CLI to see backend reachability and launch
+hints.
+
+## Deferred Work
+
+This port intentionally does not include:
+
+- P0 ArtifactLedger.
+- P0 AgentOrchestrator.
+- P0 ExecutionPolicyEngine.
+- P0 Worktree/checkpoint service.
+- P0 `SKILL.md` discovery bridge.
+- P0 RepoKnowledgeService.
+- P1 GitHub App integration, webhooks, or ChatOps.
+- SSH/VPS behavior.
+- Desktop app behavior.
+- A large deprecated `web/` migration.
+
+`hermesWeb/` is absent in this checkout, so Code Cockpit UI work is deferred to
+a later frontend-specific port.

--- a/docs/HERMES_CODE_MODE.md
+++ b/docs/HERMES_CODE_MODE.md
@@ -1,94 +1,148 @@
 # Hermes Code Mode
 
-Hermes Code Mode is the base coding-console foundation for Hermes Agent. This
-port keeps the feature aligned with the current `origin/main` architecture and
-intentionally does not include the later P0 Engineering Control Plane or P1
-GitHub integration.
+Hermes Code Mode now includes the base console plus the P0 Engineering Control
+Plane foundation, adapted to the current main-compatible architecture.
 
-## What Is Included
+## Included Capabilities
 
-- CLI status console through `/code`.
-- Code Mode slash commands:
+- CLI Code Mode commands:
   - `/code`
   - `/web`
   - `/workspace`
   - `/session`
   - `/approvals`
   - `/skills-code`
-- Minimal backend API endpoints under `/api/code/*`.
-- SQLite state support for Code Mode workspace, session, and event metadata.
-- Graceful degraded behavior when the backend, state database, or Git metadata
-  is unavailable.
+- Code Mode state and events in `state.db`.
+- P0 services:
+  - `ExecutionPolicyEngine`
+  - `ArtifactLedger`
+  - `AgentOrchestrator`
+  - `WorktreeService` (safe capability/checkpoint foundation)
+  - `SkillDiscoveryService` (`SKILL.md` + `scripts/` + `resources/`)
+  - `RepoKnowledgeService` (`AGENTS.md` + docs guidance detection)
+- Normalized Code Mode event envelope persisted to `code_events`.
 
-## CLI Commands
+## Execution Policy Risk Classes
 
-`/code` shows the active provider, model, profile, workspace path, Git branch,
-backend reachability, dashboard URL, schema version, and Code Mode state counts.
+- `safe_readonly`
+- `safe_local_write`
+- `network`
+- `git_write`
+- `secret_sensitive`
+- `remote_mutating`
+- `destructive`
+- `production_sensitive`
 
-`/web` shows the local dashboard URL and launch command. In this checkout,
-`hermesWeb/` is not present, so richer Code Cockpit UI work is deferred.
+Destructive commands are blocked, higher-risk classes are approval candidates,
+and command text is secret-redacted before reporting.
 
-`/workspace` lists stored Code Mode workspaces from state when available, and
-falls back to the current working directory and Git branch.
+## Artifact Categories
 
-`/session` lists stored Code Mode sessions from state when available.
+- `task_intake`
+- `prd_lite`
+- `acceptance_criteria`
+- `architecture_note`
+- `adr`
+- `implementation_plan`
+- `command_log`
+- `diff_summary`
+- `test_report`
+- `review_report`
+- `deploy_plan`
+- `deploy_report`
+- `memory_update`
 
-`/approvals` reports that approval orchestration is deferred to the P0 port.
+Artifacts can link to workspace/session/orchestrated run/command metadata.
 
-`/skills-code` reports installed slash skill visibility and notes that
-repository `SKILL.md` discovery is deferred to the P0 port.
+## Orchestrator States
 
-## Backend API
+- `intake`
+- `discovery`
+- `product_framing`
+- `architecture`
+- `planning`
+- `approval`
+- `implementation`
+- `validation`
+- `review`
+- `ready_for_pr`
+- `completed`
+- `cancelled`
+- `failed`
 
-The current base port exposes:
+P0 provides state validation and persistence only. No autonomous execution loop
+is enabled in this port.
 
-- `GET /api/code/status`
+## API Endpoints
+
+Existing Code Mode endpoints:
+
+- `GET /api/code/status` (public read-only)
 - `GET /api/code/workspaces`
 - `GET /api/code/sessions`
 - `GET /api/code/events`
 
-`/api/code/status` is public and read-only so the CLI can detect whether the
-dashboard backend is online. Other `/api/code/*` endpoints use the existing
-dashboard session-token middleware.
+P0 endpoints:
 
-## State
+- `GET /api/code/artifacts`
+- `POST /api/code/artifacts`
+- `GET /api/code/sessions/{code_session_id}/artifacts`
+- `GET /api/code/orchestrator/runs`
+- `POST /api/code/orchestrator/runs`
+- `GET /api/code/orchestrator/runs/{run_id}`
+- `POST /api/code/orchestrator/runs/{run_id}/transition`
+- `POST /api/code/policy/assess-command`
+- `GET /api/code/workspaces/{workspace_id}/git/capabilities`
+- `GET /api/code/workspaces/{workspace_id}/git/worktrees`
+- `GET /api/code/skills/discovered`
+- `GET /api/code/workspaces/{workspace_id}/repo-knowledge`
+- `POST /api/code/workspaces/{workspace_id}/repo-knowledge/bootstrap`
 
-Code Mode state lives in `state.db` with schema version `12`.
+## State / Schema
 
-Tables:
+Code Mode state lives in `state.db`, schema version `13`.
+
+Code Mode + P0 tables:
 
 - `code_workspaces`
 - `code_sessions`
 - `code_events`
+- `code_artifacts`
+- `code_orchestrated_runs`
+- `code_run_transitions`
+- `code_checkpoints`
 
-Fresh databases create these tables directly. Existing databases migrate through
-the normal declarative reconciliation path and the v12 migration step.
+No separate SQLite database is used for P0.
+
+## Skill and Repo Guidance Discovery
+
+- `/skills-code` now reports discovered skills and workspace-local `SKILL.md`
+  capability.
+- Repo knowledge supports:
+  - repo-root `AGENTS.md`
+  - docs guidance folders:
+    - `docs/architecture/`
+    - `docs/engineering/`
+    - `docs/operations/`
+
+Bootstrap creates `AGENTS.md` only when missing and never overwrites.
 
 ## Startup
 
-Start the dashboard backend with:
+Start backend:
 
 ```bash
 python -m hermes_cli.main dashboard --port 9119
 ```
 
-Then run `/code` or `/web` in the CLI to see backend reachability and launch
-hints.
+Then use `/code` or `/web` in the CLI.
 
-## Deferred Work
+## Deferred (Not in P0)
 
-This port intentionally does not include:
-
-- P0 ArtifactLedger.
-- P0 AgentOrchestrator.
-- P0 ExecutionPolicyEngine.
-- P0 Worktree/checkpoint service.
-- P0 `SKILL.md` discovery bridge.
-- P0 RepoKnowledgeService.
-- P1 GitHub App integration, webhooks, or ChatOps.
-- SSH/VPS behavior.
+- P1 GitHub integration (GitHub App auth, webhooks, ChatOps, sync).
+- SSH/VPS automation.
 - Desktop app behavior.
-- A large deprecated `web/` migration.
+- `hermesWeb/` UI integration.
 
-`hermesWeb/` is absent in this checkout, so Code Cockpit UI work is deferred to
-a later frontend-specific port.
+`hermesWeb/` is absent in this checkout, and no large frontend work was added
+under deprecated `web/`.

--- a/hermes_cli/code/__init__.py
+++ b/hermes_cli/code/__init__.py
@@ -1,0 +1,1 @@
+"""Hermes Code Mode control-plane services."""

--- a/hermes_cli/code/agent_orchestrator.py
+++ b/hermes_cli/code/agent_orchestrator.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""AgentOrchestrator state machine foundation for Hermes Code Mode."""
+
+from __future__ import annotations
+
+import time
+import uuid
+from typing import Any
+
+from hermes_cli.code.artifact_ledger import ArtifactLedger
+from hermes_state import SessionDB
+
+
+class OrchestratorState:
+    INTAKE = "intake"
+    DISCOVERY = "discovery"
+    PRODUCT_FRAMING = "product_framing"
+    ARCHITECTURE = "architecture"
+    PLANNING = "planning"
+    APPROVAL = "approval"
+    IMPLEMENTATION = "implementation"
+    VALIDATION = "validation"
+    REVIEW = "review"
+    READY_FOR_PR = "ready_for_pr"
+    COMPLETED = "completed"
+    CANCELLED = "cancelled"
+    FAILED = "failed"
+
+    ALL = frozenset(
+        {
+            INTAKE,
+            DISCOVERY,
+            PRODUCT_FRAMING,
+            ARCHITECTURE,
+            PLANNING,
+            APPROVAL,
+            IMPLEMENTATION,
+            VALIDATION,
+            REVIEW,
+            READY_FOR_PR,
+            COMPLETED,
+            CANCELLED,
+            FAILED,
+        }
+    )
+    TERMINAL = frozenset({COMPLETED, CANCELLED, FAILED})
+
+
+TRANSITIONS: dict[str, frozenset[str]] = {
+    OrchestratorState.INTAKE: frozenset({OrchestratorState.DISCOVERY, OrchestratorState.PRODUCT_FRAMING, OrchestratorState.CANCELLED, OrchestratorState.FAILED}),
+    OrchestratorState.DISCOVERY: frozenset({OrchestratorState.PRODUCT_FRAMING, OrchestratorState.ARCHITECTURE, OrchestratorState.PLANNING, OrchestratorState.APPROVAL, OrchestratorState.CANCELLED, OrchestratorState.FAILED}),
+    OrchestratorState.PRODUCT_FRAMING: frozenset({OrchestratorState.ARCHITECTURE, OrchestratorState.PLANNING, OrchestratorState.APPROVAL, OrchestratorState.CANCELLED, OrchestratorState.FAILED}),
+    OrchestratorState.ARCHITECTURE: frozenset({OrchestratorState.PLANNING, OrchestratorState.APPROVAL, OrchestratorState.CANCELLED, OrchestratorState.FAILED}),
+    OrchestratorState.PLANNING: frozenset({OrchestratorState.APPROVAL, OrchestratorState.IMPLEMENTATION, OrchestratorState.CANCELLED, OrchestratorState.FAILED}),
+    OrchestratorState.APPROVAL: frozenset({OrchestratorState.IMPLEMENTATION, OrchestratorState.PLANNING, OrchestratorState.ARCHITECTURE, OrchestratorState.CANCELLED, OrchestratorState.FAILED}),
+    OrchestratorState.IMPLEMENTATION: frozenset({OrchestratorState.VALIDATION, OrchestratorState.APPROVAL, OrchestratorState.REVIEW, OrchestratorState.CANCELLED, OrchestratorState.FAILED}),
+    OrchestratorState.VALIDATION: frozenset({OrchestratorState.REVIEW, OrchestratorState.IMPLEMENTATION, OrchestratorState.APPROVAL, OrchestratorState.CANCELLED, OrchestratorState.FAILED}),
+    OrchestratorState.REVIEW: frozenset({OrchestratorState.READY_FOR_PR, OrchestratorState.IMPLEMENTATION, OrchestratorState.VALIDATION, OrchestratorState.COMPLETED, OrchestratorState.CANCELLED, OrchestratorState.FAILED}),
+    OrchestratorState.READY_FOR_PR: frozenset({OrchestratorState.COMPLETED, OrchestratorState.IMPLEMENTATION, OrchestratorState.CANCELLED, OrchestratorState.FAILED}),
+    OrchestratorState.COMPLETED: frozenset(),
+    OrchestratorState.CANCELLED: frozenset(),
+    OrchestratorState.FAILED: frozenset(),
+}
+
+
+def validate_transition(from_state: str, to_state: str) -> tuple[bool, str]:
+    if from_state not in OrchestratorState.ALL:
+        return False, f"Unknown from_state: {from_state}"
+    if to_state not in OrchestratorState.ALL:
+        return False, f"Unknown to_state: {to_state}"
+    if from_state in OrchestratorState.TERMINAL:
+        return False, f"State {from_state} is terminal"
+    if to_state not in TRANSITIONS.get(from_state, frozenset()):
+        return False, f"Invalid transition {from_state} -> {to_state}"
+    return True, ""
+
+
+class AgentOrchestrator:
+    def __init__(self, db_path=None):
+        self._db_path = db_path
+
+    def _db(self) -> SessionDB:
+        return SessionDB(db_path=self._db_path) if self._db_path else SessionDB()
+
+    def _ledger(self) -> ArtifactLedger:
+        return ArtifactLedger(db_path=self._db_path)
+
+    def create_run(
+        self,
+        *,
+        title: str | None = None,
+        goal: str | None = None,
+        workspace_id: str | None = None,
+        code_session_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        create_intake_artifact: bool = True,
+    ) -> dict[str, Any]:
+        now = time.time()
+        run = {
+            "id": str(uuid.uuid4()),
+            "title": title or "Untitled Run",
+            "goal": goal or "",
+            "state": OrchestratorState.INTAKE,
+            "workspace_id": workspace_id,
+            "code_session_id": code_session_id,
+            "current_phase": OrchestratorState.INTAKE,
+            "metadata": metadata or {},
+            "created_at": now,
+            "updated_at": now,
+            "completed_at": None,
+        }
+        db = self._db()
+        try:
+            db.create_code_orchestrated_run(run)
+            db.append_code_event(
+                event_type="orchestrator.run.created",
+                workspace_id=workspace_id,
+                code_session_id=code_session_id,
+                payload={"run_id": run["id"], "state": run["state"], "title": run["title"]},
+                source="orchestrator",
+            )
+        finally:
+            db.close()
+
+        if create_intake_artifact and goal:
+            self._ledger().create_artifact(
+                "task_intake",
+                goal,
+                title=title or "Task Intake",
+                workspace_id=workspace_id,
+                code_session_id=code_session_id,
+                orchestrated_run_id=run["id"],
+            )
+        return run
+
+    def get_run(self, run_id: str) -> dict[str, Any] | None:
+        db = self._db()
+        try:
+            return db.get_code_orchestrated_run(run_id)
+        finally:
+            db.close()
+
+    def list_runs(
+        self,
+        *,
+        workspace_id: str | None = None,
+        code_session_id: str | None = None,
+        state: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        db = self._db()
+        try:
+            return db.list_code_orchestrated_runs(
+                workspace_id=workspace_id,
+                code_session_id=code_session_id,
+                state=state,
+                limit=limit,
+                offset=offset,
+            )
+        finally:
+            db.close()
+
+    def transition_run(
+        self,
+        run_id: str,
+        to_state: str,
+        *,
+        reason: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        db = self._db()
+        try:
+            run = db.get_code_orchestrated_run(run_id)
+            if not run:
+                raise ValueError(f"Run not found: {run_id}")
+            from_state = run["state"]
+            valid, msg = validate_transition(from_state, to_state)
+            if not valid:
+                raise ValueError(msg)
+            now = time.time()
+            updates: dict[str, Any] = {
+                "state": to_state,
+                "current_phase": to_state,
+                "updated_at": now,
+            }
+            if metadata:
+                current_metadata = run.get("metadata") or {}
+                if isinstance(current_metadata, dict):
+                    current_metadata = dict(current_metadata)
+                    current_metadata.update(metadata)
+                    updates["metadata"] = current_metadata
+            if to_state in OrchestratorState.TERMINAL:
+                updates["completed_at"] = now
+            db.update_code_orchestrated_run(run_id, updates)
+            db.add_code_run_transition(
+                {
+                    "id": str(uuid.uuid4()),
+                    "run_id": run_id,
+                    "from_state": from_state,
+                    "to_state": to_state,
+                    "reason": reason or f"{from_state} -> {to_state}",
+                    "created_at": now,
+                }
+            )
+            db.append_code_event(
+                event_type="orchestrator.run.transitioned",
+                workspace_id=run.get("workspace_id"),
+                code_session_id=run.get("code_session_id"),
+                payload={
+                    "run_id": run_id,
+                    "from_state": from_state,
+                    "to_state": to_state,
+                    "reason": reason,
+                },
+                source="orchestrator",
+            )
+            updated = db.get_code_orchestrated_run(run_id)
+            return updated or run
+        finally:
+            db.close()
+
+    def list_transitions(self, run_id: str) -> list[dict[str, Any]]:
+        db = self._db()
+        try:
+            return db.list_code_run_transitions(run_id=run_id)
+        finally:
+            db.close()

--- a/hermes_cli/code/artifact_ledger.py
+++ b/hermes_cli/code/artifact_ledger.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Typed artifact ledger for Hermes Code Mode."""
+
+from __future__ import annotations
+
+import time
+import uuid
+from typing import Any
+
+from hermes_state import SessionDB
+
+
+ARTIFACT_TYPES: tuple[str, ...] = (
+    "task_intake",
+    "prd_lite",
+    "acceptance_criteria",
+    "architecture_note",
+    "adr",
+    "implementation_plan",
+    "command_log",
+    "diff_summary",
+    "test_report",
+    "review_report",
+    "deploy_plan",
+    "deploy_report",
+    "memory_update",
+)
+
+
+class ArtifactLedger:
+    def __init__(self, db_path=None):
+        self._db_path = db_path
+
+    def _db(self) -> SessionDB:
+        return SessionDB(db_path=self._db_path) if self._db_path else SessionDB()
+
+    def create_artifact(
+        self,
+        artifact_type: str,
+        content: str,
+        *,
+        title: str | None = None,
+        content_type: str = "markdown",
+        workspace_id: str | None = None,
+        code_session_id: str | None = None,
+        orchestrated_run_id: str | None = None,
+        command_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        if artifact_type not in ARTIFACT_TYPES:
+            raise ValueError(f"Unknown artifact_type: {artifact_type}")
+        artifact = {
+            "id": str(uuid.uuid4()),
+            "artifact_type": artifact_type,
+            "title": title or artifact_type.replace("_", " ").title(),
+            "content": content or "",
+            "content_type": content_type or "markdown",
+            "workspace_id": workspace_id,
+            "code_session_id": code_session_id,
+            "orchestrated_run_id": orchestrated_run_id,
+            "command_id": command_id,
+            "metadata": metadata or {},
+            "created_at": time.time(),
+            "updated_at": time.time(),
+        }
+        db = self._db()
+        try:
+            db.create_code_artifact(artifact)
+            return artifact
+        finally:
+            db.close()
+
+    def list_artifacts(
+        self,
+        *,
+        workspace_id: str | None = None,
+        code_session_id: str | None = None,
+        orchestrated_run_id: str | None = None,
+        artifact_type: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        db = self._db()
+        try:
+            return db.list_code_artifacts(
+                workspace_id=workspace_id,
+                code_session_id=code_session_id,
+                orchestrated_run_id=orchestrated_run_id,
+                artifact_type=artifact_type,
+                limit=limit,
+                offset=offset,
+            )
+        finally:
+            db.close()
+
+    def list_session_artifacts(
+        self,
+        code_session_id: str,
+        *,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        return self.list_artifacts(code_session_id=code_session_id, limit=limit, offset=offset)

--- a/hermes_cli/code/execution_policy.py
+++ b/hermes_cli/code/execution_policy.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Execution policy engine for Hermes Code Mode.
+
+Provides command/tool risk classification and secret redaction helpers.
+"""
+
+from __future__ import annotations
+
+import re
+import shlex
+from typing import Any
+
+
+class RiskClass:
+    SAFE_READONLY = "safe_readonly"
+    SAFE_LOCAL_WRITE = "safe_local_write"
+    NETWORK = "network"
+    GIT_WRITE = "git_write"
+    SECRET_SENSITIVE = "secret_sensitive"
+    REMOTE_MUTATING = "remote_mutating"
+    DESTRUCTIVE = "destructive"
+    PRODUCTION_SENSITIVE = "production_sensitive"
+
+
+_DESTRUCTIVE_PATTERNS = [
+    r"\brm\s+-[a-z]*r[a-z]*f",
+    r"\bgit\s+reset\s+--hard\b",
+    r"\bgit\s+clean\s+-[a-z]*f[a-z]*d[a-z]*x\b",
+    r"\bgit\s+clean\s+-fdx\b",
+    r"\bchmod\s+-R\b",
+    r"\bchown\s+-R\b",
+    r"\bdrop\s+database\b",
+    r"\bdropdb\b",
+    r"\btruncate\s+table\b",
+    r"\bdrop\s+table\b",
+]
+
+_PRODUCTION_PATTERNS = [
+    r"\bterraform\s+(apply|destroy)\b",
+    r"\bkubectl\s+(apply|delete|rollout)\b",
+    r"\bhelm\s+(upgrade|install|uninstall)\b",
+    r"\bdeploy\b.*\bprod",
+    r"\bprod\b.*\bdeploy",
+    r"\balembic\s+upgrade\s+head\b",
+    r"\bdjango.*\bmigrate\b",
+    r"\brails\s+db:migrate\b",
+]
+
+_SECRET_PATTERNS = [
+    r"\b(cat|less|more)\b.*\b\.env\b",
+    r"\b(printenv|env)\b",
+    r"\b(set)\b\s*\|\s*grep\b",
+    r"\bcurl\b.*(?:token|secret|password|api[_-]?key)",
+    r"\becho\b.*(?:token|secret|password|api[_-]?key)\s*=",
+    r"\bcurl\s+[^|]*\|\s*(sh|bash|zsh)\b",
+    r"\bwget\s+[^|]*\|\s*(sh|bash|zsh)\b",
+]
+
+_REMOTE_MUTATING_PATTERNS = [
+    r"\bssh\b",
+    r"\bscp\b",
+    r"\brsync\b.*--delete",
+    r"\bsftp\b",
+]
+
+_GIT_WRITE_PATTERNS = [
+    r"\bgit\s+(commit|push|merge|rebase|cherry-pick|tag)\b",
+    r"\bgit\s+(checkout|switch)\b",
+    r"\bgit\s+branch\s+-[dD]\b",
+    r"\bgit\s+stash\s+(pop|drop)\b",
+    r"\bgit\s+worktree\s+(add|remove)\b",
+]
+
+_NETWORK_PATTERNS = [
+    r"\bcurl\b",
+    r"\bwget\b",
+    r"\bpip\s+install\b",
+    r"\bnpm\s+install\b",
+    r"\bpnpm\s+install\b",
+    r"\byarn\s+install\b",
+    r"\buv\s+add\b",
+]
+
+_SAFE_READONLY_PATTERNS = [
+    r"\bgit\s+(status|diff|log|show)\b",
+    r"\bls\b",
+    r"\bfind\b",
+    r"\brg\b",
+    r"\bgrep\b",
+    r"\bcat\b",
+    r"\bhead\b",
+    r"\btail\b",
+    r"\bpwd\b",
+]
+
+_SAFE_LOCAL_WRITE_PATTERNS = [
+    r"\bpytest\b",
+    r"\bpython3?\s+-m\s+pytest\b",
+    r"\bnpm\s+run\b",
+    r"\bpnpm\s+run\b",
+    r"\byarn\s+run\b",
+    r"\bmake\s+(test|lint|build|check|typecheck)\b",
+    r"\bruff\b",
+    r"\bmypy\b",
+    r"\bblack\b",
+    r"\beslint\b",
+]
+
+_COMPILED: list[tuple[str, list[re.Pattern[str]]]] = [
+    (RiskClass.DESTRUCTIVE, [re.compile(p, re.IGNORECASE) for p in _DESTRUCTIVE_PATTERNS]),
+    (RiskClass.PRODUCTION_SENSITIVE, [re.compile(p, re.IGNORECASE) for p in _PRODUCTION_PATTERNS]),
+    (RiskClass.SECRET_SENSITIVE, [re.compile(p, re.IGNORECASE) for p in _SECRET_PATTERNS]),
+    (RiskClass.REMOTE_MUTATING, [re.compile(p, re.IGNORECASE) for p in _REMOTE_MUTATING_PATTERNS]),
+    (RiskClass.GIT_WRITE, [re.compile(p, re.IGNORECASE) for p in _GIT_WRITE_PATTERNS]),
+    (RiskClass.NETWORK, [re.compile(p, re.IGNORECASE) for p in _NETWORK_PATTERNS]),
+    (RiskClass.SAFE_READONLY, [re.compile(p, re.IGNORECASE) for p in _SAFE_READONLY_PATTERNS]),
+    (RiskClass.SAFE_LOCAL_WRITE, [re.compile(p, re.IGNORECASE) for p in _SAFE_LOCAL_WRITE_PATTERNS]),
+]
+
+_TOOL_RISK_MAP = {
+    "terminal": RiskClass.SAFE_LOCAL_WRITE,
+    "read_file": RiskClass.SAFE_READONLY,
+    "search_files": RiskClass.SAFE_READONLY,
+    "web_search": RiskClass.NETWORK,
+    "execute_code": RiskClass.SAFE_LOCAL_WRITE,
+}
+
+_REDACT_RULES: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"(?i)((?:api[_-]?key|token|secret|password|passwd)\s*[:=]\s*)\S+"), r"\1[REDACTED]"),
+    (re.compile(r"(?i)(authorization\s*:\s*(?:bearer\s+)?)(\S+)"), r"\1[REDACTED]"),
+    (re.compile(r"(?i)(bearer\s+)\S+"), r"\1[REDACTED]"),
+    (re.compile(r"(?i)(--(?:api-key|token|secret|password|access-token)[= ])\S+"), r"\1[REDACTED]"),
+    (re.compile(r"(?i)(HERMES_[A-Z0-9_]+)\s*=\s*([^\s]+)"), r"\1=[REDACTED]"),
+    (re.compile(r"\bsk-[A-Za-z0-9]{10,}\b"), "[REDACTED]"),
+    (re.compile(r"\bgh[pousr]_[A-Za-z0-9]{20,}\b"), "[REDACTED]"),
+    (re.compile(r"\bAKIA[A-Z0-9]{10,}\b"), "[REDACTED]"),
+    (re.compile(r"\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\b"), "[REDACTED]"),
+]
+
+
+def redact_secrets(text: str) -> str:
+    redacted = text or ""
+    for pattern, replacement in _REDACT_RULES:
+        redacted = pattern.sub(replacement, redacted)
+    return redacted
+
+
+def _has_shell_injection(command: str) -> bool:
+    try:
+        shlex.split(command)
+    except ValueError:
+        return True
+    lowered = command.lower()
+    return any(token in lowered for token in ("`", ";", "&&", "||", " | sh", " | bash", " | zsh"))
+
+
+def classify_command(command: str) -> str:
+    cmd = (command or "").strip()
+    if not cmd:
+        return RiskClass.SAFE_READONLY
+    if re.search(r"\bsudo\b", cmd, re.IGNORECASE):
+        return RiskClass.DESTRUCTIVE
+    if _has_shell_injection(cmd):
+        return RiskClass.DESTRUCTIVE
+    for risk_class, patterns in _COMPILED:
+        if any(pattern.search(cmd) for pattern in patterns):
+            return risk_class
+    return RiskClass.SAFE_LOCAL_WRITE
+
+
+def classify_tool(tool_name: str) -> str:
+    return _TOOL_RISK_MAP.get((tool_name or "").strip(), RiskClass.SAFE_LOCAL_WRITE)
+
+
+class ExecutionPolicyEngine:
+    REQUIRES_APPROVAL: frozenset[str] = frozenset(
+        {
+            RiskClass.GIT_WRITE,
+            RiskClass.NETWORK,
+            RiskClass.REMOTE_MUTATING,
+            RiskClass.PRODUCTION_SENSITIVE,
+            RiskClass.SECRET_SENSITIVE,
+        }
+    )
+    BLOCKED: frozenset[str] = frozenset({RiskClass.DESTRUCTIVE})
+
+    def classify(self, command: str) -> str:
+        return classify_command(command)
+
+    def classify_tool(self, tool_name: str) -> str:
+        return classify_tool(tool_name)
+
+    def assess_command(self, command: str) -> dict[str, Any]:
+        risk_class = self.classify(command)
+        return {
+            "command": redact_secrets(command),
+            "risk_class": risk_class,
+            "allowed": risk_class not in self.BLOCKED and risk_class not in self.REQUIRES_APPROVAL,
+            "requires_approval": risk_class in self.REQUIRES_APPROVAL,
+            "blocked": risk_class in self.BLOCKED,
+        }
+
+    def assess_tool(self, tool_name: str) -> dict[str, Any]:
+        risk_class = self.classify_tool(tool_name)
+        return {
+            "tool_name": tool_name,
+            "risk_class": risk_class,
+            "requires_approval": risk_class in self.REQUIRES_APPROVAL,
+            "blocked": risk_class in self.BLOCKED,
+        }
+
+    def redact(self, text: str) -> str:
+        return redact_secrets(text)
+
+
+policy_engine = ExecutionPolicyEngine()

--- a/hermes_cli/code/repo_knowledge.py
+++ b/hermes_cli/code/repo_knowledge.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Repository guidance discovery with AGENTS.md support."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+AGENTS_MD_FILENAME = "AGENTS.md"
+GUIDANCE_DIRS = ("docs/architecture", "docs/engineering", "docs/operations")
+MAX_CONTENT_BYTES = 64 * 1024
+
+
+def _file_info(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        stat = path.stat()
+        return {
+            "path": str(path),
+            "name": path.name,
+            "size_bytes": stat.st_size,
+            "readable": True,
+        }
+    except Exception:
+        return None
+
+
+def detect_repo_guidance(repo_root: Path) -> dict[str, Any]:
+    manifest: dict[str, Any] = {
+        "repo_root": str(repo_root),
+        "agents_md": _file_info(repo_root / AGENTS_MD_FILENAME),
+        "guidance_docs": [],
+    }
+    for rel in GUIDANCE_DIRS:
+        directory = repo_root / rel
+        if not directory.is_dir():
+            continue
+        for doc in sorted(directory.glob("*.md")):
+            info = _file_info(doc)
+            if info:
+                manifest["guidance_docs"].append(info)
+    return manifest
+
+
+def read_agents_md(repo_root: Path) -> str | None:
+    agents_path = repo_root / AGENTS_MD_FILENAME
+    if not agents_path.is_file():
+        return None
+    try:
+        content = agents_path.read_text(encoding="utf-8", errors="replace")
+        return content[:MAX_CONTENT_BYTES]
+    except Exception:
+        return None
+
+
+def bootstrap_agents_md(repo_root: Path, project_summary: str | None = None) -> dict[str, Any]:
+    agents_path = repo_root / AGENTS_MD_FILENAME
+    if agents_path.exists():
+        return {
+            "created": False,
+            "path": str(agents_path),
+            "reason": "AGENTS.md already exists",
+        }
+    if not repo_root.is_dir():
+        return {
+            "created": False,
+            "path": str(agents_path),
+            "reason": f"Repo root does not exist: {repo_root}",
+        }
+    summary = project_summary or "Add project-specific engineering guidance here."
+    content = (
+        "# AGENTS.md\n\n"
+        "## Project summary\n"
+        f"{summary}\n\n"
+        "## Engineering Guidance\n"
+        "- Keep changes scoped and testable.\n"
+        "- Prefer existing patterns over new abstractions.\n"
+        "- Document non-obvious decisions in docs/engineering when needed.\n"
+    )
+    try:
+        agents_path.write_text(content, encoding="utf-8")
+        return {"created": True, "path": str(agents_path), "reason": "Created AGENTS.md"}
+    except Exception as exc:
+        return {"created": False, "path": str(agents_path), "reason": str(exc)}
+
+
+class RepoKnowledgeService:
+    def detect(self, workspace_path: Path) -> dict[str, Any]:
+        return detect_repo_guidance(workspace_path)
+
+    def read_agents_md(self, workspace_path: Path) -> str | None:
+        return read_agents_md(workspace_path)
+
+    def bootstrap(self, workspace_path: Path, project_summary: str | None = None) -> dict[str, Any]:
+        return bootstrap_agents_md(workspace_path, project_summary=project_summary)

--- a/hermes_cli/code/skill_discovery.py
+++ b/hermes_cli/code/skill_discovery.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Code Mode skill discovery bridge for built-in and SKILL.md folder skills."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from agent.skill_commands import scan_skill_commands
+
+SKILL_MD_FILENAME = "SKILL.md"
+_MAX_SKILL_MD_BYTES = 32 * 1024
+
+
+def _parse_skill_md(skill_md_path: Path) -> dict[str, Any]:
+    try:
+        content = skill_md_path.read_text(encoding="utf-8", errors="replace")
+    except Exception:
+        return {}
+    if len(content.encode("utf-8", errors="ignore")) > _MAX_SKILL_MD_BYTES:
+        content = content[:_MAX_SKILL_MD_BYTES]
+    title = None
+    description = None
+    lines = content.splitlines()
+    for line in lines:
+        stripped = line.strip()
+        if not title and stripped.startswith("# "):
+            title = stripped.removeprefix("# ").strip()
+        if not description and stripped and not stripped.startswith("#"):
+            description = stripped[:160]
+        if title and description:
+            break
+    return {"title": title, "description": description}
+
+
+def _discover_skills_in_dir(skills_dir: Path, source: str) -> list[dict[str, Any]]:
+    if not skills_dir.is_dir():
+        return []
+    discovered: list[dict[str, Any]] = []
+    for child in sorted(skills_dir.iterdir()):
+        if not child.is_dir():
+            continue
+        skill_md = child / SKILL_MD_FILENAME
+        if not skill_md.is_file():
+            continue
+        meta = _parse_skill_md(skill_md)
+        discovered.append(
+            {
+                "name": child.name,
+                "title": meta.get("title") or child.name,
+                "description": meta.get("description") or "",
+                "source": source,
+                "skill_md_path": str(skill_md),
+                "skill_dir": str(child),
+                "has_scripts": (child / "scripts").is_dir(),
+                "has_resources": (child / "resources").is_dir(),
+                "builtin": False,
+            }
+        )
+    return discovered
+
+
+def discover_global_skills() -> list[dict[str, Any]]:
+    from tools.skills_tool import SKILLS_DIR
+    skills = _discover_skills_in_dir(SKILLS_DIR, "global")
+    try:
+        from agent.skill_utils import get_external_skills_dirs
+
+        for directory in get_external_skills_dirs():
+            skills.extend(_discover_skills_in_dir(directory, f"external:{directory.name}"))
+    except Exception:
+        pass
+    return skills
+
+
+def discover_workspace_skills(workspace_path: Path) -> list[dict[str, Any]]:
+    return _discover_skills_in_dir(workspace_path / ".hermes" / "skills", f"workspace:{workspace_path.name}")
+
+
+def discover_builtin_skills() -> list[dict[str, Any]]:
+    skills = []
+    for command, info in scan_skill_commands().items():
+        name = command.lstrip("/")
+        skills.append(
+            {
+                "name": name,
+                "title": info.get("name") or name,
+                "description": info.get("description") or "",
+                "source": "builtin_bridge",
+                "skill_md_path": info.get("skill_md_path"),
+                "skill_dir": info.get("skill_dir"),
+                "has_scripts": bool(info.get("skill_dir") and Path(info["skill_dir"]).joinpath("scripts").is_dir()),
+                "has_resources": bool(info.get("skill_dir") and Path(info["skill_dir"]).joinpath("resources").is_dir()),
+                "builtin": True,
+            }
+        )
+    return skills
+
+
+class SkillDiscoveryService:
+    def list_skills(self, workspace_path: Path | None = None) -> list[dict[str, Any]]:
+        merged: dict[str, dict[str, Any]] = {}
+        for skill in discover_builtin_skills():
+            merged[skill["name"]] = skill
+        for skill in discover_global_skills():
+            merged[skill["name"]] = skill
+        if workspace_path:
+            for skill in discover_workspace_skills(workspace_path):
+                merged[skill["name"]] = skill
+        return sorted(merged.values(), key=lambda s: s["name"])

--- a/hermes_cli/code/worktree_service.py
+++ b/hermes_cli/code/worktree_service.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Safe git capability and worktree foundation for Code Mode."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+from hermes_state import SessionDB
+
+
+def _run_git(path: Path, args: list[str], timeout: int = 10) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(path),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def _parse_worktree_list(output: str) -> list[dict[str, Any]]:
+    worktrees: list[dict[str, Any]] = []
+    current: dict[str, Any] = {}
+    for raw_line in output.splitlines():
+        line = raw_line.strip()
+        if not line:
+            if current:
+                worktrees.append(current)
+                current = {}
+            continue
+        if line.startswith("worktree "):
+            current["path"] = line.removeprefix("worktree ")
+        elif line.startswith("HEAD "):
+            current["head"] = line.removeprefix("HEAD ")
+        elif line.startswith("branch "):
+            current["branch"] = line.removeprefix("branch ")
+        elif line == "detached":
+            current["detached"] = True
+        elif line == "bare":
+            current["bare"] = True
+    if current:
+        worktrees.append(current)
+    return worktrees
+
+
+class WorktreeService:
+    def __init__(self, db_path=None):
+        self._db_path = db_path
+
+    def _db(self) -> SessionDB:
+        return SessionDB(db_path=self._db_path) if self._db_path else SessionDB()
+
+    @staticmethod
+    def detect_git_capabilities(path: Path) -> dict[str, Any]:
+        if not path.exists():
+            return {
+                "path": str(path),
+                "is_git_repo": False,
+                "supports_worktree": False,
+                "current_branch": None,
+                "is_dirty": False,
+                "has_commits": False,
+                "toplevel": None,
+            }
+
+        try:
+            is_repo = _run_git(path, ["rev-parse", "--is-inside-work-tree"]).stdout.strip() == "true"
+        except Exception:
+            is_repo = False
+        if not is_repo:
+            return {
+                "path": str(path),
+                "is_git_repo": False,
+                "supports_worktree": False,
+                "current_branch": None,
+                "is_dirty": False,
+                "has_commits": False,
+                "toplevel": None,
+            }
+
+        toplevel = None
+        try:
+            r = _run_git(path, ["rev-parse", "--show-toplevel"])
+            if r.returncode == 0:
+                toplevel = r.stdout.strip()
+        except Exception:
+            pass
+        current_branch = None
+        try:
+            r = _run_git(path, ["branch", "--show-current"])
+            if r.returncode == 0:
+                current_branch = r.stdout.strip() or None
+        except Exception:
+            pass
+        has_commits = False
+        try:
+            has_commits = _run_git(path, ["rev-parse", "--verify", "HEAD"]).returncode == 0
+        except Exception:
+            pass
+        is_dirty = False
+        if has_commits:
+            try:
+                is_dirty = bool(_run_git(path, ["status", "--porcelain"]).stdout.strip())
+            except Exception:
+                pass
+        supports_worktree = False
+        try:
+            supports_worktree = _run_git(path, ["worktree", "list", "--porcelain"]).returncode == 0
+        except Exception:
+            pass
+        return {
+            "path": str(path),
+            "is_git_repo": True,
+            "supports_worktree": supports_worktree,
+            "current_branch": current_branch,
+            "is_dirty": is_dirty,
+            "has_commits": has_commits,
+            "toplevel": toplevel,
+        }
+
+    def _workspace_path(self, workspace_id: str) -> Path:
+        db = self._db()
+        try:
+            workspace = db.get_code_workspace(workspace_id)
+        finally:
+            db.close()
+        if not workspace or not workspace.get("path"):
+            raise ValueError(f"Workspace not found or path missing: {workspace_id}")
+        return Path(workspace["path"])
+
+    def detect_capabilities_for_workspace(self, workspace_id: str) -> dict[str, Any]:
+        try:
+            return self.detect_git_capabilities(self._workspace_path(workspace_id))
+        except Exception:
+            return {
+                "path": None,
+                "is_git_repo": False,
+                "supports_worktree": False,
+                "current_branch": None,
+                "is_dirty": False,
+                "has_commits": False,
+                "toplevel": None,
+            }
+
+    def list_worktrees_for_workspace(self, workspace_id: str) -> list[dict[str, Any]]:
+        try:
+            path = self._workspace_path(workspace_id)
+        except Exception:
+            return []
+        caps = self.detect_git_capabilities(path)
+        if not caps["is_git_repo"] or not caps["supports_worktree"]:
+            return []
+        try:
+            result = _run_git(path, ["worktree", "list", "--porcelain"])
+            if result.returncode != 0:
+                return []
+            return _parse_worktree_list(result.stdout)
+        except Exception:
+            return []
+
+    def create_checkpoint_metadata(
+        self,
+        workspace_id: str,
+        *,
+        name: str | None = None,
+    ) -> dict[str, Any]:
+        path = self._workspace_path(workspace_id)
+        caps = self.detect_git_capabilities(path)
+        head_sha = None
+        if caps["is_git_repo"] and caps["has_commits"]:
+            try:
+                result = _run_git(path, ["rev-parse", "HEAD"])
+                if result.returncode == 0:
+                    head_sha = result.stdout.strip()
+            except Exception:
+                pass
+
+        checkpoint = {
+            "id": str(uuid.uuid4()),
+            "workspace_id": workspace_id,
+            "name": name or "checkpoint",
+            "git_branch": caps.get("current_branch"),
+            "git_commit": head_sha,
+            "dirty": bool(caps.get("is_dirty")),
+            "metadata": {"capabilities": caps},
+            "created_at": time.time(),
+        }
+        db = self._db()
+        try:
+            db.create_code_checkpoint(checkpoint)
+        finally:
+            db.close()
+        return checkpoint

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -152,6 +152,20 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("plugins", "List installed plugins and their status",
                "Tools & Skills", cli_only=True),
 
+    # Code Mode
+    CommandDef("code", "Show Hermes Code Mode status and local workspace context",
+               "Code Mode", cli_only=True),
+    CommandDef("web", "Show Hermes Web dashboard and Code Cockpit launch hints",
+               "Code Mode", cli_only=True),
+    CommandDef("workspace", "Show Code Mode workspace metadata",
+               "Code Mode", cli_only=True, args_hint="[owner|search]"),
+    CommandDef("session", "Show Code Mode session metadata",
+               "Code Mode", cli_only=True, args_hint="[workspace_id]"),
+    CommandDef("approvals", "Show Code Mode approval status and deferred policy scope",
+               "Code Mode", cli_only=True),
+    CommandDef("skills-code", "Show Code Mode skill integration status",
+               "Code Mode", cli_only=True, aliases=("skillscode",)),
+
     # Info
     CommandDef("commands", "Browse all commands and skills (paginated)", "Info",
                gateway_only=True, args_hint="[page]"),

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -22,6 +22,7 @@ import threading
 import time
 import urllib.parse
 import urllib.request
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -436,6 +437,41 @@ class EnvVarReveal(BaseModel):
     key: str
 
 
+class CodeArtifactCreate(BaseModel):
+    artifact_type: str
+    content: str
+    title: str | None = None
+    content_type: str = "markdown"
+    workspace_id: str | None = None
+    code_session_id: str | None = None
+    orchestrated_run_id: str | None = None
+    command_id: str | None = None
+    metadata: dict[str, Any] = {}
+
+
+class OrchestratorRunCreate(BaseModel):
+    title: str | None = None
+    goal: str | None = None
+    workspace_id: str | None = None
+    code_session_id: str | None = None
+    metadata: dict[str, Any] = {}
+    create_intake_artifact: bool = True
+
+
+class OrchestratorTransitionRequest(BaseModel):
+    to_state: str
+    reason: str | None = None
+    metadata: dict[str, Any] = {}
+
+
+class PolicyAssessCommandRequest(BaseModel):
+    command: str
+
+
+class RepoKnowledgeBootstrapRequest(BaseModel):
+    project_summary: str | None = None
+
+
 _GATEWAY_HEALTH_URL = os.getenv("GATEWAY_HEALTH_URL")
 try:
     _GATEWAY_HEALTH_TIMEOUT = float(os.getenv("GATEWAY_HEALTH_TIMEOUT", "3"))
@@ -605,6 +641,62 @@ def _code_offset(value: int) -> int:
     return max(0, value)
 
 
+def _make_code_event(
+    event_type: str,
+    *,
+    payload: dict[str, Any] | None = None,
+    workspace_id: str | None = None,
+    code_session_id: str | None = None,
+) -> dict[str, Any]:
+    event = {
+        "type": event_type,
+        "version": 1,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "payload": payload or {},
+    }
+    if workspace_id:
+        event["workspace_id"] = workspace_id
+    if code_session_id:
+        event["code_session_id"] = code_session_id
+    return event
+
+
+def _record_code_event(
+    event_type: str,
+    *,
+    payload: dict[str, Any] | None = None,
+    workspace_id: str | None = None,
+    code_session_id: str | None = None,
+    level: str = "info",
+    source: str = "control_plane",
+) -> dict[str, Any]:
+    event = _make_code_event(
+        event_type,
+        payload=payload,
+        workspace_id=workspace_id,
+        code_session_id=code_session_id,
+    )
+    try:
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            event_id = db.append_code_event(
+                event_type=event_type,
+                payload=event,
+                workspace_id=workspace_id,
+                code_session_id=code_session_id,
+                source=source,
+                level=level,
+            )
+            event["id"] = event_id
+        finally:
+            db.close()
+    except Exception:
+        _log.exception("Failed to persist code event %s", event_type)
+    return event
+
+
 @app.get("/api/code/status")
 async def get_code_status():
     """Read-only Code Mode readiness endpoint.
@@ -705,6 +797,311 @@ async def get_code_events(
     except Exception:
         _log.exception("GET /api/code/events failed")
         raise HTTPException(status_code=500, detail="Code Mode events unavailable")
+
+
+@app.get("/api/code/artifacts")
+async def get_code_artifacts(
+    workspace_id: str | None = None,
+    code_session_id: str | None = None,
+    orchestrated_run_id: str | None = None,
+    artifact_type: str | None = None,
+    limit: int = 100,
+    offset: int = 0,
+):
+    try:
+        from hermes_cli.code.artifact_ledger import ArtifactLedger
+
+        ledger = ArtifactLedger()
+        artifacts = ledger.list_artifacts(
+            workspace_id=workspace_id,
+            code_session_id=code_session_id,
+            orchestrated_run_id=orchestrated_run_id,
+            artifact_type=artifact_type,
+            limit=_code_limit(limit, default=100, maximum=500),
+            offset=_code_offset(offset),
+        )
+        return {
+            "artifacts": artifacts,
+            "limit": _code_limit(limit, default=100, maximum=500),
+            "offset": _code_offset(offset),
+        }
+    except Exception:
+        _log.exception("GET /api/code/artifacts failed")
+        raise HTTPException(status_code=500, detail="Code artifacts unavailable")
+
+
+@app.post("/api/code/artifacts")
+async def create_code_artifact(payload: CodeArtifactCreate):
+    try:
+        from hermes_cli.code.artifact_ledger import ArtifactLedger
+
+        ledger = ArtifactLedger()
+        artifact = ledger.create_artifact(
+            payload.artifact_type,
+            payload.content,
+            title=payload.title,
+            content_type=payload.content_type,
+            workspace_id=payload.workspace_id,
+            code_session_id=payload.code_session_id,
+            orchestrated_run_id=payload.orchestrated_run_id,
+            command_id=payload.command_id,
+            metadata=payload.metadata or {},
+        )
+        event = _record_code_event(
+            "artifact.created",
+            payload={"artifact_id": artifact["id"], "artifact_type": artifact["artifact_type"]},
+            workspace_id=artifact.get("workspace_id"),
+            code_session_id=artifact.get("code_session_id"),
+        )
+        return {"ok": True, "artifact": artifact, "event": event}
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    except Exception:
+        _log.exception("POST /api/code/artifacts failed")
+        raise HTTPException(status_code=500, detail="Failed to create artifact")
+
+
+@app.get("/api/code/sessions/{code_session_id}/artifacts")
+async def get_code_session_artifacts(code_session_id: str, limit: int = 100, offset: int = 0):
+    try:
+        from hermes_cli.code.artifact_ledger import ArtifactLedger
+
+        ledger = ArtifactLedger()
+        artifacts = ledger.list_session_artifacts(
+            code_session_id=code_session_id,
+            limit=_code_limit(limit, default=100, maximum=500),
+            offset=_code_offset(offset),
+        )
+        return {
+            "code_session_id": code_session_id,
+            "artifacts": artifacts,
+            "limit": _code_limit(limit, default=100, maximum=500),
+            "offset": _code_offset(offset),
+        }
+    except Exception:
+        _log.exception("GET /api/code/sessions/%s/artifacts failed", code_session_id)
+        raise HTTPException(status_code=500, detail="Code session artifacts unavailable")
+
+
+@app.get("/api/code/orchestrator/runs")
+async def get_orchestrator_runs(
+    workspace_id: str | None = None,
+    code_session_id: str | None = None,
+    state: str | None = None,
+    limit: int = 50,
+    offset: int = 0,
+):
+    try:
+        from hermes_cli.code.agent_orchestrator import AgentOrchestrator
+
+        orchestrator = AgentOrchestrator()
+        runs = orchestrator.list_runs(
+            workspace_id=workspace_id,
+            code_session_id=code_session_id,
+            state=state,
+            limit=_code_limit(limit),
+            offset=_code_offset(offset),
+        )
+        return {"runs": runs, "limit": _code_limit(limit), "offset": _code_offset(offset)}
+    except Exception:
+        _log.exception("GET /api/code/orchestrator/runs failed")
+        raise HTTPException(status_code=500, detail="Orchestrator runs unavailable")
+
+
+@app.post("/api/code/orchestrator/runs")
+async def create_orchestrator_run(payload: OrchestratorRunCreate):
+    try:
+        from hermes_cli.code.agent_orchestrator import AgentOrchestrator
+
+        orchestrator = AgentOrchestrator()
+        run = orchestrator.create_run(
+            title=payload.title,
+            goal=payload.goal,
+            workspace_id=payload.workspace_id,
+            code_session_id=payload.code_session_id,
+            metadata=payload.metadata or {},
+            create_intake_artifact=payload.create_intake_artifact,
+        )
+        event = _record_code_event(
+            "orchestrator.run.created",
+            payload={"run_id": run["id"], "state": run["state"]},
+            workspace_id=run.get("workspace_id"),
+            code_session_id=run.get("code_session_id"),
+        )
+        return {"ok": True, "run": run, "event": event}
+    except Exception:
+        _log.exception("POST /api/code/orchestrator/runs failed")
+        raise HTTPException(status_code=500, detail="Failed to create orchestrator run")
+
+
+@app.get("/api/code/orchestrator/runs/{run_id}")
+async def get_orchestrator_run(run_id: str):
+    try:
+        from hermes_cli.code.agent_orchestrator import AgentOrchestrator
+
+        orchestrator = AgentOrchestrator()
+        run = orchestrator.get_run(run_id)
+        if not run:
+            raise HTTPException(status_code=404, detail=f"Run not found: {run_id}")
+        transitions = orchestrator.list_transitions(run_id)
+        return {"run": run, "transitions": transitions}
+    except HTTPException:
+        raise
+    except Exception:
+        _log.exception("GET /api/code/orchestrator/runs/%s failed", run_id)
+        raise HTTPException(status_code=500, detail="Orchestrator run unavailable")
+
+
+@app.post("/api/code/orchestrator/runs/{run_id}/transition")
+async def transition_orchestrator_run(run_id: str, payload: OrchestratorTransitionRequest):
+    try:
+        from hermes_cli.code.agent_orchestrator import AgentOrchestrator
+
+        orchestrator = AgentOrchestrator()
+        run = orchestrator.transition_run(
+            run_id,
+            payload.to_state,
+            reason=payload.reason,
+            metadata=payload.metadata or {},
+        )
+        event = _record_code_event(
+            "orchestrator.run.transitioned",
+            payload={
+                "run_id": run_id,
+                "to_state": payload.to_state,
+                "reason": payload.reason,
+            },
+            workspace_id=run.get("workspace_id"),
+            code_session_id=run.get("code_session_id"),
+        )
+        return {"ok": True, "run": run, "event": event}
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    except Exception:
+        _log.exception("POST /api/code/orchestrator/runs/%s/transition failed", run_id)
+        raise HTTPException(status_code=500, detail="Failed to transition orchestrator run")
+
+
+@app.post("/api/code/policy/assess-command")
+async def assess_code_command_policy(payload: PolicyAssessCommandRequest):
+    try:
+        from hermes_cli.code.execution_policy import policy_engine
+
+        assessment = policy_engine.assess_command(payload.command)
+        return {"assessment": assessment}
+    except Exception:
+        _log.exception("POST /api/code/policy/assess-command failed")
+        raise HTTPException(status_code=500, detail="Execution policy unavailable")
+
+
+@app.get("/api/code/workspaces/{workspace_id}/git/capabilities")
+async def get_workspace_git_capabilities(workspace_id: str):
+    try:
+        from hermes_cli.code.worktree_service import WorktreeService
+
+        service = WorktreeService()
+        caps = service.detect_capabilities_for_workspace(workspace_id)
+        return {"workspace_id": workspace_id, "capabilities": caps}
+    except Exception:
+        _log.exception("GET /api/code/workspaces/%s/git/capabilities failed", workspace_id)
+        raise HTTPException(status_code=500, detail="Git capability detection unavailable")
+
+
+@app.get("/api/code/workspaces/{workspace_id}/git/worktrees")
+async def get_workspace_git_worktrees(workspace_id: str):
+    try:
+        from hermes_cli.code.worktree_service import WorktreeService
+
+        service = WorktreeService()
+        worktrees = service.list_worktrees_for_workspace(workspace_id)
+        return {"workspace_id": workspace_id, "worktrees": worktrees}
+    except Exception:
+        _log.exception("GET /api/code/workspaces/%s/git/worktrees failed", workspace_id)
+        raise HTTPException(status_code=500, detail="Worktree listing unavailable")
+
+
+@app.get("/api/code/skills/discovered")
+async def get_code_discovered_skills(workspace_id: str | None = None):
+    try:
+        from hermes_cli.code.skill_discovery import SkillDiscoveryService
+        from hermes_state import SessionDB
+
+        workspace_path = None
+        if workspace_id:
+            db = SessionDB()
+            try:
+                workspace = db.get_code_workspace(workspace_id)
+            finally:
+                db.close()
+            if workspace and workspace.get("path"):
+                workspace_path = Path(workspace["path"])
+
+        service = SkillDiscoveryService()
+        skills = service.list_skills(workspace_path=workspace_path)
+        return {"skills": skills, "workspace_id": workspace_id}
+    except Exception:
+        _log.exception("GET /api/code/skills/discovered failed")
+        raise HTTPException(status_code=500, detail="Code skill discovery unavailable")
+
+
+@app.get("/api/code/workspaces/{workspace_id}/repo-knowledge")
+async def get_workspace_repo_knowledge(workspace_id: str):
+    try:
+        from hermes_cli.code.repo_knowledge import RepoKnowledgeService
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            workspace = db.get_code_workspace(workspace_id)
+        finally:
+            db.close()
+        if not workspace or not workspace.get("path"):
+            raise HTTPException(status_code=404, detail=f"Workspace not found: {workspace_id}")
+
+        service = RepoKnowledgeService()
+        root = Path(workspace["path"])
+        manifest = service.detect(root)
+        agents_md = service.read_agents_md(root)
+        return {
+            "workspace_id": workspace_id,
+            "manifest": manifest,
+            "agents_md_excerpt": agents_md,
+        }
+    except HTTPException:
+        raise
+    except Exception:
+        _log.exception("GET /api/code/workspaces/%s/repo-knowledge failed", workspace_id)
+        raise HTTPException(status_code=500, detail="Repo knowledge unavailable")
+
+
+@app.post("/api/code/workspaces/{workspace_id}/repo-knowledge/bootstrap")
+async def bootstrap_workspace_repo_knowledge(workspace_id: str, payload: RepoKnowledgeBootstrapRequest):
+    try:
+        from hermes_cli.code.repo_knowledge import RepoKnowledgeService
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            workspace = db.get_code_workspace(workspace_id)
+        finally:
+            db.close()
+        if not workspace or not workspace.get("path"):
+            raise HTTPException(status_code=404, detail=f"Workspace not found: {workspace_id}")
+
+        service = RepoKnowledgeService()
+        root = Path(workspace["path"])
+        result = service.bootstrap(root, project_summary=payload.project_summary)
+        event = _record_code_event(
+            "repo_knowledge.bootstrap",
+            payload={"workspace_id": workspace_id, "created": bool(result.get("created"))},
+            workspace_id=workspace_id,
+        )
+        return {"ok": True, "result": result, "event": event}
+    except HTTPException:
+        raise
+    except Exception:
+        _log.exception("POST /api/code/workspaces/%s/repo-knowledge/bootstrap failed", workspace_id)
+        raise HTTPException(status_code=500, detail="Repo knowledge bootstrap unavailable")
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -100,6 +100,7 @@ app.add_middleware(
 # ---------------------------------------------------------------------------
 _PUBLIC_API_PATHS: frozenset = frozenset({
     "/api/status",
+    "/api/code/status",
     "/api/config/defaults",
     "/api/config/schema",
     "/api/model/info",
@@ -338,6 +339,7 @@ _CATEGORY_MERGE: Dict[str, str] = {
     "human_delay": "display",
     "dashboard": "display",
     "code_execution": "agent",
+    "prompt_caching": "agent",
 }
 
 # Display order for tabs — unlisted categories sort alphabetically after these.
@@ -585,6 +587,124 @@ async def get_status():
         "gateway_updated_at": gateway_updated_at,
         "active_sessions": active_sessions,
     }
+
+
+def _code_limit(value: int, default: int = 50, maximum: int = 200) -> int:
+    try:
+        value = int(value)
+    except Exception:
+        value = default
+    return max(1, min(value, maximum))
+
+
+def _code_offset(value: int) -> int:
+    try:
+        value = int(value)
+    except Exception:
+        value = 0
+    return max(0, value)
+
+
+@app.get("/api/code/status")
+async def get_code_status():
+    """Read-only Code Mode readiness endpoint.
+
+    This endpoint is public so the CLI can detect whether the dashboard backend
+    is reachable without knowing the dashboard session token.
+    """
+    try:
+        from hermes_state import SCHEMA_VERSION, SessionDB
+
+        db = SessionDB()
+        try:
+            status = db.code_mode_status()
+        finally:
+            db.close()
+        return {
+            "mode": "code_mode",
+            "ready": status.get("mode") == "enabled",
+            "schema_version": status.get("schema_version") or SCHEMA_VERSION,
+            "state": status,
+            "workspace_path": os.getcwd(),
+            "web_url": None,
+        }
+    except Exception as exc:
+        _log.exception("GET /api/code/status failed")
+        return {
+            "mode": "code_mode",
+            "ready": False,
+            "schema_version": None,
+            "state": {"mode": "unavailable", "error": str(exc)},
+            "workspace_path": os.getcwd(),
+            "web_url": None,
+        }
+
+
+@app.get("/api/code/workspaces")
+async def get_code_workspaces(owner: str | None = None, q: str = "", limit: int = 50, offset: int = 0):
+    try:
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            workspaces = db.list_code_workspaces(
+                owner=owner,
+                q=q or "",
+                limit=_code_limit(limit),
+                offset=_code_offset(offset),
+            )
+            return {"workspaces": workspaces, "limit": _code_limit(limit), "offset": _code_offset(offset)}
+        finally:
+            db.close()
+    except Exception:
+        _log.exception("GET /api/code/workspaces failed")
+        raise HTTPException(status_code=500, detail="Code Mode workspaces unavailable")
+
+
+@app.get("/api/code/sessions")
+async def get_code_sessions(workspace_id: str | None = None, limit: int = 50, offset: int = 0):
+    try:
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            sessions = db.list_code_sessions(
+                workspace_id=workspace_id,
+                limit=_code_limit(limit),
+                offset=_code_offset(offset),
+            )
+            return {"sessions": sessions, "limit": _code_limit(limit), "offset": _code_offset(offset)}
+        finally:
+            db.close()
+    except Exception:
+        _log.exception("GET /api/code/sessions failed")
+        raise HTTPException(status_code=500, detail="Code Mode sessions unavailable")
+
+
+@app.get("/api/code/events")
+async def get_code_events(
+    workspace_id: str | None = None,
+    session_id: str | None = None,
+    limit: int = 50,
+    offset: int = 0,
+):
+    try:
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            events = db.list_code_events(
+                workspace_id=workspace_id,
+                session_id=session_id,
+                limit=_code_limit(limit),
+                offset=_code_offset(offset),
+            )
+            return {"events": events, "limit": _code_limit(limit), "offset": _code_offset(offset)}
+        finally:
+            db.close()
+    except Exception:
+        _log.exception("GET /api/code/events failed")
+        raise HTTPException(status_code=500, detail="Code Mode events unavailable")
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -21,6 +21,7 @@ import re
 import sqlite3
 import threading
 import time
+import uuid
 from pathlib import Path
 
 from agent.memory_manager import sanitize_context
@@ -33,7 +34,7 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 12
+SCHEMA_VERSION = 13
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -147,6 +148,80 @@ CREATE INDEX IF NOT EXISTS idx_code_events_workspace
 
 CREATE INDEX IF NOT EXISTS idx_code_events_session
     ON code_events(session_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS code_artifacts (
+    id TEXT PRIMARY KEY,
+    artifact_type TEXT NOT NULL,
+    title TEXT,
+    content TEXT NOT NULL,
+    content_type TEXT DEFAULT 'markdown',
+    workspace_id TEXT,
+    code_session_id TEXT,
+    orchestrated_run_id TEXT,
+    command_id TEXT,
+    metadata_json TEXT DEFAULT '{}',
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_code_artifacts_workspace
+    ON code_artifacts(workspace_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_code_artifacts_session
+    ON code_artifacts(code_session_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_code_artifacts_run
+    ON code_artifacts(orchestrated_run_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS code_orchestrated_runs (
+    id TEXT PRIMARY KEY,
+    title TEXT,
+    goal TEXT,
+    state TEXT NOT NULL DEFAULT 'intake',
+    workspace_id TEXT,
+    code_session_id TEXT,
+    current_phase TEXT,
+    metadata_json TEXT DEFAULT '{}',
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL,
+    completed_at REAL
+);
+
+CREATE INDEX IF NOT EXISTS idx_code_orchestrated_runs_workspace
+    ON code_orchestrated_runs(workspace_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_code_orchestrated_runs_session
+    ON code_orchestrated_runs(code_session_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_code_orchestrated_runs_state
+    ON code_orchestrated_runs(state, updated_at DESC);
+
+CREATE TABLE IF NOT EXISTS code_run_transitions (
+    id TEXT PRIMARY KEY,
+    run_id TEXT NOT NULL,
+    from_state TEXT,
+    to_state TEXT NOT NULL,
+    reason TEXT,
+    created_at REAL NOT NULL,
+    FOREIGN KEY (run_id) REFERENCES code_orchestrated_runs(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_code_run_transitions_run
+    ON code_run_transitions(run_id, created_at ASC);
+
+CREATE TABLE IF NOT EXISTS code_checkpoints (
+    id TEXT PRIMARY KEY,
+    workspace_id TEXT,
+    name TEXT,
+    git_branch TEXT,
+    git_commit TEXT,
+    dirty INTEGER DEFAULT 0,
+    metadata_json TEXT DEFAULT '{}',
+    created_at REAL NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_code_checkpoints_workspace
+    ON code_checkpoints(workspace_id, created_at DESC);
 
 CREATE TABLE IF NOT EXISTS state_meta (
     key TEXT PRIMARY KEY,
@@ -611,6 +686,89 @@ class SessionDB:
                     # If the process lacks required migration privileges or the
                     # DB is in a transient bad state, continue with the
                     # existing migration path after creating schema in future reads.
+                    pass
+
+            if current_version < 13:
+                # v13: add P0 engineering control-plane tables.
+                try:
+                    cursor.executescript(
+                        """
+                        CREATE TABLE IF NOT EXISTS code_artifacts (
+                            id TEXT PRIMARY KEY,
+                            artifact_type TEXT NOT NULL,
+                            title TEXT,
+                            content TEXT NOT NULL,
+                            content_type TEXT DEFAULT 'markdown',
+                            workspace_id TEXT,
+                            code_session_id TEXT,
+                            orchestrated_run_id TEXT,
+                            command_id TEXT,
+                            metadata_json TEXT DEFAULT '{}',
+                            created_at REAL NOT NULL,
+                            updated_at REAL NOT NULL
+                        );
+
+                        CREATE INDEX IF NOT EXISTS idx_code_artifacts_workspace
+                            ON code_artifacts(workspace_id, created_at DESC);
+
+                        CREATE INDEX IF NOT EXISTS idx_code_artifacts_session
+                            ON code_artifacts(code_session_id, created_at DESC);
+
+                        CREATE INDEX IF NOT EXISTS idx_code_artifacts_run
+                            ON code_artifacts(orchestrated_run_id, created_at DESC);
+
+                        CREATE TABLE IF NOT EXISTS code_orchestrated_runs (
+                            id TEXT PRIMARY KEY,
+                            title TEXT,
+                            goal TEXT,
+                            state TEXT NOT NULL DEFAULT 'intake',
+                            workspace_id TEXT,
+                            code_session_id TEXT,
+                            current_phase TEXT,
+                            metadata_json TEXT DEFAULT '{}',
+                            created_at REAL NOT NULL,
+                            updated_at REAL NOT NULL,
+                            completed_at REAL
+                        );
+
+                        CREATE INDEX IF NOT EXISTS idx_code_orchestrated_runs_workspace
+                            ON code_orchestrated_runs(workspace_id, created_at DESC);
+
+                        CREATE INDEX IF NOT EXISTS idx_code_orchestrated_runs_session
+                            ON code_orchestrated_runs(code_session_id, created_at DESC);
+
+                        CREATE INDEX IF NOT EXISTS idx_code_orchestrated_runs_state
+                            ON code_orchestrated_runs(state, updated_at DESC);
+
+                        CREATE TABLE IF NOT EXISTS code_run_transitions (
+                            id TEXT PRIMARY KEY,
+                            run_id TEXT NOT NULL,
+                            from_state TEXT,
+                            to_state TEXT NOT NULL,
+                            reason TEXT,
+                            created_at REAL NOT NULL,
+                            FOREIGN KEY (run_id) REFERENCES code_orchestrated_runs(id) ON DELETE CASCADE
+                        );
+
+                        CREATE INDEX IF NOT EXISTS idx_code_run_transitions_run
+                            ON code_run_transitions(run_id, created_at ASC);
+
+                        CREATE TABLE IF NOT EXISTS code_checkpoints (
+                            id TEXT PRIMARY KEY,
+                            workspace_id TEXT,
+                            name TEXT,
+                            git_branch TEXT,
+                            git_commit TEXT,
+                            dirty INTEGER DEFAULT 0,
+                            metadata_json TEXT DEFAULT '{}',
+                            created_at REAL NOT NULL
+                        );
+
+                        CREATE INDEX IF NOT EXISTS idx_code_checkpoints_workspace
+                            ON code_checkpoints(workspace_id, created_at DESC);
+                        """
+                    )
+                except Exception:
                     pass
 
             if current_version < SCHEMA_VERSION:
@@ -1294,6 +1452,14 @@ class SessionDB:
         )
         return self._code_list_rows("code_workspaces", query=query, params=tuple(params), limit=limit, offset=offset)
 
+    def get_code_workspace(self, workspace_id: str) -> Optional[dict[str, Any]]:
+        if not self._code_tables_exist():
+            return None
+        with self._lock:
+            cursor = self._conn.execute("SELECT * FROM code_workspaces WHERE id = ? LIMIT 1", (workspace_id,))
+            row = cursor.fetchone()
+        return dict(row) if row else None
+
     def list_code_sessions(
         self,
         workspace_id: str | None = None,
@@ -1333,6 +1499,301 @@ class SessionDB:
             "ORDER BY created_at DESC LIMIT ? OFFSET ?"
         )
         return self._code_list_rows("code_events", query=query, params=tuple(params), limit=limit, offset=offset)
+
+    def append_code_event(
+        self,
+        *,
+        event_type: str,
+        payload: dict[str, Any],
+        workspace_id: str | None = None,
+        code_session_id: str | None = None,
+        sender_login: str | None = None,
+        source: str | None = "code_mode",
+        level: str = "info",
+    ) -> str:
+        event_id = str(uuid.uuid4())
+        payload_json = json.dumps(payload or {})
+        created_at = time.time()
+
+        def _do(conn):
+            conn.execute(
+                """
+                INSERT INTO code_events (
+                    id, workspace_id, session_id, event_type, sender_login,
+                    source, level, payload_json, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    event_id,
+                    workspace_id,
+                    code_session_id,
+                    event_type,
+                    sender_login,
+                    source,
+                    level,
+                    payload_json,
+                    created_at,
+                ),
+            )
+            return event_id
+
+        return self._execute_write(_do)
+
+    def create_code_artifact(self, artifact: dict[str, Any]) -> str:
+        artifact_id = artifact["id"]
+        metadata_json = json.dumps(artifact.get("metadata") or {})
+
+        def _do(conn):
+            conn.execute(
+                """
+                INSERT INTO code_artifacts (
+                    id, artifact_type, title, content, content_type,
+                    workspace_id, code_session_id, orchestrated_run_id, command_id,
+                    metadata_json, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    artifact_id,
+                    artifact["artifact_type"],
+                    artifact.get("title"),
+                    artifact.get("content", ""),
+                    artifact.get("content_type", "markdown"),
+                    artifact.get("workspace_id"),
+                    artifact.get("code_session_id"),
+                    artifact.get("orchestrated_run_id"),
+                    artifact.get("command_id"),
+                    metadata_json,
+                    artifact["created_at"],
+                    artifact["updated_at"],
+                ),
+            )
+            return artifact_id
+
+        return self._execute_write(_do)
+
+    def list_code_artifacts(
+        self,
+        *,
+        workspace_id: str | None = None,
+        code_session_id: str | None = None,
+        orchestrated_run_id: str | None = None,
+        artifact_type: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        filters = []
+        params: list[Any] = []
+        if workspace_id:
+            filters.append("workspace_id = ?")
+            params.append(workspace_id)
+        if code_session_id:
+            filters.append("code_session_id = ?")
+            params.append(code_session_id)
+        if orchestrated_run_id:
+            filters.append("orchestrated_run_id = ?")
+            params.append(orchestrated_run_id)
+        if artifact_type:
+            filters.append("artifact_type = ?")
+            params.append(artifact_type)
+        where_sql = f"WHERE {' AND '.join(filters)}" if filters else ""
+        with self._lock:
+            cursor = self._conn.execute(
+                f"SELECT * FROM code_artifacts {where_sql} ORDER BY created_at DESC LIMIT ? OFFSET ?",
+                tuple(params + [limit, offset]),
+            )
+            rows = [dict(row) for row in cursor.fetchall()]
+        for row in rows:
+            raw = row.pop("metadata_json", "{}")
+            try:
+                row["metadata"] = json.loads(raw) if raw else {}
+            except Exception:
+                row["metadata"] = {}
+        return rows
+
+    def create_code_orchestrated_run(self, run: dict[str, Any]) -> str:
+        metadata_json = json.dumps(run.get("metadata") or {})
+
+        def _do(conn):
+            conn.execute(
+                """
+                INSERT INTO code_orchestrated_runs (
+                    id, title, goal, state, workspace_id, code_session_id,
+                    current_phase, metadata_json, created_at, updated_at, completed_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    run["id"],
+                    run.get("title"),
+                    run.get("goal"),
+                    run.get("state", "intake"),
+                    run.get("workspace_id"),
+                    run.get("code_session_id"),
+                    run.get("current_phase"),
+                    metadata_json,
+                    run["created_at"],
+                    run["updated_at"],
+                    run.get("completed_at"),
+                ),
+            )
+            return run["id"]
+
+        return self._execute_write(_do)
+
+    def get_code_orchestrated_run(self, run_id: str) -> Optional[dict[str, Any]]:
+        with self._lock:
+            cursor = self._conn.execute(
+                "SELECT * FROM code_orchestrated_runs WHERE id = ? LIMIT 1",
+                (run_id,),
+            )
+            row = cursor.fetchone()
+        if not row:
+            return None
+        result = dict(row)
+        raw = result.pop("metadata_json", "{}")
+        try:
+            result["metadata"] = json.loads(raw) if raw else {}
+        except Exception:
+            result["metadata"] = {}
+        return result
+
+    def list_code_orchestrated_runs(
+        self,
+        *,
+        workspace_id: str | None = None,
+        code_session_id: str | None = None,
+        state: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        filters = []
+        params: list[Any] = []
+        if workspace_id:
+            filters.append("workspace_id = ?")
+            params.append(workspace_id)
+        if code_session_id:
+            filters.append("code_session_id = ?")
+            params.append(code_session_id)
+        if state:
+            filters.append("state = ?")
+            params.append(state)
+        where_sql = f"WHERE {' AND '.join(filters)}" if filters else ""
+        with self._lock:
+            cursor = self._conn.execute(
+                f"SELECT * FROM code_orchestrated_runs {where_sql} ORDER BY created_at DESC LIMIT ? OFFSET ?",
+                tuple(params + [limit, offset]),
+            )
+            rows = [dict(row) for row in cursor.fetchall()]
+        for row in rows:
+            raw = row.pop("metadata_json", "{}")
+            try:
+                row["metadata"] = json.loads(raw) if raw else {}
+            except Exception:
+                row["metadata"] = {}
+        return rows
+
+    def update_code_orchestrated_run(self, run_id: str, updates: dict[str, Any]) -> bool:
+        if not updates:
+            return False
+        fields = []
+        params: list[Any] = []
+        for key, value in updates.items():
+            if key == "metadata":
+                fields.append("metadata_json = ?")
+                params.append(json.dumps(value or {}))
+            else:
+                fields.append(f"{key} = ?")
+                params.append(value)
+        params.append(run_id)
+
+        def _do(conn):
+            conn.execute(
+                f"UPDATE code_orchestrated_runs SET {', '.join(fields)} WHERE id = ?",
+                tuple(params),
+            )
+            return True
+
+        return bool(self._execute_write(_do))
+
+    def add_code_run_transition(self, transition: dict[str, Any]) -> str:
+        def _do(conn):
+            conn.execute(
+                """
+                INSERT INTO code_run_transitions (
+                    id, run_id, from_state, to_state, reason, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    transition["id"],
+                    transition["run_id"],
+                    transition.get("from_state"),
+                    transition["to_state"],
+                    transition.get("reason"),
+                    transition["created_at"],
+                ),
+            )
+            return transition["id"]
+
+        return self._execute_write(_do)
+
+    def list_code_run_transitions(self, *, run_id: str) -> list[dict[str, Any]]:
+        with self._lock:
+            cursor = self._conn.execute(
+                "SELECT * FROM code_run_transitions WHERE run_id = ? ORDER BY created_at ASC",
+                (run_id,),
+            )
+            return [dict(row) for row in cursor.fetchall()]
+
+    def create_code_checkpoint(self, checkpoint: dict[str, Any]) -> str:
+        def _do(conn):
+            conn.execute(
+                """
+                INSERT INTO code_checkpoints (
+                    id, workspace_id, name, git_branch, git_commit, dirty,
+                    metadata_json, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    checkpoint["id"],
+                    checkpoint.get("workspace_id"),
+                    checkpoint.get("name"),
+                    checkpoint.get("git_branch"),
+                    checkpoint.get("git_commit"),
+                    1 if checkpoint.get("dirty") else 0,
+                    json.dumps(checkpoint.get("metadata") or {}),
+                    checkpoint["created_at"],
+                ),
+            )
+            return checkpoint["id"]
+
+        return self._execute_write(_do)
+
+    def list_code_checkpoints(
+        self,
+        *,
+        workspace_id: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        filters = []
+        params: list[Any] = []
+        if workspace_id:
+            filters.append("workspace_id = ?")
+            params.append(workspace_id)
+        where_sql = f"WHERE {' AND '.join(filters)}" if filters else ""
+        with self._lock:
+            cursor = self._conn.execute(
+                f"SELECT * FROM code_checkpoints {where_sql} ORDER BY created_at DESC LIMIT ? OFFSET ?",
+                tuple(params + [limit, offset]),
+            )
+            rows = [dict(row) for row in cursor.fetchall()]
+        for row in rows:
+            row["dirty"] = bool(row.get("dirty"))
+            raw = row.pop("metadata_json", "{}")
+            try:
+                row["metadata"] = json.loads(raw) if raw else {}
+            except Exception:
+                row["metadata"] = {}
+        return rows
 
     # =========================================================================
     # Message storage

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -33,7 +33,7 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 11
+SCHEMA_VERSION = 12
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -88,6 +88,65 @@ CREATE TABLE IF NOT EXISTS messages (
     codex_reasoning_items TEXT,
     codex_message_items TEXT
 );
+
+CREATE TABLE IF NOT EXISTS code_workspaces (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    owner TEXT,
+    repo TEXT,
+    path TEXT,
+    git_remote TEXT,
+    repo_url TEXT,
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_code_workspaces_id
+    ON code_workspaces(id);
+
+CREATE INDEX IF NOT EXISTS idx_code_workspaces_owner
+    ON code_workspaces(owner);
+
+CREATE INDEX IF NOT EXISTS idx_code_workspaces_repo
+    ON code_workspaces(owner, repo);
+
+CREATE TABLE IF NOT EXISTS code_sessions (
+    id TEXT PRIMARY KEY,
+    workspace_id TEXT,
+    status TEXT DEFAULT 'active',
+    provider TEXT,
+    branch TEXT,
+    last_synced_at REAL,
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL,
+    metadata_json TEXT,
+    FOREIGN KEY (workspace_id) REFERENCES code_workspaces(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_code_sessions_workspace
+    ON code_sessions(workspace_id);
+
+CREATE INDEX IF NOT EXISTS idx_code_sessions_status
+    ON code_sessions(status);
+
+CREATE TABLE IF NOT EXISTS code_events (
+    id TEXT PRIMARY KEY,
+    workspace_id TEXT,
+    session_id TEXT,
+    event_type TEXT NOT NULL,
+    sender_login TEXT,
+    source TEXT,
+    level TEXT DEFAULT 'info',
+    payload_json TEXT NOT NULL,
+    created_at REAL NOT NULL,
+    FOREIGN KEY (workspace_id) REFERENCES code_workspaces(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_code_events_workspace
+    ON code_events(workspace_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_code_events_session
+    ON code_events(session_id, created_at DESC);
 
 CREATE TABLE IF NOT EXISTS state_meta (
     key TEXT PRIMARY KEY,
@@ -481,6 +540,79 @@ class SessionDB:
                     "COALESCE(tool_calls, '') "
                     "FROM messages"
                 )
+
+            if current_version < 12:
+                # v12: introduce minimal code-mode tables used by the
+                # Code Mode foundation (workspace/sessions/events metadata).
+                try:
+                    cursor.executescript(
+                        """
+                        CREATE TABLE IF NOT EXISTS code_workspaces (
+                            id TEXT PRIMARY KEY,
+                            name TEXT NOT NULL,
+                            owner TEXT,
+                            repo TEXT,
+                            path TEXT,
+                            git_remote TEXT,
+                            repo_url TEXT,
+                            created_at REAL NOT NULL,
+                            updated_at REAL NOT NULL
+                        );
+
+                        CREATE UNIQUE INDEX IF NOT EXISTS idx_code_workspaces_id
+                            ON code_workspaces(id);
+
+                        CREATE INDEX IF NOT EXISTS idx_code_workspaces_owner
+                            ON code_workspaces(owner);
+
+                        CREATE INDEX IF NOT EXISTS idx_code_workspaces_repo
+                            ON code_workspaces(owner, repo);
+
+                        CREATE TABLE IF NOT EXISTS code_sessions (
+                            id TEXT PRIMARY KEY,
+                            workspace_id TEXT,
+                            status TEXT DEFAULT 'active',
+                            provider TEXT,
+                            branch TEXT,
+                            last_synced_at REAL,
+                            created_at REAL NOT NULL,
+                            updated_at REAL NOT NULL,
+                            metadata_json TEXT,
+                            FOREIGN KEY (workspace_id) REFERENCES code_workspaces(id)
+                        );
+
+                        CREATE INDEX IF NOT EXISTS idx_code_sessions_workspace
+                            ON code_sessions(workspace_id);
+
+                        CREATE INDEX IF NOT EXISTS idx_code_sessions_status
+                            ON code_sessions(status);
+
+                        CREATE TABLE IF NOT EXISTS code_events (
+                            id TEXT PRIMARY KEY,
+                            workspace_id TEXT,
+                            session_id TEXT,
+                            event_type TEXT NOT NULL,
+                            sender_login TEXT,
+                            source TEXT,
+                            level TEXT DEFAULT 'info',
+                            payload_json TEXT NOT NULL,
+                            created_at REAL NOT NULL,
+                            FOREIGN KEY (workspace_id) REFERENCES code_workspaces(id) ON DELETE CASCADE
+                        );
+
+                        CREATE INDEX IF NOT EXISTS idx_code_events_workspace
+                            ON code_events(workspace_id, created_at DESC);
+
+                        CREATE INDEX IF NOT EXISTS idx_code_events_session
+                            ON code_events(session_id, created_at DESC);
+                        """
+                    )
+                except Exception:
+                    # If the process lacks required migration privileges or the
+                    # DB is in a transient bad state, continue with the
+                    # existing migration path after creating schema in future reads.
+                    pass
+
             if current_version < SCHEMA_VERSION:
                 cursor.execute(
                     "UPDATE schema_version SET version = ?",
@@ -1083,6 +1215,124 @@ class SessionDB:
         else:
             s["preview"] = ""
         return s
+
+    # =========================================================================
+    # Code Mode support
+    # =========================================================================
+
+    def _code_tables_exist(self) -> bool:
+        with self._lock:
+            cursor = self._conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='code_workspaces'"
+            )
+            return bool(cursor.fetchone())
+
+    def code_mode_status(self) -> Dict[str, Any]:
+        """Return light-weight code mode state summary for console/dashboard."""
+        if not self._code_tables_exist():
+            return {
+                "mode": "unconfigured",
+                "schema_version": None,
+                "tables": {"code_workspaces": False, "code_sessions": False, "code_events": False},
+            }
+        with self._lock:
+            counts = {}
+            for name in ("code_workspaces", "code_sessions", "code_events"):
+                cursor = self._conn.execute(f"SELECT COUNT(1) AS c FROM {name}")
+                counts[name] = int(cursor.fetchone()["c"])
+            cursor = self._conn.execute("SELECT version FROM schema_version LIMIT 1")
+            row = cursor.fetchone()
+        return {
+            "mode": "enabled" if counts else "unknown",
+            "schema_version": row["version"] if row else None,
+            "tables": {
+                "code_workspaces": True,
+                "code_sessions": True,
+                "code_events": True,
+            },
+            "counts": counts,
+            "workspace_count": counts.get("code_workspaces", 0),
+            "session_count": counts.get("code_sessions", 0),
+            "event_count": counts.get("code_events", 0),
+        }
+
+    def _code_list_rows(
+        self,
+        table: str,
+        *,
+        query: str,
+        params: tuple = (),
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        if not self._code_tables_exist():
+            return []
+        with self._lock:
+            cursor = self._conn.execute(query, params + (limit, offset))
+            return [dict(row) for row in cursor.fetchall()]
+
+    def list_code_workspaces(
+        self,
+        owner: str | None = None,
+        q: str = "",
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        filters = []
+        params: list[Any] = []
+        if owner:
+            filters.append("owner = ?")
+            params.append(owner)
+        if q:
+            filters.append("(name LIKE ? OR path LIKE ? OR repo_url LIKE ? OR repo LIKE ?)")
+            pattern = f"%{q}%"
+            params.extend([pattern, pattern, pattern, pattern])
+        where_sql = f"WHERE {' AND '.join(filters)}" if filters else ""
+        query = (
+            f"SELECT * FROM code_workspaces {where_sql} "
+            "ORDER BY updated_at DESC LIMIT ? OFFSET ?"
+        )
+        return self._code_list_rows("code_workspaces", query=query, params=tuple(params), limit=limit, offset=offset)
+
+    def list_code_sessions(
+        self,
+        workspace_id: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        filters = []
+        params: list[Any] = []
+        if workspace_id:
+            filters.append("workspace_id = ?")
+            params.append(workspace_id)
+        where_sql = f"WHERE {' AND '.join(filters)}" if filters else ""
+        query = (
+            f"SELECT * FROM code_sessions {where_sql} "
+            "ORDER BY updated_at DESC LIMIT ? OFFSET ?"
+        )
+        return self._code_list_rows("code_sessions", query=query, params=tuple(params), limit=limit, offset=offset)
+
+    def list_code_events(
+        self,
+        workspace_id: str | None = None,
+        session_id: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        filters = []
+        params: list[Any] = []
+        if workspace_id:
+            filters.append("workspace_id = ?")
+            params.append(workspace_id)
+        if session_id:
+            filters.append("session_id = ?")
+            params.append(session_id)
+        where_sql = f"WHERE {' AND '.join(filters)}" if filters else ""
+        query = (
+            f"SELECT * FROM code_events {where_sql} "
+            "ORDER BY created_at DESC LIMIT ? OFFSET ?"
+        )
+        return self._code_list_rows("code_events", query=query, params=tuple(params), limit=limit, offset=offset)
 
     # =========================================================================
     # Message storage
@@ -2091,4 +2341,3 @@ class SessionDB:
             result["error"] = str(exc)
 
         return result
-

--- a/tests/hermes_cli/test_agent_orchestrator.py
+++ b/tests/hermes_cli/test_agent_orchestrator.py
@@ -1,0 +1,66 @@
+"""Tests for AgentOrchestrator."""
+
+import pytest
+
+from hermes_cli.code.agent_orchestrator import (
+    AgentOrchestrator,
+    OrchestratorState,
+    validate_transition,
+)
+from hermes_cli.code.artifact_ledger import ArtifactLedger
+
+
+@pytest.fixture()
+def orchestrator(tmp_path):
+    return AgentOrchestrator(db_path=tmp_path / "state.db")
+
+
+def test_create_run_defaults_to_intake(orchestrator):
+    run = orchestrator.create_run(title="Task A")
+    assert run["state"] == OrchestratorState.INTAKE
+
+
+def test_valid_transition_function():
+    ok, message = validate_transition(OrchestratorState.INTAKE, OrchestratorState.DISCOVERY)
+    assert ok is True
+    assert message == ""
+
+
+def test_invalid_transition_function():
+    ok, message = validate_transition(OrchestratorState.INTAKE, OrchestratorState.IMPLEMENTATION)
+    assert ok is False
+    assert "Invalid transition" in message
+
+
+def test_transition_run_and_persist(orchestrator):
+    run = orchestrator.create_run(title="Task B")
+    updated = orchestrator.transition_run(run["id"], OrchestratorState.DISCOVERY, reason="start discovery")
+    assert updated["state"] == OrchestratorState.DISCOVERY
+    transitions = orchestrator.list_transitions(run["id"])
+    assert len(transitions) == 1
+    assert transitions[0]["to_state"] == OrchestratorState.DISCOVERY
+
+
+def test_terminal_transition_sets_completed_at(orchestrator):
+    run = orchestrator.create_run(title="Task C")
+    run = orchestrator.transition_run(run["id"], OrchestratorState.DISCOVERY)
+    run = orchestrator.transition_run(run["id"], OrchestratorState.PLANNING)
+    run = orchestrator.transition_run(run["id"], OrchestratorState.APPROVAL)
+    run = orchestrator.transition_run(run["id"], OrchestratorState.IMPLEMENTATION)
+    run = orchestrator.transition_run(run["id"], OrchestratorState.VALIDATION)
+    run = orchestrator.transition_run(run["id"], OrchestratorState.REVIEW)
+    run = orchestrator.transition_run(run["id"], OrchestratorState.READY_FOR_PR)
+    run = orchestrator.transition_run(run["id"], OrchestratorState.COMPLETED)
+    assert run["completed_at"] is not None
+
+
+def test_create_goal_creates_task_intake_artifact(orchestrator, tmp_path):
+    run = orchestrator.create_run(
+        title="Task D",
+        goal="Add smoke tests",
+        create_intake_artifact=True,
+    )
+    ledger = ArtifactLedger(db_path=tmp_path / "state.db")
+    artifacts = ledger.list_artifacts(orchestrated_run_id=run["id"])
+    assert len(artifacts) == 1
+    assert artifacts[0]["artifact_type"] == "task_intake"

--- a/tests/hermes_cli/test_artifact_ledger.py
+++ b/tests/hermes_cli/test_artifact_ledger.py
@@ -1,0 +1,39 @@
+"""Tests for ArtifactLedger."""
+
+import pytest
+
+from hermes_cli.code.artifact_ledger import ArtifactLedger
+
+
+@pytest.fixture()
+def ledger(tmp_path):
+    return ArtifactLedger(db_path=tmp_path / "state.db")
+
+
+def test_create_and_list_artifact(ledger):
+    artifact = ledger.create_artifact(
+        "task_intake",
+        "Implement parser",
+        title="Parser Task",
+        workspace_id="ws-1",
+        code_session_id="cs-1",
+        orchestrated_run_id="run-1",
+    )
+    assert artifact["id"]
+    assert artifact["artifact_type"] == "task_intake"
+
+    rows = ledger.list_artifacts(code_session_id="cs-1")
+    assert any(row["id"] == artifact["id"] for row in rows)
+
+
+def test_invalid_artifact_type_raises(ledger):
+    with pytest.raises(ValueError):
+        ledger.create_artifact("unknown_type", "x")
+
+
+def test_artifact_filters(ledger):
+    ledger.create_artifact("task_intake", "a", code_session_id="cs-a")
+    ledger.create_artifact("review_report", "b", code_session_id="cs-b")
+    results = ledger.list_artifacts(code_session_id="cs-a")
+    assert len(results) == 1
+    assert results[0]["code_session_id"] == "cs-a"

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -66,9 +66,15 @@ class TestCommandRegistry:
                         f"Alias '{alias}' of '{cmd.name}' shadows canonical '{target.name}'"
 
     def test_every_entry_has_valid_category(self):
-        valid_categories = {"Session", "Configuration", "Tools & Skills", "Info", "Exit"}
+        valid_categories = {"Session", "Configuration", "Tools & Skills", "Code Mode", "Info", "Exit"}
         for cmd in COMMAND_REGISTRY:
             assert cmd.category in valid_categories, f"{cmd.name} has invalid category '{cmd.category}'"
+
+    def test_code_mode_commands_registered(self):
+        expected = {"code", "web", "workspace", "session", "approvals", "skills-code"}
+        names = {cmd.name for cmd in COMMAND_REGISTRY}
+        assert expected <= names
+        assert resolve_command("skillscode").name == "skills-code"
 
     def test_reasoning_subcommands_are_in_logical_order(self):
         reasoning = next(cmd for cmd in COMMAND_REGISTRY if cmd.name == "reasoning")
@@ -142,6 +148,7 @@ class TestDerivedDicts:
         assert "/exit" in COMMANDS
         assert "/reload_mcp" in COMMANDS
         assert "/gateway" in COMMANDS
+        assert "/skillscode" in COMMANDS
 
     def test_commands_by_category_covers_all_categories(self):
         registry_categories = {cmd.category for cmd in COMMAND_REGISTRY if not cmd.gateway_only}

--- a/tests/hermes_cli/test_execution_policy.py
+++ b/tests/hermes_cli/test_execution_policy.py
@@ -1,0 +1,35 @@
+"""Tests for Hermes Code Mode execution policy."""
+
+from hermes_cli.code.execution_policy import (
+    ExecutionPolicyEngine,
+    RiskClass,
+    classify_command,
+    redact_secrets,
+)
+
+
+def test_safe_command_classification():
+    assert classify_command("git status") == RiskClass.SAFE_READONLY
+
+
+def test_destructive_command_classification():
+    assert classify_command("rm -rf /tmp/demo") == RiskClass.DESTRUCTIVE
+
+
+def test_secret_sensitive_command_classification():
+    assert classify_command("cat .env") == RiskClass.SECRET_SENSITIVE
+
+
+def test_redaction_hides_sensitive_values():
+    text = "Authorization: Bearer ghp_abcdefghijklmnopqrstuvwxyz1234567890"
+    redacted = redact_secrets(text)
+    assert "ghp_" not in redacted
+    assert "[REDACTED]" in redacted
+
+
+def test_assess_command_contract():
+    engine = ExecutionPolicyEngine()
+    assessment = engine.assess_command("git commit -m test")
+    assert assessment["risk_class"] == RiskClass.GIT_WRITE
+    assert assessment["requires_approval"] is True
+    assert assessment["blocked"] is False

--- a/tests/hermes_cli/test_repo_knowledge.py
+++ b/tests/hermes_cli/test_repo_knowledge.py
@@ -1,0 +1,40 @@
+"""Tests for RepoKnowledgeService."""
+
+from hermes_cli.code.repo_knowledge import RepoKnowledgeService, detect_repo_guidance
+
+
+def test_detect_agents_md_and_guidance_docs(tmp_path):
+    (tmp_path / "AGENTS.md").write_text("# Agents\n", encoding="utf-8")
+    arch_dir = tmp_path / "docs" / "architecture"
+    arch_dir.mkdir(parents=True)
+    (arch_dir / "overview.md").write_text("# Overview\n", encoding="utf-8")
+
+    manifest = detect_repo_guidance(tmp_path)
+    assert manifest["agents_md"] is not None
+    assert len(manifest["guidance_docs"]) == 1
+
+
+def test_bootstrap_does_not_overwrite_existing_agents_md(tmp_path):
+    existing = "# Existing\nDo not overwrite\n"
+    (tmp_path / "AGENTS.md").write_text(existing, encoding="utf-8")
+    service = RepoKnowledgeService()
+    result = service.bootstrap(tmp_path, project_summary="ignored")
+    assert result["created"] is False
+    assert "already exists" in result["reason"]
+    assert (tmp_path / "AGENTS.md").read_text(encoding="utf-8") == existing
+
+
+def test_bootstrap_creates_agents_md_when_missing(tmp_path):
+    service = RepoKnowledgeService()
+    result = service.bootstrap(tmp_path, project_summary="Project summary")
+    assert result["created"] is True
+    content = (tmp_path / "AGENTS.md").read_text(encoding="utf-8")
+    assert "Project summary" in content
+
+
+def test_service_read_agents_md(tmp_path):
+    (tmp_path / "AGENTS.md").write_text("# A\n\nB\n", encoding="utf-8")
+    service = RepoKnowledgeService()
+    content = service.read_agents_md(tmp_path)
+    assert content is not None
+    assert "B" in content

--- a/tests/hermes_cli/test_skill_discovery.py
+++ b/tests/hermes_cli/test_skill_discovery.py
@@ -1,0 +1,53 @@
+"""Tests for Code Mode skill discovery bridge."""
+
+import hermes_cli.code.skill_discovery as skill_discovery
+from hermes_cli.code.skill_discovery import SkillDiscoveryService, discover_workspace_skills
+
+
+def test_builtin_skills_are_preserved(monkeypatch, tmp_path):
+    fake_dir = tmp_path / "builtin"
+    fake_dir.mkdir()
+    monkeypatch.setattr(
+        skill_discovery,
+        "scan_skill_commands",
+        lambda: {
+            "/fake-skill": {
+                "name": "Fake Skill",
+                "description": "desc",
+                "skill_md_path": str(fake_dir / "SKILL.md"),
+                "skill_dir": str(fake_dir),
+            }
+        },
+    )
+    skills = skill_discovery.discover_builtin_skills()
+    assert isinstance(skills, list)
+    assert len(skills) == 1
+    assert skills[0]["name"] == "fake-skill"
+    assert skills[0]["builtin"] is True
+
+
+def test_workspace_skill_md_discovery(tmp_path):
+    skill_dir = tmp_path / ".hermes" / "skills" / "my_skill"
+    (skill_dir / "scripts").mkdir(parents=True)
+    (skill_dir / "resources").mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "# My Skill\n\nCustom description.\n",
+        encoding="utf-8",
+    )
+
+    skills = discover_workspace_skills(tmp_path)
+    assert len(skills) == 1
+    assert skills[0]["name"] == "my_skill"
+    assert skills[0]["has_scripts"] is True
+    assert skills[0]["has_resources"] is True
+
+
+def test_skill_discovery_service_merges_sources(tmp_path):
+    skill_dir = tmp_path / ".hermes" / "skills" / "workspace_skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("# Workspace Skill\n\nDesc\n", encoding="utf-8")
+
+    service = SkillDiscoveryService()
+    merged = service.list_skills(workspace_path=tmp_path)
+    names = {item["name"] for item in merged}
+    assert "workspace_skill" in names

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -328,6 +328,88 @@ class TestWebServerEndpoints:
         resp = unauth_client.get("/api/status")
         assert resp.status_code == 200
 
+    def test_code_status_is_public(self):
+        from starlette.testclient import TestClient
+        from hermes_cli.web_server import app
+
+        unauth_client = TestClient(app)
+        resp = unauth_client.get("/api/code/status")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["mode"] == "code_mode"
+        assert data["schema_version"] == 12
+        assert "state" in data
+
+    def test_code_workspaces_requires_auth(self):
+        from starlette.testclient import TestClient
+        from hermes_cli.web_server import app
+
+        unauth_client = TestClient(app)
+        resp = unauth_client.get("/api/code/workspaces")
+
+        assert resp.status_code == 401
+
+    def test_code_workspaces_endpoint(self):
+        import time
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            now = time.time()
+            db._conn.execute(
+                """
+                INSERT INTO code_workspaces
+                    (id, name, owner, repo, path, git_remote, repo_url, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    "ws-1",
+                    "Hermes Agent",
+                    "nous",
+                    "hermes-agent",
+                    "/tmp/hermes-agent",
+                    "git@github.com:nous/hermes-agent.git",
+                    "https://github.com/nous/hermes-agent",
+                    now,
+                    now,
+                ),
+            )
+            db._conn.commit()
+        finally:
+            db.close()
+
+        resp = self.client.get("/api/code/workspaces?q=Hermes")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["workspaces"][0]["id"] == "ws-1"
+
+    def test_code_sessions_endpoint(self):
+        import time
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            now = time.time()
+            db._conn.execute(
+                """
+                INSERT INTO code_sessions
+                    (id, workspace_id, status, provider, branch, created_at, updated_at, metadata_json)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                ("cs-1", None, "active", "openrouter", "main", now, now, "{}"),
+            )
+            db._conn.commit()
+        finally:
+            db.close()
+
+        resp = self.client.get("/api/code/sessions")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["sessions"][0]["id"] == "cs-1"
+
     def test_path_traversal_blocked(self):
         """Verify URL-encoded path traversal is blocked."""
         # %2e%2e = ..

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -338,7 +338,7 @@ class TestWebServerEndpoints:
         assert resp.status_code == 200
         data = resp.json()
         assert data["mode"] == "code_mode"
-        assert data["schema_version"] == 12
+        assert data["schema_version"] == 13
         assert "state" in data
 
     def test_code_workspaces_requires_auth(self):
@@ -409,6 +409,106 @@ class TestWebServerEndpoints:
         assert resp.status_code == 200
         data = resp.json()
         assert data["sessions"][0]["id"] == "cs-1"
+
+    def test_code_artifacts_create_and_list(self):
+        create_resp = self.client.post(
+            "/api/code/artifacts",
+            json={
+                "artifact_type": "task_intake",
+                "title": "Task",
+                "content": "Implement feature X",
+                "content_type": "markdown",
+                "workspace_id": None,
+                "code_session_id": "cs-42",
+                "metadata": {"priority": "high"},
+            },
+        )
+        assert create_resp.status_code == 200
+        created = create_resp.json()["artifact"]
+        assert created["artifact_type"] == "task_intake"
+
+        list_resp = self.client.get("/api/code/artifacts?code_session_id=cs-42")
+        assert list_resp.status_code == 200
+        artifacts = list_resp.json()["artifacts"]
+        assert any(a["id"] == created["id"] for a in artifacts)
+
+    def test_orchestrator_create_get_and_transition(self):
+        create_resp = self.client.post(
+            "/api/code/orchestrator/runs",
+            json={
+                "title": "Run A",
+                "goal": "Refactor parser",
+                "workspace_id": None,
+                "code_session_id": "cs-77",
+                "metadata": {"source": "test"},
+                "create_intake_artifact": True,
+            },
+        )
+        assert create_resp.status_code == 200
+        run = create_resp.json()["run"]
+        assert run["state"] == "intake"
+
+        get_resp = self.client.get(f"/api/code/orchestrator/runs/{run['id']}")
+        assert get_resp.status_code == 200
+        assert get_resp.json()["run"]["id"] == run["id"]
+
+        transition_resp = self.client.post(
+            f"/api/code/orchestrator/runs/{run['id']}/transition",
+            json={"to_state": "discovery", "reason": "begin"},
+        )
+        assert transition_resp.status_code == 200
+        assert transition_resp.json()["run"]["state"] == "discovery"
+
+    def test_policy_assess_command_endpoint(self):
+        resp = self.client.post(
+            "/api/code/policy/assess-command",
+            json={"command": "rm -rf /tmp/x"},
+        )
+        assert resp.status_code == 200
+        assessment = resp.json()["assessment"]
+        assert assessment["risk_class"] == "destructive"
+        assert assessment["blocked"] is True
+
+    def test_code_skills_discovered_endpoint(self):
+        resp = self.client.get("/api/code/skills/discovered")
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert "skills" in payload
+        assert isinstance(payload["skills"], list)
+
+    def test_repo_knowledge_endpoints(self, tmp_path):
+        import time
+        from hermes_state import SessionDB
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / "AGENTS.md").write_text("# Agents\n\nUse pytest.\n", encoding="utf-8")
+
+        db = SessionDB()
+        try:
+            now = time.time()
+            db._conn.execute(
+                """
+                INSERT INTO code_workspaces
+                    (id, name, owner, repo, path, git_remote, repo_url, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                ("ws-rk", "Repo", "owner", "repo", str(repo), "", "", now, now),
+            )
+            db._conn.commit()
+        finally:
+            db.close()
+
+        get_resp = self.client.get("/api/code/workspaces/ws-rk/repo-knowledge")
+        assert get_resp.status_code == 200
+        assert get_resp.json()["manifest"]["agents_md"] is not None
+
+        bootstrap_resp = self.client.post(
+            "/api/code/workspaces/ws-rk/repo-knowledge/bootstrap",
+            json={"project_summary": "My test repo"},
+        )
+        assert bootstrap_resp.status_code == 200
+        assert bootstrap_resp.json()["result"]["created"] is False
 
     def test_path_traversal_blocked(self):
         """Verify URL-encoded path traversal is blocked."""

--- a/tests/hermes_cli/test_worktree_service.py
+++ b/tests/hermes_cli/test_worktree_service.py
@@ -1,0 +1,69 @@
+"""Tests for WorktreeService."""
+
+import subprocess
+import time
+from pathlib import Path
+
+from hermes_cli.code.worktree_service import WorktreeService
+from hermes_state import SessionDB
+
+
+def _init_git_repo(path: Path) -> None:
+    subprocess.run(["git", "init", str(path)], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(path), "config", "user.email", "test@example.com"], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(path), "config", "user.name", "Test User"], check=True, capture_output=True)
+    (path / "README.md").write_text("# repo\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(path), "add", "."], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(path), "commit", "-m", "init"], check=True, capture_output=True)
+
+
+def test_detect_capabilities_outside_git_repo(tmp_path):
+    caps = WorktreeService.detect_git_capabilities(tmp_path)
+    assert caps["is_git_repo"] is False
+    assert caps["supports_worktree"] is False
+
+
+def test_detect_capabilities_git_repo_and_dirty_state(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+    caps = WorktreeService.detect_git_capabilities(repo)
+    assert caps["is_git_repo"] is True
+    assert caps["has_commits"] is True
+    assert caps["is_dirty"] is False
+
+    (repo / "dirty.txt").write_text("x", encoding="utf-8")
+    dirty_caps = WorktreeService.detect_git_capabilities(repo)
+    assert dirty_caps["is_dirty"] is True
+
+
+def test_workspace_capabilities_fallback_when_missing_workspace(tmp_path):
+    service = WorktreeService(db_path=tmp_path / "state.db")
+    caps = service.detect_capabilities_for_workspace("missing")
+    assert caps["is_git_repo"] is False
+
+
+def test_checkpoint_metadata_creation(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        now = time.time()
+        db._conn.execute(
+            """
+            INSERT INTO code_workspaces
+                (id, name, owner, repo, path, git_remote, repo_url, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            ("ws-1", "repo", "owner", "repo", str(repo), "", "", now, now),
+        )
+        db._conn.commit()
+    finally:
+        db.close()
+
+    service = WorktreeService(db_path=tmp_path / "state.db")
+    checkpoint = service.create_checkpoint_metadata("ws-1", name="before-change")
+    assert checkpoint["workspace_id"] == "ws-1"
+    assert checkpoint["name"] == "before-change"
+    assert checkpoint["git_commit"]

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1315,16 +1315,20 @@ class TestSchemaInit:
         assert "code_workspaces" in tables
         assert "code_sessions" in tables
         assert "code_events" in tables
+        assert "code_artifacts" in tables
+        assert "code_orchestrated_runs" in tables
+        assert "code_run_transitions" in tables
+        assert "code_checkpoints" in tables
 
     def test_schema_version(self, db):
         cursor = db._conn.execute("SELECT version FROM schema_version")
         version = cursor.fetchone()[0]
-        assert version == 12
+        assert version == 13
 
     def test_code_mode_status(self, db):
         status = db.code_mode_status()
         assert status["mode"] == "enabled"
-        assert status["schema_version"] == 12
+        assert status["schema_version"] == 13
         assert status["workspace_count"] == 0
         assert status["session_count"] == 0
         assert status["event_count"] == 0
@@ -1388,7 +1392,7 @@ class TestSchemaInit:
 
         # Verify migration
         cursor = migrated_db._conn.execute("SELECT version FROM schema_version")
-        assert cursor.fetchone()[0] == 12
+        assert cursor.fetchone()[0] == 13
 
         # Verify title column exists and is NULL for existing sessions
         session = migrated_db.get_session("existing")
@@ -1407,6 +1411,61 @@ class TestSchemaInit:
         assert session["title"] == "Migrated Title"
 
         migrated_db.close()
+
+
+class TestCodeControlPlanePersistence:
+    def test_artifact_roundtrip(self, db):
+        created = {
+            "id": "art-1",
+            "artifact_type": "task_intake",
+            "title": "Task",
+            "content": "Build endpoint",
+            "content_type": "markdown",
+            "workspace_id": "ws-1",
+            "code_session_id": "cs-1",
+            "orchestrated_run_id": "run-1",
+            "command_id": "cmd-1",
+            "metadata": {"source": "test"},
+            "created_at": time.time(),
+            "updated_at": time.time(),
+        }
+        db.create_code_artifact(created)
+        rows = db.list_code_artifacts(code_session_id="cs-1")
+        assert len(rows) == 1
+        assert rows[0]["id"] == "art-1"
+
+    def test_orchestrated_run_and_transition_roundtrip(self, db):
+        now = time.time()
+        run = {
+            "id": "run-1",
+            "title": "Run",
+            "goal": "Goal",
+            "state": "intake",
+            "workspace_id": "ws-1",
+            "code_session_id": "cs-1",
+            "current_phase": "intake",
+            "metadata": {"k": "v"},
+            "created_at": now,
+            "updated_at": now,
+            "completed_at": None,
+        }
+        db.create_code_orchestrated_run(run)
+        db.add_code_run_transition(
+            {
+                "id": "tr-1",
+                "run_id": "run-1",
+                "from_state": "intake",
+                "to_state": "discovery",
+                "reason": "start",
+                "created_at": now + 1,
+            }
+        )
+        fetched = db.get_code_orchestrated_run("run-1")
+        assert fetched is not None
+        assert fetched["state"] == "intake"
+        transitions = db.list_code_run_transitions(run_id="run-1")
+        assert len(transitions) == 1
+        assert transitions[0]["to_state"] == "discovery"
 
     def test_reconciliation_adds_missing_columns(self, tmp_path):
         """Columns present in SCHEMA_SQL but missing from the live table
@@ -2492,6 +2551,6 @@ class TestFTS5ToolCallMigration:
                 "SELECT version FROM schema_version LIMIT 1"
             ).fetchone()
             version = row["version"] if hasattr(row, "keys") else row[0]
-            assert version == 12
+            assert version == 13
         finally:
             session_db.close()

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1312,11 +1312,22 @@ class TestSchemaInit:
         assert "sessions" in tables
         assert "messages" in tables
         assert "schema_version" in tables
+        assert "code_workspaces" in tables
+        assert "code_sessions" in tables
+        assert "code_events" in tables
 
     def test_schema_version(self, db):
         cursor = db._conn.execute("SELECT version FROM schema_version")
         version = cursor.fetchone()[0]
-        assert version == 11
+        assert version == 12
+
+    def test_code_mode_status(self, db):
+        status = db.code_mode_status()
+        assert status["mode"] == "enabled"
+        assert status["schema_version"] == 12
+        assert status["workspace_count"] == 0
+        assert status["session_count"] == 0
+        assert status["event_count"] == 0
 
     def test_title_column_exists(self, db):
         """Verify the title column was created in the sessions table."""
@@ -1372,12 +1383,12 @@ class TestSchemaInit:
         conn.commit()
         conn.close()
 
-        # Open with SessionDB — should migrate to v9
+        # Open with SessionDB — should migrate to the current schema
         migrated_db = SessionDB(db_path=db_path)
 
         # Verify migration
         cursor = migrated_db._conn.execute("SELECT version FROM schema_version")
-        assert cursor.fetchone()[0] == 11
+        assert cursor.fetchone()[0] == 12
 
         # Verify title column exists and is NULL for existing sessions
         session = migrated_db.get_session("existing")
@@ -2481,7 +2492,6 @@ class TestFTS5ToolCallMigration:
                 "SELECT version FROM schema_version LIMIT 1"
             ).fetchone()
             version = row["version"] if hasattr(row, "keys") else row[0]
-            assert version == 11
+            assert version == 12
         finally:
             session_db.close()
-


### PR DESCRIPTION
## Summary

Este PR adiciona o P0 Engineering Control Plane sobre o Hermes Code Mode portado para a main atual.

## Depends on

- #17020

Este PR está empilhado sobre o Code Mode base. Depois que #17020 for mergeado, este PR ficará com diff focado apenas no P0.

## Inclui

- ExecutionPolicyEngine
- ArtifactLedger
- AgentOrchestrator
- Fundação de worktree/checkpoint
- Descoberta de skills via SKILL.md
- RepoKnowledgeService / suporte a AGENTS.md
- Schema v13
- Endpoints P0 em /api/code/*
- Testes P0
- Atualização de docs/HERMES_CODE_MODE.md

## Endpoints adicionados

- GET /api/code/artifacts
- POST /api/code/artifacts
- GET /api/code/sessions/{code_session_id}/artifacts
- GET /api/code/orchestrator/runs
- POST /api/code/orchestrator/runs
- GET /api/code/orchestrator/runs/{run_id}
- POST /api/code/orchestrator/runs/{run_id}/transition
- POST /api/code/policy/assess-command
- GET /api/code/workspaces/{workspace_id}/git/capabilities
- GET /api/code/workspaces/{workspace_id}/git/worktrees
- GET /api/code/skills/discovered
- GET /api/code/workspaces/{workspace_id}/repo-knowledge
- POST /api/code/workspaces/{workspace_id}/repo-knowledge/bootstrap

## Validação

- python3 -m py_compile dos arquivos P0: passou
- pytest com PTY websocket excluído:
  - 475 passed
  - 11 deselected
  - 1 warning

## Notes

- Sem mudanças em web/
- Sem P1/GitHub integration
- Sem webhooks
- Sem GitHub ChatOps
- Sem SSH/VPS
- Sem desktop app