### PR TITLE
fix(nix): refresh web/ npm-deps hash to unblock main builds

### DIFF
--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -165,6 +165,17 @@
 
         NEW_HASH=$(echo "$OUTPUT" | awk '/got:/ {print $2; exit}')
         if [ -z "$NEW_HASH" ]; then
+          # Magic-Nix-Cache occasionally returns HTTP 418 / cache-throttled
+          # mid-run; nix then prints "outputs … not valid, so checking is
+          # not possible" without a `got:` line.  That's an infrastructure
+          # blip, not a stale lockfile — warn + skip rather than failing
+          # the lint.  A real hash mismatch would still surface in the
+          # primary `.#$ATTR` build, which is a separate CI job.
+          if echo "$OUTPUT" | grep -qE "throttled|HTTP error 418|substituter .* is disabled|some outputs of .* are not valid"; then
+            echo "    skipped (transient cache failure — see primary nix build for real status)" >&2
+            echo "$OUTPUT" | tail -8 >&2
+            continue
+          fi
           echo "    build failed with no hash mismatch:" >&2
           echo "$OUTPUT" | tail -40 >&2
           exit 1

--- a/nix/web.nix
+++ b/nix/web.nix
@@ -4,7 +4,7 @@ let
   src = ../web;
   npmDeps = pkgs.fetchNpmDeps {
     inherit src;
-    hash = "sha256-AahWmJ9gDQ9pMPa1FYwUjYdO2mOi6JM9Mst27E0vp68=";
+    hash = "sha256-+B2+Fe4djPzHHcUXRx+m0cuyaopAhW0PcHsMgYfV5VE=";
   };
 
   npm = hermesNpmLib.mkNpmPassthru { folder = "web"; attr = "web"; pname = "hermes-web"; };


### PR DESCRIPTION
> Closes / supersedes #17133 (hash-refresh only). This PR includes that fix plus the `fix-lockfiles` hardening that resolves the related `nix-lockfile-check` false-failures on every PR.

## Summary

Two related fixes in one PR:

### 1. Refresh `web/` npm-deps hash

`web/package-lock.json` was updated by the design-system refactor (merged via #17007 + follow-ups: spinner / select / badges / buttons) without bumping `nix/web.nix::npmDeps.hash`. Result: every `nix (ubuntu-latest)` build on `main` and every open PR has been failing since `2026-04-28T18:46`.

Drop in the new hash that the actual `Check flake` failure already calculated for us:

```
specified: sha256-AahWmJ9gDQ9pMPa1FYwUjYdO2mOi6JM9Mst27E0vp68=
got:       sha256-+B2+Fe4djPzHHcUXRx+m0cuyaopAhW0PcHsMgYfV5VE=
```

Verified locally with `nix build .#web.npmDeps` — clean.

### 2. Harden `fix-lockfiles` against magic-cache throttling

While verifying #1, the auxiliary `nix-lockfile-check` job kept failing with:

```
GitHub API error: GitHub Actions Cache throttled Magic Nix Cache. Not trying to use it again on this run.
…
error: some outputs of '/nix/store/...-npm-deps.drv' are not valid, so checking is not possible
```

The `fix-lockfiles` script in `nix/lib.nix` then bailed with `build failed with no hash mismatch` and exit 1 — even though the actual `nix (ubuntu-latest)` build passed both web AND tui in the same workflow.

The script now recognizes throttling / cache-disabled signatures (HTTP 418, "substituter … disabled", "outputs … not valid") and skips the entry with a warning instead of failing the lint. Real stale hashes still surface in the primary `.#$ATTR` build, so we don't lose coverage.

## Test plan

- [x] Local: `nix build .#web.npmDeps` succeeds with new hash.
- [x] CI: `nix (ubuntu-latest)` + `nix (macos-latest)` both green on previous push.
- [ ] CI: `nix-lockfile-check` no longer false-failing on cache-throttled runs.

## Refs

- Originating drift: #17007 (`austin/fix/more-design-system`) + follow-up commits that touched `web/package-lock.json`.
- Auto-fix CI added in #16285 was supposed to catch the original drift; appears not to have run on those merges. Worth a separate look but outside this PR's scope.
- Closes #17133.
