### PR TITLE
fix(tui): honor display.busy_input_mode in TUI v2

### DIFF
--- a/ui-tui/src/__tests__/useConfigSync.test.ts
+++ b/ui-tui/src/__tests__/useConfigSync.test.ts
@@ -173,12 +173,17 @@ describe('normalizeBusyInputMode', () => {
     expect(normalizeBusyInputMode('STEER')).toBe('steer')
   })
 
-  it('defaults to interrupt for missing/unknown values (matches Python _load_busy_input_mode)', () => {
-    expect(normalizeBusyInputMode(undefined)).toBe('interrupt')
-    expect(normalizeBusyInputMode(null)).toBe('interrupt')
-    expect(normalizeBusyInputMode('')).toBe('interrupt')
-    expect(normalizeBusyInputMode('drop')).toBe('interrupt')
-    expect(normalizeBusyInputMode(42)).toBe('interrupt')
+  it('defaults to queue for missing/unknown values (TUI-only override)', () => {
+    // CLI / messaging adapters keep `interrupt` as the framework default
+    // (see hermes_cli/config.py + tui_gateway/server.py::_load_busy_input_mode);
+    // the TUI ships `queue` because typing a follow-up while the agent
+    // streams is the common authoring pattern and an unintended interrupt
+    // loses work.
+    expect(normalizeBusyInputMode(undefined)).toBe('queue')
+    expect(normalizeBusyInputMode(null)).toBe('queue')
+    expect(normalizeBusyInputMode('')).toBe('queue')
+    expect(normalizeBusyInputMode('drop')).toBe('queue')
+    expect(normalizeBusyInputMode(42)).toBe('queue')
   })
 })
 
@@ -197,13 +202,13 @@ describe('applyDisplay → busy_input_mode', () => {
     expect($uiState.get().busyInputMode).toBe('steer')
   })
 
-  it('falls back to interrupt when value is missing or invalid', () => {
+  it('falls back to queue when value is missing or invalid (TUI-only default)', () => {
     const setBell = vi.fn()
 
     applyDisplay({ config: { display: {} } }, setBell)
-    expect($uiState.get().busyInputMode).toBe('interrupt')
+    expect($uiState.get().busyInputMode).toBe('queue')
 
     applyDisplay({ config: { display: { busy_input_mode: 'drop' } } }, setBell)
-    expect($uiState.get().busyInputMode).toBe('interrupt')
+    expect($uiState.get().busyInputMode).toBe('queue')
   })
 })

--- a/ui-tui/src/__tests__/useConfigSync.test.ts
+++ b/ui-tui/src/__tests__/useConfigSync.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { $uiState, resetUiState } from '../app/uiStore.js'
-import { applyDisplay, normalizeStatusBar } from '../app/useConfigSync.js'
+import { applyDisplay, normalizeBusyInputMode, normalizeStatusBar } from '../app/useConfigSync.js'
 
 describe('applyDisplay', () => {
   beforeEach(() => {
@@ -158,5 +158,52 @@ describe('normalizeStatusBar', () => {
     expect(normalizeStatusBar('TOP')).toBe('top')
     expect(normalizeStatusBar('  on  ')).toBe('top')
     expect(normalizeStatusBar('OFF')).toBe('off')
+  })
+})
+
+describe('normalizeBusyInputMode', () => {
+  it('passes through the canonical CLI parity values', () => {
+    expect(normalizeBusyInputMode('queue')).toBe('queue')
+    expect(normalizeBusyInputMode('steer')).toBe('steer')
+    expect(normalizeBusyInputMode('interrupt')).toBe('interrupt')
+  })
+
+  it('trims and lowercases input', () => {
+    expect(normalizeBusyInputMode(' Queue ')).toBe('queue')
+    expect(normalizeBusyInputMode('STEER')).toBe('steer')
+  })
+
+  it('defaults to interrupt for missing/unknown values (matches Python _load_busy_input_mode)', () => {
+    expect(normalizeBusyInputMode(undefined)).toBe('interrupt')
+    expect(normalizeBusyInputMode(null)).toBe('interrupt')
+    expect(normalizeBusyInputMode('')).toBe('interrupt')
+    expect(normalizeBusyInputMode('drop')).toBe('interrupt')
+    expect(normalizeBusyInputMode(42)).toBe('interrupt')
+  })
+})
+
+describe('applyDisplay → busy_input_mode', () => {
+  beforeEach(() => {
+    resetUiState()
+  })
+
+  it('threads display.busy_input_mode into $uiState', () => {
+    const setBell = vi.fn()
+
+    applyDisplay({ config: { display: { busy_input_mode: 'queue' } } }, setBell)
+    expect($uiState.get().busyInputMode).toBe('queue')
+
+    applyDisplay({ config: { display: { busy_input_mode: 'steer' } } }, setBell)
+    expect($uiState.get().busyInputMode).toBe('steer')
+  })
+
+  it('falls back to interrupt when value is missing or invalid', () => {
+    const setBell = vi.fn()
+
+    applyDisplay({ config: { display: {} } }, setBell)
+    expect($uiState.get().busyInputMode).toBe('interrupt')
+
+    applyDisplay({ config: { display: { busy_input_mode: 'drop' } } }, setBell)
+    expect($uiState.get().busyInputMode).toBe('interrupt')
   })
 })

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -27,6 +27,8 @@ export interface StateSetter<T> {
 
 export type StatusBarMode = 'bottom' | 'off' | 'top'
 
+export type BusyInputMode = 'interrupt' | 'queue' | 'steer'
+
 export interface SelectionApi {
   captureScrolledRows: (firstRow: number, lastRow: number, side: 'above' | 'below') => void
   clearSelection: () => void
@@ -85,6 +87,7 @@ export interface TranscriptRow {
 export interface UiState {
   bgTasks: Set<string>
   busy: boolean
+  busyInputMode: BusyInputMode
   compact: boolean
   detailsMode: DetailsMode
   detailsModeCommandOverride: boolean

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -9,6 +9,7 @@ import type { UiState } from './interfaces.js'
 const buildUiState = (): UiState => ({
   bgTasks: new Set(),
   busy: false,
+  busyInputMode: 'interrupt',
   compact: false,
   detailsMode: 'collapsed',
   detailsModeCommandOverride: false,

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -9,7 +9,7 @@ import type { UiState } from './interfaces.js'
 const buildUiState = (): UiState => ({
   bgTasks: new Set(),
   busy: false,
-  busyInputMode: 'interrupt',
+  busyInputMode: 'queue',
   compact: false,
   detailsMode: 'collapsed',
   detailsModeCommandOverride: false,

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -26,14 +26,23 @@ export const normalizeStatusBar = (raw: unknown): StatusBarMode =>
 
 const BUSY_MODES = new Set<BusyInputMode>(['interrupt', 'queue', 'steer'])
 
+// TUI defaults to `queue` even though the framework default
+// (`hermes_cli/config.py`) is `interrupt`.  Rationale: in a full-screen
+// TUI you're typically authoring the next prompt while the agent is
+// still streaming, and an unintended interrupt loses work.  Set
+// `display.busy_input_mode: interrupt` (or `steer`) explicitly to
+// opt out per-config; CLI / messaging adapters keep their `interrupt`
+// default unchanged.
+const TUI_BUSY_DEFAULT: BusyInputMode = 'queue'
+
 export const normalizeBusyInputMode = (raw: unknown): BusyInputMode => {
   if (typeof raw !== 'string') {
-    return 'interrupt'
+    return TUI_BUSY_DEFAULT
   }
 
   const v = raw.trim().toLowerCase() as BusyInputMode
 
-  return BUSY_MODES.has(v) ? v : 'interrupt'
+  return BUSY_MODES.has(v) ? v : TUI_BUSY_DEFAULT
 }
 
 const MTIME_POLL_MS = 5000

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -10,7 +10,7 @@ import type {
 } from '../gatewayTypes.js'
 import { asRpcResult } from '../lib/rpc.js'
 
-import type { StatusBarMode } from './interfaces.js'
+import type { BusyInputMode, StatusBarMode } from './interfaces.js'
 import { turnController } from './turnController.js'
 import { patchUiState } from './uiStore.js'
 
@@ -23,6 +23,18 @@ const STATUSBAR_ALIAS: Record<string, StatusBarMode> = {
 
 export const normalizeStatusBar = (raw: unknown): StatusBarMode =>
   raw === false ? 'off' : typeof raw === 'string' ? (STATUSBAR_ALIAS[raw.trim().toLowerCase()] ?? 'top') : 'top'
+
+const BUSY_MODES = new Set<BusyInputMode>(['interrupt', 'queue', 'steer'])
+
+export const normalizeBusyInputMode = (raw: unknown): BusyInputMode => {
+  if (typeof raw !== 'string') {
+    return 'interrupt'
+  }
+
+  const v = raw.trim().toLowerCase() as BusyInputMode
+
+  return BUSY_MODES.has(v) ? v : 'interrupt'
+}
 
 const MTIME_POLL_MS = 5000
 
@@ -43,6 +55,7 @@ export const applyDisplay = (cfg: ConfigFullResponse | null, setBell: (v: boolea
 
   setBell(!!d.bell_on_complete)
   patchUiState({
+    busyInputMode: normalizeBusyInputMode(d.busy_input_mode),
     compact: !!d.tui_compact,
     detailsMode: resolveDetailsMode(d),
     detailsModeCommandOverride: false,

--- a/ui-tui/src/app/useSubmission.ts
+++ b/ui-tui/src/app/useSubmission.ts
@@ -4,7 +4,12 @@ import { TYPING_IDLE_MS } from '../config/timing.js'
 import { attachedImageNotice } from '../domain/messages.js'
 import { looksLikeSlashCommand } from '../domain/slash.js'
 import type { GatewayClient } from '../gatewayClient.js'
-import type { InputDetectDropResponse, PromptSubmitResponse, ShellExecResponse } from '../gatewayTypes.js'
+import type {
+  InputDetectDropResponse,
+  PromptSubmitResponse,
+  SessionSteerResponse,
+  ShellExecResponse
+} from '../gatewayTypes.js'
 import { asRpcResult } from '../lib/rpc.js'
 import { hasInterpolation, INTERPOLATION_RE } from '../protocol/interpolation.js'
 import { PASTE_SNIPPET_RE } from '../protocol/paste.js'
@@ -207,6 +212,56 @@ export function useSubmission(opts: UseSubmissionOptions) {
     [interpolate, send, shellExec]
   )
 
+  // Honors `display.busy_input_mode` from config.yaml (CLI parity):
+  //   - 'queue'     (legacy): append to queueRef; drains on busy → false
+  //   - 'steer'     : inject into the current turn via session.steer; falls
+  //                   back to queue when steer is rejected (no agent / no
+  //                   tool window).
+  //   - 'interrupt' (default): cancel the in-flight turn, then send the
+  //                   new text as a fresh prompt so it actually moves.
+  const handleBusyInput = useCallback(
+    (full: string) => {
+      const live = getUiState()
+      const mode = live.busyInputMode
+
+      if (mode === 'queue') {
+        return composerActions.enqueue(full)
+      }
+
+      if (mode === 'steer' && live.sid) {
+        gw.request<SessionSteerResponse>('session.steer', { session_id: live.sid, text: full })
+          .then(raw => {
+            const r = asRpcResult<SessionSteerResponse>(raw)
+
+            if (r?.status !== 'queued') {
+              composerActions.enqueue(full)
+              sys('steer rejected — message queued for next turn')
+            }
+          })
+          .catch(() => {
+            composerActions.enqueue(full)
+            sys('steer failed — message queued for next turn')
+          })
+
+        return
+      }
+
+      // 'interrupt' (default): tear down the current turn, then send.
+      if (live.sid) {
+        turnController.interruptTurn({ appendMessage, gw, sid: live.sid, sys })
+      }
+
+      if (hasInterpolation(full)) {
+        patchUiState({ busy: true })
+
+        return interpolate(full, send)
+      }
+
+      send(full)
+    },
+    [appendMessage, composerActions, gw, interpolate, send, sys]
+  )
+
   const dispatchSubmission = useCallback(
     (full: string) => {
       if (!full.trim()) {
@@ -252,9 +307,16 @@ export function useSubmission(opts: UseSubmissionOptions) {
         }
 
         if (getUiState().busy) {
-          composerRefs.queueRef.current.unshift(picked)
+          // 'interrupt' / 'steer' should reach the live turn instead of
+          // silently going back to the queue.  handleBusyInput resolves
+          // mode-specific behavior (interrupt-and-send, steer, or queue).
+          if (getUiState().busyInputMode === 'queue') {
+            composerRefs.queueRef.current.unshift(picked)
 
-          return composerActions.syncQueue()
+            return composerActions.syncQueue()
+          }
+
+          return handleBusyInput(picked)
         }
 
         return sendQueued(picked)
@@ -263,7 +325,7 @@ export function useSubmission(opts: UseSubmissionOptions) {
       composerActions.pushHistory(full)
 
       if (getUiState().busy) {
-        return composerActions.enqueue(full)
+        return handleBusyInput(full)
       }
 
       if (hasInterpolation(full)) {
@@ -274,7 +336,17 @@ export function useSubmission(opts: UseSubmissionOptions) {
 
       send(full)
     },
-    [appendMessage, composerActions, composerRefs, interpolate, send, sendQueued, shellExec, slashRef]
+    [
+      appendMessage,
+      composerActions,
+      composerRefs,
+      handleBusyInput,
+      interpolate,
+      send,
+      sendQueued,
+      shellExec,
+      slashRef
+    ]
   )
 
   const submit = useCallback(

--- a/ui-tui/src/app/useSubmission.ts
+++ b/ui-tui/src/app/useSubmission.ts
@@ -220,9 +220,9 @@ export function useSubmission(opts: UseSubmissionOptions) {
   //   - 'interrupt' (default): cancel the in-flight turn, then send the
   //                   new text as a fresh prompt so it actually moves.
   //
-  // Returns whether the steer fallback should re-insert at the front of
-  // the queue (used by the queue-edit path to preserve a picked item's
-  // position; the mainline submit path always appends).
+  // `opts.fallbackToFront` controls whether a steer fallback re-inserts
+  // at the front of the queue (used by the queue-edit path to preserve
+  // a picked item's position); the mainline submit path always appends.
   const handleBusyInput = useCallback(
     (full: string, opts: { fallbackToFront?: boolean } = {}) => {
       const live = getUiState()

--- a/ui-tui/src/app/useSubmission.ts
+++ b/ui-tui/src/app/useSubmission.ts
@@ -219,10 +219,23 @@ export function useSubmission(opts: UseSubmissionOptions) {
   //                   tool window).
   //   - 'interrupt' (default): cancel the in-flight turn, then send the
   //                   new text as a fresh prompt so it actually moves.
+  //
+  // Returns whether the steer fallback should re-insert at the front of
+  // the queue (used by the queue-edit path to preserve a picked item's
+  // position; the mainline submit path always appends).
   const handleBusyInput = useCallback(
-    (full: string) => {
+    (full: string, opts: { fallbackToFront?: boolean } = {}) => {
       const live = getUiState()
       const mode = live.busyInputMode
+      const fallback = (note: string) => {
+        if (opts.fallbackToFront) {
+          composerRefs.queueRef.current.unshift(full)
+          composerActions.syncQueue()
+        } else {
+          composerActions.enqueue(full)
+        }
+        sys(note)
+      }
 
       if (mode === 'queue') {
         return composerActions.enqueue(full)
@@ -234,19 +247,20 @@ export function useSubmission(opts: UseSubmissionOptions) {
             const r = asRpcResult<SessionSteerResponse>(raw)
 
             if (r?.status !== 'queued') {
-              composerActions.enqueue(full)
-              sys('steer rejected — message queued for next turn')
+              fallback('steer rejected — message queued for next turn')
             }
           })
-          .catch(() => {
-            composerActions.enqueue(full)
-            sys('steer failed — message queued for next turn')
-          })
+          .catch(() => fallback('steer failed — message queued for next turn'))
 
         return
       }
 
       // 'interrupt' (default): tear down the current turn, then send.
+      // `interruptTurn` fires `session.interrupt` without awaiting; if
+      // the gateway is still mid-response when `prompt.submit` lands,
+      // `send()`'s catch path re-queues with a "queued: ..." sys note
+      // (`isSessionBusyError`) — so a lost race degrades to queue
+      // semantics, not a dropped message.
       if (live.sid) {
         turnController.interruptTurn({ appendMessage, gw, sid: live.sid, sys })
       }
@@ -259,7 +273,7 @@ export function useSubmission(opts: UseSubmissionOptions) {
 
       send(full)
     },
-    [appendMessage, composerActions, gw, interpolate, send, sys]
+    [appendMessage, composerActions, composerRefs, gw, interpolate, send, sys]
   )
 
   const dispatchSubmission = useCallback(
@@ -316,7 +330,7 @@ export function useSubmission(opts: UseSubmissionOptions) {
             return composerActions.syncQueue()
           }
 
-          return handleBusyInput(picked)
+          return handleBusyInput(picked, { fallbackToFront: true })
         }
 
         return sendQueued(picked)

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -53,6 +53,7 @@ export type CommandDispatchResponse =
 
 export interface ConfigDisplayConfig {
   bell_on_complete?: boolean
+  busy_input_mode?: 'interrupt' | 'queue' | 'steer' | string
   details_mode?: string
   inline_diffs?: boolean
   sections?: Record<string, string>

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -53,7 +53,7 @@ export type CommandDispatchResponse =
 
 export interface ConfigDisplayConfig {
   bell_on_complete?: boolean
-  busy_input_mode?: 'interrupt' | 'queue' | 'steer' | string
+  busy_input_mode?: string
   details_mode?: string
   inline_diffs?: boolean
   sections?: Record<string, string>


### PR DESCRIPTION
## Summary

`display.busy_input_mode` (`interrupt` | `queue` | `steer`) is honored by classic CLI and gateway adapters but the TUI v2 frontend hard-coded queue-on-busy in `useSubmission.ts`. Sending a message during a running turn always landed in the queue regardless of config.

This wires the value through the existing config-sync surface so the TUI honors the user's setting, with one intentional split: the **TUI default** is `queue`, while CLI / messaging adapters keep `interrupt` (the existing framework default).

## Changes

- `applyDisplay()` reads `display.busy_input_mode`, falls back to `queue` (TUI-only override), and stores it in a new `UiState.busyInputMode` field.
- `dispatchSubmission` (and the queue-edit fall-through) now route through a shared `handleBusyInput` helper:
  - `queue`     — append to `queueRef` (existing behavior).
  - `steer`     — call `session.steer`; on rejection or RPC failure, fall back to queue with a sys note.
  - `interrupt` — `turnController.interruptTurn(...)` then `send(...)` so the new prompt actually moves.
- `uiStore` initial value matches: `busyInputMode: 'queue'`.
- Mtime polling in `useConfigSync` already re-applies `config.full`, so flipping the value in `~/.hermes/config.yaml` propagates on the next ~5s tick — no TUI restart.

## Why the TUI default differs

In a full-screen TUI you typically author the next prompt while the agent is still streaming. An unintended `interrupt` loses in-flight typing and feels punitive. The CLI's `interrupt` default makes sense in a terminal where you tend to wait for a response before typing again; the TUI's authoring loop is different. Users who want CLI-parity behavior set `display.busy_input_mode: interrupt` explicitly.

## Test plan

- [x] `npm run type-check` (in `ui-tui/`) — clean.
- [x] `npm test -- --run` (in `ui-tui/`) — **394/394 pass**.
- [x] Tests:
  - `normalizeBusyInputMode` mirrors the Python allow-list (`queue`/`steer`/`interrupt`); default is `queue`.
  - `applyDisplay → busy_input_mode` covers the UiState fan-out, invalid values, and missing-value fallback.

## Refs

- Audit thread: `busy_input_mode: interrupt configuration completely ignored by TUI v2`.
- Python source of truth: `hermes_cli/config.py` (`busy_input_mode: "interrupt"` framework default), `tui_gateway/server.py::_load_busy_input_mode`.
