### PR TITLE
fix(gateway): don't give up on retryable platform reconnect (#17063)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2790,11 +2790,19 @@ class GatewayRunner:
     async def _platform_reconnect_watcher(self) -> None:
         """Background task that periodically retries connecting failed platforms.
 
-        Uses exponential backoff: 30s → 60s → 120s → 240s → 300s (cap).
-        Stops retrying a platform after 20 failed attempts or if the error
-        is non-retryable (e.g. bad auth token).
+        Uses exponential backoff: 30s → 60s → 120s → 240s → 300s (cap). A
+        platform is removed from the retry queue when it reconnects
+        successfully or when ``connect()`` reports a non-retryable fatal
+        error (e.g. bad auth token, where retries serve no purpose).
+
+        Retryable failures (network outages, proxy hiccups, transient
+        upstream 5xxs) keep retrying at the capped interval indefinitely.
+        Long-running messaging adapters such as Telegram routinely outlive
+        multi-hour proxy/network interruptions, and stopping retries after
+        a fixed attempt count converts a transient outage into a permanent
+        outage that requires manual ``hermes gateway restart`` to recover
+        from (#17063).
         """
-        _MAX_ATTEMPTS = 20
         _BACKOFF_CAP = 300  # 5 minutes max between retries
 
         await asyncio.sleep(10)  # initial delay — let startup finish
@@ -2815,19 +2823,11 @@ class GatewayRunner:
                 if now < info["next_retry"]:
                     continue  # not time yet
 
-                if info["attempts"] >= _MAX_ATTEMPTS:
-                    logger.warning(
-                        "Giving up reconnecting %s after %d attempts",
-                        platform.value, info["attempts"],
-                    )
-                    del self._failed_platforms[platform]
-                    continue
-
                 platform_config = info["config"]
                 attempt = info["attempts"] + 1
                 logger.info(
-                    "Reconnecting %s (attempt %d/%d)...",
-                    platform.value, attempt, _MAX_ATTEMPTS,
+                    "Reconnecting %s (attempt %d)...",
+                    platform.value, attempt,
                 )
 
                 try:

--- a/tests/gateway/test_platform_reconnect.py
+++ b/tests/gateway/test_platform_reconnect.py
@@ -208,20 +208,80 @@ class TestPlatformReconnectWatcher:
         assert runner._failed_platforms[Platform.TELEGRAM]["attempts"] == 2
 
     @pytest.mark.asyncio
-    async def test_reconnect_gives_up_after_max_attempts(self):
-        """After max attempts, platform should be removed from retry queue."""
+    async def test_reconnect_retryable_keeps_trying_past_old_max_cap(self):
+        """Retryable failures are not given up on after the old 20-attempt cap.
+
+        Regression for #17063: a real Telegram outage retried 20 times under
+        proxy unavailability and the old fixed cap then deleted the platform
+        from ``_failed_platforms`` permanently, even though the proxy
+        recovered later. Retryable failures should keep being retried
+        indefinitely with capped backoff.
+        """
         runner = _make_runner()
 
         platform_config = PlatformConfig(enabled=True, token="test")
         runner._failed_platforms[Platform.TELEGRAM] = {
             "config": platform_config,
-            "attempts": 20,  # At max
+            "attempts": 20,  # At the old hard cap
             "next_retry": time.monotonic() - 1,
         }
 
+        fail_adapter = StubAdapter(
+            succeed=False,
+            fatal_error="proxy unreachable",
+            fatal_retryable=True,
+        )
+
         real_sleep = asyncio.sleep
 
-        with patch.object(runner, "_create_adapter") as mock_create:
+        with patch.object(runner, "_create_adapter", return_value=fail_adapter):
+            async def run_one_iteration():
+                runner._running = True
+                call_count = 0
+
+                async def fake_sleep(n):
+                    nonlocal call_count
+                    call_count += 1
+                    if call_count > 1:
+                        runner._running = False
+                    await real_sleep(0)
+
+                with patch("asyncio.sleep", side_effect=fake_sleep):
+                    await runner._platform_reconnect_watcher()
+
+            await run_one_iteration()
+
+        # Platform must still be queued for the next retry — the gateway
+        # should not silently give up on a retryable error.
+        assert Platform.TELEGRAM in runner._failed_platforms
+        assert runner._failed_platforms[Platform.TELEGRAM]["attempts"] == 21
+
+    @pytest.mark.asyncio
+    async def test_reconnect_nonretryable_still_removed_after_many_attempts(self):
+        """Non-retryable errors stay removed regardless of attempt count.
+
+        The fix for #17063 must not blunt the existing fast-path that drops
+        platforms with a fundamentally permanent failure (bad auth token,
+        revoked credentials, etc.) — those should never re-enter the loop.
+        """
+        runner = _make_runner()
+
+        platform_config = PlatformConfig(enabled=True, token="test")
+        runner._failed_platforms[Platform.TELEGRAM] = {
+            "config": platform_config,
+            "attempts": 25,
+            "next_retry": time.monotonic() - 1,
+        }
+
+        fail_adapter = StubAdapter(
+            succeed=False,
+            fatal_error="invalid token",
+            fatal_retryable=False,
+        )
+
+        real_sleep = asyncio.sleep
+
+        with patch.object(runner, "_create_adapter", return_value=fail_adapter):
             async def run_one_iteration():
                 runner._running = True
                 call_count = 0
@@ -239,7 +299,6 @@ class TestPlatformReconnectWatcher:
             await run_one_iteration()
 
         assert Platform.TELEGRAM not in runner._failed_platforms
-        mock_create.assert_not_called()  # Should give up without trying
 
     @pytest.mark.asyncio
     async def test_reconnect_skips_when_not_time_yet(self):


### PR DESCRIPTION
## What does this PR do?

`_platform_reconnect_watcher` had a fixed `_MAX_ATTEMPTS = 20` and deleted the platform from `_failed_platforms` once that count was hit — even when the underlying error was a retryable network/proxy outage. For long-running messaging adapters (Telegram, Slack, Discord) the cap plus the 5-minute capped backoff means a multi-hour proxy interruption silently converted to a permanent outage that only `hermes gateway restart` could recover from.

The reporter observed exactly this on Telegram (#17063): `httpx.ConnectError` against the Bot API proxy → reconnect queue retried 20 times → `Giving up reconnecting telegram after 20 attempts` → Telegram stayed offline despite the proxy coming back later. Distinct from #11614, which is about the gateway exiting when *all* platforms fail at startup; here the gateway itself stays alive but silently loses one platform.

The fix drops the give-up branch entirely and lets retryable failures keep retrying at the 300s capped backoff indefinitely. The non-retryable fast-path (`adapter.has_fatal_error and not adapter.fatal_error_retryable`) is the correct "stop trying" gate and is unchanged — bad auth tokens and revoked credentials still drop out of the queue immediately.

## Related Issue

Fixes #17063

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py` — `_platform_reconnect_watcher`: removed the `_MAX_ATTEMPTS` constant + the `attempts >= _MAX_ATTEMPTS` give-up branch. Updated the docstring to describe the two real exit conditions (successful reconnect, non-retryable fatal error). Dropped the now-meaningless `/<MAX_ATTEMPTS>` suffix from the per-attempt info log; the attempt counter still increments forever per platform so attempt-count telemetry is preserved.
- `tests/gateway/test_platform_reconnect.py` — replaced the pre-existing `test_reconnect_gives_up_after_max_attempts` (which codified the buggy behavior) with two regression tests: (1) a retryable failure at `attempts=20` stays queued and `attempts` becomes 21, and (2) a non-retryable failure at `attempts=25` is still removed (the fix must not soften that path).

## How to Test

1. Reproduce the issue manually: configure Telegram with a proxy you can take offline; wait for the gateway to mark Telegram retryable; hold the proxy down for `30 + 60 + 120 + 240 + 16 * 300` ≈ 90 minutes worth of attempts.
2. **Before this fix:** gateway logs `Giving up reconnecting telegram after 20 attempts`; even after the proxy comes back, Telegram stays disconnected until `hermes gateway restart`.
3. **After this fix:** gateway keeps logging `Reconnecting telegram (attempt N)...` at the 300s capped interval; once the proxy is reachable the next attempt succeeds and Telegram comes back online without operator intervention.

Automated:
```
pytest tests/gateway/test_platform_reconnect.py tests/gateway/test_telegram_network_reconnect.py tests/gateway/test_platform_base.py -q
```

Result on macOS 15.6 / Python 3.14: `15 + 87 = 102 passed, 2 skipped`. The new test fails on `origin/main` (the buggy `Giving up reconnecting telegram after 20 attempts` log line shows up in the failure).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_platform_reconnect.py tests/gateway/test_telegram_network_reconnect.py tests/gateway/test_platform_base.py -q` and the touched surface (102 tests) all passes. Full `pytest tests/ -q` not run; the gateway-platform reconnect path has dedicated test files which are exercised in full above.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.6 (Python 3.14)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A *(updated `_platform_reconnect_watcher`'s docstring to describe the two real exit conditions; no user-facing docs reference the old 20-attempt limit)*
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A *(N/A — no config keys touched; the watcher remains a fixed-policy background task)*
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A *(N/A)*
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A *(N/A — pure asyncio/logging, identical across platforms)*
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A *(N/A — gateway internal, not a tool)*

## Screenshots / Logs

```
$ pytest tests/gateway/test_platform_reconnect.py -q
...............                                                          [100%]
15 passed, 2 warnings in 3.18s
```

Without the fix, `test_reconnect_retryable_keeps_trying_past_old_max_cap` fails with the exact symptom the reporter described:
```
WARNING  gateway.run:run.py:2819 Giving up reconnecting telegram after 20 attempts
AssertionError: assert <Platform.TELEGRAM: 'telegram'> in {}
```