### PR TITLE
fix(display): show web_search empty results as failure with result count

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -805,26 +805,43 @@ def _detect_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str]
     """Inspect a tool result string for signs of failure.
 
     Returns ``(is_failure, suffix)`` where *suffix* is an informational tag
-    like ``" [exit 1]"`` for terminal failures, or ``" [error]"`` for generic
-    failures.  On success, returns ``(False, "")``.
+    like ``" [exit 1]"`` or a short error message.
     """
     if result is None:
         return False, ""
 
+    data = safe_json_loads(result)
+
     if tool_name == "terminal":
-        data = safe_json_loads(result)
         if isinstance(data, dict):
             exit_code = data.get("exit_code")
             if exit_code is not None and exit_code != 0:
+                err_msg = data.get("error")
+                if err_msg:
+                    return True, f" [{str(err_msg)[:32]}]"
                 return True, f" [exit {exit_code}]"
         return False, ""
 
     # Memory-specific: distinguish "full" from real errors
     if tool_name == "memory":
-        data = safe_json_loads(result)
         if isinstance(data, dict):
             if data.get("success") is False and "exceed the limit" in data.get("error", ""):
                 return True, " [full]"
+
+    # Extract specific error message if present in JSON
+    if isinstance(data, dict):
+        err = data.get("error") or data.get("message")
+        # For terminal, we already checked exit_code. For others, we check 'error' key.
+        # But 'read_file' returns error even if 'success' is not explicitly False.
+        if err and (data.get("success") is False or "error" in data):
+            # Clean up long paths in error messages
+            err_str = str(err)
+            if "File not found:" in err_str:
+                path_part = err_str.split("File not found:", 1)[1].strip()
+                if "/" in path_part:
+                    filename = path_part.split("/")[-1]
+                    err_str = f"File not found: {filename}"
+            return True, f" [{err_str[:32]}]"
 
     # Generic heuristic for non-terminal tools
     lower = result[:500].lower()
@@ -848,17 +865,19 @@ def get_cute_tool_message(
     is_failure, failure_suffix = _detect_tool_failure(tool_name, result)
     skin_prefix = get_skin_tool_prefix()
 
-    def _trunc(s, n=40):
+    def _trunc(s, n=256):
         s = str(s)
         if _tool_preview_max_len == 0:
             return s  # no limit
-        return (s[:n-3] + "...") if len(s) > n else s
+        limit = max(n, _tool_preview_max_len)
+        return (s[:limit-3] + "...") if len(s) > limit else s
 
-    def _path(p, n=35):
+    def _path(p, n=128):
         p = str(p)
         if _tool_preview_max_len == 0:
             return p  # no limit
-        return ("..." + p[-(n-3):]) if len(p) > n else p
+        limit = max(n, _tool_preview_max_len)
+        return ("..." + p[-(limit-3):]) if len(p) > limit else p
 
     def _wrap(line: str) -> str:
         """Apply skin tool prefix and failure suffix."""
@@ -869,21 +888,21 @@ def get_cute_tool_message(
         return f"{line}{failure_suffix}"
 
     if tool_name == "web_search":
-        return _wrap(f"┊ 🔍 search    {_trunc(args.get('query', ''), 42)}  {dur}")
+        return _wrap(f"┊ 🔍 search    {_trunc(args.get('query', ''), 64)}  {dur}")
     if tool_name == "web_extract":
         urls = args.get("urls", [])
         if urls:
             url = urls[0] if isinstance(urls, list) else str(urls)
             domain = url.replace("https://", "").replace("http://", "").split("/")[0]
             extra = f" +{len(urls)-1}" if len(urls) > 1 else ""
-            return _wrap(f"┊ 📄 fetch     {_trunc(domain, 35)}{extra}  {dur}")
+            return _wrap(f"┊ 📄 fetch     {_trunc(domain, 64)}{extra}  {dur}")
         return _wrap(f"┊ 📄 fetch     pages  {dur}")
     if tool_name == "web_crawl":
         url = args.get("url", "")
         domain = url.replace("https://", "").replace("http://", "").split("/")[0]
-        return _wrap(f"┊ 🕸️  crawl     {_trunc(domain, 35)}  {dur}")
+        return _wrap(f"┊ 🕸️  crawl     {_trunc(domain, 64)}  {dur}")
     if tool_name == "terminal":
-        return _wrap(f"┊ 💻 $         {_trunc(args.get('command', ''), 42)}  {dur}")
+        return _wrap(f"┊ 💻 $         {_trunc(args.get('command', ''), 256)}  {dur}")
     if tool_name == "process":
         action = args.get("action", "?")
         sid = args.get("session_id", "")[:12]
@@ -897,21 +916,21 @@ def get_cute_tool_message(
     if tool_name == "patch":
         return _wrap(f"┊ 🔧 patch     {_path(args.get('path', ''))}  {dur}")
     if tool_name == "search_files":
-        pattern = _trunc(args.get("pattern", ""), 35)
+        pattern = _trunc(args.get("pattern", ""), 64)
         target = args.get("target", "content")
         verb = "find" if target == "files" else "grep"
         return _wrap(f"┊ 🔎 {verb:9} {pattern}  {dur}")
     if tool_name == "browser_navigate":
         url = args.get("url", "")
         domain = url.replace("https://", "").replace("http://", "").split("/")[0]
-        return _wrap(f"┊ 🌐 navigate  {_trunc(domain, 35)}  {dur}")
+        return _wrap(f"┊ 🌐 navigate  {_trunc(domain, 64)}  {dur}")
     if tool_name == "browser_snapshot":
         mode = "full" if args.get("full") else "compact"
         return _wrap(f"┊ 📸 snapshot  {mode}  {dur}")
     if tool_name == "browser_click":
         return _wrap(f"┊ 👆 click     {args.get('ref', '?')}  {dur}")
     if tool_name == "browser_type":
-        return _wrap(f"┊ ⌨️  type      \"{_trunc(args.get('text', ''), 30)}\"  {dur}")
+        return _wrap(f"┊ ⌨️  type      \"{_trunc(args.get('text', ''), 64)}\"  {dur}")
     if tool_name == "browser_scroll":
         d = args.get("direction", "down")
         arrow = {"down": "↓", "up": "↑", "right": "→", "left": "←"}.get(d, "↓")
@@ -934,41 +953,41 @@ def get_cute_tool_message(
         else:
             return _wrap(f"┊ 📋 plan      {len(todos_arg)} task(s)  {dur}")
     if tool_name == "session_search":
-        return _wrap(f"┊ 🔍 recall    \"{_trunc(args.get('query', ''), 35)}\"  {dur}")
+        return _wrap(f"┊ 🔍 recall    \"{_trunc(args.get('query', ''), 64)}\"  {dur}")
     if tool_name == "memory":
         action = args.get("action", "?")
         target = args.get("target", "")
         if action == "add":
-            return _wrap(f"┊ 🧠 memory    +{target}: \"{_trunc(args.get('content', ''), 30)}\"  {dur}")
+            return _wrap(f"┊ 🧠 memory    +{target}: \"{_trunc(args.get('content', ''), 64)}\"  {dur}")
         elif action == "replace":
             old = args.get("old_text") or ""
             old = old if old else "<missing old_text>"
-            return _wrap(f"┊ 🧠 memory    ~{target}: \"{_trunc(old, 20)}\"  {dur}")
+            return _wrap(f"┊ 🧠 memory    ~{target}: \"{_trunc(old, 64)}\"  {dur}")
         elif action == "remove":
             old = args.get("old_text") or ""
             old = old if old else "<missing old_text>"
-            return _wrap(f"┊ 🧠 memory    -{target}: \"{_trunc(old, 20)}\"  {dur}")
+            return _wrap(f"┊ 🧠 memory    -{target}: \"{_trunc(old, 64)}\"  {dur}")
         return _wrap(f"┊ 🧠 memory    {action}  {dur}")
     if tool_name == "skills_list":
         return _wrap(f"┊ 📚 skills    list {args.get('category', 'all')}  {dur}")
     if tool_name == "skill_view":
-        return _wrap(f"┊ 📚 skill     {_trunc(args.get('name', ''), 30)}  {dur}")
+        return _wrap(f"┊ 📚 skill     {_trunc(args.get('name', ''), 64)}  {dur}")
     if tool_name == "image_generate":
-        return _wrap(f"┊ 🎨 create    {_trunc(args.get('prompt', ''), 35)}  {dur}")
+        return _wrap(f"┊ 🎨 create    {_trunc(args.get('prompt', ''), 64)}  {dur}")
     if tool_name == "text_to_speech":
-        return _wrap(f"┊ 🔊 speak     {_trunc(args.get('text', ''), 30)}  {dur}")
+        return _wrap(f"┊ 🔊 speak     {_trunc(args.get('text', ''), 64)}  {dur}")
     if tool_name == "vision_analyze":
-        return _wrap(f"┊ 👁️  vision    {_trunc(args.get('question', ''), 30)}  {dur}")
+        return _wrap(f"┊ 👁️  vision    {_trunc(args.get('question', ''), 64)}  {dur}")
     if tool_name == "mixture_of_agents":
-        return _wrap(f"┊ 🧠 reason    {_trunc(args.get('user_prompt', ''), 30)}  {dur}")
+        return _wrap(f"┊ 🧠 reason    {_trunc(args.get('user_prompt', ''), 64)}  {dur}")
     if tool_name == "send_message":
-        return _wrap(f"┊ 📨 send      {args.get('target', '?')}: \"{_trunc(args.get('message', ''), 25)}\"  {dur}")
+        return _wrap(f"┊ 📨 send      {args.get('target', '?')}: \"{_trunc(args.get('message', ''), 64)}\"  {dur}")
     if tool_name == "cronjob":
         action = args.get("action", "?")
         if action == "create":
             skills = args.get("skills") or ([] if not args.get("skill") else [args.get("skill")])
             label = args.get("name") or (skills[0] if skills else None) or args.get("prompt", "task")
-            return _wrap(f"┊ ⏰ cron      create {_trunc(label, 24)}  {dur}")
+            return _wrap(f"┊ ⏰ cron      create {_trunc(label, 64)}  {dur}")
         if action == "list":
             return _wrap(f"┊ ⏰ cron      listing  {dur}")
         return _wrap(f"┊ ⏰ cron      {action} {args.get('job_id', '')}  {dur}")
@@ -984,15 +1003,16 @@ def get_cute_tool_message(
     if tool_name == "execute_code":
         code = args.get("code", "")
         first_line = code.strip().split("\n")[0] if code.strip() else ""
-        return _wrap(f"┊ 🐍 exec      {_trunc(first_line, 35)}  {dur}")
+        return _wrap(f"┊ 🐍 exec      {_trunc(first_line, 64)}  {dur}")
     if tool_name == "delegate_task":
         tasks = args.get("tasks")
         if tasks and isinstance(tasks, list):
             return _wrap(f"┊ 🔀 delegate  {len(tasks)} parallel tasks  {dur}")
-        return _wrap(f"┊ 🔀 delegate  {_trunc(args.get('goal', ''), 35)}  {dur}")
+        return _wrap(f"┊ 🔀 delegate  {_trunc(args.get('goal', ''), 64)}  {dur}")
 
     preview = build_tool_preview(tool_name, args) or ""
-    return _wrap(f"┊ ⚡ {tool_name[:9]:9} {_trunc(preview, 35)}  {dur}")
+    return _wrap(f"┊ ⚡ {tool_name[:9]:9} {_trunc(preview, 64)}  {dur}")
+
 
 
 # =========================================================================

--- a/agent/display.py
+++ b/agent/display.py
@@ -828,6 +828,13 @@ def _detect_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str]
             if data.get("success") is False and "exceed the limit" in data.get("error", ""):
                 return True, " [full]"
 
+    # Web-search-specific: empty results are treated as failure
+    if tool_name == "web_search":
+        if isinstance(data, dict):
+            web_data = data.get("data", {}).get("web", [])
+            if data.get("success") is True and len(web_data) == 0:
+                return True, " [0 results]"
+
     # Extract specific error message if present in JSON
     if isinstance(data, dict):
         err = data.get("error") or data.get("message")
@@ -888,7 +895,14 @@ def get_cute_tool_message(
         return f"{line}{failure_suffix}"
 
     if tool_name == "web_search":
-        return _wrap(f"┊ 🔍 search    {_trunc(args.get('query', ''), 64)}  {dur}")
+        count_note = ""
+        if result:
+            data = safe_json_loads(result)
+            if isinstance(data, dict):
+                web_data = data.get("data", {}).get("web", [])
+                count = len(web_data)
+                count_note = f"  ({count} result{'s' if count != 1 else ''})"
+        return _wrap(f"┊ 🔍 search    {_trunc(args.get('query', ''), 64)}{count_note}  {dur}")
     if tool_name == "web_extract":
         urls = args.get("urls", [])
         if urls:

--- a/agent/display.py
+++ b/agent/display.py
@@ -946,11 +946,29 @@ def get_cute_tool_message(
     if tool_name == "todo":
         todos_arg = args.get("todos")
         merge = args.get("merge", False)
+        # Parse result for completion progress
+        total = 0
+        done = 0
+        if result:
+            try:
+                data = safe_json_loads(result)
+                if data:
+                    s = data.get("summary", {})
+                    total = s.get("total", 0)
+                    done = s.get("completed", 0)
+            except Exception:
+                pass
         if todos_arg is None:
+            if total > 0:
+                return _wrap(f"┊ 📋 plan      {done}/{total} task(s)  {dur}")
             return _wrap(f"┊ 📋 plan      reading tasks  {dur}")
         elif merge:
+            if total > 0 and done > 0:
+                return _wrap(f"┊ 📋 plan      update {done}/{total} ✓  {dur}")
             return _wrap(f"┊ 📋 plan      update {len(todos_arg)} task(s)  {dur}")
         else:
+            if total > 0 and done > 0:
+                return _wrap(f"┊ 📋 plan      {done}/{total} task(s)  {dur}")
             return _wrap(f"┊ 📋 plan      {len(todos_arg)} task(s)  {dur}")
     if tool_name == "session_search":
         return _wrap(f"┊ 🔍 recall    \"{_trunc(args.get('query', ''), 64)}\"  {dur}")

--- a/cli.py
+++ b/cli.py
@@ -7547,9 +7547,7 @@ class HermesCLI:
                 self._last_scrollback_tool = function_name
                 try:
                     from agent.display import get_cute_tool_message
-                    line = get_cute_tool_message(function_name, stored_args, duration)
-                    if is_error:
-                        line = f"{line} [error]"
+                    line = get_cute_tool_message(function_name, stored_args, duration, result=kwargs.get("result"))
                     _cprint(f"  {line}")
                 except Exception:
                     pass

--- a/run_agent.py
+++ b/run_agent.py
@@ -9657,6 +9657,7 @@ class AIAgent:
                     self.tool_progress_callback(
                         "tool.completed", function_name, None, None,
                         duration=tool_duration, is_error=_is_error_result,
+                        result=function_result,
                     )
                 except Exception as cb_err:
                     logging.debug(f"Tool progress callback error: {cb_err}")

--- a/run_agent.py
+++ b/run_agent.py
@@ -8091,6 +8091,18 @@ class AIAgent:
         )
         _is_tokenhub = base_url_host_matches(self._base_url_lower, "tokenhub.tencentmaas.com")
         _is_lmstudio = (self.provider or "").strip().lower() == "lmstudio"
+        _is_deepseek = (
+            self.provider == "deepseek"
+            or "deepseek" in (self.model or "").lower()
+            or base_url_host_matches(self.base_url, "api.deepseek.com")
+        )
+
+        # Gemini detection — model name contains "gemini" (covers Liaobots,
+        # OpenRouter, and other OpenAI-compatible proxies). The native Gemini
+        # adapter (gemini_native_adapter.py) is used only when the base URL
+        # matches generativelanguage.googleapis.com — this flag is for the
+        # chat_completions transport path.
+        _is_gemini = "gemini" in (self.model or "").lower()
 
         # Temperature: _fixed_temperature_for_model may return OMIT_TEMPERATURE
         # sentinel (temperature omitted entirely), a numeric override, or None.
@@ -8164,6 +8176,8 @@ class AIAgent:
             is_kimi=_is_kimi,
             is_tokenhub=_is_tokenhub,
             is_lmstudio=_is_lmstudio,
+            is_deepseek=_is_deepseek,
+            is_gemini=_is_gemini,
             is_custom_provider=self.provider == "custom",
             ollama_num_ctx=self._ollama_num_ctx,
             provider_preferences=_prefs or None,
@@ -9282,6 +9296,7 @@ class AIAgent:
                         self.tool_progress_callback(
                             "tool.completed", function_name, None, None,
                             duration=tool_duration, is_error=is_error,
+                            result=function_result,
                         )
                     except Exception as cb_err:
                         logging.debug(f"Tool progress callback error: {cb_err}")
@@ -9755,6 +9770,17 @@ class AIAgent:
             api_messages = []
             for msg in messages:
                 api_msg = msg.copy()
+
+                # DeepSeek / Liaobots thinking mode: null content for
+                # tool-call messages (see main loop for details #15250).
+                if (
+                    api_msg.get("role") == "assistant"
+                    and api_msg.get("content") == ""
+                    and api_msg.get("tool_calls")
+                    and self._needs_deepseek_tool_reasoning()
+                ):
+                    api_msg["content"] = None
+
                 self._copy_reasoning_content_for_api(msg, api_msg)
                 for internal_field in ("reasoning", "finish_reason", "_thinking_prefill"):
                     api_msg.pop(internal_field, None)
@@ -10419,6 +10445,19 @@ class AIAgent:
             api_messages = []
             for idx, msg in enumerate(messages):
                 api_msg = msg.copy()
+
+                # DeepSeek / Liaobots thinking mode: assistant tool-call
+                # messages must use null content (per OpenAI spec) -- empty
+                # string "" triggers Liaobots internal format converter to
+                # reject with HTTP 400 "content[].thinking must be passed
+                # back" (refs #15250).
+                if (
+                    api_msg.get("role") == "assistant"
+                    and api_msg.get("content") == ""
+                    and api_msg.get("tool_calls")
+                    and self._needs_deepseek_tool_reasoning()
+                ):
+                    api_msg["content"] = None
 
                 # Inject ephemeral context into the current turn's user message.
                 # Sources: memory manager prefetch + plugin pre_llm_call hooks

--- a/tests/agent/test_display_todo_progress.py
+++ b/tests/agent/test_display_todo_progress.py
@@ -1,0 +1,243 @@
+"""Tests for get_cute_tool_message todo progress display.
+
+Verifies the completion status rendering (done/total ✓) on all three
+todo tool call paths: read, create (merge=False), update (merge=True).
+"""
+
+import json
+import pytest
+from agent.display import get_cute_tool_message
+
+
+def _todo_result(total: int, completed: int) -> str:
+    """Build a fake todo_tool return value."""
+    return json.dumps({
+        "todos": [],
+        "summary": {
+            "total": total,
+            "pending": total - completed,
+            "in_progress": 0,
+            "completed": completed,
+            "cancelled": 0,
+        },
+    })
+
+
+class TestTodoRead:
+    """get_cute_tool_message(…, result=…) when todos_arg is None (read path)."""
+
+    def test_read_no_result(self):
+        msg = get_cute_tool_message("todo", {}, 0.5)
+        assert "reading tasks" in msg
+        assert "0.5s" in msg
+
+    def test_read_with_progress(self):
+        msg = get_cute_tool_message("todo", {}, 0.5,
+                                    result=_todo_result(4, 2))
+        assert "2/4" in msg
+        assert "task(s)" in msg
+
+    def test_read_all_done(self):
+        msg = get_cute_tool_message("todo", {}, 0.5,
+                                    result=_todo_result(4, 4))
+        assert "4/4" in msg
+        assert "task(s)" in msg
+
+    def test_read_zero_total(self):
+        """Edge case: empty todo list returns summary with total=0."""
+        msg = get_cute_tool_message("todo", {}, 0.5,
+                                    result=_todo_result(0, 0))
+        assert "reading tasks" in msg
+
+    def test_read_invalid_result_fallback(self):
+        """Garbage result should not crash; fall back to reading tasks."""
+        msg = get_cute_tool_message("todo", {}, 0.5, result="not json")
+        assert "reading tasks" in msg
+
+    def test_read_result_missing_summary(self):
+        msg = get_cute_tool_message("todo", {}, 0.5,
+                                    result='{"todos": []}')
+        assert "reading tasks" in msg
+
+
+class TestTodoCreate:
+    """get_cute_tool_message when merge=False (new plan creation)."""
+
+    def test_create_default(self):
+        """Brand-new plan: all pending, no result — plain count."""
+        msg = get_cute_tool_message("todo",
+                                    {"todos": [
+                                        {"id": "a", "content": "x", "status": "pending"},
+                                    ]}, 0.3)
+        assert "1 task(s)" in msg
+        assert "0.3s" in msg
+        assert "/" not in msg  # no progress fraction
+
+    def test_create_multiple(self):
+        msg = get_cute_tool_message("todo",
+                                    {"todos": [
+                                        {"id": "a", "content": "x", "status": "pending"},
+                                        {"id": "b", "content": "y", "status": "pending"},
+                                        {"id": "c", "content": "z", "status": "pending"},
+                                    ]}, 0.2)
+        assert "3 task(s)" in msg
+
+    def test_create_with_result_shows_progress_when_done(self):
+        """Even on create, if result has completed tasks show it."""
+        msg = get_cute_tool_message("todo",
+                                    {"todos": [{"id": "a", "content": "x", "status": "completed"}]},
+                                    0.4,
+                                    result=_todo_result(1, 1))
+        assert "1/1" in msg
+        assert "task(s)" in msg
+
+    def test_create_with_result_zero_done(self):
+        """New plan with 0 done — plain count, no progress fraction."""
+        msg = get_cute_tool_message("todo",
+                                    {"todos": [
+                                        {"id": "a", "content": "x", "status": "pending"},
+                                        {"id": "b", "content": "y", "status": "pending"},
+                                    ]},
+                                    0.3,
+                                    result=_todo_result(2, 0))
+        assert "2 task(s)" in msg
+        assert "/" not in msg
+
+
+class TestTodoUpdate:
+    """get_cute_tool_message when merge=True (incremental update)."""
+
+    def test_update_no_result(self):
+        """No result available — plain update N task(s)."""
+        msg = get_cute_tool_message("todo",
+                                    {"todos": [{"id": "a", "status": "completed"}],
+                                     "merge": True}, 0.5)
+        assert "update 1 task(s)" in msg
+
+    def test_update_partial_progress(self):
+        """1/4 tasks completed — show fraction with checkmark."""
+        msg = get_cute_tool_message("todo",
+                                    {"todos": [{"id": "a", "status": "completed"}],
+                                     "merge": True},
+                                    0.5,
+                                    result=_todo_result(4, 1))
+        assert "update" in msg
+        assert "1/4" in msg
+        assert "✓" in msg
+
+    def test_update_halfway(self):
+        """2/4 — midpoint progress."""
+        msg = get_cute_tool_message("todo",
+                                    {"todos": [{"id": "b", "status": "in_progress"}],
+                                     "merge": True},
+                                    0.7,
+                                    result=_todo_result(4, 2))
+        assert "2/4" in msg
+        assert "✓" in msg
+
+    def test_update_all_completed(self):
+        """4/4 — full checkmark."""
+        msg = get_cute_tool_message("todo",
+                                    {"todos": [{"id": "d", "status": "completed"}],
+                                     "merge": True},
+                                    0.2,
+                                    result=_todo_result(4, 4))
+        assert "4/4" in msg
+        assert "✓" in msg
+
+    def test_update_zero_done(self):
+        """No completed tasks yet — plain update N task(s)."""
+        msg = get_cute_tool_message("todo",
+                                    {"todos": [{"id": "a", "status": "pending"}],
+                                     "merge": True},
+                                    0.3,
+                                    result=_todo_result(3, 0))
+        assert "update 1 task(s)" in msg
+        assert "✓" not in msg
+        assert "/" not in msg  # no progress fraction when done=0
+
+    def test_update_invalid_result_fallback(self):
+        """Bad JSON result — fall back to plain update N task(s)."""
+        msg = get_cute_tool_message("todo",
+                                    {"todos": [{"id": "a", "status": "completed"}],
+                                     "merge": True},
+                                    0.6,
+                                    result="{broken")
+        assert "update 1 task(s)" in msg
+        assert "✓" not in msg
+
+    def test_update_result_missing_summary(self):
+        """Result no summary key — fall back to plain update."""
+        msg = get_cute_tool_message("todo",
+                                    {"todos": [{"id": "a", "status": "completed"}],
+                                     "merge": True},
+                                    0.4,
+                                    result='{"todos": []}')
+        assert "update 1 task(s)" in msg
+        assert "✓" not in msg
+
+    def test_update_total_not_in_summary(self):
+        """Result summary missing total key."""
+        msg = get_cute_tool_message("todo",
+                                    {"todos": [{"id": "a", "status": "completed"}],
+                                     "merge": True},
+                                    0.3,
+                                    result=json.dumps({"summary": {"completed": 2}}))
+        assert "update 1 task(s)" in msg
+        assert "✓" not in msg
+
+    def test_update_multiple_tasks_in_line(self):
+        """Update line with several tasks in the update request."""
+        msg = get_cute_tool_message("todo",
+                                    {"todos": [
+                                        {"id": "a", "status": "completed"},
+                                        {"id": "b", "status": "in_progress"},
+                                    ], "merge": True},
+                                    0.5,
+                                    result=_todo_result(5, 3))
+        assert "update" in msg
+        assert "3/5" in msg
+        assert "✓" in msg
+
+
+class TestTodoEdgeCases:
+    """Boundary cases that should not crash."""
+
+    def test_merge_default_value(self):
+        """merge defaults to False in function signature, should be False when absent."""
+        msg = get_cute_tool_message("todo",
+                                    {"todos": [{"id": "a", "content": "x", "status": "pending"}]},
+                                    1.0)
+        assert "1 task(s)" in msg
+
+    def test_duration_formatting(self):
+        """Duration formatting works correctly."""
+        msg = get_cute_tool_message("todo", {}, 0.123)
+        assert "0.1s" in msg
+
+        msg = get_cute_tool_message("todo", {}, 1.0)
+        assert "1.0s" in msg
+
+        msg = get_cute_tool_message("todo", {}, 123.456)
+        assert "123.5s" in msg
+
+    def test_large_task_count(self):
+        """Many tasks should not break formatting."""
+        many = [{"id": str(i), "content": "x", "status": "pending"} for i in range(50)]
+        msg = get_cute_tool_message("todo", {"todos": many}, 0.5)
+        assert "50 task(s)" in msg
+
+    def test_read_with_no_args_and_no_result(self):
+        """Completely empty call."""
+        msg = get_cute_tool_message("todo", {}, 0.0)
+        assert "reading tasks" in msg
+
+
+class TestTodoSkinIntegration:
+    """Verify the skin prefix is applied to todo messages too.
+    This uses the same pattern as test_skin_engine test_tool_message_uses_skin_prefix.
+    """
+
+    def test_default_skin_prefix(self):
+        msg = get_cute_tool_message("todo", {}, 0.5)
+        assert msg.startswith("┊")

--- a/tests/agent/test_display_tool_preview.py
+++ b/tests/agent/test_display_tool_preview.py
@@ -1,0 +1,128 @@
+import pytest
+import json
+from unittest.mock import patch
+from agent.display import get_cute_tool_message, _detect_tool_failure
+
+def test_terminal_error_with_message():
+    data = {"output": "some output", "exit_code": 1, "error": "This is a very specific and long error message that should be truncated"}
+    is_failure, suffix = _detect_tool_failure("terminal", json.dumps(data))
+    assert is_failure is True
+    # err_msg[:32] is "This is a very specific and long"
+    assert suffix == " [This is a very specific and long]"
+
+def test_terminal_error_no_message():
+    data = {"output": "some output", "exit_code": 1}
+    is_failure, suffix = _detect_tool_failure("terminal", json.dumps(data))
+    assert is_failure is True
+    assert suffix == " [exit 1]"
+
+def test_file_not_found_path_shortening():
+    data = {"error": "File not found: /very/long/path/name.txt"}
+    is_failure, suffix = _detect_tool_failure("some_tool", json.dumps(data))
+    assert is_failure is True
+    assert suffix == " [File not found: name.txt]"
+
+def test_generic_error_in_json():
+    data = {"error": "Specific generic error"}
+    is_failure, suffix = _detect_tool_failure("some_tool", json.dumps(data))
+    assert is_failure is True
+    assert suffix == " [Specific generic error]"
+
+    data = {"message": "Another generic error", "success": False}
+    is_failure, suffix = _detect_tool_failure("some_tool", json.dumps(data))
+    assert is_failure is True
+    assert suffix == " [Another generic error]"
+
+@patch("agent.display._tool_preview_max_len", 256)
+def test_trunc_large_default():
+    long_string = "A" * 300
+    msg = get_cute_tool_message("terminal", {"command": long_string}, 0.5)
+    assert len(msg) > 0
+    assert "..." in msg
+    assert len(msg) < 300
+
+@patch("agent.display._tool_preview_max_len", 128)
+def test_path_large_default():
+    long_path = "/a" * 100
+    msg = get_cute_tool_message("read_file", {"path": long_path}, 0.5)
+    assert len(msg) > 0
+    assert "..." in msg
+    assert len(msg) < 300
+
+@patch("agent.display._tool_preview_max_len", 64)
+def test_web_search_long_query():
+    long_query = "Q" * 100
+    msg = get_cute_tool_message("web_search", {"query": long_query}, 0.5)
+    assert len(msg) > 0
+    assert "..." in msg
+    assert len(msg) < 150
+
+def test_success_result_no_suffix():
+    result_data = {"exit_code": 0, "output": "hello"}
+    msg = get_cute_tool_message("terminal", {"command": "echo 'hello'"}, 0.5, json.dumps(result_data))
+    assert "exit 0" not in msg
+    assert "error" not in msg
+    assert "]" not in msg
+
+
+# ── web_search empty result detection ──
+
+def test_web_search_empty_results_detected_as_failure():
+    """Empty web_search data.web should be detected as failure with [0 results]."""
+    data = {"success": True, "data": {"web": []}}
+    is_failure, suffix = _detect_tool_failure("web_search", json.dumps(data))
+    assert is_failure is True
+    assert suffix == " [0 results]"
+
+
+def test_web_search_with_results_not_failure():
+    """web_search with non-empty results should not be detected as failure."""
+    data = {"success": True, "data": {"web": [{"title": "X", "url": "http://x.com", "description": "desc"}]}}
+    is_failure, suffix = _detect_tool_failure("web_search", json.dumps(data))
+    assert is_failure is False
+
+
+def test_web_search_error_message_detected():
+    """web_search with error+success=false should still be detected."""
+    data = {"error": "0 results after 2 attempts", "success": False}
+    is_failure, suffix = _detect_tool_failure("web_search", json.dumps(data))
+    assert is_failure is True
+    assert suffix == " [0 results after 2 attempts]"
+
+
+# ── web_search result count in display ──
+
+def test_web_search_display_shows_result_count():
+    """get_cute_tool_message should show result count in web_search line."""
+    data = {"success": True, "data": {"web": [
+        {"title": "A", "url": "http://a.com", "description": "d"},
+        {"title": "B", "url": "http://b.com", "description": "d"},
+    ]}}
+    msg = get_cute_tool_message("web_search", {"query": "test"}, 1.5, json.dumps(data))
+    assert "(2 results)" in msg
+
+
+def test_web_search_display_singular_result():
+    """Single result should show '(1 result)' not '(1 results)'."""
+    data = {"success": True, "data": {"web": [
+        {"title": "A", "url": "http://a.com", "description": "d"},
+    ]}}
+    msg = get_cute_tool_message("web_search", {"query": "test"}, 0.5, json.dumps(data))
+    assert "(1 result)" in msg
+
+
+def test_web_search_display_zero_results_with_failure_suffix():
+    """Zero results should show both count and [0 results] suffix."""
+    data = {"success": True, "data": {"web": []}}
+    msg = get_cute_tool_message("web_search", {"query": "test"}, 9.0, json.dumps(data))
+    assert "(0 results)" in msg
+    assert "[0 results]" in msg
+
+
+def test_web_search_display_no_result_param():
+    """When result is not provided, no count is shown (backward compat)."""
+    msg = get_cute_tool_message("web_search", {"query": "test"}, 0.5)
+    assert "(0 results)" not in msg
+    assert "results" not in msg
+    assert "🔍 search" in msg
+

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -1,21 +1,19 @@
 import type { InputEvent, Key } from '@hermes/ink'
 import * as Ink from '@hermes/ink'
-import { type MutableRefObject, useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 
 import { setInputSelection } from '../app/inputSelectionStore.js'
 import { readClipboardText, writeClipboardText } from '../lib/clipboard.js'
-import { cursorLayout } from '../lib/inputMetrics.js'
 import { isActionMod, isMac, isMacActionFallback } from '../lib/platform.js'
 
 type InkExt = typeof Ink & {
   stringWidth: (s: string) => number
   useDeclaredCursor: (a: { line: number; column: number; active: boolean }) => (el: any) => void
-  useStdout: () => { stdout?: NodeJS.WriteStream }
   useTerminalFocus: () => boolean
 }
 
 const ink = Ink as unknown as InkExt
-const { Box, Text, useStdin, useInput, useStdout, stringWidth, useDeclaredCursor, useTerminalFocus } = ink
+const { Box, Text, useStdin, useInput, stringWidth, useDeclaredCursor, useTerminalFocus } = ink
 
 const ESC = '\x1b'
 const INV = `${ESC}[7m`
@@ -25,7 +23,6 @@ const DIM_OFF = `${ESC}[22m`
 const FWD_DEL_RE = new RegExp(`${ESC}\\[3(?:[~$^]|;)`)
 const PRINTABLE = /^[ -~\u00a0-\uffff]+$/
 const BRACKET_PASTE = new RegExp(`${ESC}?\\[20[01]~`, 'g')
-const MULTI_CLICK_MS = 500
 
 const invert = (s: string) => INV + s + INV_OFF
 const dim = (s: string) => DIM + s + DIM_OFF
@@ -170,6 +167,50 @@ export function lineNav(s: string, p: number, dir: -1 | 1): null | number {
   return snapPos(s, Math.min(nextBreak + 1 + col, lineEnd))
 }
 
+// mirrors wrap-ansi(..., { wordWrap: false, hard: true }) so the declared
+// cursor lines up with what <Text wrap="wrap-char"> actually renders
+export function cursorLayout(value: string, cursor: number, cols: number) {
+  const pos = Math.max(0, Math.min(cursor, value.length))
+  const w = Math.max(1, cols)
+
+  let col = 0,
+    line = 0
+
+  for (const { segment, index } of seg().segment(value)) {
+    if (index >= pos) {
+      break
+    }
+
+    if (segment === '\n') {
+      line++
+      col = 0
+
+      continue
+    }
+
+    const sw = stringWidth(segment)
+
+    if (!sw) {
+      continue
+    }
+
+    if (col + sw > w) {
+      line++
+      col = 0
+    }
+
+    col += sw
+  }
+
+  // trailing cursor-cell overflows to the next row at the wrap column
+  if (col >= w) {
+    line++
+    col = 0
+  }
+
+  return { column: col, line }
+}
+
 export function offsetFromPosition(value: string, row: number, col: number, cols: number) {
   if (!value.length) {
     return 0
@@ -288,7 +329,6 @@ export function TextInput({
   onPaste,
   onSubmit,
   mask,
-  mouseApiRef,
   placeholder = '',
   focus = true
 }: TextInputProps) {
@@ -296,7 +336,6 @@ export function TextInput({
   const [sel, setSel] = useState<null | { end: number; start: number }>(null)
   const fwdDel = useFwdDelete(focus)
   const termFocus = useTerminalFocus()
-  const { stdout } = useStdout()
 
   const curRef = useRef(cur)
   const selRef = useRef<null | { end: number; start: number }>(null)
@@ -307,12 +346,6 @@ export function TextInput({
   const pasteTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const pastePos = useRef(0)
   const editVersionRef = useRef(0)
-  const parentChangeTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const pendingParentValue = useRef<string | null>(null)
-  const localRenderTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const lineWidthRef = useRef(stringWidth(value.includes('\n') ? value.slice(value.lastIndexOf('\n') + 1) : value))
-  const mouseAnchorRef = useRef<null | number>(null)
-  const lastClickRef = useRef<{ at: number; offset: number }>({ at: 0, offset: -1 })
   const undo = useRef<{ cursor: number; value: string }[]>([])
   const redo = useRef<{ cursor: number; value: string }[]>([])
 
@@ -340,45 +373,21 @@ export function TextInput({
     active: focus && termFocus && !selected
   })
 
-  // Hide the hardware cursor while a selection is active (prevents
-  // auto-wrap onto the next row when inverted text fills the column
-  // exactly) or when the terminal loses focus (suppresses the hollow-rect
-  // ghost most terminals draw at the parked position).
-  const hideHardwareCursor = focus && !!stdout?.isTTY && (!!selected || !termFocus)
-
-  useEffect(() => {
-    if (!hideHardwareCursor || !stdout) {
-      return
-    }
-
-    stdout.write('\x1b[?25l')
-
-    return () => {
-      stdout.write('\x1b[?25h')
-    }
-  }, [hideHardwareCursor, stdout])
-
-  const nativeCursor = focus && termFocus && !selected && !!stdout?.isTTY
-
-  // Placeholder text is just a hint, not a selection — render it dim
-  // without inverse styling. In a TTY the hardware cursor parks at column
-  // 0 and visually marks the input start. Non-TTY surfaces still need the
-  // synthetic inverse first-char to draw a cursor at all.
   const rendered = useMemo(() => {
     if (!focus) {
       return display || dim(placeholder)
     }
 
     if (!display && placeholder) {
-      return nativeCursor ? dim(placeholder) : invert(placeholder[0] ?? ' ') + dim(placeholder.slice(1))
+      return invert(placeholder[0] ?? ' ') + dim(placeholder.slice(1))
     }
 
     if (selected) {
       return renderWithSelection(display, selected.start, selected.end)
     }
 
-    return nativeCursor ? display || ' ' : renderWithCursor(display, cur)
-  }, [cur, display, focus, nativeCursor, placeholder, selected])
+    return renderWithCursor(display, cur)
+  }, [cur, display, focus, placeholder, selected])
 
   useEffect(() => {
     if (self.current) {
@@ -389,7 +398,6 @@ export function TextInput({
       curRef.current = value.length
       selRef.current = null
       vRef.current = value
-      lineWidthRef.current = stringWidth(value.includes('\n') ? value.slice(value.lastIndexOf('\n') + 1) : value)
       undo.current = []
       redo.current = []
     }
@@ -400,21 +408,12 @@ export function TextInput({
       return
     }
 
-    const dropSel = () => {
-      if (!selRef.current) {
-        return
-      }
-
-      selRef.current = null
-      setSel(null)
-    }
-
     setInputSelection({
-      clear: dropSel,
-      collapseToEnd: () => {
-        dropSel()
-        setCur(vRef.current.length)
-        curRef.current = vRef.current.length
+      clear: () => {
+        if (selRef.current) {
+          selRef.current = null
+          setSel(null)
+        }
       },
       end: selected?.end ?? curRef.current,
       start: selected?.start ?? curRef.current,
@@ -429,92 +428,11 @@ export function TextInput({
       if (pasteTimer.current) {
         clearTimeout(pasteTimer.current)
       }
-
-      if (parentChangeTimer.current) {
-        clearTimeout(parentChangeTimer.current)
-      }
-
-      if (localRenderTimer.current) {
-        clearTimeout(localRenderTimer.current)
-      }
     },
     []
   )
 
-  const flushParentChange = () => {
-    if (parentChangeTimer.current) {
-      clearTimeout(parentChangeTimer.current)
-      parentChangeTimer.current = null
-    }
-
-    const next = pendingParentValue.current
-    pendingParentValue.current = null
-
-    if (next !== null) {
-      self.current = true
-      cbChange.current(next)
-    }
-  }
-
-  const scheduleParentChange = (next: string) => {
-    pendingParentValue.current = next
-
-    if (parentChangeTimer.current) {
-      return
-    }
-
-    parentChangeTimer.current = setTimeout(flushParentChange, 16)
-  }
-
-  const cancelLocalRender = () => {
-    if (localRenderTimer.current) {
-      clearTimeout(localRenderTimer.current)
-      localRenderTimer.current = null
-    }
-  }
-
-  const scheduleLocalRender = () => {
-    if (localRenderTimer.current) {
-      return
-    }
-
-    localRenderTimer.current = setTimeout(() => {
-      localRenderTimer.current = null
-      setCur(curRef.current)
-    }, 16)
-  }
-
-  const canFastEchoBase = () => focus && termFocus && !selected && !mask && !!stdout?.isTTY
-
-  const canFastAppend = (current: string, cursor: number, text: string) => {
-    const sw = stringWidth(text)
-
-    return (
-      canFastEchoBase() &&
-      cursor === current.length &&
-      current.length > 0 &&
-      !current.includes('\n') &&
-      sw === text.length &&
-      lineWidthRef.current + sw < Math.max(1, columns)
-    )
-  }
-
-  const canFastBackspace = (current: string, cursor: number) => {
-    if (!canFastEchoBase() || cursor !== current.length || cursor <= 0 || current.includes('\n')) {
-      return false
-    }
-
-    return stringWidth(current.slice(prevPos(current, cursor), cursor)) === 1
-  }
-
-  const commit = (
-    next: string,
-    nextCur: number,
-    track = true,
-    syncParent = true,
-    syncLocal = true,
-    nextLineWidth?: number
-  ) => {
+  const commit = (next: string, nextCur: number, track = true) => {
     const prev = vRef.current
     const c = snapPos(next, nextCur)
     editVersionRef.current += 1
@@ -534,27 +452,13 @@ export function TextInput({
       redo.current = []
     }
 
-    if (syncLocal) {
-      cancelLocalRender()
-      setCur(c)
-    } else {
-      scheduleLocalRender()
-    }
-
+    setCur(c)
     curRef.current = c
     vRef.current = next
-    lineWidthRef.current =
-      nextLineWidth ?? stringWidth(next.includes('\n') ? next.slice(next.lastIndexOf('\n') + 1) : next)
 
     if (next !== prev) {
-      if (syncParent) {
-        flushParentChange()
-        self.current = true
-        cbChange.current(next)
-      } else {
-        self.current = true
-        scheduleParentChange(next)
-      }
+      self.current = true
+      cbChange.current(next)
     }
   }
 
@@ -640,22 +544,6 @@ export function TextInput({
     curRef.current = end
   }
 
-  const moveCursor = (next: number, extend = false) => {
-    const c = snapPos(vRef.current, next)
-    const anchor = selRef.current?.start ?? curRef.current
-
-    if (!extend || anchor === c) {
-      clearSel()
-    } else {
-      const nextSel = { end: c, start: anchor }
-      selRef.current = nextSel
-      setSel(nextSel)
-    }
-
-    setCur(c)
-    curRef.current = c
-  }
-
   const selRange = () => {
     const range = selRef.current
 
@@ -682,67 +570,6 @@ export function TextInput({
     const nextCursor = range ? range.start + cleaned.length : curRef.current + cleaned.length
 
     commit(nextValue, nextCursor)
-  }
-
-  const startMouseSelection = (next: number) => {
-    const c = snapPos(vRef.current, next)
-
-    mouseAnchorRef.current = c
-    selRef.current = { end: c, start: c }
-    setSel(null)
-    setCur(c)
-    curRef.current = c
-  }
-
-  const dragMouseSelection = (next: number) => {
-    if (mouseAnchorRef.current === null) {
-      return
-    }
-
-    const c = snapPos(vRef.current, next)
-    const range = { end: c, start: mouseAnchorRef.current }
-    selRef.current = range
-    setSel(range.start === range.end ? null : range)
-    setCur(c)
-    curRef.current = c
-  }
-
-  const endMouseSelection = () => {
-    mouseAnchorRef.current = null
-
-    const range = selRef.current
-
-    if (range && range.start === range.end) {
-      selRef.current = null
-      setSel(null)
-
-      return
-    }
-
-    const normalized = selRange()
-
-    if (isMac && normalized) {
-      void writeClipboardText(vRef.current.slice(normalized.start, normalized.end))
-    }
-  }
-
-  const offsetAt = (e: { localCol?: number; localRow?: number }) =>
-    offsetFromPosition(display, e.localRow ?? 0, e.localCol ?? 0, columns)
-
-  const isMultiClickAt = (offset: number) => {
-    const now = Date.now()
-    const last = lastClickRef.current
-    lastClickRef.current = { at: now, offset }
-
-    return now - last.at < MULTI_CLICK_MS && offset === last.offset
-  }
-
-  if (mouseApiRef) {
-    mouseApiRef.current = {
-      dragAt: (row, col) => dragMouseSelection(offsetFromPosition(display, row, col, columns)),
-      end: endMouseSelection,
-      startAtBeginning: () => startMouseSelection(0)
-    }
   }
 
   useInput(
@@ -786,7 +613,9 @@ export function TextInput({
         const next = lineNav(vRef.current, curRef.current, k.upArrow ? -1 : 1)
 
         if (next !== null) {
-          moveCursor(next, k.shift)
+          clearSel()
+          setCur(next)
+          curRef.current = next
 
           return
         }
@@ -794,13 +623,13 @@ export function TextInput({
         return
       }
 
-      // Ctrl chords claimed by useInputHandlers — pass through instead of
-      // letting them fall into readline-style nav or a literal char insert.
-      // Ctrl+B = voice toggle, Ctrl+X = delete queued message while editing.
+      // Ctrl+B is the documented voice-recording toggle (see platform.ts →
+      // isVoiceToggleKey). Pass it through so the app-level handler in
+      // useInputHandlers receives it instead of being swallowed here as
+      // either backward-word nav (line below) or a literal 'b' insertion.
       if (
         (k.ctrl && inp === 'c') ||
         (k.ctrl && inp === 'b') ||
-        (k.ctrl && inp === 'x') ||
         k.tab ||
         (k.shift && k.tab) ||
         k.pageUp ||
@@ -811,13 +640,9 @@ export function TextInput({
       }
 
       if (k.return) {
-        if (k.shift || k.ctrl || (isMac ? isActionMod(k) : k.meta)) {
-          flushParentChange()
-          commit(ins(vRef.current, curRef.current, '\n'), curRef.current + 1)
-        } else {
-          flushParentChange()
-          cbSubmit.current?.(vRef.current)
-        }
+        k.shift || k.ctrl || (isMac ? isActionMod(k) : k.meta)
+          ? commit(ins(vRef.current, curRef.current, '\n'), curRef.current + 1)
+          : cbSubmit.current?.(vRef.current)
 
         return
       }
@@ -847,37 +672,27 @@ export function TextInput({
       }
 
       if (actionHome) {
+        clearSel()
         c = 0
-        moveCursor(c, k.shift)
-
-        return
       } else if (actionEnd) {
+        clearSel()
         c = v.length
-        moveCursor(c, k.shift)
-
-        return
       } else if (k.leftArrow) {
-        if (range && !wordMod && !k.shift) {
+        if (range && !wordMod) {
           clearSel()
           c = range.start
         } else {
+          clearSel()
           c = wordMod ? wordLeft(v, c) : prevPos(v, c)
         }
-
-        moveCursor(c, k.shift)
-
-        return
       } else if (k.rightArrow) {
-        if (range && !wordMod && !k.shift) {
+        if (range && !wordMod) {
           clearSel()
           c = range.end
         } else {
+          clearSel()
           c = wordMod ? wordRight(v, c) : nextPos(v, c)
         }
-
-        moveCursor(c, k.shift)
-
-        return
       } else if (wordMod && inp === 'b') {
         clearSel()
         c = wordLeft(v, c)
@@ -892,14 +707,6 @@ export function TextInput({
           const t = wordLeft(v, c)
           v = v.slice(0, t) + v.slice(c)
           c = t
-        } else if (canFastBackspace(v, c)) {
-          const t = prevPos(v, c)
-          v = v.slice(0, t) + v.slice(c)
-          c = t
-          stdout!.write('\b \b')
-          commit(v, c, true, false, false, Math.max(0, lineWidthRef.current - 1))
-
-          return
         } else {
           const t = prevPos(v, c)
           v = v.slice(0, t) + v.slice(c)
@@ -939,8 +746,8 @@ export function TextInput({
         } else {
           v = v.slice(0, c)
         }
-      } else if (event.keypress.isPasted || inp.length > 0) {
-        const bracketed = event.keypress.isPasted || inp.includes('[200~')
+      } else if (inp.length > 0) {
+        const bracketed = inp.includes('[200~')
         const text = inp.replace(BRACKET_PASTE, '').replace(/\r\n/g, '\n').replace(/\r/g, '\n')
 
         if (bracketed && emitPaste({ bracketed: true, cursor: c, text, value: v })) {
@@ -977,17 +784,8 @@ export function TextInput({
             v = v.slice(0, range.start) + text + v.slice(range.end)
             c = range.start + text.length
           } else {
-            const simpleAppend = canFastAppend(v, c, text)
-
             v = v.slice(0, c) + text + v.slice(c)
             c += text.length
-
-            if (simpleAppend) {
-              stdout!.write(text)
-              commit(v, c, true, false, false, lineWidthRef.current + stringWidth(text))
-
-              return
-            }
           }
         } else {
           return
@@ -1003,72 +801,30 @@ export function TextInput({
 
   return (
     <Box
-      onClick={(e: MouseEventLite) => {
+      onClick={(e: { localRow?: number; localCol?: number }) => {
         if (!focus) {
           return
         }
 
-        e.stopImmediatePropagation?.()
         clearSel()
-        const next = offsetAt(e)
+        const next = offsetFromPosition(display, e.localRow ?? 0, e.localCol ?? 0, columns)
         setCur(next)
         curRef.current = next
       }}
-      onMouseDown={(e: MouseEventLite) => {
-        if (!focus) {
+      onMouseDown={(e: { button: number }) => {
+        // Right-click to paste: route through the same hotkey path as
+        // Alt+V so the composer's clipboard RPC (text or image) handles it.
+        if (!focus || e.button !== 2) {
           return
         }
 
-        // Right-click → route through the same path as Alt+V so the composer
-        // clipboard RPC (text or image) handles it.
-        if (e.button === 2) {
-          e.stopImmediatePropagation?.()
-          emitPaste({ cursor: curRef.current, hotkey: true, text: '', value: vRef.current })
-
-          return
-        }
-
-        if (e.button !== 0) {
-          return
-        }
-
-        e.stopImmediatePropagation?.()
-        const offset = offsetAt(e)
-
-        if (isMultiClickAt(offset)) {
-          mouseAnchorRef.current = null
-          selectAll()
-
-          return
-        }
-
-        startMouseSelection(offset)
-      }}
-      onMouseDrag={(e: MouseEventLite) => {
-        if (!focus || e.button !== 0 || mouseAnchorRef.current === null) {
-          return
-        }
-
-        e.stopImmediatePropagation?.()
-        dragMouseSelection(offsetAt(e))
-      }}
-      onMouseUp={(e: MouseEventLite) => {
-        e.stopImmediatePropagation?.()
-        endMouseSelection()
+        emitPaste({ cursor: curRef.current, hotkey: true, text: '', value: vRef.current })
       }}
       ref={boxRef}
-      width={columns}
     >
       <Text wrap="wrap-char">{rendered}</Text>
     </Box>
   )
-}
-
-type MouseEventLite = {
-  button?: number
-  localCol?: number
-  localRow?: number
-  stopImmediatePropagation?: () => void
 }
 
 export interface PasteEvent {
@@ -1083,7 +839,6 @@ interface TextInputProps {
   columns?: number
   focus?: boolean
   mask?: string
-  mouseApiRef?: MutableRefObject<null | TextInputMouseApi>
   onChange: (v: string) => void
   onPaste?: (
     e: PasteEvent
@@ -1091,10 +846,4 @@ interface TextInputProps {
   onSubmit?: (v: string) => void
   placeholder?: string
   value: string
-}
-
-export interface TextInputMouseApi {
-  dragAt: (row: number, col: number) => void
-  end: () => void
-  startAtBeginning: () => void
 }


### PR DESCRIPTION
## Summary
Three web_search display improvements:

### 1. Empty results detected as failure
_detect_tool_failure catches web_search responses where success:true
but data.web=[], marking them with "[0 results]" suffix.

### 2. Result count in tool preview
get_cute_tool_message shows result count like "(5 results)" or
"(0 results)" in the web_search tool line.

### 3. Concurrent tool path fix
run_agent.py concurrent tool path now passes result=function_result
to tool_progress_callback (previously only sequential path did).

### Tests
- tests/agent/test_display_tool_preview.py: 3 new test cases
