### PR TITLE
feat: add token generation speed to status bar

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2207,6 +2207,7 @@ class HermesCLI:
             "session_total_tokens": 0,
             "session_api_calls": 0,
             "compressions": 0,
+            "last_tokens_per_second": 0.0,
         }
 
         if not agent:
@@ -2220,6 +2221,7 @@ class HermesCLI:
         snapshot["session_completion_tokens"] = getattr(agent, "session_completion_tokens", 0) or 0
         snapshot["session_total_tokens"] = getattr(agent, "session_total_tokens", 0) or 0
         snapshot["session_api_calls"] = getattr(agent, "session_api_calls", 0) or 0
+        snapshot["last_tokens_per_second"] = getattr(agent, "_last_tokens_per_second", 0.0) or 0.0
 
         compressor = getattr(agent, "context_compressor", None)
         if compressor:
@@ -2385,6 +2387,9 @@ class HermesCLI:
 
             parts = [f"⚕ {snapshot['model_short']}", context_label, percent_label]
             parts.append(duration_label)
+            tps = snapshot.get("last_tokens_per_second", 0.0)
+            if tps > 0:
+                parts.append(f"{tps:.1f} t/s")
             prompt_elapsed = snapshot.get("prompt_elapsed")
             if prompt_elapsed:
                 parts.append(prompt_elapsed)
@@ -2447,6 +2452,11 @@ class HermesCLI:
                         ("class:status-bar-dim", " │ "),
                         ("class:status-bar-dim", duration_label),
                     ]
+                    # Token generation speed (last call)
+                    tps = snapshot.get("last_tokens_per_second", 0.0)
+                    if tps > 0:
+                        frags.append(("class:status-bar-dim", " │ "))
+                        frags.append(("class:status-bar-dim", f"{tps:.1f} t/s"))
                     # Position 7: per-prompt elapsed timer (live or frozen)
                     prompt_elapsed = snapshot.get("prompt_elapsed")
                     if prompt_elapsed:

--- a/run_agent.py
+++ b/run_agent.py
@@ -1974,6 +1974,10 @@ class AIAgent:
         self.session_cost_status = "unknown"
         self.session_cost_source = "none"
         
+        # Token generation speed tracking
+        self._last_api_duration = 0.0
+        self._last_tokens_per_second = 0.0
+        
         # ── Ollama num_ctx injection ──
         # Ollama defaults to 2048 context regardless of the model's capabilities.
         # When running against an Ollama server, detect the model's max context
@@ -2075,6 +2079,8 @@ class AIAgent:
         self.session_estimated_cost_usd = 0.0
         self.session_cost_status = "unknown"
         self.session_cost_source = "none"
+        self._last_api_duration = 0.0
+        self._last_tokens_per_second = 0.0
         
         # Turn counter (added after reset_session_state was first written — #2635)
         self._user_turn_count = 0
@@ -9969,6 +9975,7 @@ class AIAgent:
                         response = self._interruptible_api_call(api_kwargs)
                     
                     api_duration = time.time() - api_start_time
+                    self._last_api_duration = api_duration
                     
                     # Stop thinking spinner silently -- the response box or tool
                     # execution messages that follow are more informative.
@@ -10427,6 +10434,11 @@ class AIAgent:
                         )
                         prompt_tokens = canonical_usage.prompt_tokens
                         completion_tokens = canonical_usage.output_tokens
+                        # Track per-call token generation speed
+                        if self._last_api_duration > 0 and completion_tokens > 0:
+                            self._last_tokens_per_second = completion_tokens / self._last_api_duration
+                        else:
+                            self._last_tokens_per_second = 0.0
                         total_tokens = canonical_usage.total_tokens
                         usage_dict = {
                             "prompt_tokens": prompt_tokens,


### PR DESCRIPTION
Add per-call token generation speed (t/s) display to Hermes CLI status bar.

Changes:
- Track api_duration and completion_tokens in run_agent.py
- Show XX.X t/s in both plain text and rich status bar
- Only shown when width >= 76 and speed > 0