### PR TITLE
fix(qqbot): retry gateway fetch and fallback to cached URL

### DIFF
--- a/gateway/platforms/qqbot.py
+++ b/gateway/platforms/qqbot.py
@@ -97,6 +97,7 @@ CONNECT_TIMEOUT_SECONDS = 20.0
 RECONNECT_BACKOFF = [2, 5, 10, 30, 60]
 MAX_RECONNECT_ATTEMPTS = 100
 RATE_LIMIT_DELAY = 60  # seconds
+GATEWAY_URL_RETRY_DELAYS = [0.5, 1.5, 3.0]
 QUICK_DISCONNECT_THRESHOLD = 5.0  # seconds
 MAX_QUICK_DISCONNECT_COUNT = 3
 
@@ -188,6 +189,7 @@ class QQAdapter(BasePlatformAdapter):
 
         # Upload cache: content_hash -> {file_info, file_uuid, expires_at}
         self._upload_cache: Dict[str, Dict[str, Any]] = {}
+        self._last_gateway_url: Optional[str] = None
 
     # ------------------------------------------------------------------
     # Properties
@@ -333,23 +335,39 @@ class QQAdapter(BasePlatformAdapter):
             return self._access_token
 
     async def _get_gateway_url(self) -> str:
-        """Fetch the WebSocket gateway URL from the REST API."""
-        token = await self._ensure_token()
-        try:
-            resp = await self._http_client.get(
-                f"{API_BASE}{GATEWAY_URL_PATH}",
-                headers={"Authorization": f"QQBot {token}"},
-                timeout=DEFAULT_API_TIMEOUT,
-            )
-            resp.raise_for_status()
-            data = resp.json()
-        except Exception as exc:
-            raise RuntimeError(f"Failed to get QQ Bot gateway URL: {exc}") from exc
+        """Fetch the WebSocket gateway URL with retry and cache fallback."""
+        last_exc: Optional[Exception] = None
+        for attempt, delay in enumerate(GATEWAY_URL_RETRY_DELAYS, start=1):
+            if delay > 0:
+                await asyncio.sleep(delay)
+            token = await self._ensure_token()
+            try:
+                resp = await self._http_client.get(
+                    f"{API_BASE}{GATEWAY_URL_PATH}",
+                    headers={"Authorization": f"QQBot {token}"},
+                    timeout=DEFAULT_API_TIMEOUT,
+                )
+                resp.raise_for_status()
+                data = resp.json()
+                url = data.get("url")
+                if not url:
+                    raise RuntimeError(f"QQ Bot gateway response missing url: {data}")
+                self._last_gateway_url = str(url)
+                return self._last_gateway_url
+            except Exception as exc:
+                last_exc = exc
+                logger.warning(
+                    "[%s] Failed to fetch gateway URL (attempt %d/%d): %s",
+                    self.name,
+                    attempt,
+                    len(GATEWAY_URL_RETRY_DELAYS),
+                    exc,
+                )
 
-        url = data.get("url")
-        if not url:
-            raise RuntimeError(f"QQ Bot gateway response missing url: {data}")
-        return url
+        if self._last_gateway_url:
+            logger.warning("[%s] Falling back to cached gateway URL", self.name)
+            return self._last_gateway_url
+        raise RuntimeError(f"Failed to get QQ Bot gateway URL: {last_exc}")
 
     # ------------------------------------------------------------------
     # WebSocket lifecycle

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -3,6 +3,7 @@
 import json
 import os
 import sys
+import asyncio
 from unittest import mock
 
 import pytest
@@ -458,3 +459,52 @@ class TestBuildTextBody:
         adapter = self._make_adapter(app_id="a", client_secret="b", markdown_support=False)
         body = adapter._build_text_body("reply text", reply_to="msg_123")
         assert body.get("message_reference", {}).get("message_id") == "msg_123"
+
+
+class TestGatewayUrlFetch:
+    def _make_adapter(self, **extra):
+        from gateway.platforms.qqbot import QQAdapter
+        return QQAdapter(_make_config(**extra))
+
+    def test_get_gateway_url_retries_then_succeeds(self):
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        adapter._ensure_token = mock.AsyncMock(return_value="tok")
+
+        resp_fail = mock.Mock()
+        resp_fail.raise_for_status.side_effect = RuntimeError("temporary error")
+
+        resp_ok = mock.Mock()
+        resp_ok.raise_for_status.return_value = None
+        resp_ok.json.return_value = {"url": "wss://qq-gateway.example/ws"}
+
+        adapter._http_client = mock.Mock()
+        adapter._http_client.get = mock.AsyncMock(side_effect=[resp_fail, resp_ok])
+
+        async def _run():
+            with mock.patch("gateway.platforms.qqbot.asyncio.sleep", new=mock.AsyncMock()):
+                return await adapter._get_gateway_url()
+
+        url = asyncio.run(_run())
+
+        assert url == "wss://qq-gateway.example/ws"
+        assert adapter._last_gateway_url == "wss://qq-gateway.example/ws"
+        assert adapter._http_client.get.await_count == 2
+
+    def test_get_gateway_url_uses_cached_value_after_retries_fail(self):
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        adapter._ensure_token = mock.AsyncMock(return_value="tok")
+        adapter._last_gateway_url = "wss://cached.qq/ws"
+
+        resp_fail = mock.Mock()
+        resp_fail.raise_for_status.side_effect = RuntimeError("gateway down")
+
+        adapter._http_client = mock.Mock()
+        adapter._http_client.get = mock.AsyncMock(return_value=resp_fail)
+
+        async def _run():
+            with mock.patch("gateway.platforms.qqbot.asyncio.sleep", new=mock.AsyncMock()):
+                return await adapter._get_gateway_url()
+
+        url = asyncio.run(_run())
+
+        assert url == "wss://cached.qq/ws"


### PR DESCRIPTION
Retry QQ gateway URL fetch with short backoff and reuse the last known gateway URL when the endpoint is temporarily unavailable, so reconnects can recover from transient gateway API failures.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

