### PR TITLE
fix: add PLATFORM_HINTS entry for api_server platform

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -451,6 +451,12 @@ PLATFORM_HINTS = {
         "image and is the WRONG path. Bare Unicode emoji in text is also not a substitute "
         "— when a sticker is the right response, use yb_send_sticker."
     ),
+    "api_server": (
+        "You're responding through an API server. The rendering layer is unknown — "
+        "assume plain text. No markdown formatting (no asterisks, bullets, headers, "
+        "code fences). Treat this like a conversation, not a document. Keep responses "
+        "brief and natural."
+    ),
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -788,6 +788,7 @@ class TestPromptBuilderConstants:
         assert "discord" in PLATFORM_HINTS
         assert "cron" in PLATFORM_HINTS
         assert "cli" in PLATFORM_HINTS
+        assert "api_server" in PLATFORM_HINTS
 
     def test_cli_hint_does_not_suggest_media_tags(self):
         # Regression: MEDIA:/path tags are intercepted only by messaging


### PR DESCRIPTION
The API server is a documented, first-class messaging platform with its own gateway adapter, docs pages, and toolset. But it's the only messaging platform missing from PLATFORM_HINTS in agent/prompt_builder.py.

Without a platform hint, the agent has no context about the API server's rendering environment and defaults to markdown-heavy document-style outputs (code fences, bold, bullet points) — which break on the plain-text frontends most API server consumers wrap (Open WebUI, custom agents, third-party bridges).

Adds a generic api_server entry that describes the medium (unknown rendering, assume plain text) without encoding any specific use case. Individual consumers can layer additional style guidance via ephemeral system prompts.

Before (DeepSeek V4 Pro via API server, no hint):
**Sendblue bridge** at /opt/sendblue-bridge - **68MB** on disk

After (same prompt, with hint):
Sendblue bridge at /opt/sendblue-bridge, 68MB on disk

No breaking changes — new dict entry only. Existing API server consumers see no behavioral change except for models that previously defaulted to markdown formatting, which now produce cleaner plain-text output.

## What does this PR do?

Adds a missing `PLATFORM_HINTS` entry for the `api_server` platform. See full description above.

## Related Issue

N/A — no existing issue. The gap was identified while building an external API server consumer.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Added `api_server` entry to `PLATFORM_HINTS` dict in `agent/prompt_builder.py`
- Updated `test_platform_hints_known_platforms` in `tests/agent/test_prompt_builder.py` to include the new key

## How to Test

`pytest tests/agent/test_prompt_builder.py -v`

Or test end-to-end by running an API server session and checking the effective system prompt includes the new hint.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: api_server

### Documentation & Housekeeping

- [x] N/A — no doc changes needed
- [x] N/A — no config keys changed
- [x] N/A — no architecture changes
- [x] N/A — cross-platform compatibility unaffected (string constant)
- [x] N/A — no tool behavior changes
