### PR TITLE
fix(anthropic_adapter): preserve unsigned thinking blocks for DeepSeek /anthropic (#16748)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -367,6 +367,24 @@ def _is_kimi_coding_endpoint(base_url: str | None) -> bool:
     return normalized.rstrip("/").lower().startswith("https://api.kimi.com/coding")
 
 
+def _is_deepseek_anthropic_endpoint(base_url: str | None) -> bool:
+    """Return True for DeepSeek's Anthropic-compatible thinking-mode endpoint.
+
+    DeepSeek V4 thinking models served via ``api.deepseek.com/anthropic``
+    require unsigned ``thinking`` content blocks to round-trip on
+    subsequent turns, identical in shape to Kimi's ``/coding`` endpoint
+    (#16748). The generic third-party strip path drops all thinking
+    blocks, so the next request fails with HTTP 400::
+
+        The ``content[].thinking`` in the thinking mode must be passed
+        back to the API.
+    """
+    normalized = _normalize_base_url_text(base_url)
+    if not normalized:
+        return False
+    return normalized.rstrip("/").lower().startswith("https://api.deepseek.com/anthropic")
+
+
 def _requires_bearer_auth(base_url: str | None) -> bool:
     """Return True for Anthropic-compatible providers that require Bearer auth.
 
@@ -1541,6 +1559,13 @@ def convert_messages_to_anthropic(
     _THINKING_TYPES = frozenset(("thinking", "redacted_thinking"))
     _is_third_party = _is_third_party_anthropic_endpoint(base_url)
     _is_kimi = _is_kimi_coding_endpoint(base_url)
+    _is_deepseek_anthropic = _is_deepseek_anthropic_endpoint(base_url)
+    # Both Kimi /coding and DeepSeek /anthropic enable model-native
+    # thinking server-side and require unsigned thinking blocks to
+    # round-trip on replayed assistant tool-call messages.  They share
+    # the same strip strategy: drop Anthropic-signed blocks they can't
+    # validate, keep unsigned ones we synthesised from reasoning_content.
+    _preserves_unsigned_thinking = _is_kimi or _is_deepseek_anthropic
 
     last_assistant_idx = None
     for i in range(len(result) - 1, -1, -1):
@@ -1552,22 +1577,21 @@ def convert_messages_to_anthropic(
         if m.get("role") != "assistant" or not isinstance(m.get("content"), list):
             continue
 
-        if _is_kimi:
-            # Kimi's /coding endpoint enables thinking server-side and
-            # requires unsigned thinking blocks on replayed assistant
-            # tool-call messages.  Strip signed Anthropic blocks (Kimi
-            # can't validate signatures) but preserve the unsigned ones
-            # we synthesised from reasoning_content above.
+        if _preserves_unsigned_thinking:
+            # Strip signed Anthropic blocks (the third party can't
+            # validate signatures) but preserve the unsigned ones we
+            # synthesised from reasoning_content — those are exactly
+            # what the third party needs for message-history validation
+            # in its own thinking mode.
             new_content = []
             for b in m["content"]:
                 if not isinstance(b, dict) or b.get("type") not in _THINKING_TYPES:
                     new_content.append(b)
                     continue
                 if b.get("signature") or b.get("data"):
-                    # Anthropic-signed block — Kimi can't validate, strip
+                    # Anthropic-signed block — third party can't validate, strip
                     continue
-                # Unsigned thinking (synthesised from reasoning_content) —
-                # keep it: Kimi needs it for message-history validation.
+                # Unsigned thinking (synthesised from reasoning_content) — keep it.
                 new_content.append(b)
             m["content"] = new_content or [{"type": "text", "text": "(empty)"}]
         elif _is_third_party or idx != last_assistant_idx:

--- a/tests/agent/test_deepseek_anthropic_thinking.py
+++ b/tests/agent/test_deepseek_anthropic_thinking.py
@@ -1,0 +1,149 @@
+"""Regression guard: preserve unsigned thinking blocks for DeepSeek /anthropic.
+
+DeepSeek V4 thinking models served via ``api.deepseek.com/anthropic`` speak
+the Anthropic Messages protocol but require model-native ``thinking`` content
+blocks to round-trip on every replayed assistant tool-call message. The
+generic third-party strip path in ``convert_messages_to_anthropic`` drops
+all thinking blocks, so the second turn fails with HTTP 400::
+
+    The ``content[].thinking`` in the thinking mode must be passed back
+    to the API.
+
+The fix mirrors the strategy that already handles Kimi's ``/coding`` endpoint:
+strip Anthropic-signed blocks (the third party can't validate them) but keep
+the unsigned ones synthesised from ``reasoning_content`` (#16748).
+"""
+from __future__ import annotations
+
+import pytest
+
+
+def _build_assistant_with_thinking(thinking_text: str = "let me think...") -> dict:
+    """Return an assistant message that carries one unsigned thinking block."""
+    return {
+        "role": "assistant",
+        "content": [
+            {"type": "thinking", "thinking": thinking_text},
+            {"type": "text", "text": "Tool result analysed."},
+            {
+                "type": "tool_use",
+                "id": "toolu_01ABC",
+                "name": "lookup",
+                "input": {"q": "x"},
+            },
+        ],
+    }
+
+
+def _build_signed_assistant_thinking() -> dict:
+    """Anthropic-signed thinking — must be stripped on third parties."""
+    return {
+        "role": "assistant",
+        "content": [
+            {
+                "type": "thinking",
+                "thinking": "signed reasoning",
+                "signature": "sig-from-anthropic",
+            },
+            {"type": "text", "text": "Done."},
+        ],
+    }
+
+
+class TestDeepSeekAnthropicEndpointDetector:
+    @pytest.mark.parametrize(
+        "url,expected",
+        [
+            ("https://api.deepseek.com/anthropic", True),
+            ("https://api.deepseek.com/anthropic/", True),
+            ("https://api.deepseek.com/anthropic/v1/messages", True),
+            ("https://api.deepseek.com/v1", False),
+            ("https://api.deepseek.com", False),
+            ("https://api.minimax.io/anthropic", False),
+            (None, False),
+            ("", False),
+        ],
+    )
+    def test_endpoint_match(self, url, expected):
+        from agent.anthropic_adapter import _is_deepseek_anthropic_endpoint
+        assert _is_deepseek_anthropic_endpoint(url) is expected
+
+
+class TestDeepSeekPreservesUnsignedThinking:
+    """convert_messages_to_anthropic must keep unsigned thinking on history
+    when speaking to DeepSeek /anthropic — otherwise the next replay fails
+    with the documented 400 about missing ``content[].thinking``.
+    """
+
+    def _convert(self, messages, *, base_url):
+        from agent.anthropic_adapter import convert_messages_to_anthropic
+        _, converted = convert_messages_to_anthropic(messages, base_url=base_url)
+        return converted
+
+    def test_unsigned_thinking_kept_on_deepseek(self):
+        msgs = [
+            {"role": "user", "content": "hi"},
+            _build_assistant_with_thinking("step-by-step plan"),
+            {"role": "user", "content": "ok continue"},
+            _build_assistant_with_thinking("part 2"),
+        ]
+
+        converted = self._convert(
+            msgs, base_url="https://api.deepseek.com/anthropic"
+        )
+
+        assistants = [m for m in converted if m.get("role") == "assistant"]
+        assert len(assistants) == 2
+        for a in assistants:
+            blocks = a.get("content", [])
+            thinking = [b for b in blocks if isinstance(b, dict) and b.get("type") == "thinking"]
+            assert len(thinking) == 1, (
+                "DeepSeek /anthropic must keep unsigned thinking on every "
+                f"assistant message; got blocks={blocks}"
+            )
+
+    def test_signed_thinking_stripped_on_deepseek(self):
+        """Anthropic-signed thinking blocks must be removed — DeepSeek can't
+        validate Anthropic's signatures, so leaving them would fail."""
+        msgs = [
+            {"role": "user", "content": "hi"},
+            _build_signed_assistant_thinking(),
+        ]
+
+        converted = self._convert(
+            msgs, base_url="https://api.deepseek.com/anthropic"
+        )
+
+        assistant = next(m for m in converted if m.get("role") == "assistant")
+        thinking = [
+            b for b in assistant["content"]
+            if isinstance(b, dict) and b.get("type") == "thinking"
+        ]
+        assert thinking == [], (
+            "Anthropic-signed thinking must be stripped on DeepSeek /anthropic"
+        )
+
+    def test_other_third_party_endpoint_still_strips_unsigned(self):
+        """Endpoints we haven't whitelisted must keep behaving as before
+        (strip thinking on every assistant message). Locks in that the
+        DeepSeek branch is opt-in."""
+        msgs = [
+            {"role": "user", "content": "hi"},
+            _build_assistant_with_thinking("plan A"),
+            {"role": "user", "content": "next"},
+            _build_assistant_with_thinking("plan B"),
+        ]
+
+        converted = self._convert(
+            msgs, base_url="https://api.minimax.io/anthropic"
+        )
+
+        for a in [m for m in converted if m.get("role") == "assistant"]:
+            thinking = [
+                b for b in a["content"]
+                if isinstance(b, dict) and b.get("type") == "thinking"
+            ]
+            assert thinking == [], (
+                "Generic third-party endpoint must continue stripping all "
+                "thinking blocks — this gating is DeepSeek-specific."
+            )


### PR DESCRIPTION
## What does this PR do?

DeepSeek V4 thinking models served via `api.deepseek.com/anthropic` speak the Anthropic Messages protocol but require model-native `thinking` content blocks to round-trip on every replayed assistant tool-call message — the same shape as Kimi's `/coding` endpoint. The generic third-party strip path in `convert_messages_to_anthropic` drops *all* thinking blocks because Anthropic-signed blocks aren't validatable elsewhere, so after one turn with a tool call the next request fails with HTTP 400 (#16748):

```
The content[].thinking in the thinking mode must be passed back to the API.
```

The fix mirrors the strategy that already handles Kimi's `/coding` endpoint: strip Anthropic-signed blocks (the third party can't validate them) but keep the unsigned ones synthesised from `reasoning_content`. Adds an endpoint detector for `https://api.deepseek.com/anthropic[/...]` and routes it through the same preserve-unsigned-strip-signed branch, renaming the local gate to `_preserves_unsigned_thinking` so the shared semantics is explicit instead of duplicating the body for each endpoint family.

Out of scope (the reporter's *Optionally* item): the request-side `thinking` / `output_config` knobs are still sent. DeepSeek documentation indicates it accepts these and uses them; if a follow-up reveals it rejects them we can extend the existing `_is_kimi_coding` gate at the `build_anthropic_kwargs` level — that's a separate change.

## Related Issue

Fixes #16748

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/anthropic_adapter.py` — new `_is_deepseek_anthropic_endpoint(base_url)` helper next to the existing `_is_kimi_coding_endpoint`. In `convert_messages_to_anthropic`, the strip loop computes `_preserves_unsigned_thinking = _is_kimi or _is_deepseek_anthropic` and uses it as the branch condition; the body is unchanged from the existing Kimi path. Comment block above the loop reinforces that the two endpoints share semantics.
- `tests/agent/test_deepseek_anthropic_thinking.py` (new) — endpoint-detector matrix across realistic URL shapes; assistant-history shape that locks in (a) unsigned thinking is preserved on every assistant message under DeepSeek (reproducing the exact second-turn HTTP 400 path), (b) signed Anthropic thinking is still stripped (DeepSeek can't validate signatures), and (c) other third-party endpoints still get the generic strip behavior so the new branch is opt-in.

## How to Test

1. Configure a custom Anthropic-mode provider:
   ```yaml
   custom_providers:
     - name: deepseek-thinking
       base_url: https://api.deepseek.com/anthropic
       api_key: ${DEEPSEEK_API_KEY}
       api_mode: anthropic_messages
       model: deepseek-v4-pro
   ```
2. Send a turn that triggers a tool call (DeepSeek emits a `thinking` block), then a follow-up turn that replays the assistant history.
3. **Before this fix:** the second request returns HTTP 400 with `The content[].thinking in the thinking mode must be passed back to the API.`
4. **After this fix:** the unsigned thinking block from the first turn is preserved on the replay; DeepSeek validates the history and the conversation continues.

Automated:
```
pytest tests/agent/test_deepseek_anthropic_thinking.py tests/agent/test_kimi_coding_anthropic_thinking.py -q
```

Result on macOS 15.6 / Python 3.14: `19 passed`. The new DeepSeek tests fail on `origin/main` without the fix.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/agent/test_deepseek_anthropic_thinking.py tests/agent/test_kimi_coding_anthropic_thinking.py -q` (19 passed). Pre-existing failures in `tests/agent/test_anthropic_adapter.py::TestReadClaudeCodeCredentials` and `TestResolveAnthropicToken` reproduce on `origin/main` without this change and are unrelated to the message-conversion path.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.6 (Python 3.14)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A *(updated the in-loop comment block to reference DeepSeek alongside Kimi; no user-facing docs reference the strip-policy internals)*
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A *(N/A — no new config keys; the endpoint is detected from the existing `base_url`)*
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A *(N/A)*
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A *(N/A — pure URL-string match + dict mutation; identical across platforms)*
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A *(N/A — adapter internal, not a tool)*

## Screenshots / Logs

```
$ pytest tests/agent/test_deepseek_anthropic_thinking.py tests/agent/test_kimi_coding_anthropic_thinking.py -q
...................                                                      [100%]
19 passed, 19 warnings in 2.68s
```