### PR TITLE
fix(skills): resolve external_dirs relative to HERMES_HOME, not cwd (salvage #9966)

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -200,6 +200,9 @@ def get_external_skills_dirs() -> List[Path]:
     if not isinstance(raw_dirs, list):
         return []
 
+    from hermes_constants import get_hermes_home
+
+    hermes_home = get_hermes_home()
     local_skills = get_skills_dir().resolve()
     seen: Set[Path] = set()
     result: List[Path] = []
@@ -210,7 +213,12 @@ def get_external_skills_dirs() -> List[Path]:
             continue
         # Expand ~ and environment variables
         expanded = os.path.expanduser(os.path.expandvars(entry))
-        p = Path(expanded).resolve()
+        p = Path(expanded)
+        # Resolve relative paths against HERMES_HOME, not cwd
+        if not p.is_absolute():
+            p = (hermes_home / p).resolve()
+        else:
+            p = p.resolve()
         if p == local_skills:
             continue
         if p in seen:


### PR DESCRIPTION
Salvages #9966 from @MagicRay1217.

Closes #9949.

## Summary
Relative entries in `skills.external_dirs` (e.g. `../shared-skills`) now resolve consistently against `HERMES_HOME`, regardless of which directory hermes was launched from.

## Root cause
`agent/skill_utils.py:213` did `Path(expanded).resolve()`, which resolves relative paths against the process cwd. Same config worked from one launch directory and silently failed from another (CLI vs gateway vs cron vs subprocess all see different cwds).

## Fix
For non-absolute entries, resolve against `get_hermes_home()` instead of cwd. Absolute paths and `~` / `${VAR}` expansion are unchanged.

## Validation
- `tests/agent/test_external_skills.py` — 11/11 pass
- E2E reproducing the issue: `config.yaml` with `external_dirs: [../shared-skills]`, sibling `shared-skills/` directory, hermes launched from a third unrelated dir → resolves to `<HERMES_HOME>/../shared-skills` correctly (was returning `[]` before).

## Credit
@MagicRay1217 authored the fix in #9966. Cherry-picked onto current main with authorship preserved.