### PR TITLE
fix(gateway): handle wmic encoding errors on Windows non-English locales

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -279,9 +279,11 @@ def _scan_gateway_pids(exclude_pids: set[int], all_profiles: bool = False) -> li
                 ["wmic", "process", "get", "ProcessId,CommandLine", "/FORMAT:LIST"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="ignore",
                 timeout=10,
             )
-            if result.returncode != 0:
+            if result.returncode != 0 or result.stdout is None:
                 return []
             current_cmd = ""
             for line in result.stdout.split("\n"):


### PR DESCRIPTION
## Summary

Fix `UnicodeDecodeError` and cascading `AttributeError` in Windows gateway process scanning on non-English locales.

## Problem

On Windows systems with non-English locales, `wmic` outputs text in the system code page (e.g. `cp936` for Chinese, `cp1252` for Western European) rather than UTF-8. When Python's `subprocess.run` decodes the output as UTF-8, a `UnicodeDecodeError` is raised in the reader thread, causing `result.stdout` to become `None`. This produces two cascading failures:

1. `UnicodeDecodeError: 'utf-8' codec can't decode byte 0xd0 in position 8177` in the subprocess reader thread
2. `AttributeError: 'NoneType' object has no attribute 'split'` in `_scan_gateway_pids`

## Fix

- Pass `encoding='utf-8'` and `errors='ignore'` explicitly to `subprocess.run` so undecodable bytes are silently skipped rather than raising
- Add a `None` guard on `result.stdout` before calling `.split()` so the function returns an empty list cleanly instead of crashing

## Testing

- Syntax validation: `python3 -m py_compile hermes_cli/gateway.py` passes
- No existing test coverage for Windows `wmic` path — the fix is defensive and non-breaking (adding `encoding`/`errors` to `subprocess.run` with non-Windows platforms has no effect; the `None` guard is a safe idempotent check)

Closes #17049.
