### PR TITLE
fix(memory): restore prefix cache hits in background review fork (~26% token saving per run)

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -38,6 +38,7 @@ import importlib.metadata
 import importlib.util
 import logging
 import sys
+import threading
 import types
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -1082,6 +1083,21 @@ def invoke_hook(hook_name: str, **kwargs: Any) -> List[Any]:
 
 
 
+_thread_tool_whitelist = threading.local()
+
+
+def set_thread_tool_whitelist(
+    allowed: Optional[Set[str]],
+    deny_msg_fmt: str = "Tool '{tool_name}' denied: not in this thread's tool whitelist",
+) -> None:
+    _thread_tool_whitelist.allowed = allowed
+    _thread_tool_whitelist.fmt = deny_msg_fmt
+
+
+def clear_thread_tool_whitelist() -> None:
+    _thread_tool_whitelist.allowed = None
+
+
 def get_pre_tool_call_block_message(
     tool_name: str,
     args: Optional[Dict[str, Any]],
@@ -1100,6 +1116,11 @@ def get_pre_tool_call_block_message(
     directive wins.  Invalid or irrelevant hook return values are
     silently ignored so existing observer-only hooks are unaffected.
     """
+    allowed = getattr(_thread_tool_whitelist, "allowed", None)
+    if allowed is not None and tool_name not in allowed:
+        fmt = getattr(_thread_tool_whitelist, "fmt", "Tool '{tool_name}' denied")
+        return fmt.format(tool_name=tool_name)
+
     hook_results = invoke_hook(
         "pre_tool_call",
         tool_name=tool_name,

--- a/run_agent.py
+++ b/run_agent.py
@@ -3489,7 +3489,6 @@ class AIAgent:
                         api_key=_parent_runtime.get("api_key") or None,
                         credential_pool=getattr(self, "_credential_pool", None),
                         parent_session_id=self.session_id,
-                        enabled_toolsets=["memory", "skills"],
                     )
                     review_agent._memory_write_origin = "background_review"
                     review_agent._memory_write_context = "background_review"
@@ -3498,11 +3497,40 @@ class AIAgent:
                     review_agent._user_profile_enabled = self._user_profile_enabled
                     review_agent._memory_nudge_interval = 0
                     review_agent._skill_nudge_interval = 0
+                    review_agent._cached_system_prompt = self._cached_system_prompt
 
-                    review_agent.run_conversation(
-                        user_message=prompt,
-                        conversation_history=messages_snapshot,
+                    from model_tools import get_tool_definitions
+                    from hermes_cli.plugins import (
+                        set_thread_tool_whitelist,
+                        clear_thread_tool_whitelist,
                     )
+
+                    review_whitelist = {
+                        t["function"]["name"]
+                        for t in get_tool_definitions(
+                            enabled_toolsets=["memory", "skills"],
+                            quiet_mode=True,
+                        )
+                    }
+                    set_thread_tool_whitelist(
+                        review_whitelist,
+                        deny_msg_fmt=(
+                            "Background review denied non-whitelisted tool: "
+                            "{tool_name}. Only memory/skill tools are allowed."
+                        ),
+                    )
+                    try:
+                        review_agent.run_conversation(
+                            user_message=(
+                                prompt
+                                + "\n\nYou can only call memory and skill "
+                                "management tools. Other tools will be denied "
+                                "at runtime — do not attempt them."
+                            ),
+                            conversation_history=messages_snapshot,
+                        )
+                    finally:
+                        clear_thread_tool_whitelist()
 
                 # Scan the review agent's messages for successful tool actions
                 # and surface a compact summary to the user. Tool messages

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -536,6 +536,95 @@ class TestPreToolCallBlocking:
         assert get_pre_tool_call_block_message("terminal", {}) == "first blocker"
 
 
+class TestThreadToolWhitelist:
+    """Tests for the thread-local tool whitelist used by background review forks."""
+
+    def test_allowed_tool_passes_through_to_hooks(self, monkeypatch):
+        from hermes_cli.plugins import (
+            set_thread_tool_whitelist,
+            clear_thread_tool_whitelist,
+        )
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [],
+        )
+        set_thread_tool_whitelist({"memory", "skill_manage"})
+        try:
+            assert get_pre_tool_call_block_message("memory", {}) is None
+        finally:
+            clear_thread_tool_whitelist()
+
+    def test_disallowed_tool_blocked_with_message(self, monkeypatch):
+        from hermes_cli.plugins import (
+            set_thread_tool_whitelist,
+            clear_thread_tool_whitelist,
+        )
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [],
+        )
+        set_thread_tool_whitelist(
+            {"memory"}, deny_msg_fmt="denied: {tool_name}"
+        )
+        try:
+            msg = get_pre_tool_call_block_message("terminal", {})
+            assert msg == "denied: terminal"
+        finally:
+            clear_thread_tool_whitelist()
+
+    def test_clear_restores_unrestricted_behavior(self, monkeypatch):
+        from hermes_cli.plugins import (
+            set_thread_tool_whitelist,
+            clear_thread_tool_whitelist,
+        )
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [],
+        )
+        set_thread_tool_whitelist({"memory"})
+        clear_thread_tool_whitelist()
+        # After clearing, any tool should pass through to plugin hooks (which
+        # return [] here, so result is None).
+        assert get_pre_tool_call_block_message("terminal", {}) is None
+
+    def test_whitelist_is_thread_local(self, monkeypatch):
+        """Setting a whitelist in one thread must NOT leak into another."""
+        import threading
+
+        from hermes_cli.plugins import (
+            set_thread_tool_whitelist,
+            clear_thread_tool_whitelist,
+        )
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [],
+        )
+
+        # Main thread: install a restrictive whitelist.
+        set_thread_tool_whitelist({"memory"})
+        try:
+            assert get_pre_tool_call_block_message("terminal", {}) is not None
+
+            # Worker thread: should NOT inherit main thread's whitelist.
+            result = {}
+
+            def worker():
+                result["msg"] = get_pre_tool_call_block_message("terminal", {})
+
+            t = threading.Thread(target=worker)
+            t.start()
+            t.join()
+            assert result["msg"] is None, (
+                "thread-local whitelist leaked across threads"
+            )
+        finally:
+            clear_thread_tool_whitelist()
+
+
 # ── TestPluginContext ──────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Background review fork is supposed to hit Anthropic's prefix cache on the parent's `messages_snapshot`, but currently doesn't (`cache_read=0` on every fork). This PR fixes that.

Real E2E on Sonnet 4.5 (single run: model reads 12 files via 12 `read_file` calls, then `_spawn_background_review` fires naturally on skill-nudge):

| | upstream/main | this PR | Δ |
|---|---|---|---|
| Per review-call cost | $0.331 | $0.035 | **−89%** |
| End-to-end per run | $0.848 | $0.629 | **−26%** |
| Review fork `cache_create` / `cache_read` | 88,385 / **0** | 1,234 / **94,404** | cache hit |

Two root causes, one fix each.

## Root cause #1 — System prompt rebuilt at fork time → 1-character timestamp drift

The fork's `_cached_system_prompt` starts as `None`, so `run_conversation` rebuilds via `_build_system_prompt`, which embeds `Conversation started: Wednesday, April 29, 2026 12:58 AM` at `%I:%M %p` (minute precision). Reviews fire 10+ turns after session start, so the minute almost always differs from main's — one character diverges, byte-exact cache key misses, entire system prefix invalidated.

Fix: inherit the parent's cached prompt directly.

```python
review_agent._cached_system_prompt = self._cached_system_prompt
```

(Same idea as #17089, which I self-closed because it only fixed half the problem.)

## Root cause #2 — Narrowed tools schema → cache key mismatch on `tools`

The fork uses `enabled_toolsets=["memory","skills"]` (4 tools) for safety. Anthropic's cache key includes `tools`, which sits before `system` in the hierarchy, so even byte-identical `system` won't hit when `tools` differs from main's 16-tool set.

Fix: drop the schema-level restriction so `tools` matches main, and deny non-whitelisted tools at **runtime** via the existing `get_pre_tool_call_block_message` gate (`hermes_cli/plugins.py:1085`, already called at all 3 dispatch sites). A small thread-local whitelist is added on top; the fork installs it on its daemon thread before `run_conversation` and clears it after.

## Diff

| File | Lines | What |
|---|---|---|
| `hermes_cli/plugins.py` | +21 | thread-local whitelist + check |
| `run_agent.py` `_spawn_background_review` | +36 −4 | drop `enabled_toolsets`; share `_cached_system_prompt`; install/clear whitelist; soft constraint in prompt |
| `tests/hermes_cli/test_plugins.py` | +89 | 4 tests (allow / deny / clear / cross-thread isolation) |

`pytest tests/hermes_cli/test_plugins.py` → 62/62 passed. Tested on macOS 14 / Python 3.12.
