### PR TITLE
fix(anthropic_adapter): preserve Kimi thinking blocks and strip signatures to fix intermittent 400s

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1646,22 +1646,37 @@ def convert_messages_to_anthropic(
         if m.get("role") != "assistant" or not isinstance(m.get("content"), list):
             continue
 
-        if _preserve_unsigned_thinking:
-            # Kimi's /coding and DeepSeek's /anthropic endpoints both enable
-            # thinking server-side and require unsigned thinking blocks on
-            # replayed assistant tool-call messages.  Strip signed Anthropic
-            # blocks (neither upstream can validate Anthropic signatures) but
-            # preserve the unsigned ones we synthesised from reasoning_content.
+        if _is_kimi_family_endpoint(base_url, model):
+            # Kimi returns thinking blocks with real non-empty signatures
+            # via the Anthropic SDK.  When replayed, Kimi rejects those
+            # signatures with HTTP 400 because they are opaque tokens it
+            # cannot re-validate.  However Kimi *requires* thinking blocks
+            # on tool-call messages for history validation.
+            #
+            # Fix: keep every thinking block's *content* but strip the
+            # ``signature`` and ``data`` fields.  Emit only
+            # ``{type, thinking}`` — the minimal shape Kimi accepts.
+            new_content = []
+            for b in m["content"]:
+                if not isinstance(b, dict) or b.get("type") not in _THINKING_TYPES:
+                    new_content.append(b)
+                    continue
+                thinking_text = b.get("thinking", "")
+                new_content.append({"type": b["type"], "thinking": thinking_text})
+            m["content"] = new_content or [{"type": "text", "text": "(empty)"}]
+        elif _preserve_unsigned_thinking:
+            # DeepSeek's /anthropic endpoint requires unsigned thinking
+            # blocks on replayed assistant tool-call messages.  Strip
+            # signed Anthropic blocks (DeepSeek can't validate Anthropic
+            # signatures) but preserve the unsigned ones we synthesised
+            # from reasoning_content.
             new_content = []
             for b in m["content"]:
                 if not isinstance(b, dict) or b.get("type") not in _THINKING_TYPES:
                     new_content.append(b)
                     continue
                 if b.get("signature") or b.get("data"):
-                    # Anthropic-signed block — upstream can't validate, strip
                     continue
-                # Unsigned thinking (synthesised from reasoning_content) —
-                # keep it: the upstream needs it for message-history validation.
                 new_content.append(b)
             m["content"] = new_content or [{"type": "text", "text": "(empty)"}]
         elif _is_third_party or idx != last_assistant_idx:

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1850,24 +1850,17 @@ def build_anthropic_kwargs(
     # not adaptive).  Haiku does NOT support extended thinking — skip entirely.
     #
     # Kimi's /coding endpoint speaks the Anthropic Messages protocol but has
-    # its own thinking semantics: when ``thinking.enabled`` is sent, Kimi
-    # validates the message history and requires every prior assistant
-    # tool-call message to carry OpenAI-style ``reasoning_content``.  The
-    # Anthropic path never populates that field, and
-    # ``convert_messages_to_anthropic`` strips all Anthropic thinking blocks
-    # on third-party endpoints — so the request fails with HTTP 400
-    # "thinking is enabled but reasoning_content is missing in assistant
-    # tool call message at index N".  Kimi's reasoning is driven server-side
-    # on the /coding route, so skip Anthropic's thinking parameter entirely
-    # for that host.  (Kimi on chat_completions enables thinking via
-    # extra_body in the ChatCompletionsTransport — see #13503.)
-    #
     # On 4.7+ the `thinking.display` field defaults to "omitted", which
     # silently hides reasoning text that Hermes surfaces in its CLI. We
     # request "summarized" so the reasoning blocks stay populated — matching
     # 4.6 behavior and preserving the activity-feed UX during long tool runs.
-    _is_kimi_coding = _is_kimi_family_endpoint(base_url, model)
-    if reasoning_config and isinstance(reasoning_config, dict) and not _is_kimi_coding:
+    #
+    # NOTE: Previously skipped thinking for Kimi family endpoints due to
+    # tool-call reasoning_content validation issues (#13826).  Those issues
+    # have been resolved in convert_messages_to_anthropic — thinking blocks
+    # are now preserved (with signatures stripped) on assistant messages.
+    # Re-enable thinking so the Reasoning box displays correctly.
+    if reasoning_config and isinstance(reasoning_config, dict):
         if reasoning_config.get("enabled") is not False and "haiku" not in model.lower():
             effort = str(reasoning_config.get("effort", "medium")).lower()
             budget = THINKING_BUDGET.get(effort, 8000)

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1681,7 +1681,8 @@ def convert_messages_to_anthropic(
             m["content"] = new_content or [{"type": "text", "text": "(empty)"}]
         elif _is_third_party or idx != last_assistant_idx:
             # Third-party endpoint: strip ALL thinking blocks from every
-            # assistant message — signatures are Anthropic-proprietary.
+            # assistant message — signatures are Anthropic-proprietary and
+            # some providers reject unrecognised content block types.
             # Direct Anthropic: strip from non-latest assistant messages only.
             stripped = [
                 b for b in m["content"]

--- a/tests/agent/test_kimi_coding_anthropic_thinking.py
+++ b/tests/agent/test_kimi_coding_anthropic_thinking.py
@@ -24,8 +24,8 @@ from __future__ import annotations
 import pytest
 
 
-class TestKimiCodingSkipsAnthropicThinking:
-    """build_anthropic_kwargs must not inject ``thinking`` for Kimi /coding."""
+class TestKimiCodingAnthropicThinking:
+    """build_anthropic_kwargs must inject ``thinking`` for Kimi /coding when reasoning is enabled."""
 
     @pytest.mark.parametrize(
         "base_url",
@@ -36,7 +36,7 @@ class TestKimiCodingSkipsAnthropicThinking:
             "https://api.kimi.com/coding/",
         ],
     )
-    def test_kimi_coding_endpoint_omits_thinking(self, base_url: str) -> None:
+    def test_kimi_coding_endpoint_gets_thinking(self, base_url: str) -> None:
         from agent.anthropic_adapter import build_anthropic_kwargs
 
         kwargs = build_anthropic_kwargs(
@@ -47,13 +47,12 @@ class TestKimiCodingSkipsAnthropicThinking:
             reasoning_config={"enabled": True, "effort": "medium"},
             base_url=base_url,
         )
-        assert "thinking" not in kwargs, (
-            "Anthropic thinking must not be sent to Kimi /coding — "
-            "endpoint requires reasoning_content on history we don't preserve."
+        assert "thinking" in kwargs, (
+            "Anthropic thinking must be sent to Kimi /coding so the Reasoning box displays."
         )
-        assert "output_config" not in kwargs
+        assert kwargs["thinking"]["type"] == "enabled"
 
-    def test_kimi_coding_with_explicit_disabled_also_omits(self) -> None:
+    def test_kimi_coding_with_explicit_disabled_omits_thinking(self) -> None:
         from agent.anthropic_adapter import build_anthropic_kwargs
 
         kwargs = build_anthropic_kwargs(


### PR DESCRIPTION
## Problem

After upgrading from v0.10.0 to v0.11.0, the CLI no longer displays the Reasoning box when using the **kimi-coding** provider with **kimi-k2.6** model. Additionally, re-enabling thinking causes frequent **intermittent HTTP 400 errors** during multi-turn tool-calling conversations (closes #17201).

## Root Cause 1: Reasoning Box Missing

v0.11.0 introduced two changes that together broke reasoning display for Kimi /coding:

1. **api_mode switched to `anthropic_messages`**: `_detect_api_mode_for_url()` started routing `api.kimi.com/coding` to the Anthropic transport.
2. **thinking parameter was disabled for kimi-coding**: To avoid HTTP 400 errors, `build_anthropic_kwargs()` skipped the thinking parameter entirely for Kimi family endpoints — which meant Kimi stopped returning thinking blocks.

**Fix**: Remove the `not _is_kimi_coding` guard in `build_anthropic_kwargs()`, re-enabling thinking for all Kimi family endpoints.

## Root Cause 2: Intermittent HTTP 400 on Multi-Turn Tool Calls

Kimi's `/coding` endpoint returns thinking blocks with **real non-empty signatures** (long base64-like strings) via the Anthropic SDK. These are Kimi's own opaque tokens, not Anthropic signatures.

After #17455 merged, `convert_messages_to_anthropic` uses a shared `_preserve_unsigned_thinking` branch for both Kimi and DeepSeek. This branch strips blocks where `b.get("signature") or b.get("data")` is truthy:

```python
if _preserve_unsigned_thinking:
    # shared Kimi + DeepSeek path
    ...
    if b.get("signature") or b.get("data"):
        # Anthropic-signed block — upstream can't validate, strip
        continue
    new_content.append(b)
```

Since Kimi's signatures are **truthy** (non-empty strings), this stripped **ALL** thinking blocks from Kimi assistant messages. On replay, Kimi's history validation requires thinking blocks on tool-call messages — finding none, it returns HTTP 400.

### Why It's Intermittent

The 400 only triggers on the **2nd+ API call** in a multi-turn conversation with tool calls, because that's when prior assistant messages with (now-stripped) thinking blocks get replayed. First-turn requests always succeed.

## Fix

Split Kimi out of the shared `_preserve_unsigned_thinking` branch into its own dedicated branch that **preserves** all thinking blocks but **strips only the `signature` and `data` fields**. Emit the minimal `{type, thinking}` shape that Kimi accepts for replayed history:

```python
if _is_kimi_family_endpoint(base_url, model):
    # Kimi-specific: preserve content, strip signatures
    new_content = []
    for b in m["content"]:
        if not isinstance(b, dict) or b.get("type") not in _THINKING_TYPES:
            new_content.append(b)
            continue
        thinking_text = b.get("thinking", "")
        new_content.append({"type": b["type"], "thinking": thinking_text})
    m["content"] = new_content or [{"type": "text", "text": "(empty)"}]
elif _preserve_unsigned_thinking:
    # DeepSeek: existing behavior unchanged — strip signed, keep unsigned
    ...
```

DeepSeek's `/anthropic` endpoint behavior is **unchanged** — it stays on the `_preserve_unsigned_thinking` branch with the original strip-signed/keep-unsigned logic.

## Verification

- Live 3-turn tool-call conversation against `api.kimi.com/coding` with `kimi-k2.6` — all turns succeeded, no 400 errors
- All 26 related unit tests pass (`test_kimi_coding_anthropic_thinking.py` + thinking/reasoning tests in `test_anthropic_adapter.py`)

## Changes

- `agent/anthropic_adapter.py`:
  - Re-enable thinking for Kimi family endpoints by removing the `not _is_kimi_coding` guard in `build_anthropic_kwargs`
  - Split Kimi out of the shared `_preserve_unsigned_thinking` branch into a dedicated branch that preserves thinking block content and strips only `signature`/`data` fields (adapted to the #17455 refactor that broadened Kimi detection to `_is_kimi_family_endpoint` and merged Kimi+DeepSeek paths)
  - DeepSeek behavior unchanged
- `tests/agent/test_kimi_coding_anthropic_thinking.py`: Updated test expectations (thinking must now be sent to Kimi)