### PR TITLE
feat(code): adiciona realtime event fanout P3

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4578,24 +4578,36 @@ class HermesCLI:
             "\n".join([
                 "Code Mode Approvals",
                 "",
-                "Base Code Mode has no approval queue yet.",
-                "Approval-gated execution policy is deferred to the later P0 port.",
+                "P0 execution policy is available.",
+                "Risk classes include safe_readonly, network, git_write, secret_sensitive, destructive.",
+                "Use /code for backend status; policy assessments are exposed via /api/code/policy/assess-command.",
             ]),
             highlight=False,
             markup=False,
         )
 
     def _handle_skills_code_command(self, _cmd: str):
-        self._console_print(
-            "\n".join([
-                "Code Mode Skills",
-                "",
-                f"Installed slash skills visible to this CLI: {len(_skill_commands)}",
-                "SKILL.md repository discovery is deferred to the later P0 port.",
-            ]),
-            highlight=False,
-            markup=False,
-        )
+        discovered = []
+        workspace_skills = 0
+        workspace_path = Path(os.getenv("TERMINAL_CWD", os.getcwd()))
+        try:
+            from hermes_cli.code.skill_discovery import SkillDiscoveryService
+
+            service = SkillDiscoveryService()
+            discovered = service.list_skills(workspace_path=workspace_path)
+            workspace_skills = sum(1 for s in discovered if str(s.get("source", "")).startswith("workspace:"))
+        except Exception:
+            discovered = []
+
+        lines = [
+            "Code Mode Skills",
+            "",
+            f"Installed slash skills visible to this CLI: {len(_skill_commands)}",
+            f"Discovered skills (builtin/global/workspace): {len(discovered)}",
+            f"Workspace-local SKILL.md skills: {workspace_skills}",
+            "Skill folders supported: SKILL.md, scripts/, resources/",
+        ]
+        self._console_print("\n".join(lines), highlight=False, markup=False)
     
     def _fast_command_available(self) -> bool:
         try:

--- a/cli.py
+++ b/cli.py
@@ -4412,6 +4412,190 @@ class HermesCLI:
             f"Agent Running: {'Yes' if is_running else 'No'}",
         ])
         self._console_print("\n".join(lines), highlight=False, markup=False)
+
+    def _code_mode_dashboard_url(self) -> str:
+        dashboard = self.config.get("dashboard", {}) if isinstance(self.config, dict) else {}
+        host = str(dashboard.get("host") or "127.0.0.1")
+        port = int(dashboard.get("port") or 9119)
+        return f"http://{host}:{port}"
+
+    def _code_mode_backend_probe(self) -> tuple[str, dict[str, Any] | None]:
+        url = f"{self._code_mode_dashboard_url()}/api/code/status"
+        try:
+            import urllib.request
+            req = urllib.request.Request(url, method="GET")
+            with urllib.request.urlopen(req, timeout=0.75) as resp:
+                if resp.status == 200:
+                    return "online", json.loads(resp.read().decode("utf-8"))
+                return f"http {resp.status}", None
+        except Exception:
+            return "offline", None
+
+    def _code_mode_git_branch(self, cwd: str) -> str:
+        try:
+            result = subprocess.run(
+                ["git", "branch", "--show-current"],
+                cwd=cwd,
+                capture_output=True,
+                text=True,
+                timeout=2,
+            )
+            branch = result.stdout.strip()
+            return branch or "(detached or unavailable)"
+        except Exception:
+            return "(not a git repo)"
+
+    def _code_mode_state_status(self) -> dict[str, Any]:
+        if self._session_db:
+            try:
+                return self._session_db.code_mode_status()
+            except Exception as exc:
+                return {"mode": "unavailable", "error": str(exc)}
+        return {"mode": "unavailable", "error": "state database not available"}
+
+    def _handle_code_command(self, _cmd: str):
+        """Show the current Code Mode console summary."""
+        from hermes_cli.profiles import get_active_profile_name
+
+        cwd = os.getenv("TERMINAL_CWD", os.getcwd())
+        backend_status, backend_payload = self._code_mode_backend_probe()
+        state_status = (backend_payload or {}).get("state") if backend_payload else self._code_mode_state_status()
+        if not isinstance(state_status, dict):
+            state_status = self._code_mode_state_status()
+        schema_version = state_status.get("schema_version", "(unknown)")
+        counts = state_status.get("counts") or {}
+
+        lines = [
+            "Hermes Code Mode",
+            "",
+            f"Provider: {getattr(self, 'provider', None) or 'unknown'}",
+            f"Model: {getattr(self, 'model', None) or '(unknown)'}",
+            f"Profile: {get_active_profile_name()}",
+            f"Workspace: {cwd}",
+            f"Git Branch: {self._code_mode_git_branch(cwd)}",
+            f"Backend: {backend_status}",
+            f"Web/Cockpit: {self._code_mode_dashboard_url()}",
+            f"Schema: {schema_version}",
+            (
+                "State: "
+                f"{counts.get('code_workspaces', 0)} workspace(s), "
+                f"{counts.get('code_sessions', 0)} session(s), "
+                f"{counts.get('code_events', 0)} event(s)"
+            ),
+            "",
+            "Commands: /workspace, /session, /web, /approvals, /skills-code",
+        ]
+        if state_status.get("error"):
+            lines.insert(-2, f"State Note: {state_status['error']}")
+        self._console_print("\n".join(lines), highlight=False, markup=False)
+
+    def _handle_web_command(self, _cmd: str):
+        """Show dashboard launch hints for Code Mode."""
+        backend_status, _payload = self._code_mode_backend_probe()
+        url = self._code_mode_dashboard_url()
+        lines = [
+            "Hermes Web / Code Cockpit",
+            "",
+            f"URL: {url}",
+            f"Backend: {backend_status}",
+            "",
+            "Launch: python -m hermes_cli.main dashboard --port 9119",
+            "Note: hermesWeb is not present in this checkout; UI expansion is deferred.",
+        ]
+        self._console_print("\n".join(lines), highlight=False, markup=False)
+
+    def _handle_workspace_command(self, cmd: str):
+        """List known Code Mode workspaces, falling back to current cwd."""
+        query = ""
+        parts = cmd.strip().split(maxsplit=1)
+        if len(parts) > 1:
+            query = parts[1].strip()
+
+        workspaces = []
+        if self._session_db:
+            try:
+                workspaces = self._session_db.list_code_workspaces(q=query, limit=20)
+            except Exception:
+                workspaces = []
+
+        if not workspaces:
+            cwd = os.getenv("TERMINAL_CWD", os.getcwd())
+            lines = [
+                "Code Mode Workspaces",
+                "",
+                "No stored Code Mode workspaces found.",
+                f"Current Path: {cwd}",
+                f"Git Branch: {self._code_mode_git_branch(cwd)}",
+            ]
+            self._console_print("\n".join(lines), highlight=False, markup=False)
+            return
+
+        lines = ["Code Mode Workspaces", ""]
+        for workspace in workspaces:
+            name = workspace.get("name") or workspace.get("id") or "(unnamed)"
+            repo = workspace.get("repo_url") or workspace.get("git_remote") or workspace.get("repo") or ""
+            path = workspace.get("path") or ""
+            lines.append(f"- {name}")
+            if repo:
+                lines.append(f"  Repo: {repo}")
+            if path:
+                lines.append(f"  Path: {path}")
+        self._console_print("\n".join(lines), highlight=False, markup=False)
+
+    def _handle_code_session_command(self, cmd: str):
+        """List known Code Mode sessions."""
+        workspace_id = None
+        parts = cmd.strip().split(maxsplit=1)
+        if len(parts) > 1:
+            workspace_id = parts[1].strip() or None
+
+        sessions = []
+        if self._session_db:
+            try:
+                sessions = self._session_db.list_code_sessions(workspace_id=workspace_id, limit=20)
+            except Exception:
+                sessions = []
+
+        if not sessions:
+            self._console_print(
+                "Code Mode Sessions\n\nNo stored Code Mode sessions found.",
+                highlight=False,
+                markup=False,
+            )
+            return
+
+        lines = ["Code Mode Sessions", ""]
+        for session in sessions:
+            sid = session.get("id") or "(unknown)"
+            status = session.get("status") or "(unknown)"
+            workspace = session.get("workspace_id") or "(none)"
+            branch = session.get("branch") or "(unknown)"
+            lines.append(f"- {sid}: {status} workspace={workspace} branch={branch}")
+        self._console_print("\n".join(lines), highlight=False, markup=False)
+
+    def _handle_code_approvals_command(self, _cmd: str):
+        self._console_print(
+            "\n".join([
+                "Code Mode Approvals",
+                "",
+                "Base Code Mode has no approval queue yet.",
+                "Approval-gated execution policy is deferred to the later P0 port.",
+            ]),
+            highlight=False,
+            markup=False,
+        )
+
+    def _handle_skills_code_command(self, _cmd: str):
+        self._console_print(
+            "\n".join([
+                "Code Mode Skills",
+                "",
+                f"Installed slash skills visible to this CLI: {len(_skill_commands)}",
+                "SKILL.md repository discovery is deferred to the later P0 port.",
+            ]),
+            highlight=False,
+            markup=False,
+        )
     
     def _fast_command_available(self) -> bool:
         try:
@@ -6226,6 +6410,18 @@ class HermesCLI:
             self._show_gateway_status()
         elif canonical == "status":
             self._show_session_status()
+        elif canonical == "code":
+            self._handle_code_command(cmd_original)
+        elif canonical == "web":
+            self._handle_web_command(cmd_original)
+        elif canonical == "workspace":
+            self._handle_workspace_command(cmd_original)
+        elif canonical == "session":
+            self._handle_code_session_command(cmd_original)
+        elif canonical == "approvals":
+            self._handle_code_approvals_command(cmd_original)
+        elif canonical == "skills-code":
+            self._handle_skills_code_command(cmd_original)
         elif canonical == "statusbar":
             self._status_bar_visible = not self._status_bar_visible
             state = "visible" if self._status_bar_visible else "hidden"

--- a/cli.py
+++ b/cli.py
@@ -4486,6 +4486,7 @@ class HermesCLI:
             "",
             "Commands: /workspace, /session, /web, /approvals, /skills-code, /github",
             "Approval Governance: /api/code/approvals/*",
+            "Realtime Events: /api/code/events/ws (token-required)",
         ]
         if state_status.get("error"):
             lines.insert(-2, f"State Note: {state_status['error']}")
@@ -4601,13 +4602,14 @@ class HermesCLI:
                                     "",
                                     f"Backend: {backend_status}",
                                     f"Pending approvals: {pending}",
-                                    f"Pending GitHub write approvals: {github_pending}",
-                                    f"Approved: {int(by_status.get('approved', 0) or 0)}",
-                                    f"Executed: {int(by_status.get('executed', 0) or 0)}",
-                                    "",
-                                    "Use /code for backend status and /github for integration status.",
-                                ]
-                            ),
+                    f"Pending GitHub write approvals: {github_pending}",
+                    f"Approved: {int(by_status.get('approved', 0) or 0)}",
+                    f"Executed: {int(by_status.get('executed', 0) or 0)}",
+                    "",
+                    "Realtime approval updates: /api/code/events/ws (filter by approval_id).",
+                    "Use /code for backend status and /github for integration status.",
+                ]
+            ),
                             highlight=False,
                             markup=False,
                         )

--- a/cli.py
+++ b/cli.py
@@ -4480,10 +4480,12 @@ class HermesCLI:
                 "State: "
                 f"{counts.get('code_workspaces', 0)} workspace(s), "
                 f"{counts.get('code_sessions', 0)} session(s), "
-                f"{counts.get('code_events', 0)} event(s)"
+                f"{counts.get('code_events', 0)} event(s), "
+                f"{counts.get('code_approval_requests', 0)} approval request(s)"
             ),
             "",
             "Commands: /workspace, /session, /web, /approvals, /skills-code, /github",
+            "Approval Governance: /api/code/approvals/*",
         ]
         if state_status.get("error"):
             lines.insert(-2, f"State Note: {state_status['error']}")
@@ -4574,14 +4576,70 @@ class HermesCLI:
         self._console_print("\n".join(lines), highlight=False, markup=False)
 
     def _handle_code_approvals_command(self, _cmd: str):
+        backend_status, _payload = self._code_mode_backend_probe()
+        if backend_status == "online":
+            try:
+                import urllib.request
+
+                url = f"{self._code_mode_dashboard_url()}/api/code/approvals/summary"
+                req = urllib.request.Request(url, method="GET")
+                with urllib.request.urlopen(req, timeout=1.0) as resp:
+                    if resp.status == 200:
+                        data = json.loads(resp.read().decode("utf-8"))
+                        summary = data.get("summary") or {}
+                        by_status = summary.get("status") or {}
+                        by_kind = summary.get("kind") or {}
+                        pending = int(by_status.get("pending", 0) or 0)
+                        github_pending = int(by_kind.get("github_comment", 0) or 0)
+                        github_pending += int(by_kind.get("github_pr_prepare", 0) or 0)
+                        github_pending += int(by_kind.get("github_check_update", 0) or 0)
+                        github_pending += int(by_kind.get("github_status_update", 0) or 0)
+                        self._console_print(
+                            "\n".join(
+                                [
+                                    "Code Mode Approvals",
+                                    "",
+                                    f"Backend: {backend_status}",
+                                    f"Pending approvals: {pending}",
+                                    f"Pending GitHub write approvals: {github_pending}",
+                                    f"Approved: {int(by_status.get('approved', 0) or 0)}",
+                                    f"Executed: {int(by_status.get('executed', 0) or 0)}",
+                                    "",
+                                    "Use /code for backend status and /github for integration status.",
+                                ]
+                            ),
+                            highlight=False,
+                            markup=False,
+                        )
+                        return
+            except Exception as exc:
+                if "401" in str(exc):
+                    self._console_print(
+                        "\n".join(
+                            [
+                                "Code Mode Approvals",
+                                "",
+                                f"Backend: {backend_status}",
+                                "Approval summary endpoint requires dashboard auth.",
+                                "Use the dashboard session for /api/code/approvals/* operations.",
+                            ]
+                        ),
+                        highlight=False,
+                        markup=False,
+                    )
+                    return
+
         self._console_print(
-            "\n".join([
-                "Code Mode Approvals",
-                "",
-                "P0 execution policy is available.",
-                "Risk classes include safe_readonly, network, git_write, secret_sensitive, destructive.",
-                "Use /code for backend status; policy assessments are exposed via /api/code/policy/assess-command.",
-            ]),
+            "\n".join(
+                [
+                    "Code Mode Approvals",
+                    "",
+                    f"Backend: {backend_status}",
+                    "P0 execution policy is available.",
+                    "Risk classes include safe_readonly, network, git_write, secret_sensitive, destructive.",
+                    "Use /code for backend status; policy assessments are exposed via /api/code/policy/assess-command.",
+                ]
+            ),
             highlight=False,
             markup=False,
         )

--- a/cli.py
+++ b/cli.py
@@ -4483,7 +4483,7 @@ class HermesCLI:
                 f"{counts.get('code_events', 0)} event(s)"
             ),
             "",
-            "Commands: /workspace, /session, /web, /approvals, /skills-code",
+            "Commands: /workspace, /session, /web, /approvals, /skills-code, /github",
         ]
         if state_status.get("error"):
             lines.insert(-2, f"State Note: {state_status['error']}")
@@ -4608,6 +4608,93 @@ class HermesCLI:
             "Skill folders supported: SKILL.md, scripts/, resources/",
         ]
         self._console_print("\n".join(lines), highlight=False, markup=False)
+
+    def _handle_github_command(self, cmd: str):
+        parts = [p for p in cmd.strip().split() if p]
+        action = parts[1].lower() if len(parts) > 1 else "status"
+        try:
+            if action == "status":
+                from hermes_cli.code.github_integration import GitHubIntegrationService
+
+                status = GitHubIntegrationService().status()
+                lines = [
+                    "GitHub Integration",
+                    "",
+                    f"Mode: {status.get('mode')}",
+                    f"Configured: {'yes' if status.get('configured') else 'no'}",
+                    f"App ID configured: {'yes' if status.get('app_id_configured') else 'no'}",
+                    f"Private key configured: {'yes' if status.get('private_key_configured') else 'no'}",
+                    f"Webhook secret configured: {'yes' if status.get('webhook_secret_configured') else 'no'}",
+                    f"PAT dev enabled: {'yes' if status.get('pat_dev_configured') else 'no'}",
+                    f"Installations: {status.get('installations', 0)}",
+                    f"Repositories: {status.get('repositories', 0)}",
+                    "",
+                    "Usage: /github repos | /github sync [--dry-run]",
+                ]
+                self._console_print("\n".join(lines), highlight=False, markup=False)
+                return
+
+            if action == "repos":
+                from hermes_cli.code.github_integration import GitHubIntegrationStore
+
+                query = ""
+                if len(parts) > 2:
+                    query = " ".join(parts[2:])
+                store = GitHubIntegrationStore()
+                try:
+                    repos = store.list_repositories(q=query or None, limit=50)
+                finally:
+                    store.close()
+                if not repos:
+                    self._console_print(
+                        "GitHub Repositories\n\nNo synced repositories found.",
+                        highlight=False,
+                        markup=False,
+                    )
+                    return
+                lines = ["GitHub Repositories", ""]
+                for repo in repos:
+                    lines.append(f"- {repo.get('full_name')}")
+                    lines.append(f"  default: {repo.get('default_branch') or '(unknown)'}")
+                    lines.append(f"  private: {'yes' if repo.get('private') else 'no'}")
+                self._console_print("\n".join(lines), highlight=False, markup=False)
+                return
+
+            if action == "sync":
+                from hermes_cli.code.github_sync import GitHubSyncService
+
+                dry_run = "--dry-run" in parts
+                result = GitHubSyncService().sync_repositories(dry_run=dry_run, limit=100)
+                lines = [
+                    "GitHub Sync",
+                    "",
+                    f"Dry run: {'yes' if dry_run else 'no'}",
+                    f"Synced: {result.get('synced', 0)}",
+                    f"Returned: {len(result.get('repositories') or [])}",
+                ]
+                self._console_print("\n".join(lines), highlight=False, markup=False)
+                return
+
+            self._console_print(
+                "\n".join(
+                    [
+                        "GitHub Command",
+                        "",
+                        "Usage:",
+                        "/github status",
+                        "/github repos [query]",
+                        "/github sync [--dry-run]",
+                    ]
+                ),
+                highlight=False,
+                markup=False,
+            )
+        except Exception as exc:
+            self._console_print(
+                f"GitHub command unavailable: {exc}",
+                highlight=False,
+                markup=False,
+            )
     
     def _fast_command_available(self) -> bool:
         try:
@@ -6434,6 +6521,8 @@ class HermesCLI:
             self._handle_code_approvals_command(cmd_original)
         elif canonical == "skills-code":
             self._handle_skills_code_command(cmd_original)
+        elif canonical == "github":
+            self._handle_github_command(cmd_original)
         elif canonical == "statusbar":
             self._status_bar_visible = not self._status_bar_visible
             state = "visible" if self._status_bar_visible else "hidden"

--- a/docs/HERMES_APPROVAL_GOVERNANCE.md
+++ b/docs/HERMES_APPROVAL_GOVERNANCE.md
@@ -1,0 +1,124 @@
+# Hermes Approval Governance (P2)
+
+P2 adds persistent approval governance for Code Mode actions, with GitHub
+write safety as the first concrete use case.
+
+## Scope
+
+- Persistent approval requests in `state.db` (`code_approval_requests` table).
+- Approval lifecycle state machine with transition validation.
+- Redacted API responses and event payloads.
+- Integration with `ExecutionPolicyEngine` risk classes.
+- GitHub write endpoints gated by approval lifecycle (no ad-hoc `approved=true`).
+
+## Lifecycle
+
+Statuses:
+
+- `pending`
+- `approved`
+- `rejected`
+- `expired`
+- `cancelled`
+- `executed`
+- `failed`
+
+Allowed transitions:
+
+- `pending -> approved | rejected | cancelled | expired`
+- `approved -> executed | failed | cancelled`
+- `rejected`, `expired`, `cancelled`, `executed`, `failed` are terminal
+
+Invalid transitions return safe errors.
+
+## Risk Classes
+
+Risk classes align with Code Mode policy:
+
+- `safe_readonly`
+- `safe_local_write`
+- `network`
+- `git_write`
+- `secret_sensitive`
+- `remote_mutating`
+- `destructive`
+- `production_sensitive`
+
+GitHub write actions are classified as `git_write` and tagged with
+`network + git_write`.
+
+## API
+
+- `GET /api/code/approvals`
+- `POST /api/code/approvals`
+- `GET /api/code/approvals/{approval_id}`
+- `POST /api/code/approvals/{approval_id}/approve`
+- `POST /api/code/approvals/{approval_id}/reject`
+- `POST /api/code/approvals/{approval_id}/cancel`
+- `POST /api/code/approvals/expire`
+- `GET /api/code/approvals/summary`
+
+All responses are redacted for secret-bearing keys and token-like values.
+
+## GitHub Write Flow
+
+For `POST /api/code/github/comments` and
+`POST /api/code/github/pull-requests/prepare`:
+
+1. Call without `approval_id`.
+2. Backend creates persistent `pending` approval and returns:
+   - `requires_approval: true`
+   - `approval_id`
+   - `status: pending`
+3. Approve via `POST /api/code/approvals/{approval_id}/approve`.
+4. Call the same GitHub endpoint with `approval_id`.
+5. Backend validates kind/action/resource/payload binding and expiry.
+6. On success: write executes once and approval becomes `executed`.
+7. On execution failure: approval becomes `failed`.
+
+Rejected/expired/cancelled/executed approvals never execute writes.
+
+## Event Model
+
+Persisted in `code_events` with normalized envelope:
+
+- `code.approval.created`
+- `code.approval.approved`
+- `code.approval.rejected`
+- `code.approval.cancelled`
+- `code.approval.expired`
+- `code.approval.executed`
+- `code.approval.failed`
+- `github.write.approval_required`
+- `github.write.executed`
+- `github.write.rejected`
+- `github.write.failed`
+
+Realtime fanout is deferred; persistence is authoritative in P2.
+
+## Security / Redaction
+
+Never exposed in API/events:
+
+- Authorization headers
+- GitHub/PAT/install tokens
+- private keys, webhook secrets
+- client secrets, passwords
+
+Keys matching `token`, `authorization`, `secret`, `password`, and related
+variants are redacted recursively.
+
+## Known Limitations
+
+- No dashboard approval panel (`hermesWeb` UI remains deferred).
+- Approval actor identity is best-effort (`local`) where strong identity is
+  unavailable.
+- Optional `/execute` endpoint is intentionally omitted; action endpoints
+  perform their own execution after validation.
+
+## P3 Recommendations
+
+- Add signed user identity/claims for `requested_by`/`approved_by`.
+- Add policy-driven TTL profiles by risk class.
+- Add realtime event fanout for approval changes.
+- Add dashboard approval management UI on top of existing APIs.

--- a/docs/HERMES_APPROVAL_GOVERNANCE.md
+++ b/docs/HERMES_APPROVAL_GOVERNANCE.md
@@ -94,7 +94,11 @@ Persisted in `code_events` with normalized envelope:
 - `github.write.rejected`
 - `github.write.failed`
 
-Realtime fanout is deferred; persistence is authoritative in P2.
+Realtime fanout is available in P3 through:
+
+- `WS /api/code/events/ws`
+- filtered replay/catch-up with `since_id`
+- REST views under `/api/code/events`, `/recent`, and `/summary`
 
 ## Security / Redaction
 

--- a/docs/HERMES_CODE_EVENTS.md
+++ b/docs/HERMES_CODE_EVENTS.md
@@ -1,0 +1,115 @@
+# Hermes Code Events (P3)
+
+P3 adds a central realtime event fanout layer for Code Mode, backed by
+persisted `code_events` records and additive WebSocket subscriptions.
+
+## Event Bus
+
+Central service: `hermes_cli/code/event_bus.py`
+
+Responsibilities:
+
+- normalize event envelope
+- recursive payload redaction
+- persist into `code_events`
+- in-process fanout to subscribers
+- replay/catch-up from persisted events
+- filter matching by Code Mode dimensions
+
+All published events are redacted before persistence and before fanout.
+
+## Envelope
+
+```json
+{
+  "id": "uuid",
+  "type": "code.approval.approved",
+  "version": 1,
+  "timestamp": "2026-01-01T00:00:00+00:00",
+  "workspace_id": "optional",
+  "code_session_id": "optional",
+  "orchestrated_run_id": "optional",
+  "approval_id": "optional",
+  "github_repo_full_name": "optional",
+  "payload": {},
+  "metadata": {}
+}
+```
+
+## WebSocket
+
+Additive endpoint:
+
+- `WS /api/code/events/ws`
+
+Supported query params:
+
+- `type`
+- `workspace_id`
+- `code_session_id`
+- `orchestrated_run_id`
+- `approval_id`
+- `github_repo_full_name`
+- `since_id`
+- `replay=true|false`
+- `limit`
+- `token` (dashboard session token)
+
+Behavior:
+
+1. Optional replay/catch-up (ordered by persisted insertion order)
+2. Live filtered stream
+3. Heartbeat frames when idle
+4. Safe disconnect and subscriber cleanup
+
+## REST
+
+- `GET /api/code/events`
+- `GET /api/code/events/recent`
+- `GET /api/code/events/summary`
+- `GET /api/code/events/subscriptions`
+
+Filter support:
+
+- `type`
+- `workspace_id`
+- `code_session_id`
+- `orchestrated_run_id`
+- `approval_id`
+- `github_repo_full_name`
+- `since_id`
+- `limit`
+
+## Replay semantics
+
+- `since_id` does not rely on UUID ordering.
+- Replay is deterministic using persisted insertion order.
+- Returned items are events strictly after `since_id`.
+
+## Security
+
+Redaction applies recursively to keys including:
+
+- `token`
+- `access_token`
+- `refresh_token`
+- `authorization`
+- `private_key`
+- `webhook_secret`
+- `client_secret`
+- `secret`
+- `password`
+- `HERMES_GITHUB_DEV_PAT`
+
+Raw webhook payload bodies and secret-bearing values are not exposed.
+
+## Compatibility
+
+- Existing `/api/ws` and dashboard sidecar websocket behavior are unchanged.
+- Existing REST polling remains supported.
+- Legacy event names are preserved where needed; canonical P3 names are added.
+
+## Deferred
+
+- No frontend event panel implementation in this phase.
+- `hermesWeb` UI remains deferred.

--- a/docs/HERMES_CODE_MODE.md
+++ b/docs/HERMES_CODE_MODE.md
@@ -1,0 +1,94 @@
+# Hermes Code Mode
+
+Hermes Code Mode is the base coding-console foundation for Hermes Agent. This
+port keeps the feature aligned with the current `origin/main` architecture and
+intentionally does not include the later P0 Engineering Control Plane or P1
+GitHub integration.
+
+## What Is Included
+
+- CLI status console through `/code`.
+- Code Mode slash commands:
+  - `/code`
+  - `/web`
+  - `/workspace`
+  - `/session`
+  - `/approvals`
+  - `/skills-code`
+- Minimal backend API endpoints under `/api/code/*`.
+- SQLite state support for Code Mode workspace, session, and event metadata.
+- Graceful degraded behavior when the backend, state database, or Git metadata
+  is unavailable.
+
+## CLI Commands
+
+`/code` shows the active provider, model, profile, workspace path, Git branch,
+backend reachability, dashboard URL, schema version, and Code Mode state counts.
+
+`/web` shows the local dashboard URL and launch command. In this checkout,
+`hermesWeb/` is not present, so richer Code Cockpit UI work is deferred.
+
+`/workspace` lists stored Code Mode workspaces from state when available, and
+falls back to the current working directory and Git branch.
+
+`/session` lists stored Code Mode sessions from state when available.
+
+`/approvals` reports that approval orchestration is deferred to the P0 port.
+
+`/skills-code` reports installed slash skill visibility and notes that
+repository `SKILL.md` discovery is deferred to the P0 port.
+
+## Backend API
+
+The current base port exposes:
+
+- `GET /api/code/status`
+- `GET /api/code/workspaces`
+- `GET /api/code/sessions`
+- `GET /api/code/events`
+
+`/api/code/status` is public and read-only so the CLI can detect whether the
+dashboard backend is online. Other `/api/code/*` endpoints use the existing
+dashboard session-token middleware.
+
+## State
+
+Code Mode state lives in `state.db` with schema version `12`.
+
+Tables:
+
+- `code_workspaces`
+- `code_sessions`
+- `code_events`
+
+Fresh databases create these tables directly. Existing databases migrate through
+the normal declarative reconciliation path and the v12 migration step.
+
+## Startup
+
+Start the dashboard backend with:
+
+```bash
+python -m hermes_cli.main dashboard --port 9119
+```
+
+Then run `/code` or `/web` in the CLI to see backend reachability and launch
+hints.
+
+## Deferred Work
+
+This port intentionally does not include:
+
+- P0 ArtifactLedger.
+- P0 AgentOrchestrator.
+- P0 ExecutionPolicyEngine.
+- P0 Worktree/checkpoint service.
+- P0 `SKILL.md` discovery bridge.
+- P0 RepoKnowledgeService.
+- P1 GitHub App integration, webhooks, or ChatOps.
+- SSH/VPS behavior.
+- Desktop app behavior.
+- A large deprecated `web/` migration.
+
+`hermesWeb/` is absent in this checkout, so Code Cockpit UI work is deferred to
+a later frontend-specific port.

--- a/docs/HERMES_CODE_MODE.md
+++ b/docs/HERMES_CODE_MODE.md
@@ -1,8 +1,8 @@
 # Hermes Code Mode
 
 Hermes Code Mode now includes the base console, P0 Engineering Control Plane,
-P1 GitHub integration foundation, and P2 approval governance, adapted to the
-current architecture.
+P1 GitHub integration foundation, P2 approval governance, and P3 realtime
+event fanout, adapted to the current architecture.
 
 ## Included Capabilities
 
@@ -31,6 +31,10 @@ current architecture.
 - P2 approval governance service:
   - `approval_governance`
   - persistent approval lifecycle for Code Mode actions
+- P3 realtime event bus service:
+  - `event_bus`
+  - persisted + fanout Code Mode events
+  - replay/catch-up and subscriptions
 
 ## Execution Policy Risk Classes
 
@@ -91,6 +95,10 @@ Existing Code Mode endpoints:
 - `GET /api/code/workspaces`
 - `GET /api/code/sessions`
 - `GET /api/code/events`
+- `GET /api/code/events/recent`
+- `GET /api/code/events/summary`
+- `GET /api/code/events/subscriptions`
+- `WS /api/code/events/ws` (additive, token-protected)
 
 P0 endpoints:
 
@@ -135,7 +143,7 @@ P2 approval endpoints:
 
 ## State / Schema
 
-Code Mode state lives in `state.db`, schema version `15`.
+Code Mode state lives in `state.db`, schema version `17`.
 
 Code Mode + P0 tables:
 
@@ -189,6 +197,7 @@ Then use `/code` or `/web` in the CLI.
 - Autonomous coding loop from GitHub events.
 - Auto-merge / force-push / destructive GitHub write flows.
 - HermesWeb approval panel (dashboard UI) for lifecycle actions.
+- HermesWeb realtime event panel (dashboard UI).
 
 `hermesWeb/` is absent in this checkout, and no large frontend work was added
 under deprecated `web/`.

--- a/docs/HERMES_CODE_MODE.md
+++ b/docs/HERMES_CODE_MODE.md
@@ -1,7 +1,8 @@
 # Hermes Code Mode
 
 Hermes Code Mode now includes the base console, P0 Engineering Control Plane,
-and P1 GitHub integration foundation, adapted to the current architecture.
+P1 GitHub integration foundation, and P2 approval governance, adapted to the
+current architecture.
 
 ## Included Capabilities
 
@@ -27,6 +28,9 @@ and P1 GitHub integration foundation, adapted to the current architecture.
   - `github_webhooks`
   - `github_sync`
   - `github_chatops`
+- P2 approval governance service:
+  - `approval_governance`
+  - persistent approval lifecycle for Code Mode actions
 
 ## Execution Policy Risk Classes
 
@@ -118,15 +122,27 @@ P1 GitHub endpoints:
 - `POST /api/code/github/comments`
 - `POST /api/code/github/pull-requests/prepare`
 
+P2 approval endpoints:
+
+- `GET /api/code/approvals`
+- `POST /api/code/approvals`
+- `GET /api/code/approvals/{approval_id}`
+- `POST /api/code/approvals/{approval_id}/approve`
+- `POST /api/code/approvals/{approval_id}/reject`
+- `POST /api/code/approvals/{approval_id}/cancel`
+- `POST /api/code/approvals/expire`
+- `GET /api/code/approvals/summary`
+
 ## State / Schema
 
-Code Mode state lives in `state.db`, schema version `14`.
+Code Mode state lives in `state.db`, schema version `15`.
 
 Code Mode + P0 tables:
 
 - `code_workspaces`
 - `code_sessions`
 - `code_events`
+- `code_approval_requests`
 - `code_artifacts`
 - `code_orchestrated_runs`
 - `code_run_transitions`
@@ -172,6 +188,7 @@ Then use `/code` or `/web` in the CLI.
 - `hermesWeb/` UI integration.
 - Autonomous coding loop from GitHub events.
 - Auto-merge / force-push / destructive GitHub write flows.
+- HermesWeb approval panel (dashboard UI) for lifecycle actions.
 
 `hermesWeb/` is absent in this checkout, and no large frontend work was added
 under deprecated `web/`.

--- a/docs/HERMES_CODE_MODE.md
+++ b/docs/HERMES_CODE_MODE.md
@@ -1,7 +1,7 @@
 # Hermes Code Mode
 
-Hermes Code Mode now includes the base console plus the P0 Engineering Control
-Plane foundation, adapted to the current main-compatible architecture.
+Hermes Code Mode now includes the base console, P0 Engineering Control Plane,
+and P1 GitHub integration foundation, adapted to the current architecture.
 
 ## Included Capabilities
 
@@ -12,6 +12,7 @@ Plane foundation, adapted to the current main-compatible architecture.
   - `/session`
   - `/approvals`
   - `/skills-code`
+  - `/github`
 - Code Mode state and events in `state.db`.
 - P0 services:
   - `ExecutionPolicyEngine`
@@ -21,6 +22,11 @@ Plane foundation, adapted to the current main-compatible architecture.
   - `SkillDiscoveryService` (`SKILL.md` + `scripts/` + `resources/`)
   - `RepoKnowledgeService` (`AGENTS.md` + docs guidance detection)
 - Normalized Code Mode event envelope persisted to `code_events`.
+- GitHub integration services:
+  - `github_integration`
+  - `github_webhooks`
+  - `github_sync`
+  - `github_chatops`
 
 ## Execution Policy Risk Classes
 
@@ -98,9 +104,23 @@ P0 endpoints:
 - `GET /api/code/workspaces/{workspace_id}/repo-knowledge`
 - `POST /api/code/workspaces/{workspace_id}/repo-knowledge/bootstrap`
 
+P1 GitHub endpoints:
+
+- `GET /api/code/github/status`
+- `GET /api/code/github/installations`
+- `GET /api/code/github/repositories`
+- `POST /api/code/github/repositories/sync`
+- `GET /api/code/github/repositories/{owner}/{repo}`
+- `GET /api/code/github/repositories/{owner}/{repo}/issues`
+- `GET /api/code/github/repositories/{owner}/{repo}/pulls`
+- `POST /api/code/github/webhooks`
+- `POST /api/code/github/chatops/{command_id}/run`
+- `POST /api/code/github/comments`
+- `POST /api/code/github/pull-requests/prepare`
+
 ## State / Schema
 
-Code Mode state lives in `state.db`, schema version `13`.
+Code Mode state lives in `state.db`, schema version `14`.
 
 Code Mode + P0 tables:
 
@@ -111,6 +131,14 @@ Code Mode + P0 tables:
 - `code_orchestrated_runs`
 - `code_run_transitions`
 - `code_checkpoints`
+- `github_app_installations`
+- `github_repositories`
+- `github_branches`
+- `github_issues`
+- `github_pull_requests`
+- `github_webhook_deliveries`
+- `github_chatops_commands`
+- `github_status_reports`
 
 No separate SQLite database is used for P0.
 
@@ -137,12 +165,13 @@ python -m hermes_cli.main dashboard --port 9119
 
 Then use `/code` or `/web` in the CLI.
 
-## Deferred (Not in P0)
+## Deferred
 
-- P1 GitHub integration (GitHub App auth, webhooks, ChatOps, sync).
 - SSH/VPS automation.
 - Desktop app behavior.
 - `hermesWeb/` UI integration.
+- Autonomous coding loop from GitHub events.
+- Auto-merge / force-push / destructive GitHub write flows.
 
 `hermesWeb/` is absent in this checkout, and no large frontend work was added
 under deprecated `web/`.

--- a/docs/HERMES_CODE_MODE.md
+++ b/docs/HERMES_CODE_MODE.md
@@ -1,94 +1,148 @@
 # Hermes Code Mode
 
-Hermes Code Mode is the base coding-console foundation for Hermes Agent. This
-port keeps the feature aligned with the current `origin/main` architecture and
-intentionally does not include the later P0 Engineering Control Plane or P1
-GitHub integration.
+Hermes Code Mode now includes the base console plus the P0 Engineering Control
+Plane foundation, adapted to the current main-compatible architecture.
 
-## What Is Included
+## Included Capabilities
 
-- CLI status console through `/code`.
-- Code Mode slash commands:
+- CLI Code Mode commands:
   - `/code`
   - `/web`
   - `/workspace`
   - `/session`
   - `/approvals`
   - `/skills-code`
-- Minimal backend API endpoints under `/api/code/*`.
-- SQLite state support for Code Mode workspace, session, and event metadata.
-- Graceful degraded behavior when the backend, state database, or Git metadata
-  is unavailable.
+- Code Mode state and events in `state.db`.
+- P0 services:
+  - `ExecutionPolicyEngine`
+  - `ArtifactLedger`
+  - `AgentOrchestrator`
+  - `WorktreeService` (safe capability/checkpoint foundation)
+  - `SkillDiscoveryService` (`SKILL.md` + `scripts/` + `resources/`)
+  - `RepoKnowledgeService` (`AGENTS.md` + docs guidance detection)
+- Normalized Code Mode event envelope persisted to `code_events`.
 
-## CLI Commands
+## Execution Policy Risk Classes
 
-`/code` shows the active provider, model, profile, workspace path, Git branch,
-backend reachability, dashboard URL, schema version, and Code Mode state counts.
+- `safe_readonly`
+- `safe_local_write`
+- `network`
+- `git_write`
+- `secret_sensitive`
+- `remote_mutating`
+- `destructive`
+- `production_sensitive`
 
-`/web` shows the local dashboard URL and launch command. In this checkout,
-`hermesWeb/` is not present, so richer Code Cockpit UI work is deferred.
+Destructive commands are blocked, higher-risk classes are approval candidates,
+and command text is secret-redacted before reporting.
 
-`/workspace` lists stored Code Mode workspaces from state when available, and
-falls back to the current working directory and Git branch.
+## Artifact Categories
 
-`/session` lists stored Code Mode sessions from state when available.
+- `task_intake`
+- `prd_lite`
+- `acceptance_criteria`
+- `architecture_note`
+- `adr`
+- `implementation_plan`
+- `command_log`
+- `diff_summary`
+- `test_report`
+- `review_report`
+- `deploy_plan`
+- `deploy_report`
+- `memory_update`
 
-`/approvals` reports that approval orchestration is deferred to the P0 port.
+Artifacts can link to workspace/session/orchestrated run/command metadata.
 
-`/skills-code` reports installed slash skill visibility and notes that
-repository `SKILL.md` discovery is deferred to the P0 port.
+## Orchestrator States
 
-## Backend API
+- `intake`
+- `discovery`
+- `product_framing`
+- `architecture`
+- `planning`
+- `approval`
+- `implementation`
+- `validation`
+- `review`
+- `ready_for_pr`
+- `completed`
+- `cancelled`
+- `failed`
 
-The current base port exposes:
+P0 provides state validation and persistence only. No autonomous execution loop
+is enabled in this port.
 
-- `GET /api/code/status`
+## API Endpoints
+
+Existing Code Mode endpoints:
+
+- `GET /api/code/status` (public read-only)
 - `GET /api/code/workspaces`
 - `GET /api/code/sessions`
 - `GET /api/code/events`
 
-`/api/code/status` is public and read-only so the CLI can detect whether the
-dashboard backend is online. Other `/api/code/*` endpoints use the existing
-dashboard session-token middleware.
+P0 endpoints:
 
-## State
+- `GET /api/code/artifacts`
+- `POST /api/code/artifacts`
+- `GET /api/code/sessions/{code_session_id}/artifacts`
+- `GET /api/code/orchestrator/runs`
+- `POST /api/code/orchestrator/runs`
+- `GET /api/code/orchestrator/runs/{run_id}`
+- `POST /api/code/orchestrator/runs/{run_id}/transition`
+- `POST /api/code/policy/assess-command`
+- `GET /api/code/workspaces/{workspace_id}/git/capabilities`
+- `GET /api/code/workspaces/{workspace_id}/git/worktrees`
+- `GET /api/code/skills/discovered`
+- `GET /api/code/workspaces/{workspace_id}/repo-knowledge`
+- `POST /api/code/workspaces/{workspace_id}/repo-knowledge/bootstrap`
 
-Code Mode state lives in `state.db` with schema version `12`.
+## State / Schema
 
-Tables:
+Code Mode state lives in `state.db`, schema version `13`.
+
+Code Mode + P0 tables:
 
 - `code_workspaces`
 - `code_sessions`
 - `code_events`
+- `code_artifacts`
+- `code_orchestrated_runs`
+- `code_run_transitions`
+- `code_checkpoints`
 
-Fresh databases create these tables directly. Existing databases migrate through
-the normal declarative reconciliation path and the v12 migration step.
+No separate SQLite database is used for P0.
+
+## Skill and Repo Guidance Discovery
+
+- `/skills-code` now reports discovered skills and workspace-local `SKILL.md`
+  capability.
+- Repo knowledge supports:
+  - repo-root `AGENTS.md`
+  - docs guidance folders:
+    - `docs/architecture/`
+    - `docs/engineering/`
+    - `docs/operations/`
+
+Bootstrap creates `AGENTS.md` only when missing and never overwrites.
 
 ## Startup
 
-Start the dashboard backend with:
+Start backend:
 
 ```bash
 python -m hermes_cli.main dashboard --port 9119
 ```
 
-Then run `/code` or `/web` in the CLI to see backend reachability and launch
-hints.
+Then use `/code` or `/web` in the CLI.
 
-## Deferred Work
+## Deferred (Not in P0)
 
-This port intentionally does not include:
-
-- P0 ArtifactLedger.
-- P0 AgentOrchestrator.
-- P0 ExecutionPolicyEngine.
-- P0 Worktree/checkpoint service.
-- P0 `SKILL.md` discovery bridge.
-- P0 RepoKnowledgeService.
-- P1 GitHub App integration, webhooks, or ChatOps.
-- SSH/VPS behavior.
+- P1 GitHub integration (GitHub App auth, webhooks, ChatOps, sync).
+- SSH/VPS automation.
 - Desktop app behavior.
-- A large deprecated `web/` migration.
+- `hermesWeb/` UI integration.
 
-`hermesWeb/` is absent in this checkout, so Code Cockpit UI work is deferred to
-a later frontend-specific port.
+`hermesWeb/` is absent in this checkout, and no large frontend work was added
+under deprecated `web/`.

--- a/docs/HERMES_GITHUB_INTEGRATION.md
+++ b/docs/HERMES_GITHUB_INTEGRATION.md
@@ -1,0 +1,128 @@
+# Hermes GitHub Integration (P1)
+
+P1 adds a secure GitHub metadata + webhook + ChatOps bridge for Hermes Code
+Mode. This port is backend/API/CLI/docs/tests only.
+
+`hermesWeb/` is not present in this repository, and deprecated `web/` was not
+used for new UI work.
+
+## Capabilities
+
+- Detect GitHub App configuration and expose safe status.
+- Optional local/dev PAT fallback gated by:
+  - `HERMES_GITHUB_DEV_PAT`
+  - `HERMES_GITHUB_ALLOW_DEV_PAT=1`
+- Sync repository, branch, issue, and pull request metadata.
+- Validate GitHub webhook signatures before processing.
+- Persist webhook deliveries and deduplicate by delivery ID.
+- Parse ChatOps commands from comments:
+  - `@hermes plan`
+  - `@hermes review`
+  - `@hermes fix`
+  - `@hermes explain`
+  - `@hermes status`
+- Create P0 `ArtifactLedger` artifacts and `AgentOrchestrator` runs from
+  ChatOps requests.
+- Prepare PR metadata (no auto-push, no auto-merge).
+- Support GitHub comments endpoint with explicit approval gate behavior.
+
+## GitHub App Setup
+
+Recommended minimum repository permissions:
+
+- Metadata: read
+- Contents: read
+- Issues: read/write
+- Pull requests: read/write
+- Checks: read/write
+- Commit statuses: read/write
+
+Supported webhook events:
+
+- `installation`
+- `installation_repositories`
+- `issues`
+- `issue_comment`
+- `pull_request`
+- `pull_request_review`
+- `pull_request_review_comment`
+- `check_suite`
+- `check_run`
+- `push`
+
+Example env variable names:
+
+```bash
+HERMES_GITHUB_APP_ID=
+HERMES_GITHUB_APP_PRIVATE_KEY_PATH=
+HERMES_GITHUB_WEBHOOK_SECRET=
+HERMES_GITHUB_DEV_PAT=
+HERMES_GITHUB_ALLOW_DEV_PAT=
+```
+
+Do not commit `.env` values.
+
+## Security Model
+
+- Private key contents are loaded from file path and are not persisted in DB.
+- Installation tokens are cached in memory with expiry metadata.
+- Webhook processing requires valid `X-Hub-Signature-256`.
+- Sensitive values are redacted from errors/log-safe strings.
+- GitHub write actions are approval-gated or prepare-only.
+- P1 does not auto-merge, force-push, delete branches, or modify repository
+  settings/permissions.
+
+## API Endpoints
+
+- `GET /api/code/github/status`
+- `GET /api/code/github/installations`
+- `GET /api/code/github/repositories`
+- `POST /api/code/github/repositories/sync`
+- `GET /api/code/github/repositories/{owner}/{repo}`
+- `GET /api/code/github/repositories/{owner}/{repo}/issues`
+- `GET /api/code/github/repositories/{owner}/{repo}/pulls`
+- `POST /api/code/github/webhooks`
+- `POST /api/code/github/chatops/{command_id}/run`
+- `POST /api/code/github/comments`
+- `POST /api/code/github/pull-requests/prepare`
+
+`/api/code/github/webhooks` is public only for GitHub delivery. It is protected
+by webhook HMAC validation, not by dashboard session token.
+
+## CLI
+
+Minimal CLI support:
+
+- `/github status`
+- `/github repos`
+- `/github sync`
+
+## Schema
+
+P1 extends schema to `v14` with:
+
+- `github_app_installations`
+- `github_repositories`
+- `github_branches`
+- `github_issues`
+- `github_pull_requests`
+- `github_webhook_deliveries`
+- `github_chatops_commands`
+- `github_status_reports`
+
+## Local Webhook Testing
+
+Expose local backend with a tunnel (for example ngrok/cloudflared) and set
+GitHub App webhook URL:
+
+`https://<tunnel-host>/api/code/github/webhooks`
+
+Use the same secret in GitHub App settings and `HERMES_GITHUB_WEBHOOK_SECRET`.
+
+## Non-goals in P1
+
+- HermesWeb GitHub panel
+- Autonomous coding loop
+- SSH/VPS flows
+- Desktop app integration
+- Auto PR merge/push/delete operations

--- a/docs/HERMES_GITHUB_INTEGRATION.md
+++ b/docs/HERMES_GITHUB_INTEGRATION.md
@@ -24,7 +24,7 @@ used for new UI work.
 - Create P0 `ArtifactLedger` artifacts and `AgentOrchestrator` runs from
   ChatOps requests.
 - Prepare PR metadata (no auto-push, no auto-merge).
-- Support GitHub comments endpoint with explicit approval gate behavior.
+- Support GitHub write safety via persistent Code Mode approval requests.
 
 ## GitHub App Setup
 
@@ -68,7 +68,7 @@ Do not commit `.env` values.
 - Installation tokens are cached in memory with expiry metadata.
 - Webhook processing requires valid `X-Hub-Signature-256`.
 - Sensitive values are redacted from errors/log-safe strings.
-- GitHub write actions are approval-gated or prepare-only.
+- GitHub write actions require approved persistent approval requests.
 - P1 does not auto-merge, force-push, delete branches, or modify repository
   settings/permissions.
 
@@ -86,6 +86,16 @@ Do not commit `.env` values.
 - `POST /api/code/github/comments`
 - `POST /api/code/github/pull-requests/prepare`
 
+GitHub write endpoints now follow a two-step flow:
+
+1. Call without `approval_id` to receive `requires_approval: true` and a new
+   persistent `approval_id`.
+2. Approve the request via `/api/code/approvals/{approval_id}/approve`, then
+   call the same write endpoint with `approval_id` to execute once.
+
+Replay protection verifies action kind + resource + payload binding; executed
+approvals cannot be reused.
+
 `/api/code/github/webhooks` is public only for GitHub delivery. It is protected
 by webhook HMAC validation, not by dashboard session token.
 
@@ -99,7 +109,7 @@ Minimal CLI support:
 
 ## Schema
 
-P1 extends schema to `v14` with:
+P2 extends schema to `v15` with:
 
 - `github_app_installations`
 - `github_repositories`
@@ -109,6 +119,7 @@ P1 extends schema to `v14` with:
 - `github_webhook_deliveries`
 - `github_chatops_commands`
 - `github_status_reports`
+- `code_approval_requests`
 
 ## Local Webhook Testing
 

--- a/docs/HERMES_GITHUB_INTEGRATION.md
+++ b/docs/HERMES_GITHUB_INTEGRATION.md
@@ -96,6 +96,9 @@ GitHub write endpoints now follow a two-step flow:
 Replay protection verifies action kind + resource + payload binding; executed
 approvals cannot be reused.
 
+P3 adds realtime fanout for GitHub-related Code Mode events through
+`WS /api/code/events/ws` and REST event filters in `/api/code/events*`.
+
 `/api/code/github/webhooks` is public only for GitHub delivery. It is protected
 by webhook HMAC validation, not by dashboard session token.
 
@@ -109,7 +112,9 @@ Minimal CLI support:
 
 ## Schema
 
-P2 extends schema to `v15` with:
+P3 keeps schema at `v17` and reuses `code_events` for realtime replay/fanout.
+
+P2/P3 related tables include:
 
 - `github_app_installations`
 - `github_repositories`

--- a/hermes_cli/code/__init__.py
+++ b/hermes_cli/code/__init__.py
@@ -1,0 +1,1 @@
+"""Hermes Code Mode control-plane services."""

--- a/hermes_cli/code/agent_orchestrator.py
+++ b/hermes_cli/code/agent_orchestrator.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""AgentOrchestrator state machine foundation for Hermes Code Mode."""
+
+from __future__ import annotations
+
+import time
+import uuid
+from typing import Any
+
+from hermes_cli.code.artifact_ledger import ArtifactLedger
+from hermes_state import SessionDB
+
+
+class OrchestratorState:
+    INTAKE = "intake"
+    DISCOVERY = "discovery"
+    PRODUCT_FRAMING = "product_framing"
+    ARCHITECTURE = "architecture"
+    PLANNING = "planning"
+    APPROVAL = "approval"
+    IMPLEMENTATION = "implementation"
+    VALIDATION = "validation"
+    REVIEW = "review"
+    READY_FOR_PR = "ready_for_pr"
+    COMPLETED = "completed"
+    CANCELLED = "cancelled"
+    FAILED = "failed"
+
+    ALL = frozenset(
+        {
+            INTAKE,
+            DISCOVERY,
+            PRODUCT_FRAMING,
+            ARCHITECTURE,
+            PLANNING,
+            APPROVAL,
+            IMPLEMENTATION,
+            VALIDATION,
+            REVIEW,
+            READY_FOR_PR,
+            COMPLETED,
+            CANCELLED,
+            FAILED,
+        }
+    )
+    TERMINAL = frozenset({COMPLETED, CANCELLED, FAILED})
+
+
+TRANSITIONS: dict[str, frozenset[str]] = {
+    OrchestratorState.INTAKE: frozenset({OrchestratorState.DISCOVERY, OrchestratorState.PRODUCT_FRAMING, OrchestratorState.CANCELLED, OrchestratorState.FAILED}),
+    OrchestratorState.DISCOVERY: frozenset({OrchestratorState.PRODUCT_FRAMING, OrchestratorState.ARCHITECTURE, OrchestratorState.PLANNING, OrchestratorState.APPROVAL, OrchestratorState.CANCELLED, OrchestratorState.FAILED}),
+    OrchestratorState.PRODUCT_FRAMING: frozenset({OrchestratorState.ARCHITECTURE, OrchestratorState.PLANNING, OrchestratorState.APPROVAL, OrchestratorState.CANCELLED, OrchestratorState.FAILED}),
+    OrchestratorState.ARCHITECTURE: frozenset({OrchestratorState.PLANNING, OrchestratorState.APPROVAL, OrchestratorState.CANCELLED, OrchestratorState.FAILED}),
+    OrchestratorState.PLANNING: frozenset({OrchestratorState.APPROVAL, OrchestratorState.IMPLEMENTATION, OrchestratorState.CANCELLED, OrchestratorState.FAILED}),
+    OrchestratorState.APPROVAL: frozenset({OrchestratorState.IMPLEMENTATION, OrchestratorState.PLANNING, OrchestratorState.ARCHITECTURE, OrchestratorState.CANCELLED, OrchestratorState.FAILED}),
+    OrchestratorState.IMPLEMENTATION: frozenset({OrchestratorState.VALIDATION, OrchestratorState.APPROVAL, OrchestratorState.REVIEW, OrchestratorState.CANCELLED, OrchestratorState.FAILED}),
+    OrchestratorState.VALIDATION: frozenset({OrchestratorState.REVIEW, OrchestratorState.IMPLEMENTATION, OrchestratorState.APPROVAL, OrchestratorState.CANCELLED, OrchestratorState.FAILED}),
+    OrchestratorState.REVIEW: frozenset({OrchestratorState.READY_FOR_PR, OrchestratorState.IMPLEMENTATION, OrchestratorState.VALIDATION, OrchestratorState.COMPLETED, OrchestratorState.CANCELLED, OrchestratorState.FAILED}),
+    OrchestratorState.READY_FOR_PR: frozenset({OrchestratorState.COMPLETED, OrchestratorState.IMPLEMENTATION, OrchestratorState.CANCELLED, OrchestratorState.FAILED}),
+    OrchestratorState.COMPLETED: frozenset(),
+    OrchestratorState.CANCELLED: frozenset(),
+    OrchestratorState.FAILED: frozenset(),
+}
+
+
+def validate_transition(from_state: str, to_state: str) -> tuple[bool, str]:
+    if from_state not in OrchestratorState.ALL:
+        return False, f"Unknown from_state: {from_state}"
+    if to_state not in OrchestratorState.ALL:
+        return False, f"Unknown to_state: {to_state}"
+    if from_state in OrchestratorState.TERMINAL:
+        return False, f"State {from_state} is terminal"
+    if to_state not in TRANSITIONS.get(from_state, frozenset()):
+        return False, f"Invalid transition {from_state} -> {to_state}"
+    return True, ""
+
+
+class AgentOrchestrator:
+    def __init__(self, db_path=None):
+        self._db_path = db_path
+
+    def _db(self) -> SessionDB:
+        return SessionDB(db_path=self._db_path) if self._db_path else SessionDB()
+
+    def _ledger(self) -> ArtifactLedger:
+        return ArtifactLedger(db_path=self._db_path)
+
+    def create_run(
+        self,
+        *,
+        title: str | None = None,
+        goal: str | None = None,
+        workspace_id: str | None = None,
+        code_session_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        create_intake_artifact: bool = True,
+    ) -> dict[str, Any]:
+        now = time.time()
+        run = {
+            "id": str(uuid.uuid4()),
+            "title": title or "Untitled Run",
+            "goal": goal or "",
+            "state": OrchestratorState.INTAKE,
+            "workspace_id": workspace_id,
+            "code_session_id": code_session_id,
+            "current_phase": OrchestratorState.INTAKE,
+            "metadata": metadata or {},
+            "created_at": now,
+            "updated_at": now,
+            "completed_at": None,
+        }
+        db = self._db()
+        try:
+            db.create_code_orchestrated_run(run)
+            db.append_code_event(
+                event_type="orchestrator.run.created",
+                workspace_id=workspace_id,
+                code_session_id=code_session_id,
+                payload={"run_id": run["id"], "state": run["state"], "title": run["title"]},
+                source="orchestrator",
+            )
+        finally:
+            db.close()
+
+        if create_intake_artifact and goal:
+            self._ledger().create_artifact(
+                "task_intake",
+                goal,
+                title=title or "Task Intake",
+                workspace_id=workspace_id,
+                code_session_id=code_session_id,
+                orchestrated_run_id=run["id"],
+            )
+        return run
+
+    def get_run(self, run_id: str) -> dict[str, Any] | None:
+        db = self._db()
+        try:
+            return db.get_code_orchestrated_run(run_id)
+        finally:
+            db.close()
+
+    def list_runs(
+        self,
+        *,
+        workspace_id: str | None = None,
+        code_session_id: str | None = None,
+        state: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        db = self._db()
+        try:
+            return db.list_code_orchestrated_runs(
+                workspace_id=workspace_id,
+                code_session_id=code_session_id,
+                state=state,
+                limit=limit,
+                offset=offset,
+            )
+        finally:
+            db.close()
+
+    def transition_run(
+        self,
+        run_id: str,
+        to_state: str,
+        *,
+        reason: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        db = self._db()
+        try:
+            run = db.get_code_orchestrated_run(run_id)
+            if not run:
+                raise ValueError(f"Run not found: {run_id}")
+            from_state = run["state"]
+            valid, msg = validate_transition(from_state, to_state)
+            if not valid:
+                raise ValueError(msg)
+            now = time.time()
+            updates: dict[str, Any] = {
+                "state": to_state,
+                "current_phase": to_state,
+                "updated_at": now,
+            }
+            if metadata:
+                current_metadata = run.get("metadata") or {}
+                if isinstance(current_metadata, dict):
+                    current_metadata = dict(current_metadata)
+                    current_metadata.update(metadata)
+                    updates["metadata"] = current_metadata
+            if to_state in OrchestratorState.TERMINAL:
+                updates["completed_at"] = now
+            db.update_code_orchestrated_run(run_id, updates)
+            db.add_code_run_transition(
+                {
+                    "id": str(uuid.uuid4()),
+                    "run_id": run_id,
+                    "from_state": from_state,
+                    "to_state": to_state,
+                    "reason": reason or f"{from_state} -> {to_state}",
+                    "created_at": now,
+                }
+            )
+            db.append_code_event(
+                event_type="orchestrator.run.transitioned",
+                workspace_id=run.get("workspace_id"),
+                code_session_id=run.get("code_session_id"),
+                payload={
+                    "run_id": run_id,
+                    "from_state": from_state,
+                    "to_state": to_state,
+                    "reason": reason,
+                },
+                source="orchestrator",
+            )
+            updated = db.get_code_orchestrated_run(run_id)
+            return updated or run
+        finally:
+            db.close()
+
+    def list_transitions(self, run_id: str) -> list[dict[str, Any]]:
+        db = self._db()
+        try:
+            return db.list_code_run_transitions(run_id=run_id)
+        finally:
+            db.close()

--- a/hermes_cli/code/agent_orchestrator.py
+++ b/hermes_cli/code/agent_orchestrator.py
@@ -8,6 +8,7 @@ import uuid
 from typing import Any
 
 from hermes_cli.code.artifact_ledger import ArtifactLedger
+from hermes_cli.code.event_bus import get_code_event_bus
 from hermes_state import SessionDB
 
 
@@ -85,6 +86,18 @@ class AgentOrchestrator:
     def _ledger(self) -> ArtifactLedger:
         return ArtifactLedger(db_path=self._db_path)
 
+    def _emit(self, event_type: str, payload: dict[str, Any], *, workspace_id: str | None = None, code_session_id: str | None = None, orchestrated_run_id: str | None = None) -> None:
+        bus = get_code_event_bus(self._db_path)
+        bus.publish(
+            event_type,
+            payload=payload,
+            workspace_id=workspace_id,
+            code_session_id=code_session_id,
+            orchestrated_run_id=orchestrated_run_id,
+            metadata={"source": "orchestrator"},
+            source="orchestrator",
+        )
+
     def create_run(
         self,
         *,
@@ -112,15 +125,22 @@ class AgentOrchestrator:
         db = self._db()
         try:
             db.create_code_orchestrated_run(run)
-            db.append_code_event(
-                event_type="orchestrator.run.created",
-                workspace_id=workspace_id,
-                code_session_id=code_session_id,
-                payload={"run_id": run["id"], "state": run["state"], "title": run["title"]},
-                source="orchestrator",
-            )
         finally:
             db.close()
+        self._emit(
+            "code.orchestrator.run_created",
+            payload={"run_id": run["id"], "state": run["state"], "title": run["title"]},
+            workspace_id=workspace_id,
+            code_session_id=code_session_id,
+            orchestrated_run_id=run["id"],
+        )
+        self._emit(
+            "orchestrator.run.created",
+            payload={"run_id": run["id"], "state": run["state"], "title": run["title"]},
+            workspace_id=workspace_id,
+            code_session_id=code_session_id,
+            orchestrated_run_id=run["id"],
+        )
 
         if create_intake_artifact and goal:
             self._ledger().create_artifact(
@@ -203,22 +223,51 @@ class AgentOrchestrator:
                     "created_at": now,
                 }
             )
-            db.append_code_event(
-                event_type="orchestrator.run.transitioned",
-                workspace_id=run.get("workspace_id"),
-                code_session_id=run.get("code_session_id"),
-                payload={
-                    "run_id": run_id,
-                    "from_state": from_state,
-                    "to_state": to_state,
-                    "reason": reason,
-                },
-                source="orchestrator",
-            )
             updated = db.get_code_orchestrated_run(run_id)
-            return updated or run
+            out = updated or run
         finally:
             db.close()
+        self._emit(
+            "code.orchestrator.transitioned",
+            payload={
+                "run_id": run_id,
+                "from_state": from_state,
+                "to_state": to_state,
+                "reason": reason,
+            },
+            workspace_id=out.get("workspace_id"),
+            code_session_id=out.get("code_session_id"),
+            orchestrated_run_id=run_id,
+        )
+        self._emit(
+            "orchestrator.run.transitioned",
+            payload={
+                "run_id": run_id,
+                "from_state": from_state,
+                "to_state": to_state,
+                "reason": reason,
+            },
+            workspace_id=out.get("workspace_id"),
+            code_session_id=out.get("code_session_id"),
+            orchestrated_run_id=run_id,
+        )
+        if to_state == OrchestratorState.COMPLETED:
+            self._emit(
+                "code.orchestrator.completed",
+                payload={"run_id": run_id, "state": to_state, "reason": reason},
+                workspace_id=out.get("workspace_id"),
+                code_session_id=out.get("code_session_id"),
+                orchestrated_run_id=run_id,
+            )
+        if to_state == OrchestratorState.FAILED:
+            self._emit(
+                "code.orchestrator.failed",
+                payload={"run_id": run_id, "state": to_state, "reason": reason},
+                workspace_id=out.get("workspace_id"),
+                code_session_id=out.get("code_session_id"),
+                orchestrated_run_id=run_id,
+            )
+        return out
 
     def list_transitions(self, run_id: str) -> list[dict[str, Any]]:
         db = self._db()

--- a/hermes_cli/code/approval_governance.py
+++ b/hermes_cli/code/approval_governance.py
@@ -12,6 +12,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
 
+from hermes_cli.code.event_bus import get_code_event_bus
 from hermes_cli.code.execution_policy import RiskClass, redact_secrets
 from hermes_cli.code.github_integration import redact_github_secrets
 from hermes_state import SessionDB
@@ -222,24 +223,19 @@ class ApprovalGovernanceService:
         }
         if extra_payload:
             payload.update(extra_payload)
-        envelope = self._with_event_envelope(
+        bus = get_code_event_bus(self._db_path)
+        bus.publish(
             event_type,
-            payload,
+            payload=payload,
             workspace_id=approval.get("workspace_id"),
             code_session_id=approval.get("code_session_id"),
+            orchestrated_run_id=approval.get("orchestrated_run_id"),
+            approval_id=approval.get("id"),
+            github_repo_full_name=approval.get("github_repo_full_name"),
+            metadata={"source": "approval_governance"},
+            source="approval_governance",
+            level=level,
         )
-        db = self._db()
-        try:
-            db.append_code_event(
-                event_type=event_type,
-                payload=envelope,
-                workspace_id=approval.get("workspace_id"),
-                code_session_id=approval.get("code_session_id"),
-                source="approval_governance",
-                level=level,
-            )
-        finally:
-            db.close()
 
     def _serialize(self, approval: dict[str, Any]) -> dict[str, Any]:
         return redact_for_api(approval) if approval else {}

--- a/hermes_cli/code/approval_governance.py
+++ b/hermes_cli/code/approval_governance.py
@@ -1,0 +1,542 @@
+#!/usr/bin/env python3
+"""Persistent approval governance lifecycle for Hermes Code Mode."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+from hermes_cli.code.execution_policy import RiskClass, redact_secrets
+from hermes_cli.code.github_integration import redact_github_secrets
+from hermes_state import SessionDB
+
+
+class ApprovalStatus:
+    PENDING = "pending"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+    EXPIRED = "expired"
+    CANCELLED = "cancelled"
+    EXECUTED = "executed"
+    FAILED = "failed"
+
+    ALL = frozenset({PENDING, APPROVED, REJECTED, EXPIRED, CANCELLED, EXECUTED, FAILED})
+    TERMINAL = frozenset({REJECTED, EXPIRED, CANCELLED, EXECUTED, FAILED})
+
+
+class ApprovalKind:
+    GITHUB_COMMENT = "github_comment"
+    GITHUB_PR_PREPARE = "github_pr_prepare"
+    GITHUB_CHECK_UPDATE = "github_check_update"
+    GITHUB_STATUS_UPDATE = "github_status_update"
+    COMMAND_EXECUTION = "command_execution"
+    GIT_WRITE = "git_write"
+    PRODUCTION_SENSITIVE = "production_sensitive"
+    DESTRUCTIVE = "destructive"
+    GENERIC = "generic"
+
+    ALL = frozenset(
+        {
+            GITHUB_COMMENT,
+            GITHUB_PR_PREPARE,
+            GITHUB_CHECK_UPDATE,
+            GITHUB_STATUS_UPDATE,
+            COMMAND_EXECUTION,
+            GIT_WRITE,
+            PRODUCTION_SENSITIVE,
+            DESTRUCTIVE,
+            GENERIC,
+        }
+    )
+
+
+RISK_CLASS_ALL = frozenset(
+    {
+        RiskClass.SAFE_READONLY,
+        RiskClass.SAFE_LOCAL_WRITE,
+        RiskClass.NETWORK,
+        RiskClass.GIT_WRITE,
+        RiskClass.SECRET_SENSITIVE,
+        RiskClass.REMOTE_MUTATING,
+        RiskClass.DESTRUCTIVE,
+        RiskClass.PRODUCTION_SENSITIVE,
+    }
+)
+
+
+_TRANSITIONS: dict[str, frozenset[str]] = {
+    ApprovalStatus.PENDING: frozenset(
+        {
+            ApprovalStatus.APPROVED,
+            ApprovalStatus.REJECTED,
+            ApprovalStatus.CANCELLED,
+            ApprovalStatus.EXPIRED,
+        }
+    ),
+    ApprovalStatus.APPROVED: frozenset(
+        {
+            ApprovalStatus.EXECUTED,
+            ApprovalStatus.FAILED,
+            ApprovalStatus.CANCELLED,
+        }
+    ),
+    ApprovalStatus.REJECTED: frozenset(),
+    ApprovalStatus.EXPIRED: frozenset(),
+    ApprovalStatus.CANCELLED: frozenset(),
+    ApprovalStatus.EXECUTED: frozenset(),
+    ApprovalStatus.FAILED: frozenset(),
+}
+
+
+_EVENT_BY_STATUS: dict[str, str] = {
+    ApprovalStatus.APPROVED: "code.approval.approved",
+    ApprovalStatus.REJECTED: "code.approval.rejected",
+    ApprovalStatus.CANCELLED: "code.approval.cancelled",
+    ApprovalStatus.EXPIRED: "code.approval.expired",
+    ApprovalStatus.EXECUTED: "code.approval.executed",
+    ApprovalStatus.FAILED: "code.approval.failed",
+}
+
+
+_SECRET_KEY_PATTERN = re.compile(
+    r"(?i)(token|access_token|refresh_token|authorization|private_key|webhook_secret|client_secret|secret|password|HERMES_GITHUB_DEV_PAT)"
+)
+
+
+def _now_ts() -> float:
+    return time.time()
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _is_sensitive_key(key: str) -> bool:
+    return bool(_SECRET_KEY_PATTERN.search(str(key or "")))
+
+
+def _redact_scalar(value: Any) -> Any:
+    if isinstance(value, str):
+        return redact_github_secrets(redact_secrets(value))
+    return value
+
+
+def redact_for_api(value: Any, *, key: Optional[str] = None) -> Any:
+    if key and _is_sensitive_key(key):
+        return "[REDACTED]"
+    if isinstance(value, dict):
+        return {str(k): redact_for_api(v, key=str(k)) for k, v in value.items()}
+    if isinstance(value, list):
+        return [redact_for_api(v) for v in value]
+    return _redact_scalar(value)
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value if value is not None else {}, separators=(",", ":"), sort_keys=True)
+
+
+def _binding_fingerprint(
+    *,
+    kind: str,
+    requested_action: str,
+    resource_type: str | None,
+    resource_id: str | None,
+    github_repo_full_name: str | None,
+    github_issue_number: int | None,
+    github_pr_number: int | None,
+    requested_payload: dict[str, Any] | None,
+) -> str:
+    payload = {
+        "kind": kind,
+        "requested_action": requested_action,
+        "resource_type": resource_type or "",
+        "resource_id": resource_id or "",
+        "github_repo_full_name": github_repo_full_name or "",
+        "github_issue_number": int(github_issue_number) if github_issue_number is not None else None,
+        "github_pr_number": int(github_pr_number) if github_pr_number is not None else None,
+        "requested_payload": requested_payload or {},
+    }
+    return hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+def _validate_transition(current_status: str, next_status: str) -> tuple[bool, str]:
+    if current_status not in ApprovalStatus.ALL:
+        return False, f"Unknown current status: {current_status}"
+    if next_status not in ApprovalStatus.ALL:
+        return False, f"Unknown target status: {next_status}"
+    if next_status not in _TRANSITIONS.get(current_status, frozenset()):
+        return False, f"Invalid transition {current_status} -> {next_status}"
+    return True, ""
+
+
+class ApprovalGovernanceError(ValueError):
+    """Raised when approval lifecycle operations fail safely."""
+
+
+class ApprovalGovernanceService:
+    DEFAULT_EXPIRY_SECONDS = 30 * 60
+
+    def __init__(self, db_path: Optional[Path] = None) -> None:
+        self._db_path = db_path
+
+    def _db(self) -> SessionDB:
+        return SessionDB(db_path=self._db_path) if self._db_path else SessionDB()
+
+    @staticmethod
+    def _with_event_envelope(
+        event_type: str,
+        payload: dict[str, Any],
+        *,
+        workspace_id: str | None = None,
+        code_session_id: str | None = None,
+    ) -> dict[str, Any]:
+        event = {
+            "type": event_type,
+            "version": 1,
+            "timestamp": _now_iso(),
+            "payload": redact_for_api(payload),
+        }
+        if workspace_id:
+            event["workspace_id"] = workspace_id
+        if code_session_id:
+            event["code_session_id"] = code_session_id
+        return event
+
+    def _emit(self, event_type: str, approval: dict[str, Any], *, extra_payload: dict[str, Any] | None = None, level: str = "info") -> None:
+        payload = {
+            "approval_id": approval.get("id"),
+            "kind": approval.get("kind"),
+            "status": approval.get("status"),
+            "risk_class": approval.get("risk_class"),
+            "resource_type": approval.get("resource_type"),
+            "resource_id": approval.get("resource_id"),
+            "github_repo_full_name": approval.get("github_repo_full_name"),
+            "github_issue_number": approval.get("github_issue_number"),
+            "github_pr_number": approval.get("github_pr_number"),
+        }
+        if extra_payload:
+            payload.update(extra_payload)
+        envelope = self._with_event_envelope(
+            event_type,
+            payload,
+            workspace_id=approval.get("workspace_id"),
+            code_session_id=approval.get("code_session_id"),
+        )
+        db = self._db()
+        try:
+            db.append_code_event(
+                event_type=event_type,
+                payload=envelope,
+                workspace_id=approval.get("workspace_id"),
+                code_session_id=approval.get("code_session_id"),
+                source="approval_governance",
+                level=level,
+            )
+        finally:
+            db.close()
+
+    def _serialize(self, approval: dict[str, Any]) -> dict[str, Any]:
+        return redact_for_api(approval) if approval else {}
+
+    def create_request(
+        self,
+        *,
+        kind: str,
+        risk_class: str,
+        title: str,
+        description: str | None = None,
+        requested_action: str,
+        requested_payload: dict[str, Any] | None = None,
+        resource_type: str | None = None,
+        resource_id: str | None = None,
+        workspace_id: str | None = None,
+        code_session_id: str | None = None,
+        orchestrated_run_id: str | None = None,
+        artifact_id: str | None = None,
+        github_repo_full_name: str | None = None,
+        github_issue_number: int | None = None,
+        github_pr_number: int | None = None,
+        requested_by: str | None = None,
+        expires_at: float | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        if kind not in ApprovalKind.ALL:
+            raise ApprovalGovernanceError(f"Unknown approval kind: {kind}")
+        if risk_class not in RISK_CLASS_ALL:
+            raise ApprovalGovernanceError(f"Unknown risk_class: {risk_class}")
+
+        now = _now_ts()
+        payload = requested_payload or {}
+        effective_expires_at = float(expires_at) if expires_at is not None else (now + self.DEFAULT_EXPIRY_SECONDS)
+        metadata_value = dict(metadata or {})
+        metadata_value["binding_fingerprint"] = _binding_fingerprint(
+            kind=kind,
+            requested_action=requested_action,
+            resource_type=resource_type,
+            resource_id=resource_id,
+            github_repo_full_name=github_repo_full_name,
+            github_issue_number=github_issue_number,
+            github_pr_number=github_pr_number,
+            requested_payload=payload,
+        )
+        approval = {
+            "id": str(uuid.uuid4()),
+            "kind": kind,
+            "risk_class": risk_class,
+            "title": title or kind,
+            "description": description or "",
+            "requested_action": requested_action,
+            "requested_payload": payload,
+            "resource_type": resource_type,
+            "resource_id": resource_id,
+            "workspace_id": workspace_id,
+            "code_session_id": code_session_id,
+            "orchestrated_run_id": orchestrated_run_id,
+            "artifact_id": artifact_id,
+            "github_repo_full_name": github_repo_full_name,
+            "github_issue_number": int(github_issue_number) if github_issue_number is not None else None,
+            "github_pr_number": int(github_pr_number) if github_pr_number is not None else None,
+            "requested_by": requested_by or "local",
+            "approved_by": None,
+            "rejected_by": None,
+            "status": ApprovalStatus.PENDING,
+            "expires_at": effective_expires_at,
+            "created_at": now,
+            "updated_at": now,
+            "resolved_at": None,
+            "metadata": metadata_value,
+        }
+        db = self._db()
+        try:
+            db.create_code_approval_request(approval)
+            created = db.get_code_approval_request(approval["id"]) or approval
+        finally:
+            db.close()
+        self._emit("code.approval.created", created)
+        return self._serialize(created)
+
+    def list_requests(
+        self,
+        *,
+        status: str | None = None,
+        kind: str | None = None,
+        risk_class: str | None = None,
+        workspace_id: str | None = None,
+        code_session_id: str | None = None,
+        orchestrated_run_id: str | None = None,
+        github_repo_full_name: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        db = self._db()
+        try:
+            items = db.list_code_approval_requests(
+                status=status,
+                kind=kind,
+                risk_class=risk_class,
+                workspace_id=workspace_id,
+                code_session_id=code_session_id,
+                orchestrated_run_id=orchestrated_run_id,
+                github_repo_full_name=github_repo_full_name,
+                limit=max(1, min(int(limit), 500)),
+                offset=max(0, int(offset)),
+            )
+        finally:
+            db.close()
+        return [self._serialize(item) for item in items]
+
+    def get_request(self, approval_id: str) -> dict[str, Any] | None:
+        db = self._db()
+        try:
+            item = db.get_code_approval_request(approval_id)
+        finally:
+            db.close()
+        return self._serialize(item) if item else None
+
+    def _transition(
+        self,
+        approval_id: str,
+        next_status: str,
+        *,
+        actor: str | None = None,
+        reason: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        db = self._db()
+        try:
+            current = db.get_code_approval_request(approval_id)
+            if not current:
+                raise ApprovalGovernanceError(f"Approval not found: {approval_id}")
+            ok, msg = _validate_transition(str(current.get("status")), next_status)
+            if not ok:
+                raise ApprovalGovernanceError(msg)
+
+            now = _now_ts()
+            updates: dict[str, Any] = {
+                "status": next_status,
+                "updated_at": now,
+            }
+            if next_status == ApprovalStatus.APPROVED:
+                updates["approved_by"] = actor or "local"
+            if next_status == ApprovalStatus.REJECTED:
+                updates["rejected_by"] = actor or "local"
+            if next_status in ApprovalStatus.TERMINAL:
+                updates["resolved_at"] = now
+            if metadata:
+                merged_metadata = dict(current.get("metadata") or {})
+                merged_metadata.update(metadata)
+                updates["metadata"] = merged_metadata
+            if reason:
+                merged_metadata = dict(updates.get("metadata") or current.get("metadata") or {})
+                merged_metadata["reason"] = reason
+                updates["metadata"] = merged_metadata
+
+            updated_ok = db.update_code_approval_request(approval_id, updates)
+            if not updated_ok:
+                raise ApprovalGovernanceError(f"Failed to update approval: {approval_id}")
+            updated = db.get_code_approval_request(approval_id)
+            if not updated:
+                raise ApprovalGovernanceError(f"Approval not found after update: {approval_id}")
+        finally:
+            db.close()
+
+        event_type = _EVENT_BY_STATUS.get(next_status)
+        if event_type:
+            self._emit(event_type, updated)
+        return self._serialize(updated)
+
+    def approve_request(self, approval_id: str, *, approved_by: str | None = None) -> dict[str, Any]:
+        return self._transition(approval_id, ApprovalStatus.APPROVED, actor=approved_by)
+
+    def reject_request(self, approval_id: str, *, rejected_by: str | None = None, reason: str | None = None) -> dict[str, Any]:
+        return self._transition(approval_id, ApprovalStatus.REJECTED, actor=rejected_by, reason=reason)
+
+    def cancel_request(self, approval_id: str, *, cancelled_by: str | None = None, reason: str | None = None) -> dict[str, Any]:
+        return self._transition(approval_id, ApprovalStatus.CANCELLED, actor=cancelled_by, reason=reason)
+
+    def mark_executed(self, approval_id: str, *, metadata: dict[str, Any] | None = None) -> dict[str, Any]:
+        return self._transition(approval_id, ApprovalStatus.EXECUTED, metadata=metadata)
+
+    def mark_failed(self, approval_id: str, *, reason: str | None = None, metadata: dict[str, Any] | None = None) -> dict[str, Any]:
+        merged = dict(metadata or {})
+        if reason:
+            merged["failure_reason"] = reason
+        return self._transition(approval_id, ApprovalStatus.FAILED, reason=reason, metadata=merged)
+
+    def expire_pending(self, *, now: float | None = None, limit: int = 500) -> dict[str, Any]:
+        now_ts = float(now) if now is not None else _now_ts()
+        db = self._db()
+        try:
+            pending = db.list_code_approval_requests(status=ApprovalStatus.PENDING, limit=max(1, min(limit, 2000)))
+            expiring_ids = [
+                item["id"]
+                for item in pending
+                if item.get("expires_at") is not None and float(item["expires_at"]) <= now_ts
+            ]
+        finally:
+            db.close()
+
+        expired: list[dict[str, Any]] = []
+        for approval_id in expiring_ids:
+            try:
+                expired.append(self._transition(approval_id, ApprovalStatus.EXPIRED))
+            except ApprovalGovernanceError:
+                continue
+        return {"expired": expired, "count": len(expired)}
+
+    def summary(
+        self,
+        *,
+        workspace_id: str | None = None,
+        code_session_id: str | None = None,
+        orchestrated_run_id: str | None = None,
+        github_repo_full_name: str | None = None,
+    ) -> dict[str, Any]:
+        db = self._db()
+        try:
+            summary = db.summarize_code_approval_requests(
+                workspace_id=workspace_id,
+                code_session_id=code_session_id,
+                orchestrated_run_id=orchestrated_run_id,
+                github_repo_full_name=github_repo_full_name,
+            )
+        finally:
+            db.close()
+        safe = redact_for_api(summary)
+        return {
+            "status": safe.get("status", {}),
+            "risk_class": safe.get("risk_class", {}),
+            "kind": safe.get("kind", {}),
+        }
+
+    def validate_for_execution(
+        self,
+        approval_id: str,
+        *,
+        expected_kind: str,
+        expected_requested_action: str,
+        expected_resource_type: str | None = None,
+        expected_resource_id: str | None = None,
+        expected_github_repo_full_name: str | None = None,
+        expected_github_issue_number: int | None = None,
+        expected_github_pr_number: int | None = None,
+        expected_requested_payload: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        db = self._db()
+        try:
+            approval = db.get_code_approval_request(approval_id)
+        finally:
+            db.close()
+        if not approval:
+            raise ApprovalGovernanceError(f"Approval not found: {approval_id}")
+
+        status = str(approval.get("status") or "")
+        if status == ApprovalStatus.PENDING:
+            raise ApprovalGovernanceError("Approval is still pending")
+        if status == ApprovalStatus.REJECTED:
+            raise ApprovalGovernanceError("Approval was rejected")
+        if status == ApprovalStatus.CANCELLED:
+            raise ApprovalGovernanceError("Approval was cancelled")
+        if status == ApprovalStatus.EXPIRED:
+            raise ApprovalGovernanceError("Approval expired")
+        if status == ApprovalStatus.EXECUTED:
+            raise ApprovalGovernanceError("Approval already executed")
+        if status == ApprovalStatus.FAILED:
+            raise ApprovalGovernanceError("Approval already failed")
+        if status != ApprovalStatus.APPROVED:
+            raise ApprovalGovernanceError(f"Approval status is not executable: {status}")
+
+        expires_at = approval.get("expires_at")
+        if expires_at is not None and float(expires_at) <= _now_ts():
+            try:
+                self._transition(approval_id, ApprovalStatus.EXPIRED)
+            except ApprovalGovernanceError:
+                pass
+            raise ApprovalGovernanceError("Approval expired")
+
+        if approval.get("kind") != expected_kind:
+            raise ApprovalGovernanceError("Approval kind does not match requested action")
+        if str(approval.get("requested_action") or "") != str(expected_requested_action or ""):
+            raise ApprovalGovernanceError("Approval action does not match requested action")
+
+        current_fingerprint = str((approval.get("metadata") or {}).get("binding_fingerprint") or "")
+        expected_fingerprint = _binding_fingerprint(
+            kind=expected_kind,
+            requested_action=expected_requested_action,
+            resource_type=expected_resource_type,
+            resource_id=expected_resource_id,
+            github_repo_full_name=expected_github_repo_full_name,
+            github_issue_number=expected_github_issue_number,
+            github_pr_number=expected_github_pr_number,
+            requested_payload=expected_requested_payload or {},
+        )
+        if not current_fingerprint or current_fingerprint != expected_fingerprint:
+            raise ApprovalGovernanceError("Approval binding does not match requested resource/payload")
+
+        return self._serialize(approval)

--- a/hermes_cli/code/artifact_ledger.py
+++ b/hermes_cli/code/artifact_ledger.py
@@ -7,6 +7,7 @@ import time
 import uuid
 from typing import Any
 
+from hermes_cli.code.event_bus import get_code_event_bus
 from hermes_state import SessionDB
 
 
@@ -33,6 +34,23 @@ class ArtifactLedger:
 
     def _db(self) -> SessionDB:
         return SessionDB(db_path=self._db_path) if self._db_path else SessionDB()
+
+    def _emit(self, event_type: str, artifact: dict[str, Any]) -> None:
+        bus = get_code_event_bus(self._db_path)
+        payload = {
+            "artifact_id": artifact.get("id"),
+            "artifact_type": artifact.get("artifact_type"),
+            "title": artifact.get("title"),
+        }
+        bus.publish(
+            event_type,
+            payload=payload,
+            workspace_id=artifact.get("workspace_id"),
+            code_session_id=artifact.get("code_session_id"),
+            orchestrated_run_id=artifact.get("orchestrated_run_id"),
+            metadata={"source": "artifact_ledger"},
+            source="artifact_ledger",
+        )
 
     def create_artifact(
         self,
@@ -66,9 +84,12 @@ class ArtifactLedger:
         db = self._db()
         try:
             db.create_code_artifact(artifact)
-            return artifact
+            created = artifact
         finally:
             db.close()
+        self._emit("code.artifact.created", created)
+        self._emit("artifact.created", created)
+        return created
 
     def list_artifacts(
         self,

--- a/hermes_cli/code/artifact_ledger.py
+++ b/hermes_cli/code/artifact_ledger.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Typed artifact ledger for Hermes Code Mode."""
+
+from __future__ import annotations
+
+import time
+import uuid
+from typing import Any
+
+from hermes_state import SessionDB
+
+
+ARTIFACT_TYPES: tuple[str, ...] = (
+    "task_intake",
+    "prd_lite",
+    "acceptance_criteria",
+    "architecture_note",
+    "adr",
+    "implementation_plan",
+    "command_log",
+    "diff_summary",
+    "test_report",
+    "review_report",
+    "deploy_plan",
+    "deploy_report",
+    "memory_update",
+)
+
+
+class ArtifactLedger:
+    def __init__(self, db_path=None):
+        self._db_path = db_path
+
+    def _db(self) -> SessionDB:
+        return SessionDB(db_path=self._db_path) if self._db_path else SessionDB()
+
+    def create_artifact(
+        self,
+        artifact_type: str,
+        content: str,
+        *,
+        title: str | None = None,
+        content_type: str = "markdown",
+        workspace_id: str | None = None,
+        code_session_id: str | None = None,
+        orchestrated_run_id: str | None = None,
+        command_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        if artifact_type not in ARTIFACT_TYPES:
+            raise ValueError(f"Unknown artifact_type: {artifact_type}")
+        artifact = {
+            "id": str(uuid.uuid4()),
+            "artifact_type": artifact_type,
+            "title": title or artifact_type.replace("_", " ").title(),
+            "content": content or "",
+            "content_type": content_type or "markdown",
+            "workspace_id": workspace_id,
+            "code_session_id": code_session_id,
+            "orchestrated_run_id": orchestrated_run_id,
+            "command_id": command_id,
+            "metadata": metadata or {},
+            "created_at": time.time(),
+            "updated_at": time.time(),
+        }
+        db = self._db()
+        try:
+            db.create_code_artifact(artifact)
+            return artifact
+        finally:
+            db.close()
+
+    def list_artifacts(
+        self,
+        *,
+        workspace_id: str | None = None,
+        code_session_id: str | None = None,
+        orchestrated_run_id: str | None = None,
+        artifact_type: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        db = self._db()
+        try:
+            return db.list_code_artifacts(
+                workspace_id=workspace_id,
+                code_session_id=code_session_id,
+                orchestrated_run_id=orchestrated_run_id,
+                artifact_type=artifact_type,
+                limit=limit,
+                offset=offset,
+            )
+        finally:
+            db.close()
+
+    def list_session_artifacts(
+        self,
+        code_session_id: str,
+        *,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        return self.list_artifacts(code_session_id=code_session_id, limit=limit, offset=offset)

--- a/hermes_cli/code/event_bus.py
+++ b/hermes_cli/code/event_bus.py
@@ -1,0 +1,434 @@
+#!/usr/bin/env python3
+"""Central realtime/persistent event bus for Hermes Code Mode."""
+
+from __future__ import annotations
+
+import json
+import queue
+import re
+import sqlite3
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+from hermes_cli.code.execution_policy import redact_secrets
+from hermes_cli.code.github_integration import redact_github_secrets
+from hermes_state import SessionDB
+
+EVENT_VERSION = 1
+
+_SECRET_KEY_PATTERN = re.compile(
+    r"(?i)(token|access_token|refresh_token|authorization|private_key|webhook_secret|client_secret|secret|password|HERMES_GITHUB_DEV_PAT)"
+)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _redact_scalar(value: Any) -> Any:
+    if isinstance(value, str):
+        return redact_github_secrets(redact_secrets(value))
+    return value
+
+
+def redact_payload(value: Any, *, key: Optional[str] = None) -> Any:
+    if key and _SECRET_KEY_PATTERN.search(str(key)):
+        return "[REDACTED]"
+    if isinstance(value, dict):
+        return {str(k): redact_payload(v, key=str(k)) for k, v in value.items()}
+    if isinstance(value, list):
+        return [redact_payload(v) for v in value]
+    return _redact_scalar(value)
+
+
+def _normalize_type(value: str | None) -> str:
+    return str(value or "code.event.unknown").strip() or "code.event.unknown"
+
+
+def _safe_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except Exception:
+        return default
+
+
+def _parse_bool(value: Any, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    text = str(value).strip().lower()
+    if text in {"1", "true", "yes", "on"}:
+        return True
+    if text in {"0", "false", "no", "off"}:
+        return False
+    return default
+
+
+@dataclass(frozen=True)
+class EventFilters:
+    event_type: str | None = None
+    workspace_id: str | None = None
+    code_session_id: str | None = None
+    orchestrated_run_id: str | None = None
+    approval_id: str | None = None
+    github_repo_full_name: str | None = None
+
+    @classmethod
+    def from_dict(cls, values: dict[str, Any] | None = None) -> "EventFilters":
+        raw = values or {}
+        return cls(
+            event_type=(raw.get("type") or raw.get("event_type") or None),
+            workspace_id=(raw.get("workspace_id") or None),
+            code_session_id=(raw.get("code_session_id") or raw.get("session_id") or None),
+            orchestrated_run_id=(raw.get("orchestrated_run_id") or None),
+            approval_id=(raw.get("approval_id") or None),
+            github_repo_full_name=(raw.get("github_repo_full_name") or None),
+        )
+
+
+class CodeEventBus:
+    """Central event bus: normalize, redact, persist, and fanout."""
+
+    def __init__(self, db_path: Optional[Path] = None) -> None:
+        self._db_path = db_path
+        self._subs_lock = threading.RLock()
+        self._subscribers: dict[str, dict[str, Any]] = {}
+        self._started_at = time.time()
+
+    def _db(self) -> SessionDB:
+        return SessionDB(db_path=self._db_path) if self._db_path else SessionDB()
+
+    def _normalize_event(
+        self,
+        *,
+        event_type: str,
+        payload: dict[str, Any] | None = None,
+        workspace_id: str | None = None,
+        code_session_id: str | None = None,
+        orchestrated_run_id: str | None = None,
+        approval_id: str | None = None,
+        github_repo_full_name: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        event: dict[str, Any] = {
+            "id": str(uuid.uuid4()),
+            "type": _normalize_type(event_type),
+            "version": EVENT_VERSION,
+            "timestamp": _now_iso(),
+            "payload": redact_payload(payload or {}),
+        }
+        if workspace_id:
+            event["workspace_id"] = str(workspace_id)
+        if code_session_id:
+            event["code_session_id"] = str(code_session_id)
+        if orchestrated_run_id:
+            event["orchestrated_run_id"] = str(orchestrated_run_id)
+        if approval_id:
+            event["approval_id"] = str(approval_id)
+        if github_repo_full_name:
+            event["github_repo_full_name"] = str(github_repo_full_name)
+        if metadata:
+            event["metadata"] = redact_payload(metadata)
+        return event
+
+    @staticmethod
+    def _event_matches(event: dict[str, Any], filters: EventFilters) -> bool:
+        if filters.event_type and str(event.get("type")) != str(filters.event_type):
+            return False
+        if filters.workspace_id and str(event.get("workspace_id") or "") != str(filters.workspace_id):
+            return False
+        if filters.code_session_id and str(event.get("code_session_id") or "") != str(filters.code_session_id):
+            return False
+        if filters.orchestrated_run_id and str(event.get("orchestrated_run_id") or "") != str(filters.orchestrated_run_id):
+            return False
+        if filters.approval_id and str(event.get("approval_id") or "") != str(filters.approval_id):
+            return False
+        if filters.github_repo_full_name and str(event.get("github_repo_full_name") or "") != str(filters.github_repo_full_name):
+            return False
+        return True
+
+    @staticmethod
+    def _inflate_row_event(row: dict[str, Any]) -> dict[str, Any]:
+        raw_payload = row.get("payload_json")
+        try:
+            payload = json.loads(raw_payload) if raw_payload else {}
+        except Exception:
+            payload = {}
+
+        event = payload if isinstance(payload, dict) else {}
+        event["id"] = row.get("id")
+        if "type" not in event:
+            event["type"] = row.get("event_type")
+        if "version" not in event:
+            event["version"] = EVENT_VERSION
+        if "timestamp" not in event:
+            event["timestamp"] = datetime.fromtimestamp(float(row.get("created_at") or time.time()), tz=timezone.utc).isoformat()
+        if "workspace_id" not in event and row.get("workspace_id"):
+            event["workspace_id"] = row.get("workspace_id")
+        if "code_session_id" not in event and row.get("session_id"):
+            event["code_session_id"] = row.get("session_id")
+        if "payload" not in event:
+            event["payload"] = {}
+        return redact_payload(event)
+
+    def publish(
+        self,
+        event_type: str,
+        *,
+        payload: dict[str, Any] | None = None,
+        workspace_id: str | None = None,
+        code_session_id: str | None = None,
+        orchestrated_run_id: str | None = None,
+        approval_id: str | None = None,
+        github_repo_full_name: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        source: str = "code_mode",
+        level: str = "info",
+    ) -> dict[str, Any]:
+        event = self._normalize_event(
+            event_type=event_type,
+            payload=payload,
+            workspace_id=workspace_id,
+            code_session_id=code_session_id,
+            orchestrated_run_id=orchestrated_run_id,
+            approval_id=approval_id,
+            github_repo_full_name=github_repo_full_name,
+            metadata=metadata,
+        )
+
+        db = self._db()
+        try:
+            try:
+                event_id = db.append_code_event(
+                    event_type=event["type"],
+                    payload=event,
+                    workspace_id=workspace_id,
+                    code_session_id=code_session_id,
+                    source=source,
+                    level=level,
+                )
+            except sqlite3.IntegrityError:
+                event.pop("workspace_id", None)
+                event_id = db.append_code_event(
+                    event_type=event["type"],
+                    payload=event,
+                    workspace_id=None,
+                    code_session_id=code_session_id,
+                    source=source,
+                    level=level,
+                )
+        finally:
+            db.close()
+        event["id"] = event_id
+
+        stale_ids: list[str] = []
+        with self._subs_lock:
+            subscribers = list(self._subscribers.items())
+        for sub_id, sub in subscribers:
+            filters = sub["filters"]
+            if not self._event_matches(event, filters):
+                continue
+            try:
+                sub["queue"].put_nowait(event)
+            except Exception:
+                stale_ids.append(sub_id)
+        for sub_id in stale_ids:
+            self.unsubscribe(sub_id)
+        return event
+
+    def subscribe(self, *, filters: EventFilters | dict[str, Any] | None = None, max_queue_size: int = 256) -> tuple[str, queue.Queue]:
+        sub_id = str(uuid.uuid4())
+        filt = filters if isinstance(filters, EventFilters) else EventFilters.from_dict(filters)
+        q: queue.Queue = queue.Queue(maxsize=max(1, _safe_int(max_queue_size, 256)))
+        with self._subs_lock:
+            self._subscribers[sub_id] = {
+                "id": sub_id,
+                "filters": filt,
+                "queue": q,
+                "created_at": time.time(),
+            }
+        return sub_id, q
+
+    def unsubscribe(self, subscription_id: str) -> None:
+        with self._subs_lock:
+            self._subscribers.pop(subscription_id, None)
+
+    def _find_rowid_by_event_id(self, event_id: str) -> Optional[int]:
+        if not event_id:
+            return None
+        db = self._db()
+        try:
+            with db._lock:
+                row = db._conn.execute(
+                    "SELECT rowid AS rowid FROM code_events WHERE id = ? LIMIT 1",
+                    (event_id,),
+                ).fetchone()
+            if not row:
+                return None
+            return int(row["rowid"] if hasattr(row, "keys") else row[0])
+        finally:
+            db.close()
+
+    def fetch_events(
+        self,
+        *,
+        filters: EventFilters | dict[str, Any] | None = None,
+        since_id: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+        newest_first: bool = True,
+    ) -> list[dict[str, Any]]:
+        filt = filters if isinstance(filters, EventFilters) else EventFilters.from_dict(filters)
+        max_limit = max(1, min(_safe_int(limit, 50), 1000))
+        safe_offset = max(0, _safe_int(offset, 0))
+
+        where = []
+        params: list[Any] = []
+        if filt.workspace_id:
+            where.append("workspace_id = ?")
+            params.append(filt.workspace_id)
+        if filt.code_session_id:
+            where.append("session_id = ?")
+            params.append(filt.code_session_id)
+        if filt.event_type:
+            where.append("event_type = ?")
+            params.append(filt.event_type)
+
+        since_rowid = self._find_rowid_by_event_id(str(since_id or ""))
+        if since_rowid is not None:
+            where.append("rowid > ?")
+            params.append(int(since_rowid))
+
+        where_sql = f"WHERE {' AND '.join(where)}" if where else ""
+        order_sql = "ORDER BY rowid DESC" if newest_first else "ORDER BY rowid ASC"
+
+        db = self._db()
+        try:
+            with db._lock:
+                rows = db._conn.execute(
+                    f"""
+                    SELECT rowid AS _rowid, id, workspace_id, session_id, event_type, payload_json, created_at
+                    FROM code_events
+                    {where_sql}
+                    {order_sql}
+                    LIMIT ? OFFSET ?
+                    """,
+                    tuple(params + [max_limit, safe_offset]),
+                ).fetchall()
+            events = [self._inflate_row_event(dict(row)) for row in rows]
+        finally:
+            db.close()
+
+        filtered = [event for event in events if self._event_matches(event, filt)]
+        return filtered
+
+    def replay(
+        self,
+        *,
+        filters: EventFilters | dict[str, Any] | None = None,
+        since_id: str | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        # replay/catch-up uses persisted insertion order (rowid ASC).
+        return self.fetch_events(
+            filters=filters,
+            since_id=since_id,
+            limit=max(1, min(_safe_int(limit, 100), 2000)),
+            offset=0,
+            newest_first=False,
+        )
+
+    def summary(
+        self,
+        *,
+        filters: EventFilters | dict[str, Any] | None = None,
+        recent_limit: int = 200,
+    ) -> dict[str, Any]:
+        events = self.fetch_events(
+            filters=filters,
+            since_id=None,
+            limit=max(1, min(_safe_int(recent_limit, 200), 2000)),
+            offset=0,
+            newest_first=True,
+        )
+        by_type: dict[str, int] = {}
+        for event in events:
+            et = str(event.get("type") or "code.event.unknown")
+            by_type[et] = by_type.get(et, 0) + 1
+        return {
+            "total": len(events),
+            "by_type": by_type,
+            "latest_event_id": events[0]["id"] if events else None,
+            "latest_timestamp": events[0]["timestamp"] if events else None,
+        }
+
+    def subscription_stats(self) -> dict[str, Any]:
+        with self._subs_lock:
+            subscribers = list(self._subscribers.values())
+        filters_summary: list[dict[str, Any]] = []
+        for sub in subscribers:
+            filt: EventFilters = sub["filters"]
+            filters_summary.append(
+                {
+                    "type": filt.event_type,
+                    "workspace_id": filt.workspace_id,
+                    "code_session_id": filt.code_session_id,
+                    "orchestrated_run_id": filt.orchestrated_run_id,
+                    "approval_id": filt.approval_id,
+                    "github_repo_full_name": filt.github_repo_full_name,
+                }
+            )
+        return {
+            "active_subscribers": len(subscribers),
+            "uptime_seconds": max(0, int(time.time() - self._started_at)),
+            "filters": filters_summary,
+        }
+
+
+_BUS_LOCK = threading.RLock()
+_DEFAULT_BUS: CodeEventBus | None = None
+
+
+def get_code_event_bus(db_path: Optional[Path] = None) -> CodeEventBus:
+    global _DEFAULT_BUS
+    if db_path is not None:
+        return CodeEventBus(db_path=db_path)
+    with _BUS_LOCK:
+        if _DEFAULT_BUS is None:
+            _DEFAULT_BUS = CodeEventBus()
+        return _DEFAULT_BUS
+
+
+def build_event_filters_from_query(
+    *,
+    event_type: str | None = None,
+    workspace_id: str | None = None,
+    code_session_id: str | None = None,
+    orchestrated_run_id: str | None = None,
+    approval_id: str | None = None,
+    github_repo_full_name: str | None = None,
+) -> EventFilters:
+    return EventFilters(
+        event_type=event_type,
+        workspace_id=workspace_id,
+        code_session_id=code_session_id,
+        orchestrated_run_id=orchestrated_run_id,
+        approval_id=approval_id,
+        github_repo_full_name=github_repo_full_name,
+    )
+
+
+__all__ = [
+    "CodeEventBus",
+    "EventFilters",
+    "build_event_filters_from_query",
+    "get_code_event_bus",
+    "redact_payload",
+    "_parse_bool",
+]

--- a/hermes_cli/code/execution_policy.py
+++ b/hermes_cli/code/execution_policy.py
@@ -209,6 +209,15 @@ class ExecutionPolicyEngine:
             "blocked": risk_class in self.BLOCKED,
         }
 
+    def assess_github_write(self, action: str) -> dict[str, Any]:
+        return {
+            "action": action,
+            "risk_class": RiskClass.GIT_WRITE,
+            "risk_tags": [RiskClass.NETWORK, RiskClass.GIT_WRITE],
+            "requires_approval": True,
+            "blocked": False,
+        }
+
     def redact(self, text: str) -> str:
         return redact_secrets(text)
 

--- a/hermes_cli/code/execution_policy.py
+++ b/hermes_cli/code/execution_policy.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Execution policy engine for Hermes Code Mode.
+
+Provides command/tool risk classification and secret redaction helpers.
+"""
+
+from __future__ import annotations
+
+import re
+import shlex
+from typing import Any
+
+
+class RiskClass:
+    SAFE_READONLY = "safe_readonly"
+    SAFE_LOCAL_WRITE = "safe_local_write"
+    NETWORK = "network"
+    GIT_WRITE = "git_write"
+    SECRET_SENSITIVE = "secret_sensitive"
+    REMOTE_MUTATING = "remote_mutating"
+    DESTRUCTIVE = "destructive"
+    PRODUCTION_SENSITIVE = "production_sensitive"
+
+
+_DESTRUCTIVE_PATTERNS = [
+    r"\brm\s+-[a-z]*r[a-z]*f",
+    r"\bgit\s+reset\s+--hard\b",
+    r"\bgit\s+clean\s+-[a-z]*f[a-z]*d[a-z]*x\b",
+    r"\bgit\s+clean\s+-fdx\b",
+    r"\bchmod\s+-R\b",
+    r"\bchown\s+-R\b",
+    r"\bdrop\s+database\b",
+    r"\bdropdb\b",
+    r"\btruncate\s+table\b",
+    r"\bdrop\s+table\b",
+]
+
+_PRODUCTION_PATTERNS = [
+    r"\bterraform\s+(apply|destroy)\b",
+    r"\bkubectl\s+(apply|delete|rollout)\b",
+    r"\bhelm\s+(upgrade|install|uninstall)\b",
+    r"\bdeploy\b.*\bprod",
+    r"\bprod\b.*\bdeploy",
+    r"\balembic\s+upgrade\s+head\b",
+    r"\bdjango.*\bmigrate\b",
+    r"\brails\s+db:migrate\b",
+]
+
+_SECRET_PATTERNS = [
+    r"\b(cat|less|more)\b.*\b\.env\b",
+    r"\b(printenv|env)\b",
+    r"\b(set)\b\s*\|\s*grep\b",
+    r"\bcurl\b.*(?:token|secret|password|api[_-]?key)",
+    r"\becho\b.*(?:token|secret|password|api[_-]?key)\s*=",
+    r"\bcurl\s+[^|]*\|\s*(sh|bash|zsh)\b",
+    r"\bwget\s+[^|]*\|\s*(sh|bash|zsh)\b",
+]
+
+_REMOTE_MUTATING_PATTERNS = [
+    r"\bssh\b",
+    r"\bscp\b",
+    r"\brsync\b.*--delete",
+    r"\bsftp\b",
+]
+
+_GIT_WRITE_PATTERNS = [
+    r"\bgit\s+(commit|push|merge|rebase|cherry-pick|tag)\b",
+    r"\bgit\s+(checkout|switch)\b",
+    r"\bgit\s+branch\s+-[dD]\b",
+    r"\bgit\s+stash\s+(pop|drop)\b",
+    r"\bgit\s+worktree\s+(add|remove)\b",
+]
+
+_NETWORK_PATTERNS = [
+    r"\bcurl\b",
+    r"\bwget\b",
+    r"\bpip\s+install\b",
+    r"\bnpm\s+install\b",
+    r"\bpnpm\s+install\b",
+    r"\byarn\s+install\b",
+    r"\buv\s+add\b",
+]
+
+_SAFE_READONLY_PATTERNS = [
+    r"\bgit\s+(status|diff|log|show)\b",
+    r"\bls\b",
+    r"\bfind\b",
+    r"\brg\b",
+    r"\bgrep\b",
+    r"\bcat\b",
+    r"\bhead\b",
+    r"\btail\b",
+    r"\bpwd\b",
+]
+
+_SAFE_LOCAL_WRITE_PATTERNS = [
+    r"\bpytest\b",
+    r"\bpython3?\s+-m\s+pytest\b",
+    r"\bnpm\s+run\b",
+    r"\bpnpm\s+run\b",
+    r"\byarn\s+run\b",
+    r"\bmake\s+(test|lint|build|check|typecheck)\b",
+    r"\bruff\b",
+    r"\bmypy\b",
+    r"\bblack\b",
+    r"\beslint\b",
+]
+
+_COMPILED: list[tuple[str, list[re.Pattern[str]]]] = [
+    (RiskClass.DESTRUCTIVE, [re.compile(p, re.IGNORECASE) for p in _DESTRUCTIVE_PATTERNS]),
+    (RiskClass.PRODUCTION_SENSITIVE, [re.compile(p, re.IGNORECASE) for p in _PRODUCTION_PATTERNS]),
+    (RiskClass.SECRET_SENSITIVE, [re.compile(p, re.IGNORECASE) for p in _SECRET_PATTERNS]),
+    (RiskClass.REMOTE_MUTATING, [re.compile(p, re.IGNORECASE) for p in _REMOTE_MUTATING_PATTERNS]),
+    (RiskClass.GIT_WRITE, [re.compile(p, re.IGNORECASE) for p in _GIT_WRITE_PATTERNS]),
+    (RiskClass.NETWORK, [re.compile(p, re.IGNORECASE) for p in _NETWORK_PATTERNS]),
+    (RiskClass.SAFE_READONLY, [re.compile(p, re.IGNORECASE) for p in _SAFE_READONLY_PATTERNS]),
+    (RiskClass.SAFE_LOCAL_WRITE, [re.compile(p, re.IGNORECASE) for p in _SAFE_LOCAL_WRITE_PATTERNS]),
+]
+
+_TOOL_RISK_MAP = {
+    "terminal": RiskClass.SAFE_LOCAL_WRITE,
+    "read_file": RiskClass.SAFE_READONLY,
+    "search_files": RiskClass.SAFE_READONLY,
+    "web_search": RiskClass.NETWORK,
+    "execute_code": RiskClass.SAFE_LOCAL_WRITE,
+}
+
+_REDACT_RULES: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"(?i)((?:api[_-]?key|token|secret|password|passwd)\s*[:=]\s*)\S+"), r"\1[REDACTED]"),
+    (re.compile(r"(?i)(authorization\s*:\s*(?:bearer\s+)?)(\S+)"), r"\1[REDACTED]"),
+    (re.compile(r"(?i)(bearer\s+)\S+"), r"\1[REDACTED]"),
+    (re.compile(r"(?i)(--(?:api-key|token|secret|password|access-token)[= ])\S+"), r"\1[REDACTED]"),
+    (re.compile(r"(?i)(HERMES_[A-Z0-9_]+)\s*=\s*([^\s]+)"), r"\1=[REDACTED]"),
+    (re.compile(r"\bsk-[A-Za-z0-9]{10,}\b"), "[REDACTED]"),
+    (re.compile(r"\bgh[pousr]_[A-Za-z0-9]{20,}\b"), "[REDACTED]"),
+    (re.compile(r"\bAKIA[A-Z0-9]{10,}\b"), "[REDACTED]"),
+    (re.compile(r"\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\b"), "[REDACTED]"),
+]
+
+
+def redact_secrets(text: str) -> str:
+    redacted = text or ""
+    for pattern, replacement in _REDACT_RULES:
+        redacted = pattern.sub(replacement, redacted)
+    return redacted
+
+
+def _has_shell_injection(command: str) -> bool:
+    try:
+        shlex.split(command)
+    except ValueError:
+        return True
+    lowered = command.lower()
+    return any(token in lowered for token in ("`", ";", "&&", "||", " | sh", " | bash", " | zsh"))
+
+
+def classify_command(command: str) -> str:
+    cmd = (command or "").strip()
+    if not cmd:
+        return RiskClass.SAFE_READONLY
+    if re.search(r"\bsudo\b", cmd, re.IGNORECASE):
+        return RiskClass.DESTRUCTIVE
+    if _has_shell_injection(cmd):
+        return RiskClass.DESTRUCTIVE
+    for risk_class, patterns in _COMPILED:
+        if any(pattern.search(cmd) for pattern in patterns):
+            return risk_class
+    return RiskClass.SAFE_LOCAL_WRITE
+
+
+def classify_tool(tool_name: str) -> str:
+    return _TOOL_RISK_MAP.get((tool_name or "").strip(), RiskClass.SAFE_LOCAL_WRITE)
+
+
+class ExecutionPolicyEngine:
+    REQUIRES_APPROVAL: frozenset[str] = frozenset(
+        {
+            RiskClass.GIT_WRITE,
+            RiskClass.NETWORK,
+            RiskClass.REMOTE_MUTATING,
+            RiskClass.PRODUCTION_SENSITIVE,
+            RiskClass.SECRET_SENSITIVE,
+        }
+    )
+    BLOCKED: frozenset[str] = frozenset({RiskClass.DESTRUCTIVE})
+
+    def classify(self, command: str) -> str:
+        return classify_command(command)
+
+    def classify_tool(self, tool_name: str) -> str:
+        return classify_tool(tool_name)
+
+    def assess_command(self, command: str) -> dict[str, Any]:
+        risk_class = self.classify(command)
+        return {
+            "command": redact_secrets(command),
+            "risk_class": risk_class,
+            "allowed": risk_class not in self.BLOCKED and risk_class not in self.REQUIRES_APPROVAL,
+            "requires_approval": risk_class in self.REQUIRES_APPROVAL,
+            "blocked": risk_class in self.BLOCKED,
+        }
+
+    def assess_tool(self, tool_name: str) -> dict[str, Any]:
+        risk_class = self.classify_tool(tool_name)
+        return {
+            "tool_name": tool_name,
+            "risk_class": risk_class,
+            "requires_approval": risk_class in self.REQUIRES_APPROVAL,
+            "blocked": risk_class in self.BLOCKED,
+        }
+
+    def redact(self, text: str) -> str:
+        return redact_secrets(text)
+
+
+policy_engine = ExecutionPolicyEngine()

--- a/hermes_cli/code/github_chatops.py
+++ b/hermes_cli/code/github_chatops.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""GitHub ChatOps parser and orchestration bridge (P1)."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+from hermes_cli.code.agent_orchestrator import AgentOrchestrator, OrchestratorState
+from hermes_cli.code.artifact_ledger import ArtifactLedger
+from hermes_cli.code.execution_policy import policy_engine
+from hermes_cli.code.github_integration import GitHubIntegrationStore
+from hermes_cli.code.repo_knowledge import RepoKnowledgeService
+from hermes_state import SessionDB
+
+SUPPORTED_COMMANDS = frozenset({"plan", "review", "fix", "explain", "status"})
+_COMMAND_RE = re.compile(r"(?im)^\s*@hermes(?:\s+|:)(plan|review|fix|explain|status)\b[ \t]*(.*)$")
+
+
+@dataclass(frozen=True)
+class ChatOpsCommand:
+    command: str
+    args: str = ""
+
+
+def parse_chatops_commands(text: str) -> list[ChatOpsCommand]:
+    if not text:
+        return []
+    commands: list[ChatOpsCommand] = []
+    for match in _COMMAND_RE.finditer(text):
+        command = match.group(1).lower()
+        if command in SUPPORTED_COMMANDS:
+            commands.append(ChatOpsCommand(command=command, args=match.group(2).strip()))
+    return commands
+
+
+def _task_title(command: dict[str, Any]) -> str:
+    repo = command.get("repo_full_name") or "GitHub"
+    number = command.get("pr_number") or command.get("issue_number")
+    suffix = f" #{number}" if number else ""
+    return f"GitHub @{command.get('command')} request: {repo}{suffix}"
+
+
+def _task_description(command: dict[str, Any]) -> str:
+    lines = [
+        f"GitHub ChatOps command: @hermes {command.get('command')}",
+        f"Repository: {command.get('repo_full_name')}",
+        f"Sender: {command.get('sender_login') or 'unknown'}",
+    ]
+    if command.get("issue_number"):
+        lines.append(f"Issue: #{command.get('issue_number')}")
+    if command.get("pr_number"):
+        lines.append(f"Pull request: #{command.get('pr_number')}")
+    if command.get("comment_id"):
+        lines.append(f"Comment: {command.get('comment_id')}")
+    if command.get("args"):
+        lines.extend(["", str(command["args"])])
+    return "\n".join(lines)
+
+
+class GitHubChatOpsService:
+    def __init__(self, db_path: Optional[Path] = None) -> None:
+        self._db_path = db_path
+
+    def _store(self) -> GitHubIntegrationStore:
+        return GitHubIntegrationStore(db_path=self._db_path)
+
+    def _orchestrator(self) -> AgentOrchestrator:
+        return AgentOrchestrator(db_path=self._db_path)
+
+    def _ledger(self) -> ArtifactLedger:
+        return ArtifactLedger(db_path=self._db_path)
+
+    def create_commands_from_comment(
+        self,
+        *,
+        delivery_id: Optional[str],
+        repo_full_name: str,
+        issue_number: Optional[int],
+        pr_number: Optional[int],
+        comment_id: Optional[int],
+        sender_login: Optional[str],
+        body: str,
+    ) -> list[dict[str, Any]]:
+        commands = parse_chatops_commands(body)
+        if not commands:
+            return []
+        store = self._store()
+        try:
+            return [
+                store.create_chatops_command(
+                    delivery_id=delivery_id,
+                    repo_full_name=repo_full_name,
+                    issue_number=issue_number,
+                    pr_number=pr_number,
+                    comment_id=comment_id,
+                    sender_login=sender_login,
+                    command=item.command,
+                    args=item.args,
+                )
+                for item in commands
+            ]
+        finally:
+            store.close()
+
+    def _workspace_for_repo(self, repo_full_name: str) -> tuple[Optional[str], Optional[dict[str, Any]]]:
+        db = SessionDB(db_path=self._db_path) if self._db_path else SessionDB()
+        try:
+            for workspace in db.list_code_workspaces(limit=500):
+                repo_url = str(workspace.get("repo_url") or "").removesuffix(".git")
+                if repo_url.endswith(f"github.com/{repo_full_name}") or repo_url.endswith(f":{repo_full_name}"):
+                    return workspace.get("id"), workspace
+        finally:
+            db.close()
+        return None, None
+
+    def _repo_guidance(self, workspace: Optional[dict[str, Any]]) -> Optional[dict[str, Any]]:
+        if not workspace or not workspace.get("path"):
+            return None
+        try:
+            return RepoKnowledgeService().detect(Path(workspace["path"]))
+        except Exception:
+            return None
+
+    def _link_latest_run_for_status(self, command: dict[str, Any]) -> Optional[dict[str, Any]]:
+        store = self._store()
+        try:
+            recent = store.list_chatops_commands(limit=200)
+            for item in recent:
+                if item.get("id") == command.get("id"):
+                    continue
+                if item.get("repo_full_name") != command.get("repo_full_name"):
+                    continue
+                if item.get("orchestrated_run_id") and (
+                    item.get("issue_number") == command.get("issue_number")
+                    or item.get("pr_number") == command.get("pr_number")
+                ):
+                    run = self._orchestrator().get_run(item["orchestrated_run_id"])
+                    if run:
+                        store.update_chatops_command(
+                            command["id"],
+                            status="linked_existing_run",
+                            orchestrated_run_id=item["orchestrated_run_id"],
+                            code_session_id=run.get("code_session_id"),
+                        )
+                        return run
+        finally:
+            store.close()
+        return None
+
+    def run_command(self, command_id: str) -> dict[str, Any]:
+        store = self._store()
+        try:
+            command = store.get_chatops_command(command_id)
+        finally:
+            store.close()
+        if not command:
+            raise ValueError(f"GitHub ChatOps command not found: {command_id}")
+
+        if command.get("orchestrated_run_id"):
+            run = self._orchestrator().get_run(command["orchestrated_run_id"])
+            return {"command": command, "run": run, "resumed": True}
+
+        if str(command.get("command")) == "status":
+            linked = self._link_latest_run_for_status(command)
+            if linked is not None:
+                refreshed_store = self._store()
+                try:
+                    updated = refreshed_store.get_chatops_command(command_id)
+                finally:
+                    refreshed_store.close()
+                return {"command": updated, "run": linked, "resumed": True}
+
+        workspace_id, workspace = self._workspace_for_repo(str(command.get("repo_full_name") or ""))
+        guidance = self._repo_guidance(workspace)
+        title = _task_title(command)
+        description = _task_description(command)
+
+        metadata = {
+            "source": "github_chatops",
+            "github": {
+                "repo_full_name": command.get("repo_full_name"),
+                "issue_number": command.get("issue_number"),
+                "pr_number": command.get("pr_number"),
+                "comment_id": command.get("comment_id"),
+                "sender_login": command.get("sender_login"),
+                "command": command.get("command"),
+                "args": command.get("args"),
+            },
+            "repo_guidance": guidance,
+        }
+
+        run = self._orchestrator().create_run(
+            title=title,
+            goal=description,
+            workspace_id=workspace_id,
+            metadata=metadata,
+            create_intake_artifact=True,
+        )
+
+        command_name = str(command.get("command") or "")
+        if command_name == "plan":
+            self._ledger().create_artifact(
+                "implementation_plan",
+                f"Planning requested from GitHub.\n\n{description}",
+                title="GitHub Planning Request",
+                workspace_id=workspace_id,
+                code_session_id=run.get("code_session_id"),
+                orchestrated_run_id=run["id"],
+            )
+        elif command_name == "review":
+            self._ledger().create_artifact(
+                "review_report",
+                f"Review requested from GitHub.\n\n{description}",
+                title="GitHub Review Request",
+                workspace_id=workspace_id,
+                code_session_id=run.get("code_session_id"),
+                orchestrated_run_id=run["id"],
+            )
+        elif command_name == "fix":
+            run = self._orchestrator().transition_run(run["id"], OrchestratorState.DISCOVERY, reason="GitHub fix request intake")
+            run = self._orchestrator().transition_run(run["id"], OrchestratorState.PLANNING, reason="Plan fix before implementation")
+            run = self._orchestrator().transition_run(
+                run["id"],
+                OrchestratorState.APPROVAL,
+                reason="Fix request requires approval before implementation",
+                metadata={"risk": policy_engine.assess_command("git commit -m fix")},
+            )
+        elif command_name == "explain":
+            self._ledger().create_artifact(
+                "architecture_note",
+                f"Explanation requested from GitHub.\n\n{description}",
+                title="GitHub Explanation Request",
+                workspace_id=workspace_id,
+                code_session_id=run.get("code_session_id"),
+                orchestrated_run_id=run["id"],
+            )
+
+        updated_store = self._store()
+        try:
+            updated = updated_store.update_chatops_command(
+                command_id,
+                status="run_created",
+                orchestrated_run_id=run["id"],
+                code_session_id=run.get("code_session_id"),
+            )
+        finally:
+            updated_store.close()
+        return {"command": updated, "run": run, "resumed": False}

--- a/hermes_cli/code/github_integration.py
+++ b/hermes_cli/code/github_integration.py
@@ -1,0 +1,903 @@
+#!/usr/bin/env python3
+"""GitHub integration primitives for Hermes Code Mode (P1)."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sqlite3
+import time
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+import httpx
+
+from hermes_constants import get_hermes_home
+
+GITHUB_API_BASE = "https://api.github.com"
+GITHUB_API_VERSION = "2022-11-28"
+
+_REDACT_RULES: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"(?i)(authorization\s*:\s*(?:bearer\s+)?)(\S+)"), r"\1[REDACTED]"),
+    (re.compile(r"(?i)(bearer\s+)\S+"), r"\1[REDACTED]"),
+    (
+        re.compile(
+            r"(?i)((?:token|private_key|webhook_secret|access_token|refresh_token|client_secret)\s*[:=]\s*)\S+"
+        ),
+        r"\1[REDACTED]",
+    ),
+    (re.compile(r"gh[pousr]_[A-Za-z0-9_]{8,}"), "[REDACTED]"),
+    (re.compile(r"\bHERMES_GITHUB_DEV_PAT\s*=\s*\S+"), "HERMES_GITHUB_DEV_PAT=[REDACTED]"),
+]
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _env_value(name: str) -> str:
+    value = os.getenv(name, "")
+    if value:
+        return value
+    try:
+        from hermes_cli.config import load_env
+
+        return str(load_env().get(name, "") or "")
+    except Exception:
+        return ""
+
+
+def redact_github_secrets(text: str) -> str:
+    value = str(text or "")
+    for pattern, replacement in _REDACT_RULES:
+        value = pattern.sub(replacement, value)
+    return value
+
+
+def _json_dumps(value: Any) -> str:
+    return json.dumps(value if value is not None else {}, separators=(",", ":"), sort_keys=True)
+
+
+def _json_loads(value: Any, default: Any) -> Any:
+    if not value:
+        return default
+    try:
+        return json.loads(value)
+    except Exception:
+        return default
+
+
+@dataclass(frozen=True)
+class GitHubAppConfig:
+    app_id: Optional[str]
+    private_key_path: Optional[str]
+    webhook_secret_configured: bool
+    dev_pat_configured: bool
+    allow_dev_pat: bool
+
+    @property
+    def app_configured(self) -> bool:
+        return bool(self.app_id and self.private_key_path)
+
+    @property
+    def mode(self) -> str:
+        if self.app_configured:
+            return "github_app"
+        if self.dev_pat_configured and self.allow_dev_pat:
+            return "pat_dev"
+        return "unconfigured"
+
+
+class GitHubAPIError(RuntimeError):
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: Optional[int] = None,
+        rate_limit: Optional[dict[str, str]] = None,
+        response: Optional[Any] = None,
+    ) -> None:
+        super().__init__(redact_github_secrets(message))
+        self.message = redact_github_secrets(message)
+        self.status_code = status_code
+        self.rate_limit = rate_limit or {}
+        self.response = response
+
+
+class GitHubAPIClient:
+    def __init__(
+        self,
+        token_provider: Callable[[], str],
+        *,
+        base_url: str = GITHUB_API_BASE,
+        http_client: Optional[Any] = None,
+    ) -> None:
+        self._token_provider = token_provider
+        self._base_url = base_url.rstrip("/")
+        self._http = http_client or httpx.Client(timeout=30.0)
+
+    @staticmethod
+    def _rate_limit(headers: Any) -> dict[str, str]:
+        return {
+            "limit": str(headers.get("x-ratelimit-limit", "")),
+            "remaining": str(headers.get("x-ratelimit-remaining", "")),
+            "reset": str(headers.get("x-ratelimit-reset", "")),
+            "resource": str(headers.get("x-ratelimit-resource", "")),
+        }
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[dict[str, Any]] = None,
+        json_body: Optional[dict[str, Any]] = None,
+    ) -> dict[str, Any]:
+        url = path if path.startswith("http") else f"{self._base_url}/{path.lstrip('/')}"
+        token = self._token_provider()
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": GITHUB_API_VERSION,
+            "User-Agent": "Hermes-Agent-Code-Mode",
+        }
+        try:
+            response = self._http.request(
+                method.upper(),
+                url,
+                params=params,
+                json=json_body,
+                headers=headers,
+            )
+        except Exception as exc:
+            raise GitHubAPIError(f"GitHub request failed: {exc}") from exc
+
+        rate_limit = self._rate_limit(response.headers)
+        if response.status_code >= 400:
+            message = f"HTTP {response.status_code}"
+            try:
+                payload = response.json()
+                if isinstance(payload, dict):
+                    message = str(payload.get("message") or message)
+            except Exception:
+                message = getattr(response, "text", message) or message
+            raise GitHubAPIError(
+                message,
+                status_code=response.status_code,
+                rate_limit=rate_limit,
+                response=response,
+            )
+
+        if response.status_code == 204:
+            data: Any = None
+        else:
+            try:
+                data = response.json()
+            except Exception:
+                data = getattr(response, "text", "")
+        return {"data": data, "status_code": response.status_code, "rate_limit": rate_limit}
+
+    def list_paginated(
+        self,
+        path: str,
+        *,
+        params: Optional[dict[str, Any]] = None,
+        limit: int = 100,
+    ) -> list[Any]:
+        page = 1
+        per_page = min(100, max(1, int(limit)))
+        results: list[Any] = []
+        while len(results) < limit:
+            query = dict(params or {})
+            query["page"] = page
+            query["per_page"] = per_page
+            payload = self.request("GET", path, params=query)["data"]
+            if isinstance(payload, dict) and isinstance(payload.get("repositories"), list):
+                items = payload["repositories"]
+            elif isinstance(payload, list):
+                items = payload
+            else:
+                items = []
+            if not items:
+                break
+            for item in items:
+                if len(results) >= limit:
+                    break
+                results.append(item)
+            if len(items) < per_page:
+                break
+            page += 1
+        return results
+
+
+class GitHubIntegrationStore:
+    """Persistence layer over the main Hermes state.db."""
+
+    _WRITE_MAX_RETRIES = 5
+
+    def __init__(self, db_path: Optional[Path] = None) -> None:
+        self._db_path = db_path or (get_hermes_home() / "state.db")
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        # Ensure schema migrations (including GitHub tables) are applied
+        # through the canonical SessionDB path before direct sqlite access.
+        try:
+            from hermes_state import SessionDB
+
+            SessionDB(db_path=self._db_path).close()
+        except Exception:
+            pass
+        self._conn = sqlite3.connect(str(self._db_path), check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute("PRAGMA foreign_keys=ON")
+
+    def close(self) -> None:
+        try:
+            self._conn.close()
+        except Exception:
+            pass
+
+    def _execute_write(self, fn):
+        last_error = None
+        for _ in range(self._WRITE_MAX_RETRIES):
+            try:
+                self._conn.execute("BEGIN IMMEDIATE")
+                try:
+                    result = fn(self._conn)
+                    self._conn.commit()
+                    return result
+                except BaseException:
+                    self._conn.rollback()
+                    raise
+            except sqlite3.OperationalError as exc:
+                last_error = exc
+                if "locked" not in str(exc).lower():
+                    raise
+                time.sleep(0.05)
+        if last_error:
+            raise last_error
+
+    @staticmethod
+    def _row(row: Optional[sqlite3.Row]) -> Optional[dict[str, Any]]:
+        if not row:
+            return None
+        result = dict(row)
+        for key in ("permissions_json", "events_json", "labels_json", "assignees_json", "milestone_json"):
+            if key in result:
+                result[key.removesuffix("_json")] = _json_loads(
+                    result.pop(key),
+                    [] if key.endswith("s_json") else {},
+                )
+        for key in ("private", "archived", "disabled", "mergeable", "draft", "protected"):
+            if key in result and result[key] is not None:
+                result[key] = bool(result[key])
+        return result
+
+    def upsert_installation(self, installation: dict[str, Any]) -> dict[str, Any]:
+        now = time.time()
+        installation_id = int(installation["installation_id"])
+
+        def _do(conn):
+            conn.execute(
+                """
+                INSERT INTO github_app_installations
+                    (id, installation_id, account_login, account_type, app_id, permissions_json,
+                     events_json, status, created_at, updated_at, last_synced_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(installation_id) DO UPDATE SET
+                    account_login=excluded.account_login,
+                    account_type=excluded.account_type,
+                    app_id=excluded.app_id,
+                    permissions_json=excluded.permissions_json,
+                    events_json=excluded.events_json,
+                    status=excluded.status,
+                    updated_at=excluded.updated_at,
+                    last_synced_at=excluded.last_synced_at
+                """,
+                (
+                    str(uuid.uuid4()),
+                    installation_id,
+                    installation.get("account_login"),
+                    installation.get("account_type"),
+                    str(installation.get("app_id") or ""),
+                    _json_dumps(installation.get("permissions") or {}),
+                    _json_dumps(installation.get("events") or []),
+                    installation.get("status") or "active",
+                    now,
+                    now,
+                    now,
+                ),
+            )
+
+        self._execute_write(_do)
+        return self.get_installation(installation_id) or {}
+
+    def get_installation(self, installation_id: int) -> Optional[dict[str, Any]]:
+        row = self._conn.execute(
+            "SELECT * FROM github_app_installations WHERE installation_id = ?",
+            (int(installation_id),),
+        ).fetchone()
+        return self._row(row)
+
+    def list_installations(self, limit: int = 100) -> list[dict[str, Any]]:
+        rows = self._conn.execute(
+            "SELECT * FROM github_app_installations ORDER BY updated_at DESC LIMIT ?",
+            (int(limit),),
+        ).fetchall()
+        return [self._row(row) or {} for row in rows]
+
+    def upsert_repository(self, repo: dict[str, Any], *, installation_id: Optional[int] = None) -> dict[str, Any]:
+        now = time.time()
+        owner = repo.get("owner", {}).get("login") if isinstance(repo.get("owner"), dict) else repo.get("owner")
+        full_name = repo.get("full_name") or f"{owner}/{repo.get('name')}"
+        if "/" in str(full_name):
+            owner, name = str(full_name).split("/", 1)
+        else:
+            name = repo.get("name")
+
+        def _do(conn):
+            conn.execute(
+                """
+                INSERT INTO github_repositories
+                    (id, installation_id, github_repo_id, owner, name, full_name, default_branch, private,
+                     html_url, clone_url, ssh_url, archived, disabled, pushed_at, created_at, updated_at, last_synced_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(full_name) DO UPDATE SET
+                    installation_id=excluded.installation_id,
+                    github_repo_id=excluded.github_repo_id,
+                    owner=excluded.owner,
+                    name=excluded.name,
+                    default_branch=excluded.default_branch,
+                    private=excluded.private,
+                    html_url=excluded.html_url,
+                    clone_url=excluded.clone_url,
+                    ssh_url=excluded.ssh_url,
+                    archived=excluded.archived,
+                    disabled=excluded.disabled,
+                    pushed_at=excluded.pushed_at,
+                    updated_at=excluded.updated_at,
+                    last_synced_at=excluded.last_synced_at
+                """,
+                (
+                    str(uuid.uuid4()),
+                    installation_id,
+                    repo.get("id") or repo.get("github_repo_id"),
+                    owner,
+                    name,
+                    full_name,
+                    repo.get("default_branch"),
+                    int(bool(repo.get("private"))),
+                    repo.get("html_url"),
+                    repo.get("clone_url"),
+                    repo.get("ssh_url"),
+                    int(bool(repo.get("archived"))),
+                    int(bool(repo.get("disabled"))),
+                    repo.get("pushed_at"),
+                    now,
+                    now,
+                    now,
+                ),
+            )
+
+        self._execute_write(_do)
+        return self.get_repository(str(owner), str(name)) or {}
+
+    def list_repositories(
+        self,
+        *,
+        owner: Optional[str] = None,
+        q: Optional[str] = None,
+        installation_id: Optional[int] = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        clauses: list[str] = []
+        params: list[Any] = []
+        if owner:
+            clauses.append("owner = ?")
+            params.append(owner)
+        if q:
+            clauses.append("(full_name LIKE ? OR name LIKE ?)")
+            params.extend([f"%{q}%", f"%{q}%"])
+        if installation_id is not None:
+            clauses.append("installation_id = ?")
+            params.append(int(installation_id))
+        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        params.append(int(limit))
+        rows = self._conn.execute(
+            f"SELECT * FROM github_repositories {where} ORDER BY full_name ASC LIMIT ?",
+            tuple(params),
+        ).fetchall()
+        return [self._row(row) or {} for row in rows]
+
+    def get_repository(self, owner: str, repo: str) -> Optional[dict[str, Any]]:
+        row = self._conn.execute(
+            "SELECT * FROM github_repositories WHERE full_name = ?",
+            (f"{owner}/{repo}",),
+        ).fetchone()
+        return self._row(row)
+
+    def upsert_issue(self, repo_full_name: str, issue: dict[str, Any]) -> dict[str, Any]:
+        now = time.time()
+
+        def _do(conn):
+            conn.execute(
+                """
+                INSERT INTO github_issues
+                    (id, repo_full_name, github_issue_id, number, title, state, author_login, labels_json,
+                     assignees_json, milestone_json, html_url, created_at, updated_at, closed_at, last_synced_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(repo_full_name, number) DO UPDATE SET
+                    github_issue_id=excluded.github_issue_id,
+                    title=excluded.title,
+                    state=excluded.state,
+                    author_login=excluded.author_login,
+                    labels_json=excluded.labels_json,
+                    assignees_json=excluded.assignees_json,
+                    milestone_json=excluded.milestone_json,
+                    html_url=excluded.html_url,
+                    updated_at=excluded.updated_at,
+                    closed_at=excluded.closed_at,
+                    last_synced_at=excluded.last_synced_at
+                """,
+                (
+                    str(uuid.uuid4()),
+                    repo_full_name,
+                    issue.get("id") or issue.get("github_issue_id"),
+                    issue.get("number"),
+                    issue.get("title"),
+                    issue.get("state"),
+                    (issue.get("user") or {}).get("login") if isinstance(issue.get("user"), dict) else issue.get("author_login"),
+                    _json_dumps(issue.get("labels") or []),
+                    _json_dumps(issue.get("assignees") or []),
+                    _json_dumps(issue.get("milestone") or {}),
+                    issue.get("html_url"),
+                    issue.get("created_at") or now,
+                    issue.get("updated_at") or now,
+                    issue.get("closed_at"),
+                    now,
+                ),
+            )
+
+        self._execute_write(_do)
+        row = self._conn.execute(
+            "SELECT * FROM github_issues WHERE repo_full_name = ? AND number = ?",
+            (repo_full_name, issue.get("number")),
+        ).fetchone()
+        return self._row(row) or {}
+
+    def list_issues(self, repo_full_name: str, limit: int = 100) -> list[dict[str, Any]]:
+        rows = self._conn.execute(
+            "SELECT * FROM github_issues WHERE repo_full_name = ? ORDER BY updated_at DESC LIMIT ?",
+            (repo_full_name, int(limit)),
+        ).fetchall()
+        return [self._row(row) or {} for row in rows]
+
+    def upsert_pull_request(self, repo_full_name: str, pr: dict[str, Any]) -> dict[str, Any]:
+        now = time.time()
+
+        def _do(conn):
+            conn.execute(
+                """
+                INSERT INTO github_pull_requests
+                    (id, repo_full_name, github_pr_id, number, title, state, author_login, base_branch, head_branch,
+                     head_sha, mergeable, draft, html_url, created_at, updated_at, closed_at, merged_at, last_synced_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(repo_full_name, number) DO UPDATE SET
+                    github_pr_id=excluded.github_pr_id,
+                    title=excluded.title,
+                    state=excluded.state,
+                    author_login=excluded.author_login,
+                    base_branch=excluded.base_branch,
+                    head_branch=excluded.head_branch,
+                    head_sha=excluded.head_sha,
+                    mergeable=excluded.mergeable,
+                    draft=excluded.draft,
+                    html_url=excluded.html_url,
+                    updated_at=excluded.updated_at,
+                    closed_at=excluded.closed_at,
+                    merged_at=excluded.merged_at,
+                    last_synced_at=excluded.last_synced_at
+                """,
+                (
+                    str(uuid.uuid4()),
+                    repo_full_name,
+                    pr.get("id") or pr.get("github_pr_id"),
+                    pr.get("number"),
+                    pr.get("title"),
+                    pr.get("state"),
+                    (pr.get("user") or {}).get("login") if isinstance(pr.get("user"), dict) else pr.get("author_login"),
+                    (pr.get("base") or {}).get("ref") if isinstance(pr.get("base"), dict) else pr.get("base_branch"),
+                    (pr.get("head") or {}).get("ref") if isinstance(pr.get("head"), dict) else pr.get("head_branch"),
+                    (pr.get("head") or {}).get("sha") if isinstance(pr.get("head"), dict) else pr.get("head_sha"),
+                    None if pr.get("mergeable") is None else int(bool(pr.get("mergeable"))),
+                    int(bool(pr.get("draft"))),
+                    pr.get("html_url"),
+                    pr.get("created_at") or now,
+                    pr.get("updated_at") or now,
+                    pr.get("closed_at"),
+                    pr.get("merged_at"),
+                    now,
+                ),
+            )
+
+        self._execute_write(_do)
+        row = self._conn.execute(
+            "SELECT * FROM github_pull_requests WHERE repo_full_name = ? AND number = ?",
+            (repo_full_name, pr.get("number")),
+        ).fetchone()
+        return self._row(row) or {}
+
+    def list_pull_requests(self, repo_full_name: str, limit: int = 100) -> list[dict[str, Any]]:
+        rows = self._conn.execute(
+            "SELECT * FROM github_pull_requests WHERE repo_full_name = ? ORDER BY updated_at DESC LIMIT ?",
+            (repo_full_name, int(limit)),
+        ).fetchall()
+        return [self._row(row) or {} for row in rows]
+
+    def upsert_branch(self, repo_full_name: str, branch: dict[str, Any]) -> dict[str, Any]:
+        now = time.time()
+        sha = (branch.get("commit") or {}).get("sha") if isinstance(branch.get("commit"), dict) else branch.get("sha")
+
+        def _do(conn):
+            conn.execute(
+                """
+                INSERT INTO github_branches
+                    (id, repo_full_name, name, sha, protected, created_at, updated_at, last_synced_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(repo_full_name, name) DO UPDATE SET
+                    sha=excluded.sha,
+                    protected=excluded.protected,
+                    updated_at=excluded.updated_at,
+                    last_synced_at=excluded.last_synced_at
+                """,
+                (
+                    str(uuid.uuid4()),
+                    repo_full_name,
+                    branch.get("name"),
+                    sha,
+                    int(bool(branch.get("protected"))),
+                    now,
+                    now,
+                    now,
+                ),
+            )
+
+        self._execute_write(_do)
+        row = self._conn.execute(
+            "SELECT * FROM github_branches WHERE repo_full_name = ? AND name = ?",
+            (repo_full_name, branch.get("name")),
+        ).fetchone()
+        return self._row(row) or {}
+
+    def list_branches(self, repo_full_name: str, limit: int = 100) -> list[dict[str, Any]]:
+        rows = self._conn.execute(
+            "SELECT * FROM github_branches WHERE repo_full_name = ? ORDER BY name ASC LIMIT ?",
+            (repo_full_name, int(limit)),
+        ).fetchall()
+        return [self._row(row) or {} for row in rows]
+
+    def get_delivery(self, delivery_id: str) -> Optional[dict[str, Any]]:
+        row = self._conn.execute(
+            "SELECT * FROM github_webhook_deliveries WHERE delivery_id = ?",
+            (delivery_id,),
+        ).fetchone()
+        return self._row(row)
+
+    def record_webhook_delivery(
+        self,
+        *,
+        delivery_id: str,
+        event: str,
+        action: Optional[str],
+        repo_full_name: Optional[str],
+        sender_login: Optional[str],
+        payload_hash: str,
+        status: str,
+        error: Optional[str] = None,
+    ) -> dict[str, Any]:
+        now = time.time()
+
+        def _do(conn):
+            conn.execute(
+                """
+                INSERT INTO github_webhook_deliveries
+                    (id, delivery_id, event, action, repo_full_name, sender_login, payload_hash, status, error, received_at, processed_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(delivery_id) DO NOTHING
+                """,
+                (
+                    str(uuid.uuid4()),
+                    delivery_id,
+                    event,
+                    action,
+                    repo_full_name,
+                    sender_login,
+                    payload_hash,
+                    status,
+                    error,
+                    now,
+                    now if status not in {"received", "pending"} else None,
+                ),
+            )
+
+        self._execute_write(_do)
+        return self.get_delivery(delivery_id) or {}
+
+    def update_delivery_status(self, delivery_id: str, status: str, error: Optional[str] = None) -> None:
+        now = time.time()
+
+        def _do(conn):
+            conn.execute(
+                """
+                UPDATE github_webhook_deliveries
+                SET status = ?, error = ?, processed_at = ?
+                WHERE delivery_id = ?
+                """,
+                (status, error, now, delivery_id),
+            )
+
+        self._execute_write(_do)
+
+    def create_chatops_command(
+        self,
+        *,
+        delivery_id: Optional[str],
+        repo_full_name: str,
+        issue_number: Optional[int],
+        pr_number: Optional[int],
+        comment_id: Optional[int],
+        sender_login: Optional[str],
+        command: str,
+        args: str = "",
+        status: str = "pending",
+        orchestrated_run_id: Optional[str] = None,
+        code_session_id: Optional[str] = None,
+    ) -> dict[str, Any]:
+        now = time.time()
+        command_id = str(uuid.uuid4())
+
+        def _do(conn):
+            conn.execute(
+                """
+                INSERT INTO github_chatops_commands
+                    (id, delivery_id, repo_full_name, issue_number, pr_number, comment_id, sender_login,
+                     command, args, status, orchestrated_run_id, code_session_id, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    command_id,
+                    delivery_id,
+                    repo_full_name,
+                    issue_number,
+                    pr_number,
+                    comment_id,
+                    sender_login,
+                    command,
+                    args,
+                    status,
+                    orchestrated_run_id,
+                    code_session_id,
+                    now,
+                    now,
+                ),
+            )
+
+        self._execute_write(_do)
+        return self.get_chatops_command(command_id) or {}
+
+    def get_chatops_command(self, command_id: str) -> Optional[dict[str, Any]]:
+        row = self._conn.execute(
+            "SELECT * FROM github_chatops_commands WHERE id = ?",
+            (command_id,),
+        ).fetchone()
+        return self._row(row)
+
+    def update_chatops_command(self, command_id: str, **updates: Any) -> Optional[dict[str, Any]]:
+        allowed = {"status", "orchestrated_run_id", "code_session_id", "args"}
+        fields = {k: v for k, v in updates.items() if k in allowed}
+        if not fields:
+            return self.get_chatops_command(command_id)
+        fields["updated_at"] = time.time()
+        assignments = ", ".join(f"{name} = ?" for name in fields)
+        values = list(fields.values()) + [command_id]
+
+        def _do(conn):
+            conn.execute(
+                f"UPDATE github_chatops_commands SET {assignments} WHERE id = ?",
+                tuple(values),
+            )
+
+        self._execute_write(_do)
+        return self.get_chatops_command(command_id)
+
+    def list_chatops_commands(self, limit: int = 100) -> list[dict[str, Any]]:
+        rows = self._conn.execute(
+            "SELECT * FROM github_chatops_commands ORDER BY created_at DESC LIMIT ?",
+            (int(limit),),
+        ).fetchall()
+        return [self._row(row) or {} for row in rows]
+
+    def create_status_report(self, report: dict[str, Any]) -> dict[str, Any]:
+        now = time.time()
+        report_id = str(uuid.uuid4())
+
+        def _do(conn):
+            conn.execute(
+                """
+                INSERT INTO github_status_reports
+                    (id, repo_full_name, sha, context, status, conclusion, details_url, external_id, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    report_id,
+                    report.get("repo_full_name"),
+                    report.get("sha"),
+                    report.get("context"),
+                    report.get("status"),
+                    report.get("conclusion"),
+                    report.get("details_url"),
+                    report.get("external_id"),
+                    now,
+                    now,
+                ),
+            )
+
+        self._execute_write(_do)
+        row = self._conn.execute("SELECT * FROM github_status_reports WHERE id = ?", (report_id,)).fetchone()
+        return self._row(row) or {}
+
+
+class GitHubIntegrationService:
+    """High-level GitHub integration facade."""
+
+    _token_cache: dict[int, dict[str, Any]] = {}
+
+    def __init__(self, db_path: Optional[Path] = None, *, http_client: Optional[Any] = None) -> None:
+        self._db_path = db_path
+        self._http_client = http_client
+
+    def _store(self) -> GitHubIntegrationStore:
+        return GitHubIntegrationStore(db_path=self._db_path)
+
+    def config(self) -> GitHubAppConfig:
+        return GitHubAppConfig(
+            app_id=_env_value("HERMES_GITHUB_APP_ID").strip() or None,
+            private_key_path=_env_value("HERMES_GITHUB_APP_PRIVATE_KEY_PATH").strip() or None,
+            webhook_secret_configured=bool(_env_value("HERMES_GITHUB_WEBHOOK_SECRET").strip()),
+            dev_pat_configured=bool(_env_value("HERMES_GITHUB_DEV_PAT").strip()),
+            allow_dev_pat=_env_value("HERMES_GITHUB_ALLOW_DEV_PAT").strip() == "1",
+        )
+
+    def status(self) -> dict[str, Any]:
+        config = self.config()
+        store = self._store()
+        try:
+            installation_count = len(store.list_installations(limit=500))
+            repository_count = len(store.list_repositories(limit=1000))
+        finally:
+            store.close()
+        private_key_available = False
+        if config.private_key_path:
+            try:
+                private_key_available = Path(config.private_key_path).expanduser().is_file()
+            except Exception:
+                private_key_available = False
+        return {
+            "configured": config.mode != "unconfigured",
+            "mode": config.mode,
+            "app_id_configured": bool(config.app_id),
+            "private_key_configured": bool(config.private_key_path),
+            "private_key_available": private_key_available,
+            "webhook_secret_configured": config.webhook_secret_configured,
+            "pat_dev_configured": config.dev_pat_configured and config.allow_dev_pat,
+            "installations": installation_count,
+            "repositories": repository_count,
+        }
+
+    def _make_app_jwt(self) -> str:
+        config = self.config()
+        if not config.app_configured:
+            raise GitHubAPIError("GitHub App is not configured")
+        try:
+            import jwt
+        except Exception as exc:
+            raise GitHubAPIError("PyJWT is required for GitHub App authentication") from exc
+
+        key_path = Path(str(config.private_key_path)).expanduser()
+        try:
+            private_key = key_path.read_text(encoding="utf-8")
+        except Exception as exc:
+            raise GitHubAPIError(f"Unable to read GitHub private key: {exc}") from exc
+
+        now = int(time.time())
+        payload = {"iat": now - 60, "exp": now + 540, "iss": str(config.app_id)}
+        token = jwt.encode(payload, private_key, algorithm="RS256")
+        return token if isinstance(token, str) else token.decode("utf-8")
+
+    @staticmethod
+    def _parse_expiry(expires_at: str) -> datetime:
+        return datetime.fromisoformat(str(expires_at).replace("Z", "+00:00"))
+
+    def _request_installation_token(self, installation_id: int) -> dict[str, Any]:
+        client = GitHubAPIClient(self._make_app_jwt, http_client=self._http_client)
+        payload = client.request("POST", f"/app/installations/{int(installation_id)}/access_tokens")["data"]
+        data = payload if isinstance(payload, dict) else {}
+        return {"token": data.get("token"), "expires_at": data.get("expires_at")}
+
+    def get_installation_token(self, installation_id: int) -> str:
+        config = self.config()
+        if config.mode == "pat_dev":
+            pat = _env_value("HERMES_GITHUB_DEV_PAT").strip()
+            if not pat:
+                raise GitHubAPIError("GitHub PAT fallback is enabled but token is missing")
+            return pat
+
+        cached = self._token_cache.get(int(installation_id))
+        if cached:
+            expires_at_dt = cached.get("expires_at_dt")
+            if isinstance(expires_at_dt, datetime) and expires_at_dt > datetime.now(timezone.utc) + timedelta(seconds=60):
+                return str(cached["token"])
+
+        token_data = self._request_installation_token(int(installation_id))
+        token = token_data.get("token")
+        expires_at = token_data.get("expires_at")
+        if not token or not expires_at:
+            raise GitHubAPIError("GitHub installation token response is incomplete")
+        self._token_cache[int(installation_id)] = {
+            "token": token,
+            "expires_at": expires_at,
+            "expires_at_dt": self._parse_expiry(str(expires_at)),
+        }
+        return str(token)
+
+    def api_client(self, installation_id: Optional[int] = None) -> GitHubAPIClient:
+        config = self.config()
+        if config.mode == "pat_dev":
+            return GitHubAPIClient(lambda: _env_value("HERMES_GITHUB_DEV_PAT").strip(), http_client=self._http_client)
+
+        if installation_id is None:
+            store = self._store()
+            try:
+                installations = store.list_installations(limit=1)
+            finally:
+                store.close()
+            if not installations:
+                raise GitHubAPIError("No GitHub installation is registered")
+            installation_id = int(installations[0]["installation_id"])
+
+        return GitHubAPIClient(
+            lambda: self.get_installation_token(int(installation_id)),
+            http_client=self._http_client,
+        )
+
+    def post_issue_comment(
+        self,
+        *,
+        repo_full_name: str,
+        issue_number: int,
+        body: str,
+        installation_id: Optional[int] = None,
+    ) -> dict[str, Any]:
+        result = self.api_client(installation_id).request(
+            "POST",
+            f"/repos/{repo_full_name}/issues/{int(issue_number)}/comments",
+            json_body={"body": body},
+        )
+        return result["data"] if isinstance(result["data"], dict) else {"result": result["data"]}
+
+    def prepare_pull_request(self, metadata: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "id": str(uuid.uuid4()),
+            "prepared_at": _utc_now_iso(),
+            "repo_full_name": metadata.get("repo_full_name"),
+            "title": metadata.get("title"),
+            "head": metadata.get("head"),
+            "base": metadata.get("base") or "main",
+            "body": metadata.get("body") or "",
+            "auto_push": False,
+            "auto_merge": False,
+        }

--- a/hermes_cli/code/github_sync.py
+++ b/hermes_cli/code/github_sync.py
@@ -6,8 +6,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Optional
 
+from hermes_cli.code.event_bus import get_code_event_bus
 from hermes_cli.code.github_integration import GitHubIntegrationService, GitHubIntegrationStore
-from hermes_state import SessionDB
 
 
 class GitHubSyncService:
@@ -29,19 +29,14 @@ class GitHubSyncService:
         return GitHubIntegrationService(db_path=self._db_path).api_client(installation_id)
 
     def _emit(self, event_type: str, payload: dict[str, Any]) -> None:
-        db = SessionDB(db_path=self._db_path) if self._db_path else SessionDB()
-        try:
-            db.append_code_event(
-                event_type=event_type,
-                payload={
-                    "type": event_type,
-                    "version": 1,
-                    "payload": payload,
-                },
-                source="github_sync",
-            )
-        finally:
-            db.close()
+        bus = get_code_event_bus(self._db_path)
+        bus.publish(
+            event_type,
+            payload=payload,
+            github_repo_full_name=(payload or {}).get("repo_full_name"),
+            metadata={"source": "github_sync"},
+            source="github_sync",
+        )
 
     def sync_repositories(
         self,

--- a/hermes_cli/code/github_sync.py
+++ b/hermes_cli/code/github_sync.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""GitHub metadata sync service for Hermes Code Mode (P1)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Optional
+
+from hermes_cli.code.github_integration import GitHubIntegrationService, GitHubIntegrationStore
+from hermes_state import SessionDB
+
+
+class GitHubSyncService:
+    def __init__(
+        self,
+        db_path: Optional[Path] = None,
+        *,
+        api_client: Optional[Any] = None,
+    ) -> None:
+        self._db_path = db_path
+        self._api_client = api_client
+
+    def _store(self) -> GitHubIntegrationStore:
+        return GitHubIntegrationStore(db_path=self._db_path)
+
+    def _client(self, installation_id: Optional[int] = None):
+        if self._api_client is not None:
+            return self._api_client
+        return GitHubIntegrationService(db_path=self._db_path).api_client(installation_id)
+
+    def _emit(self, event_type: str, payload: dict[str, Any]) -> None:
+        db = SessionDB(db_path=self._db_path) if self._db_path else SessionDB()
+        try:
+            db.append_code_event(
+                event_type=event_type,
+                payload={
+                    "type": event_type,
+                    "version": 1,
+                    "payload": payload,
+                },
+                source="github_sync",
+            )
+        finally:
+            db.close()
+
+    def sync_repositories(
+        self,
+        *,
+        installation_id: Optional[int] = None,
+        dry_run: bool = False,
+        limit: int = 100,
+    ) -> dict[str, Any]:
+        client = self._client(installation_id)
+        repositories = client.list_paginated("/installation/repositories", limit=limit)
+
+        if dry_run:
+            return {"dry_run": True, "synced": 0, "repositories": repositories}
+
+        store = self._store()
+        try:
+            synced = [store.upsert_repository(repo, installation_id=installation_id) for repo in repositories]
+        finally:
+            store.close()
+        self._emit(
+            "github.repository.synced",
+            {"installation_id": installation_id, "synced": len(synced)},
+        )
+        return {"dry_run": False, "synced": len(synced), "repositories": synced}
+
+    def sync_issues(self, repo_full_name: str, *, limit: int = 100) -> dict[str, Any]:
+        client = self._client()
+        issues = client.list_paginated(
+            f"/repos/{repo_full_name}/issues",
+            params={"state": "all"},
+            limit=limit,
+        )
+        issues = [issue for issue in issues if not issue.get("pull_request")]
+        store = self._store()
+        try:
+            synced = [store.upsert_issue(repo_full_name, issue) for issue in issues]
+        finally:
+            store.close()
+        self._emit("github.issue.synced", {"repo_full_name": repo_full_name, "synced": len(synced)})
+        return {"repo_full_name": repo_full_name, "synced": len(synced), "issues": synced}
+
+    def sync_pull_requests(self, repo_full_name: str, *, limit: int = 100) -> dict[str, Any]:
+        client = self._client()
+        pulls = client.list_paginated(
+            f"/repos/{repo_full_name}/pulls",
+            params={"state": "all"},
+            limit=limit,
+        )
+        store = self._store()
+        try:
+            synced = [store.upsert_pull_request(repo_full_name, pr) for pr in pulls]
+        finally:
+            store.close()
+        self._emit("github.pull_request.synced", {"repo_full_name": repo_full_name, "synced": len(synced)})
+        return {"repo_full_name": repo_full_name, "synced": len(synced), "pull_requests": synced}
+
+    def sync_branches(self, repo_full_name: str, *, limit: int = 100) -> dict[str, Any]:
+        client = self._client()
+        branches = client.list_paginated(f"/repos/{repo_full_name}/branches", limit=limit)
+        store = self._store()
+        try:
+            synced = [store.upsert_branch(repo_full_name, branch) for branch in branches]
+        finally:
+            store.close()
+        return {"repo_full_name": repo_full_name, "synced": len(synced), "branches": synced}
+
+    def sync_repository_details(self, repo_full_name: str, *, limit: int = 100) -> dict[str, Any]:
+        return {
+            "repo_full_name": repo_full_name,
+            "issues": self.sync_issues(repo_full_name, limit=limit),
+            "pull_requests": self.sync_pull_requests(repo_full_name, limit=limit),
+            "branches": self.sync_branches(repo_full_name, limit=limit),
+        }

--- a/hermes_cli/code/github_webhooks.py
+++ b/hermes_cli/code/github_webhooks.py
@@ -9,9 +9,9 @@ import json
 from pathlib import Path
 from typing import Any, Optional
 
+from hermes_cli.code.event_bus import get_code_event_bus
 from hermes_cli.code.github_chatops import GitHubChatOpsService
 from hermes_cli.code.github_integration import GitHubIntegrationStore, _env_value, redact_github_secrets
-from hermes_state import SessionDB
 
 SUPPORTED_EVENTS = frozenset(
     {
@@ -83,15 +83,14 @@ class GitHubWebhookService:
         return GitHubIntegrationStore(db_path=self._db_path)
 
     def _emit(self, event_type: str, payload: dict[str, Any]) -> None:
-        db = SessionDB(db_path=self._db_path) if self._db_path else SessionDB()
-        try:
-            db.append_code_event(
-                event_type=event_type,
-                payload={"type": event_type, "version": 1, "payload": payload},
-                source="github_webhook",
-            )
-        finally:
-            db.close()
+        bus = get_code_event_bus(self._db_path)
+        bus.publish(
+            event_type,
+            payload=payload,
+            github_repo_full_name=(payload or {}).get("repo_full_name"),
+            metadata={"source": "github_webhook"},
+            source="github_webhook",
+        )
 
     def process(
         self,

--- a/hermes_cli/code/github_webhooks.py
+++ b/hermes_cli/code/github_webhooks.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""GitHub webhook verification and normalization for Hermes Code Mode."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from pathlib import Path
+from typing import Any, Optional
+
+from hermes_cli.code.github_chatops import GitHubChatOpsService
+from hermes_cli.code.github_integration import GitHubIntegrationStore, _env_value, redact_github_secrets
+from hermes_state import SessionDB
+
+SUPPORTED_EVENTS = frozenset(
+    {
+        "installation",
+        "installation_repositories",
+        "issues",
+        "issue_comment",
+        "pull_request",
+        "pull_request_review",
+        "pull_request_review_comment",
+        "check_suite",
+        "check_run",
+        "push",
+    }
+)
+
+
+class WebhookSignatureError(ValueError):
+    """Raised when a GitHub webhook signature is missing or invalid."""
+
+
+def verify_signature(secret: str, body: bytes, signature: Optional[str]) -> bool:
+    if not secret:
+        raise WebhookSignatureError("GitHub webhook secret is not configured")
+    if not signature or not signature.startswith("sha256="):
+        raise WebhookSignatureError("Missing GitHub webhook signature")
+    expected = "sha256=" + hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(expected, signature):
+        raise WebhookSignatureError("Invalid GitHub webhook signature")
+    return True
+
+
+def _payload_hash(body: bytes) -> str:
+    return hashlib.sha256(body).hexdigest()
+
+
+def _normalize(event: str, payload: dict[str, Any]) -> dict[str, Any]:
+    repo = payload.get("repository") if isinstance(payload.get("repository"), dict) else {}
+    sender = payload.get("sender") if isinstance(payload.get("sender"), dict) else {}
+    issue = payload.get("issue") if isinstance(payload.get("issue"), dict) else {}
+    pull_request = payload.get("pull_request") if isinstance(payload.get("pull_request"), dict) else {}
+    comment = payload.get("comment") if isinstance(payload.get("comment"), dict) else {}
+    review = payload.get("review") if isinstance(payload.get("review"), dict) else {}
+
+    repo_full_name = repo.get("full_name")
+    issue_number = issue.get("number")
+    pr_number = pull_request.get("number")
+    if event in {"issue_comment", "issues"} and issue.get("pull_request"):
+        pr_number = issue_number
+
+    return {
+        "event": event,
+        "action": payload.get("action"),
+        "repo_full_name": repo_full_name,
+        "sender_login": sender.get("login"),
+        "issue_number": issue_number,
+        "pr_number": pr_number,
+        "comment_id": comment.get("id"),
+        "comment_body": comment.get("body") or "",
+        "review_id": review.get("id"),
+    }
+
+
+class GitHubWebhookService:
+    def __init__(self, db_path: Optional[Path] = None) -> None:
+        self._db_path = db_path
+
+    def _store(self) -> GitHubIntegrationStore:
+        return GitHubIntegrationStore(db_path=self._db_path)
+
+    def _emit(self, event_type: str, payload: dict[str, Any]) -> None:
+        db = SessionDB(db_path=self._db_path) if self._db_path else SessionDB()
+        try:
+            db.append_code_event(
+                event_type=event_type,
+                payload={"type": event_type, "version": 1, "payload": payload},
+                source="github_webhook",
+            )
+        finally:
+            db.close()
+
+    def process(
+        self,
+        *,
+        delivery_id: str,
+        event: str,
+        body: bytes,
+        signature: Optional[str],
+    ) -> dict[str, Any]:
+        verify_signature(_env_value("HERMES_GITHUB_WEBHOOK_SECRET").strip(), body, signature)
+        payload_sha = _payload_hash(body)
+
+        store = self._store()
+        try:
+            existing = store.get_delivery(delivery_id)
+            if existing:
+                return {
+                    "accepted": True,
+                    "duplicate": True,
+                    "status": existing.get("status"),
+                    "delivery": existing,
+                    "chatops_commands": [],
+                }
+
+            try:
+                payload = json.loads(body.decode("utf-8"))
+            except json.JSONDecodeError as exc:
+                store.record_webhook_delivery(
+                    delivery_id=delivery_id,
+                    event=event,
+                    action=None,
+                    repo_full_name=None,
+                    sender_login=None,
+                    payload_hash=payload_sha,
+                    status="error",
+                    error="Invalid JSON payload",
+                )
+                raise ValueError("Invalid GitHub webhook JSON") from exc
+
+            normalized = _normalize(event, payload if isinstance(payload, dict) else {})
+            if event not in SUPPORTED_EVENTS:
+                delivery = store.record_webhook_delivery(
+                    delivery_id=delivery_id,
+                    event=event,
+                    action=normalized.get("action"),
+                    repo_full_name=normalized.get("repo_full_name"),
+                    sender_login=normalized.get("sender_login"),
+                    payload_hash=payload_sha,
+                    status="ignored",
+                )
+                self._emit(
+                    "github.webhook.received",
+                    {"delivery_id": delivery_id, "event": event, "status": "ignored"},
+                )
+                return {
+                    "accepted": True,
+                    "duplicate": False,
+                    "status": "ignored",
+                    "delivery": delivery,
+                    "normalized": normalized,
+                    "chatops_commands": [],
+                }
+
+            delivery = store.record_webhook_delivery(
+                delivery_id=delivery_id,
+                event=event,
+                action=normalized.get("action"),
+                repo_full_name=normalized.get("repo_full_name"),
+                sender_login=normalized.get("sender_login"),
+                payload_hash=payload_sha,
+                status="processed",
+            )
+        finally:
+            store.close()
+
+        chatops_commands: list[dict[str, Any]] = []
+        if event in {"issue_comment", "pull_request_review_comment"} and normalized.get("comment_body"):
+            chatops_commands = GitHubChatOpsService(db_path=self._db_path).create_commands_from_comment(
+                delivery_id=delivery_id,
+                repo_full_name=str(normalized.get("repo_full_name") or ""),
+                issue_number=normalized.get("issue_number"),
+                pr_number=normalized.get("pr_number"),
+                comment_id=normalized.get("comment_id"),
+                sender_login=normalized.get("sender_login"),
+                body=str(normalized.get("comment_body") or ""),
+            )
+
+        self._emit(
+            "github.webhook.received",
+            {
+                "delivery_id": delivery_id,
+                "event": event,
+                "duplicate": False,
+                "repo_full_name": normalized.get("repo_full_name"),
+            },
+        )
+        self._emit(
+            "github.webhook.processed",
+            {
+                "delivery_id": delivery_id,
+                "event": event,
+                "status": "processed",
+                "chatops_commands": [item.get("id") for item in chatops_commands],
+            },
+        )
+        if chatops_commands:
+            self._emit("github.chatops.detected", {"commands": chatops_commands})
+
+        return {
+            "accepted": True,
+            "duplicate": False,
+            "status": "processed",
+            "delivery": delivery,
+            "normalized": normalized,
+            "chatops_commands": chatops_commands,
+        }
+
+    @staticmethod
+    def safe_error(exc: Exception) -> str:
+        return redact_github_secrets(str(exc))

--- a/hermes_cli/code/repo_knowledge.py
+++ b/hermes_cli/code/repo_knowledge.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Repository guidance discovery with AGENTS.md support."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+AGENTS_MD_FILENAME = "AGENTS.md"
+GUIDANCE_DIRS = ("docs/architecture", "docs/engineering", "docs/operations")
+MAX_CONTENT_BYTES = 64 * 1024
+
+
+def _file_info(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        stat = path.stat()
+        return {
+            "path": str(path),
+            "name": path.name,
+            "size_bytes": stat.st_size,
+            "readable": True,
+        }
+    except Exception:
+        return None
+
+
+def detect_repo_guidance(repo_root: Path) -> dict[str, Any]:
+    manifest: dict[str, Any] = {
+        "repo_root": str(repo_root),
+        "agents_md": _file_info(repo_root / AGENTS_MD_FILENAME),
+        "guidance_docs": [],
+    }
+    for rel in GUIDANCE_DIRS:
+        directory = repo_root / rel
+        if not directory.is_dir():
+            continue
+        for doc in sorted(directory.glob("*.md")):
+            info = _file_info(doc)
+            if info:
+                manifest["guidance_docs"].append(info)
+    return manifest
+
+
+def read_agents_md(repo_root: Path) -> str | None:
+    agents_path = repo_root / AGENTS_MD_FILENAME
+    if not agents_path.is_file():
+        return None
+    try:
+        content = agents_path.read_text(encoding="utf-8", errors="replace")
+        return content[:MAX_CONTENT_BYTES]
+    except Exception:
+        return None
+
+
+def bootstrap_agents_md(repo_root: Path, project_summary: str | None = None) -> dict[str, Any]:
+    agents_path = repo_root / AGENTS_MD_FILENAME
+    if agents_path.exists():
+        return {
+            "created": False,
+            "path": str(agents_path),
+            "reason": "AGENTS.md already exists",
+        }
+    if not repo_root.is_dir():
+        return {
+            "created": False,
+            "path": str(agents_path),
+            "reason": f"Repo root does not exist: {repo_root}",
+        }
+    summary = project_summary or "Add project-specific engineering guidance here."
+    content = (
+        "# AGENTS.md\n\n"
+        "## Project summary\n"
+        f"{summary}\n\n"
+        "## Engineering Guidance\n"
+        "- Keep changes scoped and testable.\n"
+        "- Prefer existing patterns over new abstractions.\n"
+        "- Document non-obvious decisions in docs/engineering when needed.\n"
+    )
+    try:
+        agents_path.write_text(content, encoding="utf-8")
+        return {"created": True, "path": str(agents_path), "reason": "Created AGENTS.md"}
+    except Exception as exc:
+        return {"created": False, "path": str(agents_path), "reason": str(exc)}
+
+
+class RepoKnowledgeService:
+    def detect(self, workspace_path: Path) -> dict[str, Any]:
+        return detect_repo_guidance(workspace_path)
+
+    def read_agents_md(self, workspace_path: Path) -> str | None:
+        return read_agents_md(workspace_path)
+
+    def bootstrap(self, workspace_path: Path, project_summary: str | None = None) -> dict[str, Any]:
+        return bootstrap_agents_md(workspace_path, project_summary=project_summary)

--- a/hermes_cli/code/skill_discovery.py
+++ b/hermes_cli/code/skill_discovery.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Code Mode skill discovery bridge for built-in and SKILL.md folder skills."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from agent.skill_commands import scan_skill_commands
+
+SKILL_MD_FILENAME = "SKILL.md"
+_MAX_SKILL_MD_BYTES = 32 * 1024
+
+
+def _parse_skill_md(skill_md_path: Path) -> dict[str, Any]:
+    try:
+        content = skill_md_path.read_text(encoding="utf-8", errors="replace")
+    except Exception:
+        return {}
+    if len(content.encode("utf-8", errors="ignore")) > _MAX_SKILL_MD_BYTES:
+        content = content[:_MAX_SKILL_MD_BYTES]
+    title = None
+    description = None
+    lines = content.splitlines()
+    for line in lines:
+        stripped = line.strip()
+        if not title and stripped.startswith("# "):
+            title = stripped.removeprefix("# ").strip()
+        if not description and stripped and not stripped.startswith("#"):
+            description = stripped[:160]
+        if title and description:
+            break
+    return {"title": title, "description": description}
+
+
+def _discover_skills_in_dir(skills_dir: Path, source: str) -> list[dict[str, Any]]:
+    if not skills_dir.is_dir():
+        return []
+    discovered: list[dict[str, Any]] = []
+    for child in sorted(skills_dir.iterdir()):
+        if not child.is_dir():
+            continue
+        skill_md = child / SKILL_MD_FILENAME
+        if not skill_md.is_file():
+            continue
+        meta = _parse_skill_md(skill_md)
+        discovered.append(
+            {
+                "name": child.name,
+                "title": meta.get("title") or child.name,
+                "description": meta.get("description") or "",
+                "source": source,
+                "skill_md_path": str(skill_md),
+                "skill_dir": str(child),
+                "has_scripts": (child / "scripts").is_dir(),
+                "has_resources": (child / "resources").is_dir(),
+                "builtin": False,
+            }
+        )
+    return discovered
+
+
+def discover_global_skills() -> list[dict[str, Any]]:
+    from tools.skills_tool import SKILLS_DIR
+    skills = _discover_skills_in_dir(SKILLS_DIR, "global")
+    try:
+        from agent.skill_utils import get_external_skills_dirs
+
+        for directory in get_external_skills_dirs():
+            skills.extend(_discover_skills_in_dir(directory, f"external:{directory.name}"))
+    except Exception:
+        pass
+    return skills
+
+
+def discover_workspace_skills(workspace_path: Path) -> list[dict[str, Any]]:
+    return _discover_skills_in_dir(workspace_path / ".hermes" / "skills", f"workspace:{workspace_path.name}")
+
+
+def discover_builtin_skills() -> list[dict[str, Any]]:
+    skills = []
+    for command, info in scan_skill_commands().items():
+        name = command.lstrip("/")
+        skills.append(
+            {
+                "name": name,
+                "title": info.get("name") or name,
+                "description": info.get("description") or "",
+                "source": "builtin_bridge",
+                "skill_md_path": info.get("skill_md_path"),
+                "skill_dir": info.get("skill_dir"),
+                "has_scripts": bool(info.get("skill_dir") and Path(info["skill_dir"]).joinpath("scripts").is_dir()),
+                "has_resources": bool(info.get("skill_dir") and Path(info["skill_dir"]).joinpath("resources").is_dir()),
+                "builtin": True,
+            }
+        )
+    return skills
+
+
+class SkillDiscoveryService:
+    def list_skills(self, workspace_path: Path | None = None) -> list[dict[str, Any]]:
+        merged: dict[str, dict[str, Any]] = {}
+        for skill in discover_builtin_skills():
+            merged[skill["name"]] = skill
+        for skill in discover_global_skills():
+            merged[skill["name"]] = skill
+        if workspace_path:
+            for skill in discover_workspace_skills(workspace_path):
+                merged[skill["name"]] = skill
+        return sorted(merged.values(), key=lambda s: s["name"])

--- a/hermes_cli/code/worktree_service.py
+++ b/hermes_cli/code/worktree_service.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Safe git capability and worktree foundation for Code Mode."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+from hermes_state import SessionDB
+
+
+def _run_git(path: Path, args: list[str], timeout: int = 10) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(path),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def _parse_worktree_list(output: str) -> list[dict[str, Any]]:
+    worktrees: list[dict[str, Any]] = []
+    current: dict[str, Any] = {}
+    for raw_line in output.splitlines():
+        line = raw_line.strip()
+        if not line:
+            if current:
+                worktrees.append(current)
+                current = {}
+            continue
+        if line.startswith("worktree "):
+            current["path"] = line.removeprefix("worktree ")
+        elif line.startswith("HEAD "):
+            current["head"] = line.removeprefix("HEAD ")
+        elif line.startswith("branch "):
+            current["branch"] = line.removeprefix("branch ")
+        elif line == "detached":
+            current["detached"] = True
+        elif line == "bare":
+            current["bare"] = True
+    if current:
+        worktrees.append(current)
+    return worktrees
+
+
+class WorktreeService:
+    def __init__(self, db_path=None):
+        self._db_path = db_path
+
+    def _db(self) -> SessionDB:
+        return SessionDB(db_path=self._db_path) if self._db_path else SessionDB()
+
+    @staticmethod
+    def detect_git_capabilities(path: Path) -> dict[str, Any]:
+        if not path.exists():
+            return {
+                "path": str(path),
+                "is_git_repo": False,
+                "supports_worktree": False,
+                "current_branch": None,
+                "is_dirty": False,
+                "has_commits": False,
+                "toplevel": None,
+            }
+
+        try:
+            is_repo = _run_git(path, ["rev-parse", "--is-inside-work-tree"]).stdout.strip() == "true"
+        except Exception:
+            is_repo = False
+        if not is_repo:
+            return {
+                "path": str(path),
+                "is_git_repo": False,
+                "supports_worktree": False,
+                "current_branch": None,
+                "is_dirty": False,
+                "has_commits": False,
+                "toplevel": None,
+            }
+
+        toplevel = None
+        try:
+            r = _run_git(path, ["rev-parse", "--show-toplevel"])
+            if r.returncode == 0:
+                toplevel = r.stdout.strip()
+        except Exception:
+            pass
+        current_branch = None
+        try:
+            r = _run_git(path, ["branch", "--show-current"])
+            if r.returncode == 0:
+                current_branch = r.stdout.strip() or None
+        except Exception:
+            pass
+        has_commits = False
+        try:
+            has_commits = _run_git(path, ["rev-parse", "--verify", "HEAD"]).returncode == 0
+        except Exception:
+            pass
+        is_dirty = False
+        if has_commits:
+            try:
+                is_dirty = bool(_run_git(path, ["status", "--porcelain"]).stdout.strip())
+            except Exception:
+                pass
+        supports_worktree = False
+        try:
+            supports_worktree = _run_git(path, ["worktree", "list", "--porcelain"]).returncode == 0
+        except Exception:
+            pass
+        return {
+            "path": str(path),
+            "is_git_repo": True,
+            "supports_worktree": supports_worktree,
+            "current_branch": current_branch,
+            "is_dirty": is_dirty,
+            "has_commits": has_commits,
+            "toplevel": toplevel,
+        }
+
+    def _workspace_path(self, workspace_id: str) -> Path:
+        db = self._db()
+        try:
+            workspace = db.get_code_workspace(workspace_id)
+        finally:
+            db.close()
+        if not workspace or not workspace.get("path"):
+            raise ValueError(f"Workspace not found or path missing: {workspace_id}")
+        return Path(workspace["path"])
+
+    def detect_capabilities_for_workspace(self, workspace_id: str) -> dict[str, Any]:
+        try:
+            return self.detect_git_capabilities(self._workspace_path(workspace_id))
+        except Exception:
+            return {
+                "path": None,
+                "is_git_repo": False,
+                "supports_worktree": False,
+                "current_branch": None,
+                "is_dirty": False,
+                "has_commits": False,
+                "toplevel": None,
+            }
+
+    def list_worktrees_for_workspace(self, workspace_id: str) -> list[dict[str, Any]]:
+        try:
+            path = self._workspace_path(workspace_id)
+        except Exception:
+            return []
+        caps = self.detect_git_capabilities(path)
+        if not caps["is_git_repo"] or not caps["supports_worktree"]:
+            return []
+        try:
+            result = _run_git(path, ["worktree", "list", "--porcelain"])
+            if result.returncode != 0:
+                return []
+            return _parse_worktree_list(result.stdout)
+        except Exception:
+            return []
+
+    def create_checkpoint_metadata(
+        self,
+        workspace_id: str,
+        *,
+        name: str | None = None,
+    ) -> dict[str, Any]:
+        path = self._workspace_path(workspace_id)
+        caps = self.detect_git_capabilities(path)
+        head_sha = None
+        if caps["is_git_repo"] and caps["has_commits"]:
+            try:
+                result = _run_git(path, ["rev-parse", "HEAD"])
+                if result.returncode == 0:
+                    head_sha = result.stdout.strip()
+            except Exception:
+                pass
+
+        checkpoint = {
+            "id": str(uuid.uuid4()),
+            "workspace_id": workspace_id,
+            "name": name or "checkpoint",
+            "git_branch": caps.get("current_branch"),
+            "git_commit": head_sha,
+            "dirty": bool(caps.get("is_dirty")),
+            "metadata": {"capabilities": caps},
+            "created_at": time.time(),
+        }
+        db = self._db()
+        try:
+            db.create_code_checkpoint(checkpoint)
+        finally:
+            db.close()
+        return checkpoint

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -165,6 +165,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                "Code Mode", cli_only=True),
     CommandDef("skills-code", "Show Code Mode skill integration status",
                "Code Mode", cli_only=True, aliases=("skillscode",)),
+    CommandDef("github", "Show GitHub integration status, repositories, or trigger sync",
+               "Code Mode", cli_only=True, args_hint="[status|repos|sync [--dry-run]]"),
 
     # Info
     CommandDef("commands", "Browse all commands and skills (paginated)", "Info",

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -152,6 +152,20 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("plugins", "List installed plugins and their status",
                "Tools & Skills", cli_only=True),
 
+    # Code Mode
+    CommandDef("code", "Show Hermes Code Mode status and local workspace context",
+               "Code Mode", cli_only=True),
+    CommandDef("web", "Show Hermes Web dashboard and Code Cockpit launch hints",
+               "Code Mode", cli_only=True),
+    CommandDef("workspace", "Show Code Mode workspace metadata",
+               "Code Mode", cli_only=True, args_hint="[owner|search]"),
+    CommandDef("session", "Show Code Mode session metadata",
+               "Code Mode", cli_only=True, args_hint="[workspace_id]"),
+    CommandDef("approvals", "Show Code Mode approval status and deferred policy scope",
+               "Code Mode", cli_only=True),
+    CommandDef("skills-code", "Show Code Mode skill integration status",
+               "Code Mode", cli_only=True, aliases=("skillscode",)),
+
     # Info
     CommandDef("commands", "Browse all commands and skills (paginated)", "Info",
                gateway_only=True, args_hint="[page]"),

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1659,6 +1659,45 @@ OPTIONAL_ENV_VARS = {
         "password": True,
         "category": "tool",
     },
+    "HERMES_GITHUB_APP_ID": {
+        "description": "GitHub App ID for Code Mode P1 integration",
+        "prompt": "Hermes GitHub App ID",
+        "url": "https://github.com/settings/apps",
+        "password": False,
+        "category": "tool",
+        "advanced": True,
+    },
+    "HERMES_GITHUB_APP_PRIVATE_KEY_PATH": {
+        "description": "Filesystem path to GitHub App private key PEM",
+        "prompt": "GitHub App private key path",
+        "url": "https://github.com/settings/apps",
+        "password": False,
+        "category": "tool",
+        "advanced": True,
+    },
+    "HERMES_GITHUB_WEBHOOK_SECRET": {
+        "description": "Webhook HMAC secret for /api/code/github/webhooks",
+        "prompt": "GitHub webhook secret",
+        "url": "https://github.com/settings/apps",
+        "password": True,
+        "category": "tool",
+        "advanced": True,
+    },
+    "HERMES_GITHUB_DEV_PAT": {
+        "description": "Local development PAT fallback (disabled unless explicitly allowed)",
+        "prompt": "Hermes GitHub dev PAT",
+        "url": "https://github.com/settings/tokens",
+        "password": True,
+        "category": "tool",
+        "advanced": True,
+    },
+    "HERMES_GITHUB_ALLOW_DEV_PAT": {
+        "description": "Set to 1 to allow HERMES_GITHUB_DEV_PAT fallback in local development",
+        "prompt": "Allow GitHub dev PAT fallback (1/0)",
+        "password": False,
+        "category": "tool",
+        "advanced": True,
+    },
 
     # ── Bundled skills (opt-in: only needed if the user uses that skill) ──
     # These use category="skill" (distinct from "tool") so the sandbox

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -22,6 +22,7 @@ import threading
 import time
 import urllib.parse
 import urllib.request
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -436,6 +437,41 @@ class EnvVarReveal(BaseModel):
     key: str
 
 
+class CodeArtifactCreate(BaseModel):
+    artifact_type: str
+    content: str
+    title: str | None = None
+    content_type: str = "markdown"
+    workspace_id: str | None = None
+    code_session_id: str | None = None
+    orchestrated_run_id: str | None = None
+    command_id: str | None = None
+    metadata: dict[str, Any] = {}
+
+
+class OrchestratorRunCreate(BaseModel):
+    title: str | None = None
+    goal: str | None = None
+    workspace_id: str | None = None
+    code_session_id: str | None = None
+    metadata: dict[str, Any] = {}
+    create_intake_artifact: bool = True
+
+
+class OrchestratorTransitionRequest(BaseModel):
+    to_state: str
+    reason: str | None = None
+    metadata: dict[str, Any] = {}
+
+
+class PolicyAssessCommandRequest(BaseModel):
+    command: str
+
+
+class RepoKnowledgeBootstrapRequest(BaseModel):
+    project_summary: str | None = None
+
+
 _GATEWAY_HEALTH_URL = os.getenv("GATEWAY_HEALTH_URL")
 try:
     _GATEWAY_HEALTH_TIMEOUT = float(os.getenv("GATEWAY_HEALTH_TIMEOUT", "3"))
@@ -605,6 +641,62 @@ def _code_offset(value: int) -> int:
     return max(0, value)
 
 
+def _make_code_event(
+    event_type: str,
+    *,
+    payload: dict[str, Any] | None = None,
+    workspace_id: str | None = None,
+    code_session_id: str | None = None,
+) -> dict[str, Any]:
+    event = {
+        "type": event_type,
+        "version": 1,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "payload": payload or {},
+    }
+    if workspace_id:
+        event["workspace_id"] = workspace_id
+    if code_session_id:
+        event["code_session_id"] = code_session_id
+    return event
+
+
+def _record_code_event(
+    event_type: str,
+    *,
+    payload: dict[str, Any] | None = None,
+    workspace_id: str | None = None,
+    code_session_id: str | None = None,
+    level: str = "info",
+    source: str = "control_plane",
+) -> dict[str, Any]:
+    event = _make_code_event(
+        event_type,
+        payload=payload,
+        workspace_id=workspace_id,
+        code_session_id=code_session_id,
+    )
+    try:
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            event_id = db.append_code_event(
+                event_type=event_type,
+                payload=event,
+                workspace_id=workspace_id,
+                code_session_id=code_session_id,
+                source=source,
+                level=level,
+            )
+            event["id"] = event_id
+        finally:
+            db.close()
+    except Exception:
+        _log.exception("Failed to persist code event %s", event_type)
+    return event
+
+
 @app.get("/api/code/status")
 async def get_code_status():
     """Read-only Code Mode readiness endpoint.
@@ -705,6 +797,311 @@ async def get_code_events(
     except Exception:
         _log.exception("GET /api/code/events failed")
         raise HTTPException(status_code=500, detail="Code Mode events unavailable")
+
+
+@app.get("/api/code/artifacts")
+async def get_code_artifacts(
+    workspace_id: str | None = None,
+    code_session_id: str | None = None,
+    orchestrated_run_id: str | None = None,
+    artifact_type: str | None = None,
+    limit: int = 100,
+    offset: int = 0,
+):
+    try:
+        from hermes_cli.code.artifact_ledger import ArtifactLedger
+
+        ledger = ArtifactLedger()
+        artifacts = ledger.list_artifacts(
+            workspace_id=workspace_id,
+            code_session_id=code_session_id,
+            orchestrated_run_id=orchestrated_run_id,
+            artifact_type=artifact_type,
+            limit=_code_limit(limit, default=100, maximum=500),
+            offset=_code_offset(offset),
+        )
+        return {
+            "artifacts": artifacts,
+            "limit": _code_limit(limit, default=100, maximum=500),
+            "offset": _code_offset(offset),
+        }
+    except Exception:
+        _log.exception("GET /api/code/artifacts failed")
+        raise HTTPException(status_code=500, detail="Code artifacts unavailable")
+
+
+@app.post("/api/code/artifacts")
+async def create_code_artifact(payload: CodeArtifactCreate):
+    try:
+        from hermes_cli.code.artifact_ledger import ArtifactLedger
+
+        ledger = ArtifactLedger()
+        artifact = ledger.create_artifact(
+            payload.artifact_type,
+            payload.content,
+            title=payload.title,
+            content_type=payload.content_type,
+            workspace_id=payload.workspace_id,
+            code_session_id=payload.code_session_id,
+            orchestrated_run_id=payload.orchestrated_run_id,
+            command_id=payload.command_id,
+            metadata=payload.metadata or {},
+        )
+        event = _record_code_event(
+            "artifact.created",
+            payload={"artifact_id": artifact["id"], "artifact_type": artifact["artifact_type"]},
+            workspace_id=artifact.get("workspace_id"),
+            code_session_id=artifact.get("code_session_id"),
+        )
+        return {"ok": True, "artifact": artifact, "event": event}
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    except Exception:
+        _log.exception("POST /api/code/artifacts failed")
+        raise HTTPException(status_code=500, detail="Failed to create artifact")
+
+
+@app.get("/api/code/sessions/{code_session_id}/artifacts")
+async def get_code_session_artifacts(code_session_id: str, limit: int = 100, offset: int = 0):
+    try:
+        from hermes_cli.code.artifact_ledger import ArtifactLedger
+
+        ledger = ArtifactLedger()
+        artifacts = ledger.list_session_artifacts(
+            code_session_id=code_session_id,
+            limit=_code_limit(limit, default=100, maximum=500),
+            offset=_code_offset(offset),
+        )
+        return {
+            "code_session_id": code_session_id,
+            "artifacts": artifacts,
+            "limit": _code_limit(limit, default=100, maximum=500),
+            "offset": _code_offset(offset),
+        }
+    except Exception:
+        _log.exception("GET /api/code/sessions/%s/artifacts failed", code_session_id)
+        raise HTTPException(status_code=500, detail="Code session artifacts unavailable")
+
+
+@app.get("/api/code/orchestrator/runs")
+async def get_orchestrator_runs(
+    workspace_id: str | None = None,
+    code_session_id: str | None = None,
+    state: str | None = None,
+    limit: int = 50,
+    offset: int = 0,
+):
+    try:
+        from hermes_cli.code.agent_orchestrator import AgentOrchestrator
+
+        orchestrator = AgentOrchestrator()
+        runs = orchestrator.list_runs(
+            workspace_id=workspace_id,
+            code_session_id=code_session_id,
+            state=state,
+            limit=_code_limit(limit),
+            offset=_code_offset(offset),
+        )
+        return {"runs": runs, "limit": _code_limit(limit), "offset": _code_offset(offset)}
+    except Exception:
+        _log.exception("GET /api/code/orchestrator/runs failed")
+        raise HTTPException(status_code=500, detail="Orchestrator runs unavailable")
+
+
+@app.post("/api/code/orchestrator/runs")
+async def create_orchestrator_run(payload: OrchestratorRunCreate):
+    try:
+        from hermes_cli.code.agent_orchestrator import AgentOrchestrator
+
+        orchestrator = AgentOrchestrator()
+        run = orchestrator.create_run(
+            title=payload.title,
+            goal=payload.goal,
+            workspace_id=payload.workspace_id,
+            code_session_id=payload.code_session_id,
+            metadata=payload.metadata or {},
+            create_intake_artifact=payload.create_intake_artifact,
+        )
+        event = _record_code_event(
+            "orchestrator.run.created",
+            payload={"run_id": run["id"], "state": run["state"]},
+            workspace_id=run.get("workspace_id"),
+            code_session_id=run.get("code_session_id"),
+        )
+        return {"ok": True, "run": run, "event": event}
+    except Exception:
+        _log.exception("POST /api/code/orchestrator/runs failed")
+        raise HTTPException(status_code=500, detail="Failed to create orchestrator run")
+
+
+@app.get("/api/code/orchestrator/runs/{run_id}")
+async def get_orchestrator_run(run_id: str):
+    try:
+        from hermes_cli.code.agent_orchestrator import AgentOrchestrator
+
+        orchestrator = AgentOrchestrator()
+        run = orchestrator.get_run(run_id)
+        if not run:
+            raise HTTPException(status_code=404, detail=f"Run not found: {run_id}")
+        transitions = orchestrator.list_transitions(run_id)
+        return {"run": run, "transitions": transitions}
+    except HTTPException:
+        raise
+    except Exception:
+        _log.exception("GET /api/code/orchestrator/runs/%s failed", run_id)
+        raise HTTPException(status_code=500, detail="Orchestrator run unavailable")
+
+
+@app.post("/api/code/orchestrator/runs/{run_id}/transition")
+async def transition_orchestrator_run(run_id: str, payload: OrchestratorTransitionRequest):
+    try:
+        from hermes_cli.code.agent_orchestrator import AgentOrchestrator
+
+        orchestrator = AgentOrchestrator()
+        run = orchestrator.transition_run(
+            run_id,
+            payload.to_state,
+            reason=payload.reason,
+            metadata=payload.metadata or {},
+        )
+        event = _record_code_event(
+            "orchestrator.run.transitioned",
+            payload={
+                "run_id": run_id,
+                "to_state": payload.to_state,
+                "reason": payload.reason,
+            },
+            workspace_id=run.get("workspace_id"),
+            code_session_id=run.get("code_session_id"),
+        )
+        return {"ok": True, "run": run, "event": event}
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    except Exception:
+        _log.exception("POST /api/code/orchestrator/runs/%s/transition failed", run_id)
+        raise HTTPException(status_code=500, detail="Failed to transition orchestrator run")
+
+
+@app.post("/api/code/policy/assess-command")
+async def assess_code_command_policy(payload: PolicyAssessCommandRequest):
+    try:
+        from hermes_cli.code.execution_policy import policy_engine
+
+        assessment = policy_engine.assess_command(payload.command)
+        return {"assessment": assessment}
+    except Exception:
+        _log.exception("POST /api/code/policy/assess-command failed")
+        raise HTTPException(status_code=500, detail="Execution policy unavailable")
+
+
+@app.get("/api/code/workspaces/{workspace_id}/git/capabilities")
+async def get_workspace_git_capabilities(workspace_id: str):
+    try:
+        from hermes_cli.code.worktree_service import WorktreeService
+
+        service = WorktreeService()
+        caps = service.detect_capabilities_for_workspace(workspace_id)
+        return {"workspace_id": workspace_id, "capabilities": caps}
+    except Exception:
+        _log.exception("GET /api/code/workspaces/%s/git/capabilities failed", workspace_id)
+        raise HTTPException(status_code=500, detail="Git capability detection unavailable")
+
+
+@app.get("/api/code/workspaces/{workspace_id}/git/worktrees")
+async def get_workspace_git_worktrees(workspace_id: str):
+    try:
+        from hermes_cli.code.worktree_service import WorktreeService
+
+        service = WorktreeService()
+        worktrees = service.list_worktrees_for_workspace(workspace_id)
+        return {"workspace_id": workspace_id, "worktrees": worktrees}
+    except Exception:
+        _log.exception("GET /api/code/workspaces/%s/git/worktrees failed", workspace_id)
+        raise HTTPException(status_code=500, detail="Worktree listing unavailable")
+
+
+@app.get("/api/code/skills/discovered")
+async def get_code_discovered_skills(workspace_id: str | None = None):
+    try:
+        from hermes_cli.code.skill_discovery import SkillDiscoveryService
+        from hermes_state import SessionDB
+
+        workspace_path = None
+        if workspace_id:
+            db = SessionDB()
+            try:
+                workspace = db.get_code_workspace(workspace_id)
+            finally:
+                db.close()
+            if workspace and workspace.get("path"):
+                workspace_path = Path(workspace["path"])
+
+        service = SkillDiscoveryService()
+        skills = service.list_skills(workspace_path=workspace_path)
+        return {"skills": skills, "workspace_id": workspace_id}
+    except Exception:
+        _log.exception("GET /api/code/skills/discovered failed")
+        raise HTTPException(status_code=500, detail="Code skill discovery unavailable")
+
+
+@app.get("/api/code/workspaces/{workspace_id}/repo-knowledge")
+async def get_workspace_repo_knowledge(workspace_id: str):
+    try:
+        from hermes_cli.code.repo_knowledge import RepoKnowledgeService
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            workspace = db.get_code_workspace(workspace_id)
+        finally:
+            db.close()
+        if not workspace or not workspace.get("path"):
+            raise HTTPException(status_code=404, detail=f"Workspace not found: {workspace_id}")
+
+        service = RepoKnowledgeService()
+        root = Path(workspace["path"])
+        manifest = service.detect(root)
+        agents_md = service.read_agents_md(root)
+        return {
+            "workspace_id": workspace_id,
+            "manifest": manifest,
+            "agents_md_excerpt": agents_md,
+        }
+    except HTTPException:
+        raise
+    except Exception:
+        _log.exception("GET /api/code/workspaces/%s/repo-knowledge failed", workspace_id)
+        raise HTTPException(status_code=500, detail="Repo knowledge unavailable")
+
+
+@app.post("/api/code/workspaces/{workspace_id}/repo-knowledge/bootstrap")
+async def bootstrap_workspace_repo_knowledge(workspace_id: str, payload: RepoKnowledgeBootstrapRequest):
+    try:
+        from hermes_cli.code.repo_knowledge import RepoKnowledgeService
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            workspace = db.get_code_workspace(workspace_id)
+        finally:
+            db.close()
+        if not workspace or not workspace.get("path"):
+            raise HTTPException(status_code=404, detail=f"Workspace not found: {workspace_id}")
+
+        service = RepoKnowledgeService()
+        root = Path(workspace["path"])
+        result = service.bootstrap(root, project_summary=payload.project_summary)
+        event = _record_code_event(
+            "repo_knowledge.bootstrap",
+            payload={"workspace_id": workspace_id, "created": bool(result.get("created"))},
+            workspace_id=workspace_id,
+        )
+        return {"ok": True, "result": result, "event": event}
+    except HTTPException:
+        raise
+    except Exception:
+        _log.exception("POST /api/code/workspaces/%s/repo-knowledge/bootstrap failed", workspace_id)
+        raise HTTPException(status_code=500, detail="Repo knowledge bootstrap unavailable")
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -484,7 +484,7 @@ class GitHubCommentBody(BaseModel):
     issue_number: int | None = None
     pr_number: int | None = None
     body: str
-    approved: bool = False
+    approval_id: str | None = None
     installation_id: int | None = None
 
 
@@ -494,6 +494,33 @@ class GitHubPreparePullRequestBody(BaseModel):
     head: str
     base: str = "main"
     body: str = ""
+    approval_id: str | None = None
+
+
+class CodeApprovalCreateBody(BaseModel):
+    kind: str
+    risk_class: str
+    title: str
+    description: str | None = None
+    requested_action: str
+    requested_payload: dict[str, Any] = {}
+    resource_type: str | None = None
+    resource_id: str | None = None
+    workspace_id: str | None = None
+    code_session_id: str | None = None
+    orchestrated_run_id: str | None = None
+    artifact_id: str | None = None
+    github_repo_full_name: str | None = None
+    github_issue_number: int | None = None
+    github_pr_number: int | None = None
+    requested_by: str | None = None
+    expires_at: float | None = None
+    metadata: dict[str, Any] = {}
+
+
+class CodeApprovalDecisionBody(BaseModel):
+    actor: str | None = None
+    reason: str | None = None
 
 
 _GATEWAY_HEALTH_URL = os.getenv("GATEWAY_HEALTH_URL")
@@ -1018,6 +1045,175 @@ async def assess_code_command_policy(payload: PolicyAssessCommandRequest):
         raise HTTPException(status_code=500, detail="Execution policy unavailable")
 
 
+@app.get("/api/code/approvals")
+async def get_code_approvals(
+    status: str | None = None,
+    kind: str | None = None,
+    risk_class: str | None = None,
+    workspace_id: str | None = None,
+    code_session_id: str | None = None,
+    orchestrated_run_id: str | None = None,
+    github_repo_full_name: str | None = None,
+    limit: int = 100,
+    offset: int = 0,
+):
+    try:
+        from hermes_cli.code.approval_governance import ApprovalGovernanceService
+
+        service = ApprovalGovernanceService()
+        approvals = service.list_requests(
+            status=status,
+            kind=kind,
+            risk_class=risk_class,
+            workspace_id=workspace_id,
+            code_session_id=code_session_id,
+            orchestrated_run_id=orchestrated_run_id,
+            github_repo_full_name=github_repo_full_name,
+            limit=_code_limit(limit, default=100, maximum=500),
+            offset=_code_offset(offset),
+        )
+        return {
+            "approvals": approvals,
+            "limit": _code_limit(limit, default=100, maximum=500),
+            "offset": _code_offset(offset),
+        }
+    except Exception:
+        _log.exception("GET /api/code/approvals failed")
+        raise HTTPException(status_code=500, detail="Code approvals unavailable")
+
+
+@app.post("/api/code/approvals")
+async def create_code_approval(payload: CodeApprovalCreateBody):
+    try:
+        from hermes_cli.code.approval_governance import ApprovalGovernanceError, ApprovalGovernanceService
+
+        service = ApprovalGovernanceService()
+        approval = service.create_request(
+            kind=payload.kind,
+            risk_class=payload.risk_class,
+            title=payload.title,
+            description=payload.description,
+            requested_action=payload.requested_action,
+            requested_payload=payload.requested_payload or {},
+            resource_type=payload.resource_type,
+            resource_id=payload.resource_id,
+            workspace_id=payload.workspace_id,
+            code_session_id=payload.code_session_id,
+            orchestrated_run_id=payload.orchestrated_run_id,
+            artifact_id=payload.artifact_id,
+            github_repo_full_name=payload.github_repo_full_name,
+            github_issue_number=payload.github_issue_number,
+            github_pr_number=payload.github_pr_number,
+            requested_by=payload.requested_by,
+            expires_at=payload.expires_at,
+            metadata=payload.metadata or {},
+        )
+        return {"approval": approval}
+    except ApprovalGovernanceError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    except Exception:
+        _log.exception("POST /api/code/approvals failed")
+        raise HTTPException(status_code=500, detail="Failed to create code approval")
+
+
+@app.get("/api/code/approvals/summary")
+async def get_code_approval_summary(
+    workspace_id: str | None = None,
+    code_session_id: str | None = None,
+    orchestrated_run_id: str | None = None,
+    github_repo_full_name: str | None = None,
+):
+    try:
+        from hermes_cli.code.approval_governance import ApprovalGovernanceService
+
+        service = ApprovalGovernanceService()
+        summary = service.summary(
+            workspace_id=workspace_id,
+            code_session_id=code_session_id,
+            orchestrated_run_id=orchestrated_run_id,
+            github_repo_full_name=github_repo_full_name,
+        )
+        return {"summary": summary}
+    except Exception:
+        _log.exception("GET /api/code/approvals/summary failed")
+        raise HTTPException(status_code=500, detail="Approval summary unavailable")
+
+
+@app.post("/api/code/approvals/expire")
+async def expire_code_approvals(limit: int = 500):
+    try:
+        from hermes_cli.code.approval_governance import ApprovalGovernanceService
+
+        service = ApprovalGovernanceService()
+        expired = service.expire_pending(limit=max(1, min(int(limit), 2000)))
+        return {"expired": expired.get("expired", []), "count": int(expired.get("count", 0))}
+    except Exception:
+        _log.exception("POST /api/code/approvals/expire failed")
+        raise HTTPException(status_code=500, detail="Failed to expire approvals")
+
+
+@app.get("/api/code/approvals/{approval_id}")
+async def get_code_approval(approval_id: str):
+    try:
+        from hermes_cli.code.approval_governance import ApprovalGovernanceService
+
+        service = ApprovalGovernanceService()
+        approval = service.get_request(approval_id)
+        if not approval:
+            raise HTTPException(status_code=404, detail=f"Approval not found: {approval_id}")
+        return {"approval": approval}
+    except HTTPException:
+        raise
+    except Exception:
+        _log.exception("GET /api/code/approvals/%s failed", approval_id)
+        raise HTTPException(status_code=500, detail="Code approval unavailable")
+
+
+@app.post("/api/code/approvals/{approval_id}/approve")
+async def approve_code_approval(approval_id: str, payload: CodeApprovalDecisionBody):
+    try:
+        from hermes_cli.code.approval_governance import ApprovalGovernanceError, ApprovalGovernanceService
+
+        service = ApprovalGovernanceService()
+        approval = service.approve_request(approval_id, approved_by=payload.actor)
+        return {"approval": approval}
+    except ApprovalGovernanceError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    except Exception:
+        _log.exception("POST /api/code/approvals/%s/approve failed", approval_id)
+        raise HTTPException(status_code=500, detail="Failed to approve request")
+
+
+@app.post("/api/code/approvals/{approval_id}/reject")
+async def reject_code_approval(approval_id: str, payload: CodeApprovalDecisionBody):
+    try:
+        from hermes_cli.code.approval_governance import ApprovalGovernanceError, ApprovalGovernanceService
+
+        service = ApprovalGovernanceService()
+        approval = service.reject_request(approval_id, rejected_by=payload.actor, reason=payload.reason)
+        return {"approval": approval}
+    except ApprovalGovernanceError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    except Exception:
+        _log.exception("POST /api/code/approvals/%s/reject failed", approval_id)
+        raise HTTPException(status_code=500, detail="Failed to reject request")
+
+
+@app.post("/api/code/approvals/{approval_id}/cancel")
+async def cancel_code_approval(approval_id: str, payload: CodeApprovalDecisionBody):
+    try:
+        from hermes_cli.code.approval_governance import ApprovalGovernanceError, ApprovalGovernanceService
+
+        service = ApprovalGovernanceService()
+        approval = service.cancel_request(approval_id, cancelled_by=payload.actor, reason=payload.reason)
+        return {"approval": approval}
+    except ApprovalGovernanceError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    except Exception:
+        _log.exception("POST /api/code/approvals/%s/cancel failed", approval_id)
+        raise HTTPException(status_code=500, detail="Failed to cancel request")
+
+
 @app.get("/api/code/workspaces/{workspace_id}/git/capabilities")
 async def get_workspace_git_capabilities(workspace_id: str):
     try:
@@ -1293,6 +1489,11 @@ async def github_chatops_run(command_id: str):
 
 @app.post("/api/code/github/comments")
 async def github_comments(body: GitHubCommentBody):
+    from hermes_cli.code.approval_governance import (
+        ApprovalGovernanceError,
+        ApprovalGovernanceService,
+        ApprovalKind,
+    )
     from hermes_cli.code.execution_policy import policy_engine
     from hermes_cli.code.github_integration import GitHubAPIError, GitHubIntegrationService, redact_github_secrets
 
@@ -1302,13 +1503,46 @@ async def github_comments(body: GitHubCommentBody):
     if not body.body.strip():
         raise HTTPException(status_code=400, detail="comment body must not be empty")
 
-    assessment = policy_engine.assess_command("curl https://api.github.com/repos/x/issues/y/comments")
-    if assessment.get("requires_approval") and not body.approved:
+    assessment = policy_engine.assess_github_write("github.comment.post")
+    service = ApprovalGovernanceService()
+    expected_payload = {
+        "repo_full_name": body.repo_full_name,
+        "issue_number": int(target_number),
+        "body": body.body,
+    }
+    resource_type = "github_issue_or_pr"
+    resource_id = f"{body.repo_full_name}#{int(target_number)}"
+
+    if not body.approval_id:
+        approval = service.create_request(
+            kind=ApprovalKind.GITHUB_COMMENT,
+            risk_class=str(assessment.get("risk_class")),
+            title=f"GitHub comment write: {body.repo_full_name}#{int(target_number)}",
+            description="Posting a GitHub comment requires explicit approval.",
+            requested_action="github.comment.post",
+            requested_payload=expected_payload,
+            resource_type=resource_type,
+            resource_id=resource_id,
+            github_repo_full_name=body.repo_full_name,
+            github_issue_number=int(target_number),
+            metadata={"risk_tags": assessment.get("risk_tags", [])},
+        )
+        _record_code_event(
+            "github.write.approval_required",
+            payload={
+                "approval_id": approval.get("id"),
+                "kind": ApprovalKind.GITHUB_COMMENT,
+                "repo_full_name": body.repo_full_name,
+                "issue_number": int(target_number),
+            },
+            source="github",
+        )
         return {
-            "approval_required": True,
-            "approved": False,
-            "risk_class": assessment.get("risk_class"),
-            "message": "GitHub comment write requires explicit approval.",
+            "requires_approval": True,
+            "approval_id": approval.get("id"),
+            "status": approval.get("status"),
+            "risk_class": approval.get("risk_class"),
+            "message": "GitHub comment write requires approval before execution.",
             "prepared": {
                 "repo_full_name": body.repo_full_name,
                 "issue_number": int(target_number),
@@ -1317,39 +1551,238 @@ async def github_comments(body: GitHubCommentBody):
         }
 
     try:
+        validated = service.validate_for_execution(
+            body.approval_id,
+            expected_kind=ApprovalKind.GITHUB_COMMENT,
+            expected_requested_action="github.comment.post",
+            expected_resource_type=resource_type,
+            expected_resource_id=resource_id,
+            expected_github_repo_full_name=body.repo_full_name,
+            expected_github_issue_number=int(target_number),
+            expected_requested_payload=expected_payload,
+        )
+    except ApprovalGovernanceError as exc:
+        _record_code_event(
+            "github.write.rejected",
+            payload={
+                "approval_id": body.approval_id,
+                "kind": ApprovalKind.GITHUB_COMMENT,
+                "repo_full_name": body.repo_full_name,
+                "issue_number": int(target_number),
+                "error": str(exc),
+            },
+            source="github",
+            level="warning",
+        )
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    try:
         comment = GitHubIntegrationService().post_issue_comment(
             repo_full_name=body.repo_full_name,
             issue_number=int(target_number),
             body=body.body,
             installation_id=body.installation_id,
         )
+        service.mark_executed(
+            body.approval_id,
+            metadata={"github_comment_id": (comment or {}).get("id")},
+        )
     except GitHubAPIError as exc:
+        try:
+            service.mark_failed(body.approval_id, reason=exc.message)
+        except Exception:
+            pass
+        _record_code_event(
+            "github.write.failed",
+            payload={
+                "approval_id": body.approval_id,
+                "kind": ApprovalKind.GITHUB_COMMENT,
+                "repo_full_name": body.repo_full_name,
+                "issue_number": int(target_number),
+                "error": exc.message,
+            },
+            source="github",
+            level="error",
+        )
         raise HTTPException(status_code=400, detail=exc.message)
     except Exception:
+        try:
+            service.mark_failed(body.approval_id, reason="GitHub comment request failed")
+        except Exception:
+            pass
+        _record_code_event(
+            "github.write.failed",
+            payload={
+                "approval_id": body.approval_id,
+                "kind": ApprovalKind.GITHUB_COMMENT,
+                "repo_full_name": body.repo_full_name,
+                "issue_number": int(target_number),
+                "error": "GitHub comment request failed",
+            },
+            source="github",
+            level="error",
+        )
         _log.exception("POST /api/code/github/comments failed")
         raise HTTPException(status_code=500, detail="GitHub comment request failed")
 
+    _record_code_event(
+        "github.write.executed",
+        payload={
+            "approval_id": body.approval_id,
+            "kind": ApprovalKind.GITHUB_COMMENT,
+            "repo_full_name": body.repo_full_name,
+            "issue_number": int(target_number),
+        },
+        source="github",
+    )
     _record_code_event(
         "github.comment.posted",
         payload={"repo_full_name": body.repo_full_name, "issue_number": int(target_number)},
         source="github",
     )
-    return {"approval_required": False, "approved": True, "comment": comment}
+    return {
+        "requires_approval": False,
+        "approval_id": body.approval_id,
+        "status": "executed",
+        "approved": True,
+        "approval": validated,
+        "comment": comment,
+    }
 
 
 @app.post("/api/code/github/pull-requests/prepare")
 async def github_pull_request_prepare(body: GitHubPreparePullRequestBody):
+    from hermes_cli.code.approval_governance import (
+        ApprovalGovernanceError,
+        ApprovalGovernanceService,
+        ApprovalKind,
+    )
     from hermes_cli.code.artifact_ledger import ArtifactLedger
+    from hermes_cli.code.execution_policy import policy_engine
     from hermes_cli.code.github_integration import GitHubIntegrationService
 
-    prepared = GitHubIntegrationService().prepare_pull_request(body.model_dump())
-    artifact = ArtifactLedger().create_artifact(
-        "implementation_plan",
-        json.dumps(prepared, indent=2),
-        title=f"Prepared GitHub PR: {body.title}",
-        metadata={"source": "github_pull_request_prepare", "repo_full_name": body.repo_full_name},
+    assessment = policy_engine.assess_github_write("github.pull_request.prepare")
+    service = ApprovalGovernanceService()
+    expected_payload = {
+        "repo_full_name": body.repo_full_name,
+        "title": body.title,
+        "head": body.head,
+        "base": body.base,
+        "body": body.body,
+    }
+    resource_type = "github_repo"
+    resource_id = body.repo_full_name
+
+    if not body.approval_id:
+        approval = service.create_request(
+            kind=ApprovalKind.GITHUB_PR_PREPARE,
+            risk_class=str(assessment.get("risk_class")),
+            title=f"Prepare GitHub PR metadata: {body.repo_full_name}",
+            description="Preparing/storing PR metadata requires approval.",
+            requested_action="github.pull_request.prepare",
+            requested_payload=expected_payload,
+            resource_type=resource_type,
+            resource_id=resource_id,
+            github_repo_full_name=body.repo_full_name,
+            metadata={"risk_tags": assessment.get("risk_tags", [])},
+        )
+        _record_code_event(
+            "github.write.approval_required",
+            payload={
+                "approval_id": approval.get("id"),
+                "kind": ApprovalKind.GITHUB_PR_PREPARE,
+                "repo_full_name": body.repo_full_name,
+            },
+            source="github",
+        )
+        return {
+            "requires_approval": True,
+            "approval_id": approval.get("id"),
+            "status": approval.get("status"),
+            "risk_class": approval.get("risk_class"),
+            "prepared": {
+                "repo_full_name": body.repo_full_name,
+                "title": body.title,
+                "head": body.head,
+                "base": body.base,
+                "body": body.body,
+                "auto_push": False,
+                "auto_merge": False,
+            },
+        }
+
+    try:
+        validated = service.validate_for_execution(
+            body.approval_id,
+            expected_kind=ApprovalKind.GITHUB_PR_PREPARE,
+            expected_requested_action="github.pull_request.prepare",
+            expected_resource_type=resource_type,
+            expected_resource_id=resource_id,
+            expected_github_repo_full_name=body.repo_full_name,
+            expected_requested_payload=expected_payload,
+        )
+    except ApprovalGovernanceError as exc:
+        _record_code_event(
+            "github.write.rejected",
+            payload={
+                "approval_id": body.approval_id,
+                "kind": ApprovalKind.GITHUB_PR_PREPARE,
+                "repo_full_name": body.repo_full_name,
+                "error": str(exc),
+            },
+            source="github",
+            level="warning",
+        )
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    try:
+        prepared = GitHubIntegrationService().prepare_pull_request(body.model_dump())
+        artifact = ArtifactLedger().create_artifact(
+            "implementation_plan",
+            json.dumps(prepared, indent=2),
+            title=f"Prepared GitHub PR: {body.title}",
+            metadata={"source": "github_pull_request_prepare", "repo_full_name": body.repo_full_name},
+        )
+        service.mark_executed(
+            body.approval_id,
+            metadata={"artifact_id": artifact.get("id"), "prepared_pr_id": prepared.get("id")},
+        )
+    except Exception:
+        try:
+            service.mark_failed(body.approval_id, reason="GitHub pull request prepare failed")
+        except Exception:
+            pass
+        _record_code_event(
+            "github.write.failed",
+            payload={
+                "approval_id": body.approval_id,
+                "kind": ApprovalKind.GITHUB_PR_PREPARE,
+                "repo_full_name": body.repo_full_name,
+                "error": "GitHub pull request prepare failed",
+            },
+            source="github",
+            level="error",
+        )
+        _log.exception("POST /api/code/github/pull-requests/prepare failed")
+        raise HTTPException(status_code=500, detail="GitHub pull request prepare failed")
+
+    _record_code_event(
+        "github.write.executed",
+        payload={
+            "approval_id": body.approval_id,
+            "kind": ApprovalKind.GITHUB_PR_PREPARE,
+            "repo_full_name": body.repo_full_name,
+        },
+        source="github",
     )
-    return {"prepared": prepared, "artifact": artifact}
+    return {
+        "requires_approval": False,
+        "approval_id": body.approval_id,
+        "status": "executed",
+        "approval": validated,
+        "prepared": prepared,
+        "artifact": artifact,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -102,6 +102,7 @@ app.add_middleware(
 _PUBLIC_API_PATHS: frozenset = frozenset({
     "/api/status",
     "/api/code/status",
+    "/api/code/github/webhooks",
     "/api/config/defaults",
     "/api/config/schema",
     "/api/model/info",
@@ -470,6 +471,29 @@ class PolicyAssessCommandRequest(BaseModel):
 
 class RepoKnowledgeBootstrapRequest(BaseModel):
     project_summary: str | None = None
+
+
+class GitHubSyncBody(BaseModel):
+    installation_id: int | None = None
+    dry_run: bool = False
+    limit: int = 100
+
+
+class GitHubCommentBody(BaseModel):
+    repo_full_name: str
+    issue_number: int | None = None
+    pr_number: int | None = None
+    body: str
+    approved: bool = False
+    installation_id: int | None = None
+
+
+class GitHubPreparePullRequestBody(BaseModel):
+    repo_full_name: str
+    title: str
+    head: str
+    base: str = "main"
+    body: str = ""
 
 
 _GATEWAY_HEALTH_URL = os.getenv("GATEWAY_HEALTH_URL")
@@ -1102,6 +1126,230 @@ async def bootstrap_workspace_repo_knowledge(workspace_id: str, payload: RepoKno
     except Exception:
         _log.exception("POST /api/code/workspaces/%s/repo-knowledge/bootstrap failed", workspace_id)
         raise HTTPException(status_code=500, detail="Repo knowledge bootstrap unavailable")
+
+
+@app.get("/api/code/github/status")
+async def github_status():
+    from hermes_cli.code.github_integration import GitHubIntegrationService
+
+    try:
+        status = GitHubIntegrationService().status()
+        _record_code_event(
+            "github.integration.configured" if status.get("configured") else "github.error",
+            payload={"status": status},
+            source="github",
+        )
+        return {"status": status}
+    except Exception:
+        _log.exception("GET /api/code/github/status failed")
+        raise HTTPException(status_code=500, detail="GitHub integration unavailable")
+
+
+@app.get("/api/code/github/installations")
+async def github_installations(limit: int = 100):
+    from hermes_cli.code.github_integration import GitHubIntegrationStore
+
+    store = GitHubIntegrationStore()
+    try:
+        items = store.list_installations(limit=_code_limit(limit, default=100, maximum=1000))
+        return {"installations": items, "total": len(items)}
+    finally:
+        store.close()
+
+
+@app.get("/api/code/github/repositories")
+async def github_repositories(
+    owner: str | None = None,
+    q: str | None = None,
+    installation_id: int | None = None,
+    limit: int = 100,
+):
+    from hermes_cli.code.github_integration import GitHubIntegrationStore
+
+    store = GitHubIntegrationStore()
+    try:
+        repos = store.list_repositories(
+            owner=owner,
+            q=q,
+            installation_id=installation_id,
+            limit=_code_limit(limit, default=100, maximum=1000),
+        )
+        return {"repositories": repos, "total": len(repos)}
+    finally:
+        store.close()
+
+
+@app.post("/api/code/github/repositories/sync")
+async def github_repositories_sync(body: GitHubSyncBody):
+    from hermes_cli.code.github_integration import GitHubAPIError
+    from hermes_cli.code.github_sync import GitHubSyncService
+
+    try:
+        result = GitHubSyncService().sync_repositories(
+            installation_id=body.installation_id,
+            dry_run=body.dry_run,
+            limit=_code_limit(body.limit, default=100, maximum=1000),
+        )
+    except GitHubAPIError as exc:
+        _record_code_event("github.error", payload={"error": exc.message}, source="github")
+        raise HTTPException(status_code=400, detail=exc.message)
+    except Exception:
+        _log.exception("POST /api/code/github/repositories/sync failed")
+        raise HTTPException(status_code=500, detail="GitHub repository sync failed")
+
+    _record_code_event("github.repository.synced", payload={"result": result}, source="github")
+    return {"result": result}
+
+
+@app.get("/api/code/github/repositories/{owner}/{repo}")
+async def github_repository(owner: str, repo: str):
+    from hermes_cli.code.github_integration import GitHubIntegrationStore
+
+    store = GitHubIntegrationStore()
+    try:
+        repository = store.get_repository(owner, repo)
+    finally:
+        store.close()
+    if not repository:
+        raise HTTPException(status_code=404, detail="GitHub repository not found")
+    return {"repository": repository}
+
+
+@app.get("/api/code/github/repositories/{owner}/{repo}/issues")
+async def github_repository_issues(owner: str, repo: str, limit: int = 100):
+    from hermes_cli.code.github_integration import GitHubIntegrationStore
+
+    repo_full_name = f"{owner}/{repo}"
+    store = GitHubIntegrationStore()
+    try:
+        issues = store.list_issues(repo_full_name, limit=_code_limit(limit, default=100, maximum=1000))
+    finally:
+        store.close()
+    return {"repo_full_name": repo_full_name, "issues": issues, "total": len(issues)}
+
+
+@app.get("/api/code/github/repositories/{owner}/{repo}/pulls")
+async def github_repository_pulls(owner: str, repo: str, limit: int = 100):
+    from hermes_cli.code.github_integration import GitHubIntegrationStore
+
+    repo_full_name = f"{owner}/{repo}"
+    store = GitHubIntegrationStore()
+    try:
+        pulls = store.list_pull_requests(repo_full_name, limit=_code_limit(limit, default=100, maximum=1000))
+    finally:
+        store.close()
+    return {"repo_full_name": repo_full_name, "pull_requests": pulls, "total": len(pulls)}
+
+
+@app.post("/api/code/github/webhooks")
+async def github_webhook(request: Request):
+    from hermes_cli.code.github_webhooks import GitHubWebhookService, WebhookSignatureError
+
+    event = request.headers.get("X-GitHub-Event", "")
+    delivery_id = request.headers.get("X-GitHub-Delivery", "")
+    signature = request.headers.get("X-Hub-Signature-256")
+    if not event or not delivery_id:
+        raise HTTPException(status_code=400, detail="Missing GitHub webhook headers")
+
+    body = await request.body()
+    try:
+        result = GitHubWebhookService().process(
+            delivery_id=delivery_id,
+            event=event,
+            body=body,
+            signature=signature,
+        )
+        return result
+    except WebhookSignatureError as exc:
+        raise HTTPException(status_code=401, detail=str(exc))
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    except Exception as exc:
+        _log.error("POST /api/code/github/webhooks failed: %s", GitHubWebhookService.safe_error(exc))
+        raise HTTPException(status_code=500, detail="GitHub webhook processing failed")
+
+
+@app.post("/api/code/github/chatops/{command_id}/run")
+async def github_chatops_run(command_id: str):
+    from hermes_cli.code.github_chatops import GitHubChatOpsService
+
+    try:
+        result = GitHubChatOpsService().run_command(command_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    except Exception:
+        _log.exception("POST /api/code/github/chatops/%s/run failed", command_id)
+        raise HTTPException(status_code=500, detail="GitHub ChatOps run failed")
+
+    _record_code_event(
+        "github.chatops.run_created",
+        payload={"command_id": command_id, "run": result.get("run")},
+        workspace_id=(result.get("run") or {}).get("workspace_id"),
+        code_session_id=(result.get("run") or {}).get("code_session_id"),
+        source="github",
+    )
+    return result
+
+
+@app.post("/api/code/github/comments")
+async def github_comments(body: GitHubCommentBody):
+    from hermes_cli.code.execution_policy import policy_engine
+    from hermes_cli.code.github_integration import GitHubAPIError, GitHubIntegrationService, redact_github_secrets
+
+    target_number = body.issue_number or body.pr_number
+    if not target_number:
+        raise HTTPException(status_code=400, detail="issue_number or pr_number is required")
+    if not body.body.strip():
+        raise HTTPException(status_code=400, detail="comment body must not be empty")
+
+    assessment = policy_engine.assess_command("curl https://api.github.com/repos/x/issues/y/comments")
+    if assessment.get("requires_approval") and not body.approved:
+        return {
+            "approval_required": True,
+            "approved": False,
+            "risk_class": assessment.get("risk_class"),
+            "message": "GitHub comment write requires explicit approval.",
+            "prepared": {
+                "repo_full_name": body.repo_full_name,
+                "issue_number": int(target_number),
+                "body": redact_github_secrets(body.body),
+            },
+        }
+
+    try:
+        comment = GitHubIntegrationService().post_issue_comment(
+            repo_full_name=body.repo_full_name,
+            issue_number=int(target_number),
+            body=body.body,
+            installation_id=body.installation_id,
+        )
+    except GitHubAPIError as exc:
+        raise HTTPException(status_code=400, detail=exc.message)
+    except Exception:
+        _log.exception("POST /api/code/github/comments failed")
+        raise HTTPException(status_code=500, detail="GitHub comment request failed")
+
+    _record_code_event(
+        "github.comment.posted",
+        payload={"repo_full_name": body.repo_full_name, "issue_number": int(target_number)},
+        source="github",
+    )
+    return {"approval_required": False, "approved": True, "comment": comment}
+
+
+@app.post("/api/code/github/pull-requests/prepare")
+async def github_pull_request_prepare(body: GitHubPreparePullRequestBody):
+    from hermes_cli.code.artifact_ledger import ArtifactLedger
+    from hermes_cli.code.github_integration import GitHubIntegrationService
+
+    prepared = GitHubIntegrationService().prepare_pull_request(body.model_dump())
+    artifact = ArtifactLedger().create_artifact(
+        "implementation_plan",
+        json.dumps(prepared, indent=2),
+        title=f"Prepared GitHub PR: {body.title}",
+        metadata={"source": "github_pull_request_prepare", "repo_full_name": body.repo_full_name},
+    )
+    return {"prepared": prepared, "artifact": artifact}
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -15,6 +15,7 @@ import importlib.util
 import json
 import logging
 import os
+import queue
 import secrets
 import subprocess
 import sys
@@ -46,6 +47,11 @@ from hermes_cli.config import (
     remove_env_value,
     check_config_version,
     redact_key,
+)
+from hermes_cli.code.event_bus import (
+    build_event_filters_from_query,
+    get_code_event_bus,
+    _parse_bool,
 )
 from gateway.status import get_running_pid, read_runtime_status
 
@@ -692,26 +698,6 @@ def _code_offset(value: int) -> int:
     return max(0, value)
 
 
-def _make_code_event(
-    event_type: str,
-    *,
-    payload: dict[str, Any] | None = None,
-    workspace_id: str | None = None,
-    code_session_id: str | None = None,
-) -> dict[str, Any]:
-    event = {
-        "type": event_type,
-        "version": 1,
-        "timestamp": datetime.now(timezone.utc).isoformat(),
-        "payload": payload or {},
-    }
-    if workspace_id:
-        event["workspace_id"] = workspace_id
-    if code_session_id:
-        event["code_session_id"] = code_session_id
-    return event
-
-
 def _record_code_event(
     event_type: str,
     *,
@@ -721,31 +707,25 @@ def _record_code_event(
     level: str = "info",
     source: str = "control_plane",
 ) -> dict[str, Any]:
-    event = _make_code_event(
-        event_type,
-        payload=payload,
-        workspace_id=workspace_id,
-        code_session_id=code_session_id,
-    )
     try:
-        from hermes_state import SessionDB
-
-        db = SessionDB()
-        try:
-            event_id = db.append_code_event(
-                event_type=event_type,
-                payload=event,
-                workspace_id=workspace_id,
-                code_session_id=code_session_id,
-                source=source,
-                level=level,
-            )
-            event["id"] = event_id
-        finally:
-            db.close()
+        payload_value = payload or {}
+        bus = get_code_event_bus()
+        event = bus.publish(
+            event_type,
+            payload=payload_value,
+            workspace_id=workspace_id,
+            code_session_id=code_session_id,
+            orchestrated_run_id=payload_value.get("orchestrated_run_id") or payload_value.get("run_id"),
+            approval_id=payload_value.get("approval_id"),
+            github_repo_full_name=payload_value.get("github_repo_full_name") or payload_value.get("repo_full_name"),
+            metadata={"source": source},
+            source=source,
+            level=level,
+        )
+        return event
     except Exception:
         _log.exception("Failed to persist code event %s", event_type)
-    return event
+    return {"type": event_type, "version": 1, "timestamp": datetime.now(timezone.utc).isoformat(), "payload": payload or {}}
 
 
 @app.get("/api/code/status")
@@ -826,28 +806,166 @@ async def get_code_sessions(workspace_id: str | None = None, limit: int = 50, of
 
 @app.get("/api/code/events")
 async def get_code_events(
+    type: str | None = None,
     workspace_id: str | None = None,
+    code_session_id: str | None = None,
     session_id: str | None = None,
+    orchestrated_run_id: str | None = None,
+    approval_id: str | None = None,
+    github_repo_full_name: str | None = None,
+    since_id: str | None = None,
     limit: int = 50,
     offset: int = 0,
 ):
     try:
-        from hermes_state import SessionDB
-
-        db = SessionDB()
-        try:
-            events = db.list_code_events(
-                workspace_id=workspace_id,
-                session_id=session_id,
-                limit=_code_limit(limit),
-                offset=_code_offset(offset),
-            )
-            return {"events": events, "limit": _code_limit(limit), "offset": _code_offset(offset)}
-        finally:
-            db.close()
+        bus = get_code_event_bus()
+        filters = build_event_filters_from_query(
+            event_type=type,
+            workspace_id=workspace_id,
+            code_session_id=code_session_id or session_id,
+            orchestrated_run_id=orchestrated_run_id,
+            approval_id=approval_id,
+            github_repo_full_name=github_repo_full_name,
+        )
+        events = bus.fetch_events(
+            filters=filters,
+            since_id=since_id,
+            limit=_code_limit(limit),
+            offset=_code_offset(offset),
+            newest_first=True,
+        )
+        return {"events": events, "limit": _code_limit(limit), "offset": _code_offset(offset)}
     except Exception:
         _log.exception("GET /api/code/events failed")
         raise HTTPException(status_code=500, detail="Code Mode events unavailable")
+
+
+@app.get("/api/code/events/recent")
+async def get_code_events_recent(
+    type: str | None = None,
+    workspace_id: str | None = None,
+    code_session_id: str | None = None,
+    orchestrated_run_id: str | None = None,
+    approval_id: str | None = None,
+    github_repo_full_name: str | None = None,
+    since_id: str | None = None,
+    limit: int = 50,
+):
+    try:
+        bus = get_code_event_bus()
+        filters = build_event_filters_from_query(
+            event_type=type,
+            workspace_id=workspace_id,
+            code_session_id=code_session_id,
+            orchestrated_run_id=orchestrated_run_id,
+            approval_id=approval_id,
+            github_repo_full_name=github_repo_full_name,
+        )
+        events = bus.fetch_events(
+            filters=filters,
+            since_id=since_id,
+            limit=_code_limit(limit),
+            offset=0,
+            newest_first=True,
+        )
+        return {"events": events, "limit": _code_limit(limit)}
+    except Exception:
+        _log.exception("GET /api/code/events/recent failed")
+        raise HTTPException(status_code=500, detail="Recent Code Mode events unavailable")
+
+
+@app.get("/api/code/events/summary")
+async def get_code_events_summary(
+    type: str | None = None,
+    workspace_id: str | None = None,
+    code_session_id: str | None = None,
+    orchestrated_run_id: str | None = None,
+    approval_id: str | None = None,
+    github_repo_full_name: str | None = None,
+    limit: int = 200,
+):
+    try:
+        bus = get_code_event_bus()
+        filters = build_event_filters_from_query(
+            event_type=type,
+            workspace_id=workspace_id,
+            code_session_id=code_session_id,
+            orchestrated_run_id=orchestrated_run_id,
+            approval_id=approval_id,
+            github_repo_full_name=github_repo_full_name,
+        )
+        summary = bus.summary(filters=filters, recent_limit=_code_limit(limit, default=200, maximum=2000))
+        return {"summary": summary}
+    except Exception:
+        _log.exception("GET /api/code/events/summary failed")
+        raise HTTPException(status_code=500, detail="Code Mode event summary unavailable")
+
+
+@app.get("/api/code/events/subscriptions")
+async def get_code_event_subscriptions():
+    try:
+        bus = get_code_event_bus()
+        return {"subscriptions": bus.subscription_stats()}
+    except Exception:
+        _log.exception("GET /api/code/events/subscriptions failed")
+        raise HTTPException(status_code=500, detail="Code Mode event subscriptions unavailable")
+
+
+@app.websocket("/api/code/events/ws")
+async def code_events_ws(ws: WebSocket) -> None:
+    token = ws.query_params.get("token", "")
+    if not hmac.compare_digest(token.encode(), _SESSION_TOKEN.encode()):
+        await ws.close(code=4401)
+        return
+
+    client_host = ws.client.host if ws.client else ""
+    if client_host and client_host not in _LOOPBACK_HOSTS:
+        await ws.close(code=4403)
+        return
+
+    filters = build_event_filters_from_query(
+        event_type=ws.query_params.get("type") or None,
+        workspace_id=ws.query_params.get("workspace_id") or None,
+        code_session_id=ws.query_params.get("code_session_id") or None,
+        orchestrated_run_id=ws.query_params.get("orchestrated_run_id") or None,
+        approval_id=ws.query_params.get("approval_id") or None,
+        github_repo_full_name=ws.query_params.get("github_repo_full_name") or None,
+    )
+    since_id = ws.query_params.get("since_id") or None
+    replay = _parse_bool(ws.query_params.get("replay"), default=bool(since_id))
+    limit = _code_limit(ws.query_params.get("limit", 200), default=200, maximum=2000)
+
+    await ws.accept()
+    bus = get_code_event_bus()
+    if replay or since_id:
+        try:
+            replay_events = bus.replay(filters=filters, since_id=since_id, limit=limit)
+            for item in replay_events:
+                await ws.send_json(item)
+        except Exception:
+            _log.exception("Code event replay failed for websocket subscriber")
+
+    sub_id, sub_queue = bus.subscribe(filters=filters, max_queue_size=512)
+    try:
+        while True:
+            try:
+                event = await asyncio.to_thread(sub_queue.get, True, 20.0)
+                await ws.send_json(event)
+            except queue.Empty:
+                await ws.send_json(
+                    {
+                        "type": "code.events.heartbeat",
+                        "version": 1,
+                        "timestamp": datetime.now(timezone.utc).isoformat(),
+                        "payload": {},
+                    }
+                )
+    except WebSocketDisconnect:
+        pass
+    except Exception:
+        _log.exception("Code events websocket failed")
+    finally:
+        bus.unsubscribe(sub_id)
 
 
 @app.get("/api/code/artifacts")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -100,6 +100,7 @@ app.add_middleware(
 # ---------------------------------------------------------------------------
 _PUBLIC_API_PATHS: frozenset = frozenset({
     "/api/status",
+    "/api/code/status",
     "/api/config/defaults",
     "/api/config/schema",
     "/api/model/info",
@@ -338,6 +339,7 @@ _CATEGORY_MERGE: Dict[str, str] = {
     "human_delay": "display",
     "dashboard": "display",
     "code_execution": "agent",
+    "prompt_caching": "agent",
 }
 
 # Display order for tabs — unlisted categories sort alphabetically after these.
@@ -585,6 +587,124 @@ async def get_status():
         "gateway_updated_at": gateway_updated_at,
         "active_sessions": active_sessions,
     }
+
+
+def _code_limit(value: int, default: int = 50, maximum: int = 200) -> int:
+    try:
+        value = int(value)
+    except Exception:
+        value = default
+    return max(1, min(value, maximum))
+
+
+def _code_offset(value: int) -> int:
+    try:
+        value = int(value)
+    except Exception:
+        value = 0
+    return max(0, value)
+
+
+@app.get("/api/code/status")
+async def get_code_status():
+    """Read-only Code Mode readiness endpoint.
+
+    This endpoint is public so the CLI can detect whether the dashboard backend
+    is reachable without knowing the dashboard session token.
+    """
+    try:
+        from hermes_state import SCHEMA_VERSION, SessionDB
+
+        db = SessionDB()
+        try:
+            status = db.code_mode_status()
+        finally:
+            db.close()
+        return {
+            "mode": "code_mode",
+            "ready": status.get("mode") == "enabled",
+            "schema_version": status.get("schema_version") or SCHEMA_VERSION,
+            "state": status,
+            "workspace_path": os.getcwd(),
+            "web_url": None,
+        }
+    except Exception as exc:
+        _log.exception("GET /api/code/status failed")
+        return {
+            "mode": "code_mode",
+            "ready": False,
+            "schema_version": None,
+            "state": {"mode": "unavailable", "error": str(exc)},
+            "workspace_path": os.getcwd(),
+            "web_url": None,
+        }
+
+
+@app.get("/api/code/workspaces")
+async def get_code_workspaces(owner: str | None = None, q: str = "", limit: int = 50, offset: int = 0):
+    try:
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            workspaces = db.list_code_workspaces(
+                owner=owner,
+                q=q or "",
+                limit=_code_limit(limit),
+                offset=_code_offset(offset),
+            )
+            return {"workspaces": workspaces, "limit": _code_limit(limit), "offset": _code_offset(offset)}
+        finally:
+            db.close()
+    except Exception:
+        _log.exception("GET /api/code/workspaces failed")
+        raise HTTPException(status_code=500, detail="Code Mode workspaces unavailable")
+
+
+@app.get("/api/code/sessions")
+async def get_code_sessions(workspace_id: str | None = None, limit: int = 50, offset: int = 0):
+    try:
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            sessions = db.list_code_sessions(
+                workspace_id=workspace_id,
+                limit=_code_limit(limit),
+                offset=_code_offset(offset),
+            )
+            return {"sessions": sessions, "limit": _code_limit(limit), "offset": _code_offset(offset)}
+        finally:
+            db.close()
+    except Exception:
+        _log.exception("GET /api/code/sessions failed")
+        raise HTTPException(status_code=500, detail="Code Mode sessions unavailable")
+
+
+@app.get("/api/code/events")
+async def get_code_events(
+    workspace_id: str | None = None,
+    session_id: str | None = None,
+    limit: int = 50,
+    offset: int = 0,
+):
+    try:
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            events = db.list_code_events(
+                workspace_id=workspace_id,
+                session_id=session_id,
+                limit=_code_limit(limit),
+                offset=_code_offset(offset),
+            )
+            return {"events": events, "limit": _code_limit(limit), "offset": _code_offset(offset)}
+        finally:
+            db.close()
+    except Exception:
+        _log.exception("GET /api/code/events failed")
+        raise HTTPException(status_code=500, detail="Code Mode events unavailable")
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -34,7 +34,7 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 14
+SCHEMA_VERSION = 15
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -148,6 +148,59 @@ CREATE INDEX IF NOT EXISTS idx_code_events_workspace
 
 CREATE INDEX IF NOT EXISTS idx_code_events_session
     ON code_events(session_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS code_approval_requests (
+    id TEXT PRIMARY KEY,
+    kind TEXT NOT NULL,
+    risk_class TEXT NOT NULL,
+    title TEXT NOT NULL,
+    description TEXT,
+    requested_action TEXT NOT NULL,
+    requested_payload_json TEXT NOT NULL DEFAULT '{}',
+    resource_type TEXT,
+    resource_id TEXT,
+    workspace_id TEXT,
+    code_session_id TEXT,
+    orchestrated_run_id TEXT,
+    artifact_id TEXT,
+    github_repo_full_name TEXT,
+    github_issue_number INTEGER,
+    github_pr_number INTEGER,
+    requested_by TEXT,
+    approved_by TEXT,
+    rejected_by TEXT,
+    status TEXT NOT NULL DEFAULT 'pending',
+    expires_at REAL,
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL,
+    resolved_at REAL,
+    metadata_json TEXT NOT NULL DEFAULT '{}',
+    FOREIGN KEY (workspace_id) REFERENCES code_workspaces(id) ON DELETE SET NULL,
+    FOREIGN KEY (code_session_id) REFERENCES code_sessions(id) ON DELETE SET NULL,
+    FOREIGN KEY (orchestrated_run_id) REFERENCES code_orchestrated_runs(id) ON DELETE SET NULL,
+    FOREIGN KEY (artifact_id) REFERENCES code_artifacts(id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_code_approvals_status_created
+    ON code_approval_requests(status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_code_approvals_kind_created
+    ON code_approval_requests(kind, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_code_approvals_risk_created
+    ON code_approval_requests(risk_class, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_code_approvals_workspace_created
+    ON code_approval_requests(workspace_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_code_approvals_session_created
+    ON code_approval_requests(code_session_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_code_approvals_run_created
+    ON code_approval_requests(orchestrated_run_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_code_approvals_github_repo_created
+    ON code_approval_requests(github_repo_full_name, created_at DESC);
 
 CREATE TABLE IF NOT EXISTS code_artifacts (
     id TEXT PRIMARY KEY,
@@ -1102,6 +1155,68 @@ class SessionDB:
                 except Exception:
                     pass
 
+            if current_version < 15:
+                # v15: add persistent approval governance table for Code Mode.
+                try:
+                    cursor.executescript(
+                        """
+                        CREATE TABLE IF NOT EXISTS code_approval_requests (
+                            id TEXT PRIMARY KEY,
+                            kind TEXT NOT NULL,
+                            risk_class TEXT NOT NULL,
+                            title TEXT NOT NULL,
+                            description TEXT,
+                            requested_action TEXT NOT NULL,
+                            requested_payload_json TEXT NOT NULL DEFAULT '{}',
+                            resource_type TEXT,
+                            resource_id TEXT,
+                            workspace_id TEXT,
+                            code_session_id TEXT,
+                            orchestrated_run_id TEXT,
+                            artifact_id TEXT,
+                            github_repo_full_name TEXT,
+                            github_issue_number INTEGER,
+                            github_pr_number INTEGER,
+                            requested_by TEXT,
+                            approved_by TEXT,
+                            rejected_by TEXT,
+                            status TEXT NOT NULL DEFAULT 'pending',
+                            expires_at REAL,
+                            created_at REAL NOT NULL,
+                            updated_at REAL NOT NULL,
+                            resolved_at REAL,
+                            metadata_json TEXT NOT NULL DEFAULT '{}',
+                            FOREIGN KEY (workspace_id) REFERENCES code_workspaces(id) ON DELETE SET NULL,
+                            FOREIGN KEY (code_session_id) REFERENCES code_sessions(id) ON DELETE SET NULL,
+                            FOREIGN KEY (orchestrated_run_id) REFERENCES code_orchestrated_runs(id) ON DELETE SET NULL,
+                            FOREIGN KEY (artifact_id) REFERENCES code_artifacts(id) ON DELETE SET NULL
+                        );
+
+                        CREATE INDEX IF NOT EXISTS idx_code_approvals_status_created
+                            ON code_approval_requests(status, created_at DESC);
+
+                        CREATE INDEX IF NOT EXISTS idx_code_approvals_kind_created
+                            ON code_approval_requests(kind, created_at DESC);
+
+                        CREATE INDEX IF NOT EXISTS idx_code_approvals_risk_created
+                            ON code_approval_requests(risk_class, created_at DESC);
+
+                        CREATE INDEX IF NOT EXISTS idx_code_approvals_workspace_created
+                            ON code_approval_requests(workspace_id, created_at DESC);
+
+                        CREATE INDEX IF NOT EXISTS idx_code_approvals_session_created
+                            ON code_approval_requests(code_session_id, created_at DESC);
+
+                        CREATE INDEX IF NOT EXISTS idx_code_approvals_run_created
+                            ON code_approval_requests(orchestrated_run_id, created_at DESC);
+
+                        CREATE INDEX IF NOT EXISTS idx_code_approvals_github_repo_created
+                            ON code_approval_requests(github_repo_full_name, created_at DESC);
+                        """
+                    )
+                except Exception:
+                    pass
+
             if current_version < SCHEMA_VERSION:
                 cursor.execute(
                     "UPDATE schema_version SET version = ?",
@@ -1722,27 +1837,41 @@ class SessionDB:
             return {
                 "mode": "unconfigured",
                 "schema_version": None,
-                "tables": {"code_workspaces": False, "code_sessions": False, "code_events": False},
+                "tables": {
+                    "code_workspaces": False,
+                    "code_sessions": False,
+                    "code_events": False,
+                    "code_approval_requests": False,
+                },
             }
         with self._lock:
+            tracked = ("code_workspaces", "code_sessions", "code_events", "code_approval_requests")
+            tables: dict[str, bool] = {}
             counts = {}
-            for name in ("code_workspaces", "code_sessions", "code_events"):
-                cursor = self._conn.execute(f"SELECT COUNT(1) AS c FROM {name}")
-                counts[name] = int(cursor.fetchone()["c"])
+            for name in tracked:
+                exists = bool(
+                    self._conn.execute(
+                        "SELECT 1 FROM sqlite_master WHERE type='table' AND name = ? LIMIT 1",
+                        (name,),
+                    ).fetchone()
+                )
+                tables[name] = exists
+                if exists:
+                    cursor = self._conn.execute(f"SELECT COUNT(1) AS c FROM {name}")
+                    counts[name] = int(cursor.fetchone()["c"])
+                else:
+                    counts[name] = 0
             cursor = self._conn.execute("SELECT version FROM schema_version LIMIT 1")
             row = cursor.fetchone()
         return {
             "mode": "enabled" if counts else "unknown",
             "schema_version": row["version"] if row else None,
-            "tables": {
-                "code_workspaces": True,
-                "code_sessions": True,
-                "code_events": True,
-            },
+            "tables": tables,
             "counts": counts,
             "workspace_count": counts.get("code_workspaces", 0),
             "session_count": counts.get("code_sessions", 0),
             "event_count": counts.get("code_events", 0),
+            "approval_count": counts.get("code_approval_requests", 0),
         }
 
     def _code_list_rows(
@@ -1869,6 +1998,191 @@ class SessionDB:
             return event_id
 
         return self._execute_write(_do)
+
+    @staticmethod
+    def _decode_json_value(raw: Any, default: Any) -> Any:
+        if raw is None or raw == "":
+            return default
+        try:
+            return json.loads(raw)
+        except Exception:
+            return default
+
+    def create_code_approval_request(self, request: dict[str, Any]) -> str:
+        def _do(conn):
+            conn.execute(
+                """
+                INSERT INTO code_approval_requests (
+                    id, kind, risk_class, title, description, requested_action, requested_payload_json,
+                    resource_type, resource_id, workspace_id, code_session_id, orchestrated_run_id,
+                    artifact_id, github_repo_full_name, github_issue_number, github_pr_number,
+                    requested_by, approved_by, rejected_by, status, expires_at,
+                    created_at, updated_at, resolved_at, metadata_json
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    request["id"],
+                    request["kind"],
+                    request["risk_class"],
+                    request.get("title") or request["kind"],
+                    request.get("description"),
+                    request.get("requested_action") or request["kind"],
+                    json.dumps(request.get("requested_payload") or {}),
+                    request.get("resource_type"),
+                    request.get("resource_id"),
+                    request.get("workspace_id"),
+                    request.get("code_session_id"),
+                    request.get("orchestrated_run_id"),
+                    request.get("artifact_id"),
+                    request.get("github_repo_full_name"),
+                    request.get("github_issue_number"),
+                    request.get("github_pr_number"),
+                    request.get("requested_by"),
+                    request.get("approved_by"),
+                    request.get("rejected_by"),
+                    request.get("status", "pending"),
+                    request.get("expires_at"),
+                    request["created_at"],
+                    request["updated_at"],
+                    request.get("resolved_at"),
+                    json.dumps(request.get("metadata") or {}),
+                ),
+            )
+            return request["id"]
+
+        return self._execute_write(_do)
+
+    def _hydrate_code_approval_row(self, row: sqlite3.Row | dict[str, Any] | None) -> Optional[dict[str, Any]]:
+        if not row:
+            return None
+        result = dict(row)
+        result["requested_payload"] = self._decode_json_value(result.pop("requested_payload_json", "{}"), {})
+        result["metadata"] = self._decode_json_value(result.pop("metadata_json", "{}"), {})
+        return result
+
+    def get_code_approval_request(self, approval_id: str) -> Optional[dict[str, Any]]:
+        with self._lock:
+            cursor = self._conn.execute(
+                "SELECT * FROM code_approval_requests WHERE id = ? LIMIT 1",
+                (approval_id,),
+            )
+            row = cursor.fetchone()
+        return self._hydrate_code_approval_row(row)
+
+    def list_code_approval_requests(
+        self,
+        *,
+        status: str | None = None,
+        kind: str | None = None,
+        risk_class: str | None = None,
+        workspace_id: str | None = None,
+        code_session_id: str | None = None,
+        orchestrated_run_id: str | None = None,
+        github_repo_full_name: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        if not self._code_tables_exist():
+            return []
+        filters = []
+        params: list[Any] = []
+        if status:
+            filters.append("status = ?")
+            params.append(status)
+        if kind:
+            filters.append("kind = ?")
+            params.append(kind)
+        if risk_class:
+            filters.append("risk_class = ?")
+            params.append(risk_class)
+        if workspace_id:
+            filters.append("workspace_id = ?")
+            params.append(workspace_id)
+        if code_session_id:
+            filters.append("code_session_id = ?")
+            params.append(code_session_id)
+        if orchestrated_run_id:
+            filters.append("orchestrated_run_id = ?")
+            params.append(orchestrated_run_id)
+        if github_repo_full_name:
+            filters.append("github_repo_full_name = ?")
+            params.append(github_repo_full_name)
+        where_sql = f"WHERE {' AND '.join(filters)}" if filters else ""
+
+        with self._lock:
+            cursor = self._conn.execute(
+                f"SELECT * FROM code_approval_requests {where_sql} ORDER BY created_at DESC LIMIT ? OFFSET ?",
+                tuple(params + [limit, offset]),
+            )
+            rows = cursor.fetchall()
+        return [self._hydrate_code_approval_row(row) or {} for row in rows]
+
+    def update_code_approval_request(self, approval_id: str, updates: dict[str, Any]) -> bool:
+        if not updates:
+            return False
+        fields = []
+        params: list[Any] = []
+        for key, value in updates.items():
+            if key == "requested_payload":
+                fields.append("requested_payload_json = ?")
+                params.append(json.dumps(value or {}))
+            elif key == "metadata":
+                fields.append("metadata_json = ?")
+                params.append(json.dumps(value or {}))
+            else:
+                fields.append(f"{key} = ?")
+                params.append(value)
+        params.append(approval_id)
+
+        def _do(conn):
+            cursor = conn.execute(
+                f"UPDATE code_approval_requests SET {', '.join(fields)} WHERE id = ?",
+                tuple(params),
+            )
+            return bool(cursor.rowcount)
+
+        return bool(self._execute_write(_do))
+
+    def summarize_code_approval_requests(
+        self,
+        *,
+        workspace_id: str | None = None,
+        code_session_id: str | None = None,
+        orchestrated_run_id: str | None = None,
+        github_repo_full_name: str | None = None,
+    ) -> dict[str, dict[str, int]]:
+        if not self._code_tables_exist():
+            return {"status": {}, "risk_class": {}, "kind": {}}
+
+        filters = []
+        params: list[Any] = []
+        if workspace_id:
+            filters.append("workspace_id = ?")
+            params.append(workspace_id)
+        if code_session_id:
+            filters.append("code_session_id = ?")
+            params.append(code_session_id)
+        if orchestrated_run_id:
+            filters.append("orchestrated_run_id = ?")
+            params.append(orchestrated_run_id)
+        if github_repo_full_name:
+            filters.append("github_repo_full_name = ?")
+            params.append(github_repo_full_name)
+        where_sql = f"WHERE {' AND '.join(filters)}" if filters else ""
+
+        summary: dict[str, dict[str, int]] = {"status": {}, "risk_class": {}, "kind": {}}
+        with self._lock:
+            for column, key in (("status", "status"), ("risk_class", "risk_class"), ("kind", "kind")):
+                cursor = self._conn.execute(
+                    f"SELECT {column} AS bucket, COUNT(1) AS c FROM code_approval_requests {where_sql} GROUP BY {column}",
+                    tuple(params),
+                )
+                summary[key] = {
+                    str(row["bucket"]): int(row["c"])
+                    for row in cursor.fetchall()
+                    if row["bucket"] is not None
+                }
+        return summary
 
     def create_code_artifact(self, artifact: dict[str, Any]) -> str:
         artifact_id = artifact["id"]

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -34,7 +34,7 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 13
+SCHEMA_VERSION = 14
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -222,6 +222,167 @@ CREATE TABLE IF NOT EXISTS code_checkpoints (
 
 CREATE INDEX IF NOT EXISTS idx_code_checkpoints_workspace
     ON code_checkpoints(workspace_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS github_app_installations (
+    id TEXT PRIMARY KEY,
+    installation_id INTEGER NOT NULL UNIQUE,
+    account_login TEXT,
+    account_type TEXT,
+    app_id TEXT,
+    permissions_json TEXT DEFAULT '{}',
+    events_json TEXT DEFAULT '[]',
+    status TEXT NOT NULL DEFAULT 'active',
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL,
+    last_synced_at REAL
+);
+
+CREATE INDEX IF NOT EXISTS idx_github_installations_account
+    ON github_app_installations(account_login);
+
+CREATE TABLE IF NOT EXISTS github_repositories (
+    id TEXT PRIMARY KEY,
+    installation_id INTEGER,
+    github_repo_id INTEGER,
+    owner TEXT NOT NULL,
+    name TEXT NOT NULL,
+    full_name TEXT NOT NULL UNIQUE,
+    default_branch TEXT,
+    private INTEGER DEFAULT 0,
+    html_url TEXT,
+    clone_url TEXT,
+    ssh_url TEXT,
+    archived INTEGER DEFAULT 0,
+    disabled INTEGER DEFAULT 0,
+    pushed_at TEXT,
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL,
+    last_synced_at REAL
+);
+
+CREATE INDEX IF NOT EXISTS idx_github_repositories_owner
+    ON github_repositories(owner);
+
+CREATE INDEX IF NOT EXISTS idx_github_repositories_installation
+    ON github_repositories(installation_id);
+
+CREATE TABLE IF NOT EXISTS github_branches (
+    id TEXT PRIMARY KEY,
+    repo_full_name TEXT NOT NULL,
+    name TEXT NOT NULL,
+    sha TEXT,
+    protected INTEGER DEFAULT 0,
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL,
+    last_synced_at REAL,
+    UNIQUE(repo_full_name, name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_github_branches_repo
+    ON github_branches(repo_full_name);
+
+CREATE TABLE IF NOT EXISTS github_issues (
+    id TEXT PRIMARY KEY,
+    repo_full_name TEXT NOT NULL,
+    github_issue_id INTEGER,
+    number INTEGER NOT NULL,
+    title TEXT,
+    state TEXT,
+    author_login TEXT,
+    labels_json TEXT DEFAULT '[]',
+    assignees_json TEXT DEFAULT '[]',
+    milestone_json TEXT DEFAULT '{}',
+    html_url TEXT,
+    created_at TEXT,
+    updated_at TEXT,
+    closed_at TEXT,
+    last_synced_at REAL,
+    UNIQUE(repo_full_name, number)
+);
+
+CREATE INDEX IF NOT EXISTS idx_github_issues_repo
+    ON github_issues(repo_full_name);
+
+CREATE TABLE IF NOT EXISTS github_pull_requests (
+    id TEXT PRIMARY KEY,
+    repo_full_name TEXT NOT NULL,
+    github_pr_id INTEGER,
+    number INTEGER NOT NULL,
+    title TEXT,
+    state TEXT,
+    author_login TEXT,
+    base_branch TEXT,
+    head_branch TEXT,
+    head_sha TEXT,
+    mergeable INTEGER,
+    draft INTEGER DEFAULT 0,
+    html_url TEXT,
+    created_at TEXT,
+    updated_at TEXT,
+    closed_at TEXT,
+    merged_at TEXT,
+    last_synced_at REAL,
+    UNIQUE(repo_full_name, number)
+);
+
+CREATE INDEX IF NOT EXISTS idx_github_pull_requests_repo
+    ON github_pull_requests(repo_full_name);
+
+CREATE TABLE IF NOT EXISTS github_webhook_deliveries (
+    id TEXT PRIMARY KEY,
+    delivery_id TEXT NOT NULL UNIQUE,
+    event TEXT NOT NULL,
+    action TEXT,
+    repo_full_name TEXT,
+    sender_login TEXT,
+    payload_hash TEXT NOT NULL,
+    status TEXT NOT NULL,
+    error TEXT,
+    received_at REAL NOT NULL,
+    processed_at REAL
+);
+
+CREATE INDEX IF NOT EXISTS idx_github_webhooks_repo
+    ON github_webhook_deliveries(repo_full_name);
+
+CREATE TABLE IF NOT EXISTS github_chatops_commands (
+    id TEXT PRIMARY KEY,
+    delivery_id TEXT,
+    repo_full_name TEXT NOT NULL,
+    issue_number INTEGER,
+    pr_number INTEGER,
+    comment_id INTEGER,
+    sender_login TEXT,
+    command TEXT NOT NULL,
+    args TEXT DEFAULT '',
+    status TEXT NOT NULL DEFAULT 'pending',
+    orchestrated_run_id TEXT,
+    code_session_id TEXT,
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_github_chatops_status
+    ON github_chatops_commands(status);
+
+CREATE INDEX IF NOT EXISTS idx_github_chatops_repo
+    ON github_chatops_commands(repo_full_name);
+
+CREATE TABLE IF NOT EXISTS github_status_reports (
+    id TEXT PRIMARY KEY,
+    repo_full_name TEXT NOT NULL,
+    sha TEXT,
+    context TEXT,
+    status TEXT,
+    conclusion TEXT,
+    details_url TEXT,
+    external_id TEXT,
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_github_status_reports_repo_sha
+    ON github_status_reports(repo_full_name, sha);
 
 CREATE TABLE IF NOT EXISTS state_meta (
     key TEXT PRIMARY KEY,
@@ -766,6 +927,176 @@ class SessionDB:
 
                         CREATE INDEX IF NOT EXISTS idx_code_checkpoints_workspace
                             ON code_checkpoints(workspace_id, created_at DESC);
+                        """
+                    )
+                except Exception:
+                    pass
+
+            if current_version < 14:
+                # v14: add GitHub P1 integration metadata tables.
+                try:
+                    cursor.executescript(
+                        """
+                        CREATE TABLE IF NOT EXISTS github_app_installations (
+                            id TEXT PRIMARY KEY,
+                            installation_id INTEGER NOT NULL UNIQUE,
+                            account_login TEXT,
+                            account_type TEXT,
+                            app_id TEXT,
+                            permissions_json TEXT DEFAULT '{}',
+                            events_json TEXT DEFAULT '[]',
+                            status TEXT NOT NULL DEFAULT 'active',
+                            created_at REAL NOT NULL,
+                            updated_at REAL NOT NULL,
+                            last_synced_at REAL
+                        );
+
+                        CREATE INDEX IF NOT EXISTS idx_github_installations_account
+                            ON github_app_installations(account_login);
+
+                        CREATE TABLE IF NOT EXISTS github_repositories (
+                            id TEXT PRIMARY KEY,
+                            installation_id INTEGER,
+                            github_repo_id INTEGER,
+                            owner TEXT NOT NULL,
+                            name TEXT NOT NULL,
+                            full_name TEXT NOT NULL UNIQUE,
+                            default_branch TEXT,
+                            private INTEGER DEFAULT 0,
+                            html_url TEXT,
+                            clone_url TEXT,
+                            ssh_url TEXT,
+                            archived INTEGER DEFAULT 0,
+                            disabled INTEGER DEFAULT 0,
+                            pushed_at TEXT,
+                            created_at REAL NOT NULL,
+                            updated_at REAL NOT NULL,
+                            last_synced_at REAL
+                        );
+
+                        CREATE INDEX IF NOT EXISTS idx_github_repositories_owner
+                            ON github_repositories(owner);
+
+                        CREATE INDEX IF NOT EXISTS idx_github_repositories_installation
+                            ON github_repositories(installation_id);
+
+                        CREATE TABLE IF NOT EXISTS github_branches (
+                            id TEXT PRIMARY KEY,
+                            repo_full_name TEXT NOT NULL,
+                            name TEXT NOT NULL,
+                            sha TEXT,
+                            protected INTEGER DEFAULT 0,
+                            created_at REAL NOT NULL,
+                            updated_at REAL NOT NULL,
+                            last_synced_at REAL,
+                            UNIQUE(repo_full_name, name)
+                        );
+
+                        CREATE INDEX IF NOT EXISTS idx_github_branches_repo
+                            ON github_branches(repo_full_name);
+
+                        CREATE TABLE IF NOT EXISTS github_issues (
+                            id TEXT PRIMARY KEY,
+                            repo_full_name TEXT NOT NULL,
+                            github_issue_id INTEGER,
+                            number INTEGER NOT NULL,
+                            title TEXT,
+                            state TEXT,
+                            author_login TEXT,
+                            labels_json TEXT DEFAULT '[]',
+                            assignees_json TEXT DEFAULT '[]',
+                            milestone_json TEXT DEFAULT '{}',
+                            html_url TEXT,
+                            created_at TEXT,
+                            updated_at TEXT,
+                            closed_at TEXT,
+                            last_synced_at REAL,
+                            UNIQUE(repo_full_name, number)
+                        );
+
+                        CREATE INDEX IF NOT EXISTS idx_github_issues_repo
+                            ON github_issues(repo_full_name);
+
+                        CREATE TABLE IF NOT EXISTS github_pull_requests (
+                            id TEXT PRIMARY KEY,
+                            repo_full_name TEXT NOT NULL,
+                            github_pr_id INTEGER,
+                            number INTEGER NOT NULL,
+                            title TEXT,
+                            state TEXT,
+                            author_login TEXT,
+                            base_branch TEXT,
+                            head_branch TEXT,
+                            head_sha TEXT,
+                            mergeable INTEGER,
+                            draft INTEGER DEFAULT 0,
+                            html_url TEXT,
+                            created_at TEXT,
+                            updated_at TEXT,
+                            closed_at TEXT,
+                            merged_at TEXT,
+                            last_synced_at REAL,
+                            UNIQUE(repo_full_name, number)
+                        );
+
+                        CREATE INDEX IF NOT EXISTS idx_github_pull_requests_repo
+                            ON github_pull_requests(repo_full_name);
+
+                        CREATE TABLE IF NOT EXISTS github_webhook_deliveries (
+                            id TEXT PRIMARY KEY,
+                            delivery_id TEXT NOT NULL UNIQUE,
+                            event TEXT NOT NULL,
+                            action TEXT,
+                            repo_full_name TEXT,
+                            sender_login TEXT,
+                            payload_hash TEXT NOT NULL,
+                            status TEXT NOT NULL,
+                            error TEXT,
+                            received_at REAL NOT NULL,
+                            processed_at REAL
+                        );
+
+                        CREATE INDEX IF NOT EXISTS idx_github_webhooks_repo
+                            ON github_webhook_deliveries(repo_full_name);
+
+                        CREATE TABLE IF NOT EXISTS github_chatops_commands (
+                            id TEXT PRIMARY KEY,
+                            delivery_id TEXT,
+                            repo_full_name TEXT NOT NULL,
+                            issue_number INTEGER,
+                            pr_number INTEGER,
+                            comment_id INTEGER,
+                            sender_login TEXT,
+                            command TEXT NOT NULL,
+                            args TEXT DEFAULT '',
+                            status TEXT NOT NULL DEFAULT 'pending',
+                            orchestrated_run_id TEXT,
+                            code_session_id TEXT,
+                            created_at REAL NOT NULL,
+                            updated_at REAL NOT NULL
+                        );
+
+                        CREATE INDEX IF NOT EXISTS idx_github_chatops_status
+                            ON github_chatops_commands(status);
+
+                        CREATE INDEX IF NOT EXISTS idx_github_chatops_repo
+                            ON github_chatops_commands(repo_full_name);
+
+                        CREATE TABLE IF NOT EXISTS github_status_reports (
+                            id TEXT PRIMARY KEY,
+                            repo_full_name TEXT NOT NULL,
+                            sha TEXT,
+                            context TEXT,
+                            status TEXT,
+                            conclusion TEXT,
+                            details_url TEXT,
+                            external_id TEXT,
+                            created_at REAL NOT NULL,
+                            updated_at REAL NOT NULL
+                        );
+
+                        CREATE INDEX IF NOT EXISTS idx_github_status_reports_repo_sha
+                            ON github_status_reports(repo_full_name, sha);
                         """
                     )
                 except Exception:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -34,7 +34,7 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 15
+SCHEMA_VERSION = 17
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -21,6 +21,7 @@ import re
 import sqlite3
 import threading
 import time
+import uuid
 from pathlib import Path
 
 from agent.memory_manager import sanitize_context
@@ -33,7 +34,7 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 12
+SCHEMA_VERSION = 13
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -147,6 +148,80 @@ CREATE INDEX IF NOT EXISTS idx_code_events_workspace
 
 CREATE INDEX IF NOT EXISTS idx_code_events_session
     ON code_events(session_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS code_artifacts (
+    id TEXT PRIMARY KEY,
+    artifact_type TEXT NOT NULL,
+    title TEXT,
+    content TEXT NOT NULL,
+    content_type TEXT DEFAULT 'markdown',
+    workspace_id TEXT,
+    code_session_id TEXT,
+    orchestrated_run_id TEXT,
+    command_id TEXT,
+    metadata_json TEXT DEFAULT '{}',
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_code_artifacts_workspace
+    ON code_artifacts(workspace_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_code_artifacts_session
+    ON code_artifacts(code_session_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_code_artifacts_run
+    ON code_artifacts(orchestrated_run_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS code_orchestrated_runs (
+    id TEXT PRIMARY KEY,
+    title TEXT,
+    goal TEXT,
+    state TEXT NOT NULL DEFAULT 'intake',
+    workspace_id TEXT,
+    code_session_id TEXT,
+    current_phase TEXT,
+    metadata_json TEXT DEFAULT '{}',
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL,
+    completed_at REAL
+);
+
+CREATE INDEX IF NOT EXISTS idx_code_orchestrated_runs_workspace
+    ON code_orchestrated_runs(workspace_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_code_orchestrated_runs_session
+    ON code_orchestrated_runs(code_session_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_code_orchestrated_runs_state
+    ON code_orchestrated_runs(state, updated_at DESC);
+
+CREATE TABLE IF NOT EXISTS code_run_transitions (
+    id TEXT PRIMARY KEY,
+    run_id TEXT NOT NULL,
+    from_state TEXT,
+    to_state TEXT NOT NULL,
+    reason TEXT,
+    created_at REAL NOT NULL,
+    FOREIGN KEY (run_id) REFERENCES code_orchestrated_runs(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_code_run_transitions_run
+    ON code_run_transitions(run_id, created_at ASC);
+
+CREATE TABLE IF NOT EXISTS code_checkpoints (
+    id TEXT PRIMARY KEY,
+    workspace_id TEXT,
+    name TEXT,
+    git_branch TEXT,
+    git_commit TEXT,
+    dirty INTEGER DEFAULT 0,
+    metadata_json TEXT DEFAULT '{}',
+    created_at REAL NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_code_checkpoints_workspace
+    ON code_checkpoints(workspace_id, created_at DESC);
 
 CREATE TABLE IF NOT EXISTS state_meta (
     key TEXT PRIMARY KEY,
@@ -611,6 +686,89 @@ class SessionDB:
                     # If the process lacks required migration privileges or the
                     # DB is in a transient bad state, continue with the
                     # existing migration path after creating schema in future reads.
+                    pass
+
+            if current_version < 13:
+                # v13: add P0 engineering control-plane tables.
+                try:
+                    cursor.executescript(
+                        """
+                        CREATE TABLE IF NOT EXISTS code_artifacts (
+                            id TEXT PRIMARY KEY,
+                            artifact_type TEXT NOT NULL,
+                            title TEXT,
+                            content TEXT NOT NULL,
+                            content_type TEXT DEFAULT 'markdown',
+                            workspace_id TEXT,
+                            code_session_id TEXT,
+                            orchestrated_run_id TEXT,
+                            command_id TEXT,
+                            metadata_json TEXT DEFAULT '{}',
+                            created_at REAL NOT NULL,
+                            updated_at REAL NOT NULL
+                        );
+
+                        CREATE INDEX IF NOT EXISTS idx_code_artifacts_workspace
+                            ON code_artifacts(workspace_id, created_at DESC);
+
+                        CREATE INDEX IF NOT EXISTS idx_code_artifacts_session
+                            ON code_artifacts(code_session_id, created_at DESC);
+
+                        CREATE INDEX IF NOT EXISTS idx_code_artifacts_run
+                            ON code_artifacts(orchestrated_run_id, created_at DESC);
+
+                        CREATE TABLE IF NOT EXISTS code_orchestrated_runs (
+                            id TEXT PRIMARY KEY,
+                            title TEXT,
+                            goal TEXT,
+                            state TEXT NOT NULL DEFAULT 'intake',
+                            workspace_id TEXT,
+                            code_session_id TEXT,
+                            current_phase TEXT,
+                            metadata_json TEXT DEFAULT '{}',
+                            created_at REAL NOT NULL,
+                            updated_at REAL NOT NULL,
+                            completed_at REAL
+                        );
+
+                        CREATE INDEX IF NOT EXISTS idx_code_orchestrated_runs_workspace
+                            ON code_orchestrated_runs(workspace_id, created_at DESC);
+
+                        CREATE INDEX IF NOT EXISTS idx_code_orchestrated_runs_session
+                            ON code_orchestrated_runs(code_session_id, created_at DESC);
+
+                        CREATE INDEX IF NOT EXISTS idx_code_orchestrated_runs_state
+                            ON code_orchestrated_runs(state, updated_at DESC);
+
+                        CREATE TABLE IF NOT EXISTS code_run_transitions (
+                            id TEXT PRIMARY KEY,
+                            run_id TEXT NOT NULL,
+                            from_state TEXT,
+                            to_state TEXT NOT NULL,
+                            reason TEXT,
+                            created_at REAL NOT NULL,
+                            FOREIGN KEY (run_id) REFERENCES code_orchestrated_runs(id) ON DELETE CASCADE
+                        );
+
+                        CREATE INDEX IF NOT EXISTS idx_code_run_transitions_run
+                            ON code_run_transitions(run_id, created_at ASC);
+
+                        CREATE TABLE IF NOT EXISTS code_checkpoints (
+                            id TEXT PRIMARY KEY,
+                            workspace_id TEXT,
+                            name TEXT,
+                            git_branch TEXT,
+                            git_commit TEXT,
+                            dirty INTEGER DEFAULT 0,
+                            metadata_json TEXT DEFAULT '{}',
+                            created_at REAL NOT NULL
+                        );
+
+                        CREATE INDEX IF NOT EXISTS idx_code_checkpoints_workspace
+                            ON code_checkpoints(workspace_id, created_at DESC);
+                        """
+                    )
+                except Exception:
                     pass
 
             if current_version < SCHEMA_VERSION:
@@ -1294,6 +1452,14 @@ class SessionDB:
         )
         return self._code_list_rows("code_workspaces", query=query, params=tuple(params), limit=limit, offset=offset)
 
+    def get_code_workspace(self, workspace_id: str) -> Optional[dict[str, Any]]:
+        if not self._code_tables_exist():
+            return None
+        with self._lock:
+            cursor = self._conn.execute("SELECT * FROM code_workspaces WHERE id = ? LIMIT 1", (workspace_id,))
+            row = cursor.fetchone()
+        return dict(row) if row else None
+
     def list_code_sessions(
         self,
         workspace_id: str | None = None,
@@ -1333,6 +1499,301 @@ class SessionDB:
             "ORDER BY created_at DESC LIMIT ? OFFSET ?"
         )
         return self._code_list_rows("code_events", query=query, params=tuple(params), limit=limit, offset=offset)
+
+    def append_code_event(
+        self,
+        *,
+        event_type: str,
+        payload: dict[str, Any],
+        workspace_id: str | None = None,
+        code_session_id: str | None = None,
+        sender_login: str | None = None,
+        source: str | None = "code_mode",
+        level: str = "info",
+    ) -> str:
+        event_id = str(uuid.uuid4())
+        payload_json = json.dumps(payload or {})
+        created_at = time.time()
+
+        def _do(conn):
+            conn.execute(
+                """
+                INSERT INTO code_events (
+                    id, workspace_id, session_id, event_type, sender_login,
+                    source, level, payload_json, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    event_id,
+                    workspace_id,
+                    code_session_id,
+                    event_type,
+                    sender_login,
+                    source,
+                    level,
+                    payload_json,
+                    created_at,
+                ),
+            )
+            return event_id
+
+        return self._execute_write(_do)
+
+    def create_code_artifact(self, artifact: dict[str, Any]) -> str:
+        artifact_id = artifact["id"]
+        metadata_json = json.dumps(artifact.get("metadata") or {})
+
+        def _do(conn):
+            conn.execute(
+                """
+                INSERT INTO code_artifacts (
+                    id, artifact_type, title, content, content_type,
+                    workspace_id, code_session_id, orchestrated_run_id, command_id,
+                    metadata_json, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    artifact_id,
+                    artifact["artifact_type"],
+                    artifact.get("title"),
+                    artifact.get("content", ""),
+                    artifact.get("content_type", "markdown"),
+                    artifact.get("workspace_id"),
+                    artifact.get("code_session_id"),
+                    artifact.get("orchestrated_run_id"),
+                    artifact.get("command_id"),
+                    metadata_json,
+                    artifact["created_at"],
+                    artifact["updated_at"],
+                ),
+            )
+            return artifact_id
+
+        return self._execute_write(_do)
+
+    def list_code_artifacts(
+        self,
+        *,
+        workspace_id: str | None = None,
+        code_session_id: str | None = None,
+        orchestrated_run_id: str | None = None,
+        artifact_type: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        filters = []
+        params: list[Any] = []
+        if workspace_id:
+            filters.append("workspace_id = ?")
+            params.append(workspace_id)
+        if code_session_id:
+            filters.append("code_session_id = ?")
+            params.append(code_session_id)
+        if orchestrated_run_id:
+            filters.append("orchestrated_run_id = ?")
+            params.append(orchestrated_run_id)
+        if artifact_type:
+            filters.append("artifact_type = ?")
+            params.append(artifact_type)
+        where_sql = f"WHERE {' AND '.join(filters)}" if filters else ""
+        with self._lock:
+            cursor = self._conn.execute(
+                f"SELECT * FROM code_artifacts {where_sql} ORDER BY created_at DESC LIMIT ? OFFSET ?",
+                tuple(params + [limit, offset]),
+            )
+            rows = [dict(row) for row in cursor.fetchall()]
+        for row in rows:
+            raw = row.pop("metadata_json", "{}")
+            try:
+                row["metadata"] = json.loads(raw) if raw else {}
+            except Exception:
+                row["metadata"] = {}
+        return rows
+
+    def create_code_orchestrated_run(self, run: dict[str, Any]) -> str:
+        metadata_json = json.dumps(run.get("metadata") or {})
+
+        def _do(conn):
+            conn.execute(
+                """
+                INSERT INTO code_orchestrated_runs (
+                    id, title, goal, state, workspace_id, code_session_id,
+                    current_phase, metadata_json, created_at, updated_at, completed_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    run["id"],
+                    run.get("title"),
+                    run.get("goal"),
+                    run.get("state", "intake"),
+                    run.get("workspace_id"),
+                    run.get("code_session_id"),
+                    run.get("current_phase"),
+                    metadata_json,
+                    run["created_at"],
+                    run["updated_at"],
+                    run.get("completed_at"),
+                ),
+            )
+            return run["id"]
+
+        return self._execute_write(_do)
+
+    def get_code_orchestrated_run(self, run_id: str) -> Optional[dict[str, Any]]:
+        with self._lock:
+            cursor = self._conn.execute(
+                "SELECT * FROM code_orchestrated_runs WHERE id = ? LIMIT 1",
+                (run_id,),
+            )
+            row = cursor.fetchone()
+        if not row:
+            return None
+        result = dict(row)
+        raw = result.pop("metadata_json", "{}")
+        try:
+            result["metadata"] = json.loads(raw) if raw else {}
+        except Exception:
+            result["metadata"] = {}
+        return result
+
+    def list_code_orchestrated_runs(
+        self,
+        *,
+        workspace_id: str | None = None,
+        code_session_id: str | None = None,
+        state: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        filters = []
+        params: list[Any] = []
+        if workspace_id:
+            filters.append("workspace_id = ?")
+            params.append(workspace_id)
+        if code_session_id:
+            filters.append("code_session_id = ?")
+            params.append(code_session_id)
+        if state:
+            filters.append("state = ?")
+            params.append(state)
+        where_sql = f"WHERE {' AND '.join(filters)}" if filters else ""
+        with self._lock:
+            cursor = self._conn.execute(
+                f"SELECT * FROM code_orchestrated_runs {where_sql} ORDER BY created_at DESC LIMIT ? OFFSET ?",
+                tuple(params + [limit, offset]),
+            )
+            rows = [dict(row) for row in cursor.fetchall()]
+        for row in rows:
+            raw = row.pop("metadata_json", "{}")
+            try:
+                row["metadata"] = json.loads(raw) if raw else {}
+            except Exception:
+                row["metadata"] = {}
+        return rows
+
+    def update_code_orchestrated_run(self, run_id: str, updates: dict[str, Any]) -> bool:
+        if not updates:
+            return False
+        fields = []
+        params: list[Any] = []
+        for key, value in updates.items():
+            if key == "metadata":
+                fields.append("metadata_json = ?")
+                params.append(json.dumps(value or {}))
+            else:
+                fields.append(f"{key} = ?")
+                params.append(value)
+        params.append(run_id)
+
+        def _do(conn):
+            conn.execute(
+                f"UPDATE code_orchestrated_runs SET {', '.join(fields)} WHERE id = ?",
+                tuple(params),
+            )
+            return True
+
+        return bool(self._execute_write(_do))
+
+    def add_code_run_transition(self, transition: dict[str, Any]) -> str:
+        def _do(conn):
+            conn.execute(
+                """
+                INSERT INTO code_run_transitions (
+                    id, run_id, from_state, to_state, reason, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    transition["id"],
+                    transition["run_id"],
+                    transition.get("from_state"),
+                    transition["to_state"],
+                    transition.get("reason"),
+                    transition["created_at"],
+                ),
+            )
+            return transition["id"]
+
+        return self._execute_write(_do)
+
+    def list_code_run_transitions(self, *, run_id: str) -> list[dict[str, Any]]:
+        with self._lock:
+            cursor = self._conn.execute(
+                "SELECT * FROM code_run_transitions WHERE run_id = ? ORDER BY created_at ASC",
+                (run_id,),
+            )
+            return [dict(row) for row in cursor.fetchall()]
+
+    def create_code_checkpoint(self, checkpoint: dict[str, Any]) -> str:
+        def _do(conn):
+            conn.execute(
+                """
+                INSERT INTO code_checkpoints (
+                    id, workspace_id, name, git_branch, git_commit, dirty,
+                    metadata_json, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    checkpoint["id"],
+                    checkpoint.get("workspace_id"),
+                    checkpoint.get("name"),
+                    checkpoint.get("git_branch"),
+                    checkpoint.get("git_commit"),
+                    1 if checkpoint.get("dirty") else 0,
+                    json.dumps(checkpoint.get("metadata") or {}),
+                    checkpoint["created_at"],
+                ),
+            )
+            return checkpoint["id"]
+
+        return self._execute_write(_do)
+
+    def list_code_checkpoints(
+        self,
+        *,
+        workspace_id: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        filters = []
+        params: list[Any] = []
+        if workspace_id:
+            filters.append("workspace_id = ?")
+            params.append(workspace_id)
+        where_sql = f"WHERE {' AND '.join(filters)}" if filters else ""
+        with self._lock:
+            cursor = self._conn.execute(
+                f"SELECT * FROM code_checkpoints {where_sql} ORDER BY created_at DESC LIMIT ? OFFSET ?",
+                tuple(params + [limit, offset]),
+            )
+            rows = [dict(row) for row in cursor.fetchall()]
+        for row in rows:
+            row["dirty"] = bool(row.get("dirty"))
+            raw = row.pop("metadata_json", "{}")
+            try:
+                row["metadata"] = json.loads(raw) if raw else {}
+            except Exception:
+                row["metadata"] = {}
+        return rows
 
     # =========================================================================
     # Message storage

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -33,7 +33,7 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 11
+SCHEMA_VERSION = 12
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -88,6 +88,65 @@ CREATE TABLE IF NOT EXISTS messages (
     codex_reasoning_items TEXT,
     codex_message_items TEXT
 );
+
+CREATE TABLE IF NOT EXISTS code_workspaces (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    owner TEXT,
+    repo TEXT,
+    path TEXT,
+    git_remote TEXT,
+    repo_url TEXT,
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_code_workspaces_id
+    ON code_workspaces(id);
+
+CREATE INDEX IF NOT EXISTS idx_code_workspaces_owner
+    ON code_workspaces(owner);
+
+CREATE INDEX IF NOT EXISTS idx_code_workspaces_repo
+    ON code_workspaces(owner, repo);
+
+CREATE TABLE IF NOT EXISTS code_sessions (
+    id TEXT PRIMARY KEY,
+    workspace_id TEXT,
+    status TEXT DEFAULT 'active',
+    provider TEXT,
+    branch TEXT,
+    last_synced_at REAL,
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL,
+    metadata_json TEXT,
+    FOREIGN KEY (workspace_id) REFERENCES code_workspaces(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_code_sessions_workspace
+    ON code_sessions(workspace_id);
+
+CREATE INDEX IF NOT EXISTS idx_code_sessions_status
+    ON code_sessions(status);
+
+CREATE TABLE IF NOT EXISTS code_events (
+    id TEXT PRIMARY KEY,
+    workspace_id TEXT,
+    session_id TEXT,
+    event_type TEXT NOT NULL,
+    sender_login TEXT,
+    source TEXT,
+    level TEXT DEFAULT 'info',
+    payload_json TEXT NOT NULL,
+    created_at REAL NOT NULL,
+    FOREIGN KEY (workspace_id) REFERENCES code_workspaces(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_code_events_workspace
+    ON code_events(workspace_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_code_events_session
+    ON code_events(session_id, created_at DESC);
 
 CREATE TABLE IF NOT EXISTS state_meta (
     key TEXT PRIMARY KEY,
@@ -481,6 +540,79 @@ class SessionDB:
                     "COALESCE(tool_calls, '') "
                     "FROM messages"
                 )
+
+            if current_version < 12:
+                # v12: introduce minimal code-mode tables used by the
+                # Code Mode foundation (workspace/sessions/events metadata).
+                try:
+                    cursor.executescript(
+                        """
+                        CREATE TABLE IF NOT EXISTS code_workspaces (
+                            id TEXT PRIMARY KEY,
+                            name TEXT NOT NULL,
+                            owner TEXT,
+                            repo TEXT,
+                            path TEXT,
+                            git_remote TEXT,
+                            repo_url TEXT,
+                            created_at REAL NOT NULL,
+                            updated_at REAL NOT NULL
+                        );
+
+                        CREATE UNIQUE INDEX IF NOT EXISTS idx_code_workspaces_id
+                            ON code_workspaces(id);
+
+                        CREATE INDEX IF NOT EXISTS idx_code_workspaces_owner
+                            ON code_workspaces(owner);
+
+                        CREATE INDEX IF NOT EXISTS idx_code_workspaces_repo
+                            ON code_workspaces(owner, repo);
+
+                        CREATE TABLE IF NOT EXISTS code_sessions (
+                            id TEXT PRIMARY KEY,
+                            workspace_id TEXT,
+                            status TEXT DEFAULT 'active',
+                            provider TEXT,
+                            branch TEXT,
+                            last_synced_at REAL,
+                            created_at REAL NOT NULL,
+                            updated_at REAL NOT NULL,
+                            metadata_json TEXT,
+                            FOREIGN KEY (workspace_id) REFERENCES code_workspaces(id)
+                        );
+
+                        CREATE INDEX IF NOT EXISTS idx_code_sessions_workspace
+                            ON code_sessions(workspace_id);
+
+                        CREATE INDEX IF NOT EXISTS idx_code_sessions_status
+                            ON code_sessions(status);
+
+                        CREATE TABLE IF NOT EXISTS code_events (
+                            id TEXT PRIMARY KEY,
+                            workspace_id TEXT,
+                            session_id TEXT,
+                            event_type TEXT NOT NULL,
+                            sender_login TEXT,
+                            source TEXT,
+                            level TEXT DEFAULT 'info',
+                            payload_json TEXT NOT NULL,
+                            created_at REAL NOT NULL,
+                            FOREIGN KEY (workspace_id) REFERENCES code_workspaces(id) ON DELETE CASCADE
+                        );
+
+                        CREATE INDEX IF NOT EXISTS idx_code_events_workspace
+                            ON code_events(workspace_id, created_at DESC);
+
+                        CREATE INDEX IF NOT EXISTS idx_code_events_session
+                            ON code_events(session_id, created_at DESC);
+                        """
+                    )
+                except Exception:
+                    # If the process lacks required migration privileges or the
+                    # DB is in a transient bad state, continue with the
+                    # existing migration path after creating schema in future reads.
+                    pass
+
             if current_version < SCHEMA_VERSION:
                 cursor.execute(
                     "UPDATE schema_version SET version = ?",
@@ -1083,6 +1215,124 @@ class SessionDB:
         else:
             s["preview"] = ""
         return s
+
+    # =========================================================================
+    # Code Mode support
+    # =========================================================================
+
+    def _code_tables_exist(self) -> bool:
+        with self._lock:
+            cursor = self._conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='code_workspaces'"
+            )
+            return bool(cursor.fetchone())
+
+    def code_mode_status(self) -> Dict[str, Any]:
+        """Return light-weight code mode state summary for console/dashboard."""
+        if not self._code_tables_exist():
+            return {
+                "mode": "unconfigured",
+                "schema_version": None,
+                "tables": {"code_workspaces": False, "code_sessions": False, "code_events": False},
+            }
+        with self._lock:
+            counts = {}
+            for name in ("code_workspaces", "code_sessions", "code_events"):
+                cursor = self._conn.execute(f"SELECT COUNT(1) AS c FROM {name}")
+                counts[name] = int(cursor.fetchone()["c"])
+            cursor = self._conn.execute("SELECT version FROM schema_version LIMIT 1")
+            row = cursor.fetchone()
+        return {
+            "mode": "enabled" if counts else "unknown",
+            "schema_version": row["version"] if row else None,
+            "tables": {
+                "code_workspaces": True,
+                "code_sessions": True,
+                "code_events": True,
+            },
+            "counts": counts,
+            "workspace_count": counts.get("code_workspaces", 0),
+            "session_count": counts.get("code_sessions", 0),
+            "event_count": counts.get("code_events", 0),
+        }
+
+    def _code_list_rows(
+        self,
+        table: str,
+        *,
+        query: str,
+        params: tuple = (),
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        if not self._code_tables_exist():
+            return []
+        with self._lock:
+            cursor = self._conn.execute(query, params + (limit, offset))
+            return [dict(row) for row in cursor.fetchall()]
+
+    def list_code_workspaces(
+        self,
+        owner: str | None = None,
+        q: str = "",
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        filters = []
+        params: list[Any] = []
+        if owner:
+            filters.append("owner = ?")
+            params.append(owner)
+        if q:
+            filters.append("(name LIKE ? OR path LIKE ? OR repo_url LIKE ? OR repo LIKE ?)")
+            pattern = f"%{q}%"
+            params.extend([pattern, pattern, pattern, pattern])
+        where_sql = f"WHERE {' AND '.join(filters)}" if filters else ""
+        query = (
+            f"SELECT * FROM code_workspaces {where_sql} "
+            "ORDER BY updated_at DESC LIMIT ? OFFSET ?"
+        )
+        return self._code_list_rows("code_workspaces", query=query, params=tuple(params), limit=limit, offset=offset)
+
+    def list_code_sessions(
+        self,
+        workspace_id: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        filters = []
+        params: list[Any] = []
+        if workspace_id:
+            filters.append("workspace_id = ?")
+            params.append(workspace_id)
+        where_sql = f"WHERE {' AND '.join(filters)}" if filters else ""
+        query = (
+            f"SELECT * FROM code_sessions {where_sql} "
+            "ORDER BY updated_at DESC LIMIT ? OFFSET ?"
+        )
+        return self._code_list_rows("code_sessions", query=query, params=tuple(params), limit=limit, offset=offset)
+
+    def list_code_events(
+        self,
+        workspace_id: str | None = None,
+        session_id: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        filters = []
+        params: list[Any] = []
+        if workspace_id:
+            filters.append("workspace_id = ?")
+            params.append(workspace_id)
+        if session_id:
+            filters.append("session_id = ?")
+            params.append(session_id)
+        where_sql = f"WHERE {' AND '.join(filters)}" if filters else ""
+        query = (
+            f"SELECT * FROM code_events {where_sql} "
+            "ORDER BY created_at DESC LIMIT ? OFFSET ?"
+        )
+        return self._code_list_rows("code_events", query=query, params=tuple(params), limit=limit, offset=offset)
 
     # =========================================================================
     # Message storage
@@ -2091,4 +2341,3 @@ class SessionDB:
             result["error"] = str(exc)
 
         return result
-

--- a/tests/hermes_cli/test_agent_orchestrator.py
+++ b/tests/hermes_cli/test_agent_orchestrator.py
@@ -1,0 +1,66 @@
+"""Tests for AgentOrchestrator."""
+
+import pytest
+
+from hermes_cli.code.agent_orchestrator import (
+    AgentOrchestrator,
+    OrchestratorState,
+    validate_transition,
+)
+from hermes_cli.code.artifact_ledger import ArtifactLedger
+
+
+@pytest.fixture()
+def orchestrator(tmp_path):
+    return AgentOrchestrator(db_path=tmp_path / "state.db")
+
+
+def test_create_run_defaults_to_intake(orchestrator):
+    run = orchestrator.create_run(title="Task A")
+    assert run["state"] == OrchestratorState.INTAKE
+
+
+def test_valid_transition_function():
+    ok, message = validate_transition(OrchestratorState.INTAKE, OrchestratorState.DISCOVERY)
+    assert ok is True
+    assert message == ""
+
+
+def test_invalid_transition_function():
+    ok, message = validate_transition(OrchestratorState.INTAKE, OrchestratorState.IMPLEMENTATION)
+    assert ok is False
+    assert "Invalid transition" in message
+
+
+def test_transition_run_and_persist(orchestrator):
+    run = orchestrator.create_run(title="Task B")
+    updated = orchestrator.transition_run(run["id"], OrchestratorState.DISCOVERY, reason="start discovery")
+    assert updated["state"] == OrchestratorState.DISCOVERY
+    transitions = orchestrator.list_transitions(run["id"])
+    assert len(transitions) == 1
+    assert transitions[0]["to_state"] == OrchestratorState.DISCOVERY
+
+
+def test_terminal_transition_sets_completed_at(orchestrator):
+    run = orchestrator.create_run(title="Task C")
+    run = orchestrator.transition_run(run["id"], OrchestratorState.DISCOVERY)
+    run = orchestrator.transition_run(run["id"], OrchestratorState.PLANNING)
+    run = orchestrator.transition_run(run["id"], OrchestratorState.APPROVAL)
+    run = orchestrator.transition_run(run["id"], OrchestratorState.IMPLEMENTATION)
+    run = orchestrator.transition_run(run["id"], OrchestratorState.VALIDATION)
+    run = orchestrator.transition_run(run["id"], OrchestratorState.REVIEW)
+    run = orchestrator.transition_run(run["id"], OrchestratorState.READY_FOR_PR)
+    run = orchestrator.transition_run(run["id"], OrchestratorState.COMPLETED)
+    assert run["completed_at"] is not None
+
+
+def test_create_goal_creates_task_intake_artifact(orchestrator, tmp_path):
+    run = orchestrator.create_run(
+        title="Task D",
+        goal="Add smoke tests",
+        create_intake_artifact=True,
+    )
+    ledger = ArtifactLedger(db_path=tmp_path / "state.db")
+    artifacts = ledger.list_artifacts(orchestrated_run_id=run["id"])
+    assert len(artifacts) == 1
+    assert artifacts[0]["artifact_type"] == "task_intake"

--- a/tests/hermes_cli/test_approval_governance.py
+++ b/tests/hermes_cli/test_approval_governance.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import time
 
 import pytest
@@ -156,3 +157,25 @@ def test_validate_for_execution_replay_and_kind_binding(service):
             expected_github_issue_number=7,
             expected_requested_payload={"arg": "value", "token": "secret-token"},
         )
+
+
+def test_approval_events_persist_with_approval_id(service):
+    created = _create(service, kind=ApprovalKind.GITHUB_COMMENT)
+    service.approve_request(created["id"], approved_by="alice")
+    service.reject_request(_create(service, title="Reject Me")["id"], rejected_by="alice")
+
+    db = service._db()
+    try:
+        rows = db.list_code_events(limit=200)
+    finally:
+        db.close()
+
+    event_types = {row["event_type"] for row in rows}
+    assert "code.approval.created" in event_types
+    assert "code.approval.approved" in event_types
+    assert "code.approval.rejected" in event_types
+
+    matching = [row for row in rows if row["event_type"] == "code.approval.approved"]
+    assert matching, "Expected code.approval.approved event"
+    payload = json.loads(matching[0]["payload_json"])
+    assert payload.get("approval_id") == created["id"]

--- a/tests/hermes_cli/test_approval_governance.py
+++ b/tests/hermes_cli/test_approval_governance.py
@@ -1,0 +1,158 @@
+"""Tests for persistent Code Mode approval governance."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from hermes_cli.code.approval_governance import (
+    ApprovalGovernanceError,
+    ApprovalGovernanceService,
+    ApprovalKind,
+    ApprovalStatus,
+)
+from hermes_cli.code.execution_policy import RiskClass
+from hermes_state import SessionDB
+
+
+@pytest.fixture()
+def service(tmp_path):
+    db_path = tmp_path / "state.db"
+    SessionDB(db_path=db_path).close()
+    return ApprovalGovernanceService(db_path=db_path)
+
+
+def _create(service: ApprovalGovernanceService, *, kind: str = ApprovalKind.GENERIC, title: str = "Approval A", expires_at=None):
+    return service.create_request(
+        kind=kind,
+        risk_class=RiskClass.GIT_WRITE,
+        title=title,
+        description="desc",
+        requested_action=f"{kind}.action",
+        requested_payload={"arg": "value", "token": "secret-token"},
+        resource_type="test_resource",
+        resource_id="res-1",
+        github_repo_full_name="acme/repo",
+        github_issue_number=7,
+        expires_at=expires_at,
+    )
+
+
+def test_create_list_get_approval_request(service):
+    created = _create(service)
+    assert created["status"] == ApprovalStatus.PENDING
+    assert created["kind"] == ApprovalKind.GENERIC
+
+    listed = service.list_requests()
+    assert any(item["id"] == created["id"] for item in listed)
+
+    fetched = service.get_request(created["id"])
+    assert fetched is not None
+    assert fetched["id"] == created["id"]
+    assert fetched["resource_id"] == "res-1"
+
+
+def test_approve_pending(service):
+    created = _create(service)
+    approved = service.approve_request(created["id"], approved_by="local")
+    assert approved["status"] == ApprovalStatus.APPROVED
+    assert approved["approved_by"] == "local"
+
+
+def test_reject_pending(service):
+    created = _create(service)
+    rejected = service.reject_request(created["id"], rejected_by="local", reason="no")
+    assert rejected["status"] == ApprovalStatus.REJECTED
+    assert rejected["rejected_by"] == "local"
+
+
+def test_cancel_pending(service):
+    created = _create(service)
+    cancelled = service.cancel_request(created["id"], cancelled_by="local", reason="stop")
+    assert cancelled["status"] == ApprovalStatus.CANCELLED
+
+
+def test_expire_pending(service):
+    created = _create(service, expires_at=time.time() - 2)
+    expired = service.expire_pending()
+    assert expired["count"] >= 1
+    fetched = service.get_request(created["id"])
+    assert fetched is not None
+    assert fetched["status"] == ApprovalStatus.EXPIRED
+
+
+def test_mark_executed(service):
+    created = _create(service)
+    service.approve_request(created["id"], approved_by="alice")
+    executed = service.mark_executed(created["id"], metadata={"run": "ok"})
+    assert executed["status"] == ApprovalStatus.EXECUTED
+
+
+def test_mark_failed(service):
+    created = _create(service)
+    service.approve_request(created["id"], approved_by="alice")
+    failed = service.mark_failed(created["id"], reason="network error")
+    assert failed["status"] == ApprovalStatus.FAILED
+
+
+def test_invalid_transitions_rejected(service):
+    created = _create(service)
+    with pytest.raises(ApprovalGovernanceError):
+        service.mark_executed(created["id"])
+
+
+def test_terminal_states_cannot_transition(service):
+    created = _create(service)
+    service.reject_request(created["id"], rejected_by="alice")
+    with pytest.raises(ApprovalGovernanceError):
+        service.approve_request(created["id"], approved_by="bob")
+
+
+def test_redaction_of_sensitive_payloads(service):
+    created = _create(service)
+    payload = created["requested_payload"]
+    assert payload["token"] == "[REDACTED]"
+    assert "secret-token" not in str(created)
+
+
+def test_summary_counts(service):
+    one = _create(service, kind=ApprovalKind.GITHUB_COMMENT, title="A")
+    two = _create(service, kind=ApprovalKind.GITHUB_PR_PREPARE, title="B")
+    service.approve_request(one["id"], approved_by="alice")
+    service.reject_request(two["id"], rejected_by="alice")
+
+    summary = service.summary()
+    assert summary["status"]["approved"] >= 1
+    assert summary["status"]["rejected"] >= 1
+    assert summary["kind"]["github_comment"] >= 1
+    assert summary["kind"]["github_pr_prepare"] >= 1
+
+
+def test_validate_for_execution_replay_and_kind_binding(service):
+    created = _create(service, kind=ApprovalKind.GITHUB_COMMENT)
+    service.approve_request(created["id"], approved_by="alice")
+
+    valid = service.validate_for_execution(
+        created["id"],
+        expected_kind=ApprovalKind.GITHUB_COMMENT,
+        expected_requested_action="github_comment.action",
+        expected_resource_type="test_resource",
+        expected_resource_id="res-1",
+        expected_github_repo_full_name="acme/repo",
+        expected_github_issue_number=7,
+        expected_requested_payload={"arg": "value", "token": "secret-token"},
+    )
+    assert valid["id"] == created["id"]
+
+    with pytest.raises(ApprovalGovernanceError):
+        service.validate_for_execution(
+            created["id"],
+            expected_kind=ApprovalKind.GITHUB_PR_PREPARE,
+            expected_requested_action="github_pr_prepare.action",
+            expected_resource_type="test_resource",
+            expected_resource_id="res-1",
+            expected_github_repo_full_name="acme/repo",
+            expected_github_issue_number=7,
+            expected_requested_payload={"arg": "value", "token": "secret-token"},
+        )

--- a/tests/hermes_cli/test_artifact_ledger.py
+++ b/tests/hermes_cli/test_artifact_ledger.py
@@ -1,0 +1,39 @@
+"""Tests for ArtifactLedger."""
+
+import pytest
+
+from hermes_cli.code.artifact_ledger import ArtifactLedger
+
+
+@pytest.fixture()
+def ledger(tmp_path):
+    return ArtifactLedger(db_path=tmp_path / "state.db")
+
+
+def test_create_and_list_artifact(ledger):
+    artifact = ledger.create_artifact(
+        "task_intake",
+        "Implement parser",
+        title="Parser Task",
+        workspace_id="ws-1",
+        code_session_id="cs-1",
+        orchestrated_run_id="run-1",
+    )
+    assert artifact["id"]
+    assert artifact["artifact_type"] == "task_intake"
+
+    rows = ledger.list_artifacts(code_session_id="cs-1")
+    assert any(row["id"] == artifact["id"] for row in rows)
+
+
+def test_invalid_artifact_type_raises(ledger):
+    with pytest.raises(ValueError):
+        ledger.create_artifact("unknown_type", "x")
+
+
+def test_artifact_filters(ledger):
+    ledger.create_artifact("task_intake", "a", code_session_id="cs-a")
+    ledger.create_artifact("review_report", "b", code_session_id="cs-b")
+    results = ledger.list_artifacts(code_session_id="cs-a")
+    assert len(results) == 1
+    assert results[0]["code_session_id"] == "cs-a"

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -66,9 +66,15 @@ class TestCommandRegistry:
                         f"Alias '{alias}' of '{cmd.name}' shadows canonical '{target.name}'"
 
     def test_every_entry_has_valid_category(self):
-        valid_categories = {"Session", "Configuration", "Tools & Skills", "Info", "Exit"}
+        valid_categories = {"Session", "Configuration", "Tools & Skills", "Code Mode", "Info", "Exit"}
         for cmd in COMMAND_REGISTRY:
             assert cmd.category in valid_categories, f"{cmd.name} has invalid category '{cmd.category}'"
+
+    def test_code_mode_commands_registered(self):
+        expected = {"code", "web", "workspace", "session", "approvals", "skills-code"}
+        names = {cmd.name for cmd in COMMAND_REGISTRY}
+        assert expected <= names
+        assert resolve_command("skillscode").name == "skills-code"
 
     def test_reasoning_subcommands_are_in_logical_order(self):
         reasoning = next(cmd for cmd in COMMAND_REGISTRY if cmd.name == "reasoning")
@@ -142,6 +148,7 @@ class TestDerivedDicts:
         assert "/exit" in COMMANDS
         assert "/reload_mcp" in COMMANDS
         assert "/gateway" in COMMANDS
+        assert "/skillscode" in COMMANDS
 
     def test_commands_by_category_covers_all_categories(self):
         registry_categories = {cmd.category for cmd in COMMAND_REGISTRY if not cmd.gateway_only}

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -71,10 +71,11 @@ class TestCommandRegistry:
             assert cmd.category in valid_categories, f"{cmd.name} has invalid category '{cmd.category}'"
 
     def test_code_mode_commands_registered(self):
-        expected = {"code", "web", "workspace", "session", "approvals", "skills-code"}
+        expected = {"code", "web", "workspace", "session", "approvals", "skills-code", "github"}
         names = {cmd.name for cmd in COMMAND_REGISTRY}
         assert expected <= names
         assert resolve_command("skillscode").name == "skills-code"
+        assert resolve_command("github").name == "github"
 
     def test_reasoning_subcommands_are_in_logical_order(self):
         reasoning = next(cmd for cmd in COMMAND_REGISTRY if cmd.name == "reasoning")

--- a/tests/hermes_cli/test_event_bus.py
+++ b/tests/hermes_cli/test_event_bus.py
@@ -1,0 +1,158 @@
+"""Tests for Hermes Code Mode realtime event bus."""
+
+from __future__ import annotations
+
+from hermes_cli.code.event_bus import CodeEventBus, build_event_filters_from_query
+from hermes_state import SessionDB
+
+
+def _bus(tmp_path):
+    db_path = tmp_path / "state.db"
+    SessionDB(db_path=db_path).close()
+    return CodeEventBus(db_path=db_path), db_path
+
+
+def _seed_workspace(db_path, workspace_id: str):
+    import time
+
+    db = SessionDB(db_path=db_path)
+    try:
+        now = time.time()
+        db._conn.execute(
+            """
+            INSERT OR REPLACE INTO code_workspaces
+                (id, name, owner, repo, path, git_remote, repo_url, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                workspace_id,
+                workspace_id,
+                "owner",
+                "repo",
+                f"/tmp/{workspace_id}",
+                "",
+                "",
+                now,
+                now,
+            ),
+        )
+        db._conn.commit()
+    finally:
+        db.close()
+
+
+def test_publish_persists_event(tmp_path):
+    bus, db_path = _bus(tmp_path)
+    _seed_workspace(db_path, "ws-1")
+    event = bus.publish(
+        "code.approval.created",
+        payload={"approval_id": "a1"},
+        workspace_id="ws-1",
+        code_session_id="cs-1",
+        approval_id="a1",
+    )
+    assert event["type"] == "code.approval.created"
+    assert event["approval_id"] == "a1"
+
+    db = SessionDB(db_path=db_path)
+    try:
+        rows = db.list_code_events(workspace_id="ws-1", session_id="cs-1", limit=10)
+    finally:
+        db.close()
+    assert len(rows) == 1
+    assert rows[0]["event_type"] == "code.approval.created"
+
+
+def test_publish_broadcasts_to_subscribers(tmp_path):
+    bus, _db_path = _bus(tmp_path)
+    sub_id, sub_queue = bus.subscribe(filters={"type": "code.approval.approved"})
+    try:
+        bus.publish("code.approval.approved", payload={"status": "approved"})
+        event = sub_queue.get(timeout=1.0)
+    finally:
+        bus.unsubscribe(sub_id)
+    assert event["type"] == "code.approval.approved"
+
+
+def test_filters_type_workspace_session_approval_repo(tmp_path):
+    bus, _db_path = _bus(tmp_path)
+    _seed_workspace(_db_path, "ws-1")
+    _seed_workspace(_db_path, "ws-2")
+    bus.publish(
+        "github.write.executed",
+        payload={"ok": True},
+        workspace_id="ws-1",
+        code_session_id="cs-1",
+        approval_id="ap-1",
+        github_repo_full_name="acme/repo",
+    )
+    bus.publish(
+        "github.write.executed",
+        payload={"ok": True},
+        workspace_id="ws-2",
+        code_session_id="cs-2",
+        approval_id="ap-2",
+        github_repo_full_name="acme/other",
+    )
+    items = bus.fetch_events(
+        filters=build_event_filters_from_query(
+            event_type="github.write.executed",
+            workspace_id="ws-1",
+            code_session_id="cs-1",
+            approval_id="ap-1",
+            github_repo_full_name="acme/repo",
+        ),
+        limit=50,
+    )
+    assert len(items) == 1
+    assert items[0]["workspace_id"] == "ws-1"
+    assert items[0]["approval_id"] == "ap-1"
+
+
+def test_replay_since_id_uses_persisted_order(tmp_path):
+    bus, _db_path = _bus(tmp_path)
+    first = bus.publish("code.test.a", payload={"n": 1})
+    second = bus.publish("code.test.b", payload={"n": 2})
+    third = bus.publish("code.test.c", payload={"n": 3})
+
+    replay = bus.replay(since_id=second["id"], limit=10)
+    assert [event["id"] for event in replay] == [third["id"]]
+    assert replay[0]["payload"]["n"] == 3
+    assert first["id"] != third["id"]
+
+
+def test_redaction_recursive_for_persist_and_replay(tmp_path):
+    bus, _db_path = _bus(tmp_path)
+    bus.publish(
+        "code.secret.test",
+        payload={
+            "token": "abc123",
+            "nested": {"authorization": "Bearer super-secret", "safe": "ok"},
+            "list": [{"password": "hidden"}, {"value": "ok"}],
+        },
+    )
+    events = bus.fetch_events(filters={"type": "code.secret.test"}, limit=10)
+    assert len(events) == 1
+    payload = events[0]["payload"]
+    assert payload["token"] == "[REDACTED]"
+    assert payload["nested"]["authorization"] == "[REDACTED]"
+    assert payload["nested"]["safe"] == "ok"
+    assert payload["list"][0]["password"] == "[REDACTED]"
+
+
+def test_no_subscriber_safety(tmp_path):
+    bus, _db_path = _bus(tmp_path)
+    event = bus.publish("code.events.safe", payload={"x": 1})
+    assert event["type"] == "code.events.safe"
+
+
+def test_stale_subscriber_cleanup(tmp_path):
+    bus, _db_path = _bus(tmp_path)
+    sub_id, _sub_queue = bus.subscribe(filters={"type": "code.queue.test"}, max_queue_size=1)
+    bus.publish("code.queue.test", payload={"n": 1})
+    # second push overflows the queue and should evict stale subscriber
+    bus.publish("code.queue.test", payload={"n": 2})
+    stats = bus.subscription_stats()
+    assert stats["active_subscribers"] == 0
+    # unsubscribe remains safe even if already evicted
+    bus.unsubscribe(sub_id)

--- a/tests/hermes_cli/test_execution_policy.py
+++ b/tests/hermes_cli/test_execution_policy.py
@@ -1,0 +1,35 @@
+"""Tests for Hermes Code Mode execution policy."""
+
+from hermes_cli.code.execution_policy import (
+    ExecutionPolicyEngine,
+    RiskClass,
+    classify_command,
+    redact_secrets,
+)
+
+
+def test_safe_command_classification():
+    assert classify_command("git status") == RiskClass.SAFE_READONLY
+
+
+def test_destructive_command_classification():
+    assert classify_command("rm -rf /tmp/demo") == RiskClass.DESTRUCTIVE
+
+
+def test_secret_sensitive_command_classification():
+    assert classify_command("cat .env") == RiskClass.SECRET_SENSITIVE
+
+
+def test_redaction_hides_sensitive_values():
+    text = "Authorization: Bearer ghp_abcdefghijklmnopqrstuvwxyz1234567890"
+    redacted = redact_secrets(text)
+    assert "ghp_" not in redacted
+    assert "[REDACTED]" in redacted
+
+
+def test_assess_command_contract():
+    engine = ExecutionPolicyEngine()
+    assessment = engine.assess_command("git commit -m test")
+    assert assessment["risk_class"] == RiskClass.GIT_WRITE
+    assert assessment["requires_approval"] is True
+    assert assessment["blocked"] is False

--- a/tests/hermes_cli/test_github_api_endpoints.py
+++ b/tests/hermes_cli/test_github_api_endpoints.py
@@ -127,10 +127,16 @@ def test_github_comments_endpoint_approval_flow(monkeypatch, clients):
     auth, _unauth = clients
     from hermes_cli.code.github_integration import GitHubIntegrationService
 
+    calls = {"count": 0}
+
+    def _fake_post(self, repo_full_name, issue_number, body, installation_id=None):
+        calls["count"] += 1
+        return {"id": calls["count"], "body": body}
+
     monkeypatch.setattr(
         GitHubIntegrationService,
         "post_issue_comment",
-        lambda self, repo_full_name, issue_number, body, installation_id=None: {"id": 1, "body": body},
+        _fake_post,
     )
 
     pending = auth.post(
@@ -139,28 +145,118 @@ def test_github_comments_endpoint_approval_flow(monkeypatch, clients):
             "repo_full_name": "acme/repo",
             "issue_number": 7,
             "body": "hello",
-            "approved": False,
         },
     )
     assert pending.status_code == 200
-    assert pending.json()["approval_required"] is True
+    payload = pending.json()
+    assert payload["requires_approval"] is True
+    approval_id = payload["approval_id"]
+    assert approval_id
 
-    approved = auth.post(
+    approve = auth.post(f"/api/code/approvals/{approval_id}/approve", json={"actor": "local"})
+    assert approve.status_code == 200
+
+    executed = auth.post(
         "/api/code/github/comments",
         json={
             "repo_full_name": "acme/repo",
             "issue_number": 7,
             "body": "hello",
-            "approved": True,
+            "approval_id": approval_id,
         },
     )
-    assert approved.status_code == 200
-    assert approved.json()["approval_required"] is False
+    assert executed.status_code == 200
+    assert executed.json()["requires_approval"] is False
+    assert executed.json()["status"] == "executed"
+    assert calls["count"] == 1
+
+
+def test_github_comments_rejected_expired_executed_or_mismatch_do_not_execute(monkeypatch, clients):
+    auth, _unauth = clients
+    from hermes_cli.code.github_integration import GitHubIntegrationService
+    from hermes_state import SessionDB
+
+    calls = {"count": 0}
+
+    def _fake_post(self, repo_full_name, issue_number, body, installation_id=None):
+        calls["count"] += 1
+        return {"id": 77, "body": body}
+
+    monkeypatch.setattr(GitHubIntegrationService, "post_issue_comment", _fake_post)
+
+    pending = auth.post(
+        "/api/code/github/comments",
+        json={"repo_full_name": "acme/repo", "issue_number": 9, "body": "token=abc123"},
+    )
+    approval_id = pending.json()["approval_id"]
+
+    # Rejected: should not execute
+    reject = auth.post(f"/api/code/approvals/{approval_id}/reject", json={"actor": "local", "reason": "deny"})
+    assert reject.status_code == 200
+    rejected_call = auth.post(
+        "/api/code/github/comments",
+        json={"repo_full_name": "acme/repo", "issue_number": 9, "body": "token=abc123", "approval_id": approval_id},
+    )
+    assert rejected_call.status_code == 400
+    assert calls["count"] == 0
+    assert "abc123" not in str(rejected_call.json())
+
+    # Approved + expired: should not execute
+    pending2 = auth.post(
+        "/api/code/github/comments",
+        json={"repo_full_name": "acme/repo", "issue_number": 11, "body": "hello-expired"},
+    )
+    approval_id2 = pending2.json()["approval_id"]
+    auth.post(f"/api/code/approvals/{approval_id2}/approve", json={"actor": "local"})
+    db = SessionDB()
+    try:
+        db.update_code_approval_request(approval_id2, {"expires_at": time.time() - 10})
+    finally:
+        db.close()
+    expired_call = auth.post(
+        "/api/code/github/comments",
+        json={"repo_full_name": "acme/repo", "issue_number": 11, "body": "hello-expired", "approval_id": approval_id2},
+    )
+    assert expired_call.status_code == 400
+    assert calls["count"] == 0
+
+    # Approved then executed cannot be reused
+    pending3 = auth.post(
+        "/api/code/github/comments",
+        json={"repo_full_name": "acme/repo", "issue_number": 12, "body": "hello-reuse"},
+    )
+    approval_id3 = pending3.json()["approval_id"]
+    auth.post(f"/api/code/approvals/{approval_id3}/approve", json={"actor": "local"})
+    first_exec = auth.post(
+        "/api/code/github/comments",
+        json={"repo_full_name": "acme/repo", "issue_number": 12, "body": "hello-reuse", "approval_id": approval_id3},
+    )
+    assert first_exec.status_code == 200
+    second_exec = auth.post(
+        "/api/code/github/comments",
+        json={"repo_full_name": "acme/repo", "issue_number": 12, "body": "hello-reuse", "approval_id": approval_id3},
+    )
+    assert second_exec.status_code == 400
+    assert calls["count"] == 1
+
+    # Kind/resource mismatch: approved approval for repo A cannot be replayed for repo B
+    pending4 = auth.post(
+        "/api/code/github/comments",
+        json={"repo_full_name": "acme/repo", "issue_number": 13, "body": "hello-match"},
+    )
+    approval_id4 = pending4.json()["approval_id"]
+    auth.post(f"/api/code/approvals/{approval_id4}/approve", json={"actor": "local"})
+    mismatch = auth.post(
+        "/api/code/github/comments",
+        json={"repo_full_name": "acme/other", "issue_number": 13, "body": "hello-match", "approval_id": approval_id4},
+    )
+    assert mismatch.status_code == 400
+    assert calls["count"] == 1
 
 
 def test_github_pull_request_prepare_endpoint(clients):
     auth, _unauth = clients
-    resp = auth.post(
+    pending = auth.post(
         "/api/code/github/pull-requests/prepare",
         json={
             "repo_full_name": "acme/repo",
@@ -170,7 +266,28 @@ def test_github_pull_request_prepare_endpoint(clients):
             "body": "desc",
         },
     )
+    assert pending.status_code == 200
+    payload = pending.json()
+    assert payload["requires_approval"] is True
+    approval_id = payload["approval_id"]
+    assert approval_id
+
+    approve = auth.post(f"/api/code/approvals/{approval_id}/approve", json={"actor": "local"})
+    assert approve.status_code == 200
+
+    resp = auth.post(
+        "/api/code/github/pull-requests/prepare",
+        json={
+            "repo_full_name": "acme/repo",
+            "title": "feat: x",
+            "head": "feature/x",
+            "base": "main",
+            "body": "desc",
+            "approval_id": approval_id,
+        },
+    )
     assert resp.status_code == 200
     payload = resp.json()
+    assert payload["requires_approval"] is False
     assert payload["prepared"]["auto_push"] is False
     assert payload["prepared"]["auto_merge"] is False

--- a/tests/hermes_cli/test_github_api_endpoints.py
+++ b/tests/hermes_cli/test_github_api_endpoints.py
@@ -1,0 +1,176 @@
+"""API tests for /api/code/github/* endpoints."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import time
+
+import pytest
+
+
+def _signature(secret: str, body: bytes) -> str:
+    return "sha256=" + hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+
+
+@pytest.fixture()
+def clients(monkeypatch, _isolate_hermes_home):
+    from starlette.testclient import TestClient
+    import hermes_state
+    from hermes_constants import get_hermes_home
+    from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", get_hermes_home() / "state.db")
+    auth_client = TestClient(app)
+    auth_client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+    unauth_client = TestClient(app)
+    return auth_client, unauth_client
+
+
+def test_github_status_endpoint(clients):
+    auth, _unauth = clients
+    resp = auth.get("/api/code/github/status")
+    assert resp.status_code == 200
+    assert "status" in resp.json()
+    assert "mode" in resp.json()["status"]
+
+
+def test_github_repositories_endpoint(clients, tmp_path):
+    auth, _unauth = clients
+    from hermes_state import SessionDB
+
+    db = SessionDB()
+    try:
+        now = time.time()
+        db._conn.execute(
+            """
+            INSERT INTO github_repositories
+                (id, installation_id, github_repo_id, owner, name, full_name, default_branch, private,
+                 html_url, clone_url, ssh_url, archived, disabled, pushed_at, created_at, updated_at, last_synced_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "gr-1",
+                11,
+                22,
+                "acme",
+                "repo",
+                "acme/repo",
+                "main",
+                0,
+                "https://github.com/acme/repo",
+                "https://github.com/acme/repo.git",
+                "git@github.com:acme/repo.git",
+                0,
+                0,
+                None,
+                now,
+                now,
+                now,
+            ),
+        )
+        db._conn.commit()
+    finally:
+        db.close()
+
+    resp = auth.get("/api/code/github/repositories")
+    assert resp.status_code == 200
+    assert resp.json()["total"] >= 1
+
+
+def test_github_repositories_sync_endpoint(monkeypatch, clients):
+    auth, _unauth = clients
+    from hermes_cli.code.github_sync import GitHubSyncService
+
+    monkeypatch.setattr(
+        GitHubSyncService,
+        "sync_repositories",
+        lambda self, installation_id=None, dry_run=False, limit=100: {"dry_run": dry_run, "synced": 1, "repositories": [{"full_name": "acme/repo"}]},
+    )
+    resp = auth.post("/api/code/github/repositories/sync", json={"dry_run": True, "limit": 5})
+    assert resp.status_code == 200
+    assert resp.json()["result"]["dry_run"] is True
+
+
+def test_github_webhook_endpoint_signature_validation(monkeypatch, clients):
+    _auth, unauth = clients
+    monkeypatch.setenv("HERMES_GITHUB_WEBHOOK_SECRET", "secret")
+    payload = {"repository": {"full_name": "acme/repo"}}
+    body = json.dumps(payload).encode("utf-8")
+
+    bad = unauth.post(
+        "/api/code/github/webhooks",
+        data=body,
+        headers={
+            "X-GitHub-Event": "push",
+            "X-GitHub-Delivery": "deliv-1",
+            "X-Hub-Signature-256": "sha256=deadbeef",
+        },
+    )
+    assert bad.status_code == 401
+
+    ok = unauth.post(
+        "/api/code/github/webhooks",
+        data=body,
+        headers={
+            "X-GitHub-Event": "push",
+            "X-GitHub-Delivery": "deliv-2",
+            "X-Hub-Signature-256": _signature("secret", body),
+        },
+    )
+    assert ok.status_code == 200
+    assert ok.json()["accepted"] is True
+
+
+def test_github_comments_endpoint_approval_flow(monkeypatch, clients):
+    auth, _unauth = clients
+    from hermes_cli.code.github_integration import GitHubIntegrationService
+
+    monkeypatch.setattr(
+        GitHubIntegrationService,
+        "post_issue_comment",
+        lambda self, repo_full_name, issue_number, body, installation_id=None: {"id": 1, "body": body},
+    )
+
+    pending = auth.post(
+        "/api/code/github/comments",
+        json={
+            "repo_full_name": "acme/repo",
+            "issue_number": 7,
+            "body": "hello",
+            "approved": False,
+        },
+    )
+    assert pending.status_code == 200
+    assert pending.json()["approval_required"] is True
+
+    approved = auth.post(
+        "/api/code/github/comments",
+        json={
+            "repo_full_name": "acme/repo",
+            "issue_number": 7,
+            "body": "hello",
+            "approved": True,
+        },
+    )
+    assert approved.status_code == 200
+    assert approved.json()["approval_required"] is False
+
+
+def test_github_pull_request_prepare_endpoint(clients):
+    auth, _unauth = clients
+    resp = auth.post(
+        "/api/code/github/pull-requests/prepare",
+        json={
+            "repo_full_name": "acme/repo",
+            "title": "feat: x",
+            "head": "feature/x",
+            "base": "main",
+            "body": "desc",
+        },
+    )
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["prepared"]["auto_push"] is False
+    assert payload["prepared"]["auto_merge"] is False

--- a/tests/hermes_cli/test_github_api_endpoints.py
+++ b/tests/hermes_cli/test_github_api_endpoints.py
@@ -291,3 +291,47 @@ def test_github_pull_request_prepare_endpoint(clients):
     assert payload["requires_approval"] is False
     assert payload["prepared"]["auto_push"] is False
     assert payload["prepared"]["auto_merge"] is False
+
+
+def test_github_write_events_are_emitted_and_redacted(monkeypatch, clients):
+    auth, _unauth = clients
+    from hermes_cli.code.github_integration import GitHubIntegrationService
+
+    monkeypatch.setattr(
+        GitHubIntegrationService,
+        "post_issue_comment",
+        lambda self, repo_full_name, issue_number, body, installation_id=None: {"id": 99, "body": body},
+    )
+
+    pending = auth.post(
+        "/api/code/github/comments",
+        json={
+            "repo_full_name": "acme/repo",
+            "issue_number": 77,
+            "body": "token=very-secret-value",
+        },
+    )
+    assert pending.status_code == 200
+    approval_id = pending.json()["approval_id"]
+
+    approve = auth.post(f"/api/code/approvals/{approval_id}/approve", json={"actor": "local"})
+    assert approve.status_code == 200
+
+    execute = auth.post(
+        "/api/code/github/comments",
+        json={
+            "repo_full_name": "acme/repo",
+            "issue_number": 77,
+            "body": "token=very-secret-value",
+            "approval_id": approval_id,
+        },
+    )
+    assert execute.status_code == 200
+
+    events = auth.get("/api/code/events?limit=200")
+    assert events.status_code == 200
+    rows = events.json()["events"]
+    types = {item.get("type") for item in rows}
+    assert "github.write.approval_required" in types
+    assert "github.write.executed" in types
+    assert "very-secret-value" not in str(rows)

--- a/tests/hermes_cli/test_github_chatops.py
+++ b/tests/hermes_cli/test_github_chatops.py
@@ -1,0 +1,107 @@
+"""Tests for GitHub ChatOps parsing and orchestration bridge."""
+
+from __future__ import annotations
+
+import time
+
+from hermes_cli.code.github_chatops import GitHubChatOpsService, parse_chatops_commands
+from hermes_cli.code.github_integration import GitHubIntegrationStore
+from hermes_state import SessionDB
+
+
+def test_parse_supported_commands():
+    text = "@hermes plan do this\n@hermes review\n@hermes fix now\n@hermes explain why\n@hermes status"
+    parsed = parse_chatops_commands(text)
+    assert [item.command for item in parsed] == ["plan", "review", "fix", "explain", "status"]
+
+
+def test_non_hermes_comment_is_ignored():
+    assert parse_chatops_commands("hello world") == []
+
+
+def test_create_command_from_comment_and_run(tmp_path):
+    db_path = tmp_path / "state.db"
+    SessionDB(db_path=db_path).close()
+    service = GitHubChatOpsService(db_path=db_path)
+    commands = service.create_commands_from_comment(
+        delivery_id="d1",
+        repo_full_name="acme/repo",
+        issue_number=7,
+        pr_number=None,
+        comment_id=100,
+        sender_login="alice",
+        body="@hermes plan implement auth",
+    )
+    assert len(commands) == 1
+    cmd = commands[0]
+    result = service.run_command(cmd["id"])
+    assert result["run"] is not None
+    assert result["command"]["orchestrated_run_id"] is not None
+
+
+def test_fix_command_moves_to_approval(tmp_path):
+    db_path = tmp_path / "state.db"
+    SessionDB(db_path=db_path).close()
+    service = GitHubChatOpsService(db_path=db_path)
+    cmd = service.create_commands_from_comment(
+        delivery_id="d2",
+        repo_full_name="acme/repo",
+        issue_number=8,
+        pr_number=None,
+        comment_id=101,
+        sender_login="bob",
+        body="@hermes fix failing tests",
+    )[0]
+    result = service.run_command(cmd["id"])
+    assert result["run"]["state"] == "approval"
+
+
+def test_status_links_existing_run_when_possible(tmp_path):
+    db_path = tmp_path / "state.db"
+    SessionDB(db_path=db_path).close()
+    service = GitHubChatOpsService(db_path=db_path)
+
+    first = service.create_commands_from_comment(
+        delivery_id="d3",
+        repo_full_name="acme/repo",
+        issue_number=9,
+        pr_number=None,
+        comment_id=102,
+        sender_login="alice",
+        body="@hermes plan do x",
+    )[0]
+    first_result = service.run_command(first["id"])
+    run_id = first_result["run"]["id"]
+
+    second = service.create_commands_from_comment(
+        delivery_id="d4",
+        repo_full_name="acme/repo",
+        issue_number=9,
+        pr_number=None,
+        comment_id=103,
+        sender_login="alice",
+        body="@hermes status",
+    )[0]
+    second_result = service.run_command(second["id"])
+    assert second_result["run"]["id"] == run_id
+    assert second_result["resumed"] is True
+
+
+def test_command_links_repo_issue_pr_sender_fields(tmp_path):
+    db_path = tmp_path / "state.db"
+    SessionDB(db_path=db_path).close()
+    service = GitHubChatOpsService(db_path=db_path)
+    created = service.create_commands_from_comment(
+        delivery_id="d5",
+        repo_full_name="acme/repo",
+        issue_number=1,
+        pr_number=2,
+        comment_id=99,
+        sender_login="charlie",
+        body="@hermes review",
+    )[0]
+    assert created["repo_full_name"] == "acme/repo"
+    assert created["issue_number"] == 1
+    assert created["pr_number"] == 2
+    assert created["comment_id"] == 99
+    assert created["sender_login"] == "charlie"

--- a/tests/hermes_cli/test_github_integration.py
+++ b/tests/hermes_cli/test_github_integration.py
@@ -1,0 +1,113 @@
+"""Tests for GitHub integration service."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from hermes_cli.code.github_integration import (
+    GitHubAPIClient,
+    GitHubAPIError,
+    GitHubAppConfig,
+    GitHubIntegrationService,
+    redact_github_secrets,
+)
+
+
+def test_status_unconfigured(monkeypatch, tmp_path):
+    monkeypatch.delenv("HERMES_GITHUB_APP_ID", raising=False)
+    monkeypatch.delenv("HERMES_GITHUB_APP_PRIVATE_KEY_PATH", raising=False)
+    monkeypatch.delenv("HERMES_GITHUB_DEV_PAT", raising=False)
+    monkeypatch.delenv("HERMES_GITHUB_ALLOW_DEV_PAT", raising=False)
+    status = GitHubIntegrationService(db_path=tmp_path / "state.db").status()
+    assert status["mode"] == "unconfigured"
+    assert status["configured"] is False
+
+
+def test_app_config_detection_without_secret_leak(monkeypatch, tmp_path):
+    key_file = tmp_path / "github-app.pem"
+    key_file.write_text("-----BEGIN PRIVATE KEY-----\nFAKE\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_GITHUB_APP_ID", "123456")
+    monkeypatch.setenv("HERMES_GITHUB_APP_PRIVATE_KEY_PATH", str(key_file))
+    monkeypatch.setenv("HERMES_GITHUB_WEBHOOK_SECRET", "super-secret")
+    status = GitHubIntegrationService(db_path=tmp_path / "state.db").status()
+    assert status["mode"] == "github_app"
+    assert status["app_id_configured"] is True
+    assert status["private_key_configured"] is True
+    assert status["webhook_secret_configured"] is True
+    assert "super-secret" not in str(status)
+
+
+def test_pat_fallback_requires_env_gate(monkeypatch, tmp_path):
+    monkeypatch.delenv("HERMES_GITHUB_APP_ID", raising=False)
+    monkeypatch.delenv("HERMES_GITHUB_APP_PRIVATE_KEY_PATH", raising=False)
+    monkeypatch.setenv("HERMES_GITHUB_DEV_PAT", "ghp_abcdefghijklmnopqrstuvwxyz")
+    monkeypatch.setenv("HERMES_GITHUB_ALLOW_DEV_PAT", "0")
+    status = GitHubIntegrationService(db_path=tmp_path / "state.db").status()
+    assert status["mode"] == "unconfigured"
+    monkeypatch.setenv("HERMES_GITHUB_ALLOW_DEV_PAT", "1")
+    status = GitHubIntegrationService(db_path=tmp_path / "state.db").status()
+    assert status["mode"] == "pat_dev"
+
+
+def test_installation_token_cache(monkeypatch, tmp_path):
+    service = GitHubIntegrationService(db_path=tmp_path / "state.db")
+    service._token_cache.clear()
+    calls = {"count": 0}
+
+    def _fake_request(_installation_id: int):
+        calls["count"] += 1
+        return {
+            "token": "token-123",
+            "expires_at": (datetime.now(timezone.utc) + timedelta(minutes=10)).isoformat(),
+        }
+
+    monkeypatch.setattr(service, "_request_installation_token", _fake_request)
+    monkeypatch.setattr(
+        service,
+        "config",
+        lambda: GitHubAppConfig(
+            app_id="1",
+            private_key_path="/tmp/key.pem",
+            webhook_secret_configured=False,
+            dev_pat_configured=False,
+            allow_dev_pat=False,
+        ),
+    )
+    first = service.get_installation_token(42)
+    second = service.get_installation_token(42)
+    assert first == "token-123"
+    assert second == "token-123"
+    assert calls["count"] == 1
+
+
+def test_api_error_normalization_and_rate_limit():
+    class _Response:
+        status_code = 403
+        headers = {
+            "x-ratelimit-limit": "5000",
+            "x-ratelimit-remaining": "0",
+            "x-ratelimit-reset": "123",
+            "x-ratelimit-resource": "core",
+        }
+
+        def json(self):
+            return {"message": "Bad token ghp_abcdefghijklmnopqrstuvwxyz"}
+
+    class _HTTP:
+        def request(self, *_args, **_kwargs):
+            return _Response()
+
+    client = GitHubAPIClient(lambda: "ghp_secret", http_client=_HTTP())
+    with pytest.raises(GitHubAPIError) as exc:
+        client.request("GET", "/user")
+    assert "ghp_" not in exc.value.message
+    assert exc.value.status_code == 403
+    assert exc.value.rate_limit["remaining"] == "0"
+
+
+def test_redaction_masks_sensitive_values():
+    redacted = redact_github_secrets("Authorization: Bearer ghp_abcdefghijklmnopqrstuvwxyz")
+    assert "ghp_" not in redacted
+    assert "[REDACTED]" in redacted

--- a/tests/hermes_cli/test_github_sync.py
+++ b/tests/hermes_cli/test_github_sync.py
@@ -1,0 +1,81 @@
+"""Tests for GitHub sync service."""
+
+from __future__ import annotations
+
+from hermes_cli.code.github_sync import GitHubSyncService
+from hermes_state import SessionDB
+
+
+class _MockClient:
+    def __init__(self):
+        self.calls = []
+
+    def list_paginated(self, path, params=None, limit=100):
+        self.calls.append((path, params or {}, limit))
+        if path == "/installation/repositories":
+            return [
+                {"id": 1, "full_name": "acme/repo1", "name": "repo1", "owner": {"login": "acme"}, "default_branch": "main"},
+                {"id": 2, "full_name": "acme/repo2", "name": "repo2", "owner": {"login": "acme"}, "default_branch": "main"},
+            ]
+        if path.endswith("/issues"):
+            return [
+                {"id": 10, "number": 1, "title": "bug", "state": "open", "user": {"login": "alice"}},
+                {"id": 11, "number": 2, "title": "feature", "state": "closed", "user": {"login": "bob"}},
+            ]
+        if path.endswith("/pulls"):
+            return [
+                {"id": 20, "number": 3, "title": "PR", "state": "open", "user": {"login": "alice"}, "head": {"ref": "x", "sha": "abc"}, "base": {"ref": "main"}},
+            ]
+        if path.endswith("/branches"):
+            return [{"name": "main", "protected": True, "commit": {"sha": "abc"}}]
+        return []
+
+
+def test_sync_repositories_dry_run(tmp_path):
+    db_path = tmp_path / "state.db"
+    SessionDB(db_path=db_path).close()
+    mock = _MockClient()
+    service = GitHubSyncService(db_path=db_path, api_client=mock)
+    result = service.sync_repositories(dry_run=True, limit=50)
+    assert result["dry_run"] is True
+    assert result["synced"] == 0
+    assert len(result["repositories"]) == 2
+
+
+def test_sync_repositories_persist(tmp_path):
+    db_path = tmp_path / "state.db"
+    SessionDB(db_path=db_path).close()
+    mock = _MockClient()
+    service = GitHubSyncService(db_path=db_path, api_client=mock)
+    result = service.sync_repositories(dry_run=False, limit=50)
+    assert result["synced"] == 2
+
+
+def test_sync_issues_and_pull_requests(tmp_path):
+    db_path = tmp_path / "state.db"
+    SessionDB(db_path=db_path).close()
+    mock = _MockClient()
+    service = GitHubSyncService(db_path=db_path, api_client=mock)
+    issues = service.sync_issues("acme/repo1", limit=100)
+    pulls = service.sync_pull_requests("acme/repo1", limit=100)
+    assert issues["synced"] == 2
+    assert pulls["synced"] == 1
+
+
+def test_sync_branches(tmp_path):
+    db_path = tmp_path / "state.db"
+    SessionDB(db_path=db_path).close()
+    mock = _MockClient()
+    service = GitHubSyncService(db_path=db_path, api_client=mock)
+    branches = service.sync_branches("acme/repo1", limit=100)
+    assert branches["synced"] == 1
+    assert branches["branches"][0]["name"] == "main"
+
+
+def test_sync_calls_are_pagination_aware(tmp_path):
+    db_path = tmp_path / "state.db"
+    SessionDB(db_path=db_path).close()
+    mock = _MockClient()
+    service = GitHubSyncService(db_path=db_path, api_client=mock)
+    service.sync_repositories(dry_run=True, limit=37)
+    assert mock.calls[0][2] == 37

--- a/tests/hermes_cli/test_github_webhooks.py
+++ b/tests/hermes_cli/test_github_webhooks.py
@@ -1,0 +1,119 @@
+"""Tests for GitHub webhook verification and processing."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+
+import pytest
+
+from hermes_cli.code.github_webhooks import GitHubWebhookService, WebhookSignatureError, verify_signature
+from hermes_state import SessionDB
+
+
+def _signature(secret: str, body: bytes) -> str:
+    return "sha256=" + hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+
+
+def test_verify_signature_valid():
+    body = b'{"ok":true}'
+    secret = "abc123"
+    assert verify_signature(secret, body, _signature(secret, body)) is True
+
+
+def test_verify_signature_missing_signature():
+    with pytest.raises(WebhookSignatureError):
+        verify_signature("abc", b"{}", None)
+
+
+def test_verify_signature_invalid_signature():
+    with pytest.raises(WebhookSignatureError):
+        verify_signature("abc", b"{}", "sha256=deadbeef")
+
+
+def test_process_duplicate_delivery_dedup(monkeypatch, tmp_path):
+    db_path = tmp_path / "state.db"
+    SessionDB(db_path=db_path).close()
+    monkeypatch.setenv("HERMES_GITHUB_WEBHOOK_SECRET", "secret")
+    service = GitHubWebhookService(db_path=db_path)
+    payload = {
+        "action": "created",
+        "repository": {"full_name": "acme/repo"},
+        "sender": {"login": "alice"},
+        "comment": {"id": 10, "body": "@hermes plan"},
+        "issue": {"number": 1},
+    }
+    body = json.dumps(payload).encode("utf-8")
+    sig = _signature("secret", body)
+    first = service.process(delivery_id="d-1", event="issue_comment", body=body, signature=sig)
+    second = service.process(delivery_id="d-1", event="issue_comment", body=body, signature=sig)
+    assert first["accepted"] is True
+    assert second["duplicate"] is True
+
+
+def test_process_issue_comment_parses_chatops(monkeypatch, tmp_path):
+    db_path = tmp_path / "state.db"
+    SessionDB(db_path=db_path).close()
+    monkeypatch.setenv("HERMES_GITHUB_WEBHOOK_SECRET", "secret")
+    service = GitHubWebhookService(db_path=db_path)
+    payload = {
+        "action": "created",
+        "repository": {"full_name": "acme/repo"},
+        "sender": {"login": "alice"},
+        "comment": {"id": 10, "body": "@hermes review please"},
+        "issue": {"number": 7, "pull_request": {"url": "x"}},
+    }
+    body = json.dumps(payload).encode("utf-8")
+    result = service.process(
+        delivery_id="d-2",
+        event="issue_comment",
+        body=body,
+        signature=_signature("secret", body),
+    )
+    assert result["status"] == "processed"
+    assert len(result["chatops_commands"]) == 1
+    assert result["chatops_commands"][0]["command"] == "review"
+
+
+def test_process_pull_request_event(monkeypatch, tmp_path):
+    db_path = tmp_path / "state.db"
+    SessionDB(db_path=db_path).close()
+    monkeypatch.setenv("HERMES_GITHUB_WEBHOOK_SECRET", "secret")
+    service = GitHubWebhookService(db_path=db_path)
+    payload = {
+        "action": "opened",
+        "repository": {"full_name": "acme/repo"},
+        "sender": {"login": "bob"},
+        "pull_request": {"id": 3, "number": 12},
+    }
+    body = json.dumps(payload).encode("utf-8")
+    result = service.process(
+        delivery_id="d-3",
+        event="pull_request",
+        body=body,
+        signature=_signature("secret", body),
+    )
+    assert result["normalized"]["pr_number"] == 12
+
+
+def test_process_unsupported_event_is_safe(monkeypatch, tmp_path):
+    db_path = tmp_path / "state.db"
+    SessionDB(db_path=db_path).close()
+    monkeypatch.setenv("HERMES_GITHUB_WEBHOOK_SECRET", "secret")
+    service = GitHubWebhookService(db_path=db_path)
+    payload = {"repository": {"full_name": "acme/repo"}}
+    body = json.dumps(payload).encode("utf-8")
+    result = service.process(
+        delivery_id="d-4",
+        event="fork",
+        body=body,
+        signature=_signature("secret", body),
+    )
+    assert result["status"] == "ignored"
+    assert result["accepted"] is True
+
+
+def test_safe_error_redacts_tokens():
+    message = GitHubWebhookService.safe_error(Exception("Authorization: Bearer ghp_abcdefghijklmnopqrstuvwxyz"))
+    assert "ghp_" not in message

--- a/tests/hermes_cli/test_repo_knowledge.py
+++ b/tests/hermes_cli/test_repo_knowledge.py
@@ -1,0 +1,40 @@
+"""Tests for RepoKnowledgeService."""
+
+from hermes_cli.code.repo_knowledge import RepoKnowledgeService, detect_repo_guidance
+
+
+def test_detect_agents_md_and_guidance_docs(tmp_path):
+    (tmp_path / "AGENTS.md").write_text("# Agents\n", encoding="utf-8")
+    arch_dir = tmp_path / "docs" / "architecture"
+    arch_dir.mkdir(parents=True)
+    (arch_dir / "overview.md").write_text("# Overview\n", encoding="utf-8")
+
+    manifest = detect_repo_guidance(tmp_path)
+    assert manifest["agents_md"] is not None
+    assert len(manifest["guidance_docs"]) == 1
+
+
+def test_bootstrap_does_not_overwrite_existing_agents_md(tmp_path):
+    existing = "# Existing\nDo not overwrite\n"
+    (tmp_path / "AGENTS.md").write_text(existing, encoding="utf-8")
+    service = RepoKnowledgeService()
+    result = service.bootstrap(tmp_path, project_summary="ignored")
+    assert result["created"] is False
+    assert "already exists" in result["reason"]
+    assert (tmp_path / "AGENTS.md").read_text(encoding="utf-8") == existing
+
+
+def test_bootstrap_creates_agents_md_when_missing(tmp_path):
+    service = RepoKnowledgeService()
+    result = service.bootstrap(tmp_path, project_summary="Project summary")
+    assert result["created"] is True
+    content = (tmp_path / "AGENTS.md").read_text(encoding="utf-8")
+    assert "Project summary" in content
+
+
+def test_service_read_agents_md(tmp_path):
+    (tmp_path / "AGENTS.md").write_text("# A\n\nB\n", encoding="utf-8")
+    service = RepoKnowledgeService()
+    content = service.read_agents_md(tmp_path)
+    assert content is not None
+    assert "B" in content

--- a/tests/hermes_cli/test_skill_discovery.py
+++ b/tests/hermes_cli/test_skill_discovery.py
@@ -1,0 +1,53 @@
+"""Tests for Code Mode skill discovery bridge."""
+
+import hermes_cli.code.skill_discovery as skill_discovery
+from hermes_cli.code.skill_discovery import SkillDiscoveryService, discover_workspace_skills
+
+
+def test_builtin_skills_are_preserved(monkeypatch, tmp_path):
+    fake_dir = tmp_path / "builtin"
+    fake_dir.mkdir()
+    monkeypatch.setattr(
+        skill_discovery,
+        "scan_skill_commands",
+        lambda: {
+            "/fake-skill": {
+                "name": "Fake Skill",
+                "description": "desc",
+                "skill_md_path": str(fake_dir / "SKILL.md"),
+                "skill_dir": str(fake_dir),
+            }
+        },
+    )
+    skills = skill_discovery.discover_builtin_skills()
+    assert isinstance(skills, list)
+    assert len(skills) == 1
+    assert skills[0]["name"] == "fake-skill"
+    assert skills[0]["builtin"] is True
+
+
+def test_workspace_skill_md_discovery(tmp_path):
+    skill_dir = tmp_path / ".hermes" / "skills" / "my_skill"
+    (skill_dir / "scripts").mkdir(parents=True)
+    (skill_dir / "resources").mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "# My Skill\n\nCustom description.\n",
+        encoding="utf-8",
+    )
+
+    skills = discover_workspace_skills(tmp_path)
+    assert len(skills) == 1
+    assert skills[0]["name"] == "my_skill"
+    assert skills[0]["has_scripts"] is True
+    assert skills[0]["has_resources"] is True
+
+
+def test_skill_discovery_service_merges_sources(tmp_path):
+    skill_dir = tmp_path / ".hermes" / "skills" / "workspace_skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("# Workspace Skill\n\nDesc\n", encoding="utf-8")
+
+    service = SkillDiscoveryService()
+    merged = service.list_skills(workspace_path=tmp_path)
+    names = {item["name"] for item in merged}
+    assert "workspace_skill" in names

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -328,6 +328,88 @@ class TestWebServerEndpoints:
         resp = unauth_client.get("/api/status")
         assert resp.status_code == 200
 
+    def test_code_status_is_public(self):
+        from starlette.testclient import TestClient
+        from hermes_cli.web_server import app
+
+        unauth_client = TestClient(app)
+        resp = unauth_client.get("/api/code/status")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["mode"] == "code_mode"
+        assert data["schema_version"] == 12
+        assert "state" in data
+
+    def test_code_workspaces_requires_auth(self):
+        from starlette.testclient import TestClient
+        from hermes_cli.web_server import app
+
+        unauth_client = TestClient(app)
+        resp = unauth_client.get("/api/code/workspaces")
+
+        assert resp.status_code == 401
+
+    def test_code_workspaces_endpoint(self):
+        import time
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            now = time.time()
+            db._conn.execute(
+                """
+                INSERT INTO code_workspaces
+                    (id, name, owner, repo, path, git_remote, repo_url, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    "ws-1",
+                    "Hermes Agent",
+                    "nous",
+                    "hermes-agent",
+                    "/tmp/hermes-agent",
+                    "git@github.com:nous/hermes-agent.git",
+                    "https://github.com/nous/hermes-agent",
+                    now,
+                    now,
+                ),
+            )
+            db._conn.commit()
+        finally:
+            db.close()
+
+        resp = self.client.get("/api/code/workspaces?q=Hermes")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["workspaces"][0]["id"] == "ws-1"
+
+    def test_code_sessions_endpoint(self):
+        import time
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            now = time.time()
+            db._conn.execute(
+                """
+                INSERT INTO code_sessions
+                    (id, workspace_id, status, provider, branch, created_at, updated_at, metadata_json)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                ("cs-1", None, "active", "openrouter", "main", now, now, "{}"),
+            )
+            db._conn.commit()
+        finally:
+            db.close()
+
+        resp = self.client.get("/api/code/sessions")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["sessions"][0]["id"] == "cs-1"
+
     def test_path_traversal_blocked(self):
         """Verify URL-encoded path traversal is blocked."""
         # %2e%2e = ..

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -339,7 +339,7 @@ class TestWebServerEndpoints:
         assert resp.status_code == 200
         data = resp.json()
         assert data["mode"] == "code_mode"
-        assert data["schema_version"] == 15
+        assert data["schema_version"] == 17
         assert "state" in data
 
     def test_code_workspaces_requires_auth(self):
@@ -574,6 +574,84 @@ class TestWebServerEndpoints:
         fetched = self.client.get(f"/api/code/approvals/{approval_id}")
         assert fetched.status_code == 200
         assert fetched.json()["approval"]["status"] == "expired"
+
+    def test_code_events_filters_recent_summary_and_subscriptions(self):
+        create = self.client.post(
+            "/api/code/approvals",
+            json={
+                "kind": "github_comment",
+                "risk_class": "git_write",
+                "title": "Realtime",
+                "requested_action": "github.comment.post",
+                "requested_payload": {"body": "hello"},
+                "github_repo_full_name": "acme/repo",
+            },
+        )
+        assert create.status_code == 200
+        approval_id = create.json()["approval"]["id"]
+
+        events = self.client.get(
+            "/api/code/events",
+            params={
+                "type": "code.approval.created",
+                "approval_id": approval_id,
+                "github_repo_full_name": "acme/repo",
+                "limit": 50,
+            },
+        )
+        assert events.status_code == 200
+        payload = events.json()["events"]
+        assert any(e.get("type") == "code.approval.created" for e in payload)
+
+        recent = self.client.get("/api/code/events/recent?type=code.approval.created&limit=10")
+        assert recent.status_code == 200
+        assert "events" in recent.json()
+
+        summary = self.client.get("/api/code/events/summary?limit=100")
+        assert summary.status_code == 200
+        assert "summary" in summary.json()
+        assert "by_type" in summary.json()["summary"]
+
+        subs = self.client.get("/api/code/events/subscriptions")
+        assert subs.status_code == 200
+        assert "subscriptions" in subs.json()
+        assert "active_subscribers" in subs.json()["subscriptions"]
+
+    def test_code_events_ws_replay_and_live_stream(self):
+        from hermes_cli.web_server import _SESSION_TOKEN
+
+        created = self.client.post(
+            "/api/code/approvals",
+            json={
+                "kind": "generic",
+                "risk_class": "git_write",
+                "title": "WS Replay",
+                "requested_action": "generic.action",
+                "requested_payload": {"arg": "x"},
+            },
+        )
+        assert created.status_code == 200
+
+        ws_url = f"/api/code/events/ws?token={_SESSION_TOKEN}&type=code.approval.created&replay=true&limit=20"
+        with self.client.websocket_connect(ws_url) as conn:
+            first = conn.receive_json()
+            assert first["type"] == "code.approval.created"
+
+            live = self.client.post(
+                "/api/code/approvals",
+                json={
+                    "kind": "generic",
+                    "risk_class": "git_write",
+                    "title": "WS Live",
+                    "requested_action": "generic.action",
+                    "requested_payload": {"token": "secret", "arg": "y"},
+                },
+            )
+            assert live.status_code == 200
+
+            second = conn.receive_json()
+            assert second["type"] == "code.approval.created"
+            assert "secret" not in str(second)
 
     def test_path_traversal_blocked(self):
         """Verify URL-encoded path traversal is blocked."""
@@ -2005,6 +2083,14 @@ class TestPtyWebSocket:
 
         q = {"token": tok, **params}
         return f"/api/pty?{urlencode(q)}"
+
+    def test_existing_api_ws_endpoint_still_rejects_bad_token(self):
+        from starlette.websockets import WebSocketDisconnect
+
+        with pytest.raises(WebSocketDisconnect) as exc:
+            with self.client.websocket_connect("/api/ws?token=wrong"):
+                pass
+        assert exc.value.code == 4401
 
     def test_rejects_when_embedded_chat_disabled(self, monkeypatch):
         monkeypatch.setattr(self.ws_module, "_DASHBOARD_EMBEDDED_CHAT_ENABLED", False)

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -338,7 +338,7 @@ class TestWebServerEndpoints:
         assert resp.status_code == 200
         data = resp.json()
         assert data["mode"] == "code_mode"
-        assert data["schema_version"] == 13
+        assert data["schema_version"] == 14
         assert "state" in data
 
     def test_code_workspaces_requires_auth(self):

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -338,7 +338,7 @@ class TestWebServerEndpoints:
         assert resp.status_code == 200
         data = resp.json()
         assert data["mode"] == "code_mode"
-        assert data["schema_version"] == 12
+        assert data["schema_version"] == 13
         assert "state" in data
 
     def test_code_workspaces_requires_auth(self):
@@ -409,6 +409,106 @@ class TestWebServerEndpoints:
         assert resp.status_code == 200
         data = resp.json()
         assert data["sessions"][0]["id"] == "cs-1"
+
+    def test_code_artifacts_create_and_list(self):
+        create_resp = self.client.post(
+            "/api/code/artifacts",
+            json={
+                "artifact_type": "task_intake",
+                "title": "Task",
+                "content": "Implement feature X",
+                "content_type": "markdown",
+                "workspace_id": None,
+                "code_session_id": "cs-42",
+                "metadata": {"priority": "high"},
+            },
+        )
+        assert create_resp.status_code == 200
+        created = create_resp.json()["artifact"]
+        assert created["artifact_type"] == "task_intake"
+
+        list_resp = self.client.get("/api/code/artifacts?code_session_id=cs-42")
+        assert list_resp.status_code == 200
+        artifacts = list_resp.json()["artifacts"]
+        assert any(a["id"] == created["id"] for a in artifacts)
+
+    def test_orchestrator_create_get_and_transition(self):
+        create_resp = self.client.post(
+            "/api/code/orchestrator/runs",
+            json={
+                "title": "Run A",
+                "goal": "Refactor parser",
+                "workspace_id": None,
+                "code_session_id": "cs-77",
+                "metadata": {"source": "test"},
+                "create_intake_artifact": True,
+            },
+        )
+        assert create_resp.status_code == 200
+        run = create_resp.json()["run"]
+        assert run["state"] == "intake"
+
+        get_resp = self.client.get(f"/api/code/orchestrator/runs/{run['id']}")
+        assert get_resp.status_code == 200
+        assert get_resp.json()["run"]["id"] == run["id"]
+
+        transition_resp = self.client.post(
+            f"/api/code/orchestrator/runs/{run['id']}/transition",
+            json={"to_state": "discovery", "reason": "begin"},
+        )
+        assert transition_resp.status_code == 200
+        assert transition_resp.json()["run"]["state"] == "discovery"
+
+    def test_policy_assess_command_endpoint(self):
+        resp = self.client.post(
+            "/api/code/policy/assess-command",
+            json={"command": "rm -rf /tmp/x"},
+        )
+        assert resp.status_code == 200
+        assessment = resp.json()["assessment"]
+        assert assessment["risk_class"] == "destructive"
+        assert assessment["blocked"] is True
+
+    def test_code_skills_discovered_endpoint(self):
+        resp = self.client.get("/api/code/skills/discovered")
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert "skills" in payload
+        assert isinstance(payload["skills"], list)
+
+    def test_repo_knowledge_endpoints(self, tmp_path):
+        import time
+        from hermes_state import SessionDB
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / "AGENTS.md").write_text("# Agents\n\nUse pytest.\n", encoding="utf-8")
+
+        db = SessionDB()
+        try:
+            now = time.time()
+            db._conn.execute(
+                """
+                INSERT INTO code_workspaces
+                    (id, name, owner, repo, path, git_remote, repo_url, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                ("ws-rk", "Repo", "owner", "repo", str(repo), "", "", now, now),
+            )
+            db._conn.commit()
+        finally:
+            db.close()
+
+        get_resp = self.client.get("/api/code/workspaces/ws-rk/repo-knowledge")
+        assert get_resp.status_code == 200
+        assert get_resp.json()["manifest"]["agents_md"] is not None
+
+        bootstrap_resp = self.client.post(
+            "/api/code/workspaces/ws-rk/repo-knowledge/bootstrap",
+            json={"project_summary": "My test repo"},
+        )
+        assert bootstrap_resp.status_code == 200
+        assert bootstrap_resp.json()["result"]["created"] is False
 
     def test_path_traversal_blocked(self):
         """Verify URL-encoded path traversal is blocked."""

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2,6 +2,7 @@
 
 import os
 import json
+import time
 import tempfile
 from pathlib import Path
 from unittest.mock import patch, MagicMock
@@ -338,7 +339,7 @@ class TestWebServerEndpoints:
         assert resp.status_code == 200
         data = resp.json()
         assert data["mode"] == "code_mode"
-        assert data["schema_version"] == 14
+        assert data["schema_version"] == 15
         assert "state" in data
 
     def test_code_workspaces_requires_auth(self):
@@ -509,6 +510,70 @@ class TestWebServerEndpoints:
         )
         assert bootstrap_resp.status_code == 200
         assert bootstrap_resp.json()["result"]["created"] is False
+
+    def test_code_approvals_endpoints(self):
+        create = self.client.post(
+            "/api/code/approvals",
+            json={
+                "kind": "generic",
+                "risk_class": "git_write",
+                "title": "Need approval",
+                "description": "desc",
+                "requested_action": "generic.action",
+                "requested_payload": {"token": "secret", "arg": "x"},
+                "resource_type": "resource",
+                "resource_id": "r-1",
+                "github_repo_full_name": "acme/repo",
+            },
+        )
+        assert create.status_code == 200
+        approval = create.json()["approval"]
+        approval_id = approval["id"]
+        assert approval["status"] == "pending"
+        assert approval["requested_payload"]["token"] == "[REDACTED]"
+
+        listing = self.client.get("/api/code/approvals?status=pending")
+        assert listing.status_code == 200
+        assert any(item["id"] == approval_id for item in listing.json()["approvals"])
+
+        fetched = self.client.get(f"/api/code/approvals/{approval_id}")
+        assert fetched.status_code == 200
+        assert fetched.json()["approval"]["id"] == approval_id
+
+        summary = self.client.get("/api/code/approvals/summary")
+        assert summary.status_code == 200
+        assert summary.json()["summary"]["status"]["pending"] >= 1
+
+        approved = self.client.post(f"/api/code/approvals/{approval_id}/approve", json={"actor": "local"})
+        assert approved.status_code == 200
+        assert approved.json()["approval"]["status"] == "approved"
+
+        cancelled = self.client.post(f"/api/code/approvals/{approval_id}/cancel", json={"actor": "local", "reason": "stop"})
+        assert cancelled.status_code == 200
+        assert cancelled.json()["approval"]["status"] == "cancelled"
+
+    def test_code_approvals_expire_endpoint(self):
+        create = self.client.post(
+            "/api/code/approvals",
+            json={
+                "kind": "generic",
+                "risk_class": "git_write",
+                "title": "Expire me",
+                "requested_action": "generic.action",
+                "requested_payload": {"arg": "x"},
+                "expires_at": time.time() - 5,
+            },
+        )
+        assert create.status_code == 200
+        approval_id = create.json()["approval"]["id"]
+
+        expired = self.client.post("/api/code/approvals/expire")
+        assert expired.status_code == 200
+        assert expired.json()["count"] >= 1
+
+        fetched = self.client.get(f"/api/code/approvals/{approval_id}")
+        assert fetched.status_code == 200
+        assert fetched.json()["approval"]["status"] == "expired"
 
     def test_path_traversal_blocked(self):
         """Verify URL-encoded path traversal is blocked."""

--- a/tests/hermes_cli/test_worktree_service.py
+++ b/tests/hermes_cli/test_worktree_service.py
@@ -1,0 +1,69 @@
+"""Tests for WorktreeService."""
+
+import subprocess
+import time
+from pathlib import Path
+
+from hermes_cli.code.worktree_service import WorktreeService
+from hermes_state import SessionDB
+
+
+def _init_git_repo(path: Path) -> None:
+    subprocess.run(["git", "init", str(path)], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(path), "config", "user.email", "test@example.com"], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(path), "config", "user.name", "Test User"], check=True, capture_output=True)
+    (path / "README.md").write_text("# repo\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(path), "add", "."], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(path), "commit", "-m", "init"], check=True, capture_output=True)
+
+
+def test_detect_capabilities_outside_git_repo(tmp_path):
+    caps = WorktreeService.detect_git_capabilities(tmp_path)
+    assert caps["is_git_repo"] is False
+    assert caps["supports_worktree"] is False
+
+
+def test_detect_capabilities_git_repo_and_dirty_state(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+    caps = WorktreeService.detect_git_capabilities(repo)
+    assert caps["is_git_repo"] is True
+    assert caps["has_commits"] is True
+    assert caps["is_dirty"] is False
+
+    (repo / "dirty.txt").write_text("x", encoding="utf-8")
+    dirty_caps = WorktreeService.detect_git_capabilities(repo)
+    assert dirty_caps["is_dirty"] is True
+
+
+def test_workspace_capabilities_fallback_when_missing_workspace(tmp_path):
+    service = WorktreeService(db_path=tmp_path / "state.db")
+    caps = service.detect_capabilities_for_workspace("missing")
+    assert caps["is_git_repo"] is False
+
+
+def test_checkpoint_metadata_creation(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        now = time.time()
+        db._conn.execute(
+            """
+            INSERT INTO code_workspaces
+                (id, name, owner, repo, path, git_remote, repo_url, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            ("ws-1", "repo", "owner", "repo", str(repo), "", "", now, now),
+        )
+        db._conn.commit()
+    finally:
+        db.close()
+
+    service = WorktreeService(db_path=tmp_path / "state.db")
+    checkpoint = service.create_checkpoint_metadata("ws-1", name="before-change")
+    assert checkpoint["workspace_id"] == "ws-1"
+    assert checkpoint["name"] == "before-change"
+    assert checkpoint["git_commit"]

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1295,6 +1295,11 @@ class TestSanitizeTitle:
 
 
 class TestSchemaInit:
+    def test_schema_constant_is_v17(self):
+        import hermes_state
+
+        assert hermes_state.SCHEMA_VERSION == 17
+
     def test_wal_mode(self, db):
         cursor = db._conn.execute("PRAGMA journal_mode")
         mode = cursor.fetchone()[0]
@@ -1332,7 +1337,7 @@ class TestSchemaInit:
     def test_schema_version(self, db):
         cursor = db._conn.execute("SELECT version FROM schema_version")
         version = cursor.fetchone()[0]
-        assert version == 15
+        assert version == 17
 
     def test_schema_migration_idempotent(self, tmp_path):
         db_path = tmp_path / "idempotent.db"
@@ -1342,7 +1347,7 @@ class TestSchemaInit:
         second = SessionDB(db_path=db_path)
         try:
             version = second._conn.execute("SELECT version FROM schema_version LIMIT 1").fetchone()[0]
-            assert version == 15
+            assert version == 17
             table = second._conn.execute(
                 "SELECT name FROM sqlite_master WHERE type='table' AND name='code_approval_requests'"
             ).fetchone()
@@ -1353,7 +1358,7 @@ class TestSchemaInit:
     def test_code_mode_status(self, db):
         status = db.code_mode_status()
         assert status["mode"] == "enabled"
-        assert status["schema_version"] == 15
+        assert status["schema_version"] == 17
         assert status["workspace_count"] == 0
         assert status["session_count"] == 0
         assert status["event_count"] == 0
@@ -1418,7 +1423,7 @@ class TestSchemaInit:
 
         # Verify migration
         cursor = migrated_db._conn.execute("SELECT version FROM schema_version")
-        assert cursor.fetchone()[0] == 15
+        assert cursor.fetchone()[0] == 17
 
         # Verify title column exists and is NULL for existing sessions
         session = migrated_db.get_session("existing")
@@ -2577,6 +2582,6 @@ class TestFTS5ToolCallMigration:
                 "SELECT version FROM schema_version LIMIT 1"
             ).fetchone()
             version = row["version"] if hasattr(row, "keys") else row[0]
-            assert version == 15
+            assert version == 17
         finally:
             session_db.close()

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1319,16 +1319,24 @@ class TestSchemaInit:
         assert "code_orchestrated_runs" in tables
         assert "code_run_transitions" in tables
         assert "code_checkpoints" in tables
+        assert "github_app_installations" in tables
+        assert "github_repositories" in tables
+        assert "github_branches" in tables
+        assert "github_issues" in tables
+        assert "github_pull_requests" in tables
+        assert "github_webhook_deliveries" in tables
+        assert "github_chatops_commands" in tables
+        assert "github_status_reports" in tables
 
     def test_schema_version(self, db):
         cursor = db._conn.execute("SELECT version FROM schema_version")
         version = cursor.fetchone()[0]
-        assert version == 13
+        assert version == 14
 
     def test_code_mode_status(self, db):
         status = db.code_mode_status()
         assert status["mode"] == "enabled"
-        assert status["schema_version"] == 13
+        assert status["schema_version"] == 14
         assert status["workspace_count"] == 0
         assert status["session_count"] == 0
         assert status["event_count"] == 0
@@ -1392,7 +1400,7 @@ class TestSchemaInit:
 
         # Verify migration
         cursor = migrated_db._conn.execute("SELECT version FROM schema_version")
-        assert cursor.fetchone()[0] == 13
+        assert cursor.fetchone()[0] == 14
 
         # Verify title column exists and is NULL for existing sessions
         session = migrated_db.get_session("existing")
@@ -2551,6 +2559,6 @@ class TestFTS5ToolCallMigration:
                 "SELECT version FROM schema_version LIMIT 1"
             ).fetchone()
             version = row["version"] if hasattr(row, "keys") else row[0]
-            assert version == 13
+            assert version == 14
         finally:
             session_db.close()

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1315,16 +1315,20 @@ class TestSchemaInit:
         assert "code_workspaces" in tables
         assert "code_sessions" in tables
         assert "code_events" in tables
+        assert "code_artifacts" in tables
+        assert "code_orchestrated_runs" in tables
+        assert "code_run_transitions" in tables
+        assert "code_checkpoints" in tables
 
     def test_schema_version(self, db):
         cursor = db._conn.execute("SELECT version FROM schema_version")
         version = cursor.fetchone()[0]
-        assert version == 12
+        assert version == 13
 
     def test_code_mode_status(self, db):
         status = db.code_mode_status()
         assert status["mode"] == "enabled"
-        assert status["schema_version"] == 12
+        assert status["schema_version"] == 13
         assert status["workspace_count"] == 0
         assert status["session_count"] == 0
         assert status["event_count"] == 0
@@ -1388,7 +1392,7 @@ class TestSchemaInit:
 
         # Verify migration
         cursor = migrated_db._conn.execute("SELECT version FROM schema_version")
-        assert cursor.fetchone()[0] == 12
+        assert cursor.fetchone()[0] == 13
 
         # Verify title column exists and is NULL for existing sessions
         session = migrated_db.get_session("existing")
@@ -1407,6 +1411,61 @@ class TestSchemaInit:
         assert session["title"] == "Migrated Title"
 
         migrated_db.close()
+
+
+class TestCodeControlPlanePersistence:
+    def test_artifact_roundtrip(self, db):
+        created = {
+            "id": "art-1",
+            "artifact_type": "task_intake",
+            "title": "Task",
+            "content": "Build endpoint",
+            "content_type": "markdown",
+            "workspace_id": "ws-1",
+            "code_session_id": "cs-1",
+            "orchestrated_run_id": "run-1",
+            "command_id": "cmd-1",
+            "metadata": {"source": "test"},
+            "created_at": time.time(),
+            "updated_at": time.time(),
+        }
+        db.create_code_artifact(created)
+        rows = db.list_code_artifacts(code_session_id="cs-1")
+        assert len(rows) == 1
+        assert rows[0]["id"] == "art-1"
+
+    def test_orchestrated_run_and_transition_roundtrip(self, db):
+        now = time.time()
+        run = {
+            "id": "run-1",
+            "title": "Run",
+            "goal": "Goal",
+            "state": "intake",
+            "workspace_id": "ws-1",
+            "code_session_id": "cs-1",
+            "current_phase": "intake",
+            "metadata": {"k": "v"},
+            "created_at": now,
+            "updated_at": now,
+            "completed_at": None,
+        }
+        db.create_code_orchestrated_run(run)
+        db.add_code_run_transition(
+            {
+                "id": "tr-1",
+                "run_id": "run-1",
+                "from_state": "intake",
+                "to_state": "discovery",
+                "reason": "start",
+                "created_at": now + 1,
+            }
+        )
+        fetched = db.get_code_orchestrated_run("run-1")
+        assert fetched is not None
+        assert fetched["state"] == "intake"
+        transitions = db.list_code_run_transitions(run_id="run-1")
+        assert len(transitions) == 1
+        assert transitions[0]["to_state"] == "discovery"
 
     def test_reconciliation_adds_missing_columns(self, tmp_path):
         """Columns present in SCHEMA_SQL but missing from the live table
@@ -2492,6 +2551,6 @@ class TestFTS5ToolCallMigration:
                 "SELECT version FROM schema_version LIMIT 1"
             ).fetchone()
             version = row["version"] if hasattr(row, "keys") else row[0]
-            assert version == 12
+            assert version == 13
         finally:
             session_db.close()

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1327,19 +1327,37 @@ class TestSchemaInit:
         assert "github_webhook_deliveries" in tables
         assert "github_chatops_commands" in tables
         assert "github_status_reports" in tables
+        assert "code_approval_requests" in tables
 
     def test_schema_version(self, db):
         cursor = db._conn.execute("SELECT version FROM schema_version")
         version = cursor.fetchone()[0]
-        assert version == 14
+        assert version == 15
+
+    def test_schema_migration_idempotent(self, tmp_path):
+        db_path = tmp_path / "idempotent.db"
+        first = SessionDB(db_path=db_path)
+        first.close()
+
+        second = SessionDB(db_path=db_path)
+        try:
+            version = second._conn.execute("SELECT version FROM schema_version LIMIT 1").fetchone()[0]
+            assert version == 15
+            table = second._conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='code_approval_requests'"
+            ).fetchone()
+            assert table is not None
+        finally:
+            second.close()
 
     def test_code_mode_status(self, db):
         status = db.code_mode_status()
         assert status["mode"] == "enabled"
-        assert status["schema_version"] == 14
+        assert status["schema_version"] == 15
         assert status["workspace_count"] == 0
         assert status["session_count"] == 0
         assert status["event_count"] == 0
+        assert status["approval_count"] == 0
 
     def test_title_column_exists(self, db):
         """Verify the title column was created in the sessions table."""
@@ -1400,7 +1418,7 @@ class TestSchemaInit:
 
         # Verify migration
         cursor = migrated_db._conn.execute("SELECT version FROM schema_version")
-        assert cursor.fetchone()[0] == 14
+        assert cursor.fetchone()[0] == 15
 
         # Verify title column exists and is NULL for existing sessions
         session = migrated_db.get_session("existing")
@@ -2559,6 +2577,6 @@ class TestFTS5ToolCallMigration:
                 "SELECT version FROM schema_version LIMIT 1"
             ).fetchone()
             version = row["version"] if hasattr(row, "keys") else row[0]
-            assert version == 14
+            assert version == 15
         finally:
             session_db.close()

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1312,11 +1312,22 @@ class TestSchemaInit:
         assert "sessions" in tables
         assert "messages" in tables
         assert "schema_version" in tables
+        assert "code_workspaces" in tables
+        assert "code_sessions" in tables
+        assert "code_events" in tables
 
     def test_schema_version(self, db):
         cursor = db._conn.execute("SELECT version FROM schema_version")
         version = cursor.fetchone()[0]
-        assert version == 11
+        assert version == 12
+
+    def test_code_mode_status(self, db):
+        status = db.code_mode_status()
+        assert status["mode"] == "enabled"
+        assert status["schema_version"] == 12
+        assert status["workspace_count"] == 0
+        assert status["session_count"] == 0
+        assert status["event_count"] == 0
 
     def test_title_column_exists(self, db):
         """Verify the title column was created in the sessions table."""
@@ -1372,12 +1383,12 @@ class TestSchemaInit:
         conn.commit()
         conn.close()
 
-        # Open with SessionDB — should migrate to v9
+        # Open with SessionDB — should migrate to the current schema
         migrated_db = SessionDB(db_path=db_path)
 
         # Verify migration
         cursor = migrated_db._conn.execute("SELECT version FROM schema_version")
-        assert cursor.fetchone()[0] == 11
+        assert cursor.fetchone()[0] == 12
 
         # Verify title column exists and is NULL for existing sessions
         session = migrated_db.get_session("existing")
@@ -2481,7 +2492,6 @@ class TestFTS5ToolCallMigration:
                 "SELECT version FROM schema_version LIMIT 1"
             ).fetchone()
             version = row["version"] if hasattr(row, "keys") else row[0]
-            assert version == 11
+            assert version == 12
         finally:
             session_db.close()
-


### PR DESCRIPTION
## Resumo

Implementa a Phase 3 do Hermes Code Mode com fanout realtime de eventos, EventBus centralizado, replay filtrado, endpoints REST adicionais e WebSocket dedicado para eventos de Code Mode.

## Principais mudanças

- Adiciona `CodeEventBus` central em `hermes_cli/code/event_bus.py`
- Normaliza envelopes de eventos com `id`, `type`, `version`, `timestamp` e dimensões opcionais
- Aplica redaction recursivo antes de persistência e fanout
- Reutiliza `code_events`, sem criar novas tabelas
- Mantém schema em `v17`
- Estende `GET /api/code/events` com filtros adicionais
- Adiciona:
  - `GET /api/code/events/recent`
  - `GET /api/code/events/summary`
  - `GET /api/code/events/subscriptions`
  - `WS /api/code/events/ws`
- Adiciona replay com `since_id`
- Adiciona heartbeat `code.events.heartbeat`
- Roteia eventos de approvals, GitHub, orchestrator e artifacts pelo `CodeEventBus`

## Eventos canônicos P3 adicionados

- `code.artifact.created`
- `code.orchestrator.run_created`
- `code.orchestrator.transitioned`
- `code.orchestrator.completed`
- `code.orchestrator.failed`
- `code.events.heartbeat`

## Compatibilidade

- Mantém eventos legados onde necessário:
  - `artifact.created`
  - `orchestrator.run.created`
  - `orchestrator.run.transitioned`
- Preserva `/ws` existente
- Preserva REST polling atual do Code Cockpit
- Sem alterações em frontend/UI
- Sem alteração de schema para v18

## Testes

Executado:

```bash
python3 -m py_compile cli.py hermes_state.py hermes_cli/web_server.py hermes_cli/commands.py hermes_cli/code/event_bus.py hermes_cli/code/approval_governance.py hermes_cli/code/github_integration.py hermes_cli/code/github_chatops.py hermes_cli/code/github_sync.py hermes_cli/code/github_webhooks.py hermes_cli/code/artifact_ledger.py hermes_cli/code/agent_orchestrator.py

python3 -m pytest tests/hermes_cli/test_event_bus.py tests/hermes_cli/test_approval_governance.py tests/hermes_cli/test_github_api_endpoints.py tests/test_hermes_state.py tests/hermes_cli/test_web_server.py tests/hermes_cli/test_commands.py -k 'not TestPtyWebSocket' --tb=short --override-ini="addopts=" -s