### PR TITLE
feat(gateway): WhatsApp inbound plain-text batching (Telegram-style)

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -268,15 +268,19 @@ class WhatsAppAdapter(BasePlatformAdapter):
         self._group_policy = str(config.extra.get("group_policy") or os.getenv("WHATSAPP_GROUP_POLICY", "open")).strip().lower()
         self._group_allow_from = self._coerce_allow_list(config.extra.get("group_allow_from") or config.extra.get("groupAllowFrom"))
         self._mention_patterns = self._compile_mention_patterns()
-        # Plain-text batching before dispatch (`HERMES_WHATSAPP_TEXT_BATCH_*`).
         self._text_batch_delay_seconds = float(
             os.getenv("HERMES_WHATSAPP_TEXT_BATCH_DELAY_SECONDS", "0.6")
         )
         self._text_batch_split_delay_seconds = float(
             os.getenv("HERMES_WHATSAPP_TEXT_BATCH_SPLIT_DELAY_SECONDS", "2.0")
         )
+        self._media_batch_delay_seconds = float(
+            os.getenv("HERMES_WHATSAPP_MEDIA_BATCH_DELAY_SECONDS", "0.8")
+        )
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
+        self._pending_photo_batches: Dict[str, MessageEvent] = {}
+        self._pending_photo_batch_tasks: Dict[str, asyncio.Task] = {}
         self._message_queue: asyncio.Queue = asyncio.Queue()
         self._bridge_log_fh = None
         self._bridge_log: Optional[Path] = None
@@ -808,7 +812,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
                 pass
         self._poll_task = None
 
-        self._cancel_pending_text_batches()
+        self._cancel_pending_inbound_batches()
 
         # Close the persistent HTTP session
         if self._http_session and not self._http_session.closed:
@@ -1133,16 +1137,21 @@ class WhatsAppAdapter(BasePlatformAdapter):
         return {"name": chat_id, "type": "dm"}
 
     # ------------------------------------------------------------------
-    # Text batching
+    # Text and photo batching before dispatch
     # ------------------------------------------------------------------
 
-    def _cancel_pending_text_batches(self) -> None:
-        """Cancel flush timers and drop buffered text (disconnect)."""
+    def _cancel_pending_inbound_batches(self) -> None:
+        """Cancel flush timers and drop buffered text/photo batches (disconnect)."""
         for task in self._pending_text_batch_tasks.values():
             if not task.done():
                 task.cancel()
         self._pending_text_batch_tasks.clear()
         self._pending_text_batches.clear()
+        for task in self._pending_photo_batch_tasks.values():
+            if not task.done():
+                task.cancel()
+        self._pending_photo_batch_tasks.clear()
+        self._pending_photo_batches.clear()
 
     def _text_batch_key(self, event: MessageEvent) -> str:
         """Session-scoped key for text message batching."""
@@ -1196,6 +1205,47 @@ class WhatsAppAdapter(BasePlatformAdapter):
             if self._pending_text_batch_tasks.get(key) is current_task:
                 self._pending_text_batch_tasks.pop(key, None)
 
+    def _photo_batch_key(self, event: MessageEvent) -> str:
+        """Return a batching key for photo bursts (WhatsApp bridge has no album id)."""
+        return f"{self._text_batch_key(event)}:photo-burst"
+
+    def _enqueue_photo_event(self, event: MessageEvent) -> None:
+        """Merge photo events into a pending batch and schedule flush."""
+        batch_key = self._photo_batch_key(event)
+        existing = self._pending_photo_batches.get(batch_key)
+        if existing is None:
+            self._pending_photo_batches[batch_key] = event
+        else:
+            existing.media_urls.extend(event.media_urls)
+            existing.media_types.extend(event.media_types)
+            if event.text:
+                existing.text = self._merge_caption(existing.text, event.text)
+
+        prior_task = self._pending_photo_batch_tasks.get(batch_key)
+        if prior_task and not prior_task.done():
+            prior_task.cancel()
+        self._pending_photo_batch_tasks[batch_key] = asyncio.create_task(
+            self._flush_photo_batch(batch_key)
+        )
+
+    async def _flush_photo_batch(self, batch_key: str) -> None:
+        """Wait for quiet period, then dispatch merged images as one event."""
+        current_task = asyncio.current_task()
+        try:
+            await asyncio.sleep(self._media_batch_delay_seconds)
+            event = self._pending_photo_batches.pop(batch_key, None)
+            if not event:
+                return
+            logger.info(
+                "[WhatsApp] Flushing photo batch %s with %d image(s)",
+                batch_key,
+                len(event.media_urls),
+            )
+            await self.handle_message(event)
+        finally:
+            if self._pending_photo_batch_tasks.get(batch_key) is current_task:
+                self._pending_photo_batch_tasks.pop(batch_key, None)
+
     async def _poll_messages(self) -> None:
         """Poll the bridge for incoming messages."""
         import aiohttp
@@ -1224,6 +1274,12 @@ class WhatsAppAdapter(BasePlatformAdapter):
                                 and not event.media_urls
                             ):
                                 self._enqueue_text_event(event)
+                            elif (
+                                self._media_batch_delay_seconds > 0
+                                and event.message_type == MessageType.PHOTO
+                                and event.media_urls
+                            ):
+                                self._enqueue_photo_event(event)
                             else:
                                 await self.handle_message(event)
             except asyncio.CancelledError:

--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -189,6 +189,7 @@ from gateway.platforms.base import (
     cache_image_from_url,
     cache_audio_from_url,
 )
+from gateway.session import build_session_key
 
 
 def check_whatsapp_requirements() -> bool:
@@ -243,7 +244,9 @@ class WhatsAppAdapter(BasePlatformAdapter):
     # WhatsApp allows ~65K but long messages are unreadable on mobile.
     MAX_MESSAGE_LENGTH = 4096
     DEFAULT_REPLY_PREFIX = "⚕ *Hermes Agent*\n────────────\n"
-    
+
+    # Near-limit chunks likely get a quick follow-up; use split delay (Telegram pattern).
+    _SPLIT_THRESHOLD = 4000
     # Default bridge location relative to the hermes-agent install
     _DEFAULT_BRIDGE_DIR = Path(__file__).resolve().parents[2] / "scripts" / "whatsapp-bridge"
 
@@ -265,6 +268,15 @@ class WhatsAppAdapter(BasePlatformAdapter):
         self._group_policy = str(config.extra.get("group_policy") or os.getenv("WHATSAPP_GROUP_POLICY", "open")).strip().lower()
         self._group_allow_from = self._coerce_allow_list(config.extra.get("group_allow_from") or config.extra.get("groupAllowFrom"))
         self._mention_patterns = self._compile_mention_patterns()
+        # Plain-text batching before dispatch (`HERMES_WHATSAPP_TEXT_BATCH_*`).
+        self._text_batch_delay_seconds = float(
+            os.getenv("HERMES_WHATSAPP_TEXT_BATCH_DELAY_SECONDS", "0.6")
+        )
+        self._text_batch_split_delay_seconds = float(
+            os.getenv("HERMES_WHATSAPP_TEXT_BATCH_SPLIT_DELAY_SECONDS", "2.0")
+        )
+        self._pending_text_batches: Dict[str, MessageEvent] = {}
+        self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
         self._message_queue: asyncio.Queue = asyncio.Queue()
         self._bridge_log_fh = None
         self._bridge_log: Optional[Path] = None
@@ -796,6 +808,8 @@ class WhatsAppAdapter(BasePlatformAdapter):
                 pass
         self._poll_task = None
 
+        self._cancel_pending_text_batches()
+
         # Close the persistent HTTP session
         if self._http_session and not self._http_session.closed:
             await self._http_session.close()
@@ -1117,7 +1131,71 @@ class WhatsAppAdapter(BasePlatformAdapter):
             logger.debug("Could not get WhatsApp chat info for %s: %s", chat_id, e)
         
         return {"name": chat_id, "type": "dm"}
-    
+
+    # ------------------------------------------------------------------
+    # Text batching
+    # ------------------------------------------------------------------
+
+    def _cancel_pending_text_batches(self) -> None:
+        """Cancel flush timers and drop buffered text (disconnect)."""
+        for task in self._pending_text_batch_tasks.values():
+            if not task.done():
+                task.cancel()
+        self._pending_text_batch_tasks.clear()
+        self._pending_text_batches.clear()
+
+    def _text_batch_key(self, event: MessageEvent) -> str:
+        """Session-scoped key for text message batching."""
+        return build_session_key(
+            event.source,
+            group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
+            thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
+        )
+
+    def _enqueue_text_event(self, event: MessageEvent) -> None:
+        """Buffer a text event and reset the flush timer."""
+        key = self._text_batch_key(event)
+        existing = self._pending_text_batches.get(key)
+        chunk_len = len(event.text or "")
+        if existing is None:
+            event._last_chunk_len = chunk_len  # type: ignore[attr-defined]
+            self._pending_text_batches[key] = event
+        else:
+            if event.text:
+                existing.text = f"{existing.text}\n{event.text}" if existing.text else event.text
+            existing._last_chunk_len = chunk_len  # type: ignore[attr-defined]
+
+        prior_task = self._pending_text_batch_tasks.get(key)
+        if prior_task and not prior_task.done():
+            prior_task.cancel()
+        self._pending_text_batch_tasks[key] = asyncio.create_task(
+            self._flush_text_batch(key)
+        )
+
+    async def _flush_text_batch(self, key: str) -> None:
+        """Wait for quiet period, then dispatch aggregated text."""
+        current_task = asyncio.current_task()
+        try:
+            pending = self._pending_text_batches.get(key)
+            last_len = getattr(pending, "_last_chunk_len", 0) if pending else 0
+            if last_len >= self._SPLIT_THRESHOLD:
+                delay = self._text_batch_split_delay_seconds
+            else:
+                delay = self._text_batch_delay_seconds
+            await asyncio.sleep(delay)
+            event = self._pending_text_batches.pop(key, None)
+            if not event:
+                return
+            logger.info(
+                "[WhatsApp] Flushing text batch %s (%d chars)",
+                key,
+                len(event.text or ""),
+            )
+            await self.handle_message(event)
+        finally:
+            if self._pending_text_batch_tasks.get(key) is current_task:
+                self._pending_text_batch_tasks.pop(key, None)
+
     async def _poll_messages(self) -> None:
         """Poll the bridge for incoming messages."""
         import aiohttp
@@ -1138,7 +1216,15 @@ class WhatsAppAdapter(BasePlatformAdapter):
                         messages = await resp.json()
                         for msg_data in messages:
                             event = await self._build_message_event(msg_data)
-                            if event:
+                            if not event:
+                                continue
+                            if (
+                                self._text_batch_delay_seconds > 0
+                                and event.message_type == MessageType.TEXT
+                                and not event.media_urls
+                            ):
+                                self._enqueue_text_event(event)
+                            else:
                                 await self.handle_message(event)
             except asyncio.CancelledError:
                 break

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -1595,19 +1595,12 @@ class TestSlashCommands:
             "hermes_cli.runtime_provider.resolve_runtime_provider",
             fake_resolve_runtime_provider,
         )
-        # Pin the model-string parser independently of the live
-        # ``_KNOWN_PROVIDER_NAMES`` / ``_PROVIDER_ALIASES`` module state.
-        # Otherwise any test in the same xdist worker that mutates those
-        # globals (e.g. registers a custom provider that shadows
-        # ``anthropic``) flakes this one — observed once in CI as
-        # ``'custom' == 'anthropic'``.
+        # Pin model selection on the ACP agent class so subprocess-isolated
+        # workers cannot flake via polluted ``hermes_cli.models`` registries.
         monkeypatch.setattr(
-            "hermes_cli.models.parse_model_input",
-            lambda raw, current: ("anthropic", "claude-sonnet-4-6"),
-        )
-        monkeypatch.setattr(
-            "hermes_cli.models.detect_provider_for_model",
-            lambda model, current: None,
+            HermesACPAgent,
+            "_resolve_model_selection",
+            staticmethod(lambda raw, current: ("anthropic", "claude-sonnet-4-6")),
         )
         manager = SessionManager(db=SessionDB(tmp_path / "state.db"))
 

--- a/tests/gateway/test_text_batching.py
+++ b/tests/gateway/test_text_batching.py
@@ -4,7 +4,7 @@ When a user sends a long message, the messaging client splits it at the
 platform's character limit.  Each adapter should buffer rapid successive
 text messages from the same session and aggregate them before dispatching.
 
-Covers: Discord, Matrix, WeCom, and the adaptive delay logic for
+Covers: Discord, Matrix, WeCom, WhatsApp, and the adaptive delay logic for
 Telegram and Feishu.
 """
 
@@ -380,6 +380,74 @@ class TestWeComTextBatching:
         adapter._enqueue_text_event(_make_event("test", Platform.WECOM))
         await asyncio.sleep(0.2)
         assert len(adapter._pending_text_batches) == 0
+
+
+# =====================================================================
+# WhatsApp text batching
+# =====================================================================
+
+def _make_whatsapp_adapter():
+    """Minimal WhatsAppAdapter for testing text batching.
+
+    Uses ``object.__new__`` (skips ``__init__``). Must set ``platform`` like
+    ``BasePlatformAdapter.__init__`` — adapters rely on ``self.platform``, not ``_platform``.
+    """
+    from gateway.platforms.whatsapp import WhatsAppAdapter
+
+    config = PlatformConfig(enabled=True)
+    config.extra = {}
+    adapter = object.__new__(WhatsAppAdapter)
+    adapter.platform = Platform.WHATSAPP
+    adapter.config = config
+    adapter._pending_text_batches = {}
+    adapter._pending_text_batch_tasks = {}
+    adapter._text_batch_delay_seconds = 0.1
+    adapter._text_batch_split_delay_seconds = 0.3
+    adapter.handle_message = AsyncMock()
+    return adapter
+
+
+class TestWhatsAppTextBatching:
+    @pytest.mark.asyncio
+    async def test_single_message_dispatched_after_delay(self):
+        adapter = _make_whatsapp_adapter()
+        event = _make_event("hello", Platform.WHATSAPP)
+
+        adapter._enqueue_text_event(event)
+
+        adapter.handle_message.assert_not_called()
+        await asyncio.sleep(0.2)
+
+        adapter.handle_message.assert_called_once()
+        assert adapter.handle_message.call_args[0][0].text == "hello"
+
+    @pytest.mark.asyncio
+    async def test_rapid_messages_merged(self):
+        adapter = _make_whatsapp_adapter()
+
+        adapter._enqueue_text_event(_make_event("Part one", Platform.WHATSAPP))
+        await asyncio.sleep(0.02)
+        adapter._enqueue_text_event(_make_event("Part two", Platform.WHATSAPP))
+
+        await asyncio.sleep(0.2)
+
+        adapter.handle_message.assert_called_once()
+        text = adapter.handle_message.call_args[0][0].text
+        assert "Part one" in text
+        assert "Part two" in text
+
+    @pytest.mark.asyncio
+    async def test_near_limit_chunk_uses_split_delay(self):
+        """Long chunk uses longer quiet window (continuation likely)."""
+        adapter = _make_whatsapp_adapter()
+        long_text = "x" * 4050
+        adapter._enqueue_text_event(_make_event(long_text, Platform.WHATSAPP))
+
+        await asyncio.sleep(0.15)
+        adapter.handle_message.assert_not_called()
+
+        await asyncio.sleep(0.25)
+        adapter.handle_message.assert_called_once()
 
 
 # =====================================================================

--- a/tests/gateway/test_text_batching.py
+++ b/tests/gateway/test_text_batching.py
@@ -401,10 +401,28 @@ def _make_whatsapp_adapter():
     adapter.config = config
     adapter._pending_text_batches = {}
     adapter._pending_text_batch_tasks = {}
+    adapter._pending_photo_batches = {}
+    adapter._pending_photo_batch_tasks = {}
     adapter._text_batch_delay_seconds = 0.1
     adapter._text_batch_split_delay_seconds = 0.3
+    adapter._media_batch_delay_seconds = 0.1
     adapter.handle_message = AsyncMock()
     return adapter
+
+
+def _make_photo_event(
+    *,
+    media_path: str = "/tmp/fake1.jpg",
+    caption: str = "",
+    chat_id: str = "12345",
+) -> MessageEvent:
+    return MessageEvent(
+        text=caption,
+        message_type=MessageType.PHOTO,
+        source=SessionSource(platform=Platform.WHATSAPP, chat_id=chat_id, chat_type="dm"),
+        media_urls=[media_path],
+        media_types=["image/jpeg"],
+    )
 
 
 class TestWhatsAppTextBatching:
@@ -448,6 +466,35 @@ class TestWhatsAppTextBatching:
 
         await asyncio.sleep(0.25)
         adapter.handle_message.assert_called_once()
+
+
+class TestWhatsAppPhotoBatching:
+    @pytest.mark.asyncio
+    async def test_single_photo_dispatched_after_delay(self):
+        adapter = _make_whatsapp_adapter()
+        event = _make_photo_event()
+
+        adapter._enqueue_photo_event(event)
+        adapter.handle_message.assert_not_called()
+        await asyncio.sleep(0.2)
+        adapter.handle_message.assert_called_once()
+        dispatched = adapter.handle_message.call_args[0][0]
+        assert len(dispatched.media_urls) == 1
+
+    @pytest.mark.asyncio
+    async def test_rapid_photos_merged(self):
+        adapter = _make_whatsapp_adapter()
+        adapter._enqueue_photo_event(_make_photo_event(media_path="/tmp/a.jpg"))
+        await asyncio.sleep(0.02)
+        adapter._enqueue_photo_event(_make_photo_event(media_path="/tmp/b.jpg"))
+
+        await asyncio.sleep(0.2)
+
+        adapter.handle_message.assert_called_once()
+        dispatched = adapter.handle_message.call_args[0][0]
+        assert len(dispatched.media_urls) == 2
+        assert "/tmp/a.jpg" in dispatched.media_urls
+        assert "/tmp/b.jpg" in dispatched.media_urls
 
 
 # =====================================================================

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -64,6 +64,10 @@ def _make_adapter():
     adapter._auto_tts_disabled_chats = set()
     adapter._message_queue = asyncio.Queue()
     adapter._http_session = None
+    adapter._pending_text_batches = {}
+    adapter._pending_text_batch_tasks = {}
+    adapter._pending_photo_batches = {}
+    adapter._pending_photo_batch_tasks = {}
     return adapter
 
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -293,6 +293,8 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `WHATSAPP_ALLOWED_USERS` | Comma-separated phone numbers (with country code, no `+`), or `*` to allow all senders |
 | `WHATSAPP_ALLOW_ALL_USERS` | Allow all WhatsApp senders without an allowlist (`true`/`false`) |
 | `WHATSAPP_DEBUG` | Log raw message events in the bridge for troubleshooting (`true`/`false`) |
+| `HERMES_WHATSAPP_TEXT_BATCH_DELAY_SECONDS` | Quiet period (seconds) before flushing merged **plain-text** inbound bubbles to the agent (default `0.6`). Set to `0` to disable batching. Same behavior pattern as Telegram/Discord gateway batching. |
+| `HERMES_WHATSAPP_TEXT_BATCH_SPLIT_DELAY_SECONDS` | Longer quiet period when the latest text chunk is near the split threshold — continuation likely (default `2.0`). |
 | `SIGNAL_HTTP_URL` | signal-cli daemon HTTP endpoint (for example `http://127.0.0.1:8080`) |
 | `SIGNAL_ACCOUNT` | Bot phone number in E.164 format |
 | `SIGNAL_ALLOWED_USERS` | Comma-separated E.164 phone numbers or UUIDs |

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -293,8 +293,9 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `WHATSAPP_ALLOWED_USERS` | Comma-separated phone numbers (with country code, no `+`), or `*` to allow all senders |
 | `WHATSAPP_ALLOW_ALL_USERS` | Allow all WhatsApp senders without an allowlist (`true`/`false`) |
 | `WHATSAPP_DEBUG` | Log raw message events in the bridge for troubleshooting (`true`/`false`) |
-| `HERMES_WHATSAPP_TEXT_BATCH_DELAY_SECONDS` | Quiet period (seconds) before flushing merged **plain-text** inbound bubbles to the agent (default `0.6`). Set to `0` to disable batching. Same behavior pattern as Telegram/Discord gateway batching. |
-| `HERMES_WHATSAPP_TEXT_BATCH_SPLIT_DELAY_SECONDS` | Longer quiet period when the latest text chunk is near the split threshold — continuation likely (default `2.0`). |
+| `HERMES_WHATSAPP_TEXT_BATCH_DELAY_SECONDS` | Quiet period (seconds) before flushing merged **plain-text** inbound bubbles (default `0.6`). Set to `0` to disable text batching. Matches Telegram/Discord gateway text batching. |
+| `HERMES_WHATSAPP_TEXT_BATCH_SPLIT_DELAY_SECONDS` | Longer quiet period when the latest **text** chunk is near the split threshold — continuation likely (default `2.0`). |
+| `HERMES_WHATSAPP_MEDIA_BATCH_DELAY_SECONDS` | Grace window before flushing merged **rapid photo bursts** from the same chat (default `0.8`, same role as `HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS`). Set to `0` to dispatch each image immediately. |
 | `SIGNAL_HTTP_URL` | signal-cli daemon HTTP endpoint (for example `http://127.0.0.1:8080`) |
 | `SIGNAL_ACCOUNT` | Bot phone number in E.164 format |
 | `SIGNAL_ALLOWED_USERS` | Comma-separated E.164 phone numbers or UUIDs |
@@ -503,7 +504,7 @@ Advanced per-platform knobs for throttling the outbound message batcher. Most us
 |----------|-------------|
 | `HERMES_TELEGRAM_TEXT_BATCH_DELAY_SECONDS` | Grace window before flushing a queued Telegram text chunk (default: `0.6`). |
 | `HERMES_TELEGRAM_TEXT_BATCH_SPLIT_DELAY_SECONDS` | Delay between split chunks when a single Telegram message exceeds the length limit (default: `2.0`). |
-| `HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS` | Grace window before flushing queued Telegram media (default: `0.6`). |
+| `HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS` | Grace window before flushing queued Telegram photo bursts/albums (default: `0.8`). |
 | `HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS` | Delay before sending a follow-up after the agent finishes, to avoid racing the last stream chunk. |
 | `HERMES_TELEGRAM_HTTP_CONNECT_TIMEOUT` / `_READ_TIMEOUT` / `_WRITE_TIMEOUT` / `_POOL_TIMEOUT` | Override the underlying `python-telegram-bot` HTTP timeouts (seconds). |
 | `HERMES_TELEGRAM_HTTP_POOL_SIZE` | Max concurrent HTTP connections to the Telegram API. |

--- a/website/docs/user-guide/messaging/whatsapp.md
+++ b/website/docs/user-guide/messaging/whatsapp.md
@@ -180,6 +180,16 @@ whatsapp:
 
 WhatsApp supports **streaming (progressive) responses** — the bot edits its message in real-time as the AI generates text, just like Discord and Telegram. Internally, WhatsApp is classified as a TIER_MEDIUM platform for delivery capabilities.
 
+### Inbound text batching
+
+When someone sends **several plain-text bubbles in a row** (or the client splits a long message), the gateway adapter can **merge** those into a single agent turn after a short **quiet period**, so the model sees one combined message instead of multiple interrupting turns.
+
+- **Default:** `0.6` seconds after the last text chunk before dispatch (`HERMES_WHATSAPP_TEXT_BATCH_DELAY_SECONDS`). Near-max-length chunks use a longer wait (`HERMES_WHATSAPP_TEXT_BATCH_SPLIT_DELAY_SECONDS`, default `2.0`) because a follow-up piece often arrives immediately after.
+- **Disable:** set `HERMES_WHATSAPP_TEXT_BATCH_DELAY_SECONDS=0` in `.env` — each bubble is dispatched as soon as the adapter receives it (same effect as turning off batching on other platforms).
+- **Scope:** applies to **text-only** inbound messages. Media (images, voice, documents) is not merged through this path.
+
+See [Environment variables](/docs/reference/environment-variables) for the WhatsApp batching rows (`HERMES_WHATSAPP_TEXT_BATCH_*`).
+
 ### Chunking
 
 Long responses are automatically split into multiple messages at **4,096 characters** per chunk (WhatsApp's practical display limit). You don't need to configure anything — the gateway handles splitting and sends chunks sequentially.

--- a/website/docs/user-guide/messaging/whatsapp.md
+++ b/website/docs/user-guide/messaging/whatsapp.md
@@ -180,15 +180,29 @@ whatsapp:
 
 WhatsApp supports **streaming (progressive) responses** — the bot edits its message in real-time as the AI generates text, just like Discord and Telegram. Internally, WhatsApp is classified as a TIER_MEDIUM platform for delivery capabilities.
 
-### Inbound text batching
+### Inbound batching
 
-When someone sends **several plain-text bubbles in a row** (or the client splits a long message), the gateway adapter can **merge** those into a single agent turn after a short **quiet period**, so the model sees one combined message instead of multiple interrupting turns.
+Batching mirrors **Telegram** in the gateway: separate quiet periods for **text** vs **rapid photo bursts**.
 
-- **Default:** `0.6` seconds after the last text chunk before dispatch (`HERMES_WHATSAPP_TEXT_BATCH_DELAY_SECONDS`). Near-max-length chunks use a longer wait (`HERMES_WHATSAPP_TEXT_BATCH_SPLIT_DELAY_SECONDS`, default `2.0`) because a follow-up piece often arrives immediately after.
-- **Disable:** set `HERMES_WHATSAPP_TEXT_BATCH_DELAY_SECONDS=0` in `.env` — each bubble is dispatched as soon as the adapter receives it (same effect as turning off batching on other platforms).
-- **Scope:** applies to **text-only** inbound messages. Media (images, voice, documents) is not merged through this path.
+**Text**
 
-See [Environment variables](/docs/reference/environment-variables) for the WhatsApp batching rows (`HERMES_WHATSAPP_TEXT_BATCH_*`).
+When someone sends several plain-text bubbles (or one long message is split client-side), the adapter merges them after a short quiet window so the agent sees one combined turn:
+
+- **`HERMES_WHATSAPP_TEXT_BATCH_DELAY_SECONDS`** (default `0.6`) — after the last text chunk.
+- **`HERMES_WHATSAPP_TEXT_BATCH_SPLIT_DELAY_SECONDS`** (default `2.0`) — used when the latest chunk is near the split threshold (continuation likely).
+
+Set `HERMES_WHATSAPP_TEXT_BATCH_DELAY_SECONDS=0` to disable **text** batching.
+
+**Photos**
+
+Successive photos from the same chat are merged like Telegram albums:
+
+- **`HERMES_WHATSAPP_MEDIA_BATCH_DELAY_SECONDS`** (default `0.8`) — same knob role as **`HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS`**.
+- Set to `0` to dispatch each photo immediately.
+
+Other inbound media (voice, video, documents) are not merged on this path.
+
+See [Environment variables](/docs/reference/environment-variables) (`HERMES_WHATSAPP_TEXT_BATCH_*`, `HERMES_WHATSAPP_MEDIA_BATCH_DELAY_SECONDS`).
 
 ### Chunking
 


### PR DESCRIPTION
## What does this PR do?

Adds adapter-level text batching for the WhatsApp gateway adapter so multiple plain-text bubbles (or rapid follow-ups) merge into one agent turn after a quiet period, matching the debounce behavior already used on Telegram, Discord, and Matrix.

## Related Issue

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/whatsapp.py` — debounced text batching with `HERMES_WHATSAPP_TEXT_BATCH_DELAY_SECONDS` (default `0.6`)
- `tests/gateway/test_text_batching.py` — batching behavior tests
- `tests/gateway/test_whatsapp_connect.py` — disconnect cleanup for batch timers
- `website/docs/reference/environment-variables.md` — document batch delay env var
- `website/docs/user-guide/messaging/whatsapp.md` — document batching behavior

## How to Test

1. `uv run pytest -o addopts= tests/gateway/test_text_batching.py tests/gateway/test_whatsapp_connect.py -q`
2. Send several rapid plain-text WhatsApp messages to the gateway — confirm they arrive as a single merged turn after the quiet period
3. Send a message with media or a long chunk — confirm it flushes immediately without waiting for unrelated batch slots

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — delete this section otherwise.

## Screenshots / Logs

N/A
