### PR TITLE
test(update-autostash): include stdout in fake_run defaults so stale-dashboard scan doesn't crash

### DIFF
--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -328,12 +328,12 @@ def test_cmd_update_retries_optional_extras_individually_when_all_fails(monkeypa
         if cmd == ["/usr/bin/uv", "pip", "install", "-e", ".[all]", "--quiet"]:
             raise CalledProcessError(returncode=1, cmd=cmd)
         if cmd == ["/usr/bin/uv", "pip", "install", "-e", ".", "--quiet"]:
-            return SimpleNamespace(returncode=0)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
         if cmd == ["/usr/bin/uv", "pip", "install", "-e", ".[matrix]", "--quiet"]:
             raise CalledProcessError(returncode=1, cmd=cmd)
         if cmd == ["/usr/bin/uv", "pip", "install", "-e", ".[mcp]", "--quiet"]:
-            return SimpleNamespace(returncode=0)
-        return SimpleNamespace(returncode=0)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
 
     monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
 
@@ -370,7 +370,7 @@ def test_cmd_update_succeeds_with_extras(monkeypatch, tmp_path):
             return SimpleNamespace(stdout="1\n", stderr="", returncode=0)
         if cmd == ["git", "pull", "origin", "main"]:
             return SimpleNamespace(stdout="Updating\n", stderr="", returncode=0)
-        return SimpleNamespace(returncode=0)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
 
     monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
 


### PR DESCRIPTION
## Summary
- Lifts a CI baseline introduced by 66b114238 — two `cmd_update` integration tests in `test_update_autostash.py` have been crashing on `origin/main` since the `_warn_stale_dashboard_processes()` call landed in `_cmd_update_impl`.

## The bug
Commit 66b114238 (\"fix(cli): warn about stale dashboard processes after hermes update\") added a new

    subprocess.run([\"ps\", \"-A\", \"-o\", \"pid=,command=\"], capture_output=True, text=True, timeout=10)

call inside `_cmd_update_impl` and reads `result.stdout.split(\"\\n\")`. The two `cmd_update` integration tests in `tests/hermes_cli/test_update_autostash.py` mock `subprocess.run` with a catch-all `SimpleNamespace(returncode=0)` that omits `stdout`. After 66b114238, both tests crash inside `_warn_stale_dashboard_processes` with:

```
hermes_cli/main.py:5309: AttributeError
'types.SimpleNamespace' object has no attribute 'stdout'
```

Affected tests:
- `tests/hermes_cli/test_update_autostash.py::test_cmd_update_succeeds_with_extras`
- `tests/hermes_cli/test_update_autostash.py::test_cmd_update_retries_optional_extras_individually_when_all_fails`

Reproduces deterministically on a clean clone of `origin/main` (verified at `a830f25f7`).

## The fix
Add `stdout=\"\"`, `stderr=\"\"` to the catch-all `SimpleNamespace(returncode=0)` returns in both tests' `fake_run` so the new ps-scan finds zero dashboard processes and short-circuits cleanly. The two explicit pip-install branches that returned bare `SimpleNamespace(returncode=0)` are extended the same way for symmetry — no production behavior changes, only test fixture hygiene.

This is intentionally test-only. The production path is already covered by the `_warn_stale_dashboard_processes` regression tests added in #17123 (and the wmic-encoding fix in #17074).

## Test plan
- [x] `uv run --with pytest --with pytest-xdist python3 -m pytest tests/hermes_cli/test_update_autostash.py -v` — 23 passed, was 21 passed + 2 failed on `origin/main`.
- [x] `uv run --with pytest --with pytest-xdist python3 -m pytest tests/hermes_cli/test_update_stale_dashboard.py -v` — 10 passed (no regression).
- [x] Regression guard: removed the `stdout=\"\"` additions on a clean origin/main clone, reproduced the original `AttributeError: 'types.SimpleNamespace' object has no attribute 'stdout'` failure with identical traceback at `hermes_cli/main.py:5309`. Restored the fix, both tests pass.

## Related
- Source of the regression: 66b114238 (\"fix(cli): warn about stale dashboard processes after hermes update\"), fixes #16872.
- Production path is exercised by the regression suite added in #17123 and #17074.