### PR TITLE
feat: support Ctrl-N/P menu navigation

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9702,12 +9702,14 @@ class HermesCLI:
 
         # --- /model picker: arrow-key navigation ---
         @kb.add('up', filter=Condition(lambda: bool(self._model_picker_state)))
+        @kb.add('c-p', filter=Condition(lambda: bool(self._model_picker_state)))
         def model_picker_up(event):
             if self._model_picker_state:
                 self._model_picker_state["selected"] = max(0, self._model_picker_state.get("selected", 0) - 1)
                 event.app.invalidate()
 
         @kb.add('down', filter=Condition(lambda: bool(self._model_picker_state)))
+        @kb.add('c-n', filter=Condition(lambda: bool(self._model_picker_state)))
         def model_picker_down(event):
             state = self._model_picker_state
             if not state:

--- a/hermes_cli/curses_ui.py
+++ b/hermes_cli/curses_ui.py
@@ -139,9 +139,9 @@ def curses_checklist(
                 stdscr.refresh()
                 key = stdscr.getch()
 
-                if key in (curses.KEY_UP, ord("k")):
+                if key in (curses.KEY_UP, ord("k"), 16):  # 16 = Ctrl-P, curses doesn't define KEY_CTRL_P
                     cursor = (cursor - 1) % len(items)
-                elif key in (curses.KEY_DOWN, ord("j")):
+                elif key in (curses.KEY_DOWN, ord("j"), 14):  # 14 = Ctrl-N
                     cursor = (cursor + 1) % len(items)
                 elif key == ord(" "):
                     chosen.symmetric_difference_update({cursor})
@@ -263,9 +263,9 @@ def curses_radiolist(
                 stdscr.refresh()
                 key = stdscr.getch()
 
-                if key in (curses.KEY_UP, ord("k")):
+                if key in (curses.KEY_UP, ord("k"), 16):  # 16 = Ctrl-P
                     cursor = (cursor - 1) % len(items)
-                elif key in (curses.KEY_DOWN, ord("j")):
+                elif key in (curses.KEY_DOWN, ord("j"), 14):  # 14 = Ctrl-N
                     cursor = (cursor + 1) % len(items)
                 elif key in (ord(" "), curses.KEY_ENTER, 10, 13):
                     result_holder[0] = cursor
@@ -384,9 +384,9 @@ def curses_single_select(
                 stdscr.refresh()
                 key = stdscr.getch()
 
-                if key in (curses.KEY_UP, ord("k")):
+                if key in (curses.KEY_UP, ord("k"), 16):  # 16 = Ctrl-P
                     cursor = (cursor - 1) % len(all_items)
-                elif key in (curses.KEY_DOWN, ord("j")):
+                elif key in (curses.KEY_DOWN, ord("j"), 14):  # 14 = Ctrl-N
                     cursor = (cursor + 1) % len(all_items)
                 elif key in (curses.KEY_ENTER, 10, 13):
                     result_holder[0] = cursor


### PR DESCRIPTION
## Summary
- Add Ctrl-P/Ctrl-N shortcuts to the inline /model picker
- Add Ctrl-P/Ctrl-N shortcuts to curses checklist, radiolist, and single-select menus

## Test Plan
- python3 -m py_compile cli.py hermes_cli/curses_ui.py
- python -m pytest tests/hermes_cli/test_model_picker_viewport.py tests/hermes_cli/test_plugins_cmd.py -q -o 'addopts='