### PR TITLE
fix(auxiliary): don't treat api.kimi.com/coding/v1 as Anthropic Messages

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -815,6 +815,12 @@ def _endpoint_speaks_anthropic_messages(base_url: str) -> bool:
     if hostname == "api.anthropic.com":
         return True
     if hostname == "api.kimi.com" and "/coding" in normalized:
+        # The /coding route speaks Anthropic Messages, but /coding/v1 is
+        # the OpenAI-compatible endpoint.  Only treat it as Anthropic when
+        # the path does NOT end in /v1 (or /v1/...).
+        path = urlparse(normalized).path
+        if path.endswith("/v1") or "/v1/" in path:
+            return False
         return True
     return False
 


### PR DESCRIPTION
## Problem

The `_endpoint_speaks_anthropic_messages()` function introduced in #17027 treats ANY api.kimi.com URL containing /coding as an Anthropic Messages endpoint. This includes https://api.kimi.com/coding/v1, which is actually the **OpenAI-compatible** endpoint.

This causes 404s for users configuring auxiliary tasks (e.g. title_generation) with:

    provider: kimi-coding
    base_url: https://api.kimi.com/coding/v1

The client gets wrongly wrapped in AnthropicAuxiliaryClient, which calls /v1/messages instead of /v1/chat/completions.

## Fix

Check if the URL path ends with /v1 (or contains /v1/) before treating api.kimi.com/coding URLs as Anthropic. Only the bare /coding route speaks Anthropic Messages; /coding/v1 is OpenAI-compatible.

## Test Results

- https://api.kimi.com/coding -> True (Anthropic) ✓
- https://api.kimi.com/coding/v1 -> False (OpenAI) ✓
- https://api.kimi.com/coding/v1/ -> False (OpenAI) ✓
- https://api.kimi.com/coding/v1/chat/completions -> False (OpenAI) ✓

Fixes regression from #17027.
