### PR TITLE
Add auxiliary same-provider model fallbacks

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1331,6 +1331,24 @@ def _is_payment_error(exc: Exception) -> bool:
     return False
 
 
+def _is_aux_model_fallback_error(exc: Exception) -> bool:
+    """Return True when retrying the same provider with another model may help."""
+    status = getattr(exc, "status_code", None)
+    err_lower = str(exc).lower()
+    if status in (429, 503):
+        return True
+    return any(kw in err_lower for kw in (
+        "resource_exhausted",
+        "rate limit",
+        "rate_limit",
+        "quota",
+        "too many requests",
+        "capacity",
+        "overloaded",
+        "temporarily unavailable",
+    ))
+
+
 def _is_connection_error(exc: Exception) -> bool:
     """Detect connection/network errors that warrant provider fallback.
 
@@ -2767,6 +2785,26 @@ def _get_auxiliary_task_config(task: str) -> Dict[str, Any]:
     return task_config if isinstance(task_config, dict) else {}
 
 
+def _get_task_fallback_models(task: str) -> List[str]:
+    """Read ordered same-provider fallback models from auxiliary.{task}.fallback_models."""
+    if not task:
+        return []
+    raw = _get_auxiliary_task_config(task).get("fallback_models")
+    if not isinstance(raw, list):
+        return []
+    seen = set()
+    models: List[str] = []
+    for item in raw:
+        if not isinstance(item, str):
+            continue
+        model = item.strip()
+        if not model or model in seen:
+            continue
+        seen.add(model)
+        models.append(model)
+    return models
+
+
 def _get_task_timeout(task: str, default: float = _DEFAULT_AUX_TIMEOUT) -> float:
     """Read timeout from auxiliary.{task}.timeout in config, falling back to *default*."""
     if not task:
@@ -3194,6 +3232,59 @@ def call_llm(
                     return _validate_llm_response(
                         retry_client.chat.completions.create(**retry_kwargs), task)
 
+        # ── Same-provider model fallback ──────────────────────────────
+        # Explicit auxiliary providers are hard constraints, but a task may
+        # declare fallback_models to rotate within that same provider on
+        # model-specific quota/rate-limit/capacity failures.
+        if _is_aux_model_fallback_error(first_err):
+            attempted_models = {str(final_model or resolved_model or "").strip()}
+            for fallback_model in _get_task_fallback_models(task):
+                if fallback_model in attempted_models:
+                    continue
+                attempted_models.add(fallback_model)
+                logger.info(
+                    "Auxiliary %s: model fallback after %s on %s/%s, retrying %s/%s",
+                    task or "call", type(first_err).__name__,
+                    resolved_provider or "auto", final_model or resolved_model or "default",
+                    resolved_provider or "auto", fallback_model,
+                )
+                if task == "vision":
+                    _, fb_model_client, fb_model_final = resolve_vision_provider_client(
+                        provider=resolved_provider if resolved_provider != "auto" else provider,
+                        model=fallback_model,
+                        base_url=resolved_base_url or base_url,
+                        api_key=resolved_api_key or api_key,
+                        async_mode=False,
+                    )
+                else:
+                    fb_model_client, fb_model_final = _get_cached_client(
+                        resolved_provider,
+                        fallback_model,
+                        base_url=resolved_base_url,
+                        api_key=resolved_api_key,
+                        api_mode=resolved_api_mode,
+                        main_runtime=main_runtime,
+                    )
+                if fb_model_client is None:
+                    continue
+                fb_model_kwargs = _build_call_kwargs(
+                    resolved_provider, fb_model_final or fallback_model, messages,
+                    temperature=temperature, max_tokens=max_tokens,
+                    tools=tools, timeout=effective_timeout,
+                    extra_body=effective_extra_body,
+                    base_url=str(getattr(fb_model_client, "base_url", "") or resolved_base_url or ""),
+                )
+                _fb_model_base = str(getattr(fb_model_client, "base_url", "") or "")
+                if _is_anthropic_compat_endpoint(resolved_provider, _fb_model_base):
+                    fb_model_kwargs["messages"] = _convert_openai_images_to_anthropic(fb_model_kwargs["messages"])
+                try:
+                    return _validate_llm_response(
+                        fb_model_client.chat.completions.create(**fb_model_kwargs), task)
+                except Exception as model_err:
+                    first_err = model_err
+                    if not _is_aux_model_fallback_error(model_err):
+                        raise
+
         # ── Payment / credit exhaustion fallback ──────────────────────
         # When the resolved provider returns 402 or a credit-related error,
         # try alternative providers instead of giving up.  This handles the
@@ -3483,6 +3574,58 @@ async def async_call_llm(
                         retry_kwargs["messages"] = _convert_openai_images_to_anthropic(retry_kwargs["messages"])
                     return _validate_llm_response(
                         await retry_client.chat.completions.create(**retry_kwargs), task)
+
+        # ── Same-provider model fallback (mirrors sync call_llm) ──────
+        if _is_aux_model_fallback_error(first_err):
+            attempted_models = {str(final_model or resolved_model or "").strip()}
+            for fallback_model in _get_task_fallback_models(task):
+                if fallback_model in attempted_models:
+                    continue
+                attempted_models.add(fallback_model)
+                logger.info(
+                    "Auxiliary %s (async): model fallback after %s on %s/%s, retrying %s/%s",
+                    task or "call", type(first_err).__name__,
+                    resolved_provider or "auto", final_model or resolved_model or "default",
+                    resolved_provider or "auto", fallback_model,
+                )
+                if task == "vision":
+                    _, sync_fb_client, fb_model_final = resolve_vision_provider_client(
+                        provider=resolved_provider if resolved_provider != "auto" else provider,
+                        model=fallback_model,
+                        base_url=resolved_base_url or base_url,
+                        api_key=resolved_api_key or api_key,
+                        async_mode=False,
+                    )
+                    fb_model_client, fb_model_final = _to_async_client(
+                        sync_fb_client, fb_model_final or fallback_model, is_vision=True) if sync_fb_client is not None else (None, None)
+                else:
+                    fb_model_client, fb_model_final = _get_cached_client(
+                        resolved_provider,
+                        fallback_model,
+                        async_mode=True,
+                        base_url=resolved_base_url,
+                        api_key=resolved_api_key,
+                        api_mode=resolved_api_mode,
+                    )
+                if fb_model_client is None:
+                    continue
+                fb_model_kwargs = _build_call_kwargs(
+                    resolved_provider, fb_model_final or fallback_model, messages,
+                    temperature=temperature, max_tokens=max_tokens,
+                    tools=tools, timeout=effective_timeout,
+                    extra_body=effective_extra_body,
+                    base_url=str(getattr(fb_model_client, "base_url", "") or resolved_base_url or ""),
+                )
+                _fb_model_base = str(getattr(fb_model_client, "base_url", "") or "")
+                if _is_anthropic_compat_endpoint(resolved_provider, _fb_model_base):
+                    fb_model_kwargs["messages"] = _convert_openai_images_to_anthropic(fb_model_kwargs["messages"])
+                try:
+                    return _validate_llm_response(
+                        await fb_model_client.chat.completions.create(**fb_model_kwargs), task)
+                except Exception as model_err:
+                    first_err = model_err
+                    if not _is_aux_model_fallback_error(model_err):
+                        raise
 
         # ── Payment / connection fallback (mirrors sync call_llm) ─────
         should_fallback = _is_payment_error(first_err) or _is_connection_error(first_err)

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -376,6 +376,9 @@ prompt_caching:
 #   vision:
 #     provider: "auto"
 #     model: ""              # e.g. "google/gemini-2.5-flash", "openai/gpt-4o"
+#     # Optional ordered same-provider model fallbacks for model-level rate limits/quotas.
+#     # Retried only on 429/503/quota/capacity-style failures; auth and bad requests fail normally.
+#     fallback_models: []     # e.g. ["gemini-2.5-flash-lite", "gemini-3-flash-preview"]
 #     timeout: 30            # LLM API call timeout (seconds)
 #     download_timeout: 30   # Image HTTP download timeout (seconds)
 #                            # Increase for slow connections or self-hosted image servers
@@ -384,6 +387,7 @@ prompt_caching:
 #   web_extract:
 #     provider: "auto"
 #     model: ""
+#     fallback_models: []
 #
 #   # Session search — summarizes matching past sessions
 #   session_search:

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1320,6 +1320,13 @@ class _AuxAuth401(Exception):
         super().__init__(message)
 
 
+class _AuxRateLimit429(Exception):
+    status_code = 429
+
+    def __init__(self, message="RESOURCE_EXHAUSTED: rate limit exceeded"):
+        super().__init__(message)
+
+
 class _DummyResponse:
     def __init__(self, text="ok"):
         self.choices = [MagicMock(message=MagicMock(content=text))]
@@ -1345,6 +1352,128 @@ class _AsyncFailingThenSuccessCompletions:
         if self.calls == 1:
             raise _AuxAuth401()
         return _DummyResponse("async-ok")
+
+
+class TestAuxiliarySameProviderModelFallback:
+    def test_call_llm_retries_configured_fallback_model_on_429(self):
+        primary_client = MagicMock()
+        primary_client.base_url = "https://generativelanguage.googleapis.com/v1beta/openai"
+        primary_client.chat.completions.create.side_effect = _AuxRateLimit429()
+
+        fallback_client = MagicMock()
+        fallback_client.base_url = "https://generativelanguage.googleapis.com/v1beta/openai"
+        fallback_client.chat.completions.create.return_value = _DummyResponse("fallback-ok")
+
+        with (
+            patch("agent.auxiliary_client._resolve_task_provider_model", return_value=("google", "gemini-2.5-flash", None, None, None)),
+            patch("agent.auxiliary_client._get_task_fallback_models", return_value=["gemini-2.5-flash-lite"]),
+            patch("agent.auxiliary_client._get_cached_client", side_effect=[
+                (primary_client, "gemini-2.5-flash"),
+                (fallback_client, "gemini-2.5-flash-lite"),
+            ]),
+        ):
+            resp = call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+        assert resp.choices[0].message.content == "fallback-ok"
+        assert primary_client.chat.completions.create.call_count == 1
+        assert fallback_client.chat.completions.create.call_count == 1
+        assert fallback_client.chat.completions.create.call_args.kwargs["model"] == "gemini-2.5-flash-lite"
+
+    def test_call_llm_walks_full_ordered_fallback_model_chain(self):
+        primary_client = MagicMock()
+        primary_client.base_url = "https://generativelanguage.googleapis.com/v1beta/openai"
+        primary_client.chat.completions.create.side_effect = _AuxRateLimit429("primary exhausted")
+
+        first_fallback_client = MagicMock()
+        first_fallback_client.base_url = "https://generativelanguage.googleapis.com/v1beta/openai"
+        first_fallback_client.chat.completions.create.side_effect = _AuxRateLimit429("fallback one exhausted")
+
+        second_fallback_client = MagicMock()
+        second_fallback_client.base_url = "https://generativelanguage.googleapis.com/v1beta/openai"
+        second_fallback_client.chat.completions.create.return_value = _DummyResponse("second-fallback-ok")
+
+        with (
+            patch("agent.auxiliary_client._resolve_task_provider_model", return_value=("google", "gemini-2.5-flash", None, None, None)),
+            patch("agent.auxiliary_client._get_task_fallback_models", return_value=[
+                "gemini-2.5-flash-lite",
+                "gemini-3-flash-preview",
+            ]),
+            patch("agent.auxiliary_client._get_cached_client", side_effect=[
+                (primary_client, "gemini-2.5-flash"),
+                (first_fallback_client, "gemini-2.5-flash-lite"),
+                (second_fallback_client, "gemini-3-flash-preview"),
+            ]),
+        ):
+            resp = call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+        assert resp.choices[0].message.content == "second-fallback-ok"
+        assert primary_client.chat.completions.create.call_count == 1
+        assert first_fallback_client.chat.completions.create.call_count == 1
+        assert second_fallback_client.chat.completions.create.call_count == 1
+        assert first_fallback_client.chat.completions.create.call_args.kwargs["model"] == "gemini-2.5-flash-lite"
+        assert second_fallback_client.chat.completions.create.call_args.kwargs["model"] == "gemini-3-flash-preview"
+
+    @pytest.mark.asyncio
+    async def test_async_call_llm_walks_full_ordered_fallback_model_chain(self):
+        primary_client = MagicMock()
+        primary_client.base_url = "https://generativelanguage.googleapis.com/v1beta/openai"
+        primary_client.chat.completions.create = AsyncMock(side_effect=_AuxRateLimit429("primary exhausted"))
+
+        first_fallback_client = MagicMock()
+        first_fallback_client.base_url = "https://generativelanguage.googleapis.com/v1beta/openai"
+        first_fallback_client.chat.completions.create = AsyncMock(side_effect=_AuxRateLimit429("fallback one exhausted"))
+
+        second_fallback_client = MagicMock()
+        second_fallback_client.base_url = "https://generativelanguage.googleapis.com/v1beta/openai"
+        second_fallback_client.chat.completions.create = AsyncMock(return_value=_DummyResponse("async-second-fallback-ok"))
+
+        with (
+            patch("agent.auxiliary_client._resolve_task_provider_model", return_value=("google", "gemini-2.5-flash", None, None, None)),
+            patch("agent.auxiliary_client._get_task_fallback_models", return_value=[
+                "gemini-2.5-flash-lite",
+                "gemini-3-flash-preview",
+            ]),
+            patch("agent.auxiliary_client._get_cached_client", side_effect=[
+                (primary_client, "gemini-2.5-flash"),
+                (first_fallback_client, "gemini-2.5-flash-lite"),
+                (second_fallback_client, "gemini-3-flash-preview"),
+            ]),
+        ):
+            resp = await async_call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+        assert resp.choices[0].message.content == "async-second-fallback-ok"
+        assert primary_client.chat.completions.create.await_count == 1
+        assert first_fallback_client.chat.completions.create.await_count == 1
+        assert second_fallback_client.chat.completions.create.await_count == 1
+        assert first_fallback_client.chat.completions.create.call_args.kwargs["model"] == "gemini-2.5-flash-lite"
+        assert second_fallback_client.chat.completions.create.call_args.kwargs["model"] == "gemini-3-flash-preview"
+
+    def test_call_llm_does_not_retry_fallback_model_on_non_retryable_error(self):
+        primary_client = MagicMock()
+        primary_client.base_url = "https://generativelanguage.googleapis.com/v1beta/openai"
+        primary_client.chat.completions.create.side_effect = ValueError("bad request")
+
+        with (
+            patch("agent.auxiliary_client._resolve_task_provider_model", return_value=("google", "gemini-2.5-flash", None, None, None)),
+            patch("agent.auxiliary_client._get_task_fallback_models", return_value=["gemini-2.5-flash-lite"]),
+            patch("agent.auxiliary_client._get_cached_client", return_value=(primary_client, "gemini-2.5-flash")),
+        ):
+            with pytest.raises(ValueError):
+                call_llm(
+                    task="compression",
+                    messages=[{"role": "user", "content": "hi"}],
+                )
+
+        assert primary_client.chat.completions.create.call_count == 1
 
 
 class TestAuxiliaryAuthRefreshRetry:


### PR DESCRIPTION
What does this PR do?
    
    Adds ordered same-provider fallback models for auxiliary LLM calls.
    
    Today, auxiliary tasks like vision/compression/session search can be configured with an explicit provider/model, but if that selected model hits a retryable provider-side failure such as quota exhaustion, rate limiting, or temporary unavailability, the auxiliary call has no task-local ordered model chain to walk.
    
    This PR adds auxiliary.<task>.fallback_models, allowing users to configure a provider-local ordered fallback list, for example:
    
    yaml
    auxiliary:
      vision:
        provider: google
        model: gemini-2.5-flash
        fallback_models:
          - gemini-2.5-flash-lite
          - gemini-3-flash-preview
    
    
    The fallback stays within the same configured provider/client. That keeps behavior predictable, avoids silently switching credentials/providers, and lets users choose the exact model order they trust for auxiliary tasks.
    
    Related Issue
    
    No linked issue.
    
    Fixes #
    
    Type of Change
    
    - [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
    - [x] ✨ New feature (non-breaking change that adds functionality)
    - [ ] 🔒 Security fix
    - [x] 📝 Documentation update
    - [x] ✅ Tests (adding or improving test coverage)
    - [ ] ♻️ Refactor (no behavior change)
    - [ ] 🎯 New skill (bundled or hub)
    
    Changes Made
    
    - agent/auxiliary_client.py
      - Added support for ordered fallback_models on auxiliary task configuration.
      - Retries retryable auxiliary model failures against the configured fallback model chain.
      - Keeps fallbacks on the same provider/client instead of switching providers implicitly.
      - Preserves existing behavior when fallback_models is unset.
    
    - cli-config.yaml.example
      - Documented the new fallback_models config key with examples for auxiliary task configuration.
    
    - tests/agent/test_auxiliary_client.py
      - Added test coverage proving the full ordered fallback chain is walked.
      - Added async coverage for the same fallback behavior.
    
    How to Test
    
    1. Run the targeted auxiliary client test suite:
    
    bash
    python -m pytest tests/agent/test_auxiliary_client.py -q -o 'addopts='
    
    
    2. Run related auxiliary/session-search/vision regression tests:
    
    bash
    python -m pytest \
      tests/agent/test_auxiliary_main_first.py \
      tests/agent/test_auxiliary_config_bridge.py \
      tests/agent/test_vision_resolved_args.py \
      tests/tools/test_session_search.py \
      -q -o 'addopts='
    
    
    3. Validate compilation and config compatibility:
    
    bash
    python -m compileall -q agent/auxiliary_client.py tests/agent/test_auxiliary_client.py
    hermes config check
    
    
    Tested locally:
    
    text
    tests/agent/test_auxiliary_client.py: 101 passed
    related auxiliary/session-search/vision tests: 71 passed
    compileall: passed
    hermes config check: passed
    
    
    Checklist
    
    Code
    
    - [x] I've read the Contributing Guide
    - [x] My commit messages follow Conventional Commits (fix(scope):, feat(scope):, etc.)
    - [x] I searched for existing PRs to make sure this isn't a duplicate
    - [x] My PR contains only changes related to this fix/feature (no unrelated commits)
    - [ ] I've run pytest tests/ -q and all tests pass
    - [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
    - [x] I've tested on my platform: Linux Mint 22.3, Linux 6.14.0-37-generic x86_64
    
    Documentation & Housekeeping
    
    - [x] I've updated relevant documentation (README, docs/, docstrings) — or N/A
    - [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
    - [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
    - [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
    - [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
    
    For New Skills
    
    N/A — this PR does not add a skill.
    
    Screenshots / Logs
    
    text
    $ python -m pytest tests/agent/test_auxiliary_client.py -q -o 'addopts='
    101 passed
    
    $ python -m pytest tests/agent/test_auxiliary_main_first.py tests/agent/test_auxiliary_config_bridge.py tests/agent/test_vision_resolved_args.py tests/tools/test_session_search.py -q -o 'addopts='
    71 passed
    
    $ python -m compileall -q agent/auxiliary_client.py tests/agent/test_auxiliary_client.py
    passed
    
    $ hermes config check
    passed