### PR TITLE
fix(nix): refresh hermes-web npm-deps hash

### DIFF
--- a/nix/web.nix
+++ b/nix/web.nix
@@ -4,7 +4,7 @@ let
   src = ../web;
   npmDeps = pkgs.fetchNpmDeps {
     inherit src;
-    hash = "sha256-AahWmJ9gDQ9pMPa1FYwUjYdO2mOi6JM9Mst27E0vp68=";
+    hash = "sha256-+B2+Fe4djPzHHcUXRx+m0cuyaopAhW0PcHsMgYfV5VE=";
   };
 
   npm = hermesNpmLib.mkNpmPassthru { folder = "web"; attr = "web"; pname = "hermes-web"; };


### PR DESCRIPTION
## Summary

The hash currently checked into `nix/web.nix` (`sha256-AahWmJ9gDQ9pMPa1FYwUjYdO2mOi6JM9Mst27E0vp68=`) doesn't match what `fetchNpmDeps` actually produces from `web/package-lock.json`. Builds on `nixos-unstable`-tracking consumers fail with:

```
error: hash mismatch in fixed-output derivation '.../npm-deps.drv':
         specified: sha256-AahWmJ9gDQ9pMPa1FYwUjYdO2mOi6JM9Mst27E0vp68=
            got:    sha256-+B2+Fe4djPzHHcUXRx+m0cuyaopAhW0PcHsMgYfV5VE=
```

The hash-refresh bot last ran at f62272b (Apr 28); since then the hash has drifted. This is the mechanical fix the bot would otherwise produce — recomputed via:

```
nix build .#web 2>&1 | grep got:
```

Reproduced on x86_64-linux against `inputs.hermes-agent.inputs.nixpkgs` (NixOS/nixpkgs@6201e203, the rev pinned in `flake.lock`), so this isn't a consumer-side nixpkgs drift.

## Test plan

- [x] `nix build .#web` succeeds with new hash
- [x] hermes-agent default package builds end-to-end (since `web` is a build-time dep of the agent closure)