### PR TITLE
fix(env): apply TZ from dotenv to process timezone

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import sys
+import time
 from pathlib import Path
 
 from dotenv import load_dotenv
@@ -171,5 +172,11 @@ def load_hermes_dotenv(
     if project_env_path and project_env_path.exists():
         _load_dotenv_with_fallback(project_env_path, override=not loaded)
         loaded.append(project_env_path)
+
+    if os.environ.get("TZ") and hasattr(time, "tzset"):
+        try:
+            time.tzset()
+        except Exception:
+            pass
 
     return loaded

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -1,6 +1,7 @@
 import importlib
 import os
 import sys
+import time
 from pathlib import Path
 
 from hermes_cli.env_loader import load_hermes_dotenv
@@ -68,6 +69,23 @@ def test_user_env_takes_precedence_over_project_env(tmp_path, monkeypatch):
     assert loaded == [user_env, project_env]
     assert os.getenv("OPENAI_BASE_URL") == "https://user.example/v1"
     assert os.getenv("OPENAI_API_KEY") == "project-key"
+
+
+def test_tz_env_applies_to_process_timezone(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    env_file = home / ".env"
+    env_file.write_text("TZ=Asia/Shanghai\n", encoding="utf-8")
+
+    calls = []
+    monkeypatch.delenv("TZ", raising=False)
+    monkeypatch.setattr(time, "tzset", lambda: calls.append(os.environ.get("TZ")), raising=False)
+
+    loaded = load_hermes_dotenv(hermes_home=home)
+
+    assert loaded == [env_file]
+    assert os.getenv("TZ") == "Asia/Shanghai"
+    assert calls == ["Asia/Shanghai"]
 
 
 def test_main_import_applies_user_env_over_shell_values(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Apply `time.tzset()` after loading Hermes dotenv files when `TZ` is configured
- Add regression coverage for timezone application from `$HERMES_HOME/.env`

## Test Plan
- `python -m pytest tests/hermes_cli/test_env_loader.py -q`
