### PR TITLE
fix(copilot-acp): recover from tool-permission-denied thinking-only responses

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -9,6 +9,7 @@ back into the minimal shape Hermes expects from an OpenAI client.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import queue
 import re
@@ -20,6 +21,8 @@ from collections import deque
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 from agent.file_safety import get_read_block_error, is_write_denied
 from agent.redact import redact_sensitive_text
@@ -554,6 +557,43 @@ class CopilotACPClient:
                 text_parts=text_parts,
                 reasoning_parts=reasoning_parts,
             )
+
+            # When the ACP agent only produced thought chunks and no visible
+            # text (e.g. because a tool-call permission was denied mid-run),
+            # make one follow-up turn in the same session asking the model to
+            # answer from its existing knowledge.  This avoids the
+            # thinking-only retry loop in run_agent.py that would otherwise
+            # deliver "(empty)" to the user after two failed prefill attempts.
+            if not "".join(text_parts).strip() and "".join(reasoning_parts).strip():
+                logger.info(
+                    "Copilot ACP: first turn produced only thought chunks "
+                    "(tool call likely denied) — retrying with no-tools hint."
+                )
+                text_parts_retry: list[str] = []
+                reasoning_parts_retry: list[str] = []
+                _request(
+                    "session/prompt",
+                    {
+                        "sessionId": session_id,
+                        "prompt": [
+                            {
+                                "type": "text",
+                                "text": (
+                                    "Please answer based on what you already know, "
+                                    "without running any commands or reading files."
+                                ),
+                            }
+                        ],
+                    },
+                    text_parts=text_parts_retry,
+                    reasoning_parts=reasoning_parts_retry,
+                )
+                if "".join(text_parts_retry).strip():
+                    return "".join(text_parts_retry), "".join(reasoning_parts_retry)
+                # Final fallback: surface the original reasoning as text so
+                # run_agent.py never sees a thinking-only or empty response.
+                return "".join(reasoning_parts), ""
+
             return "".join(text_parts), "".join(reasoning_parts)
         finally:
             self.close()


### PR DESCRIPTION
> ⚠️ **This PR has been superseded by #17604**, which implements a proper root-cause fix instead of the follow-up prompt workaround described here. Please review and merge #17604 instead.

---

Fixes #17284

## Problem

When using `provider: copilot-acp`, any query that causes the Copilot CLI to attempt a tool call (e.g. reading config files via shell) results in `(empty)` being delivered to the user. The UI shows the characteristic loop:

```
↻ Thinking-only response — prefilling to continue (1/2)
↻ Thinking-only response — prefilling to continue (2/2)
⚠️ Empty response from model — retrying (1/3)
```

**Root cause:** Hermes always denies `session/request_permission` with `outcome: cancelled`. When the Copilot CLI's tool call is denied, it ends the turn with `stopReason: end_turn` having emitted only `agent_thought_chunk` events — zero `agent_message_chunk` text. The empty-content + non-empty-reasoning combination triggers `run_agent.py`'s thinking-only detection, which exhausts its prefill retry budget and delivers `(empty)`.

## Fix (workaround — see #17604 for root-cause fix)

In `agent/copilot_acp_client.py`, after a `session/prompt` turn that produces only thought chunks, sends a follow-up prompt asking the model to answer from existing knowledge. Falls back to surfacing reasoning as reply text if still empty.

## Changed files

- `agent/copilot_acp_client.py` — follow-up prompt retry logic in `_run_prompt`