### PR TITLE
feat(skills): add clinical trial competitive intel skill

### DIFF
--- a/skills/research/clinical-trial-competitive-intel/SKILL.md
+++ b/skills/research/clinical-trial-competitive-intel/SKILL.md
@@ -1,0 +1,335 @@
+---
+name: clinical-trial-competitive-intel
+description: Use whenever the user asks for clinical-trial competitive intelligence, competitor analysis, pipeline landscape, target/MoA landscape, CDE/ClinicalTrials.gov/ChiCTR/CTIS trial lookup, China/global trial comparison, or asks to merge registry exports into a competitive-intelligence workbook. This skill is mandatory for pharma/biotech competitor analysis tasks, especially when the user mentions assets, indications, targets, clinical phases, CDE, CTR/NCT IDs, or Excel deliverables. It prevents the common failure of returning only the target asset's own trials without true competitor data.
+version: 2.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [clinical-trials, competitive-intelligence, pharma, pipeline, CDE, ClinicalTrials.gov, Excel, medical-affairs]
+    related_skills: [ocr-and-documents]
+---
+
+# Clinical Trial Competitive Intelligence
+
+## Purpose
+
+Turn public clinical-trial and company-disclosure data into a source-backed competitive-intelligence deliverable for clinical strategy, statistics, medical affairs, and business teams.
+
+The deliverable should answer:
+
+- Who is developing what asset?
+- Against which target/MoA or pathway?
+- For which indication and patient population?
+- In which geography?
+- At what clinical stage and recruitment status?
+- What changed recently?
+- Why does it matter competitively?
+
+Do not produce a raw registry dump. Do not produce a target-asset-only excerpt and call it competitive intelligence.
+
+## Control-System Frame
+
+Use this operating loop, matching the user's preferred engineering-control framing:
+
+1. Objective: define the decision question and scope.
+2. State observation: collect global and China trial/regulatory/public-disclosure evidence.
+3. State estimation: normalize assets, companies, indications, phases, statuses, and geographies.
+4. Control action: synthesize competitor ranking, gaps, risks, and milestones.
+5. Feedback: verify workbook completeness, source coverage, and failure modes before final response.
+
+## Required Skill References
+
+Load only the reference needed for the task:
+
+- `references/competitor-discovery.md`: how to identify true competitors beyond the target asset.
+- `references/source-workflows.md`: ClinicalTrials.gov, PubMed, CDE, ChiCTR, CTIS/EUCTR, company-disclosure collection workflows.
+- `references/excel-schema-and-qc.md`: workbook schema, bilingual sheet requirements, openpyxl formatting, validation gates.
+- `references/cde-normal-chrome.md`: macOS normal Chrome / Apple Events workflow for CDE, and merging saved CDE exports.
+
+## When to Use
+
+Use this skill for requests like:
+
+- “帮我做某资产/靶点/适应症的竞品分析。”
+- “查一下这个药在 CDE / ClinicalTrials.gov 上的临床试验。”
+- “整理 COPD / EGFR / GLP-1 / ADC 等方向国内外竞品格局。”
+- “把 CDE 查询结果合并进竞品分析 Excel。”
+- “做一个医学部能看的竞品临床试验表。”
+- “追踪最近 90 天竞品临床动态。”
+
+Do not use it for medical advice or unsupported efficacy/safety conclusions.
+
+## Default Scope
+
+If the user does not specify scope, default to:
+
+```yaml
+geography_scope: global_and_china
+trial_phase_scope: all interventional drug/biologic trials
+status_scope:
+  - not_yet_recruiting
+  - recruiting
+  - enrolling_by_invitation
+  - active_not_recruiting
+  - completed
+lookback_days: 90
+output_format: Excel workbook plus concise markdown/terminal brief
+language: Chinese first, English sheets also required
+```
+
+Ask clarification only when the ambiguity changes the data sources or output meaning. Otherwise act.
+
+## Non-Negotiable Deliverables
+
+For a full competitive-intelligence task, output a single `.xlsx` workbook plus a concise brief. Markdown-only is incomplete.
+
+The workbook must contain Chinese-first and English versions of core sheets:
+
+1. `README`
+2. `asset_summary_中文`
+3. `trial_records_中文`
+4. `competitor_comparison_中文`
+5. `competitor_trials_中文`
+6. `recent_changes_中文` if monitoring or lookback requested
+7. `source_log_中文`
+8. `search_dictionary_中文`
+9. `dedup_log_中文` if cross-source linking/deduplication was done
+10. corresponding `_EN` sheets
+
+For CDE imports, also include:
+
+- `CDE_trials_中文`
+- `CDE_trials_EN`
+
+Place the output in:
+
+```text
+~/Desktop/<project_name>_<YYYYMMDD>/<project_name>.xlsx
+```
+
+Use `openpyxl` formatting: blue header row with white text, frozen header row, borders, wrapped text, sensible column widths, status/severity color coding, and yellow highlight for the user's own asset.
+
+## First 10 Minutes Protocol
+
+1. Parse the user's stated asset, target/MoA, indication, sponsor, geography, and expected output.
+2. Create a search dictionary before querying:
+   - asset names/codes/generic/brand names
+   - sponsor and subsidiaries
+   - target/MoA and pathway terms
+   - indication aliases in English and Chinese
+   - known competitor assets and companies
+3. Run pre-flight checks before ClinicalTrials.gov calls:
+   - inspect proxy variables
+   - test direct `curl --noproxy '*' https://clinicaltrials.gov/`
+4. Query the target asset, but immediately query competitors too.
+5. Save raw source outputs before normalization.
+6. Build workbook incrementally, not at the end only.
+7. Update `source_log` for every source attempted, including blocked/unavailable sources.
+8. Verify the workbook before final response.
+
+## Competitor Coverage Rule
+
+A competitive-intelligence workbook is failed if it only contains the user's target asset.
+
+After collecting the target asset, always collect at least one of the following competitor sets unless demonstrably none exist:
+
+- same target/MoA assets
+- same pathway assets
+- same indication + same treatment line assets
+- reference product and biosimilars, for biosimilar tasks
+- company-disclosed direct competitors
+- region-specific competitors in China, US, EU, or Japan as relevant
+
+For example, for anti-ST2 COPD work, do not stop at 9MW1911. Also query astegolimab and IL-33 pathway competitors such as itepekimab and tozorakimab.
+
+Document the competitor search terms in `search_dictionary` and `source_log`.
+
+See `references/competitor-discovery.md` for the detailed competitor-discovery playbook.
+
+## Source Priority
+
+Use structured sources first:
+
+1. ClinicalTrials.gov API v2 for global registry records.
+2. PubMed / MEDLINE for published results, trial IDs, lead authors, PI clues.
+3. China public sources: CDE / China drug clinical trial registration platform, ChiCTR, NMPA/CDE announcements.
+4. EU CTIS / EUCTR for EU records.
+5. Company press releases, investor decks, annual/interim reports, exchange filings.
+6. User-provided exports from permitted commercial tools.
+7. Dynamic scraping only when allowed and necessary.
+
+Do not bypass paywalls, login, CAPTCHA, verification, or access controls. For CDE, prefer compliant normal Chrome workflow when automation-controlled browsers are blocked.
+
+## Collection Requirements
+
+For each trial-level record, capture where available:
+
+- source and source URL
+- retrieval date
+- source trial ID: NCT / CTR / ChiCTR / EUCT / CTIS ID
+- company/sponsor/applicant and role
+- asset raw and canonical name
+- target/MoA and modality
+- indication and patient population
+- phase raw and normalized phase
+- status raw and normalized status
+- title and official title
+- arms/interventions
+- primary and secondary endpoints
+- enrollment
+- dates: start, primary completion, completion, last update
+- country/region and China flag
+- PI names and affiliations if available
+- notes and confidence
+
+Keep raw and normalized fields. Do not overwrite raw registry language.
+
+## Normalization Rules
+
+Normalize but do not erase uncertainty.
+
+- Company: parent, subsidiary, Chinese name, English name, historical name, license partner.
+- Asset: generic, brand, code, Chinese transliteration, combination components.
+- Indication: canonical English term plus Chinese alias; preserve line of therapy and biomarker subgroup.
+- Phase: map Early Phase 1 / Phase 1 / Phase 1-2 / Phase 2 / Phase 2-3 / Phase 3 into standard labels.
+- Status: map to `not_yet_recruiting`, `recruiting`, `enrolling_by_invitation`, `active_not_recruiting`, `completed`, `suspended`, `terminated`, `withdrawn`, or `unknown`.
+
+If inference is needed, label confidence as high/medium/low and put the reason in notes or `dedup_log`.
+
+## Deduplication and Cross-Registry Linking
+
+Never blindly delete China records as duplicates of global records.
+
+Use this hierarchy:
+
+1. exact source ID match
+2. explicit cross-registry ID reference
+3. same sponsor + asset + indication + very similar title + overlapping dates
+4. global MRCT evidence
+5. company-disclosure linkage
+
+Keep both records when they represent different source systems. Link them in `dedup_log` and mark a primary record only when justified.
+
+For CDE list-page-only records, treat CTR-to-NCT crosswalks as medium confidence unless the title/phase/status/indication mapping is obvious.
+
+## CDE-Specific Policy
+
+CDE is important for this user. Do not give up after a static curl or automation-controlled browser fails.
+
+Preferred order:
+
+1. Use existing saved CDE export if present under `~/Desktop/CDE_Query/<keyword>_<timestamp>/`.
+2. Use normal Google Chrome + Apple Events/JXA workflow (`cde-query-normal`) on macOS.
+3. If verification appears, ask the user to complete legitimate verification in that same ordinary Chrome session, then continue extraction.
+4. If still blocked, record `verification_required`, `waf_challenge`, or `geo_blocked` with evidence in `source_log`.
+5. Accept user-provided CSV/PDF/export and label it as user-supplied.
+
+CDE list-page fields are limited. If details pages are not captured, do not invent phase, enrollment, endpoints, PI, sites, or dates. Write `未抓取 / Not captured` or `未报告 / Not reported`.
+
+See `references/cde-normal-chrome.md` for exact commands and merge procedure.
+
+## Workbook Quality Gates
+
+Before final response, run an actual verification script with `openpyxl`.
+
+Minimum checks:
+
+- workbook opens without error
+- required sheets exist
+- Chinese sheets precede English sheets
+- `trial_records` has rows beyond header
+- `competitor_comparison` and `competitor_trials` are populated for CI tasks
+- rows have source and retrieval date or source file
+- data exists beyond column A in every core sheet
+- `source_log` includes all attempted sources, even failures
+- CDE status is not stale if CDE data was later merged successfully
+- output path is absolute
+
+A workbook with only IDs in column A is failed even if row counts are nonzero.
+
+## Recent Changes / Monitoring
+
+When the task is monitoring or has a lookback window, compare the new normalized table with the prior snapshot if available.
+
+Track:
+
+- new trial records
+- status changes
+- phase changes
+- enrollment changes
+- primary completion date shifts >90 days
+- new countries/sites, especially China
+- new endpoints or arms
+- company-disclosed milestones
+- termination/suspension
+
+Classify severity:
+
+- High: new Phase III/pivotal trial, China IND/trial start, termination, topline results.
+- Medium: Phase II start, recruitment status change, major enrollment/date shift, new combination arm.
+- Low: metadata cleanup, contacts/sites, minor date or typo changes.
+
+If no prior snapshot exists, label findings as first-pass discovery rather than changes.
+
+## Final Response Pattern
+
+Keep final response concise and evidence-based:
+
+1. Scope and sources checked.
+2. Output workbook path.
+3. Top 3-5 takeaways.
+4. Direct competitor table or short list.
+5. China-specific notes if applicable.
+6. Caveats and next recommended expansion.
+
+Do not overclaim. Public registries can lag company disclosures.
+
+## Common Failure Modes to Avoid
+
+- Only querying the target asset and missing true competitors.
+- Producing markdown but no workbook.
+- Producing English-only output for a Chinese-speaking user.
+- Failing to log blocked sources.
+- Treating CDE regulatory status as trial recruitment status.
+- Treating ClinicalTrials.gov as globally exhaustive.
+- Ignoring Chinese aliases and company subsidiaries.
+- Guessing CDE detail fields from a list page.
+- Forgetting PI fields when PubMed or registry pages can provide them.
+- Not verifying workbook contents after saving.
+- Re-running blocked CDE/ChiCTR dynamic fetches repeatedly instead of switching strategy.
+
+## Evaluation and Maintenance
+
+This skill has a skill-creator-compatible eval set at `evals/evals.json`.
+Use it when changing this skill instead of relying only on intuition.
+
+The eval set covers three failure-prone workflows:
+
+1. Full 9MW1911 COPD competitive-intelligence workbook.
+   - Expected: 9MW1911 plus same-target/pathway competitors such as astegolimab, itepekimab, and tozorakimab or justified alternatives.
+   - Expected: bilingual workbook, source log, search dictionary, and workbook verification.
+2. Saved CDE export merge into an existing workbook.
+   - Expected: read `cde_result.json/csv`, back up the workbook, add bilingual CDE sheets, merge CDE rows into main trial records, update source log, and create dedup/crosswalk notes.
+3. GLP-1/GIP obesity 90-day monitoring workbook.
+   - Expected: competitor discovery, China/global source attempts, recent-change severity classification, and clear first-pass-vs-diff labeling.
+
+Before committing changes to this skill, run:
+
+```bash
+python scripts/validate_skill.py
+```
+
+For larger rewrites, follow the `skill-creator` loop:
+
+1. Snapshot the previous skill version.
+2. Run each eval with the changed skill and with the previous version as baseline.
+3. Grade expectations from `evals/evals.json`.
+4. Generate a review artifact with `eval-viewer/generate_review.py` or a static report.
+5. Revise based on failed expectations and user feedback.
+
+## Reference Loading Guide
+
+- For any full CI task: read `references/competitor-discovery.md` and `references/excel-schema-and-qc.md`.
+- For any data pull: read `references/source-workflows.md`.
+- For any CDE query/merge: read `references/cde-normal-chrome.md`.

--- a/skills/research/clinical-trial-competitive-intel/evals/evals.json
+++ b/skills/research/clinical-trial-competitive-intel/evals/evals.json
@@ -1,0 +1,45 @@
+{
+  "skill_name": "clinical-trial-competitive-intel",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "帮我做 9MW1911 COPD 的国内外竞品临床试验分析，输出 Excel。不要只列 9MW1911 自己的试验。",
+      "expected_output": "Creates a bilingual Excel competitive-intelligence workbook with target-asset trials, true competitor trials, source logs, search dictionary, and QC evidence.",
+      "files": [],
+      "expectations": [
+        "The plan or output includes 9MW1911 plus at least two plausible competitors such as astegolimab, itepekimab, or tozorakimab unless a source-backed exclusion is given.",
+        "The deliverable is an .xlsx workbook, not markdown-only.",
+        "The workbook includes Chinese and English core sheets.",
+        "The workbook includes source_log and search_dictionary sheets or equivalent bilingual variants.",
+        "The response reports actual verification with openpyxl or an equivalent workbook-open check."
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "继续处理 CDE 查询结果。文件在 ~/Desktop/CDE_Query/9MW1911_xxxxxx/，请读取 cde_result.json/csv，并合并进 9MW1911 竞品分析 Excel。",
+      "expected_output": "Reads saved CDE JSON/CSV results, backs up the workbook, adds bilingual CDE sheets, merges CDE records into main trial_records, updates source_log, and records CTR-to-NCT dedup/crosswalk confidence.",
+      "files": [],
+      "expectations": [
+        "The workflow first locates and reads both cde_result.json and cde_result.csv when available.",
+        "The existing workbook is backed up before modification.",
+        "CDE records are merged into main trial_records sheets, not left only in side sheets.",
+        "CDE_trials_中文 and CDE_trials_EN or equivalent bilingual CDE sheets are created or updated.",
+        "source_log is updated so prior CDE blocked or failed status is not stale after a successful import.",
+        "dedup/crosswalk logic records CTR-to-NCT confidence and rationale."
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "追踪 GLP-1/GIP 肥胖方向最近 90 天全球和中国临床动态，输出给医学部看的 Excel。",
+      "expected_output": "Builds a current monitoring workbook for GLP-1/GIP obesity competitors with global and China registry coverage, recent-change classification, and a clear note when no prior snapshot exists.",
+      "files": [],
+      "expectations": [
+        "The workflow creates a search dictionary covering asset names, companies, targets, pathway terms, and Chinese/English indication aliases.",
+        "The output contains competitor-level comparison and trial-level records, not only a narrative summary.",
+        "Recent changes are classified by severity and separated from first-pass discovery when no prior snapshot exists.",
+        "China sources such as CDE or ChiCTR are attempted or explicitly logged as blocked/unavailable with evidence.",
+        "The final response includes the absolute workbook path and top takeaways."
+      ]
+    }
+  ]
+}

--- a/skills/research/clinical-trial-competitive-intel/references/cde-normal-chrome.md
+++ b/skills/research/clinical-trial-competitive-intel/references/cde-normal-chrome.md
@@ -1,0 +1,148 @@
+# CDE Normal Chrome Workflow and Merge Procedure
+
+## Why This Exists
+
+`chinadrugtrials.org.cn` often returns WAF/blank pages to static HTTP, Scrapling, Playwright, or automation-controlled Chrome. The user's preference is to automate CDE as much as possible and avoid repeated manual verification.
+
+The compliant workaround is to drive the user's ordinary Google Chrome session with Apple Events/JXA on macOS. This does not crack CAPTCHA or bypass access control; it only automates a browser session the user can normally access.
+
+## Preferred Query Workflow on macOS
+
+Prerequisites:
+
+1. Use ordinary Google Chrome, not Playwright/remote-debug Chrome.
+2. Chrome: `View -> Developer -> Allow JavaScript from Apple Events`.
+3. Allow Terminal/iTerm/Hermes to control Google Chrome if macOS prompts for Automation permission.
+
+Convenience command:
+
+```bash
+cde-query-normal 9MW1911
+```
+
+Expected outputs:
+
+```text
+~/Desktop/CDE_Query/<keyword>_<timestamp>/cde_result.html
+~/Desktop/CDE_Query/<keyword>_<timestamp>/cde_result.txt
+~/Desktop/CDE_Query/<keyword>_<timestamp>/cde_result.csv
+~/Desktop/CDE_Query/<keyword>_<timestamp>/cde_result.json
+```
+
+Successful list-page extraction should include:
+
+- URL: `https://www.chinadrugtrials.org.cn/clinicaltrials.searchlist.dhtml`
+- title: `试验公示和查询`
+- headers: `序号 / 登记号 / 试验状态 / 药物名称 / 适应症 / 试验通俗题目`
+- rows containing CTR IDs
+
+If verification appears, ask the user to complete it in that same ordinary Chrome window, then continue extraction.
+
+## WAF / Verification Handling
+
+Do not bypass verification. Detect and log:
+
+- page title/body contains `Verification`, `验证`, `验证码`
+- tiny/empty body
+- WAF challenge HTML or strange meta markers
+- HTTP 400/202 challenge behavior
+
+Record in source_log as:
+
+- `verification_required`
+- `waf_challenge`
+- `geo_blocked`
+- `blocked`
+
+Include evidence: HTTP status, title, screenshot path, or raw file path.
+
+## Merging Saved CDE Results Into Workbook
+
+Use this when user says: “文件在 ~/Desktop/CDE_Query/...，读取 cde_result.json/csv，并合并进竞品分析 Excel。”
+
+### Steps
+
+1. Locate CDE directory and workbook.
+   - CDE: `~/Desktop/CDE_Query/<keyword>_<timestamp>/cde_result.json`
+   - Workbook: `~/Desktop/<project_name>_<YYYYMMDD>/<project_name>.xlsx`
+2. Read `cde_result.json` first. It preserves URL, title, captured_at, table rows, links, and WAF evidence.
+3. Use CSV as provenance and secondary table source.
+4. Create timestamped workbook backup before editing:
+   - `<workbook>_backup_before_CDE_merge_<YYYYMMDD_HHMMSS>.xlsx`
+5. Normalize CDE rows into:
+   - `CDE_trials_中文`
+   - `CDE_trials_EN`
+6. Merge the same rows into:
+   - `trial_records_中文`
+   - `trial_records_EN`
+7. Make merge idempotent: remove/replace previous CDE rows before appending new rows.
+8. Update source log. If old CDE row says unavailable/blocked, replace with success and record count.
+9. Add/update dedup/crosswalk sheets:
+   - `dedup_log_中文`
+   - `dedup_log_EN`
+10. Reorder sheets Chinese first.
+11. Verify workbook with openpyxl.
+
+## CDE List-Page Field Mapping
+
+CDE list page normally has:
+
+- `登记号` -> source_trial_id / CTR ID
+- `试验状态` -> status_raw
+- `药物名称` -> asset_raw
+- `适应症` -> indication_raw
+- `试验通俗题目` -> trial_title
+
+List page usually does not include:
+
+- full phase
+- enrollment
+- endpoints
+- PI
+- sites
+- dates
+- detailed design
+
+If detail page was not captured, write:
+
+- `未抓取 / Not captured` for fields that could exist but were not captured
+- `未报告 / Not reported` for fields not reported in the captured source
+
+## CTR-to-NCT Crosswalk
+
+Crosswalk only when supported by evidence:
+
+- same drug name
+- same sponsor/applicant
+- same indication
+- similar title
+- matching phase/status if available
+- overlapping dates if available
+
+Confidence:
+
+- High: explicit cross-registry ID or obvious same trial from title + details.
+- Medium: list-page-only match with same asset/indication/title but no dates/details.
+- Low: plausible but weak match; do not merge, only note.
+
+Keep both source records unless there is a strong reason to collapse them. CDE and CT.gov serve different regional/source roles.
+
+## Verification Expectations
+
+After CDE merge, verify:
+
+- `CDE_trials_中文` and `CDE_trials_EN` have imported rows.
+- `trial_records_中文` and `trial_records_EN` include CDE rows, not only side sheets.
+- `source_log` CDE status is success with correct record count.
+- `dedup_log` includes crosswalk decisions and confidence.
+- core sheets have data beyond column A.
+
+## Example Interpretation
+
+For 9MW1911 CDE list results:
+
+- CTR20252324: COPD, recruiting; likely Phase II based on matched CT.gov NCT07292714 if title/indication align.
+- CTR20230380: COPD, recruitment complete; likely Phase I/II based on matched CT.gov NCT06175351 if title/indication align.
+- CTR20213300 / CTR20212590: healthy-volunteer early trials; matching to CT.gov Phase I records may be medium confidence if only list-page data is available.
+
+State these as inferred crosswalks, not as CDE-provided full details.

--- a/skills/research/clinical-trial-competitive-intel/references/competitor-discovery.md
+++ b/skills/research/clinical-trial-competitive-intel/references/competitor-discovery.md
@@ -1,0 +1,116 @@
+# Competitor Discovery Playbook
+
+## Core Principle
+
+Competitive intelligence is about the competitive set, not only the named asset. A report that only contains the user's asset is a pipeline excerpt, not competitor analysis.
+
+## Build the Search Dictionary First
+
+Create a structured dictionary before querying:
+
+```yaml
+project:
+  asset: 9MW1911
+  sponsor: Mabwell / 迈威生物
+  indication: COPD / 慢性阻塞性肺疾病 / 慢阻肺
+  target: ST2 / IL-33 receptor / IL1RL1
+  pathway: IL-33/ST2 axis
+asset_aliases:
+  - 9MW1911
+  - 9MW1911 injection
+  - 9MW1911注射液
+company_aliases:
+  - Mabwell
+  - Mabwell (Shanghai) Bioscience
+  - 迈威生物
+same_target_competitors:
+  - astegolimab
+same_pathway_competitors:
+  - itepekimab
+  - tozorakimab
+indication_terms:
+  - COPD
+  - chronic obstructive pulmonary disease
+  - 慢性阻塞性肺疾病
+  - 慢阻肺
+```
+
+## Competitor Rings
+
+Use rings to avoid missing relevant assets:
+
+1. Ring 0: user's asset and sponsor.
+2. Ring 1: same target/MoA assets.
+3. Ring 2: same pathway assets.
+4. Ring 3: same indication and same treatment line assets.
+5. Ring 4: region-specific alternatives or standard-of-care context.
+6. Ring 5: biosimilars/reference product, when the asset is a biosimilar.
+
+The workbook should clearly label `competitive_relevance` as:
+
+- `direct`: same target/MoA or same intended positioning.
+- `adjacent`: same pathway or same line but different target.
+- `background`: useful context but not a direct competitor.
+
+## Query Axes
+
+Do not rely on a single query. Query by:
+
+- asset name/code
+- sponsor/company/subsidiary
+- target/MoA
+- pathway
+- indication + target
+- indication + sponsor
+- Chinese indication + Chinese company/drug name
+- known trial IDs from company disclosures
+- reference product class for biosimilars
+
+## Minimum Evidence For Inclusion
+
+Include a competitor when one of these is true:
+
+- registry trial explicitly involves the asset in the same indication or pathway
+- company disclosure states development in the same indication/pathway
+- PubMed publication links asset to relevant trial/result
+- regulatory announcement shows clinical development or approval in the relevant disease area
+
+## Exclusion Rules
+
+Exclude or move to background when:
+
+- observational/non-drug study is irrelevant
+- indication is only loosely related
+- target/pathway is unrelated
+- terminated/withdrawn trial has no current competitive implication
+- data source is commercial/proprietary and not user-supplied or permitted
+
+## Required Workbook Implications
+
+The competitor set must appear in:
+
+- `competitor_comparison_中文` / `_EN`: asset-level head-to-head comparison.
+- `competitor_trials_中文` / `_EN`: trial-level records for competitor assets.
+- `search_dictionary_中文` / `_EN`: all terms used.
+- `source_log_中文` / `_EN`: all searches attempted, including no-result searches.
+
+## Example: Anti-ST2 / IL-33 Pathway COPD
+
+If user asks for 9MW1911 COPD:
+
+- Target asset: 9MW1911, anti-ST2.
+- Same target: astegolimab, anti-ST2.
+- Same pathway: itepekimab, anti-IL-33; tozorakimab, anti-IL-33.
+- Do not stop after 9MW1911 records.
+
+## Biosimilar Special Rule
+
+If the asset is a biosimilar, search:
+
+- target asset code/name
+- reference product generic and brand
+- `generic biosimilar`
+- same indication competitors
+- China-specific biosimilar applicants
+
+A biosimilar landscape without reference-product and same-class biosimilar competitors is incomplete.

--- a/skills/research/clinical-trial-competitive-intel/references/excel-schema-and-qc.md
+++ b/skills/research/clinical-trial-competitive-intel/references/excel-schema-and-qc.md
@@ -1,0 +1,204 @@
+# Excel Schema and Quality Control
+
+## Required Workbook Sheets
+
+For Chinese-speaking users, sheet order should be Chinese first:
+
+1. `README`
+2. `asset_summary_中文`
+3. `trial_records_中文`
+4. `competitor_comparison_中文`
+5. `competitor_trials_中文`
+6. `recent_changes_中文` when applicable
+7. `CDE_trials_中文` when CDE data is used/imported
+8. `dedup_log_中文` when dedup/crosswalk is done
+9. `source_log_中文`
+10. `search_dictionary_中文`
+11. corresponding `_EN` sheets
+
+## `trial_records` Core Columns
+
+Use bilingual equivalents for Chinese/English sheets.
+
+- source
+- source_trial_id
+- source_url
+- retrieved_at
+- last_updated_source
+- company_canonical
+- sponsor_raw
+- sponsor_role
+- partner_companies
+- asset_canonical
+- asset_raw
+- asset_aliases
+- brand_name
+- modality
+- target_or_moa
+- combination_components
+- indication_canonical
+- indication_raw
+- line_of_therapy
+- biomarker_population
+- trial_title
+- official_title
+- study_type
+- phase_raw
+- phase_std
+- status_raw
+- status_std
+- randomized
+- blinded
+- control_type
+- arms
+- primary_endpoints
+- secondary_endpoints
+- enrollment_planned
+- enrollment_actual
+- start_date
+- primary_completion_date
+- completion_date
+- countries
+- has_china
+- has_us
+- has_eu
+- is_global_mrct
+- china_sites
+- pi_names
+- pi_affiliations
+- regulatory_context
+- notes
+- confidence
+
+If the workbook uses a smaller practical column set, do not omit source, trial ID, sponsor, asset, indication, phase/status raw+normalized, endpoints, dates, geography, PI fields, notes, URL.
+
+## `asset_summary`
+
+One row per asset:
+
+- company_canonical
+- asset_canonical
+- aliases
+- target_or_moa
+- modality
+- indications
+- highest_global_phase
+- highest_china_phase
+- active_global_trials
+- active_china_trials
+- completed_trials
+- key_trial_ids
+- next_expected_milestone
+- competitive_relevance
+- medical_affairs_note
+
+## `competitor_comparison`
+
+Head-to-head asset table:
+
+- company
+- asset
+- target/pathway
+- modality
+- indication / population
+- highest global phase
+- highest China phase
+- key active trial(s)
+- route/dosing if available
+- primary endpoint/readout timing
+- geography
+- competitive relevance
+- evidence/source
+- strategic note
+
+## `competitor_trials`
+
+Trial-level records for competitor assets. It can reuse the `trial_records` schema or a compact version, but must include enough metadata to support the comparison.
+
+## `source_log`
+
+Rows for every attempted source:
+
+- source
+- query
+- retrieval date
+- status
+- records found
+- notes/evidence/path
+
+If an earlier source row says blocked/unavailable and later data is successfully imported, update the stale status.
+
+## `search_dictionary`
+
+Rows for:
+
+- indication terms
+- target/MoA terms
+- pathway terms
+- asset aliases
+- company aliases
+- competitor assets
+- Chinese aliases
+- excluded/no-result terms when useful
+
+## `dedup_log`
+
+Required when linking CDE/ChiCTR/EU/CT.gov/company records:
+
+- duplicate_or_link_group_id
+- records_in_group
+- primary_record if any
+- reason
+- confidence
+- action: kept both / merged / excluded / linked only
+
+## Formatting
+
+Use `openpyxl`:
+
+- blue header fill (`1F4E78`) with white bold text
+- frozen top row
+- thin borders
+- wrapped text
+- sensible widths
+- filters if practical
+- yellow fill (`FFF2CC`) for user's own asset
+- green/blue fills for successful imported source rows when useful
+- severity/status color coding
+
+## Verification Script Pattern
+
+After saving, run an actual validation:
+
+```python
+import openpyxl
+p = '/absolute/path/to/workbook.xlsx'
+wb = openpyxl.load_workbook(p, data_only=True)
+required = ['README','asset_summary_中文','trial_records_中文','competitor_comparison_中文','competitor_trials_中文','source_log_中文','search_dictionary_中文','asset_summary_EN','trial_records_EN','source_log_EN','search_dictionary_EN']
+missing = [s for s in required if s not in wb.sheetnames]
+if missing:
+    raise SystemExit(f'missing sheets: {missing}')
+for s in required:
+    ws = wb[s]
+    rows_with_data_beyond_a = 0
+    for row in ws.iter_rows(min_row=2, values_only=True):
+        if any(v not in (None, '') for v in row[1:]):
+            rows_with_data_beyond_a += 1
+    print(s, ws.max_row, ws.max_column, rows_with_data_beyond_a)
+    if ws.max_row < 2 or rows_with_data_beyond_a == 0:
+        raise SystemExit(f'empty or one-column-only sheet: {s}')
+```
+
+## Failure Conditions
+
+Treat the deliverable as incomplete if:
+
+- no Excel workbook was created
+- workbook cannot be opened
+- only target asset is present in a CI task
+- competitor sheets are missing or empty
+- Chinese/English split is absent
+- source_log is missing failures or blocked sources
+- CDE side sheet is present but main `trial_records` was not updated
+- data exists only in column A
+- phase/status were inferred without notes/confidence

--- a/skills/research/clinical-trial-competitive-intel/references/source-workflows.md
+++ b/skills/research/clinical-trial-competitive-intel/references/source-workflows.md
@@ -1,0 +1,137 @@
+# Source Workflows
+
+## ClinicalTrials.gov API v2
+
+Run connectivity checks first:
+
+```bash
+env | grep -i '_proxy\|NO_PROXY' || true
+curl --noproxy '*' -I -L --connect-timeout 15 --max-time 30 https://clinicaltrials.gov/
+```
+
+If proxy breaks TLS, bypass it:
+
+```bash
+curl --noproxy '*' 'https://clinicaltrials.gov/api/v2/studies?query.term=9MW1911&pageSize=20&format=json' -o /tmp/ctgov_raw.json
+```
+
+Use two-step save-then-parse. Avoid `curl | python`.
+
+Collect:
+
+- NCT ID
+- titles
+- conditions
+- interventions/types
+- phases
+- status
+- start / primary completion / completion dates
+- enrollment
+- sponsor and collaborators
+- arms and outcomes
+- countries/facilities when available
+- last update
+- URL
+
+Known quirks:
+
+- `totalCount` may be 0 even when `studies` contains records. Check `len(studies)`.
+- `enrollmentInfo` can be null, dict, or list. Parse defensively.
+- Stop pagination when payload is tiny, `studies` is empty, or no `nextPageToken` exists.
+
+## PubMed / MEDLINE
+
+Use PubMed for:
+
+- published trial results
+- PI/lead-author clues
+- trial IDs not obvious in registries
+- Chinese-origin trials published in English-language journals
+
+Commands:
+
+```bash
+curl 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=pubmed&term=DRUG+AND+INDICATION&retmax=30&retmode=json' -o /tmp/pubmed_search.json
+curl 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&id=PMID1,PMID2&rettype=abstract&retmode=text' -o /tmp/pubmed_abstracts.txt
+```
+
+Create `pubmed_derived` trial/result records when appropriate. Link PMIDs to known NCT/CTR IDs in notes.
+
+## CDE / China Drug Trial Registration
+
+Use Chinese and English terms:
+
+- drug code + 注射液/片/胶囊 as applicable
+- Chinese company name
+- Chinese indication
+- target/MoA Chinese alias
+- CTR IDs discovered elsewhere
+
+Prefer normal Chrome workflow on macOS when automation-controlled browser fails. See `cde-normal-chrome.md`.
+
+Collect when visible:
+
+- CTR registration number
+- drug name
+- indication
+- trial title
+- trial status
+- phase/design/details when detail page is captured
+- sponsor/applicant
+- institutions/sites/PI if visible
+- first public/latest update date
+- source URL and captured time
+
+Do not treat CDE regulatory acceptance/review/approval as trial recruitment status. Put regulatory milestones in `regulatory_context`.
+
+## ChiCTR
+
+ChiCTR can contain investigator-initiated and broader China trial records. It often requires JS rendering and may block non-China IPs.
+
+Stop if verification/CAPTCHA appears. Do not bypass. Mark `verification_required` or `geo_blocked` in source_log.
+
+## EU CTIS / EUCTR
+
+Use for EU-specific footprint and regional status.
+
+Collect:
+
+- EU trial number / CTIS identifier
+- sponsor
+- product/IMP
+- condition
+- phase
+- member states
+- status by country if available
+- start/end dates
+- protocol title
+- URL
+
+Do not assume EU status equals global status.
+
+## Company Disclosures
+
+Use company sites, press releases, investor decks, annual/interim reports, HKEX/SEC filings, and Chinese exchange announcements to enrich:
+
+- asset aliases and ownership
+- partnerships/licensing
+- pipeline stage claimed by company
+- expected readout windows
+- topline/result announcements
+- trial IDs not obvious from registries
+- strategic positioning: first-in-class, best-in-class, pivotal, China-only, global MRCT
+
+If company claims conflict with registries, report both and label sources.
+
+## Source Log Requirements
+
+Every source attempt gets a row:
+
+- source name
+- query term
+- retrieval date
+- status: success / no_result / blocked / unavailable / verification_required / geo_blocked / user_supplied
+- records found
+- notes/evidence: HTTP status, file path, screenshot path, raw JSON path, or reason
+
+Never silently omit failed sources.

--- a/skills/research/clinical-trial-competitive-intel/scripts/validate_skill.py
+++ b/skills/research/clinical-trial-competitive-intel/scripts/validate_skill.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Static validator for the clinical-trial-competitive-intel skill.
+
+This script intentionally checks only deterministic structure: frontmatter,
+reference files, eval schema, and core instruction phrases. It does not grade
+LLM output quality; use skill-creator eval runs for that.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL = ROOT / "SKILL.md"
+REQUIRED_REFERENCES = [
+    "references/competitor-discovery.md",
+    "references/source-workflows.md",
+    "references/excel-schema-and-qc.md",
+    "references/cde-normal-chrome.md",
+]
+REQUIRED_PHRASES = [
+    "Do not produce a target-asset-only excerpt",
+    "A competitive-intelligence workbook is failed if it only contains the user's target asset",
+    "normal Google Chrome + Apple Events/JXA workflow",
+    "Before final response, run an actual verification script with `openpyxl`",
+    "For any CDE query/merge: read `references/cde-normal-chrome.md`",
+]
+
+
+def fail(msg: str) -> None:
+    print(f"FAIL: {msg}")
+    sys.exit(1)
+
+
+def parse_frontmatter(text: str) -> dict[str, str]:
+    if not text.startswith("---\n"):
+        fail("SKILL.md missing YAML frontmatter")
+    try:
+        _, fm, _ = text.split("---", 2)
+    except ValueError:
+        fail("SKILL.md frontmatter is not delimited by ---")
+    out: dict[str, str] = {}
+    for line in fm.splitlines():
+        if ":" in line and not line.startswith(" "):
+            key, value = line.split(":", 1)
+            out[key.strip()] = value.strip().strip('"')
+    return out
+
+
+def main() -> None:
+    if not SKILL.exists():
+        fail(f"missing {SKILL}")
+    text = SKILL.read_text(encoding="utf-8")
+    fm = parse_frontmatter(text)
+    if fm.get("name") != "clinical-trial-competitive-intel":
+        fail("frontmatter name mismatch")
+    desc = fm.get("description", "")
+    for token in ["competitive intelligence", "CDE", "Excel", "target asset"]:
+        if token not in desc:
+            fail(f"description missing trigger token: {token}")
+    for ref in REQUIRED_REFERENCES:
+        path = ROOT / ref
+        if not path.exists():
+            fail(f"missing reference file: {ref}")
+        if ref not in text:
+            fail(f"SKILL.md does not point to reference: {ref}")
+    for phrase in REQUIRED_PHRASES:
+        if phrase not in text:
+            fail(f"missing core instruction phrase: {phrase}")
+    eval_path = ROOT / "evals" / "evals.json"
+    if not eval_path.exists():
+        fail("missing evals/evals.json")
+    data = json.loads(eval_path.read_text(encoding="utf-8"))
+    if data.get("skill_name") != "clinical-trial-competitive-intel":
+        fail("evals.json skill_name mismatch")
+    evals = data.get("evals")
+    if not isinstance(evals, list) or len(evals) < 3:
+        fail("evals.json must contain at least 3 evals")
+    ids = set()
+    for item in evals:
+        if item.get("id") in ids:
+            fail(f"duplicate eval id: {item.get('id')}")
+        ids.add(item.get("id"))
+        for field in ["prompt", "expected_output", "files", "expectations"]:
+            if field not in item:
+                fail(f"eval {item.get('id')} missing {field}")
+        if len(item.get("expectations") or []) < 4:
+            fail(f"eval {item.get('id')} has too few expectations")
+    print("OK: clinical-trial-competitive-intel skill structure validated")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add a clinical-trial competitive-intelligence skill for pharma/biotech workflows
- Include references for competitor discovery, source workflows, Excel schema/QC, and CDE normal-Chrome handling
- Add skill-creator evals and a deterministic validator script

## Validation
- python3 skills/research/clinical-trial-competitive-intel/scripts/validate_skill.py
- python3 -m json.tool skills/research/clinical-trial-competitive-intel/evals/evals.json

Note: package-lock.json and ui-tui/package-lock.json had unrelated pre-existing local modifications and were not included in this commit.