### PR TITLE
fix: recognize ret=-2 as stale-session signal in Weixin adapter (#17228)

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -92,6 +92,18 @@ SESSION_EXPIRED_ERRCODE = -14
 RATE_LIMIT_ERRCODE = -2  # iLink frequency limit — backoff and retry
 MESSAGE_DEDUP_TTL_SECONDS = 300
 
+
+def _is_stale_session_ret(
+    ret: "Optional[int]", errcode: "Optional[int]", errmsg: "Optional[str]",
+) -> bool:
+    """True when iLink returns ret=-2 / errcode=-2 with 'unknown error',
+    which is a stale-session signal (same as errcode=-14) rather than
+    a genuine rate limit."""
+    if ret != RATE_LIMIT_ERRCODE and errcode != RATE_LIMIT_ERRCODE:
+        return False
+    return (errmsg or "").lower() == "unknown error"
+
+
 MEDIA_IMAGE = 1
 MEDIA_VIDEO = 2
 MEDIA_FILE = 3
@@ -1254,7 +1266,8 @@ class WeixinAdapter(BasePlatformAdapter):
                 ret = response.get("ret", 0)
                 errcode = response.get("errcode", 0)
                 if ret not in (0, None) or errcode not in (0, None):
-                    if ret == SESSION_EXPIRED_ERRCODE or errcode == SESSION_EXPIRED_ERRCODE:
+                    if (ret == SESSION_EXPIRED_ERRCODE or errcode == SESSION_EXPIRED_ERRCODE
+                            or _is_stale_session_ret(ret, errcode, response.get("errmsg"))):
                         logger.error("[%s] Session expired; pausing for 10 minutes", self.name)
                         await asyncio.sleep(600)
                         consecutive_failures = 0
@@ -1519,6 +1532,7 @@ class WeixinAdapter(BasePlatformAdapter):
                         is_session_expired = (
                             ret == SESSION_EXPIRED_ERRCODE
                             or errcode == SESSION_EXPIRED_ERRCODE
+                            or _is_stale_session_ret(ret, errcode, resp.get("errmsg"))
                         )
                         # Session expired — strip token and retry once
                         if is_session_expired and not retried_without_token and context_token:


### PR DESCRIPTION
## Problem

The Weixin adapter's session-expired fallback only recognizes `errcode=-14` as a stale-session signal. In practice, iLink also returns `ret=-2` with `errmsg="unknown error"` for the same underlying condition — typically when a cron job tries to push a message to a chat that hasn't had user activity for many hours.

The adapter treats `ret=-2` as a rate-limit, exhausting retries with the same stale `context_token` instead of refreshing the session. Cron deliveries silently fail on the Weixin leg.

## Fix

Added `_is_stale_session_ret()` helper function that distinguishes `ret=-2` with `errmsg="unknown error"` from genuine rate limits. Updated both the poll loop (`_run_poll_loop`) and `_send_text_chunk` to use the helper.

**3 changes in `gateway/platforms/weixin.py`:**
1. Added `_is_stale_session_ret()` helper (centralizes the dual-meaning logic)
2. Updated poll-loop stale-session check (line ~1257)
3. Updated `_send_text_chunk` stale-session check (lines ~1519-1522)

## Before vs After

| Scenario | Before | After |
|----------|--------|-------|
| iLink ret=-2, errmsg="unknown error" | Treated as rate-limit, retries fail silently | Recognized as stale session, strips context_token and retries |
| iLink ret=-2, errmsg="freq limit" | Rate-limit backoff (correct) | Rate-limit backoff (unchanged) |
| iLink errcode=-14 | Session expired pause (correct) | Session expired pause (unchanged) |

## Tests

No existing tests cover this specific behavior. The fix is minimal and follows the same pattern as the existing `errcode=-14` handling.

Fixes #17228