### PR TITLE
fix(cli): prevent .env sanitizer from splitting GLM_API_KEY by LM_API_KEY suffix

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3710,18 +3710,27 @@ def _sanitize_env_lines(lines: list) -> list:
 
         # Detect concatenated KEY=VALUE pairs on one line.
         # Search for known KEY= patterns at any position in the line.
-        split_positions = []
+        # We collect full needle ranges so we can drop matches that are
+        # fully contained within a longer overlapping needle. Without this,
+        # suffix collisions corrupt the file: e.g. LM_API_KEY= inside
+        # GLM_API_KEY= would otherwise split the line into "G\nLM_API_KEY=...".
+        match_ranges: list[tuple[int, int]] = []
         for key_name in known_keys:
             needle = key_name + "="
             idx = stripped.find(needle)
             while idx >= 0:
-                split_positions.append(idx)
+                match_ranges.append((idx, idx + len(needle)))
                 idx = stripped.find(needle, idx + len(needle))
 
+        split_positions = sorted({
+            s for s, e in match_ranges
+            if not any(
+                s2 <= s and e2 >= e and (s2, e2) != (s, e)
+                for s2, e2 in match_ranges
+            )
+        })
+
         if len(split_positions) > 1:
-            split_positions.sort()
-            # Deduplicate (shouldn't happen, but be safe)
-            split_positions = sorted(set(split_positions))
             for i, pos in enumerate(split_positions):
                 end = split_positions[i + 1] if i + 1 < len(split_positions) else len(stripped)
                 part = stripped[pos:end].strip()

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -319,6 +319,23 @@ class TestSanitizeEnvLines:
         assert result[0].startswith("OPENROUTER_API_KEY=")
         assert result[1].startswith("OPENAI_BASE_URL=")
 
+    def test_glm_suffix_collision_not_split(self):
+        """GLM_API_KEY / GLM_BASE_URL must not be mangled by LM_API_KEY / LM_BASE_URL suffixes (#17138)."""
+        lines = [
+            "GLM_API_KEY=glm-secret\n",
+            "GLM_BASE_URL=https://api.z.ai/api/paas/v4\n",
+        ]
+        result = _sanitize_env_lines(lines)
+        assert result == lines, f"GLM_* lines were corrupted by suffix collision: {result}"
+
+    def test_suffix_collision_does_not_break_real_concatenation(self):
+        """A genuine concatenation that happens to start with a suffix-superset key still splits."""
+        lines = ["GLM_API_KEY=glmLM_API_KEY=lm-key\n"]
+        result = _sanitize_env_lines(lines)
+        assert len(result) == 2
+        assert result[0].startswith("GLM_API_KEY=")
+        assert result[1].startswith("LM_API_KEY=")
+
     def test_save_env_value_fixes_corruption_on_write(self, tmp_path):
         """save_env_value sanitizes corrupted lines when writing a new key."""
         env_file = tmp_path / ".env"


### PR DESCRIPTION
Salvage of #17141 by @jackjin1997 onto current main.

Fixes #17138.

`_sanitize_env_lines` searched every registered env key name as a substring with no word-boundary check. `LM_API_KEY=` (LM Studio) is a literal suffix of `GLM_API_KEY=` (Z.AI/GLM), so `doctor` — or any code path that sanitizes `.env` — rewrote user files from `GLM_API_KEY=...` into `G\nLM_API_KEY=...`, silently killing Z.AI auth. Same shape for `GLM_BASE_URL` vs `LM_BASE_URL`.

Fix collects full `(start, end)` ranges per match and drops ranges fully contained inside a longer overlapping match. Real concatenations (no nesting) still split.

## Validation

| | Before | After |
|---|---|---|
| `GLM_API_KEY=glm-secret` | `G\nLM_API_KEY=glm-secret` | unchanged |
| `GLM_API_KEY=glmLM_API_KEY=lm-key` (genuine concat) | splits | splits |
| `tests/hermes_cli/test_config.py::TestSanitizeEnvLines` | 11 passing | 13 passing (2 new regressions) |

Contributor authorship preserved via rebase-merge.