### PR TITLE
fix(commands): strip hyphens from Slack slash command names

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -820,14 +820,14 @@ def discord_skill_commands_by_category(
 # commands per app.
 _SLACK_MAX_SLASH_COMMANDS = 50
 _SLACK_NAME_LIMIT = 32
-_SLACK_INVALID_CHARS = re.compile(r"[^a-z0-9_\-]")
+_SLACK_INVALID_CHARS = re.compile(r"[^a-z0-9_]")
 
 
 def _sanitize_slack_name(raw: str) -> str:
     """Convert a command name to a valid Slack slash command name.
 
-    Slack allows lowercase a-z, digits, hyphens, and underscores. Max 32
-    chars. Uppercase is lowercased; invalid chars are stripped.
+    Slack allows lowercase a-z, digits, and underscores only (no hyphens).
+    Max 32 chars. Uppercase is lowercased; invalid chars are stripped.
     """
     name = raw.lower()
     name = _SLACK_INVALID_CHARS.sub("", name)


### PR DESCRIPTION
## Summary

Slack slash command names only allow lowercase letters, digits, and underscores — hyphens are not permitted.

**Root cause:** The `_sanitize_slack_name` function's regex `[^a-z0-9_\-]` was **keeping** hyphens (the `\-` inside `[]` makes hyphen a literal character to match, not a range operator). The docstring also incorrectly claimed Slack allows hyphens.

**What this caused:** Commands like `/reload-mcp` and `/set-home` were emitted into the Slack app manifest with hyphens, which Slack rejects with "the slash command has an invalid name".

**Fix:**
- Changed `_SLACK_INVALID_CHARS` regex from `[^a-z0-9_\-]` to `[^a-z0-9_]` so hyphens are stripped, not kept.
- Updated the docstring to correctly document Slack's allowed character set.

After this fix:
- `/reload-mcp` → `/reloadmcp`
- `/set-home` (alias) → `/sethome` (already canonical)

Closes #17054