### PR TITLE
feat(holographic): parallel dual-path prefetch + remove bridge

### DIFF
--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -207,11 +207,87 @@ class HolographicMemoryProvider(MemoryProvider):
         if not self._retriever or not query:
             return ""
         try:
-            results = self._retriever.search(query, min_trust=self._min_trust, limit=5)
-            if not results:
+            # Parallel dual-path retrieval:
+            #   Path A — FTS5 keyword + Jaccard + HRR rerank  (shallow, fast)
+            #   Path B — HRR reason() algebraic bind/unbind      (deep, semantic)
+            # Both paths are independent; results are merged and deduped by fact_id.
+            import concurrent.futures
+
+            fts_results: list[dict] = []
+            hrr_results: list[dict] = []
+
+            def run_fts():
+                return self._retriever.search(
+                    query, min_trust=0.0, limit=8
+                )
+
+            def run_hrr():
+                # reason() does not accept min_trust; trust scoring is applied
+                # during score fusion in the merge step below.
+                tokens = [t.strip(".,!?;:\"'()[]{}-") for t in query.lower().split()]
+                tokens = [t for t in tokens if t]
+                return self._retriever.reason(
+                    tokens if tokens else [query.lower().strip()],
+                    limit=8,
+                )
+
+            with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+                fts_future = executor.submit(run_fts)
+                hrr_future = executor.submit(run_hrr)
+                try:
+                    fts_results = fts_future.result(timeout=2.0)
+                except Exception:
+                    fts_results = []
+                try:
+                    hrr_results = hrr_future.result(timeout=2.0)
+                except Exception:
+                    hrr_results = []
+
+            # Score quality gate:
+            # HRR produces near-random ~0.25 with dim=1024, n=21 when no entity
+            # signal is present.  Use HRR only when:
+            #   (a) FTS has results AND HRR clearly beats them (ratio-gated), OR
+            #   (b) FTS returns nothing — HRR is the only signal, accept if above
+            #       a higher floor since we have no calibration baseline.
+            fts_best = fts_results[0].get("score", 0) if fts_results else 0.0
+            _FTS_FAIL_FLOOR = 0.10   # below this FTS is unreliable
+            _HRR_NOISE_FLOOR = 0.27  # empirical: ~random for this corpus size/dim
+
+            # Merge: FTS primary, HRR supplement
+            seen: dict[int, dict] = {}
+            for r in fts_results:
+                fid = r.get("fact_id")
+                if fid is not None and fid not in seen:
+                    seen[fid] = r
+
+            # Adopt HRR results when FTS is weak or absent
+            for r in hrr_results:
+                fid = r.get("fact_id")
+                if fid is None or fid in seen:
+                    continue
+                hrr_score = r.get("score", 0)
+                # FTS strong enough to judge HRR on ratio?
+                if fts_best >= _FTS_FAIL_FLOOR:
+                    # Yes: require HRR beat FTS by meaningful margin
+                    if hrr_score > fts_best * 1.05 and hrr_score > _HRR_NOISE_FLOOR:
+                        seen[fid] = r
+                else:
+                    # No FTS signal: accept HRR only if above higher floor
+                    # (no calibration baseline, must be clearly non-noise)
+                    if hrr_score > 0.29:
+                        seen[fid] = r
+
+            # Sort by score descending, take top 5
+            merged = sorted(seen.values(), key=lambda x: x.get("score", 0), reverse=True)[:5]
+
+            # Apply trust threshold after score fusion
+            merged = [r for r in merged if r.get("trust_score", 0) >= self._min_trust]
+
+            if not merged:
                 return ""
+
             lines = []
-            for r in results:
+            for r in merged:
                 trust = r.get("trust_score", r.get("trust", 0))
                 lines.append(f"- [{trust:.1f}] {r.get('content', '')}")
             return "## Holographic Memory\n" + "\n".join(lines)
@@ -243,12 +319,19 @@ class HolographicMemoryProvider(MemoryProvider):
 
     def on_memory_write(self, action: str, target: str, content: str) -> None:
         """Mirror built-in memory writes as facts."""
-        if action == "add" and self._store and content:
+        if not self._store or not content:
+            return
+        if action == "add":
             try:
                 category = "user_pref" if target == "user" else "general"
                 self._store.add_fact(content, category=category)
             except Exception as e:
                 logger.debug("Holographic memory_write mirror failed: %s", e)
+        elif action == "remove":
+            try:
+                self._store.remove_fact_by_content(content)
+            except Exception as e:
+                logger.debug("Holographic memory_write remove mirror failed: %s", e)
 
     def shutdown(self) -> None:
         self._store = None

--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -494,9 +494,32 @@ class FactRetriever:
 
         # Build query - FTS5 rank is negative (lower = better match)
         # We need to join facts_fts with facts to get all columns
+        # For multi-token queries, use OR to match any token (FTS5 tokenization
+        # splits Chinese on character boundaries, so each character or word becomes
+        # a separate token).  Single-token queries are passed as-is.
+        # For tokens containing ASCII characters (English/case-sensitive), use
+        # prefix matching so "vegf" matches "VEGF通路" in the index.
+        import re
+        tokens = [t.strip(".,!?;:\"'()[]{}-") for t in query.lower().split()]
+        tokens = [t for t in tokens if t]
+        if len(tokens) > 1:
+            fts_terms = []
+            for token in tokens:
+                if re.search(r"[a-zA-Z0-9]", token):
+                    fts_terms.append(token + "*")
+                else:
+                    fts_terms.append(token)
+            fts_query = " OR ".join(fts_terms)
+        elif tokens:
+            # Single token: still apply prefix matching for ASCII tokens
+            token = tokens[0]
+            fts_query = token + "*" if re.search(r"[a-zA-Z0-9]", token) else token
+        else:
+            fts_query = query
+
         params: list = []
         where_clauses = ["facts_fts MATCH ?"]
-        params.append(query)
+        params.append(fts_query)
 
         if category:
             where_clauses.append("f.category = ?")

--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -316,6 +316,18 @@ class MemoryStore:
             self._rebuild_bank(row["category"])
             return True
 
+    def remove_fact_by_content(self, content: str) -> bool:
+        """Delete a fact by exact content match. Returns True if a row was deleted."""
+        if not content:
+            return False
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT fact_id FROM facts WHERE content = ?", (content,)
+            ).fetchone()
+            if row is None:
+                return False
+            return self.remove_fact(row["fact_id"])
+
     def list_facts(
         self,
         category: str | None = None,

--- a/run_agent.py
+++ b/run_agent.py
@@ -9086,12 +9086,16 @@ class AIAgent:
                 store=self._memory_store,
             )
             # Bridge: notify external memory provider of built-in memory writes
-            if self._memory_manager and function_args.get("action") in ("add", "replace"):
+            if self._memory_manager and function_args.get("action") in ("add", "replace", "remove"):
                 try:
+                    bridge_content = function_args.get("content", "")
+                    # For remove, the actual removed content comes in result
+                    if function_args.get("action") == "remove" and isinstance(result, dict):
+                        bridge_content = result.get("deleted_content", bridge_content)
                     self._memory_manager.on_memory_write(
                         function_args.get("action", ""),
                         target,
-                        function_args.get("content", ""),
+                        bridge_content,
                         metadata=self._build_memory_write_metadata(
                             task_id=effective_task_id,
                             tool_call_id=tool_call_id,
@@ -9628,12 +9632,16 @@ class AIAgent:
                     store=self._memory_store,
                 )
                 # Bridge: notify external memory provider of built-in memory writes
-                if self._memory_manager and function_args.get("action") in ("add", "replace"):
+                if self._memory_manager and function_args.get("action") in ("add", "replace", "remove"):
                     try:
+                        bridge_content = function_args.get("content", "")
+                        # For remove, the actual removed content comes in result
+                        if function_args.get("action") == "remove" and isinstance(function_result, dict):
+                            bridge_content = function_result.get("deleted_content", bridge_content)
                         self._memory_manager.on_memory_write(
                             function_args.get("action", ""),
                             target,
-                            function_args.get("content", ""),
+                            bridge_content,
                             metadata=self._build_memory_write_metadata(
                                 task_id=effective_task_id,
                                 tool_call_id=getattr(tool_call, "id", None),

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -352,11 +352,14 @@ class MemoryStore:
                 # All identical -- safe to remove just the first
 
             idx = matches[0][0]
+            deleted_content = entries[idx]
             entries.pop(idx)
             self._set_entries(target, entries)
             self.save_to_disk(target)
 
-        return self._success_response(target, "Entry removed.")
+        response = self._success_response(target, "Entry removed.")
+        response["deleted_content"] = deleted_content
+        return response
 
     def format_for_system_prompt(self, target: str) -> Optional[str]:
         """


### PR DESCRIPTION
## Summary
Add parallel dual-path retrieval (FTS + HRR) for holographic memory with score fusion and 2s timeout, plus bridge support for remove operations.

## Changes
- `holographic/prefetch`: FTS + HRR parallel dual-path retrieval with score fusion (2s timeout)
- `holographic/on_memory_write`: add remove action support via `remove_fact_by_content`
- `holographic/retrieval`: FTS query uses OR-prefix variant for better recall
- `holographic/store`: add `remove_fact_by_content` method
- `run_agent`: bridge now handles add/replace/remove; remove passes `deleted_content`
- `memory_tool`: `remove()` returns `deleted_content` in response

## Files Changed
- `holographic/agent.py`: parallel prefetch + remove bridge
- `holographic/store.py`: `remove_fact_by_content`
- `holographic/retrieval.py`: OR-prefix FTS query
- `agent/run_agent.py`: bridge add/replace/remove
- `agent/tools/memory_tool.py`: `deleted_content` in remove response