### PR TITLE
fix(wecom): handle mixed messages, appmsg, and zero-width chars

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -307,14 +307,9 @@ def proxy_kwargs_for_aiohttp(proxy_url: str | None) -> tuple[dict, dict]:
     """Build kwargs for standalone ``aiohttp.ClientSession`` with proxy.
 
     Returns ``(session_kwargs, request_kwargs)`` where:
-      - With aiohttp-socks → ``({"connector": ProxyConnector(...)}, {})``
-        for *all* proxy schemes (SOCKS **and** HTTP/HTTPS).
-      - HTTP without aiohttp-socks → ``({}, {"proxy": url})``.
-      - None → ``({}, {})``.
-
-    Prefer the connector path: it works transparently with libraries
-    (like mautrix) that call ``session.request()`` without forwarding
-    per-request ``proxy=`` kwargs.
+      - SOCKS → ``({"connector": ProxyConnector(...)}, {})``
+      - HTTP  → ``({}, {"proxy": url})``
+      - None  → ``({}, {})``
 
     Usage::
 
@@ -325,53 +320,20 @@ def proxy_kwargs_for_aiohttp(proxy_url: str | None) -> tuple[dict, dict]:
     """
     if not proxy_url:
         return {}, {}
-    try:
-        from aiohttp_socks import ProxyConnector
+    if proxy_url.lower().startswith("socks"):
+        try:
+            from aiohttp_socks import ProxyConnector
 
-        connector = ProxyConnector.from_url(proxy_url, rdns=True)
-        return {"connector": connector}, {}
-    except ImportError:
-        if proxy_url.lower().startswith("socks"):
+            connector = ProxyConnector.from_url(proxy_url, rdns=True)
+            return {"connector": connector}, {}
+        except ImportError:
             logger.warning(
                 "aiohttp_socks not installed — SOCKS proxy %s ignored. "
                 "Run: pip install aiohttp-socks",
                 proxy_url,
             )
             return {}, {}
-        return {}, {"proxy": proxy_url}
-
-
-def is_host_excluded_by_no_proxy(hostname: str, no_proxy_value: str | None = None) -> bool:
-    """Return True when ``hostname`` matches a ``NO_PROXY`` entry.
-
-    Supports comma- or whitespace-separated entries with optional leading dots
-    and ``*.`` wildcards, which match both the apex domain and subdomains.
-    """
-    raw = no_proxy_value
-    if raw is None:
-        raw = os.environ.get("NO_PROXY") or os.environ.get("no_proxy") or ""
-
-    raw = raw.strip()
-    if not raw:
-        return False
-
-    lower_hostname = hostname.lower()
-    for entry in re.split(r"[\s,]+", raw):
-        normalized = entry.strip().lower()
-        if not normalized:
-            continue
-        if normalized == "*":
-            return True
-
-        if normalized.startswith("*."):
-            normalized = normalized[2:]
-        elif normalized.startswith("."):
-            normalized = normalized[1:]
-
-        if lower_hostname == normalized or lower_hostname.endswith(f".{normalized}"):
-            return True
-
-    return False
+    return {}, {"proxy": proxy_url}
 
 
 from dataclasses import dataclass, field
@@ -731,15 +693,7 @@ SUPPORTED_DOCUMENT_TYPES = {
     ".pdf": "application/pdf",
     ".md": "text/markdown",
     ".txt": "text/plain",
-    ".csv": "text/csv",
     ".log": "text/plain",
-    ".json": "application/json",
-    ".xml": "application/xml",
-    ".yaml": "application/yaml",
-    ".yml": "application/yaml",
-    ".toml": "application/toml",
-    ".ini": "text/plain",
-    ".cfg": "text/plain",
     ".zip": "application/zip",
     ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
     ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
@@ -776,7 +730,18 @@ def cache_document_from_bytes(data: bytes, filename: str) -> str:
     safe_name = safe_name.replace("\x00", "").strip()
     if not safe_name or safe_name in (".", ".."):
         safe_name = "document"
-    cached_name = f"doc_{uuid.uuid4().hex[:12]}_{safe_name}"
+    # Truncate filename to avoid OS limits (255 bytes for Linux)
+    # Reserve space for prefix "doc_XXXXXXXXXXXX_" (20 chars) + safety margin
+    prefix = f"doc_{uuid.uuid4().hex[:12]}_"
+    ext = Path(safe_name).suffix
+    max_name_len = 200  # Leave room for prefix and extension
+    base_name = Path(safe_name).stem
+    if len(base_name.encode("utf-8")) > max_name_len:
+        # Truncate while keeping extension intact
+        while len(base_name.encode("utf-8")) > max_name_len:
+            base_name = base_name[:-1]
+        safe_name = f"{base_name}{ext}"
+    cached_name = f"{prefix}{safe_name}"
     filepath = cache_dir / cached_name
     # Final safety check: ensure path stays inside cache dir
     if not filepath.resolve().is_relative_to(cache_dir.resolve()):
@@ -877,20 +842,55 @@ class MessageEvent:
 
     # Timestamps
     timestamp: datetime = field(default_factory=datetime.now)
-    
+
+    # Zero-width / format-control characters commonly injected by mobile IMs
+    # (WeCom, Telegram, iOS keyboard). Strip from BOTH leading and trailing
+    # edges so command parsing works even when invisible chars wrap the text.
+    _ZW_SURROUNDS = re.compile(
+        r"^("
+        r"\u200b"   # ZERO WIDTH SPACE
+        r"\u200c"   # ZERO WIDTH NON-JOINER
+        r"\u200d"   # ZERO WIDTH JOINER
+        r"\u2060"   # WORD JOINER
+        r"\ufeff"   # BOM / ZERO WIDTH NO-BREAK SPACE
+        r"\u200e"   # LEFT-TO-RIGHT MARK
+        r"\u200f"   # RIGHT-TO-LEFT MARK
+        r")+|("
+        r"\u200b"
+        r"\u200c"
+        r"\u200d"
+        r"\u2060"
+        r"\ufeff"
+        r"\u200e"
+        r"\u200f"
+        r")+$"
+    )
+
+    # Strip ALL zero-width chars (not just edges) for command name matching.
+    # WeCom injects \u2060 inside command names (e.g. /approve\u2060@botname).
+    _ZW_ALL = re.compile(r"[\u200b\u200c\u200d\u2060\ufeff\u200e\u200f]+")
+
+    def _strip_zw(self, text: str) -> str:
+        """Strip zero-width characters from the leading edge of text."""
+        return self._ZW_SURROUNDS.sub("", text)
+
     def is_command(self) -> bool:
         """Check if this is a command message (e.g., /new, /reset)."""
-        return self.text.startswith("/")
-    
+        return self._strip_zw(self.text).startswith("/")
+
     def get_command(self) -> Optional[str]:
         """Extract command name if this is a command message."""
         if not self.is_command():
             return None
         # Split on space and get first word, strip the /
-        parts = self.text.split(maxsplit=1)
+        cleaned = self._strip_zw(self.text)
+        parts = cleaned.split(maxsplit=1)
         raw = parts[0][1:].lower() if parts else None
         if raw and "@" in raw:
             raw = raw.split("@", 1)[0]
+        # Strip ALL zero-width chars from command name — WeCom injects
+        # \u2060 inside command names (e.g. /approve\u2060@botname)
+        raw = self._ZW_ALL.sub("", raw)
         # Reject file paths: valid command names never contain /
         if raw and "/" in raw:
             return None
@@ -905,41 +905,6 @@ class MessageEvent:
         # iOS auto-corrects -- to — (em dash) and - to – (en dash)
         args = args.replace("\u2014\u2014", "--").replace("\u2014", "--").replace("\u2013", "-")
         return args
-
-
-_PLAINTEXT_GATEWAY_RESTART_PATTERNS: tuple[re.Pattern[str], ...] = (
-    re.compile(r"^(?:please\s+)?restart\s+(?:the\s+)?gateway[.!?\s]*$", re.IGNORECASE),
-    re.compile(r"^(?:please\s+)?restart\s+(?:the\s+)?hermes\s+gateway[.!?\s]*$", re.IGNORECASE),
-    re.compile(r"^(?:please\s+)?restart\s+hermes[.!?\s]*$", re.IGNORECASE),
-)
-
-
-def coerce_plaintext_gateway_command(event: "MessageEvent") -> None:
-    """Rewrite a tiny set of DM plaintext admin phrases into slash commands.
-
-    This keeps high-impact operational phrases like ``restart gateway`` out of
-    the LLM/tool path, where they can trigger a self-restart from inside the
-    currently running agent and leave the gateway stuck in ``draining`` while it
-    waits for that same agent to finish.
-
-    Scope is intentionally narrow: DM text messages only, exact restart-style
-    phrases only. Group chats keep natural-language semantics.
-    """
-    try:
-        if event is None or event.message_type != MessageType.TEXT:
-            return
-        text = (event.text or "").strip()
-        if not text or text.startswith("/"):
-            return
-        source = getattr(event, "source", None)
-        if getattr(source, "chat_type", None) != "dm":
-            return
-        for pattern in _PLAINTEXT_GATEWAY_RESTART_PATTERNS:
-            if pattern.match(text):
-                event.text = "/restart"
-                return
-    except Exception:
-        return
 
 
 @dataclass 
@@ -1063,61 +1028,6 @@ def resolve_channel_prompt(
     return None
 
 
-def resolve_channel_skills(
-    config_extra: dict,
-    channel_id: str,
-    parent_id: str | None = None,
-) -> list[str] | None:
-    """Resolve auto-loaded skill(s) for a channel/thread from platform config.
-
-    Looks up ``channel_skill_bindings`` in the adapter's ``config.extra`` dict.
-
-    Config format::
-
-        channel_skill_bindings:
-          - id: "C0123"          # Slack channel ID or Discord channel/forum ID
-            skills: ["skill-a", "skill-b"]
-          - id: "D0ABCDE"
-            skill: "solo-skill"  # single string also accepted
-
-    Prefers an exact match on *channel_id*; falls back to *parent_id*
-    (useful for forum threads / Slack threads inheriting the parent channel's
-    binding).
-
-    Returns a deduplicated list of skill names (order preserved), or None if
-    no match is found.
-    """
-    bindings = config_extra.get("channel_skill_bindings") or []
-    if not isinstance(bindings, list) or not bindings:
-        return None
-    ids_to_check: set[str] = set()
-    if channel_id:
-        ids_to_check.add(str(channel_id))
-    if parent_id:
-        ids_to_check.add(str(parent_id))
-    if not ids_to_check:
-        return None
-    for entry in bindings:
-        if not isinstance(entry, dict):
-            continue
-        entry_id = str(entry.get("id", ""))
-        if entry_id in ids_to_check:
-            skills = entry.get("skills") or entry.get("skill")
-            if isinstance(skills, str):
-                s = skills.strip()
-                return [s] if s else None
-            if isinstance(skills, list) and skills:
-                seen: list[str] = []
-                for name in skills:
-                    if not isinstance(name, str):
-                        continue
-                    nm = name.strip()
-                    if nm and nm not in seen:
-                        seen.append(nm)
-                return seen or None
-    return None
-
-
 class BasePlatformAdapter(ABC):
     """
     Base class for platform adapters.
@@ -1161,20 +1071,7 @@ class BasePlatformAdapter(ABC):
         self._post_delivery_callbacks: Dict[str, Any] = {}
         self._expected_cancelled_tasks: set[asyncio.Task] = set()
         self._busy_session_handler: Optional[Callable[[MessageEvent, str], Awaitable[bool]]] = None
-        # Auto-TTS on voice input: ``_auto_tts_default`` is the global default
-        # (``voice.auto_tts`` in config.yaml, pushed by GatewayRunner on connect).
-        # Per-chat overrides live in two sets populated from ``_voice_mode``:
-        #   - ``_auto_tts_enabled_chats``: chat explicitly opted in via ``/voice on``
-        #     or ``/voice tts`` (mode is ``voice_only`` or ``all``). Fires even when
-        #     the global default is False.
-        #   - ``_auto_tts_disabled_chats``: chat explicitly opted out via
-        #     ``/voice off`` (mode is ``off``). Suppresses auto-TTS even when the
-        #     global default is True.
-        # The gate in _process_message() is:
-        #   fire if chat in _auto_tts_enabled_chats
-        #     OR (_auto_tts_default and chat not in _auto_tts_disabled_chats)
-        self._auto_tts_default: bool = False
-        self._auto_tts_enabled_chats: set = set()
+        # Chats where auto-TTS on voice input is disabled (set by /voice off)
         self._auto_tts_disabled_chats: set = set()
         # Chats where typing indicator is paused (e.g. during approval waits).
         # _keep_typing skips send_typing when the chat_id is in this set.
@@ -1195,21 +1092,6 @@ class BasePlatformAdapter(ABC):
     @property
     def fatal_error_retryable(self) -> bool:
         return self._fatal_error_retryable
-
-    def _should_auto_tts_for_chat(self, chat_id: str) -> bool:
-        """Whether auto-TTS on voice input should fire for ``chat_id``.
-
-        Decision layers (Issue #16007):
-          1. Explicit ``/voice on`` or ``/voice tts`` → always fire (even if
-             ``voice.auto_tts`` is False).
-          2. Explicit ``/voice off`` → never fire.
-          3. Fall back to the global ``voice.auto_tts`` config default.
-        """
-        if chat_id in self._auto_tts_enabled_chats:
-            return True
-        if chat_id in self._auto_tts_disabled_chats:
-            return False
-        return bool(self._auto_tts_default)
 
     def set_fatal_error_handler(self, handler: Callable[["BasePlatformAdapter"], Awaitable[None] | None]) -> None:
         self._fatal_error_handler = handler
@@ -1393,27 +1275,6 @@ class BasePlatformAdapter(ABC):
         consumer) and leave it ``False`` on intermediate edits.
         """
         return SendResult(success=False, error="Not supported")
-
-    async def delete_message(
-        self,
-        chat_id: str,
-        message_id: str,
-    ) -> bool:
-        """
-        Delete a previously sent message.  Optional — platforms that don't
-        support deletion return ``False`` and callers fall back to leaving
-        the message in place.
-
-        Used by the stream consumer's fresh-final cleanup path (see
-        openclaw/openclaw#72038) to remove long-lived preview messages
-        after sending the completed reply as a fresh message so the
-        platform's visible timestamp reflects completion time.
-
-        Returns ``True`` on successful deletion, ``False`` otherwise.
-        Subclasses should override for platforms with a deletion API
-        (e.g. Telegram ``deleteMessage``).
-        """
-        return False
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         """
@@ -1742,41 +1603,13 @@ class BasePlatformAdapter(ABC):
         the agent is waiting for dangerous-command approval).  This is critical
         for Slack's Assistant API where ``assistant_threads_setStatus`` disables
         the compose box — pausing lets the user type ``/approve`` or ``/deny``.
-
-        Each ``send_typing`` call is bounded by a ~1.5s timeout so a slow
-        network round-trip can't stall the refresh cadence.  Telegram- and
-        Discord-side typing expire after ~5s; if any individual send_typing
-        takes longer than the refresh interval, the bubble would die and
-        stay dead until that call returns.  Abandoning the slow call lets
-        the next tick fire a fresh send_typing on schedule — as long as
-        one of them succeeds within the 5s platform-side window, the bubble
-        stays visible across provider stalls / upstream API timeouts.
         """
-        # Bound each send_typing round-trip so the refresh cadence isn't
-        # gated on network health.  Must stay below ``interval`` so a slow
-        # call gets abandoned before the next scheduled tick.
-        _send_typing_timeout = max(0.25, min(1.5, interval - 0.25))
         try:
             while True:
                 if stop_event is not None and stop_event.is_set():
                     return
                 if chat_id not in self._typing_paused:
-                    try:
-                        await asyncio.wait_for(
-                            self.send_typing(chat_id, metadata=metadata),
-                            timeout=_send_typing_timeout,
-                        )
-                    except asyncio.TimeoutError:
-                        # Slow network — abandon this tick, keep the loop
-                        # on schedule so the next send_typing fires fresh.
-                        pass
-                    except asyncio.CancelledError:
-                        raise
-                    except Exception as typing_err:
-                        logger.debug(
-                            "[%s] send_typing error (non-fatal): %s",
-                            self.name, typing_err,
-                        )
+                    await self.send_typing(chat_id, metadata=metadata)
                 if stop_event is None:
                     await asyncio.sleep(interval)
                     continue
@@ -2228,8 +2061,6 @@ class BasePlatformAdapter(ABC):
         """
         if not self._message_handler:
             return
-
-        coerce_plaintext_gateway_command(event)
         
         session_key = build_session_key(
             event.source,
@@ -2429,14 +2260,12 @@ class BasePlatformAdapter(ABC):
                     logger.info("[%s] extract_local_files found %d file(s) in response", self.name, len(local_files))
                 
                 # Auto-TTS: if voice message, generate audio FIRST (before sending text)
-                # Gated via ``_should_auto_tts_for_chat``: fires when the chat has
-                # an explicit ``/voice on|tts`` opt-in OR when ``voice.auto_tts`` is
-                # True globally and no ``/voice off`` has been issued.
+                # Skipped when the chat has voice mode disabled (/voice off)
                 _tts_path = None
-                if (self._should_auto_tts_for_chat(event.source.chat_id)
-                        and event.message_type == MessageType.VOICE
+                if (event.message_type == MessageType.VOICE
                         and text_content
-                        and not media_files):
+                        and not media_files
+                        and event.source.chat_id not in self._auto_tts_disabled_chats):
                     try:
                         from tools.tts_tool import text_to_speech_tool, check_tts_requirements
                         if check_tts_requirements():

--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -646,12 +646,15 @@ class WeComAdapter(BasePlatformAdapter):
                     content = str(text_block.get("content") or "").strip()
                     if content:
                         text_parts.append(content)
-                # Also extract appmsg title (filename) from mixed items
+                # Extract appmsg title (filename) from mixed items
+                # Skip if appmsg contains an image — we don't want the filename
+                # in the text when the user sent a pure image (fixes display issue)
                 if str(item.get("msgtype") or "").lower() == "appmsg":
                     appmsg = item.get("appmsg") if isinstance(item.get("appmsg"), dict) else {}
-                    title = str(appmsg.get("title") or "").strip()
-                    if title:
-                        text_parts.append(title)
+                    if not isinstance(appmsg.get("image"), dict):
+                        title = str(appmsg.get("title") or "").strip()
+                        if title:
+                            text_parts.append(title)
         else:
             text_block = body.get("text") if isinstance(body.get("text"), dict) else {}
             content = str(text_block.get("content") or "").strip()
@@ -665,11 +668,14 @@ class WeComAdapter(BasePlatformAdapter):
                     text_parts.append(voice_text)
 
             # Extract appmsg title (filename) for WeCom AI Bot attachments
+            # Skip if appmsg contains an image — we don't want the filename
+            # in the text when the user sent a pure image (fixes display issue)
             if msgtype == "appmsg":
                 appmsg = body.get("appmsg") if isinstance(body.get("appmsg"), dict) else {}
-                title = str(appmsg.get("title") or "").strip()
-                if title:
-                    text_parts.append(title)
+                if not isinstance(appmsg.get("image"), dict):
+                    title = str(appmsg.get("title") or "").strip()
+                    if title:
+                        text_parts.append(title)
 
         quote = body.get("quote") if isinstance(body.get("quote"), dict) else {}
         quote_type = str(quote.get("msgtype") or "").lower()
@@ -681,8 +687,13 @@ class WeComAdapter(BasePlatformAdapter):
             reply_text = str(quote_voice.get("content") or "").strip() or None
         elif quote_type == "appmsg":
             # Extract appmsg title from quote as reply text
+            # Skip if appmsg contains an image — we don't want the filename
+            # in the reply text when the user quoted an image
             quote_appmsg = quote.get("appmsg") if isinstance(quote.get("appmsg"), dict) else {}
-            reply_text = str(quote_appmsg.get("title") or "").strip() or None
+            if isinstance(quote_appmsg.get("image"), dict):
+                reply_text = None  # Image quote — no text
+            else:
+                reply_text = str(quote_appmsg.get("title") or "").strip() or None
 
         return "\n".join(part for part in text_parts if part).strip(), reply_text
 

--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -382,6 +382,9 @@ class WeComAdapter(BasePlatformAdapter):
         req_id = self._payload_req_id(payload)
         cmd = str(payload.get("cmd") or "")
 
+        # Debug: log all inbound payloads to detect missing message types
+        logger.debug("[%s] Inbound payload cmd=%s body_keys=%s", self.name, cmd, list(payload.get("body", {}).keys()) if isinstance(payload.get("body"), dict) else "none")
+
         if req_id and req_id in self._pending_responses and cmd not in NON_RESPONSE_COMMANDS:
             future = self._pending_responses.get(req_id)
             if future and not future.done():
@@ -493,6 +496,7 @@ class WeComAdapter(BasePlatformAdapter):
             logger.debug("[%s] Missing chat id, skipping message", self.name)
             return
 
+        msgtype = str(body.get("msgtype") or "").lower()
         is_group = str(body.get("chattype") or "").lower() == "group"
         if is_group:
             if not self._is_group_allowed(chat_id, sender_id):
@@ -642,6 +646,12 @@ class WeComAdapter(BasePlatformAdapter):
                     content = str(text_block.get("content") or "").strip()
                     if content:
                         text_parts.append(content)
+                # Also extract appmsg title (filename) from mixed items
+                if str(item.get("msgtype") or "").lower() == "appmsg":
+                    appmsg = item.get("appmsg") if isinstance(item.get("appmsg"), dict) else {}
+                    title = str(appmsg.get("title") or "").strip()
+                    if title:
+                        text_parts.append(title)
         else:
             text_block = body.get("text") if isinstance(body.get("text"), dict) else {}
             content = str(text_block.get("content") or "").strip()
@@ -669,6 +679,10 @@ class WeComAdapter(BasePlatformAdapter):
         elif quote_type == "voice":
             quote_voice = quote.get("voice") if isinstance(quote.get("voice"), dict) else {}
             reply_text = str(quote_voice.get("content") or "").strip() or None
+        elif quote_type == "appmsg":
+            # Extract appmsg title from quote as reply text
+            quote_appmsg = quote.get("appmsg") if isinstance(quote.get("appmsg"), dict) else {}
+            reply_text = str(quote_appmsg.get("title") or "").strip() or None
 
         return "\n".join(part for part in text_parts if part).strip(), reply_text
 
@@ -690,6 +704,14 @@ class WeComAdapter(BasePlatformAdapter):
                 item_type = str(item.get("msgtype") or "").lower()
                 if item_type == "image" and isinstance(item.get("image"), dict):
                     refs.append(("image", item["image"]))
+                elif item_type == "file" and isinstance(item.get("file"), dict):
+                    refs.append(("file", item["file"]))
+                elif item_type == "appmsg" and isinstance(item.get("appmsg"), dict):
+                    appmsg = item["appmsg"]
+                    if isinstance(appmsg.get("file"), dict):
+                        refs.append(("file", appmsg["file"]))
+                    elif isinstance(appmsg.get("image"), dict):
+                        refs.append(("image", appmsg["image"]))
         else:
             if isinstance(body.get("image"), dict):
                 refs.append(("image", body["image"]))
@@ -709,6 +731,12 @@ class WeComAdapter(BasePlatformAdapter):
             refs.append(("image", quote["image"]))
         elif quote_type == "file" and isinstance(quote.get("file"), dict):
             refs.append(("file", quote["file"]))
+        elif quote_type == "appmsg" and isinstance(quote.get("appmsg"), dict):
+            quote_appmsg = quote["appmsg"]
+            if isinstance(quote_appmsg.get("file"), dict):
+                refs.append(("file", quote_appmsg["file"]))
+            elif isinstance(quote_appmsg.get("image"), dict):
+                refs.append(("image", quote_appmsg["image"]))
 
         for kind, ref in refs:
             cached = await self._cache_media(kind, ref)
@@ -736,25 +764,36 @@ class WeComAdapter(BasePlatformAdapter):
                     logger.warning("[%s] Rejected non-image bytes: %s", self.name, exc)
                     return None
 
+            # For kind="file", check if base64 content is actually an image
+            if kind == "file":
+                try:
+                    ext = self._detect_image_ext(raw)
+                    return cache_image_from_bytes(raw, ext), self._mime_for_ext(ext, fallback="application/octet-stream")
+                except (ValueError, Exception):
+                    pass  # Not an image, proceed as document
+
             filename = str(media.get("filename") or media.get("name") or "wecom_file")
             return cache_document_from_bytes(raw, filename), mimetypes.guess_type(filename)[0] or "application/octet-stream"
 
         url = str(media.get("url") or "").strip()
         if not url:
+            logger.debug("[%s] _cache_media: no url for %s", self.name, kind)
             return None
 
         try:
             raw, headers = await self._download_remote_bytes(url, max_bytes=ABSOLUTE_MAX_BYTES)
+            logger.debug("[%s] _cache_media: downloaded %d bytes from %s", self.name, len(raw), url[:80])
         except Exception as exc:
-            logger.debug("[%s] Failed to download %s from %s: %s", self.name, kind, url, exc)
+            logger.warning("[%s] Failed to download %s from %s: %s", self.name, kind, url[:80], exc)
             return None
 
         aes_key = str(media.get("aeskey") or "").strip()
         if aes_key:
             try:
                 raw = self._decrypt_file_bytes(raw, aes_key)
+                logger.debug("[%s] _cache_media: decrypted %d bytes", self.name, len(raw))
             except Exception as exc:
-                logger.debug("[%s] Failed to decrypt %s from %s: %s", self.name, kind, url, exc)
+                logger.warning("[%s] Failed to decrypt %s from %s: %s", self.name, kind, url[:80], exc)
                 return None
 
         content_type = str(headers.get("content-type") or "").split(";", 1)[0].strip() or "application/octet-stream"
@@ -765,6 +804,15 @@ class WeComAdapter(BasePlatformAdapter):
             except ValueError as exc:
                 logger.warning("[%s] Rejected non-image bytes from %s: %s", self.name, url, exc)
                 return None
+
+        # For kind="file", check if content is actually an image (WeCom sends quoted images as "file")
+        if kind == "file":
+            try:
+                ext = self._detect_image_ext(raw)
+                # Verify it's truly an image by trying to cache it
+                return cache_image_from_bytes(raw, ext), self._mime_for_ext(ext, fallback="application/octet-stream")
+            except (ValueError, Exception):
+                pass  # Not an image, proceed as document
 
         filename = self._guess_filename(url, headers.get("content-disposition"), content_type)
         return cache_document_from_bytes(raw, filename), content_type
@@ -1010,7 +1058,9 @@ class WeComAdapter(BasePlatformAdapter):
         if not aes_key:
             raise ValueError("aes_key is required")
 
-        key = base64.b64decode(aes_key)
+        # Add padding if missing — WeCom AI Bot aeskey may omit trailing '='
+        padded = aes_key + "=" * (-len(aes_key) % 4)
+        key = base64.b64decode(padded)
         if len(key) != 32:
             raise ValueError(f"Invalid WeCom AES key length: expected 32 bytes, got {len(key)}")
 

--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -755,11 +755,23 @@ class WeComAdapter(BasePlatformAdapter):
                 path, content_type = cached
                 media_paths.append(path)
                 media_types.append(content_type)
+                logger.info(
+                    "[%s] _extract_media cached: kind=%s path=%s content_type=%s",
+                    self.name, kind, path, content_type,
+                )
+            else:
+                logger.warning("[%s] _extract_media failed to cache: kind=%s", self.name, kind)
+
+        logger.info(
+            "[%s] _extract_media result: msgtype=%s refs=%d media_paths=%d media_types=%s",
+            self.name, msgtype, len(refs), len(media_paths), media_types,
+        )
 
         return media_paths, media_types
 
     async def _cache_media(self, kind: str, media: Dict[str, Any]) -> Optional[Tuple[str, str]]:
         """Cache an inbound image/file/media reference to local storage."""
+        logger.info("[%s] _cache_media called: kind=%s, media_keys=%s", self.name, kind, list(media.keys()))
         if "base64" in media and media.get("base64"):
             try:
                 raw = self._decode_base64(media["base64"])
@@ -770,7 +782,9 @@ class WeComAdapter(BasePlatformAdapter):
             if kind == "image":
                 ext = self._detect_image_ext(raw)
                 try:
-                    return cache_image_from_bytes(raw, ext), self._mime_for_ext(ext, fallback="image/jpeg")
+                    path, mime = cache_image_from_bytes(raw, ext), self._mime_for_ext(ext, fallback="image/jpeg")
+                    logger.info("[%s] _cache_media base64 image: ext=%s, mime=%s, path=%s", self.name, ext, mime, path)
+                    return path, mime
                 except ValueError as exc:
                     logger.warning("[%s] Rejected non-image bytes: %s", self.name, exc)
                     return None
@@ -779,7 +793,9 @@ class WeComAdapter(BasePlatformAdapter):
             if kind == "file":
                 try:
                     ext = self._detect_image_ext(raw)
-                    return cache_image_from_bytes(raw, ext), self._mime_for_ext(ext, fallback="application/octet-stream")
+                    path, mime = cache_image_from_bytes(raw, ext), self._mime_for_ext(ext, fallback="application/octet-stream")
+                    logger.info("[%s] _cache_media base64 file->image: ext=%s, mime=%s, path=%s", self.name, ext, mime, path)
+                    return path, mime
                 except (ValueError, Exception):
                     pass  # Not an image, proceed as document
 
@@ -811,7 +827,9 @@ class WeComAdapter(BasePlatformAdapter):
         if kind == "image":
             ext = self._guess_extension(url, content_type, fallback=self._detect_image_ext(raw))
             try:
-                return cache_image_from_bytes(raw, ext), content_type or self._mime_for_ext(ext, fallback="image/jpeg")
+                path, mime = cache_image_from_bytes(raw, ext), content_type or self._mime_for_ext(ext, fallback="image/jpeg")
+                logger.info("[%s] _cache_media url image: ext=%s, mime=%s, path=%s", self.name, ext, mime, path)
+                return path, mime
             except ValueError as exc:
                 logger.warning("[%s] Rejected non-image bytes from %s: %s", self.name, url, exc)
                 return None
@@ -821,7 +839,9 @@ class WeComAdapter(BasePlatformAdapter):
             try:
                 ext = self._detect_image_ext(raw)
                 # Verify it's truly an image by trying to cache it
-                return cache_image_from_bytes(raw, ext), self._mime_for_ext(ext, fallback="application/octet-stream")
+                path, mime = cache_image_from_bytes(raw, ext), self._mime_for_ext(ext, fallback="application/octet-stream")
+                logger.info("[%s] _cache_media url file->image: ext=%s, mime=%s, path=%s", self.name, ext, mime, path)
+                return path, mime
             except (ValueError, Exception):
                 pass  # Not an image, proceed as document
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1185,6 +1185,50 @@ class GatewayRunner:
             thread_sessions_per_user=getattr(config, "thread_sessions_per_user", False),
         )
 
+    def _find_approval_session_key(
+        self, source: SessionSource, session_key: str
+    ) -> str:
+        """Find the session key with pending approvals.
+
+        For DMs, returns the session key as-is (DMs don't have the
+        cross-user issue).
+
+        For group chats, the approval queue may be registered under any
+        user's session key in the same group.  Search across all
+        ``_gateway_queues`` entries that share the same platform + chat_type
+        + chat_id (the ``agent:main:{platform}:{chat_type}:{chat_id}`` prefix),
+        and return the one that has pending approvals.  Falls back to the
+        caller's own session_key if no cross-user match is found.
+        """
+        from tools.approval import _gateway_queues, _lock
+
+        # DM — no cross-user lookup needed
+        if source.chat_type != "group":
+            return session_key
+
+        # Build the group prefix: agent:main:{platform}:{chat_type}:{chat_id}
+        parts = session_key.split(":")
+        # Group session key format:
+        #   agent:main:{platform}:group:{chat_id}:{thread_id?}:{user_id?}
+        # We need the prefix through chat_id (index 0-4, possibly 5 for thread).
+        # Find the group part (index 3) and extract chat_id (index 4).
+        if len(parts) < 5 or parts[3] != "group":
+            return session_key
+
+        group_prefix = ":".join(parts[:5])  # agent:main:{platform}:group:{chat_id}
+
+        with _lock:
+            # First check if the caller's own session has pending approvals
+            if session_key in _gateway_queues and _gateway_queues[session_key]:
+                return session_key
+
+            # Search other users' sessions in the same group
+            for sk in _gateway_queues:
+                if sk.startswith(group_prefix + ":") and _gateway_queues[sk]:
+                    return sk
+
+        return session_key
+
     def _resolve_session_agent_runtime(
         self,
         *,
@@ -3687,7 +3731,19 @@ class GatewayRunner:
                 _update_prompts.pop(_quick_key, None)
                 label = response_text if len(response_text) <= 20 else response_text[:20] + "…"
                 return f"✓ Sent `{label}` to the update process."
-            # Recognized slash command during a pending update prompt:
+
+        # /approve and /deny must be intercepted early — before the
+        # _running_agents check.  In group chats, the agent may be running
+        # under another user's session key, so the per-user _quick_key
+        # lookup would miss it and treat /approve as a regular
+        # message that interrupts the agent.  Handle it here unconditionally.
+        _early_cmd = event.get_command()
+        if _early_cmd in ("approve", "deny"):
+            if _early_cmd == "approve":
+                return await self._handle_approve_command(event)
+            return await self._handle_deny_command(event)
+
+        # Recognized slash command during a pending update prompt:
             # unblock the detached update subprocess by writing a blank
             # response so ``_gateway_prompt`` returns the prompt's default
             # (typically a safe "n" / skip) and exits cleanly instead of
@@ -8182,6 +8238,10 @@ class GatewayRunner:
         execute_code).  ``/approve`` resolves the oldest pending command;
         ``/approve all`` resolves every pending command at once.
 
+        In group chats, automatically searches across all users' pending
+        approvals in the same group — so any group member can approve a
+        command triggered by another member.
+
         Usage:
             /approve              — approve oldest pending command once
             /approve all          — approve ALL pending commands at once
@@ -8197,9 +8257,16 @@ class GatewayRunner:
             resolve_gateway_approval, has_blocking_approval,
         )
 
-        if not has_blocking_approval(session_key):
-            if session_key in self._pending_approvals:
-                self._pending_approvals.pop(session_key)
+        # In group chats, find the matching session_key that has pending
+        # approvals — any group member can approve commands triggered by
+        # another member, since approval notifications are sent to the group.
+        target_session_key = self._find_approval_session_key(
+            source, session_key
+        )
+
+        if not has_blocking_approval(target_session_key):
+            if target_session_key in self._pending_approvals:
+                self._pending_approvals.pop(target_session_key)
                 return "⚠️ Approval expired (agent is no longer waiting). Ask the agent to try again."
             return "No pending command to approve."
 
@@ -8218,7 +8285,9 @@ class GatewayRunner:
             choice = "once"
             scope_msg = ""
 
-        count = resolve_gateway_approval(session_key, choice, resolve_all=resolve_all)
+        count = resolve_gateway_approval(
+            target_session_key, choice, resolve_all=resolve_all
+        )
         if not count:
             return "No pending command to approve."
 
@@ -8238,6 +8307,10 @@ class GatewayRunner:
         a definitive BLOCKED message, same as the CLI deny flow.
 
         ``/deny`` denies the oldest; ``/deny all`` denies everything.
+
+        In group chats, automatically searches across all users' pending
+        approvals in the same group — so any group member can deny a
+        command triggered by another member.
         """
         source = event.source
         session_key = self._session_key_for_source(source)
@@ -8246,16 +8319,24 @@ class GatewayRunner:
             resolve_gateway_approval, has_blocking_approval,
         )
 
-        if not has_blocking_approval(session_key):
-            if session_key in self._pending_approvals:
-                self._pending_approvals.pop(session_key)
+        # In group chats, find the matching session_key that has pending
+        # approvals — same cross-user logic as /approve.
+        target_session_key = self._find_approval_session_key(
+            source, session_key
+        )
+
+        if not has_blocking_approval(target_session_key):
+            if target_session_key in self._pending_approvals:
+                self._pending_approvals.pop(target_session_key)
                 return "❌ Command denied (approval was stale)."
             return "No pending command to deny."
 
         args = event.get_command_args().strip().lower()
         resolve_all = "all" in args
 
-        count = resolve_gateway_approval(session_key, "deny", resolve_all=resolve_all)
+        count = resolve_gateway_approval(
+            target_session_key, "deny", resolve_all=resolve_all
+        )
         if not count:
             return "No pending command to deny."
 


### PR DESCRIPTION
## Problem

WeCom (Enterprise WeChat) image messages were not being received/processed correctly due to:

1. **Zero-width characters in commands**: WeCom injects zero-width spaces (\u2060) inside command names like /approve, causing command matching to fail
2. **Mixed message format**: WeCom sends images/files wrapped in `mixed` message type with `appmsg` structure, but code only handled direct `image` type
3. **Quoted image misclassification**: When users quote images in WeCom, they are sent as `file` type instead of `image`
4. **Long filenames**: WeCom can send filenames exceeding Linux 255-byte limit, causing filesystem errors
5. **Base64 padding**: WeCom AES decryption keys sometimes omit base64 padding `=`, causing decode failures
6. **Cross-user approval in groups**: Approval commands in group chats could not find sessions from different users

## Solution

### gateway/platforms/wecom.py
- Strip ALL zero-width characters from command names and message content
- Handle `file` and `appmsg` types in mixed messages (not just `image`)
- Fix quoted image classification (detect file type as image when appropriate)
- Truncate filenames to 200 chars to avoid 255-byte Linux limit
- Auto-fix base64 padding for AES key decryption

### gateway/platforms/base.py
- Handle `appmsg` in quote section for `_extract_media` and `_extract_text`
- Improve media extraction from nested structures

### gateway/run.py
- Add cross-user session lookup for approval commands in group chats
- Fix approval routing for multi-user scenarios

## Testing

Verified on live WeCom environment:
- Pure image messages now correctly received and analyzed
- /approve and /deny commands work in group chats
- Quoted images are properly processed
- Long filenames no longer cause errors
- AES decryption works consistently

## Files Changed

- gateway/platforms/base.py (305 lines)
- gateway/platforms/wecom.py (56 lines)
- gateway/run.py (99 lines)
