### PR TITLE
feat: add Feishu media attachment support to send_message tool

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -556,11 +556,24 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             last_result = result
         return last_result
 
+    # --- Feishu: native attachment support via adapter ---
+    if platform == Platform.FEISHU and media_files:
+        last_result = None
+        for i, chunk in enumerate(chunks):
+            is_last = (i == len(chunks) - 1)
+            result = await _send_feishu(
+                pconfig, chat_id, chunk, media_files=media_files if is_last else [], thread_id=thread_id
+            )
+            if isinstance(result, dict) and result.get("error"):
+                return result
+            last_result = result
+        return last_result
+
     # --- Non-media platforms ---
     if media_files and not message.strip():
         return {
             "error": (
-                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal and yuanbao; "
+                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, feishu, and yuanbao; "
                 f"target {platform.value} had only media attachments"
             )
         }
@@ -568,7 +581,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if media_files:
         warning = (
             f"MEDIA attachments were omitted for {platform.value}; "
-            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal and yuanbao"
+            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, feishu, and yuanbao"
         )
 
     last_result = None
@@ -592,7 +605,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         elif platform == Platform.DINGTALK:
             result = await _send_dingtalk(pconfig.extra, chat_id, chunk)
         elif platform == Platform.FEISHU:
-            result = await _send_feishu(pconfig, chat_id, chunk, thread_id=thread_id)
+            result = await _send_feishu(pconfig, chat_id, chunk, media_files=media_files, thread_id=thread_id)
         elif platform == Platform.WECOM:
             result = await _send_wecom(pconfig.extra, chat_id, chunk)
         elif platform == Platform.BLUEBUBBLES:


### PR DESCRIPTION
## Summary

Adds native media attachment support for Feishu/Lark platform in the `send_message` tool.

## Changes

- Add Feishu platform to media-capable platforms list (alongside Telegram, Discord, Matrix, Weixin, Signal)
- Enable native media file sending (images, videos, documents) via existing FeishuAdapter
- Update error messages to include Feishu in supported platforms list
- Pass `media_files` parameter to `_send_feishu` function

## Background

The `FeishuAdapter` already has full support for sending documents, images, videos, and audio files via `send_document()`, `send_image_file()`, `send_video()`, and `send_voice()` methods. However, the `send_message` tool was not connecting its media handling to these existing adapter capabilities.

This change adds the missing connection, allowing users to send file attachments to Feishu chats using the `MEDIA:<path>` syntax.

## Testing

- Verified file attachment sending works on Feishu platform
- No more "MEDIA attachments were omitted" warning for Feishu
- Backward compatible: text-only messages still work as before

## Related

- Feishu adapter: `gateway/platforms/feishu.py`
- Send message tool: `tools/send_message_tool.py`