### PR TITLE
fix: sync model.context_length on --global model switch

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5321,6 +5321,7 @@ class HermesCLI:
         # Copilot, and Nous-enforced caps win over the raw models.dev entry
         # (e.g. gpt-5.5 is 1.05M on openai but 272K on Codex OAuth).
         mi = result.model_info
+        ctx = None
         try:
             from hermes_cli.model_switch import resolve_display_context_length
             ctx = resolve_display_context_length(
@@ -5353,6 +5354,8 @@ class HermesCLI:
             save_config_value("model.default", result.new_model)
             if result.provider_changed:
                 save_config_value("model.provider", result.target_provider)
+            if ctx:
+                save_config_value("model.context_length", ctx)
             _cprint("    Saved to config.yaml (--global)")
         else:
             _cprint("    (session only — add --global to persist)")


### PR DESCRIPTION
## Problem

When using `/model <name> --global`, the resolved context length was displayed correctly in the switch confirmation but **not persisted** to `config.yaml`. This caused:

- `model.context_length` stayed at the old model value
- Compression thresholds and token budgets used stale context window
- Users switching between models (e.g. gpt-5.5 to mimo-v2.5-pro) got incorrect context limits

## Root Cause

In `_apply_model_switch_result()`, the context length was resolved via `resolve_display_context_length()` for display, but the `persist_global` block only saved `model.default` and `model.provider` — it never saved `model.context_length`.

## Fix

- Extract `ctx` variable to outer scope so it is available after the try/except block
- When `persist_global` is true and `ctx` is resolved, save it with `save_config_value("model.context_length", ctx)`

## Testing

- All existing model switch tests pass (28/28)
- Full tests/hermes_cli/ suite: 3168 passed, 13 failed (pre-existing, unrelated)