### PR TITLE
fix(cron): accept list-shaped deliver in delivery target resolver (#17139)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -234,11 +234,26 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
 
 
 def _resolve_delivery_targets(job: dict) -> List[dict]:
-    """Resolve all concrete auto-delivery targets for a cron job (supports comma-separated deliver)."""
+    """Resolve all concrete auto-delivery targets for a cron job.
+
+    ``deliver`` accepts both a comma-separated string ("telegram,discord")
+    and a list (``["telegram", "discord"]``). The list shape comes from
+    LLM tool calls and from older config that round-tripped through code
+    paths like ``hermes_cli.cron`` which already normalises to lists. The
+    previous implementation only handled the string shape and treated a
+    list as ``str([...])`` → ``"['telegram']"``, splitting on ``,`` to
+    produce a single literal ``"['telegram']"`` token that no resolver
+    branch matched (#17139). Result: ``last_delivery_error="no delivery
+    target resolved for deliver=['telegram']"`` and the user's daily
+    briefing was saved to disk but never reached Telegram.
+    """
     deliver = job.get("deliver", "local")
     if deliver == "local":
         return []
-    parts = [p.strip() for p in str(deliver).split(",") if p.strip()]
+    if isinstance(deliver, (list, tuple)):
+        parts = [str(p).strip() for p in deliver if str(p).strip()]
+    else:
+        parts = [p.strip() for p in str(deliver).split(",") if p.strip()]
     seen = set()
     targets = []
     for part in parts:

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -279,6 +279,64 @@ class TestResolveDeliveryTarget:
             "thread_id": None,
         }
 
+    def test_deliver_as_list_with_single_telegram_target(self, monkeypatch):
+        """deliver=['telegram'] (list shape) must resolve like 'telegram'.
+
+        Regression for #17139: jobs whose ``deliver`` was persisted as a
+        Python list (typical when the LLM cron tool wrote it as an array)
+        produced ``"no delivery target resolved for deliver=['telegram']"``
+        because the resolver did ``str(deliver).split(",")`` and got back
+        the literal token ``"['telegram']"`` which no branch matched.
+        """
+        from cron.scheduler import _resolve_delivery_targets
+
+        monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "1234567890")
+        targets = _resolve_delivery_targets({"deliver": ["telegram"]})
+        assert targets == [
+            {"platform": "telegram", "chat_id": "1234567890", "thread_id": None}
+        ]
+
+    def test_deliver_as_list_with_multiple_targets(self, monkeypatch):
+        """deliver=['telegram', 'discord'] resolves both."""
+        from cron.scheduler import _resolve_delivery_targets
+
+        monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "111")
+        monkeypatch.setenv("DISCORD_HOME_CHANNEL", "222")
+        targets = _resolve_delivery_targets(
+            {"deliver": ["telegram", "discord"]}
+        )
+        assert {t["platform"] for t in targets} == {"telegram", "discord"}
+
+    def test_deliver_as_list_drops_empty_entries(self, monkeypatch):
+        """Stray empty / whitespace-only entries in a list are skipped."""
+        from cron.scheduler import _resolve_delivery_targets
+
+        monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "111")
+        targets = _resolve_delivery_targets(
+            {"deliver": ["", "   ", "telegram"]}
+        )
+        assert len(targets) == 1
+        assert targets[0]["platform"] == "telegram"
+
+    def test_deliver_as_string_still_resolves(self, monkeypatch):
+        """Existing string shape ("telegram") must keep working."""
+        from cron.scheduler import _resolve_delivery_targets
+
+        monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "1234567890")
+        targets = _resolve_delivery_targets({"deliver": "telegram"})
+        assert targets == [
+            {"platform": "telegram", "chat_id": "1234567890", "thread_id": None}
+        ]
+
+    def test_deliver_as_comma_separated_string_still_resolves(self, monkeypatch):
+        """Existing 'telegram,discord' shape must keep working."""
+        from cron.scheduler import _resolve_delivery_targets
+
+        monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "111")
+        monkeypatch.setenv("DISCORD_HOME_CHANNEL", "222")
+        targets = _resolve_delivery_targets({"deliver": "telegram,discord"})
+        assert {t["platform"] for t in targets} == {"telegram", "discord"}
+
 
 class TestDeliverResultWrapping:
     """Verify that cron deliveries are wrapped with header/footer and no longer mirrored."""


### PR DESCRIPTION
## What does this PR do?

`_resolve_delivery_targets` only handled the comma-separated-string shape of `deliver` (`"telegram"` / `"telegram,discord"`). Jobs whose `deliver` was persisted as a Python list (typical when the LLM cron tool wrote it as an array, or when older code paths in `hermes_cli.cron` already normalize to lists) reached `str(["telegram"]).split(",")` and produced the literal token `"['telegram']"` — no resolver branch matched, the job logged `last_delivery_error="no delivery target resolved for deliver=['telegram']"`, and the user's daily briefing was saved to disk but never reached Telegram (#17139), even though manual delivery from inside an active Telegram session worked fine.

The fix branches on `isinstance(deliver, (list, tuple))`: in that case treat each element as a pre-tokenised delivery target; otherwise keep the existing comma-split string path. `str(p).strip()` plus an empty filter mirrors the comma-split path's whitespace handling.

## Related Issue

Fixes #17139

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cron/scheduler.py` — `_resolve_delivery_targets`: branch on `isinstance(deliver, (list, tuple))`. Updated docstring with an explicit reference to the issue's `str(["telegram"]).split(",")` failure mode.
- `tests/cron/test_scheduler.py` — six new cases in `TestResolveDeliveryTarget`: list with single telegram (the exact reproducer), list with two platforms, list with stray empty entries, plus the two pre-existing string shapes pinned so the comma-split path doesn't regress.

## How to Test

1. Create a cron job whose `deliver` is persisted as a list (`deliver: [telegram]`):
   ```python
   from cron.jobs import update_job
   update_job("daily-briefing", deliver=["telegram"])
   ```
2. Set `TELEGRAM_HOME_CHANNEL` and let the job run.
3. **Before this fix:** `last_delivery_error="no delivery target resolved for deliver=['telegram']"`; output saved to `~/.hermes/cron/output/<job_id>/`, but no Telegram message arrives.
4. **After this fix:** the message lands in the Telegram home channel as expected.

Automated:
```
pytest tests/cron/test_scheduler.py::TestResolveDeliveryTarget -q
```

Result on macOS 15.6 / Python 3.14: `29 passed`. The two list-shape tests (`test_deliver_as_list_with_single_telegram_target`, `test_deliver_as_list_with_multiple_targets`) fail on `origin/main` without the fix.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/cron/test_scheduler.py -q`. The targeted `TestResolveDeliveryTarget` block (29 cases) passes; full `tests/cron/test_scheduler.py` shows 2 pre-existing failures in `TestSilentDelivery` that reproduce on `origin/main` without this change and are unrelated to the delivery-target resolver.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.6 (Python 3.14)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A *(updated `_resolve_delivery_targets`'s docstring to document both shapes; no user-facing docs reference the resolver internals)*
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A *(N/A — no config keys touched; `deliver` is a per-job field whose accepted shapes are now broader)*
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A *(N/A)*
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A *(N/A — pure Python isinstance + iteration; identical across platforms)*
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A *(N/A — `cronjob` tool's `deliver` parameter schema still documents the string shape; this PR only makes the consumer accept the list shape that some upstream call sites already produce)*

## Screenshots / Logs

```
$ pytest tests/cron/test_scheduler.py::TestResolveDeliveryTarget -q
.............................                                            [100%]
29 passed, 29 warnings in 2.82s
```