### PR TITLE
fix(gateway): map telegram reply_to_mode from config.yaml to PlatformConfig

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -729,6 +729,12 @@ def load_gateway_config() -> GatewayConfig:
                         extra = {}
                         plat_data["extra"] = extra
                     extra["disable_link_previews"] = telegram_cfg["disable_link_previews"]
+                if "reply_to_mode" in telegram_cfg and not os.getenv("TELEGRAM_REPLY_TO_MODE"):
+                    plat_data = platforms_data.setdefault(Platform.TELEGRAM.value, {})
+                    if not isinstance(plat_data, dict):
+                        plat_data = {}
+                        platforms_data[Platform.TELEGRAM.value] = plat_data
+                    plat_data["reply_to_mode"] = str(telegram_cfg["reply_to_mode"]).lower()
 
             whatsapp_cfg = yaml_cfg.get("whatsapp", {})
             if isinstance(whatsapp_cfg, dict):


### PR DESCRIPTION
## Problem

The `reply_to_mode` setting under `telegram:` in `config.yaml` was never mapped to `PlatformConfig.reply_to_mode` in `_build_gateway_config()`. This means the value was always the default `"first"` regardless of what users configured.

Setting `reply_to_mode: "off"` in config.yaml had no effect — the gateway still threaded replies to the user's message.

## Fix

Adds the missing mapping in `load_gateway_config()`, consistent with how other telegram-specific settings (`disable_link_previews`, etc.) are handled.

Respects the existing env var override: if `TELEGRAM_REPLY_TO_MODE` is set, the env var takes precedence (no change to existing behavior).

## Changes

- `gateway/config.py`: 6 lines — map `telegram_cfg["reply_to_mode"]` to `plat_data["reply_to_mode"]`