### PR TITLE
feat(cron): support persistent sessions via 'persistent:' name prefix

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -819,7 +819,24 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
 
     prompt = _build_job_prompt(job, prerun_script=prerun_script)
     origin = _resolve_origin(job)
-    _cron_session_id = f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}"
+    _is_persistent = job_name.startswith("persistent:")
+    _cron_session_id = (
+        f"cron_{job_id}"
+        if _is_persistent
+        else f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}"
+    )
+
+    # For persistent jobs, load previous conversation history so the agent
+    # can resume with context from last run (e.g. "continue where we left off").
+    _conversation_history = None
+    if _is_persistent:
+        try:
+            _conversation_history = _session_db.get_messages_as_conversation(_cron_session_id)
+            if _conversation_history:
+                logger.info("Loaded %d prior messages for persistent session '%s'", len(_conversation_history), _cron_session_id)
+        except Exception as _e:
+            logger.warning("Failed to load history for persistent session '%s': %s", _cron_session_id, _e)
+            _conversation_history = None
 
     logger.info("Running job '%s' (ID: %s)", job_name, job_id)
     logger.info("Prompt: %s", prompt[:100])
@@ -1039,7 +1056,12 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         # env passthrough registrations) when the cron run hops into the worker
         # thread used for inactivity timeout monitoring.
         _cron_context = contextvars.copy_context()
-        _cron_future = _cron_pool.submit(_cron_context.run, agent.run_conversation, prompt)
+        _cron_future = _cron_pool.submit(
+            _cron_context.run,
+            agent.run_conversation,
+            prompt,
+            conversation_history=_conversation_history,
+        )
         _inactivity_timeout = False
         try:
             if _cron_inactivity_limit is None:


### PR DESCRIPTION
### Problem

By default, every cron job run creates a new session with a timestamped ID (e.g. `cron_abc123_20260429_083000`). This means:

- **No conversation history is preserved** across runs — the agent cannot "remember" what it said or did in previous executions
- The agent cannot reference or build upon prior output
- The session list becomes polluted with many one-off session entries

### Solution

Introduce a `persistent:` name prefix for cron jobs. When a job name starts with `persistent:`, the scheduler:

1. Uses a **fixed session ID** (`cron_{job_id}`) instead of a timestamped one
2. **Loads prior conversation history** from the session database before each run
3. Passes that history to `run_conversation()`, so the agent sees previous messages as context

This enables use cases like:
- Daily briefings that avoid repeating previous content
- Task agents that build on their prior work across scheduled runs
- Continuous, context-aware automation instead of isolated one-shot runs

### What agents can do with history

Since history is loaded into the same conversation context as a normal multi-turn chat, the agent can autonomously perform any context-dependent task — no special tooling required. The only requirement is a brief instruction in the prompt telling the agent what to do with the context. For example:

- **Skip duplication**: include a rule like "if a news topic was already covered in prior runs, skip it even if there's new development"
- **Continue long-running work**: "the analysis from last run is incomplete — pick up where you left off"
- **Build incrementally**: "update the report based on changes since yesterday's version"

### History accumulation

Conversation history grows with each run and is automatically managed by Hermes's built-in context compression (enabled by default with a 50% threshold). When the conversation approaches the model's context limit, older messages are compressed into a concise summary, ensuring persistent sessions remain stable indefinitely without manual intervention.

### Code changes (`cron/scheduler.py`)

**1. Session ID logic:**
```python
_is_persistent = job_name.startswith("persistent:")
_cron_session_id = (
    f"cron_{job_id}"
    if _is_persistent
    else f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}"
)
```

**2. History loading:**
```python
if _is_persistent:
    _conversation_history = _session_db.get_messages_as_conversation(_cron_session_id)
```

**3. Pass to agent:**
```python
_cron_future = _cron_pool.submit(
    _cron_context.run,
    agent.run_conversation,
    prompt,
    conversation_history=_conversation_history,
)
```

### Backward compatibility

Fully opt-in — existing jobs without the `persistent:` prefix are unaffected and continue using timestamped session IDs unchanged.
