### PR TITLE
fix(gateway): only auto-continue explicitly interrupted sessions

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1191,7 +1191,11 @@ def normalize_model_name(model: str, preserve_dots: bool = False) -> str:
         # Non-Anthropic models (gpt-5.4, gemini-2.5, etc.) use dots
         # as part of their canonical names.  See issue #17171.
         _lower = model.lower()
-        if _lower.startswith("claude-") or _lower.startswith("anthropic/"):
+        if (
+            _lower.startswith("claude-")
+            or _lower.startswith("anthropic/")
+            or _lower.startswith("minimax-")
+        ):
             model = model.replace(".", "-")
     return model
 

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1191,11 +1191,7 @@ def normalize_model_name(model: str, preserve_dots: bool = False) -> str:
         # Non-Anthropic models (gpt-5.4, gemini-2.5, etc.) use dots
         # as part of their canonical names.  See issue #17171.
         _lower = model.lower()
-        if (
-            _lower.startswith("claude-")
-            or _lower.startswith("anthropic/")
-            or _lower.startswith("minimax-")
-        ):
+        if _lower.startswith("claude-") or _lower.startswith("anthropic/"):
             model = model.replace(".", "-")
     return model
 

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -670,7 +670,7 @@ def _read_claude_code_credentials_from_keychain() -> Optional[Dict[str, Any]]:
 
     try:
         data = json.loads(raw)
-    except json.JSONDecodeError:
+    except (json.JSONDecodeError, TypeError):
         logger.debug("Keychain: credentials payload is not valid JSON")
         return None
 

--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -608,6 +608,9 @@ class CopilotACPClient:
                     end = start + limit if isinstance(limit, int) and limit > 0 else None
                     content = "".join(lines[start:end])
                 if content:
+                    # ACP file reads cross a process/tool boundary; always
+                    # redact credential-shaped content here even when global
+                    # user-facing log redaction is disabled by default.
                     content = redact_sensitive_text(content, force=True)
                 response = {
                     "jsonrpc": "2.0",

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -310,8 +310,8 @@ def redact_sensitive_text(text: str, *, force: bool = False) -> str:
 
     Safe to call on any string -- non-matching text passes through unchanged.
     Disabled by default — enable via security.redact_secrets: true in config.yaml.
-    Set force=True for safety boundaries that must never return raw secrets
-    regardless of the user's global logging redaction preference.
+    Pass ``force=True`` for security boundaries that must never echo raw
+    credential-shaped content regardless of the user's display preference.
     """
     if text is None:
         return None
@@ -319,7 +319,7 @@ def redact_sensitive_text(text: str, *, force: bool = False) -> str:
         text = str(text)
     if not text:
         return text
-    if not (force or _REDACT_ENABLED):
+    if not force and not _REDACT_ENABLED:
         return text
 
     # Known prefixes (sk-, ghp_, etc.)

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1854,16 +1854,17 @@ class BasePlatformAdapter(ABC):
                 if stop_event is None:
                     await asyncio.sleep(interval)
                     continue
+                # Avoid wrapping Event.wait() in wait_for(): cancelling a
+                # parent message-processing task while this helper is inside
+                # wait_for(stop_event.wait()) can leave the inner Event.wait()
+                # task pending and stall shutdown. Polling on sleep keeps
+                # cancellation immediate while still observing stop_event.
                 loop = asyncio.get_running_loop()
                 deadline = loop.time() + interval
                 while not stop_event.is_set():
                     remaining = deadline - loop.time()
                     if remaining <= 0:
                         break
-                    # Poll instead of wait_for(stop_event.wait()).  Cancelling
-                    # wait_for while it owns the inner Event.wait task can leave
-                    # shutdown paths stuck awaiting the typing task on Python
-                    # 3.11/pytest-asyncio; sleep cancellation is immediate.
                     await asyncio.sleep(min(0.25, remaining))
                 if stop_event.is_set():
                     return
@@ -2861,6 +2862,18 @@ class BasePlatformAdapter(ABC):
         whole shutdown path.  Stragglers are released from our tracking and
         allowed to finish unwinding on their own.
         """
+        # Wake typing/interrupt waiters before cancelling owner tasks.  A
+        # just-started processing task may have spawned _keep_typing() and then
+        # blocked in the message handler; if shutdown cancels it immediately,
+        # the cleanup path can otherwise wait on a typing task that has not had
+        # a chance to observe its stop event yet.
+        for guard in list(self._active_sessions.values()):
+            try:
+                guard.set()
+            except Exception:
+                pass
+        await asyncio.sleep(0)
+
         # Loop until no new tasks appear.  Without this, a message
         # arriving during the `await asyncio.gather` below would spawn
         # a fresh _process_message_background task (added to

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -48,18 +48,13 @@ from hermes_cli.config import cfg_get
 _AGENT_CACHE_MAX_SIZE = 128
 _AGENT_CACHE_IDLE_TTL_SECS = 3600.0  # evict agents idle for >1h
 _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
-# Only auto-continue interrupted gateway turns while the interruption is fresh.
-# Stale tool-tail/resume markers can otherwise revive an unrelated old task
-# after a gateway restart when the user's next message starts new work.
-#
-# The freshness signal is the timestamp of the last transcript row, which
-# ``hermes_state.get_messages`` carries on every persisted message.  This
-# handles the two auto-continue cases uniformly:
-#   * resume_pending (gateway restart/shutdown watchdog marked the session)
-#   * tool-tail     (last persisted message is a tool result the agent
-#                    never got to reply to)
-# In both cases "when did we last do anything on this transcript" is the
-# correct freshness question, so one signal replaces two divergent ones.
+# Only auto-continue gateway work that was explicitly marked as interrupted.
+# The trusted recovery signal is SessionEntry.last_resume_marked_at, written
+# by SessionStore.mark_resume_pending() for sessions still present in
+# GatewayRunner._running_agents after the restart/shutdown drain timeout.
+# Transcript shape (especially a trailing tool result) is intentionally NOT a
+# recovery signal: long-lived sessions can retain old unfinished history that
+# must not be revived by a later gateway restart.
 #
 # Default window: 1 hour.  This comfortably covers ``agent.gateway_timeout``
 # (30 min default) plus runtime slack — a legitimate long-running turn that
@@ -72,8 +67,9 @@ _AUTO_CONTINUE_FRESHNESS_SECS_DEFAULT = 60 * 60
 def _coerce_gateway_timestamp(value: Any) -> Optional[float]:
     """Best-effort conversion of stored gateway timestamps to epoch seconds.
 
-    Missing/unparseable timestamps return None so legacy transcripts keep the
-    historical auto-continue behaviour instead of being silently dropped.
+    Missing/unparseable timestamps return None.  Callers that gate automatic
+    resume must treat None as stale/fail-closed unless they have an explicit
+    compatibility reason not to.
     Accepts: datetime, epoch seconds (int/float), epoch milliseconds (when
     the magnitude exceeds year-2286), ISO-8601 strings (with or without a
     trailing ``Z``), and numeric strings.
@@ -145,22 +141,22 @@ def _is_fresh_gateway_interruption(
 ) -> bool:
     """Return True when an interruption marker is fresh enough to auto-continue.
 
-    Unknown timestamps are treated as fresh for backward compatibility with
-    legacy transcripts (pre-dating timestamp persistence) and with in-memory
-    test scaffolding that constructs history entries without timestamps.
+    Unknown timestamps are treated as stale.  This is deliberate fail-closed
+    behaviour: if the gateway cannot prove when it explicitly marked a
+    running session as interrupted, it must not auto-continue old work.
 
-    A non-positive ``window_secs`` disables the gate (always fresh), which
-    restores the pre-fix behaviour for users who opt out via config.
+    A non-positive ``window_secs`` disables the age gate, but not the explicit
+    marker requirement; malformed/missing marker timestamps still fail closed.
     """
+    timestamp = _coerce_gateway_timestamp(value)
+    if timestamp is None:
+        return False
     window = (
         float(window_secs)
         if window_secs is not None
         else float(_AUTO_CONTINUE_FRESHNESS_SECS_DEFAULT)
     )
     if window <= 0:
-        return True
-    timestamp = _coerce_gateway_timestamp(value)
-    if timestamp is None:
         return True
     current = time.time() if now is None else now
     return current - timestamp <= window
@@ -170,9 +166,9 @@ def _last_transcript_timestamp(history: Optional[List[Dict[str, Any]]]) -> Any:
     """Return the ``timestamp`` of the last usable transcript row, if any.
 
     Skips metadata-only rows (``session_meta``, system injections) that are
-    dropped before being handed to the agent.  Returns ``None`` when no
-    usable row carries a timestamp — callers should treat that as "fresh"
-    for backward compatibility.
+    dropped before being handed to the agent.  This helper is intentionally
+    not used as an automatic-resume signal; transcript recency is not proof
+    that a gateway restart interrupted the current turn.
     """
     if not history:
         return None
@@ -3091,9 +3087,9 @@ class GatewayRunner:
                 # Mark forcibly-interrupted sessions as resume_pending BEFORE
                 # interrupting the agents.  This preserves each session's
                 # session_id + transcript so the next message on the same
-                # session_key auto-resumes from the existing conversation
-                # instead of getting routed through suspend_recently_active()
-                # and converted into a fresh session.  Terminal escalation
+                # session_key can resume only if this fresh marker is still
+                # present; stale/missing markers fail closed instead of
+                # reviving old transcript tails.  Terminal escalation
                 # for genuinely stuck sessions still flows through the
                 # existing ``.restart_failure_counts`` stuck-loop counter
                 # (incremented below, threshold 3), which sets
@@ -11402,50 +11398,51 @@ class GatewayRunner:
             if _msn:
                 message = _msn + "\n\n" + message
 
-            # Auto-continue: if the loaded history ends with a tool result,
-            # the previous agent turn was interrupted mid-work (gateway
-            # restart, crash, SIGTERM).  Prepend a system note so the model
-            # finishes processing the pending tool results before addressing
-            # the user's new message.  (#4493)
+            # Auto-continue: only a session explicitly marked resume_pending
+            # by gateway restart/shutdown drain handling can prepend a system
+            # note that asks the model to finish interrupted work before
+            # addressing the user's new message.
             #
-            # Session-level resume_pending (set on drain-timeout shutdown)
-            # escalates the wording — the transcript's last role may be
-            # anything (tool, assistant with unfinished work, etc.), so we
-            # give a stronger, reason-aware instruction that subsumes the
-            # tool-tail case.
+            # Freshness gate (#16802) avoids reviving stale work after a
+            # gateway restart.  A bare transcript ending in ``role=tool`` can
+            # mean the previous turn was interrupted while processing tool
+            # output, but it can also be an old, already-abandoned task.
+            # Injecting the note on a normal user message makes the next turn
+            # jump back into that old tool-tail.
             #
-            # Freshness gate (#16802): both branches are gated on the age
-            # of the last persisted transcript row.  That is the correct
-            # "when did we last do anything here" signal for both the
-            # resume_pending path (restart watchdog) and the tool-tail
-            # path (in-flight tool loop killed).  We read ``history[-1]``
-            # here because ``agent_history`` has already stripped the
-            # ``timestamp`` field off tool/tool_call rows for API purity
-            # (see the `k != "timestamp"` filter above).  Rows without a
-            # timestamp (legacy transcripts) are treated as fresh so the
-            # historical auto-continue behaviour is preserved.
+            # Only a session-level resume_pending marker set by the gateway
+            # restart/shutdown watchdog is allowed to auto-continue, and even
+            # that marker must be fresh.  A bare tool tail remains in history
+            # for context, but no longer overrides the user's new message.
+            #
+            # Freshness reads the explicit marker timestamp written by
+            # SessionStore.mark_resume_pending().  Do not use transcript
+            # timestamps here: a long-lived chat can contain old tool-tail or
+            # abandoned work that should not become the restart recovery target.
             _freshness_window = _auto_continue_freshness_window()
-            _interruption_is_fresh = _is_fresh_gateway_interruption(
-                _last_transcript_timestamp(history),
-                window_secs=_freshness_window,
-            )
-
             _resume_entry = None
             if session_key:
                 try:
                     _resume_entry = self.session_store._entries.get(session_key)
                 except Exception:
                     _resume_entry = None
-            _is_resume_pending = bool(
+            _has_resume_pending = bool(
                 _resume_entry is not None
                 and getattr(_resume_entry, "resume_pending", False)
-                and _interruption_is_fresh
             )
-            _has_fresh_tool_tail = bool(
-                agent_history
-                and agent_history[-1].get("role") == "tool"
-                and _interruption_is_fresh
-            )
+            _resume_marker_is_fresh = _is_fresh_gateway_interruption(
+                getattr(_resume_entry, "last_resume_marked_at", None),
+                window_secs=_freshness_window,
+            ) if _has_resume_pending else False
+            if _has_resume_pending and not _resume_marker_is_fresh and session_key:
+                try:
+                    self.session_store.clear_resume_pending(session_key)
+                except Exception as _e:
+                    logger.debug(
+                        "clear stale resume_pending failed for %s: %s",
+                        session_key[:20], _e,
+                    )
+            _is_resume_pending = _has_resume_pending and _resume_marker_is_fresh
 
             if _is_resume_pending:
                 _reason = getattr(_resume_entry, "resume_reason", None) or "restart_timeout"
@@ -11462,15 +11459,6 @@ class GatewayRunner:
                     f"If it contains unfinished tool result(s), process them first and "
                     f"summarize what was accomplished, then address the user's new "
                     f"message below.]\n\n"
-                    + message
-                )
-            elif _has_fresh_tool_tail:
-                message = (
-                    "[System note: Your previous turn was interrupted before you could "
-                    "process the last tool result(s). The conversation history contains "
-                    "tool outputs you haven't responded to yet. Please finish processing "
-                    "those results and summarize what was accomplished, then address the "
-                    "user's new message below.]\n\n"
                     + message
                 )
 

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -62,7 +62,7 @@ from .config import (
 )
 from .whatsapp_identity import (
     canonical_whatsapp_identifier,
-    normalize_whatsapp_identifier,  # noqa: F401 - re-exported for gateway.session callers
+    normalize_whatsapp_identifier,  # noqa: F401 — re-exported for gateway.session compatibility
 )
 from utils import atomic_replace
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -429,15 +429,13 @@ DEFAULT_CONFIG = {
         # After a gateway crash/restart/SIGTERM mid-run, the next user
         # message gets a "[System note: your previous turn was
         # interrupted — process the unfinished tool result(s) first]"
-        # prepended so the model picks up where it left off.  That's the
-        # right behaviour while the interruption is fresh, but stale
-        # markers (transcript last touched hours or days ago) can revive
-        # an unrelated old task when the user's next message starts new
-        # work.  This window is the max age of the last persisted
-        # transcript row for which we still inject the continue note.
-        # Default 3600s comfortably covers a long turn (gateway_timeout
-        # default is 1800s) plus runtime slack.  Set to 0 to disable the
-        # gate and restore pre-fix behaviour (always inject).
+        # prepended so the model picks up where it left off.  Auto-continue
+        # is only allowed for sessions explicitly marked resume_pending by
+        # gateway restart/shutdown drain handling; transcript shape alone is
+        # not a recovery signal.  This window is the max age of that explicit
+        # resume_pending marker.  Default 3600s comfortably covers a long turn
+        # (gateway_timeout default is 1800s) plus runtime slack.  Set to 0 to
+        # disable only the age gate; auto-continue still requires the marker.
         "gateway_auto_continue_freshness": 3600,
         # How user-attached images are presented to the main model on each turn.
         #   "auto"   — attach natively when the active model reports

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5403,7 +5403,7 @@ def _find_stale_dashboard_pids() -> list[int]:
                 capture_output=True, text=True, timeout=10,
             )
             if result.returncode == 0:
-                for line in getattr(result, "stdout", "").split("\n"):
+                for line in (getattr(result, "stdout", "") or "").split("\n"):
                     stripped = line.strip()
                     if not stripped or "grep" in stripped:
                         continue

--- a/hermes_cli/pty_bridge.py
+++ b/hermes_cli/pty_bridge.py
@@ -110,7 +110,8 @@ class PtyBridge:
             raise PtyUnavailableError("Pseudo-terminals are unavailable.")
         # Let caller-supplied env fully override inheritance; if they pass
         # None we inherit the server's env (same semantics as subprocess).
-        spawn_env = os.environ.copy() if env is None else env
+        spawn_env = os.environ.copy() if env is None else dict(env)
+        spawn_env.setdefault("TERM", "xterm-256color")
         proc = ptyprocess.PtyProcess.spawn(  # type: ignore[union-attr]
             list(argv),
             cwd=cwd,

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -712,11 +712,11 @@ def _prompt_vercel_sandbox_settings(config: dict):
     token = prompt("    Vercel access token", get_env_value("VERCEL_TOKEN") or "", password=True)
     project = prompt(
         "    Vercel project ID",
-        linked_project.get("projectId", "") or get_env_value("VERCEL_PROJECT_ID") or "",
+        get_env_value("VERCEL_PROJECT_ID") or linked_project.get("projectId", ""),
     )
     team = prompt(
         "    Vercel team ID",
-        linked_project.get("orgId", "") or get_env_value("VERCEL_TEAM_ID") or "",
+        get_env_value("VERCEL_TEAM_ID") or linked_project.get("orgId", ""),
     )
     if token:
         save_env_value("VERCEL_TOKEN", token)

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -712,11 +712,11 @@ def _prompt_vercel_sandbox_settings(config: dict):
     token = prompt("    Vercel access token", get_env_value("VERCEL_TOKEN") or "", password=True)
     project = prompt(
         "    Vercel project ID",
-        get_env_value("VERCEL_PROJECT_ID") or linked_project.get("projectId", ""),
+        linked_project.get("projectId", "") or get_env_value("VERCEL_PROJECT_ID") or "",
     )
     team = prompt(
         "    Vercel team ID",
-        get_env_value("VERCEL_TEAM_ID") or linked_project.get("orgId", ""),
+        linked_project.get("orgId", "") or get_env_value("VERCEL_TEAM_ID") or "",
     )
     if token:
         save_env_value("VERCEL_TOKEN", token)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2766,6 +2766,8 @@ async def pty_ws(ws: WebSocket) -> None:
             if chunk is None:  # EOF
                 return
             if not chunk:  # no data this tick; yield control and retry
+                if not bridge.is_alive():
+                    return
                 await asyncio.sleep(0)
                 continue
             try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -348,9 +348,25 @@ def _reset_module_state():
     # so caplog assertions are not affected by earlier tests on the same worker.
     logging.disable(logging.NOTSET)
     try:
-        for _obj in logging.root.manager.loggerDict.values():
+        for _name, _obj in logging.root.manager.loggerDict.items():
             if isinstance(_obj, logging.Logger):
                 _obj.disabled = False
+                # AIAgent quiet-mode tests intentionally raise project logger
+                # thresholds (``hermes_cli``, ``tools``, ``run_agent``, ...)
+                # to ERROR.  xdist workers reuse processes, so reset project
+                # loggers before the next test or caplog WARNING assertions
+                # silently miss records.
+                if _name == "run_agent" or _name.startswith((
+                    "agent",
+                    "cron",
+                    "gateway",
+                    "hermes_cli",
+                    "tools",
+                    "trajectory_compressor",
+                    "tui_gateway",
+                )):
+                    _obj.setLevel(logging.NOTSET)
+                    _obj.propagate = True
     except Exception:
         pass
     for _logger_name in ("tools", "run_agent", "trajectory_compressor", "cron", "hermes_cli"):
@@ -364,6 +380,16 @@ def _reset_module_state():
         import hermes_constants as _hc_mod
         _hc_mod._wsl_detected = None
         _hc_mod._container_detected = None
+    except Exception:
+        pass
+    # Some tests remove/re-import hermes_constants.  Modules that imported the
+    # old function object (for example hermes_cli.clipboard._is_wsl) keep that
+    # function's original globals dict, so also reset the cached values through
+    # the imported function object when present.
+    try:
+        from hermes_cli import clipboard as _clipboard_mod
+        _clipboard_mod._is_wsl.__globals__["_wsl_detected"] = None
+        _clipboard_mod._is_wsl.__globals__["_container_detected"] = None
     except Exception:
         pass
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,6 @@ import signal
 import sys
 import tempfile
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 
@@ -187,6 +186,7 @@ _HERMES_BEHAVIORAL_VARS = frozenset({
     "HERMES_REDACT_SECRETS",
     "HERMES_BACKGROUND_NOTIFICATIONS",
     "HERMES_EXEC_ASK",
+    "HERMES_CRON_SESSION",
     "HERMES_HOME_MODE",
     "TERMINAL_CWD",
     "TERMINAL_ENV",
@@ -338,13 +338,35 @@ def _reset_module_state():
     that don't exist yet (test collection before production import) are
     skipped silently — production import later creates fresh empty state.
     """
-    # --- logging — quiet/one-shot paths mutate process-global logger state ---
+    # --- logging — legacy tests sometimes call logging.disable() directly.
+    # Re-enable logs before every test so caplog-based assertions are not
+    # affected by worker-local state from earlier tests.
     logging.disable(logging.NOTSET)
     for _logger_name in ("tools", "run_agent", "trajectory_compressor", "cron", "hermes_cli"):
         _logger = logging.getLogger(_logger_name)
         _logger.disabled = False
         _logger.setLevel(logging.NOTSET)
         _logger.propagate = True
+
+    # --- hermes_constants — environment detection caches shared by helpers ---
+    try:
+        import hermes_constants as _hc_mod
+        _hc_mod._wsl_detected = None
+        _hc_mod._container_detected = None
+    except Exception:
+        pass
+
+    # --- hermes_cli.config — path/value caches are keyed by patched paths and
+    # env-sensitive expanded values. Clear per test to prevent monkeypatched
+    # config/env paths from reusing another test's cached config on the same
+    # xdist worker.
+    try:
+        from hermes_cli import config as _cli_config_mod
+        _cli_config_mod._LOAD_CONFIG_CACHE.clear()
+        _cli_config_mod._RAW_CONFIG_CACHE.clear()
+        _cli_config_mod._LAST_EXPANDED_CONFIG_BY_PATH.clear()
+    except Exception:
+        pass
 
     # --- tools.approval — the single biggest source of cross-test pollution ---
     try:
@@ -440,7 +462,10 @@ def _reset_module_state():
     except Exception:
         pass
 
-    yield
+    try:
+        yield
+    finally:
+        logging.disable(logging.NOTSET)
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -198,6 +198,11 @@ _HERMES_BEHAVIORAL_VARS = frozenset({
     "TERMINAL_DOCKER_RUN_AS_HOST_USER",
     "BROWSER_CDP_URL",
     "CAMOFOX_URL",
+    # Terminal backend selectors are process-global and can leak between tests
+    # in a reused xdist worker, changing check_terminal_requirements() results.
+    "TERMINAL_ENV",
+    "TERMINAL_CWD",
+    "TERMINAL_MODAL_MODE",
     # Platform allowlists — not credentials, but if set from any source
     # (user shell, earlier leaky test, CI env), they change gateway auth
     # behavior and flake button-authorization tests.
@@ -338,10 +343,16 @@ def _reset_module_state():
     that don't exist yet (test collection before production import) are
     skipped silently — production import later creates fresh empty state.
     """
-    # --- logging — legacy tests sometimes call logging.disable() directly.
-    # Re-enable logs before every test so caplog-based assertions are not
-    # affected by worker-local state from earlier tests.
+    # --- logging — legacy tests sometimes mutate global logging state.
+    # Re-enable global logging threshold and undo per-logger "disabled" flags
+    # so caplog assertions are not affected by earlier tests on the same worker.
     logging.disable(logging.NOTSET)
+    try:
+        for _obj in logging.root.manager.loggerDict.values():
+            if isinstance(_obj, logging.Logger):
+                _obj.disabled = False
+    except Exception:
+        pass
     for _logger_name in ("tools", "run_agent", "trajectory_compressor", "cron", "hermes_cli"):
         _logger = logging.getLogger(_logger_name)
         _logger.disabled = False
@@ -459,6 +470,31 @@ def _reset_module_state():
             _ft_mod._read_tracker.clear()
         with _ft_mod._file_ops_lock:
             _ft_mod._file_ops_cache.clear()
+    except Exception:
+        pass
+
+    # --- tools.terminal_tool — live environment maps are process-global ---
+    # Stale entries here override TERMINAL_CWD in file_tools._resolve_path(),
+    # causing relative paths to resolve against an old repo/workdir.
+    try:
+        from tools import terminal_tool as _tt_mod
+        with _tt_mod._env_lock:
+            _tt_mod._active_environments.clear()
+            _tt_mod._last_activity.clear()
+        _tt_mod._task_env_overrides.clear()
+        with _tt_mod._creation_locks_lock:
+            _tt_mod._creation_locks.clear()
+    except Exception:
+        pass
+
+    # --- tools.browser_tool — cached probes leak across tests ---
+    # _run_browser_command short-circuits before _write_owner_pid when a stale
+    # cached Chromium-missing result survives from an earlier test.
+    try:
+        from tools import browser_tool as _bt_mod
+        _bt_mod._cached_chromium_installed = None
+        _bt_mod._cached_cloud_provider = None
+        _bt_mod._cloud_provider_resolved = False
     except Exception:
         pass
 

--- a/tests/gateway/test_auto_continue.py
+++ b/tests/gateway/test_auto_continue.py
@@ -1,38 +1,28 @@
-"""Tests for the auto-continue feature (#4493).
+"""Tests for the retired bare tool-tail auto-continue heuristic (#4493).
 
-When the gateway restarts mid-agent-work, the session transcript ends on a
-tool result that the agent never processed.  The auto-continue logic detects
-this and prepends a system note to the next user message so the model
-finishes the interrupted work before addressing the new input.
+Hermes used to infer an interrupted turn when the persisted transcript ended
+with a ``tool`` message.  That was ambiguous in long-lived messaging sessions:
+a stale tool-tail could revive an unrelated old task after a later gateway
+restart.  Current restart recovery is covered by
+``test_restart_resume_pending.py`` and requires an explicit fresh
+``resume_pending`` marker instead.
 """
-
-import pytest
 
 
 def _simulate_auto_continue(agent_history: list, user_message: str) -> str:
-    """Reproduce the auto-continue injection logic from _run_agent().
+    """Mirror the current bare tool-tail policy from _run_agent().
 
-    This mirrors the exact code in gateway/run.py so we can test the
-    detection and message transformation without spinning up a full
-    gateway runner.
+    A trailing tool result alone no longer prepends a continuation note.  The
+    explicit ``resume_pending`` path is tested separately because it depends on
+    SessionEntry metadata, not just agent_history shape.
     """
-    message = user_message
-    if agent_history and agent_history[-1].get("role") == "tool":
-        message = (
-            "[System note: Your previous turn was interrupted before you could "
-            "process the last tool result(s). The conversation history contains "
-            "tool outputs you haven't responded to yet. Please finish processing "
-            "those results and summarize what was accomplished, then address the "
-            "user's new message below.]\n\n"
-            + message
-        )
-    return message
+    return user_message
 
 
-class TestAutoDetection:
-    """Test that trailing tool results are correctly detected."""
+class TestBareToolTailDoesNotAutoContinue:
+    """Trailing tool results are preserved as history, not recovery triggers."""
 
-    def test_trailing_tool_result_triggers_note(self):
+    def test_trailing_tool_result_does_not_trigger_note(self):
         history = [
             {"role": "user", "content": "deploy the app"},
             {"role": "assistant", "content": None, "tool_calls": [
@@ -41,9 +31,8 @@ class TestAutoDetection:
             {"role": "tool", "tool_call_id": "call_1", "content": "deployed successfully"},
         ]
         result = _simulate_auto_continue(history, "what happened?")
-        assert "[System note:" in result
-        assert "interrupted" in result
-        assert "what happened?" in result
+        assert result == "what happened?"
+        assert "[System note:" not in result
 
     def test_trailing_assistant_message_no_note(self):
         history = [
@@ -51,7 +40,6 @@ class TestAutoDetection:
             {"role": "assistant", "content": "Hi there!"},
         ]
         result = _simulate_auto_continue(history, "how are you?")
-        assert "[System note:" not in result
         assert result == "how are you?"
 
     def test_empty_history_no_note(self):
@@ -59,15 +47,13 @@ class TestAutoDetection:
         assert result == "hello"
 
     def test_trailing_user_message_no_note(self):
-        """Shouldn't happen in practice, but ensure no false positive."""
         history = [
             {"role": "user", "content": "hello"},
         ]
         result = _simulate_auto_continue(history, "hello again")
         assert result == "hello again"
 
-    def test_multiple_tool_results_still_triggers(self):
-        """Multiple tool calls in a row — last one is still role=tool."""
+    def test_multiple_tool_results_do_not_trigger_note(self):
         history = [
             {"role": "user", "content": "search and read"},
             {"role": "assistant", "content": None, "tool_calls": [
@@ -78,10 +64,9 @@ class TestAutoDetection:
             {"role": "tool", "tool_call_id": "call_2", "content": "file content here"},
         ]
         result = _simulate_auto_continue(history, "continue")
-        assert "[System note:" in result
+        assert result == "continue"
 
-    def test_original_message_preserved_after_note(self):
-        """The user's actual message must appear after the system note."""
+    def test_original_message_preserved_without_note(self):
         history = [
             {"role": "assistant", "content": None, "tool_calls": [
                 {"id": "c1", "function": {"name": "t", "arguments": "{}"}}
@@ -89,7 +74,4 @@ class TestAutoDetection:
             {"role": "tool", "tool_call_id": "c1", "content": "done"},
         ]
         result = _simulate_auto_continue(history, "now do X")
-        # System note comes first, then user's message
-        note_end = result.index("]\n\n")
-        user_msg_start = result.index("now do X")
-        assert user_msg_start > note_end
+        assert result == "now do X"

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -14,11 +14,9 @@ PRs #9850, #9934, #7536):
 2. ``suspended=True`` (from ``/stop`` or stuck-loop escalation) still
    wins over ``resume_pending`` — the forced-wipe path is preserved.
 
-3. The restart-resume system note injected into the next user message is
-   a superset of the existing tool-tail auto-continue note (from
-   PR #9934), using session-entry metadata rather than just transcript
-   shape so it fires even when the interrupted transcript does NOT end
-   with a ``tool`` role.
+3. The restart-resume system note is gated only by explicit, fresh
+   ``resume_pending`` metadata written during gateway drain timeout.  Bare
+   tool-tail transcript shape is not enough to auto-continue old work.
 
 4. The existing ``.restart_failure_counts`` stuck-loop counter from
    PR #7536 remains the single source of escalation — no parallel
@@ -92,12 +90,13 @@ def _simulate_note_injection(
     agent_history: list | None = None,
     window_secs: float | None = None,
 ) -> str:
-    """Mirror the note-injection logic in gateway/run.py _run_agent().
+    """Mirror the strict resume-note gate in gateway/run.py _run_agent().
 
-    The freshness signal reads ``history[-1].timestamp`` (the raw transcript
-    row), NOT ``agent_history[-1].timestamp`` (which has been stripped).
-    Tests pass the raw ``history`` — ``agent_history`` is derived from it
-    via the real conversion if not supplied explicitly.
+    The freshness signal is the explicit ``SessionEntry.last_resume_marked_at``
+    written by ``SessionStore.mark_resume_pending()`` during a gateway
+    drain-timeout interruption.  Raw transcript timestamps and bare tool-tail
+    shape are intentionally ignored: they are session history, not proof of
+    the turn that was active when the gateway stopped.
     """
     if agent_history is None:
         agent_history = _build_agent_history(history)
@@ -107,8 +106,13 @@ def _simulate_note_injection(
         if window_secs is not None
         else _auto_continue_freshness_window()
     )
+    marker_timestamp = (
+        getattr(resume_entry, "last_resume_marked_at", None)
+        if resume_entry is not None
+        else None
+    )
     interruption_is_fresh = _is_fresh_gateway_interruption(
-        _last_transcript_timestamp(history),
+        marker_timestamp,
         window_secs=window,
     )
 
@@ -118,12 +122,6 @@ def _simulate_note_injection(
         and getattr(resume_entry, "resume_pending", False)
         and interruption_is_fresh
     )
-    has_fresh_tool_tail = bool(
-        agent_history
-        and agent_history[-1].get("role") == "tool"
-        and interruption_is_fresh
-    )
-
     if is_resume_pending:
         reason = getattr(resume_entry, "resume_reason", None) or "restart_timeout"
         reason_phrase = (
@@ -139,15 +137,6 @@ def _simulate_note_injection(
             f"If it contains unfinished tool result(s), process them first and "
             f"summarize what was accomplished, then address the user's new "
             f"message below.]\n\n"
-            + message
-        )
-    elif has_fresh_tool_tail:
-        message = (
-            "[System note: Your previous turn was interrupted before you could "
-            "process the last tool result(s). The conversation history contains "
-            "tool outputs you haven't responded to yet. Please finish processing "
-            "those results and summarize what was accomplished, then address the "
-            "user's new message below.]\n\n"
             + message
         )
     return message
@@ -462,8 +451,8 @@ class TestResumePendingSystemNote:
         # Old tool-tail wording absent
         assert "haven't responded to yet" not in result
 
-    def test_no_resume_pending_preserves_tool_tail_note(self):
-        """Regression: the old PR #9934 tool-tail behaviour is unchanged."""
+    def test_no_resume_pending_does_not_inject_tool_tail_note(self):
+        """Bare tool-tail transcript shape does not auto-continue."""
         history = [
             {"role": "assistant", "content": None, "tool_calls": [
                 {"id": "c1", "function": {"name": "x", "arguments": "{}"}},
@@ -472,16 +461,10 @@ class TestResumePendingSystemNote:
              "timestamp": time.time()},
         ]
         result = _simulate_note_injection(history, "ping", resume_entry=None)
-        assert "[System note:" in result
-        assert "tool result" in result
+        assert result == "ping"
 
     def test_stale_resume_pending_does_not_inject_restart_note(self):
-        """Old restart markers must not revive an unrelated stale task.
-
-        The transcript's last row is from an hour ago — well outside the
-        default 1h freshness window (fixture uses window=1800 to exercise
-        the stale path without tying the test to the production default).
-        """
+        """Old restart markers must not revive an unrelated stale task."""
         entry = self._pending_entry()
         entry.last_resume_marked_at = datetime.now() - timedelta(hours=1)
 
@@ -497,7 +480,42 @@ class TestResumePendingSystemNote:
         )
         assert result == "start a new task"
 
-    def test_fresh_tool_tail_preserves_auto_continue_note(self):
+    def test_resume_pending_freshness_uses_marker_not_transcript_timestamp(self):
+        """A fresh transcript row must not rescue a stale resume marker.
+
+        This is the core strict-resume rule: the only trusted freshness source
+        is when the gateway explicitly marked the still-running session
+        ``resume_pending`` during drain timeout.
+        """
+        entry = self._pending_entry()
+        entry.last_resume_marked_at = datetime.now() - timedelta(hours=2)
+        history = [
+            {"role": "assistant", "content": "recent chat after old marker",
+             "timestamp": time.time()},
+        ]
+
+        result = _simulate_note_injection(
+            history=history,
+            user_message="new task",
+            resume_entry=entry,
+            window_secs=1800,
+        )
+
+        assert result == "new task"
+
+    def test_resume_pending_without_marker_timestamp_does_not_resume(self):
+        entry = self._pending_entry()
+        entry.last_resume_marked_at = None
+        history = [
+            {"role": "assistant", "content": "recent transcript",
+             "timestamp": time.time()},
+        ]
+
+        result = _simulate_note_injection(history, "new task", resume_entry=entry)
+
+        assert result == "new task"
+
+    def test_fresh_tool_tail_without_resume_pending_does_not_auto_continue(self):
         history = [
             {"role": "assistant", "content": None, "tool_calls": [
                 {"id": "c1", "function": {"name": "x", "arguments": "{}"}},
@@ -510,8 +528,7 @@ class TestResumePendingSystemNote:
             },
         ]
         result = _simulate_note_injection(history, "ping", resume_entry=None)
-        assert "[System note:" in result
-        assert "tool result" in result
+        assert result == "ping"
 
     def test_stale_tool_tail_does_not_inject_auto_continue_note(self):
         """The core bug fix: stale tool-tail must not revive a dead task.
@@ -585,8 +602,8 @@ class TestResumePendingSystemNote:
         )
         assert result == "start a new task"
 
-    def test_freshness_gate_disabled_via_zero_window(self):
-        """window_secs=0 restores pre-fix behaviour (always inject)."""
+    def test_zero_window_does_not_revive_bare_tool_tail(self):
+        """Even with the freshness gate disabled, bare tool-tail is not enough."""
         history = [
             {"role": "assistant", "content": None, "tool_calls": [
                 {"id": "c1", "function": {"name": "x", "arguments": "{}"}},
@@ -601,12 +618,10 @@ class TestResumePendingSystemNote:
         result = _simulate_note_injection(
             history, "ping", resume_entry=None, window_secs=0,
         )
-        assert "[System note:" in result
-        assert "tool result" in result
+        assert result == "ping"
 
-    def test_legacy_history_without_timestamps_still_injects(self):
-        """Transcripts predating timestamp persistence must keep the old
-        behaviour — freshness unknown → treat as fresh."""
+    def test_legacy_history_without_timestamps_requires_resume_pending(self):
+        """Legacy transcript timestamps are ignored without explicit resume_pending."""
         history = [
             {"role": "assistant", "content": None, "tool_calls": [
                 {"id": "c1", "function": {"name": "x", "arguments": "{}"}},
@@ -614,8 +629,7 @@ class TestResumePendingSystemNote:
             {"role": "tool", "tool_call_id": "c1", "content": "result"},
         ]
         result = _simulate_note_injection(history, "ping", resume_entry=None)
-        assert "[System note:" in result
-        assert "tool result" in result
+        assert result == "ping"
 
     def test_no_note_when_nothing_to_resume(self):
         history = [
@@ -665,10 +679,10 @@ class TestFreshnessHelpers:
         assert _coerce_gateway_timestamp(False) is None
         assert _coerce_gateway_timestamp([1, 2, 3]) is None
 
-    def test_is_fresh_unknown_is_fresh(self):
-        """Legacy-compat: unknown timestamp → fresh."""
-        assert _is_fresh_gateway_interruption(None) is True
-        assert _is_fresh_gateway_interruption("not-a-timestamp") is True
+    def test_is_fresh_unknown_is_stale(self):
+        """Strict resume: missing/malformed markers fail closed."""
+        assert _is_fresh_gateway_interruption(None) is False
+        assert _is_fresh_gateway_interruption("not-a-timestamp") is False
 
     def test_is_fresh_window_bounds(self):
         now = 1_700_000_000.0
@@ -708,8 +722,7 @@ class TestFreshnessHelpers:
         assert _last_transcript_timestamp(None) is None
 
     def test_last_transcript_timestamp_row_without_timestamp(self):
-        """Legacy transcript row (no timestamp) returns None → caller
-        treats as fresh."""
+        """Legacy transcript row (no timestamp) returns None."""
         history = [
             {"role": "user", "content": "hi"},
             {"role": "assistant", "content": "hey"},

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -901,6 +901,9 @@ class TestProfileRestoration:
         hermes_home.mkdir()
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        # Keep host-specific aliases (e.g. ~/.local/bin/coder) from leaking
+        # into check_alias_collision() during import wrapper restoration.
+        monkeypatch.setenv("PATH", "/usr/bin:/bin")
 
         # Mock the wrapper dir to be inside tmp_path
         wrapper_dir = tmp_path / ".local" / "bin"
@@ -937,6 +940,7 @@ class TestProfileRestoration:
         hermes_home.mkdir()
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("PATH", "/usr/bin:/bin")
 
         wrapper_dir = tmp_path / ".local" / "bin"
         wrapper_dir.mkdir(parents=True)
@@ -963,6 +967,7 @@ class TestProfileRestoration:
         hermes_home.mkdir()
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("PATH", "/usr/bin:/bin")
 
         zip_path = tmp_path / "backup.zip"
         self._make_backup_zip(zip_path, {
@@ -1362,10 +1367,16 @@ class TestRunPreUpdateBackup:
         monkeypatch.setenv("HERMES_HOME", str(root))
         # Make Path.home() point at tmp_path for anything that uses it
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
-        # Bust caches for hermes_cli.config + hermes_constants so they pick up HERMES_HOME
-        for mod in list(__import__("sys").modules.keys()):
-            if mod.startswith("hermes_cli.config") or mod == "hermes_constants":
-                del __import__("sys").modules[mod]
+        # Bust config/env detection caches without replacing module objects.
+        # Replacing modules in sys.modules breaks tests that imported
+        # `load_config` directly (stale function globals).
+        from hermes_cli import config as _cfg_mod
+        _cfg_mod._LOAD_CONFIG_CACHE.clear()
+        _cfg_mod._RAW_CONFIG_CACHE.clear()
+        _cfg_mod._LAST_EXPANDED_CONFIG_BY_PATH.clear()
+        import hermes_constants as _hc_mod
+        _hc_mod._wsl_detected = None
+        _hc_mod._container_detected = None
         return root
 
     def test_backup_flag_creates_backup(self, hermes_home, capsys):
@@ -1412,10 +1423,10 @@ class TestRunPreUpdateBackup:
             "_config_version": 22,
             "updates": {"pre_update_backup": True},
         }))
-        import sys as _sys
-        for mod in list(_sys.modules.keys()):
-            if mod.startswith("hermes_cli.config"):
-                del _sys.modules[mod]
+        from hermes_cli import config as _cfg_mod
+        _cfg_mod._LOAD_CONFIG_CACHE.clear()
+        _cfg_mod._RAW_CONFIG_CACHE.clear()
+        _cfg_mod._LAST_EXPANDED_CONFIG_BY_PATH.clear()
 
         from hermes_cli.main import _run_pre_update_backup
         _run_pre_update_backup(Namespace(no_backup=False, backup=False))
@@ -1434,10 +1445,10 @@ class TestRunPreUpdateBackup:
             "updates": {"pre_update_backup": False},
         }))
         # Ensure config module re-reads
-        import sys as _sys
-        for mod in list(_sys.modules.keys()):
-            if mod.startswith("hermes_cli.config"):
-                del _sys.modules[mod]
+        from hermes_cli import config as _cfg_mod
+        _cfg_mod._LOAD_CONFIG_CACHE.clear()
+        _cfg_mod._RAW_CONFIG_CACHE.clear()
+        _cfg_mod._LAST_EXPANDED_CONFIG_BY_PATH.clear()
 
         from hermes_cli.main import _run_pre_update_backup
         _run_pre_update_backup(Namespace(no_backup=False, backup=False))
@@ -1453,10 +1464,10 @@ class TestRunPreUpdateBackup:
             "_config_version": 22,
             "updates": {"pre_update_backup": True},
         }))
-        import sys as _sys
-        for mod in list(_sys.modules.keys()):
-            if mod.startswith("hermes_cli.config"):
-                del _sys.modules[mod]
+        from hermes_cli import config as _cfg_mod
+        _cfg_mod._LOAD_CONFIG_CACHE.clear()
+        _cfg_mod._RAW_CONFIG_CACHE.clear()
+        _cfg_mod._LAST_EXPANDED_CONFIG_BY_PATH.clear()
 
         from hermes_cli.main import _run_pre_update_backup
         _run_pre_update_backup(Namespace(no_backup=True, backup=False))

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -35,6 +35,14 @@ class TestUserSystemdPrivateSocketPreflight:
 
 
 class TestSystemdServiceRefresh:
+    @pytest.fixture(autouse=True)
+    def _mock_user_systemd_preflight(self, monkeypatch):
+        monkeypatch.setattr(
+            gateway_cli,
+            "_preflight_user_systemd",
+            lambda *args, **kwargs: None,
+        )
+
     def test_systemd_install_repairs_outdated_unit_without_force(self, tmp_path, monkeypatch):
         unit_path = tmp_path / "hermes-gateway.service"
         unit_path.write_text("old unit\n", encoding="utf-8")
@@ -483,6 +491,14 @@ class TestGatewayServiceDetection:
         assert gateway_cli._is_service_running() is False
 
 class TestGatewaySystemServiceRouting:
+    @pytest.fixture(autouse=True)
+    def _mock_user_systemd_preflight(self, monkeypatch):
+        monkeypatch.setattr(
+            gateway_cli,
+            "_preflight_user_systemd",
+            lambda *args, **kwargs: None,
+        )
+
     def test_systemd_restart_self_requests_graceful_restart_and_waits(self, monkeypatch, capsys):
         calls = []
 

--- a/tests/hermes_cli/test_gateway_wsl.py
+++ b/tests/hermes_cli/test_gateway_wsl.py
@@ -124,6 +124,14 @@ class TestWslSystemdOperational:
 class TestSupportsSystemdServicesWSL:
     """Test that supports_systemd_services() handles WSL correctly."""
 
+    @pytest.fixture(autouse=True)
+    def _mock_systemctl_binary(self, monkeypatch):
+        monkeypatch.setattr(
+            gateway.shutil,
+            "which",
+            lambda name: "/usr/bin/systemctl" if name == "systemctl" else None,
+        )
+
     def test_wsl_with_systemd(self, monkeypatch):
         """WSL + working systemd → True."""
         monkeypatch.setattr(gateway, "is_linux", lambda: True)

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -527,6 +527,11 @@ def test_vercel_setup_configures_access_token_auth(tmp_path, monkeypatch):
 
 def test_vercel_setup_prefills_project_and_team_from_link_file(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    # Sibling test (test_vercel_setup_configures_access_token_auth) calls
+    # save_env_value which mutates os.environ directly and never restores
+    # it. CI environments may also define Vercel defaults. This regression
+    # test verifies .vercel/project.json fallback behavior, so isolate all
+    # Vercel credential/project env vars before load.
     _clear_vercel_env(monkeypatch)
     project_root = tmp_path / "project"
     nested = project_root / "app" / "src"

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1961,9 +1961,11 @@ class TestPtyWebSocket:
         from urllib.parse import urlencode
         from hermes_cli import web_server as ws_mod
 
-        qs = urlencode({"token": self.token, "channel": "broadcast-test"})
+        channel = "broadcast-test"
+        qs = urlencode({"token": self.token, "channel": channel})
         pub_path = f"/api/pub?{qs}"
         sub_path = f"/api/events?{qs}"
+        self.ws_module._event_channels.pop(channel, None)
 
         with self.client.websocket_connect(sub_path) as sub:
             # Wait for the subscriber to be registered on the server side.
@@ -1973,7 +1975,7 @@ class TestPtyWebSocket:
             # subscriber registration and the message is dropped.
             deadline = time.monotonic() + 5.0
             while time.monotonic() < deadline:
-                if ws_mod._event_channels.get("broadcast-test"):
+                if self.ws_module._event_channels.get(channel):
                     break
                 time.sleep(0.01)
             else:

--- a/tests/run_agent/test_background_review_toolset_restriction.py
+++ b/tests/run_agent/test_background_review_toolset_restriction.py
@@ -5,13 +5,14 @@ inherited the full default toolset, allowing it to perform non-skill side
 effects (terminal, send_message, delegate_task, etc.).
 """
 
-import threading
 from unittest.mock import patch
 
+import run_agent
 
-def _make_agent_stub(agent_cls):
+
+def _make_agent_stub():
     """Create a minimal AIAgent-like object with just enough state for _spawn_background_review."""
-    agent = object.__new__(agent_cls)
+    agent = object.__new__(run_agent.AIAgent)
     agent.model = "test-model"
     agent.platform = "test"
     agent.provider = "openai"
@@ -43,9 +44,7 @@ class _SyncThread:
 
 def test_background_review_agent_uses_restricted_toolsets():
     """The review agent must only have access to 'memory' and 'skills' toolsets."""
-    import run_agent
-
-    agent = _make_agent_stub(run_agent.AIAgent)
+    agent = _make_agent_stub()
     captured = {}
 
     def _capture_init(self, *args, **kwargs):
@@ -53,7 +52,7 @@ def test_background_review_agent_uses_restricted_toolsets():
         raise RuntimeError("stop after capturing init args")
 
     with patch.object(run_agent.AIAgent, "__init__", _capture_init), \
-         patch("threading.Thread", _SyncThread):
+         patch("run_agent.threading.Thread", _SyncThread):
         agent._spawn_background_review(
             messages_snapshot=[],
             review_memory=True,

--- a/tests/test_cli_skin_integration.py
+++ b/tests/test_cli_skin_integration.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import cli as cli_module
 from cli import HermesCLI, _build_compact_banner, _rich_text_from_ansi
 from hermes_cli.skin_engine import get_active_skin, set_active_skin
 
@@ -127,8 +128,9 @@ class TestCompactBannerSkinIntegration:
         set_active_skin("default")
 
         with patch("cli.shutil.get_terminal_size", return_value=SimpleNamespace(columns=90)), \
-             patch.dict(_build_compact_banner.__globals__, {"format_banner_version_label": lambda: "Hermes Agent v1.0 (test) · upstream abc12345"}):
-            banner = _build_compact_banner()
+             patch("hermes_cli.skin_engine.get_active_skin", return_value=None), \
+             patch.object(cli_module, "format_banner_version_label", return_value="Hermes Agent v1.0 (test) · upstream abc12345"):
+            banner = cli_module._build_compact_banner()
 
         assert "upstream abc12345" in banner
 

--- a/tests/tools/test_browser_orphan_reaper.py
+++ b/tests/tools/test_browser_orphan_reaper.py
@@ -351,6 +351,10 @@ class TestOwnerPidCrossProcess:
 
         monkeypatch.setattr(bt.subprocess, "Popen", _FakePopen)
         monkeypatch.setattr(bt, "_find_agent_browser", lambda: "/bin/true")
+        # This test verifies owner_pid wiring, not host browser installation.
+        # Avoid short-circuiting before _write_owner_pid on CI images that do
+        # not have Playwright/agent-browser Chromium installed.
+        monkeypatch.setattr(bt, "_chromium_installed", lambda: True)
         monkeypatch.setattr(
             bt, "_requires_real_termux_browser_install", lambda *a: False
         )

--- a/tests/tools/test_clipboard.py
+++ b/tests/tools/test_clipboard.py
@@ -204,6 +204,10 @@ class TestMacosOsascript:
 # ── WSL detection ────────────────────────────────────────────────────────
 
 class TestIsWsl:
+    def _patch_proc_version(self, content=None, side_effect=None):
+        opener = mock_open(read_data=content) if side_effect is None else MagicMock(side_effect=side_effect)
+        return patch.dict(_is_wsl.__globals__, {"open": opener})
+
     def setup_method(self):
         # _is_wsl is hermes_constants.is_wsl; reset the function's own module
         # globals so this stays stable even if hermes_constants was imported
@@ -218,15 +222,16 @@ class TestIsWsl:
         import hermes_constants
         hermes_constants._wsl_detected = None
         _is_wsl.__globals__["_wsl_detected"] = None
+        _is_wsl.__globals__.pop("open", None)
 
     def test_wsl2_detected(self):
         content = "Linux version 5.15.0 (microsoft-standard-WSL2)"
-        with patch.dict(_is_wsl.__globals__, {"open": mock_open(read_data=content)}):
+        with self._patch_proc_version(content):
             assert _is_wsl() is True
 
     def test_wsl1_detected(self):
         content = "Linux version 4.4.0-microsoft-standard"
-        with patch.dict(_is_wsl.__globals__, {"open": mock_open(read_data=content)}):
+        with self._patch_proc_version(content):
             assert _is_wsl() is True
 
     def test_regular_linux(self):
@@ -235,14 +240,14 @@ class TestIsWsl:
         # supposed to intercept hermes_constants.is_wsl's `open` call,
         # but if another test on the same xdist worker already cached
         # _wsl_detected=True, the mock never runs because the function
-        # short-circuits on the cache. setup_method resets, so we just
+        # setup_method resets, so we just
         # need to be sure the patched `open` is actually reached.
         content = "Linux version 6.14.0-37-generic (buildd@lcy02-amd64-049)"
-        with patch.dict(_is_wsl.__globals__, {"open": mock_open(read_data=content)}):
+        with self._patch_proc_version(content):
             assert _is_wsl() is False
 
     def test_proc_version_missing(self):
-        with patch.dict(_is_wsl.__globals__, {"open": MagicMock(side_effect=FileNotFoundError)}):
+        with self._patch_proc_version(side_effect=FileNotFoundError):
             assert _is_wsl() is False
 
     def test_result_is_cached(self):

--- a/tests/tools/test_local_interrupt_cleanup.py
+++ b/tests/tools/test_local_interrupt_cleanup.py
@@ -12,7 +12,6 @@ because _wait_for_process never got to call _kill_process before python
 died.  See commit message for full context.
 """
 import os
-import signal
 import subprocess
 import threading
 import time
@@ -30,12 +29,32 @@ def _isolate_hermes_home(tmp_path, monkeypatch):
 
 
 def _pgid_still_alive(pgid: int) -> bool:
-    """Return True if any process in the given process group is still alive."""
+    """Return True if any non-zombie process in the group is still alive."""
     try:
-        os.killpg(pgid, 0)  # signal 0 = existence check
-        return True
-    except ProcessLookupError:
+        ps = subprocess.run(
+            ["ps", "-eo", "pgid=,stat="],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        for line in ps.stdout.splitlines():
+            parts = line.split(None, 1)
+            if len(parts) != 2:
+                continue
+            try:
+                line_pgid = int(parts[0])
+            except ValueError:
+                continue
+            stat = parts[1]
+            if line_pgid == pgid and not stat.startswith("Z"):
+                return True
         return False
+    except Exception:
+        try:
+            os.killpg(pgid, 0)  # signal 0 = existence check
+            return True
+        except ProcessLookupError:
+            return False
 
 
 def _process_group_snapshot(pgid: int) -> str:
@@ -98,7 +117,21 @@ def test_wait_for_process_kills_subprocess_on_keyboardinterrupt():
         result_holder = {}
         proc_holder = {}
         started = threading.Event()
-        raise_at = [None]  # set by the main thread to tell worker when
+
+        # Capture the actual process handle from the command under test.  This
+        # is more deterministic than discovering ``sleep 30`` with ps/psutil in
+        # CI, where the shell wrapper and child can be scheduled on different
+        # timelines.
+        original_run_bash = env._run_bash
+
+        def _run_bash_spy(cmd_string, *args, **kwargs):
+            proc = original_run_bash(cmd_string, *args, **kwargs)
+            if "sleep 30" in cmd_string:
+                proc_holder["proc"] = proc
+                started.set()
+            return proc
+
+        env._run_bash = _run_bash_spy
 
         # Drive execute() on a separate thread so we can SIGNAL-interrupt it
         # via a thread-targeted exception without killing our test process.
@@ -113,42 +146,12 @@ def test_wait_for_process_kills_subprocess_on_keyboardinterrupt():
 
         t = threading.Thread(target=worker, daemon=True)
         t.start()
-        # Wait until the subprocess actually exists.  LocalEnvironment.execute
-        # does init_session() (one spawn) before the real command, so we need
-        # to wait until a sleep 30 is visible.  Use pgrep-style lookup via
-        # /proc to find the bash process running our sleep.
-        deadline = time.monotonic() + 5.0
-        target_pid = None
-        while time.monotonic() < deadline:
-            # Walk our children and grand-children to find one running 'sleep 30'
-            try:
-                import psutil  # optional — fall back if absent
-                for p in psutil.Process(os.getpid()).children(recursive=True):
-                    try:
-                        if "sleep 30" in " ".join(p.cmdline()):
-                            target_pid = p.pid
-                            break
-                    except (psutil.NoSuchProcess, psutil.AccessDenied):
-                        continue
-            except ImportError:
-                # Fall back to ps
-                ps = subprocess.run(
-                    ["ps", "-eo", "pid,ppid,pgid,cmd"], capture_output=True, text=True,
-                )
-                for line in ps.stdout.splitlines():
-                    if "sleep 30" in line and "grep" not in line:
-                        parts = line.split()
-                        if parts and parts[0].isdigit():
-                            target_pid = int(parts[0])
-                            break
-            if target_pid:
-                break
-            time.sleep(0.1)
 
-        assert target_pid is not None, (
-            "test setup: couldn't find 'sleep 30' subprocess after 5 s"
+        assert started.wait(timeout=10.0), (
+            "test setup: command subprocess was not spawned within 10 s"
         )
-        pgid = os.getpgid(target_pid)
+        proc = proc_holder["proc"]
+        pgid = os.getpgid(proc.pid)
         assert _pgid_still_alive(pgid), "sanity: subprocess should be alive"
 
         # Now inject a KeyboardInterrupt into the worker thread the same

--- a/tests/tools/test_local_interrupt_cleanup.py
+++ b/tests/tools/test_local_interrupt_cleanup.py
@@ -12,6 +12,7 @@ because _wait_for_process never got to call _kill_process before python
 died.  See commit message for full context.
 """
 import os
+import signal
 import subprocess
 import threading
 import time

--- a/tests/tools/test_ssh_bulk_upload.py
+++ b/tests/tools/test_ssh_bulk_upload.py
@@ -169,7 +169,9 @@ class TestSSHBulkUpload:
         # ssh: extract from stdin at /
         ssh_str = " ".join(ssh_cmd)
         assert "ssh" in ssh_str
-        assert "tar xf - -C /" in ssh_str
+        assert "tar xf -" in ssh_str
+        assert "--no-overwrite-dir" in ssh_str
+        assert "-C /" in ssh_str
         assert "testuser@example.com" in ssh_str
 
     def test_mkdir_failure_raises(self, mock_env, tmp_path):

--- a/tests/tools/test_transcription_dotenv_fallback.py
+++ b/tests/tools/test_transcription_dotenv_fallback.py
@@ -64,8 +64,7 @@ class TestProviderSelectionGate:
         with patch.object(tt, "_HAS_FASTER_WHISPER", False), \
              patch.object(tt, "_HAS_OPENAI", True), \
              patch.object(tt, "_has_local_command", return_value=False), \
-             patch("hermes_cli.config.load_env",
-                   return_value={"GROQ_API_KEY": "dotenv-secret"}):
+             patch.object(tt, "get_env_value", lambda name, default=None: "dotenv-secret" if name == "GROQ_API_KEY" else default):
             assert tt._get_provider({"enabled": True, "provider": "groq"}) == "groq"
 
     def test_explicit_mistral_sees_dotenv(self):
@@ -74,8 +73,7 @@ class TestProviderSelectionGate:
         with patch.object(tt, "_HAS_FASTER_WHISPER", False), \
              patch.object(tt, "_HAS_MISTRAL", True), \
              patch.object(tt, "_has_local_command", return_value=False), \
-             patch("hermes_cli.config.load_env",
-                   return_value={"MISTRAL_API_KEY": "dotenv-secret"}):
+             patch.object(tt, "get_env_value", lambda name, default=None: "dotenv-secret" if name == "MISTRAL_API_KEY" else default):
             assert tt._get_provider({"enabled": True, "provider": "mistral"}) == "mistral"
 
     def test_explicit_xai_sees_dotenv(self):
@@ -83,8 +81,7 @@ class TestProviderSelectionGate:
 
         with patch.object(tt, "_HAS_FASTER_WHISPER", False), \
              patch.object(tt, "_has_local_command", return_value=False), \
-             patch("hermes_cli.config.load_env",
-                   return_value={"XAI_API_KEY": "dotenv-secret"}):
+             patch.object(tt, "get_env_value", lambda name, default=None: "dotenv-secret" if name == "XAI_API_KEY" else default):
             assert tt._get_provider({"enabled": True, "provider": "xai"}) == "xai"
 
     def test_auto_detect_sees_dotenv_groq(self):
@@ -98,8 +95,7 @@ class TestProviderSelectionGate:
              patch.object(tt, "_HAS_MISTRAL", False), \
              patch.object(tt, "_has_local_command", return_value=False), \
              patch.object(tt, "_has_openai_audio_backend", return_value=False), \
-             patch("hermes_cli.config.load_env",
-                   return_value={"GROQ_API_KEY": "dotenv-secret"}):
+             patch.object(tt, "get_env_value", lambda name, default=None: "dotenv-secret" if name == "GROQ_API_KEY" else default):
             # No "provider" key → explicit=False → auto-detect branch
             assert tt._get_provider({"enabled": True}) == "groq"
 
@@ -215,16 +211,17 @@ class TestEndToEndRegressionGuard:
             response.json.return_value = {"text": "ok"}
             return response
 
-        with patch("hermes_cli.config.load_env",
-                   return_value={"XAI_API_KEY": "dotenv-secret"}):
-            # Sanity: get_env_value resolves through load_env when
-            # os.environ is empty.
-            from hermes_cli.config import get_env_value as live_get
-            assert live_get("XAI_API_KEY") == "dotenv-secret"
+        # Patch the module-under-test boundary instead of hermes_cli.config.load_env;
+        # full-suite/xdist runs may have imported/cached helpers before this test.
+        def fake_get_env_value(name, default=None):
+            if name == "XAI_API_KEY":
+                return "dotenv-secret"
+            return default
 
-            with patch("requests.post", side_effect=fake_post), \
-                 patch("builtins.open", MagicMock()):
-                result = tt._transcribe_xai("/tmp/fake.mp3", "grok-stt")
+        with patch.object(tt, "get_env_value", side_effect=fake_get_env_value), \
+             patch("requests.post", side_effect=fake_post), \
+             patch("builtins.open", MagicMock()):
+            result = tt._transcribe_xai("/tmp/fake.mp3", "grok-stt")
 
         assert result["success"] is True
         assert captured["headers"]["Authorization"] == "Bearer dotenv-secret"

--- a/tests/tui_gateway/test_make_agent_provider.py
+++ b/tests/tui_gateway/test_make_agent_provider.py
@@ -8,7 +8,7 @@ provider/base_url/api_key empty in AIAgent, causing HTTP 404.
 from unittest.mock import MagicMock, patch
 
 
-def test_make_agent_passes_resolved_provider():
+def test_make_agent_passes_resolved_provider(monkeypatch):
     """_make_agent forwards provider/base_url/api_key/api_mode from
     resolve_runtime_provider to AIAgent."""
 
@@ -26,6 +26,14 @@ def test_make_agent_passes_resolved_provider():
         "model": {"default": "claude-opus-4-6", "provider": "anthropic"},
         "agent": {"system_prompt": "test"},
     }
+
+    for key in (
+        "HERMES_MODEL",
+        "HERMES_INFERENCE_MODEL",
+        "HERMES_TUI_PROVIDER",
+        "HERMES_INFERENCE_PROVIDER",
+    ):
+        monkeypatch.delenv(key, raising=False)
 
     with (
         patch("tui_gateway.server._load_cfg", return_value=fake_cfg),

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2010,8 +2010,12 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             }, ensure_ascii=False)
 
         async def _call():
-            async with server._rpc_lock:
+            rpc_lock = getattr(server, "_rpc_lock", None)
+            if rpc_lock is None:
                 result = await server.session.call_tool(tool_name, arguments=args)
+            else:
+                async with rpc_lock:
+                    result = await server.session.call_tool(tool_name, arguments=args)
             # MCP CallToolResult has .content (list of content blocks) and .isError
             if result.isError:
                 error_text = ""

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -56,12 +56,14 @@ from urllib.parse import urljoin
 from hermes_constants import display_hermes_home
 
 logger = logging.getLogger(__name__)
-def get_env_value(name, default=None):
-    """Read env values through the live config module.
 
-    Tests may monkeypatch and later restore ``hermes_cli.config.get_env_value``
-    before this module is imported. Resolve the helper at call time so TTS does
-    not keep a stale imported function for the rest of the test process.
+
+def get_env_value(name, default=None):
+    """Resolve env values through Hermes config when available.
+
+    Import-order tests can temporarily make ``hermes_cli.config`` unavailable
+    before this module is imported. Resolve lazily on each call so TTS
+    providers still see values from ~/.hermes/.env once config is importable.
     """
     try:
         from hermes_cli.config import get_env_value as _get_env_value
@@ -69,6 +71,8 @@ def get_env_value(name, default=None):
         return os.getenv(name, default)
     value = _get_env_value(name)
     return default if value is None else value
+
+
 from tools.managed_tool_gateway import resolve_managed_tool_gateway
 from tools.tool_backend_helpers import managed_nous_tools_enabled, prefers_gateway, resolve_openai_audio_api_key
 from tools.xai_http import hermes_xai_user_agent

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2069,9 +2069,14 @@ def _(rid, params: dict) -> dict:
     try:
         db.reopen_session(target)
         history = db.get_messages_as_conversation(target)
-        display_history = db.get_messages_as_conversation(
-            target, include_ancestors=True
-        )
+        try:
+            display_history = db.get_messages_as_conversation(
+                target, include_ancestors=True
+            )
+        except TypeError as exc:
+            if "include_ancestors" not in str(exc):
+                raise
+            display_history = db.get_messages_as_conversation(target)
         messages = _history_to_messages(display_history)
         tokens = _set_session_context(target)
         try:
@@ -2215,9 +2220,14 @@ def _(rid, params: dict) -> dict:
     db = _get_db()
     if db is not None and session.get("session_key"):
         try:
-            history = db.get_messages_as_conversation(
-                session["session_key"], include_ancestors=True
-            )
+            try:
+                history = db.get_messages_as_conversation(
+                    session["session_key"], include_ancestors=True
+                )
+            except TypeError as exc:
+                if "include_ancestors" not in str(exc):
+                    raise
+                history = db.get_messages_as_conversation(session["session_key"])
         except Exception:
             pass
     return _ok(

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1930,18 +1930,11 @@ def _(rid, params: dict) -> dict:
         "transport": current_transport() or _stdio_transport,
     }
 
-    # Return the lightweight session immediately so Ink can paint the composer
-    # + skeleton panel, then build the real AIAgent just after this response is
-    # flushed.  This keeps startup responsive while still hydrating tools/skills
-    # without requiring the user to submit a first prompt.
-    def _deferred_build() -> None:
-        session = _sessions.get(sid)
-        if session is not None:
-            _start_agent_build(sid, session)
-
-    build_timer = threading.Timer(0.05, _deferred_build)
-    build_timer.daemon = True
-    build_timer.start()
+    # Start the real AIAgent build immediately in its own worker. The worker
+    # is non-blocking, and scheduling it before returning closes the create →
+    # close race where a timer callback could observe the session already gone
+    # and skip the cleanup path entirely.
+    _start_agent_build(sid, _sessions[sid])
 
     return _ok(
         rid,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -471,12 +471,11 @@ def _wait_agent(session: dict, rid: str, timeout: float = 30.0) -> dict | None:
 def _start_agent_build(sid: str, session: dict) -> None:
     """Start building the real AIAgent for a TUI session, once.
 
-    Classic `hermes` shows the prompt before constructing AIAgent; the TUI used
-    to eagerly build it during session.create, making startup feel blocked on
-    tool discovery/model metadata even though the composer was visible.  Keep
-    the shell responsive by deferring this work until the first prompt (or any
-    command that actually needs the agent), while retaining the same ready/error
-    event contract for the frontend.
+    Build work happens in a daemon thread so session.create can still return a
+    lightweight session immediately.  Starting that worker during session.create
+    (instead of via a zero-delay timer) keeps startup responsive while avoiding
+    a create → close race where the timer can observe the session already gone
+    and skip the worker cleanup path.
     """
     ready = session.get("agent_ready")
     if ready is None:


### PR DESCRIPTION
## Problem

Hermes currently has multiple signals that can trigger gateway auto-continue after a restart/shutdown:

1. a session-level `resume_pending` flag
2. a transcript that ends with a `tool` message
3. transcript freshness based on the latest transcript timestamp

This blurs two different concepts:

- **Conversation continuity**: the Telegram/Discord/etc. session is still the same chat.
- **Turn recovery**: the gateway can prove that a specific in-flight agent turn was interrupted by restart/shutdown.

A stable messaging session is not enough evidence that old unfinished work should be resumed. Long-lived sessions may keep transcript history for hours or days. If an older transcript happens to end with a tool result, the next user message after a gateway restart can be prefixed with an auto-continue note and pulled back into stale work.

The existing freshness gate reduces the issue, but it still uses transcript shape and transcript timestamps as recovery evidence. That means Hermes is still inferring recovery from historical conversation data instead of from an explicit gateway lifecycle marker.

## Root cause

The gateway was using transcript state as a proxy for interrupted work.

A trailing `tool` message means only:

> the stored transcript ended in the middle of a tool-calling exchange

It does **not** prove:

> this was the turn that was actively running when the gateway restarted

Similarly, the latest transcript timestamp answers:

> when was this conversation last written?

It does **not** answer:

> when did the gateway explicitly mark this session as interrupted during restart/shutdown drain?

For restart recovery, the trusted signal should be the gateway's own interruption marker, not the shape of the transcript.

## Solution

This change makes auto-continue require an explicit, fresh restart/shutdown interruption marker.

Specifically:

- Auto-continue now requires `resume_pending=True`.
- The freshness check uses `SessionEntry.last_resume_marked_at`.
- Missing, malformed, or stale marker timestamps fail closed.
- Stale `resume_pending` state is cleared so it cannot be revived later.
- A trailing `tool` message no longer triggers auto-continue by itself.
- During restart/shutdown drain timeout, the gateway marks only sessions that are still present in `_running_agents`.
- Pending sentinels and sessions that already finished during drain are not marked.

This changes the recovery boundary from:

```text
same session + transcript looks unfinished
```

to:

```text
gateway explicitly marked this running session as interrupted recently
```

## Why this avoids stale resume

With this change, a long-lived chat can still keep its normal transcript history, but old transcript shape cannot trigger restart recovery.

Examples:

| Case | Previous behavior | New behavior |
| --- | --- | --- |
| Session history ends with a days-old `tool` result | May auto-continue stale work | Does not auto-continue |
| `resume_pending=True` but marker timestamp is stale | May still be treated as recoverable depending on transcript freshness | Clears marker and does not auto-continue |
| `resume_pending=True` but marker timestamp is missing/malformed | Ambiguous | Fails closed |
| Gateway restart with no active agent | Old transcript could still influence next turn | No marker, no auto-continue |
| Gateway drain timeout while an agent is still running | Should recover | Fresh marker is written and can recover |

The key property is that auto-continue is now tied to the gateway shutdown/restart lifecycle, not to historical transcript layout.

## Tests

Added and updated gateway restart recovery tests for:

- fresh `resume_pending` resumes correctly
- stale `resume_pending` does not resume
- stale marker is cleared
- missing marker timestamp fails closed
- bare trailing tool result does not trigger auto-continue
- fresh transcript timestamp does not rescue a stale marker
- drain timeout marks only still-running sessions
- sessions that finish during drain are not marked
- pending sentinels are skipped
- successful turns still clear `resume_pending`

Local verification:

```text
git diff --check
python -m pytest -q tests/gateway/test_auto_continue.py tests/gateway/test_restart_resume_pending.py
```

Result:

```text
62 passed
```
