### PR TITLE
fix(gateway): silence unknown-command notice for externally-handled commands

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4338,6 +4338,16 @@ class GatewayRunner:
                     # built-ins (command may be an alias target set by the
                     # quick-command block above, so _cmd_def can be stale).
                     if command.replace("_", "-") not in GATEWAY_KNOWN_COMMANDS:
+                        # Suppress the unknown-command notice for slash
+                        # commands handled by an external service (e.g.
+                        # FIXiq's Telegram webhook handles /fixiq itself).
+                        from hermes_cli.commands import EXTERNALLY_HANDLED_COMMANDS as _EXT_CMDS
+                        if command.lower() in _EXT_CMDS:
+                            logger.debug(
+                                "Slash command /%s is externally handled — silently ignoring",
+                                command,
+                            )
+                            return None
                         logger.warning(
                             "Unrecognized slash command /%s from %s — "
                             "replying with unknown-command notice",

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -314,6 +314,16 @@ ACTIVE_SESSION_BYPASS_COMMANDS: frozenset[str] = frozenset(
 )
 
 
+# Commands handled by external services/webhooks (e.g. FIXiq's Telegram
+# webhook handles /fixiq directly). The gateway must NOT reply with
+# "Unknown command" for these — that produces noise in shared chats.
+EXTERNALLY_HANDLED_COMMANDS: frozenset[str] = frozenset(
+    {
+        "fixiq",
+    }
+)
+
+
 def should_bypass_active_session(command_name: str | None) -> bool:
     """Return True for any resolvable slash command.
 

--- a/tests/gateway/test_unknown_command.py
+++ b/tests/gateway/test_unknown_command.py
@@ -147,6 +147,30 @@ async def test_known_slash_command_not_flagged_as_unknown(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_externally_handled_command_silenced(monkeypatch):
+    """Slash commands handled by an external service (e.g. /fixiq is owned by
+    FIXiq's Telegram webhook) must NOT trigger the unknown-command notice —
+    Hermes should silently absorb them so shared chats don't get noise."""
+    import gateway.run as gateway_run
+
+    runner = _make_runner()
+    runner._run_agent = AsyncMock(
+        side_effect=AssertionError(
+            "externally-handled command leaked through to the agent"
+        )
+    )
+
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    result = await runner._handle_message(_make_event("/fixiq Unit 350 leak"))
+
+    assert result is None
+    runner._run_agent.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_underscored_alias_for_hyphenated_builtin_not_flagged(monkeypatch):
     """Telegram autocomplete sends /reload_mcp for the /reload-mcp built-in.
     That must NOT be flagged as unknown."""


### PR DESCRIPTION
## Summary
- suppress the unknown-command notice for slash commands handled by an external service
- add an explicit externally-handled command allowlist in `hermes_cli.commands`
- add targeted gateway coverage for `/fixiq`

## Test Plan
- `pytest -q tests/gateway/test_unknown_command.py`
