### PR TITLE
fix(ui-tui): prevent React effect cleanup from killing python TUI gateway subprocess

### DIFF
--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -557,10 +557,10 @@ export function useMainApp(gw: GatewayClient) {
     gw.on('exit', exitHandler)
     gw.drain()
 
+    // entry.tsx's setupGracefulExit handles process cleanup on real exit.
     return () => {
       gw.off('event', handler)
       gw.off('exit', exitHandler)
-      gw.kill()
     }
   }, [gw, sys])
 


### PR DESCRIPTION
## What does this PR do?

Removes `gw.kill()` from the `useEffect` cleanup in `useMainApp.ts`. The cleanup fires on every React re-render when the `[gw, sys]` dependency array shifts — which happens whenever `sys` changes identity (any system message). This was silently killing the Python TUI gateway subprocess mid-session with SIGTERM, then the `exit` listener was already removed by the time cleanup ran, so the "gateway exited" error never surfaced. The TUI just had a dead backend.

## Related Issue

No issue filed. Bug identified during TUI usage: after the first turn, the gateway would exit with `stdin EOF (TUI closed the command pipe)` in the crash log. Root cause traced through crash logs to the React effect pattern.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `ui-tui/src/app/useMainApp.ts` (line 563): Removed `gw.kill()` from effect cleanup. The kill path is still covered by:
  - `entry.tsx`'s `setupGracefulExit` (`cleanups: [() => gw.kill()]`) — handles SIGINT, SIGTERM, uncaught exceptions at the process level
  - `useMainApp.ts`'s `die()` function — handles explicit user exit (`/exit` or Ctrl+D)
  - `gatewayClient.ts`'s `start()` — kills old process before spawn restart

## How to Test

1. Run `hermes --tui`
2. Send a message and wait for the response
3. Send another message — previously this would show "gateway exited" or silently fail
4. Verify the gateway stays alive across multiple turns
5. Exit the TUI with `/exit` or Ctrl+C — verify the gateway process is cleaned up

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — 163 tests run, 0 failed (2 pre-existing failures in test_protocol and test_make_agent_provider also fail on main, unrelated to this change)
- [x] I've tested on my platform: Arch Linux (6.19.14, x86_64)

### Documentation & Housekeeping

- [x] Cross-platform impact: N/A — TypeScript/React fix in the TUI; no OS-specific code touched
