### PR TITLE
feat(gateway): expose Responses reasoning in API server

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -710,6 +710,9 @@ class APIServerAdapter(BasePlatformAdapter):
         ephemeral_system_prompt: Optional[str] = None,
         session_id: Optional[str] = None,
         stream_delta_callback=None,
+        reasoning_callback=None,
+        reasoning_config: Optional[Dict[str, Any]] = None,
+        service_tier: Optional[str] = None,
         tool_progress_callback=None,
         tool_start_callback=None,
         tool_complete_callback=None,
@@ -738,6 +741,10 @@ class APIServerAdapter(BasePlatformAdapter):
         # same fallback behaviour as Telegram/Discord/Slack (fixes #4954).
         from gateway.run import GatewayRunner
         fallback_model = GatewayRunner._load_fallback_model()
+        if reasoning_config is None:
+            reasoning_config = GatewayRunner._load_reasoning_config()
+        if service_tier is None:
+            service_tier = GatewayRunner._load_service_tier()
 
         agent = AIAgent(
             model=model,
@@ -750,6 +757,9 @@ class APIServerAdapter(BasePlatformAdapter):
             session_id=session_id,
             platform="api_server",
             stream_delta_callback=stream_delta_callback,
+            reasoning_callback=reasoning_callback,
+            reasoning_config=reasoning_config,
+            service_tier=service_tier,
             tool_progress_callback=tool_progress_callback,
             tool_start_callback=tool_start_callback,
             tool_complete_callback=tool_complete_callback,
@@ -1186,6 +1196,8 @@ class APIServerAdapter(BasePlatformAdapter):
         conversation: Optional[str],
         store: bool,
         session_id: str,
+        include_reasoning: bool = False,
+        stream_reasoning: bool = False,
     ) -> "web.StreamResponse":
         """Write an SSE stream for POST /v1/responses (OpenAI Responses API).
 
@@ -1253,6 +1265,7 @@ class APIServerAdapter(BasePlatformAdapter):
         message_item_id = f"msg_{uuid.uuid4().hex[:24]}"
         message_output_index: Optional[int] = None
         message_opened = False
+        reasoning_delta_seen = False
 
         async def _write_event(event_type: str, data: Dict[str, Any]) -> None:
             nonlocal sequence_number
@@ -1273,6 +1286,7 @@ class APIServerAdapter(BasePlatformAdapter):
             return env
 
         final_response_text = ""
+        result: Dict[str, Any] = {}
         agent_error: Optional[str] = None
         usage: Dict[str, int] = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
         terminal_snapshot_persisted = False
@@ -1373,6 +1387,18 @@ class APIServerAdapter(BasePlatformAdapter):
                     "content_index": 0,
                     "delta": delta_text,
                     "logprobs": [],
+                })
+
+            async def _emit_reasoning_delta(delta_text: str) -> None:
+                nonlocal reasoning_delta_seen
+                if not (include_reasoning and stream_reasoning and delta_text):
+                    return
+                reasoning_delta_seen = True
+                await _write_event("hermes.reasoning.delta", {
+                    "type": "hermes.reasoning.delta",
+                    "response_id": response_id,
+                    "item_id": message_item_id,
+                    "delta": delta_text,
                 })
 
             async def _emit_tool_started(payload: Dict[str, Any]) -> str:
@@ -1495,6 +1521,9 @@ class APIServerAdapter(BasePlatformAdapter):
                         await _emit_tool_started(payload)
                     elif tag == "__tool_completed__":
                         await _emit_tool_completed(payload)
+                    elif tag == "__reasoning_delta__":
+                        delta_text = payload.get("delta", "") if isinstance(payload, dict) else ""
+                        await _emit_reasoning_delta(delta_text)
                     # Unknown tags are silently ignored (forward-compat).
                 elif isinstance(it, str):
                     await _emit_text_delta(it)
@@ -1549,6 +1578,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
             # Close the message item if it was opened
             final_response_text = "".join(final_text_parts) or final_response_text
+            final_reasoning_text = self._extract_reasoning_text(result) if isinstance(result, dict) else ""
             if message_opened:
                 await _write_event("response.output_text.done", {
                     "type": "response.output_text.done",
@@ -1571,6 +1601,13 @@ class APIServerAdapter(BasePlatformAdapter):
                     "type": "response.output_item.done",
                     "output_index": message_output_index,
                     "item": msg_done_item,
+                })
+
+            if include_reasoning and stream_reasoning and reasoning_delta_seen:
+                await _write_event("hermes.reasoning.done", {
+                    "type": "hermes.reasoning.done",
+                    "response_id": response_id,
+                    "item_id": message_item_id,
                 })
 
             # Always append a final message item in the completed
@@ -1619,6 +1656,11 @@ class APIServerAdapter(BasePlatformAdapter):
                     "output_tokens": usage.get("output_tokens", 0),
                     "total_tokens": usage.get("total_tokens", 0),
                 }
+                if include_reasoning and final_reasoning_text:
+                    completed_env.setdefault("hermes", {})["reasoning"] = {
+                        "text": final_reasoning_text,
+                        "status": "completed",
+                    }
                 full_history = list(conversation_history)
                 full_history.append({"role": "user", "content": user_message})
                 if isinstance(result, dict) and result.get("messages"):
@@ -1694,6 +1736,14 @@ class APIServerAdapter(BasePlatformAdapter):
         previous_response_id = body.get("previous_response_id")
         conversation = body.get("conversation")
         store = body.get("store", True)
+        hermes_options = body.get("hermes") if isinstance(body.get("hermes"), dict) else {}
+        reasoning_options = hermes_options.get("reasoning") if isinstance(hermes_options.get("reasoning"), dict) else {}
+        include_reasoning = bool(reasoning_options.get("include"))
+        stream_reasoning = bool(reasoning_options.get("stream"))
+
+        from gateway.run import GatewayRunner
+        reasoning_config = GatewayRunner._load_reasoning_config()
+        service_tier = GatewayRunner._load_service_tier()
 
         # conversation and previous_response_id are mutually exclusive
         if conversation and previous_response_id:
@@ -1817,6 +1867,11 @@ class APIServerAdapter(BasePlatformAdapter):
                     "result": function_result,
                 }))
 
+            def _on_reasoning_delta(delta_text):
+                """Queue live reasoning deltas when the request opted in."""
+                if include_reasoning and stream_reasoning and delta_text:
+                    _stream_q.put(("__reasoning_delta__", {"delta": delta_text}))
+
             agent_ref = [None]
             agent_task = asyncio.ensure_future(self._run_agent(
                 user_message=user_message,
@@ -1824,6 +1879,9 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=instructions,
                 session_id=session_id,
                 stream_delta_callback=_on_delta,
+                reasoning_callback=_on_reasoning_delta if include_reasoning else None,
+                reasoning_config=reasoning_config,
+                service_tier=service_tier,
                 tool_progress_callback=_on_tool_progress,
                 tool_start_callback=_on_tool_start,
                 tool_complete_callback=_on_tool_complete,
@@ -1848,6 +1906,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 conversation=conversation,
                 store=store,
                 session_id=session_id,
+                include_reasoning=include_reasoning,
+                stream_reasoning=stream_reasoning,
             )
 
         async def _compute_response():
@@ -1856,6 +1916,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 conversation_history=conversation_history,
                 ephemeral_system_prompt=instructions,
                 session_id=session_id,
+                reasoning_config=reasoning_config,
+                service_tier=service_tier,
             )
 
         idempotency_key = request.headers.get("Idempotency-Key")
@@ -1916,6 +1978,12 @@ class APIServerAdapter(BasePlatformAdapter):
                 "total_tokens": usage.get("total_tokens", 0),
             },
         }
+        reasoning_text = self._extract_reasoning_text(result)
+        if include_reasoning and reasoning_text:
+            response_data.setdefault("hermes", {})["reasoning"] = {
+                "text": reasoning_text,
+                "status": "completed",
+            }
 
         # Store the complete response object for future chaining / GET retrieval
         if store:
@@ -2237,6 +2305,24 @@ class APIServerAdapter(BasePlatformAdapter):
         })
         return items
 
+    @staticmethod
+    def _extract_reasoning_text(result: Dict[str, Any]) -> str:
+        """Extract final reasoning text from an agent result if available."""
+        text = result.get("last_reasoning") or ""
+        if isinstance(text, str) and text.strip():
+            return text
+
+        messages = result.get("messages", [])
+        if not isinstance(messages, list):
+            return ""
+        for msg in reversed(messages):
+            if not isinstance(msg, dict) or msg.get("role") != "assistant":
+                continue
+            msg_reasoning = msg.get("reasoning")
+            if isinstance(msg_reasoning, str) and msg_reasoning.strip():
+                return msg_reasoning
+        return ""
+
     # ------------------------------------------------------------------
     # Agent execution
     # ------------------------------------------------------------------
@@ -2248,6 +2334,9 @@ class APIServerAdapter(BasePlatformAdapter):
         ephemeral_system_prompt: Optional[str] = None,
         session_id: Optional[str] = None,
         stream_delta_callback=None,
+        reasoning_callback=None,
+        reasoning_config: Optional[Dict[str, Any]] = None,
+        service_tier: Optional[str] = None,
         tool_progress_callback=None,
         tool_start_callback=None,
         tool_complete_callback=None,
@@ -2271,6 +2360,9 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=ephemeral_system_prompt,
                 session_id=session_id,
                 stream_delta_callback=stream_delta_callback,
+                reasoning_callback=reasoning_callback,
+                reasoning_config=reasoning_config,
+                service_tier=service_tier,
                 tool_progress_callback=tool_progress_callback,
                 tool_start_callback=tool_start_callback,
                 tool_complete_callback=tool_complete_callback,

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1246,6 +1246,116 @@ class TestResponsesEndpoint:
             )
             assert resp.status == 400
 
+    @pytest.mark.asyncio
+    async def test_responses_completed_includes_hermes_reasoning_when_requested(self, adapter):
+        mock_result = {
+            "final_response": "Final answer.",
+            "last_reasoning": "I considered the request step by step.",
+            "messages": [{"role": "assistant", "content": "Final answer."}],
+            "api_calls": 1,
+        }
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3})
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "Explain briefly",
+                        "hermes": {"reasoning": {"include": True}},
+                    },
+                )
+
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["hermes"]["reasoning"] == {
+                "text": "I considered the request step by step.",
+                "status": "completed",
+            }
+            assert "reasoning_config" in mock_run.call_args.kwargs
+            assert "service_tier" in mock_run.call_args.kwargs
+
+    @pytest.mark.asyncio
+    async def test_get_response_preserves_hermes_reasoning(self, adapter):
+        mock_result = {
+            "final_response": "Stored answer.",
+            "last_reasoning": "Stored reasoning.",
+            "messages": [{"role": "assistant", "content": "Stored answer."}],
+            "api_calls": 1,
+        }
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3})
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "Store this",
+                        "store": True,
+                        "hermes": {"reasoning": {"include": True}},
+                    },
+                )
+
+            assert resp.status == 200
+            created = await resp.json()
+            get_resp = await cli.get(f"/v1/responses/{created['id']}")
+            assert get_resp.status == 200
+            stored = await get_resp.json()
+            assert stored["hermes"]["reasoning"]["text"] == "Stored reasoning."
+
+    @pytest.mark.asyncio
+    async def test_responses_omit_reasoning_without_request(self, adapter):
+        mock_result = {
+            "final_response": "Final answer.",
+            "last_reasoning": "This should not be exposed.",
+            "messages": [{"role": "assistant", "content": "Final answer."}],
+            "api_calls": 1,
+        }
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3})
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={"model": "hermes-agent", "input": "Explain briefly"},
+                )
+
+            assert resp.status == 200
+            data = await resp.json()
+            assert "hermes" not in data
+
+    @pytest.mark.asyncio
+    async def test_api_server_passes_reasoning_config_to_agent(self, adapter):
+        class FakeAgent:
+            session_prompt_tokens = 1
+            session_completion_tokens = 2
+            session_total_tokens = 3
+
+            def run_conversation(self, **kwargs):
+                return {"final_response": "ok", "messages": [], "api_calls": 1}
+
+        reasoning_callback = MagicMock()
+        with patch.object(adapter, "_create_agent", return_value=FakeAgent()) as create_agent:
+            result, usage = await adapter._run_agent(
+                user_message="hi",
+                conversation_history=[],
+                reasoning_config={"effort": "high"},
+                service_tier="priority",
+                reasoning_callback=reasoning_callback,
+            )
+
+        assert result["final_response"] == "ok"
+        assert usage["total_tokens"] == 3
+        create_agent.assert_called_once()
+        assert create_agent.call_args.kwargs["reasoning_config"] == {"effort": "high"}
+        assert create_agent.call_args.kwargs["service_tier"] == "priority"
+        assert create_agent.call_args.kwargs["reasoning_callback"] is reasoning_callback
+
 
 class TestResponsesStreaming:
     @pytest.mark.asyncio
@@ -1373,6 +1483,165 @@ class TestResponsesStreaming:
                 assert data["id"] == response_id
                 assert data["status"] == "completed"
                 assert data["output"][-1]["content"][0]["text"] == "Stored response"
+
+    @pytest.mark.asyncio
+    async def test_streamed_completed_response_includes_hermes_reasoning_when_requested(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                cb = kwargs.get("stream_delta_callback")
+                if cb:
+                    cb("Answer")
+                return (
+                    {
+                        "final_response": "Answer",
+                        "last_reasoning": "Streamed final reasoning.",
+                        "messages": [{"role": "assistant", "content": "Answer"}],
+                        "api_calls": 1,
+                    },
+                    {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "hi",
+                        "stream": True,
+                        "hermes": {"reasoning": {"include": True}},
+                    },
+                )
+                assert resp.status == 200
+                body = await resp.text()
+
+        completed = None
+        for line in body.splitlines():
+            if line.startswith("data: "):
+                payload = json.loads(line[len("data: "):])
+                if payload.get("type") == "response.completed":
+                    completed = payload["response"]
+                    break
+        assert completed is not None
+        assert completed["hermes"]["reasoning"]["text"] == "Streamed final reasoning."
+
+    @pytest.mark.asyncio
+    async def test_streamed_response_get_preserves_hermes_reasoning(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                cb = kwargs.get("stream_delta_callback")
+                if cb:
+                    cb("Stored stream")
+                return (
+                    {
+                        "final_response": "Stored stream",
+                        "last_reasoning": "Stored stream reasoning.",
+                        "messages": [{"role": "assistant", "content": "Stored stream"}],
+                        "api_calls": 1,
+                    },
+                    {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "store streamed",
+                        "stream": True,
+                        "store": True,
+                        "hermes": {"reasoning": {"include": True}},
+                    },
+                )
+                body = await resp.text()
+
+            response_id = None
+            for line in body.splitlines():
+                if line.startswith("data: "):
+                    payload = json.loads(line[len("data: "):])
+                    if payload.get("type") == "response.completed":
+                        response_id = payload["response"]["id"]
+                        break
+            assert response_id
+
+            get_resp = await cli.get(f"/v1/responses/{response_id}")
+            assert get_resp.status == 200
+            data = await get_resp.json()
+            assert data["hermes"]["reasoning"]["text"] == "Stored stream reasoning."
+
+    @pytest.mark.asyncio
+    async def test_stream_emits_hermes_reasoning_delta_when_requested(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                reasoning_cb = kwargs.get("reasoning_callback")
+                text_cb = kwargs.get("stream_delta_callback")
+                if reasoning_cb:
+                    reasoning_cb("thinking ")
+                    reasoning_cb("out loud")
+                if text_cb:
+                    text_cb("Final")
+                return (
+                    {
+                        "final_response": "Final",
+                        "last_reasoning": "thinking out loud",
+                        "messages": [{"role": "assistant", "content": "Final"}],
+                        "api_calls": 1,
+                    },
+                    {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "hi",
+                        "stream": True,
+                        "hermes": {"reasoning": {"include": True, "stream": True}},
+                    },
+                )
+                body = await resp.text()
+
+        assert "event: hermes.reasoning.delta" in body
+        assert '"type": "hermes.reasoning.delta"' in body
+        assert '"delta": "thinking "' in body
+        assert '"delta": "out loud"' in body
+        assert "event: hermes.reasoning.done" in body
+
+    @pytest.mark.asyncio
+    async def test_stream_omits_hermes_reasoning_delta_when_stream_false(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                reasoning_cb = kwargs.get("reasoning_callback")
+                if reasoning_cb:
+                    reasoning_cb("hidden live reasoning")
+                return (
+                    {
+                        "final_response": "Final",
+                        "last_reasoning": "hidden live reasoning",
+                        "messages": [{"role": "assistant", "content": "Final"}],
+                        "api_calls": 1,
+                    },
+                    {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "hi",
+                        "stream": True,
+                        "hermes": {"reasoning": {"include": True, "stream": False}},
+                    },
+                )
+                body = await resp.text()
+
+        assert "event: hermes.reasoning.delta" not in body
+        assert "hidden live reasoning" in body
 
     @pytest.mark.asyncio
     async def test_stream_cancelled_persists_incomplete_snapshot(self, adapter):

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -138,6 +138,29 @@ OpenAI Responses API format. Supports server-side conversation state via `previo
 }
 ```
 
+#### Hermes reasoning extension
+
+Reasoning is private by default. Clients that need to show or archive the model's reasoning trace can opt in with the Hermes-specific `hermes.reasoning` request options:
+
+```json
+{
+  "model": "hermes-agent",
+  "input": "Explain the trade-offs briefly.",
+  "hermes": {
+    "reasoning": {
+      "include": true,
+      "stream": true
+    }
+  }
+}
+```
+
+- `include: true` adds final reasoning text to the completed response envelope at `hermes.reasoning.text` when the active provider returns reasoning content.
+- `stream: true` additionally emits `hermes.reasoning.delta` SSE events during streaming responses, followed by `hermes.reasoning.done` when reasoning output has completed.
+- If `include` is omitted or false, reasoning is not exposed in either streaming events or final response payloads.
+
+The API server forwards the gateway's configured `reasoning` and `service_tier` settings to the agent, so `/v1/responses` uses the same reasoning/provider behavior as other Hermes gateway platforms.
+
 **Inline image input:** `input[].content` can contain `input_text` and `input_image` parts. Both remote URLs and `data:image/...` URLs are supported:
 
 ```json


### PR DESCRIPTION
## What does this PR do?

Adds opt-in reasoning support to the API server's `/v1/responses` endpoint.

Clients can request Hermes reasoning output with a Hermes-specific extension:

```json
{
  "hermes": {
    "reasoning": {
      "include": true,
      "stream": true
    }
  }
}
```

When requested, completed response payloads include `hermes.reasoning.text`, and streaming responses can emit `hermes.reasoning.delta` events followed by `hermes.reasoning.done`. Reasoning remains private by default unless the client explicitly opts in.

The API server also now forwards the gateway's configured reasoning and service-tier settings into `AIAgent`, so `/v1/responses` behaves consistently with other Hermes gateway platforms.

## Related Issue

N/A — no linked issue.

Related but not duplicate: #7742 covers `/v1/chat/completions` + `display.show_reasoning` think-tag behavior. This PR adds structured, opt-in reasoning support for `/v1/responses`.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/api_server.py`
  - Parses `hermes.reasoning.include` and `hermes.reasoning.stream` from `/v1/responses` requests.
  - Passes reasoning callbacks, configured reasoning options, and service tier into `AIAgent`.
  - Includes final reasoning text at `hermes.reasoning.text` for non-streaming and streaming completed response envelopes when requested.
  - Emits `hermes.reasoning.delta` and `hermes.reasoning.done` SSE events for streaming `/v1/responses` requests when both `include` and `stream` are enabled.
  - Keeps reasoning omitted by default when clients do not opt in.
- `tests/gateway/test_api_server.py`
  - Adds coverage for non-streaming reasoning inclusion, stored-response retrieval, default omission, agent config forwarding, streaming completed payloads, streaming GET retrieval, live reasoning deltas, and omission when `stream` is false.
- `website/docs/user-guide/features/api-server.md`
  - Documents the Hermes reasoning request extension, final response payload, streaming events, and default-private behavior.

## How to Test

1. Run the targeted reasoning coverage:
   ```bash
   python -m pytest tests/gateway/test_api_server.py -k 'reasoning'
   ```
   Expected result:
   ```text
   8 passed, 7 warnings
   ```
2. Run the full API server test module with ambient CORS config unset:
   ```bash
   env -u API_SERVER_CORS_ORIGINS python -m pytest tests/gateway/test_api_server.py
   ```
   Expected result:
   ```text
   127 passed, 81 warnings
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — targeted/API-server tests were run instead
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 25.10 via the API server pytest suite

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — `website/docs/user-guide/features/api-server.md`
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A; API-server request/response behavior only, no platform-specific file, process, or terminal handling added
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Backend/API change; no screenshots.

```text
python -m pytest tests/gateway/test_api_server.py -k 'reasoning'
8 passed, 7 warnings

env -u API_SERVER_CORS_ORIGINS python -m pytest tests/gateway/test_api_server.py
127 passed, 81 warnings
```
