### PR TITLE
fix(cli): prevent .env sanitizer from splitting GLM_API_KEY by LM_API_KEY suffix

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3702,18 +3702,27 @@ def _sanitize_env_lines(lines: list) -> list:
 
         # Detect concatenated KEY=VALUE pairs on one line.
         # Search for known KEY= patterns at any position in the line.
-        split_positions = []
+        # We collect full needle ranges so we can drop matches that are
+        # fully contained within a longer overlapping needle. Without this,
+        # suffix collisions corrupt the file: e.g. LM_API_KEY= inside
+        # GLM_API_KEY= would otherwise split the line into "G\nLM_API_KEY=...".
+        match_ranges: list[tuple[int, int]] = []
         for key_name in known_keys:
             needle = key_name + "="
             idx = stripped.find(needle)
             while idx >= 0:
-                split_positions.append(idx)
+                match_ranges.append((idx, idx + len(needle)))
                 idx = stripped.find(needle, idx + len(needle))
 
+        split_positions = sorted({
+            s for s, e in match_ranges
+            if not any(
+                s2 <= s and e2 >= e and (s2, e2) != (s, e)
+                for s2, e2 in match_ranges
+            )
+        })
+
         if len(split_positions) > 1:
-            split_positions.sort()
-            # Deduplicate (shouldn't happen, but be safe)
-            split_positions = sorted(set(split_positions))
             for i, pos in enumerate(split_positions):
                 end = split_positions[i + 1] if i + 1 < len(split_positions) else len(stripped)
                 part = stripped[pos:end].strip()

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -319,6 +319,23 @@ class TestSanitizeEnvLines:
         assert result[0].startswith("OPENROUTER_API_KEY=")
         assert result[1].startswith("OPENAI_BASE_URL=")
 
+    def test_glm_suffix_collision_not_split(self):
+        """GLM_API_KEY / GLM_BASE_URL must not be mangled by LM_API_KEY / LM_BASE_URL suffixes (#17138)."""
+        lines = [
+            "GLM_API_KEY=glm-secret\n",
+            "GLM_BASE_URL=https://api.z.ai/api/paas/v4\n",
+        ]
+        result = _sanitize_env_lines(lines)
+        assert result == lines, f"GLM_* lines were corrupted by suffix collision: {result}"
+
+    def test_suffix_collision_does_not_break_real_concatenation(self):
+        """A genuine concatenation that happens to start with a suffix-superset key still splits."""
+        lines = ["GLM_API_KEY=glmLM_API_KEY=lm-key\n"]
+        result = _sanitize_env_lines(lines)
+        assert len(result) == 2
+        assert result[0].startswith("GLM_API_KEY=")
+        assert result[1].startswith("LM_API_KEY=")
+
     def test_save_env_value_fixes_corruption_on_write(self, tmp_path):
         """save_env_value sanitizes corrupted lines when writing a new key."""
         env_file = tmp_path / ".env"


### PR DESCRIPTION
## What does this PR do?

Fix a corruption bug in `_sanitize_env_lines` where any registered env var name that is a suffix of another (e.g. `LM_API_KEY` is a suffix of `GLM_API_KEY`) would cause the longer key's line to be silently split into corrupted halves like `G\nLM_API_KEY=...`. This rewrote the user's `.env` file on disk and disabled provider auth for the affected key (Z.AI/GLM in the report; same shape applies to `GLM_BASE_URL` vs `LM_BASE_URL`).

The reporter pinpointed the exact mechanism: the splitter walks each `.env` line scanning for any known-key name as a substring, with no word-boundary check. `stripped.find(\"LM_API_KEY=\")` returns 1 inside `\"GLM_API_KEY=...\"` because `LM_API_KEY=` is a literal suffix of `GLM_API_KEY=`.

## Related Issue

Fixes #17138

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `hermes_cli/config.py` — `_sanitize_env_lines`: collect full needle ranges `(start, end)` for every known-key match, then drop matches whose range is fully contained within a longer overlapping match. This kills suffix-collision splits while keeping every legitimate concatenation case (where matches do not nest).
- `tests/hermes_cli/test_config.py` — two new tests under `TestSanitizeEnvLines`:
  - `test_glm_suffix_collision_not_split` — direct regression for #17138.
  - `test_suffix_collision_does_not_break_real_concatenation` — confirms a genuine concat `GLM_API_KEY=glmLM_API_KEY=lm-key` still splits at the second key, since that match is not nested inside the first.

## How to Test

```bash
pytest tests/hermes_cli/test_config.py::TestSanitizeEnvLines -v
```

All 13 tests (11 existing + 2 new) pass. Full \`tests/hermes_cli/test_config.py\` suite (52 tests) also passes.

Manual repro:

1. Put \`GLM_API_KEY=glm-secret\` in \`~/.hermes/.env\`.
2. Run \`hermes\` (or any code path that triggers \`sanitize_env_file\`).
3. Before the fix: the file is rewritten as \`G\\nLM_API_KEY=glm-secret\` and \`os.getenv(\"GLM_API_KEY\")\` returns \`None\`. After the fix: the file is unchanged.

## Checklist

- [x] Tests added and pass locally
- [x] Conventional Commit format
- [x] Single logical change, scope limited to the sanitizer
- [x] No hardcoded \`~/.hermes\` paths (uses existing \`HERMES_HOME\` flow)
- [x] No \`simple_term_menu\` / ANSI erase / cross-toolset schema references
- [x] No \`prompt_toolkit\` cache-breaking changes

## AI Disclosure

This bug was identified and fixed with AI assistance.