### PR TITLE
Fix UnicodeDecodeError in Windows wmic process scanning  #17049

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -279,9 +279,11 @@ def _scan_gateway_pids(exclude_pids: set[int], all_profiles: bool = False) -> li
                 ["wmic", "process", "get", "ProcessId,CommandLine", "/FORMAT:LIST"],
                 capture_output=True,
                 text=True,
+                encoding='utf-8',  # Explicitly specify
+                errors='ignore',   # Ignore undecodable bytes instead of crashing
                 timeout=10,
             )
-            if result.returncode != 0:
+            if result.returncode != 0 or result.stdout is None:  # Added null check
                 return []
             current_cmd = ""
             for line in result.stdout.split("\n"):


### PR DESCRIPTION
## What does this PR do?
Fixes #17049  UnicodeDecodeError and AttributeError in Windows gateway process scanning.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Critical (blocks `hermes setup` on Windows)



## Related Issue
https://github.com/NousResearch/hermes-agent/issues/17049


### Problem
The `_scan_gateway_pids()` function crashes on Windows systems with non-UTF-8 locales (e.g., Chinese `cp936`) because:

1. **wmic output uses system code page, not UTF-8:** Windows `wmic` outputs text encoded in the system's locale code page, not UTF-8
2. **UnicodeDecodeError in subprocess reader:** When Python tries to decode as UTF-8, it fails with `UnicodeDecodeError: 'utf-8' codec can't decode byte 0xd0`
3. **Cascading failure:** The decode error causes `result.stdout` to become `None`, then `AttributeError` when trying to split it

This completely blocks `hermes setup` on affected Windows systems.

### Solution
Added `errors='ignore'` parameter to the `subprocess.run()` call. This tells Python to skip undecodable bytes instead of crashing. For process scanning, losing a few non-UTF-8 characters is acceptable and doesn't affect functionality.

Also added a null check for `result.stdout` as defensive programming.

### Changes Made
- **File:** `hermes_cli/gateway.py`
- **Lines:** 278-290 (Windows process scanning section)
- **Changes:**
  1. Added `errors='ignore'` to handle non-UTF-8 bytes gracefully
  2. Added null check: `or result.stdout is None` in the early exit condition
