### PR TITLE
fix(agent): send thinking control to DeepSeek direct API to prevent 400 on tool-call replay

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -182,6 +182,7 @@ class ChatCompletionsTransport(ProviderTransport):
             is_github_models: bool
             is_nvidia_nim: bool
             is_kimi: bool
+            is_deepseek_direct: bool
             is_lmstudio: bool
             is_custom_provider: bool
             ollama_num_ctx: int | None
@@ -351,6 +352,19 @@ class ChatCompletionsTransport(ProviderTransport):
                     _kimi_thinking_enabled = False
             extra_body["thinking"] = {
                 "type": "enabled" if _kimi_thinking_enabled else "disabled",
+            }
+
+        # DeepSeek direct API: extra_body.thinking
+        is_deepseek_direct = params.get("is_deepseek_direct", False)
+        if is_deepseek_direct:
+            _ds_thinking_enabled = True
+            if reasoning_config and isinstance(reasoning_config, dict):
+                if reasoning_config.get("enabled") is False:
+                    _ds_thinking_enabled = False
+                elif (reasoning_config.get("effort") or "").strip().lower() == "none":
+                    _ds_thinking_enabled = False
+            extra_body["thinking"] = {
+                "type": "enabled" if _ds_thinking_enabled else "disabled",
             }
 
         # Reasoning. LM Studio is handled above via top-level reasoning_effort,

--- a/run_agent.py
+++ b/run_agent.py
@@ -8410,6 +8410,10 @@ class AIAgent:
             or base_url_host_matches(self.base_url, "moonshot.ai")
             or base_url_host_matches(self.base_url, "moonshot.cn")
         )
+        _is_deepseek_direct = (
+            (self.provider or "").strip().lower() == "deepseek"
+            or base_url_host_matches(self.base_url, "api.deepseek.com")
+        )
         _is_tokenhub = base_url_host_matches(self._base_url_lower, "tokenhub.tencentmaas.com")
         _is_lmstudio = (self.provider or "").strip().lower() == "lmstudio"
 
@@ -8484,6 +8488,7 @@ class AIAgent:
             is_github_models=_is_gh,
             is_nvidia_nim=_is_nvidia,
             is_kimi=_is_kimi,
+            is_deepseek_direct=_is_deepseek_direct,
             is_tokenhub=_is_tokenhub,
             is_lmstudio=_is_lmstudio,
             is_custom_provider=self.provider == "custom",

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -454,6 +454,49 @@ class TestChatCompletionsKimi:
         assert "type" not in kw["tools"][0]["function"]["parameters"]["properties"]["q"]
 
 
+class TestChatCompletionsDeepSeekDirect:
+    """DeepSeek direct API (api.deepseek.com) thinking control via extra_body."""
+
+    def test_deepseek_thinking_enabled_by_default(self, transport):
+        kw = transport.build_kwargs(
+            model="deepseek-chat", messages=[{"role": "user", "content": "Hi"}],
+            is_deepseek_direct=True,
+        )
+        assert kw["extra_body"]["thinking"] == {"type": "enabled"}
+
+    def test_deepseek_thinking_disabled_when_enabled_false(self, transport):
+        kw = transport.build_kwargs(
+            model="deepseek-chat", messages=[{"role": "user", "content": "Hi"}],
+            is_deepseek_direct=True,
+            reasoning_config={"enabled": False},
+        )
+        assert kw["extra_body"]["thinking"] == {"type": "disabled"}
+
+    def test_deepseek_thinking_disabled_when_effort_none(self, transport):
+        kw = transport.build_kwargs(
+            model="deepseek-chat", messages=[{"role": "user", "content": "Hi"}],
+            is_deepseek_direct=True,
+            reasoning_config={"effort": "none"},
+        )
+        assert kw["extra_body"]["thinking"] == {"type": "disabled"}
+
+    def test_openrouter_deepseek_no_thinking_param(self, transport):
+        kw = transport.build_kwargs(
+            model="deepseek/deepseek-chat",
+            messages=[{"role": "user", "content": "Hi"}],
+            is_openrouter=True,
+        )
+        assert "thinking" not in kw.get("extra_body", {})
+
+    def test_kimi_thinking_unchanged_with_deepseek_present(self, transport):
+        kw = transport.build_kwargs(
+            model="kimi-k2", messages=[{"role": "user", "content": "Hi"}],
+            is_kimi=True,
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        assert kw["extra_body"]["thinking"] == {"type": "enabled"}
+
+
 class TestChatCompletionsLmStudioReasoning:
     """LM Studio publishes per-model reasoning ``allowed_options``. When the
     user requests an effort the model can't honor (e.g. ``high`` on a


### PR DESCRIPTION
## What does this PR do?

DeepSeek's direct API (`api.deepseek.com`) defaults to `thinking=enabled` when no explicit `thinking` parameter is sent. When the user sets `reasoning_effort: none` in config, the setting was silently ignored because `_supports_reasoning_extra_body()` returns `False` for direct DeepSeek endpoints — so `extra_body.reasoning` (OpenRouter format) was never sent. The model defaulted to thinking=enabled, generated `reasoning_content` in its response, and the next API call failed with HTTP 400: `"reasoning_content must be passed back"`.

This PR adds DeepSeek direct API thinking control to `ChatCompletionsTransport.build_kwargs()`, following the existing Kimi pattern: emit `extra_body.thinking` with `type: "enabled"` or `type: "disabled"` based on the user's `reasoning_config`. The `is_deepseek_direct` flag is threaded from `run_agent.py`, detected via provider name (`deepseek`) or base URL matching (`api.deepseek.com`).

The OpenRouter DeepSeek path is unchanged — it uses `extra_body.reasoning` which is a separate parameter handled by the existing `supports_reasoning` gate.

## Related Issue

Fixes #17212

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/transports/chat_completions.py`: Added DeepSeek direct API `extra_body.thinking` block (after existing Kimi block), with `enabled`/`disabled` control based on `reasoning_config`
- `run_agent.py`: Added `_is_deepseek_direct` detection (provider == "deepseek" or base_url matches api.deepseek.com) and threaded it to transport params
- `tests/agent/transports/test_chat_completions.py`: Added 5 test cases covering default enabled, disabled via config, effort=none, OpenRouter unchanged, Kimi unchanged

## How to Test

1. Configure Hermes with DeepSeek direct API (`api.deepseek.com`) and `reasoning_effort: none`
2. Send a message that triggers tool calls (e.g. "run date")
3. Verify the second API call succeeds (no 400 error)
4. Run the targeted tests: `pytest tests/agent/transports/test_chat_completions.py -v`
5. Run full suite: `pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (Darwin 25.4.0, Apple Silicon), Python 3.11

### Documentation & Housekeeping

- [x] Updated relevant documentation — or N/A
- [x] Updated cli-config.yaml.example — or N/A
- [x] Updated contributing / agents docs — or N/A
- [x] Considered cross-platform impact — or N/A
- [x] Updated tool descriptions/schemas — or N/A
