### PR TITLE
docs(weixin): clarify QR-login iLink bot DM-only group delivery (#17094)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3277,6 +3277,12 @@ def _setup_weixin():
         print_warning("  Direct messages disabled.")
 
     print()
+    print_info("  Note: QR-login connects an iLink bot identity (e.g. ...@im.bot), which")
+    print_info("  cannot be invited into ordinary WeChat groups like a normal contact.")
+    print_info("  Group settings only take effect if iLink delivers group events for your")
+    print_info("  bot type — for many QR-login deployments that's bot-DM only. Leaving")
+    print_info("  group chats disabled is safe; enable group policy only if you've")
+    print_info("  confirmed iLink is forwarding group messages to your gateway.")
     group_choices = [
         "Disable group chats (recommended)",
         "Allow all group chats",
@@ -3290,12 +3296,12 @@ def _setup_weixin():
     elif group_idx == 1:
         save_env_value("WEIXIN_GROUP_POLICY", "open")
         save_env_value("WEIXIN_GROUP_ALLOWED_USERS", "")
-        print_warning("  All group chats enabled.")
+        print_warning("  All group chats enabled (subject to iLink delivering group events).")
     else:
         allow_groups = prompt("  Allowed group chat IDs (comma-separated)", "", password=False).replace(" ", "")
         save_env_value("WEIXIN_GROUP_POLICY", "allowlist")
         save_env_value("WEIXIN_GROUP_ALLOWED_USERS", allow_groups)
-        print_success("  Group allowlist saved.")
+        print_success("  Group allowlist saved (subject to iLink delivering group events).")
 
     if user_id:
         print()

--- a/tests/gateway/test_setup_weixin.py
+++ b/tests/gateway/test_setup_weixin.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock, patch
 def _run_setup_weixin(*, group_idx: int):
     """Drive ``_setup_weixin`` to the group-chat prompt and capture I/O.
 
-    Returns ``(saved_env, info_calls, warning_calls)``.
+    Returns ``(saved_env, info_calls, warning_calls, success_calls)``.
     """
     saved_env: dict[str, str] = {}
     existing_env: dict[str, str] = {}
@@ -26,6 +26,7 @@ def _run_setup_weixin(*, group_idx: int):
 
     info_mock = MagicMock()
     warning_mock = MagicMock()
+    success_mock = MagicMock()
 
     qr_credentials = {
         "account_id": "test-account",
@@ -45,7 +46,7 @@ def _run_setup_weixin(*, group_idx: int):
          patch("hermes_cli.gateway.prompt_choice", side_effect=prompt_choice_responses), \
          patch("hermes_cli.gateway.prompt", side_effect=prompt_responses), \
          patch("hermes_cli.gateway.print_info", info_mock), \
-         patch("hermes_cli.gateway.print_success"), \
+         patch("hermes_cli.gateway.print_success", success_mock), \
          patch("hermes_cli.gateway.print_warning", warning_mock), \
          patch("hermes_cli.gateway.print_error"), \
          patch("hermes_cli.gateway.color", side_effect=lambda t, c: t), \
@@ -58,14 +59,15 @@ def _run_setup_weixin(*, group_idx: int):
 
     info_calls = [str(c.args[0]) if c.args else "" for c in info_mock.call_args_list]
     warning_calls = [str(c.args[0]) if c.args else "" for c in warning_mock.call_args_list]
-    return saved_env, info_calls, warning_calls
+    success_calls = [str(c.args[0]) if c.args else "" for c in success_mock.call_args_list]
+    return saved_env, info_calls, warning_calls, success_calls
 
 
 class TestSetupWeixinIlinkBotClarification:
     """#17094: setup must warn that QR-login iLink bots may not deliver group events."""
 
     def test_disabled_path_prints_ilink_bot_dm_only_note(self):
-        _, info_calls, _ = _run_setup_weixin(group_idx=0)
+        _, info_calls, _, _ = _run_setup_weixin(group_idx=0)
         joined = "\n".join(info_calls)
         # Three independent assertions so a future trim that drops one of the
         # three load-bearing facts (bot identity, group delivery, group@bot
@@ -75,7 +77,7 @@ class TestSetupWeixinIlinkBotClarification:
         assert "@im.bot" in joined, info_calls
 
     def test_open_path_still_prints_note_and_qualifies_warning(self):
-        saved_env, info_calls, warning_calls = _run_setup_weixin(group_idx=1)
+        saved_env, info_calls, warning_calls, _ = _run_setup_weixin(group_idx=1)
         joined_info = "\n".join(info_calls)
         joined_warning = "\n".join(warning_calls)
 
@@ -86,7 +88,14 @@ class TestSetupWeixinIlinkBotClarification:
         assert "iLink" in joined_warning, warning_calls
 
     def test_allowlist_path_still_prints_note_and_qualifies_success(self):
-        saved_env, info_calls, _ = _run_setup_weixin(group_idx=2)
+        saved_env, info_calls, _, success_calls = _run_setup_weixin(group_idx=2)
         joined_info = "\n".join(info_calls)
+        joined_success = "\n".join(success_calls)
         assert saved_env["WEIXIN_GROUP_POLICY"] == "allowlist"
         assert "iLink bot" in joined_info, info_calls
+        # The allowlist success line must be qualified with the iLink-delivery
+        # caveat so users don't assume the policy alone guarantees delivery.
+        assert any(
+            "Group allowlist saved" in line and "iLink" in line
+            for line in success_calls
+        ), success_calls

--- a/tests/gateway/test_setup_weixin.py
+++ b/tests/gateway/test_setup_weixin.py
@@ -1,0 +1,92 @@
+"""Tests for ``_setup_weixin()`` in ``hermes_cli/gateway.py``.
+
+Locks in the iLink-bot DM-only clarification surfaced by issue #17094 — the
+group-chat prompt must be preceded by a note that QR-login bots may not
+receive ordinary WeChat group events, so users do not waste time debugging
+``WEIXIN_GROUP_POLICY`` / ``WEIXIN_GROUP_ALLOWED_USERS`` for messages iLink
+never delivers in the first place.
+"""
+
+from unittest.mock import MagicMock, patch
+
+
+def _run_setup_weixin(*, group_idx: int):
+    """Drive ``_setup_weixin`` to the group-chat prompt and capture I/O.
+
+    Returns ``(saved_env, info_calls, warning_calls)``.
+    """
+    saved_env: dict[str, str] = {}
+    existing_env: dict[str, str] = {}
+
+    def mock_save(name, value):
+        saved_env[name] = value
+
+    def mock_get(name):
+        return existing_env.get(name, "")
+
+    info_mock = MagicMock()
+    warning_mock = MagicMock()
+
+    qr_credentials = {
+        "account_id": "test-account",
+        "token": "test-token",
+        "base_url": "https://ilinkai.weixin.qq.com",
+        "user_id": "test-user",
+    }
+
+    # access_idx=0 (DM pairing), then group_idx; finally home-channel yes/no.
+    prompt_choice_responses = [0, group_idx]
+    prompt_yes_no_responses = [True, False]  # start QR; skip home channel
+    prompt_responses = [""]  # group allowlist input (only consumed if group_idx==2)
+
+    with patch("hermes_cli.gateway.save_env_value", side_effect=mock_save), \
+         patch("hermes_cli.gateway.get_env_value", side_effect=mock_get), \
+         patch("hermes_cli.gateway.prompt_yes_no", side_effect=prompt_yes_no_responses), \
+         patch("hermes_cli.gateway.prompt_choice", side_effect=prompt_choice_responses), \
+         patch("hermes_cli.gateway.prompt", side_effect=prompt_responses), \
+         patch("hermes_cli.gateway.print_info", info_mock), \
+         patch("hermes_cli.gateway.print_success"), \
+         patch("hermes_cli.gateway.print_warning", warning_mock), \
+         patch("hermes_cli.gateway.print_error"), \
+         patch("hermes_cli.gateway.color", side_effect=lambda t, c: t), \
+         patch("gateway.platforms.weixin.check_weixin_requirements", return_value=True), \
+         patch("gateway.platforms.weixin.qr_login", new=lambda *_a, **_k: qr_credentials), \
+         patch("asyncio.run", return_value=qr_credentials):
+
+        from hermes_cli.gateway import _setup_weixin
+        _setup_weixin()
+
+    info_calls = [str(c.args[0]) if c.args else "" for c in info_mock.call_args_list]
+    warning_calls = [str(c.args[0]) if c.args else "" for c in warning_mock.call_args_list]
+    return saved_env, info_calls, warning_calls
+
+
+class TestSetupWeixinIlinkBotClarification:
+    """#17094: setup must warn that QR-login iLink bots may not deliver group events."""
+
+    def test_disabled_path_prints_ilink_bot_dm_only_note(self):
+        _, info_calls, _ = _run_setup_weixin(group_idx=0)
+        joined = "\n".join(info_calls)
+        # Three independent assertions so a future trim that drops one of the
+        # three load-bearing facts (bot identity, group delivery, group@bot
+        # mention semantics) still fails this test.
+        assert "iLink bot" in joined, info_calls
+        assert "ordinary WeChat groups" in joined or "ordinary WeChat group" in joined, info_calls
+        assert "@im.bot" in joined, info_calls
+
+    def test_open_path_still_prints_note_and_qualifies_warning(self):
+        saved_env, info_calls, warning_calls = _run_setup_weixin(group_idx=1)
+        joined_info = "\n".join(info_calls)
+        joined_warning = "\n".join(warning_calls)
+
+        assert saved_env["WEIXIN_GROUP_POLICY"] == "open"
+        assert "iLink bot" in joined_info, info_calls
+        # The "All group chats enabled" warning is now qualified so the user
+        # knows the policy is necessary-but-not-sufficient.
+        assert "iLink" in joined_warning, warning_calls
+
+    def test_allowlist_path_still_prints_note_and_qualifies_success(self):
+        saved_env, info_calls, _ = _run_setup_weixin(group_idx=2)
+        joined_info = "\n".join(info_calls)
+        assert saved_env["WEIXIN_GROUP_POLICY"] == "allowlist"
+        assert "iLink bot" in joined_info, info_calls

--- a/website/docs/user-guide/messaging/weixin.md
+++ b/website/docs/user-guide/messaging/weixin.md
@@ -150,6 +150,17 @@ WEIXIN_GROUP_ALLOWED_USERS=group_id_1,group_id_2
 The default group policy is `disabled` for Weixin (unlike WeCom where it defaults to `open`). This is intentional since personal WeChat accounts may be in many groups.
 :::
 
+:::warning Ordinary WeChat groups may not be delivered for QR-login bots
+QR login connects Hermes to an **iLink bot identity** (e.g. `<hex>@im.bot`), not to a fully automated personal WeChat account. The iLink bot identity cannot be invited into ordinary WeChat groups the way a normal contact can, and `getUpdates` typically returns zero messages for ordinary group chats — even when `WEIXIN_GROUP_POLICY` is `open` or `allowlist`.
+
+In practice, this means:
+
+- **Bot DMs work** — messages sent to the iLink bot's DM entry reach the gateway.
+- **Ordinary WeChat group messages may not arrive at all**, and `@`-mentioning the personal WeChat account used for QR login is **not** the same as `@`-mentioning the iLink bot.
+
+Set a non-`disabled` group policy only if you have confirmed (e.g. via gateway logs) that iLink is forwarding group events for your bot type.
+:::
+
 ## Media Support
 
 ### Inbound (receiving)
@@ -290,7 +301,7 @@ Only one Weixin gateway instance can use a given token at a time. The adapter ac
 | Session expired (`errcode=-14`) | Your login session has expired. Re-run `hermes gateway setup` to scan a new QR code |
 | QR code expired during setup | The QR auto-refreshes up to 3 times. If it keeps expiring, check your network connection |
 | Bot doesn't respond to DMs | Check `WEIXIN_DM_POLICY` — if set to `allowlist`, the sender must be in `WEIXIN_ALLOWED_USERS` |
-| Bot ignores group messages | Group policy defaults to `disabled`. Set `WEIXIN_GROUP_POLICY=open` or `allowlist` |
+| Bot ignores group messages | Group policy defaults to `disabled`. Set `WEIXIN_GROUP_POLICY=open` or `allowlist`. Note: QR-login iLink bots may not receive ordinary WeChat group events at all — see [Group Policy](#group-policy) |
 | Media download/upload fails | Ensure `cryptography` is installed. Check network access to `novac2c.cdn.weixin.qq.com` |
 | `Blocked unsafe URL (SSRF protection)` | The outbound media URL points to a private/internal address. Only public URLs are allowed |
 | Voice messages show as text | If WeChat provides a transcription, the adapter uses the text. This is expected behavior |

--- a/website/docs/user-guide/messaging/weixin.md
+++ b/website/docs/user-guide/messaging/weixin.md
@@ -151,7 +151,7 @@ The default group policy is `disabled` for Weixin (unlike WeCom where it default
 :::
 
 :::warning Ordinary WeChat groups may not be delivered for QR-login bots
-QR login connects Hermes to an **iLink bot identity** (e.g. `<hex>@im.bot`), not to a fully automated personal WeChat account. The iLink bot identity cannot be invited into ordinary WeChat groups the way a normal contact can, and `getUpdates` typically returns zero messages for ordinary group chats — even when `WEIXIN_GROUP_POLICY` is `open` or `allowlist`.
+QR login connects Hermes to an **iLink bot identity** (e.g. `<hex>@im.bot`), not to a fully automated personal WeChat account. The iLink bot identity cannot be invited into ordinary WeChat groups the way a normal contact can, and `getupdates` typically returns zero messages for ordinary group chats — even when `WEIXIN_GROUP_POLICY` is `open` or `allowlist`.
 
 In practice, this means:
 


### PR DESCRIPTION
## Summary
- Setup wizard prints an explicit note before the group-chat prompt explaining that the QR-login flow connects an **iLink bot identity** (`...@im.bot`), which cannot be invited into ordinary WeChat groups the way a normal contact can — and that iLink's `getUpdates` typically returns zero ordinary-group messages even when `WEIXIN_GROUP_POLICY=open` or `allowlist`.
- Open + allowlist confirmations are qualified with "subject to iLink delivering group events" so the user knows the policy is necessary-but-not-sufficient.
- `website/docs/user-guide/messaging/weixin.md` adds a `:::warning` callout in **Group Policy** and updates the **Troubleshooting** row for "Bot ignores group messages" with the same caveat.

## The bug
Reporter on #17094 ran `hermes gateway setup`, completed Weixin QR login, and saw:

```text
How should group chats be handled?
- Disable group chats (recommended)
- Allow all group chats
- Only allow listed group chat IDs
```

…then spent significant time debugging `WEIXIN_GROUP_POLICY`, `WEIXIN_GROUP_ALLOWED_USERS`, and `WEIXIN_GROUP_MENTION_ONLY` to make ordinary WeChat group messages reach the agent. Their gateway logs show that the bot is correctly connected and DM messages flow end-to-end, but ordinary group messages never arrive at the gateway in the first place:

```text
[Weixin] getUpdates response ret=0 errcode=0 msgs=0 sync_buf_changed=True
```

The root cause is that QR login binds an iLink **bot** identity, not a fully automated personal WeChat account, and that bot identity cannot be added to ordinary WeChat groups by users. There is nothing for Hermes to filter; iLink simply doesn't deliver group events for this bot type. The setup wizard / docs didn't say this, so users naturally assumed Hermes was filtering.

## The fix
Pure docs/help correctness — no runtime behavior changes:

1. `hermes_cli/gateway.py::_setup_weixin` adds a 6-line `print_info` block before the group-chat prompt that names the iLink bot identity, states ordinary groups may not deliver, and recommends leaving group chats disabled unless the user has confirmed iLink is forwarding group events. The "All group chats enabled" warning and "Group allowlist saved" success line are qualified with "(subject to iLink delivering group events)".
2. `website/docs/user-guide/messaging/weixin.md`:
   - **Group Policy** section gains a `:::warning Ordinary WeChat groups may not be delivered for QR-login bots` callout that explains the iLink bot identity, the typical `msgs=0` behavior, and that `@`-mentioning the personal WeChat account used for QR login is **not** the same as `@`-mentioning the iLink bot.
   - **Troubleshooting** row "Bot ignores group messages" now points at the new callout instead of just suggesting `WEIXIN_GROUP_POLICY=open`.

The default `WEIXIN_GROUP_POLICY=disabled` is unchanged. No env-var rename, no startup warning emission, no behavioral change for existing deployments — only setup-time messaging and docs.

## Test plan
- [x] **Regression test:** `tests/gateway/test_setup_weixin.py` drives `_setup_weixin()` through all three group-policy branches with the QR `qr_login` / `check_weixin_requirements` / `asyncio.run` patched, captures `print_info` and `print_warning` calls via `MagicMock`, and asserts:
  - `disabled` path: info contains both `iLink bot` + `@im.bot` + `ordinary WeChat group`
  - `open` path: info contains `iLink bot` and the warning is qualified with `iLink`
  - `allowlist` path: info contains `iLink bot` and `WEIXIN_GROUP_POLICY=allowlist` is still saved
- [x] Adjacent suite: `tests/gateway/test_setup_feishu.py`, `tests/hermes_cli/test_setup.py`, `tests/hermes_cli/test_setup_prompt_menus.py`, `tests/gateway/test_weixin.py` — all pass (78 tests, 0 failures).
- [x] Regression guard: the test asserts on the `iLink bot` literal which only exists in the new info block — removing the new lines fails the test.

## Related
- Fixes #17094
- Adjacent (no overlap): #16422 (weixin: fail fast on permanent iLink error codes), #11634 (weixin Batch-5 polish — merged).