### PR TITLE
fix(anthropic): suppress thinking on Kimi-compatible custom endpoints (#17057)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -352,6 +352,34 @@ def _is_kimi_coding_endpoint(base_url: str | None) -> bool:
     return normalized.rstrip("/").lower().startswith("https://api.kimi.com/coding")
 
 
+def _is_kimi_anthropic_compat(base_url: str | None, model: str | None) -> bool:
+    """Detect Kimi-compatible Anthropic Messages endpoints (official + custom).
+
+    Kimi's ``/coding`` route speaks the Anthropic Messages protocol but has
+    its own thinking semantics: when ``thinking.enabled`` is sent, Kimi
+    validates the message history and requires every prior assistant
+    tool-call message to carry OpenAI-style ``reasoning_content``. The
+    Anthropic path doesn't populate that field, so the next request after a
+    tool call fails with::
+
+        HTTP 400: thinking is enabled but reasoning_content is missing in
+        assistant tool call message at index N
+
+    The official endpoint lives at ``api.kimi.com/coding``, and
+    :func:`_is_kimi_coding_endpoint` covers it. But users also configure
+    Hermes against proxied or self-hosted Kimi deployments — same wire
+    protocol, same failure mode, different base_url. Recognise those by
+    pairing any non-empty ``base_url`` with a Kimi-family model name; that
+    excludes native Anthropic (no base_url) and other custom Anthropic-
+    compatible endpoints (non-Kimi model). See #17057.
+    """
+    if _is_kimi_coding_endpoint(base_url):
+        return True
+    if not base_url or not isinstance(model, str):
+        return False
+    return "kimi" in model.lower()
+
+
 def _requires_bearer_auth(base_url: str | None) -> bool:
     """Return True for Anthropic-compatible providers that require Bearer auth.
 
@@ -1716,11 +1744,17 @@ def build_anthropic_kwargs(
     # for that host.  (Kimi on chat_completions enables thinking via
     # extra_body in the ChatCompletionsTransport — see #13503.)
     #
+    # The same failure mode hits proxied / self-hosted Kimi deployments
+    # whose base_url isn't ``api.kimi.com/coding`` — recognise them via
+    # ``_is_kimi_anthropic_compat`` (URL match OR base_url + kimi-family
+    # model name) so the thinking suppression covers custom endpoints too
+    # (#17057).
+    #
     # On 4.7+ the `thinking.display` field defaults to "omitted", which
     # silently hides reasoning text that Hermes surfaces in its CLI. We
     # request "summarized" so the reasoning blocks stay populated — matching
     # 4.6 behavior and preserving the activity-feed UX during long tool runs.
-    _is_kimi_coding = _is_kimi_coding_endpoint(base_url)
+    _is_kimi_coding = _is_kimi_anthropic_compat(base_url, model)
     if reasoning_config and isinstance(reasoning_config, dict) and not _is_kimi_coding:
         if reasoning_config.get("enabled") is not False and "haiku" not in model.lower():
             effort = str(reasoning_config.get("effort", "medium")).lower()

--- a/tests/agent/test_kimi_coding_anthropic_thinking.py
+++ b/tests/agent/test_kimi_coding_anthropic_thinking.py
@@ -94,13 +94,17 @@ class TestKimiCodingSkipsAnthropicThinking:
         )
         assert "thinking" in kwargs
 
-    def test_kimi_root_endpoint_unaffected(self) -> None:
-        """Only the /coding route is special-cased — plain api.kimi.com is not.
+    def test_kimi_root_endpoint_on_anthropic_route_omits_thinking(self) -> None:
+        """If a Kimi-family model reaches the anthropic adapter on a non-/coding
+        URL, suppress thinking too (#17057).
 
-        ``api.kimi.com`` without ``/coding`` uses the chat_completions transport
-        (see runtime_provider._detect_api_mode_for_url); build_anthropic_kwargs
-        should never see it, but if it somehow does we should not suppress
-        thinking there — that path has different semantics.
+        ``api.kimi.com`` without ``/coding`` is normally routed through
+        chat_completions (see runtime_provider._detect_api_mode_for_url), but
+        nothing prevents an operator from forcing ``api_mode: anthropic_messages``
+        with that base_url.  The wire failure mode is identical to the official
+        /coding endpoint — Kimi requires reasoning_content on tool-call history
+        whenever thinking is enabled — so the suppression must follow the
+        protocol, not the URL path.
         """
         from agent.anthropic_adapter import build_anthropic_kwargs
 
@@ -112,4 +116,68 @@ class TestKimiCodingSkipsAnthropicThinking:
             reasoning_config={"enabled": True, "effort": "medium"},
             base_url="https://api.kimi.com/v1",
         )
+        assert "thinking" not in kwargs
+
+
+class TestKimiCustomEndpointSkipsAnthropicThinking:
+    """Custom / proxied Kimi-compatible endpoints must skip thinking too (#17057)."""
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "kimi-2.6",
+            "kimi-k2.6",
+            "kimi-coding",
+            "Moonshot-Kimi-Pro",  # case-insensitive model match
+        ],
+    )
+    def test_custom_proxy_with_kimi_model_omits_thinking(self, model: str) -> None:
+        from agent.anthropic_adapter import build_anthropic_kwargs
+
+        kwargs = build_anthropic_kwargs(
+            model=model,
+            messages=[{"role": "user", "content": "hello"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config={"enabled": True, "effort": "medium"},
+            base_url="http://kimi-proxy.internal:8080",
+        )
+        assert "thinking" not in kwargs, (
+            "Custom Kimi-compatible endpoints replicate the /coding endpoint's "
+            "tool-call reasoning_content validation — thinking must be omitted "
+            "or the next turn after a tool call 400s."
+        )
+        assert "output_config" not in kwargs
+
+    def test_custom_proxy_without_kimi_model_keeps_thinking(self) -> None:
+        """Non-Kimi models on custom endpoints (e.g. MiniMax) keep thinking."""
+        from agent.anthropic_adapter import build_anthropic_kwargs
+
+        kwargs = build_anthropic_kwargs(
+            model="MiniMax-M2.7",
+            messages=[{"role": "user", "content": "hello"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config={"enabled": True, "effort": "medium"},
+            base_url="http://anthropic-compat.internal:8080",
+        )
+        assert "thinking" in kwargs
+
+    def test_native_anthropic_with_kimi_substring_keeps_thinking(self) -> None:
+        """A model name containing 'kimi' on native Anthropic (no base_url)
+        must NOT trigger Kimi suppression — that's a fictional model path,
+        but the guard exists so user typos don't silently strip thinking
+        on the canonical Anthropic endpoint."""
+        from agent.anthropic_adapter import build_anthropic_kwargs
+
+        kwargs = build_anthropic_kwargs(
+            model="kimi-claude-fictional",
+            messages=[{"role": "user", "content": "hello"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config={"enabled": True, "effort": "medium"},
+            base_url=None,
+        )
+        # No base_url => native Anthropic. Even though the model name contains
+        # "kimi", the suppression requires *both* signals.
         assert "thinking" in kwargs


### PR DESCRIPTION
## Summary

\`build_anthropic_kwargs\` skips Anthropic \`thinking\` for Kimi's official \`/coding\` endpoint via \`_is_kimi_coding_endpoint(base_url)\`, because Kimi validates the message history when thinking is enabled and requires every assistant tool-call to carry OpenAI-style \`reasoning_content\` — which the Anthropic path never populates. Without that suppression, the turn after any tool call fails with:

> HTTP 400: thinking is enabled but reasoning_content is missing in assistant tool call message at index N

That guard only matched the literal \`api.kimi.com/coding\` URL. Users running Hermes against a proxied or self-hosted Kimi deployment (same wire protocol, different \`base_url\`) hit the same 400 and are forced to disable \`reasoning_effort\` as a workaround. Reported in #17057.

## Fix

Add \`_is_kimi_anthropic_compat(base_url, model)\` that returns True for either:

- the official \`api.kimi.com/coding\` URL (existing behaviour, preserved), or
- any non-empty \`base_url\` paired with a Kimi-family model name (\`\"kimi\" in model.lower()\`)

Native Anthropic (no \`base_url\`) is unaffected — both signals are required, so a fictional model name containing \"kimi\" on a direct Anthropic call still gets thinking. Non-Kimi models on custom endpoints (MiniMax, etc.) keep their thinking parameter.

## Behaviour matrix

| base_url | model | Before | After |
|----------|-------|--------|-------|
| \`api.kimi.com/coding\` | kimi-* | thinking omitted | thinking omitted (unchanged) |
| \`http://kimi-proxy.local\` | kimi-2.6 | thinking sent → 400 | thinking omitted ✓ |
| \`http://anthropic-proxy.local\` | MiniMax-M2.7 | thinking sent | thinking sent (unchanged) |
| \`None\` (native Anthropic) | claude-sonnet-4-* | thinking sent | thinking sent (unchanged) |
| \`api.kimi.com/v1\` | kimi-k2.5 | thinking sent (paranoid path) | thinking omitted (now consistent) |

## Test plan

- [x] \`tests/agent/test_kimi_coding_anthropic_thinking.py\` — 14 tests pass (10 existing + 5 new in \`TestKimiCustomEndpointSkipsAnthropicThinking\` + 1 retargeted)
- [x] \`tests/agent/test_anthropic_adapter.py\` (kimi/thinking subset) — 14 tests pass

The \`test_kimi_root_endpoint_unaffected\` paranoid test is retargeted to assert the new (consistent) behaviour: if a Kimi-family model reaches \`build_anthropic_kwargs\`, suppress thinking regardless of whether the URL is \`/coding\` or \`/v1\`. The wire failure mode follows the protocol, not the URL path.

Fixes #17057