### PR TITLE
fix: bridge HOME_CHANNEL keys from config.yaml to env on Gateway restart

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -778,6 +778,14 @@ def load_gateway_config() -> GatewayConfig:
                 if "dm_mention_threads" in matrix_cfg and not os.getenv("MATRIX_DM_MENTION_THREADS"):
                     os.environ["MATRIX_DM_MENTION_THREADS"] = str(matrix_cfg["dm_mention_threads"]).lower()
 
+            # Bridge top-level *_HOME_CHANNEL / *_HOME_CHANNEL_NAME keys
+            # written by /sethome into os.environ so _apply_env_overrides()
+            # can pick them up after a Gateway restart.
+            for key in list(yaml_cfg.keys()):
+                if key.endswith("_HOME_CHANNEL") or key.endswith("_HOME_CHANNEL_NAME"):
+                    if not os.getenv(key):
+                        os.environ[key] = str(yaml_cfg[key])
+
     except Exception as e:
         logger.warning(
             "Failed to process config.yaml — falling back to .env / gateway.json values. "


### PR DESCRIPTION
## Problem

When a user runs `/sethome` in a platform (e.g. WeCom), the command writes the home channel info as top-level keys like `WECOM_HOME_CHANNEL` and `WECOM_HOME_CHANNEL_NAME` into `config.yaml`.

However, when the Gateway restarts, `load_gateway_config()` does **not** bridge these top-level `*_HOME_CHANNEL` / `*_HOME_CHANNEL_NAME` keys back into `os.environ`. As a result, `_apply_env_overrides()` cannot pick them up, and the home channel setting is effectively lost after restart — the user has to run `/sethome` again every time.

## Fix

In `load_gateway_config()`, after loading `config.yaml`, iterate all top-level keys and bridge any ending with `_HOME_CHANNEL` or `_HOME_CHANNEL_NAME` into `os.environ` (only if the env var is not already set). This ensures `_apply_env_overrides()` can pick them up.

## Changes

- `gateway/config.py`: Added 6-line loop to bridge `*_HOME_CHANNEL` / `*_HOME_CHANNEL_NAME` keys from YAML config to environment variables

## Testing

1. Configured WeCom with `/sethome` — `config.yaml` gets `WECOM_HOME_CHANNEL` and `WECOM_HOME_CHANNEL_NAME`
2. Restarted Gateway — verified home channel is now correctly loaded from config
3. Confirmed `_apply_env_overrides()` picks up the values as expected