### PR TITLE
fix(cli): persist manual compress handoff

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7182,6 +7182,10 @@ class HermesCLI:
                 ):
                     self.session_id = self.agent.session_id
                     self._pending_title = None
+                    # Manual /compress replaces conversation_history with a new
+                    # compressed handoff for the child session. Persist it from
+                    # offset 0 so resume can recover the continuation after exit.
+                    self.agent._flush_messages_to_session_db(self.conversation_history, None)
                 new_tokens = estimate_messages_tokens_rough(self.conversation_history)
                 summary = summarize_manual_compression(
                     original_history,

--- a/tests/cli/test_manual_compress.py
+++ b/tests/cli/test_manual_compress.py
@@ -108,6 +108,57 @@ def test_manual_compress_syncs_session_id_after_split():
     assert shell._pending_title is None
 
 
+def test_manual_compress_flushes_compressed_history_to_child_session_db():
+    """Manual /compress must persist the handoff in the continuation DB.
+
+    _compress_context rotates the agent to a new child session and returns a
+    compressed transcript whose first messages include the handoff summary. The
+    CLI then replaces its in-memory conversation_history with that transcript.
+    Because the child DB starts empty, the flush must start from offset 0 rather
+    than treating the compressed history as already persisted.
+    """
+    shell = _make_cli()
+    history = _make_history()
+    old_id = shell.session_id
+    new_child_id = "20260101_000000_child1"
+    compressed = [
+        {"role": "user", "content": "[CONTEXT COMPACTION — REFERENCE ONLY] compacted"},
+        history[-1],
+    ]
+    shell.conversation_history = history
+    shell.agent = MagicMock()
+    shell.agent.compression_enabled = True
+    shell.agent._cached_system_prompt = ""
+    shell.agent.session_id = old_id
+
+    def _fake_compress(*args, **kwargs):
+        shell.agent.session_id = new_child_id
+        return (compressed, "")
+
+    shell.agent._compress_context.side_effect = _fake_compress
+
+    with patch("agent.model_metadata.estimate_messages_tokens_rough", return_value=100):
+        shell._manual_compress()
+
+    shell.agent._flush_messages_to_session_db.assert_called_once_with(compressed, None)
+
+
+def test_manual_compress_does_not_flush_full_history_when_session_id_unchanged():
+    shell = _make_cli()
+    history = _make_history()
+    shell.conversation_history = history
+    shell.agent = MagicMock()
+    shell.agent.compression_enabled = True
+    shell.agent._cached_system_prompt = ""
+    shell.agent.session_id = shell.session_id
+    shell.agent._compress_context.return_value = (list(history), "")
+
+    with patch("agent.model_metadata.estimate_messages_tokens_rough", return_value=100):
+        shell._manual_compress()
+
+    shell.agent._flush_messages_to_session_db.assert_not_called()
+
+
 def test_manual_compress_no_sync_when_session_id_unchanged():
     """If compression is a no-op (agent.session_id didn't change), the CLI
     must NOT clear _pending_title or otherwise disturb session state.


### PR DESCRIPTION
## Summary

Manual `/compress` now persists the compressed handoff transcript into the continuation child session DB when compression rotates the CLI to a new session.

## Root cause

`_compress_context()` can end the parent session and create a child continuation session, then return the compressed transcript containing the handoff summary. The CLI replaces its in-memory `conversation_history` with that transcript and syncs `self.session_id` to the child.

Without an immediate child DB flush, the handoff can remain only in process memory. If the CLI exits before a later normal turn flushes the child, resume follows the compression chain into a child session whose SQLite messages do not contain the handoff summary.

## Changes

- After manual `/compress` detects a session split, call `_flush_messages_to_session_db(self.conversation_history, None)` so the child DB is populated from offset 0.
- Keep no-op/no-split manual compression from flushing the full existing history again.
- Add regression tests for both split and no-split behavior.

## Validation

- `scripts/run_tests.sh tests/cli/test_manual_compress.py tests/test_cli_manual_compress.py -q` → 7 passed
- `python3 -m py_compile cli.py tests/cli/test_manual_compress.py tests/test_cli_manual_compress.py`
