### PR TITLE
fix: gateway reconnect watcher retries indefinitely instead of giving up after 20 attempts

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2816,11 +2816,17 @@ class GatewayRunner:
                     continue  # not time yet
 
                 if info["attempts"] >= _MAX_ATTEMPTS:
-                    logger.warning(
-                        "Giving up reconnecting %s after %d attempts",
-                        platform.value, info["attempts"],
+                    # Reset the counter and continue retrying at the
+                    # backoff cap instead of permanently abandoning the
+                    # platform.  A long-running gateway (days/weeks) should
+                    # recover from transient outages that exceed 20 attempts.
+                    logger.info(
+                        "Reconnect %s: %d attempts reached, continuing at "
+                        "backoff cap (%ds)",
+                        platform.value, info["attempts"], _BACKOFF_CAP,
                     )
-                    del self._failed_platforms[platform]
+                    info["attempts"] = 0
+                    info["next_retry"] = time.monotonic() + _BACKOFF_CAP
                     continue
 
                 platform_config = info["config"]


### PR DESCRIPTION
## Problem

The platform reconnect watcher in `gateway/run.py` permanently removes retryable platforms from `_failed_platforms` after 20 failed attempts (`_MAX_ATTEMPTS = 20`). For long-running gateways (days/weeks), this converts transient network/proxy outages into permanent disconnections requiring manual `hermes gateway restart`.

**Observed timeline** (from a real gateway):
- Telegram hit repeated `httpx.ConnectError` during proxy-backed Bot API calls
- Gateway retried for ~2 hours (20 attempts with exponential backoff)
- Gateway logged `Giving up reconnecting telegram after 20 attempts` and removed Telegram from `_failed_platforms`
- Telegram remained disconnected until manual restart, even after network recovered

Fixes #17063

## Fix

Instead of deleting the platform from the retry queue after 20 attempts, reset the attempt counter and continue retrying at the backoff cap (5 minutes). This ensures long-running gateways eventually recover from transient outages.

**Before:** Platform permanently abandoned after 20 failed attempts
**After:** Platform retries every 5 minutes indefinitely (until gateway restart or successful reconnect)

## Changes

- `gateway/run.py`: Replace `del self._failed_platforms[platform]` with `info["attempts"] = 0` and schedule next retry at backoff cap
- Change log level from `WARNING` to `INFO` (this is expected behavior, not an error)

## Tests

- Existing gateway reconnect tests should still pass
- The fix is minimal (4 lines changed) and preserves all existing behavior except the permanent abandonment