### PR TITLE
feat(tui): opt-in auto-resume of the most recent session

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -703,6 +703,11 @@ DEFAULT_CONFIG = {
         "personality": "kawaii",
         "resume_display": "full",
         "busy_input_mode": "interrupt",  # interrupt | queue | steer
+        # When true, `hermes --tui` auto-resumes the most recent human-
+        # facing session on launch instead of forging a fresh one.
+        # Mirrors `hermes -c` muscle memory.  Default off so existing
+        # users aren't surprised.  HERMES_TUI_RESUME=<id> always wins.
+        "tui_auto_resume_recent": False,
         "bell_on_complete": False,
         "show_reasoning": False,
         "streaming": False,

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2663,7 +2663,7 @@ def test_session_most_recent_returns_first_non_denied(monkeypatch):
     """Drops `tool` rows like session.list does, returns the first hit."""
 
     class _DB:
-        def list_sessions_rich(self, *, source=None, limit=20):
+        def list_sessions_rich(self, *, source=None, limit=200):
             return [
                 {"id": "tool-1", "source": "tool", "title": "noise", "started_at": 100},
                 {"id": "tui-1", "source": "tui", "title": "real", "started_at": 99},
@@ -2682,7 +2682,7 @@ def test_session_most_recent_returns_first_non_denied(monkeypatch):
 
 def test_session_most_recent_returns_null_when_only_tool_rows(monkeypatch):
     class _DB:
-        def list_sessions_rich(self, *, source=None, limit=20):
+        def list_sessions_rich(self, *, source=None, limit=200):
             return [{"id": "tool-1", "source": "tool", "started_at": 1}]
 
     monkeypatch.setattr(server, "_get_db", lambda: _DB())
@@ -2691,6 +2691,25 @@ def test_session_most_recent_returns_null_when_only_tool_rows(monkeypatch):
         {"id": "1", "method": "session.most_recent", "params": {}}
     )
 
+    assert resp["result"]["session_id"] is None
+
+
+def test_session_most_recent_folds_db_exception_into_null_result(monkeypatch):
+    """Per contract, errors are folded into the null-result shape so
+    callers don't have to special-case JSON-RPC error envelopes for
+    'no answer' (Copilot review on #17130)."""
+
+    class _BrokenDB:
+        def list_sessions_rich(self, *, source=None, limit=200):
+            raise RuntimeError("db locked")
+
+    monkeypatch.setattr(server, "_get_db", lambda: _BrokenDB())
+
+    resp = server.handle_request(
+        {"id": "1", "method": "session.most_recent", "params": {}}
+    )
+
+    assert "error" not in resp
     assert resp["result"]["session_id"] is None
 
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2654,3 +2654,51 @@ def test_prompt_submit_skips_auto_title_when_response_empty(monkeypatch):
         )
 
     mock_title.assert_not_called()
+
+
+# ── session.most_recent ──────────────────────────────────────────────
+
+
+def test_session_most_recent_returns_first_non_denied(monkeypatch):
+    """Drops `tool` rows like session.list does, returns the first hit."""
+
+    class _DB:
+        def list_sessions_rich(self, *, source=None, limit=20):
+            return [
+                {"id": "tool-1", "source": "tool", "title": "noise", "started_at": 100},
+                {"id": "tui-1", "source": "tui", "title": "real", "started_at": 99},
+            ]
+
+    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+
+    resp = server.handle_request(
+        {"id": "1", "method": "session.most_recent", "params": {}}
+    )
+
+    assert resp["result"]["session_id"] == "tui-1"
+    assert resp["result"]["title"] == "real"
+    assert resp["result"]["source"] == "tui"
+
+
+def test_session_most_recent_returns_null_when_only_tool_rows(monkeypatch):
+    class _DB:
+        def list_sessions_rich(self, *, source=None, limit=20):
+            return [{"id": "tool-1", "source": "tool", "started_at": 1}]
+
+    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+
+    resp = server.handle_request(
+        {"id": "1", "method": "session.most_recent", "params": {}}
+    )
+
+    assert resp["result"]["session_id"] is None
+
+
+def test_session_most_recent_handles_db_unavailable(monkeypatch):
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+
+    resp = server.handle_request(
+        {"id": "1", "method": "session.most_recent", "params": {}}
+    )
+
+    assert resp["result"]["session_id"] is None

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1788,6 +1788,42 @@ def _(rid, params: dict) -> dict:
         return _err(rid, 5006, str(e))
 
 
+@method("session.most_recent")
+def _(rid, params: dict) -> dict:
+    """Return the most recent human-facing session id, or ``None``.
+
+    Mirrors ``session.list``'s deny-list behaviour (drops ``tool``
+    sub-agent rows).  Used by TUI auto-resume when
+    ``display.tui_auto_resume_recent`` is on; the field is also handy
+    for any CLI tooling that wants "latest session" without paginating
+    the full list.
+    """
+    db = _get_db()
+    if db is None:
+        return _ok(rid, {"session_id": None})
+    try:
+        deny = frozenset({"tool"})
+        # Over-fetch modestly so per-source filtering doesn't leave us
+        # without a hit; we only need the first non-denied row.
+        rows = db.list_sessions_rich(source=None, limit=20)
+        for row in rows:
+            src = (row.get("source") or "").strip().lower()
+            if src in deny:
+                continue
+            return _ok(
+                rid,
+                {
+                    "session_id": row.get("id"),
+                    "title": row.get("title") or "",
+                    "started_at": row.get("started_at") or 0,
+                    "source": row.get("source") or "",
+                },
+            )
+        return _ok(rid, {"session_id": None})
+    except Exception as e:
+        return _err(rid, 5006, str(e))
+
+
 @method("session.resume")
 def _(rid, params: dict) -> dict:
     target = params.get("session_id", "")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1797,15 +1797,22 @@ def _(rid, params: dict) -> dict:
     ``display.tui_auto_resume_recent`` is on; the field is also handy
     for any CLI tooling that wants "latest session" without paginating
     the full list.
+
+    Contract: a ``{"session_id": null}`` result means "no eligible
+    session found right now".  Errors are also folded into that
+    null-result shape (and logged) so callers don't have to special-
+    case JSON-RPC error envelopes for what is a normal "no answer".
     """
     db = _get_db()
     if db is None:
         return _ok(rid, {"session_id": None})
     try:
         deny = frozenset({"tool"})
-        # Over-fetch modestly so per-source filtering doesn't leave us
-        # without a hit; we only need the first non-denied row.
-        rows = db.list_sessions_rich(source=None, limit=20)
+        # Over-fetch by a generous bounded amount so heavy sub-agent
+        # users (lots of recent ``tool`` rows) don't get a false
+        # "no eligible session" answer.  ``session.list`` uses a
+        # similar over-fetch strategy.
+        rows = db.list_sessions_rich(source=None, limit=200)
         for row in rows:
             src = (row.get("source") or "").strip().lower()
             if src in deny:
@@ -1820,8 +1827,9 @@ def _(rid, params: dict) -> dict:
                 },
             )
         return _ok(rid, {"session_id": None})
-    except Exception as e:
-        return _err(rid, 5006, str(e))
+    except Exception:
+        logger.exception("session.most_recent failed")
+        return _ok(rid, {"session_id": None})
 
 
 @method("session.resume")

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -456,11 +456,7 @@ describe('createGatewayEventHandler', () => {
 
     createGatewayEventHandler(ctx)({ payload: {}, type: 'gateway.ready' } as any)
 
-    await Promise.resolve()
-    await Promise.resolve()
-    await Promise.resolve()
-
-    expect(newSession).toHaveBeenCalled()
+    await vi.waitFor(() => expect(newSession).toHaveBeenCalled())
     expect(resumeById).not.toHaveBeenCalled()
   })
 
@@ -487,12 +483,7 @@ describe('createGatewayEventHandler', () => {
 
     createGatewayEventHandler(ctx)({ payload: {}, type: 'gateway.ready' } as any)
 
-    // Drain enough microtasks for two chained `.then` handlers.
-    for (let i = 0; i < 5; i += 1) {
-      await Promise.resolve()
-    }
-
-    expect(resumeById).toHaveBeenCalledWith('sess-most-recent')
+    await vi.waitFor(() => expect(resumeById).toHaveBeenCalledWith('sess-most-recent'))
     expect(newSession).not.toHaveBeenCalled()
   })
 
@@ -519,11 +510,7 @@ describe('createGatewayEventHandler', () => {
 
     createGatewayEventHandler(ctx)({ payload: {}, type: 'gateway.ready' } as any)
 
-    for (let i = 0; i < 5; i += 1) {
-      await Promise.resolve()
-    }
-
-    expect(newSession).toHaveBeenCalled()
+    await vi.waitFor(() => expect(newSession).toHaveBeenCalled())
     expect(resumeById).not.toHaveBeenCalled()
   })
 
@@ -542,9 +529,7 @@ describe('createGatewayEventHandler', () => {
 
     createGatewayEventHandler(ctx)({ payload: {}, type: 'gateway.ready' } as any)
 
-    await Promise.resolve()
-
-    expect(resumeById).toHaveBeenCalledWith('env-explicit')
+    await vi.waitFor(() => expect(resumeById).toHaveBeenCalledWith('env-explicit'))
     expect(newSession).not.toHaveBeenCalled()
   })
 

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -437,6 +437,117 @@ describe('createGatewayEventHandler', () => {
     })
   })
 
+  it('on gateway.ready with no STARTUP_RESUME_ID and auto_resume off, forges a new session', async () => {
+    const appended: Msg[] = []
+    const newSession = vi.fn()
+    const resumeById = vi.fn()
+    const ctx = buildCtx(appended)
+
+    ctx.session.newSession = newSession
+    ctx.session.resumeById = resumeById
+    ctx.session.STARTUP_RESUME_ID = ''
+    ctx.gateway.rpc = vi.fn(async (method: string) => {
+      if (method === 'config.get') {
+        return { config: { display: { tui_auto_resume_recent: false } } }
+      }
+
+      return null
+    })
+
+    createGatewayEventHandler(ctx)({ payload: {}, type: 'gateway.ready' } as any)
+
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(newSession).toHaveBeenCalled()
+    expect(resumeById).not.toHaveBeenCalled()
+  })
+
+  it('on gateway.ready with auto_resume on and a recent session, resumes it', async () => {
+    const appended: Msg[] = []
+    const newSession = vi.fn()
+    const resumeById = vi.fn()
+    const ctx = buildCtx(appended)
+
+    ctx.session.newSession = newSession
+    ctx.session.resumeById = resumeById
+    ctx.session.STARTUP_RESUME_ID = ''
+    ctx.gateway.rpc = vi.fn(async (method: string) => {
+      if (method === 'config.get') {
+        return { config: { display: { tui_auto_resume_recent: true } } }
+      }
+
+      if (method === 'session.most_recent') {
+        return { session_id: 'sess-most-recent' }
+      }
+
+      return null
+    })
+
+    createGatewayEventHandler(ctx)({ payload: {}, type: 'gateway.ready' } as any)
+
+    // Drain enough microtasks for two chained `.then` handlers.
+    for (let i = 0; i < 5; i += 1) {
+      await Promise.resolve()
+    }
+
+    expect(resumeById).toHaveBeenCalledWith('sess-most-recent')
+    expect(newSession).not.toHaveBeenCalled()
+  })
+
+  it('on gateway.ready with auto_resume on but no eligible session, falls back to new', async () => {
+    const appended: Msg[] = []
+    const newSession = vi.fn()
+    const resumeById = vi.fn()
+    const ctx = buildCtx(appended)
+
+    ctx.session.newSession = newSession
+    ctx.session.resumeById = resumeById
+    ctx.session.STARTUP_RESUME_ID = ''
+    ctx.gateway.rpc = vi.fn(async (method: string) => {
+      if (method === 'config.get') {
+        return { config: { display: { tui_auto_resume_recent: true } } }
+      }
+
+      if (method === 'session.most_recent') {
+        return { session_id: null }
+      }
+
+      return null
+    })
+
+    createGatewayEventHandler(ctx)({ payload: {}, type: 'gateway.ready' } as any)
+
+    for (let i = 0; i < 5; i += 1) {
+      await Promise.resolve()
+    }
+
+    expect(newSession).toHaveBeenCalled()
+    expect(resumeById).not.toHaveBeenCalled()
+  })
+
+  it('on gateway.ready with STARTUP_RESUME_ID set, the env wins over config auto_resume', async () => {
+    const appended: Msg[] = []
+    const newSession = vi.fn()
+    const resumeById = vi.fn()
+    const ctx = buildCtx(appended)
+
+    ctx.session.newSession = newSession
+    ctx.session.resumeById = resumeById
+    ctx.session.STARTUP_RESUME_ID = 'env-explicit'
+    ctx.gateway.rpc = vi.fn(async () => ({
+      config: { display: { tui_auto_resume_recent: true } }
+    }))
+
+    createGatewayEventHandler(ctx)({ payload: {}, type: 'gateway.ready' } as any)
+
+    await Promise.resolve()
+
+    expect(resumeById).toHaveBeenCalledWith('env-explicit')
+    expect(newSession).not.toHaveBeenCalled()
+  })
+
   it('keeps gateway noise informational and approval out of Activity', async () => {
     const appended: Msg[] = []
     const ctx = buildCtx(appended)

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -514,6 +514,56 @@ describe('createGatewayEventHandler', () => {
     expect(resumeById).not.toHaveBeenCalled()
   })
 
+  it('on gateway.ready when config.get rejects, falls back to new session', async () => {
+    const appended: Msg[] = []
+    const newSession = vi.fn()
+    const resumeById = vi.fn()
+    const ctx = buildCtx(appended)
+
+    ctx.session.newSession = newSession
+    ctx.session.resumeById = resumeById
+    ctx.session.STARTUP_RESUME_ID = ''
+    ctx.gateway.rpc = vi.fn(async (method: string) => {
+      if (method === 'config.get') {
+        throw new Error('gateway timeout')
+      }
+
+      return null
+    })
+
+    createGatewayEventHandler(ctx)({ payload: {}, type: 'gateway.ready' } as any)
+
+    await vi.waitFor(() => expect(newSession).toHaveBeenCalled())
+    expect(resumeById).not.toHaveBeenCalled()
+  })
+
+  it('on gateway.ready when session.most_recent rejects, falls back to new session', async () => {
+    const appended: Msg[] = []
+    const newSession = vi.fn()
+    const resumeById = vi.fn()
+    const ctx = buildCtx(appended)
+
+    ctx.session.newSession = newSession
+    ctx.session.resumeById = resumeById
+    ctx.session.STARTUP_RESUME_ID = ''
+    ctx.gateway.rpc = vi.fn(async (method: string) => {
+      if (method === 'config.get') {
+        return { config: { display: { tui_auto_resume_recent: true } } }
+      }
+
+      if (method === 'session.most_recent') {
+        throw new Error('db locked')
+      }
+
+      return null
+    })
+
+    createGatewayEventHandler(ctx)({ payload: {}, type: 'gateway.ready' } as any)
+
+    await vi.waitFor(() => expect(newSession).toHaveBeenCalled())
+    expect(resumeById).not.toHaveBeenCalled()
+  })
+
   it('on gateway.ready with STARTUP_RESUME_ID set, the env wins over config auto_resume', async () => {
     const appended: Msg[] = []
     const newSession = vi.fn()

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -1,6 +1,13 @@
 import { STREAM_BATCH_MS } from '../config/timing.js'
 import { buildSetupRequiredSections, SETUP_REQUIRED_TITLE } from '../content/setup.js'
-import type { CommandsCatalogResponse, DelegationStatusResponse, GatewayEvent, GatewaySkin } from '../gatewayTypes.js'
+import type {
+  CommandsCatalogResponse,
+  ConfigFullResponse,
+  DelegationStatusResponse,
+  GatewayEvent,
+  GatewaySkin,
+  SessionMostRecentResponse
+} from '../gatewayTypes.js'
 import { rpcErrorMessage } from '../lib/rpc.js'
 import { topLevelSubagents } from '../lib/subagentTree.js'
 import { formatToolCall, stripAnsi } from '../lib/text.js'
@@ -184,7 +191,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
     // `hermes --tui` muscle memory and addresses the audit's "session
     // unrecoverable after disconnection" gap.  Default off so existing
     // users aren't surprised.
-    rpc<{ config?: { display?: { tui_auto_resume_recent?: boolean } } }>('config.get', { key: 'full' })
+    rpc<ConfigFullResponse>('config.get', { key: 'full' })
       .then(cfg => {
         if (!cfg?.config?.display?.tui_auto_resume_recent) {
           patchUiState({ status: 'forging session…' })
@@ -193,7 +200,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
           return
         }
 
-        return rpc<{ session_id?: null | string; title?: string }>('session.most_recent', {}).then(r => {
+        return rpc<SessionMostRecentResponse>('session.most_recent', {}).then(r => {
           const target = r?.session_id
 
           if (target) {

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -171,15 +171,46 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
       })
       .catch((e: unknown) => turnController.pushActivity(`command catalog unavailable: ${rpcErrorMessage(e)}`, 'info'))
 
-    if (!STARTUP_RESUME_ID) {
-      patchUiState({ status: 'forging session…' })
-      newSession()
+    if (STARTUP_RESUME_ID) {
+      patchUiState({ status: 'resuming…' })
+      resumeById(STARTUP_RESUME_ID)
 
       return
     }
 
-    patchUiState({ status: 'resuming…' })
-    resumeById(STARTUP_RESUME_ID)
+    // Opt-in: when `display.tui_auto_resume_recent` is true, look up
+    // the most recent human-facing session and resume it instead of
+    // forging a brand-new one.  Mirrors classic CLI's `hermes -c` /
+    // `hermes --tui` muscle memory and addresses the audit's "session
+    // unrecoverable after disconnection" gap.  Default off so existing
+    // users aren't surprised.
+    rpc<{ config?: { display?: { tui_auto_resume_recent?: boolean } } }>('config.get', { key: 'full' })
+      .then(cfg => {
+        if (!cfg?.config?.display?.tui_auto_resume_recent) {
+          patchUiState({ status: 'forging session…' })
+          newSession()
+
+          return
+        }
+
+        return rpc<{ session_id?: null | string; title?: string }>('session.most_recent', {}).then(r => {
+          const target = r?.session_id
+
+          if (target) {
+            patchUiState({ status: 'resuming most recent…' })
+            resumeById(target)
+
+            return
+          }
+
+          patchUiState({ status: 'forging session…' })
+          newSession()
+        })
+      })
+      .catch(() => {
+        patchUiState({ status: 'forging session…' })
+        newSession()
+      })
   }
 
   return (ev: GatewayEvent) => {

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -60,6 +60,7 @@ export interface ConfigDisplayConfig {
   show_reasoning?: boolean
   streaming?: boolean
   thinking_mode?: string
+  tui_auto_resume_recent?: boolean
   tui_compact?: boolean
   tui_mouse?: boolean
   tui_statusbar?: 'bottom' | 'off' | 'on' | 'top' | boolean
@@ -117,6 +118,13 @@ export interface SessionListItem {
 
 export interface SessionListResponse {
   sessions?: SessionListItem[]
+}
+
+export interface SessionMostRecentResponse {
+  session_id?: null | string
+  source?: string
+  started_at?: number
+  title?: string
 }
 
 export interface SessionTitleResponse {


### PR DESCRIPTION
## Summary

\`hermes --tui\` always forges a fresh session at startup unless \`HERMES_TUI_RESUME=<id>\` is set. Disconnects, terminal-window crashes, and accidental Ctrl+D therefore lose every piece of in-flight context even though \`state.db\` already has the full history a \`/resume\` away.

This adds an opt-in path that matches classic CLI's \`hermes -c\` muscle memory: when \`display.tui_auto_resume_recent: true\` is in \`~/.hermes/config.yaml\`, the TUI resumes the most recent human-facing session at startup instead of forging.

Default off so existing users aren't surprised. Explicit \`HERMES_TUI_RESUME\` always wins.

## Wires

- New \`session.most_recent\` JSON-RPC in \`tui_gateway/server.py\` that returns the first non-\`tool\` row from \`list_sessions_rich\`, or \`{"session_id": null}\` when none. Same deny-list as \`session.list\` so sub-agent rows can't sneak in.
- \`createGatewayEventHandler.handleReady\` re-ordered: explicit \`STARTUP_RESUME_ID\` first (unchanged), then conditional auto-resume via \`config.get full → display.tui_auto_resume_recent\`, then the legacy \`newSession()\` fallback. Failures of either RPC fall back to \`newSession()\` so the path is always finite.
- Default \`display.tui_auto_resume_recent: False\` added to \`DEFAULT_CONFIG\`. No \`_config_version\` bump per \`AGENTS.md\` — deep-merge handles the additive key.

## Test plan

- [x] 4 new vitest cases in \`createGatewayEventHandler.test.ts\` cover every gate-and-fallback combination (env wins, config off, config on with hit, config on with miss).
- [x] 3 new pytest cases for \`session.most_recent\` (deny-list skip, tool-only → null, db-unavailable → null).
- [x] \`scripts/run_tests.sh tests/test_tui_gateway_server.py\` — **93/93 pass**.
- [x] \`npm run type-check\` clean (in \`ui-tui/\`); \`npm test -- --run\` — **393/393 pass**.

## Refs

Audit High #2 (asheriif): "Session unrecoverable after disconnection". Building blocks (\`STARTUP_RESUME_ID\`, \`writeActiveSessionFile\`, \`session.list\`, \`session.resume\`) were already in place; this PR wires them into the default startup path under an explicit opt-in.