### PR TITLE
feat(skins): add bunnny — barbie-pink coquette theme ♡

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ mini-swe-agent/
 result
 website/static/api/skills-index.json
 models-dev-upstream/
+.venv

--- a/hermes_cli/skin_engine.py
+++ b/hermes_cli/skin_engine.py
@@ -103,6 +103,10 @@ BUILT-IN SKINS
 - ``slate``   — Cool blue developer-focused theme
 - ``daylight`` — Light background theme with dark text and blue accents
 - ``warm-lightmode`` — Warm brown/gold text for light terminal backgrounds
+- ``poseidon`` — Ocean-god theme (deep blue and seafoam)
+- ``sisyphus`` — Austere grayscale with boulder motif
+- ``charizard`` — Volcanic burnt-orange and ember
+- ``bunnny``   — Barbie-pink coquette theme (sparkles, hearts, bunnies)
 
 USER SKINS
 ==========
@@ -635,6 +639,83 @@ _BUILTIN_SKINS: Dict[str, Dict[str, Any]] = {
 [#F29C38]⠀⠀⠀⠀⠀⠀⠀⠀⣰⡿⢿⣆⠀⠀⠀⠀⠀⠀⠀⠀⠀[/]
 [#F29C38]⠀⠀⠀⠀⠀⠀⠀⣼⡟⠀⠀⢻⣧⠀⠀⠀⠀⠀⠀⠀⠀[/]
 [dim #7A3511]⠀⠀⠀⠀⠀⠀⠀tail flame lit⠀⠀⠀⠀⠀⠀⠀⠀[/]""",
+    },
+    "bunnny": {
+        "name": "bunnny",
+        "description": "Barbie-pink coquette theme — sparkles, bows, and bubblegum",
+        "colors": {
+            "banner_border": "#E91E63",
+            "banner_title": "#FF3366",
+            "banner_accent": "#FF69B4",
+            "banner_dim": "#C2185B",
+            "banner_text": "#FFF0F5",
+            "ui_accent": "#FF3366",
+            "ui_label": "#FF69B4",
+            "ui_ok": "#FFB6C1",
+            "ui_error": "#FF1744",
+            "ui_warn": "#FFAB91",
+            "prompt": "#FFF0F5",
+            "input_rule": "#E91E63",
+            "response_border": "#FF69B4",
+            "status_bar_bg": "#2A0E1E",
+            "status_bar_text": "#FFE4EC",
+            "status_bar_strong": "#FF3366",
+            "status_bar_dim": "#8E4B6B",
+            "status_bar_good": "#FFB6C1",
+            "status_bar_warn": "#FF69B4",
+            "status_bar_bad": "#FF3366",
+            "status_bar_critical": "#FF1744",
+            "session_label": "#FF69B4",
+            "session_border": "#8E4B6B",
+            "voice_status_bg": "#2A0E1E",
+            "completion_menu_bg": "#2A0E1E",
+            "completion_menu_current_bg": "#5A1D3A",
+            "completion_menu_meta_bg": "#2A0E1E",
+            "completion_menu_meta_current_bg": "#5A1D3A",
+        },
+        "spinner": {
+            "waiting_faces": ["(♡)", "(✿)", "(✧)", "(❀)", "(ෆ)", "(˘ᵕ˘)", "(⑅)"],
+            "thinking_faces": ["(♡)", "(✧)", "(❀)", "(✿)", "(ෆ)", "(˘ᵕ˘)"],
+            "thinking_verbs": [
+                "sparkling", "twirling", "glittering", "frosting",
+                "bedazzling", "bowtying", "sprinkling sugar", "picking ribbons",
+                "glossing up", "curating the vibe", "dusting pink",
+                "tying a little bow", "making it cute",
+            ],
+            "wings": [
+                ["⟪♡", "♡⟫"],
+                ["⟪✧", "✧⟫"],
+                ["⟪✿", "✿⟫"],
+                ["⟪❀", "❀⟫"],
+                ["⟪ෆ", "ෆ⟫"],
+            ],
+        },
+        "branding": {
+            "agent_name": "Hermes Agent",
+            "welcome": "hi bestie ♡ welcome to Hermes Agent! type your message or /help for commands (ﾉ◕ヮ◕)ﾉ*:･ﾟ✧",
+            "goodbye": "bye bestie ♡ ✧",
+            "response_label": " ♡ Hermes ",
+            "prompt_symbol": "♡",
+            "help_header": "(ﾉ◕ヮ◕)ﾉ*:･ﾟ✧ Commands",
+        },
+        "tool_prefix": "♡",
+        "banner_logo": """[bold #FFB6C1]██╗  ██╗███████╗██████╗ ███╗   ███╗███████╗███████╗  ██╗  ██╗ [/]
+[bold #FF69B4]██║  ██║██╔════╝██╔══██╗████╗ ████║██╔════╝██╔════╝ ████████╗[/]
+[#FF3C7F]███████║█████╗  ██████╔╝██╔████╔██║█████╗  ███████╗ ╚██████╔╝[/]
+[#FF3366]██╔══██║██╔══╝  ██╔══██╗██║╚██╔╝██║██╔══╝  ╚════██║  ╚████╔╝ [/]
+[#E91E63]██║  ██║███████╗██║  ██║██║ ╚═╝ ██║███████╗███████║   ╚██╔╝  [/]
+[#C2185B]╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝╚═╝     ╚═╝╚══════╝╚══════╝    ╚═╝   [/]""",
+        "banner_hero": """[#FF69B4]⠀⠀✧⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀✧⠀⠀[/]
+[#FFB6C1]⠀⠀⠀⠀⠀⠀♡⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣀⠀⠀⠀⠀⠀⢀⣀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀♡⠀⠀⠀⠀[/]
+[#FF69B4]⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢠⣯⢬⣷⡀⠀⠀⣴⡯⢌⣧⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀[/]
+[#FF3366]⠀✿⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠸⣿♡⠹⣷⠀⢸⡝♡⢸⡿⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀✿⠀[/]
+[#FF3C7F]⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠻⣧⣀⣿⣦⣼⡁⣠⣿⠃⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀[/]
+[#FF3366]⠀⠀⠀⠀✧⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⡾⠋⠀⠀⠀⠈⣙⣯⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀✧[/]
+[#FF3366]⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣾⠀⠀⠀⠀⠀⠀⠀⠸⡆⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀[/]
+[#E91E63]⠀⠀⠀⠀⠀⠀⠀♡⠀⠀⠀⠀⠀⠀⠀⠀⢰⡧⢄⢰⡆⠀⢰⡆⡠⢄⣧⠀⠀⠀⠀⠀⠀⠀⠀♡⠀⠀⠀⠀⠀[/]
+[#C2185B]⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠳⣼⣤⣤⣤⣤⣤⣧⠾⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀[/]
+[#FF69B4]⠀⠀⠀⠀⠀✿⠀⠀⠀⠀⠀⠀❀⠀⠀⠀⠀⠀❀⠀⠀❀⠀⠀⠀⠀⠀❀⠀⠀⠀⠀⠀⠀✿⠀⠀⠀⠀⠀[/]
+[dim #C2185B]⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀xoxo⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀[/]""",
     },
 }
 

--- a/hermes_cli/skin_engine.py
+++ b/hermes_cli/skin_engine.py
@@ -133,6 +133,10 @@ BUILT-IN SKINS
 - ``slate``   — Cool blue developer-focused theme
 - ``daylight`` — Light background theme with dark text and blue accents
 - ``warm-lightmode`` — Warm brown/gold text for light terminal backgrounds
+- ``poseidon`` — Ocean-god theme (deep blue and seafoam)
+- ``sisyphus`` — Austere grayscale with boulder motif
+- ``charizard`` — Volcanic burnt-orange and ember
+- ``bunnny``   — Barbie-pink coquette theme (sparkles, hearts, bunnies)
 
 USER SKINS
 ==========
@@ -773,6 +777,85 @@ _BUILTIN_SKINS: Dict[str, Dict[str, Any]] = {
 [#F29C38]⠀⠀⠀⠀⠀⠀⠀⠀⣰⡿⢿⣆⠀⠀⠀⠀⠀⠀⠀⠀⠀[/]
 [#F29C38]⠀⠀⠀⠀⠀⠀⠀⣼⡟⠀⠀⢻⣧⠀⠀⠀⠀⠀⠀⠀⠀[/]
 [dim #7A3511]⠀⠀⠀⠀⠀⠀⠀tail flame lit⠀⠀⠀⠀⠀⠀⠀⠀[/]""",
+    },
+    "bunnny": {
+        "name": "bunnny",
+        "description": "Barbie-pink coquette theme — sparkles, bows, and bubblegum",
+        "colors": {
+            "banner_border": "#E91E63",
+            "banner_title": "#FF3366",
+            "banner_accent": "#FF69B4",
+            "banner_dim": "#C2185B",
+            "banner_text": "#FFF0F5",
+            "ui_accent": "#FF3366",
+            "ui_label": "#FF69B4",
+            "ui_ok": "#FFB6C1",
+            "ui_error": "#FF1744",
+            "ui_warn": "#FFAB91",
+            "prompt": "#FFF0F5",
+            "input_rule": "#E91E63",
+            "response_border": "#FF69B4",
+            "status_bar_bg": "#2A0E1E",
+            "status_bar_text": "#FFE4EC",
+            "status_bar_strong": "#FF3366",
+            "status_bar_dim": "#8E4B6B",
+            "status_bar_good": "#FFB6C1",
+            "status_bar_warn": "#FF69B4",
+            "status_bar_bad": "#FF3366",
+            "status_bar_critical": "#FF1744",
+            "session_label": "#FF69B4",
+            "session_border": "#8E4B6B",
+            "voice_status_bg": "#2A0E1E",
+            "completion_menu_bg": "#2A0E1E",
+            "completion_menu_current_bg": "#5A1D3A",
+            "completion_menu_meta_bg": "#2A0E1E",
+            "completion_menu_meta_current_bg": "#5A1D3A",
+            "selection_bg": "#5A1D3A",
+            "shell_dollar": "#FF69B4",
+        },
+        "spinner": {
+            "waiting_faces": ["(♡)", "(✿)", "(✧)", "(❀)", "(ෆ)", "(˘ᵕ˘)", "(⑅)"],
+            "thinking_faces": ["(♡)", "(✧)", "(❀)", "(✿)", "(ෆ)", "(˘ᵕ˘)"],
+            "thinking_verbs": [
+                "sparkling", "twirling", "glittering", "frosting",
+                "bedazzling", "bowtying", "sprinkling sugar", "picking ribbons",
+                "glossing up", "curating the vibe", "dusting pink",
+                "tying a little bow", "making it cute",
+            ],
+            "wings": [
+                ["⟪♡", "♡⟫"],
+                ["⟪✧", "✧⟫"],
+                ["⟪✿", "✿⟫"],
+                ["⟪❀", "❀⟫"],
+                ["⟪ෆ", "ෆ⟫"],
+            ],
+        },
+        "branding": {
+            "agent_name": "Hermes Agent",
+            "welcome": "hi bestie ♡ welcome to Hermes Agent! type your message or /help for commands (ﾉ◕ヮ◕)ﾉ*:･ﾟ✧",
+            "goodbye": "bye bestie ♡ ✧",
+            "response_label": " ♡ Hermes ",
+            "prompt_symbol": "♡",
+            "help_header": "(ﾉ◕ヮ◕)ﾉ*:･ﾟ✧ Commands",
+        },
+        "tool_prefix": "♡",
+        "banner_logo": """[bold #FFB6C1]██╗  ██╗███████╗██████╗ ███╗   ███╗███████╗███████╗  ██╗  ██╗ [/]
+[bold #FF69B4]██║  ██║██╔════╝██╔══██╗████╗ ████║██╔════╝██╔════╝ ████████╗[/]
+[#FF3C7F]███████║█████╗  ██████╔╝██╔████╔██║█████╗  ███████╗ ╚██████╔╝[/]
+[#FF3366]██╔══██║██╔══╝  ██╔══██╗██║╚██╔╝██║██╔══╝  ╚════██║  ╚████╔╝ [/]
+[#E91E63]██║  ██║███████╗██║  ██║██║ ╚═╝ ██║███████╗███████║   ╚██╔╝  [/]
+[#C2185B]╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝╚═╝     ╚═╝╚══════╝╚══════╝    ╚═╝   [/]""",
+        "banner_hero": """[#FF69B4]⠀⠀✧⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀✧⠀⠀[/]
+[#FFB6C1]⠀⠀⠀⠀⠀⠀♡⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣀⠀⠀⠀⠀⠀⢀⣀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀♡⠀⠀⠀⠀[/]
+[#FF69B4]⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢠⣯⢬⣷⡀⠀⠀⣴⡯⢌⣧⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀[/]
+[#FF3366]⠀✿⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠸⣿♡⠹⣷⠀⢸⡝♡⢸⡿⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀✿⠀[/]
+[#FF3C7F]⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠻⣧⣀⣿⣦⣼⡁⣠⣿⠃⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀[/]
+[#FF3366]⠀⠀⠀⠀✧⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⡾⠋⠀⠀⠀⠈⣙⣯⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀✧[/]
+[#FF3366]⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣾⠀⠀⠀⠀⠀⠀⠀⠸⡆⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀[/]
+[#E91E63]⠀⠀⠀⠀⠀⠀⠀♡⠀⠀⠀⠀⠀⠀⠀⠀⢰⡧⢄⢰⡆⠀⢰⡆⡠⢄⣧⠀⠀⠀⠀⠀⠀⠀⠀♡⠀⠀⠀⠀⠀[/]
+[#C2185B]⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠳⣼⣤⣤⣤⣤⣤⣧⠾⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀[/]
+[#FF69B4]⠀⠀⠀⠀⠀✿⠀⠀⠀⠀⠀⠀❀⠀⠀⠀⠀⠀❀⠀⠀❀⠀⠀⠀⠀⠀❀⠀⠀⠀⠀⠀⠀✿⠀⠀⠀⠀⠀[/]
+[dim #C2185B]⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀xoxo⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀[/]""",
     },
 }
 

--- a/website/docs/user-guide/features/skins.md
+++ b/website/docs/user-guide/features/skins.md
@@ -41,6 +41,7 @@ display:
 | `poseidon` | Ocean-god theme — deep blue and seafoam | `Poseidon Agent` | Deep blue to seafoam gradient. Ocean-themed spinners ("charting currents", "sounding the depth"). Trident ASCII art banner. |
 | `sisyphus` | Sisyphean theme — austere grayscale with persistence | `Sisyphus Agent` | Light grays with stark contrast. Boulder-themed spinners ("pushing uphill", "resetting the boulder", "enduring the loop"). Boulder-and-hill ASCII art banner. |
 | `charizard` | Volcanic theme — burnt orange and ember | `Charizard Agent` | Warm burnt orange to ember gradient. Fire-themed spinners ("banking into the draft", "measuring burn"). Dragon-silhouette ASCII art banner. |
+| `bunnny` | Barbie-pink coquette theme — sparkles, bows, and bubblegum | `Hermes Agent` | Hot pink (`#E91E63`) borders with Barbie-pink (`#FF69B4`) accents and lavender-blush text. Coquette spinner verbs ("sparkling", "twirling", "tying a little bow"). Heart (♡) prompt symbol, sparkle-kaomoji greeting, twin-bunny hero art. |
 
 ## Complete list of configurable keys
 


### PR DESCRIPTION
<img width="1848" height="1244" alt="image" src="https://github.com/user-attachments/assets/56b7ee4a-c60f-43ff-a812-5c3ed8100d75" />


Adds a new built-in skin preset `bunnny` — barbie pink, sparkles, bows, bubblegum xx.

## Palette

| Role | Color |
|---|---|
| banner_title / ui_accent | `#FF3366` hot pink |
| banner_accent | `#FF69B4` barbie pink |
| banner_border / input_rule | `#E91E63` deep magenta rose |
| banner_text / prompt | `#FFF0F5` lavender blush |
| status_bar_bg | `#2A0E1E` deep plum |
| ui_ok | `#FFB6C1` light pink |
| ui_error | `#FF1744` |

## Vibe

- Prompt symbol + tool prefix: `♡`
- Spinner faces: `(♡) (✿) (✧) (❀) (ෆ) (˘ᵕ˘) (⑅)`
- Spinner verbs: `sparkling, twirling, glittering, frosting, bedazzling, bowtying, sprinkling sugar, picking ribbons, glossing up, curating the vibe, dusting pink, tying a little bow, making it cute`
- Welcome: `hi bestie ♡ welcome to Hermes Agent! type your message or /help for commands (ﾉ◕ヮ◕)ﾉ*:･ﾟ✧`
- Help header: `(ﾉ◕ヮ◕)ﾉ*:･ﾟ✧ Commands`
- Goodbye: `bye bestie ♡ ✧`
- Custom `banner_logo` — `HERMES ♥` (HERMES + pixel-block heart) in pink gradient
- Custom `banner_hero` — twin coquette bunnies holding paws with ♡ eyes, framed by scattered ✧ sparkles, ♡ hearts, and ✿/❀ flowers filling the full banner width
- `agent_name` stays `Hermes Agent` — skin is cosmetic only

## Activate

```bash
/skin bunnny
```

or set in `~/.hermes/config.yaml`:

```yaml
display:
  skin: bunnny
```

## Changes

- `hermes_cli/skin_engine.py` — added `bunnny` entry to `_BUILTIN_SKINS` + updated module docstring built-in list
- `website/docs/user-guide/features/skins.md` — added row to built-in skins table
- `.gitignore` — ignore local `.venv` symlinks

## Tests

- `tests/cli/` — all pass except 2 pre-existing failures in `test_resume_display.py` unrelated to this change (verified by stashing the diff and re-running; same failures).
- Manual render check with Rich in truecolor: banner, hero, branding all render clean.
