### PR TITLE
fix: add auxiliary fallback for Gemini OAuth quotas

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -8,20 +8,22 @@ Resolution order for text tasks (auto mode):
   1. OpenRouter  (OPENROUTER_API_KEY)
   2. Nous Portal (~/.hermes/auth.json active provider)
   3. Custom endpoint (config.yaml model.base_url + OPENAI_API_KEY)
-  4. Codex OAuth (Responses API via chatgpt.com with gpt-5.3-codex,
+  4. Codex OAuth (Responses API via chatgpt.com with gpt-5.5,
      wrapped to look like a chat.completions client)
-  5. Native Anthropic
-  6. Direct API-key providers (z.ai/GLM, Kimi/Moonshot, MiniMax, MiniMax-CN)
-  7. None
+  5. Google Gemini CLI OAuth / Code Assist
+  6. Native Anthropic
+  7. Direct API-key providers (z.ai/GLM, Kimi/Moonshot, MiniMax, MiniMax-CN)
+  8. None
 
 Resolution order for vision/multimodal tasks (auto mode):
   1. Selected main provider, if it is one of the supported vision backends below
   2. OpenRouter
   3. Nous Portal
-  4. Codex OAuth (gpt-5.3-codex supports vision via Responses API)
-  5. Native Anthropic
-  6. Custom endpoint (for local vision models: Qwen-VL, LLaVA, Pixtral, etc.)
-  7. None
+  4. Codex OAuth (gpt-5.5 supports vision via Responses API)
+  5. Google Gemini CLI OAuth / Code Assist
+  6. Native Anthropic
+  7. Custom endpoint (for local vision models: Qwen-VL, LLaVA, Pixtral, etc.)
+  8. None
 
 Per-task overrides are configured in config.yaml under the ``auxiliary:`` section
 (e.g. ``auxiliary.vision.provider``, ``auxiliary.compression.model``).
@@ -268,6 +270,7 @@ _AUTH_JSON_PATH = get_hermes_home() / "auth.json"
 # vision via Responses.
 _CODEX_AUX_MODEL = "gpt-5.2-codex"
 _CODEX_AUX_BASE_URL = "https://chatgpt.com/backend-api/codex"
+_GEMINI_OAUTH_AUX_MODEL = "gemini-3-flash-preview"
 
 
 def _codex_cloudflare_headers(access_token: str) -> Dict[str, str]:
@@ -663,6 +666,39 @@ class AsyncCodexAuxiliaryClient:
         self.chat = _AsyncCodexChatShim(async_adapter)
         self.api_key = sync_wrapper.api_key
         self.base_url = sync_wrapper.base_url
+
+
+class _AsyncThreadedCompletionsAdapter:
+    """Async facade for sync OpenAI-shaped clients that do their own routing."""
+
+    def __init__(self, sync_completions: Any):
+        self._sync = sync_completions
+
+    async def create(self, **kwargs) -> Any:
+        import asyncio
+        return await asyncio.to_thread(self._sync.create, **kwargs)
+
+
+class _AsyncThreadedChatShim:
+    def __init__(self, adapter: _AsyncThreadedCompletionsAdapter):
+        self.completions = adapter
+
+
+class AsyncThreadedAuxiliaryClient:
+    """Async-compatible wrapper for sync auxiliary clients such as Gemini OAuth."""
+
+    def __init__(self, sync_client: Any):
+        self._sync_client = sync_client
+        self.chat = _AsyncThreadedChatShim(
+            _AsyncThreadedCompletionsAdapter(sync_client.chat.completions)
+        )
+        self.api_key = getattr(sync_client, "api_key", "")
+        self.base_url = getattr(sync_client, "base_url", "")
+
+    def close(self):
+        close_fn = getattr(self._sync_client, "close", None)
+        if callable(close_fn):
+            close_fn()
 
 
 class _AnthropicCompletionsAdapter:
@@ -1419,6 +1455,50 @@ def _try_codex() -> Tuple[Optional[Any], Optional[str]]:
     return CodexAuxiliaryClient(real_client, _CODEX_AUX_MODEL), _CODEX_AUX_MODEL
 
 
+def _try_gemini_oauth() -> Tuple[Optional[Any], Optional[str]]:
+    """Try Google Gemini CLI OAuth / Code Assist for auxiliary fallback."""
+    # Keep the unauthenticated path very cheap: auxiliary auto-detection can run
+    # during agent construction and tests may create many agents concurrently.
+    # Avoid importing the heavy Code Assist adapter unless credentials exist.
+    try:
+        if not (get_hermes_home() / "auth" / "google_oauth.json").exists():
+            return None, None
+    except Exception:
+        return None, None
+
+    try:
+        from agent.google_oauth import GoogleOAuthError, get_valid_access_token
+    except ImportError as exc:
+        logger.debug("Auxiliary client: Gemini OAuth unavailable: %s", exc)
+        return None, None
+
+    try:
+        # Validate that OAuth credentials exist and can refresh before selecting
+        # this backend. GeminiCloudCodeClient refreshes again per call if needed;
+        # this probe keeps auto-detect/fallback from choosing an unauthenticated
+        # provider and only failing later.
+        token = get_valid_access_token()
+    except GoogleOAuthError as exc:
+        logger.debug("Auxiliary client: Gemini OAuth not authenticated: %s", exc)
+        return None, None
+    except Exception as exc:
+        logger.debug("Auxiliary client: Gemini OAuth credential check failed: %s", exc)
+        return None, None
+
+    if not str(token or "").strip():
+        return None, None
+
+    try:
+        from agent.gemini_cloudcode_adapter import GeminiCloudCodeClient
+    except ImportError as exc:
+        logger.debug("Auxiliary client: Gemini OAuth adapter unavailable: %s", exc)
+        return None, None
+
+    logger.debug("Auxiliary client: Gemini OAuth / Code Assist (%s)", _GEMINI_OAUTH_AUX_MODEL)
+    return GeminiCloudCodeClient(), _GEMINI_OAUTH_AUX_MODEL
+
+
+
 def _try_anthropic() -> Tuple[Optional[Any], Optional[str]]:
     try:
         from agent.anthropic_adapter import build_anthropic_client, resolve_anthropic_token
@@ -1472,6 +1552,7 @@ _AUTO_PROVIDER_LABELS = {
     "_try_nous": "nous",
     "_try_custom_endpoint": "local/custom",
     "_try_codex": "openai-codex",
+    "_try_gemini_oauth": "google-gemini-cli",
     "_resolve_api_key_provider": "api-key",
 }
 
@@ -1504,6 +1585,7 @@ def _get_provider_chain() -> List[tuple]:
         ("nous", _try_nous),
         ("local/custom", _try_custom_endpoint),
         ("openai-codex", _try_codex),
+        ("google-gemini-cli", _try_gemini_oauth),
         ("api-key", _resolve_api_key_provider),
     ]
 
@@ -1521,11 +1603,50 @@ def _is_payment_error(exc: Exception) -> bool:
     # OpenRouter and other providers include "credits" or "afford" in 402 bodies,
     # but sometimes wrap them in 429 or other codes.
     if status in (402, 429, None):
-        if any(kw in err_lower for kw in ("credits", "insufficient funds",
-                                           "can only afford", "billing",
-                                           "payment required")):
+        if any(kw in err_lower for kw in (
+            "credits",
+            "insufficient funds",
+            "can only afford",
+            "billing",
+            "payment required",
+            # ChatGPT/Codex quota exhaustion is surfaced as HTTP 429 with
+            # a body like {'type': 'usage_limit_reached', 'message': 'The
+            # usage limit has been reached', ...}.  Treat that as an
+            # exhaustible backend, not a transient per-second rate limit.
+            "usage_limit_reached",
+            "usage limit has been reached",
+            "quota exhausted",
+            "quota will reset",
+            "exceeded your current quota",
+        )):
             return True
     return False
+
+
+def _infer_failed_provider_label(client: Any, resolved_provider: Optional[str]) -> str:
+    """Best-effort provider label for fallback skipping/logging.
+
+    ``resolved_provider`` can still be ``auto`` even though auto-detection
+    selected a concrete backend, and vision auto-routing overwrites it with the
+    effective provider.  Infer the concrete backend from the client shape/base
+    URL so fallback does not immediately retry the same exhausted provider.
+    """
+    provider = (resolved_provider or "auto").strip().lower()
+    try:
+        if isinstance(client, (CodexAuxiliaryClient, AsyncCodexAuxiliaryClient)):
+            return "openai-codex"
+    except NameError:
+        pass
+    base_url = str(getattr(client, "base_url", "") or "").lower()
+    if "chatgpt.com/backend-api/codex" in base_url:
+        return "openai-codex"
+    if base_url.startswith("cloudcode-pa://"):
+        return "google-gemini-cli"
+    if "openrouter.ai" in base_url:
+        return "openrouter"
+    if "inference-api.nousresearch.com" in base_url:
+        return "nous"
+    return provider
 
 
 def _is_connection_error(exc: Exception) -> bool:
@@ -1692,6 +1813,7 @@ def _try_payment_fallback(
     # Map common resolved_provider values back to chain labels.
     _alias_to_label = {"openrouter": "openrouter", "nous": "nous",
                        "openai-codex": "openai-codex", "codex": "openai-codex",
+                       "google-gemini-cli": "google-gemini-cli", "gemini-cli": "google-gemini-cli",
                        "custom": "local/custom", "local/custom": "local/custom"}
     skip_chain_labels = {_alias_to_label.get(s, s) for s in skip_labels}
 
@@ -1836,6 +1958,13 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
 
         if isinstance(sync_client, GeminiNativeClient):
             return AsyncGeminiNativeClient(sync_client), model
+    except ImportError:
+        pass
+    try:
+        from agent.gemini_cloudcode_adapter import GeminiCloudCodeClient
+
+        if isinstance(sync_client, GeminiCloudCodeClient):
+            return AsyncThreadedAuxiliaryClient(sync_client), model
     except ImportError:
         pass
     try:
@@ -2349,6 +2478,17 @@ def resolve_provider_client(
             return resolve_provider_client("nous", model, async_mode)
         if provider == "openai-codex":
             return resolve_provider_client("openai-codex", model, async_mode)
+        if provider == "google-gemini-cli":
+            client, default = _try_gemini_oauth()
+            if client is None:
+                logger.warning(
+                    "resolve_provider_client: google-gemini-cli requested but "
+                    "Gemini OAuth credentials are unavailable (run: hermes auth add google-gemini-cli)"
+                )
+                return None, None
+            final_model = _normalize_resolved_model(model or default, provider)
+            return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+                    else (client, final_model))
         # Other OAuth providers not directly supported
         logger.warning("resolve_provider_client: OAuth provider %s not "
                        "directly supported, try 'auto'", provider)
@@ -2428,6 +2568,8 @@ def _resolve_strict_vision_backend(
         return _try_nous(vision=True)
     if provider == "openai-codex":
         return _try_codex()
+    if provider == "google-gemini-cli":
+        return _try_gemini_oauth()
     if provider == "anthropic":
         return _try_anthropic()
     if provider == "custom":
@@ -3209,6 +3351,7 @@ def call_llm(
     """
     resolved_provider, resolved_model, resolved_base_url, resolved_api_key, resolved_api_mode = _resolve_task_provider_model(
         task, provider, model, base_url, api_key)
+    requested_auto = resolved_provider in ("auto", "", None)
     effective_extra_body = _get_task_extra_body(task)
     effective_extra_body.update(extra_body or {})
 
@@ -3427,13 +3570,14 @@ def call_llm(
         # Only try alternative providers when the user didn't explicitly
         # configure this task's provider.  Explicit provider = hard constraint;
         # auto (the default) = best-effort fallback chain.  (#7559)
-        is_auto = resolved_provider in ("auto", "", None)
+        is_auto = requested_auto or resolved_provider in ("auto", "", None)
         if should_fallback and is_auto:
             reason = "payment error" if _is_payment_error(first_err) else "connection error"
+            failed_label = _infer_failed_provider_label(client, resolved_provider)
             logger.info("Auxiliary %s: %s on %s (%s), trying fallback",
-                        task or "call", reason, resolved_provider, first_err)
+                        task or "call", reason, failed_label, first_err)
             fb_client, fb_model, fb_label = _try_payment_fallback(
-                resolved_provider, task, reason=reason)
+                failed_label, task, reason=reason)
             if fb_client is not None:
                 fb_kwargs = _build_call_kwargs(
                     fb_label, fb_model, messages,
@@ -3522,6 +3666,7 @@ async def async_call_llm(
     """
     resolved_provider, resolved_model, resolved_base_url, resolved_api_key, resolved_api_mode = _resolve_task_provider_model(
         task, provider, model, base_url, api_key)
+    requested_auto = resolved_provider in ("auto", "", None)
     effective_extra_body = _get_task_extra_body(task)
     effective_extra_body.update(extra_body or {})
 
@@ -3703,13 +3848,14 @@ async def async_call_llm(
 
         # ── Payment / connection fallback (mirrors sync call_llm) ─────
         should_fallback = _is_payment_error(first_err) or _is_connection_error(first_err)
-        is_auto = resolved_provider in ("auto", "", None)
+        is_auto = requested_auto or resolved_provider in ("auto", "", None)
         if should_fallback and is_auto:
             reason = "payment error" if _is_payment_error(first_err) else "connection error"
+            failed_label = _infer_failed_provider_label(client, resolved_provider)
             logger.info("Auxiliary %s (async): %s on %s (%s), trying fallback",
-                        task or "call", reason, resolved_provider, first_err)
+                        task or "call", reason, failed_label, first_err)
             fb_client, fb_model, fb_label = _try_payment_fallback(
-                resolved_provider, task, reason=reason)
+                failed_label, task, reason=reason)
             if fb_client is not None:
                 fb_kwargs = _build_call_kwargs(
                     fb_label, fb_model, messages,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -507,8 +507,13 @@ def _try_resolve_fallback_provider() -> dict | None:
         fb = cfg.get("fallback_providers") or cfg.get("fallback_model")
         if not fb:
             return None
-        # Normalize to list
-        fb_list = fb if isinstance(fb, list) else [fb]
+        # Normalize to list; accepts both dict entries and compact
+        # "provider:model" strings for parity with AIAgent fallback parsing.
+        try:
+            from run_agent import _normalize_fallback_chain_config
+            fb_list = _normalize_fallback_chain_config(fb)
+        except Exception:
+            fb_list = fb if isinstance(fb, list) else [fb]
         for entry in fb_list:
             if not isinstance(entry, dict):
                 continue

--- a/run_agent.py
+++ b/run_agent.py
@@ -811,8 +811,45 @@ def _routermint_headers() -> dict:
     }
 
 
+def _normalize_fallback_chain_config(fallback_model: Any) -> List[Dict[str, Any]]:
+    """Normalize fallback_model/fallback_providers config into provider/model dicts.
+
+    Supports the canonical dict form::
+
+        {"provider": "google-gemini-cli", "model": "gemini-3-flash-preview"}
+
+    and the compact CLI/YAML form::
+
+        "google-gemini-cli:gemini-3-flash-preview"
+
+    Invalid entries are ignored so a bad fallback does not break startup.
+    """
+    entries = fallback_model if isinstance(fallback_model, list) else [fallback_model]
+    chain: List[Dict[str, Any]] = []
+    for entry in entries:
+        if isinstance(entry, dict):
+            provider = str(entry.get("provider") or "").strip()
+            model = str(entry.get("model") or "").strip()
+            if provider and model:
+                normalized = dict(entry)
+                normalized["provider"] = provider
+                normalized["model"] = model
+                chain.append(normalized)
+            continue
+        if isinstance(entry, str):
+            raw = entry.strip()
+            if not raw or ":" not in raw:
+                continue
+            provider, model = raw.split(":", 1)
+            provider = provider.strip()
+            model = model.strip()
+            if provider and model:
+                chain.append({"provider": provider, "model": model})
+    return chain
+
+
 def _pool_may_recover_from_rate_limit(pool) -> bool:
-    """Decide whether to wait for credential-pool rotation instead of falling back.
+    """Return True when credential-pool rotation may handle a 429.
 
     The existing pool-rotation path requires the pool to (1) exist and (2) have
     at least one entry not currently in exhaustion cooldown.  But rotation is
@@ -1491,15 +1528,7 @@ class AIAgent:
         # when the primary is exhausted (rate-limit, overload, connection
         # failure).  Supports both legacy single-dict ``fallback_model`` and
         # new list ``fallback_providers`` format.
-        if isinstance(fallback_model, list):
-            self._fallback_chain = [
-                f for f in fallback_model
-                if isinstance(f, dict) and f.get("provider") and f.get("model")
-            ]
-        elif isinstance(fallback_model, dict) and fallback_model.get("provider") and fallback_model.get("model"):
-            self._fallback_chain = [fallback_model]
-        else:
-            self._fallback_chain = []
+        self._fallback_chain = _normalize_fallback_chain_config(fallback_model)
         self._fallback_index = 0
         self._fallback_activated = False
         # Legacy attribute kept for backward compat (tests, external callers)

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch, MagicMock, AsyncMock
 
 import pytest
@@ -760,6 +761,20 @@ class TestIsPaymentError:
         exc.status_code = 429
         assert _is_payment_error(exc) is True
 
+    def test_codex_usage_limit_reached_is_payment_error(self):
+        exc = Exception(
+            "Error code: 429 - {'error': {'type': 'usage_limit_reached', "
+            "'message': 'The usage limit has been reached', "
+            "'resets_in_seconds': 4220}}"
+        )
+        exc.status_code = 429
+        assert _is_payment_error(exc) is True
+
+    def test_quota_exhausted_is_payment_error(self):
+        exc = Exception("Gemini quota exhausted; quota will reset after 46s")
+        exc.status_code = 429
+        assert _is_payment_error(exc) is True
+
     def test_429_without_credits_message_is_not_payment(self):
         """Normal rate limits should NOT be treated as payment errors."""
         exc = Exception("Rate limit exceeded, try again in 2 seconds")
@@ -783,11 +798,17 @@ class TestIsPaymentError:
 class TestGetProviderChain:
     """_get_provider_chain() resolves functions at call time (testable)."""
 
-    def test_returns_five_entries(self):
+    def test_returns_oauth_gemini_before_api_key_fallback(self):
         chain = _get_provider_chain()
-        assert len(chain) == 5
         labels = [label for label, _ in chain]
-        assert labels == ["openrouter", "nous", "local/custom", "openai-codex", "api-key"]
+        assert labels == [
+            "openrouter",
+            "nous",
+            "local/custom",
+            "openai-codex",
+            "google-gemini-cli",
+            "api-key",
+        ]
 
     def test_picks_up_patched_functions(self):
         """Patches on _try_* functions must be visible in the chain."""
@@ -843,6 +864,39 @@ class TestTryPaymentFallback:
         assert model == "gpt-5.2-codex"
         assert label == "openai-codex"
 
+    def test_falls_back_to_gemini_oauth_before_api_key_provider(self):
+        mock_gemini = MagicMock()
+        with patch("agent.auxiliary_client._try_openrouter", return_value=(None, None)), \
+             patch("agent.auxiliary_client._try_nous", return_value=(None, None)), \
+             patch("agent.auxiliary_client._try_custom_endpoint", return_value=(None, None)), \
+             patch("agent.auxiliary_client._try_codex", return_value=(None, None)), \
+             patch("agent.auxiliary_client._try_gemini_oauth", return_value=(mock_gemini, "gemini-3-flash-preview")), \
+             patch("agent.auxiliary_client._resolve_api_key_provider", return_value=(MagicMock(), "api-key-model")), \
+             patch("agent.auxiliary_client._read_main_provider", return_value="openai-codex"):
+            client, model, label = _try_payment_fallback("openai-codex")
+        assert client is mock_gemini
+        assert model == "gemini-3-flash-preview"
+        assert label == "google-gemini-cli"
+
+    def test_resolve_provider_client_supports_gemini_oauth_directly(self):
+        mock_gemini = MagicMock()
+        with patch("agent.auxiliary_client._try_gemini_oauth",
+                   return_value=(mock_gemini, "gemini-3-flash-preview")):
+            client, model = resolve_provider_client("google-gemini-cli")
+        assert client is mock_gemini
+        assert model == "gemini-3-flash-preview"
+
+    def test_resolve_provider_client_wraps_gemini_oauth_for_async_mode(self):
+        mock_gemini = MagicMock()
+        mock_gemini.api_key = "google-oauth"
+        mock_gemini.base_url = "cloudcode-pa://google"
+        with patch("agent.auxiliary_client._try_gemini_oauth",
+                   return_value=(mock_gemini, "gemini-3-flash-preview")):
+            client, model = resolve_provider_client("google-gemini-cli", async_mode=True)
+        assert model == "gemini-3-flash-preview"
+        assert client.base_url == "cloudcode-pa://google"
+        assert hasattr(client.chat.completions, "create")
+
 
 class TestCallLlmPaymentFallback:
     """call_llm() retries with a different provider on 402 / payment errors."""
@@ -870,6 +924,75 @@ class TestCallLlmPaymentFallback:
                     task="compression",
                     messages=[{"role": "user", "content": "hello"}],
                 )
+
+    def test_auto_vision_falls_back_from_codex_usage_limit_to_api_key_provider(self):
+        """Vision auto-routing may resolve to Codex; quota errors must still fallback."""
+        primary_client = MagicMock()
+        quota_err = Exception(
+            "Error code: 429 - {'error': {'type': 'usage_limit_reached', "
+            "'message': 'The usage limit has been reached'}}"
+        )
+        quota_err.status_code = 429
+        primary_client.chat.completions.create.side_effect = quota_err
+
+        fallback_response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="fallback ok"))]
+        )
+        fallback_client = MagicMock()
+        fallback_client.base_url = "https://generativelanguage.googleapis.com/v1beta/openai/"
+        fallback_client.chat.completions.create.return_value = fallback_response
+
+        with patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("auto", None, None, None, None)), \
+             patch("agent.auxiliary_client.resolve_vision_provider_client",
+                   return_value=("openai-codex", primary_client, "gpt-5.5")), \
+             patch("agent.auxiliary_client._try_payment_fallback",
+                   return_value=(fallback_client, "gemini-3-flash-preview", "api-key")) as mock_fb:
+            result = call_llm(
+                task="vision",
+                messages=[{"role": "user", "content": "describe image"}],
+            )
+
+        assert result is fallback_response
+        mock_fb.assert_called_once()
+        assert mock_fb.call_args.args[0] == "openai-codex"
+        assert fallback_client.chat.completions.create.call_args.kwargs["model"] == "gemini-3-flash-preview"
+
+    @pytest.mark.asyncio
+    async def test_async_auto_vision_falls_back_from_codex_usage_limit(self):
+        primary_client = MagicMock()
+        quota_err = Exception(
+            "Error code: 429 - {'error': {'type': 'usage_limit_reached', "
+            "'message': 'The usage limit has been reached'}}"
+        )
+        quota_err.status_code = 429
+        primary_client.chat.completions.create = AsyncMock(side_effect=quota_err)
+
+        sync_fb = MagicMock()
+        sync_fb.base_url = "https://generativelanguage.googleapis.com/v1beta/openai/"
+        async_fb = MagicMock()
+        fallback_response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="fallback ok"))]
+        )
+        async_fb.chat.completions.create = AsyncMock(return_value=fallback_response)
+
+        with patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("auto", None, None, None, None)), \
+             patch("agent.auxiliary_client.resolve_vision_provider_client",
+                   return_value=("openai-codex", primary_client, "gpt-5.5")), \
+             patch("agent.auxiliary_client._try_payment_fallback",
+                   return_value=(sync_fb, "gemini-3-flash-preview", "api-key")) as mock_fb, \
+             patch("agent.auxiliary_client._to_async_client",
+                   return_value=(async_fb, "gemini-3-flash-preview")):
+            result = await async_call_llm(
+                task="vision",
+                messages=[{"role": "user", "content": "describe image"}],
+            )
+
+        assert result is fallback_response
+        mock_fb.assert_called_once()
+        assert mock_fb.call_args.args[0] == "openai-codex"
+        assert async_fb.chat.completions.create.call_args.kwargs["model"] == "gemini-3-flash-preview"
 
 # ---------------------------------------------------------------------------
 # Gate: _resolve_api_key_provider must skip anthropic when not configured

--- a/tests/run_agent/test_fallback_config_normalization.py
+++ b/tests/run_agent/test_fallback_config_normalization.py
@@ -1,0 +1,21 @@
+from run_agent import _normalize_fallback_chain_config
+
+
+def test_normalizes_compact_provider_model_fallback_string():
+    assert _normalize_fallback_chain_config(
+        ["google-gemini-cli:gemini-3-flash-preview"]
+    ) == [
+        {"provider": "google-gemini-cli", "model": "gemini-3-flash-preview"}
+    ]
+
+
+def test_normalizes_dict_and_preserves_extra_fields():
+    assert _normalize_fallback_chain_config([
+        {"provider": " openrouter ", "model": " google/gemini-3-flash-preview ", "key_env": "OPENROUTER_API_KEY"}
+    ]) == [
+        {"provider": "openrouter", "model": "google/gemini-3-flash-preview", "key_env": "OPENROUTER_API_KEY"}
+    ]
+
+
+def test_ignores_invalid_fallback_entries():
+    assert _normalize_fallback_chain_config(["missing-model", {}, None, {"provider": "x"}]) == []


### PR DESCRIPTION

## What does this PR do?

Adds a fallback path for auxiliary/vision/compression calls when the primary provider is unavailable due to quota, payment, or usage-limit errors.

In particular, this makes `openai-codex` quota/429/payment failures fallbackable instead of treating them as final auxiliary-call failures, and allows the auto provider chain to continue to `google-gemini-cli:gemini-3-flash-preview`.

This helps Hermes continue operating when the selected session model/provider is temporarily exhausted, while keeping the change focused on existing fallback/config-normalization paths.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Update `agent/auxiliary_client.py` so Codex quota/payment/usage-limit failures can continue through the auxiliary fallback chain.
- Add `google-gemini-cli` / Gemini OAuth handling to the auxiliary auto provider chain.
- Normalize fallback config entries like `google-gemini-cli:gemini-3-flash-preview`.
- Update gateway/run-agent fallback resolution to preserve provider/model fallback entries consistently.
- Add tests in:
  - `tests/agent/test_auxiliary_client.py`
  - `tests/run_agent/test_fallback_config_normalization.py`

## How to Test

1. Run:

   bash
   venv/bin/python -m pytest tests/agent/test_auxiliary_client.py tests/run_agent/test_fallback_config_normalization.py tests/run_agent/test_run_agent.py::TestCredentialPoolRecovery tests/gateway/test_session_model_reset.py -o 'addopts=' -q
   
2. Confirm the targeted fallback-related test suite passes.

3. Result from this branch:

   text
   127 passed in 6.76s
   
## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, feat(scope):, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run pytest tests/ -q and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, docs/, docstrings) — or N/A
- [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Targeted fallback-related tests pass:text
127 passed in 6.76s
A full `pytest tests/ -q` run was not completed here; targeted fallback coverage passes, and a previously observed full-suite failure was isolated to an unrelated existing gateway cache spillover test.
