### PR TITLE
fix: sync context_length on model switch and show updated limit

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5321,6 +5321,7 @@ class HermesCLI:
         # Copilot, and Nous-enforced caps win over the raw models.dev entry
         # (e.g. gpt-5.5 is 1.05M on openai but 272K on Codex OAuth).
         mi = result.model_info
+        ctx = None
         try:
             from hermes_cli.model_switch import resolve_display_context_length
             ctx = resolve_display_context_length(
@@ -5353,9 +5354,20 @@ class HermesCLI:
             save_config_value("model.default", result.new_model)
             if result.provider_changed:
                 save_config_value("model.provider", result.target_provider)
+            if ctx:
+                save_config_value("model.context_length", ctx)
             _cprint("    Saved to config.yaml (--global)")
         else:
             _cprint("    (session only — add --global to persist)")
+
+        # Print updated context limit so the user sees the runtime effect
+        # immediately — mirrors the startup 📊 banner.
+        if self.agent is not None and hasattr(self.agent, "context_compressor") and self.agent.context_compressor:
+            _new_cl = self.agent.context_compressor.context_length
+            _threshold_pct = int(self.agent.context_compressor.threshold_ratio * 100)
+            _threshold_tokens = self.agent.context_compressor.threshold_tokens
+            if _new_cl and _threshold_tokens:
+                _cprint(f"    📊 Context limit updated: {_new_cl:,} tokens (compress at {_threshold_pct}% = {_threshold_tokens:,})")
 
     def _handle_model_picker_selection(self, persist_global: bool = False) -> None:
         state = self._model_picker_state

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6386,6 +6386,10 @@ class GatewayRunner:
                 model_cfg["provider"] = result.target_provider
                 if result.base_url:
                     model_cfg["base_url"] = result.base_url
+                # Persist context_length so the next session starts with
+                # the correct value instead of the old model's default.
+                if ctx:
+                    model_cfg["context_length"] = ctx
                 from hermes_cli.config import save_config
                 save_config(cfg)
             except Exception as e:
@@ -6432,6 +6436,14 @@ class GatewayRunner:
             lines.append("Saved to config.yaml (`--global`)")
         else:
             lines.append("_(session only -- add `--global` to persist)_")
+
+        # Show updated context limit so the user sees runtime effect immediately.
+        if cached_entry and hasattr(cached_entry[0], "context_compressor") and cached_entry[0].context_compressor:
+            _new_cl = cached_entry[0].context_compressor.context_length
+            _threshold_pct = int(cached_entry[0].context_compressor.threshold_ratio * 100)
+            _threshold_tokens = cached_entry[0].context_compressor.threshold_tokens
+            if _new_cl and _threshold_tokens:
+                lines.append(f"📊 Context limit updated: {_new_cl:,} tokens (compress at {_threshold_pct}% = {_threshold_tokens:,})")
 
         return "\n".join(lines)
 


### PR DESCRIPTION
## Problem

When switching models with `/model`, two things were wrong:

1. **Config not synced**: `/model <name> --global` persisted `model.default` and `model.provider` to `config.yaml`, but **not** `model.context_length`. The next session would start with the old model's context window value, causing compression thresholds and token budgets to be wrong.

2. **No runtime feedback**: The agent's compressor was correctly updated by `switch_model()` in `run_agent.py`, but there was **no visual confirmation** to the user — the startup 📊 banner was stale, and `/model` output only showed the resolved context length without telling the user the runtime compression settings had changed.

## Root Cause

In `_apply_model_switch_result()` (cli.py) and `_handle_model_switch_command()` (gateway/run.py):
- `resolve_display_context_length()` was called for display, but the result (`ctx`) was scoped inside a try/except and not available for the `persist_global` block
- Neither path wrote `model.context_length` when persisting
- Neither path printed the updated runtime context limit after the switch

## Fix

### CLI (`cli.py`)
- Extract `ctx` to outer scope so it's available after the try/except block
- When `--global` is specified, persist `model.context_length` via `save_config_value()`
- After the switch, print `📊 Context limit updated` line mirroring the startup banner, showing the new runtime context length and compression threshold

### Gateway (`gateway/run.py`)
- When `--global` is specified, write `context_length` into the model config dict before `save_config()`
- Append the updated context limit line to the confirmation message sent to the messaging platform

## Example

Before:
```
/model mimo-v2.5-pro --global
  ✓ Model switched: mimo-v2.5-pro
    Provider: xiaomi
    Context: 1,000,000 tokens
    Saved to config.yaml (--global)
```
Next session starts with `context_length: 272000` (old model's value) ❌

After:
```
/model mimo-v2.5-pro --global
  ✓ Model switched: mimo-v2.5-pro
    Provider: xiaomi
    Context: 1,000,000 tokens
    Saved to config.yaml (--global)
    📊 Context limit updated: 1,000,000 tokens (compress at 50% = 500,000)
```
Next session starts with `context_length: 1000000` ✅

## Testing

- All model switch tests pass (28/28)
- Gateway command tests pass (58/58)