### PR TITLE
feat(bedrock): support custom runtime endpoint with bearer token auth

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -492,7 +492,11 @@ def build_anthropic_client(api_key: str, base_url: str = None, timeout: float = 
     return _anthropic_sdk.Anthropic(**kwargs)
 
 
-def build_anthropic_bedrock_client(region: str):
+def build_anthropic_bedrock_client(
+    region: str,
+    endpoint_url: str = "",
+    bearer_token: str = "",
+):
     """Create an AnthropicBedrock client for Bedrock Claude models.
 
     Uses the Anthropic SDK's native Bedrock adapter, which provides full
@@ -507,6 +511,10 @@ def build_anthropic_bedrock_client(region: str):
     serves them with 1M natively.
 
     Auth uses the boto3 default credential chain (IAM roles, SSO, env vars).
+
+    When a bearer token is provided (or ``AWS_BEARER_TOKEN_BEDROCK`` is set),
+    the SDK's native ``api_key`` parameter is used — ``AnthropicBedrock``
+    natively sets ``Authorization: Bearer <api_key>`` and skips SigV4 signing.
     """
     _anthropic_sdk = _get_anthropic_sdk()
     if _anthropic_sdk is None:
@@ -521,11 +529,27 @@ def build_anthropic_bedrock_client(region: str):
         )
     from httpx import Timeout
 
-    return _anthropic_sdk.AnthropicBedrock(
-        aws_region=region,
-        timeout=Timeout(timeout=900.0, connect=10.0),
-        default_headers={"anthropic-beta": ",".join(_COMMON_BETAS)},
-    )
+    effective_endpoint = endpoint_url or os.environ.get("AWS_ENDPOINT_URL_BEDROCK_RUNTIME", "").strip()
+    if not effective_endpoint:
+        try:
+            from hermes_cli.config import load_config
+
+            effective_endpoint = (load_config().get("bedrock", {}).get("runtime_endpoint") or "").strip()
+        except (ImportError, OSError):
+            pass
+    effective_bearer = bearer_token or os.environ.get("AWS_BEARER_TOKEN_BEDROCK", "").strip()
+
+    kwargs = {
+        "aws_region": region,
+        "timeout": Timeout(timeout=900.0, connect=10.0),
+        "default_headers": {"anthropic-beta": ",".join(_COMMON_BETAS)},
+    }
+    if effective_endpoint:
+        kwargs["base_url"] = effective_endpoint
+    if effective_bearer:
+        kwargs["api_key"] = effective_bearer
+
+    return _anthropic_sdk.AnthropicBedrock(**kwargs)
 
 
 def _read_claude_code_credentials_from_keychain() -> Optional[Dict[str, Any]]:
@@ -1788,5 +1812,4 @@ def build_anthropic_kwargs(
         kwargs["extra_headers"] = {"anthropic-beta": ",".join(betas)}
 
     return kwargs
-
 

--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -58,17 +58,72 @@ def _require_boto3():
         )
 
 
-def _get_bedrock_runtime_client(region: str):
+def _resolve_custom_endpoint() -> str:
+    """Return the custom Bedrock runtime endpoint, preferring env var override over config."""
+    env_val = os.environ.get("AWS_ENDPOINT_URL_BEDROCK_RUNTIME", "").strip()
+    if env_val:
+        return env_val
+    try:
+        from hermes_cli.config import load_config
+        return (load_config().get("bedrock", {}).get("runtime_endpoint") or "").strip()
+    except (ImportError, OSError) as exc:
+        logger.debug("bedrock: could not read runtime_endpoint from config: %s", exc)
+        return ""
+
+
+def _get_bedrock_runtime_client(
+    region: str,
+    endpoint_url: str = "",
+    bearer_token: str = "",
+):
     """Get or create a cached ``bedrock-runtime`` client for the given region.
 
     Uses the default AWS credential chain (env vars → profile → instance role).
+
+    When a bearer token is present — whether for a native AWS Bedrock API key
+    or a custom AI-gateway proxy — creates an unsigned client with bearer
+    auth injected via a ``before-sign`` event handler.
     """
-    if region not in _bedrock_runtime_client_cache:
-        boto3 = _require_boto3()
-        _bedrock_runtime_client_cache[region] = boto3.client(
+    effective_endpoint = endpoint_url or _resolve_custom_endpoint()
+    effective_bearer = bearer_token or os.environ.get("AWS_BEARER_TOKEN_BEDROCK", "").strip()
+
+    _bearer_tag = effective_bearer[:8] if effective_bearer else ""
+    cache_key = f"{region}|{effective_endpoint}|{_bearer_tag}"
+    if cache_key in _bedrock_runtime_client_cache:
+        return _bedrock_runtime_client_cache[cache_key]
+
+    boto3 = _require_boto3()
+
+    if effective_bearer:
+        # Bearer auth — unsigned client.  Works for both native AWS Bedrock
+        # API keys and custom AI-gateway proxies.
+        from botocore import UNSIGNED
+        from botocore.config import Config
+
+        client_kwargs = {
+            "region_name": region,
+            "config": Config(signature_version=UNSIGNED),
+        }
+        if effective_endpoint:
+            client_kwargs["endpoint_url"] = effective_endpoint
+
+        client = boto3.client("bedrock-runtime", **client_kwargs)
+
+        def _inject_bearer(request, **kwargs):
+            request.headers["Authorization"] = f"Bearer {effective_bearer}"
+
+        client.meta.events.register("before-sign.bedrock-runtime.*", _inject_bearer)
+    elif effective_endpoint:
+        client = boto3.client(
+            "bedrock-runtime", region_name=region, endpoint_url=effective_endpoint,
+        )
+    else:
+        client = boto3.client(
             "bedrock-runtime", region_name=region,
         )
-    return _bedrock_runtime_client_cache[region]
+
+    _bedrock_runtime_client_cache[cache_key] = client
+    return client
 
 
 def _get_bedrock_control_client(region: str):
@@ -87,7 +142,7 @@ def reset_client_cache():
     _bedrock_control_client_cache.clear()
 
 
-def invalidate_runtime_client(region: str) -> bool:
+def invalidate_runtime_client(region: str, endpoint_url: str = "") -> bool:
     """Evict the cached ``bedrock-runtime`` client for a single region.
 
     Per-region counterpart to :func:`reset_client_cache`. Used by the converse
@@ -98,8 +153,12 @@ def invalidate_runtime_client(region: str) -> bool:
     Returns True if a cached entry was evicted, False if the region was not
     cached.
     """
-    existed = region in _bedrock_runtime_client_cache
-    _bedrock_runtime_client_cache.pop(region, None)
+    effective_endpoint = endpoint_url or _resolve_custom_endpoint()
+    effective_bearer = os.environ.get("AWS_BEARER_TOKEN_BEDROCK", "").strip()
+    _bearer_tag = effective_bearer[:8] if effective_bearer else ""
+    cache_key = f"{region}|{effective_endpoint}|{_bearer_tag}"
+    existed = cache_key in _bedrock_runtime_client_cache
+    _bedrock_runtime_client_cache.pop(cache_key, None)
     return existed
 
 
@@ -226,7 +285,9 @@ def resolve_aws_auth_env_var(env: Optional[Dict[str, str]] = None) -> Optional[s
     attempting to authenticate.
     """
     env = env if env is not None else os.environ
-    # Bearer token takes highest priority
+    # Bearer token takes highest priority.  Works for both native AWS Bedrock
+    # API keys (short/long-term, against the standard bedrock-runtime endpoint)
+    # and custom AI-gateway proxies that use bearer auth.
     if env.get("AWS_BEARER_TOKEN_BEDROCK", "").strip():
         return "AWS_BEARER_TOKEN_BEDROCK"
     # Explicit access key pair

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -96,6 +96,16 @@ model:
 #         stale_timeout_seconds: 1800  # Longer non-stream stale timeout for slow large-context turns
 
 # =============================================================================
+# AWS Bedrock Configuration (only applies when using the Bedrock provider)
+# =============================================================================
+# bedrock:
+#   region: us-east-1                    # AWS region (or set AWS_REGION env var)
+#   runtime_endpoint: ""                 # Custom Bedrock runtime endpoint URL
+#                                        # (e.g. AI gateway proxy). Leave empty
+#                                        # for the standard AWS endpoint.
+#                                        # Env override: AWS_ENDPOINT_URL_BEDROCK_RUNTIME
+
+# =============================================================================
 # OpenRouter Provider Routing (only applies when using OpenRouter)
 # =============================================================================
 # Control how requests are routed across providers on OpenRouter.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -612,6 +612,7 @@ DEFAULT_CONFIG = {
             "provider_filter": [],     # Only show models from these providers (e.g. ["anthropic", "amazon"])
             "refresh_interval": 3600,  # Cache discovery results for this many seconds
         },
+        "runtime_endpoint": "",  # Custom Bedrock runtime endpoint URL (empty = default AWS endpoint)
         "guardrail": {
             # Amazon Bedrock Guardrails — content filtering and safety policies.
             # Create a guardrail in the Bedrock console, then set the ID and version here.
@@ -1527,6 +1528,14 @@ OPTIONAL_ENV_VARS = {
         "prompt": "AWS Profile",
         "url": None,
         "password": False,
+        "category": "provider",
+        "advanced": True,
+    },
+    "AWS_BEARER_TOKEN_BEDROCK": {
+        "description": "AWS Bedrock API key (native short/long-term) or bearer token for custom AI-gateway endpoints",
+        "prompt": "Bedrock Bearer Token",
+        "url": None,
+        "password": True,
         "category": "provider",
         "advanced": True,
     },

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4108,6 +4108,19 @@ def _model_flow_stepfun(config, current_model=""):
         print("No change.")
 
 
+def _clear_custom_bedrock_endpoint(cfg: dict) -> None:
+    bedrock_cfg = cfg.get("bedrock", {})
+    if isinstance(bedrock_cfg, dict) and bedrock_cfg.get("runtime_endpoint"):
+        bedrock_cfg["runtime_endpoint"] = ""
+        cfg["bedrock"] = bedrock_cfg
+        print("Cleared custom Bedrock endpoint from config.")
+        if os.environ.get("AWS_ENDPOINT_URL_BEDROCK_RUNTIME", "").strip():
+            print(
+                "Note: AWS_ENDPOINT_URL_BEDROCK_RUNTIME env var is still set — "
+                "remove it to fully switch back to IAM."
+            )
+
+
 def _model_flow_bedrock_api_key(config, region, current_model=""):
     """Bedrock API Key mode — uses the OpenAI-compatible bedrock-mantle endpoint.
 
@@ -4132,7 +4145,7 @@ def _model_flow_bedrock_api_key(config, region, current_model=""):
     # Prompt for API key
     existing_key = get_env_value("AWS_BEARER_TOKEN_BEDROCK") or ""
     if existing_key:
-        print(f"  Bedrock API Key: {existing_key[:12]}... ✓")
+        print("  Bedrock API Key: ✓ configured")
     else:
         print(f"  Endpoint: {mantle_base_url}")
         print()
@@ -4182,6 +4195,7 @@ def _model_flow_bedrock_api_key(config, region, current_model=""):
             bedrock_cfg = {}
         bedrock_cfg["region"] = region
         cfg["bedrock"] = bedrock_cfg
+        _clear_custom_bedrock_endpoint(cfg)
 
         # Save the API key env var name so hermes knows where to find it
         save_env_value("OPENAI_API_KEY", existing_key)
@@ -4192,6 +4206,106 @@ def _model_flow_bedrock_api_key(config, region, current_model=""):
 
         print(f"  Default model set to: {selected} (via Bedrock API Key, {region})")
         print(f"  Endpoint: {mantle_base_url}")
+    else:
+        print("  No change.")
+
+
+def _model_flow_bedrock_custom_endpoint(config, region, current_model=""):
+    """Custom Bedrock endpoint with bearer token authentication.
+
+    For AI gateway proxies (e.g. corporate gateways) that expose a
+    Bedrock-compatible API with bearer token auth instead of SigV4.
+
+    Saves the endpoint URL to config.yaml (bedrock.runtime_endpoint) and
+    AWS_BEARER_TOKEN_BEDROCK (secret) to .env. Sets provider to "bedrock"
+    so the native Bedrock adapter is used with the custom endpoint and bearer auth.
+    """
+    from hermes_cli.auth import (
+        _prompt_model_selection,
+        _save_model_choice,
+        deactivate_provider,
+    )
+    from hermes_cli.config import (
+        load_config,
+        save_config,
+        get_env_value,
+        save_env_value,
+    )
+    from hermes_cli.models import _PROVIDER_MODELS
+
+    _bedrock_cfg_existing = load_config().get("bedrock", {}) or {}
+    existing_url = (_bedrock_cfg_existing.get("runtime_endpoint") or "").strip()
+    print()
+    try:
+        url_input = input(
+            f"  Bedrock endpoint URL [{existing_url or 'e.g. https://ai-gateway.example.com/bedrock'}]: "
+        ).strip()
+    except (KeyboardInterrupt, EOFError):
+        print()
+        return
+    endpoint_url = url_input or existing_url
+    if not endpoint_url:
+        print("  No URL provided. Cancelled.")
+        return
+    if not endpoint_url.startswith(("http://", "https://")):
+        print(f"  Invalid URL: {endpoint_url} (must start with http:// or https://)")
+        return
+
+    existing_token = get_env_value("AWS_BEARER_TOKEN_BEDROCK") or ""
+    if existing_token:
+        print("  Bearer token: ✓ token configured")
+    try:
+        import getpass
+        token_input = getpass.getpass(
+            "  Bearer token [leave blank to keep existing]: "
+        ).strip()
+    except (KeyboardInterrupt, EOFError):
+        print()
+        return
+    bearer_token = token_input or existing_token
+    if not bearer_token:
+        print("  No bearer token provided. Cancelled.")
+        return
+
+    save_env_value("AWS_BEARER_TOKEN_BEDROCK", bearer_token)
+    print("  ✓ Token saved.")
+    print()
+
+    model_list = _PROVIDER_MODELS.get("bedrock", [])
+    print(f"  Showing {len(model_list)} curated models")
+
+    if model_list:
+        selected = _prompt_model_selection(model_list, current_model=current_model)
+    else:
+        try:
+            selected = input("  Model ID: ").strip()
+        except (KeyboardInterrupt, EOFError):
+            selected = None
+
+    if selected:
+        _save_model_choice(selected)
+
+        cfg = load_config()
+        model = cfg.get("model")
+        if not isinstance(model, dict):
+            model = {"default": model} if model else {}
+            cfg["model"] = model
+        model["provider"] = "bedrock"
+        model.pop("api_mode", None)
+        model.pop("base_url", None)
+
+        bedrock_cfg = cfg.get("bedrock", {})
+        if not isinstance(bedrock_cfg, dict):
+            bedrock_cfg = {}
+        bedrock_cfg["region"] = region
+        bedrock_cfg["runtime_endpoint"] = endpoint_url
+        cfg["bedrock"] = bedrock_cfg
+
+        save_config(cfg)
+        deactivate_provider()
+
+        print(f"  Default model set to: {selected} (via custom Bedrock endpoint)")
+        print(f"  Endpoint: {endpoint_url}")
     else:
         print("  No change.")
 
@@ -4254,6 +4368,9 @@ def _model_flow_bedrock(config, current_model=""):
     print("    2. Bedrock API Key")
     print("       Enter your Bedrock API Key directly — also supports")
     print("       team scenarios where an admin distributes keys")
+    print("    3. Custom Bedrock endpoint (Bearer token)")
+    print("       For AI gateway proxies that expose a Bedrock-compatible API")
+    print("       with bearer token authentication")
     print()
     try:
         auth_choice = input("  Choice [1]: ").strip()
@@ -4263,6 +4380,9 @@ def _model_flow_bedrock(config, current_model=""):
 
     if auth_choice == "2":
         _model_flow_bedrock_api_key(config, region, current_model)
+        return
+    if auth_choice == "3":
+        _model_flow_bedrock_custom_endpoint(config, region, current_model)
         return
 
     # 3. Model discovery — try live API first, fall back to static list
@@ -4370,6 +4490,7 @@ def _model_flow_bedrock(config, current_model=""):
             bedrock_cfg = {}
         bedrock_cfg["region"] = region
         cfg["bedrock"] = bedrock_cfg
+        _clear_custom_bedrock_endpoint(cfg)
 
         save_config(cfg)
         deactivate_provider()

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1197,6 +1197,12 @@ def resolve_runtime_provider(
         # Region priority: config.yaml bedrock.region → env var → us-east-1
         region = (_bedrock_cfg.get("region") or "").strip() or resolve_bedrock_region()
         auth_source = resolve_aws_auth_env_var() or "aws-sdk-default-chain"
+        _custom_endpoint = (
+            os.environ.get("AWS_ENDPOINT_URL_BEDROCK_RUNTIME", "").strip()
+            or (_bedrock_cfg.get("runtime_endpoint") or "").strip()
+        )
+        _default_base_url = f"https://bedrock-runtime.{region}.amazonaws.com"
+        _effective_base_url = _custom_endpoint or _default_base_url
         # Build guardrail config if configured
         _gr = _bedrock_cfg.get("guardrail", {})
         guardrail_config = None
@@ -1218,11 +1224,11 @@ def resolve_runtime_provider(
             runtime = {
                 "provider": "bedrock",
                 "api_mode": "anthropic_messages",
-                "base_url": f"https://bedrock-runtime.{region}.amazonaws.com",
+                "base_url": _effective_base_url,
                 "api_key": "aws-sdk",
                 "source": auth_source,
                 "region": region,
-                "bedrock_anthropic": True,  # Signal to use AnthropicBedrock client
+                "bedrock_anthropic": True,
                 "requested_provider": requested_provider,
             }
         else:
@@ -1230,7 +1236,7 @@ def resolve_runtime_provider(
             runtime = {
                 "provider": "bedrock",
                 "api_mode": "bedrock_converse",
-                "base_url": f"https://bedrock-runtime.{region}.amazonaws.com",
+                "base_url": _effective_base_url,
                 "api_key": "aws-sdk",
                 "source": auth_source,
                 "region": region,

--- a/run_agent.py
+++ b/run_agent.py
@@ -849,6 +849,22 @@ def _qwen_portal_headers() -> dict:
     }
 
 
+def _resolve_bedrock_region_for_init(base_url: str = "") -> str:
+    """Resolve Bedrock region from base_url pattern, config.yaml, or env vars."""
+    _match = re.search(r"bedrock-runtime\.([a-z0-9-]+)\.", base_url or "")
+    if _match:
+        return _match.group(1)
+    try:
+        from hermes_cli.config import load_config
+        _cfg_region = (load_config().get("bedrock", {}).get("region") or "").strip()
+        if _cfg_region:
+            return _cfg_region
+    except (ImportError, OSError):
+        pass
+    from agent.bedrock_adapter import resolve_bedrock_region
+    return resolve_bedrock_region()
+
+
 class AIAgent:
     """
     AI Agent with tool calling capabilities.
@@ -1295,8 +1311,7 @@ class AIAgent:
             _is_bedrock_anthropic = self.provider == "bedrock"
             if _is_bedrock_anthropic:
                 from agent.anthropic_adapter import build_anthropic_bedrock_client
-                _region_match = re.search(r"bedrock-runtime\.([a-z0-9-]+)\.", base_url or "")
-                _br_region = _region_match.group(1) if _region_match else "us-east-1"
+                _br_region = _resolve_bedrock_region_for_init(base_url)
                 self._bedrock_region = _br_region
                 self._anthropic_client = build_anthropic_bedrock_client(_br_region)
                 self._anthropic_api_key = "aws-sdk"
@@ -1335,9 +1350,8 @@ class AIAgent:
                         print(f"🔑 Using token: {effective_key[:8]}...{effective_key[-4:]}")
         elif self.api_mode == "bedrock_converse":
             # AWS Bedrock — uses boto3 directly, no OpenAI client needed.
-            # Region is extracted from the base_url or defaults to us-east-1.
-            _region_match = re.search(r"bedrock-runtime\.([a-z0-9-]+)\.", base_url or "")
-            self._bedrock_region = _region_match.group(1) if _region_match else "us-east-1"
+            # Region is taken from base_url or config.yaml.
+            self._bedrock_region = _resolve_bedrock_region_for_init(base_url)
             # Guardrail config — read from config.yaml at init time.
             self._bedrock_guardrail_config = None
             try:

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -28,10 +28,21 @@ class TestResolveAwsAuthEnvVar:
     Mirrors OpenClaw's resolveAwsSdkEnvVarName() priority order.
     """
 
-    def test_prefers_bearer_token_over_access_keys_and_profile(self):
+    def test_prefers_bearer_token_over_access_keys_when_endpoint_set(self):
         from agent.bedrock_adapter import resolve_aws_auth_env_var
         env = {
-            "AWS_BEARER_TOKEN_BEDROCK": "bearer-token",
+            "AWS_BEARER_TOKEN_BEDROCK": "test-bearer-token",
+            "AWS_ENDPOINT_URL_BEDROCK_RUNTIME": "https://gateway.example.com/bedrock",
+            "AWS_ACCESS_KEY_ID": "AKIA...",
+            "AWS_SECRET_ACCESS_KEY": "secret",
+            "AWS_PROFILE": "default",
+        }
+        assert resolve_aws_auth_env_var(env) == "AWS_BEARER_TOKEN_BEDROCK"
+
+    def test_bearer_token_without_endpoint_still_valid(self):
+        from agent.bedrock_adapter import resolve_aws_auth_env_var
+        env = {
+            "AWS_BEARER_TOKEN_BEDROCK": "test-bearer-token",
             "AWS_ACCESS_KEY_ID": "AKIA...",
             "AWS_SECRET_ACCESS_KEY": "secret",
             "AWS_PROFILE": "default",
@@ -1264,14 +1275,17 @@ class TestInvalidateRuntimeClient:
             reset_client_cache,
         )
         reset_client_cache()
-        _bedrock_runtime_client_cache["us-east-1"] = "dead-client"
-        _bedrock_runtime_client_cache["us-west-2"] = "live-client"
+        _bedrock_runtime_client_cache["us-east-1||"] = "dead-client"
+        _bedrock_runtime_client_cache["us-west-2||"] = "live-client"
 
-        evicted = invalidate_runtime_client("us-east-1")
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("AWS_ENDPOINT_URL_BEDROCK_RUNTIME", None)
+            os.environ.pop("AWS_BEARER_TOKEN_BEDROCK", None)
+            evicted = invalidate_runtime_client("us-east-1")
 
         assert evicted is True
-        assert "us-east-1" not in _bedrock_runtime_client_cache
-        assert _bedrock_runtime_client_cache["us-west-2"] == "live-client"
+        assert "us-east-1||" not in _bedrock_runtime_client_cache
+        assert _bedrock_runtime_client_cache["us-west-2||"] == "live-client"
 
     def test_returns_false_when_region_not_cached(self):
         from agent.bedrock_adapter import invalidate_runtime_client, reset_client_cache
@@ -1367,16 +1381,19 @@ class TestCallConverseInvalidatesOnStaleError:
         dead_client.converse.side_effect = ConnectionClosedError(
             endpoint_url="https://bedrock.example",
         )
-        _bedrock_runtime_client_cache["us-east-1"] = dead_client
+        _bedrock_runtime_client_cache["us-east-1||"] = dead_client
 
-        with pytest.raises(ConnectionClosedError):
-            call_converse(
-                region="us-east-1",
-                model="anthropic.claude-3-sonnet-20240229-v1:0",
-                messages=[{"role": "user", "content": "hi"}],
-            )
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("AWS_ENDPOINT_URL_BEDROCK_RUNTIME", None)
+            os.environ.pop("AWS_BEARER_TOKEN_BEDROCK", None)
+            with pytest.raises(ConnectionClosedError):
+                call_converse(
+                    region="us-east-1",
+                    model="anthropic.claude-3-sonnet-20240229-v1:0",
+                    messages=[{"role": "user", "content": "hi"}],
+                )
 
-        assert "us-east-1" not in _bedrock_runtime_client_cache, (
+        assert "us-east-1||" not in _bedrock_runtime_client_cache, (
             "stale client should have been evicted so the retry reconnects"
         )
 
@@ -1393,16 +1410,19 @@ class TestCallConverseInvalidatesOnStaleError:
         dead_client.converse_stream.side_effect = ConnectionClosedError(
             endpoint_url="https://bedrock.example",
         )
-        _bedrock_runtime_client_cache["us-east-1"] = dead_client
+        _bedrock_runtime_client_cache["us-east-1||"] = dead_client
 
-        with pytest.raises(ConnectionClosedError):
-            call_converse_stream(
-                region="us-east-1",
-                model="anthropic.claude-3-sonnet-20240229-v1:0",
-                messages=[{"role": "user", "content": "hi"}],
-            )
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("AWS_ENDPOINT_URL_BEDROCK_RUNTIME", None)
+            os.environ.pop("AWS_BEARER_TOKEN_BEDROCK", None)
+            with pytest.raises(ConnectionClosedError):
+                call_converse_stream(
+                    region="us-east-1",
+                    model="anthropic.claude-3-sonnet-20240229-v1:0",
+                    messages=[{"role": "user", "content": "hi"}],
+                )
 
-        assert "us-east-1" not in _bedrock_runtime_client_cache
+        assert "us-east-1||" not in _bedrock_runtime_client_cache
 
     def test_converse_does_not_evict_on_non_stale_error(self):
         """Non-stale errors (e.g. ValidationException) leave the client cache alone."""
@@ -1419,16 +1439,19 @@ class TestCallConverseInvalidatesOnStaleError:
             error_response={"Error": {"Code": "ValidationException", "Message": "bad"}},
             operation_name="Converse",
         )
-        _bedrock_runtime_client_cache["us-east-1"] = live_client
+        _bedrock_runtime_client_cache["us-east-1||"] = live_client
 
-        with pytest.raises(ClientError):
-            call_converse(
-                region="us-east-1",
-                model="anthropic.claude-3-sonnet-20240229-v1:0",
-                messages=[{"role": "user", "content": "hi"}],
-            )
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("AWS_ENDPOINT_URL_BEDROCK_RUNTIME", None)
+            os.environ.pop("AWS_BEARER_TOKEN_BEDROCK", None)
+            with pytest.raises(ClientError):
+                call_converse(
+                    region="us-east-1",
+                    model="anthropic.claude-3-sonnet-20240229-v1:0",
+                    messages=[{"role": "user", "content": "hi"}],
+                )
 
-        assert _bedrock_runtime_client_cache.get("us-east-1") is live_client, (
+        assert _bedrock_runtime_client_cache.get("us-east-1||") is live_client, (
             "validation errors do not indicate a dead connection — keep the client"
         )
 
@@ -1446,12 +1469,363 @@ class TestCallConverseInvalidatesOnStaleError:
             "stopReason": "end_turn",
             "usage": {"inputTokens": 1, "outputTokens": 1, "totalTokens": 2},
         }
-        _bedrock_runtime_client_cache["us-east-1"] = live_client
+        _bedrock_runtime_client_cache["us-east-1||"] = live_client
 
-        call_converse(
-            region="us-east-1",
-            model="anthropic.claude-3-sonnet-20240229-v1:0",
-            messages=[{"role": "user", "content": "hi"}],
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("AWS_ENDPOINT_URL_BEDROCK_RUNTIME", None)
+            os.environ.pop("AWS_BEARER_TOKEN_BEDROCK", None)
+            call_converse(
+                region="us-east-1",
+                model="anthropic.claude-3-sonnet-20240229-v1:0",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+        assert _bedrock_runtime_client_cache.get("us-east-1||") is live_client
+
+
+# ---------------------------------------------------------------------------
+# Custom endpoint with bearer token auth
+# ---------------------------------------------------------------------------
+
+class TestCustomEndpointBearerAuth:
+    """Test custom Bedrock endpoint with bearer token authentication.
+
+    When both AWS_ENDPOINT_URL_BEDROCK_RUNTIME and AWS_BEARER_TOKEN_BEDROCK
+    are set, the client should:
+      - Use the custom endpoint URL
+      - Disable AWS SigV4 signing (UNSIGNED)
+      - Inject bearer token via Authorization header
+    """
+
+    def test_creates_unsigned_client_with_custom_endpoint(self):
+        """Client uses UNSIGNED signature and custom endpoint when both env vars set."""
+        from agent.bedrock_adapter import _get_bedrock_runtime_client, reset_client_cache
+        from botocore import UNSIGNED
+        reset_client_cache()
+
+        with patch.dict(os.environ, {
+            "AWS_ENDPOINT_URL_BEDROCK_RUNTIME": "https://gateway.example.com/bedrock",
+            "AWS_BEARER_TOKEN_BEDROCK": "test-bearer-token-123",
+        }):
+            client = _get_bedrock_runtime_client("us-east-1")
+
+            assert client.meta.endpoint_url == "https://gateway.example.com/bedrock"
+            assert client._client_config.signature_version is UNSIGNED
+
+    def test_bearer_token_injected_via_event_handler(self):
+        """Bearer token is injected into Authorization header via before-sign event."""
+        from agent.bedrock_adapter import _get_bedrock_runtime_client, reset_client_cache
+        reset_client_cache()
+
+        with patch.dict(os.environ, {
+            "AWS_ENDPOINT_URL_BEDROCK_RUNTIME": "https://gateway.example.com/bedrock",
+            "AWS_BEARER_TOKEN_BEDROCK": "my-secret-token",
+        }):
+            client = _get_bedrock_runtime_client("us-east-1")
+
+            mock_request = MagicMock()
+            mock_request.headers = {}
+            client.meta.events.emit(
+                "before-sign.bedrock-runtime.InvokeModel",
+                request=mock_request,
+            )
+            assert mock_request.headers.get("Authorization") == "Bearer my-secret-token"
+
+    def test_cache_key_includes_endpoint_url(self):
+        """Different endpoint URLs should result in different cache keys."""
+        from agent.bedrock_adapter import (
+            _bedrock_runtime_client_cache,
+            _get_bedrock_runtime_client,
+            reset_client_cache,
         )
+        reset_client_cache()
 
-        assert _bedrock_runtime_client_cache.get("us-east-1") is live_client
+        with patch.dict(os.environ, {
+            "AWS_ENDPOINT_URL_BEDROCK_RUNTIME": "https://gateway1.example.com/bedrock",
+            "AWS_BEARER_TOKEN_BEDROCK": "token1",
+        }):
+            client1 = _get_bedrock_runtime_client("us-east-1")
+
+        reset_client_cache()
+
+        with patch.dict(os.environ, {
+            "AWS_ENDPOINT_URL_BEDROCK_RUNTIME": "https://gateway2.example.com/bedrock",
+            "AWS_BEARER_TOKEN_BEDROCK": "token2",
+        }):
+            client2 = _get_bedrock_runtime_client("us-east-1")
+
+        # Clients should be different objects (different endpoints)
+        assert client1 is not client2
+        assert client1.meta.endpoint_url == "https://gateway1.example.com/bedrock"
+        assert client2.meta.endpoint_url == "https://gateway2.example.com/bedrock"
+
+    def test_custom_endpoint_without_bearer_uses_sigv4(self):
+        """Custom endpoint without bearer token should use normal SigV4 signing."""
+        from agent.bedrock_adapter import _get_bedrock_runtime_client, reset_client_cache
+        from botocore import UNSIGNED
+        reset_client_cache()
+
+        with patch.dict(os.environ, {
+            "AWS_ENDPOINT_URL_BEDROCK_RUNTIME": "https://custom.aws.endpoint.com",
+        }, clear=False):
+            os.environ.pop("AWS_BEARER_TOKEN_BEDROCK", None)
+            client = _get_bedrock_runtime_client("us-east-1")
+
+            assert client.meta.endpoint_url == "https://custom.aws.endpoint.com"
+            assert client._client_config.signature_version is not UNSIGNED
+
+    def test_no_custom_endpoint_uses_default_aws_endpoint(self):
+        """Without custom endpoint, client uses default AWS bedrock-runtime endpoint."""
+        from agent.bedrock_adapter import _get_bedrock_runtime_client, reset_client_cache
+        reset_client_cache()
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("AWS_ENDPOINT_URL_BEDROCK_RUNTIME", None)
+            os.environ.pop("AWS_BEARER_TOKEN_BEDROCK", None)
+            client = _get_bedrock_runtime_client("us-west-2")
+
+            # Default endpoint follows AWS naming pattern
+            assert "bedrock-runtime" in client.meta.endpoint_url
+            assert "us-west-2" in client.meta.endpoint_url
+
+    def test_invalidate_runtime_client_with_custom_endpoint(self):
+        """Invalidation should use correct cache key when custom endpoint is set."""
+        from agent.bedrock_adapter import (
+            _bedrock_runtime_client_cache,
+            invalidate_runtime_client,
+            reset_client_cache,
+        )
+        reset_client_cache()
+
+        endpoint_url = "https://gateway.example.com/bedrock"
+        cache_key = f"us-east-1|{endpoint_url}|"
+        default_key = "us-east-1||"
+        _bedrock_runtime_client_cache[cache_key] = "custom-endpoint-client"
+        _bedrock_runtime_client_cache[default_key] = "default-client"
+
+        with patch.dict(os.environ, {
+            "AWS_ENDPOINT_URL_BEDROCK_RUNTIME": endpoint_url,
+        }, clear=False):
+            os.environ.pop("AWS_BEARER_TOKEN_BEDROCK", None)
+            evicted = invalidate_runtime_client("us-east-1")
+
+        assert evicted is True
+        assert cache_key not in _bedrock_runtime_client_cache
+        assert _bedrock_runtime_client_cache.get(default_key) == "default-client"
+
+    def test_whitespace_env_vars_treated_as_empty(self):
+        """Whitespace-only env vars should be treated as not set."""
+        from agent.bedrock_adapter import (
+            _bedrock_runtime_client_cache,
+            _get_bedrock_runtime_client,
+            reset_client_cache,
+        )
+        reset_client_cache()
+
+        mock_client = MagicMock()
+        mock_client.meta.endpoint_url = "https://bedrock-runtime.us-east-1.amazonaws.com"
+
+        with patch.dict(os.environ, {
+            "AWS_ENDPOINT_URL_BEDROCK_RUNTIME": "   ",
+            "AWS_BEARER_TOKEN_BEDROCK": "  \t  ",
+        }):
+            with patch("agent.bedrock_adapter._require_boto3") as mock_boto3:
+                mock_boto3.return_value.client.return_value = mock_client
+                client = _get_bedrock_runtime_client("us-east-1")
+
+                mock_boto3.return_value.client.assert_called_once_with(
+                    "bedrock-runtime", region_name="us-east-1",
+                )
+                assert "us-east-1||" in _bedrock_runtime_client_cache
+
+
+class TestBearerTokenAuthEnvVarPriority:
+    """Test AWS_BEARER_TOKEN_BEDROCK credential resolution semantics."""
+
+    def test_bearer_token_with_endpoint_takes_priority(self):
+        from agent.bedrock_adapter import resolve_aws_auth_env_var
+        env = {
+            "AWS_BEARER_TOKEN_BEDROCK": "test-bearer-token",
+            "AWS_ENDPOINT_URL_BEDROCK_RUNTIME": "https://gateway.example.com/bedrock",
+            "AWS_ACCESS_KEY_ID": "AKIAIOSFODNN7EXAMPLE",
+            "AWS_SECRET_ACCESS_KEY": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            "AWS_PROFILE": "production",
+            "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI": "/v2/creds",
+            "AWS_WEB_IDENTITY_TOKEN_FILE": "/var/run/token",
+        }
+        assert resolve_aws_auth_env_var(env) == "AWS_BEARER_TOKEN_BEDROCK"
+
+    def test_bearer_token_without_endpoint_is_valid(self):
+        from agent.bedrock_adapter import resolve_aws_auth_env_var
+        env = {
+            "AWS_BEARER_TOKEN_BEDROCK": "test-bearer-token",
+            "AWS_ACCESS_KEY_ID": "AKIAIOSFODNN7EXAMPLE",
+            "AWS_SECRET_ACCESS_KEY": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        }
+        assert resolve_aws_auth_env_var(env) == "AWS_BEARER_TOKEN_BEDROCK"
+
+    def test_bearer_token_with_endpoint_indicates_custom_auth(self):
+        from agent.bedrock_adapter import has_aws_credentials
+        env = {
+            "AWS_BEARER_TOKEN_BEDROCK": "test-bearer-token",
+            "AWS_ENDPOINT_URL_BEDROCK_RUNTIME": "https://gateway.example.com/bedrock",
+        }
+        assert has_aws_credentials(env) is True
+
+    def test_bearer_token_alone_indicates_native_auth(self):
+        from agent.bedrock_adapter import has_aws_credentials
+        env = {"AWS_BEARER_TOKEN_BEDROCK": "native-aws-api-key"}
+        assert has_aws_credentials(env) is True
+
+
+class TestNativeBearerAuth:
+    """Bearer token without custom endpoint — native AWS Bedrock API keys."""
+
+    def test_bearer_only_creates_unsigned_client(self):
+        from agent.bedrock_adapter import _get_bedrock_runtime_client, reset_client_cache
+        from botocore import UNSIGNED
+        reset_client_cache()
+
+        with patch.dict(os.environ, {
+            "AWS_BEARER_TOKEN_BEDROCK": "native-api-key-123",
+        }, clear=False):
+            os.environ.pop("AWS_ENDPOINT_URL_BEDROCK_RUNTIME", None)
+            client = _get_bedrock_runtime_client("us-east-1")
+
+            assert client._client_config.signature_version is UNSIGNED
+            assert "bedrock-runtime" in client.meta.endpoint_url
+            assert "us-east-1" in client.meta.endpoint_url
+
+    def test_bearer_only_injects_auth_header(self):
+        from agent.bedrock_adapter import _get_bedrock_runtime_client, reset_client_cache
+        reset_client_cache()
+
+        with patch.dict(os.environ, {
+            "AWS_BEARER_TOKEN_BEDROCK": "native-api-key-abc",
+        }, clear=False):
+            os.environ.pop("AWS_ENDPOINT_URL_BEDROCK_RUNTIME", None)
+            client = _get_bedrock_runtime_client("us-east-1")
+
+            mock_request = MagicMock()
+            mock_request.headers = {}
+            client.meta.events.emit(
+                "before-sign.bedrock-runtime.Converse",
+                request=mock_request,
+            )
+            assert mock_request.headers["Authorization"] == "Bearer native-api-key-abc"
+
+    def test_bearer_rotation_gets_new_client(self):
+        from agent.bedrock_adapter import (
+            _bedrock_runtime_client_cache,
+            _get_bedrock_runtime_client,
+            reset_client_cache,
+        )
+        reset_client_cache()
+
+        with patch.dict(os.environ, {
+            "AWS_BEARER_TOKEN_BEDROCK": "token-v1",
+        }, clear=False):
+            os.environ.pop("AWS_ENDPOINT_URL_BEDROCK_RUNTIME", None)
+            client_v1 = _get_bedrock_runtime_client("us-east-1")
+
+        with patch.dict(os.environ, {
+            "AWS_BEARER_TOKEN_BEDROCK": "token-v2",
+        }, clear=False):
+            os.environ.pop("AWS_ENDPOINT_URL_BEDROCK_RUNTIME", None)
+            client_v2 = _get_bedrock_runtime_client("us-east-1")
+
+        assert client_v1 is not client_v2
+
+
+class TestBearerAuthViaSdkNative:
+    """Verify that bearer token auth uses the SDK's native api_key parameter."""
+
+    def test_build_bedrock_client_bearer_sets_api_key(self):
+        from agent.anthropic_adapter import build_anthropic_bedrock_client
+        import anthropic
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("AWS_ENDPOINT_URL_BEDROCK_RUNTIME", None)
+            os.environ.pop("AWS_BEARER_TOKEN_BEDROCK", None)
+            client = build_anthropic_bedrock_client(
+                "us-east-1",
+                endpoint_url="https://gateway.example.com/bedrock",
+                bearer_token="test-bearer-token",
+            )
+        assert isinstance(client, anthropic.AnthropicBedrock)
+        assert client.api_key == "test-bearer-token"
+
+    def test_build_bedrock_client_no_bearer_has_no_api_key(self):
+        import anthropic
+        from agent.anthropic_adapter import build_anthropic_bedrock_client
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("AWS_ENDPOINT_URL_BEDROCK_RUNTIME", None)
+            os.environ.pop("AWS_BEARER_TOKEN_BEDROCK", None)
+            client = build_anthropic_bedrock_client("us-east-1")
+        assert isinstance(client, anthropic.AnthropicBedrock)
+        assert client.api_key is None
+
+    def test_build_bedrock_client_bearer_uses_custom_base_url(self):
+        from agent.anthropic_adapter import build_anthropic_bedrock_client
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("AWS_ENDPOINT_URL_BEDROCK_RUNTIME", None)
+            os.environ.pop("AWS_BEARER_TOKEN_BEDROCK", None)
+            client = build_anthropic_bedrock_client(
+                "us-east-1",
+                endpoint_url="https://gateway.example.com/bedrock",
+                bearer_token="test-bearer-token",
+            )
+        assert "gateway.example.com" in str(client.base_url)
+
+
+class TestConfigOnlyRegionFallback:
+
+    def test_region_from_config_when_no_env_var(self):
+        from agent.bedrock_adapter import reset_client_cache
+        reset_client_cache()
+        mock_client = MagicMock()
+        mock_client.meta.endpoint_url = "https://gateway.example.com/bedrock"
+
+        fake_config = {"bedrock": {"region": "eu-west-1", "runtime_endpoint": "https://gateway.example.com/bedrock"}}
+
+        with patch.dict(os.environ, {
+            "AWS_BEARER_TOKEN_BEDROCK": "test-bearer-token",
+        }, clear=False):
+            os.environ.pop("AWS_ENDPOINT_URL_BEDROCK_RUNTIME", None)
+            os.environ.pop("AWS_REGION", None)
+            os.environ.pop("AWS_DEFAULT_REGION", None)
+            with patch("agent.bedrock_adapter._require_boto3") as mock_boto3, \
+                 patch("hermes_cli.config.load_config", return_value=fake_config):
+                mock_boto3.return_value.client.return_value = mock_client
+                from agent.bedrock_adapter import _resolve_custom_endpoint
+                endpoint = _resolve_custom_endpoint()
+                assert endpoint == "https://gateway.example.com/bedrock"
+
+    def test_region_from_bedrock_config_used_in_agent_init(self):
+        fake_config = {"bedrock": {"region": "ap-southeast-1", "runtime_endpoint": ""}}
+        with patch("hermes_cli.config.load_config", return_value=fake_config), \
+             patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("AWS_REGION", None)
+            os.environ.pop("AWS_DEFAULT_REGION", None)
+            from run_agent import _resolve_bedrock_region_for_init
+            region = _resolve_bedrock_region_for_init("")
+            assert region == "ap-southeast-1"
+
+class TestModeSwitchClearsEndpoint:
+
+    def test_clear_custom_bedrock_endpoint_removes_runtime_endpoint(self):
+        from hermes_cli.main import _clear_custom_bedrock_endpoint
+        cfg = {"bedrock": {"region": "us-east-1", "runtime_endpoint": "https://gw.example.com/bedrock"}}
+        _clear_custom_bedrock_endpoint(cfg)
+        assert cfg["bedrock"]["runtime_endpoint"] == ""
+
+    def test_clear_custom_bedrock_endpoint_noop_when_empty(self):
+        from hermes_cli.main import _clear_custom_bedrock_endpoint
+        cfg = {"bedrock": {"region": "us-east-1", "runtime_endpoint": ""}}
+        _clear_custom_bedrock_endpoint(cfg)
+        assert cfg["bedrock"]["runtime_endpoint"] == ""
+
+    def test_clear_custom_bedrock_endpoint_noop_when_missing(self):
+        from hermes_cli.main import _clear_custom_bedrock_endpoint
+        cfg = {"bedrock": {"region": "us-east-1"}}
+        _clear_custom_bedrock_endpoint(cfg)
+        assert cfg["bedrock"].get("runtime_endpoint") is None

--- a/website/docs/guides/aws-bedrock.md
+++ b/website/docs/guides/aws-bedrock.md
@@ -139,12 +139,56 @@ hermes gateway start
 
 The gateway reads `config.yaml` and uses the same Bedrock provider configuration.
 
+## Custom Endpoint (AI Gateway Proxies)
+
+Some organizations deploy AI gateway proxies that expose a Bedrock-compatible API with bearer token authentication instead of AWS SigV4. Hermes supports this via option 3 in the `hermes model` picker.
+
+### Setup
+
+```bash
+hermes model
+# → Choose "More providers..." → "AWS Bedrock"
+# → Choose "3. Custom Bedrock endpoint (Bearer token)"
+# → Enter your gateway URL and bearer token
+```
+
+The wizard stores the endpoint URL in `config.yaml` and the bearer token in `.env` (as a secret).
+
+### Configuration
+
+After setup, `~/.hermes/config.yaml` will contain:
+
+```yaml
+bedrock:
+  region: us-east-1
+  runtime_endpoint: https://ai-gateway.example.com/bedrock
+```
+
+And `~/.hermes/.env` will contain:
+
+```
+AWS_BEARER_TOKEN_BEDROCK=<your-token>
+```
+
+### Switching Back to IAM
+
+When you switch back to standard IAM auth (option 1 or 2 in `hermes model`), Hermes automatically clears `bedrock.runtime_endpoint` from the config so traffic returns to the standard AWS endpoint.
+
+### Power-User Override
+
+For scripting or CI, you can override the endpoint via environment variable — this takes priority over `config.yaml`:
+
+```bash
+export AWS_ENDPOINT_URL_BEDROCK_RUNTIME=https://ai-gateway.example.com/bedrock
+export AWS_BEARER_TOKEN_BEDROCK=<your-token>
+```
+
 ## Troubleshooting
 
 ### "No API key found" / "No AWS credentials"
 
 Hermes checks for credentials in this order:
-1. `AWS_BEARER_TOKEN_BEDROCK`
+1. `AWS_BEARER_TOKEN_BEDROCK` (native AWS Bedrock API key or custom endpoint bearer token)
 2. `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY`
 3. `AWS_PROFILE`
 4. EC2 instance metadata (IMDS)

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -75,6 +75,8 @@ All variables go in `~/.hermes/.env`. You can also set them with `hermes config 
 | `AWS_REGION` | AWS region for Bedrock inference (e.g. `us-east-1`, `eu-central-1`). Read by boto3. |
 | `AWS_PROFILE` | AWS named profile for Bedrock authentication (reads `~/.aws/credentials`). Leave unset to use default boto3 credential chain. |
 | `BEDROCK_BASE_URL` | Override Bedrock runtime base URL (default: `https://bedrock-runtime.us-east-1.amazonaws.com`; usually leave unset and use `AWS_REGION` instead) |
+| `AWS_BEARER_TOKEN_BEDROCK` | AWS Bedrock API key (native short/long-term) or bearer token for custom AI-gateway endpoints. See [Bedrock guide](../guides/aws-bedrock.md). |
+| `AWS_ENDPOINT_URL_BEDROCK_RUNTIME` | Custom Bedrock runtime endpoint URL (e.g. `https://ai-gateway.example.com/bedrock`). Overrides `bedrock.runtime_endpoint` in config.yaml. |
 | `HERMES_QWEN_BASE_URL` | Qwen Portal base URL override (default: `https://portal.qwen.ai/v1`) |
 | `OPENCODE_ZEN_API_KEY` | OpenCode Zen API key — pay-as-you-go access to curated models ([opencode.ai](https://opencode.ai/auth)) |
 | `OPENCODE_ZEN_BASE_URL` | Override OpenCode Zen base URL |


### PR DESCRIPTION
## What does this PR do?

Adds support for custom Bedrock runtime endpoints with bearer token authentication. This enables organizations that deploy AI gateway proxies (e.g. corporate gateways, LiteLLM, AWS PrivateLink endpoints) exposing a Bedrock-compatible API with bearer token auth instead of SigV4.

**Why this approach:** The change adds a third authentication path alongside the existing IAM (option 1) and API Key/mantle (option 2) flows. Bearer + custom endpoint uses an unsigned boto3 client with bearer injection via `before-sign` event handler for the Converse API, and the Anthropic SDK's native `api_key` parameter for the `anthropic_messages` path. This avoids patching request signing and works with both API modes.

Bearer tokens without a custom endpoint are also supported — this covers native AWS Bedrock API keys (short/long-term) which authenticate against the standard `bedrock-runtime.<region>.amazonaws.com` endpoint.

## Related Issue

No existing issue — this is a new feature request from an AI gateway proxy use case.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

**Core auth pipeline (4 files):**
- `agent/bedrock_adapter.py` — `_resolve_custom_endpoint()` (env→config fallback), `_get_bedrock_runtime_client()` handles 3 auth modes (SigV4, bearer+endpoint, bearer-only), cache key includes endpoint+bearer prefix, `resolve_aws_auth_env_var()` accepts bearer alone as valid auth, narrowed `except` clauses
- `agent/anthropic_adapter.py` — `build_anthropic_bedrock_client()` accepts optional `endpoint_url`/`bearer_token`, passes to `AnthropicBedrock(base_url=..., api_key=...)`
- `hermes_cli/runtime_provider.py` — `resolve_runtime_provider()` resolves custom endpoint for `base_url` (env var overrides config)
- `run_agent.py` — extracted `_resolve_bedrock_region_for_init()` (base_url regex → config → env fallback), replaces 2 inline regex blocks that defaulted to `us-east-1` when region wasn't in hostname

**Wizard + config (2 files):**
- `hermes_cli/main.py` — `_model_flow_bedrock_custom_endpoint()` (option 3 in `hermes model` → Bedrock), `_clear_custom_bedrock_endpoint()` cleanup when switching auth modes
- `hermes_cli/config.py` — `bedrock.runtime_endpoint` in `DEFAULT_CONFIG`, `AWS_BEARER_TOKEN_BEDROCK` in `OPTIONAL_ENV_VARS`

**Tests (1 file):**
- `tests/agent/test_bedrock_adapter.py` — +415 lines: `TestCustomEndpointBearerAuth` (unsigned client, bearer injection, cache keys, whitespace handling), `TestNativeBearerAuth` (bearer-only without endpoint), `TestBearerAuthViaSdkNative` (AnthropicBedrock api_key param), `TestBearerTokenAuthEnvVarPriority`, `TestConfigOnlyRegionFallback`, `TestModeSwitchClearsEndpoint`. Pre-existing stale-error tests updated for new cache key format.

**Docs (3 files):**
- `website/docs/guides/aws-bedrock.md` — "Custom Endpoint" section, env var override docs, updated troubleshooting credential order
- `website/docs/reference/environment-variables.md` — `AWS_BEARER_TOKEN_BEDROCK`, `AWS_ENDPOINT_URL_BEDROCK_RUNTIME`
- `cli-config.yaml.example` — `bedrock:` section with `region` and `runtime_endpoint`

## How to Test

1. **Custom endpoint + bearer (AI gateway proxy):**
   ```bash
   export AWS_ENDPOINT_URL_BEDROCK_RUNTIME=https://your-gateway.example.com/bedrock
   export AWS_BEARER_TOKEN_BEDROCK=your-token
   hermes -m bedrock:anthropic.claude-sonnet-4-20250514-v1:0
   ```

2. **Via wizard:**
   ```bash
   hermes model
   # → More providers... → AWS Bedrock → 3. Custom Bedrock endpoint
   ```

3. **Run tests:**
   ```bash
   pytest tests/agent/test_bedrock_adapter.py -q
   # 141 passed
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (no platform-specific code; all stdlib + boto3 + anthropic SDK)
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Notes

- 141/141 Bedrock-specific tests pass. 4 pre-existing test failures in `test_anthropic_adapter.py` reproduce on `main` and are unrelated to this PR.
- The `_resolve_custom_endpoint()` helper imports `hermes_cli.config.load_config` from the agent layer. This matches the existing pattern in `run_agent.py` (which already does the same for guardrail config). A neutral shared module would be cleaner but is out of scope for this PR.
- Env var `AWS_ENDPOINT_URL_BEDROCK_RUNTIME` follows the [AWS service-specific endpoint env var convention](https://docs.aws.amazon.com/sdkref/latest/guide/feature-ss-endpoints.html).