### PR TITLE
fix(kimi): map xhigh reasoning effort to high

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -217,6 +217,8 @@ class ChatCompletionsTransport(ProviderTransport):
                     _e = (reasoning_config.get("effort") or "").strip().lower()
                     if _e in ("low", "medium", "high"):
                         _kimi_effort = _e
+                    elif _e == "xhigh":
+                        _kimi_effort = "high"
                 api_kwargs["reasoning_effort"] = _kimi_effort
 
         # extra_body assembly

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -214,6 +214,16 @@ class TestChatCompletionsKimi:
         # Kimi requires reasoning_effort as a top-level parameter
         assert kw["reasoning_effort"] == "high"
 
+    def test_kimi_reasoning_effort_xhigh_maps_to_high(self, transport):
+        kw = transport.build_kwargs(
+            model="kimi-k2", messages=[{"role": "user", "content": "Hi"}],
+            is_kimi=True,
+            reasoning_config={"effort": "xhigh"},
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        # xhigh is a Hermes-internal level; Kimi only accepts low/medium/high
+        assert kw["reasoning_effort"] == "high"
+
     def test_kimi_reasoning_effort_omitted_when_thinking_disabled(self, transport):
         kw = transport.build_kwargs(
             model="kimi-k2", messages=[{"role": "user", "content": "Hi"}],


### PR DESCRIPTION
## Summary

- `xhigh` is a Hermes-internal effort level not accepted by the Kimi API (which only supports `low`/`medium`/`high`)
- Without this fix, `reasoning_effort: xhigh` in config silently falls through to the `"medium"` default — the user gets medium reasoning instead of maximum
- Gemini already handles this correctly (`xhigh → "high"`); this brings Kimi in line with that pattern

## Changes

- `agent/transports/chat_completions.py`: add `elif _e == "xhigh": _kimi_effort = "high"` branch
- `tests/agent/transports/test_chat_completions.py`: add regression test `test_kimi_reasoning_effort_xhigh_maps_to_high`

## Test plan

- [ ] `pytest tests/agent/transports/test_chat_completions.py` — 42 passed