### PR TITLE
fix(utils): chown atomic-replace target to match parent when root (#17144)

### DIFF
--- a/tests/test_atomic_replace_chown_parent.py
+++ b/tests/test_atomic_replace_chown_parent.py
@@ -1,0 +1,149 @@
+"""Regression tests for GitHub #17144 — atomic writes from a root-context
+must chown the resulting file to match the parent directory's owner so
+the gateway service user can read it.
+
+Containerized hermes deployments (``nousresearch/hermes-agent:latest``)
+run PID 1 as root via tini and the gateway as ``hermes`` / UID 10000.
+Memory-tool / aux writes that happen to land on the root side of that
+boundary land on the persistent volume as ``root:root`` and the gateway
+silently can't read them — the agent looks like it persisted the memory
+but the next session never sees it.
+
+The fix sticks the parent directory's owner/group onto the new file
+inside ``atomic_replace`` so every atomic-write call site benefits and
+no per-tool plumbing is needed. These tests pin the gating logic
+without requiring real root: ``os.geteuid`` / ``os.stat`` / ``os.chown``
+are monkey-patched, and the chown call is observed.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+import utils as utils_mod
+from utils import atomic_replace
+
+
+pytestmark = pytest.mark.skipif(os.name != "posix", reason="POSIX-only")
+
+
+def _write_tmp(dir_: Path, content: str = "x") -> Path:
+    tmp = dir_ / ".src.tmp"
+    tmp.write_text(content, encoding="utf-8")
+    return tmp
+
+
+def _fake_parent_stat(uid: int, gid: int) -> SimpleNamespace:
+    return SimpleNamespace(st_uid=uid, st_gid=gid)
+
+
+def test_chown_to_match_parent_runs_when_root_and_parent_is_user(tmp_path):
+    """As root, after replace, chown to parent's non-root owner.
+
+    Repro: gateway runs as ``hermes`` (UID 10000), persistent volume
+    parent is owned by 10000, but the write happens from a root context.
+    The new file should end up owned by 10000:10000.
+    """
+    target = tmp_path / "MEMORY.md"
+    target.write_text("old\n", encoding="utf-8")
+    tmp = _write_tmp(tmp_path, "new\n")
+
+    chown_calls: list[tuple[str, int, int]] = []
+
+    def fake_chown(path, uid, gid):
+        chown_calls.append((str(path), uid, gid))
+
+    real_stat = os.stat
+
+    def fake_stat(path, *args, **kwargs):
+        if str(path) == str(tmp_path):
+            return _fake_parent_stat(uid=10000, gid=10000)
+        return real_stat(path, *args, **kwargs)
+
+    with patch.object(utils_mod.os, "geteuid", lambda: 0), \
+         patch.object(utils_mod.os, "chown", side_effect=fake_chown), \
+         patch.object(utils_mod.os, "stat", side_effect=fake_stat):
+        atomic_replace(tmp, target)
+
+    assert chown_calls, "expected chown call when root + non-root parent"
+    chown_path, chown_uid, chown_gid = chown_calls[-1]
+    assert chown_path == str(target)
+    assert chown_uid == 10000
+    assert chown_gid == 10000
+
+
+def test_chown_skipped_when_not_root(tmp_path):
+    """As non-root, the chown is a no-op (would EPERM anyway)."""
+    target = tmp_path / "f.txt"
+    target.write_text("old", encoding="utf-8")
+    tmp = _write_tmp(tmp_path, "new")
+
+    chown_calls: list = []
+
+    with patch.object(utils_mod.os, "geteuid", lambda: 1000), \
+         patch.object(utils_mod.os, "chown", side_effect=lambda *a, **k: chown_calls.append(a)):
+        atomic_replace(tmp, target)
+
+    assert chown_calls == [], (
+        "chown must not run when the process is not root"
+    )
+
+
+def test_chown_skipped_when_parent_is_also_root(tmp_path):
+    """If the parent dir is itself root-owned, there's nothing to fix."""
+    target = tmp_path / "f.txt"
+    target.write_text("old", encoding="utf-8")
+    tmp = _write_tmp(tmp_path, "new")
+
+    chown_calls: list = []
+    real_stat = os.stat
+
+    def fake_stat(path, *args, **kwargs):
+        if str(path) == str(tmp_path):
+            return _fake_parent_stat(uid=0, gid=0)
+        return real_stat(path, *args, **kwargs)
+
+    with patch.object(utils_mod.os, "geteuid", lambda: 0), \
+         patch.object(utils_mod.os, "chown", side_effect=lambda *a, **k: chown_calls.append(a)), \
+         patch.object(utils_mod.os, "stat", side_effect=fake_stat):
+        atomic_replace(tmp, target)
+
+    assert chown_calls == [], (
+        "chown must not run when both the process and the parent are root"
+    )
+
+
+def test_chown_failure_does_not_break_atomic_replace(tmp_path):
+    """The replace must succeed even if the chown is rejected."""
+    target = tmp_path / "f.txt"
+    target.write_text("old", encoding="utf-8")
+    tmp = _write_tmp(tmp_path, "new")
+
+    real_stat = os.stat
+
+    def fake_stat(path, *args, **kwargs):
+        if str(path) == str(tmp_path):
+            return _fake_parent_stat(uid=10000, gid=10000)
+        return real_stat(path, *args, **kwargs)
+
+    def chown_eperm(*_args, **_kwargs):
+        raise OSError(1, "Operation not permitted")  # EPERM
+
+    with patch.object(utils_mod.os, "geteuid", lambda: 0), \
+         patch.object(utils_mod.os, "chown", side_effect=chown_eperm), \
+         patch.object(utils_mod.os, "stat", side_effect=fake_stat):
+        # Must not raise.
+        atomic_replace(tmp, target)
+
+    assert target.read_text(encoding="utf-8") == "new", (
+        "atomic_replace must commit the new content even if chown fails"
+    )

--- a/utils.py
+++ b/utils.py
@@ -58,6 +58,52 @@ def _restore_file_mode(path: Path, mode: "int | None") -> None:
         pass
 
 
+def _chown_to_match_parent(path: str) -> None:
+    """Chown *path* to its parent directory's owner when running as root.
+
+    Containerized deployments (#17144) typically have a root-init
+    entrypoint (``tini``, ``s6``, etc.) that spawns the gateway as a
+    less-privileged user — e.g. ``nousresearch/hermes-agent:latest``
+    runs PID 1 as root and the gateway process as ``hermes`` / UID
+    ``10000``. When a code path inadvertently runs an atomic write from
+    the root side of that boundary (memory tool consolidation triggered
+    from a root-context worker, hook scripts, etc.), the resulting file
+    on the persistent volume is owned by ``root:root`` and cannot be
+    read by the gateway, so memory updates appear to succeed but never
+    re-enter the agent's session context.
+
+    Sticking the parent directory's owner/group onto the new file after
+    ``os.replace`` is the simplest deterministic way to restore
+    reachability without forcing every call site to know which user
+    owns the host volume.
+
+    Best-effort and POSIX-only:
+      * no-op on Windows (no concept of UID/GID);
+      * no-op when the process is not running as root, where ``chown``
+        to a foreign UID would just ``EPERM`` anyway;
+      * no-op when the parent itself is owned by root (nothing to
+        propagate);
+      * no-op on any ``OSError`` (e.g. the path was unlinked, parent
+        stat failed, filesystem rejects chown like FUSE without
+        ``allow_other``).
+    """
+    if os.name != "posix":
+        return
+    try:
+        if os.geteuid() != 0:
+            return
+        parent = os.path.dirname(path) or "."
+        parent_stat = os.stat(parent)
+        if parent_stat.st_uid == 0 and parent_stat.st_gid == 0:
+            return
+        os.chown(path, parent_stat.st_uid, parent_stat.st_gid)
+    except OSError:
+        # Best-effort: keep going even if the chown is rejected.  The
+        # write itself already succeeded and downstream readers will
+        # surface the permission problem with a more specific error.
+        pass
+
+
 def atomic_replace(tmp_path: Union[str, Path], target: Union[str, Path]) -> str:
     """Atomically move *tmp_path* onto *target*, preserving symlinks.
 
@@ -75,10 +121,17 @@ def atomic_replace(tmp_path: Union[str, Path], target: Union[str, Path]) -> str:
 
     Returns the resolved real path used for the replace, so callers that
     need to re-apply permissions can target it instead of the symlink.
+
+    When the process is running as root and the parent directory is
+    owned by a non-root user, the new file is chown'd to match the
+    parent (#17144). This keeps Docker / NAS volume mounts where the
+    container's gateway runs as a service user readable after writes
+    that happened to land on the root side of the entrypoint.
     """
     target_str = str(target)
     real_path = os.path.realpath(target_str) if os.path.islink(target_str) else target_str
     os.replace(str(tmp_path), real_path)
+    _chown_to_match_parent(real_path)
     return real_path
 
 


### PR DESCRIPTION
## What does this PR do?

Containerized hermes deployments (e.g. `nousresearch/hermes-agent:latest` on Synology / Docker / Podman) typically have a root-init entrypoint (`tini`) that spawns the gateway as `hermes` / UID 10000 against a host-mounted persistent volume that is also owned by 10000. When a memory-tool consolidation, hook script, or any other atomic write happens to land on the root side of that boundary, the new file lands as `root:root` with restrictive perms — and the running gateway cannot read it. Memory updates appear to succeed (the agent gets a write-OK response) but the gateway never re-injects them on the next session, silently breaking the persistent-memory promise (#17144).

The fix adds a `_chown_to_match_parent` helper in `utils.py` and calls it from `atomic_replace`, so every atomic-write call site (memory tool, `atomic_json_write`, `atomic_yaml_write`, future writers) inherits the fix without touching every call site.

The helper is best-effort and POSIX-only: no-op on Windows, no-op when not running as root (where `chown` to a foreign UID would `EPERM` anyway), no-op when the parent directory is itself root-owned, and swallows `OSError` so a chown rejection from a FUSE mount or ACL-locked filesystem doesn't fail the user-visible write.

## Related Issue

Fixes #17144

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `utils.py` — new private helper `_chown_to_match_parent(path)` with `os.geteuid() == 0` gate, parent-stat read, root-parent skip, and an `OSError` swallow. `atomic_replace` calls it on the resolved real path after `os.replace`. Docstring updated to describe the new behavior.
- `tests/test_atomic_replace_chown_parent.py` (new) — four cases pinning the gating logic by monkey-patching `os.geteuid` / `os.stat` / `os.chown` so we don't need real root in CI:
  1. root + non-root parent → chown propagates the parent's owner/gid
  2. non-root → no chown call
  3. root + root-owned parent → no chown call
  4. root + chown EPERM → `atomic_replace` still commits content

## How to Test

1. Run hermes inside a container where the entrypoint is root and the gateway runs as a service user (`hermes`/10000). The persistent volume parent should be owned by 10000:10000.
2. From a root-side code path (e.g. a startup hook), invoke a memory write that touches `~/.hermes/memories/MEMORY.md`.
3. **Before this fix:** the resulting file is `root:root`; `docker exec hermes ls -l /opt/data/memories` shows `root root MEMORY.md`; the gateway logs cannot read the file on the next session reset.
4. **After this fix:** the file is `hermes:hermes` (matches parent); the gateway re-injects it normally.

Automated:
```
pytest tests/test_atomic_replace_chown_parent.py tests/test_atomic_replace_symlinks.py tests/hermes_cli/test_atomic_json_write.py tests/hermes_cli/test_atomic_yaml_write.py tests/tools/test_memory_tool.py -q
```

Result on macOS 15.6 / Python 3.14: `62 passed`. The new tests fail on `origin/main` because no chown call is ever made (the helper does not exist there).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/test_atomic_replace_chown_parent.py tests/test_atomic_replace_symlinks.py tests/hermes_cli/test_atomic_json_write.py tests/hermes_cli/test_atomic_yaml_write.py tests/tools/test_memory_tool.py -q` (62 passed). Full `pytest tests/ -q` not run; the atomic-write surface above is fully exercised.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.6 (Python 3.14)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A *(updated `atomic_replace`'s docstring to describe the new chown step; no user-facing docs reference atomic-write internals)*
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A *(N/A — no config keys touched)*
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A *(N/A)*
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A *(explicit `os.name != "posix"` early-return on Windows; macOS and Linux both go through the same POSIX path; the helper is also a no-op when not root, so Linux/macOS users running as themselves see zero behavior change)*
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A *(N/A — internal helper, not a tool)*

## Screenshots / Logs

```
$ pytest tests/test_atomic_replace_chown_parent.py tests/test_atomic_replace_symlinks.py tests/hermes_cli/test_atomic_json_write.py tests/hermes_cli/test_atomic_yaml_write.py tests/tools/test_memory_tool.py -q
............                                                             [ 19%]
..................................................                       [100%]
62 passed, 62 warnings in 2.44s
```