### PR TITLE
fix(anthropic_adapter): only mangle dots in Claude-shaped model IDs (#17171)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1102,15 +1102,32 @@ def normalize_model_name(model: str, preserve_dots: bool = False) -> str:
     - Preserves Bedrock model IDs (``anthropic.claude-opus-4-7``) and
       regional inference profiles (``us.anthropic.claude-*``) whose dots
       are namespace separators, not version separators.
+    - Preserves dots in non-Claude model IDs (e.g. ``gpt-5.4``,
+      ``glm-4.7``, ``z-ai/glm-5.1``, ``minimax-m2.5-free``). The dot→hyphen
+      rewrite is an Anthropic-specific quirk (OpenRouter ``4.6`` →
+      Anthropic ``4-6``) and must not corrupt model IDs from other
+      vendors that legitimately use dots as version separators.  See
+      issues #17171, #16417, #13061, #7421.
     """
     lower = model.lower()
     if lower.startswith("anthropic/"):
         model = model[len("anthropic/"):]
+        lower = model.lower()
     if not preserve_dots:
         # Bedrock model IDs use dots as namespace separators
         # (e.g. "anthropic.claude-opus-4-7", "us.anthropic.claude-*").
         # These must not be converted to hyphens.  See issue #12295.
         if _is_bedrock_model_id(model):
+            return model
+        # The dot→hyphen rewrite is the Anthropic Messages API's own quirk:
+        # claude-opus-4.6 (OpenRouter form) → claude-opus-4-6 (Anthropic
+        # form).  Only Claude IDs should be subject to it.  Routing a
+        # non-Claude model (e.g. gpt-5.4, glm-4.7) through this code path
+        # — typically via misconfigured provider resolution that defaults
+        # to "anthropic" — would otherwise rewrite a perfectly valid
+        # vendor ID into a non-existent one (gpt-5-4) and produce a 404
+        # whose error text refers to a name the user never typed.
+        if "claude" not in lower:
             return model
         # OpenRouter uses dots for version separators (claude-opus-4.6),
         # Anthropic uses hyphens (claude-opus-4-6). Convert dots to hyphens.

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -513,6 +513,80 @@ class TestNormalizeModelName:
         assert normalize_model_name("qwen3.5-flash", preserve_dots=True) == "qwen3.5-flash"
 
 
+class TestNormalizeModelNameNonClaudeInvariant:
+    """The dot→hyphen rewrite is Anthropic-specific: OpenRouter form
+    ``claude-opus-4.6`` must become ``claude-opus-4-6`` for the Anthropic
+    Messages API.  But the rewrite must NOT corrupt non-Claude vendor IDs
+    that travel through ``normalize_model_name`` — typically because a
+    misconfigured caller routes a non-Anthropic model through the
+    Anthropic adapter (e.g. webui ``resolve_model_provider`` failing to
+    infer ``openai-codex`` from a ``gpt-*`` model name and falling back
+    to the default Anthropic provider).
+
+    Regression coverage for #17171, #16417, #13061, #7421.
+    """
+
+    @pytest.mark.parametrize(
+        "model_id",
+        [
+            # #17171 — OpenAI Codex; the reporter's exact ID
+            "gpt-5.4",
+            # #16417 — custom anthropic_messages providers
+            "glm-4.7",
+            "qwen3.5-plus",
+            # #13061 — zenmux + custom anthropic_messages
+            "z-ai/glm-5.1",
+            # #7421 — opencode-zen
+            "minimax-m2.5-free",
+            # OpenRouter-style namespaced non-Claude IDs
+            "openai/gpt-5.4",
+            "google/gemini-2.5-pro",
+            # Bare non-Claude with version dots
+            "gemini-2.5-pro",
+            "deepseek-v3.1",
+        ],
+    )
+    def test_non_claude_model_ids_preserve_dots(self, model_id):
+        """Non-Claude models routed through normalize_model_name with the
+        default ``preserve_dots=False`` must retain their dots verbatim."""
+        assert normalize_model_name(model_id) == model_id
+
+    def test_negative_claude_dotted_still_mangled(self):
+        """Genuine Claude IDs with dots still get the Anthropic-form
+        rewrite — the invariant only narrows mangling to Claude shapes,
+        it does not disable mangling entirely."""
+        assert normalize_model_name("claude-opus-4.6") == "claude-opus-4-6"
+        assert normalize_model_name("claude-sonnet-4.5") == "claude-sonnet-4-5"
+        # OpenRouter-prefixed Claude — prefix stripped, then mangled.
+        assert normalize_model_name("anthropic/claude-opus-4.6") == "claude-opus-4-6"
+        # Mixed-case Claude name — case-insensitive Claude detection.
+        assert normalize_model_name("Claude-Opus-4.6") == "Claude-Opus-4-6"
+
+    def test_repro_17171_default_anthropic_provider_with_gpt_model(self):
+        """The reporter's repro: webui falls back to default ``anthropic``
+        provider for ``gpt-5.4`` (no provider hint, no Codex-from-name
+        inference), and the request reaches the Anthropic Messages API
+        with ``model='gpt-5-4'`` instead of the user-supplied
+        ``gpt-5.4``.  After the fix, the model ID survives intact so the
+        downstream 404 (if any) at least names the model the user typed.
+        """
+        assert normalize_model_name("gpt-5.4") == "gpt-5.4"
+        # And the same string survives with the OpenRouter-style prefix
+        # stripped — confirming the prefix-strip path also benefits.
+        assert normalize_model_name("anthropic/gpt-5.4") == "gpt-5.4"
+
+    def test_preserve_dots_true_remains_authoritative_for_non_claude(self):
+        """``preserve_dots=True`` short-circuits before the Claude-shape
+        check — provider-explicit allowlist behavior is unchanged."""
+        assert normalize_model_name("qwen3.5-plus", preserve_dots=True) == "qwen3.5-plus"
+        # And remains the only safe path for non-Claude IDs that *do*
+        # contain the substring ``claude`` anywhere (hypothetical and
+        # rare, but the explicit flag still wins).
+        assert normalize_model_name(
+            "claude-but-actually-qwen-3.5", preserve_dots=True
+        ) == "claude-but-actually-qwen-3.5"
+
+
 # ---------------------------------------------------------------------------
 # Tool conversion
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_minimax_provider.py
+++ b/tests/agent/test_minimax_provider.py
@@ -308,10 +308,16 @@ class TestMinimaxPreserveDots:
         from agent.anthropic_adapter import normalize_model_name
         assert normalize_model_name("MiniMax-M2.7", preserve_dots=True) == "MiniMax-M2.7"
 
-    def test_normalize_converts_without_preserve(self):
+    def test_normalize_preserves_dots_for_non_claude_without_preserve_flag(self):
         from agent.anthropic_adapter import normalize_model_name
-        # Without preserve_dots, dots become hyphens (broken for MiniMax)
-        assert normalize_model_name("MiniMax-M2.7", preserve_dots=False) == "MiniMax-M2-7"
+        # Even without ``preserve_dots=True``, non-Claude IDs (no
+        # ``claude`` substring) survive intact: the Anthropic-specific
+        # dot→hyphen rewrite is gated on Claude shape.  The explicit
+        # ``preserve_dots=True`` flag remains the documented contract for
+        # MiniMax callers, but a missing flag no longer corrupts the
+        # model ID into ``MiniMax-M2-7`` (which MiniMax 404s).  See
+        # #17171 / #16417 / #13061.
+        assert normalize_model_name("MiniMax-M2.7", preserve_dots=False) == "MiniMax-M2.7"
 
 
 class TestMinimaxSwitchModelCredentialGuard:


### PR DESCRIPTION
## Summary
- `normalize_model_name` blindly rewrote dots to hyphens for every non-Bedrock model, corrupting non-Anthropic vendor IDs whose dots are version separators (`gpt-5.4` → `gpt-5-4`, `glm-4.7` → `glm-4-7`, `z-ai/glm-5.1` → `z-ai/glm-5-1`, `minimax-m2.5-free` → `minimax-m2-5-free`).
- After the prefix-strip and Bedrock-detection guards, the rewrite is now gated on the model containing `claude` (case-insensitive). Claude callers are unaffected; non-Claude IDs survive intact even when `preserve_dots=False`.

## The bug
The dot→hyphen rewrite is an Anthropic-Messages-API quirk: OpenRouter form `claude-opus-4.6` must become Anthropic form `claude-opus-4-6`. The function applied it unconditionally to every model except Bedrock IDs, so a non-Claude model accidentally routed through the Anthropic adapter — typically because the caller defaulted to `provider=anthropic` after failing to infer the right provider — got its name mangled into a non-existent ID and 404'd at the API. The user-facing failure named a model they never typed (`gpt-5-4`), making the misconfiguration hard to recognize.

The reporter's repro (#17171):

1. webui session created with `{"model": "gpt-5.4"}` and no provider hint.
2. `resolve_model_provider("gpt-5.4")` returns `(gpt-5.4, None, None)` — no inference from the `gpt-*` shape.
3. `resolve_runtime_provider(requested=None)` falls back to the default-detected `anthropic` provider.
4. `AIAgent` is built with `provider="anthropic"`, `api_mode="anthropic_messages"`, `model="gpt-5.4"`.
5. `normalize_model_name("gpt-5.4", preserve_dots=False)` returns `"gpt-5-4"`.
6. Request goes to `api.anthropic.com/v1/messages` with `model: gpt-5-4` → HTTP 404.

Same root cause underlies #16417 (custom `anthropic_messages` providers) and #13061 (zenmux + custom `anthropic_messages`). The opencode-zen subset (#7421) was previously mitigated by adding the provider to the `_anthropic_preserve_dots()` allowlist, but the underlying invariant — *only Anthropic-shaped names need Anthropic-shaped normalization* — was never enforced at the function itself.

## The fix
Narrow the rewrite to Claude-shaped IDs:

```python
if not preserve_dots:
    if _is_bedrock_model_id(model):
        return model
    if "claude" not in lower:        # ← new
        return model
    model = model.replace(".", "-")
```

- Claude users are unaffected (`claude-opus-4.6` → `claude-opus-4-6` still works, mixed case `Claude-Opus-4.6` too).
- The explicit `preserve_dots=True` flag still short-circuits before the new check, so the documented contract for the alibaba / minimax / opencode-zen / zai / bedrock allowlist is preserved.
- The default `preserve_dots=False` path becomes safe for non-Claude IDs that get routed through the Anthropic adapter — they round-trip verbatim instead of being silently corrupted.

## Contract Protected
**Invariant:** the dot→hyphen rewrite in `normalize_model_name` only fires when both (a) the caller has not opted into `preserve_dots=True` and (b) the model name shape is Claude-like (contains `claude` after the optional `anthropic/` prefix strip).

| Input class | Example | Before | After |
|---|---|---|---|
| Claude bare | `claude-opus-4.6` | `claude-opus-4-6` | `claude-opus-4-6` ✅ |
| Claude OpenRouter | `anthropic/claude-opus-4.6` | `claude-opus-4-6` | `claude-opus-4-6` ✅ |
| Claude mixed case | `Claude-Opus-4.6` | `Claude-Opus-4-6` | `Claude-Opus-4-6` ✅ |
| Bedrock inference profile | `global.anthropic.claude-opus-4-7` | `global.anthropic.claude-opus-4-7` | `global.anthropic.claude-opus-4-7` ✅ |
| OpenAI Codex | `gpt-5.4` | `gpt-5-4` ❌ | `gpt-5.4` ✅ (#17171) |
| ZAI | `glm-4.7` | `glm-4-7` ❌ | `glm-4.7` ✅ (#16417) |
| zenmux/GLM | `z-ai/glm-5.1` | `z-ai/glm-5-1` ❌ | `z-ai/glm-5.1` ✅ (#13061) |
| MiniMax | `MiniMax-M2.7` | `MiniMax-M2-7` ❌ | `MiniMax-M2.7` ✅ |
| Gemini | `google/gemini-2.5-pro` | `google/gemini-2-5-pro` ❌ | `google/gemini-2.5-pro` ✅ |

## Test plan
- [x] Parametrized regression `TestNormalizeModelNameNonClaudeInvariant::test_non_claude_model_ids_preserve_dots[…]` for nine known-bad IDs from #17171, #16417, #13061, #7421.
- [x] Negative invariant `test_negative_claude_dotted_still_mangled`: Claude IDs continue to be rewritten; mixed-case detection works.
- [x] Reporter repro `test_repro_17171_default_anthropic_provider_with_gpt_model`: `gpt-5.4` and `anthropic/gpt-5.4` both round-trip.
- [x] `preserve_dots=True` still authoritative for non-Claude callers (`test_preserve_dots_true_remains_authoritative_for_non_claude`).
- [x] Updated `test_minimax_provider.py::test_normalize_converts_without_preserve` — its docstring previously labelled the behavior "broken for MiniMax"; it now documents the fix.
- [x] `tests/agent/test_bedrock_integration.py` (55 tests) all pass — Bedrock detection still wins before the new Claude check.
- [x] `tests/agent/test_minimax_provider.py` (41 tests) all pass.
- [x] Regression guard: reverting the production change made 10/12 invariant tests fail with the expected `gpt-5-4`/`MiniMax-M2-7`/etc. outputs; restoring the fix flipped them back to green.

## Related
Fixes #17171
Related: #16417, #13061, #7421 (mitigated earlier via `_anthropic_preserve_dots()` allowlist; this PR enforces the same outcome at the normalization layer for vendors not on that allowlist)

## Positioning vs #17290
@vominh1919's #17290 (opened ~12 min after this one) is a narrower fix at the same line. Differences in scope:

- This PR uses a substring guard (`if "claude" not in lower`) applied **after** the `anthropic/` prefix has been stripped, with an explicit re-`lower()` so the stripped name's case is captured. #17290 keeps an `_lower.startswith("anthropic/")` arm in its guard which is unreachable at that point in the function.
- This PR adds a parametrized invariant (`TestNormalizeModelNameNonClaudeInvariant`, 12 cases) covering each of #17171, #16417, #13061, #7421. #17290 ships no new tests and relies on the existing `claude-*` tests still passing.
- This PR replaces the stale `test_normalize_converts_without_preserve` in `tests/agent/test_minimax_provider.py` (which currently asserts the broken `MiniMax-M2-7` output and labels it "broken for MiniMax") with a positive assertion that documents the fix. #17290 leaves that test as-is, which would silently keep encoding the old bug as the expected behavior.

Either fix unblocks the reporter's repro on #17171; this PR additionally protects the invariant against future regressions and cleans up the stale test.