### PR TITLE
fix(config): sanitize_env substring false positive breaks valid API keys

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3685,10 +3685,13 @@ def load_env() -> Dict[str, str]:
 def _sanitize_env_lines(lines: list) -> list:
     """Fix corrupted .env lines before reading or writing.
 
-    Handles two known corruption patterns:
+    Handles three known corruption patterns:
     1. Concatenated KEY=VALUE pairs on a single line (missing newline between
-       entries, e.g. ``ANTHROPIC_API_KEY=sk-...OPENAI_BASE_URL=https://...``).
+       entries, e.g. ``ANTHROPIC_API_KEY=sk-......``).
     2. Stale ``KEY=***`` placeholder entries left by incomplete setup runs.
+    3. Split key names (input method / editor corruption broke a key across
+       two lines, e.g. ``G`` + newline + ``LM_API_KEY=...`` instead of
+       ``GLM_API_KEY=...``).
 
     Uses a known-keys set (OPTIONAL_ENV_VARS + _EXTRA_ENV_KEYS) so we only
     split on real Hermes env var names, avoiding false positives from values
@@ -3698,8 +3701,42 @@ def _sanitize_env_lines(lines: list) -> list:
     # Done inside the function so OPTIONAL_ENV_VARS is guaranteed to be defined.
     known_keys = set(OPTIONAL_ENV_VARS.keys()) | _EXTRA_ENV_KEYS
 
+    # ── Pass 0: merge split key names ──
+    # Some input methods (fcitx5, etc.) can insert a newline in the middle
+    # of an environment variable name, producing e.g. "G\nLM_API_KEY=val".
+    # Detect and merge such lines back into a single KEY=VALUE line.
+    _ENV_VAR_NAME_CHAR = re.compile(r'^[A-Z_][A-Z0-9_]*$')
+    merged: list[str] = []
+    i = 0
+    while i < len(lines):
+        raw = lines[i].rstrip("\r\n")
+        stripped = raw.strip()
+        # Check if this line is a bare uppercase fragment (no '=') that could
+        # be the leading part of a split key name.
+        did_merge = False
+        if stripped and "=" not in stripped and _ENV_VAR_NAME_CHAR.match(stripped):
+            # Peek at the next non-empty, non-comment line
+            j = i + 1
+            while j < len(lines):
+                nxt = lines[j].rstrip("\r\n").strip()
+                if not nxt or nxt.startswith("#"):
+                    j += 1
+                    continue
+                # If the next real line, when joined with the fragment,
+                # forms a known KEY=VALUE, merge them.
+                combined_key = (stripped + nxt).partition("=")[0]
+                if "=" in nxt and combined_key in known_keys:
+                    merged.append((stripped + nxt) + "\n")
+                    i = j + 1
+                    did_merge = True
+                break  # stop peeking regardless of merge result
+        if not did_merge:
+            merged.append(raw + "\n")
+            i += 1
+
+    # ── Pass 1: split concatenated KEY=VALUE pairs ──
     sanitized: list[str] = []
-    for line in lines:
+    for line in merged:
         raw = line.rstrip("\r\n")
         stripped = raw.strip()
 
@@ -3709,22 +3746,48 @@ def _sanitize_env_lines(lines: list) -> list:
             continue
 
         # Detect concatenated KEY=VALUE pairs on one line.
-        # Search for known KEY= patterns at any position in the line.
-        split_positions = []
-        for key_name in known_keys:
-            needle = key_name + "="
-            idx = stripped.find(needle)
-            while idx >= 0:
-                split_positions.append(idx)
-                idx = stripped.find(needle, idx + len(needle))
+        # Use a greedy left-to-right scan: find the longest known key that
+        # matches at position 0 (via startswith), then scan forward for the
+        # next position where a known KEY= starts. This avoids false positives
+        # from key names that are substrings of other key names (e.g. LM_API_KEY
+        # at position 1 inside GLM_API_KEY=...).
+        parts = []
+        remaining = stripped
+        while remaining:
+            # Find longest known KEY= that starts at position 0
+            best_key = None
+            for key_name in known_keys:
+                if remaining.startswith(key_name + "=") and (
+                    best_key is None or len(key_name) > len(best_key)
+                ):
+                    best_key = key_name
+            if best_key is None:
+                # No known key at position 0 — keep the rest as-is
+                parts.append(remaining)
+                break
+            # Scan forward to find where the value ends and the next
+            # concatenated key begins. Try every position looking for a
+            # known key via startswith (not find/substring).
+            prefix = best_key + "="
+            after_prefix = remaining[len(prefix):]
+            next_pos = None
+            for offset in range(len(after_prefix)):
+                for key_name in known_keys:
+                    if after_prefix[offset:].startswith(key_name + "="):
+                        candidate = len(prefix) + offset
+                        if next_pos is None or candidate < next_pos:
+                            next_pos = candidate
+                        break  # found a key at this offset, move to next
+            if next_pos is not None:
+                parts.append(remaining[:next_pos])
+                remaining = remaining[next_pos:]
+            else:
+                parts.append(remaining)
+                remaining = ""
 
-        if len(split_positions) > 1:
-            split_positions.sort()
-            # Deduplicate (shouldn't happen, but be safe)
-            split_positions = sorted(set(split_positions))
-            for i, pos in enumerate(split_positions):
-                end = split_positions[i + 1] if i + 1 < len(split_positions) else len(stripped)
-                part = stripped[pos:end].strip()
+        if len(parts) > 1:
+            for part in parts:
+                part = part.strip()
                 if part:
                     sanitized.append(part + "\n")
         else:


### PR DESCRIPTION
## Problem

`_sanitize_env_lines()` in `hermes_cli/config.py` uses `str.find()` to detect concatenated `KEY=VALUE` pairs on a single line. This substring search causes false positives when one known env var name is a substring of another:

- `LM_API_KEY=` matches at **position 1** inside `GLM_API_KEY=<value>`, because `find()` does not require a word boundary.
- The sanitizer then splits the valid entry into a bare `G` line and an `LM_API_KEY=...` line, **destroying the key**.
- On the next gateway startup, `sanitize_env_file()` runs again and sees the two fragments as-is (neither is a valid known key), preserving the corruption permanently.

This is a **general bug** — any pair of known keys where one name contains another as a substring is affected (e.g., `API_KEY=` inside `OPENAI_API_KEY=`, `ANTHROPIC_TOKEN=` inside `ANTHROPIC_API_KEY=`, etc.). The practical impact is limited because most users do not encounter the initial corruption that triggers the cycle.

## Trigger scenario (CJK input methods)

The bug becomes a persistent data-loss issue when combined with CJK input methods (fcitx5, ibus). These can occasionally insert a stray newline in the middle of a pasted env var name, producing:

```
G
LM_API_KEY=<actual_value>
```

Once this corruption exists:
1. The old sanitizer has no merge logic — it preserves both fragments as-is.
2. If the user manually fixes the split (e.g., via sed), the sanitizer re-splits it on the next startup due to the substring match described above.
3. This creates a repair loop that makes the `.env` file unfixable without patching the code.

## Fix

**Pass 0 (new):** Detect and merge split key names. If a line contains only uppercase letters/underscores (no `=`) and the next non-empty line, when concatenated, forms a known env var name with `=`, merge them.

**Pass 1 (improved):** Replace `str.find()` (arbitrary substring search) with `str.startswith()` at position 0 + forward offset scanning. This ensures concatenated key detection only matches actual key names at line/segment boundaries, never as substrings inside other key names.

## Testing

Verified with these scenarios:
- Split key merge: `G` + newline + `LM_API_KEY=<value>` → `GLM_API_KEY=<value>`
- Normal key preserved: `GLM_API_KEY=abc` → `GLM_API_KEY=abc`
- Concatenated keys still split: `KEY1=val1KEY2=val2` → two lines
- Comments/blanks preserved
- No false merge on unrelated uppercase text