### PR TITLE
Fix/dashboard theme layout shift

### DIFF
--- a/web/src/themes/presets.ts
+++ b/web/src/themes/presets.ts
@@ -70,12 +70,11 @@ export const midnightTheme: DashboardTheme = {
     fontMono: `"JetBrains Mono", ${SYSTEM_MONO}`,
     fontUrl:
       "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap",
-    lineHeight: "1.6",
     letterSpacing: "-0.005em",
   },
   layout: {
+    ...DEFAULT_LAYOUT,
     radius: "0.75rem",
-    density: "comfortable",
   },
 };
 
@@ -96,12 +95,10 @@ export const emberTheme: DashboardTheme = {
     fontMono: `"IBM Plex Mono", ${SYSTEM_MONO}`,
     fontUrl:
       "https://fonts.googleapis.com/css2?family=Spectral:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;700&display=swap",
-    lineHeight: "1.6",
-    letterSpacing: "0",
   },
   layout: {
+    ...DEFAULT_LAYOUT,
     radius: "0.25rem",
-    density: "comfortable",
   },
   colorOverrides: {
     destructive: "#c92d0f",
@@ -126,12 +123,10 @@ export const monoTheme: DashboardTheme = {
     fontMono: `"IBM Plex Mono", ${SYSTEM_MONO}`,
     fontUrl:
       "https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap",
-    lineHeight: "1.5",
-    letterSpacing: "0",
   },
   layout: {
+    ...DEFAULT_LAYOUT,
     radius: "0",
-    density: "comfortable",
   },
 };
 
@@ -152,12 +147,10 @@ export const cyberpunkTheme: DashboardTheme = {
     fontMono: `"Share Tech Mono", "JetBrains Mono", ${SYSTEM_MONO}`,
     fontUrl:
       "https://fonts.googleapis.com/css2?family=Share+Tech+Mono&family=JetBrains+Mono:wght@400;700&display=swap",
-    lineHeight: "1.5",
-    letterSpacing: "0",
   },
   layout: {
+    ...DEFAULT_LAYOUT,
     radius: "0",
-    density: "comfortable",
   },
   colorOverrides: {
     success: "#00ff88",
@@ -183,11 +176,10 @@ export const roseTheme: DashboardTheme = {
     fontMono: `"DM Mono", ${SYSTEM_MONO}`,
     fontUrl:
       "https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=DM+Mono:wght@400;500&display=swap",
-    letterSpacing: "0",
   },
   layout: {
+    ...DEFAULT_LAYOUT,
     radius: "1rem",
-    density: "comfortable",
   },
 };
 

--- a/web/src/themes/presets.ts
+++ b/web/src/themes/presets.ts
@@ -65,11 +65,11 @@ export const midnightTheme: DashboardTheme = {
     noiseOpacity: 0.8,
   },
   typography: {
+    ...DEFAULT_TYPOGRAPHY,
     fontSans: `"Inter", ${SYSTEM_SANS}`,
     fontMono: `"JetBrains Mono", ${SYSTEM_MONO}`,
     fontUrl:
       "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap",
-    baseSize: "14px",
     lineHeight: "1.6",
     letterSpacing: "-0.005em",
   },
@@ -91,11 +91,11 @@ export const emberTheme: DashboardTheme = {
     noiseOpacity: 1,
   },
   typography: {
+    ...DEFAULT_TYPOGRAPHY,
     fontSans: `"Spectral", Georgia, "Times New Roman", serif`,
     fontMono: `"IBM Plex Mono", ${SYSTEM_MONO}`,
     fontUrl:
       "https://fonts.googleapis.com/css2?family=Spectral:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;700&display=swap",
-    baseSize: "15px",
     lineHeight: "1.6",
     letterSpacing: "0",
   },
@@ -121,17 +121,17 @@ export const monoTheme: DashboardTheme = {
     noiseOpacity: 0.6,
   },
   typography: {
+    ...DEFAULT_TYPOGRAPHY,
     fontSans: `"IBM Plex Sans", ${SYSTEM_SANS}`,
     fontMono: `"IBM Plex Mono", ${SYSTEM_MONO}`,
     fontUrl:
       "https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap",
-    baseSize: "13px",
     lineHeight: "1.5",
     letterSpacing: "0",
   },
   layout: {
     radius: "0",
-    density: "compact",
+    density: "comfortable",
   },
 };
 
@@ -147,17 +147,17 @@ export const cyberpunkTheme: DashboardTheme = {
     noiseOpacity: 1.2,
   },
   typography: {
+    ...DEFAULT_TYPOGRAPHY,
     fontSans: `"Share Tech Mono", "JetBrains Mono", ${SYSTEM_MONO}`,
     fontMono: `"Share Tech Mono", "JetBrains Mono", ${SYSTEM_MONO}`,
     fontUrl:
       "https://fonts.googleapis.com/css2?family=Share+Tech+Mono&family=JetBrains+Mono:wght@400;700&display=swap",
-    baseSize: "14px",
     lineHeight: "1.5",
-    letterSpacing: "0.02em",
+    letterSpacing: "0",
   },
   layout: {
     radius: "0",
-    density: "compact",
+    density: "comfortable",
   },
   colorOverrides: {
     success: "#00ff88",
@@ -178,17 +178,16 @@ export const roseTheme: DashboardTheme = {
     noiseOpacity: 0.9,
   },
   typography: {
+    ...DEFAULT_TYPOGRAPHY,
     fontSans: `"Fraunces", Georgia, serif`,
     fontMono: `"DM Mono", ${SYSTEM_MONO}`,
     fontUrl:
       "https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=DM+Mono:wght@400;500&display=swap",
-    baseSize: "16px",
-    lineHeight: "1.7",
     letterSpacing: "0",
   },
   layout: {
     radius: "1rem",
-    density: "spacious",
+    density: "comfortable",
   },
 };
 


### PR DESCRIPTION
## What does this PR do?

Switching between dashboard themes caused visible layout shifts across four axes: font sizes varied by up to 3px, spacing scaled by up to 40% (compact/spacious density), the rose navbar was taller due to an orphaned `lineHeight: 1.7`, and the cyberpunk theme caused text to wrap earlier than other themes due to extra `letterSpacing: 0.02em` on top of an already-wide monospace font.

The root cause was that each built-in theme independently hardcoded typography and layout values rather than inheriting from `DEFAULT_TYPOGRAPHY`. Divergence was silent — no single author made a wrong decision, but the values accumulated without a shared constraint.

The fix spreads `DEFAULT_TYPOGRAPHY` into every per-theme typography object, removing explicit overrides for `baseSize`, `density`, `lineHeight` (rose), and `letterSpacing` (cyberpunk). Layout-affecting values now default to a shared baseline; themes retain their distinct identity through palette, font family, border-radius, and stylistic typographic choices.

## Related Issue

Fixes https://github.com/NousResearch/hermes-agent/issues/17229

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `web/src/themes/presets.ts`:
  - All five non-default themes now spread `...DEFAULT_TYPOGRAPHY`, removing independent `baseSize` values and converging on 15px
  - `mono`, `cyberpunk`, `rose`: `density` changed to `"comfortable"` (was `compact`, `compact`, `spacious`)
  - `rose`: `lineHeight: "1.7"` removed — now inherits `1.55` via spread (was orphaned after density normalization, causing nav item height drift)
  - `cyberpunk`: `letterSpacing` changed from `"0.02em"` to `"0"` — extra tracking on a monospace font caused text to wrap earlier than other themes

## How to Test

1. Run `hermes dashboard` and navigate to the Skills page — note how many skill rows are visible.
2. Open Settings → Theme and cycle through all six themes (default, midnight, ember, mono, cyberpunk, rose).
3. After each switch, confirm:
   - The number of visible skill rows does not change
   - The font size does not visibly change
   - The sidebar nav item height is consistent
   - The badge label "Dark-themed SVG architecture/cloud/infra diagrams as HTML." does not wrap in cyberpunk when it doesn't wrap in other themes
4. Confirm each theme still looks visually distinct (colors, font family, border-radius differ as expected).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

### Before
<img width="3020" height="1734" alt="before" src="https://github.com/user-attachments/assets/e2d736d3-36d7-4778-8cb4-837ff60a4998" />


### After
<img width="3020" height="1734" alt="after" src="https://github.com/user-attachments/assets/137956cf-f36b-419c-a897-769a4c01fd57" />

