### PR TITLE
fix(gateway): re-export normalize_whatsapp_identifier from gateway.session

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -62,6 +62,7 @@ from .config import (
 )
 from .whatsapp_identity import (
     canonical_whatsapp_identifier,
+    normalize_whatsapp_identifier,
 )
 from utils import atomic_replace
 


### PR DESCRIPTION
## Problem
`tests/gateway/test_session.py` imports `normalize_whatsapp_identifier` from `gateway.session`, but `session.py` only re-exported `canonical_whatsapp_identifier` from `whatsapp_identity`. Pytest fails at collection with:

`ImportError: cannot import name 'normalize_whatsapp_identifier' from 'gateway.session'`

This showed up in CI (e.g. fork sync workflow focused tests).

## Fix
Add `normalize_whatsapp_identifier` to the existing `whatsapp_identity` import block in `gateway/session.py`.

## Verification
`pytest tests/gateway/test_session.py` — 77 passed locally.