### PR TITLE
fix(weixin): rebuild aiohttp session for cross-loop send_* calls

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import contextlib
 import hashlib
 import json
 import logging
@@ -1232,6 +1233,35 @@ class WeixinAdapter(BasePlatformAdapter):
         self._mark_disconnected()
         logger.info("[%s] Disconnected", self.name)
 
+    @contextlib.asynccontextmanager
+    async def _loop_safe_session(self):
+        """Yield with self._send_session bound to the current event loop.
+
+        The gateway-owned aiohttp.ClientSession is bound to the loop that
+        created it.  When ``send_message`` is invoked from an agent tool it
+        runs in a worker thread under a fresh loop (see model_tools._run_async),
+        and reusing the original session there triggers aiohttp's
+        "Timeout context manager should be used inside a task" RuntimeError.
+        Detect that case and swap in a per-call session bound to the running
+        loop so every send_* path Just Works regardless of where it was called.
+        """
+        cur = asyncio.get_running_loop()
+        if (
+            self._send_session is None
+            or getattr(self._send_session, "_loop", None) is cur
+        ):
+            yield
+            return
+        saved = self._send_session
+        async with aiohttp.ClientSession(
+            trust_env=True, connector=_make_ssl_connector()
+        ) as ad_hoc:
+            self._send_session = ad_hoc
+            try:
+                yield
+            finally:
+                self._send_session = saved
+
     async def _poll_loop(self) -> None:
         assert self._poll_session is not None
         sync_buf = _load_sync_buf(self._hermes_home, self._account_id)
@@ -1611,33 +1641,34 @@ class WeixinAdapter(BasePlatformAdapter):
                 await self.send_document(chat_id=chat_id, file_path=path, metadata=metadata)
 
         try:
-            # Deliver extracted MEDIA: attachments first.
-            for media_path, is_voice in media_files:
-                try:
-                    await _deliver_media(media_path, is_voice)
-                except Exception as exc:
-                    logger.warning("[%s] media delivery failed for %s: %s", self.name, media_path, exc)
+            async with self._loop_safe_session():
+                # Deliver extracted MEDIA: attachments first.
+                for media_path, is_voice in media_files:
+                    try:
+                        await _deliver_media(media_path, is_voice)
+                    except Exception as exc:
+                        logger.warning("[%s] media delivery failed for %s: %s", self.name, media_path, exc)
 
-            # Deliver bare local file paths.
-            for file_path in local_files:
-                try:
-                    await _deliver_media(file_path, is_voice=False)
-                except Exception as exc:
-                    logger.warning("[%s] local file delivery failed for %s: %s", self.name, file_path, exc)
+                # Deliver bare local file paths.
+                for file_path in local_files:
+                    try:
+                        await _deliver_media(file_path, is_voice=False)
+                    except Exception as exc:
+                        logger.warning("[%s] local file delivery failed for %s: %s", self.name, file_path, exc)
 
-            # Deliver text content.
-            chunks = [c for c in self._split_text(self.format_message(final_content)) if c and c.strip()]
-            for idx, chunk in enumerate(chunks):
-                client_id = f"hermes-weixin-{uuid.uuid4().hex}"
-                await self._send_text_chunk(
-                    chat_id=chat_id,
-                    chunk=chunk,
-                    context_token=context_token,
-                    client_id=client_id,
-                )
-                last_message_id = client_id
-                if idx < len(chunks) - 1 and self._send_chunk_delay_seconds > 0:
-                    await asyncio.sleep(self._send_chunk_delay_seconds)
+                # Deliver text content.
+                chunks = [c for c in self._split_text(self.format_message(final_content)) if c and c.strip()]
+                for idx, chunk in enumerate(chunks):
+                    client_id = f"hermes-weixin-{uuid.uuid4().hex}"
+                    await self._send_text_chunk(
+                        chat_id=chat_id,
+                        chunk=chunk,
+                        context_token=context_token,
+                        client_id=client_id,
+                    )
+                    last_message_id = client_id
+                    if idx < len(chunks) - 1 and self._send_chunk_delay_seconds > 0:
+                        await asyncio.sleep(self._send_chunk_delay_seconds)
             return SendResult(success=True, message_id=last_message_id)
         except Exception as exc:
             logger.error("[%s] send failed to=%s: %s", self.name, _safe_id(chat_id), exc)
@@ -1687,22 +1718,23 @@ class WeixinAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        if image_url.startswith(("http://", "https://")):
-            file_path = await self._download_remote_media(image_url)
-            cleanup = True
-        else:
-            file_path = image_url.replace("file://", "")
-            if not os.path.isabs(file_path):
-                file_path = os.path.abspath(file_path)
-            cleanup = False
-        try:
-            return await self.send_document(chat_id, file_path, caption=caption, metadata=metadata)
-        finally:
-            if cleanup and file_path and os.path.exists(file_path):
-                try:
-                    os.unlink(file_path)
-                except OSError:
-                    pass
+        async with self._loop_safe_session():
+            if image_url.startswith(("http://", "https://")):
+                file_path = await self._download_remote_media(image_url)
+                cleanup = True
+            else:
+                file_path = image_url.replace("file://", "")
+                if not os.path.isabs(file_path):
+                    file_path = os.path.abspath(file_path)
+                cleanup = False
+            try:
+                return await self.send_document(chat_id, file_path, caption=caption, metadata=metadata)
+            finally:
+                if cleanup and file_path and os.path.exists(file_path):
+                    try:
+                        os.unlink(file_path)
+                    except OSError:
+                        pass
 
     async def send_image_file(
         self,
@@ -1714,12 +1746,13 @@ class WeixinAdapter(BasePlatformAdapter):
         **kwargs,
     ) -> SendResult:
         del reply_to, kwargs
-        return await self.send_document(
-            chat_id=chat_id,
-            file_path=image_path,
-            caption=caption,
-            metadata=metadata,
-        )
+        async with self._loop_safe_session():
+            return await self.send_document(
+                chat_id=chat_id,
+                file_path=image_path,
+                caption=caption,
+                metadata=metadata,
+            )
 
     async def send_document(
         self,
@@ -1735,7 +1768,8 @@ class WeixinAdapter(BasePlatformAdapter):
         if not self._send_session or not self._token:
             return SendResult(success=False, error="Not connected")
         try:
-            message_id = await self._send_file(chat_id, file_path, caption or "")
+            async with self._loop_safe_session():
+                message_id = await self._send_file(chat_id, file_path, caption or "")
             return SendResult(success=True, message_id=message_id)
         except Exception as exc:
             logger.error("[%s] send_document failed to=%s: %s", self.name, _safe_id(chat_id), exc)
@@ -1752,7 +1786,8 @@ class WeixinAdapter(BasePlatformAdapter):
         if not self._send_session or not self._token:
             return SendResult(success=False, error="Not connected")
         try:
-            message_id = await self._send_file(chat_id, video_path, caption or "")
+            async with self._loop_safe_session():
+                message_id = await self._send_file(chat_id, video_path, caption or "")
             return SendResult(success=True, message_id=message_id)
         except Exception as exc:
             logger.error("[%s] send_video failed to=%s: %s", self.name, _safe_id(chat_id), exc)
@@ -1774,12 +1809,13 @@ class WeixinAdapter(BasePlatformAdapter):
         # fallback so users at least receive playable audio, even for .silk.
         fallback_caption = caption or "[voice message as attachment]"
         try:
-            message_id = await self._send_file(
-                chat_id,
-                audio_path,
-                fallback_caption,
-                force_file_attachment=True,
-            )
+            async with self._loop_safe_session():
+                message_id = await self._send_file(
+                    chat_id,
+                    audio_path,
+                    fallback_caption,
+                    force_file_attachment=True,
+                )
             return SendResult(success=True, message_id=message_id)
         except Exception as exc:
             logger.error("[%s] send_voice failed to=%s: %s", self.name, _safe_id(chat_id), exc)

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -309,6 +309,84 @@ class TestWeixinSendMessageIntegration:
         )
 
 
+class TestWeixinLoopSafeSession:
+    """Regression coverage for issues #13099, #12154, #13281, #16293.
+
+    The gateway-owned aiohttp.ClientSession is bound to the loop that
+    created it. When ``send_message`` is invoked from an agent tool it runs
+    in a worker thread under a fresh loop and reusing that session there
+    triggers aiohttp's "Timeout context manager should be used inside a task".
+
+    ``WeixinAdapter._loop_safe_session`` swaps in a per-call session bound
+    to the current running loop when it detects the cached session belongs
+    to a different loop.
+    """
+
+    def test_loop_safe_session_swaps_when_session_loop_differs(self):
+        """A session bound to a foreign loop is replaced inside the helper."""
+        foreign_loop = asyncio.new_event_loop()
+        try:
+            class _FakeForeignSession:
+                closed = False
+                _loop = foreign_loop
+
+            adapter = _make_adapter()
+            adapter._send_session = _FakeForeignSession()
+            saw_session = {}
+
+            async def _scenario():
+                async with adapter._loop_safe_session():
+                    saw_session["inside"] = adapter._send_session
+                saw_session["after"] = adapter._send_session
+
+            with patch("gateway.platforms.weixin._make_ssl_connector", return_value=None):
+                asyncio.run(_scenario())
+
+            # Inside the helper the foreign session was swapped out for an
+            # aiohttp.ClientSession bound to the current loop.
+            assert saw_session["inside"] is not None
+            assert not isinstance(saw_session["inside"], _FakeForeignSession)
+            # After the helper exits, the original (foreign) session is restored.
+            assert isinstance(saw_session["after"], _FakeForeignSession)
+        finally:
+            foreign_loop.close()
+
+    def test_loop_safe_session_passes_through_when_session_loop_matches(self):
+        """A session already on the current loop is left untouched."""
+        adapter = _make_adapter()
+        observations = {}
+
+        async def _scenario():
+            current = asyncio.get_running_loop()
+
+            class _FakeSameLoopSession:
+                closed = False
+                _loop = current
+
+            same_loop_session = _FakeSameLoopSession()
+            adapter._send_session = same_loop_session
+            async with adapter._loop_safe_session():
+                observations["inside"] = adapter._send_session
+            observations["after"] = adapter._send_session
+            observations["expected"] = same_loop_session
+
+        asyncio.run(_scenario())
+
+        assert observations["inside"] is observations["expected"]
+        assert observations["after"] is observations["expected"]
+
+    def test_loop_safe_session_is_noop_when_no_session(self):
+        """No swap when adapter has not yet connected (defensive)."""
+        adapter = _make_adapter()
+        adapter._send_session = None
+
+        async def _scenario():
+            async with adapter._loop_safe_session():
+                assert adapter._send_session is None
+
+        asyncio.run(_scenario())
+
+
 class TestWeixinChunkDelivery:
     def _connected_adapter(self) -> WeixinAdapter:
         adapter = _make_adapter()


### PR DESCRIPTION
## What does this PR do?

Fix the long-standing `RuntimeError: Timeout context manager should be used inside a task` raised by the Weixin adapter whenever the agent uses the `send_message` tool to send media (files, images, voice, video).

**Root cause** (verified with runtime debug logging on macOS, Python 3.11.15, aiohttp 3.13.5):

When the agent invokes the `send_message` tool, `model_tools._run_async()` detects an active event loop in the gateway's main thread and dispatches the call to a worker thread that calls `asyncio.run()`. This creates a **fresh event loop in the worker thread**. Inside that loop, `_send_to_platform → WeixinAdapter.send_document → _send_file → _api_post` reuses `self._send_session`, which is an `aiohttp.ClientSession` bound to the **gateway's main loop**. aiohttp's `TimerContext.__enter__` then calls `asyncio.current_task()` against the session's original loop, gets `None`, and raises.

The bug only fires for media sends, because the gateway delivers normal text replies inline on its own loop — that path never crosses loops.

Debug capture from a failing call:

```
[WEIXIN-DBG] task=<Task-33 coro=<_send_to_platform() at send_message_tool.py:507>
             cb=[_run_until_complete_cb()]>
             loop=<_UnixSelectorEventLoop ...>
             session_loop=<_UnixSelectorEventLoop ...>
             thread='asyncio_1'                       ← worker thread, fresh loop
ERROR: Timeout context manager should be used inside a task
```

`loop` and `session_loop` reprs look identical but are different instances (one in MainThread, one in `asyncio_1`).

**Fix:** add `WeixinAdapter._loop_safe_session()`, an async context manager that swaps in a per-call `aiohttp.ClientSession` bound to the running loop when it detects the cached session belongs to a different loop. Each `send_*` method wraps its body with `async with self._loop_safe_session():`. When the call is on the original loop the helper is a no-op (no new session, no extra connection).

## Related Issue

Refs #13099, #12154, #13281, #16293

(Partial fix — addresses the immediate Weixin symptom in all four issues. The deeper `model_tools._run_async` cross-loop architecture concern raised in #13281 is left for a separate change.)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/weixin.py`:
  - Add `import contextlib`
  - Add `WeixinAdapter._loop_safe_session()` async context manager
  - Wrap method bodies with `async with self._loop_safe_session():` in `send`, `send_image`, `send_image_file`, `send_document`, `send_video`, `send_voice`
  - `send_typing` is left untouched (gateway-internal, never crosses loops)
- `tests/gateway/test_weixin.py`: add `TestWeixinLoopSafeSession` regression class with three cases (foreign-loop session swap, same-loop pass-through, no-session no-op)

## How to Test

1. `pytest tests/gateway/test_weixin.py -q` — 45 passed (42 existing + 3 new)
2. End-to-end repro on macOS:
   - Configure Weixin gateway, start `hermes gateway`, chat with the bot from WeChat
   - Ask the agent to send a file (e.g. \"请把 README 发给我\")
   - **Before:** `[Weixin] send_document failed to=...: Timeout context manager should be used inside a task`
   - **After:** file is delivered successfully

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(weixin): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_weixin.py -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.x, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (internal behavior fix, no user-facing surface change)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — fix is OS-independent (the bug shows up on macOS but the cross-loop issue is platform-agnostic; Linux just happens to schedule timing-sensitive paths differently)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

<details>
<summary>Debug log capturing the cross-loop root cause</summary>

\`\`\`
[WEIXIN-DBG] task=<Task pending name='weixin-poll' coro=<WeixinAdapter._poll_loop()>>
             loop=<_UnixSelectorEventLoop running=True closed=False debug=False>
             session_loop=<_UnixSelectorEventLoop running=True closed=False debug=False>
             thread='MainThread'
[WEIXIN-DBG] task=<Task pending name='Task-25' coro=<WeixinAdapter.send_typing()>>
             ... thread='MainThread'                         ← gateway-owned, OK
[WEIXIN-DBG] task=<Task pending name='Task-33'
             coro=<_send_to_platform() running at .../send_message_tool.py:507>
             cb=[_run_until_complete_cb()]>
             loop=<_UnixSelectorEventLoop running=True closed=False debug=False>
             session_loop=<_UnixSelectorEventLoop running=True closed=False debug=False>
             thread='asyncio_1'                              ← worker thread, fresh loop
ERROR gateway.platforms.weixin: [Weixin] send_document failed to=o9cq80xK:
       Timeout context manager should be used inside a task
Traceback (most recent call last):
  File ".../weixin.py", line 1715, in send_document
    message_id = await self._send_file(chat_id, file_path, caption or \"\")
  File ".../weixin.py", line 1795, in _send_file
    upload_response = await _get_upload_url(...)
  File ".../weixin.py", line 508, in _get_upload_url
    return await _api_post(...)
  File ".../weixin.py", line 366, in _api_post
    async with session.post(url, ..., timeout=timeout) as response:
  File \".../aiohttp/client.py\", line 632, in _request
    with timer:
  File \".../aiohttp/helpers.py\", line 678, in __enter__
    raise RuntimeError(\"Timeout context manager should be used inside a task\")
\`\`\`

After the fix, the same call path on `thread='asyncio_1'` swaps in a fresh `aiohttp.ClientSession` bound to that thread's loop, and the upload completes normally.

</details>