### PR TITLE
fix: use configured drain timeout for gateway restart wait (#17198)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4101,7 +4101,8 @@ def _gateway_command_inner(args):
             total = killed + (1 if service_stopped else 0)
             if total:
                 print(f"✓ Stopped {total} gateway process(es) across all profiles")
-            _wait_for_gateway_exit(timeout=10.0, force_after=5.0)
+            _drain = _get_restart_drain_timeout()
+            _wait_for_gateway_exit(timeout=max(_drain, 20.0), force_after=min(_drain * 0.5, 10.0))
 
             # Start the current profile's service fresh
             print("Starting gateway...")
@@ -4156,7 +4157,8 @@ def _gateway_command_inner(args):
             if stop_profile_gateway():
                 print("✓ Stopped gateway for this profile")
 
-            _wait_for_gateway_exit(timeout=10.0, force_after=5.0)
+            _drain = _get_restart_drain_timeout()
+            _wait_for_gateway_exit(timeout=max(_drain, 20.0), force_after=min(_drain * 0.5, 10.0))
 
             # Start fresh
             print("Starting gateway...")


### PR DESCRIPTION
## Problem

The `hermes gateway restart` command hardcoded a 10-second timeout for `_wait_for_gateway_exit()`, but platform adapters like Weixin can take 18+ seconds to release their tokens during graceful shutdown. This causes a race condition where the new gateway fails to start because the old process's platform lock is still held.

## Fix

Now uses the configured `restart_drain_timeout` (default 60s) with a minimum of 20s for the wait timeout, and 50% of the drain timeout (capped at 10s) for the force-kill threshold. This matches the existing drain timeout mechanism used by systemd/launchd restarts.

**Before:**
```python
_wait_for_gateway_exit(timeout=10.0, force_after=5.0)
```

**After:**
```python
_drain = _get_restart_drain_timeout()
_wait_for_gateway_exit(timeout=max(_drain, 20.0), force_after=min(_drain * 0.5, 10.0))
```

## Before vs After

| Scenario | Before | After |
|----------|--------|-------|
| Weixin disconnect takes 18s | Timeout at 10s, new gateway fails | Waits up to 60s (configurable), new gateway succeeds |
| Quick disconnect (2s) | Works (10s > 2s) | Works (20s > 2s) |
| Process hung (needs force-kill) | SIGKILL at 5s | SIGKILL at 10s (or 50% of drain timeout) |

Fixes #17198