### PR TITLE
fix(tui): honor documented mouse_tracking config key

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -944,6 +944,33 @@ def test_config_set_section_rejects_unknown_section_or_mode(tmp_path, monkeypatc
     assert bad_mode["error"]["code"] == 4002
 
 
+def test_config_mouse_uses_documented_key_with_legacy_fallback(monkeypatch):
+    cfg = {"display": {"tui_mouse": False}}
+    writes = []
+
+    monkeypatch.setattr(server, "_load_cfg", lambda: cfg)
+    monkeypatch.setattr(
+        server, "_write_config_key", lambda path, value: writes.append((path, value))
+    )
+
+    get_legacy = server.handle_request(
+        {"id": "1", "method": "config.get", "params": {"key": "mouse"}}
+    )
+    assert get_legacy["result"]["value"] == "off"
+
+    set_toggle = server.handle_request(
+        {"id": "2", "method": "config.set", "params": {"key": "mouse"}}
+    )
+    assert set_toggle["result"] == {"key": "mouse", "value": "on"}
+    assert writes == [("display.mouse_tracking", True)]
+
+    cfg["display"] = {"mouse_tracking": "off", "tui_mouse": True}
+    get_canonical = server.handle_request(
+        {"id": "3", "method": "config.get", "params": {"key": "mouse"}}
+    )
+    assert get_canonical["result"]["value"] == "off"
+
+
 def test_enable_gateway_prompts_sets_gateway_env(monkeypatch):
     monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
     monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -964,11 +964,17 @@ def test_config_mouse_uses_documented_key_with_legacy_fallback(monkeypatch):
     assert set_toggle["result"] == {"key": "mouse", "value": "on"}
     assert writes == [("display.mouse_tracking", True)]
 
-    cfg["display"] = {"mouse_tracking": "off", "tui_mouse": True}
+    cfg["display"] = {"mouse_tracking": 0, "tui_mouse": True}
     get_canonical = server.handle_request(
         {"id": "3", "method": "config.get", "params": {"key": "mouse"}}
     )
     assert get_canonical["result"]["value"] == "off"
+
+    cfg["display"] = {"mouse_tracking": None, "tui_mouse": False}
+    get_null = server.handle_request(
+        {"id": "4", "method": "config.get", "params": {"key": "mouse"}}
+    )
+    assert get_null["result"]["value"] == "on"
 
 
 def test_enable_gateway_prompts_sets_gateway_env(monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -690,6 +690,21 @@ def _coerce_statusbar(raw) -> str:
     return "top"
 
 
+def _display_mouse_tracking(display: dict) -> bool:
+    """Return canonical display.mouse_tracking with legacy tui_mouse fallback."""
+    if not isinstance(display, dict):
+        return True
+    if "mouse_tracking" in display:
+        raw = display.get("mouse_tracking")
+    else:
+        raw = display.get("tui_mouse", True)
+    if raw is False:
+        return False
+    if isinstance(raw, str):
+        return raw.strip().lower() not in {"0", "false", "no", "off"}
+    return True
+
+
 def _load_reasoning_config() -> dict | None:
     from hermes_constants import parse_reasoning_effort
 
@@ -3177,7 +3192,7 @@ def _(rid, params: dict) -> dict:
             if isinstance(_load_cfg().get("display"), dict)
             else {}
         )
-        current = bool(display.get("tui_mouse", True))
+        current = _display_mouse_tracking(display)
 
         if raw in ("", "toggle"):
             nv = not current
@@ -3188,7 +3203,7 @@ def _(rid, params: dict) -> dict:
         else:
             return _err(rid, 4002, f"unknown mouse value: {value}")
 
-        _write_config_key("display.tui_mouse", nv)
+        _write_config_key("display.mouse_tracking", nv)
         return _ok(rid, {"key": key, "value": "on" if nv else "off"})
 
     if key == "indicator":
@@ -3361,7 +3376,7 @@ def _(rid, params: dict) -> dict:
         return _ok(rid, {"value": _coerce_statusbar(raw)})
     if key == "mouse":
         display = _load_cfg().get("display")
-        on = display.get("tui_mouse", True) if isinstance(display, dict) else True
+        on = _display_mouse_tracking(display)
         return _ok(rid, {"value": "on" if on else "off"})
     if key == "mtime":
         cfg_path = _hermes_home / "config.yaml"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -698,7 +698,7 @@ def _display_mouse_tracking(display: dict) -> bool:
         raw = display.get("mouse_tracking")
     else:
         raw = display.get("tui_mouse", True)
-    if raw is False:
+    if raw is False or raw == 0:
         return False
     if isinstance(raw, str):
         return raw.strip().lower() not in {"0", "false", "no", "off"}
@@ -3187,11 +3187,8 @@ def _(rid, params: dict) -> dict:
 
     if key == "mouse":
         raw = str(value or "").strip().lower()
-        display = (
-            _load_cfg().get("display")
-            if isinstance(_load_cfg().get("display"), dict)
-            else {}
-        )
+        cfg = _load_cfg()
+        display = cfg.get("display") if isinstance(cfg.get("display"), dict) else {}
         current = _display_mouse_tracking(display)
 
         if raw in ("", "toggle"):

--- a/ui-tui/src/__tests__/useConfigSync.test.ts
+++ b/ui-tui/src/__tests__/useConfigSync.test.ts
@@ -5,6 +5,7 @@ import {
   applyDisplay,
   normalizeBusyInputMode,
   normalizeIndicatorStyle,
+  normalizeMouseTracking,
   normalizeStatusBar
 } from '../app/useConfigSync.js'
 
@@ -68,6 +69,19 @@ describe('applyDisplay', () => {
     expect(s.statusBar).toBe('top')
     expect(s.streaming).toBe(true)
     expect(s.sections).toEqual({})
+  })
+
+  it('uses documented mouse_tracking with legacy tui_mouse fallback', () => {
+    const setBell = vi.fn()
+
+    applyDisplay({ config: { display: { mouse_tracking: false } } }, setBell)
+    expect($uiState.get().mouseTracking).toBe(false)
+
+    applyDisplay({ config: { display: { mouse_tracking: true, tui_mouse: false } } }, setBell)
+    expect($uiState.get().mouseTracking).toBe(true)
+
+    applyDisplay({ config: { display: { tui_mouse: false } } }, setBell)
+    expect($uiState.get().mouseTracking).toBe(false)
   })
 
   it('parses display.sections into per-section overrides', () => {
@@ -163,6 +177,17 @@ describe('normalizeStatusBar', () => {
     expect(normalizeStatusBar('TOP')).toBe('top')
     expect(normalizeStatusBar('  on  ')).toBe('top')
     expect(normalizeStatusBar('OFF')).toBe('off')
+  })
+})
+
+describe('normalizeMouseTracking', () => {
+  it('defaults on and prefers canonical mouse_tracking over legacy tui_mouse', () => {
+    expect(normalizeMouseTracking({})).toBe(true)
+    expect(normalizeMouseTracking({ mouse_tracking: false })).toBe(false)
+    expect(normalizeMouseTracking({ mouse_tracking: 'off' })).toBe(false)
+    expect(normalizeMouseTracking({ mouse_tracking: 'false' })).toBe(false)
+    expect(normalizeMouseTracking({ mouse_tracking: true, tui_mouse: false })).toBe(true)
+    expect(normalizeMouseTracking({ tui_mouse: false })).toBe(false)
   })
 })
 

--- a/ui-tui/src/__tests__/useConfigSync.test.ts
+++ b/ui-tui/src/__tests__/useConfigSync.test.ts
@@ -184,8 +184,10 @@ describe('normalizeMouseTracking', () => {
   it('defaults on and prefers canonical mouse_tracking over legacy tui_mouse', () => {
     expect(normalizeMouseTracking({})).toBe(true)
     expect(normalizeMouseTracking({ mouse_tracking: false })).toBe(false)
+    expect(normalizeMouseTracking({ mouse_tracking: 0 })).toBe(false)
     expect(normalizeMouseTracking({ mouse_tracking: 'off' })).toBe(false)
     expect(normalizeMouseTracking({ mouse_tracking: 'false' })).toBe(false)
+    expect(normalizeMouseTracking({ mouse_tracking: null, tui_mouse: false })).toBe(true)
     expect(normalizeMouseTracking({ mouse_tracking: true, tui_mouse: false })).toBe(true)
     expect(normalizeMouseTracking({ tui_mouse: false })).toBe(false)
   })

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -64,11 +64,12 @@ export const normalizeIndicatorStyle = (raw: unknown): IndicatorStyle => {
 }
 
 const FALSEY_MOUSE = new Set(['0', 'false', 'no', 'off'])
+const hasOwn = (obj: object, key: PropertyKey) => Object.prototype.hasOwnProperty.call(obj, key)
 
 export const normalizeMouseTracking = (display: { mouse_tracking?: unknown; tui_mouse?: unknown }): boolean => {
-  const raw = display.mouse_tracking ?? display.tui_mouse
+  const raw = hasOwn(display, 'mouse_tracking') ? display.mouse_tracking : display.tui_mouse
 
-  if (raw === false) {
+  if (raw === false || raw === 0) {
     return false
   }
 

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -63,6 +63,18 @@ export const normalizeIndicatorStyle = (raw: unknown): IndicatorStyle => {
   return INDICATOR_STYLE_SET.has(v) ? v : DEFAULT_INDICATOR_STYLE
 }
 
+const FALSEY_MOUSE = new Set(['0', 'false', 'no', 'off'])
+
+export const normalizeMouseTracking = (display: { mouse_tracking?: unknown; tui_mouse?: unknown }): boolean => {
+  const raw = display.mouse_tracking ?? display.tui_mouse
+
+  if (raw === false) {
+    return false
+  }
+
+  return typeof raw === 'string' ? !FALSEY_MOUSE.has(raw.trim().toLowerCase()) : true
+}
+
 const MTIME_POLL_MS = 5000
 
 const quietRpc = async <T extends Record<string, any> = Record<string, any>>(
@@ -88,7 +100,7 @@ export const applyDisplay = (cfg: ConfigFullResponse | null, setBell: (v: boolea
     detailsModeCommandOverride: false,
     indicatorStyle: normalizeIndicatorStyle(d.tui_status_indicator),
     inlineDiffs: d.inline_diffs !== false,
-    mouseTracking: d.tui_mouse !== false,
+    mouseTracking: normalizeMouseTracking(d),
     sections: resolveSections(d.sections),
     showCost: !!d.show_cost,
     showReasoning: !!d.show_reasoning,

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -56,7 +56,7 @@ export interface ConfigDisplayConfig {
   busy_input_mode?: string
   details_mode?: string
   inline_diffs?: boolean
-  mouse_tracking?: boolean
+  mouse_tracking?: boolean | null | number | string
   sections?: Record<string, string>
   show_cost?: boolean
   show_reasoning?: boolean
@@ -65,7 +65,7 @@ export interface ConfigDisplayConfig {
   tui_auto_resume_recent?: boolean
   tui_compact?: boolean
   /** Legacy alias for display.mouse_tracking. */
-  tui_mouse?: boolean
+  tui_mouse?: boolean | null | number | string
   // Forward-compat: backend may send styles this client doesn't know yet —
   // `normalizeIndicatorStyle` falls back to 'kaomoji' for those — but the
   // wire type is documented as `string` so consumers don't get a false

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -56,6 +56,7 @@ export interface ConfigDisplayConfig {
   busy_input_mode?: string
   details_mode?: string
   inline_diffs?: boolean
+  mouse_tracking?: boolean
   sections?: Record<string, string>
   show_cost?: boolean
   show_reasoning?: boolean
@@ -63,6 +64,7 @@ export interface ConfigDisplayConfig {
   thinking_mode?: string
   tui_auto_resume_recent?: boolean
   tui_compact?: boolean
+  /** Legacy alias for display.mouse_tracking. */
   tui_mouse?: boolean
   // Forward-compat: backend may send styles this client doesn't know yet —
   // `normalizeIndicatorStyle` falls back to 'kaomoji' for those — but the


### PR DESCRIPTION
## Summary
- Treat `display.mouse_tracking` as the canonical TUI mouse-tracking config key, with `display.tui_mouse` kept as a legacy fallback.
- Make `/mouse` write `display.mouse_tracking`, so persistent config matches docs and user-facing examples.
- Add TUI/client and gateway tests for canonical-vs-legacy precedence.

## Test plan
- `cd ui-tui && npm run type-check`
- `cd ui-tui && npm test -- --run src/__tests__/useConfigSync.test.ts`
- `cd ui-tui && npm test -- --run`
- `scripts/run_tests.sh tests/test_tui_gateway_server.py::test_config_mouse_uses_documented_key_with_legacy_fallback`