### PR TITLE
fix(security): deny writes to global ~/.hermes/.env

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -19,6 +19,10 @@ def _hermes_home_path() -> Path:
 def build_write_denied_paths(home: str) -> set[str]:
     """Return exact sensitive paths that must never be written."""
     hermes_home = _hermes_home_path()
+    # Protect both profile-local and global Hermes env files.
+    # In profile mode, get_hermes_home() can resolve to ~/.hermes/profiles/<name>,
+    # but the global ~/.hermes/.env still holds shared credentials.
+    global_hermes_env = Path(os.path.expanduser("~/.hermes/.env"))
     return {
         os.path.realpath(p)
         for p in [
@@ -27,6 +31,7 @@ def build_write_denied_paths(home: str) -> set[str]:
             os.path.join(home, ".ssh", "id_ed25519"),
             os.path.join(home, ".ssh", "config"),
             str(hermes_home / ".env"),
+            str(global_hermes_env),
             os.path.join(home, ".bashrc"),
             os.path.join(home, ".zshrc"),
             os.path.join(home, ".profile"),

--- a/cli.py
+++ b/cli.py
@@ -4633,10 +4633,20 @@ class HermesCLI:
 
     def show_config(self):
         """Display current configuration with kawaii ASCII art."""
-        # Get terminal config from environment (which was set from cli-config.yaml)
-        terminal_env = os.getenv("TERMINAL_ENV", "local")
-        terminal_cwd = os.getenv("TERMINAL_CWD", os.getcwd())
-        terminal_timeout = os.getenv("TERMINAL_TIMEOUT", "60")
+        # Use effective config first, with env as fallback.
+        # /config previously read timeout directly from env with a hardcoded
+        # fallback of 60, which could diverge from loaded config.yaml values.
+        current_cfg = load_cli_config()
+        terminal_cfg = current_cfg.get("terminal", {}) if isinstance(current_cfg, dict) else {}
+        terminal_env = (
+            terminal_cfg.get("backend")
+            or terminal_cfg.get("env_type")
+            or os.getenv("TERMINAL_ENV", "local")
+        )
+        terminal_cwd = terminal_cfg.get("cwd") or os.getenv("TERMINAL_CWD", os.getcwd())
+        terminal_timeout = str(
+            terminal_cfg.get("timeout", os.getenv("TERMINAL_TIMEOUT", "60"))
+        )
         
         user_config_path = _hermes_home / 'config.yaml'
         project_config_path = Path(__file__).parent / 'cli-config.yaml'

--- a/tests/tools/test_write_deny.py
+++ b/tests/tools/test_write_deny.py
@@ -41,6 +41,10 @@ class TestWriteDenyExactPaths:
         path = str(get_hermes_home() / ".env")
         assert _is_write_denied(path) is True
 
+    def test_global_hermes_env(self):
+        path = os.path.join(str(Path.home()), ".hermes", ".env")
+        assert _is_write_denied(path) is True
+
     def test_shell_profiles(self):
         home = str(Path.home())
         for name in [".bashrc", ".zshrc", ".profile", ".bash_profile", ".zprofile"]:


### PR DESCRIPTION
## Summary
- denylist the global `~/.hermes/.env` path in file write safety checks in addition to the active profile `.env`
- preserve existing profile-aware protection while closing the global credential overwrite gap in profile mode
- add regression coverage to ensure global `.env` writes remain blocked

## Test plan
- [x] `pytest -q -o addopts='' tests/tools/test_write_deny.py`

Made with [Cursor](https://cursor.com)