### PR TITLE
fix: add safe gateway restart for manual runs

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2325,6 +2325,73 @@ def launchd_status(deep: bool = False):
 # Gateway Runner
 # =============================================================================
 
+def _manual_gateway_restart_command() -> list[str]:
+    """Build the command used for a detached manual gateway replacement."""
+    import shlex
+
+    cmd = [sys.executable, "-m", "hermes_cli.main"]
+    profile_arg = _profile_arg()
+    if profile_arg:
+        cmd.extend(shlex.split(profile_arg))
+    cmd.extend(["gateway", "run", "--replace"])
+    return cmd
+
+
+def _tail_file(path: Path, max_lines: int = 80) -> str:
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return ""
+    return "\n".join(lines[-max_lines:])
+
+
+def restart_manual_gateway_background(wait_seconds: float = 5.0) -> int:
+    """Restart a manually-run gateway with a detached `gateway run --replace`.
+
+    This is the non-service equivalent of `gateway restart`: it starts a fresh
+    replacement process in the background and lets `--replace` safely retire the
+    existing foreground/tmux/nohup gateway for the current profile.
+    """
+    import time
+
+    home = get_hermes_home()
+    log_dir = home / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    stamp = time.strftime("%Y%m%dT%H%M%S")
+    log_path = log_dir / f"gateway-safe-restart-{stamp}.log"
+    cmd = _manual_gateway_restart_command()
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(home)
+
+    print("Starting gateway replacement in the background...")
+    print(f"  Command: {' '.join(cmd)}")
+    print(f"  Log: {log_path}")
+
+    with log_path.open("ab") as log_file:
+        process = subprocess.Popen(
+            cmd,
+            cwd=str(PROJECT_ROOT),
+            env=env,
+            stdout=log_file,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
+
+    time.sleep(max(0.0, wait_seconds))
+    if process.poll() is not None:
+        print_error("Gateway replacement exited before it became healthy.")
+        tail = _tail_file(log_path)
+        if tail:
+            print()
+            print("Recent restart log:")
+            print(tail)
+        sys.exit(process.returncode or 1)
+
+    print_success(f"Gateway replacement launched (PID {process.pid})")
+    print_info("Send Hermes a message to confirm the platform adapter is responding.")
+    return process.pid
+
+
 def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False):
     """Run the gateway in foreground.
     
@@ -4075,8 +4142,8 @@ def _gateway_command_inner(args):
             else:
                 print(f"✓ Stopped {get_service_name()} service")
     
-    elif subcmd == "restart":
-        # Try service first, fall back to killing and restarting
+    elif subcmd in ("restart", "safe-restart"):
+        # Try service first, fall back to a detached manual `gateway run --replace` restart
         service_available = False
         system = getattr(args, 'system', False)
         restart_all = getattr(args, 'all', False)
@@ -4152,15 +4219,11 @@ def _gateway_command_inner(args):
                 print("  Fix the service, then retry: hermes gateway start")
                 sys.exit(1)
 
-            # Manual restart: stop only this profile's gateway
-            if stop_profile_gateway():
-                print("✓ Stopped gateway for this profile")
-
-            _wait_for_gateway_exit(timeout=10.0, force_after=5.0)
-
-            # Start fresh
-            print("Starting gateway...")
-            run_gateway(verbose=0)
+            # Manual restart: start a detached replacement for this profile.
+            # `gateway run --replace` handles retiring the old manual process
+            # without turning this CLI invocation into the long-running gateway.
+            restart_manual_gateway_background()
+            return
     
     elif subcmd == "status":
         deep = getattr(args, 'deep', False)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8166,6 +8166,22 @@ For more help on a command:
         help="Kill ALL gateway processes across all profiles before restarting",
     )
 
+    # gateway safe-restart
+    gateway_safe_restart = gateway_subparsers.add_parser(
+        "safe-restart",
+        help="Restart service or manually-run gateway without staying attached",
+        description=(
+            "Restart the gateway safely. Uses the installed systemd/launchd "
+            "service when present; otherwise launches a detached `gateway run "
+            "--replace` replacement and writes a restart log."
+        ),
+    )
+    gateway_safe_restart.add_argument(
+        "--system",
+        action="store_true",
+        help="Target the Linux system-level gateway service",
+    )
+
     # gateway status
     gateway_status = gateway_subparsers.add_parser("status", help="Show gateway status")
     gateway_status.add_argument("--deep", action="store_true", help="Deep status check")

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -175,6 +175,44 @@ class TestGatewayStopCleanup:
         assert kill_calls == [False]
 
 
+class TestGatewaySafeRestart:
+    def test_safe_restart_uses_background_manual_replacement_without_service(self, monkeypatch):
+        calls = []
+
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_wsl", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_container", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
+        monkeypatch.setattr(
+            gateway_cli,
+            "restart_manual_gateway_background",
+            lambda: calls.append("manual-background-replace") or 1234,
+        )
+
+        gateway_cli.gateway_command(SimpleNamespace(gateway_command="safe-restart"))
+
+        assert calls == ["manual-background-replace"]
+
+    def test_restart_uses_safe_restart_for_manual_process_when_service_absent(self, monkeypatch):
+        calls = []
+
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_wsl", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_container", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
+        monkeypatch.setattr(
+            gateway_cli,
+            "restart_manual_gateway_background",
+            lambda: calls.append("manual-background-replace") or 1234,
+        )
+
+        gateway_cli.gateway_command(SimpleNamespace(gateway_command="restart", all=False, system=False))
+
+        assert calls == ["manual-background-replace"]
+
+
 class TestLaunchdServiceRecovery:
     def test_get_restart_drain_timeout_prefers_env_then_config_then_default(self, monkeypatch):
         monkeypatch.delenv("HERMES_RESTART_DRAIN_TIMEOUT", raising=False)


### PR DESCRIPTION
## Summary
- Adds `hermes gateway safe-restart` as a one-command restart path for both service-managed and manually-run gateways.
- Makes plain `hermes gateway restart` fall back to a detached manual `gateway run --replace` replacement when no systemd/launchd service is available.
- Writes restart logs under the active Hermes profile log directory and verifies the replacement process stays alive briefly before returning.

## Why
Manual/nohup/tmux gateway runs currently make restart UX confusing: the service-oriented `gateway restart` path can fall back into foreground `gateway run`, leaving the operator attached to the long-running gateway instead of giving a clean one-command restart. This makes routine config reloads feel risky and unnecessarily complex.

## Test Plan
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /root/.hermes/hermes-agent/.venv/bin/python -m pytest -q -o addopts='' tests/hermes_cli/test_gateway_service.py::TestGatewaySafeRestart`
- `/root/.hermes/hermes-agent/.venv/bin/python -m py_compile hermes_cli/gateway.py hermes_cli/main.py tests/hermes_cli/test_gateway_service.py`
- `/root/.hermes/hermes-agent/.venv/bin/python -m hermes_cli.main gateway --help | grep -E 'safe-restart|restart'`
- `/root/.hermes/hermes-agent/.venv/bin/python -m hermes_cli.main gateway safe-restart --help`

Note: the full `tests/hermes_cli/test_gateway_service.py` file currently has unrelated root/container environment failures around user-systemd preflight and system-service-as-root guardrails in this test environment. The new focused tests pass.

🤖 This PR was created by an AI coding agent
🤖 This was written by an AI coding agent
