### PR TITLE
Allow smaller auxiliary compression models

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2401,30 +2401,20 @@ class AIAgent:
                 config_context_length=getattr(self, "_aux_compression_context_length_config", None),
             )
 
-            # Hard floor: the auxiliary compression model must have at least
-            # MINIMUM_CONTEXT_LENGTH (64K) tokens of context.  The main model
-            # is already required to meet this floor (checked earlier in
-            # __init__), so the compression model must too — otherwise it
-            # cannot summarise a full threshold-sized window of main-model
-            # content.  Mirrors the main-model rejection pattern.
-            if aux_context and aux_context < MINIMUM_CONTEXT_LENGTH:
-                raise ValueError(
-                    f"Auxiliary compression model {aux_model} has a context "
-                    f"window of {aux_context:,} tokens, which is below the "
-                    f"minimum {MINIMUM_CONTEXT_LENGTH:,} required by Hermes "
-                    f"Agent.  Choose a compression model with at least "
-                    f"{MINIMUM_CONTEXT_LENGTH // 1000}K context (set "
-                    f"auxiliary.compression.model in config.yaml), or set "
-                    f"auxiliary.compression.context_length to override the "
-                    f"detected value if it is wrong."
-                )
+            # The auxiliary compression model does not need to match the main
+            # model's minimum context window.  If it is smaller, compress in
+            # smaller pieces by lowering this session's live compression
+            # threshold to the auxiliary model's real window instead of
+            # refusing startup.  This lets 32K local models handle long
+            # sessions incrementally without pretending they support 64K+.
 
             threshold = self.context_compressor.threshold_tokens
-            if aux_context < threshold:
+            if aux_context and aux_context < threshold:
                 # Auto-correct: lower the live session threshold so
-                # compression actually works this session.  The hard floor
-                # above guarantees aux_context >= MINIMUM_CONTEXT_LENGTH,
-                # so the new threshold is always >= 64K.
+                # compression actually works this session.  The new threshold
+                # may be below MINIMUM_CONTEXT_LENGTH for auxiliary-only
+                # compression; the main model floor remains enforced by the
+                # main model startup checks.
                 old_threshold = threshold
                 new_threshold = aux_context
                 self.context_compressor.threshold_tokens = new_threshold
@@ -2442,15 +2432,17 @@ class AIAgent:
                     f"{aux_context:,} tokens, but the main model's "
                     f"compression threshold was {old_threshold:,} tokens. "
                     f"Auto-lowered this session's threshold to "
-                    f"{new_threshold:,} tokens so compression can run.\n"
+                    f"{new_threshold:,} tokens so compression can run in "
+                    f"smaller chunks.\n"
                     f"  To make this permanent, edit config.yaml — either:\n"
-                    f"  1. Use a larger compression model:\n"
+                    f"  1. Keep this smaller auxiliary model and lower the "
+                    f"compression threshold:\n"
+                    f"       compression:\n"
+                    f"         threshold: 0.{safe_pct:02d}\n"
+                    f"  2. Or use a larger compression model:\n"
                     f"       auxiliary:\n"
                     f"         compression:\n"
-                    f"           model: <model-with-{old_threshold:,}+-context>\n"
-                    f"  2. Lower the compression threshold:\n"
-                    f"       compression:\n"
-                    f"         threshold: 0.{safe_pct:02d}"
+                    f"           model: <model-with-{old_threshold:,}+-context>"
                 )
                 self._compression_warning = msg
                 self._emit_status(msg)

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -56,8 +56,8 @@ def _make_agent(
 @patch("agent.model_metadata.get_model_context_length", return_value=80_000)
 @patch("agent.auxiliary_client.get_text_auxiliary_client")
 def test_auto_corrects_threshold_when_aux_context_below_threshold(mock_get_client, mock_ctx_len):
-    """Auto-correction: aux >= 64K floor but < threshold → lower threshold
-    to aux_context so compression still works this session."""
+    """Auto-correction: aux < threshold → lower threshold to aux_context
+    so compression still works this session."""
     agent = _make_agent(main_context=200_000, threshold_percent=0.50)
     # threshold = 100,000 — aux has 80,000 (above 64K floor, below threshold)
     mock_client = MagicMock()
@@ -88,25 +88,28 @@ def test_auto_corrects_threshold_when_aux_context_below_threshold(mock_get_clien
 
 @patch("agent.model_metadata.get_model_context_length", return_value=32_768)
 @patch("agent.auxiliary_client.get_text_auxiliary_client")
-def test_rejects_aux_below_minimum_context(mock_get_client, mock_ctx_len):
-    """Hard floor: aux context < MINIMUM_CONTEXT_LENGTH (64K) → session
-    refuses to start (ValueError), mirroring the main-model rejection."""
+def test_aux_below_minimum_context_lowers_threshold_for_chunking(mock_get_client, mock_ctx_len):
+    """Aux context < MINIMUM_CONTEXT_LENGTH should not block startup.
+
+    Hermes can compress in smaller chunks by lowering the live compression
+    threshold to the auxiliary model's actual window.
+    """
     agent = _make_agent(main_context=200_000, threshold_percent=0.50)
     mock_client = MagicMock()
     mock_client.base_url = "https://openrouter.ai/api/v1"
     mock_client.api_key = "sk-aux"
     mock_get_client.return_value = (mock_client, "tiny-aux-model")
 
-    agent._emit_status = lambda msg: None
+    messages = []
+    agent._emit_status = lambda msg: messages.append(msg)
 
-    with pytest.raises(ValueError) as exc_info:
-        agent._check_compression_model_feasibility()
+    agent._check_compression_model_feasibility()
 
-    err = str(exc_info.value)
-    assert "tiny-aux-model" in err
-    assert "32,768" in err
-    assert "64,000" in err
-    assert "below the minimum" in err
+    assert len(messages) == 1
+    assert "tiny-aux-model" in messages[0]
+    assert "32,768" in messages[0]
+    assert "smaller chunks" in messages[0]
+    assert agent.context_compressor.threshold_tokens == 32_768
 
 
 @patch("agent.model_metadata.get_model_context_length", return_value=200_000)


### PR DESCRIPTION
## Summary
- remove the hard 64K minimum requirement for auxiliary compression models
- lower the live compression threshold to the auxiliary model's detected context window when it is smaller than the main threshold
- update compression feasibility coverage so 32K auxiliary models run in smaller chunks instead of blocking startup

## Verification
- python3 shimmed pytest for tests/run_agent/test_compression_feasibility.py → 16 passed, 1 warning
- exercised through Conductor skill review bridge with current qwen2.5:7b 32K local model setup

## Context
This supports local setups where the available auxiliary model is 32K and cannot run a larger 64K+ model. Hermes can still compress/review incrementally without pretending the model has more context than it actually reports.