### PR TITLE
fix(gateway): check for systemd private socket in preflight (fixes #17243)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -829,6 +829,10 @@ def _user_dbus_socket_path() -> Path:
     xdg = os.environ.get("XDG_RUNTIME_DIR") or f"/run/user/{os.getuid()}"
     return Path(xdg) / "bus"
 
+def _user_systemd_private_socket_path() -> Path:
+    """Return the expected per-user systemd private socket path (regardless of existence)."""
+    xdg = os.environ.get("XDG_RUNTIME_DIR") or f"/run/user/{os.getuid()}"
+    return Path(xdg) / "systemd" / "private"
 
 def _ensure_user_systemd_env() -> None:
     """Ensure DBUS_SESSION_BUS_ADDRESS and XDG_RUNTIME_DIR are set for systemctl --user.
@@ -870,7 +874,8 @@ def _wait_for_user_dbus_socket(timeout: float = 3.0) -> bool:
 
 
 def _preflight_user_systemd(*, auto_enable_linger: bool = True) -> None:
-    """Ensure ``systemctl --user`` will reach the user D-Bus session bus.
+    """Ensure ``systemctl --user`` will reach the user D-Bus session bus
+    or the user systemd private socket.
 
     No-op when the bus socket is already there (the common case on desktops
     and linger-enabled servers).  On fresh SSH sessions where the socket is
@@ -890,6 +895,9 @@ def _preflight_user_systemd(*, auto_enable_linger: bool = True) -> None:
     _ensure_user_systemd_env()
     bus_path = _user_dbus_socket_path()
     if bus_path.exists():
+        return
+    systemd_private_path = _user_systemd_private_socket_path()
+    if systemd_private_path.exists():
         return
 
     import getpass

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1108,10 +1108,32 @@ class TestPreflightUserSystemd:
         # Should not raise, no subprocess calls needed.
         gateway_cli._preflight_user_systemd()
 
+    def test_noop_when_systemd_private_socket_exists(self, monkeypatch):
+        """Debian 13 scenario: D-Bus socket missing but systemd private socket present.
+
+        Covers issue #17243: systemctl --user works by connecting to the per-user
+        systemd private socket at /run/user/{uid}/systemd/private when the D-Bus
+        socket at /run/user/{uid}/bus is absent.
+        """
+        monkeypatch.setattr(
+            gateway_cli, "_user_dbus_socket_path",
+            lambda: type("P", (), {"exists": lambda self: False})(),
+        )
+        monkeypatch.setattr(
+            gateway_cli, "_user_systemd_private_socket_path",
+            lambda: type("P", (), {"exists": lambda self: True})(),
+        )
+        # Should not raise, no subprocess calls needed.
+        gateway_cli._preflight_user_systemd()
+
     def test_raises_when_linger_disabled_and_loginctl_denied(self, monkeypatch):
         """Rick's scenario: no D-Bus, no linger, non-root SSH → clear error."""
         monkeypatch.setattr(
             gateway_cli, "_user_dbus_socket_path",
+            lambda: type("P", (), {"exists": lambda self: False})(),
+        )
+        monkeypatch.setattr(
+            gateway_cli, "_user_systemd_private_socket_path",
             lambda: type("P", (), {"exists": lambda self: False})(),
         )
         monkeypatch.setattr(
@@ -1143,6 +1165,10 @@ class TestPreflightUserSystemd:
             lambda: type("P", (), {"exists": lambda self: False})(),
         )
         monkeypatch.setattr(
+            gateway_cli, "_user_systemd_private_socket_path",
+            lambda: type("P", (), {"exists": lambda self: False})(),
+        )
+        monkeypatch.setattr(
             gateway_cli, "get_systemd_linger_status",
             lambda: (None, "loginctl not found"),
         )
@@ -1157,6 +1183,10 @@ class TestPreflightUserSystemd:
         """Edge case: linger says yes but the bus socket never came up."""
         monkeypatch.setattr(
             gateway_cli, "_user_dbus_socket_path",
+            lambda: type("P", (), {"exists": lambda self: False})(),
+        )
+        monkeypatch.setattr(
+            gateway_cli, "_user_systemd_private_socket_path",
             lambda: type("P", (), {"exists": lambda self: False})(),
         )
         monkeypatch.setattr(
@@ -1175,6 +1205,10 @@ class TestPreflightUserSystemd:
         """Happy remediation path: polkit allows enable-linger, socket spawns."""
         monkeypatch.setattr(
             gateway_cli, "_user_dbus_socket_path",
+            lambda: type("P", (), {"exists": lambda self: False})(),
+        )
+        monkeypatch.setattr(
+            gateway_cli, "_user_systemd_private_socket_path",
             lambda: type("P", (), {"exists": lambda self: False})(),
         )
         monkeypatch.setattr(


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

On Debian 13 and similar distros, the D-Bus socket at `/run/user/{uid}/bus` may not exist even when linger is enabled, but `systemctl --user` still works by connecting to the per-user systemd private socket at `/run/user/{uid}/systemd/private`. This PR added detection for per-user systemd private socket besides per-user D-Bus socket.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #17243

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `_preflight_user_systemd()` now checks for **both** the D-Bus socket and the systemd private socket before reporting "user systemd not reachable"
- Added `_user_systemd_private_socket_path()` helper function
- Added `test_noop_when_systemd_private_socket_exists()` test for the Debian 13 scenario
- Updated 4 existing tests to mock the `_user_systemd_private_socket_path` function

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Reproduce #17243
2. Switch to this PR
3. It works

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian 13.4 cloud image <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

N/A