### PR TITLE
fix(install): croniter should be a core dependency, not an optional extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
   "requests>=2.33.0,<3",  # CVE-2026-25645
   "jinja2>=3.1.5,<4",
   "pydantic>=2.12.5,<3",
+  "croniter>=6.0.0,<7",   # Required by built-in cron scheduler
   # Interactive CLI (prompt_toolkit is used directly by cli.py)
   "prompt_toolkit>=3.0.52,<4",
   # Tools
@@ -41,7 +42,7 @@ modal = ["modal>=1.0.0,<2"]
 daytona = ["daytona>=0.148.0,<1"]
 dev = ["debugpy>=1.8.0,<2", "pytest>=9.0.2,<10", "pytest-asyncio>=1.3.0,<2", "pytest-xdist>=3.0,<4", "mcp>=1.2.0,<2", "ty>=0.0.1a29,<0.0.22", "ruff"]
 messaging = ["python-telegram-bot[webhooks]>=22.6,<23", "discord.py[voice]>=2.7.1,<3", "aiohttp>=3.13.3,<4", "slack-bolt>=1.18.0,<2", "slack-sdk>=3.27.0,<4", "qrcode>=7.0,<8"]
-cron = ["croniter>=6.0.0,<7"]
+cron = []   # croniter is now in base dependencies
 slack = ["slack-bolt>=1.18.0,<2", "slack-sdk>=3.27.0,<4"]
 matrix = ["mautrix[encryption]>=0.20,<1", "Markdown>=3.6,<4", "aiosqlite>=0.20", "asyncpg>=0.29", "aiohttp-socks>=0.10,<1"]
 cli = ["simple-term-menu>=1.0,<2"]


### PR DESCRIPTION
## What

Move `croniter` from the `[cron]` optional extra into the core `dependencies` list in `pyproject.toml`.

## Why

`croniter` is a direct import in `cron/scheduler.py`. The cron scheduler is a **built-in feature** of Hermes — it should not require a user to manually install an optional extra (`hermes-agent[cron]`) in order to work.

Currently:
- `croniter` is only declared in `[project.optional-dependencies]`
- The `cron` extra is **not included in `[all]`**
- Installing `hermes-agent[all]` does NOT install `croniter`
- After `hermes update`, the venv is rebuilt and `croniter` is lost
- All cron jobs immediately fail with `ModuleNotFoundError: No module named 'croniter'`

Moving `croniter` into core dependencies ensures it is always present after any install or update path.

## How to test

```bash
# After a fresh install
pip install hermes-agent
python -c "import croniter; print(croniter.__version__)"

# After an update
hermes update
python -c "import croniter"
```

## What platforms tested on

Linux (WSL2). This is a dependency declaration change — no runtime code changes.

## Related

Fixes the issue where `hermes update` silently strips `croniter` from the venv, causing all cron jobs to fail after every update.