### PR TITLE
fix(gateway): add missing config.yaml mapping for telegram reply_to_mode

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -729,6 +729,12 @@ def load_gateway_config() -> GatewayConfig:
                         extra = {}
                         plat_data["extra"] = extra
                     extra["disable_link_previews"] = telegram_cfg["disable_link_previews"]
+                if "reply_to_mode" in telegram_cfg and not os.getenv("TELEGRAM_REPLY_TO_MODE"):
+                    plat_data = platforms_data.setdefault(Platform.TELEGRAM.value, {})
+                    if not isinstance(plat_data, dict):
+                        plat_data = {}
+                        platforms_data[Platform.TELEGRAM.value] = plat_data
+                    plat_data["reply_to_mode"] = str(telegram_cfg["reply_to_mode"]).lower()
 
             whatsapp_cfg = yaml_cfg.get("whatsapp", {})
             if isinstance(whatsapp_cfg, dict):


### PR DESCRIPTION
## Problem

 in config.yaml is silently ignored. Only  env var works because  never maps the yaml value to .

Other telegram-specific settings like  already have this mapping —  was just missed.

## Fix

6 lines, same pattern as . Env var takes precedence when both are set.