### PR TITLE
fix(tui): stabilize status bar ticker width (#13610)

### DIFF
--- a/ui-tui/src/__tests__/statusBarTicker.test.ts
+++ b/ui-tui/src/__tests__/statusBarTicker.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+
+import { padVerb, VERB_PAD_LEN } from '../components/appChrome.js'
+import { VERBS } from '../content/verbs.js'
+
+describe('FaceTicker verb padding (#13610)', () => {
+  it('pads every verb in the catalogue to the same column width', () => {
+    for (const verb of VERBS) {
+      expect(padVerb(verb)).toHaveLength(VERB_PAD_LEN)
+    }
+  })
+
+  it('keeps the trailing ellipsis attached to the verb', () => {
+    for (const verb of VERBS) {
+      expect(padVerb(verb).startsWith(`${verb}…`)).toBe(true)
+    }
+  })
+
+  it('handles empty verbs without truncating the pad target', () => {
+    expect(padVerb('')).toHaveLength(VERB_PAD_LEN)
+  })
+
+  it('does not pad when the verb is already at the limit', () => {
+    const longest = VERBS.reduce((a, b) => (b.length > a.length ? b : a), '')
+    expect(padVerb(longest)).toBe(`${longest}…`)
+  })
+})

--- a/ui-tui/src/__tests__/statusBarTicker.test.ts
+++ b/ui-tui/src/__tests__/statusBarTicker.test.ts
@@ -4,9 +4,9 @@ import { padVerb, VERB_PAD_LEN } from '../components/appChrome.js'
 import { VERBS } from '../content/verbs.js'
 
 describe('FaceTicker verb padding (#13610)', () => {
-  it('pads every verb in the catalogue to the same column width', () => {
+  it('pads every verb in the catalogue to the same column width (+1 separator)', () => {
     for (const verb of VERBS) {
-      expect(padVerb(verb)).toHaveLength(VERB_PAD_LEN)
+      expect(padVerb(verb)).toHaveLength(VERB_PAD_LEN + 1)
     }
   })
 
@@ -17,11 +17,12 @@ describe('FaceTicker verb padding (#13610)', () => {
   })
 
   it('handles empty verbs without truncating the pad target', () => {
-    expect(padVerb('')).toHaveLength(VERB_PAD_LEN)
+    expect(padVerb('')).toHaveLength(VERB_PAD_LEN + 1)
   })
 
-  it('does not pad when the verb is already at the limit', () => {
+  it('keeps a trailing space even when the verb is already at the limit', () => {
     const longest = VERBS.reduce((a, b) => (b.length > a.length ? b : a), '')
-    expect(padVerb(longest)).toBe(`${longest}…`)
+    expect(padVerb(longest)).toBe(`${longest}… `)
+    expect(padVerb(longest).endsWith(' ')).toBe(true)
   })
 })

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -17,6 +17,16 @@ import type { Msg, Usage } from '../types.js'
 const FACE_TICK_MS = 2500
 const HEART_COLORS = ['#ff5fa2', '#ff4d6d']
 
+// Stable verb-segment width keeps the rest of the status bar from
+// jittering when the ticker rotates between short/long verbs (#13610).
+// `processing…` is 12 chars, `synthesizing…` is 13, `cogitating…` is 11
+// — without padding the cwd label and ctx bar to the right shift on
+// every cycle.  We pad to the longest verb in the catalogue + the
+// trailing ellipsis so every rotation lands on the same column.
+export const VERB_PAD_LEN = VERBS.reduce((max, v) => Math.max(max, v.length), 0) + 1 // + the '…'
+
+export const padVerb = (verb: string) => `${verb}…`.padEnd(VERB_PAD_LEN, ' ')
+
 function FaceTicker({ color, startedAt }: { color: string; startedAt?: null | number }) {
   const [tick, setTick] = useState(() => Math.floor(Math.random() * 1000))
   const [now, setNow] = useState(() => Date.now())
@@ -33,7 +43,8 @@ function FaceTicker({ color, startedAt }: { color: string; startedAt?: null | nu
 
   return (
     <Text color={color}>
-      {FACES[tick % FACES.length]} {VERBS[tick % VERBS.length]}…{startedAt ? ` · ${fmtDuration(now - startedAt)}` : ''}
+      {FACES[tick % FACES.length]} {padVerb(VERBS[tick % VERBS.length] ?? '')}
+      {startedAt ? `· ${fmtDuration(now - startedAt)}` : ''}
     </Text>
   )
 }

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -18,14 +18,16 @@ const FACE_TICK_MS = 2500
 const HEART_COLORS = ['#ff5fa2', '#ff4d6d']
 
 // Stable verb-segment width keeps the rest of the status bar from
-// jittering when the ticker rotates between short/long verbs (#13610).
-// `processing…` is 12 chars, `synthesizing…` is 13, `cogitating…` is 11
-// — without padding the cwd label and ctx bar to the right shift on
-// every cycle.  We pad to the longest verb in the catalogue + the
-// trailing ellipsis so every rotation lands on the same column.
+// jittering when the ticker rotates between short and long verbs
+// (#13610).  Without padding, the cwd label and ctx bar to the right
+// shift on every cycle.  We pad to the longest verb in the catalogue
+// plus the trailing ellipsis so every rotation lands on the same
+// column.
 export const VERB_PAD_LEN = VERBS.reduce((max, v) => Math.max(max, v.length), 0) + 1 // + the '…'
 
-export const padVerb = (verb: string) => `${verb}…`.padEnd(VERB_PAD_LEN, ' ')
+// Always include the trailing space so the duration suffix has a
+// stable separator even when the verb is already at the pad limit.
+export const padVerb = (verb: string) => `${verb}…`.padEnd(VERB_PAD_LEN + 1, ' ')
 
 function FaceTicker({ color, startedAt }: { color: string; startedAt?: null | number }) {
   const [tick, setTick] = useState(() => Math.floor(Math.random() * 1000))


### PR DESCRIPTION
## Summary

The \`FaceTicker\` rotates verbs every 2.5s with no padding. Since verb lengths vary (\`cogitating…\` is 11 chars, \`synthesizing…\` is 13), the rest of the status bar (cwd label, ctx bar, voice, bg-task counter) shifted by 1–3 columns on every tick. Visually distracting, especially on narrow terminals.

## Fix

Pad the verb to the longest entry in \`VERBS\` + the trailing ellipsis. This keeps the segment a stable column width without making narrow terminals waste extra space — \`wrap=\"truncate-end\"\` on the parent Text already handles overflow.

## Test plan

- [x] \`npm run type-check\` — clean
- [x] \`npm test -- --run\` — **393/393 pass**
- [x] New \`statusBarTicker.test.ts\` exports \`padVerb\` / \`VERB_PAD_LEN\` and asserts every catalogue verb pads to the same width and preserves its trailing ellipsis.

## Refs

Closes #13610. Supersedes #13806 (community-authored, model-name-based fix that did not address verb length).