### PR TITLE
fix: pass through Volcengine ARK endpoint IDs (ep-*) in DeepSeek normalization

### DIFF
--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -143,6 +143,12 @@ _DEEPSEEK_CANONICAL_MODELS: frozenset[str] = frozenset({
 # of ``deepseek-chat`` and must not be folded into it.
 _DEEPSEEK_V_SERIES_RE = re.compile(r"^deepseek-v\d+([-.].+)?$")
 
+# Volcengine ARK endpoint IDs (``ep-20250428-xxxxx``) and other third-party
+# custom endpoint model names.  These must NOT be normalized when the user
+# has configured a custom DEEPSEEK_BASE_URL pointing to a non-DeepSeek
+# endpoint — the remote endpoint doesn't know about ``deepseek-chat``.
+_DEEPSEEK_CUSTOM_ENDPOINT_RE = re.compile(r"^ep-\w+", re.IGNORECASE)
+
 
 def _normalize_for_deepseek(model_name: str) -> str:
     """Map a model input to a DeepSeek-accepted identifier.
@@ -152,6 +158,8 @@ def _normalize_for_deepseek(model_name: str) -> str:
       ``deepseek-v4-pro``/``deepseek-v4-flash``) -> pass through.
     - Matches the V-series pattern ``deepseek-v<digit>...`` -> pass through
       (covers future ``deepseek-v5-*`` and dated variants without a release).
+    - Matches a custom endpoint ID (``ep-*``) and a non-default
+      ``DEEPSEEK_BASE_URL`` is configured -> pass through.
     - Contains a reasoner keyword (r1, think, reasoning, cot, reasoner)
       -> ``deepseek-reasoner``.
     - Everything else -> ``deepseek-chat``.
@@ -170,6 +178,15 @@ def _normalize_for_deepseek(model_name: str) -> str:
     # V-series first-class IDs (v4-pro, v4-flash, future v5-*, dated variants)
     if _DEEPSEEK_V_SERIES_RE.match(bare):
         return bare
+
+    # Custom endpoint IDs (e.g. Volcengine ARK ``ep-20250428-xxxxx``) must
+    # pass through when the user has configured a non-default base URL.
+    # The remote endpoint doesn't recognise ``deepseek-chat``.
+    if _DEEPSEEK_CUSTOM_ENDPOINT_RE.match(bare):
+        import os
+        custom_base = os.getenv("DEEPSEEK_BASE_URL", "").strip()
+        if custom_base and "api.deepseek.com" not in custom_base:
+            return bare
 
     # Check for reasoner-like keywords anywhere in the name
     for keyword in _DEEPSEEK_REASONER_KEYWORDS:


### PR DESCRIPTION
## Problem

When using a custom DeepSeek-compatible endpoint (e.g. Volcengine ARK at `ark.cn-beijing.volces.com/api/v3`), custom endpoint model IDs like `ep-20250428-xxxxx` are silently normalized to `deepseek-chat`, causing HTTP 404 errors on the remote endpoint.

The V-series regex already handles `deepseek-v*` IDs correctly. This fix addresses the `ep-*` pattern used by Volcengine ARK endpoints.

Fixes #17199 (Bug 1)

## Fix

Add a regex pattern for `ep-*` prefixed IDs (Volcengine ARK endpoint IDs). When the model name matches this pattern AND `DEEPSEEK_BASE_URL` is set to a non-DeepSeek endpoint, pass the model name through unchanged.

**Before:** `ep-20250428-xxxxx` → `deepseek-chat` (404 on Volcengine)
**After:** `ep-20250428-xxxxx` → `ep-20250428-xxxxx` (passed through when custom base URL is set)

## Changes

- `hermes_cli/model_normalize.py`:
  - Add `_DEEPSEEK_CUSTOM_ENDPOINT_RE` regex pattern for `ep-*` IDs
  - Update `_normalize_for_deepseek()` to pass through custom endpoint IDs when `DEEPSEEK_BASE_URL` points to a non-DeepSeek endpoint

## Tests

- All existing normalization tests should still pass
- The fix is conservative: only passes through when custom base URL is explicitly configured