### PR TITLE
fix(aux): honor explicit base_url for named providers; preserve /anthropic

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1775,6 +1775,14 @@ def _resolve_auto(main_runtime: Optional[Dict[str, Any]] = None) -> Tuple[Option
             resolved_provider = "custom"
             explicit_base_url = runtime_base_url
             explicit_api_key = runtime_api_key or None
+        elif runtime_base_url:
+            # Named provider with a user-overridden base_url (#16719) — forward
+            # it so the PROVIDER_REGISTRY branch can honor it instead of falling
+            # back to pconfig.inference_base_url.  Without this, configuring
+            # provider=zai + base_url=https://custom/v1 silently sends auxiliary
+            # traffic to z.ai's default endpoint.
+            explicit_base_url = runtime_base_url
+            explicit_api_key = runtime_api_key or None
         client, resolved = resolve_provider_client(
             resolved_provider,
             main_model,
@@ -2047,7 +2055,21 @@ def resolve_provider_client(
     # ── Custom endpoint (OPENAI_BASE_URL + OPENAI_API_KEY) ───────────
     if provider == "custom":
         if explicit_base_url:
-            custom_base = _to_openai_base_url(explicit_base_url).strip()
+            # When the endpoint speaks Anthropic Messages, preserve the
+            # /anthropic suffix — _to_openai_base_url would rewrite it to /v1
+            # and the AnthropicAuxiliaryClient wrapping below would then point
+            # at a route that doesn't exist (#17086).  Mirrors the same guard
+            # in _try_custom_endpoint() and the named-provider branches.
+            _raw_explicit = explicit_base_url.strip().rstrip("/")
+            _is_anthropic_endpoint = (
+                api_mode == "anthropic_messages"
+                or _endpoint_speaks_anthropic_messages(_raw_explicit)
+            )
+            custom_base = (
+                _raw_explicit
+                if _is_anthropic_endpoint
+                else _to_openai_base_url(_raw_explicit).strip()
+            )
             custom_key = (
                 (explicit_api_key or "").strip()
                 or os.getenv("OPENAI_API_KEY", "").strip()
@@ -2203,7 +2225,13 @@ def resolve_provider_client(
             return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode else (client, final_model))
 
         creds = resolve_api_key_provider_credentials(provider)
-        api_key = str(creds.get("api_key", "")).strip()
+        # Honor explicit_base_url / explicit_api_key forwarded by _resolve_auto
+        # when a named provider has a user-overridden base_url (#16719).
+        # Without this, "provider: zai, base_url: https://custom/v1" silently
+        # routes auxiliary traffic to zai's default endpoint.
+        _explicit_base = (explicit_base_url or "").strip().rstrip("/")
+        _explicit_key = (explicit_api_key or "").strip()
+        api_key = _explicit_key or str(creds.get("api_key", "")).strip()
         if not api_key:
             tried_sources = list(pconfig.api_key_env_vars)
             if provider == "copilot":
@@ -2213,8 +2241,21 @@ def resolve_provider_client(
                          provider, ", ".join(tried_sources))
             return None, None
 
-        base_url = _to_openai_base_url(
-            str(creds.get("base_url", "")).strip().rstrip("/") or pconfig.inference_base_url
+        _resolved_base = (
+            _explicit_base
+            or str(creds.get("base_url", "")).strip().rstrip("/")
+            or pconfig.inference_base_url
+        )
+        # Skip the /anthropic → /v1 rewrite when the endpoint speaks Anthropic
+        # Messages, same reasoning as the custom branch above (#17086).
+        _is_anthropic_endpoint = (
+            api_mode == "anthropic_messages"
+            or _endpoint_speaks_anthropic_messages(_resolved_base)
+        )
+        base_url = (
+            _resolved_base
+            if _is_anthropic_endpoint
+            else _to_openai_base_url(_resolved_base)
         )
 
         default_model = _API_KEY_PROVIDER_AUX_MODELS.get(provider, "")

--- a/tests/agent/test_auxiliary_named_custom_providers.py
+++ b/tests/agent/test_auxiliary_named_custom_providers.py
@@ -230,6 +230,138 @@ class TestResolveProviderClientModelNormalization:
         assert model == "anthropic/claude-sonnet-4.6"
 
 
+class TestExplicitBaseUrlForNamedProvider:
+    """#16719: PROVIDER_REGISTRY branch must honor explicit_base_url /
+    explicit_api_key forwarded by _resolve_auto, instead of always falling
+    back to pconfig.inference_base_url."""
+
+    def test_explicit_base_url_overrides_provider_default(self, tmp_path):
+        _write_config(tmp_path, {
+            "model": {"default": "glm-5.1", "provider": "zai"},
+        })
+        with (
+            patch("hermes_cli.auth.resolve_api_key_provider_credentials", return_value={
+                "api_key": "creds-key",
+                "base_url": "https://api.z.ai/api/paas/v4",
+            }),
+            patch("agent.auxiliary_client.OpenAI") as mock_openai,
+        ):
+            mock_openai.return_value = MagicMock()
+            from agent.auxiliary_client import resolve_provider_client
+
+            client, model = resolve_provider_client(
+                "zai",
+                "glm-5.1",
+                explicit_base_url="https://custom-zai.example.com/v1",
+                explicit_api_key="explicit-key",
+            )
+
+        assert client is not None
+        assert model == "glm-5.1"
+        kwargs = mock_openai.call_args.kwargs
+        assert kwargs["base_url"] == "https://custom-zai.example.com/v1"
+        assert kwargs["api_key"] == "explicit-key"
+
+    def test_falls_back_to_creds_when_no_explicit(self, tmp_path):
+        """Regression: existing behavior preserved when explicit_* not given."""
+        _write_config(tmp_path, {
+            "model": {"default": "glm-5.1", "provider": "zai"},
+        })
+        with (
+            patch("hermes_cli.auth.resolve_api_key_provider_credentials", return_value={
+                "api_key": "creds-key",
+                "base_url": "https://api.z.ai/api/paas/v4",
+            }),
+            patch("agent.auxiliary_client.OpenAI") as mock_openai,
+        ):
+            mock_openai.return_value = MagicMock()
+            from agent.auxiliary_client import resolve_provider_client
+
+            client, _ = resolve_provider_client("zai", "glm-5.1")
+
+        kwargs = mock_openai.call_args.kwargs
+        assert "api.z.ai" in kwargs["base_url"]
+        assert kwargs["api_key"] == "creds-key"
+
+
+class TestAnthropicMessagesPreservesPath:
+    """#17086: when api_mode=anthropic_messages or the URL ends in /anthropic,
+    the /anthropic suffix must NOT be rewritten to /v1 — the AnthropicAuxiliary
+    wrapper expects to talk to the original /anthropic surface."""
+
+    def test_custom_branch_keeps_anthropic_suffix_with_explicit_api_mode(self, tmp_path):
+        from unittest.mock import patch as _patch
+        with _patch("agent.anthropic_adapter.build_anthropic_client") as mock_build:
+            mock_build.return_value = MagicMock(name="anthropic_sdk_client")
+            from agent.auxiliary_client import resolve_provider_client
+
+            client, _ = resolve_provider_client(
+                "custom",
+                "claude-3-5",
+                explicit_base_url="http://localhost:6655/anthropic/",
+                explicit_api_key="k",
+                api_mode="anthropic_messages",
+            )
+        assert client is not None
+        # build_anthropic_client must be called with the original /anthropic
+        # path, not the rewritten /v1.
+        called_base = mock_build.call_args.args[1] if mock_build.call_args.args else \
+            mock_build.call_args.kwargs.get("base_url", "")
+        assert called_base.endswith("/anthropic"), (
+            f"Anthropic adapter must receive the /anthropic path, got: {called_base!r}"
+        )
+
+    def test_custom_branch_rewrites_when_no_anthropic_signal(self, tmp_path):
+        """Regression: non-Anthropic /anthropic URLs (none in practice, but
+        guard against the gate misfiring) — when api_mode is unset and
+        endpoint isn't recognized as Anthropic, no rewrite should happen
+        either, since the URL doesn't end in /anthropic."""
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            from agent.auxiliary_client import resolve_provider_client
+
+            client, _ = resolve_provider_client(
+                "custom",
+                "gpt-4o",
+                explicit_base_url="https://api.example.com/v1",
+                explicit_api_key="k",
+            )
+        assert client is not None
+        assert mock_openai.call_args.kwargs["base_url"] == "https://api.example.com/v1"
+
+
+class TestResolveAutoForwardsBaseUrlForNamedProvider:
+    """#16719: _resolve_auto must forward main_runtime.base_url as
+    explicit_base_url for ANY provider, not just 'custom' / 'custom:*'.
+    Without this, configuring `provider: zai, base_url: <custom>` silently
+    routes auxiliary traffic to z.ai's default endpoint."""
+
+    def test_named_provider_with_custom_base_url_forwards(self, tmp_path):
+        _write_config(tmp_path, {
+            "model": {"default": "glm-5.1", "provider": "zai"},
+        })
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+        ) as mock_resolve:
+            mock_resolve.return_value = (MagicMock(), "glm-5.1")
+            from agent.auxiliary_client import _resolve_auto
+
+            _resolve_auto(main_runtime={
+                "provider": "zai",
+                "model": "glm-5.1",
+                "base_url": "https://custom-zai.example.com/v1",
+                "api_key": "user-key",
+                "api_mode": "",
+            })
+
+        assert mock_resolve.called
+        kwargs = mock_resolve.call_args.kwargs
+        assert kwargs["explicit_base_url"] == "https://custom-zai.example.com/v1"
+        assert kwargs["explicit_api_key"] == "user-key"
+        # provider stays "zai" — not rewritten to "custom".
+        assert mock_resolve.call_args.args[0] == "zai"
+
+
 class TestResolveVisionProviderClientModelNormalization:
     """Vision auto-routing should reuse the same provider-specific normalization."""
 


### PR DESCRIPTION
## Summary

Three related config-inheritance bugs in `agent/auxiliary_client.py` that
surface when the auxiliary client (compression, title generation, vision,
session search, etc.) tries to reuse the user's main provider config:

1. **`_resolve_auto` only forwarded `base_url` for `custom` / `custom:*`
   providers (#16719).** With `provider: zai` + `base_url: <override>`, the
   override was silently dropped and auxiliary traffic went to z.ai's
   default endpoint. Now forwarded as `explicit_base_url` /
   `explicit_api_key` for any named provider.

2. **PROVIDER_REGISTRY branch ignored `explicit_base_url` / `explicit_api_key`.**
   Even after fix (1), the named-provider branch unconditionally pulled
   `base_url` from `creds["base_url"]` or `pconfig.inference_base_url`. Now
   prefers the forwarded explicit values.

3. **`custom` branch unconditionally rewrote `/anthropic` → `/v1` (#17086).**
   `_to_openai_base_url()` is the right normalization for OpenAI-wire
   gateways, but for `api_mode: anthropic_messages` (or any URL the
   `_endpoint_speaks_anthropic_messages()` heuristic recognizes) the
   rewrite breaks the AnthropicAuxiliaryClient — requests land on
   `/v1/chat/completions` instead of `/anthropic/v1/messages` → 404 on
   every aux task. The same guard already existed in
   `_try_custom_endpoint()` and the named-custom-provider branch; this PR
   extends it to the `explicit_base_url` custom branch and the
   PROVIDER_REGISTRY branch.

Out of scope (mentioned in the original issues but separately resolved):

- `github-copilot` slug normalization (#15017) was already addressed in
  commit 2e2de12.
- `title_generator.py` / `context_compressor.py` already pass `main_runtime`
  to `call_llm()`; the original issue's claim about missing `main_runtime`
  is stale.

## Test plan

- [x] `tests/agent/test_auxiliary_named_custom_providers.py` — 31 passed
      (3 new test classes, 5 new tests)
- [x] `tests/agent/test_auxiliary_client.py` — 194 sync tests pass; 5
      pre-existing async failures unrelated (require `pytest-asyncio`)
- [x] `tests/agent/test_auxiliary_client_anthropic_custom.py` — passes
      (existing `_try_custom_endpoint` anthropic_messages coverage)
- [x] `tests/agent/test_auxiliary_main_first.py`,
      `test_auxiliary_transport_autodetect.py`,
      `test_minimax_auxiliary_url.py`,
      `test_auxiliary_config_bridge.py` — all pass
- [x] `tests/agent/test_context_compressor.py` — 65 passed (no compression
      regressions)
- [ ] Manual: configure `provider: zai` + `base_url:
      https://custom-zai.example.com/v1` and verify compression hits the
      custom URL (logs show `Auxiliary auto-detect: using main provider zai`
      and the request goes to the override).
- [ ] Manual: configure custom Anthropic-compat proxy with `api_mode:
      anthropic_messages` + `base_url: http://localhost:6655/anthropic/`
      and verify auxiliary tasks no longer 404.

Closes: #16719, #17086
