### PR TITLE
Fix explicit provider model aliases

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2021,13 +2021,45 @@ class HermesCLI:
             or os.getenv("HERMES_INFERENCE_PROVIDER")
             or "auto"
         )
+        if model:
+            try:
+                from hermes_cli.model_switch import resolve_alias
+
+                alias_result = resolve_alias(str(model), self.requested_provider or "auto")
+                if alias_result is not None:
+                    alias_provider, alias_model, alias_name = alias_result
+                    self.model = alias_model
+
+                    # If the user did not pin --provider, let direct aliases
+                    # carry their configured route. With --provider, keep the
+                    # explicit route and only use the alias as a model shorthand.
+                    if alias_provider and not provider:
+                        self.requested_provider = alias_provider
+
+                    alias_provider_matches = (
+                        alias_provider
+                        and alias_provider.strip().lower()
+                        == (self.requested_provider or "").strip().lower()
+                    )
+                    if not base_url and alias_provider_matches:
+                        try:
+                            from hermes_cli.model_switch import DIRECT_ALIASES, _ensure_direct_aliases
+
+                            _ensure_direct_aliases()
+                            direct_alias = DIRECT_ALIASES.get(alias_name)
+                            if direct_alias is not None and direct_alias.base_url:
+                                self._explicit_base_url = direct_alias.base_url
+                        except Exception:
+                            logger.debug("Failed to apply base_url from model alias", exc_info=True)
+            except Exception:
+                logger.debug("Failed to resolve CLI model alias", exc_info=True)
         self._provider_source: Optional[str] = None
         self.provider = self.requested_provider
         self.api_mode = "chat_completions"
         self.acp_command: Optional[str] = None
         self.acp_args: list[str] = []
         self.base_url = (
-            base_url
+            self._explicit_base_url
             or CLI_CONFIG["model"].get("base_url", "")
             or os.getenv("OPENROUTER_BASE_URL", "")
         ) or None

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -129,11 +129,11 @@ def _run_agent(
     # the caller just asked for.
     effective_provider = (provider or "").strip() or None
     explicit_base_url_from_alias: Optional[str] = None
-    if effective_provider is None and (model or env_model):
+    explicit_model = (model or "").strip() or env_model
+    if explicit_model:
         # Only auto-detect when the model was explicitly requested via arg or
         # env var (not when it came from config — that's the "use my defaults"
         # path and the configured provider is already correct).
-        explicit_model = (model or "").strip() or env_model
         if explicit_model:
             # First check DIRECT_ALIASES populated from config.yaml `model_aliases:`.
             # These map a user-defined alias to (model, provider, base_url) for
@@ -146,10 +146,16 @@ def _run_agent(
                 direct = None
             if direct is not None:
                 effective_model = direct.model
-                effective_provider = direct.provider
-                if direct.base_url:
+                if effective_provider is None:
+                    effective_provider = direct.provider
+                provider_matches_alias = (
+                    direct.provider
+                    and direct.provider.strip().lower()
+                    == (effective_provider or "").strip().lower()
+                )
+                if direct.base_url and provider_matches_alias:
                     explicit_base_url_from_alias = direct.base_url.rstrip("/")
-            else:
+            elif effective_provider is None:
                 cfg_provider = ""
                 if isinstance(model_cfg, dict):
                     cfg_provider = str(model_cfg.get("provider") or "").strip().lower()

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -134,39 +134,38 @@ def _run_agent(
         # Only auto-detect when the model was explicitly requested via arg or
         # env var (not when it came from config — that's the "use my defaults"
         # path and the configured provider is already correct).
-        if explicit_model:
-            # First check DIRECT_ALIASES populated from config.yaml `model_aliases:`.
-            # These map a user-defined alias to (model, provider, base_url) for
-            # endpoints not in any catalog (local servers, custom proxies, etc.).
-            try:
-                from hermes_cli import model_switch as _ms
-                _ms._ensure_direct_aliases()
-                direct = _ms.DIRECT_ALIASES.get(explicit_model.strip().lower())
-            except Exception:
-                direct = None
-            if direct is not None:
-                effective_model = direct.model
-                if effective_provider is None:
-                    effective_provider = direct.provider
-                provider_matches_alias = (
-                    direct.provider
-                    and direct.provider.strip().lower()
-                    == (effective_provider or "").strip().lower()
-                )
-                if direct.base_url and provider_matches_alias:
-                    explicit_base_url_from_alias = direct.base_url.rstrip("/")
-            elif effective_provider is None:
-                cfg_provider = ""
-                if isinstance(model_cfg, dict):
-                    cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
-                current_provider = (
-                    cfg_provider
-                    or os.getenv("HERMES_INFERENCE_PROVIDER", "").strip().lower()
-                    or "auto"
-                )
-                detected = detect_provider_for_model(explicit_model, current_provider)
-                if detected:
-                    effective_provider, effective_model = detected
+        # First check DIRECT_ALIASES populated from config.yaml `model_aliases:`.
+        # These map a user-defined alias to (model, provider, base_url) for
+        # endpoints not in any catalog (local servers, custom proxies, etc.).
+        try:
+            from hermes_cli import model_switch as _ms
+            _ms._ensure_direct_aliases()
+            direct = _ms.DIRECT_ALIASES.get(explicit_model.strip().lower())
+        except Exception:
+            direct = None
+        if direct is not None:
+            effective_model = direct.model
+            if effective_provider is None:
+                effective_provider = direct.provider
+            provider_matches_alias = (
+                direct.provider
+                and direct.provider.strip().lower()
+                == (effective_provider or "").strip().lower()
+            )
+            if direct.base_url and provider_matches_alias:
+                explicit_base_url_from_alias = direct.base_url.rstrip("/")
+        elif effective_provider is None:
+            cfg_provider = ""
+            if isinstance(model_cfg, dict):
+                cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
+            current_provider = (
+                cfg_provider
+                or os.getenv("HERMES_INFERENCE_PROVIDER", "").strip().lower()
+                or "auto"
+            )
+            detected = detect_provider_for_model(explicit_model, current_provider)
+            if detected:
+                effective_provider, effective_model = detected
 
     runtime = resolve_runtime_provider(
         requested=effective_provider,

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -230,6 +230,34 @@ def test_cli_prefers_config_provider_over_stale_env_override(monkeypatch):
     assert shell.requested_provider == "custom"
 
 
+def test_cli_model_alias_with_explicit_provider(monkeypatch):
+    cli = _import_cli()
+    from hermes_cli.model_switch import DirectAlias
+    import hermes_cli.model_switch as ms
+
+    monkeypatch.setattr(
+        ms,
+        "DIRECT_ALIASES",
+        {
+            "kimi26-cloud": DirectAlias(
+                "kimi-k2.6:cloud",
+                "ollama-cloud",
+                "https://ollama.com/v1",
+            )
+        },
+    )
+    shell = cli.HermesCLI(
+        model="kimi26-cloud",
+        provider="ollama-cloud",
+        compact=True,
+        max_turns=1,
+    )
+
+    assert shell.model == "kimi-k2.6:cloud"
+    assert shell.requested_provider == "ollama-cloud"
+    assert shell._explicit_base_url == "https://ollama.com/v1"
+
+
 def test_codex_provider_replaces_incompatible_default_model(monkeypatch):
     """When provider resolves to openai-codex and no model was explicitly
     chosen, the global config default (e.g. anthropic/claude-opus-4.6) must

--- a/tests/hermes_cli/test_oneshot_aliases.py
+++ b/tests/hermes_cli/test_oneshot_aliases.py
@@ -1,0 +1,98 @@
+import sys
+from types import SimpleNamespace
+
+from hermes_cli.model_switch import DirectAlias
+
+
+class _DummyAgent:
+    last_kwargs = None
+
+    def __init__(self, **kwargs):
+        type(self).last_kwargs = kwargs
+
+    def chat(self, prompt):
+        return f"ok:{prompt}"
+
+
+def test_oneshot_direct_alias_with_explicit_provider(monkeypatch):
+    """`hermes --provider X -m alias -z` should send the resolved model id."""
+    import hermes_cli.model_switch as ms
+    from hermes_cli import oneshot
+
+    captured_runtime = {}
+    monkeypatch.setattr(
+        ms,
+        "DIRECT_ALIASES",
+        {
+            "kimi26-cloud": DirectAlias(
+                "kimi-k2.6:cloud",
+                "ollama-cloud",
+                "https://ollama.com/v1",
+            )
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"model": {"provider": "ollama-cloud", "default": "kimi-k2.6:cloud"}},
+    )
+    monkeypatch.setattr("hermes_cli.tools_config._get_platform_tools", lambda cfg, platform: set())
+
+    def _runtime(**kwargs):
+        captured_runtime.update(kwargs)
+        return {
+            "api_key": "test-key",
+            "base_url": "https://ollama.com/v1",
+            "provider": "ollama-cloud",
+            "api_mode": "chat_completions",
+        }
+
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", _runtime)
+    monkeypatch.setitem(sys.modules, "run_agent", SimpleNamespace(AIAgent=_DummyAgent))
+
+    assert oneshot._run_agent("ping", model="kimi26-cloud", provider="ollama-cloud") == "ok:ping"
+    assert captured_runtime["requested"] == "ollama-cloud"
+    assert captured_runtime["target_model"] == "kimi-k2.6:cloud"
+    assert captured_runtime["explicit_base_url"] == "https://ollama.com/v1"
+    assert _DummyAgent.last_kwargs["model"] == "kimi-k2.6:cloud"
+
+
+def test_oneshot_direct_alias_without_provider_uses_alias_route(monkeypatch):
+    """Bare `hermes -m alias -z` should route through the alias provider."""
+    import hermes_cli.model_switch as ms
+    from hermes_cli import oneshot
+
+    captured_runtime = {}
+    monkeypatch.setattr(
+        ms,
+        "DIRECT_ALIASES",
+        {
+            "qwen35-cloud": DirectAlias(
+                "qwen3.5:397b-cloud",
+                "ollama-cloud",
+                "https://ollama.com/v1",
+            )
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"model": {"provider": "openrouter", "default": "openai/gpt-5"}},
+    )
+    monkeypatch.setattr("hermes_cli.tools_config._get_platform_tools", lambda cfg, platform: set())
+
+    def _runtime(**kwargs):
+        captured_runtime.update(kwargs)
+        return {
+            "api_key": "test-key",
+            "base_url": "https://ollama.com/v1",
+            "provider": "ollama-cloud",
+            "api_mode": "chat_completions",
+        }
+
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", _runtime)
+    monkeypatch.setitem(sys.modules, "run_agent", SimpleNamespace(AIAgent=_DummyAgent))
+
+    assert oneshot._run_agent("ping", model="qwen35-cloud") == "ok:ping"
+    assert captured_runtime["requested"] == "ollama-cloud"
+    assert captured_runtime["target_model"] == "qwen3.5:397b-cloud"
+    assert captured_runtime["explicit_base_url"] == "https://ollama.com/v1"
+    assert _DummyAgent.last_kwargs["model"] == "qwen3.5:397b-cloud"


### PR DESCRIPTION
## Summary
- resolve configured model aliases for CLI model overrides before runtime credentials are finalized
- keep an explicit `--provider` as the route while still using the alias as a model shorthand
- apply direct-alias `base_url` only when the alias provider matches the active provider
- add regression coverage for explicit-provider direct aliases in `-z` oneshot and interactive CLI initialization paths

## Verification
- `venv/bin/python -m pytest tests/hermes_cli/test_oneshot_aliases.py tests/cli/test_cli_provider_resolution.py::test_cli_model_alias_with_explicit_provider`
- `venv/bin/python -m pytest tests/hermes_cli/test_ollama_cloud_auth.py tests/hermes_cli/test_ollama_cloud_provider.py tests/hermes_cli/test_setup_ollama_cloud_force_refresh.py tests/hermes_cli/test_regression_16767.py tests/hermes_cli/test_runtime_provider_resolution.py tests/hermes_cli/test_oneshot_aliases.py tests/cli/test_cli_provider_resolution.py -q --tb=short`
- `venv/bin/python -m py_compile cli.py hermes_cli/oneshot.py tests/hermes_cli/test_oneshot_aliases.py tests/cli/test_cli_provider_resolution.py`
- `venv/bin/ruff check --select F821,F823,F841 cli.py hermes_cli/oneshot.py tests/hermes_cli/test_oneshot_aliases.py tests/cli/test_cli_provider_resolution.py`
- `git diff --check -- cli.py hermes_cli/oneshot.py tests/hermes_cli/test_oneshot_aliases.py tests/cli/test_cli_provider_resolution.py`
- `hermes --provider ollama-cloud -m kimi26-cloud -z 'Responda exatamente HERMES_ALIAS_PR_OK, sem explicação.'`
