### PR TITLE
fix: auto-load topic skills after manual /reset command

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5641,6 +5641,14 @@ class GatewayRunner:
         # Reset the session
         new_entry = self.session_store.reset_session(session_key)
 
+        # Mark as auto-reset so that the next message in this session triggers
+        # skill auto-loading (group_topics / channel_skill_bindings).  Without
+        # this flag, `_is_new_session` in `_run_agent` evaluates to False for
+        # manually-reset sessions, causing topic-bound skills to be skipped.
+        if new_entry:
+            new_entry.was_auto_reset = True
+            new_entry.auto_reset_reason = "manual_reset"
+
         # Clear any session-scoped model/reasoning overrides so the next agent
         # picks up configured defaults instead of previous session switches.
         self._session_model_overrides.pop(session_key, None)


### PR DESCRIPTION
## Bug

When a session is reset via `/reset` or `/new` command, topic-bound skills (configured via `group_topics` or `channel_skill_bindings`) are **not** auto-loaded on the first message of the new session.

This does **not** affect auto-resets triggered by idle timeout / schedule — those work correctly.

## Root Cause

`_handle_reset_command()` creates a new session via `session_store.reset_session()`, but does not set `was_auto_reset = True` on the new entry.

In `_run_agent()`, the skill auto-load gate at line ~4531 checks:

```python
_is_new_session = (
    session_entry.created_at == session_entry.updated_at
    or getattr(session_entry, "was_auto_reset", False)
)

if _is_new_session and _auto:
    # inject skill...
```

For auto-resets, `get_or_create_session()` in `session.py` already sets `was_auto_reset = True`. For manual resets, it stays `False`, and `created_at != updated_at` (the entry was already updated during the reset flow), so `_is_new_session` evaluates to `False` and skills are skipped.

## Fix

Set `was_auto_reset = True` and `auto_reset_reason = "manual_reset"` on the new session entry in `_handle_reset_command()`, right after `reset_session()` returns. This ensures the skill auto-loading path fires on the next inbound message.

## Reproduction

1. Configure a topic-bound skill in `config.yaml`:
   ```yaml
   platforms:
     telegram:
       extra:
         group_topics:
           - chat_id: "-100XXXXXXXXXX"
             topics:
               - name: "coding fork"
                 skill: coding-fork
                 thread_id: 1939
   ```
2. Send a message in that topic → skill loads ✅
3. Run `/reset`
4. Send another message in the same topic → skill does NOT load ❌

After this fix, step 4 correctly loads the skill ✅

## Testing

- Syntax check passed (`ast.parse`)
- Manual testing: `/reset` in a topic thread → next message correctly triggers `[Gateway] Auto-loaded skill(s) ['coding-fork']` in gateway.log