### PR TITLE
fix(model-normalize): strip base-vendor prefix for regional-variant providers

### DIFF
--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -222,12 +222,34 @@ def _normalize_provider_alias(provider_name: str) -> str:
         return raw
 
 
+# Regional-variant providers that should also accept their base vendor's
+# prefix when stripping ``provider/`` — e.g. when the target provider is
+# ``minimax-cn`` (MiniMax's China API route), a model written as
+# ``minimax/minimax-m2.7`` in config.yaml or emitted by the aggregator
+# catalog should still have its ``minimax/`` prefix stripped.  Without
+# this, the regional adapter is handed ``minimax/minimax-m2.7`` verbatim
+# and the upstream API rejects it with ``unknown model`` (see #12140).
+#
+# Maps: regional variant (canonical) -> base vendor (canonical).
+_REGIONAL_VARIANT_ROOTS: dict[str, str] = {
+    "minimax-cn": "minimax",
+    "kimi-coding-cn": "kimi-coding",
+}
+
+
 def _strip_matching_provider_prefix(model_name: str, target_provider: str) -> str:
     """Strip ``provider/`` only when the prefix matches the target provider.
 
     This prevents arbitrary slash-bearing model IDs from being mangled on
     native providers while still repairing manual config values like
     ``zai/glm-5.1`` for the ``zai`` provider.
+
+    For regional-variant targets (``minimax-cn``, ``kimi-coding-cn``),
+    also accept the base vendor's prefix (``minimax/…``,
+    ``kimi/…`` / ``moonshot/…`` via existing aliases).  Regression for
+    #12140 — before this, ``minimax/minimax-m2.7`` routed through
+    ``provider: minimax-cn`` reached the MiniMax-CN API with the
+    vendor slash intact and produced ``unknown model`` failures.
     """
     if "/" not in model_name:
         return model_name
@@ -239,6 +261,10 @@ def _strip_matching_provider_prefix(model_name: str, target_provider: str) -> st
     normalized_prefix = _normalize_provider_alias(prefix)
     normalized_target = _normalize_provider_alias(target_provider)
     if normalized_prefix and normalized_prefix == normalized_target:
+        return remainder.strip()
+    # Regional variant: accept the base vendor's prefix too.
+    root = _REGIONAL_VARIANT_ROOTS.get(normalized_target)
+    if root and normalized_prefix == root:
         return remainder.strip()
     return model_name
 

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -261,3 +261,72 @@ class TestDeepseekCanonicalAndReasonerMapping:
     ])
     def test_unknown_names_fall_back_to_chat(self, model):
         assert _normalize_for_deepseek(model) == "deepseek-chat"
+
+
+# ── Issue #12140 — Regional-variant vendor-prefix stripping ────────────
+#
+# Regional-variant providers (``minimax-cn``, ``kimi-coding-cn``) route
+# to the China-region API of the same vendor. Users and catalogs commonly
+# write the model name with the base-vendor prefix (``minimax/minimax-m2.7``
+# from the OpenRouter catalog, ``moonshot/kimi-k2`` from legacy config).
+# Before the fix, those prefixes weren't recognised as vendor-match for
+# the regional target, so the full ``vendor/model`` slug was sent to the
+# regional API and rejected with ``unknown model`` errors.
+
+
+class TestIssue12140RegionalVariantPrefixStripping:
+    """MiniMax-CN and Kimi-Coding-CN must accept their base-vendor prefix."""
+
+    @pytest.mark.parametrize("model,expected", [
+        # Reporter's exact input: lowercase slug from OpenRouter catalog.
+        ("minimax/minimax-m2.7", "minimax-m2.7"),
+        # PascalCase variant (direct-MiniMax canonical form).
+        ("MiniMax/MiniMax-M2.7", "MiniMax-M2.7"),
+        # Mixed-case — prefix gets stripped, remainder preserved verbatim.
+        ("minimax/MiniMax-M2.7", "MiniMax-M2.7"),
+    ])
+    def test_minimax_cn_strips_minimax_prefix(self, model, expected):
+        assert normalize_model_for_provider(model, "minimax-cn") == expected
+
+    @pytest.mark.parametrize("model,expected", [
+        ("kimi/kimi-k2-turbo-preview", "kimi-k2-turbo-preview"),
+        # ``moonshot`` is a pre-existing alias of ``kimi-coding`` in
+        # ``hermes_cli.models._PROVIDER_ALIASES``; the fix makes it work
+        # for the regional variant too.
+        ("moonshot/kimi-k2", "kimi-k2"),
+        # The canonical ``kimi-coding`` prefix (the base vendor) also
+        # gets stripped for the regional target.
+        ("kimi-coding/kimi-k2", "kimi-k2"),
+    ])
+    def test_kimi_coding_cn_strips_base_vendor_prefix(self, model, expected):
+        assert normalize_model_for_provider(model, "kimi-coding-cn") == expected
+
+    # ── Preserved behaviour canaries ───────────────────────────────────
+
+    @pytest.mark.parametrize("model,provider,expected", [
+        # Non-matching prefix on a regional target must NOT be stripped.
+        ("arbitrary/path", "minimax-cn", "arbitrary/path"),
+        ("huggingface/Qwen3.5-397B", "minimax-cn", "huggingface/Qwen3.5-397B"),
+        # No slash at all — no-op, returned verbatim.
+        ("minimax-m2.7", "minimax-cn", "minimax-m2.7"),
+        ("MiniMax-M2.7", "minimax-cn", "MiniMax-M2.7"),
+        # Base vendor + matching target still strip (original feature).
+        ("minimax/minimax-m2.7", "minimax", "minimax-m2.7"),
+        ("kimi-coding/kimi-k2", "kimi-coding", "kimi-k2"),
+        # Non-regional providers unchanged.
+        ("zai/glm-5.1", "zai", "glm-5.1"),
+        ("glm/glm-4.7", "zai", "glm-4.7"),
+        ("anthropic/claude-sonnet-4.6", "openrouter", "anthropic/claude-sonnet-4.6"),
+        # A regional-target prefix on a non-regional target is not stripped.
+        ("minimax-cn/minimax-m2.7", "minimax", "minimax-cn/minimax-m2.7"),
+    ])
+    def test_preserved_behaviours(self, model, provider, expected):
+        assert normalize_model_for_provider(model, provider) == expected
+
+    def test_regional_root_map_is_only_for_exact_base_vendor(self):
+        """The fix must not silently accept *any* alias of the regional
+        variant as a base — only the documented base vendor."""
+        from hermes_cli.model_normalize import _REGIONAL_VARIANT_ROOTS
+
+        assert _REGIONAL_VARIANT_ROOTS["minimax-cn"] == "minimax"
+        assert _REGIONAL_VARIANT_ROOTS["kimi-coding-cn"] == "kimi-coding"


### PR DESCRIPTION
## Fix #12140 — Regional-variant provider prefix stripping

### Problem
Catalog entries like `minimax/minimax-m2.7` routed through `provider: minimax-cn` kept the vendor slash intact, causing API `unknown model` failures. This cascaded into memory summarisation collapse and image recognition timeouts.

### Solution
- Added `_REGIONAL_VARIANT_ROOTS` mapping (`minimax-cn` → `minimax`, `kimi-coding-cn` → `kimi-coding`)
- `_strip_matching_provider_prefix` now checks this mapping as a fallback after primary prefix match fails
- Added full test suite covering MiniMax-CN, Kimi-Coding-CN, preserved behaviours, and edge cases

### Testing
All new tests pass. Verified against the exact reporter inputs from #12140.

### Related
Base PR: #12140 (Briandevans) — this fork diverges slightly in test structure but implements the same fix.
