### PR TITLE
fix(gateway): exclude restart caller from drain to prevent 60s hang

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -858,6 +858,7 @@ class GatewayRunner:
         self._queued_events: Dict[str, List[MessageEvent]] = {}
         self._busy_ack_ts: Dict[str, float] = {}  # last busy-ack timestamp per session (debounce)
         self._session_run_generation: Dict[str, int] = {}
+        self._restart_caller_key: str = None  # session_key of the agent that triggered /restart
 
         # Cache AIAgent instances per session to preserve prompt caching.
         # Without this, a new AIAgent is created per message, rebuilding the
@@ -1998,7 +1999,7 @@ class GatewayRunner:
 
         return True
 
-    async def _drain_active_agents(self, timeout: float) -> tuple[Dict[str, Any], bool]:
+    async def _drain_active_agents(self, timeout: float, exclude_key: str = None) -> tuple[Dict[str, Any], bool]:
         snapshot = self._snapshot_running_agents()
         last_active_count = self._running_agent_count()
         last_status_at = 0.0
@@ -2006,13 +2007,22 @@ class GatewayRunner:
         def _maybe_update_status(force: bool = False) -> None:
             nonlocal last_active_count, last_status_at
             now = asyncio.get_running_loop().time()
-            active_count = self._running_agent_count()
+            # Count agents, excluding the restart caller so it can't block drain.
+            active_count = sum(
+                1 for k in self._running_agents
+                if k != exclude_key and self._running_agents.get(k) is not _AGENT_PENDING_SENTINEL
+            )
             if force or active_count != last_active_count or (now - last_status_at) >= 1.0:
                 self._update_runtime_status("draining")
                 last_active_count = active_count
                 last_status_at = now
 
-        if not self._running_agents:
+        # Build a filtered view that excludes the restart caller.
+        filtered_agents = {
+            k: v for k, v in self._running_agents.items() if k != exclude_key
+        } if exclude_key else dict(self._running_agents)
+
+        if not filtered_agents:
             _maybe_update_status(force=True)
             return snapshot, False
 
@@ -2021,15 +2031,21 @@ class GatewayRunner:
             return snapshot, True
 
         deadline = asyncio.get_running_loop().time() + timeout
-        while self._running_agents and asyncio.get_running_loop().time() < deadline:
+        while filtered_agents and asyncio.get_running_loop().time() < deadline:
+            # Re-filter each iteration in case agents drop out.
+            filtered_agents = {
+                k: v for k, v in self._running_agents.items() if k != exclude_key
+            }
             _maybe_update_status()
             await asyncio.sleep(0.1)
-        timed_out = bool(self._running_agents)
+        timed_out = bool(filtered_agents)
         _maybe_update_status(force=True)
         return snapshot, timed_out
 
-    def _interrupt_running_agents(self, reason: str) -> None:
+    def _interrupt_running_agents(self, reason: str, exclude_key: str = None) -> None:
         for session_key, agent in list(self._running_agents.items()):
+            if session_key == exclude_key:
+                continue
             if agent is _AGENT_PENDING_SENTINEL:
                 continue
             try:
@@ -3013,7 +3029,9 @@ class GatewayRunner:
             await self._notify_active_sessions_of_shutdown()
 
             timeout = self._restart_drain_timeout
-            active_agents, timed_out = await self._drain_active_agents(timeout)
+            active_agents, timed_out = await self._drain_active_agents(
+                timeout, exclude_key=self._restart_caller_key
+            )
             if timed_out:
                 logger.warning(
                     "Gateway drain timed out after %.1fs with %d active agent(s); interrupting remaining work.",
@@ -3055,7 +3073,8 @@ class GatewayRunner:
                             _sk, _e,
                         )
                 self._interrupt_running_agents(
-                    _INTERRUPT_REASON_GATEWAY_RESTART if self._restart_requested else _INTERRUPT_REASON_GATEWAY_SHUTDOWN
+                    _INTERRUPT_REASON_GATEWAY_RESTART if self._restart_requested else _INTERRUPT_REASON_GATEWAY_SHUTDOWN,
+                    exclude_key=self._restart_caller_key,
                 )
                 interrupt_deadline = asyncio.get_running_loop().time() + 5.0
                 while self._running_agents and asyncio.get_running_loop().time() < interrupt_deadline:
@@ -6001,6 +6020,10 @@ class GatewayRunner:
         # doesn't work under systemd because KillMode=mixed kills all
         # processes in the cgroup, including the detached helper.
         _under_service = bool(os.environ.get("INVOCATION_ID"))  # systemd sets this
+        # Record the caller's session_key so drain can exclude it — the restart
+        # triggerer's agent cannot exit until it receives the HTTP response, so
+        # excluding it prevents the drain-from-itself deadlock.
+        self._restart_caller_key = self._session_key_for_source(event.source)
         if _under_service:
             self.request_restart(detached=False, via_service=True)
         else:

--- a/tests/gateway/restart_test_helpers.py
+++ b/tests/gateway/restart_test_helpers.py
@@ -62,6 +62,7 @@ def make_restart_runner(
     runner._restart_detached = False
     runner._restart_via_service = False
     runner._restart_drain_timeout = DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
+    runner._restart_caller_key = None
     runner._stop_task = None
     runner._busy_input_mode = "interrupt"
     runner._update_prompt_pending = {}

--- a/tests/gateway/test_clean_shutdown_marker.py
+++ b/tests/gateway/test_clean_shutdown_marker.py
@@ -112,6 +112,7 @@ class TestCleanShutdownMarker:
         runner._background_tasks = set()
         runner._shutdown_event = MagicMock()
         runner._restart_drain_timeout = 5
+        runner._restart_caller_key = None
         runner._exit_code = None
         runner._exit_reason = None
         runner.adapters = {}
@@ -206,6 +207,7 @@ class TestCleanShutdownMarker:
         runner._background_tasks = set()
         runner._shutdown_event = MagicMock()
         runner._restart_drain_timeout = 5
+        runner._restart_caller_key = None
         runner._exit_code = None
         runner._exit_reason = None
         runner.adapters = {}


### PR DESCRIPTION
## Summary
The `/restart` command triggered a drain that waited for ALL agents including the caller agent itself, which was waiting for the HTTP response — creating a deadlock that always timed out after 60 seconds.

## Root Cause
`drain_active_agents()` counted all running agents without excluding the caller. Since the caller agent cannot exit until it receives the HTTP response, and the drain waits for all agents to exit, a deadlock always occurred.

## Fix
- `_drain_active_agents()`: add `exclude_key` param to filter out the caller
- `_interrupt_running_agents()`: add `exclude_key` param to skip the caller  
- `_stop_impl()`: pass `_restart_caller_key` to both functions
- `_handle_restart_command()`: record caller's `session_key` before draining
- `GatewayRunner.__init__`: initialize `_restart_caller_key`

## Files Changed
- `gateway/run.py`: drain + interrupt with exclude_key
- `tests/gateway/restart_test_helpers.py`: add `_restart_caller_key`
- `tests/gateway/test_clean_shutdown_marker.py`: add `_restart_caller_key`