### PR TITLE
Fix gateway service identity for scoped Hermes homes

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -37,6 +37,13 @@ from hermes_cli.setup import (
     prompt, prompt_choice, prompt_yes_no,
 )
 from hermes_cli.colors import Colors, color
+from hermes_cli.gateway_service_identity import (
+    gateway_launchd_plist_path,
+    gateway_profile_arg,
+    gateway_service_suffix,
+    get_gateway_service_identity,
+    service_definition_matches_hermes_home,
+)
 
 
 # =============================================================================
@@ -66,6 +73,73 @@ class ProfileGatewayProcess:
     profile: str
     path: Path
     pid: int
+
+
+def _parse_launchd_pid(stdout: str, label: str) -> int | None:
+    import re
+
+    for line in stdout.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+
+        # `launchctl list <label>` may render either a table-style row or a
+        # plist-style block depending on macOS version.
+        parts = stripped.split()
+        if len(parts) >= 3 and parts[2] == label:
+            try:
+                pid = int(parts[0])
+            except ValueError:
+                continue
+            return pid if pid > 0 else None
+
+        match = re.search(r'"?PID"?\s*=\s*(\d+)', stripped)
+        if match:
+            pid = int(match.group(1))
+            return pid if pid > 0 else None
+
+    return None
+
+
+def _launchd_label_pid(label: str, *, timeout: float = 5.0) -> int | None:
+    try:
+        result = subprocess.run(
+            ["launchctl", "list", label],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return _parse_launchd_pid(result.stdout, label)
+
+
+def _wait_for_pid_exit(
+    pid: int | None,
+    *,
+    timeout: float = 10.0,
+    description: str = "process",
+) -> bool:
+    if pid is None or pid <= 0:
+        return True
+
+    import time
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return True
+        except PermissionError:
+            pass
+        time.sleep(0.3)
+
+    print(f"⚠ {description} PID {pid} still running after {timeout:g}s")
+    return False
+
 
 def _get_service_pids() -> set:
     """Return PIDs currently managed by systemd or launchd gateway services.
@@ -108,22 +182,14 @@ def _get_service_pids() -> set:
     # --- launchd (macOS) ---
     if is_macos():
         try:
-            label = get_launchd_label()
-            result = subprocess.run(
-                ["launchctl", "list", label],
-                capture_output=True, text=True, timeout=5,
-            )
-            if result.returncode == 0:
-                # Output: "PID\tStatus\tLabel" header, then one data line
-                for line in result.stdout.strip().splitlines():
-                    parts = line.split()
-                    if len(parts) >= 3 and parts[2] == label:
-                        try:
-                            pid = int(parts[0])
-                            if pid > 0:
-                                pids.add(pid)
-                        except ValueError:
-                            pass
+            if not _has_launchd_service_definition():
+                return pids
+            for label, plist_path in _launchd_service_targets():
+                if not plist_path.exists():
+                    continue
+                pid = _launchd_label_pid(label)
+                if pid is not None:
+                    pids.add(pid)
         except (FileNotFoundError, subprocess.TimeoutExpired):
             pass
 
@@ -482,20 +548,25 @@ def launch_detached_profile_gateway_restart(profile: str, old_pid: int) -> bool:
 
 def _probe_systemd_service_running(system: bool = False) -> tuple[bool, bool]:
     selected_system = _select_systemd_scope(system)
-    unit_exists = get_systemd_unit_path(system=selected_system).exists()
+    unit_exists = _has_systemd_service_definition(system=selected_system)
     if not unit_exists:
         return selected_system, False
-    try:
-        result = _run_systemctl(
-            ["is-active", get_service_name()],
-            system=selected_system,
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (RuntimeError, subprocess.TimeoutExpired):
-        return selected_system, False
-    return selected_system, result.stdout.strip() == "active"
+    for service_name, unit_path in _systemd_service_targets(system=selected_system):
+        if not unit_path.exists():
+            continue
+        try:
+            result = _run_systemctl(
+                ["is-active", service_name],
+                system=selected_system,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except (RuntimeError, subprocess.TimeoutExpired):
+            continue
+        if result.stdout.strip() == "active":
+            return selected_system, True
+    return selected_system, False
 
 
 def _read_systemd_unit_properties(
@@ -640,18 +711,23 @@ def _recover_pending_systemd_restart(system: bool = False, previous_pid: int | N
 
 
 def _probe_launchd_service_running() -> bool:
-    if not get_launchd_plist_path().exists():
+    if not _has_launchd_service_definition():
         return False
-    try:
-        result = subprocess.run(
-            ["launchctl", "list", get_launchd_label()],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except subprocess.TimeoutExpired:
-        return False
-    return result.returncode == 0
+    for label, plist_path in _launchd_service_targets():
+        if not plist_path.exists():
+            continue
+        try:
+            result = subprocess.run(
+                ["launchctl", "list", label],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except subprocess.TimeoutExpired:
+            continue
+        if result.returncode == 0:
+            return True
+    return False
 
 
 def get_gateway_runtime_snapshot(system: bool = False) -> GatewayRuntimeSnapshot:
@@ -676,7 +752,7 @@ def get_gateway_runtime_snapshot(system: bool = False) -> GatewayRuntimeSnapshot
         scope_label = _service_scope_label(selected_system)
         return GatewayRuntimeSnapshot(
             manager=f"systemd ({scope_label})",
-            service_installed=get_systemd_unit_path(system=selected_system).exists(),
+            service_installed=_has_systemd_service_definition(system=selected_system),
             service_running=service_running,
             gateway_pids=gateway_pids,
             service_scope=scope_label,
@@ -685,7 +761,7 @@ def get_gateway_runtime_snapshot(system: bool = False) -> GatewayRuntimeSnapshot
     if is_macos():
         return GatewayRuntimeSnapshot(
             manager="launchd",
-            service_installed=get_launchd_plist_path().exists(),
+            service_installed=_has_launchd_service_definition(),
             service_running=_probe_launchd_service_running(),
             gateway_pids=gateway_pids,
             service_scope="launchd",
@@ -878,8 +954,9 @@ def is_windows() -> bool:
 # Service Configuration
 # =============================================================================
 
-_SERVICE_BASE = "hermes-gateway"
 SERVICE_DESCRIPTION = "Hermes Agent Gateway - Messaging Platform Integration"
+_LEGACY_DEFAULT_SERVICE_NAME = "hermes-gateway"
+_LEGACY_DEFAULT_LAUNCHD_LABEL = "ai.hermes.gateway"
 
 
 def _profile_suffix() -> str:
@@ -889,24 +966,7 @@ def _profile_suffix() -> str:
     ``<root>/profiles/<name>``, or a short hash for any other path.
     Works correctly in Docker (HERMES_HOME=/opt/data) and standard deployments.
     """
-    import hashlib
-    import re
-    from hermes_constants import get_default_hermes_root
-    home = get_hermes_home().resolve()
-    default = get_default_hermes_root().resolve()
-    if home == default:
-        return ""
-    # Detect <root>/profiles/<name> pattern → use the profile name
-    profiles_root = (default / "profiles").resolve()
-    try:
-        rel = home.relative_to(profiles_root)
-        parts = rel.parts
-        if len(parts) == 1 and re.match(r"^[a-z0-9][a-z0-9_-]{0,63}$", parts[0]):
-            return parts[0]
-    except ValueError:
-        pass
-    # Fallback: short hash for arbitrary HERMES_HOME paths
-    return hashlib.sha256(str(home).encode()).hexdigest()[:8]
+    return gateway_service_suffix()
 
 
 def _profile_arg(hermes_home: str | None = None) -> str:
@@ -920,21 +980,7 @@ def _profile_arg(hermes_home: str | None = None) -> str:
             ``get_hermes_home()`` value. Should be passed when generating a
             service definition for a different user (e.g. system service).
     """
-    import re
-    from hermes_constants import get_default_hermes_root
-    home = Path(hermes_home or str(get_hermes_home())).resolve()
-    default = get_default_hermes_root().resolve()
-    if home == default:
-        return ""
-    profiles_root = (default / "profiles").resolve()
-    try:
-        rel = home.relative_to(profiles_root)
-        parts = rel.parts
-        if len(parts) == 1 and re.match(r"^[a-z0-9][a-z0-9_-]{0,63}$", parts[0]):
-            return f"--profile {parts[0]}"
-    except ValueError:
-        pass
-    return ""
+    return gateway_profile_arg(hermes_home)
 
 
 def get_service_name() -> str:
@@ -944,10 +990,7 @@ def get_service_name() -> str:
     Profile ``~/.hermes/profiles/coder`` returns ``hermes-gateway-coder``.
     Any other HERMES_HOME appends a short hash for uniqueness.
     """
-    suffix = _profile_suffix()
-    if not suffix:
-        return _SERVICE_BASE
-    return f"{_SERVICE_BASE}-{suffix}"
+    return get_gateway_service_identity().systemd_service_name
 
 
 
@@ -956,6 +999,211 @@ def get_systemd_unit_path(system: bool = False) -> Path:
     if system:
         return Path("/etc/systemd/system") / f"{name}.service"
     return Path.home() / ".config" / "systemd" / "user" / f"{name}.service"
+
+
+def _uses_scoped_service_identity() -> bool:
+    return (
+        get_service_name() != _LEGACY_DEFAULT_SERVICE_NAME
+        and get_launchd_label() != _LEGACY_DEFAULT_LAUNCHD_LABEL
+    )
+
+
+def _legacy_custom_root_systemd_unit_path(system: bool = False) -> Path:
+    if system:
+        return Path("/etc/systemd/system") / f"{_LEGACY_DEFAULT_SERVICE_NAME}.service"
+    return (
+        Path.home()
+        / ".config"
+        / "systemd"
+        / "user"
+        / f"{_LEGACY_DEFAULT_SERVICE_NAME}.service"
+    )
+
+
+def _has_migratable_custom_root_systemd_service(system: bool = False) -> bool:
+    legacy_path = _legacy_custom_root_systemd_unit_path(system=system)
+    return (
+        _uses_scoped_service_identity()
+        and legacy_path.exists()
+        and legacy_path != get_systemd_unit_path(system=system)
+        and _service_definition_matches_current_hermes_home(legacy_path)
+    )
+
+
+def _has_systemd_service_definition(system: bool = False) -> bool:
+    return get_systemd_unit_path(system=system).exists() or _has_migratable_custom_root_systemd_service(system=system)
+
+
+def _has_any_systemd_service_definition() -> bool:
+    return _has_systemd_service_definition(system=False) or _has_systemd_service_definition(system=True)
+
+
+def _systemd_service_name_for_definition(system: bool = False) -> str:
+    if _has_migratable_custom_root_systemd_service(system=system):
+        return _LEGACY_DEFAULT_SERVICE_NAME
+    if get_systemd_unit_path(system=system).exists():
+        return get_service_name()
+    return get_service_name()
+
+
+def _systemd_service_targets(system: bool = False) -> list[tuple[str, Path]]:
+    targets = [(get_service_name(), get_systemd_unit_path(system=system))]
+    if _has_migratable_custom_root_systemd_service(system=system):
+        targets.append(
+            (
+                _LEGACY_DEFAULT_SERVICE_NAME,
+                _legacy_custom_root_systemd_unit_path(system=system),
+            )
+        )
+    return targets
+
+
+def _service_definition_matches_current_hermes_home(path: Path) -> bool:
+    return service_definition_matches_hermes_home(path)
+
+
+def _systemd_service_is_enabled(service_name: str, system: bool = False) -> bool:
+    try:
+        result = _run_systemctl(
+            ["is-enabled", service_name],
+            system=system,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+    except (RuntimeError, subprocess.TimeoutExpired):
+        return False
+    return result.stdout.strip() in {"enabled", "enabled-runtime"}
+
+
+def _systemd_service_is_active(service_name: str, system: bool = False) -> bool:
+    try:
+        result = _run_systemctl(
+            ["is-active", service_name],
+            system=system,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+    except (RuntimeError, subprocess.TimeoutExpired):
+        return False
+    return result.stdout.strip() == "active"
+
+
+def _migrate_custom_root_systemd_service(
+    system: bool = False,
+    enable_new: bool = False,
+    preserve_enabled: bool = True,
+    start_new_if_active: bool = False,
+) -> bool:
+    """Move a matching legacy unit to the scoped service name."""
+    if not _uses_scoped_service_identity():
+        return False
+
+    legacy_path = _legacy_custom_root_systemd_unit_path(system=system)
+    current_path = get_systemd_unit_path(system=system)
+    if not legacy_path.exists() or legacy_path == current_path:
+        return False
+    if not _service_definition_matches_current_hermes_home(legacy_path):
+        return False
+
+    legacy_was_enabled = (
+        preserve_enabled
+        and _systemd_service_is_enabled(
+            _LEGACY_DEFAULT_SERVICE_NAME,
+            system=system,
+        )
+    )
+    legacy_was_active = start_new_if_active and _systemd_service_is_active(
+        _LEGACY_DEFAULT_SERVICE_NAME,
+        system=system,
+    )
+
+    current_existed = current_path.exists()
+    previous_current_text = (
+        current_path.read_text(encoding="utf-8") if current_existed else None
+    )
+
+    current_was_enabled = False
+    enabled_current_during_migration = False
+
+    try:
+        expected_user = _read_systemd_user_from_unit(legacy_path) if system else None
+        expected_unit = generate_systemd_unit(system=system, run_as_user=expected_user)
+        if previous_current_text is None or _normalize_service_definition(
+            previous_current_text
+        ) != _normalize_service_definition(expected_unit):
+            current_path.parent.mkdir(parents=True, exist_ok=True)
+            current_path.write_text(expected_unit, encoding="utf-8")
+
+        _run_systemctl(["daemon-reload"], system=system, check=True, timeout=30)
+        if enable_new or legacy_was_enabled:
+            current_was_enabled = _systemd_service_is_enabled(
+                get_service_name(),
+                system=system,
+            )
+            _run_systemctl(
+                ["enable", get_service_name()],
+                system=system,
+                check=True,
+                timeout=30,
+            )
+            enabled_current_during_migration = not current_was_enabled
+        if legacy_was_active:
+            _run_systemctl(
+                ["stop", _LEGACY_DEFAULT_SERVICE_NAME],
+                system=system,
+                check=True,
+                timeout=90,
+            )
+            try:
+                _run_systemctl(
+                    ["start", get_service_name()],
+                    system=system,
+                    check=True,
+                    timeout=90,
+                )
+            except Exception:
+                _run_systemctl(
+                    ["start", _LEGACY_DEFAULT_SERVICE_NAME],
+                    system=system,
+                    check=False,
+                    timeout=90,
+                )
+                raise
+    except Exception:
+        if enabled_current_during_migration:
+            _run_systemctl(
+                ["disable", get_service_name()],
+                system=system,
+                check=False,
+                timeout=30,
+            )
+        try:
+            if previous_current_text is None:
+                current_path.unlink(missing_ok=True)
+            else:
+                current_path.write_text(previous_current_text, encoding="utf-8")
+        except OSError:
+            pass
+        _run_systemctl(["daemon-reload"], system=system, check=False, timeout=30)
+        raise
+
+    _run_systemctl(
+        ["disable", _LEGACY_DEFAULT_SERVICE_NAME],
+        system=system,
+        check=False,
+        timeout=30,
+    )
+    legacy_path.unlink(missing_ok=True)
+    _run_systemctl(["daemon-reload"], system=system, check=False, timeout=30)
+    print(
+        "↻ Migrated legacy gateway service "
+        f"from {_LEGACY_DEFAULT_SERVICE_NAME} to {get_service_name()}"
+    )
+    return True
 
 
 class UserSystemdUnavailableError(RuntimeError):
@@ -1550,9 +1798,170 @@ def get_launchd_plist_path() -> Path:
     Default ``~/.hermes`` → ``ai.hermes.gateway.plist`` (backward compatible).
     Profile ``~/.hermes/profiles/coder`` → ``ai.hermes.gateway-coder.plist``.
     """
-    suffix = _profile_suffix()
-    name = f"ai.hermes.gateway-{suffix}" if suffix else "ai.hermes.gateway"
-    return _launchd_user_home() / "Library" / "LaunchAgents" / f"{name}.plist"
+    return gateway_launchd_plist_path(_launchd_user_home())
+
+
+def _legacy_custom_root_launchd_plist_path() -> Path:
+    return (
+        _launchd_user_home()
+        / "Library"
+        / "LaunchAgents"
+        / f"{_LEGACY_DEFAULT_LAUNCHD_LABEL}.plist"
+    )
+
+
+def _migrate_custom_root_launchd_service() -> bool:
+    """Remove old unsuffixed plists before using scoped launchd labels."""
+    if not _uses_scoped_service_identity():
+        return False
+
+    legacy_path = _legacy_custom_root_launchd_plist_path()
+    current_path = get_launchd_plist_path()
+    if not legacy_path.exists() or legacy_path == current_path:
+        return False
+    if not _service_definition_matches_current_hermes_home(legacy_path):
+        return False
+
+    current_existed = current_path.exists()
+    previous_current_text = (
+        current_path.read_text(encoding="utf-8") if current_existed else None
+    )
+    current_was_loaded = current_existed and _launchd_label_is_loaded(
+        get_launchd_label()
+    )
+    legacy_pid = _launchd_label_pid(_LEGACY_DEFAULT_LAUNCHD_LABEL)
+    bootout = subprocess.run(
+        ["launchctl", "bootout", f"{_launchd_domain()}/{_LEGACY_DEFAULT_LAUNCHD_LABEL}"],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=90,
+    )
+    if bootout.returncode not in (0, 3, 113):
+        raise subprocess.CalledProcessError(
+            bootout.returncode,
+            bootout.args,
+            output=bootout.stdout,
+            stderr=bootout.stderr,
+        )
+    legacy_was_stopped = bootout.returncode == 0
+
+    try:
+        if legacy_was_stopped and not _wait_for_pid_exit(
+            legacy_pid,
+            timeout=10.0,
+            description=f"legacy launchd service {_LEGACY_DEFAULT_LAUNCHD_LABEL}",
+        ):
+            raise RuntimeError(
+                "Legacy launchd gateway did not stop cleanly; refusing to start "
+                f"{get_launchd_label()} while {_LEGACY_DEFAULT_LAUNCHD_LABEL} may still be running"
+            )
+
+        expected_plist = generate_launchd_plist()
+        rewrote_current = False
+        if not current_path.exists() or _normalize_launchd_plist_for_comparison(
+            current_path.read_text(encoding="utf-8")
+        ) != _normalize_launchd_plist_for_comparison(expected_plist):
+            current_path.parent.mkdir(parents=True, exist_ok=True)
+            current_path.write_text(expected_plist, encoding="utf-8")
+            rewrote_current = True
+
+        label = get_launchd_label()
+        if rewrote_current and current_was_loaded:
+            subprocess.run(
+                ["launchctl", "bootout", f"{_launchd_domain()}/{label}"],
+                check=False,
+                timeout=90,
+            )
+            subprocess.run(
+                ["launchctl", "bootstrap", _launchd_domain(), str(current_path)],
+                check=True,
+                timeout=30,
+            )
+        elif legacy_was_stopped and not current_was_loaded:
+            subprocess.run(
+                ["launchctl", "bootstrap", _launchd_domain(), str(current_path)],
+                check=True,
+                timeout=30,
+            )
+    except Exception:
+        try:
+            if previous_current_text is None:
+                current_path.unlink(missing_ok=True)
+            else:
+                current_path.write_text(previous_current_text, encoding="utf-8")
+        except OSError:
+            pass
+        if current_was_loaded and current_path.exists():
+            label = get_launchd_label()
+            subprocess.run(
+                ["launchctl", "bootstrap", _launchd_domain(), str(current_path)],
+                check=False,
+                timeout=30,
+            )
+            subprocess.run(
+                ["launchctl", "kickstart", f"{_launchd_domain()}/{label}"],
+                check=False,
+                timeout=30,
+            )
+        if legacy_was_stopped and legacy_path.exists():
+            subprocess.run(
+                ["launchctl", "bootstrap", _launchd_domain(), str(legacy_path)],
+                check=False,
+                timeout=30,
+            )
+            subprocess.run(
+                [
+                    "launchctl",
+                    "kickstart",
+                    f"{_launchd_domain()}/{_LEGACY_DEFAULT_LAUNCHD_LABEL}",
+                ],
+                check=False,
+                timeout=30,
+            )
+        raise
+
+    legacy_path.unlink(missing_ok=True)
+    print(
+        "↻ Migrated legacy gateway launchd service "
+        f"from {_LEGACY_DEFAULT_LAUNCHD_LABEL} to {get_launchd_label()}"
+    )
+    return True
+
+
+def _has_migratable_custom_root_launchd_service() -> bool:
+    legacy_path = _legacy_custom_root_launchd_plist_path()
+    return (
+        _uses_scoped_service_identity()
+        and legacy_path.exists()
+        and legacy_path != get_launchd_plist_path()
+        and _service_definition_matches_current_hermes_home(legacy_path)
+    )
+
+
+def _has_launchd_service_definition() -> bool:
+    return get_launchd_plist_path().exists() or _has_migratable_custom_root_launchd_service()
+
+
+def _launchd_label_for_definition() -> str:
+    if _has_migratable_custom_root_launchd_service():
+        return _LEGACY_DEFAULT_LAUNCHD_LABEL
+    if get_launchd_plist_path().exists():
+        return get_launchd_label()
+    return get_launchd_label()
+
+
+def _launchd_service_targets() -> list[tuple[str, Path]]:
+    targets = [(get_launchd_label(), get_launchd_plist_path())]
+    if _has_migratable_custom_root_launchd_service():
+        targets.append(
+            (
+                _LEGACY_DEFAULT_LAUNCHD_LABEL,
+                _legacy_custom_root_launchd_plist_path(),
+            )
+        )
+    return targets
+
 
 def _detect_venv_dir() -> Path | None:
     """Detect the active virtualenv directory.
@@ -1927,7 +2336,7 @@ def _ensure_linger_enabled() -> None:
 def _select_systemd_scope(system: bool = False) -> bool:
     if system:
         return True
-    return get_systemd_unit_path(system=True).exists() and not get_systemd_unit_path(system=False).exists()
+    return _has_systemd_service_definition(system=True) and not _has_systemd_service_definition(system=False)
 
 
 def _get_restart_drain_timeout() -> float:
@@ -1947,6 +2356,11 @@ def _get_restart_drain_timeout() -> float:
 def systemd_install(force: bool = False, system: bool = False, run_as_user: str | None = None):
     if system:
         _require_root_for_system_service("install")
+    _migrate_custom_root_systemd_service(
+        system=system,
+        enable_new=True,
+        start_new_if_active=True,
+    )
 
     # Offer to remove legacy units (hermes.service from pre-rename installs)
     # before installing the new hermes-gateway.service. If both remain, they
@@ -2007,13 +2421,12 @@ def systemd_uninstall(system: bool = False):
     if system:
         _require_root_for_system_service("uninstall")
 
-    _run_systemctl(["stop", get_service_name()], system=system, check=False, timeout=90)
-    _run_systemctl(["disable", get_service_name()], system=system, check=False, timeout=30)
-
-    unit_path = get_systemd_unit_path(system=system)
-    if unit_path.exists():
-        unit_path.unlink()
-        print(f"✓ Removed {unit_path}")
+    for service_name, unit_path in _systemd_service_targets(system=system):
+        _run_systemctl(["stop", service_name], system=system, check=False, timeout=90)
+        _run_systemctl(["disable", service_name], system=system, check=False, timeout=30)
+        if unit_path.exists():
+            unit_path.unlink()
+            print(f"✓ Removed {unit_path}")
 
     _run_systemctl(["daemon-reload"], system=system, check=True, timeout=30)
     print(f"✓ {_service_scope_label(system).capitalize()} service uninstalled")
@@ -2037,7 +2450,9 @@ def systemd_start(system: bool = False):
         # reachable (common on fresh RHEL/Debian SSH sessions without linger).
         # Raises UserSystemdUnavailableError with a remediation message.
         _preflight_user_systemd()
-    _require_service_installed("start", system=system)
+    _migrate_custom_root_systemd_service(system=system, start_new_if_active=True)
+    if not _has_systemd_service_definition(system=system):
+        _require_service_installed("start", system=system)
     refresh_systemd_unit_if_needed(system=system)
     _run_systemctl(["start", get_service_name()], system=system, check=True, timeout=30)
     print(f"✓ {_service_scope_label(system).capitalize()} service started")
@@ -2048,7 +2463,6 @@ def systemd_stop(system: bool = False):
     system = _select_systemd_scope(system)
     if system:
         _require_root_for_system_service("stop")
-    _require_service_installed("stop", system=system)
     try:
         from gateway.status import get_running_pid, write_planned_stop_marker
         pid = get_running_pid(cleanup_stale=False)
@@ -2056,7 +2470,15 @@ def systemd_stop(system: bool = False):
             write_planned_stop_marker(pid)
     except Exception:
         pass
-    _run_systemctl(["stop", get_service_name()], system=system, check=True, timeout=90)
+    stopped = False
+    for service_name, unit_path in _systemd_service_targets(system=system):
+        if not unit_path.exists():
+            continue
+        _run_systemctl(["stop", service_name], system=system, check=True, timeout=90)
+        stopped = True
+    if not stopped:
+        _require_service_installed("stop", system=system)
+        _run_systemctl(["stop", get_service_name()], system=system, check=True, timeout=90)
     print(f"✓ {_service_scope_label(system).capitalize()} service stopped")
 
 
@@ -2067,7 +2489,9 @@ def systemd_restart(system: bool = False):
         _require_root_for_system_service("restart")
     else:
         _preflight_user_systemd()
-    _require_service_installed("restart", system=system)
+    _migrate_custom_root_systemd_service(system=system, start_new_if_active=True)
+    if not _has_systemd_service_definition(system=system):
+        _require_service_installed("restart", system=system)
     refresh_systemd_unit_if_needed(system=system)
     from gateway.status import get_running_pid
 
@@ -2129,6 +2553,20 @@ def systemd_status(deep: bool = False, system: bool = False, full: bool = False)
     scope_flag = " --system" if system else ""
 
     if not unit_path.exists():
+        if _has_migratable_custom_root_systemd_service(system=system):
+            print("⚠ Legacy gateway service is installed under the old service name")
+            print(f"  Run: {'sudo ' if system else ''}hermes gateway start{scope_flag}  # migrates it to {get_service_name()}")
+            print()
+            status_cmd = ["status", _LEGACY_DEFAULT_SERVICE_NAME, "--no-pager"]
+            if full:
+                status_cmd.append("-l")
+            _run_systemctl(
+                status_cmd,
+                system=system,
+                capture_output=False,
+                timeout=10,
+            )
+            return
         print("✗ Gateway service is not installed")
         print(f"  Run: {'sudo ' if system else ''}hermes gateway install{scope_flag}")
         return
@@ -2224,12 +2662,24 @@ def systemd_status(deep: bool = False, system: bool = False, full: bool = False)
 
 def get_launchd_label() -> str:
     """Return the launchd service label, scoped per profile."""
-    suffix = _profile_suffix()
-    return f"ai.hermes.gateway-{suffix}" if suffix else "ai.hermes.gateway"
+    return get_gateway_service_identity().launchd_label
 
 
 def _launchd_domain() -> str:
     return f"gui/{os.getuid()}"
+
+
+def _launchd_label_is_loaded(label: str) -> bool:
+    try:
+        result = subprocess.run(
+            ["launchctl", "list", label],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except subprocess.TimeoutExpired:
+        return False
+    return result.returncode == 0
 
 
 def generate_launchd_plist() -> str:
@@ -2351,7 +2801,39 @@ def refresh_launchd_plist_if_needed() -> bool:
     return True
 
 
+def _refresh_launchd_plist_file_if_stale(plist_path: Path | None = None) -> bool:
+    plist_path = plist_path or get_launchd_plist_path()
+    if not plist_path.exists() or launchd_plist_is_current():
+        return False
+    plist_path.write_text(generate_launchd_plist(), encoding="utf-8")
+    print("↻ Updated gateway launchd plist before loading service")
+    return True
+
+
+def _ensure_launchd_plist_exists() -> Path:
+    plist_path = get_launchd_plist_path()
+    if not plist_path.exists():
+        print("↻ launchd plist missing; regenerating service definition")
+        plist_path.parent.mkdir(parents=True, exist_ok=True)
+        plist_path.write_text(generate_launchd_plist(), encoding="utf-8")
+    return plist_path
+
+
+def _bootstrap_launchd_service_if_needed(label: str, plist_path: Path | None = None) -> bool:
+    if _launchd_label_is_loaded(label):
+        return False
+    plist_path = plist_path or _ensure_launchd_plist_exists()
+    _refresh_launchd_plist_file_if_stale(plist_path)
+    subprocess.run(
+        ["launchctl", "bootstrap", _launchd_domain(), str(plist_path)],
+        check=True,
+        timeout=30,
+    )
+    return True
+
+
 def launchd_install(force: bool = False):
+    migrated = _migrate_custom_root_launchd_service()
     plist_path = get_launchd_plist_path()
     
     if plist_path.exists() and not force:
@@ -2359,6 +2841,13 @@ def launchd_install(force: bool = False):
             print(f"↻ Repairing outdated launchd service at: {plist_path}")
             refresh_launchd_plist_if_needed()
             print("✓ Service definition updated")
+            if not migrated:
+                return
+        if migrated:
+            label = get_launchd_label()
+            _bootstrap_launchd_service_if_needed(label, plist_path)
+            print()
+            print("✓ Service installed and loaded!")
             return
         print(f"Service already installed at: {plist_path}")
         print("Use --force to reinstall")
@@ -2379,44 +2868,45 @@ def launchd_install(force: bool = False):
     print(f"  tail -f {_dhh()}/logs/gateway.log  # View logs")
 
 def launchd_uninstall():
-    plist_path = get_launchd_plist_path()
-    label = get_launchd_label()
-    subprocess.run(["launchctl", "bootout", f"{_launchd_domain()}/{label}"], check=False, timeout=90)
-    
-    if plist_path.exists():
-        plist_path.unlink()
-        print(f"✓ Removed {plist_path}")
+    for label, plist_path in _launchd_service_targets():
+        subprocess.run(
+            ["launchctl", "bootout", f"{_launchd_domain()}/{label}"],
+            check=False,
+            timeout=90,
+        )
+
+        if plist_path.exists():
+            plist_path.unlink()
+            print(f"✓ Removed {plist_path}")
     
     print("✓ Service uninstalled")
 
 def launchd_start():
-    plist_path = get_launchd_plist_path()
+    _migrate_custom_root_launchd_service()
+    regenerated = not get_launchd_plist_path().exists()
+    plist_path = _ensure_launchd_plist_exists()
     label = get_launchd_label()
+    target = f"{_launchd_domain()}/{label}"
 
-    # Self-heal if the plist is missing entirely (e.g., manual cleanup, failed upgrade)
-    if not plist_path.exists():
-        print("↻ launchd plist missing; regenerating service definition")
-        plist_path.parent.mkdir(parents=True, exist_ok=True)
-        plist_path.write_text(generate_launchd_plist(), encoding="utf-8")
+    refresh_launchd_plist_if_needed()
+    if regenerated:
+        subprocess.run(["launchctl", "bootout", target], check=False, timeout=90)
         subprocess.run(["launchctl", "bootstrap", _launchd_domain(), str(plist_path)], check=True, timeout=30)
-        subprocess.run(["launchctl", "kickstart", f"{_launchd_domain()}/{label}"], check=True, timeout=30)
+        subprocess.run(["launchctl", "kickstart", target], check=True, timeout=30)
         print("✓ Service started")
         return
 
-    refresh_launchd_plist_if_needed()
     try:
-        subprocess.run(["launchctl", "kickstart", f"{_launchd_domain()}/{label}"], check=True, timeout=30)
+        subprocess.run(["launchctl", "kickstart", target], check=True, timeout=30)
     except subprocess.CalledProcessError as e:
         if e.returncode not in (3, 113):
             raise
         print("↻ launchd job was unloaded; reloading service definition")
         subprocess.run(["launchctl", "bootstrap", _launchd_domain(), str(plist_path)], check=True, timeout=30)
-        subprocess.run(["launchctl", "kickstart", f"{_launchd_domain()}/{label}"], check=True, timeout=30)
+        subprocess.run(["launchctl", "kickstart", target], check=True, timeout=30)
     print("✓ Service started")
 
 def launchd_stop():
-    label = get_launchd_label()
-    target = f"{_launchd_domain()}/{label}"
     try:
         from gateway.status import get_running_pid, write_planned_stop_marker
         pid = get_running_pid(cleanup_stale=False)
@@ -2428,13 +2918,22 @@ def launchd_stop():
     # the process.  A plain `kill SIGTERM` only signals the process — launchd
     # immediately restarts it because KeepAlive.SuccessfulExit = false.
     # `hermes gateway start` re-bootstraps when it detects the job is unloaded.
-    try:
-        subprocess.run(["launchctl", "bootout", target], check=True, timeout=90)
-    except subprocess.CalledProcessError as e:
-        if e.returncode in (3, 113):
-            pass  # Already unloaded — nothing to stop.
-        else:
-            raise
+    targets = [
+        (label, plist_path)
+        for label, plist_path in _launchd_service_targets()
+        if plist_path.exists()
+    ]
+    if not targets:
+        targets = [(get_launchd_label(), get_launchd_plist_path())]
+    for label, _plist_path in targets:
+        target = f"{_launchd_domain()}/{label}"
+        try:
+            subprocess.run(["launchctl", "bootout", target], check=True, timeout=90)
+        except subprocess.CalledProcessError as e:
+            if e.returncode in (3, 113):
+                pass  # Already unloaded — nothing to stop.
+            else:
+                raise
     _wait_for_gateway_exit(timeout=10.0, force_after=5.0)
     print("✓ Service stopped")
 
@@ -2481,6 +2980,7 @@ def _wait_for_gateway_exit(timeout: float = 10.0, force_after: float | None = 5.
 
 
 def launchd_restart():
+    migrated = _migrate_custom_root_launchd_service()
     label = get_launchd_label()
     target = f"{_launchd_domain()}/{label}"
     drain_timeout = _get_restart_drain_timeout()
@@ -2489,6 +2989,22 @@ def launchd_restart():
     try:
         pid = get_running_pid()
         if pid is not None and _request_gateway_self_restart(pid):
+            if migrated:
+                if pid != os.getpid():
+                    exited = _wait_for_gateway_exit(
+                        timeout=drain_timeout,
+                        force_after=None,
+                    )
+                    if not exited:
+                        print(
+                            f"⚠ Gateway drain timed out after {drain_timeout:.0f}s — "
+                            "loading migrated launchd service anyway"
+                        )
+                plist_path = _ensure_launchd_plist_exists()
+                _bootstrap_launchd_service_if_needed(label, plist_path)
+                subprocess.run(["launchctl", "kickstart", target], check=True, timeout=30)
+                print("✓ Service restarted")
+                return
             print("✓ Service restart requested")
             return
         if pid is not None:
@@ -2507,14 +3023,18 @@ def launchd_restart():
             raise
         # Job not loaded — bootstrap and start fresh
         print("↻ launchd job was unloaded; reloading")
-        plist_path = get_launchd_plist_path()
+        plist_path = _ensure_launchd_plist_exists()
         subprocess.run(["launchctl", "bootstrap", _launchd_domain(), str(plist_path)], check=True, timeout=30)
         subprocess.run(["launchctl", "kickstart", target], check=True, timeout=30)
         print("✓ Service restarted")
 
 def launchd_status(deep: bool = False):
-    plist_path = get_launchd_plist_path()
-    label = get_launchd_label()
+    legacy_mode = (
+        _has_migratable_custom_root_launchd_service()
+        and not get_launchd_plist_path().exists()
+    )
+    plist_path = _legacy_custom_root_launchd_plist_path() if legacy_mode else get_launchd_plist_path()
+    label = _LEGACY_DEFAULT_LAUNCHD_LABEL if legacy_mode else get_launchd_label()
     try:
         result = subprocess.run(
             ["launchctl", "list", label],
@@ -2529,7 +3049,10 @@ def launchd_status(deep: bool = False):
         loaded_output = ""
 
     print(f"Launchd plist: {plist_path}")
-    if launchd_plist_is_current():
+    if legacy_mode:
+        print("⚠ Legacy gateway service is installed under the old launchd label")
+        print(f"  Run: hermes gateway start  # migrates it to {get_launchd_label()}")
+    elif launchd_plist_is_current():
         print("✓ Service definition matches the current Hermes install")
     else:
         print("⚠ Service definition is stale relative to the current Hermes install")
@@ -3445,50 +3968,46 @@ def _setup_yuanbao():
 def _is_service_installed() -> bool:
     """Check if the gateway is installed as a system service."""
     if supports_systemd_services():
-        return get_systemd_unit_path(system=False).exists() or get_systemd_unit_path(system=True).exists()
+        return _has_any_systemd_service_definition()
     elif is_macos():
-        return get_launchd_plist_path().exists()
+        return _has_launchd_service_definition()
     return False
 
 
 def _is_service_running() -> bool:
     """Check if the gateway service is currently running."""
     if supports_systemd_services():
-        user_unit_exists = get_systemd_unit_path(system=False).exists()
-        system_unit_exists = get_systemd_unit_path(system=True).exists()
-
-        if user_unit_exists:
-            try:
-                result = _run_systemctl(
-                    ["is-active", get_service_name()],
-                    system=False, capture_output=True, text=True, timeout=10,
-                )
-                if result.stdout.strip() == "active":
-                    return True
-            except (RuntimeError, subprocess.TimeoutExpired):
-                pass
-
-        if system_unit_exists:
-            try:
-                result = _run_systemctl(
-                    ["is-active", get_service_name()],
-                    system=True, capture_output=True, text=True, timeout=10,
-                )
-                if result.stdout.strip() == "active":
-                    return True
-            except (RuntimeError, subprocess.TimeoutExpired):
-                pass
+        for is_system in (False, True):
+            if not _has_systemd_service_definition(system=is_system):
+                continue
+            for service_name, unit_path in _systemd_service_targets(system=is_system):
+                if not unit_path.exists():
+                    continue
+                try:
+                    result = _run_systemctl(
+                        ["is-active", service_name],
+                        system=is_system, capture_output=True, text=True, timeout=10,
+                    )
+                    if result.stdout.strip() == "active":
+                        return True
+                except (RuntimeError, subprocess.TimeoutExpired):
+                    pass
 
         return False
-    elif is_macos() and get_launchd_plist_path().exists():
-        try:
-            result = subprocess.run(
-                ["launchctl", "list", get_launchd_label()],
-                capture_output=True, text=True, timeout=10,
-            )
-            return result.returncode == 0
-        except subprocess.TimeoutExpired:
-            return False
+    elif is_macos() and _has_launchd_service_definition():
+        for label, plist_path in _launchd_service_targets():
+            if not plist_path.exists():
+                continue
+            try:
+                result = subprocess.run(
+                    ["launchctl", "list", label],
+                    capture_output=True, text=True, timeout=10,
+                )
+            except subprocess.TimeoutExpired:
+                continue
+            if result.returncode == 0:
+                return True
+        return False
     # Check for manual processes
     return len(find_gateway_pids()) > 0
 
@@ -4407,13 +4926,13 @@ def _gateway_command_inner(args):
         if stop_all:
             # --all: kill every gateway process on the machine
             service_available = False
-            if supports_systemd_services() and (get_systemd_unit_path(system=False).exists() or get_systemd_unit_path(system=True).exists()):
+            if supports_systemd_services() and _has_any_systemd_service_definition():
                 try:
                     systemd_stop(system=system)
                     service_available = True
                 except subprocess.CalledProcessError:
                     pass
-            elif is_macos() and get_launchd_plist_path().exists():
+            elif is_macos() and _has_launchd_service_definition():
                 try:
                     launchd_stop()
                     service_available = True
@@ -4428,13 +4947,13 @@ def _gateway_command_inner(args):
         else:
             # Default: stop only the current profile's gateway
             service_available = False
-            if supports_systemd_services() and (get_systemd_unit_path(system=False).exists() or get_systemd_unit_path(system=True).exists()):
+            if supports_systemd_services() and _has_any_systemd_service_definition():
                 try:
                     systemd_stop(system=system)
                     service_available = True
                 except subprocess.CalledProcessError:
                     pass
-            elif is_macos() and get_launchd_plist_path().exists():
+            elif is_macos() and _has_launchd_service_definition():
                 try:
                     launchd_stop()
                     service_available = True
@@ -4460,13 +4979,13 @@ def _gateway_command_inner(args):
         if restart_all:
             # --all: stop every gateway process across all profiles, then start fresh
             service_stopped = False
-            if supports_systemd_services() and (get_systemd_unit_path(system=False).exists() or get_systemd_unit_path(system=True).exists()):
+            if supports_systemd_services() and _has_any_systemd_service_definition():
                 try:
                     systemd_stop(system=system)
                     service_stopped = True
                 except subprocess.CalledProcessError:
                     pass
-            elif is_macos() and get_launchd_plist_path().exists():
+            elif is_macos() and _has_launchd_service_definition():
                 try:
                     launchd_stop()
                     service_stopped = True
@@ -4480,22 +4999,22 @@ def _gateway_command_inner(args):
 
             # Start the current profile's service fresh
             print("Starting gateway...")
-            if supports_systemd_services() and (get_systemd_unit_path(system=False).exists() or get_systemd_unit_path(system=True).exists()):
+            if supports_systemd_services() and _has_any_systemd_service_definition():
                 systemd_start(system=system)
-            elif is_macos() and get_launchd_plist_path().exists():
+            elif is_macos() and _has_launchd_service_definition():
                 launchd_start()
             else:
                 run_gateway(verbose=0)
             return
         
-        if supports_systemd_services() and (get_systemd_unit_path(system=False).exists() or get_systemd_unit_path(system=True).exists()):
+        if supports_systemd_services() and _has_any_systemd_service_definition():
             service_configured = True
             try:
                 systemd_restart(system=system)
                 service_available = True
             except subprocess.CalledProcessError:
                 pass
-        elif is_macos() and get_launchd_plist_path().exists():
+        elif is_macos() and _has_launchd_service_definition():
             service_configured = True
             try:
                 launchd_restart()
@@ -4544,10 +5063,10 @@ def _gateway_command_inner(args):
         snapshot = get_gateway_runtime_snapshot(system=system)
         
         # Check for service first
-        if supports_systemd_services() and (get_systemd_unit_path(system=False).exists() or get_systemd_unit_path(system=True).exists()):
+        if supports_systemd_services() and _has_any_systemd_service_definition():
             systemd_status(deep, system=system, full=full)
             _print_gateway_process_mismatch(snapshot)
-        elif is_macos() and get_launchd_plist_path().exists():
+        elif is_macos() and _has_launchd_service_definition():
             launchd_status(deep)
             _print_gateway_process_mismatch(snapshot)
         else:

--- a/hermes_cli/gateway_service_identity.py
+++ b/hermes_cli/gateway_service_identity.py
@@ -1,0 +1,251 @@
+"""Gateway service identity helpers.
+
+This module is intentionally small and import-safe so both the main
+``hermes gateway`` command and the standalone ``scripts/hermes-gateway`` entry
+point can share service naming without importing the full CLI gateway module.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import html
+import os
+import plistlib
+import re
+import shlex
+from dataclasses import dataclass
+from pathlib import Path
+
+from hermes_constants import get_hermes_home
+
+
+_SERVICE_BASE = "hermes-gateway"
+_LAUNCHD_LABEL_BASE = "ai.hermes.gateway"
+_PROFILE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+
+
+@dataclass(frozen=True)
+class GatewayServiceIdentity:
+    """Names for the gateway service under the active Hermes home."""
+
+    suffix: str
+    systemd_service_name: str
+    launchd_label: str
+
+
+def _resolved_hermes_home(hermes_home: str | Path | None = None) -> Path:
+    return Path(hermes_home).resolve() if hermes_home is not None else get_hermes_home().resolve()
+
+
+def _native_default_hermes_homes() -> set[Path]:
+    candidates: set[Path] = set()
+
+    try:
+        candidates.add((Path.home() / ".hermes").resolve())
+    except OSError:
+        pass
+
+    try:
+        import pwd
+
+        user_home = Path(pwd.getpwuid(os.getuid()).pw_dir)
+        candidates.add((user_home / ".hermes").resolve())
+
+        sudo_user = os.environ.get("SUDO_USER", "").strip()
+        if sudo_user and sudo_user != "root":
+            sudo_home = Path(pwd.getpwnam(sudo_user).pw_dir)
+            candidates.add((sudo_home / ".hermes").resolve())
+    except (ImportError, KeyError, OSError):
+        pass
+
+    return candidates
+
+
+def gateway_profile_name(hermes_home: str | Path | None = None) -> str | None:
+    """Return the profile name when *hermes_home* is ``<root>/profiles/<name>``."""
+    home = _resolved_hermes_home(hermes_home)
+    name = home.name
+    if home.parent.name == "profiles" and _PROFILE_NAME_RE.match(name):
+        return name
+    return None
+
+
+def gateway_service_suffix(hermes_home: str | Path | None = None) -> str:
+    """Return the stable suffix for service names under *hermes_home*.
+
+    The default ``~/.hermes`` keeps the historical unsuffixed service names.
+    Named profiles use their profile name. Any other custom Hermes home gets a
+    short hash so multiple installations can coexist without service collisions.
+    """
+    home = _resolved_hermes_home(hermes_home)
+    if home in _native_default_hermes_homes():
+        return ""
+
+    profile_name = gateway_profile_name(home)
+    if profile_name:
+        return profile_name
+
+    return hashlib.sha256(str(home).encode()).hexdigest()[:8]
+
+
+def is_custom_root_hermes_home(hermes_home: str | Path | None = None) -> bool:
+    """Return True when *hermes_home* is a non-default, non-profile root."""
+    home = _resolved_hermes_home(hermes_home)
+    return (
+        home not in _native_default_hermes_homes()
+        and gateway_profile_name(home) is None
+    )
+
+
+def get_gateway_service_identity(
+    hermes_home: str | Path | None = None,
+) -> GatewayServiceIdentity:
+    """Return systemd and launchd names for *hermes_home*."""
+    suffix = gateway_service_suffix(hermes_home)
+    return GatewayServiceIdentity(
+        suffix=suffix,
+        systemd_service_name=(
+            f"{_SERVICE_BASE}-{suffix}" if suffix else _SERVICE_BASE
+        ),
+        launchd_label=(
+            f"{_LAUNCHD_LABEL_BASE}-{suffix}" if suffix else _LAUNCHD_LABEL_BASE
+        ),
+    )
+
+
+def gateway_profile_arg(hermes_home: str | Path | None = None) -> str:
+    """Return ``--profile <name>`` for named profile homes, otherwise ``""``."""
+    profile_name = gateway_profile_name(hermes_home)
+    return f"--profile {profile_name}" if profile_name else ""
+
+
+def gateway_launchd_plist_path(
+    user_home: str | Path | None = None,
+    hermes_home: str | Path | None = None,
+) -> Path:
+    """Return the launchd plist path for *hermes_home* under *user_home*."""
+    home = Path(user_home) if user_home is not None else Path.home()
+    label = get_gateway_service_identity(hermes_home).launchd_label
+    return home / "Library" / "LaunchAgents" / f"{label}.plist"
+
+
+def _gateway_script_project_dirs(text: str) -> set[Path]:
+    dirs: set[Path] = set()
+    for match in re.finditer(r"(/[^\s\"'<]+/scripts/hermes-gateway)(?:[\s\"'<]|$)", text):
+        script_path = Path(match.group(1))
+        if script_path.name == "hermes-gateway" and script_path.parent.name == "scripts":
+            dirs.add(script_path.parent.parent)
+    return dirs
+
+
+def _project_env_matches_hermes_home(project_dir: Path, resolved_home: Path) -> bool:
+    env_path = project_dir / ".env"
+    if not env_path.exists():
+        return False
+
+    try:
+        from dotenv import dotenv_values
+
+        value = (dotenv_values(env_path).get("HERMES_HOME") or "").strip()
+    except Exception:
+        return False
+    if not value:
+        return False
+
+    configured_home = Path(value).expanduser()
+    if not configured_home.is_absolute():
+        configured_home = project_dir / configured_home
+
+    try:
+        return configured_home.resolve() == resolved_home
+    except OSError:
+        return False
+
+
+def _gateway_script_definition_matches_hermes_home(
+    text: str,
+    hermes_home: str | Path | None = None,
+) -> bool:
+    resolved_home = _resolved_hermes_home(hermes_home)
+    return any(
+        _project_env_matches_hermes_home(project_dir, resolved_home)
+        for project_dir in _gateway_script_project_dirs(text)
+    )
+
+
+def _hermes_home_value_matches(value: object, resolved_home: Path) -> bool:
+    text = str(value or "").strip()
+    if not text:
+        return False
+    try:
+        return Path(text).expanduser().resolve() == resolved_home
+    except OSError:
+        return False
+
+
+def _explicit_hermes_home_values(text: str) -> list[str]:
+    values: list[str] = []
+
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("Environment="):
+            continue
+        try:
+            env_values = shlex.split(stripped.split("=", 1)[1])
+        except ValueError:
+            env_values = []
+        for value in env_values:
+            if value.startswith("HERMES_HOME="):
+                values.append(value.split("=", 1)[1])
+
+    try:
+        payload = plistlib.loads(text.encode("utf-8"))
+    except Exception:
+        payload = None
+    if isinstance(payload, dict):
+        env = payload.get("EnvironmentVariables")
+        if isinstance(env, dict) and "HERMES_HOME" in env:
+            values.append(str(env.get("HERMES_HOME") or ""))
+
+    values.extend(
+        html.unescape(match)
+        for match in re.findall(
+            r"<key>\s*HERMES_HOME\s*</key>\s*<string>(.*?)</string>",
+            text,
+            flags=re.S,
+        )
+    )
+    return values
+
+
+def service_definition_declares_hermes_home(path: Path) -> bool:
+    """Return True when a service definition explicitly sets HERMES_HOME."""
+    try:
+        text = path.read_text(encoding="utf-8", errors="ignore")
+    except (OSError, PermissionError):
+        return False
+    return bool(_explicit_hermes_home_values(text))
+
+
+def service_definition_matches_hermes_home(
+    path: Path,
+    hermes_home: str | Path | None = None,
+) -> bool:
+    """Return True when a systemd unit or launchd plist targets *hermes_home*."""
+    try:
+        text = path.read_text(encoding="utf-8", errors="ignore")
+    except (OSError, PermissionError):
+        return False
+    resolved_home = _resolved_hermes_home(hermes_home)
+
+    explicit_values = _explicit_hermes_home_values(text)
+    if explicit_values:
+        return any(
+            _hermes_home_value_matches(value, resolved_home)
+            for value in explicit_values
+        )
+
+    if _gateway_script_definition_matches_hermes_home(text, resolved_home):
+        return True
+
+    return False

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7610,6 +7610,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
             restarted_services = []
             killed_pids = set()
             relaunched_profiles = []
+            extra_service_pids = set()
 
             # --- Systemd services (Linux) ---
             # Discover all hermes-gateway* units (default + profiles)
@@ -7786,26 +7787,54 @@ def _cmd_update_impl(args, gateway_mode: bool):
             if is_macos():
                 try:
                     from hermes_cli.gateway import (
-                        launchd_restart,
-                        get_launchd_label,
-                        get_launchd_plist_path,
+                        _graceful_restart_via_sigusr1 as _gateway_sigusr1_restart,
+                        _launchd_domain,
+                        _launchd_label_pid,
                     )
 
-                    plist_path = get_launchd_plist_path()
-                    if plist_path.exists():
-                        check = subprocess.run(
-                            ["launchctl", "list", get_launchd_label()],
-                            capture_output=True,
-                            text=True,
-                            timeout=5,
-                        )
-                        if check.returncode == 0:
-                            try:
-                                launchd_restart()
-                                restarted_services.append(get_launchd_label())
-                            except subprocess.CalledProcessError as e:
-                                stderr = (getattr(e, "stderr", "") or "").strip()
+                    launchd_list = subprocess.run(
+                        ["launchctl", "list"],
+                        capture_output=True,
+                        text=True,
+                        timeout=10,
+                    )
+                    launchd_labels = []
+                    for line in launchd_list.stdout.splitlines():
+                        parts = line.split()
+                        if len(parts) < 3:
+                            continue
+                        label = parts[2]
+                        if label.startswith("ai.hermes.gateway"):
+                            launchd_labels.append(label)
+
+                    for label in sorted(set(launchd_labels)):
+                        target = f"{_launchd_domain()}/{label}"
+                        pid = _launchd_label_pid(label)
+                        graceful_ok = False
+                        if pid:
+                            print(
+                                f"  → {label}: draining (up to {int(_drain_budget)}s)..."
+                            )
+                            graceful_ok = _gateway_sigusr1_restart(
+                                pid, drain_timeout=_drain_budget,
+                            )
+                        if not graceful_ok:
+                            restart = subprocess.run(
+                                ["launchctl", "kickstart", "-k", target],
+                                capture_output=True,
+                                text=True,
+                                timeout=90,
+                            )
+                            if restart.returncode != 0:
+                                stderr = (restart.stderr or "").strip()
                                 print(f"  ⚠ Gateway restart failed: {stderr}")
+                                continue
+                        restarted_services.append(label)
+
+                    for label in launchd_labels:
+                        pid = _launchd_label_pid(label)
+                        if pid:
+                            extra_service_pids.add(pid)
                 except (FileNotFoundError, subprocess.TimeoutExpired, ImportError):
                     pass
 
@@ -7814,6 +7843,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
             # Exclude PIDs that belong to just-restarted services so we don't
             # immediately kill the process that systemd/launchd just spawned.
             service_pids = _get_service_pids()
+            service_pids.update(extra_service_pids)
             manual_pids = find_gateway_pids(
                 exclude_pids=service_pids, all_profiles=True
             )
@@ -7837,9 +7867,9 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 if not drained:
                     try:
                         os.kill(pid, _signal.SIGTERM)
+                        killed_pids.add(pid)
                     except (ProcessLookupError, PermissionError):
                         pass
-                killed_pids.add(pid)
                 relaunched_profiles.append(proc.profile)
 
             for pid in manual_pids:
@@ -7851,14 +7881,16 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 except (ProcessLookupError, PermissionError):
                     pass
 
-            if restarted_services or killed_pids:
+            if restarted_services or killed_pids or relaunched_profiles:
                 print()
                 for svc in restarted_services:
                     print(f"  ✓ Restarted {svc}")
                 if relaunched_profiles:
                     names = ", ".join(relaunched_profiles)
                     print(f"  ✓ Restarting manual gateway profile(s): {names}")
-                unmapped_count = len(killed_pids) - len(relaunched_profiles)
+                unmapped_count = len(
+                    [pid for pid in killed_pids if pid not in profile_processes]
+                )
                 if unmapped_count:
                     print(f"  → Stopped {unmapped_count} manual gateway process(es)")
                     print("    Restart manually: hermes gateway run")

--- a/hermes_cli/uninstall.py
+++ b/hermes_cli/uninstall.py
@@ -154,46 +154,50 @@ def uninstall_gateway_service():
     if system == "Linux":
         try:
             from hermes_cli.gateway import (
-                get_systemd_unit_path,
-                get_service_name,
+                _systemd_service_targets,
                 _systemctl_cmd,
             )
-            svc_name = get_service_name()
 
             for is_system in (False, True):
-                unit_path = get_systemd_unit_path(system=is_system)
-                if not unit_path.exists():
-                    continue
-
                 scope = "system" if is_system else "user"
-                try:
-                    if is_system and os.geteuid() != 0:
-                        log_warn(f"System gateway service exists at {unit_path} "
-                                 f"but needs sudo to remove")
+                for target_svc, unit_path in _systemd_service_targets(system=is_system):
+                    if not unit_path.exists():
                         continue
 
-                    cmd = _systemctl_cmd(is_system)
-                    subprocess.run(cmd + ["stop", svc_name],
-                                   capture_output=True, check=False)
-                    subprocess.run(cmd + ["disable", svc_name],
-                                   capture_output=True, check=False)
-                    unit_path.unlink()
-                    subprocess.run(cmd + ["daemon-reload"],
-                                   capture_output=True, check=False)
-                    log_success(f"Removed {scope} gateway service ({unit_path})")
-                    stopped_something = True
-                except Exception as e:
-                    log_warn(f"Could not remove {scope} gateway service: {e}")
+                    try:
+                        if is_system and os.geteuid() != 0:
+                            log_warn(f"System gateway service exists at {unit_path} "
+                                     f"but needs sudo to remove")
+                            continue
+
+                        cmd = _systemctl_cmd(is_system)
+                        subprocess.run(cmd + ["stop", target_svc],
+                                       capture_output=True, check=False)
+                        subprocess.run(cmd + ["disable", target_svc],
+                                       capture_output=True, check=False)
+                        unit_path.unlink()
+                        subprocess.run(cmd + ["daemon-reload"],
+                                       capture_output=True, check=False)
+                        log_success(f"Removed {scope} gateway service ({unit_path})")
+                        stopped_something = True
+                    except Exception as e:
+                        log_warn(f"Could not remove {scope} gateway service: {e}")
         except Exception as e:
             log_warn(f"Could not check systemd gateway services: {e}")
 
     # 3. macOS: uninstall launchd plist
     elif system == "Darwin":
         try:
-            from hermes_cli.gateway import get_launchd_plist_path
-            plist_path = get_launchd_plist_path()
-            if plist_path.exists():
-                subprocess.run(["launchctl", "unload", str(plist_path)],
+            from hermes_cli.gateway import (
+                _launchd_domain,
+                _launchd_service_targets,
+            )
+
+            for label, plist_path in _launchd_service_targets():
+                if not plist_path.exists():
+                    continue
+
+                subprocess.run(["launchctl", "bootout", f"{_launchd_domain()}/{label}"],
                                capture_output=True, check=False)
                 plist_path.unlink()
                 log_success(f"Removed macOS gateway service ({plist_path})")

--- a/scripts/hermes-gateway
+++ b/scripts/hermes-gateway
@@ -34,8 +34,19 @@ SCRIPT_DIR = Path(__file__).parent.resolve()
 PROJECT_DIR = SCRIPT_DIR.parent
 sys.path.insert(0, str(PROJECT_DIR))
 
+from hermes_constants import (
+    display_hermes_home,
+    get_hermes_home,
+)
+from hermes_cli.gateway_service_identity import (
+    gateway_launchd_plist_path,
+    get_gateway_service_identity,
+    service_definition_declares_hermes_home,
+    service_definition_matches_hermes_home,
+)
+
 # Load .env file
-from dotenv import load_dotenv
+from dotenv import dotenv_values, load_dotenv
 env_path = PROJECT_DIR / '.env'
 if env_path.exists():
     load_dotenv(dotenv_path=env_path)
@@ -45,16 +56,208 @@ if env_path.exists():
 # Service Configuration
 # =============================================================================
 
-SERVICE_NAME = "hermes-gateway"
 SERVICE_DESCRIPTION = "Hermes Agent Gateway - Messaging Platform Integration"
+LEGACY_SYSTEMD_SERVICE_NAME = "hermes-gateway"
+LEGACY_LAUNCHD_LABEL = "ai.hermes.gateway"
+
+def get_systemd_service_name() -> str:
+    """Return the systemd service name, scoped when HERMES_HOME is not default."""
+    return get_gateway_service_identity().systemd_service_name
+
+def get_launchd_label() -> str:
+    """Return the launchd label, scoped when HERMES_HOME is not the default."""
+    return get_gateway_service_identity().launchd_label
 
 def get_systemd_unit_path() -> Path:
     """Get the path for the systemd user service file."""
-    return Path.home() / ".config" / "systemd" / "user" / f"{SERVICE_NAME}.service"
+    return Path.home() / ".config" / "systemd" / "user" / f"{get_systemd_service_name()}.service"
 
 def get_launchd_plist_path() -> Path:
     """Get the path for the launchd plist file (macOS)."""
-    return Path.home() / "Library" / "LaunchAgents" / f"ai.hermes.gateway.plist"
+    return gateway_launchd_plist_path(Path.home())
+
+def get_legacy_systemd_unit_path() -> Path:
+    """Return the historical unsuffixed systemd unit path."""
+    return Path.home() / ".config" / "systemd" / "user" / f"{LEGACY_SYSTEMD_SERVICE_NAME}.service"
+
+def get_legacy_launchd_plist_path() -> Path:
+    """Return the historical unsuffixed launchd plist path."""
+    return Path.home() / "Library" / "LaunchAgents" / f"{LEGACY_LAUNCHD_LABEL}.plist"
+
+def legacy_service_matches_current_install(path: Path) -> bool:
+    """Return True when *path* targets this Hermes home or this script.
+
+    Older versions of this standalone entry point did not write HERMES_HOME
+    into service definitions. Treat those script-path-only definitions as a
+    current-root match only when the checkout .env explicitly pins HERMES_HOME
+    to this root; otherwise the legacy service could be the default install
+    from the same checkout.
+    """
+    if service_definition_matches_hermes_home(path):
+        return True
+    if service_definition_declares_hermes_home(path):
+        return False
+
+    try:
+        text = path.read_text(encoding="utf-8", errors="ignore")
+    except (OSError, PermissionError):
+        return False
+
+    return (
+        get_gateway_script_path() in text
+        and project_env_matches_current_hermes_home()
+    )
+
+def has_legacy_systemd_service() -> bool:
+    """Return True when the old unsuffixed unit targets this HERMES_HOME."""
+    legacy_path = get_legacy_systemd_unit_path()
+    return (
+        get_systemd_service_name() != LEGACY_SYSTEMD_SERVICE_NAME
+        and legacy_path != get_systemd_unit_path()
+        and legacy_path.exists()
+        and legacy_service_matches_current_install(legacy_path)
+    )
+
+def has_legacy_launchd_service() -> bool:
+    """Return True when the old unsuffixed plist targets this HERMES_HOME."""
+    legacy_path = get_legacy_launchd_plist_path()
+    return (
+        get_launchd_label() != LEGACY_LAUNCHD_LABEL
+        and legacy_path != get_launchd_plist_path()
+        and legacy_path.exists()
+        and legacy_service_matches_current_install(legacy_path)
+    )
+
+def systemd_management_target() -> tuple[str, Path]:
+    """Return the service name/path to use for management commands."""
+    return systemd_management_targets()[0]
+
+def systemd_management_targets() -> list[tuple[str, Path]]:
+    """Return all systemd service definitions for this Hermes home."""
+    current_path = get_systemd_unit_path()
+    targets = []
+    if current_path.exists():
+        targets.append((get_systemd_service_name(), current_path))
+    if has_legacy_systemd_service():
+        targets.append((LEGACY_SYSTEMD_SERVICE_NAME, get_legacy_systemd_unit_path()))
+    return targets or [(get_systemd_service_name(), current_path)]
+
+def launchd_management_target() -> tuple[str, Path]:
+    """Return the launchd label/plist to use for management commands."""
+    return launchd_management_targets()[0]
+
+def launchd_management_targets() -> list[tuple[str, Path]]:
+    """Return all launchd service definitions for this Hermes home."""
+    current_path = get_launchd_plist_path()
+    targets = []
+    if current_path.exists():
+        targets.append((get_launchd_label(), current_path))
+    if has_legacy_launchd_service():
+        targets.append((LEGACY_LAUNCHD_LABEL, get_legacy_launchd_plist_path()))
+    return targets or [(get_launchd_label(), current_path)]
+
+def systemd_service_is_active(service_name: str) -> bool:
+    """Return True when the systemd user service is currently active."""
+    result = subprocess.run(
+        ["systemctl", "--user", "is-active", service_name],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.stdout.strip() == "active"
+
+def systemd_service_is_enabled(service_name: str) -> bool:
+    """Return True when the systemd user service is currently enabled."""
+    result = subprocess.run(
+        ["systemctl", "--user", "is-enabled", service_name],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.stdout.strip() == "enabled"
+
+def parse_launchd_pid(stdout: str, label: str) -> int | None:
+    """Parse a PID from launchctl output for a specific label."""
+    import re
+
+    for line in stdout.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        parts = stripped.split()
+        if len(parts) >= 3 and parts[2] == label:
+            try:
+                pid = int(parts[0])
+            except ValueError:
+                continue
+            return pid if pid > 0 else None
+
+        match = re.search(r'"?PID"?\s*=\s*(\d+)', stripped)
+        if match:
+            pid = int(match.group(1))
+            return pid if pid > 0 else None
+    return None
+
+def launchd_label_pid(label: str) -> int | None:
+    """Return the running PID for a launchd label, if launchd reports one."""
+    try:
+        result = subprocess.run(
+            ["launchctl", "list", label],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        return None
+    if result.returncode != 0:
+        return None
+    return parse_launchd_pid(result.stdout, label)
+
+def wait_for_pid_exit(pid: int | None, timeout: float = 10.0) -> bool:
+    """Return True once the captured process exits."""
+    if pid is None or pid <= 0:
+        return True
+
+    import time
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return True
+        except PermissionError:
+            pass
+        time.sleep(0.3)
+    return False
+
+def remove_legacy_launchd_service() -> bool:
+    """Unload and remove the old unsuffixed launchd plist if it matches."""
+    if not has_legacy_launchd_service():
+        return False
+    legacy_path = get_legacy_launchd_plist_path()
+    legacy_pid = launchd_label_pid(LEGACY_LAUNCHD_LABEL)
+    unload = subprocess.run(
+        ["launchctl", "unload", str(legacy_path)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if unload.returncode not in (0, 3, 113):
+        raise subprocess.CalledProcessError(
+            unload.returncode,
+            unload.args,
+            output=unload.stdout,
+            stderr=unload.stderr,
+        )
+    if unload.returncode == 0 and not wait_for_pid_exit(legacy_pid, timeout=10.0):
+        raise RuntimeError(
+            "Legacy launchd gateway did not stop cleanly; refusing to start "
+            f"{get_launchd_label()} while {LEGACY_LAUNCHD_LABEL} may still be running"
+        )
+    legacy_path.unlink(missing_ok=True)
+    print(f"↻ Migrated legacy service from {LEGACY_LAUNCHD_LABEL} to {get_launchd_label()}")
+    return True
 
 def get_python_path() -> str:
     """Get the path to the Python interpreter."""
@@ -68,6 +271,28 @@ def get_gateway_script_path() -> str:
     """Get the path to this script."""
     return str(Path(__file__).resolve())
 
+def project_env_matches_current_hermes_home() -> bool:
+    """Return True when this checkout's .env pins HERMES_HOME to this root."""
+    project_env = PROJECT_DIR / ".env"
+    if not project_env.exists():
+        return False
+
+    try:
+        value = (dotenv_values(project_env).get("HERMES_HOME") or "").strip()
+    except Exception:
+        return False
+    if not value:
+        return False
+
+    configured_home = Path(value).expanduser()
+    if not configured_home.is_absolute():
+        configured_home = PROJECT_DIR / configured_home
+
+    try:
+        return configured_home.resolve() == get_hermes_home().resolve()
+    except OSError:
+        return False
+
 
 # =============================================================================
 # Systemd Service (Linux)
@@ -78,6 +303,7 @@ def generate_systemd_unit() -> str:
     python_path = get_python_path()
     script_path = get_gateway_script_path()
     working_dir = str(PROJECT_DIR)
+    hermes_home = str(get_hermes_home().resolve())
     
     return f"""[Unit]
 Description={SERVICE_DESCRIPTION}
@@ -89,6 +315,7 @@ StartLimitBurst=5
 Type=simple
 ExecStart={python_path} {script_path} run
 WorkingDirectory={working_dir}
+Environment="HERMES_HOME={hermes_home}"
 Restart=on-failure
 RestartSec=30
 StandardOutput=journal
@@ -104,63 +331,112 @@ WantedBy=default.target
 
 def install_systemd():
     """Install the systemd user service."""
+    service_name = get_systemd_service_name()
     unit_path = get_systemd_unit_path()
+    legacy_path = get_legacy_systemd_unit_path()
+    should_migrate_legacy = has_legacy_systemd_service()
+    legacy_was_active = should_migrate_legacy and systemd_service_is_active(
+        LEGACY_SYSTEMD_SERVICE_NAME
+    )
+    scoped_was_enabled = systemd_service_is_enabled(service_name)
+    enabled_scoped_during_install = False
+    previous_unit = unit_path.read_text(encoding="utf-8") if unit_path.exists() else None
+
     unit_path.parent.mkdir(parents=True, exist_ok=True)
-    
     print(f"Installing systemd service to: {unit_path}")
-    unit_path.write_text(generate_systemd_unit())
-    
-    # Reload systemd
-    subprocess.run(["systemctl", "--user", "daemon-reload"], check=True)
-    
-    # Enable the service (start on boot)
-    subprocess.run(["systemctl", "--user", "enable", SERVICE_NAME], check=True)
+
+    try:
+        unit_path.write_text(generate_systemd_unit())
+
+        # Reload systemd
+        subprocess.run(["systemctl", "--user", "daemon-reload"], check=True)
+
+        # Enable the service (start on boot)
+        subprocess.run(["systemctl", "--user", "enable", service_name], check=True)
+        enabled_scoped_during_install = not scoped_was_enabled
+        if legacy_was_active:
+            subprocess.run(
+                ["systemctl", "--user", "stop", LEGACY_SYSTEMD_SERVICE_NAME],
+                check=True,
+            )
+            try:
+                subprocess.run(["systemctl", "--user", "start", service_name], check=True)
+            except Exception:
+                subprocess.run(
+                    ["systemctl", "--user", "start", LEGACY_SYSTEMD_SERVICE_NAME],
+                    check=False,
+                )
+                raise
+    except Exception:
+        if enabled_scoped_during_install:
+            subprocess.run(["systemctl", "--user", "disable", service_name], check=False)
+        if previous_unit is None:
+            unit_path.unlink(missing_ok=True)
+        else:
+            unit_path.write_text(previous_unit, encoding="utf-8")
+        subprocess.run(["systemctl", "--user", "daemon-reload"], check=False)
+        raise
+
+    if should_migrate_legacy and legacy_path.exists():
+        subprocess.run(["systemctl", "--user", "disable", LEGACY_SYSTEMD_SERVICE_NAME], check=False)
+        legacy_path.unlink(missing_ok=True)
+        subprocess.run(["systemctl", "--user", "daemon-reload"], check=False)
+        print(f"↻ Migrated legacy service from {LEGACY_SYSTEMD_SERVICE_NAME} to {service_name}")
     
     print(f"✓ Service installed and enabled")
     print(f"")
     print(f"To start the service:")
-    print(f"  systemctl --user start {SERVICE_NAME}")
+    print(f"  systemctl --user start {service_name}")
     print(f"")
     print(f"To view logs:")
-    print(f"  journalctl --user -u {SERVICE_NAME} -f")
+    print(f"  journalctl --user -u {service_name} -f")
     print(f"")
     print(f"To enable lingering (keeps service running after logout):")
     print(f"  sudo loginctl enable-linger $USER")
 
 def uninstall_systemd():
     """Uninstall the systemd user service."""
+    service_name = get_systemd_service_name()
     unit_path = get_systemd_unit_path()
-    
-    # Stop and disable first
-    subprocess.run(["systemctl", "--user", "stop", SERVICE_NAME], check=False)
-    subprocess.run(["systemctl", "--user", "disable", SERVICE_NAME], check=False)
-    
-    # Remove the unit file
-    if unit_path.exists():
-        unit_path.unlink()
-        print(f"✓ Removed {unit_path}")
-    
+    targets = [(service_name, unit_path)]
+    if has_legacy_systemd_service():
+        targets.append((LEGACY_SYSTEMD_SERVICE_NAME, get_legacy_systemd_unit_path()))
+
+    for target_name, target_path in targets:
+        # Stop and disable first
+        subprocess.run(["systemctl", "--user", "stop", target_name], check=False)
+        subprocess.run(["systemctl", "--user", "disable", target_name], check=False)
+
+        # Remove the unit file
+        if target_path.exists():
+            target_path.unlink()
+            print(f"✓ Removed {target_path}")
+
     # Reload systemd
     subprocess.run(["systemctl", "--user", "daemon-reload"], check=True)
     print(f"✓ Service uninstalled")
 
 def systemd_status():
     """Show systemd service status."""
-    subprocess.run(["systemctl", "--user", "status", SERVICE_NAME])
+    for service_name, _unit_path in systemd_management_targets():
+        subprocess.run(["systemctl", "--user", "status", service_name])
 
 def systemd_start():
     """Start the systemd service."""
-    subprocess.run(["systemctl", "--user", "start", SERVICE_NAME], check=True)
+    service_name, _unit_path = systemd_management_target()
+    subprocess.run(["systemctl", "--user", "start", service_name], check=True)
     print(f"✓ Service started")
 
 def systemd_stop():
     """Stop the systemd service."""
-    subprocess.run(["systemctl", "--user", "stop", SERVICE_NAME], check=True)
+    for service_name, _unit_path in systemd_management_targets():
+        subprocess.run(["systemctl", "--user", "stop", service_name], check=True)
     print(f"✓ Service stopped")
 
 def systemd_restart():
     """Restart the systemd service."""
-    subprocess.run(["systemctl", "--user", "restart", SERVICE_NAME], check=True)
+    service_name, _unit_path = systemd_management_target()
+    subprocess.run(["systemctl", "--user", "restart", service_name], check=True)
     print(f"✓ Service restarted")
 
 
@@ -173,14 +449,17 @@ def generate_launchd_plist() -> str:
     python_path = get_python_path()
     script_path = get_gateway_script_path()
     working_dir = str(PROJECT_DIR)
-    log_dir = Path.home() / ".hermes" / "logs"
+    hermes_home_path = get_hermes_home().resolve()
+    hermes_home = str(hermes_home_path)
+    log_dir = hermes_home_path / "logs"
+    label = get_launchd_label()
     
     return f"""<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
     <key>Label</key>
-    <string>ai.hermes.gateway</string>
+    <string>{label}</string>
     
     <key>ProgramArguments</key>
     <array>
@@ -211,6 +490,8 @@ def generate_launchd_plist() -> str:
     <dict>
         <key>PATH</key>
         <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <key>HERMES_HOME</key>
+        <string>{hermes_home}</string>
     </dict>
 </dict>
 </plist>
@@ -219,53 +500,99 @@ def generate_launchd_plist() -> str:
 def install_launchd():
     """Install the launchd service (macOS)."""
     plist_path = get_launchd_plist_path()
+    legacy_path = get_legacy_launchd_plist_path()
+    should_migrate_legacy = has_legacy_launchd_service()
+    previous_plist = plist_path.read_text(encoding="utf-8") if plist_path.exists() else None
     plist_path.parent.mkdir(parents=True, exist_ok=True)
     
     # Ensure log directory exists
-    log_dir = Path.home() / ".hermes" / "logs"
+    log_dir = get_hermes_home().resolve() / "logs"
     log_dir.mkdir(parents=True, exist_ok=True)
     
     print(f"Installing launchd service to: {plist_path}")
-    plist_path.write_text(generate_launchd_plist())
-    
-    # Load the service
-    subprocess.run(["launchctl", "load", str(plist_path)], check=True)
+    legacy_pid = launchd_label_pid(LEGACY_LAUNCHD_LABEL) if should_migrate_legacy else None
+    legacy_unloaded = False
+
+    try:
+        if should_migrate_legacy:
+            unload = subprocess.run(
+                ["launchctl", "unload", str(legacy_path)],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            if unload.returncode not in (0, 3, 113):
+                raise subprocess.CalledProcessError(
+                    unload.returncode,
+                    unload.args,
+                    output=unload.stdout,
+                    stderr=unload.stderr,
+                )
+            legacy_unloaded = unload.returncode == 0
+            if legacy_unloaded and not wait_for_pid_exit(legacy_pid, timeout=10.0):
+                raise RuntimeError(
+                    "Legacy launchd gateway did not stop cleanly; refusing to start "
+                    f"{get_launchd_label()} while {LEGACY_LAUNCHD_LABEL} may still be running"
+                )
+
+        plist_path.write_text(generate_launchd_plist())
+
+        # Load the service
+        subprocess.run(["launchctl", "load", str(plist_path)], check=True)
+    except Exception:
+        if previous_plist is None:
+            plist_path.unlink(missing_ok=True)
+        else:
+            plist_path.write_text(previous_plist, encoding="utf-8")
+        if legacy_unloaded and legacy_path.exists():
+            subprocess.run(["launchctl", "load", str(legacy_path)], check=False)
+        raise
+
+    if should_migrate_legacy and legacy_path.exists():
+        legacy_path.unlink(missing_ok=True)
+        print(f"↻ Migrated legacy service from {LEGACY_LAUNCHD_LABEL} to {get_launchd_label()}")
     
     print(f"✓ Service installed and loaded")
     print(f"")
     print(f"To view logs:")
-    print(f"  tail -f ~/.hermes/logs/gateway.log")
+    print(f"  tail -f {display_hermes_home()}/logs/gateway.log")
     print(f"")
     print(f"To manage the service:")
-    print(f"  launchctl start ai.hermes.gateway")
-    print(f"  launchctl stop ai.hermes.gateway")
+    print(f"  launchctl start {get_launchd_label()}")
+    print(f"  launchctl stop {get_launchd_label()}")
 
 def uninstall_launchd():
     """Uninstall the launchd service (macOS)."""
-    plist_path = get_launchd_plist_path()
-    
-    # Unload first
-    subprocess.run(["launchctl", "unload", str(plist_path)], check=False)
-    
-    # Remove the plist file
-    if plist_path.exists():
-        plist_path.unlink()
-        print(f"✓ Removed {plist_path}")
+    targets = [(get_launchd_label(), get_launchd_plist_path())]
+    if has_legacy_launchd_service():
+        targets.append((LEGACY_LAUNCHD_LABEL, get_legacy_launchd_plist_path()))
+
+    for _label, plist_path in targets:
+        # Unload first
+        subprocess.run(["launchctl", "unload", str(plist_path)], check=False)
+
+        # Remove the plist file
+        if plist_path.exists():
+            plist_path.unlink()
+            print(f"✓ Removed {plist_path}")
     
     print(f"✓ Service uninstalled")
 
 def launchd_status():
     """Show launchd service status."""
-    subprocess.run(["launchctl", "list", "ai.hermes.gateway"])
+    for label, _plist_path in launchd_management_targets():
+        subprocess.run(["launchctl", "list", label])
 
 def launchd_start():
     """Start the launchd service."""
-    subprocess.run(["launchctl", "start", "ai.hermes.gateway"], check=True)
+    label, _plist_path = launchd_management_target()
+    subprocess.run(["launchctl", "start", label], check=True)
     print(f"✓ Service started")
 
 def launchd_stop():
     """Stop the launchd service."""
-    subprocess.run(["launchctl", "stop", "ai.hermes.gateway"], check=True)
+    for label, _plist_path in launchd_management_targets():
+        subprocess.run(["launchctl", "stop", label], check=True)
     print(f"✓ Service stopped")
 
 def launchd_restart():

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -65,6 +65,7 @@ class TestSystemdServiceRefresh:
 
         monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
         monkeypatch.setattr(gateway_cli, "generate_systemd_unit", lambda system=False, run_as_user=None: "new unit\n")
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
 
         calls = []
 
@@ -88,6 +89,7 @@ class TestSystemdServiceRefresh:
 
         monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
         monkeypatch.setattr(gateway_cli, "generate_systemd_unit", lambda system=False, run_as_user=None: "new unit\n")
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
 
         calls = []
 
@@ -617,6 +619,7 @@ class TestGatewaySystemServiceRouting:
         monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
         monkeypatch.setattr(gateway_cli, "_require_service_installed", lambda action, system=False: None)
         monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: calls.append(("refresh", system)))
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
         monkeypatch.setattr(
             "gateway.status.get_running_pid",
             lambda: 654,
@@ -672,6 +675,7 @@ class TestGatewaySystemServiceRouting:
         monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
         monkeypatch.setattr(gateway_cli, "_require_service_installed", lambda action, system=False: None)
         monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: None)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
         monkeypatch.setattr(
             "gateway.status.read_runtime_status",
             lambda: {"restart_requested": True, "gateway_state": "stopped"},

--- a/tests/hermes_cli/test_gateway_service_identity.py
+++ b/tests/hermes_cli/test_gateway_service_identity.py
@@ -1,0 +1,1666 @@
+"""Tests for shared gateway service identity naming."""
+
+import hashlib
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import hermes_cli.gateway as gateway_cli
+from hermes_cli.gateway_service_identity import (
+    gateway_launchd_plist_path,
+    gateway_profile_arg,
+    get_gateway_service_identity,
+    is_custom_root_hermes_home,
+    service_definition_matches_hermes_home,
+)
+
+
+def test_default_hermes_home_keeps_legacy_service_names(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+
+    identity = get_gateway_service_identity()
+
+    assert identity.suffix == ""
+    assert identity.systemd_service_name == "hermes-gateway"
+    assert identity.launchd_label == "ai.hermes.gateway"
+    assert (
+        gateway_launchd_plist_path(tmp_path)
+        == tmp_path / "Library" / "LaunchAgents" / "ai.hermes.gateway.plist"
+    )
+
+
+def test_default_hermes_home_keeps_legacy_names_when_home_is_redirected(
+    tmp_path, monkeypatch
+):
+    import pwd
+
+    os_home = tmp_path / "os-home"
+    hermes_home = os_home / ".hermes"
+    redirected_home = hermes_home / "home"
+    os_home.mkdir()
+    redirected_home.mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: redirected_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(
+        pwd,
+        "getpwuid",
+        lambda uid: SimpleNamespace(pw_dir=str(os_home)),
+    )
+
+    identity = get_gateway_service_identity()
+
+    assert identity.suffix == ""
+    assert identity.systemd_service_name == "hermes-gateway"
+    assert identity.launchd_label == "ai.hermes.gateway"
+    assert is_custom_root_hermes_home() is False
+    assert gateway_cli.get_service_name() == "hermes-gateway"
+
+
+def test_custom_dot_hermes_root_with_redirected_home_uses_hash_suffix(
+    tmp_path, monkeypatch
+):
+    import pwd
+
+    os_home = tmp_path / "os-home"
+    hermes_home = tmp_path / "custom-root" / ".hermes"
+    redirected_home = hermes_home / "home"
+    os_home.mkdir()
+    redirected_home.mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: redirected_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(
+        pwd,
+        "getpwuid",
+        lambda uid: SimpleNamespace(pw_dir=str(os_home)),
+    )
+    suffix = hashlib.sha256(str(hermes_home.resolve()).encode()).hexdigest()[:8]
+
+    identity = get_gateway_service_identity()
+
+    assert identity.suffix == suffix
+    assert identity.systemd_service_name == f"hermes-gateway-{suffix}"
+    assert identity.launchd_label == f"ai.hermes.gateway-{suffix}"
+    assert is_custom_root_hermes_home() is True
+
+
+def test_sudo_user_default_hermes_home_keeps_legacy_service_names(monkeypatch):
+    import pwd
+
+    monkeypatch.setattr(Path, "home", lambda: Path("/root"))
+    monkeypatch.setenv("HERMES_HOME", "/home/alice/.hermes")
+    monkeypatch.setenv("SUDO_USER", "alice")
+    monkeypatch.setattr(
+        pwd,
+        "getpwnam",
+        lambda name: SimpleNamespace(pw_dir="/home/alice"),
+    )
+
+    identity = get_gateway_service_identity()
+
+    assert identity.suffix == ""
+    assert identity.systemd_service_name == "hermes-gateway"
+    assert identity.launchd_label == "ai.hermes.gateway"
+
+
+def test_named_profile_uses_profile_suffix(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes" / "profiles" / "coder"
+    hermes_home.mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    identity = get_gateway_service_identity()
+
+    assert identity.suffix == "coder"
+    assert identity.systemd_service_name == "hermes-gateway-coder"
+    assert identity.launchd_label == "ai.hermes.gateway-coder"
+    assert gateway_profile_arg() == "--profile coder"
+
+
+def test_custom_hermes_home_uses_hash_suffix(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "custom-hermes"
+    hermes_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "os-home")
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    suffix = hashlib.sha256(str(hermes_home.resolve()).encode()).hexdigest()[:8]
+
+    identity = get_gateway_service_identity()
+
+    assert identity.suffix == suffix
+    assert identity.systemd_service_name == f"hermes-gateway-{suffix}"
+    assert identity.launchd_label == f"ai.hermes.gateway-{suffix}"
+    assert gateway_profile_arg() == ""
+    assert gateway_cli.get_service_name() == f"hermes-gateway-{suffix}"
+
+
+def test_custom_root_profile_uses_profile_name(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes-root" / "profiles" / "ops"
+    hermes_home.mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "os-home")
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    identity = get_gateway_service_identity()
+
+    assert identity.systemd_service_name == "hermes-gateway-ops"
+    assert identity.launchd_label == "ai.hermes.gateway-ops"
+    assert gateway_profile_arg() == "--profile ops"
+
+
+def test_profile_arg_handles_target_user_profile_path(monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: Path("/root"))
+    monkeypatch.setenv("HERMES_HOME", "/root/.hermes/profiles/coder")
+
+    assert gateway_profile_arg("/home/alice/.hermes/profiles/coder") == "--profile coder"
+
+
+def test_systemd_migrates_legacy_custom_root_unit(tmp_path, monkeypatch):
+    os_home = tmp_path / "os-home"
+    hermes_home = tmp_path / "custom-hermes"
+    os_home.mkdir()
+    hermes_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: os_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    legacy_unit = os_home / ".config" / "systemd" / "user" / "hermes-gateway.service"
+    legacy_unit.parent.mkdir(parents=True)
+    legacy_unit.write_text(
+        f'[Service]\nEnvironment="HERMES_HOME={hermes_home.resolve()}"\n',
+        encoding="utf-8",
+    )
+    calls = []
+    def run_systemctl(args, **kwargs):
+        calls.append(args)
+        stdout = "enabled\n" if args[:2] == ["is-enabled", "hermes-gateway"] else ""
+        return SimpleNamespace(returncode=0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(gateway_cli, "_run_systemctl", run_systemctl)
+    monkeypatch.setattr(
+        gateway_cli,
+        "generate_systemd_unit",
+        lambda system=False, run_as_user=None: "new scoped unit\n",
+    )
+    scoped_unit = gateway_cli.get_systemd_unit_path()
+
+    assert gateway_cli._migrate_custom_root_systemd_service() is True
+
+    assert not legacy_unit.exists()
+    assert scoped_unit.read_text(encoding="utf-8") == "new scoped unit\n"
+    assert calls == [
+        ["is-enabled", "hermes-gateway"],
+        ["daemon-reload"],
+        ["is-enabled", gateway_cli.get_service_name()],
+        ["enable", gateway_cli.get_service_name()],
+        ["disable", "hermes-gateway"],
+        ["daemon-reload"],
+    ]
+
+
+def test_systemd_migration_keeps_legacy_unit_when_enable_fails(
+    tmp_path, monkeypatch
+):
+    os_home = tmp_path / "os-home"
+    hermes_home = tmp_path / "custom-hermes"
+    os_home.mkdir()
+    hermes_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: os_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    legacy_unit = os_home / ".config" / "systemd" / "user" / "hermes-gateway.service"
+    legacy_unit.parent.mkdir(parents=True)
+    legacy_unit.write_text(
+        f'[Service]\nEnvironment="HERMES_HOME={hermes_home.resolve()}"\n',
+        encoding="utf-8",
+    )
+    calls = []
+
+    def run_systemctl(args, **kwargs):
+        calls.append(args)
+        if args[:2] == ["is-enabled", "hermes-gateway"]:
+            return SimpleNamespace(returncode=0, stdout="enabled\n", stderr="")
+        if args[:1] == ["enable"]:
+            raise gateway_cli.subprocess.CalledProcessError(1, args)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(gateway_cli, "_run_systemctl", run_systemctl)
+    monkeypatch.setattr(
+        gateway_cli,
+        "generate_systemd_unit",
+        lambda system=False, run_as_user=None: "new scoped unit\n",
+    )
+
+    with pytest.raises(gateway_cli.subprocess.CalledProcessError):
+        gateway_cli._migrate_custom_root_systemd_service()
+
+    assert legacy_unit.exists()
+    assert not gateway_cli.get_systemd_unit_path().exists()
+    assert ["stop", "hermes-gateway"] not in calls
+    assert ["disable", "hermes-gateway"] not in calls
+
+
+def test_systemd_migrates_legacy_named_profile_unit(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes" / "profiles" / "coder"
+    hermes_home.mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    legacy_unit = (
+        tmp_path
+        / ".config"
+        / "systemd"
+        / "user"
+        / "hermes-gateway.service"
+    )
+    legacy_unit.parent.mkdir(parents=True)
+    legacy_unit.write_text(
+        f'[Service]\nEnvironment="HERMES_HOME={hermes_home.resolve()}"\n',
+        encoding="utf-8",
+    )
+    calls = []
+
+    def run_systemctl(args, **kwargs):
+        calls.append(args)
+        stdout = "enabled\n" if args[:2] == ["is-enabled", "hermes-gateway"] else ""
+        return SimpleNamespace(returncode=0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(gateway_cli, "_run_systemctl", run_systemctl)
+    monkeypatch.setattr(
+        gateway_cli,
+        "generate_systemd_unit",
+        lambda system=False, run_as_user=None: "profile scoped unit\n",
+    )
+
+    assert gateway_cli.get_service_name() == "hermes-gateway-coder"
+    assert gateway_cli._migrate_custom_root_systemd_service() is True
+
+    scoped_unit = gateway_cli.get_systemd_unit_path()
+    assert not legacy_unit.exists()
+    assert scoped_unit.read_text(encoding="utf-8") == "profile scoped unit\n"
+    assert ["enable", "hermes-gateway-coder"] in calls
+
+
+def test_systemd_install_starts_scoped_service_when_legacy_unit_was_active(
+    tmp_path, monkeypatch
+):
+    os_home = tmp_path / "os-home"
+    hermes_home = tmp_path / "custom-hermes"
+    os_home.mkdir()
+    hermes_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: os_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    legacy_unit = os_home / ".config" / "systemd" / "user" / "hermes-gateway.service"
+    legacy_unit.parent.mkdir(parents=True)
+    legacy_unit.write_text(
+        f'[Service]\nEnvironment="HERMES_HOME={hermes_home.resolve()}"\n',
+        encoding="utf-8",
+    )
+    calls = []
+
+    def run_systemctl(args, **kwargs):
+        calls.append(args)
+        stdout = ""
+        if args[:2] == ["is-enabled", "hermes-gateway"]:
+            stdout = "enabled\n"
+        elif args[:2] == ["is-active", "hermes-gateway"]:
+            stdout = "active\n"
+        return SimpleNamespace(returncode=0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(gateway_cli, "_run_systemctl", run_systemctl)
+    monkeypatch.setattr(gateway_cli, "has_legacy_hermes_units", lambda: False)
+    monkeypatch.setattr(
+        gateway_cli,
+        "generate_systemd_unit",
+        lambda system=False, run_as_user=None: "new scoped unit\n",
+    )
+
+    gateway_cli.systemd_install()
+
+    assert ["start", gateway_cli.get_service_name()] in calls
+    assert calls.index(["start", gateway_cli.get_service_name()]) > calls.index(
+        ["enable", gateway_cli.get_service_name()]
+    )
+    assert not legacy_unit.exists()
+
+
+def test_systemd_migration_restarts_legacy_unit_when_scoped_start_fails(
+    tmp_path, monkeypatch
+):
+    os_home = tmp_path / "os-home"
+    hermes_home = tmp_path / "custom-hermes"
+    os_home.mkdir()
+    hermes_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: os_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    legacy_unit = os_home / ".config" / "systemd" / "user" / "hermes-gateway.service"
+    legacy_unit.parent.mkdir(parents=True)
+    legacy_unit.write_text(
+        f'[Service]\nEnvironment="HERMES_HOME={hermes_home.resolve()}"\n',
+        encoding="utf-8",
+    )
+    calls = []
+
+    def run_systemctl(args, **kwargs):
+        calls.append(args)
+        if args[:2] == ["is-enabled", "hermes-gateway"]:
+            return SimpleNamespace(returncode=0, stdout="enabled\n", stderr="")
+        if args[:2] == ["is-active", "hermes-gateway"]:
+            return SimpleNamespace(returncode=0, stdout="active\n", stderr="")
+        if args == ["start", gateway_cli.get_service_name()]:
+            raise gateway_cli.subprocess.CalledProcessError(1, args)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(gateway_cli, "_run_systemctl", run_systemctl)
+    monkeypatch.setattr(
+        gateway_cli,
+        "generate_systemd_unit",
+        lambda system=False, run_as_user=None: "new scoped unit\n",
+    )
+
+    with pytest.raises(gateway_cli.subprocess.CalledProcessError):
+        gateway_cli._migrate_custom_root_systemd_service(start_new_if_active=True)
+
+    assert legacy_unit.exists()
+    assert not gateway_cli.get_systemd_unit_path().exists()
+    assert ["start", "hermes-gateway"] in calls
+    assert ["disable", gateway_cli.get_service_name()] in calls
+    assert ["disable", "hermes-gateway"] not in calls
+
+
+def test_systemd_migration_disables_scoped_unit_when_legacy_stop_fails(
+    tmp_path, monkeypatch
+):
+    os_home = tmp_path / "os-home"
+    hermes_home = tmp_path / "custom-hermes"
+    os_home.mkdir()
+    hermes_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: os_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    legacy_unit = os_home / ".config" / "systemd" / "user" / "hermes-gateway.service"
+    legacy_unit.parent.mkdir(parents=True)
+    legacy_unit.write_text(
+        f'[Service]\nEnvironment="HERMES_HOME={hermes_home.resolve()}"\n',
+        encoding="utf-8",
+    )
+    calls = []
+
+    def run_systemctl(args, **kwargs):
+        calls.append(args)
+        if args[:2] == ["is-enabled", "hermes-gateway"]:
+            return SimpleNamespace(returncode=0, stdout="enabled\n", stderr="")
+        if args[:2] == ["is-active", "hermes-gateway"]:
+            return SimpleNamespace(returncode=0, stdout="active\n", stderr="")
+        if args == ["stop", "hermes-gateway"]:
+            raise gateway_cli.subprocess.CalledProcessError(1, args)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(gateway_cli, "_run_systemctl", run_systemctl)
+    monkeypatch.setattr(
+        gateway_cli,
+        "generate_systemd_unit",
+        lambda system=False, run_as_user=None: "new scoped unit\n",
+    )
+
+    with pytest.raises(gateway_cli.subprocess.CalledProcessError):
+        gateway_cli._migrate_custom_root_systemd_service(start_new_if_active=True)
+
+    assert legacy_unit.exists()
+    assert not gateway_cli.get_systemd_unit_path().exists()
+    assert ["disable", gateway_cli.get_service_name()] in calls
+    assert ["disable", "hermes-gateway"] not in calls
+
+
+def test_systemd_migration_refreshes_stale_scoped_unit_before_start(
+    tmp_path, monkeypatch
+):
+    os_home = tmp_path / "os-home"
+    hermes_home = tmp_path / "custom-hermes"
+    os_home.mkdir()
+    hermes_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: os_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    legacy_unit = os_home / ".config" / "systemd" / "user" / "hermes-gateway.service"
+    legacy_unit.parent.mkdir(parents=True)
+    legacy_unit.write_text(
+        f'[Service]\nEnvironment="HERMES_HOME={hermes_home.resolve()}"\n',
+        encoding="utf-8",
+    )
+    scoped_unit = gateway_cli.get_systemd_unit_path()
+    scoped_unit.write_text("stale scoped unit\n", encoding="utf-8")
+    calls = []
+
+    def run_systemctl(args, **kwargs):
+        calls.append(args)
+        if args == ["start", gateway_cli.get_service_name()]:
+            assert scoped_unit.read_text(encoding="utf-8") == "fresh scoped unit\n"
+        stdout = ""
+        if args[:2] == ["is-enabled", "hermes-gateway"]:
+            stdout = "enabled\n"
+        elif args[:2] == ["is-active", "hermes-gateway"]:
+            stdout = "active\n"
+        return SimpleNamespace(returncode=0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(gateway_cli, "_run_systemctl", run_systemctl)
+    monkeypatch.setattr(
+        gateway_cli,
+        "generate_systemd_unit",
+        lambda system=False, run_as_user=None: "fresh scoped unit\n",
+    )
+
+    assert (
+        gateway_cli._migrate_custom_root_systemd_service(start_new_if_active=True)
+        is True
+    )
+
+    assert scoped_unit.read_text(encoding="utf-8") == "fresh scoped unit\n"
+    assert calls.index(["daemon-reload"]) < calls.index(
+        ["start", gateway_cli.get_service_name()]
+    )
+    assert not legacy_unit.exists()
+
+
+def test_systemd_migration_preserves_disabled_legacy_unit(tmp_path, monkeypatch):
+    os_home = tmp_path / "os-home"
+    hermes_home = tmp_path / "custom-hermes"
+    os_home.mkdir()
+    hermes_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: os_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    legacy_unit = os_home / ".config" / "systemd" / "user" / "hermes-gateway.service"
+    legacy_unit.parent.mkdir(parents=True)
+    legacy_unit.write_text(
+        f'[Service]\nEnvironment="HERMES_HOME={hermes_home.resolve()}"\n',
+        encoding="utf-8",
+    )
+    calls = []
+
+    def run_systemctl(args, **kwargs):
+        calls.append(args)
+        stdout = "disabled\n" if args[:2] == ["is-enabled", "hermes-gateway"] else ""
+        return SimpleNamespace(returncode=0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(gateway_cli, "_run_systemctl", run_systemctl)
+    monkeypatch.setattr(
+        gateway_cli,
+        "generate_systemd_unit",
+        lambda system=False, run_as_user=None: "new scoped unit\n",
+    )
+
+    assert gateway_cli._migrate_custom_root_systemd_service() is True
+
+    assert ["enable", gateway_cli.get_service_name()] not in calls
+    assert calls == [
+        ["is-enabled", "hermes-gateway"],
+        ["daemon-reload"],
+        ["disable", "hermes-gateway"],
+        ["daemon-reload"],
+    ]
+
+
+def test_systemd_migration_can_skip_enable_preservation(tmp_path, monkeypatch):
+    os_home = tmp_path / "os-home"
+    hermes_home = tmp_path / "custom-hermes"
+    os_home.mkdir()
+    hermes_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: os_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    legacy_unit = os_home / ".config" / "systemd" / "user" / "hermes-gateway.service"
+    legacy_unit.parent.mkdir(parents=True)
+    legacy_unit.write_text(
+        f'[Service]\nEnvironment="HERMES_HOME={hermes_home.resolve()}"\n',
+        encoding="utf-8",
+    )
+    calls = []
+
+    def run_systemctl(args, **kwargs):
+        calls.append(args)
+        return SimpleNamespace(returncode=0, stdout="enabled\n", stderr="")
+
+    monkeypatch.setattr(gateway_cli, "_run_systemctl", run_systemctl)
+    monkeypatch.setattr(
+        gateway_cli,
+        "generate_systemd_unit",
+        lambda system=False, run_as_user=None: "new scoped unit\n",
+    )
+
+    assert (
+        gateway_cli._migrate_custom_root_systemd_service(preserve_enabled=False)
+        is True
+    )
+
+    assert ["is-enabled", "hermes-gateway"] not in calls
+    assert ["enable", gateway_cli.get_service_name()] not in calls
+
+
+def test_systemd_stop_stops_scoped_and_legacy_units_when_both_exist(
+    tmp_path, monkeypatch
+):
+    os_home = tmp_path / "os-home"
+    hermes_home = tmp_path / "custom-hermes"
+    os_home.mkdir()
+    hermes_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: os_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    scoped_unit = gateway_cli.get_systemd_unit_path()
+    legacy_unit = os_home / ".config" / "systemd" / "user" / "hermes-gateway.service"
+    scoped_unit.parent.mkdir(parents=True)
+    scoped_unit.write_text("scoped\n", encoding="utf-8")
+    legacy_unit.write_text(
+        f'[Service]\nEnvironment="HERMES_HOME={hermes_home.resolve()}"\n',
+        encoding="utf-8",
+    )
+    calls = []
+    monkeypatch.setattr(
+        gateway_cli,
+        "_run_systemctl",
+        lambda args, **kwargs: calls.append(args)
+        or SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+
+    gateway_cli.systemd_stop()
+
+    assert ["stop", gateway_cli.get_service_name()] in calls
+    assert ["stop", "hermes-gateway"] in calls
+
+
+def test_systemd_service_definition_detects_migratable_legacy_unit(tmp_path, monkeypatch):
+    os_home = tmp_path / "os-home"
+    hermes_home = tmp_path / "custom-hermes"
+    os_home.mkdir()
+    hermes_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: os_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    legacy_unit = os_home / ".config" / "systemd" / "user" / "hermes-gateway.service"
+    legacy_unit.parent.mkdir(parents=True)
+    legacy_unit.write_text(
+        f'[Service]\nEnvironment="HERMES_HOME={hermes_home.resolve()}"\n',
+        encoding="utf-8",
+    )
+
+    assert gateway_cli._has_systemd_service_definition() is True
+    assert gateway_cli.get_systemd_unit_path().exists() is False
+
+
+def test_systemd_status_reports_legacy_without_migrating(tmp_path, monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
+    monkeypatch.setattr(
+        gateway_cli,
+        "get_systemd_unit_path",
+        lambda system=False: tmp_path / "scoped.service",
+    )
+    monkeypatch.setattr(
+        gateway_cli,
+        "_has_migratable_custom_root_systemd_service",
+        lambda system=False: True,
+    )
+    monkeypatch.setattr(
+        gateway_cli,
+        "_migrate_custom_root_systemd_service",
+        lambda system=False: (_ for _ in ()).throw(AssertionError("status must not migrate")),
+    )
+    monkeypatch.setattr(
+        gateway_cli,
+        "_run_systemctl",
+        lambda args, **kwargs: calls.append(args)
+        or SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+
+    gateway_cli.systemd_status()
+
+    assert calls == [["status", "hermes-gateway", "--no-pager"]]
+
+
+def test_systemd_stop_uses_legacy_without_migrating(tmp_path, monkeypatch):
+    calls = []
+    legacy_unit = tmp_path / "legacy.service"
+    legacy_unit.write_text("legacy\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        gateway_cli,
+        "_select_systemd_scope",
+        lambda system=False: False,
+    )
+    monkeypatch.setattr(
+        gateway_cli,
+        "get_systemd_unit_path",
+        lambda system=False: tmp_path / "scoped.service",
+    )
+    monkeypatch.setattr(
+        gateway_cli,
+        "_systemd_service_targets",
+        lambda system=False: [("hermes-gateway", legacy_unit)],
+    )
+    monkeypatch.setattr(
+        gateway_cli,
+        "_migrate_custom_root_systemd_service",
+        lambda system=False: (_ for _ in ()).throw(
+            AssertionError("stop must not migrate")
+        ),
+    )
+    monkeypatch.setattr(
+        gateway_cli,
+        "_run_systemctl",
+        lambda args, **kwargs: calls.append(args)
+        or SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+
+    gateway_cli.systemd_stop()
+
+    assert calls == [["stop", "hermes-gateway"]]
+
+
+def test_systemd_uninstall_removes_legacy_without_migrating(tmp_path, monkeypatch):
+    legacy_unit = tmp_path / "hermes-gateway.service"
+    legacy_unit.write_text("legacy unit\n", encoding="utf-8")
+    calls = []
+
+    monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
+    monkeypatch.setattr(
+        gateway_cli,
+        "_migrate_custom_root_systemd_service",
+        lambda **kwargs: (_ for _ in ()).throw(
+            AssertionError("uninstall must not migrate before removing")
+        ),
+    )
+    monkeypatch.setattr(
+        gateway_cli,
+        "_systemd_service_targets",
+        lambda system=False: [("hermes-gateway", legacy_unit)],
+    )
+    monkeypatch.setattr(
+        gateway_cli,
+        "_run_systemctl",
+        lambda args, **kwargs: calls.append(args)
+        or SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+
+    gateway_cli.systemd_uninstall()
+
+    assert not legacy_unit.exists()
+    assert calls == [
+        ["stop", "hermes-gateway"],
+        ["disable", "hermes-gateway"],
+        ["daemon-reload"],
+    ]
+
+
+def test_systemd_migration_requires_exact_hermes_home_match(tmp_path, monkeypatch):
+    os_home = tmp_path / "os-home"
+    hermes_home = tmp_path / "custom-hermes"
+    os_home.mkdir()
+    hermes_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: os_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    legacy_unit = os_home / ".config" / "systemd" / "user" / "hermes-gateway.service"
+    legacy_unit.parent.mkdir(parents=True)
+    legacy_unit.write_text(
+        f'[Service]\nEnvironment="HERMES_HOME={hermes_home.resolve()}2"\n',
+        encoding="utf-8",
+    )
+
+    assert gateway_cli._service_definition_matches_current_hermes_home(legacy_unit) is False
+    assert gateway_cli._migrate_custom_root_systemd_service() is False
+    assert legacy_unit.exists()
+
+
+def test_systemd_detects_legacy_standalone_unit_with_matching_project_env(
+    tmp_path, monkeypatch
+):
+    os_home = tmp_path / "os-home"
+    hermes_home = tmp_path / "custom-hermes"
+    project_dir = tmp_path / "project"
+    script_path = project_dir / "scripts" / "hermes-gateway"
+    os_home.mkdir()
+    hermes_home.mkdir()
+    script_path.parent.mkdir(parents=True)
+    (project_dir / ".env").write_text(
+        f"HERMES_HOME={hermes_home.resolve()}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(Path, "home", lambda: os_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    legacy_unit = os_home / ".config" / "systemd" / "user" / "hermes-gateway.service"
+    legacy_unit.parent.mkdir(parents=True)
+    legacy_unit.write_text(
+        f"[Service]\nExecStart=/usr/bin/python {script_path} run\n",
+        encoding="utf-8",
+    )
+
+    assert gateway_cli._has_migratable_custom_root_systemd_service() is True
+
+
+def test_systemd_ignores_legacy_standalone_unit_without_matching_project_env(
+    tmp_path, monkeypatch
+):
+    os_home = tmp_path / "os-home"
+    hermes_home = tmp_path / "custom-hermes"
+    project_dir = tmp_path / "project"
+    script_path = project_dir / "scripts" / "hermes-gateway"
+    os_home.mkdir()
+    hermes_home.mkdir()
+    script_path.parent.mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: os_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    legacy_unit = os_home / ".config" / "systemd" / "user" / "hermes-gateway.service"
+    legacy_unit.parent.mkdir(parents=True)
+    legacy_unit.write_text(
+        f"[Service]\nExecStart=/usr/bin/python {script_path} run\n",
+        encoding="utf-8",
+    )
+
+    assert gateway_cli._has_migratable_custom_root_systemd_service() is False
+
+
+def test_explicit_nonmatching_hermes_home_overrides_standalone_script_fallback(
+    tmp_path, monkeypatch
+):
+    current_home = tmp_path / "current-hermes"
+    other_home = tmp_path / "other-hermes"
+    project_dir = tmp_path / "project"
+    script_path = project_dir / "scripts" / "hermes-gateway"
+    current_home.mkdir()
+    other_home.mkdir()
+    script_path.parent.mkdir(parents=True)
+    (project_dir / ".env").write_text(
+        f"HERMES_HOME={current_home.resolve()}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(current_home))
+    unit = tmp_path / "hermes-gateway.service"
+    unit.write_text(
+        f'[Service]\nEnvironment="HERMES_HOME={other_home.resolve()}"\n'
+        f"ExecStart=/usr/bin/python {script_path} run\n",
+        encoding="utf-8",
+    )
+
+    assert service_definition_matches_hermes_home(unit) is False
+
+
+def test_explicit_nonmatching_launchd_home_overrides_script_fallback(
+    tmp_path, monkeypatch
+):
+    current_home = tmp_path / "current-hermes"
+    other_home = tmp_path / "other-hermes"
+    project_dir = tmp_path / "project"
+    script_path = project_dir / "scripts" / "hermes-gateway"
+    current_home.mkdir()
+    other_home.mkdir()
+    script_path.parent.mkdir(parents=True)
+    (project_dir / ".env").write_text(
+        f"HERMES_HOME={current_home.resolve()}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(current_home))
+    plist = tmp_path / "ai.hermes.gateway.plist"
+    plist.write_text(
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        "<plist><dict>"
+        "<key>ProgramArguments</key><array>"
+        "<string>/usr/bin/python</string>"
+        f"<string>{script_path}</string>"
+        "<string>run</string>"
+        "</array>"
+        "<key>EnvironmentVariables</key><dict>"
+        "<key>HERMES_HOME</key>"
+        f"<string>{other_home.resolve()}</string>"
+        "</dict></dict></plist>\n",
+        encoding="utf-8",
+    )
+
+    assert service_definition_matches_hermes_home(plist) is False
+
+
+def test_launchd_migration_requires_exact_hermes_home_match(tmp_path, monkeypatch):
+    machine_home = tmp_path / "machine-home"
+    hermes_home = tmp_path / "custom-hermes"
+    machine_home.mkdir()
+    hermes_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: machine_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(gateway_cli, "_launchd_user_home", lambda: machine_home)
+    legacy_plist = (
+        machine_home
+        / "Library"
+        / "LaunchAgents"
+        / "ai.hermes.gateway.plist"
+    )
+    legacy_plist.parent.mkdir(parents=True)
+    legacy_plist.write_text(
+        "<dict>\n"
+        "<key>HERMES_HOME</key>\n"
+        f"<string>{hermes_home.resolve()}2</string>\n"
+        "</dict>\n",
+        encoding="utf-8",
+    )
+
+    assert gateway_cli._service_definition_matches_current_hermes_home(legacy_plist) is False
+    assert gateway_cli._migrate_custom_root_launchd_service() is False
+    assert legacy_plist.exists()
+
+
+def test_launchd_detects_legacy_standalone_plist_with_matching_project_env(
+    tmp_path, monkeypatch
+):
+    machine_home = tmp_path / "machine-home"
+    hermes_home = tmp_path / "custom-hermes"
+    project_dir = tmp_path / "project"
+    script_path = project_dir / "scripts" / "hermes-gateway"
+    machine_home.mkdir()
+    hermes_home.mkdir()
+    script_path.parent.mkdir(parents=True)
+    (project_dir / ".env").write_text(
+        f"HERMES_HOME={hermes_home.resolve()}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(Path, "home", lambda: machine_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(gateway_cli, "_launchd_user_home", lambda: machine_home)
+    legacy_plist = (
+        machine_home
+        / "Library"
+        / "LaunchAgents"
+        / "ai.hermes.gateway.plist"
+    )
+    legacy_plist.parent.mkdir(parents=True)
+    legacy_plist.write_text(
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" '
+        '"http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n'
+        '<plist version="1.0"><dict>'
+        '<key>ProgramArguments</key><array>'
+        '<string>/usr/bin/python</string>'
+        f'<string>{script_path}</string>'
+        '<string>run</string>'
+        '</array>'
+        '</dict></plist>\n',
+        encoding="utf-8",
+    )
+
+    assert gateway_cli._has_migratable_custom_root_launchd_service() is True
+
+
+def test_launchd_migrates_legacy_custom_root_plist(tmp_path, monkeypatch):
+    machine_home = tmp_path / "machine-home"
+    hermes_home = tmp_path / "custom-hermes"
+    machine_home.mkdir()
+    hermes_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: machine_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(gateway_cli, "_launchd_user_home", lambda: machine_home)
+    monkeypatch.setattr(gateway_cli, "generate_launchd_plist", lambda: "scoped plist\n")
+    legacy_plist = (
+        machine_home
+        / "Library"
+        / "LaunchAgents"
+        / "ai.hermes.gateway.plist"
+    )
+    legacy_plist.parent.mkdir(parents=True)
+    legacy_plist.write_text(
+        "<dict>\n"
+        "<key>HERMES_HOME</key>\n"
+        f"<string>{hermes_home.resolve()}</string>\n"
+        "</dict>\n",
+        encoding="utf-8",
+    )
+    calls = []
+    waits = []
+
+    def run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd == ["launchctl", "list", "ai.hermes.gateway"]:
+            return SimpleNamespace(
+                returncode=0,
+                stdout="PID\tStatus\tLabel\n4321\t0\tai.hermes.gateway\n",
+                stderr="",
+            )
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(
+        gateway_cli.subprocess,
+        "run",
+        run,
+    )
+    monkeypatch.setattr(
+        gateway_cli,
+        "_wait_for_pid_exit",
+        lambda pid, **kwargs: waits.append((pid, kwargs)) or True,
+    )
+    monkeypatch.setattr(
+        gateway_cli,
+        "_wait_for_gateway_exit",
+        lambda **kwargs: (_ for _ in ()).throw(
+            AssertionError("must not wait on shared gateway PID")
+        ),
+    )
+
+    assert gateway_cli._migrate_custom_root_launchd_service() is True
+
+    scoped_plist = gateway_cli.get_launchd_plist_path()
+    assert scoped_plist.exists()
+    assert scoped_plist.read_text(encoding="utf-8") == "scoped plist\n"
+    assert not legacy_plist.exists()
+    assert calls == [
+        ["launchctl", "list", "ai.hermes.gateway"],
+        ["launchctl", "bootout", f"{gateway_cli._launchd_domain()}/ai.hermes.gateway"],
+        ["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(scoped_plist)],
+    ]
+    assert waits == [
+        (
+            4321,
+            {
+                "timeout": 10.0,
+                "description": "legacy launchd service ai.hermes.gateway",
+            },
+        )
+    ]
+
+
+def test_launchd_migrates_legacy_named_profile_plist(tmp_path, monkeypatch):
+    machine_home = tmp_path / "machine-home"
+    hermes_home = tmp_path / ".hermes" / "profiles" / "coder"
+    machine_home.mkdir()
+    hermes_home.mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(gateway_cli, "_launchd_user_home", lambda: machine_home)
+    monkeypatch.setattr(gateway_cli, "generate_launchd_plist", lambda: "profile plist\n")
+    legacy_plist = (
+        machine_home
+        / "Library"
+        / "LaunchAgents"
+        / "ai.hermes.gateway.plist"
+    )
+    legacy_plist.parent.mkdir(parents=True)
+    legacy_plist.write_text(
+        "<dict>\n"
+        "<key>HERMES_HOME</key>\n"
+        f"<string>{hermes_home.resolve()}</string>\n"
+        "</dict>\n",
+        encoding="utf-8",
+    )
+    calls = []
+    monkeypatch.setattr(
+        gateway_cli.subprocess,
+        "run",
+        lambda cmd, **kwargs: calls.append(cmd)
+        or SimpleNamespace(returncode=113, stdout="", stderr=""),
+    )
+
+    assert gateway_cli.get_launchd_label() == "ai.hermes.gateway-coder"
+    assert gateway_cli._migrate_custom_root_launchd_service() is True
+
+    scoped_plist = gateway_cli.get_launchd_plist_path()
+    assert scoped_plist.exists()
+    assert scoped_plist.read_text(encoding="utf-8") == "profile plist\n"
+    assert not legacy_plist.exists()
+    assert calls == [
+        ["launchctl", "list", "ai.hermes.gateway"],
+        ["launchctl", "bootout", f"{gateway_cli._launchd_domain()}/ai.hermes.gateway"]
+    ]
+
+
+def test_launchd_migration_refreshes_stale_scoped_plist(tmp_path, monkeypatch):
+    machine_home = tmp_path / "machine-home"
+    hermes_home = tmp_path / "custom-hermes"
+    machine_home.mkdir()
+    hermes_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: machine_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(gateway_cli, "_launchd_user_home", lambda: machine_home)
+    monkeypatch.setattr(gateway_cli, "generate_launchd_plist", lambda: "fresh plist\n")
+    legacy_plist = (
+        machine_home
+        / "Library"
+        / "LaunchAgents"
+        / "ai.hermes.gateway.plist"
+    )
+    legacy_plist.parent.mkdir(parents=True)
+    legacy_plist.write_text(
+        "<dict>\n"
+        "<key>HERMES_HOME</key>\n"
+        f"<string>{hermes_home.resolve()}</string>\n"
+        "</dict>\n",
+        encoding="utf-8",
+    )
+    scoped_plist = gateway_cli.get_launchd_plist_path()
+    scoped_plist.write_text("stale plist\n", encoding="utf-8")
+    calls = []
+    waits = []
+
+    def run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd == ["launchctl", "list", "ai.hermes.gateway"]:
+            return SimpleNamespace(
+                returncode=0,
+                stdout="PID\tStatus\tLabel\n4321\t0\tai.hermes.gateway\n",
+                stderr="",
+            )
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(gateway_cli.subprocess, "run", run)
+    monkeypatch.setattr(
+        gateway_cli,
+        "_wait_for_pid_exit",
+        lambda pid, **kwargs: waits.append((pid, kwargs)) or True,
+    )
+    monkeypatch.setattr(
+        gateway_cli,
+        "_wait_for_gateway_exit",
+        lambda **kwargs: (_ for _ in ()).throw(
+            AssertionError("must not wait on shared gateway PID")
+        ),
+    )
+
+    assert gateway_cli._migrate_custom_root_launchd_service() is True
+
+    assert scoped_plist.read_text(encoding="utf-8") == "fresh plist\n"
+    assert not legacy_plist.exists()
+    scoped_label = gateway_cli.get_launchd_label()
+    assert calls == [
+        ["launchctl", "list", scoped_label],
+        ["launchctl", "list", "ai.hermes.gateway"],
+        ["launchctl", "bootout", f"{gateway_cli._launchd_domain()}/ai.hermes.gateway"],
+        ["launchctl", "bootout", f"{gateway_cli._launchd_domain()}/{scoped_label}"],
+        ["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(scoped_plist)],
+    ]
+    assert waits == [
+        (
+            4321,
+            {
+                "timeout": 10.0,
+                "description": "legacy launchd service ai.hermes.gateway",
+            },
+        )
+    ]
+
+
+def test_launchd_migration_keeps_legacy_plist_when_bootout_fails(
+    tmp_path, monkeypatch
+):
+    machine_home = tmp_path / "machine-home"
+    hermes_home = tmp_path / "custom-hermes"
+    machine_home.mkdir()
+    hermes_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: machine_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(gateway_cli, "_launchd_user_home", lambda: machine_home)
+    legacy_plist = (
+        machine_home
+        / "Library"
+        / "LaunchAgents"
+        / "ai.hermes.gateway.plist"
+    )
+    legacy_plist.parent.mkdir(parents=True)
+    legacy_plist.write_text(
+        "<dict>\n"
+        "<key>HERMES_HOME</key>\n"
+        f"<string>{hermes_home.resolve()}</string>\n"
+        "</dict>\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        gateway_cli.subprocess,
+        "run",
+        lambda cmd, **kwargs: SimpleNamespace(
+            args=cmd,
+            returncode=5,
+            stdout="",
+            stderr="bootout failed",
+        ),
+    )
+    monkeypatch.setattr(
+        gateway_cli,
+        "_wait_for_pid_exit",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("must not wait after failed bootout")
+        ),
+    )
+
+    with pytest.raises(gateway_cli.subprocess.CalledProcessError):
+        gateway_cli._migrate_custom_root_launchd_service()
+
+    assert legacy_plist.exists()
+    assert not gateway_cli.get_launchd_plist_path().exists()
+
+
+def test_launchd_migration_keeps_legacy_plist_when_gateway_does_not_exit(
+    tmp_path, monkeypatch
+):
+    machine_home = tmp_path / "machine-home"
+    hermes_home = tmp_path / "custom-hermes"
+    machine_home.mkdir()
+    hermes_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: machine_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(gateway_cli, "_launchd_user_home", lambda: machine_home)
+    legacy_plist = (
+        machine_home
+        / "Library"
+        / "LaunchAgents"
+        / "ai.hermes.gateway.plist"
+    )
+    legacy_plist.parent.mkdir(parents=True)
+    legacy_plist.write_text(
+        "<dict>\n"
+        "<key>HERMES_HOME</key>\n"
+        f"<string>{hermes_home.resolve()}</string>\n"
+        "</dict>\n",
+        encoding="utf-8",
+    )
+    calls = []
+    monkeypatch.setattr(
+        gateway_cli.subprocess,
+        "run",
+        lambda cmd, **kwargs: calls.append(cmd)
+        or SimpleNamespace(
+            args=cmd,
+            returncode=0,
+            stdout="",
+            stderr="",
+        ),
+    )
+    waits = []
+    monkeypatch.setattr(gateway_cli, "_launchd_label_pid", lambda label: 4321)
+    monkeypatch.setattr(
+        gateway_cli,
+        "_wait_for_pid_exit",
+        lambda pid, **kwargs: waits.append((pid, kwargs)) or False,
+    )
+    monkeypatch.setattr(
+        gateway_cli,
+        "_wait_for_gateway_exit",
+        lambda **kwargs: (_ for _ in ()).throw(
+            AssertionError("must not wait on shared gateway PID")
+        ),
+    )
+
+    with pytest.raises(RuntimeError):
+        gateway_cli._migrate_custom_root_launchd_service()
+
+    assert legacy_plist.exists()
+    assert not gateway_cli.get_launchd_plist_path().exists()
+    assert ["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(legacy_plist)] in calls
+    assert [
+        "launchctl",
+        "kickstart",
+        f"{gateway_cli._launchd_domain()}/ai.hermes.gateway",
+    ] in calls
+    assert waits == [
+        (
+            4321,
+            {
+                "timeout": 10.0,
+                "description": "legacy launchd service ai.hermes.gateway",
+            },
+        )
+    ]
+
+
+def test_launchd_migration_removes_scoped_plist_when_bootstrap_fails(
+    tmp_path, monkeypatch
+):
+    machine_home = tmp_path / "machine-home"
+    hermes_home = tmp_path / "custom-hermes"
+    machine_home.mkdir()
+    hermes_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: machine_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(gateway_cli, "_launchd_user_home", lambda: machine_home)
+    monkeypatch.setattr(gateway_cli, "generate_launchd_plist", lambda: "scoped plist\n")
+    legacy_plist = (
+        machine_home
+        / "Library"
+        / "LaunchAgents"
+        / "ai.hermes.gateway.plist"
+    )
+    legacy_plist.parent.mkdir(parents=True)
+    legacy_plist.write_text(
+        "<dict>\n"
+        "<key>HERMES_HOME</key>\n"
+        f"<string>{hermes_home.resolve()}</string>\n"
+        "</dict>\n",
+        encoding="utf-8",
+    )
+    scoped_plist = gateway_cli.get_launchd_plist_path()
+    calls = []
+
+    def run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd == ["launchctl", "list", "ai.hermes.gateway"]:
+            return SimpleNamespace(
+                returncode=0,
+                stdout="PID\tStatus\tLabel\n4321\t0\tai.hermes.gateway\n",
+                stderr="",
+            )
+        if cmd == [
+            "launchctl",
+            "bootstrap",
+            gateway_cli._launchd_domain(),
+            str(scoped_plist),
+        ]:
+            raise gateway_cli.subprocess.CalledProcessError(5, cmd)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(gateway_cli.subprocess, "run", run)
+    monkeypatch.setattr(gateway_cli, "_wait_for_pid_exit", lambda pid, **kwargs: True)
+    monkeypatch.setattr(
+        gateway_cli,
+        "_wait_for_gateway_exit",
+        lambda **kwargs: (_ for _ in ()).throw(
+            AssertionError("must not wait on shared gateway PID")
+        ),
+    )
+
+    with pytest.raises(gateway_cli.subprocess.CalledProcessError):
+        gateway_cli._migrate_custom_root_launchd_service()
+
+    assert legacy_plist.exists()
+    assert not scoped_plist.exists()
+    assert ["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(legacy_plist)] in calls
+
+
+def test_systemd_runtime_snapshot_probes_migratable_legacy_unit(tmp_path, monkeypatch):
+    machine_home = tmp_path / "machine-home"
+    hermes_home = tmp_path / "custom-hermes"
+    machine_home.mkdir()
+    hermes_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: machine_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    legacy_unit = (
+        machine_home
+        / ".config"
+        / "systemd"
+        / "user"
+        / "hermes-gateway.service"
+    )
+    legacy_unit.parent.mkdir(parents=True)
+    legacy_unit.write_text(
+        f'[Service]\nEnvironment="HERMES_HOME={hermes_home.resolve()}"\n',
+        encoding="utf-8",
+    )
+    calls = []
+    monkeypatch.setattr(gateway_cli, "find_gateway_pids", lambda: [])
+    monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
+    monkeypatch.setattr(gateway_cli, "is_linux", lambda: False)
+    monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: True)
+
+    def fake_run_systemctl(args, *, system=False, **kwargs):
+        calls.append((args, system))
+        return SimpleNamespace(returncode=0, stdout="active\n", stderr="")
+
+    monkeypatch.setattr(gateway_cli, "_run_systemctl", fake_run_systemctl)
+
+    snapshot = gateway_cli.get_gateway_runtime_snapshot()
+
+    assert snapshot.service_installed is True
+    assert snapshot.service_running is True
+    assert calls == [(["is-active", "hermes-gateway"], False)]
+
+
+def test_launchd_service_definition_detects_migratable_legacy_plist(tmp_path, monkeypatch):
+    machine_home = tmp_path / "machine-home"
+    hermes_home = tmp_path / "custom-hermes"
+    machine_home.mkdir()
+    hermes_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: machine_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(gateway_cli, "_launchd_user_home", lambda: machine_home)
+    legacy_plist = (
+        machine_home
+        / "Library"
+        / "LaunchAgents"
+        / "ai.hermes.gateway.plist"
+    )
+    legacy_plist.parent.mkdir(parents=True)
+    legacy_plist.write_text(
+        "<dict>\n"
+        "<key>HERMES_HOME</key>\n"
+        f"<string>{hermes_home.resolve()}</string>\n"
+        "</dict>\n",
+        encoding="utf-8",
+    )
+
+    assert gateway_cli._has_launchd_service_definition() is True
+    assert gateway_cli.get_launchd_plist_path().exists() is False
+
+
+def test_launchd_runtime_snapshot_probes_migratable_legacy_plist(tmp_path, monkeypatch):
+    machine_home = tmp_path / "machine-home"
+    hermes_home = tmp_path / "custom-hermes"
+    machine_home.mkdir()
+    hermes_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: machine_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(gateway_cli, "_launchd_user_home", lambda: machine_home)
+    legacy_plist = (
+        machine_home
+        / "Library"
+        / "LaunchAgents"
+        / "ai.hermes.gateway.plist"
+    )
+    legacy_plist.parent.mkdir(parents=True)
+    legacy_plist.write_text(
+        "<dict>\n"
+        "<key>HERMES_HOME</key>\n"
+        f"<string>{hermes_home.resolve()}</string>\n"
+        "</dict>\n",
+        encoding="utf-8",
+    )
+    calls = []
+    monkeypatch.setattr(gateway_cli, "find_gateway_pids", lambda: [])
+    monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
+    monkeypatch.setattr(gateway_cli, "is_linux", lambda: False)
+    monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
+    monkeypatch.setattr(gateway_cli, "is_macos", lambda: True)
+    monkeypatch.setattr(
+        gateway_cli.subprocess,
+        "run",
+        lambda cmd, **kwargs: calls.append(cmd)
+        or SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+
+    snapshot = gateway_cli.get_gateway_runtime_snapshot()
+
+    assert snapshot.service_installed is True
+    assert snapshot.service_running is True
+    assert calls == [["launchctl", "list", "ai.hermes.gateway"]]
+
+
+def test_launchd_uninstall_removes_legacy_without_migrating(tmp_path, monkeypatch):
+    legacy_plist = tmp_path / "legacy.plist"
+    legacy_plist.write_text("legacy plist\n", encoding="utf-8")
+    calls = []
+
+    monkeypatch.setattr(
+        gateway_cli,
+        "_migrate_custom_root_launchd_service",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("uninstall must not migrate before removing")
+        ),
+    )
+    monkeypatch.setattr(
+        gateway_cli,
+        "_launchd_service_targets",
+        lambda: [("ai.hermes.gateway", legacy_plist)],
+    )
+    monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: "gui/501")
+    monkeypatch.setattr(
+        gateway_cli.subprocess,
+        "run",
+        lambda cmd, **kwargs: calls.append(cmd)
+        or SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+
+    gateway_cli.launchd_uninstall()
+
+    assert not legacy_plist.exists()
+    assert calls == [["launchctl", "bootout", "gui/501/ai.hermes.gateway"]]
+
+
+def test_launchd_install_bootstraps_migrated_scoped_plist(tmp_path, monkeypatch):
+    plist_path = tmp_path / "ai.hermes.gateway-hash.plist"
+    plist_path.write_text("scoped plist\n", encoding="utf-8")
+    calls = []
+
+    monkeypatch.setattr(gateway_cli, "_migrate_custom_root_launchd_service", lambda: True)
+    monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+    monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway-hash")
+    monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: "gui/501")
+    monkeypatch.setattr(
+        gateway_cli.subprocess,
+        "run",
+        lambda cmd, **kwargs: calls.append(cmd)
+        or SimpleNamespace(returncode=1 if cmd[:2] == ["launchctl", "list"] else 0),
+    )
+
+    gateway_cli.launchd_install()
+
+    assert ["launchctl", "list", "ai.hermes.gateway-hash"] in calls
+    assert ["launchctl", "bootstrap", "gui/501", str(plist_path)] in calls
+
+
+def test_launchd_install_refreshes_preexisting_migrated_scoped_plist(
+    tmp_path, monkeypatch
+):
+    plist_path = tmp_path / "ai.hermes.gateway-hash.plist"
+    plist_path.write_text("stale scoped plist\n", encoding="utf-8")
+    calls = []
+
+    monkeypatch.setattr(gateway_cli, "_migrate_custom_root_launchd_service", lambda: True)
+    monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+    monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway-hash")
+    monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: "gui/501")
+    monkeypatch.setattr(gateway_cli, "launchd_plist_is_current", lambda: False)
+    monkeypatch.setattr(
+        gateway_cli,
+        "refresh_launchd_plist_if_needed",
+        lambda: calls.append(["refresh"]) or True,
+    )
+    monkeypatch.setattr(
+        gateway_cli.subprocess,
+        "run",
+        lambda cmd, **kwargs: calls.append(cmd)
+        or SimpleNamespace(returncode=1 if cmd[:2] == ["launchctl", "list"] else 0),
+    )
+
+    gateway_cli.launchd_install()
+
+    assert ["refresh"] in calls
+    assert ["launchctl", "bootstrap", "gui/501", str(plist_path)] in calls
+    assert calls.index(["refresh"]) < calls.index(
+        ["launchctl", "bootstrap", "gui/501", str(plist_path)]
+    )
+
+
+def test_launchd_status_reports_legacy_without_migrating(tmp_path, monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(gateway_cli, "_has_migratable_custom_root_launchd_service", lambda: True)
+    monkeypatch.setattr(
+        gateway_cli,
+        "_legacy_custom_root_launchd_plist_path",
+        lambda: tmp_path / "legacy.plist",
+    )
+    monkeypatch.setattr(
+        gateway_cli,
+        "_migrate_custom_root_launchd_service",
+        lambda: (_ for _ in ()).throw(AssertionError("status must not migrate")),
+    )
+    monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway-hash")
+    monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: tmp_path / "missing.plist")
+    monkeypatch.setattr(
+        gateway_cli.subprocess,
+        "run",
+        lambda cmd, **kwargs: calls.append(cmd)
+        or SimpleNamespace(returncode=1, stdout="", stderr=""),
+    )
+
+    gateway_cli.launchd_status()
+
+    assert calls == [["launchctl", "list", "ai.hermes.gateway"]]
+
+
+def test_launchd_stop_uses_legacy_without_migrating(tmp_path, monkeypatch):
+    calls = []
+    legacy_plist = tmp_path / "legacy.plist"
+    legacy_plist.write_text("legacy\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        gateway_cli,
+        "_has_migratable_custom_root_launchd_service",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        gateway_cli,
+        "_legacy_custom_root_launchd_plist_path",
+        lambda: legacy_plist,
+    )
+    monkeypatch.setattr(
+        gateway_cli,
+        "_migrate_custom_root_launchd_service",
+        lambda: (_ for _ in ()).throw(AssertionError("stop must not migrate")),
+    )
+    monkeypatch.setattr(
+        gateway_cli,
+        "get_launchd_label",
+        lambda: "ai.hermes.gateway-hash",
+    )
+    monkeypatch.setattr(
+        gateway_cli,
+        "get_launchd_plist_path",
+        lambda: tmp_path / "missing.plist",
+    )
+    monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: "gui/501")
+    monkeypatch.setattr(
+        gateway_cli,
+        "_wait_for_gateway_exit",
+        lambda **kwargs: True,
+    )
+    monkeypatch.setattr(
+        gateway_cli.subprocess,
+        "run",
+        lambda cmd, **kwargs: calls.append(cmd)
+        or SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+
+    gateway_cli.launchd_stop()
+
+    assert calls == [["launchctl", "bootout", "gui/501/ai.hermes.gateway"]]
+
+
+def test_launchd_stop_boots_out_scoped_and_legacy_plists_when_both_exist(
+    tmp_path, monkeypatch
+):
+    machine_home = tmp_path / "machine-home"
+    hermes_home = tmp_path / "custom-hermes"
+    machine_home.mkdir()
+    hermes_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: machine_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(gateway_cli, "_launchd_user_home", lambda: machine_home)
+    monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: "gui/501")
+    scoped_plist = gateway_cli.get_launchd_plist_path()
+    legacy_plist = (
+        machine_home
+        / "Library"
+        / "LaunchAgents"
+        / "ai.hermes.gateway.plist"
+    )
+    scoped_plist.parent.mkdir(parents=True)
+    scoped_plist.write_text("scoped\n", encoding="utf-8")
+    legacy_plist.write_text(
+        "<dict>\n"
+        "<key>HERMES_HOME</key>\n"
+        f"<string>{hermes_home.resolve()}</string>\n"
+        "</dict>\n",
+        encoding="utf-8",
+    )
+    calls = []
+    monkeypatch.setattr(
+        gateway_cli.subprocess,
+        "run",
+        lambda cmd, **kwargs: calls.append(cmd)
+        or SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+    monkeypatch.setattr(gateway_cli, "_wait_for_gateway_exit", lambda **kwargs: True)
+
+    gateway_cli.launchd_stop()
+
+    assert ["launchctl", "bootout", f"gui/501/{gateway_cli.get_launchd_label()}"] in calls
+    assert ["launchctl", "bootout", "gui/501/ai.hermes.gateway"] in calls
+
+
+def test_launchd_restart_migrates_and_regenerates_missing_plist(tmp_path, monkeypatch):
+    plist_path = tmp_path / "scoped.plist"
+    calls = []
+    state = {"migrated": False}
+
+    monkeypatch.setattr(
+        gateway_cli,
+        "_migrate_custom_root_launchd_service",
+        lambda: state.__setitem__("migrated", True) or True,
+    )
+    monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+    monkeypatch.setattr(gateway_cli, "generate_launchd_plist", lambda: "plist\n")
+    monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway-hash")
+    monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: False)
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+
+    def run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd[:2] == ["launchctl", "kickstart"] and "-k" in cmd:
+            raise gateway_cli.subprocess.CalledProcessError(3, cmd)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(gateway_cli.subprocess, "run", run)
+
+    gateway_cli.launchd_restart()
+
+    assert state["migrated"] is True
+    assert plist_path.read_text(encoding="utf-8") == "plist\n"
+    assert ["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(plist_path)] in calls
+
+
+def test_launchd_restart_bootstraps_migrated_service_after_self_restart(tmp_path, monkeypatch):
+    plist_path = tmp_path / "scoped.plist"
+    plist_path.write_text("plist\n", encoding="utf-8")
+    calls = []
+    waited = []
+
+    monkeypatch.setattr(gateway_cli, "_migrate_custom_root_launchd_service", lambda: True)
+    monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+    monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway-hash")
+    monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: "gui/501")
+    monkeypatch.setattr(gateway_cli, "_launchd_label_is_loaded", lambda label: False)
+    monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: True)
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: 12345)
+    monkeypatch.setattr(os, "getpid", lambda: 99999)
+    monkeypatch.setattr(
+        gateway_cli,
+        "_wait_for_gateway_exit",
+        lambda **kwargs: waited.append(kwargs) or True,
+    )
+
+    monkeypatch.setattr(
+        gateway_cli.subprocess,
+        "run",
+        lambda cmd, **kwargs: calls.append(cmd)
+        or SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+
+    gateway_cli.launchd_restart()
+
+    assert waited
+    assert ["launchctl", "bootstrap", "gui/501", str(plist_path)] in calls
+    assert ["launchctl", "kickstart", "gui/501/ai.hermes.gateway-hash"] in calls
+
+
+def test_launchd_restart_refreshes_migrated_scoped_plist_before_bootstrap(
+    tmp_path, monkeypatch
+):
+    plist_path = tmp_path / "scoped.plist"
+    plist_path.write_text("stale plist\n", encoding="utf-8")
+    calls = []
+
+    monkeypatch.setattr(gateway_cli, "_migrate_custom_root_launchd_service", lambda: True)
+    monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+    monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway-hash")
+    monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: "gui/501")
+    monkeypatch.setattr(gateway_cli, "_launchd_label_is_loaded", lambda label: False)
+    monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: True)
+    monkeypatch.setattr(gateway_cli, "_wait_for_gateway_exit", lambda **kwargs: True)
+    monkeypatch.setattr(gateway_cli, "launchd_plist_is_current", lambda: False)
+    monkeypatch.setattr(gateway_cli, "generate_launchd_plist", lambda: "fresh plist\n")
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: 12345)
+    monkeypatch.setattr(os, "getpid", lambda: 99999)
+    monkeypatch.setattr(
+        gateway_cli.subprocess,
+        "run",
+        lambda cmd, **kwargs: calls.append(cmd)
+        or SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+
+    gateway_cli.launchd_restart()
+
+    assert plist_path.read_text(encoding="utf-8") == "fresh plist\n"
+    assert ["launchctl", "bootstrap", "gui/501", str(plist_path)] in calls
+    assert ["launchctl", "kickstart", "gui/501/ai.hermes.gateway-hash"] in calls

--- a/tests/hermes_cli/test_uninstall_gateway.py
+++ b/tests/hermes_cli/test_uninstall_gateway.py
@@ -1,0 +1,96 @@
+"""Tests for top-level gateway cleanup during uninstall."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import hermes_cli.gateway as gateway_cli
+import hermes_cli.uninstall as uninstall_cli
+
+
+def test_uninstall_gateway_service_removes_legacy_custom_root_systemd_unit(
+    tmp_path, monkeypatch
+):
+    os_home = tmp_path / "home"
+    hermes_home = tmp_path / "custom-hermes"
+    os_home.mkdir()
+    hermes_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: os_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+    monkeypatch.setattr(gateway_cli, "find_gateway_pids", lambda: [])
+    monkeypatch.setattr(gateway_cli, "kill_gateway_processes", lambda: 0)
+    monkeypatch.setattr(gateway_cli, "_systemctl_cmd", lambda system=False: ["systemctl", "--user"])
+
+    legacy_unit = (
+        os_home
+        / ".config"
+        / "systemd"
+        / "user"
+        / "hermes-gateway.service"
+    )
+    legacy_unit.parent.mkdir(parents=True)
+    legacy_unit.write_text(
+        f'[Service]\nEnvironment="HERMES_HOME={hermes_home.resolve()}"\n',
+        encoding="utf-8",
+    )
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(uninstall_cli.subprocess, "run", fake_run)
+
+    assert uninstall_cli.uninstall_gateway_service() is True
+
+    assert not legacy_unit.exists()
+    assert ["systemctl", "--user", "stop", "hermes-gateway"] in calls
+    assert ["systemctl", "--user", "disable", "hermes-gateway"] in calls
+    assert ["systemctl", "--user", "daemon-reload"] in calls
+
+
+def test_uninstall_gateway_service_removes_legacy_custom_root_launchd_plist(
+    tmp_path, monkeypatch
+):
+    os_home = tmp_path / "home"
+    hermes_home = tmp_path / "custom-hermes"
+    os_home.mkdir()
+    hermes_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: os_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+    monkeypatch.setattr(gateway_cli, "find_gateway_pids", lambda: [])
+    monkeypatch.setattr(gateway_cli, "kill_gateway_processes", lambda: 0)
+    monkeypatch.setattr(gateway_cli, "_launchd_user_home", lambda: os_home)
+    monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: "gui/501")
+
+    legacy_plist = (
+        os_home
+        / "Library"
+        / "LaunchAgents"
+        / "ai.hermes.gateway.plist"
+    )
+    legacy_plist.parent.mkdir(parents=True)
+    legacy_plist.write_text(
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        "<plist><dict>"
+        "<key>EnvironmentVariables</key><dict>"
+        "<key>HERMES_HOME</key>"
+        f"<string>{hermes_home.resolve()}</string>"
+        "</dict></dict></plist>\n",
+        encoding="utf-8",
+    )
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(uninstall_cli.subprocess, "run", fake_run)
+
+    assert uninstall_cli.uninstall_gateway_service() is True
+
+    assert not legacy_plist.exists()
+    assert ["launchctl", "bootout", "gui/501/ai.hermes.gateway"] in calls

--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -6,7 +6,9 @@ rather than leaving zombie processes or telling users to manually restart
 when launchd will auto-respawn.
 """
 
+import signal
 import subprocess
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 
@@ -48,6 +50,7 @@ def _make_run_side_effect(
     system_service_active=False,
     system_restart_rc=0,
     launchctl_loaded=False,
+    launchctl_stdout=None,
 ):
     """Build a subprocess.run side_effect that simulates git + service commands."""
 
@@ -105,7 +108,11 @@ def _make_run_side_effect(
         # launchctl list ai.hermes.gateway
         if "launchctl" in joined and "list" in joined:
             if launchctl_loaded:
-                return subprocess.CompletedProcess(cmd, 0, stdout="PID\tStatus\tLabel\n123\t0\tai.hermes.gateway\n", stderr="")
+                stdout = (
+                    launchctl_stdout
+                    or "PID\tStatus\tLabel\n123\t0\tai.hermes.gateway\n"
+                )
+                return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
             return subprocess.CompletedProcess(cmd, 113, stdout="", stderr="Could not find service")
 
         return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
@@ -322,10 +329,9 @@ class TestLaunchdPlistRefresh:
 
         cmd_strs = [" ".join(c) for c in calls]
         # Should bootstrap the new plist, then kickstart
+        assert any("bootout" in s for s in cmd_strs)
         assert any("bootstrap" in s for s in cmd_strs)
         assert any("kickstart" in s for s in cmd_strs)
-        # Should NOT call bootout (nothing to bootout)
-        assert not any("bootout" in s for s in cmd_strs)
 
 
 class TestCmdUpdateLaunchdRestart:
@@ -352,17 +358,86 @@ class TestCmdUpdateLaunchdRestart:
         mock_run.side_effect = _make_run_side_effect(
             commit_count="3",
             launchctl_loaded=True,
+            launchctl_stdout=(
+                "PID\tStatus\tLabel\n"
+                "123\t0\tai.hermes.gateway\n"
+                "456\t0\tai.hermes.gateway-abcd1234\n"
+            ),
         )
 
-        # Mock launchd_restart + find_gateway_pids (new code discovers all gateways)
-        with patch.object(gateway_cli, "launchd_restart") as mock_launchd_restart, \
+        with patch.object(gateway_cli, "_launchd_label_pid", return_value=None), \
+             patch.object(gateway_cli, "_launchd_domain", return_value="gui/501"), \
              patch.object(gateway_cli, "find_gateway_pids", return_value=[]):
             cmd_update(mock_args)
 
         captured = capsys.readouterr().out
+        launchctl_kickstarts = [
+            c.args[0] for c in mock_run.call_args_list
+            if len(c.args[0]) >= 3 and c.args[0][:2] == ["launchctl", "kickstart"]
+        ]
+        assert ["launchctl", "kickstart", "-k", "gui/501/ai.hermes.gateway"] in launchctl_kickstarts
+        assert [
+            "launchctl",
+            "kickstart",
+            "-k",
+            "gui/501/ai.hermes.gateway-abcd1234",
+        ] in launchctl_kickstarts
         assert "Restarted" in captured
         assert "Restart manually: hermes gateway run" not in captured
-        mock_launchd_restart.assert_called_once_with()
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_update_detects_legacy_custom_root_launchd_service(
+        self, mock_run, _mock_which, mock_args, capsys, tmp_path, monkeypatch,
+    ):
+        """Update restart detection must recognize the legacy unsuffixed
+        label before migration, otherwise the service PID is treated as manual.
+        """
+        machine_home = tmp_path / "machine-home"
+        hermes_home = tmp_path / "custom-hermes"
+        machine_home.mkdir()
+        hermes_home.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: machine_home)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(gateway_cli, "_launchd_user_home", lambda: machine_home)
+        legacy_plist = (
+            machine_home
+            / "Library"
+            / "LaunchAgents"
+            / "ai.hermes.gateway.plist"
+        )
+        legacy_plist.parent.mkdir(parents=True)
+        legacy_plist.write_text(
+            "<dict>\n"
+            "<key>HERMES_HOME</key>\n"
+            f"<string>{hermes_home.resolve()}</string>\n"
+            "</dict>\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway_cli, "is_linux", lambda: False)
+        mock_run.side_effect = _make_run_side_effect(
+            commit_count="3",
+            launchctl_loaded=True,
+        )
+
+        with patch.object(gateway_cli, "_launchd_label_pid", return_value=None), \
+             patch.object(gateway_cli, "_launchd_domain", return_value="gui/501"), \
+             patch.object(gateway_cli, "find_gateway_pids", return_value=[]):
+            cmd_update(mock_args)
+
+        captured = capsys.readouterr().out
+        scoped_label = gateway_cli.get_launchd_label()
+        launchctl_calls = [
+            c.args[0] for c in mock_run.call_args_list
+            if c.args[0] and c.args[0][0] == "launchctl"
+        ]
+        assert ["launchctl", "list"] in launchctl_calls
+        assert ["launchctl", "list", scoped_label] not in launchctl_calls
+        assert ["launchctl", "kickstart", "-k", "gui/501/ai.hermes.gateway"] in launchctl_calls
+        assert "Restarted" in captured
+        assert "Restart manually: hermes gateway run" not in captured
 
     @patch("shutil.which", return_value=None)
     @patch("subprocess.run")
@@ -463,8 +538,12 @@ class TestCmdUpdateLaunchdRestart:
         captured = capsys.readouterr().out
         restart.assert_called_once_with("coder", 12345)
         graceful.assert_called_once()
-        # Graceful drain returned False → SIGTERM fallback.
-        kill.assert_called_once()
+        # Graceful drain returned False -> SIGTERM fallback, then the survivor
+        # sweep force-kills the same stale PID if it still appears alive.
+        assert [call.args[1] for call in kill.call_args_list] == [
+            signal.SIGTERM,
+            signal.SIGKILL,
+        ]
         assert "Restarting manual gateway profile(s): coder" in captured
 
     @patch("shutil.which", return_value=None)
@@ -789,6 +868,10 @@ class TestServicePidExclusion:
         with patch.object(
             gateway_cli, "_get_service_pids", return_value={SERVICE_PID}
         ), patch.object(
+            gateway_cli, "_launchd_label_pid", return_value=None,
+        ), patch.object(
+            gateway_cli, "_launchd_domain", return_value="gui/501",
+        ), patch.object(
             gateway_cli, "find_gateway_pids",
             side_effect=lambda exclude_pids=None, all_profiles=False: (
                 [SERVICE_PID] if not exclude_pids else
@@ -879,15 +962,22 @@ class TestServicePidExclusion:
         with patch.object(
             gateway_cli, "_get_service_pids", return_value={SERVICE_PID}
         ), patch.object(
+            gateway_cli, "_launchd_label_pid", return_value=None,
+        ), patch.object(
+            gateway_cli, "_launchd_domain", return_value="gui/501",
+        ), patch.object(
             gateway_cli, "find_gateway_pids", side_effect=fake_find,
         ), patch("os.kill") as mock_kill:
             cmd_update(mock_args)
 
         captured = capsys.readouterr().out
         assert "Restarted" in captured
-        # Manual PID should be killed
+        # Manual PID gets SIGTERM first, then SIGKILL if it survives the sweep.
         manual_kills = [c for c in mock_kill.call_args_list if c.args[0] == MANUAL_PID]
-        assert len(manual_kills) == 1
+        assert [call.args[1] for call in manual_kills] == [
+            signal.SIGTERM,
+            signal.SIGKILL,
+        ]
         # Service PID should NOT be killed
         service_kills = [c for c in mock_kill.call_args_list if c.args[0] == SERVICE_PID]
         assert len(service_kills) == 0
@@ -920,10 +1010,18 @@ class TestGetServicePids:
         pids = gateway_cli._get_service_pids()
         assert 12345 in pids
 
-    def test_returns_launchd_pid(self, monkeypatch):
+    def test_returns_launchd_pid(self, tmp_path, monkeypatch):
         monkeypatch.setattr(gateway_cli, "is_linux", lambda: False)
         monkeypatch.setattr(gateway_cli, "is_macos", lambda: True)
         monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway")
+        monkeypatch.setattr(gateway_cli, "_has_launchd_service_definition", lambda: True)
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text("plist\n", encoding="utf-8")
+        monkeypatch.setattr(
+            gateway_cli,
+            "_launchd_service_targets",
+            lambda: [("ai.hermes.gateway", plist_path)],
+        )
 
         def fake_run(cmd, **kwargs):
             joined = " ".join(str(c) for c in cmd)
@@ -939,6 +1037,48 @@ class TestGetServicePids:
 
         pids = gateway_cli._get_service_pids()
         assert 67890 in pids
+
+    def test_returns_legacy_launchd_pid_for_custom_root(self, tmp_path, monkeypatch):
+        machine_home = tmp_path / "machine-home"
+        hermes_home = tmp_path / "custom-hermes"
+        machine_home.mkdir()
+        hermes_home.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: machine_home)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(gateway_cli, "_launchd_user_home", lambda: machine_home)
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: True)
+        legacy_plist = (
+            machine_home
+            / "Library"
+            / "LaunchAgents"
+            / "ai.hermes.gateway.plist"
+        )
+        legacy_plist.parent.mkdir(parents=True)
+        legacy_plist.write_text(
+            "<dict>\n"
+            "<key>HERMES_HOME</key>\n"
+            f"<string>{hermes_home.resolve()}</string>\n"
+            "</dict>\n",
+            encoding="utf-8",
+        )
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            if cmd == ["launchctl", "list", "ai.hermes.gateway"]:
+                return subprocess.CompletedProcess(
+                    cmd, 0,
+                    stdout="PID\tStatus\tLabel\n67890\t0\tai.hermes.gateway\n",
+                    stderr="",
+                )
+            return subprocess.CompletedProcess(cmd, 113, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        pids = gateway_cli._get_service_pids()
+        assert pids == {67890}
+        assert calls == [["launchctl", "list", "ai.hermes.gateway"]]
 
     def test_returns_empty_when_no_services(self, monkeypatch):
         monkeypatch.setattr(gateway_cli, "is_linux", lambda: False)

--- a/tests/scripts/test_hermes_gateway_script.py
+++ b/tests/scripts/test_hermes_gateway_script.py
@@ -1,0 +1,698 @@
+"""Regression tests for the standalone scripts/hermes-gateway entry point."""
+
+import hashlib
+import importlib.util
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "hermes-gateway"
+
+
+def load_gateway_script():
+    loader = SourceFileLoader("hermes_gateway_script_under_test", str(SCRIPT))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    with patch("dotenv.load_dotenv"):
+        loader.exec_module(module)
+    return module
+
+
+def test_launchd_plist_preserves_active_hermes_home(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes" / "profiles" / "coder"
+    hermes_home.mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    module = load_gateway_script()
+
+    plist = module.generate_launchd_plist()
+
+    assert module.get_launchd_label() == "ai.hermes.gateway-coder"
+    assert (
+        module.get_launchd_plist_path()
+        == tmp_path / "Library" / "LaunchAgents" / "ai.hermes.gateway-coder.plist"
+    )
+    assert "<string>ai.hermes.gateway-coder</string>" in plist
+    assert "<key>HERMES_HOME</key>" in plist
+    assert f"<string>{hermes_home.resolve()}</string>" in plist
+    assert f"<string>{hermes_home}/logs/gateway.log</string>" in plist
+    assert f"<string>{hermes_home}/logs/gateway.error.log</string>" in plist
+
+
+def test_launchd_install_creates_logs_under_active_hermes_home(tmp_path, monkeypatch):
+    os_home = tmp_path / "os-home"
+    hermes_home = tmp_path / "custom-hermes-home"
+    os_home.mkdir()
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    module = load_gateway_script()
+    monkeypatch.setattr(module.Path, "home", lambda: os_home)
+    monkeypatch.setattr(
+        module,
+        "get_launchd_plist_path",
+        lambda: tmp_path / "LaunchAgents" / "ai.hermes.gateway.plist",
+    )
+    monkeypatch.setattr(
+        module.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+
+    module.install_launchd()
+
+    assert (hermes_home / "logs").is_dir()
+    assert not (os_home / ".hermes" / "logs").exists()
+
+
+def test_systemd_unit_preserves_active_hermes_home(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes" / "profiles" / "coder"
+    hermes_home.mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    module = load_gateway_script()
+    unit = module.generate_systemd_unit()
+
+    assert module.get_systemd_service_name() == "hermes-gateway-coder"
+    assert (
+        module.get_systemd_unit_path()
+        == tmp_path / ".config" / "systemd" / "user" / "hermes-gateway-coder.service"
+    )
+    assert f'Environment="HERMES_HOME={hermes_home.resolve()}"' in unit
+
+
+def test_systemd_management_commands_use_profile_service(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes" / "profiles" / "coder"
+    hermes_home.mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    module = load_gateway_script()
+    calls = []
+    monkeypatch.setattr(
+        module.subprocess,
+        "run",
+        lambda cmd, **kwargs: calls.append(cmd)
+        or SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+
+    module.systemd_start()
+    module.systemd_stop()
+    module.systemd_status()
+    module.systemd_restart()
+
+    assert calls == [
+        ["systemctl", "--user", "start", "hermes-gateway-coder"],
+        ["systemctl", "--user", "stop", "hermes-gateway-coder"],
+        ["systemctl", "--user", "status", "hermes-gateway-coder"],
+        ["systemctl", "--user", "restart", "hermes-gateway-coder"],
+    ]
+
+
+def test_systemd_management_commands_fall_back_to_matching_legacy_service(
+    tmp_path, monkeypatch
+):
+    os_home = tmp_path / "os-home"
+    hermes_home = tmp_path / "custom-hermes"
+    os_home.mkdir()
+    hermes_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: os_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    module = load_gateway_script()
+    legacy_unit = module.get_legacy_systemd_unit_path()
+    legacy_unit.parent.mkdir(parents=True)
+    legacy_unit.write_text(
+        f'[Service]\nEnvironment="HERMES_HOME={hermes_home.resolve()}"\n',
+        encoding="utf-8",
+    )
+    calls = []
+    monkeypatch.setattr(
+        module.subprocess,
+        "run",
+        lambda cmd, **kwargs: calls.append(cmd)
+        or SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+
+    module.systemd_start()
+    module.systemd_stop()
+    module.systemd_status()
+    module.systemd_restart()
+
+    assert calls == [
+        ["systemctl", "--user", "start", "hermes-gateway"],
+        ["systemctl", "--user", "stop", "hermes-gateway"],
+        ["systemctl", "--user", "status", "hermes-gateway"],
+        ["systemctl", "--user", "restart", "hermes-gateway"],
+    ]
+
+
+def test_systemd_recognizes_previous_standalone_unit_when_project_env_matches(
+    tmp_path, monkeypatch
+):
+    os_home = tmp_path / "os-home"
+    hermes_home = tmp_path / "custom-hermes"
+    project_dir = tmp_path / "project"
+    os_home.mkdir()
+    hermes_home.mkdir()
+    project_dir.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: os_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    module = load_gateway_script()
+    monkeypatch.setattr(module, "PROJECT_DIR", project_dir)
+    (project_dir / ".env").write_text(
+        f"HERMES_HOME={hermes_home.resolve()}\n",
+        encoding="utf-8",
+    )
+    legacy_unit = module.get_legacy_systemd_unit_path()
+    legacy_unit.parent.mkdir(parents=True)
+    legacy_unit.write_text(
+        "[Service]\n"
+        f"ExecStart={module.get_python_path()} {module.get_gateway_script_path()} run\n",
+        encoding="utf-8",
+    )
+
+    assert module.has_legacy_systemd_service() is True
+
+
+def test_systemd_ignores_explicit_nonmatching_home_before_script_fallback(
+    tmp_path, monkeypatch
+):
+    os_home = tmp_path / "os-home"
+    hermes_home = tmp_path / "custom-hermes"
+    other_home = tmp_path / "other-hermes"
+    project_dir = tmp_path / "project"
+    os_home.mkdir()
+    hermes_home.mkdir()
+    other_home.mkdir()
+    project_dir.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: os_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    module = load_gateway_script()
+    monkeypatch.setattr(module, "PROJECT_DIR", project_dir)
+    (project_dir / ".env").write_text(
+        f"HERMES_HOME={hermes_home.resolve()}\n",
+        encoding="utf-8",
+    )
+    legacy_unit = module.get_legacy_systemd_unit_path()
+    legacy_unit.parent.mkdir(parents=True)
+    legacy_unit.write_text(
+        "[Service]\n"
+        f'Environment="HERMES_HOME={other_home.resolve()}"\n'
+        f"ExecStart={module.get_python_path()} {module.get_gateway_script_path()} run\n",
+        encoding="utf-8",
+    )
+
+    assert module.legacy_service_matches_current_install(legacy_unit) is False
+    assert module.has_legacy_systemd_service() is False
+
+
+def test_systemd_ignores_script_path_only_legacy_unit_without_project_env(
+    tmp_path, monkeypatch
+):
+    os_home = tmp_path / "os-home"
+    hermes_home = tmp_path / "custom-hermes"
+    project_dir = tmp_path / "project"
+    os_home.mkdir()
+    hermes_home.mkdir()
+    project_dir.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: os_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    module = load_gateway_script()
+    monkeypatch.setattr(module, "PROJECT_DIR", project_dir)
+    legacy_unit = module.get_legacy_systemd_unit_path()
+    legacy_unit.parent.mkdir(parents=True)
+    legacy_unit.write_text(
+        "[Service]\n"
+        f"ExecStart={module.get_python_path()} {module.get_gateway_script_path()} run\n",
+        encoding="utf-8",
+    )
+
+    assert module.has_legacy_systemd_service() is False
+
+
+def test_systemd_uninstall_removes_matching_legacy_service(tmp_path, monkeypatch):
+    os_home = tmp_path / "os-home"
+    hermes_home = tmp_path / "custom-hermes"
+    os_home.mkdir()
+    hermes_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: os_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    module = load_gateway_script()
+    legacy_unit = module.get_legacy_systemd_unit_path()
+    legacy_unit.parent.mkdir(parents=True)
+    legacy_unit.write_text(
+        f'[Service]\nEnvironment="HERMES_HOME={hermes_home.resolve()}"\n',
+        encoding="utf-8",
+    )
+    calls = []
+    monkeypatch.setattr(
+        module.subprocess,
+        "run",
+        lambda cmd, **kwargs: calls.append(cmd)
+        or SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+
+    module.uninstall_systemd()
+
+    assert not legacy_unit.exists()
+    assert ["systemctl", "--user", "stop", "hermes-gateway"] in calls
+    assert ["systemctl", "--user", "disable", "hermes-gateway"] in calls
+
+
+def test_systemd_install_starts_scoped_service_when_legacy_service_was_active(
+    tmp_path, monkeypatch
+):
+    os_home = tmp_path / "os-home"
+    hermes_home = tmp_path / "custom-hermes"
+    os_home.mkdir()
+    hermes_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: os_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    module = load_gateway_script()
+    legacy_unit = module.get_legacy_systemd_unit_path()
+    legacy_unit.parent.mkdir(parents=True)
+    legacy_unit.write_text(
+        f'[Service]\nEnvironment="HERMES_HOME={hermes_home.resolve()}"\n',
+        encoding="utf-8",
+    )
+    calls = []
+
+    def run(cmd, **kwargs):
+        calls.append(cmd)
+        stdout = "active\n" if cmd == [
+            "systemctl",
+            "--user",
+            "is-active",
+            "hermes-gateway",
+        ] else ""
+        return SimpleNamespace(returncode=0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(module.subprocess, "run", run)
+
+    module.install_systemd()
+
+    service_name = module.get_systemd_service_name()
+    assert ["systemctl", "--user", "enable", service_name] in calls
+    assert ["systemctl", "--user", "start", service_name] in calls
+    assert not legacy_unit.exists()
+
+
+def test_systemd_install_keeps_legacy_service_when_scoped_enable_fails(
+    tmp_path, monkeypatch
+):
+    os_home = tmp_path / "os-home"
+    hermes_home = tmp_path / "custom-hermes"
+    os_home.mkdir()
+    hermes_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: os_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    module = load_gateway_script()
+    legacy_unit = module.get_legacy_systemd_unit_path()
+    legacy_unit.parent.mkdir(parents=True)
+    legacy_unit.write_text(
+        f'[Service]\nEnvironment="HERMES_HOME={hermes_home.resolve()}"\n',
+        encoding="utf-8",
+    )
+    calls = []
+
+    def run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd == ["systemctl", "--user", "enable", module.get_systemd_service_name()]:
+            raise module.subprocess.CalledProcessError(1, cmd)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(module.subprocess, "run", run)
+
+    with pytest.raises(module.subprocess.CalledProcessError):
+        module.install_systemd()
+
+    assert legacy_unit.exists()
+    assert not module.get_systemd_unit_path().exists()
+    assert ["systemctl", "--user", "stop", "hermes-gateway"] not in calls
+    assert ["systemctl", "--user", "disable", "hermes-gateway"] not in calls
+
+
+def test_systemd_install_disables_scoped_service_when_legacy_stop_fails(
+    tmp_path, monkeypatch
+):
+    os_home = tmp_path / "os-home"
+    hermes_home = tmp_path / "custom-hermes"
+    os_home.mkdir()
+    hermes_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: os_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    module = load_gateway_script()
+    legacy_unit = module.get_legacy_systemd_unit_path()
+    legacy_unit.parent.mkdir(parents=True)
+    legacy_unit.write_text(
+        f'[Service]\nEnvironment="HERMES_HOME={hermes_home.resolve()}"\n',
+        encoding="utf-8",
+    )
+    calls = []
+
+    def run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd == ["systemctl", "--user", "is-active", "hermes-gateway"]:
+            return SimpleNamespace(returncode=0, stdout="active\n", stderr="")
+        if cmd == ["systemctl", "--user", "stop", "hermes-gateway"]:
+            raise module.subprocess.CalledProcessError(1, cmd)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(module.subprocess, "run", run)
+
+    with pytest.raises(module.subprocess.CalledProcessError):
+        module.install_systemd()
+
+    service_name = module.get_systemd_service_name()
+    assert legacy_unit.exists()
+    assert not module.get_systemd_unit_path().exists()
+    assert ["systemctl", "--user", "disable", service_name] in calls
+    assert ["systemctl", "--user", "disable", "hermes-gateway"] not in calls
+
+
+def test_launchd_management_commands_use_profile_label(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes" / "profiles" / "coder"
+    hermes_home.mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    module = load_gateway_script()
+    calls = []
+    monkeypatch.setattr(
+        module.subprocess,
+        "run",
+        lambda cmd, **kwargs: calls.append(cmd)
+        or SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+
+    module.launchd_start()
+    module.launchd_stop()
+    module.launchd_status()
+
+    assert calls == [
+        ["launchctl", "start", "ai.hermes.gateway-coder"],
+        ["launchctl", "stop", "ai.hermes.gateway-coder"],
+        ["launchctl", "list", "ai.hermes.gateway-coder"],
+    ]
+
+
+def test_launchd_management_commands_fall_back_to_matching_legacy_label(
+    tmp_path, monkeypatch
+):
+    os_home = tmp_path / "os-home"
+    hermes_home = tmp_path / "custom-hermes"
+    os_home.mkdir()
+    hermes_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: os_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    module = load_gateway_script()
+    legacy_plist = module.get_legacy_launchd_plist_path()
+    legacy_plist.parent.mkdir(parents=True)
+    legacy_plist.write_text(
+        "<dict>\n"
+        "<key>HERMES_HOME</key>\n"
+        f"<string>{hermes_home.resolve()}</string>\n"
+        "</dict>\n",
+        encoding="utf-8",
+    )
+    calls = []
+    monkeypatch.setattr(
+        module.subprocess,
+        "run",
+        lambda cmd, **kwargs: calls.append(cmd)
+        or SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+
+    module.launchd_start()
+    module.launchd_stop()
+    module.launchd_status()
+
+    assert calls == [
+        ["launchctl", "start", "ai.hermes.gateway"],
+        ["launchctl", "stop", "ai.hermes.gateway"],
+        ["launchctl", "list", "ai.hermes.gateway"],
+    ]
+
+
+def test_launchd_recognizes_previous_standalone_plist_when_project_env_matches(
+    tmp_path, monkeypatch
+):
+    os_home = tmp_path / "os-home"
+    hermes_home = tmp_path / "custom-hermes"
+    project_dir = tmp_path / "project"
+    os_home.mkdir()
+    hermes_home.mkdir()
+    project_dir.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: os_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    module = load_gateway_script()
+    monkeypatch.setattr(module, "PROJECT_DIR", project_dir)
+    (project_dir / ".env").write_text(
+        f"HERMES_HOME={hermes_home.resolve()}\n",
+        encoding="utf-8",
+    )
+    legacy_plist = module.get_legacy_launchd_plist_path()
+    legacy_plist.parent.mkdir(parents=True)
+    legacy_plist.write_text(
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        "<plist><dict>"
+        "<key>Label</key>"
+        "<string>ai.hermes.gateway</string>"
+        "<key>ProgramArguments</key>"
+        "<array>"
+        f"<string>{module.get_python_path()}</string>"
+        f"<string>{module.get_gateway_script_path()}</string>"
+        "<string>run</string>"
+        "</array>"
+        "</dict></plist>\n",
+        encoding="utf-8",
+    )
+
+    assert module.has_legacy_launchd_service() is True
+
+
+def test_launchd_ignores_explicit_nonmatching_home_before_script_fallback(
+    tmp_path, monkeypatch
+):
+    os_home = tmp_path / "os-home"
+    hermes_home = tmp_path / "custom-hermes"
+    other_home = tmp_path / "other-hermes"
+    project_dir = tmp_path / "project"
+    os_home.mkdir()
+    hermes_home.mkdir()
+    other_home.mkdir()
+    project_dir.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: os_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    module = load_gateway_script()
+    monkeypatch.setattr(module, "PROJECT_DIR", project_dir)
+    (project_dir / ".env").write_text(
+        f"HERMES_HOME={hermes_home.resolve()}\n",
+        encoding="utf-8",
+    )
+    legacy_plist = module.get_legacy_launchd_plist_path()
+    legacy_plist.parent.mkdir(parents=True)
+    legacy_plist.write_text(
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        "<plist><dict>"
+        "<key>Label</key>"
+        "<string>ai.hermes.gateway</string>"
+        "<key>ProgramArguments</key>"
+        "<array>"
+        f"<string>{module.get_python_path()}</string>"
+        f"<string>{module.get_gateway_script_path()}</string>"
+        "<string>run</string>"
+        "</array>"
+        "<key>EnvironmentVariables</key>"
+        "<dict>"
+        "<key>HERMES_HOME</key>"
+        f"<string>{other_home.resolve()}</string>"
+        "</dict>"
+        "</dict></plist>\n",
+        encoding="utf-8",
+    )
+
+    assert module.legacy_service_matches_current_install(legacy_plist) is False
+    assert module.has_legacy_launchd_service() is False
+
+
+def test_launchd_ignores_script_path_only_legacy_plist_without_project_env(
+    tmp_path, monkeypatch
+):
+    os_home = tmp_path / "os-home"
+    hermes_home = tmp_path / "custom-hermes"
+    project_dir = tmp_path / "project"
+    os_home.mkdir()
+    hermes_home.mkdir()
+    project_dir.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: os_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    module = load_gateway_script()
+    monkeypatch.setattr(module, "PROJECT_DIR", project_dir)
+    legacy_plist = module.get_legacy_launchd_plist_path()
+    legacy_plist.parent.mkdir(parents=True)
+    legacy_plist.write_text(
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        "<plist><dict>"
+        "<key>Label</key>"
+        "<string>ai.hermes.gateway</string>"
+        "<key>ProgramArguments</key>"
+        "<array>"
+        f"<string>{module.get_python_path()}</string>"
+        f"<string>{module.get_gateway_script_path()}</string>"
+        "<string>run</string>"
+        "</array>"
+        "</dict></plist>\n",
+        encoding="utf-8",
+    )
+
+    assert module.has_legacy_launchd_service() is False
+
+
+def test_launchd_remove_legacy_waits_for_matching_plist(tmp_path, monkeypatch):
+    os_home = tmp_path / "os-home"
+    hermes_home = tmp_path / "custom-hermes"
+    os_home.mkdir()
+    hermes_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: os_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    module = load_gateway_script()
+    legacy_plist = module.get_legacy_launchd_plist_path()
+    legacy_plist.parent.mkdir(parents=True)
+    legacy_plist.write_text(
+        "<dict>\n"
+        "<key>HERMES_HOME</key>\n"
+        f"<string>{hermes_home.resolve()}</string>\n"
+        "</dict>\n",
+        encoding="utf-8",
+    )
+    calls = []
+    waits = []
+
+    def run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd == ["launchctl", "list", "ai.hermes.gateway"]:
+            return SimpleNamespace(
+                returncode=0,
+                stdout="PID\tStatus\tLabel\n4321\t0\tai.hermes.gateway\n",
+                stderr="",
+            )
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(
+        module.subprocess,
+        "run",
+        run,
+    )
+    monkeypatch.setattr(
+        module,
+        "wait_for_pid_exit",
+        lambda pid, **kwargs: waits.append((pid, kwargs)) or True,
+    )
+
+    assert module.remove_legacy_launchd_service() is True
+
+    assert not legacy_plist.exists()
+    assert ["launchctl", "list", "ai.hermes.gateway"] in calls
+    assert ["launchctl", "unload", str(legacy_plist)] in calls
+    assert waits == [(4321, {"timeout": 10.0})]
+
+
+def test_launchd_install_keeps_legacy_plist_when_scoped_load_fails(
+    tmp_path, monkeypatch
+):
+    os_home = tmp_path / "os-home"
+    hermes_home = tmp_path / "custom-hermes"
+    os_home.mkdir()
+    hermes_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: os_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    module = load_gateway_script()
+    legacy_plist = module.get_legacy_launchd_plist_path()
+    legacy_plist.parent.mkdir(parents=True)
+    legacy_plist.write_text(
+        "<dict>\n"
+        "<key>HERMES_HOME</key>\n"
+        f"<string>{hermes_home.resolve()}</string>\n"
+        "</dict>\n",
+        encoding="utf-8",
+    )
+    scoped_plist = module.get_launchd_plist_path()
+    calls = []
+
+    def run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd == ["launchctl", "list", "ai.hermes.gateway"]:
+            return SimpleNamespace(
+                returncode=0,
+                stdout="PID\tStatus\tLabel\n4321\t0\tai.hermes.gateway\n",
+                stderr="",
+            )
+        if cmd == ["launchctl", "load", str(scoped_plist)]:
+            raise module.subprocess.CalledProcessError(5, cmd)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(module.subprocess, "run", run)
+    monkeypatch.setattr(module, "wait_for_pid_exit", lambda pid, **kwargs: True)
+
+    with pytest.raises(module.subprocess.CalledProcessError):
+        module.install_launchd()
+
+    assert legacy_plist.exists()
+    assert not scoped_plist.exists()
+    assert ["launchctl", "unload", str(legacy_plist)] in calls
+    assert ["launchctl", "load", str(scoped_plist)] in calls
+    assert ["launchctl", "load", str(legacy_plist)] in calls
+
+
+def test_launchd_label_hashes_custom_hermes_home(tmp_path, monkeypatch):
+    os_home = tmp_path / "os-home"
+    hermes_home = tmp_path / "custom-hermes-a"
+    os_home.mkdir()
+    hermes_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: os_home)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    module = load_gateway_script()
+    suffix = hashlib.sha256(str(hermes_home.resolve()).encode()).hexdigest()[:8]
+
+    assert module.get_launchd_label() == f"ai.hermes.gateway-{suffix}"
+    assert (
+        module.get_launchd_plist_path()
+        == os_home / "Library" / "LaunchAgents" / f"ai.hermes.gateway-{suffix}.plist"
+    )
+
+
+def test_launchd_plist_uses_absolute_log_paths_for_relative_hermes_home(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("HERMES_HOME", "relative-hermes-home")
+
+    module = load_gateway_script()
+    plist = module.generate_launchd_plist()
+
+    resolved = (tmp_path / "relative-hermes-home").resolve()
+    assert f"<string>{resolved}/logs/gateway.log</string>" in plist
+    assert f"<string>{resolved}/logs/gateway.error.log</string>" in plist


### PR DESCRIPTION
## What does this PR do?

Fixes gateway service identity collisions when Hermes runs from a named profile or custom `HERMES_HOME`. The default `~/.hermes` install keeps the historical `hermes-gateway` / `ai.hermes.gateway` names, while non-default homes get stable scoped systemd and launchd identities.

The fix also safely migrates matching legacy unsuffixed service definitions only when they are tied to the active `HERMES_HOME`, and rolls back new scoped definitions if enable/start/bootstrap fails so users keep their previous working service.

## Related Issue

No open issue. I searched existing issues, PRs, and discussions; a related PR appeared stale and no active merged fix covered the same service identity collision.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `hermes_cli/gateway_service_identity.py` for shared systemd/launchd service naming and legacy definition matching.
- Updated `hermes_cli/gateway.py` service install/start/stop/status/restart migration paths for scoped identities and rollback-safe systemd/launchd migration.
- Updated `scripts/hermes-gateway` so the standalone entry point uses the same identity rules and safe legacy migration behavior.
- Updated update/uninstall handling in `hermes_cli/main.py` and `hermes_cli/uninstall.py` so scoped and matching legacy gateway services are restarted/removed correctly.
- Added focused regression coverage for service identity, migration rollback, standalone script behavior, update restart discovery, and uninstall cleanup.

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_gateway_service_identity.py tests/scripts/test_hermes_gateway_script.py tests/hermes_cli/test_uninstall_gateway.py tests/hermes_cli/test_update_gateway_restart.py tests/hermes_cli/test_gateway_service.py -q`
2. `venv/bin/python -m py_compile hermes_cli/gateway.py hermes_cli/gateway_service_identity.py hermes_cli/main.py hermes_cli/uninstall.py scripts/hermes-gateway`
3. `git diff --check`
4. `codex review --base origin/main`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin) with targeted gateway tests via `scripts/run_tests.sh`

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted gateway suite passed: `218 passed`.

I also attempted the full wrapper suite with `scripts/run_tests.sh tests -q --tb=short` on macOS. It did not pass: `70 failed, 17314 passed, 61 skipped, 192 warnings, 1 error`. The failures were outside this PR's changed test files and covered existing broad-suite/local-environment areas such as Anthropic/Claude Code credential resolution, Bedrock region defaults, DingTalk SDK mocks, `gateway.session` import drift, WSL/systemd availability tests, file guard/staleness tests, MCP structured content, Firecrawl config, and TUI gateway protocol. The focused gateway service-identity regression suite above passes.


## Rebase / conflict refresh (2026-05-06)
- Rebased onto current `main` and resolved gateway service conflicts by preserving scoped service identities plus the newer planned-stop/manual-profile restart hardening.
- Validation: `scripts/run_tests.sh tests/hermes_cli/test_gateway_service_identity.py tests/scripts/test_hermes_gateway_script.py tests/hermes_cli/test_uninstall_gateway.py tests/hermes_cli/test_update_gateway_restart.py tests/hermes_cli/test_gateway_service.py -q` (`229 passed`).
- Local merge check: `git merge-tree --write-tree --name-only origin/main HEAD` completed without conflicts.
