### PR TITLE
fix(whatsapp): normalise JIDs and resolve LID aliases in dm_policy / group_policy allowlist check

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -208,15 +208,33 @@ class WhatsAppAdapter(BasePlatformAdapter):
         if raw is None:
             return set()
         if isinstance(raw, list):
-            return {str(part).strip() for part in raw if str(part).strip()}
-        return {part.strip() for part in str(raw).split(",") if part.strip()}
+            return {self._normalize_jid(str(part)) for part in raw if str(part).strip()}
+        return {self._normalize_jid(part) for part in str(raw).split(",") if part.strip()}
+
+    @staticmethod
+    def _normalize_jid(jid: str) -> str:
+        """Strip WhatsApp JID suffixes so bare phone numbers match JID-formatted senders.
+
+        The Node.js bridge delivers ``senderId`` as a full JID such as
+        ``85296456787@s.whatsapp.net`` or ``85296456787:33@s.whatsapp.net``,
+        while ``allow_from`` in *config.yaml* is typically configured with bare
+        phone numbers like ``85296456787``.  Without normalisation the
+        ``allowlist`` dm_policy silently drops every DM.
+        """
+        return (
+            str(jid)
+            .strip()
+            .split(":")[0]   # remove device-index suffix  e.g. "85296456787:33@…"
+            .split("@")[0]   # remove @s.whatsapp.net / @lid / etc.
+            .lstrip("+")     # normalise leading +
+        )
 
     def _is_dm_allowed(self, sender_id: str) -> bool:
         """Check whether a DM from the given sender should be processed."""
         if self._dm_policy == "disabled":
             return False
         if self._dm_policy == "allowlist":
-            return sender_id in self._allow_from
+            return self._normalize_jid(sender_id) in self._allow_from
         # "open" — all DMs allowed
         return True
 
@@ -225,7 +243,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
         if self._group_policy == "disabled":
             return False
         if self._group_policy == "allowlist":
-            return chat_id in self._group_allow_from
+            return self._normalize_jid(chat_id) in self._group_allow_from
         # "open" — all groups allowed
         return True
 

--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -208,8 +208,8 @@ class WhatsAppAdapter(BasePlatformAdapter):
         if raw is None:
             return set()
         if isinstance(raw, list):
-            return {self._normalize_jid(str(part)) for part in raw if str(part).strip()}
-        return {self._normalize_jid(part) for part in str(raw).split(",") if part.strip()}
+            return {WhatsAppAdapter._normalize_jid(str(part)) for part in raw if str(part).strip()}
+        return {WhatsAppAdapter._normalize_jid(part) for part in str(raw).split(",") if part.strip()}
 
     @staticmethod
     def _normalize_jid(jid: str) -> str:

--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -229,12 +229,40 @@ class WhatsAppAdapter(BasePlatformAdapter):
             .lstrip("+")     # normalise leading +
         )
 
+    def _resolve_lid_to_phone(self, lid_identifier: str) -> str:
+        """Resolve a WhatsApp LID (Linked Identity Device) to a phone number.
+
+        When the WhatsApp account uses linked devices, incoming DM ``senderId``
+        values may arrive as a LID such as ``125619388076125`` rather than the
+        human-readable phone number ``85296456787``.  The bridge writes
+        ``lid-mapping-{lid}_reverse.json`` files in the session directory that
+        map LID → phone number.  This method consults those files so the
+        Python-level allowlist can match against phone numbers regardless of
+        whether the sender was identified by LID or phone.
+        """
+        import json as _json
+        mapping_file = self._session_path / f"lid-mapping-{lid_identifier}_reverse.json"
+        try:
+            if mapping_file.exists():
+                phone = _json.loads(mapping_file.read_text()).strip().lstrip("+")
+                if phone:
+                    return phone
+        except Exception:
+            pass
+        return lid_identifier
+
     def _is_dm_allowed(self, sender_id: str) -> bool:
         """Check whether a DM from the given sender should be processed."""
         if self._dm_policy == "disabled":
             return False
         if self._dm_policy == "allowlist":
-            return self._normalize_jid(sender_id) in self._allow_from
+            normalized = self._normalize_jid(sender_id)
+            if normalized in self._allow_from:
+                return True
+            # LID format: sender may arrive as a LID (e.g. "125619388076125@lid").
+            # Try resolving LID → phone via session mapping files.
+            phone = self._resolve_lid_to_phone(normalized)
+            return phone in self._allow_from
         # "open" — all DMs allowed
         return True
 

--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -273,7 +273,10 @@ class WhatsAppAdapter(BasePlatformAdapter):
             return ""
         normalized = str(value).strip()
         if ":" in normalized and "@" in normalized:
-            normalized = normalized.replace(":", "@", 1)
+            # Strip device suffix: "number:10@domain" → "number@domain"
+            # The old replace(":", "@", 1) produced "number@10@domain" which
+            # never matched group participant JIDs (no device suffix).
+            normalized = re.sub(r":\d+@", "@", normalized)
         return normalized
 
     def _bot_ids_from_message(self, data: Dict[str, Any]) -> set[str]:

--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -28,6 +28,10 @@ from pathlib import Path
 from typing import Dict, Optional, Any
 
 from hermes_constants import get_hermes_dir
+from gateway.whatsapp_identity import (
+    normalize_whatsapp_identifier,
+    expand_whatsapp_aliases,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -208,61 +212,18 @@ class WhatsAppAdapter(BasePlatformAdapter):
         if raw is None:
             return set()
         if isinstance(raw, list):
-            return {WhatsAppAdapter._normalize_jid(str(part)) for part in raw if str(part).strip()}
-        return {WhatsAppAdapter._normalize_jid(part) for part in str(raw).split(",") if part.strip()}
-
-    @staticmethod
-    def _normalize_jid(jid: str) -> str:
-        """Strip WhatsApp JID suffixes so bare phone numbers match JID-formatted senders.
-
-        The Node.js bridge delivers ``senderId`` as a full JID such as
-        ``85296456787@s.whatsapp.net`` or ``85296456787:33@s.whatsapp.net``,
-        while ``allow_from`` in *config.yaml* is typically configured with bare
-        phone numbers like ``85296456787``.  Without normalisation the
-        ``allowlist`` dm_policy silently drops every DM.
-        """
-        return (
-            str(jid)
-            .strip()
-            .split(":")[0]   # remove device-index suffix  e.g. "85296456787:33@…"
-            .split("@")[0]   # remove @s.whatsapp.net / @lid / etc.
-            .lstrip("+")     # normalise leading +
-        )
-
-    def _resolve_lid_to_phone(self, lid_identifier: str) -> str:
-        """Resolve a WhatsApp LID (Linked Identity Device) to a phone number.
-
-        When the WhatsApp account uses linked devices, incoming DM ``senderId``
-        values may arrive as a LID such as ``125619388076125`` rather than the
-        human-readable phone number ``85296456787``.  The bridge writes
-        ``lid-mapping-{lid}_reverse.json`` files in the session directory that
-        map LID → phone number.  This method consults those files so the
-        Python-level allowlist can match against phone numbers regardless of
-        whether the sender was identified by LID or phone.
-        """
-        import json as _json
-        mapping_file = self._session_path / f"lid-mapping-{lid_identifier}_reverse.json"
-        try:
-            if mapping_file.exists():
-                phone = _json.loads(mapping_file.read_text()).strip().lstrip("+")
-                if phone:
-                    return phone
-        except Exception:
-            pass
-        return lid_identifier
+            return {normalize_whatsapp_identifier(str(part)) for part in raw if str(part).strip()}
+        return {normalize_whatsapp_identifier(part) for part in str(raw).split(",") if part.strip()}
 
     def _is_dm_allowed(self, sender_id: str) -> bool:
         """Check whether a DM from the given sender should be processed."""
         if self._dm_policy == "disabled":
             return False
         if self._dm_policy == "allowlist":
-            normalized = self._normalize_jid(sender_id)
-            if normalized in self._allow_from:
-                return True
-            # LID format: sender may arrive as a LID (e.g. "125619388076125@lid").
-            # Try resolving LID → phone via session mapping files.
-            phone = self._resolve_lid_to_phone(normalized)
-            return phone in self._allow_from
+            # Expand phone↔LID aliases so allowlist matches regardless of which
+            # identifier format the bridge delivers (bare phone, @s.whatsapp.net
+            # JID, or @lid LID).  Mirrors the logic in gateway.run._is_user_authorized.
+            return bool(expand_whatsapp_aliases(sender_id) & self._allow_from)
         # "open" — all DMs allowed
         return True
 
@@ -271,7 +232,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
         if self._group_policy == "disabled":
             return False
         if self._group_policy == "allowlist":
-            return self._normalize_jid(chat_id) in self._group_allow_from
+            return normalize_whatsapp_identifier(chat_id) in self._group_allow_from
         # "open" — all groups allowed
         return True
 

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -64,7 +64,10 @@ function formatOutgoingMessage(message) {
 
 function normalizeWhatsAppId(value) {
   if (!value) return '';
-  return String(value).replace(':', '@');
+  // Strip device suffix: "number:10@domain" → "number@domain"
+  // The old replace(':', '@') produced "number@10@domain" which never matched
+  // group participant JIDs (which have no device suffix).
+  return String(value).replace(/:\d+@/, '@');
 }
 
 function getMessageContent(msg) {

--- a/tests/gateway/test_whatsapp_group_gating.py
+++ b/tests/gateway/test_whatsapp_group_gating.py
@@ -296,3 +296,104 @@ def test_config_bridges_whatsapp_allow_from(monkeypatch, tmp_path):
     assert config.platforms[Platform.WHATSAPP].extra["allow_from"] == ["6281234567890@s.whatsapp.net"]
     assert __import__("os").environ["WHATSAPP_DM_POLICY"] == "allowlist"
     assert __import__("os").environ["WHATSAPP_ALLOWED_USERS"] == "6281234567890@s.whatsapp.net"
+
+
+# --- JID normalization regression tests (fix: allow_from with bare numbers) ---
+
+def test_dm_allowlist_matches_full_jid_sender():
+    """allow_from with full JIDs should still match."""
+    adapter = _make_adapter(dm_policy="allowlist", allow_from=["6281234567890@s.whatsapp.net"])
+
+    assert adapter._should_process_message(_dm_message("hello")) is True
+
+
+def test_dm_allowlist_matches_bare_number_in_allow_from():
+    """allow_from configured with plain phone numbers should match full JID senders.
+
+    Regression: config.yaml / WHATSAPP_ALLOWED_USERS stores plain numbers like
+    '85296456787', but Baileys delivers sender_id as '85296456787@s.whatsapp.net'.
+    The old code did a direct set-membership check and always returned False,
+    silently dropping every DM even for explicitly allowed users.
+    """
+    # allow_from contains bare number (typical real-world config)
+    adapter = _make_adapter(dm_policy="allowlist", allow_from=["6281234567890"])
+
+    # sender_id arrives as full JID from bridge
+    dm = _dm_message("hello", senderId="6281234567890@s.whatsapp.net")
+    assert adapter._should_process_message(dm) is True
+
+
+def test_dm_allowlist_bare_number_blocks_unlisted_jid():
+    """Un-listed senders are still blocked after JID normalization."""
+    adapter = _make_adapter(dm_policy="allowlist", allow_from=["6289999999999"])
+
+    dm = _dm_message("hello", senderId="6281234567890@s.whatsapp.net")
+    assert adapter._should_process_message(dm) is False
+
+
+def test_dm_allowlist_bare_number_matches_lid_jid():
+    """Bare LID numbers in allow_from should match @lid-suffixed sender_id."""
+    adapter = _make_adapter(dm_policy="allowlist", allow_from=["125619388076125"])
+
+    dm = _dm_message("hello", senderId="125619388076125@lid")
+    assert adapter._should_process_message(dm) is True
+
+
+# --- JID device-suffix normalization regression tests ---
+
+def test_normalize_whatsapp_id_strips_device_suffix():
+    """_normalize_whatsapp_id should strip the ':10' device part, not replace ':' with '@'.
+
+    Regression: old code did replace(':', '@', 1), turning 'number:10@domain'
+    into 'number@10@domain'. Group quotedParticipant has no device suffix
+    ('number@domain'), so the comparison always failed and reply-to-bot
+    detection was broken.
+    """
+    from gateway.platforms.whatsapp import WhatsAppAdapter
+
+    assert WhatsAppAdapter._normalize_whatsapp_id("15551230000:10@s.whatsapp.net") == "15551230000@s.whatsapp.net"
+    assert WhatsAppAdapter._normalize_whatsapp_id("125619388076125:0@lid") == "125619388076125@lid"
+    # Already bare — must be unchanged
+    assert WhatsAppAdapter._normalize_whatsapp_id("15551230000@s.whatsapp.net") == "15551230000@s.whatsapp.net"
+    assert WhatsAppAdapter._normalize_whatsapp_id("125619388076125@lid") == "125619388076125@lid"
+
+
+def test_reply_to_bot_triggers_with_device_suffix_in_botids():
+    """Quoting the bot's message in a group should trigger a response.
+
+    Baileys delivers sock.user.id as 'number:10@s.whatsapp.net'.
+    Group quotedParticipant has no device suffix: 'number@s.whatsapp.net'.
+    After stripping the device part both normalize to the same string.
+    """
+    adapter = _make_adapter(require_mention=True)
+
+    msg = _group_message(
+        "replying to bot",
+        botIds=["15551230000:10@s.whatsapp.net"],
+        quotedParticipant="15551230000@s.whatsapp.net",
+    )
+    assert adapter._should_process_message(msg) is True
+
+
+def test_reply_to_bot_triggers_with_lid_device_suffix():
+    """Same regression for LID-based accounts ('@lid' suffix)."""
+    adapter = _make_adapter(require_mention=True)
+
+    msg = _group_message(
+        "replying via lid",
+        botIds=["125619388076125:0@lid"],
+        quotedParticipant="125619388076125@lid",
+    )
+    assert adapter._should_process_message(msg) is True
+
+
+def test_reply_to_non_bot_does_not_trigger():
+    """Quoting a different participant should not trigger when require_mention is set."""
+    adapter = _make_adapter(require_mention=True)
+
+    msg = _group_message(
+        "replying to someone else",
+        botIds=["15551230000:10@s.whatsapp.net"],
+        quotedParticipant="9999999999@s.whatsapp.net",
+    )
+    assert adapter._should_process_message(msg) is False


### PR DESCRIPTION
## Problem

When `dm_policy: allowlist` (or `group_policy: allowlist`) is configured in `config.yaml`, the WhatsApp gateway silently drops **all** direct messages because the allowlist comparison in `_is_dm_allowed` / `_is_group_allowed` uses raw string equality — no JID normalisation and no LID resolution.

**Two failure modes:**

1. **JID format mismatch** — The bridge delivers `sender_id` as a full JID (`85296456787@s.whatsapp.net` or with a device suffix `85296456787:33@s.whatsapp.net`) while `allow_from` in `config.yaml` stores bare phone numbers (`85296456787`). The raw equality check always returns `False`.

2. **LID sender IDs** — Linked-device accounts may arrive as a LID (`125619388076125@lid`) instead of a phone JID. Even after stripping the suffix the numeric LID (`125619388076125`) does not match the phone number (`85296456787`).

## Root cause / prior art

PR #3830 (commit `3e2c8c52`) fixed both issues for the **session-level** authorization path (`gateway.run._is_user_authorized`) and added `gateway.whatsapp_identity` as the single-source-of-truth for WhatsApp identity helpers. However, the **platform-level** `dm_policy` / `group_policy` allowlist path in `gateway/platforms/whatsapp.py` was not updated in that PR and still uses a plain `sender_id in self._allow_from` check.

## Fix

Use the shared helpers from `gateway.whatsapp_identity` — the same module already used by `run.py` — so both authorization paths stay in sync:

- `normalize_whatsapp_identifier` in `_coerce_allow_list` so stored allow-list entries are always in bare-phone form
- `expand_whatsapp_aliases` in `_is_dm_allowed` to resolve the full phone↔LID alias set before matching (mirrors `_is_user_authorized`)
- `normalize_whatsapp_identifier` in `_is_group_allowed` for group JID normalization

This removes ~40 lines of duplicated normalisation / LID-resolution logic that were introduced as a workaround.

## Testing

Manually verified on a live WhatsApp account where the sender arrives as a LID (`@lid` form). Messages that were previously silently dropped are now correctly matched against the phone-number allowlist and processed.