### PR TITLE
fix(tui): surface /mouse command in TUI help

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -980,6 +980,14 @@ def test_complete_slash_includes_tui_details_command():
     assert any(item["text"] == "/details" for item in resp["result"]["items"])
 
 
+def test_complete_slash_includes_tui_mouse_command():
+    resp = server.handle_request(
+        {"id": "1", "method": "complete.slash", "params": {"text": "/mou"}}
+    )
+
+    assert any(item["text"] == "/mouse" for item in resp["result"]["items"])
+
+
 def test_complete_slash_details_args():
     resp_root = server.handle_request(
         {"id": "0", "method": "complete.slash", "params": {"text": "/details"}}
@@ -1545,6 +1553,19 @@ def test_commands_catalog_surfaces_quick_commands(monkeypatch):
 
     assert resp["result"]["canon"]["/build"] == "/build"
     assert resp["result"]["canon"]["/notes"] == "/notes"
+
+
+def test_commands_catalog_includes_tui_mouse_command():
+    resp = server.handle_request(
+        {"id": "1", "method": "commands.catalog", "params": {}}
+    )
+
+    pairs = dict(resp["result"]["pairs"])
+    tui_cat = next(c for c in resp["result"]["categories"] if c["name"] == "TUI")
+    tui_pairs = dict(tui_cat["pairs"])
+
+    assert "/mouse" in pairs
+    assert "/mouse" in tui_pairs
 
 
 def test_command_dispatch_exec_nonzero_surfaces_error(monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3354,6 +3354,7 @@ _TUI_HIDDEN: frozenset[str] = frozenset(
 _TUI_EXTRA: list[tuple[str, str, str]] = [
     ("/compact", "Toggle compact display mode", "TUI"),
     ("/logs", "Show recent gateway log lines", "TUI"),
+    ("/mouse", "Toggle mouse/wheel tracking [on|off|toggle]", "TUI"),
 ]
 
 # Commands that queue messages onto _pending_input in the CLI.
@@ -4132,6 +4133,11 @@ def _(rid, params: dict) -> dict:
                 "text": "/logs",
                 "display": "/logs",
                 "meta": "Show recent gateway log lines",
+            },
+            {
+                "text": "/mouse",
+                "display": "/mouse",
+                "meta": "Toggle mouse/wheel tracking [on|off|toggle]",
             },
         ]
         for extra in extras:


### PR DESCRIPTION
## What does this PR do?

Surfaces the existing TUI-local `/mouse` command in the TUI command discovery paths.

`/mouse` already worked when typed directly, and `config.set` already handled the `mouse` key, but the gateway-backed TUI command catalog and slash completion only advertised `/compact`, `/details`, and `/logs`. That made the documented workaround `/mouse off` look unavailable when users checked `/help` or tab completion while troubleshooting mouse-tracking glitches.

This keeps the behavior unchanged and only fixes discoverability.

## Related Issue

No issue filed. Found while triaging a Discord support thread where `/mouse` was recommended but did not appear in TUI help/completion.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tui_gateway/server.py`
  - Adds `/mouse` to the TUI extra command catalog so it appears in `/help`.
  - Adds `/mouse` to slash completion with the existing usage shape: `[on|off|toggle]`.
- `tests/test_tui_gateway_server.py`
  - Adds regression coverage for `/mouse` in `commands.catalog`.
  - Adds regression coverage for `/mouse` in `complete.slash`.

## How to Test

1. Start `hermes --tui`.
2. Open `/help` and confirm `/mouse` appears in the TUI section.
3. Type `/mou` and confirm slash completion offers `/mouse`.
4. Run `/mouse off` or `/mouse on` and confirm the existing mouse-tracking toggle path still responds.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL2/Linux (`Linux DANKMEMES 6.6.87.2-microsoft-standard-WSL2 x86_64`)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, command already existed and this only fixes TUI discovery
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config key changes
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, no architecture/workflow change
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — discovery-only change in gateway metadata, no terminal escape behavior changed
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no tool behavior changed

## Screenshots / Logs

Passing scoped checks:

```text
python3 -m py_compile tui_gateway/server.py tests/test_tui_gateway_server.py
```

```text
scripts/run_tests.sh tests/test_tui_gateway_server.py
# 92 passed in 4.50s
```

```text
npm test -- slashParity.test.ts
# Test Files  1 passed (1)
# Tests       2 passed (2)
```

Canonical full suite was also attempted with the repo runner, which pins 4 workers:

```text
scripts/run_tests.sh
# 50 failed, 17260 passed, 42 skipped, 208 warnings, 1 error in 490.02s (0:08:10)
```

The full-suite failures were outside this PR's touched files. The collection error was in `tests/gateway/test_session.py` importing missing `normalize_whatsapp_identifier` from `gateway.session`; other failures clustered in unrelated gateway/provider/tool tests such as Dingtalk card lifecycle, Anthropic header expectations, auxiliary client provider routing, gateway config parsing, update/autostash tests, MCP structured content, Firecrawl config, and TUI provider make-agent tests.
