### PR TITLE
fix(auxiliary): pass original URL to _wrap_if_needed for anthropic detection

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2092,7 +2092,10 @@ def resolve_provider_client(
                     is_agent_turn=True, is_vision=is_vision
                 )
             client = OpenAI(api_key=custom_key, base_url=_clean_base, **extra)
-            client = _wrap_if_needed(client, final_model, custom_base, custom_key)
+            # Pass original URL for anthropic detection (not the rewritten /v1 one).
+            # _maybe_wrap_anthropic checks _endpoint_speaks_anthropic_messages(base_url)
+            # which looks for /anthropic suffix — rewritten URL loses that signal.
+            client = _wrap_if_needed(client, final_model, explicit_base_url, custom_key)
             return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                     else (client, final_model))
         # Try custom first, then codex, then API-key providers


### PR DESCRIPTION
## Summary
Wrap-if-needed checks `_endpoint_speaks_anthropic_messages()` which looks for the `/anthropic` suffix. But `_to_openai_base_url()` already rewrote `/anthropic` → `/v1` before this point, causing the anthropic wrapper to never trigger for MiniMax and similar custom endpoints.

## Root Cause
In `resolve_provider_client`, the call to `_wrap_if_needed` was passing `custom_base` (the URL **after** rewriting to OpenAI's `/v1` format). The anthropic detection relies on seeing the `/anthropic` path segment, which is lost after rewriting.

## Fix
Pass `explicit_base_url` (the original URL) instead of `custom_base` (the rewritten one) to `_wrap_if_needed`.



## Test
- `test_auxiliary_client_anthropic_custom.py`: 3 passed
- `test_title_generator.py`: 19 passed
- Functional: `generate_title` with MiniMax custom endpoint returns success (HTTP 200, non-empty title)

## Files Changed
- `agent/auxiliary_client.py`: 1 line changed (+4 comment lines)