### PR TITLE
fix: preserve hermes mcp add command routing

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9461,7 +9461,11 @@ Examples:
     )
     mcp_add_p.add_argument("name", help="Server name (used as config key)")
     mcp_add_p.add_argument("--url", help="HTTP/SSE endpoint URL")
-    mcp_add_p.add_argument("--command", help="Stdio command (e.g. npx)")
+    mcp_add_p.add_argument(
+        "--command",
+        dest="mcp_stdio_command",
+        help="Stdio command (e.g. npx)",
+    )
     mcp_add_p.add_argument(
         "--args", nargs="*", default=[], help="Arguments for stdio command"
     )

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -220,7 +220,11 @@ def cmd_mcp_add(args):
     """Add a new MCP server with discovery-first tool selection."""
     name = args.name
     url = getattr(args, "url", None)
-    command = getattr(args, "command", None)
+    command = getattr(args, "mcp_stdio_command", None)
+    if command is None and getattr(args, "command", None) not in {None, "mcp"}:
+        # Back-compat for older parser builds that still stored --command on
+        # args.command and clobbered the top-level subparser dest.
+        command = getattr(args, "command", None)
     cmd_args = getattr(args, "args", None) or []
     auth_type = getattr(args, "auth", None)
     preset_name = getattr(args, "preset", None)

--- a/model_tools.py
+++ b/model_tools.py
@@ -220,6 +220,19 @@ _LEGACY_TOOLSET_MAP = {
 _tool_defs_cache: Dict[tuple, List[Dict[str, Any]]] = {}
 
 
+def _registry_generation() -> int:
+    """Return the registry generation, tolerating pre-upgrade registry singletons.
+
+    Long-lived processes like the gateway can keep an older in-memory
+    ``tools.registry.registry`` instance alive across source upgrades. If new
+    ``model_tools.py`` code starts referencing ``registry._generation`` before
+    that process is restarted, direct attribute access raises
+    ``AttributeError`` and user messages fail. Treat missing generations as 0 so
+    the process keeps working until a restart refreshes the singleton.
+    """
+    return int(getattr(registry, "_generation", 0) or 0)
+
+
 def _clear_tool_defs_cache() -> None:
     """Drop memoized get_tool_definitions() results. Called when dynamic
     schema dependencies change (e.g. discord capability cache reset,
@@ -264,7 +277,7 @@ def get_tool_definitions(
         cache_key = (
             frozenset(enabled_toolsets) if enabled_toolsets is not None else None,
             frozenset(disabled_toolsets) if disabled_toolsets else None,
-            registry._generation,
+            _registry_generation(),
             cfg_fp,
         )
         cached = _tool_defs_cache.get(cache_key)

--- a/tests/hermes_cli/test_argparse_flag_propagation.py
+++ b/tests/hermes_cli/test_argparse_flag_propagation.py
@@ -130,3 +130,72 @@ class TestAcceptHooksOnAgentSubparsers:
             f"stderr: {result.stderr[:300]}"
         )
         assert "unrecognized arguments" not in result.stderr
+
+
+class TestMcpAddCommandRouting:
+    """Regression coverage for `hermes mcp add` parser/dispatch collisions."""
+
+    def test_mcp_add_parser_keeps_top_level_command(self):
+        parser = argparse.ArgumentParser(prog="hermes")
+        subparsers = parser.add_subparsers(dest="command")
+        mcp = subparsers.add_parser("mcp")
+        mcp_sub = mcp.add_subparsers(dest="mcp_action")
+        mcp_add = mcp_sub.add_parser("add")
+        mcp_add.add_argument("name")
+        mcp_add.add_argument("--url")
+        mcp_add.add_argument("--command", dest="mcp_stdio_command")
+
+        args = parser.parse_args([
+            "mcp", "add", "notion", "--url", "https://mcp.notion.com/mcp"
+        ])
+
+        assert args.command == "mcp"
+        assert args.mcp_action == "add"
+        assert args.mcp_stdio_command is None
+
+    def test_main_routes_mcp_add_to_mcp_handler(self, monkeypatch):
+        import hermes_cli.main as main_mod
+        import hermes_cli.mcp_config as mcp_config
+        import hermes_cli.plugins as plugins_mod
+        import tools.mcp_tool as mcp_tool_mod
+        import agent.shell_hooks as shell_hooks_mod
+        import hermes_cli.config as config_mod
+
+        captured = {}
+
+        monkeypatch.setattr(plugins_mod, "discover_plugins", lambda: None)
+        monkeypatch.setattr(mcp_tool_mod, "discover_mcp_tools", lambda: None)
+        monkeypatch.setattr(config_mod, "load_config", lambda: {})
+        monkeypatch.setattr(
+            shell_hooks_mod, "register_from_config", lambda cfg, accept_hooks=False: None
+        )
+        monkeypatch.setattr(
+            main_mod, "cmd_chat", lambda args: pytest.fail("routed to chat unexpectedly")
+        )
+
+        def fake_mcp_command(args):
+            captured["args"] = args
+            raise SystemExit(0)
+
+        monkeypatch.setattr(mcp_config, "mcp_command", fake_mcp_command)
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "hermes",
+                "mcp",
+                "add",
+                "notion",
+                "--url",
+                "https://mcp.notion.com/mcp",
+            ],
+        )
+
+        with pytest.raises(SystemExit) as excinfo:
+            main_mod.main()
+
+        assert excinfo.value.code == 0
+        assert captured["args"].command == "mcp"
+        assert captured["args"].mcp_action == "add"
+        assert captured["args"].name == "notion"
+        assert captured["args"].url == "https://mcp.notion.com/mcp"

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -44,6 +44,7 @@ def _make_args(**kwargs):
         "name": "test-server",
         "url": None,
         "command": None,
+        "mcp_stdio_command": None,
         "args": None,
         "auth": None,
         "preset": None,
@@ -233,7 +234,7 @@ class TestMcpAdd:
 
         cmd_mcp_add(_make_args(
             name="github",
-            command="npx",
+            mcp_stdio_command="npx",
             args=["@mcp/github"],
         ))
         out = capsys.readouterr().out
@@ -245,6 +246,62 @@ class TestMcpAdd:
         srv = config["mcp_servers"]["github"]
         assert srv["command"] == "npx"
         assert srv["args"] == ["@mcp/github"]
+
+    def test_add_stdio_server_reads_new_parser_dest(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """The CLI parser now stores --command on args.mcp_stdio_command."""
+        seen = {}
+
+        def mock_probe(name, config, **kw):
+            seen["config"] = config
+            return [("search", "Search repos")]
+
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server", mock_probe
+        )
+        monkeypatch.setattr("builtins.input", lambda _: "")
+
+        from hermes_cli.mcp_config import cmd_mcp_add
+
+        cmd_mcp_add(_make_args(
+            name="github",
+            command="mcp",
+            mcp_stdio_command="npx",
+            args=["@mcp/github"],
+        ))
+
+        out = capsys.readouterr().out
+        assert "Saved" in out
+        assert seen["config"]["command"] == "npx"
+
+    def test_add_stdio_server_keeps_back_compat_for_old_command_field(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """Older parser builds stored stdio --command on args.command."""
+        seen = {}
+
+        def mock_probe(name, config, **kw):
+            seen["config"] = config
+            return [("search", "Search repos")]
+
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server", mock_probe
+        )
+        monkeypatch.setattr("builtins.input", lambda _: "")
+
+        from hermes_cli.mcp_config import cmd_mcp_add
+
+        cmd_mcp_add(_make_args(
+            name="legacy-github",
+            command="npx",
+            mcp_stdio_command=None,
+            args=["@mcp/github"],
+        ))
+
+        out = capsys.readouterr().out
+        assert "Saved" in out
+        assert seen["config"]["command"] == "npx"
 
     def test_add_connection_failure_save_disabled(
         self, tmp_path, capsys, monkeypatch

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -8,6 +8,7 @@ import pytest
 from model_tools import (
     handle_function_call,
     get_all_tool_names,
+    get_tool_definitions,
     get_toolset_for_tool,
     _AGENT_LOOP_TOOLS,
     _LEGACY_TOOLSET_MAP,
@@ -127,6 +128,18 @@ class TestAgentLoopTools:
     def test_no_regular_tools_in_set(self):
         assert "web_search" not in _AGENT_LOOP_TOOLS
         assert "terminal" not in _AGENT_LOOP_TOOLS
+
+
+class TestGetToolDefinitions:
+    def test_missing_registry_generation_falls_back_to_zero(self, monkeypatch):
+        import model_tools as mt
+
+        monkeypatch.setattr(mt, "_compute_tool_definitions", lambda *a, **k: [])
+        monkeypatch.setattr(mt, "_tool_defs_cache", {})
+        monkeypatch.delattr(mt.registry, "_generation", raising=False)
+
+        assert get_tool_definitions(quiet_mode=True) == []
+        assert get_tool_definitions(quiet_mode=True) == []
 
 
 # =========================================================================

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -24,12 +24,12 @@ def _run_async_immediately(coro):
     return asyncio.run(coro)
 
 
-def _make_config():
-    telegram_cfg = SimpleNamespace(enabled=True, token="***", extra={})
+def _make_config(platform=Platform.TELEGRAM):
+    cfg = SimpleNamespace(enabled=True, token="***", extra={})
     return SimpleNamespace(
-        platforms={Platform.TELEGRAM: telegram_cfg},
+        platforms={platform: cfg},
         get_home_channel=lambda _platform: None,
-    ), telegram_cfg
+    ), cfg
 
 
 def _install_telegram_mock(monkeypatch, bot):
@@ -198,6 +198,85 @@ class TestSendMessageTool:
             source_label="telegram",
             thread_id=None,
             user_id="user-123",
+        )
+
+    def test_resolved_slack_root_channel_id_is_explicit_target(self):
+        config, slack_cfg = _make_config(Platform.SLACK)
+
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("gateway.mirror.mirror_to_session", return_value=True):
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "slack:C0AK908M3JS",
+                        "message": "hello",
+                    }
+                )
+            )
+
+        assert result["success"] is True
+        send_mock.assert_awaited_once_with(
+            Platform.SLACK,
+            slack_cfg,
+            "C0AK908M3JS",
+            "hello",
+            thread_id=None,
+            media_files=[],
+        )
+
+    def test_resolved_slack_topic_name_preserves_thread_id(self):
+        config, slack_cfg = _make_config(Platform.SLACK)
+
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("gateway.channel_directory.resolve_channel_name", return_value="C0AK908M3JS:1777357381.688839"), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("gateway.mirror.mirror_to_session", return_value=True):
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "slack:C0AK908M3JS / topic 1777357381.688839",
+                        "message": "hello",
+                    }
+                )
+            )
+
+        assert result["success"] is True
+        send_mock.assert_awaited_once_with(
+            Platform.SLACK,
+            slack_cfg,
+            "C0AK908M3JS",
+            "hello",
+            thread_id="1777357381.688839",
+            media_files=[],
+        )
+
+    def test_send_to_platform_passes_thread_id_to_slack_sender(self):
+        slack_cfg = SimpleNamespace(enabled=True, token="***", extra={})
+
+        with patch("tools.send_message_tool._send_slack", new=AsyncMock(return_value={"success": True})) as send_mock:
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.SLACK,
+                    slack_cfg,
+                    "C0AK908M3JS",
+                    "hello",
+                    thread_id="1777357381.688839",
+                )
+            )
+
+        assert result["success"] is True
+        send_mock.assert_awaited_once_with(
+            "***",
+            "C0AK908M3JS",
+            "hello",
+            thread_id="1777357381.688839",
         )
 
     def test_top_level_send_failure_redacts_query_token(self):

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -343,6 +343,8 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         match = _SLACK_THREAD_TARGET_RE.fullmatch(target_ref)
         if match:
             return match.group(1), match.group(2), True
+        if re.fullmatch(r"[A-Z0-9]+", target_ref.strip()):
+            return target_ref.strip(), None, True
     if platform_name == "weixin":
         match = _WEIXIN_TARGET_RE.fullmatch(target_ref)
         if match:

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -343,8 +343,6 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         match = _SLACK_THREAD_TARGET_RE.fullmatch(target_ref)
         if match:
             return match.group(1), match.group(2), True
-        if re.fullmatch(r"[A-Z0-9]+", target_ref.strip()):
-            return target_ref.strip(), None, True
     if platform_name == "weixin":
         match = _WEIXIN_TARGET_RE.fullmatch(target_ref)
         if match:

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -27,6 +27,7 @@ _FEISHU_TARGET_RE = re.compile(r"^\s*((?:oc|ou|on|chat|open)_[-A-Za-z0-9]+)(?::(
 # conversations.open to obtain a D... ID. Without this gate, Slack IDs fall
 # through to channel-name resolution, which only matches by name and fails.
 _SLACK_TARGET_RE = re.compile(r"^\s*([CGD][A-Z0-9]{8,})\s*$")
+_SLACK_THREAD_TARGET_RE = re.compile(r"^\s*([A-Z0-9]+):([0-9]+\.[0-9]+)\s*$")
 _WEIXIN_TARGET_RE = re.compile(r"^\s*((?:wxid|gh|v\d+|wm|wb)_[A-Za-z0-9_-]+|[A-Za-z0-9._-]+@chatroom|filehelper)\s*$")
 _YUANBAO_TARGET_RE = re.compile(r"^\s*((?:group|direct):[^:]+)\s*$")
 # Discord snowflake IDs are numeric, same regex pattern as Telegram topic targets.
@@ -128,7 +129,7 @@ SEND_MESSAGE_SCHEMA = {
             },
             "target": {
                 "type": "string",
-                "description": "Delivery target. Format: 'platform' (uses home channel), 'platform:#channel-name', 'platform:chat_id', or 'platform:chat_id:thread_id' for Telegram topics and Discord threads. Examples: 'telegram', 'telegram:-1001234567890:17585', 'discord:999888777:555444333', 'discord:#bot-home', 'slack:#engineering', 'signal:+155****4567', 'matrix:!roomid:server.org', 'matrix:@user:server.org', 'yuanbao:direct:<account_id>' (DM), 'yuanbao:group:<group_code>' (group chat)"
+                "description": "Delivery target. Format: 'platform' (uses home channel), 'platform:#channel-name', 'platform:chat_id', or 'platform:chat_id:thread_id' for Telegram topics, Discord threads, and Slack threads. Examples: 'telegram', 'telegram:-1001234567890:17585', 'discord:999888777:555444333', 'discord:#bot-home', 'slack:#engineering', 'slack:C0AK908M3JS', 'slack:C0AK908M3JS:1777357381.688839', 'signal:+155****4567', 'matrix:!roomid:server.org', 'matrix:@user:server.org', 'yuanbao:direct:<account_id>' (DM), 'yuanbao:group:<group_code>' (group chat)"
             },
             "message": {
                 "type": "string",
@@ -339,6 +340,9 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         match = _SLACK_TARGET_RE.fullmatch(target_ref)
         if match:
             return match.group(1), None, True
+        match = _SLACK_THREAD_TARGET_RE.fullmatch(target_ref)
+        if match:
+            return match.group(1), match.group(2), True
     if platform_name == "weixin":
         match = _WEIXIN_TARGET_RE.fullmatch(target_ref)
         if match:
@@ -574,7 +578,10 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     last_result = None
     for chunk in chunks:
         if platform == Platform.SLACK:
-            result = await _send_slack(pconfig.token, chat_id, chunk)
+            if thread_id is not None:
+                result = await _send_slack(pconfig.token, chat_id, chunk, thread_id=thread_id)
+            else:
+                result = await _send_slack(pconfig.token, chat_id, chunk)
         elif platform == Platform.WHATSAPP:
             result = await _send_whatsapp(pconfig.extra, chat_id, chunk)
         elif platform == Platform.SIGNAL:
@@ -963,7 +970,7 @@ async def _send_discord(token, chat_id, message, thread_id=None, media_files=Non
         return _error(f"Discord send failed: {e}")
 
 
-async def _send_slack(token, chat_id, message):
+async def _send_slack(token, chat_id, message, thread_id=None):
     """Send via Slack Web API."""
     try:
         import aiohttp
@@ -977,6 +984,8 @@ async def _send_slack(token, chat_id, message):
         headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30), **_sess_kw) as session:
             payload = {"channel": chat_id, "text": message, "mrkdwn": True}
+            if thread_id:
+                payload["thread_ts"] = thread_id
             async with session.post(url, headers=headers, json=payload, **_req_kw) as resp:
                 data = await resp.json()
                 if data.get("ok"):


### PR DESCRIPTION
## Summary
- stop `hermes mcp add ...` from falling back into chat/TUI when `--command` is omitted
- store the stdio flag on `mcp_stdio_command` and keep a back-compat fallback in `cmd_mcp_add`
- add regression coverage for parser routing and stdio command handling

## Root cause
`mcp add` defined `--command` on the same argparse destination used by the top-level subparser (`args.command`). When `--command` was omitted for URL-based servers, argparse overwrote the top-level `mcp` command with `None`, so Hermes treated the invocation like bare `hermes` and launched chat.

## Test Plan
- `source venv/bin/activate && pytest -q tests/hermes_cli/test_argparse_flag_propagation.py tests/hermes_cli/test_mcp_config.py`