### PR TITLE
docs: clarify quick commands config shape

### DIFF
--- a/website/docs/reference/slash-commands.md
+++ b/website/docs/reference/slash-commands.md
@@ -98,16 +98,24 @@ Type `/` in the CLI to open the autocomplete menu. Built-in commands are case-in
 
 ### Quick Commands
 
-User-defined quick commands map a short alias to a longer prompt. Configure them in `~/.hermes/config.yaml`:
+User-defined quick commands map a short slash command to either a shell command or another slash command. Configure them in `~/.hermes/config.yaml`:
 
 ```yaml
 quick_commands:
-  review: "Review my latest git diff and suggest improvements"
-  deploy: "Run the deployment script at scripts/deploy.sh and verify the output"
-  morning: "Check my calendar, unread emails, and summarize today's priorities"
+  status:
+    type: exec
+    command: systemctl status hermes-agent
+  deploy:
+    type: exec
+    command: scripts/deploy.sh
+  inbox:
+    type: alias
+    target: /gmail unread
 ```
 
-Then type `/review`, `/deploy`, or `/morning` in the CLI. Quick commands are resolved at dispatch time and are not shown in the built-in autocomplete/help tables.
+Then type `/status`, `/deploy`, or `/inbox` in the CLI or a messaging platform. Quick commands are resolved at dispatch time and may not appear in every built-in autocomplete/help table.
+
+String-only prompt shortcuts are not supported as quick commands. Put longer reusable prompts in a skill, or use `type: alias` to point at an existing slash command.
 
 ### Alias Resolution
 

--- a/website/docs/user-guide/cli.md
+++ b/website/docs/user-guide/cli.md
@@ -141,9 +141,12 @@ quick_commands:
   gpu:
     type: exec
     command: nvidia-smi --query-gpu=utilization.gpu,memory.used --format=csv,noheader
+  restart:
+    type: alias
+    target: /gateway restart
 ```
 
-Then type `/status` or `/gpu` in any chat. See the [Configuration guide](/docs/user-guide/configuration#quick-commands) for more examples.
+Then type `/status`, `/gpu`, or `/restart` in any chat. See the [Configuration guide](/docs/user-guide/configuration#quick-commands) for more examples.
 
 ## Preloading Skills at Launch
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1192,7 +1192,7 @@ whatsapp:
 
 ## Quick Commands
 
-Define custom commands that run shell commands without invoking the LLM — zero token usage, instant execution. Especially useful from messaging platforms (Telegram, Discord, etc.) for quick server checks or utility scripts.
+Define custom commands that either run shell commands without invoking the LLM, or alias one slash command to another. Exec quick commands are zero-token and useful from messaging platforms (Telegram, Discord, etc.) for quick server checks or utility scripts.
 
 ```yaml
 quick_commands:
@@ -1208,15 +1208,20 @@ quick_commands:
   gpu:
     type: exec
     command: nvidia-smi --query-gpu=name,utilization.gpu,memory.used,memory.total --format=csv,noheader
+  restart:
+    type: alias
+    target: /gateway restart
 ```
 
-Usage: type `/status`, `/disk`, `/update`, or `/gpu` in the CLI or any messaging platform. The command runs locally on the host and returns the output directly — no LLM call, no tokens consumed.
+Usage: type `/status`, `/disk`, `/update`, `/gpu`, or `/restart` in the CLI or any messaging platform. `exec` commands run locally on the host and return the output directly — no LLM call, no tokens consumed. `alias` commands rewrite to the configured slash command target.
 
 - **30-second timeout** — long-running commands are killed with an error message
 - **Priority** — quick commands are checked before skill commands, so you can override skill names
 - **Autocomplete** — quick commands are resolved at dispatch time and are not shown in the built-in slash-command autocomplete tables
-- **Type** — only `exec` is supported (runs a shell command); other types show an error
+- **Type** — supported types are `exec` and `alias`; other types show an error
 - **Works everywhere** — CLI, Telegram, Discord, Slack, WhatsApp, Signal, Email, Home Assistant
+
+String-only prompt shortcuts are not valid quick commands. For reusable prompt workflows, create a skill or alias to an existing slash command.
 
 ## Human Delay
 


### PR DESCRIPTION
## What does this PR do?

Clarifies the documented `quick_commands` config shape so it matches the current implementation.

The slash command reference still showed the old string-style prompt shortcut shape, for example `review: "Review my latest git diff..."`, but current quick commands expect structured entries with `type: exec` or `type: alias`. This updates the reference, CLI guide, and configuration guide to use the supported object form.

It also calls out that string-only prompt shortcuts are not valid quick commands, and points users toward skills or aliases for reusable prompt workflows.

## Related Issue

Reported from Discord support: a user configured string-style quick commands from the docs and found they were not available in the classic CLI.

## Type of Change

- [x] 📝 Documentation update

## Changes Made

- `website/docs/reference/slash-commands.md`: replace the string-style quick command example with `exec` and `alias` examples.
- `website/docs/user-guide/configuration.md`: document both supported types, update usage text, and remove the claim that only `exec` is supported.
- `website/docs/user-guide/cli.md`: include an alias example alongside exec quick commands.

## How to Test

1. Read the Quick Commands sections in the reference, CLI guide, and configuration guide.
2. Confirm examples use object entries with `type` plus `command` or `target`.
3. Confirm the docs no longer imply string-only prompt shortcuts are supported.

## Checklist

### Code

- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix/feature
- [ ] I have run the full test suite — N/A, docs-only change
- [x] I tested on my platform: Ubuntu/WSL-style Linux checkout

### Documentation & Housekeeping

- [x] I updated relevant documentation
- [x] `cli-config.yaml.example`: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A
- [x] Cross-platform impact considered: docs-only
- [x] Tool descriptions/schemas: N/A

## Validation

- `git diff --check -- website/docs/reference/slash-commands.md website/docs/user-guide/configuration.md website/docs/user-guide/cli.md`

Docusaurus build was not run locally because `website/node_modules` is not installed in this checkout.

## Screenshots / Logs

N/A.
