### PR TITLE
fix(telegram): preserve command content and formatting after approval

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1757,11 +1757,26 @@ class TelegramAdapter(BasePlatformAdapter):
 
                 await query.answer(text=label)
 
-                # Edit message to show decision, remove buttons
+                # Edit message to show decision, remove buttons.
+                # Preserve original command content so the user can review
+                # it after approving or denying.
                 try:
+                    original_text = ""
+                    # Use text_html to preserve HTML formatting (e.g. <pre> code blocks)
+                    # since the original approval message is sent with parse_mode=HTML.
+                    msg_obj = getattr(query, "message", None)
+                    if msg_obj:
+                        original_text = getattr(msg_obj, "text_html", "") or ""
+                    if original_text:
+                        updated_text = (
+                            f"{original_text}\n\n"
+                            f"━━━ {label} by {user_display} ━━━"
+                        )
+                    else:
+                        updated_text = f"{label} by {user_display}"
                     await query.edit_message_text(
-                        text=f"{label} by {user_display}",
-                        parse_mode=ParseMode.MARKDOWN,
+                        text=updated_text,
+                        parse_mode=ParseMode.HTML,
                         reply_markup=None,
                     )
                 except Exception:


### PR DESCRIPTION
## What does this PR do?

When a Telegram user clicks an approval button (Allow Once/Session/Always/Deny), the original command preview message was replaced with a short status line like `✅ Approved once by User`, losing both the command content and its HTML formatting (e.g. `<pre>` code blocks). Users could no longer review what they had approved.

This PR preserves the original message text (with HTML formatting intact) and appends the approval result below it.

**Before:**
```
✅ Approved once by User
```

**After:**
```
⚠️ Command Approval Required
┌──────────────────────────┐
│  rm -rf /var/log/app.log  │  ← preserved
│  Reason: recursive delete │  ← preserved
└──────────────────────────┘
━━━ ✅ Approved once by User ━━━
```

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/telegram.py`: Modified `_handle_callback_query` to preserve original message HTML (via `query.message.text_html`) when editing after approval, appending the result instead of replacing the entire message. Changed `parse_mode` from `MARKDOWN` to `HTML` to match the original message format.

## How to Test

1. Trigger a dangerous command approval in Telegram (e.g. ask the agent to run `rm -rf /tmp/test`)
2. Click any approval button (Allow Once / Session / Always / Deny)
3. Verify the original command text and code formatting are preserved with the result appended below

## Checklist

- [x] My commit messages follow Conventional Commits (`fix(telegram): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix (1 file, 1 logical change)
- [x] I have tested on my platform: Linux (Ubuntu 22.04) , Macos 14.8.2 