### PR TITLE
fix: prefer effective model for self-identification after /new

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4804,7 +4804,10 @@ class HermesCLI:
         agent = getattr(self, "agent", None)
         total_tokens = getattr(agent, "session_total_tokens", 0) or 0
         provider = getattr(self, "provider", None) or "unknown"
-        model = getattr(self, "model", None) or "(unknown)"
+        if agent and hasattr(agent, "get_effective_model"):
+            model = agent.get_effective_model() or getattr(self, "model", None) or "(unknown)"
+        else:
+            model = getattr(self, "model", None) or "(unknown)"
         is_running = bool(getattr(self, "_agent_running", False))
 
         lines = [

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10347,7 +10347,8 @@ class GatewayRunner:
             cache_write = getattr(agent, "session_cache_write_tokens", 0) or 0
 
             lines.append("📊 **Session Token Usage**")
-            lines.append(f"Model: `{agent.model}`")
+            _display_model = agent.get_effective_model() if hasattr(agent, "get_effective_model") else agent.model
+            lines.append(f"Model: `{_display_model}`")
             lines.append(f"Input tokens: {input_tokens:,}")
             if cache_read:
                 lines.append(f"Cache read tokens: {cache_read:,}")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10347,7 +10347,12 @@ class GatewayRunner:
             cache_write = getattr(agent, "session_cache_write_tokens", 0) or 0
 
             lines.append("📊 **Session Token Usage**")
-            _display_model = agent.get_effective_model() if hasattr(agent, "get_effective_model") else agent.model
+            _display_model = getattr(agent, "model", "")
+            get_effective_model = getattr(agent, "get_effective_model", None)
+            if callable(get_effective_model):
+                effective_model = get_effective_model()
+                if isinstance(effective_model, str) and effective_model:
+                    _display_model = effective_model
             lines.append(f"Model: `{_display_model}`")
             lines.append(f"Input tokens: {input_tokens:,}")
             if cache_read:

--- a/run_agent.py
+++ b/run_agent.py
@@ -1019,6 +1019,12 @@ class AIAgent:
         _install_safe_stdio()
 
         self.model = model
+        # Last API-reported model actually used for this requested model.  This
+        # lets self-identification prefer provider-truth over stale configured
+        # metadata (e.g. Codex runtime changed externally), while avoiding stale
+        # carryover after an intentional Hermes-side /model switch.
+        self._effective_model: Optional[str] = None
+        self._effective_model_requested_model: Optional[str] = None
         self.max_iterations = max_iterations
         # Shared iteration budget — parent creates, children inherit.
         # Consumed by every LLM turn across parent + all subagents.
@@ -5058,8 +5064,9 @@ class AIAgent:
         timestamp_line = f"Conversation started: {now.strftime('%A, %B %d, %Y %I:%M %p')}"
         if self.pass_session_id and self.session_id:
             timestamp_line += f"\nSession ID: {self.session_id}"
-        if self.model:
-            timestamp_line += f"\nModel: {self.model}"
+        display_model = self.get_effective_model()
+        if display_model:
+            timestamp_line += f"\nModel: {display_model}"
         if self.provider:
             timestamp_line += f"\nProvider: {self.provider}"
         prompt_parts.append(timestamp_line)
@@ -5457,6 +5464,36 @@ class AIAgent:
             return matches[0]
 
         return None
+
+    def get_effective_model(self) -> str:
+        """Return the best-known active model identifier for display/prompt use.
+
+        Prefer the last API-reported model only when it was observed while the
+        current requested model string was active.  This preserves useful
+        provider-truth across `/new` while avoiding stale carryover after an
+        intentional `/model` switch inside Hermes.
+        """
+        if (
+            isinstance(self._effective_model, str)
+            and self._effective_model.strip()
+            and self._effective_model_requested_model == self.model
+        ):
+            return self._effective_model.strip()
+        return self.model
+
+    def _record_effective_model(self, response_model: Optional[str]) -> None:
+        """Capture provider-reported model identity and refresh cached prompt if needed."""
+        if not isinstance(response_model, str):
+            return
+        response_model = response_model.strip()
+        if not response_model or response_model == "N/A":
+            return
+
+        prior_effective = self.get_effective_model()
+        self._effective_model = response_model
+        self._effective_model_requested_model = self.model
+        if self.get_effective_model() != prior_effective:
+            self._invalidate_system_prompt()
 
     def _invalidate_system_prompt(self):
         """
@@ -11418,6 +11455,9 @@ class AIAgent:
                         # Log response with provider info if available
                         resp_model = getattr(response, 'model', 'N/A') if response else 'N/A'
                         logging.debug(f"API Response received - Model: {resp_model}, Usage: {response.usage if hasattr(response, 'usage') else 'N/A'}")
+                    else:
+                        resp_model = getattr(response, 'model', None) if response else None
+                    self._record_effective_model(resp_model)
                     
                     # Validate response shape before proceeding
                     response_invalid = False

--- a/tests/cli/test_cli_status_command.py
+++ b/tests/cli/test_cli_status_command.py
@@ -86,6 +86,21 @@ def test_show_session_status_prints_gateway_style_summary():
     assert kwargs.get("markup") is False
 
 
+def test_show_session_status_prefers_agent_effective_model_when_available():
+    cli_obj = _make_cli()
+    cli_obj.agent = SimpleNamespace(
+        session_total_tokens=321,
+        session_api_calls=4,
+        get_effective_model=lambda: "openai/gpt-5.5",
+    )
+
+    with patch("cli.display_hermes_home", return_value="~/.hermes"):
+        cli_obj._show_session_status()
+
+    printed = "\n".join(str(call.args[0]) for call in cli_obj.console.print.call_args_list)
+    assert "Model: openai/gpt-5.5 (openai)" in printed
+
+
 def test_profile_command_reports_custom_root_profile(monkeypatch, tmp_path, capsys):
     """Profile detection works for custom-root deployments (not under ~/.hermes)."""
     cli_obj = _make_cli()

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -903,6 +903,26 @@ class TestBuildSystemPrompt:
         # Should contain current date info like "Conversation started:"
         assert "Conversation started:" in prompt
 
+    def test_prefers_effective_model_in_prompt_when_api_reports_one(self, agent):
+        agent.model = "gpt-5.4"
+        agent._effective_model = "gpt-5.5"
+        agent._effective_model_requested_model = "gpt-5.4"
+
+        prompt = agent._build_system_prompt()
+
+        assert "Model: gpt-5.5" in prompt
+        assert "Model: gpt-5.4" not in prompt
+
+    def test_ignores_stale_effective_model_after_requested_model_changes(self, agent):
+        agent.model = "gpt-5.5"
+        agent._effective_model = "gpt-5.4"
+        agent._effective_model_requested_model = "gpt-5.4"
+
+        prompt = agent._build_system_prompt()
+
+        assert "Model: gpt-5.5" in prompt
+        assert "Model: gpt-5.4" not in prompt
+
     def test_includes_nous_subscription_prompt(self, agent, monkeypatch):
         monkeypatch.setattr(run_agent, "build_nous_subscription_prompt", lambda tool_names: "NOUS SUBSCRIPTION BLOCK")
         prompt = agent._build_system_prompt()


### PR DESCRIPTION
## Summary
- record provider-reported effective model on API responses
- use effective model in system prompt self-identification instead of stale requested model metadata
- use effective model in CLI and gateway status displays
- add regression coverage for prompt and CLI status behavior

## Why
After switching from gpt-5.4 to gpt-5.5, `/new` could still inject `Model: gpt-5.4` into startup context if Hermes had stale requested-model metadata. That made the agent self-identify incorrectly even when the active provider-reported model was newer.

## Test Plan
- `pytest -q tests/run_agent/test_run_agent.py tests/cli/test_cli_status_command.py tests/hermes_cli/test_model_switch_context_display.py tests/gateway/test_session_model_reset.py tests/cli/test_cli_new_session.py`

## Notes
- commits only the model self-identification fix
- leaves unrelated dirty worktree changes untouched
