### PR TITLE
fix(config): prevent .env sanitizer from corrupting GLM_API_KEY and other suffix-trap keys

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3709,9 +3709,17 @@ def _sanitize_env_lines(lines: list) -> list:
             continue
 
         # Detect concatenated KEY=VALUE pairs on one line.
-        # Search for known KEY= patterns at any position in the line.
+        # Search for known KEY= patterns at any position in the line,
+        # but skip 'suffix traps' — known keys that are suffixes of
+        # other known keys (e.g. LM_API_KEY inside GLM_API_KEY).
+        # Pre-compute the trap set once per line for efficiency.
+        _suffix_traps = {k for k in known_keys if any(
+            lk != k and lk.endswith(k) for lk in known_keys
+        )}
         split_positions = []
         for key_name in known_keys:
+            if key_name in _suffix_traps:
+                continue  # skip known substring false-positives
             needle = key_name + "="
             idx = stripped.find(needle)
             while idx >= 0:


### PR DESCRIPTION
## Summary

The `_sanitize_env_lines()` function in `hermes_cli/config.py` silently corrupts API keys on every startup. It uses `str.find()` to detect accidentally-concatenated `KEY=VALUE` pairs, but since `LM_API_KEY` is a **substring** of `GLM_API_KEY`, scanning `GLM_API_KEY=abc123` finds `LM_API_KEY=` at position 1, triggering a false split into `G` and `LM_API_KEY=abc123`.

Because `sanitize_env_file()` is called unconditionally from `migrate_config()` on every startup, the `.env` file gets rewritten with the corruption each time.

## Affected key pairs (5 total)

| Suffix key (skipped) | Parent key that triggers false positive |
|---|---|
| `LM_API_KEY` | `GLM_API_KEY` |
| `LM_BASE_URL` | `GLM_BASE_URL` |
| `LANGFUSE_PUBLIC_KEY` | `HERMES_LANGFUSE_PUBLIC_KEY` |
| `LANGFUSE_SECRET_KEY` | `HERMES_LANGFUSE_SECRET_KEY` |
| `LANGFUSE_BASE_URL` | `HERMES_LANGFUSE_BASE_URL` |

## Fix

Pre-compute a "suffix traps" set of known keys that are suffixes of other known keys, and skip them during the scan. This eliminates substring false-positives while still correctly splitting truly concatenated lines.

## Testing

- `GLM_API_KEY=value` → unchanged (was split into `G` + `LM_API_KEY=value`)
- `LM_API_KEY=value` → unchanged (still works standalone)
- `HERMES_LANGFUSE_PUBLIC_KEY=value` → unchanged
- `OPENROUTER_API_KEY=abcGOOGLE_API_KEY=def` → correctly split into 2 lines (real concatenation still handled)