### PR TITLE
fix: narrow Anthropic adapter dot-mangling to Claude models only (#17171)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1112,9 +1112,12 @@ def normalize_model_name(model: str, preserve_dots: bool = False) -> str:
         # These must not be converted to hyphens.  See issue #12295.
         if _is_bedrock_model_id(model):
             return model
-        # OpenRouter uses dots for version separators (claude-opus-4.6),
-        # Anthropic uses hyphens (claude-opus-4-6). Convert dots to hyphens.
-        model = model.replace(".", "-")
+        # Only convert dots to hyphens for Anthropic/Claude models.
+        # Non-Anthropic models (gpt-5.4, gemini-2.5, etc.) use dots
+        # as part of their canonical names.  See issue #17171.
+        _lower = model.lower()
+        if _lower.startswith("claude-") or _lower.startswith("anthropic/"):
+            model = model.replace(".", "-")
     return model
 
 


### PR DESCRIPTION
## Problem

`normalize_model_name()` in `agent/anthropic_adapter.py` unconditionally converts dots to hyphens in **all** model names (line 1117). This causes non-Anthropic models to be mangled when routed through the Anthropic adapter path:

- `gpt-5.4` → `gpt-5-4` → HTTP 404 from Codex backend
- `gemini-2.5-pro` → `gemini-2-5-pro` → would fail similarly

This affects the webui session route when `resolve_model_provider()` doesn't infer the provider from the model name, and the Anthropic adapter is auto-selected as default.

## Fix

Added a guard in `normalize_model_name()` to only apply dot→hyphen conversion for models that look like Anthropic models (`claude-*` or `anthropic/*`). Non-Anthropic models pass through unchanged.

**Before:**
```python
model = model.replace(".", "-")  # ALL models
```

**After:**
```python
_lower = model.lower()
if _lower.startswith("claude-") or _lower.startswith("anthropic/"):
    model = model.replace(".", "-")  # Only Anthropic models
```

## Before vs After

| Model | Before | After |
|-------|--------|-------|
| `claude-opus-4.6` | `claude-opus-4-6` ✓ | `claude-opus-4-6` ✓ |
| `anthropic/claude-sonnet-4.5` | `claude-sonnet-4-5` ✓ | `claude-sonnet-4-5` ✓ |
| `gpt-5.4` | `gpt-5-4` ✗ | `gpt-5.4` ✓ |
| `gemini-2.5-pro` | `gemini-2-5-pro` ✗ | `gemini-2.5-pro` ✓ |
| Bedrock IDs | preserved (existing guard) | preserved (unchanged) |

## Tests

All existing tests pass — they all use Claude model names which still get dot→hyphen conversion.

Fixes #17171
Related: #7421, #13061, #16417