### PR TITLE
fix: DeepSeek API fixes and Gemini thinking_config support

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -155,6 +155,7 @@ class ChatCompletionsTransport(ProviderTransport):
             is_nvidia_nim: bool
             is_kimi: bool
             is_lmstudio: bool
+            is_deepseek: bool
             is_custom_provider: bool
             ollama_num_ctx: int | None
             # Provider routing
@@ -244,6 +245,7 @@ class ChatCompletionsTransport(ProviderTransport):
         is_nvidia_nim = params.get("is_nvidia_nim", False)
         is_kimi = params.get("is_kimi", False)
         is_tokenhub = params.get("is_tokenhub", False)
+        is_deepseek = params.get("is_deepseek", False)
         reasoning_config = params.get("reasoning_config")
 
         if ephemeral is not None and max_tokens_fn:
@@ -290,6 +292,22 @@ class ChatCompletionsTransport(ProviderTransport):
                         _tokenhub_effort = _e
                 api_kwargs["reasoning_effort"] = _tokenhub_effort
 
+        # DeepSeek: top-level reasoning_effort
+        # DeepSeek supports "high" and "max" (xhigh → max, low/medium → high)
+        if is_deepseek:
+            _ds_thinking_off = bool(
+                reasoning_config
+                and isinstance(reasoning_config, dict)
+                and reasoning_config.get("enabled") is False
+            )
+            if not _ds_thinking_off:
+                _ds_effort = "high"
+                if reasoning_config and isinstance(reasoning_config, dict):
+                    _e = (reasoning_config.get("effort") or "").strip().lower()
+                    if _e in ("xhigh", "max"):
+                        _ds_effort = "max"
+                api_kwargs["reasoning_effort"] = _ds_effort
+
         # LM Studio: top-level reasoning_effort. Only emit when the model
         # declares reasoning support via /api/v1/models capabilities (gated
         # upstream by params["supports_reasoning"]). resolve_lmstudio_effort
@@ -322,6 +340,17 @@ class ChatCompletionsTransport(ProviderTransport):
                     _kimi_thinking_enabled = False
             extra_body["thinking"] = {
                 "type": "enabled" if _kimi_thinking_enabled else "disabled",
+            }
+
+
+        # DeepSeek extra_body.thinking
+        if is_deepseek:
+            _ds_thinking_enabled = True
+            if reasoning_config and isinstance(reasoning_config, dict):
+                if reasoning_config.get("enabled") is False:
+                    _ds_thinking_enabled = False
+            extra_body["thinking"] = {
+                "type": "enabled" if _ds_thinking_enabled else "disabled",
             }
 
         # Reasoning. LM Studio is handled above via top-level reasoning_effort,

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -156,6 +156,7 @@ class ChatCompletionsTransport(ProviderTransport):
             is_kimi: bool
             is_lmstudio: bool
             is_deepseek: bool
+            is_gemini: bool
             is_custom_provider: bool
             ollama_num_ctx: int | None
             # Provider routing
@@ -352,6 +353,44 @@ class ChatCompletionsTransport(ProviderTransport):
             extra_body["thinking"] = {
                 "type": "enabled" if _ds_thinking_enabled else "disabled",
             }
+
+        # Gemini thinking_config via extra_body.google (OpenAI-compatible path).
+        # Gemini 3 Flash/Pro always reasons internally; thinking_config controls
+        # whether the reasoning is returned to the client and with what budget.
+        # Only the extra_body.google.thinking_config format actually returns
+        # reasoning_content — top-level reasoning_effort and extra_body.reasoning
+        # are silently accepted but don't expose the thinking chain.
+        #
+        # IMPORTANT: Gemini's thinking_level and thinking_budget are MUTUALLY
+        # EXCLUSIVE — the API rejects requests that set both with 400. We use
+        # thinking_budget exclusively because it gives finer granularity for
+        # mapping hermes effort levels (xhigh→4096, high→2048, etc.).
+        is_gemini = params.get("is_gemini", False)
+        if is_gemini:
+            _g_thinking_off = bool(
+                reasoning_config
+                and isinstance(reasoning_config, dict)
+                and reasoning_config.get("enabled") is False
+            )
+            if not _g_thinking_off:
+                # Map hermes effort levels to Gemini thinking_budget.
+                _g_budget = 1024  # default: medium
+                if reasoning_config and isinstance(reasoning_config, dict):
+                    _e = (reasoning_config.get("effort") or "").strip().lower()
+                    if _e in ("xhigh", "max"):
+                        _g_budget = 4096
+                    elif _e == "high":
+                        _g_budget = 2048
+                    elif _e == "medium":
+                        _g_budget = 1024
+                    elif _e in ("low", "minimal"):
+                        _g_budget = 512
+                extra_body["google"] = {
+                    "thinking_config": {
+                        "include_thoughts": True,
+                        "thinking_budget": _g_budget,
+                    }
+                }
 
         # Reasoning. LM Studio is handled above via top-level reasoning_effort,
         # so skip emitting extra_body.reasoning for it.

--- a/run_agent.py
+++ b/run_agent.py
@@ -9760,6 +9760,17 @@ class AIAgent:
             api_messages = []
             for msg in messages:
                 api_msg = msg.copy()
+
+                # DeepSeek / Liaobots thinking mode: null content for
+                # tool-call messages (see main loop for details #15250).
+                if (
+                    api_msg.get("role") == "assistant"
+                    and api_msg.get("content") == ""
+                    and api_msg.get("tool_calls")
+                    and self._needs_deepseek_tool_reasoning()
+                ):
+                    api_msg["content"] = None
+
                 self._copy_reasoning_content_for_api(msg, api_msg)
                 for internal_field in ("reasoning", "finish_reason", "_thinking_prefill"):
                     api_msg.pop(internal_field, None)
@@ -10424,6 +10435,19 @@ class AIAgent:
             api_messages = []
             for idx, msg in enumerate(messages):
                 api_msg = msg.copy()
+
+                # DeepSeek / Liaobots thinking mode: assistant tool-call
+                # messages must use null content (per OpenAI spec) -- empty
+                # string "" triggers Liaobots internal format converter to
+                # reject with HTTP 400 "content[].thinking must be passed
+                # back" (refs #15250).
+                if (
+                    api_msg.get("role") == "assistant"
+                    and api_msg.get("content") == ""
+                    and api_msg.get("tool_calls")
+                    and self._needs_deepseek_tool_reasoning()
+                ):
+                    api_msg["content"] = None
 
                 # Inject ephemeral context into the current turn's user message.
                 # Sources: memory manager prefetch + plugin pre_llm_call hooks

--- a/run_agent.py
+++ b/run_agent.py
@@ -8091,6 +8091,11 @@ class AIAgent:
         )
         _is_tokenhub = base_url_host_matches(self._base_url_lower, "tokenhub.tencentmaas.com")
         _is_lmstudio = (self.provider or "").strip().lower() == "lmstudio"
+        _is_deepseek = (
+            self.provider == "deepseek"
+            or "deepseek" in (self.model or "").lower()
+            or base_url_host_matches(self.base_url, "api.deepseek.com")
+        )
 
         # Temperature: _fixed_temperature_for_model may return OMIT_TEMPERATURE
         # sentinel (temperature omitted entirely), a numeric override, or None.
@@ -8164,6 +8169,7 @@ class AIAgent:
             is_kimi=_is_kimi,
             is_tokenhub=_is_tokenhub,
             is_lmstudio=_is_lmstudio,
+            is_deepseek=_is_deepseek,
             is_custom_provider=self.provider == "custom",
             ollama_num_ctx=self._ollama_num_ctx,
             provider_preferences=_prefs or None,

--- a/run_agent.py
+++ b/run_agent.py
@@ -8097,6 +8097,13 @@ class AIAgent:
             or base_url_host_matches(self.base_url, "api.deepseek.com")
         )
 
+        # Gemini detection — model name contains "gemini" (covers Liaobots,
+        # OpenRouter, and other OpenAI-compatible proxies). The native Gemini
+        # adapter (gemini_native_adapter.py) is used only when the base URL
+        # matches generativelanguage.googleapis.com — this flag is for the
+        # chat_completions transport path.
+        _is_gemini = "gemini" in (self.model or "").lower()
+
         # Temperature: _fixed_temperature_for_model may return OMIT_TEMPERATURE
         # sentinel (temperature omitted entirely), a numeric override, or None.
         try:
@@ -8170,6 +8177,7 @@ class AIAgent:
             is_tokenhub=_is_tokenhub,
             is_lmstudio=_is_lmstudio,
             is_deepseek=_is_deepseek,
+            is_gemini=_is_gemini,
             is_custom_provider=self.provider == "custom",
             ollama_num_ctx=self._ollama_num_ctx,
             provider_preferences=_prefs or None,

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -543,6 +543,103 @@ class TestChatCompletionsNormalize:
         assert nr.provider_data == {"reasoning_content": "detailed scratchpad"}
 
 
+class TestDeepSeekReasoningEffort:
+    """DeepSeek direct API: top-level reasoning_effort + extra_body.thinking."""
+
+    @pytest.fixture
+    def transport(self):
+        import agent.transports.chat_completions  # noqa: F401
+        from agent.transports import get_transport
+        return get_transport("chat_completions")
+
+    def test_xhigh_maps_to_max(self, transport):
+        """xhigh effort → top-level reasoning_effort='max' + thinking enabled."""
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="deepseek-v4-pro", messages=msgs,
+            is_deepseek=True,
+            reasoning_config={"enabled": True, "effort": "xhigh"},
+        )
+        assert kw["reasoning_effort"] == "max"
+        assert kw["extra_body"]["thinking"] == {"type": "enabled"}
+
+    def test_max_stays_max(self, transport):
+        """'max' effort passed through as-is."""
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="deepseek-v4-pro", messages=msgs,
+            is_deepseek=True,
+            reasoning_config={"enabled": True, "effort": "max"},
+        )
+        assert kw["reasoning_effort"] == "max"
+
+    def test_high_stays_high(self, transport):
+        """'high' effort stays 'high'."""
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="deepseek-v4-pro", messages=msgs,
+            is_deepseek=True,
+            reasoning_config={"enabled": True, "effort": "high"},
+        )
+        assert kw["reasoning_effort"] == "high"
+
+    def test_medium_maps_to_high(self, transport):
+        """DeepSeek doesn't support 'medium' — maps to 'high'."""
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="deepseek-v4-pro", messages=msgs,
+            is_deepseek=True,
+            reasoning_config={"enabled": True, "effort": "medium"},
+        )
+        assert kw["reasoning_effort"] == "high"
+
+    def test_default_no_config_is_high(self, transport):
+        """When no reasoning_config, default to 'high' with thinking enabled."""
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="deepseek-v4-pro", messages=msgs,
+            is_deepseek=True,
+        )
+        assert kw["reasoning_effort"] == "high"
+        assert kw["extra_body"]["thinking"] == {"type": "enabled"}
+
+    def test_disabled_skips_effort_disables_thinking(self, transport):
+        """reasoning_config.enabled=False → no reasoning_effort, thinking=disabled."""
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="deepseek-v4-pro", messages=msgs,
+            is_deepseek=True,
+            reasoning_config={"enabled": False},
+        )
+        assert "reasoning_effort" not in kw
+        assert kw["extra_body"]["thinking"] == {"type": "disabled"}
+
+    def test_no_effect_on_non_deepseek(self, transport):
+        """is_deepseek=False should not add DeepSeek parameters."""
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-4o", messages=msgs,
+            is_deepseek=False,
+            reasoning_config={"enabled": True, "effort": "xhigh"},
+        )
+        assert "reasoning_effort" not in kw
+        eb = kw.get("extra_body", {})
+        assert "thinking" not in eb
+
+    def test_deepseek_does_not_interfere_with_kimi(self, transport):
+        """Kimi and DeepSeek can be independently configured."""
+        msgs = [{"role": "user", "content": "Hi"}]
+        # set is_kimi=True but NOT is_deepseek — DeepSeek block should be skipped
+        kw = transport.build_kwargs(
+            model="kimi-latest", messages=msgs,
+            is_kimi=True,
+            is_deepseek=False,
+            reasoning_config={"enabled": True, "effort": "high"},
+        )
+        # Kimi path sets reasoning_effort to "high" (same value, but via Kimi logic)
+        assert kw["reasoning_effort"] == "high"
+
+
 class TestChatCompletionsCacheStats:
 
     def test_no_usage(self, transport):


### PR DESCRIPTION
## Summary
Three provider fixes for DeepSeek and Gemini:

### 1. DeepSeek reasoning_effort + extra_body.thinking
DeepSeek direct API (api.deepseek.com/v1) uses different parameter format from OpenRouter:
- Top-level reasoning_effort (high/max), mapping xhigh to max
- extra_body.thinking (type: enabled/disabled)
Previously, reasoning parameters were silently dropped for direct provider APIs.

### 2. DeepSeek content=null for tool-call messages
Per OpenAI spec, assistant messages with tool_calls should use null content.
Liaobots DeepSeek endpoint rejects content="" with HTTP 400.

### 3. Gemini thinking_config via extra_body.google
Gemini models via OpenAI-compatible proxies (Liaobots) need
extra_body.google.thinking_config with thinking_budget to surface reasoning_content.

### Tests
- tests/agent/transports/test_chat_completions.py
- tests/run_agent/test_deepseek_content_null.py

Replaces previously closed #16312.
