### PR TITLE
fix(tui): align /browser connect local CDP handling

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6569,6 +6569,19 @@ class HermesCLI:
             connect_parts = cmd.strip().split(None, 2)  # ["/browser", "connect", "ws://..."]
             cdp_url = connect_parts[2].strip() if len(connect_parts) > 2 else _DEFAULT_CDP
             parsed_cdp = urlparse(cdp_url if "://" in cdp_url else f"http://{cdp_url}")
+            try:
+                _port = parsed_cdp.port or (443 if parsed_cdp.scheme in {"https", "wss"} else 80)
+            except ValueError:
+                print()
+                print(f"   ⚠ Invalid port in browser url: {cdp_url}")
+                print()
+                return
+            if not parsed_cdp.hostname:
+                print()
+                print(f"   ⚠ Missing host in browser url: {cdp_url}")
+                print()
+                return
+            _host = parsed_cdp.hostname
             if parsed_cdp.path.startswith("/devtools/browser/"):
                 cdp_url = parsed_cdp.geturl()
             else:
@@ -6587,10 +6600,6 @@ class HermesCLI:
                 pass
 
             print()
-
-            # Extract port for connectivity checks
-            _host = parsed_cdp.hostname or "127.0.0.1"
-            _port = parsed_cdp.port or (443 if parsed_cdp.scheme in {"https", "wss"} else 80)
 
             # Check if Chrome is already listening on the debug port
             import socket

--- a/cli.py
+++ b/cli.py
@@ -6630,8 +6630,12 @@ class HermesCLI:
                 else:
                     print("   ⚠ Could not auto-launch Chrome")
                     sys_name = _plat.system()
-                    print(f"     Launch Chrome manually:")
-                    print(f"     {manual_chrome_debug_command(_port, sys_name)}")
+                    chrome_cmd = manual_chrome_debug_command(_port, sys_name)
+                    if chrome_cmd:
+                        print(f"     Launch Chrome manually:")
+                        print(f"     {chrome_cmd}")
+                    else:
+                        print("     No Chrome/Chromium executable found in this environment")
             else:
                 print(f"   ⚠ Port {_port} is not reachable at {cdp_url}")
 

--- a/cli.py
+++ b/cli.py
@@ -80,6 +80,11 @@ _COMMAND_SPINNER_FRAMES = ("⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧
 # Load .env from ~/.hermes/.env first, then project root as dev fallback.
 # User-managed env files should override stale shell exports on restart.
 from hermes_constants import get_hermes_home, display_hermes_home
+from hermes_cli.browser_connect import (
+    DEFAULT_BROWSER_CDP_URL,
+    manual_chrome_debug_command,
+    try_launch_chrome_debug,
+)
 from hermes_cli.env_loader import load_hermes_dotenv
 from utils import base_url_host_matches
 
@@ -239,65 +244,6 @@ def _parse_service_tier_config(raw: str) -> str | None:
         return "priority"
     logger.warning("Unknown service_tier '%s', ignoring", raw)
     return None
-
-
-
-def _get_chrome_debug_candidates(system: str) -> list[str]:
-    """Return likely browser executables for local CDP auto-launch."""
-    candidates: list[str] = []
-    seen: set[str] = set()
-
-    def _add_candidate(path: str | None) -> None:
-        if not path:
-            return
-        normalized = os.path.normcase(os.path.normpath(path))
-        if normalized in seen:
-            return
-        if os.path.isfile(path):
-            candidates.append(path)
-            seen.add(normalized)
-
-    def _add_from_path(*names: str) -> None:
-        for name in names:
-            _add_candidate(shutil.which(name))
-
-    if system == "Darwin":
-        for app in (
-            "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
-            "/Applications/Chromium.app/Contents/MacOS/Chromium",
-            "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
-            "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
-        ):
-            _add_candidate(app)
-    elif system == "Windows":
-        _add_from_path(
-            "chrome.exe", "msedge.exe", "brave.exe", "chromium.exe",
-            "chrome", "msedge", "brave", "chromium",
-        )
-
-        for base in (
-            os.environ.get("ProgramFiles"),
-            os.environ.get("ProgramFiles(x86)"),
-            os.environ.get("LOCALAPPDATA"),
-        ):
-            if not base:
-                continue
-            for parts in (
-                ("Google", "Chrome", "Application", "chrome.exe"),
-                ("Chromium", "Application", "chrome.exe"),
-                ("Chromium", "Application", "chromium.exe"),
-                ("BraveSoftware", "Brave-Browser", "Application", "brave.exe"),
-                ("Microsoft", "Edge", "Application", "msedge.exe"),
-            ):
-                _add_candidate(os.path.join(base, *parts))
-    else:
-        _add_from_path(
-            "google-chrome", "google-chrome-stable", "chromium-browser",
-            "chromium", "brave-browser", "microsoft-edge",
-        )
-
-    return candidates
-
 
 def load_cli_config() -> Dict[str, Any]:
     """
@@ -6606,34 +6552,7 @@ class HermesCLI:
 
         Returns True if a launch command was executed (doesn't guarantee success).
         """
-        import subprocess as _sp
-
-        candidates = _get_chrome_debug_candidates(system)
-
-        if not candidates:
-            return False
-
-        # Dedicated profile dir so debug Chrome won't collide with normal Chrome
-        data_dir = str(_hermes_home / "chrome-debug")
-        os.makedirs(data_dir, exist_ok=True)
-
-        chrome = candidates[0]
-        try:
-            _sp.Popen(
-                [
-                    chrome,
-                    f"--remote-debugging-port={port}",
-                    f"--user-data-dir={data_dir}",
-                    "--no-first-run",
-                    "--no-default-browser-check",
-                ],
-                stdout=_sp.DEVNULL,
-                stderr=_sp.DEVNULL,
-                start_new_session=True,  # detach from terminal
-            )
-            return True
-        except Exception:
-            return False
+        return try_launch_chrome_debug(port, system)
 
     def _handle_browser_command(self, cmd: str):
         """Handle /browser connect|disconnect|status — manage live Chrome CDP connection."""
@@ -6642,13 +6561,23 @@ class HermesCLI:
         parts = cmd.strip().split(None, 1)
         sub = parts[1].lower().strip() if len(parts) > 1 else "status"
 
-        _DEFAULT_CDP = "http://127.0.0.1:9222"
+        _DEFAULT_CDP = DEFAULT_BROWSER_CDP_URL
         current = os.environ.get("BROWSER_CDP_URL", "").strip()
 
         if sub.startswith("connect"):
             # Optionally accept a custom CDP URL: /browser connect ws://host:port
             connect_parts = cmd.strip().split(None, 2)  # ["/browser", "connect", "ws://..."]
             cdp_url = connect_parts[2].strip() if len(connect_parts) > 2 else _DEFAULT_CDP
+            parsed_cdp = urlparse(cdp_url if "://" in cdp_url else f"http://{cdp_url}")
+            if parsed_cdp.path.startswith("/devtools/browser/"):
+                cdp_url = parsed_cdp.geturl()
+            else:
+                cdp_url = parsed_cdp._replace(
+                    path="",
+                    params="",
+                    query="",
+                    fragment="",
+                ).geturl()
 
             # Clear any existing browser sessions so the next tool call uses the new backend
             try:
@@ -6660,11 +6589,8 @@ class HermesCLI:
             print()
 
             # Extract port for connectivity checks
-            _port = 9222
-            try:
-                _port = int(cdp_url.rsplit(":", 1)[-1].split("/")[0])
-            except (ValueError, IndexError):
-                pass
+            _host = parsed_cdp.hostname or "127.0.0.1"
+            _port = parsed_cdp.port or (443 if parsed_cdp.scheme in {"https", "wss"} else 80)
 
             # Check if Chrome is already listening on the debug port
             import socket
@@ -6672,7 +6598,7 @@ class HermesCLI:
             try:
                 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 s.settimeout(1)
-                s.connect(("127.0.0.1", _port))
+                s.connect((_host, _port))
                 s.close()
                 _already_open = True
             except (OSError, socket.timeout):
@@ -6690,7 +6616,7 @@ class HermesCLI:
                         try:
                             s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                             s.settimeout(1)
-                            s.connect(("127.0.0.1", _port))
+                            s.connect((_host, _port))
                             s.close()
                             _already_open = True
                             break
@@ -6703,32 +6629,17 @@ class HermesCLI:
                         print("     Try again in a few seconds — the debug instance may still be starting")
                 else:
                     print("   ⚠ Could not auto-launch Chrome")
-                    # Show manual instructions as fallback
-                    _data_dir = str(_hermes_home / "chrome-debug")
                     sys_name = _plat.system()
-                    if sys_name == "Darwin":
-                        chrome_cmd = (
-                            'open -a "Google Chrome" --args'
-                            f" --remote-debugging-port=9222"
-                            f' --user-data-dir="{_data_dir}"'
-                            " --no-first-run --no-default-browser-check"
-                        )
-                    elif sys_name == "Windows":
-                        chrome_cmd = (
-                            f'chrome.exe --remote-debugging-port=9222'
-                            f' --user-data-dir="{_data_dir}"'
-                            f" --no-first-run --no-default-browser-check"
-                        )
-                    else:
-                        chrome_cmd = (
-                            f"google-chrome --remote-debugging-port=9222"
-                            f' --user-data-dir="{_data_dir}"'
-                            f" --no-first-run --no-default-browser-check"
-                        )
                     print(f"     Launch Chrome manually:")
-                    print(f"     {chrome_cmd}")
+                    print(f"     {manual_chrome_debug_command(_port, sys_name)}")
             else:
                 print(f"   ⚠ Port {_port} is not reachable at {cdp_url}")
+
+            if not _already_open:
+                print()
+                print("Browser not connected — start Chrome with remote debugging and retry /browser connect")
+                print()
+                return
 
             os.environ["BROWSER_CDP_URL"] = cdp_url
             # Eagerly start the CDP supervisor so pending_dialogs + frame_tree

--- a/cli.py
+++ b/cli.py
@@ -6569,6 +6569,14 @@ class HermesCLI:
             connect_parts = cmd.strip().split(None, 2)  # ["/browser", "connect", "ws://..."]
             cdp_url = connect_parts[2].strip() if len(connect_parts) > 2 else _DEFAULT_CDP
             parsed_cdp = urlparse(cdp_url if "://" in cdp_url else f"http://{cdp_url}")
+            if parsed_cdp.scheme not in {"http", "https", "ws", "wss"}:
+                print()
+                print(
+                    f"   ⚠ Unsupported browser url scheme: {parsed_cdp.scheme or '(missing)'} "
+                    "(expected one of: http, https, ws, wss)"
+                )
+                print()
+                return
             try:
                 _port = parsed_cdp.port or (443 if parsed_cdp.scheme in {"https", "wss"} else 80)
             except ValueError:

--- a/hermes_cli/browser_connect.py
+++ b/hermes_cli/browser_connect.py
@@ -97,7 +97,8 @@ def manual_chrome_debug_command(port: int = DEFAULT_BROWSER_CDP_PORT, system: st
     candidates = get_chrome_debug_candidates(system)
 
     if candidates:
-        return shlex.join([candidates[0], *_chrome_debug_args(port)])
+        argv = [candidates[0], *_chrome_debug_args(port)]
+        return subprocess.list2cmdline(argv) if system == "Windows" else shlex.join(argv)
 
     if system == "Darwin":
         data_dir = chrome_debug_data_dir()
@@ -109,8 +110,18 @@ def manual_chrome_debug_command(port: int = DEFAULT_BROWSER_CDP_PORT, system: st
     return None
 
 
+def _detach_kwargs(system: str) -> dict:
+    if system != "Windows":
+        return {"start_new_session": True}
+    flags = getattr(subprocess, "DETACHED_PROCESS", 0) | getattr(
+        subprocess, "CREATE_NEW_PROCESS_GROUP", 0
+    )
+    return {"creationflags": flags} if flags else {}
+
+
 def try_launch_chrome_debug(port: int = DEFAULT_BROWSER_CDP_PORT, system: str | None = None) -> bool:
-    candidates = get_chrome_debug_candidates(system or platform.system())
+    system = system or platform.system()
+    candidates = get_chrome_debug_candidates(system)
     if not candidates:
         return False
 
@@ -120,7 +131,7 @@ def try_launch_chrome_debug(port: int = DEFAULT_BROWSER_CDP_PORT, system: str | 
             [candidates[0], *_chrome_debug_args(port)],
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
-            start_new_session=True,
+            **_detach_kwargs(system),
         )
         return True
     except Exception:

--- a/hermes_cli/browser_connect.py
+++ b/hermes_cli/browser_connect.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import platform
+import shlex
 import shutil
 import subprocess
 
@@ -64,6 +65,14 @@ def get_chrome_debug_candidates(system: str) -> list[str]:
             "google-chrome", "google-chrome-stable", "chromium-browser",
             "chromium", "brave-browser", "microsoft-edge",
         )
+        for base in ("/mnt/c/Program Files", "/mnt/c/Program Files (x86)"):
+            for parts in (
+                ("Google", "Chrome", "Application", "chrome.exe"),
+                ("Chromium", "Application", "chrome.exe"),
+                ("BraveSoftware", "Brave-Browser", "Application", "brave.exe"),
+                ("Microsoft", "Edge", "Application", "msedge.exe"),
+            ):
+                add(os.path.join(base, *parts))
 
     return candidates
 
@@ -72,27 +81,29 @@ def chrome_debug_data_dir() -> str:
     return str(get_hermes_home() / "chrome-debug")
 
 
-def manual_chrome_debug_command(port: int = DEFAULT_BROWSER_CDP_PORT, system: str | None = None) -> str:
+def _chrome_debug_args(port: int) -> list[str]:
+    return [
+        f"--remote-debugging-port={port}",
+        f"--user-data-dir={chrome_debug_data_dir()}",
+        "--no-first-run",
+        "--no-default-browser-check",
+    ]
+
+
+def manual_chrome_debug_command(port: int = DEFAULT_BROWSER_CDP_PORT, system: str | None = None) -> str | None:
     system = system or platform.system()
-    data_dir = chrome_debug_data_dir()
+    candidates = get_chrome_debug_candidates(system)
+    if candidates:
+        return " ".join(shlex.quote(part) for part in [candidates[0], *_chrome_debug_args(port)])
+
     if system == "Darwin":
         return (
             'open -a "Google Chrome" --args'
             f" --remote-debugging-port={port}"
-            f' --user-data-dir="{data_dir}"'
+            f' --user-data-dir="{chrome_debug_data_dir()}"'
             " --no-first-run --no-default-browser-check"
         )
-    if system == "Windows":
-        return (
-            f"chrome.exe --remote-debugging-port={port}"
-            f' --user-data-dir="{data_dir}"'
-            " --no-first-run --no-default-browser-check"
-        )
-    return (
-        f"google-chrome --remote-debugging-port={port}"
-        f' --user-data-dir="{data_dir}"'
-        " --no-first-run --no-default-browser-check"
-    )
+    return None
 
 
 def try_launch_chrome_debug(port: int = DEFAULT_BROWSER_CDP_PORT, system: str | None = None) -> bool:
@@ -105,10 +116,7 @@ def try_launch_chrome_debug(port: int = DEFAULT_BROWSER_CDP_PORT, system: str | 
         subprocess.Popen(
             [
                 candidates[0],
-                f"--remote-debugging-port={port}",
-                f"--user-data-dir={chrome_debug_data_dir()}",
-                "--no-first-run",
-                "--no-default-browser-check",
+                *_chrome_debug_args(port),
             ],
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,

--- a/hermes_cli/browser_connect.py
+++ b/hermes_cli/browser_connect.py
@@ -14,6 +14,31 @@ from hermes_constants import get_hermes_home
 DEFAULT_BROWSER_CDP_PORT = 9222
 DEFAULT_BROWSER_CDP_URL = f"http://127.0.0.1:{DEFAULT_BROWSER_CDP_PORT}"
 
+_DARWIN_APPS = (
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    "/Applications/Chromium.app/Contents/MacOS/Chromium",
+    "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
+    "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+)
+
+_WINDOWS_INSTALL_PARTS = (
+    ("Google", "Chrome", "Application", "chrome.exe"),
+    ("Chromium", "Application", "chrome.exe"),
+    ("Chromium", "Application", "chromium.exe"),
+    ("BraveSoftware", "Brave-Browser", "Application", "brave.exe"),
+    ("Microsoft", "Edge", "Application", "msedge.exe"),
+)
+
+_LINUX_BIN_NAMES = (
+    "google-chrome", "google-chrome-stable", "chromium-browser",
+    "chromium", "brave-browser", "microsoft-edge",
+)
+
+_WINDOWS_BIN_NAMES = (
+    "chrome.exe", "msedge.exe", "brave.exe", "chromium.exe",
+    "chrome", "msedge", "brave", "chromium",
+)
+
 
 def get_chrome_debug_candidates(system: str) -> list[str]:
     candidates: list[str] = []
@@ -28,52 +53,29 @@ def get_chrome_debug_candidates(system: str) -> list[str]:
         candidates.append(path)
         seen.add(normalized)
 
-    def add_from_path(*names: str) -> None:
-        for name in names:
-            add(shutil.which(name))
+    def add_install_paths(bases: tuple[str | None, ...]) -> None:
+        for base in filter(None, bases):
+            for parts in _WINDOWS_INSTALL_PARTS:
+                add(os.path.join(base, *parts))
 
     if system == "Darwin":
-        for app in (
-            "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
-            "/Applications/Chromium.app/Contents/MacOS/Chromium",
-            "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
-            "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
-        ):
+        for app in _DARWIN_APPS:
             add(app)
-    elif system == "Windows":
-        add_from_path(
-            "chrome.exe", "msedge.exe", "brave.exe", "chromium.exe",
-            "chrome", "msedge", "brave", "chromium",
-        )
-        for base in (
+        return candidates
+
+    if system == "Windows":
+        for name in _WINDOWS_BIN_NAMES:
+            add(shutil.which(name))
+        add_install_paths((
             os.environ.get("ProgramFiles"),
             os.environ.get("ProgramFiles(x86)"),
             os.environ.get("LOCALAPPDATA"),
-        ):
-            if not base:
-                continue
-            for parts in (
-                ("Google", "Chrome", "Application", "chrome.exe"),
-                ("Chromium", "Application", "chrome.exe"),
-                ("Chromium", "Application", "chromium.exe"),
-                ("BraveSoftware", "Brave-Browser", "Application", "brave.exe"),
-                ("Microsoft", "Edge", "Application", "msedge.exe"),
-            ):
-                add(os.path.join(base, *parts))
-    else:
-        add_from_path(
-            "google-chrome", "google-chrome-stable", "chromium-browser",
-            "chromium", "brave-browser", "microsoft-edge",
-        )
-        for base in ("/mnt/c/Program Files", "/mnt/c/Program Files (x86)"):
-            for parts in (
-                ("Google", "Chrome", "Application", "chrome.exe"),
-                ("Chromium", "Application", "chrome.exe"),
-                ("BraveSoftware", "Brave-Browser", "Application", "brave.exe"),
-                ("Microsoft", "Edge", "Application", "msedge.exe"),
-            ):
-                add(os.path.join(base, *parts))
+        ))
+        return candidates
 
+    for name in _LINUX_BIN_NAMES:
+        add(shutil.which(name))
+    add_install_paths(("/mnt/c/Program Files", "/mnt/c/Program Files (x86)"))
     return candidates
 
 
@@ -93,16 +95,17 @@ def _chrome_debug_args(port: int) -> list[str]:
 def manual_chrome_debug_command(port: int = DEFAULT_BROWSER_CDP_PORT, system: str | None = None) -> str | None:
     system = system or platform.system()
     candidates = get_chrome_debug_candidates(system)
+
     if candidates:
-        return " ".join(shlex.quote(part) for part in [candidates[0], *_chrome_debug_args(port)])
+        return shlex.join([candidates[0], *_chrome_debug_args(port)])
 
     if system == "Darwin":
+        data_dir = chrome_debug_data_dir()
         return (
-            'open -a "Google Chrome" --args'
-            f" --remote-debugging-port={port}"
-            f' --user-data-dir="{chrome_debug_data_dir()}"'
-            " --no-first-run --no-default-browser-check"
+            f'open -a "Google Chrome" --args --remote-debugging-port={port} '
+            f'--user-data-dir="{data_dir}" --no-first-run --no-default-browser-check'
         )
+
     return None
 
 
@@ -114,10 +117,7 @@ def try_launch_chrome_debug(port: int = DEFAULT_BROWSER_CDP_PORT, system: str | 
     os.makedirs(chrome_debug_data_dir(), exist_ok=True)
     try:
         subprocess.Popen(
-            [
-                candidates[0],
-                *_chrome_debug_args(port),
-            ],
+            [candidates[0], *_chrome_debug_args(port)],
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             start_new_session=True,

--- a/hermes_cli/browser_connect.py
+++ b/hermes_cli/browser_connect.py
@@ -1,0 +1,119 @@
+"""Shared helpers for attaching Hermes to a local Chrome CDP port."""
+
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import subprocess
+
+from hermes_constants import get_hermes_home
+
+
+DEFAULT_BROWSER_CDP_PORT = 9222
+DEFAULT_BROWSER_CDP_URL = f"http://127.0.0.1:{DEFAULT_BROWSER_CDP_PORT}"
+
+
+def get_chrome_debug_candidates(system: str) -> list[str]:
+    candidates: list[str] = []
+    seen: set[str] = set()
+
+    def add(path: str | None) -> None:
+        if not path:
+            return
+        normalized = os.path.normcase(os.path.normpath(path))
+        if normalized in seen or not os.path.isfile(path):
+            return
+        candidates.append(path)
+        seen.add(normalized)
+
+    def add_from_path(*names: str) -> None:
+        for name in names:
+            add(shutil.which(name))
+
+    if system == "Darwin":
+        for app in (
+            "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+            "/Applications/Chromium.app/Contents/MacOS/Chromium",
+            "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
+            "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+        ):
+            add(app)
+    elif system == "Windows":
+        add_from_path(
+            "chrome.exe", "msedge.exe", "brave.exe", "chromium.exe",
+            "chrome", "msedge", "brave", "chromium",
+        )
+        for base in (
+            os.environ.get("ProgramFiles"),
+            os.environ.get("ProgramFiles(x86)"),
+            os.environ.get("LOCALAPPDATA"),
+        ):
+            if not base:
+                continue
+            for parts in (
+                ("Google", "Chrome", "Application", "chrome.exe"),
+                ("Chromium", "Application", "chrome.exe"),
+                ("Chromium", "Application", "chromium.exe"),
+                ("BraveSoftware", "Brave-Browser", "Application", "brave.exe"),
+                ("Microsoft", "Edge", "Application", "msedge.exe"),
+            ):
+                add(os.path.join(base, *parts))
+    else:
+        add_from_path(
+            "google-chrome", "google-chrome-stable", "chromium-browser",
+            "chromium", "brave-browser", "microsoft-edge",
+        )
+
+    return candidates
+
+
+def chrome_debug_data_dir() -> str:
+    return str(get_hermes_home() / "chrome-debug")
+
+
+def manual_chrome_debug_command(port: int = DEFAULT_BROWSER_CDP_PORT, system: str | None = None) -> str:
+    system = system or platform.system()
+    data_dir = chrome_debug_data_dir()
+    if system == "Darwin":
+        return (
+            'open -a "Google Chrome" --args'
+            f" --remote-debugging-port={port}"
+            f' --user-data-dir="{data_dir}"'
+            " --no-first-run --no-default-browser-check"
+        )
+    if system == "Windows":
+        return (
+            f"chrome.exe --remote-debugging-port={port}"
+            f' --user-data-dir="{data_dir}"'
+            " --no-first-run --no-default-browser-check"
+        )
+    return (
+        f"google-chrome --remote-debugging-port={port}"
+        f' --user-data-dir="{data_dir}"'
+        " --no-first-run --no-default-browser-check"
+    )
+
+
+def try_launch_chrome_debug(port: int = DEFAULT_BROWSER_CDP_PORT, system: str | None = None) -> bool:
+    candidates = get_chrome_debug_candidates(system or platform.system())
+    if not candidates:
+        return False
+
+    os.makedirs(chrome_debug_data_dir(), exist_ok=True)
+    try:
+        subprocess.Popen(
+            [
+                candidates[0],
+                f"--remote-debugging-port={port}",
+                f"--user-data-dir={chrome_debug_data_dir()}",
+                "--no-first-run",
+                "--no-default-browser-check",
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        return True
+    except Exception:
+        return False

--- a/tests/cli/test_cli_browser_connect.py
+++ b/tests/cli/test_cli_browser_connect.py
@@ -4,6 +4,7 @@ import os
 from unittest.mock import patch
 
 from cli import HermesCLI
+from hermes_cli.browser_connect import manual_chrome_debug_command
 
 
 def _assert_chrome_debug_cmd(cmd, expected_chrome, expected_port):
@@ -55,3 +56,26 @@ class TestChromeDebugLaunch:
             assert HermesCLI._try_launch_chrome_debug(9222, "Windows") is True
 
         _assert_chrome_debug_cmd(captured["cmd"], installed, 9222)
+
+    def test_manual_command_uses_detected_linux_browser(self):
+        with patch("hermes_cli.browser_connect.shutil.which", side_effect=lambda name: "/usr/bin/chromium" if name == "chromium" else None), \
+             patch("hermes_cli.browser_connect.os.path.isfile", side_effect=lambda path: path == "/usr/bin/chromium"):
+            command = manual_chrome_debug_command(9222, "Linux")
+
+        assert command is not None
+        assert command.startswith("/usr/bin/chromium --remote-debugging-port=9222")
+
+    def test_manual_command_uses_wsl_windows_chrome_when_available(self):
+        chrome = "/mnt/c/Program Files/Google/Chrome/Application/chrome.exe"
+
+        with patch("hermes_cli.browser_connect.shutil.which", return_value=None), \
+             patch("hermes_cli.browser_connect.os.path.isfile", side_effect=lambda path: path == chrome):
+            command = manual_chrome_debug_command(9222, "Linux")
+
+        assert command is not None
+        assert command.startswith(f"'{chrome}' --remote-debugging-port=9222")
+
+    def test_manual_command_returns_none_when_linux_browser_missing(self):
+        with patch("hermes_cli.browser_connect.shutil.which", return_value=None), \
+             patch("hermes_cli.browser_connect.os.path.isfile", return_value=False):
+            assert manual_chrome_debug_command(9222, "Linux") is None

--- a/tests/cli/test_cli_browser_connect.py
+++ b/tests/cli/test_cli_browser_connect.py
@@ -1,6 +1,7 @@
 """Tests for CLI browser CDP auto-launch helpers."""
 
 import os
+import subprocess
 from unittest.mock import patch
 
 from cli import HermesCLI
@@ -33,7 +34,13 @@ class TestChromeDebugLaunch:
             assert HermesCLI._try_launch_chrome_debug(9333, "Windows") is True
 
         _assert_chrome_debug_cmd(captured["cmd"], r"C:\Chrome\chrome.exe", 9333)
-        assert captured["kwargs"]["start_new_session"] is True
+        # Windows uses creationflags (POSIX-only start_new_session would raise).
+        assert "start_new_session" not in captured["kwargs"]
+        flags = captured["kwargs"].get("creationflags", 0)
+        expected = getattr(subprocess, "DETACHED_PROCESS", 0) | getattr(
+            subprocess, "CREATE_NEW_PROCESS_GROUP", 0
+        )
+        assert flags == expected
 
     def test_windows_launch_falls_back_to_common_install_dirs(self, monkeypatch):
         captured = {}
@@ -73,7 +80,20 @@ class TestChromeDebugLaunch:
             command = manual_chrome_debug_command(9222, "Linux")
 
         assert command is not None
+        # Linux/WSL uses POSIX shell quoting (single quotes around paths with spaces).
         assert command.startswith(f"'{chrome}' --remote-debugging-port=9222")
+
+    def test_manual_command_uses_windows_quoting_on_windows(self):
+        chrome = r"C:\Program Files\Google\Chrome\Application\chrome.exe"
+
+        with patch("hermes_cli.browser_connect.shutil.which", side_effect=lambda name: chrome if name == "chrome.exe" else None), \
+             patch("hermes_cli.browser_connect.os.path.isfile", side_effect=lambda path: path == chrome):
+            command = manual_chrome_debug_command(9222, "Windows")
+
+        assert command is not None
+        # Windows uses cmd.exe-compatible quoting via subprocess.list2cmdline.
+        assert command.startswith(f'"{chrome}" --remote-debugging-port=9222')
+        assert "'" not in command
 
     def test_manual_command_returns_none_when_linux_browser_missing(self):
         with patch("hermes_cli.browser_connect.shutil.which", return_value=None), \

--- a/tests/cli/test_cli_browser_connect.py
+++ b/tests/cli/test_cli_browser_connect.py
@@ -26,8 +26,8 @@ class TestChromeDebugLaunch:
             captured["kwargs"] = kwargs
             return object()
 
-        with patch("cli.shutil.which", side_effect=lambda name: r"C:\Chrome\chrome.exe" if name == "chrome.exe" else None), \
-             patch("cli.os.path.isfile", side_effect=lambda path: path == r"C:\Chrome\chrome.exe"), \
+        with patch("hermes_cli.browser_connect.shutil.which", side_effect=lambda name: r"C:\Chrome\chrome.exe" if name == "chrome.exe" else None), \
+             patch("hermes_cli.browser_connect.os.path.isfile", side_effect=lambda path: path == r"C:\Chrome\chrome.exe"), \
              patch("subprocess.Popen", side_effect=fake_popen):
             assert HermesCLI._try_launch_chrome_debug(9333, "Windows") is True
 
@@ -49,8 +49,8 @@ class TestChromeDebugLaunch:
         monkeypatch.delenv("ProgramFiles(x86)", raising=False)
         monkeypatch.delenv("LOCALAPPDATA", raising=False)
 
-        with patch("cli.shutil.which", return_value=None), \
-             patch("cli.os.path.isfile", side_effect=lambda path: path == installed), \
+        with patch("hermes_cli.browser_connect.shutil.which", return_value=None), \
+             patch("hermes_cli.browser_connect.os.path.isfile", side_effect=lambda path: path == installed), \
              patch("subprocess.Popen", side_effect=fake_popen):
             assert HermesCLI._try_launch_chrome_debug(9222, "Windows") is True
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2754,6 +2754,8 @@ def test_session_most_recent_handles_db_unavailable(monkeypatch):
     )
 
     assert resp["result"]["session_id"] is None
+
+
 # ── browser.manage ───────────────────────────────────────────────────
 
 
@@ -2903,14 +2905,27 @@ def test_browser_manage_connect_defaults_to_loopback(monkeypatch):
 
 def test_browser_manage_connect_default_local_reports_launch_hint(monkeypatch):
     monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
+    emitted: list[tuple[str, dict]] = []
+    monkeypatch.setattr(
+        server,
+        "_emit",
+        lambda evt, sid, payload=None: emitted.append((evt, payload or {})),
+    )
     fake = types.SimpleNamespace(
         cleanup_all_browsers=lambda: None,
         _get_cdp_override=lambda: os.environ.get("BROWSER_CDP_URL", ""),
     )
     with patch.dict(sys.modules, {"tools.browser_tool": fake}):
         _stub_urlopen(monkeypatch, ok=False)
-        with patch("hermes_cli.browser_connect.try_launch_chrome_debug", return_value=False), \
-             patch("hermes_cli.browser_connect.get_chrome_debug_candidates", return_value=[]):
+        with (
+            patch(
+                "hermes_cli.browser_connect.try_launch_chrome_debug", return_value=False
+            ),
+            patch(
+                "hermes_cli.browser_connect.get_chrome_debug_candidates",
+                return_value=[],
+            ),
+        ):
             resp = server.handle_request(
                 {
                     "id": "1",
@@ -2921,10 +2936,20 @@ def test_browser_manage_connect_default_local_reports_launch_hint(monkeypatch):
 
     assert resp["result"]["connected"] is False
     assert resp["result"]["url"] == "http://127.0.0.1:9222"
-    assert resp["result"]["messages"][0] == "Chrome isn't running with remote debugging — attempting to launch..."
-    assert any("No Chrome/Chromium executable was found" in line for line in resp["result"]["messages"])
-    assert any("--remote-debugging-port=9222" in line for line in resp["result"]["messages"])
+    assert (
+        resp["result"]["messages"][0]
+        == "Chrome isn't running with remote debugging — attempting to launch..."
+    )
+    assert any(
+        "No Chrome/Chromium executable was found" in line
+        for line in resp["result"]["messages"]
+    )
+    assert any(
+        "--remote-debugging-port=9222" in line for line in resp["result"]["messages"]
+    )
     assert "BROWSER_CDP_URL" not in os.environ
+    progress = [p["message"] for evt, p in emitted if evt == "browser.progress"]
+    assert progress == resp["result"]["messages"]
 
 
 def test_browser_manage_connect_default_local_retries_after_launch(monkeypatch):
@@ -2956,7 +2981,9 @@ def test_browser_manage_connect_default_local_retries_after_launch(monkeypatch):
 
     monkeypatch.setattr(urllib.request, "urlopen", _opener)
     with patch.dict(sys.modules, {"tools.browser_tool": fake}):
-        with patch("hermes_cli.browser_connect.try_launch_chrome_debug", return_value=True):
+        with patch(
+            "hermes_cli.browser_connect.try_launch_chrome_debug", return_value=True
+        ):
             resp = server.handle_request(
                 {"id": "1", "method": "browser.manage", "params": {"action": "connect"}}
             )
@@ -2975,7 +3002,9 @@ def test_browser_manage_connect_rejects_unreachable_endpoint(monkeypatch):
     monkeypatch.setenv("BROWSER_CDP_URL", "http://existing:9222")
     cleanup_calls: list[str] = []
     fake = types.SimpleNamespace(
-        cleanup_all_browsers=lambda: cleanup_calls.append(os.environ.get("BROWSER_CDP_URL", "")),
+        cleanup_all_browsers=lambda: cleanup_calls.append(
+            os.environ.get("BROWSER_CDP_URL", "")
+        ),
         _get_cdp_override=lambda: os.environ.get("BROWSER_CDP_URL", ""),
     )
     with patch.dict(sys.modules, {"tools.browser_tool": fake}):
@@ -3055,14 +3084,19 @@ def test_browser_manage_connect_preserves_devtools_browser_endpoint(monkeypatch)
     concrete = "ws://browserbase.example/devtools/browser/abc123"
 
     class _OkSocket:
-        def __enter__(self): return self
-        def __exit__(self, *a): return False
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
 
     with patch.dict(sys.modules, {"tools.browser_tool": fake}):
         # If urlopen is reached for a concrete ws endpoint, the test
         # would still pass because _stub_urlopen returned ok=True before;
         # patch it to assert-fail so we prove the HTTP probe is skipped.
-        with patch("urllib.request.urlopen", side_effect=AssertionError("urlopen called")):
+        with patch(
+            "urllib.request.urlopen", side_effect=AssertionError("urlopen called")
+        ):
             with patch("socket.create_connection", return_value=_OkSocket()):
                 resp = server.handle_request(
                     {
@@ -3091,8 +3125,11 @@ def test_browser_manage_connect_concrete_ws_skips_http_probe(monkeypatch):
     seen_targets: list[tuple[str, int]] = []
 
     class _OkSocket:
-        def __enter__(self): return self
-        def __exit__(self, *a): return False
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
 
     def _fake_create_connection(addr, timeout=None):
         seen_targets.append(addr)
@@ -3101,7 +3138,9 @@ def test_browser_manage_connect_concrete_ws_skips_http_probe(monkeypatch):
     with patch.dict(sys.modules, {"tools.browser_tool": fake}):
         # urlopen would 404/ECONNREFUSED on a real hosted CDP endpoint;
         # asserting it's never called proves the probe was skipped.
-        with patch("urllib.request.urlopen", side_effect=AssertionError("urlopen called")):
+        with patch(
+            "urllib.request.urlopen", side_effect=AssertionError("urlopen called")
+        ):
             with patch("socket.create_connection", side_effect=_fake_create_connection):
                 resp = server.handle_request(
                     {
@@ -3145,7 +3184,9 @@ def test_browser_manage_disconnect_drops_env_and_cleans(monkeypatch):
     monkeypatch.setenv("BROWSER_CDP_URL", "http://127.0.0.1:9222")
     cleanup_count = {"n": 0}
     fake = types.SimpleNamespace(
-        cleanup_all_browsers=lambda: cleanup_count.__setitem__("n", cleanup_count["n"] + 1),
+        cleanup_all_browsers=lambda: cleanup_count.__setitem__(
+            "n", cleanup_count["n"] + 1
+        ),
         _get_cdp_override=lambda: os.environ.get("BROWSER_CDP_URL", ""),
     )
     with patch.dict(sys.modules, {"tools.browser_tool": fake}):
@@ -3213,11 +3254,16 @@ def test_config_get_indicator_falls_back_when_unset(monkeypatch):
 def test_config_set_indicator_accepts_known_value(monkeypatch):
     written: dict = {}
     monkeypatch.setattr(
-        server, "_write_config_key",
+        server,
+        "_write_config_key",
         lambda k, v: written.update({k: v}),
     )
     resp = server.handle_request(
-        {"id": "1", "method": "config.set", "params": {"key": "indicator", "value": "EMOJI"}}
+        {
+            "id": "1",
+            "method": "config.set",
+            "params": {"key": "indicator", "value": "EMOJI"},
+        }
     )
     assert resp["result"] == {"key": "indicator", "value": "emoji"}
     assert written == {"display.tui_status_indicator": "emoji"}
@@ -3231,7 +3277,11 @@ def test_config_set_indicator_falsy_non_string_surfaces_in_error(monkeypatch):
 
     for bad in (0, False, []):
         resp = server.handle_request(
-            {"id": "1", "method": "config.set", "params": {"key": "indicator", "value": bad}}
+            {
+                "id": "1",
+                "method": "config.set",
+                "params": {"key": "indicator", "value": bad},
+            }
         )
         assert "error" in resp
         msg = resp["error"]["message"]
@@ -3246,7 +3296,11 @@ def test_config_set_indicator_none_keeps_blank_repr(monkeypatch):
     """`None` is the genuine 'no value' case — empty raw is acceptable."""
     monkeypatch.setattr(server, "_write_config_key", lambda *a, **k: None)
     resp = server.handle_request(
-        {"id": "1", "method": "config.set", "params": {"key": "indicator", "value": None}}
+        {
+            "id": "1",
+            "method": "config.set",
+            "params": {"key": "indicator", "value": None},
+        }
     )
     assert "error" in resp
     assert "unknown indicator: ''" in resp["error"]["message"]

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2811,7 +2811,8 @@ def test_browser_manage_status_reads_env_var(monkeypatch):
         {"id": "1", "method": "browser.manage", "params": {"action": "status"}}
     )
 
-    assert resp["result"] == {"connected": True, "url": "http://127.0.0.1:9222"}
+    assert resp["result"]["connected"] is True
+    assert resp["result"]["url"] == "http://127.0.0.1:9222"
 
 
 def test_browser_manage_status_falls_back_to_config_cdp_url(monkeypatch):
@@ -2874,7 +2875,9 @@ def test_browser_manage_connect_sets_env_and_cleans_twice(monkeypatch):
             }
         )
 
-    assert resp["result"] == {"connected": True, "url": "http://127.0.0.1:9222"}
+    assert resp["result"]["connected"] is True
+    assert resp["result"]["url"] == "http://127.0.0.1:9222"
+    assert resp["result"]["messages"] == ["Chrome is already listening on port 9222"]
     assert os.environ.get("BROWSER_CDP_URL") == "http://127.0.0.1:9222"
     # First cleanup runs against the OLD env (none here), second against the NEW.
     assert cleanup_calls == ["", "http://127.0.0.1:9222"]
@@ -2892,7 +2895,9 @@ def test_browser_manage_connect_defaults_to_loopback(monkeypatch):
             {"id": "1", "method": "browser.manage", "params": {"action": "connect"}}
         )
 
-    assert resp["result"] == {"connected": True, "url": "http://127.0.0.1:9222"}
+    assert resp["result"]["connected"] is True
+    assert resp["result"]["url"] == "http://127.0.0.1:9222"
+    assert resp["result"]["messages"] == ["Chrome is already listening on port 9222"]
     assert urls[0] == "http://127.0.0.1:9222/json/version"
 
 
@@ -2907,12 +2912,18 @@ def test_browser_manage_connect_default_local_reports_launch_hint(monkeypatch):
         with patch("hermes_cli.browser_connect.try_launch_chrome_debug", return_value=False), \
              patch("hermes_cli.browser_connect.get_chrome_debug_candidates", return_value=[]):
             resp = server.handle_request(
-                {"id": "1", "method": "browser.manage", "params": {"action": "connect"}}
+                {
+                    "id": "1",
+                    "method": "browser.manage",
+                    "params": {"action": "connect", "url": "http://localhost:9222"},
+                }
             )
 
-    assert resp["error"]["code"] == 5031
-    assert "No Chrome/Chromium executable was found" in resp["error"]["message"]
-    assert "--remote-debugging-port=9222" in resp["error"]["message"]
+    assert resp["result"]["connected"] is False
+    assert resp["result"]["url"] == "http://127.0.0.1:9222"
+    assert resp["result"]["messages"][0] == "Chrome isn't running with remote debugging — attempting to launch..."
+    assert any("No Chrome/Chromium executable was found" in line for line in resp["result"]["messages"])
+    assert any("--remote-debugging-port=9222" in line for line in resp["result"]["messages"])
     assert "BROWSER_CDP_URL" not in os.environ
 
 
@@ -2950,7 +2961,12 @@ def test_browser_manage_connect_default_local_retries_after_launch(monkeypatch):
                 {"id": "1", "method": "browser.manage", "params": {"action": "connect"}}
             )
 
-    assert resp["result"] == {"connected": True, "url": "http://127.0.0.1:9222"}
+    assert resp["result"]["connected"] is True
+    assert resp["result"]["url"] == "http://127.0.0.1:9222"
+    assert resp["result"]["messages"] == [
+        "Chrome isn't running with remote debugging — attempting to launch...",
+        "Chrome launched and listening on port 9222",
+    ]
     assert os.environ["BROWSER_CDP_URL"] == "http://127.0.0.1:9222"
 
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3111,6 +3111,69 @@ def test_browser_manage_connect_preserves_devtools_browser_endpoint(monkeypatch)
     assert os.environ["BROWSER_CDP_URL"] == concrete
 
 
+def test_browser_manage_connect_local_devtools_ws_preserves_path(monkeypatch):
+    """Regression: ``ws://127.0.0.1:9222/devtools/browser/<id>`` is a real
+    connectable endpoint; default-local normalization must not strip the
+    ``/devtools/browser/...`` path or it breaks valid local CDP connects."""
+    monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
+    fake = types.SimpleNamespace(
+        cleanup_all_browsers=lambda: None,
+        _get_cdp_override=lambda: os.environ.get("BROWSER_CDP_URL", ""),
+    )
+    concrete = "ws://127.0.0.1:9222/devtools/browser/abc123"
+
+    class _OkSocket:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    with patch.dict(sys.modules, {"tools.browser_tool": fake}):
+        with patch("socket.create_connection", return_value=_OkSocket()):
+            resp = server.handle_request(
+                {
+                    "id": "1",
+                    "method": "browser.manage",
+                    "params": {"action": "connect", "url": concrete},
+                }
+            )
+
+    assert resp["result"]["connected"] is True
+    assert resp["result"]["url"] == concrete
+    assert os.environ["BROWSER_CDP_URL"] == concrete
+
+
+def test_browser_manage_connect_rejects_invalid_port(monkeypatch):
+    monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "browser.manage",
+            "params": {"action": "connect", "url": "http://localhost:abc"},
+        }
+    )
+
+    assert resp["error"]["code"] == 4015
+    assert "invalid port" in resp["error"]["message"]
+    assert "BROWSER_CDP_URL" not in os.environ
+
+
+def test_browser_manage_connect_rejects_missing_host(monkeypatch):
+    monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "browser.manage",
+            "params": {"action": "connect", "url": "http://:9222"},
+        }
+    )
+
+    assert resp["error"]["code"] == 4015
+    assert "missing host" in resp["error"]["message"]
+    assert "BROWSER_CDP_URL" not in os.environ
+
+
 def test_browser_manage_connect_concrete_ws_skips_http_probe(monkeypatch):
     """Regression for round-2 Copilot review: a hosted CDP endpoint
     (no HTTP discovery) must connect via TCP-only reachability check.

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2904,14 +2904,15 @@ def test_browser_manage_connect_default_local_reports_launch_hint(monkeypatch):
     )
     with patch.dict(sys.modules, {"tools.browser_tool": fake}):
         _stub_urlopen(monkeypatch, ok=False)
-        with patch("hermes_cli.browser_connect.try_launch_chrome_debug", return_value=False):
+        with patch("hermes_cli.browser_connect.try_launch_chrome_debug", return_value=False), \
+             patch("hermes_cli.browser_connect.get_chrome_debug_candidates", return_value=[]):
             resp = server.handle_request(
                 {"id": "1", "method": "browser.manage", "params": {"action": "connect"}}
             )
 
     assert resp["error"]["code"] == 5031
-    assert "Start Chrome with remote debugging" in resp["error"]["message"]
-    assert "google-chrome --remote-debugging-port=9222" in resp["error"]["message"]
+    assert "No Chrome/Chromium executable was found" in resp["error"]["message"]
+    assert "--remote-debugging-port=9222" in resp["error"]["message"]
     assert "BROWSER_CDP_URL" not in os.environ
 
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2995,6 +2995,44 @@ def test_browser_manage_connect_no_session_skips_progress_events(monkeypatch):
     assert [evt for evt, _ in emitted if evt == "browser.progress"] == []
 
 
+def test_browser_manage_connect_handles_null_url(monkeypatch):
+    """Explicit ``{"url": null}`` (or empty string) must fall back to the
+    default loopback URL instead of raising a TypeError that gets swallowed
+    by the outer 5031 catch."""
+    monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
+    fake = types.SimpleNamespace(
+        cleanup_all_browsers=lambda: None,
+        _get_cdp_override=lambda: os.environ.get("BROWSER_CDP_URL", ""),
+    )
+    with patch.dict(sys.modules, {"tools.browser_tool": fake}):
+        _stub_urlopen(monkeypatch, ok=True)
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "browser.manage",
+                "params": {"action": "connect", "url": None},
+            }
+        )
+
+    assert resp["result"]["connected"] is True
+    assert resp["result"]["url"] == "http://127.0.0.1:9222"
+
+
+def test_browser_manage_connect_rejects_non_string_url(monkeypatch):
+    monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "browser.manage",
+            "params": {"action": "connect", "url": 9222},
+        }
+    )
+
+    assert resp["error"]["code"] == 4015
+    assert "must be a string" in resp["error"]["message"]
+    assert "BROWSER_CDP_URL" not in os.environ
+
+
 def test_browser_manage_connect_default_local_retries_after_launch(monkeypatch):
     monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
     monkeypatch.setattr(server.time, "sleep", lambda _seconds: None)

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2779,6 +2779,30 @@ def _stub_urlopen(monkeypatch, *, ok: bool):
     monkeypatch.setattr(urllib.request, "urlopen", _opener)
 
 
+def _stub_urlopen_capture(monkeypatch, *, ok: bool):
+    urls: list[str] = []
+
+    class _Resp:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_):
+            return False
+
+    def _opener(url, timeout=2.0):  # noqa: ARG001 — match urllib signature
+        urls.append(url)
+        if not ok:
+            raise OSError("probe failed")
+        return _Resp()
+
+    import urllib.request
+
+    monkeypatch.setattr(urllib.request, "urlopen", _opener)
+    return urls
+
+
 def test_browser_manage_status_reads_env_var(monkeypatch):
     """Status returns the env var verbatim (no network I/O)."""
     monkeypatch.setenv("BROWSER_CDP_URL", "http://127.0.0.1:9222")
@@ -2854,6 +2878,79 @@ def test_browser_manage_connect_sets_env_and_cleans_twice(monkeypatch):
     assert os.environ.get("BROWSER_CDP_URL") == "http://127.0.0.1:9222"
     # First cleanup runs against the OLD env (none here), second against the NEW.
     assert cleanup_calls == ["", "http://127.0.0.1:9222"]
+
+
+def test_browser_manage_connect_defaults_to_loopback(monkeypatch):
+    monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
+    fake = types.SimpleNamespace(
+        cleanup_all_browsers=lambda: None,
+        _get_cdp_override=lambda: os.environ.get("BROWSER_CDP_URL", ""),
+    )
+    with patch.dict(sys.modules, {"tools.browser_tool": fake}):
+        urls = _stub_urlopen_capture(monkeypatch, ok=True)
+        resp = server.handle_request(
+            {"id": "1", "method": "browser.manage", "params": {"action": "connect"}}
+        )
+
+    assert resp["result"] == {"connected": True, "url": "http://127.0.0.1:9222"}
+    assert urls[0] == "http://127.0.0.1:9222/json/version"
+
+
+def test_browser_manage_connect_default_local_reports_launch_hint(monkeypatch):
+    monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
+    fake = types.SimpleNamespace(
+        cleanup_all_browsers=lambda: None,
+        _get_cdp_override=lambda: os.environ.get("BROWSER_CDP_URL", ""),
+    )
+    with patch.dict(sys.modules, {"tools.browser_tool": fake}):
+        _stub_urlopen(monkeypatch, ok=False)
+        with patch("hermes_cli.browser_connect.try_launch_chrome_debug", return_value=False):
+            resp = server.handle_request(
+                {"id": "1", "method": "browser.manage", "params": {"action": "connect"}}
+            )
+
+    assert resp["error"]["code"] == 5031
+    assert "Start Chrome with remote debugging" in resp["error"]["message"]
+    assert "google-chrome --remote-debugging-port=9222" in resp["error"]["message"]
+    assert "BROWSER_CDP_URL" not in os.environ
+
+
+def test_browser_manage_connect_default_local_retries_after_launch(monkeypatch):
+    monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
+    monkeypatch.setattr(server.time, "sleep", lambda _seconds: None)
+    fake = types.SimpleNamespace(
+        cleanup_all_browsers=lambda: None,
+        _get_cdp_override=lambda: os.environ.get("BROWSER_CDP_URL", ""),
+    )
+
+    class _Resp:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_):
+            return False
+
+    attempts = {"n": 0}
+
+    def _opener(_url, timeout=2.0):  # noqa: ARG001 — match urllib signature
+        attempts["n"] += 1
+        if attempts["n"] < 3:
+            raise OSError("not ready")
+        return _Resp()
+
+    import urllib.request
+
+    monkeypatch.setattr(urllib.request, "urlopen", _opener)
+    with patch.dict(sys.modules, {"tools.browser_tool": fake}):
+        with patch("hermes_cli.browser_connect.try_launch_chrome_debug", return_value=True):
+            resp = server.handle_request(
+                {"id": "1", "method": "browser.manage", "params": {"action": "connect"}}
+            )
+
+    assert resp["result"] == {"connected": True, "url": "http://127.0.0.1:9222"}
+    assert os.environ["BROWSER_CDP_URL"] == "http://127.0.0.1:9222"
 
 
 def test_browser_manage_connect_rejects_unreachable_endpoint(monkeypatch):

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2930,7 +2930,11 @@ def test_browser_manage_connect_default_local_reports_launch_hint(monkeypatch):
                 {
                     "id": "1",
                     "method": "browser.manage",
-                    "params": {"action": "connect", "url": "http://localhost:9222"},
+                    "params": {
+                        "action": "connect",
+                        "session_id": "sess-1",
+                        "url": "http://localhost:9222",
+                    },
                 }
             )
 
@@ -2950,6 +2954,45 @@ def test_browser_manage_connect_default_local_reports_launch_hint(monkeypatch):
     assert "BROWSER_CDP_URL" not in os.environ
     progress = [p["message"] for evt, p in emitted if evt == "browser.progress"]
     assert progress == resp["result"]["messages"]
+
+
+def test_browser_manage_connect_no_session_skips_progress_events(monkeypatch):
+    """Without a session_id the TUI prints messages from the response;
+    emitting ``browser.progress`` events would double-render. Gate the
+    emit so callers without a session see the bundled list only."""
+    monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
+    emitted: list[tuple[str, dict]] = []
+    monkeypatch.setattr(
+        server,
+        "_emit",
+        lambda evt, sid, payload=None: emitted.append((evt, payload or {})),
+    )
+    fake = types.SimpleNamespace(
+        cleanup_all_browsers=lambda: None,
+        _get_cdp_override=lambda: os.environ.get("BROWSER_CDP_URL", ""),
+    )
+    with patch.dict(sys.modules, {"tools.browser_tool": fake}):
+        _stub_urlopen(monkeypatch, ok=False)
+        with (
+            patch(
+                "hermes_cli.browser_connect.try_launch_chrome_debug", return_value=False
+            ),
+            patch(
+                "hermes_cli.browser_connect.get_chrome_debug_candidates",
+                return_value=[],
+            ),
+        ):
+            resp = server.handle_request(
+                {
+                    "id": "1",
+                    "method": "browser.manage",
+                    "params": {"action": "connect", "url": "http://localhost:9222"},
+                }
+            )
+
+    assert resp["result"]["connected"] is False
+    assert resp["result"]["messages"]  # bundled list still populated
+    assert [evt for evt, _ in emitted if evt == "browser.progress"] == []
 
 
 def test_browser_manage_connect_default_local_retries_after_launch(monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4777,6 +4777,15 @@ def _browser_connect_error(url: str, port: int) -> str:
     )
 
 
+def _browser_connect_failure_messages(url: str, port: int) -> list[str]:
+    command = _browser_connect_error(url, port)
+    return [
+        "Chrome isn't running with remote debugging — attempting to launch...",
+        *command.splitlines(),
+        "Browser not connected — start Chrome with remote debugging and retry /browser connect",
+    ]
+
+
 @method("browser.manage")
 def _(rid, params: dict) -> dict:
     action = params.get("action", "status")
@@ -4793,6 +4802,7 @@ def _(rid, params: dict) -> dict:
         from hermes_cli.browser_connect import DEFAULT_BROWSER_CDP_URL
 
         url = params.get("url", DEFAULT_BROWSER_CDP_URL)
+        messages: list[str] = []
         try:
             import urllib.request
             from urllib.parse import urlparse
@@ -4801,6 +4811,9 @@ def _(rid, params: dict) -> dict:
             parsed = urlparse(url if "://" in url else f"http://{url}")
             if parsed.scheme not in {"http", "https", "ws", "wss"}:
                 return _err(rid, 4015, f"unsupported browser url: {url}")
+            if _is_default_local_cdp(parsed):
+                url = DEFAULT_BROWSER_CDP_URL
+                parsed = urlparse(url)
 
             # A concrete ``ws[s]://.../devtools/browser/<id>`` endpoint is
             # already directly connectable — those are the URLs Browserbase
@@ -4846,8 +4859,10 @@ def _(rid, params: dict) -> dict:
                         from hermes_cli.browser_connect import try_launch_chrome_debug
 
                         port = parsed.port or 9222
-                        if try_launch_chrome_debug(port, platform.system()):
-                            for _ in range(10):
+                        messages.append("Chrome isn't running with remote debugging — attempting to launch...")
+                        launched = try_launch_chrome_debug(port, platform.system())
+                        if launched:
+                            for _ in range(20):
                                 time.sleep(0.5)
                                 for probe in probe_urls:
                                     try:
@@ -4859,10 +4874,15 @@ def _(rid, params: dict) -> dict:
                                         continue
                                 if ok:
                                     break
+                            if ok:
+                                messages.append(f"Chrome launched and listening on port {port}")
                         if not ok:
-                            return _err(rid, 5031, _browser_connect_error(url, port))
+                            messages.extend(_browser_connect_failure_messages(url, port)[1:])
+                            return _ok(rid, {"connected": False, "url": url, "messages": messages})
                     else:
                         return _err(rid, 5031, f"could not reach browser CDP at {url}")
+                elif _is_default_local_cdp(parsed):
+                    messages.append(f"Chrome is already listening on port {parsed.port or 9222}")
 
             # Persist a normalized URL for downstream CDP resolution.
             # Discovery-style inputs (`http://host:port` or
@@ -4898,7 +4918,10 @@ def _(rid, params: dict) -> dict:
             cleanup_all_browsers()
         except Exception as e:
             return _err(rid, 5031, str(e))
-        return _ok(rid, {"connected": True, "url": normalized})
+        payload = {"connected": True, "url": normalized}
+        if messages:
+            payload["messages"] = messages
+        return _ok(rid, payload)
     if action == "disconnect":
         try:
             from tools.browser_tool import cleanup_all_browsers

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3210,7 +3210,8 @@ def _(rid, params: dict) -> dict:
         raw = ("" if value is None else str(value)).strip().lower()
         if raw not in _INDICATOR_STYLES:
             return _err(
-                rid, 4002,
+                rid,
+                4002,
                 f"unknown indicator: {raw!r}; pick one of {'|'.join(_INDICATOR_STYLES)}",
             )
         _write_config_key("display.tui_status_indicator", raw)
@@ -4786,6 +4787,10 @@ def _browser_connect_failure_messages(url: str, port: int) -> list[str]:
     ]
 
 
+def _browser_progress(sid: str, message: str, *, level: str = "info") -> None:
+    _emit("browser.progress", sid, {"message": message, "level": level})
+
+
 @method("browser.manage")
 def _(rid, params: dict) -> dict:
     action = params.get("action", "status")
@@ -4802,7 +4807,13 @@ def _(rid, params: dict) -> dict:
         from hermes_cli.browser_connect import DEFAULT_BROWSER_CDP_URL
 
         url = params.get("url", DEFAULT_BROWSER_CDP_URL)
+        sid = params.get("session_id") or ""
         messages: list[str] = []
+
+        def announce(message: str, *, level: str = "info") -> None:
+            messages.append(message)
+            _browser_progress(sid, message, level=level)
+
         try:
             import urllib.request
             from urllib.parse import urlparse
@@ -4822,9 +4833,8 @@ def _(rid, params: dict) -> dict:
             # path.  Probing it would just reject valid endpoints.  Skip
             # the HTTP probe and do a TCP-level reachability check instead;
             # the actual CDP handshake happens on the next ``browser_navigate``.
-            is_concrete_ws = (
-                parsed.scheme in {"ws", "wss"}
-                and parsed.path.startswith("/devtools/browser/")
+            is_concrete_ws = parsed.scheme in {"ws", "wss"} and parsed.path.startswith(
+                "/devtools/browser/"
             )
             if is_concrete_ws:
                 import socket
@@ -4859,15 +4869,23 @@ def _(rid, params: dict) -> dict:
                         from hermes_cli.browser_connect import try_launch_chrome_debug
 
                         port = parsed.port or 9222
-                        messages.append("Chrome isn't running with remote debugging — attempting to launch...")
+                        announce(
+                            "Chrome isn't running with remote debugging — attempting to launch..."
+                        )
                         launched = try_launch_chrome_debug(port, platform.system())
                         if launched:
                             for _ in range(20):
                                 time.sleep(0.5)
                                 for probe in probe_urls:
                                     try:
-                                        with urllib.request.urlopen(probe, timeout=1.0) as resp:
-                                            if 200 <= getattr(resp, "status", 200) < 300:
+                                        with urllib.request.urlopen(
+                                            probe, timeout=1.0
+                                        ) as resp:
+                                            if (
+                                                200
+                                                <= getattr(resp, "status", 200)
+                                                < 300
+                                            ):
                                                 ok = True
                                                 break
                                     except Exception:
@@ -4875,14 +4893,22 @@ def _(rid, params: dict) -> dict:
                                 if ok:
                                     break
                             if ok:
-                                messages.append(f"Chrome launched and listening on port {port}")
+                                announce(
+                                    f"Chrome launched and listening on port {port}"
+                                )
                         if not ok:
-                            messages.extend(_browser_connect_failure_messages(url, port)[1:])
-                            return _ok(rid, {"connected": False, "url": url, "messages": messages})
+                            for line in _browser_connect_failure_messages(url, port)[1:]:
+                                announce(line, level="error")
+                            return _ok(
+                                rid,
+                                {"connected": False, "url": url, "messages": messages},
+                            )
                     else:
                         return _err(rid, 5031, f"could not reach browser CDP at {url}")
                 elif _is_default_local_cdp(parsed):
-                    messages.append(f"Chrome is already listening on port {parsed.port or 9222}")
+                    announce(
+                        f"Chrome is already listening on port {parsed.port or 9222}"
+                    )
 
             # Persist a normalized URL for downstream CDP resolution.
             # Discovery-style inputs (`http://host:port` or

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4762,10 +4762,18 @@ def _is_default_local_cdp(parsed) -> bool:
 def _browser_connect_error(url: str, port: int) -> str:
     from hermes_cli.browser_connect import manual_chrome_debug_command
 
+    command = manual_chrome_debug_command(port)
+    if not command:
+        return (
+            f"Chrome is not reachable at {url}. "
+            "No Chrome/Chromium executable was found in this environment; "
+            f"install one or start Chrome with --remote-debugging-port={port}, then retry /browser connect."
+        )
+
     return (
         f"Chrome is not reachable at {url}. "
         "Start Chrome with remote debugging, then retry /browser connect:\n"
-        f"{manual_chrome_debug_command(port)}"
+        f"{command}"
     )
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -140,6 +140,7 @@ _SLASH_WORKER_TIMEOUT_S = max(
 # response writes are safe.
 _LONG_HANDLERS = frozenset(
     {
+        "browser.manage",
         "cli.exec",
         "session.branch",
         "session.resume",
@@ -4753,10 +4754,23 @@ def _resolve_browser_cdp_url() -> str:
 
 
 def _is_default_local_cdp(parsed) -> bool:
+    """Match the discovery-style local default; never the concrete WS form.
+
+    A user-supplied ``ws://127.0.0.1:9222/devtools/browser/<id>`` is a
+    real, connectable endpoint — collapsing it to bare ``http://...:9222``
+    would strip the path and break the connect.
+    """
+    try:
+        port = parsed.port or 80
+    except ValueError:
+        return False
+
+    discovery_path = parsed.path in {"", "/", "/json", "/json/version"}
     return (
         parsed.scheme in {"http", "ws"}
         and parsed.hostname in {"127.0.0.1", "localhost"}
-        and (parsed.port or 80) == 9222
+        and port == 9222
+        and discovery_path
     )
 
 
@@ -4838,12 +4852,19 @@ def _browser_connect(rid, params: dict) -> dict:
     parsed = urlparse(url if "://" in url else f"http://{url}")
     if parsed.scheme not in {"http", "https", "ws", "wss"}:
         return _err(rid, 4015, f"unsupported browser url: {url}")
+    if not parsed.hostname:
+        return _err(rid, 4015, f"missing host in browser url: {url}")
+    try:
+        port = parsed.port or (443 if parsed.scheme in {"https", "wss"} else 80)
+    except ValueError:
+        return _err(rid, 4015, f"invalid port in browser url: {url}")
 
     # Always normalize default-local to 127.0.0.1:9222 so downstream
     # comparisons + messaging match what we'll actually persist.
     if _is_default_local_cdp(parsed):
         url = DEFAULT_BROWSER_CDP_URL
         parsed = urlparse(url)
+        port = parsed.port or 9222
 
     try:
         # ws[s]://.../devtools/browser/<id> endpoints (hosted CDP
@@ -4852,9 +4873,6 @@ def _browser_connect(rid, params: dict) -> dict:
         if parsed.scheme in {"ws", "wss"} and parsed.path.startswith("/devtools/browser/"):
             import socket
 
-            if not parsed.hostname:
-                return _err(rid, 4015, f"missing host in browser url: {url}")
-            port = parsed.port or (443 if parsed.scheme == "wss" else 80)
             try:
                 with socket.create_connection((parsed.hostname, port), timeout=2.0):
                     pass
@@ -4868,7 +4886,6 @@ def _browser_connect(rid, params: dict) -> dict:
                 import platform
                 from hermes_cli.browser_connect import try_launch_chrome_debug
 
-                port = parsed.port or 9222
                 announce("Chrome isn't running with remote debugging — attempting to launch...")
 
                 if try_launch_chrome_debug(port, platform.system()):
@@ -4887,7 +4904,7 @@ def _browser_connect(rid, params: dict) -> dict:
             elif not ok:
                 return _err(rid, 5031, f"could not reach browser CDP at {url}")
             elif _is_default_local_cdp(parsed):
-                announce(f"Chrome is already listening on port {parsed.port or 9222}")
+                announce(f"Chrome is already listening on port {port}")
 
         normalized = _normalize_cdp_url(parsed)
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4843,7 +4843,11 @@ def _browser_connect(rid, params: dict) -> dict:
     from tools.browser_tool import cleanup_all_browsers
     from urllib.parse import urlparse
 
-    url = params.get("url", DEFAULT_BROWSER_CDP_URL)
+    raw_url = params.get("url")
+    if raw_url is not None and not isinstance(raw_url, str):
+        return _err(rid, 4015, f"browser url must be a string, got {type(raw_url).__name__}")
+    url = (raw_url or "").strip() or DEFAULT_BROWSER_CDP_URL
+
     sid = params.get("session_id") or ""
     system = platform.system()
     messages: list[str] = []
@@ -4877,7 +4881,9 @@ def _browser_connect(rid, params: dict) -> dict:
         # ws[s]://.../devtools/browser/<id> endpoints (hosted CDP
         # providers) don't serve the HTTP discovery path; just check
         # TCP-level reachability and let browser_navigate handshake.
-        if parsed.scheme in {"ws", "wss"} and parsed.path.startswith("/devtools/browser/"):
+        if parsed.scheme in {"ws", "wss"} and parsed.path.startswith(
+            "/devtools/browser/"
+        ):
             import socket
 
             try:
@@ -4892,7 +4898,9 @@ def _browser_connect(rid, params: dict) -> dict:
             if not ok and _is_default_local_cdp(parsed):
                 from hermes_cli.browser_connect import try_launch_chrome_debug
 
-                announce("Chrome isn't running with remote debugging — attempting to launch...")
+                announce(
+                    "Chrome isn't running with remote debugging — attempting to launch..."
+                )
 
                 if try_launch_chrome_debug(port, system):
                     for _ in range(20):
@@ -4906,7 +4914,9 @@ def _browser_connect(rid, params: dict) -> dict:
                 else:
                     for line in _failure_messages(url, port, system)[1:]:
                         announce(line, level="error")
-                    return _ok(rid, {"connected": False, "url": url, "messages": messages})
+                    return _ok(
+                        rid, {"connected": False, "url": url, "messages": messages}
+                    )
             elif not ok:
                 return _err(rid, 5031, f"could not reach browser CDP at {url}")
             elif _is_default_local_cdp(parsed):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4751,6 +4751,24 @@ def _resolve_browser_cdp_url() -> str:
     return ""
 
 
+def _is_default_local_cdp(parsed) -> bool:
+    return (
+        parsed.scheme in {"http", "ws"}
+        and parsed.hostname in {"127.0.0.1", "localhost"}
+        and (parsed.port or 80) == 9222
+    )
+
+
+def _browser_connect_error(url: str, port: int) -> str:
+    from hermes_cli.browser_connect import manual_chrome_debug_command
+
+    return (
+        f"Chrome is not reachable at {url}. "
+        "Start Chrome with remote debugging, then retry /browser connect:\n"
+        f"{manual_chrome_debug_command(port)}"
+    )
+
+
 @method("browser.manage")
 def _(rid, params: dict) -> dict:
     action = params.get("action", "status")
@@ -4764,7 +4782,9 @@ def _(rid, params: dict) -> dict:
             },
         )
     if action == "connect":
-        url = params.get("url", "http://localhost:9222")
+        from hermes_cli.browser_connect import DEFAULT_BROWSER_CDP_URL
+
+        url = params.get("url", DEFAULT_BROWSER_CDP_URL)
         try:
             import urllib.request
             from urllib.parse import urlparse
@@ -4813,7 +4833,28 @@ def _(rid, params: dict) -> dict:
                     except Exception:
                         continue
                 if not ok:
-                    return _err(rid, 5031, f"could not reach browser CDP at {url}")
+                    if _is_default_local_cdp(parsed):
+                        import platform
+                        from hermes_cli.browser_connect import try_launch_chrome_debug
+
+                        port = parsed.port or 9222
+                        if try_launch_chrome_debug(port, platform.system()):
+                            for _ in range(10):
+                                time.sleep(0.5)
+                                for probe in probe_urls:
+                                    try:
+                                        with urllib.request.urlopen(probe, timeout=1.0) as resp:
+                                            if 200 <= getattr(resp, "status", 200) < 300:
+                                                ok = True
+                                                break
+                                    except Exception:
+                                        continue
+                                if ok:
+                                    break
+                        if not ok:
+                            return _err(rid, 5031, _browser_connect_error(url, port))
+                    else:
+                        return _err(rid, 5031, f"could not reach browser CDP at {url}")
 
             # Persist a normalized URL for downstream CDP resolution.
             # Discovery-style inputs (`http://host:port` or

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4800,10 +4800,10 @@ def _normalize_cdp_url(parsed) -> str:
     return parsed._replace(path="", params="", query="", fragment="").geturl()
 
 
-def _failure_messages(url: str, port: int) -> list[str]:
+def _failure_messages(url: str, port: int, system: str) -> list[str]:
     from hermes_cli.browser_connect import manual_chrome_debug_command
 
-    command = manual_chrome_debug_command(port)
+    command = manual_chrome_debug_command(port, system)
     hint = (
         ["Start Chrome with remote debugging, then retry /browser connect:", command]
         if command
@@ -4837,17 +4837,24 @@ def _(rid, params: dict) -> dict:
 
 
 def _browser_connect(rid, params: dict) -> dict:
+    import platform
+
     from hermes_cli.browser_connect import DEFAULT_BROWSER_CDP_URL
     from tools.browser_tool import cleanup_all_browsers
     from urllib.parse import urlparse
 
     url = params.get("url", DEFAULT_BROWSER_CDP_URL)
     sid = params.get("session_id") or ""
+    system = platform.system()
     messages: list[str] = []
 
     def announce(message: str, *, level: str = "info") -> None:
         messages.append(message)
-        _emit("browser.progress", sid, {"message": message, "level": level})
+        # Without a session id the TUI prints `messages` from the
+        # response; emitting an event would double-render. Only stream
+        # progress when there's a real session to scope it to.
+        if sid:
+            _emit("browser.progress", sid, {"message": message, "level": level})
 
     parsed = urlparse(url if "://" in url else f"http://{url}")
     if parsed.scheme not in {"http", "https", "ws", "wss"}:
@@ -4883,12 +4890,11 @@ def _browser_connect(rid, params: dict) -> dict:
             ok = any(_http_ok(p, timeout=2.0) for p in probes)
 
             if not ok and _is_default_local_cdp(parsed):
-                import platform
                 from hermes_cli.browser_connect import try_launch_chrome_debug
 
                 announce("Chrome isn't running with remote debugging — attempting to launch...")
 
-                if try_launch_chrome_debug(port, platform.system()):
+                if try_launch_chrome_debug(port, system):
                     for _ in range(20):
                         time.sleep(0.5)
                         if any(_http_ok(p, timeout=1.0) for p in probes):
@@ -4898,7 +4904,7 @@ def _browser_connect(rid, params: dict) -> dict:
                 if ok:
                     announce(f"Chrome launched and listening on port {port}")
                 else:
-                    for line in _failure_messages(url, port)[1:]:
+                    for line in _failure_messages(url, port, system)[1:]:
                         announce(line, level="error")
                     return _ok(rid, {"connected": False, "url": url, "messages": messages})
             elif not ok:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4760,210 +4760,168 @@ def _is_default_local_cdp(parsed) -> bool:
     )
 
 
-def _browser_connect_error(url: str, port: int) -> str:
+def _http_ok(url: str, timeout: float) -> bool:
+    import urllib.request
+
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as resp:
+            return 200 <= getattr(resp, "status", 200) < 300
+    except Exception:
+        return False
+
+
+def _probe_urls(parsed) -> list[str]:
+    scheme = {"ws": "http", "wss": "https"}.get(parsed.scheme, parsed.scheme)
+    root = f"{scheme}://{parsed.netloc}".rstrip("/")
+    return [f"{root}/json/version", f"{root}/json"]
+
+
+def _normalize_cdp_url(parsed) -> str:
+    # Concrete ``/devtools/browser/<id>`` endpoints (Browserbase et al.)
+    # are connectable as-is. Discovery-style inputs collapse to bare
+    # ``scheme://host:port`` so ``_resolve_cdp_override`` can append
+    # ``/json/version`` later without doubling the path.
+    if parsed.path.startswith("/devtools/browser/"):
+        return parsed.geturl()
+    return parsed._replace(path="", params="", query="", fragment="").geturl()
+
+
+def _failure_messages(url: str, port: int) -> list[str]:
     from hermes_cli.browser_connect import manual_chrome_debug_command
 
     command = manual_chrome_debug_command(port)
-    if not command:
-        return (
-            f"Chrome is not reachable at {url}. "
-            "No Chrome/Chromium executable was found in this environment; "
-            f"install one or start Chrome with --remote-debugging-port={port}, then retry /browser connect."
-        )
-
-    return (
-        f"Chrome is not reachable at {url}. "
-        "Start Chrome with remote debugging, then retry /browser connect:\n"
-        f"{command}"
+    hint = (
+        ["Start Chrome with remote debugging, then retry /browser connect:", command]
+        if command
+        else [
+            "No Chrome/Chromium executable was found in this environment.",
+            f"Install one or start Chrome with --remote-debugging-port={port}, then retry /browser connect.",
+        ]
     )
-
-
-def _browser_connect_failure_messages(url: str, port: int) -> list[str]:
-    command = _browser_connect_error(url, port)
     return [
-        "Chrome isn't running with remote debugging — attempting to launch...",
-        *command.splitlines(),
+        f"Chrome is not reachable at {url}.",
+        *hint,
         "Browser not connected — start Chrome with remote debugging and retry /browser connect",
     ]
-
-
-def _browser_progress(sid: str, message: str, *, level: str = "info") -> None:
-    _emit("browser.progress", sid, {"message": message, "level": level})
 
 
 @method("browser.manage")
 def _(rid, params: dict) -> dict:
     action = params.get("action", "status")
+
     if action == "status":
-        resolved_url = _resolve_browser_cdp_url()
-        return _ok(
-            rid,
-            {
-                "connected": bool(resolved_url),
-                "url": resolved_url,
-            },
-        )
-    if action == "connect":
-        from hermes_cli.browser_connect import DEFAULT_BROWSER_CDP_URL
+        url = _resolve_browser_cdp_url()
+        return _ok(rid, {"connected": bool(url), "url": url})
 
-        url = params.get("url", DEFAULT_BROWSER_CDP_URL)
-        sid = params.get("session_id") or ""
-        messages: list[str] = []
-
-        def announce(message: str, *, level: str = "info") -> None:
-            messages.append(message)
-            _browser_progress(sid, message, level=level)
-
-        try:
-            import urllib.request
-            from urllib.parse import urlparse
-            from tools.browser_tool import cleanup_all_browsers
-
-            parsed = urlparse(url if "://" in url else f"http://{url}")
-            if parsed.scheme not in {"http", "https", "ws", "wss"}:
-                return _err(rid, 4015, f"unsupported browser url: {url}")
-            if _is_default_local_cdp(parsed):
-                url = DEFAULT_BROWSER_CDP_URL
-                parsed = urlparse(url)
-
-            # A concrete ``ws[s]://.../devtools/browser/<id>`` endpoint is
-            # already directly connectable — those are the URLs Browserbase
-            # / browserless / hosted CDP providers return, and they
-            # generally DON'T serve the discovery-style ``/json/version``
-            # path.  Probing it would just reject valid endpoints.  Skip
-            # the HTTP probe and do a TCP-level reachability check instead;
-            # the actual CDP handshake happens on the next ``browser_navigate``.
-            is_concrete_ws = parsed.scheme in {"ws", "wss"} and parsed.path.startswith(
-                "/devtools/browser/"
-            )
-            if is_concrete_ws:
-                import socket
-
-                host = parsed.hostname
-                port = parsed.port or (443 if parsed.scheme == "wss" else 80)
-                if not host:
-                    return _err(rid, 4015, f"missing host in browser url: {url}")
-                try:
-                    with socket.create_connection((host, port), timeout=2.0):
-                        pass
-                except OSError as e:
-                    return _err(rid, 5031, f"could not reach browser CDP at {url}: {e}")
-            else:
-                probe_root = f"{'https' if parsed.scheme == 'wss' else 'http' if parsed.scheme == 'ws' else parsed.scheme}://{parsed.netloc}"
-                probe_urls = [
-                    f"{probe_root.rstrip('/')}/json/version",
-                    f"{probe_root.rstrip('/')}/json",
-                ]
-                ok = False
-                for probe in probe_urls:
-                    try:
-                        with urllib.request.urlopen(probe, timeout=2.0) as resp:
-                            if 200 <= getattr(resp, "status", 200) < 300:
-                                ok = True
-                                break
-                    except Exception:
-                        continue
-                if not ok:
-                    if _is_default_local_cdp(parsed):
-                        import platform
-                        from hermes_cli.browser_connect import try_launch_chrome_debug
-
-                        port = parsed.port or 9222
-                        announce(
-                            "Chrome isn't running with remote debugging — attempting to launch..."
-                        )
-                        launched = try_launch_chrome_debug(port, platform.system())
-                        if launched:
-                            for _ in range(20):
-                                time.sleep(0.5)
-                                for probe in probe_urls:
-                                    try:
-                                        with urllib.request.urlopen(
-                                            probe, timeout=1.0
-                                        ) as resp:
-                                            if (
-                                                200
-                                                <= getattr(resp, "status", 200)
-                                                < 300
-                                            ):
-                                                ok = True
-                                                break
-                                    except Exception:
-                                        continue
-                                if ok:
-                                    break
-                            if ok:
-                                announce(
-                                    f"Chrome launched and listening on port {port}"
-                                )
-                        if not ok:
-                            for line in _browser_connect_failure_messages(url, port)[1:]:
-                                announce(line, level="error")
-                            return _ok(
-                                rid,
-                                {"connected": False, "url": url, "messages": messages},
-                            )
-                    else:
-                        return _err(rid, 5031, f"could not reach browser CDP at {url}")
-                elif _is_default_local_cdp(parsed):
-                    announce(
-                        f"Chrome is already listening on port {parsed.port or 9222}"
-                    )
-
-            # Persist a normalized URL for downstream CDP resolution.
-            # Discovery-style inputs (`http://host:port` or
-            # `http://host:port/json[/version]`) collapse to bare
-            # ``scheme://host:port`` so ``_resolve_cdp_override`` can
-            # safely append ``/json/version`` without producing a
-            # double-discovery path like ``.../json/json/version``.
-            # Concrete websocket endpoints (``/devtools/browser/<id>``
-            # — what Browserbase and other cloud providers return)
-            # are preserved verbatim.
-            if parsed.path.startswith("/devtools/browser/"):
-                normalized = parsed.geturl()
-            else:
-                normalized = parsed._replace(
-                    path="",
-                    params="",
-                    query="",
-                    fragment="",
-                ).geturl()
-
-            # Order matters: clear any cached browser sessions BEFORE
-            # publishing the new env var so an in-flight tool call
-            # observing the old supervisor is reaped first, and the
-            # next call freshly resolves the new URL.  The previous
-            # ordering left a brief window where ``_ensure_cdp_supervisor``
-            # could re-attach to the *old* supervisor.
-            cleanup_all_browsers()
-            os.environ["BROWSER_CDP_URL"] = normalized
-            # Drain any further cached state that could outlive the
-            # cleanup pass (CDP supervisor for the default task,
-            # cached agent-browser timeouts, etc.) so the next
-            # ``browser_navigate`` definitively reaches ``normalized``.
-            cleanup_all_browsers()
-        except Exception as e:
-            return _err(rid, 5031, str(e))
-        payload = {"connected": True, "url": normalized}
-        if messages:
-            payload["messages"] = messages
-        return _ok(rid, payload)
     if action == "disconnect":
+        return _browser_disconnect(rid)
+
+    if action != "connect":
+        return _err(rid, 4015, f"unknown action: {action}")
+
+    return _browser_connect(rid, params)
+
+
+def _browser_connect(rid, params: dict) -> dict:
+    from hermes_cli.browser_connect import DEFAULT_BROWSER_CDP_URL
+    from tools.browser_tool import cleanup_all_browsers
+    from urllib.parse import urlparse
+
+    url = params.get("url", DEFAULT_BROWSER_CDP_URL)
+    sid = params.get("session_id") or ""
+    messages: list[str] = []
+
+    def announce(message: str, *, level: str = "info") -> None:
+        messages.append(message)
+        _emit("browser.progress", sid, {"message": message, "level": level})
+
+    parsed = urlparse(url if "://" in url else f"http://{url}")
+    if parsed.scheme not in {"http", "https", "ws", "wss"}:
+        return _err(rid, 4015, f"unsupported browser url: {url}")
+
+    # Always normalize default-local to 127.0.0.1:9222 so downstream
+    # comparisons + messaging match what we'll actually persist.
+    if _is_default_local_cdp(parsed):
+        url = DEFAULT_BROWSER_CDP_URL
+        parsed = urlparse(url)
+
+    try:
+        # ws[s]://.../devtools/browser/<id> endpoints (hosted CDP
+        # providers) don't serve the HTTP discovery path; just check
+        # TCP-level reachability and let browser_navigate handshake.
+        if parsed.scheme in {"ws", "wss"} and parsed.path.startswith("/devtools/browser/"):
+            import socket
+
+            if not parsed.hostname:
+                return _err(rid, 4015, f"missing host in browser url: {url}")
+            port = parsed.port or (443 if parsed.scheme == "wss" else 80)
+            try:
+                with socket.create_connection((parsed.hostname, port), timeout=2.0):
+                    pass
+            except OSError as e:
+                return _err(rid, 5031, f"could not reach browser CDP at {url}: {e}")
+        else:
+            probes = _probe_urls(parsed)
+            ok = any(_http_ok(p, timeout=2.0) for p in probes)
+
+            if not ok and _is_default_local_cdp(parsed):
+                import platform
+                from hermes_cli.browser_connect import try_launch_chrome_debug
+
+                port = parsed.port or 9222
+                announce("Chrome isn't running with remote debugging — attempting to launch...")
+
+                if try_launch_chrome_debug(port, platform.system()):
+                    for _ in range(20):
+                        time.sleep(0.5)
+                        if any(_http_ok(p, timeout=1.0) for p in probes):
+                            ok = True
+                            break
+
+                if ok:
+                    announce(f"Chrome launched and listening on port {port}")
+                else:
+                    for line in _failure_messages(url, port)[1:]:
+                        announce(line, level="error")
+                    return _ok(rid, {"connected": False, "url": url, "messages": messages})
+            elif not ok:
+                return _err(rid, 5031, f"could not reach browser CDP at {url}")
+            elif _is_default_local_cdp(parsed):
+                announce(f"Chrome is already listening on port {parsed.port or 9222}")
+
+        normalized = _normalize_cdp_url(parsed)
+
+        # Order matters: reap sessions BEFORE publishing the new env
+        # so an in-flight tool call sees the old supervisor closed,
+        # then again AFTER so the default task's cached supervisor
+        # is drained against the new URL.
+        cleanup_all_browsers()
+        os.environ["BROWSER_CDP_URL"] = normalized
+        cleanup_all_browsers()
+    except Exception as e:
+        return _err(rid, 5031, str(e))
+
+    payload: dict[str, object] = {"connected": True, "url": normalized}
+    if messages:
+        payload["messages"] = messages
+    return _ok(rid, payload)
+
+
+def _browser_disconnect(rid) -> dict:
+    # Reap, drop the env override, reap again — closes the same swap
+    # window covered by ``_browser_connect``.
+    def reap() -> None:
         try:
             from tools.browser_tool import cleanup_all_browsers
 
             cleanup_all_browsers()
         except Exception:
             pass
-        os.environ.pop("BROWSER_CDP_URL", None)
-        try:
-            from tools.browser_tool import cleanup_all_browsers as _again
 
-            _again()
-        except Exception:
-            pass
-        return _ok(rid, {"connected": False})
-    return _err(rid, 4015, f"unknown action: {action}")
+    reap()
+    os.environ.pop("BROWSER_CDP_URL", None)
+    reap()
+    return _ok(rid, {"connected": False})
 
 
 @method("plugins.list")

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -293,6 +293,19 @@ describe('createGatewayEventHandler', () => {
     expect(appended[1]).toMatchObject({ role: 'assistant', text: 'final answer' })
   })
 
+  it('renders browser.progress events as system transcript lines as they stream in', () => {
+    const appended: Msg[] = []
+    const ctx = buildCtx(appended)
+    const handler = createGatewayEventHandler(ctx)
+
+    handler({
+      payload: { message: 'Chrome launched and listening on port 9222' },
+      type: 'browser.progress'
+    } as any)
+
+    expect(ctx.system.sys).toHaveBeenCalledWith('Chrome launched and listening on port 9222')
+  })
+
   it('annotates gateway.start_timeout with stderr tail lines so users can diagnose without /logs', () => {
     const appended: Msg[] = []
     const onEvent = createGatewayEventHandler(buildCtx(appended))

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -727,9 +727,7 @@ describe('createGatewayEventHandler', () => {
       } as any)
 
       // Pre-interrupt todos should land in turn state.
-      expect(getTurnState().todos).toEqual([
-        { content: 'pre-interrupt', id: 'todo-1', status: 'pending' }
-      ])
+      expect(getTurnState().todos).toEqual([{ content: 'pre-interrupt', id: 'todo-1', status: 'pending' }])
 
       turnController.interruptTurn({
         appendMessage: (msg: Msg) => appended.push(msg),

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -191,8 +191,12 @@ describe('createSlashHandler', () => {
   })
 
   it.each([
-    ['/browser status', 'browser.manage', { action: 'status' }],
-    ['/browser connect', 'browser.manage', { action: 'connect', url: 'http://127.0.0.1:9222' }],
+    ['/browser status', 'browser.manage', { action: 'status', session_id: null }],
+    [
+      '/browser connect',
+      'browser.manage',
+      { action: 'connect', session_id: null, url: 'http://127.0.0.1:9222' }
+    ],
     ['/reload-mcp', 'reload.mcp', { session_id: null }],
     ['/stop', 'process.stop', {}],
     ['/fast status', 'config.get', { key: 'fast', session_id: null }],

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -207,6 +207,33 @@ describe('createSlashHandler', () => {
     expect(ctx.gateway.gw.request).not.toHaveBeenCalled()
   })
 
+  it('renders browser connect progress messages from the gateway', async () => {
+    const rpc = vi.fn(() =>
+      Promise.resolve({
+        connected: false,
+        messages: [
+          "Chrome isn't running with remote debugging — attempting to launch...",
+          'Browser not connected — start Chrome with remote debugging and retry /browser connect'
+        ],
+        url: 'http://127.0.0.1:9222'
+      })
+    )
+    const ctx = buildCtx({ gateway: { ...buildGateway(), rpc } })
+
+    expect(createSlashHandler(ctx)('/browser connect')).toBe(true)
+    expect(ctx.transcript.sys).toHaveBeenCalledWith('checking Chrome remote debugging at http://127.0.0.1:9222...')
+
+    await vi.waitFor(() => {
+      expect(ctx.transcript.sys).toHaveBeenCalledWith(
+        "Chrome isn't running with remote debugging — attempting to launch..."
+      )
+      expect(ctx.transcript.sys).toHaveBeenCalledWith(
+        'Browser not connected — start Chrome with remote debugging and retry /browser connect'
+      )
+      expect(ctx.transcript.sys).not.toHaveBeenCalledWith('browser connect failed')
+    })
+  })
+
   it('routes /rollback through native RPC when a session is active', () => {
     patchUiState({ sid: 'sid-abc' })
     const rpc = vi.fn(() => Promise.resolve({}))

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -218,6 +218,7 @@ describe('createSlashHandler', () => {
         url: 'http://127.0.0.1:9222'
       })
     )
+
     const ctx = buildCtx({ gateway: { ...buildGateway(), rpc } })
 
     expect(createSlashHandler(ctx)('/browser connect')).toBe(true)

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -192,6 +192,7 @@ describe('createSlashHandler', () => {
 
   it.each([
     ['/browser status', 'browser.manage', { action: 'status' }],
+    ['/browser connect', 'browser.manage', { action: 'connect', url: 'http://127.0.0.1:9222' }],
     ['/reload-mcp', 'reload.mcp', { session_id: null }],
     ['/stop', 'process.stop', {}],
     ['/fast status', 'config.get', { key: 'fast', session_id: null }],

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -192,11 +192,7 @@ describe('createSlashHandler', () => {
 
   it.each([
     ['/browser status', 'browser.manage', { action: 'status', session_id: null }],
-    [
-      '/browser connect',
-      'browser.manage',
-      { action: 'connect', session_id: null, url: 'http://127.0.0.1:9222' }
-    ],
+    ['/browser connect', 'browser.manage', { action: 'connect', session_id: null, url: 'http://127.0.0.1:9222' }],
     ['/reload-mcp', 'reload.mcp', { session_id: null }],
     ['/stop', 'process.stop', {}],
     ['/fast status', 'config.get', { key: 'fast', session_id: null }],

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -307,6 +307,16 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         return
       }
 
+      case 'browser.progress': {
+        const message = String(ev.payload?.message ?? '').trim()
+
+        if (message) {
+          sys(message)
+        }
+
+        return
+      }
+
       case 'voice.status': {
         // Continuous VAD loop reports its internal state so the status bar
         // can show listening / transcribing / idle without polling.

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -383,6 +383,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         // 120-char clip used for `gateway.stderr` activity entries.
         const STDERR_LINE_CAP = 120
         const STDERR_LINES_MAX = 8
+
         const tailLines = (stderrTail ?? '')
           .split('\n')
           .map(l => l.trim())

--- a/ui-tui/src/app/slash/commands/ops.ts
+++ b/ui-tui/src/app/slash/commands/ops.ts
@@ -108,12 +108,15 @@ export const opsCommands: SlashCommand[] = [
 
       if (action === 'connect') {
         payload.url = requested || 'http://127.0.0.1:9222'
+        ctx.transcript.sys(`checking Chrome remote debugging at ${payload.url}...`)
       }
 
       ctx.gateway
         .rpc<BrowserManageResponse>('browser.manage', payload)
         .then(
           ctx.guarded<BrowserManageResponse>(r => {
+            r.messages?.forEach(message => ctx.transcript.sys(message))
+
             if (action === 'status') {
               return ctx.transcript.sys(
                 r.connected
@@ -124,13 +127,14 @@ export const opsCommands: SlashCommand[] = [
 
             if (action === 'connect') {
               if (r.connected) {
-                ctx.transcript.sys(`browser connected: ${r.url || '(url unavailable)'}`)
+                ctx.transcript.sys(`Browser connected to live Chrome via CDP`)
+                ctx.transcript.sys(`Endpoint: ${r.url || '(url unavailable)'}`)
                 ctx.transcript.sys('next browser tool call will use this CDP endpoint')
 
                 return
               }
 
-              return ctx.transcript.sys('browser connect failed')
+              return
             }
 
             ctx.transcript.sys('browser disconnected')

--- a/ui-tui/src/app/slash/commands/ops.ts
+++ b/ui-tui/src/app/slash/commands/ops.ts
@@ -103,7 +103,8 @@ export const opsCommands: SlashCommand[] = [
         )
       }
 
-      const payload: Record<string, unknown> = { action }
+      const sid = ctx.sid ?? null
+      const payload: Record<string, unknown> = { action, session_id: sid }
       const requested = rest.join(' ').trim()
 
       if (action === 'connect') {
@@ -115,7 +116,9 @@ export const opsCommands: SlashCommand[] = [
         .rpc<BrowserManageResponse>('browser.manage', payload)
         .then(
           ctx.guarded<BrowserManageResponse>(r => {
-            r.messages?.forEach(message => ctx.transcript.sys(message))
+            if (!sid) {
+              r.messages?.forEach(message => ctx.transcript.sys(message))
+            }
 
             if (action === 'status') {
               return ctx.transcript.sys(

--- a/ui-tui/src/app/slash/commands/ops.ts
+++ b/ui-tui/src/app/slash/commands/ops.ts
@@ -115,7 +115,9 @@ export const opsCommands: SlashCommand[] = [
           ctx.guarded<BrowserManageResponse>(r => {
             // Without a session we can't subscribe to streamed
             // browser.progress events, so flush the bundled list.
-            if (!sid) r.messages?.forEach(message => ctx.transcript.sys(message))
+            if (!sid) {
+              r.messages?.forEach(message => ctx.transcript.sys(message))
+            }
 
             if (action === 'status') {
               return ctx.transcript.sys(

--- a/ui-tui/src/app/slash/commands/ops.ts
+++ b/ui-tui/src/app/slash/commands/ops.ts
@@ -93,9 +93,8 @@ export const opsCommands: SlashCommand[] = [
     help: 'manage browser CDP connection [connect|disconnect|status]',
     name: 'browser',
     run: (arg, ctx) => {
-      const trimmed = arg.trim()
-      const [rawAction, ...rest] = trimmed ? trimmed.split(/\s+/) : ['status']
-      const action = (rawAction || 'status').toLowerCase()
+      const [rawAction = 'status', ...rest] = arg.trim().split(/\s+/).filter(Boolean)
+      const action = rawAction.toLowerCase()
 
       if (!['connect', 'disconnect', 'status'].includes(action)) {
         return ctx.transcript.sys(
@@ -104,21 +103,19 @@ export const opsCommands: SlashCommand[] = [
       }
 
       const sid = ctx.sid ?? null
-      const payload: Record<string, unknown> = { action, session_id: sid }
-      const requested = rest.join(' ').trim()
+      const url = action === 'connect' ? rest.join(' ').trim() || 'http://127.0.0.1:9222' : undefined
 
-      if (action === 'connect') {
-        payload.url = requested || 'http://127.0.0.1:9222'
-        ctx.transcript.sys(`checking Chrome remote debugging at ${payload.url}...`)
+      if (url) {
+        ctx.transcript.sys(`checking Chrome remote debugging at ${url}...`)
       }
 
       ctx.gateway
-        .rpc<BrowserManageResponse>('browser.manage', payload)
+        .rpc<BrowserManageResponse>('browser.manage', { action, session_id: sid, ...(url && { url }) })
         .then(
           ctx.guarded<BrowserManageResponse>(r => {
-            if (!sid) {
-              r.messages?.forEach(message => ctx.transcript.sys(message))
-            }
+            // Without a session we can't subscribe to streamed
+            // browser.progress events, so flush the bundled list.
+            if (!sid) r.messages?.forEach(message => ctx.transcript.sys(message))
 
             if (action === 'status') {
               return ctx.transcript.sys(
@@ -128,19 +125,15 @@ export const opsCommands: SlashCommand[] = [
               )
             }
 
-            if (action === 'connect') {
-              if (r.connected) {
-                ctx.transcript.sys(`Browser connected to live Chrome via CDP`)
-                ctx.transcript.sys(`Endpoint: ${r.url || '(url unavailable)'}`)
-                ctx.transcript.sys('next browser tool call will use this CDP endpoint')
-
-                return
-              }
-
-              return
+            if (action === 'disconnect') {
+              return ctx.transcript.sys('browser disconnected')
             }
 
-            ctx.transcript.sys('browser disconnected')
+            if (r.connected) {
+              ctx.transcript.sys('Browser connected to live Chrome via CDP')
+              ctx.transcript.sys(`Endpoint: ${r.url || '(url unavailable)'}`)
+              ctx.transcript.sys('next browser tool call will use this CDP endpoint')
+            }
           })
         )
         .catch(ctx.guardedErr)

--- a/ui-tui/src/app/slash/commands/ops.ts
+++ b/ui-tui/src/app/slash/commands/ops.ts
@@ -107,7 +107,7 @@ export const opsCommands: SlashCommand[] = [
       const requested = rest.join(' ').trim()
 
       if (action === 'connect') {
-        payload.url = requested || 'http://localhost:9222'
+        payload.url = requested || 'http://127.0.0.1:9222'
       }
 
       ctx.gateway

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -434,6 +434,11 @@ export type GatewayEvent =
   | { payload?: { no_speech_limit?: boolean; text?: string }; session_id?: string; type: 'voice.transcript' }
   | { payload: { line: string }; session_id?: string; type: 'gateway.stderr' }
   | {
+      payload?: { level?: 'info' | 'warn' | 'error'; message?: string }
+      session_id?: string
+      type: 'browser.progress'
+    }
+  | {
       payload?: { cwd?: string; python?: string; stderr_tail?: string }
       session_id?: string
       type: 'gateway.start_timeout'

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -314,6 +314,7 @@ export interface ProcessStopResponse {
 
 export interface BrowserManageResponse {
   connected?: boolean
+  messages?: string[]
   url?: string
 }
 


### PR DESCRIPTION
## Summary
- Share Chrome CDP launch/manual-command helpers between the classic CLI and TUI.
- Make default TUI `/browser connect` use `http://127.0.0.1:9222`, retry local Chrome launch, and return a manual launch command when Chrome is unavailable.
- Stop the classic CLI from claiming a live browser connection when the debug port never becomes reachable.

## Test plan
- `scripts/run_tests.sh tests/test_tui_gateway_server.py tests/cli/test_cli_browser_connect.py`
- `cd ui-tui && npm test -- --run src/__tests__/createSlashHandler.test.ts`
- `cd ui-tui && npm run type-check`
- `git diff --check`