### PR TITLE
fix(honcho): fallback to durable peer cards for profiles

### DIFF
--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -1073,6 +1073,12 @@ class HonchoSessionManager:
 
         return target_peer_id, None
 
+    def _legacy_default_user_peer_id(self, peer_id: str) -> str | None:
+        """Return the pre-runtime-ID default-session user peer ID, if applicable."""
+        if not peer_id or peer_id.startswith("user-default-"):
+            return None
+        return self._sanitize_id(f"user-default-{peer_id}")
+
     def get_peer_card(self, session_key: str, peer: str = "user") -> list[str]:
         """
         Fetch a peer card — a curated list of key facts.
@@ -1090,10 +1096,26 @@ class HonchoSessionManager:
             card = self._fetch_peer_card(observer_peer_id, target=target_peer_id)
             if card:
                 return card
-            # Some backends store cards directly on the target peer, not the
-            # observer-target slot. Fall back so honcho_profile still works.
+
+            # Honcho can store a stable profile card on the target peer itself
+            # even when the observer-target card is empty. set_peer_card() writes
+            # this way, and some self-hosted v3 backends expose migrated cards
+            # only through the target peer's own card endpoint.
+            profile_peer_id = target_peer_id or observer_peer_id
             if target_peer_id:
-                return self._fetch_peer_card(target_peer_id)
+                card = self._fetch_peer_card(profile_peer_id)
+                if card:
+                    return card
+
+            # Older Hermes sessions derived CLI user peers from "default:<name>"
+            # (for example user-default-w0lf). Runtime user IDs now resolve to
+            # the bare user ID (w0lf), so preserve access to migrated cards.
+            if profile_peer_id == session.user_peer_id:
+                legacy_peer_id = self._legacy_default_user_peer_id(profile_peer_id)
+                if legacy_peer_id:
+                    card = self._fetch_peer_card(legacy_peer_id)
+                    if card:
+                        return card
             return []
         except Exception as e:
             logger.debug("Failed to fetch peer card from Honcho: %s", e)

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -247,6 +247,27 @@ class TestPeerLookupHelpers:
         assert result == ["Role: user"]
         assistant_peer.set_card.assert_called_once_with(["Role: user"], target=session.user_peer_id)
 
+    def test_get_peer_card_falls_back_to_legacy_default_user_peer_id(self):
+        mgr, session = self._make_cached_manager()
+        session.user_peer_id = "w0lf"
+        assistant_peer = MagicMock()
+        assistant_peer.get_card.return_value = []
+        user_peer = MagicMock()
+        user_peer.get_card.return_value = []
+        legacy_user_peer = MagicMock()
+        legacy_user_peer.get_card.return_value = ["Name: w0lf"]
+        peers = {
+            session.assistant_peer_id: assistant_peer,
+            session.user_peer_id: user_peer,
+            "user-default-w0lf": legacy_user_peer,
+        }
+        mgr._get_or_create_peer = MagicMock(side_effect=lambda peer_id: peers[peer_id])
+
+        assert mgr.get_peer_card(session.key) == ["Name: w0lf"]
+        assistant_peer.get_card.assert_called_once_with(target=session.user_peer_id)
+        user_peer.get_card.assert_called_once_with()
+        legacy_user_peer.get_card.assert_called_once_with()
+
     def test_search_context_uses_assistant_perspective_with_target(self):
         mgr, session = self._make_cached_manager()
         assistant_peer = MagicMock()


### PR DESCRIPTION
## What does this PR do?

Fixes `honcho_profile(peer="user")` returning an empty profile hint when Honcho already has a durable peer card for the user.

The lookup keeps the existing assistant observer-target card check first. If that is empty, it falls back to the target peer's own card. For the current user peer only, it also tries migrated default-session cards stored as `user-default-<peer>`.

Related to #13375. This PR keeps the scope to the minimal peer-card fallback path and does not include the broader memory-file backfill work from #13375.

## Related Issue

No linked GitHub issue.

Related PR: #13375

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/memory/honcho/session.py`
  - Add fallback lookup paths for direct target cards and migrated `user-default-<peer>` cards.
- `tests/honcho_plugin/test_session.py`
  - Add regression tests for target-peer fallback and legacy default user peer fallback.

## How to Test

1. Run the focused regression tests:
   ```bash
   python -m pytest \
     tests/honcho_plugin/test_session.py::TestPeerLookupHelpers::test_get_peer_card_uses_direct_peer_lookup \
     tests/honcho_plugin/test_session.py::TestPeerLookupHelpers::test_get_peer_card_falls_back_to_target_peer_own_card \
     tests/honcho_plugin/test_session.py::TestPeerLookupHelpers::test_get_peer_card_falls_back_to_legacy_default_user_peer_id \
     -q -o 'addopts='
   ```

2. Run the session test module:
   ```bash
   python -m pytest tests/honcho_plugin/test_session.py -q -o 'addopts='
   ```

3. Run the Honcho plugin suite:
   ```bash
   python -m pytest tests/honcho_plugin -q -o 'addopts='
   ```

4. Optional live check with local Honcho:
   ```text
   honcho_profile(peer="user") returns existing user facts for an anonymized local test user.
   ```

## Validation Status

- Regression tests fail without the production change: 2 failed.
- Targeted regression tests pass: 3 passed.
- `python -m pytest tests/honcho_plugin/test_session.py -q -o 'addopts='`: 117 passed.
- `python -m pytest tests/honcho_plugin -q -o 'addopts='`: 268 passed.
- Local live harness returned existing facts for `honcho_profile(peer="user")` with an anonymized local test user.
- GitHub checks are not currently all green.
- Failed checks: `test`, `nix (ubuntu-latest)`, `nix-lockfile-check`.
- Cancelled check: `nix (macos-latest)`.
- Full-suite checklist is not marked complete because `pytest tests/ -q` / GitHub checks are not green.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) and noted related #13375 above
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux, Python 3.14 local venv

### Documentation and Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior or N/A

## For New Skills

N/A. This PR does not add a skill.

## Screenshots / Logs

Live harness result from the original validation:

```text
honcho_profile(peer="user") returned existing user facts for an anonymized local test user.
```

