### PR TITLE
Fix Discord slash sync default diff

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -808,8 +808,10 @@ class DiscordAdapter(BasePlatformAdapter):
                 logger.info("[%s] Skipping Discord slash command sync (policy=off)", self.name)
                 return
 
+            timeout = self._get_discord_command_sync_timeout()
+
             if sync_policy == "bulk":
-                synced = await asyncio.wait_for(self._client.tree.sync(), timeout=30)
+                synced = await asyncio.wait_for(self._client.tree.sync(), timeout=timeout)
                 logger.info("[%s] Synced %d slash command(s) via bulk tree sync", self.name, len(synced))
                 return
 
@@ -820,7 +822,7 @@ class DiscordAdapter(BasePlatformAdapter):
             # left slash commands broken for ~60 min until the bucket fully
             # recovered. Use a wide ceiling; the cap still guards against a
             # true hang. (#16713)
-            summary = await asyncio.wait_for(self._safe_sync_slash_commands(), timeout=600)
+            summary = await asyncio.wait_for(self._safe_sync_slash_commands(), timeout=timeout)
             logger.info(
                 "[%s] Safely reconciled %d slash command(s): unchanged=%d updated=%d recreated=%d created=%d deleted=%d",
                 self.name,
@@ -833,9 +835,10 @@ class DiscordAdapter(BasePlatformAdapter):
             )
         except asyncio.TimeoutError:
             logger.warning(
-                "[%s] Slash command sync timed out — Discord rate-limit bucket "
+                "[%s] Slash command sync timed out after %ss; Discord rate-limit bucket "
                 "may be saturated; will retry on next reconnect",
                 self.name,
+                self._get_discord_command_sync_timeout(),
             )
         except asyncio.CancelledError:
             raise
@@ -853,6 +856,26 @@ class DiscordAdapter(BasePlatformAdapter):
                 raw,
             )
         return "safe"
+
+    def _get_discord_command_sync_timeout(self) -> float:
+        raw = str(os.getenv("DISCORD_COMMAND_SYNC_TIMEOUT", "600") or "").strip()
+        try:
+            timeout = float(raw)
+        except ValueError:
+            logger.warning(
+                "[%s] Invalid DISCORD_COMMAND_SYNC_TIMEOUT=%r; falling back to 600s",
+                self.name,
+                raw,
+            )
+            return 600.0
+        if timeout <= 0:
+            logger.warning(
+                "[%s] Invalid DISCORD_COMMAND_SYNC_TIMEOUT=%r; falling back to 600s",
+                self.name,
+                raw,
+            )
+            return 600.0
+        return timeout
 
     def _canonicalize_app_command_payload(self, payload: Dict[str, Any]) -> Dict[str, Any]:
         """Reduce command payloads to the semantic fields Hermes manages."""
@@ -945,6 +968,22 @@ class DiscordAdapter(BasePlatformAdapter):
             "options": canonical["options"],
         }
 
+    def _normalize_discord_server_defaults(
+        self, current: Dict[str, Any], desired: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Ignore Discord-filled defaults for fields Hermes did not set.
+
+        Discord returns integration_types for existing global commands even
+        when discord.py's desired payload omits integration_types. Hermes does
+        not currently manage that field, so treating it as a mismatch makes
+        every command look changed and triggers a delete+recreate storm on each
+        gateway startup.
+        """
+        normalized = dict(current)
+        if desired.get("integration_types") is None:
+            normalized["integration_types"] = None
+        return normalized
+
     async def _safe_sync_slash_commands(self) -> Dict[str, int]:
         """Diff existing global commands and only mutate the commands that changed."""
         if not self._client:
@@ -993,6 +1032,9 @@ class DiscordAdapter(BasePlatformAdapter):
             current_existing_payload = self._existing_command_to_payload(current)
             current_payload = self._canonicalize_app_command_payload(current_existing_payload)
             desired_payload = self._canonicalize_app_command_payload(desired)
+            current_payload = self._normalize_discord_server_defaults(
+                current_payload, desired_payload
+            )
             if current_payload == desired_payload:
                 unchanged += 1
                 continue

--- a/scripts/discord-slash-sync-doctor.py
+++ b/scripts/discord-slash-sync-doctor.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Diagnose Discord slash-command sync without mutating Discord.
+
+The gateway sync path is intentionally conservative, but Discord can return
+server-filled defaults that make every command look different. This script
+rebuilds Hermes' desired command payloads, fetches the currently registered
+global commands, and prints the dry-run sync plan plus timing for each phase.
+
+Usage:
+  python scripts/discord-slash-sync-doctor.py
+  HERMES_HOME=/path/to/.hermes python scripts/discord-slash-sync-doctor.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+API_BASE = "https://discord.com/api/v10"
+
+
+def _load_token() -> str:
+    token = os.getenv("DISCORD_BOT_TOKEN", "").strip()
+    if token:
+        return token
+
+    hermes_home = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes"))
+    env_path = hermes_home / ".env"
+    if not env_path.exists():
+        raise SystemExit("DISCORD_BOT_TOKEN is not set and ~/.hermes/.env was not found")
+
+    for line in env_path.read_text().splitlines():
+        if not line or line.lstrip().startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        if key == "DISCORD_BOT_TOKEN":
+            value = value.strip().strip('"').strip("'")
+            if value:
+                return value
+    raise SystemExit("DISCORD_BOT_TOKEN was not found")
+
+
+def _request_json(token: str, path: str, timeout: float = 30.0) -> tuple[float, Any]:
+    request = urllib.request.Request(
+        API_BASE + path,
+        headers={
+            "Authorization": f"Bot {token}",
+            "User-Agent": "Hermes Discord slash sync doctor",
+        },
+    )
+    start = time.monotonic()
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            payload = json.loads(response.read().decode())
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode(errors="replace")
+        raise SystemExit(f"Discord API returned HTTP {exc.code} for {path}: {body[:500]}") from exc
+    return time.monotonic() - start, payload
+
+
+def _command_key(payload: dict[str, Any]) -> tuple[int, str]:
+    return (int(payload.get("type", 1) or 1), str(payload.get("name", "") or "").lower())
+
+
+async def main() -> None:
+    token = _load_token()
+
+    from gateway.config import PlatformConfig
+    from gateway.platforms.discord import DiscordAdapter
+    import discord
+    from discord.ext import commands
+
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token=token))
+    bot = commands.Bot(command_prefix="!", intents=discord.Intents.default())
+    adapter._client = bot
+
+    start = time.monotonic()
+    adapter._register_slash_commands()
+    register_seconds = time.monotonic() - start
+    desired_payloads = [command.to_dict(bot.tree) for command in bot.tree.get_commands()]
+
+    app_seconds, app = _request_json(token, "/oauth2/applications/@me")
+    app_id = app.get("id")
+    if not app_id:
+        raise SystemExit("Could not resolve Discord application id")
+
+    fetch_seconds, existing_payloads = _request_json(token, f"/applications/{app_id}/commands")
+    if not isinstance(existing_payloads, list):
+        raise SystemExit("Unexpected Discord commands response")
+
+    desired_by_key = {_command_key(payload): payload for payload in desired_payloads}
+    existing_by_key = {_command_key(payload): payload for payload in existing_payloads}
+
+    unchanged: list[str] = []
+    edit: list[str] = []
+    recreate: list[str] = []
+    create: list[str] = []
+
+    for key, desired in desired_by_key.items():
+        existing = existing_by_key.pop(key, None)
+        if existing is None:
+            create.append(str(desired.get("name", "")))
+            continue
+
+        current_payload = adapter._canonicalize_app_command_payload(existing)
+        desired_payload = adapter._canonicalize_app_command_payload(desired)
+        current_payload = adapter._normalize_discord_server_defaults(
+            current_payload, desired_payload
+        )
+        if current_payload == desired_payload:
+            unchanged.append(str(desired.get("name", "")))
+            continue
+
+        if adapter._patchable_app_command_payload(existing) == adapter._patchable_app_command_payload(desired):
+            recreate.append(str(desired.get("name", "")))
+        else:
+            edit.append(str(desired.get("name", "")))
+
+    delete = [str(payload.get("name", "")) for payload in existing_by_key.values()]
+
+    print(json.dumps({
+        "application_id": app_id,
+        "application_name": app.get("name"),
+        "timing_seconds": {
+            "build_desired": round(register_seconds, 3),
+            "fetch_application": round(app_seconds, 3),
+            "fetch_existing_commands": round(fetch_seconds, 3),
+        },
+        "counts": {
+            "desired": len(desired_payloads),
+            "existing": len(existing_payloads),
+            "unchanged": len(unchanged),
+            "edit": len(edit),
+            "recreate": len(recreate),
+            "create": len(create),
+            "delete": len(delete),
+        },
+        "mutations": {
+            "edit": edit,
+            "recreate": recreate,
+            "create": create,
+            "delete": delete,
+        },
+    }, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -385,6 +385,79 @@ async def test_safe_sync_slash_commands_only_mutates_diffs():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("integration_types", ([0], [1]))
+async def test_safe_sync_slash_commands_ignores_discord_default_integration_types(
+    integration_types,
+):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+
+    class _DesiredCommand:
+        def __init__(self, payload):
+            self._payload = payload
+
+        def to_dict(self, tree):
+            assert tree is not None
+            return dict(self._payload)
+
+    class _ExistingCommand:
+        def __init__(self, command_id, payload):
+            self.id = command_id
+            self.name = payload["name"]
+            self.type = SimpleNamespace(value=payload["type"])
+            self._payload = payload
+
+        def to_dict(self):
+            return {
+                "id": self.id,
+                "application_id": 999,
+                **self._payload,
+                "name_localizations": {},
+                "description_localizations": {},
+            }
+
+    desired = {
+        "name": "status",
+        "description": "Show Hermes session status",
+        "type": 1,
+        "options": [],
+        "nsfw": False,
+        "dm_permission": True,
+        "default_member_permissions": None,
+    }
+    existing = _ExistingCommand(11, {**desired, "integration_types": integration_types})
+
+    fake_tree = SimpleNamespace(
+        get_commands=lambda: [_DesiredCommand(desired)],
+        fetch_commands=AsyncMock(return_value=[existing]),
+    )
+    fake_http = SimpleNamespace(
+        upsert_global_command=AsyncMock(),
+        edit_global_command=AsyncMock(),
+        delete_global_command=AsyncMock(),
+    )
+    adapter._client = SimpleNamespace(
+        tree=fake_tree,
+        http=fake_http,
+        application_id=999,
+        user=SimpleNamespace(id=999),
+    )
+
+    summary = await adapter._safe_sync_slash_commands()
+
+    assert summary == {
+        "total": 1,
+        "unchanged": 1,
+        "updated": 0,
+        "recreated": 0,
+        "created": 0,
+        "deleted": 0,
+    }
+    fake_http.edit_global_command.assert_not_awaited()
+    fake_http.delete_global_command.assert_not_awaited()
+    fake_http.upsert_global_command.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_safe_sync_slash_commands_recreates_metadata_only_diffs():
     adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
 


### PR DESCRIPTION
Fixes #17157

## Summary

This fixes Discord slash-command safe sync repeatedly recreating unchanged commands when Discord returns server-filled `integration_types` for commands whose desired Hermes payload omits that field.

## Root Cause

Hermes compares canonical current command payloads with desired command payloads before deciding whether to edit, recreate, create, or delete commands. Discord returns `integration_types` for existing global commands even when the desired command from `discord.py` does not set it. In the live path, `discord.py` surfaced the server default as `[0]`; in direct REST triage, the raw payload surfaced another default shape. Because Hermes does not manage this field, the comparison treated all managed commands as metadata mismatches and tried to delete/upsert the full command set on every gateway startup. That mutation storm could exceed the startup sync timeout.

## Changes

- Normalize server-filled `integration_types` out of the current payload when the desired Hermes payload omits it.
- Keep the existing safe-sync behavior for fields Hermes actually manages.
- Add `DISCORD_COMMAND_SYNC_TIMEOUT` so deployments can tune the timeout without code edits.
- Add a regression test for both observed default `integration_types` shapes.
- Add a read-only `scripts/discord-slash-sync-doctor.py` helper that builds desired commands, fetches registered Discord commands, and prints the dry-run mutation plan.

## Validation

- `python -m pytest tests/gateway/test_discord_connect.py -q`
- `python -m py_compile gateway/platforms/discord.py tests/gateway/test_discord_connect.py scripts/discord-slash-sync-doctor.py`
- Ran the doctor against a live Discord application before/after cleanup: final plan was 35 desired, 35 existing, 35 unchanged, and no pending mutations.
- Restarted a live gateway with slash sync enabled: it reconciled successfully with `unchanged=35 updated=0 recreated=0 created=0 deleted=6` instead of timing out.
