### PR TITLE
Add on-this-day-art-trivia: Telegram-native history guessing game

### DIFF
--- a/optional-skills/gaming/on-this-day-art-trivia/README.md
+++ b/optional-skills/gaming/on-this-day-art-trivia/README.md
@@ -1,0 +1,50 @@
+# on-this-day-art-trivia (skill)
+
+Skill component of the `on-this-day-art-trivia` package. The skill is the
+core engine; the **hook** at `hook/on-this-day-art-trivia/` and the
+**plugin** at `plugin/on_this_day_art_trivia/` wire it into Hermes.
+
+## CLI
+
+```
+python -m scripts.challenge start --chat-id 123 --user-id 99 --scope dm
+python -m scripts.challenge guess --chat-id 123 --user-id 99 --text "Ali refused the draft"
+python -m scripts.challenge hint  --chat-id 123
+python -m scripts.challenge reveal --chat-id 123 --user-id 99
+python -m scripts.challenge stats --user-id 99
+python -m scripts.challenge daily            # cron entry point
+```
+
+The CLI is the same surface the hook and plugin call into.
+
+## Direct Python use
+
+```python
+from scripts import challenge
+res = challenge.start_challenge(
+    platform="telegram",
+    chat_id="123",
+    user_id="99",
+    user_display_name="alice",
+    scope="dm",
+)
+print(res.surface_caption)            # "April 28\nHouston, Texas, United States"
+print(res.image_prompt)               # spoiler-safe prompt
+```
+
+## State
+
+`~/.hermes/data/on-this-day-art-trivia/trivia.db` — created on first use,
+WAL-mode, foreign keys on, atomic transactions.
+
+## Cron entry (daily delivery)
+
+Add this routine to your Hermes cron config:
+
+```yaml
+- name: otdat-daily
+  schedule: "0 8 * * *"     # 08:00 local time
+  command: |
+    cd ~/.hermes/skills/on-this-day-art-trivia &&
+    python -m scripts.challenge daily
+```

--- a/optional-skills/gaming/on-this-day-art-trivia/SKILL.md
+++ b/optional-skills/gaming/on-this-day-art-trivia/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: on-this-day-art-trivia
+description: |
+  Use when the user asks for an "on this day" history guessing game with an
+  AI-generated image of the scene 30 seconds before a historic event. Drives
+  Telegram-native interactive play through a companion plugin and hook.
+version: 0.1.1
+author: Hermes Agent contributors
+license: MIT
+metadata:
+  hermes:
+    tags: [game, history, telegram, image-gen, interactive]
+    surfaces: [telegram, cli]
+    state_db: ~/.hermes/data/on-this-day-art-trivia/trivia.db
+    companion_plugin: on_this_day_art_trivia
+    companion_hook: on-this-day-art-trivia
+---
+
+# On This Day — Art Trivia
+
+A Telegram-native history guessing game. The bot picks a historically
+important event for today's date, generates an image of the **scene 30
+seconds before** the event happened, and sends it with a caption that
+contains *only the date (including the year) and the location*. The user
+replies with a guess. Streaks, hints, achievements, and daily subscriptions
+are tracked locally.
+
+Image generation is delegated to the Hermes built-in image engine via the
+`gpt-image-2` bridge skill (which uses whatever provider is configured in
+the host environment). No direct API credentials are required in the skill
+or the game package itself.
+
+## When this skill applies
+
+The skill is invoked through the `/on-this-day-art-trivia` slash command
+(handled by the companion **hook** at `~/.hermes/hooks/on-this-day-art-trivia/`)
+and through inbound Telegram replies (intercepted by the companion **plugin**
+at `~/.hermes/plugins/on_this_day_art_trivia/`). The skill itself is the
+core engine — sources, scoring, prompt construction, persistence, matching,
+achievements, and the optional Telegram client used as a fallback when
+Hermes' built-in send mechanism cannot deliver an image with caption.
+
+## Subcommands
+
+| Subcommand                                                | Effect                                                                      |
+|-----------------------------------------------------------|-----------------------------------------------------------------------------|
+| `/on-this-day-art-trivia`                                 | Start a new challenge for today's date.                                     |
+| `/on-this-day-art-trivia guess <answer>`                  | Submit a guess explicitly (also works in groups).                           |
+| `/on-this-day-art-trivia hint`                            | Reveal the next hint (decade → country → initial).                          |
+| `/on-this-day-art-trivia reveal`                          | Reveal the answer; resets streak.                                           |
+| `/on-this-day-art-trivia stats`                           | Personal stats — correct, attempts, streak, longest, countries.             |
+| `/on-this-day-art-trivia achievements`                    | List unlocked achievements.                                                 |
+| `/on-this-day-art-trivia subscribe`                       | Receive a daily challenge in this chat.                                     |
+| `/on-this-day-art-trivia unsubscribe`                     | Stop daily delivery in this chat.                                           |
+| `/on-this-day-art-trivia leaderboard`                     | Top players by total correct.                                               |
+| `/on-this-day-art-trivia help`                            | Print this list.                                                            |
+
+## Interaction rules
+
+- **DM mode** — while a challenge is active, plain text in the DM is
+  treated as a guess. Only commands (anything starting with `/`) escape.
+- **Group mode** — only direct replies to the challenge image, or explicit
+  `/on-this-day-art-trivia guess <answer>`, are scored.
+- The bot **never** reveals the answer in the initial caption — caption is
+  exactly two lines: the full date (including the year) and the location.
+- After 3 wrong attempts (default), the streak resets and the answer is
+  revealed.
+
+## Source pipeline
+
+1. Britannica `/on-this-day` (editorial).
+2. Wikimedia REST `/feed/v1/wikipedia/en/onthisday/all/<MM>/<DD>` (structured).
+3. onthisday.com (HTML fallback).
+4. Cached fixtures under `scripts/fixtures/MM-DD.json` for fully-offline use.
+
+Each candidate is run through the scoring rubric in `scripts/scoring.py`.
+Disqualifying topics (graphic violence, sexual abuse, mass-casualty visuals,
+child harm) are hard-rejected — never selected.
+
+## Image generation contract
+
+The skill builds a spoiler-safe prompt in `scripts/prompt_builder.py`. Proper
+nouns from the canonical answer are scrubbed; sensitive trigger words are
+removed; defence-in-depth blocklist is applied. The prompt asks for the
+scene **before** the event, with no central protagonist, no readable text,
+no labels, no weapons, no violence.
+
+The resulting prompt is passed to the Hermes built-in image engine through
+the `gpt-image-2` bridge skill. The bridge handles provider selection,
+authentication, and model routing internally — no API credentials are
+needed in this skill package. If the bridge is unavailable, the challenge
+still goes out as a text-only message with the same surface caption.
+
+## Persistence
+
+SQLite at `~/.hermes/data/on-this-day-art-trivia/trivia.db`. Schema is
+migrated on first use. Tables: `users`, `challenges`, `acceptable_answers`,
+`guesses`, `achievements`, `subscriptions`, `schema_version`.
+
+## Daily subscriptions
+
+`python -m scripts.challenge daily` (run from the skill directory) walks
+every active subscription and starts a fresh challenge in each chat. Wire
+this into Hermes cron with the entry shown in `README.md`.
+
+## Files
+
+- `scripts/challenge.py` — orchestrator + CLI entry point.
+- `scripts/sources.py` — Britannica, Wikimedia, onthisday adapters.
+- `scripts/scoring.py` — event-scoring rubric.
+- `scripts/prompt_builder.py` — spoiler-safe image prompt.
+- `scripts/state.py` — SQLite layer.
+- `scripts/guess_matcher.py` — exact + fuzzy + anchor-token matching.
+- `scripts/achievements.py` — achievement engine.
+- `scripts/telegram_api.py` — fallback Telegram Bot API client.

--- a/optional-skills/gaming/on-this-day-art-trivia/docs/gateway-message-incoming-patch.md
+++ b/optional-skills/gaming/on-this-day-art-trivia/docs/gateway-message-incoming-patch.md
@@ -1,0 +1,87 @@
+# Optional gateway patch — `message:incoming` hook event
+
+**You probably do not need this patch.** The shipped `plugin/on_this_day_art_trivia/`
+already intercepts inbound messages via the existing `pre_gateway_dispatch`
+hook (declared in `hermes-agent/hermes_cli/plugins.py`'s `VALID_HOOKS` set,
+fired in `hermes-agent/gateway/run.py:_handle_message`). That gives us a
+return-value-driven `{"action": "skip", ...}` interception with zero core
+changes.
+
+This document is provided only for deployments that want a *pure HOOK.yaml*
+intercept path (i.e., a hook directory with a `HOOK.yaml` and a `handler.py`,
+no plugin) for inbound messages. In that case, add a `message:incoming` event
+to the `HookRegistry` so the same `decision: handled` contract used for slash
+commands also applies to inbound text.
+
+## Patch
+
+```diff
+--- a/hermes-agent/gateway/run.py
++++ b/hermes-agent/gateway/run.py
+@@ -3597,6 +3597,40 @@ class GatewayRunner:
+                 if _action == "allow":
+                     break
+
++        # message:incoming HookRegistry event.
++        # Mirrors the existing pre_gateway_dispatch plugin hook, but uses the
++        # gateway HookRegistry so HOOK.yaml-based hooks can intercept inbound
++        # text too. Honoured decisions:
++        #   {"decision": "handled", "message": "..."}  -> reply with message,
++        #                                                  do not dispatch agent
++        #   {"decision": "skip"}                        -> drop silently
++        # Hooks returning anything else (or None) fall through to normal flow.
++        if not is_internal:
++            try:
++                _msg_results = await self.hooks.emit_collect(
++                    "message:incoming",
++                    {
++                        "platform": source.platform.value if source.platform else "",
++                        "user_id": source.user_id,
++                        "user_name": source.user_name,
++                        "chat_id": source.chat_id,
++                        "chat_type": source.chat_type,
++                        "text": event.text,
++                        "reply_to_message_id": getattr(event, "reply_to_message_id", None),
++                    },
++                )
++            except Exception as _hook_err:
++                logger.debug("message:incoming hook dispatch failed: %s", _hook_err)
++                _msg_results = []
++            for _result in _msg_results:
++                if not isinstance(_result, dict):
++                    continue
++                _decision = str(_result.get("decision", "")).strip().lower()
++                if _decision == "handled":
++                    return _result.get("message")
++                if _decision == "skip":
++                    return None
++
+         if is_internal:
+             pass
+         elif source.user_id is None:
+```
+
+## Applying the patch
+
+```bash
+cd ~/.hermes/hermes-agent
+patch -p1 < ~/.hermes/on-this-day-art-trivia/docs/gateway-message-incoming.patch
+```
+
+Then restart the gateway. After this, a `HOOK.yaml` like
+
+```yaml
+name: on-this-day-art-trivia-inbound
+description: Score guesses against the active challenge
+events:
+  - message:incoming
+```
+
+with a `handler.py` returning `{"decision": "handled", "message": ...}` would
+work without the plugin.
+
+## Why this is optional
+
+The plugin path uses an existing, shipped extension point (`pre_gateway_dispatch`).
+Adding this patch to the gateway is fine — it is small and isolated — but it
+is duplicate plumbing. We recommend leaving it unpatched and using the plugin.

--- a/optional-skills/gaming/on-this-day-art-trivia/install.sh
+++ b/optional-skills/gaming/on-this-day-art-trivia/install.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# install.sh — install on-this-day-art-trivia into ~/.hermes
+#
+# Symlinks (or copies) the bundled skill, hook, and plugin into the
+# locations Hermes scans on startup. Idempotent: running it twice does
+# nothing destructive.
+#
+# Usage:
+#   ./install.sh                 # symlink into ~/.hermes
+#   ./install.sh --copy          # copy instead of symlink
+#   ./install.sh --uninstall     # remove the installed entries
+
+set -euo pipefail
+
+PKG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+
+SKILL_SRC="$PKG_DIR/skill/on-this-day-art-trivia"
+HOOK_SRC="$PKG_DIR/hook/on-this-day-art-trivia"
+PLUGIN_SRC="$PKG_DIR/plugin/on_this_day_art_trivia"
+
+SKILL_DST="$HERMES_HOME/skills/on-this-day-art-trivia"
+HOOK_DST="$HERMES_HOME/hooks/on-this-day-art-trivia"
+PLUGIN_DST="$HERMES_HOME/plugins/on_this_day_art_trivia"
+
+mode="symlink"
+do_uninstall=0
+for arg in "$@"; do
+  case "$arg" in
+    --copy) mode="copy" ;;
+    --uninstall) do_uninstall=1 ;;
+    -h|--help)
+      sed -n '1,18p' "$0"
+      exit 0
+      ;;
+    *) echo "Unknown option: $arg" >&2; exit 2 ;;
+  esac
+done
+
+uninstall_one() {
+  local target="$1"
+  if [[ -L "$target" || -e "$target" ]]; then
+    rm -rf "$target"
+    echo "  removed $target"
+  fi
+}
+
+install_one() {
+  local src="$1"
+  local dst="$2"
+  mkdir -p "$(dirname "$dst")"
+  if [[ -L "$dst" || -e "$dst" ]]; then
+    if [[ -L "$dst" && "$(readlink "$dst")" == "$src" ]]; then
+      echo "  ok   $dst (already linked)"
+      return 0
+    fi
+    echo "  warn $dst already exists; leaving in place" >&2
+    return 0
+  fi
+  if [[ "$mode" == "copy" ]]; then
+    cp -r "$src" "$dst"
+    echo "  copied $src -> $dst"
+  else
+    ln -s "$src" "$dst"
+    echo "  linked $src -> $dst"
+  fi
+}
+
+if [[ $do_uninstall -eq 1 ]]; then
+  echo "Uninstalling on-this-day-art-trivia from $HERMES_HOME ..."
+  uninstall_one "$SKILL_DST"
+  uninstall_one "$HOOK_DST"
+  uninstall_one "$PLUGIN_DST"
+  echo "Done. The SQLite database at $HERMES_HOME/data/on-this-day-art-trivia/ was left in place."
+  echo "Remove it manually if you want a clean slate."
+  exit 0
+fi
+
+echo "Installing on-this-day-art-trivia into $HERMES_HOME ($mode mode) ..."
+install_one "$SKILL_SRC"  "$SKILL_DST"
+install_one "$HOOK_SRC"   "$HOOK_DST"
+install_one "$PLUGIN_SRC" "$PLUGIN_DST"
+
+# Ensure data directory exists with the right permissions.
+mkdir -p "$HERMES_HOME/data/on-this-day-art-trivia"
+
+# Smoke-test: import the skill scripts.
+PYTHONPATH="$SKILL_DST" python3 -c "
+from scripts import state, sources, scoring, prompt_builder, guess_matcher, achievements, telegram_api, challenge
+state.migrate()
+print('on-this-day-art-trivia: skill imports OK; schema migrated.')
+"
+
+echo
+echo "Next steps:"
+echo "  1. Restart the Hermes gateway so it discovers the hook and plugin:"
+echo "       hermes restart   (or kill \$(< $HERMES_HOME/gateway.pid) && hermes start)"
+echo "  2. Send /on-this-day-art-trivia in Telegram to start your first challenge."
+echo "  3. (Optional) wire daily delivery into Hermes cron — see README.md."

--- a/optional-skills/gaming/on-this-day-art-trivia/scripts/__init__.py
+++ b/optional-skills/gaming/on-this-day-art-trivia/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""on-this-day-art-trivia skill internals."""

--- a/optional-skills/gaming/on-this-day-art-trivia/scripts/achievements.py
+++ b/optional-skills/gaming/on-this-day-art-trivia/scripts/achievements.py
@@ -1,0 +1,156 @@
+"""Achievement engine.
+
+The orchestrator calls :func:`evaluate_after_correct` after a correct guess
+is recorded, and :func:`evaluate_after_wrong` after a wrong guess. Both
+return a list of newly-awarded achievement keys.
+
+Achievements are deliberately additive — once awarded, they stay awarded.
+The evaluator is idempotent: multiple correct answers in the same day will
+not award a streak achievement twice.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Set
+
+from . import state
+
+
+@dataclass(frozen=True)
+class Achievement:
+    key: str
+    title: str
+    description: str
+
+
+CATALOG: Dict[str, Achievement] = {
+    "first_sight": Achievement(
+        key="first_sight",
+        title="First Sight",
+        description="Played your first On-This-Day challenge.",
+    ),
+    "historian_i": Achievement(
+        key="historian_i",
+        title="Historian I",
+        description="Got 3 correct answers.",
+    ),
+    "historian_ii": Achievement(
+        key="historian_ii",
+        title="Historian II",
+        description="Got 10 correct answers.",
+    ),
+    "streak_spark": Achievement(
+        key="streak_spark",
+        title="Streak Spark",
+        description="3 days in a row with a correct answer.",
+    ),
+    "calendar_beast": Achievement(
+        key="calendar_beast",
+        title="Calendar Beast",
+        description="7 days in a row with a correct answer.",
+    ),
+    "no_hints_needed": Achievement(
+        key="no_hints_needed",
+        title="No Hints Needed",
+        description="Got it right on the first try with no hints.",
+    ),
+    "cold_case": Achievement(
+        key="cold_case",
+        title="Cold Case",
+        description="Got it right after at least one wrong guess.",
+    ),
+    "globe_trotter": Achievement(
+        key="globe_trotter",
+        title="Globe Trotter",
+        description="Correct answers from 5 different countries.",
+    ),
+    "ancient_mode": Achievement(
+        key="ancient_mode",
+        title="Ancient Mode",
+        description="Solved a pre-1000 CE event.",
+    ),
+    "modern_memory": Achievement(
+        key="modern_memory",
+        title="Modern Memory",
+        description="Solved a post-2000 event.",
+    ),
+}
+
+
+def all_keys() -> Set[str]:
+    return set(CATALOG.keys())
+
+
+def evaluate_after_correct(
+    *,
+    platform: str,
+    user_id: str,
+    challenge: Dict,
+    user_after: Dict,
+    wrong_count: int,
+    hints_used: int,
+) -> List[str]:
+    """Run the rule set; award any new achievements; return newly-awarded keys.
+
+    Args:
+        platform: The user's platform.
+        user_id:  The user's stable id on that platform.
+        challenge: dict-shape result of :func:`state.get_challenge`.
+        user_after: dict returned by :func:`state.update_streak_after_correct`.
+        wrong_count: number of wrong/close guesses by this user on this challenge.
+        hints_used:  number of hints recorded against the challenge.
+    """
+    awarded: List[str] = []
+
+    def maybe(key: str) -> None:
+        if state.award_achievement(platform, user_id, key):
+            awarded.append(key)
+
+    maybe("first_sight")
+
+    total_correct = int(user_after.get("total_correct", 0))
+    if total_correct >= 3:
+        maybe("historian_i")
+    if total_correct >= 10:
+        maybe("historian_ii")
+
+    streak = int(user_after.get("current_streak", 0))
+    if streak >= 3:
+        maybe("streak_spark")
+    if streak >= 7:
+        maybe("calendar_beast")
+
+    if wrong_count == 0 and hints_used == 0:
+        maybe("no_hints_needed")
+    if wrong_count >= 1:
+        maybe("cold_case")
+
+    countries = user_after.get("countries", [])
+    if isinstance(countries, list) and len({c for c in countries if c}) >= 5:
+        maybe("globe_trotter")
+
+    year = challenge.get("event_year")
+    if isinstance(year, int):
+        if year < 1000:
+            maybe("ancient_mode")
+        if year >= 2000:
+            maybe("modern_memory")
+
+    return awarded
+
+
+def evaluate_after_wrong(*, platform: str, user_id: str) -> List[str]:
+    """Wrong-only path — currently only awards first_sight."""
+    awarded: List[str] = []
+    if state.award_achievement(platform, user_id, "first_sight"):
+        awarded.append("first_sight")
+    return awarded
+
+
+def render_achievement_line(key: str) -> str:
+    """Render a one-line description suitable for chat output."""
+    a = CATALOG.get(key)
+    if not a:
+        return key
+    return f"{a.title} — {a.description}"

--- a/optional-skills/gaming/on-this-day-art-trivia/scripts/challenge.py
+++ b/optional-skills/gaming/on-this-day-art-trivia/scripts/challenge.py
@@ -1,0 +1,713 @@
+"""Challenge orchestrator + CLI entry point.
+
+This module exposes both a Python API (used by the hook and plugin) and a
+``__main__`` CLI used by Hermes' cron for daily-subscription delivery and by
+the bundled install script for smoke-testing.
+
+Public API:
+
+* :func:`start_challenge(...)` — fetch an event, build the prompt, persist a
+  challenge row, attempt to deliver to Telegram if requested. Returns a
+  :class:`ChallengeResult`.
+* :func:`handle_guess(...)` — score a guess and return a :class:`GuessResult`
+  with the user-facing reply text.
+* :func:`handle_hint(...)`, :func:`handle_reveal(...)`,
+  :func:`render_stats(...)`, :func:`render_achievements(...)`,
+  :func:`render_leaderboard(...)` — the rest of the slash-command surface.
+* :func:`subscribe(...)` / :func:`unsubscribe(...)` / :func:`run_daily_subscriptions()`.
+
+The orchestrator delegates image generation to the Hermes built-in image
+engine via the ``gpt-image-2`` bridge skill, which resolves the active
+provider, model, and authentication internally. If the bridge is not available,
+the challenge falls back to text-only delivery.
+"""
+
+from __future__ import annotations
+
+import argparse
+import calendar
+import datetime as _dt
+import json
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
+
+# Allow both "python -m scripts.challenge" and "python challenge.py" forms.
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    from scripts import achievements, guess_matcher, prompt_builder, scoring, sources, state, telegram_api  # type: ignore
+    from scripts.guess_matcher import Acceptable, MatchResult, build_anchor_tokens  # type: ignore
+else:
+    from . import achievements, guess_matcher, prompt_builder, scoring, sources, state, telegram_api
+    from .guess_matcher import Acceptable, MatchResult, build_anchor_tokens
+
+logger = logging.getLogger(__name__)
+
+
+# --------------------------------------------------------------------------- #
+# Constants
+# --------------------------------------------------------------------------- #
+
+DEFAULT_MAX_ATTEMPTS = 3
+TELEGRAM_PLATFORM = "telegram"
+
+
+# --------------------------------------------------------------------------- #
+# Data containers
+# --------------------------------------------------------------------------- #
+
+@dataclass
+class ChallengeResult:
+    challenge_id: int
+    surface_caption: str        # ONLY date + location — never any spoiler
+    image_prompt: str
+    image_path: Optional[Path]
+    telegram_message_id: Optional[str]
+    delivered: bool
+
+
+@dataclass
+class GuessResult:
+    outcome: str                 # 'correct' | 'close' | 'wrong' | 'exhausted'
+    reply_text: str
+    awarded_achievements: List[str] = field(default_factory=list)
+    challenge_id: Optional[int] = None
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+def _today_iso(now: Optional[_dt.date] = None) -> str:
+    return (now or _dt.date.today()).isoformat()
+
+
+def _surface_date(month: int, day: int, year: Optional[int] = None) -> str:
+    base = f"{calendar.month_name[month]} {day}"
+    if year is not None:
+        return f"{base}, {year}"
+    return base
+
+
+def _build_aliases(event: scoring.CandidateEvent) -> List[Tuple[str, int]]:
+    """Build acceptable answer aliases with precision tiers.
+
+    Tier 1 = exact canonical answer.
+    Tier 2 = topic noun phrase from raw page titles (Wikimedia ``pages``).
+    Tier 3 = single-noun aliases (the most permissive).
+    """
+    out: List[Tuple[str, int]] = []
+    out.append((event.canonical_answer.strip(), 1))
+    pages = event.raw.get("pages") if isinstance(event.raw, dict) else None
+    if isinstance(pages, list):
+        for title in pages:
+            if isinstance(title, str) and title.strip():
+                out.append((title.strip(), 2))
+    # Single most-distinctive token as a tier-3 fallback alias.
+    anchors = build_anchor_tokens(event.canonical_answer)
+    if anchors:
+        out.append((anchors[0], 3))
+    # Dedup, preserve order.
+    seen: set = set()
+    deduped: List[Tuple[str, int]] = []
+    for alias, tier in out:
+        key = alias.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append((alias, tier))
+    return deduped
+
+
+# Image generation hook. Can be overridden in tests by injecting via the
+# ``image_generator`` arg.
+ImageGenerator = Callable[[str, Path], Optional[Path]]
+
+
+def _default_image_generator(prompt: str, output_dir: Path) -> Optional[Path]:
+    """Try to invoke the gpt-image-2 skill (or legacy chatgpt-images-2-operator) via subprocess.
+
+    Searches in order:
+      1. ``$HERMES_HOME/skills/creative/gpt-image-2/scripts/generate.py``
+      2. ``$HERMES_HOME/skills/gpt-image-2/scripts/generate.py``
+      3. ``$HERMES_HOME/skills/creative/chatgpt-images-2-operator/run.py``
+      4. ``$HERMES_HOME/skills/creative/chatgpt-images-2-operator/scripts/generate.py``
+
+    If none is found, returns None and the caller falls back to text-only delivery.
+    """
+    hermes_home = Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes")))
+    candidates = [
+        hermes_home / "skills" / "creative" / "gpt-image-2" / "scripts" / "generate.py",
+        hermes_home / "skills" / "gpt-image-2" / "scripts" / "generate.py",
+        hermes_home / "skills" / "creative" / "chatgpt-images-2-operator" / "run.py",
+        hermes_home / "skills" / "creative" / "chatgpt-images-2-operator" / "scripts" / "generate.py",
+    ]
+    runner = next((p for p in candidates if p.exists()), None)
+    if runner is None:
+        logger.debug("No image generator (gpt-image-2 or legacy) found; skipping image gen")
+        return None
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / "scene.png"
+    try:
+        subprocess.run(
+            [sys.executable, str(runner), "--prompt", prompt, "--output", str(output_path)],
+            check=True,
+            timeout=120,
+            capture_output=True,
+        )
+    except (subprocess.SubprocessError, FileNotFoundError) as exc:
+        logger.warning("image generator failed: %s", exc)
+        return None
+    return output_path if output_path.exists() else None
+
+
+# --------------------------------------------------------------------------- #
+# Source -> chosen event
+# --------------------------------------------------------------------------- #
+
+def _pick_event(month: int, day: int, *, allow_offline_fixtures: bool = True) -> Optional[scoring.CandidateEvent]:
+    candidates: List[scoring.CandidateEvent] = []
+    try:
+        candidates.extend(sources.fetch_all_candidates(month, day))
+    except Exception as exc:
+        logger.warning("source aggregation failed: %s", exc)
+    if not candidates and allow_offline_fixtures:
+        candidates = sources.load_fixture_events(month, day)
+    if not candidates:
+        return None
+    ranked = scoring.rank_candidates(candidates)
+    # Prefer the highest score whose prompt also passes safety. We try up to
+    # five top events to avoid getting stuck on a single failing prompt.
+    for ev in ranked[:5]:
+        try:
+            prompt = prompt_builder.build_image_prompt(ev, surface_date=_surface_date(month, day, ev.year))
+        except ValueError:
+            continue
+        if prompt_builder.prompt_passes_safety(prompt):
+            return ev
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# Public: start_challenge
+# --------------------------------------------------------------------------- #
+
+def start_challenge(
+    *,
+    platform: str,
+    chat_id: str,
+    user_id: str,
+    user_display_name: Optional[str],
+    scope: str,
+    on_date: Optional[_dt.date] = None,
+    image_generator: Optional[ImageGenerator] = None,
+    deliver_to_telegram: bool = True,
+) -> Optional[ChallengeResult]:
+    """Launch a fresh challenge for the user/chat.
+
+    Returns ``None`` if no usable event could be found.
+    """
+    state.migrate()
+    state.upsert_user(platform, user_id, user_display_name)
+
+    on_date = on_date or _dt.date.today()
+    month, day = on_date.month, on_date.day
+
+    event = _pick_event(month, day)
+    if event is None:
+        return None
+
+    surface_date = _surface_date(month, day, event.year)
+    location_line = event.location or "An unspecified location"
+    if event.country and event.location and event.country.lower() not in event.location.lower():
+        location_line = f"{event.location}, {event.country}"
+    surface_caption = f"{surface_date}\n{location_line}"
+
+    image_prompt = prompt_builder.build_image_prompt(event, surface_date=surface_date)
+
+    aliases = _build_aliases(event)
+    challenge_id = state.create_challenge(
+        platform=platform,
+        chat_id=chat_id,
+        scope=scope,
+        user_id=user_id if scope == "dm" else None,
+        event_date=surface_date,
+        event_year=event.year,
+        location=event.location,
+        country=event.country,
+        canonical_answer=event.canonical_answer,
+        short_summary=event.summary,
+        full_description=(event.raw.get("raw_entry") if isinstance(event.raw, dict) else None) or event.summary,
+        source=event.source,
+        aliases=aliases,
+        max_attempts=DEFAULT_MAX_ATTEMPTS,
+    )
+
+    image_path: Optional[Path] = None
+    image_dir = Path(tempfile.mkdtemp(prefix="otdat-"))
+    generator = image_generator or _default_image_generator
+    try:
+        image_path = generator(image_prompt, image_dir)
+    except Exception as exc:
+        logger.warning("image generator raised: %s", exc)
+        image_path = None
+
+    delivered = False
+    telegram_message_id: Optional[str] = None
+    if deliver_to_telegram and platform == TELEGRAM_PLATFORM:
+        if image_path and image_path.exists():
+            telegram_message_id = telegram_api.send_photo(chat_id, image_path, surface_caption)
+        else:
+            telegram_message_id = telegram_api.send_message(chat_id, surface_caption)
+        if telegram_message_id:
+            state.attach_telegram_message_id(challenge_id, telegram_message_id)
+            delivered = True
+
+    return ChallengeResult(
+        challenge_id=challenge_id,
+        surface_caption=surface_caption,
+        image_prompt=image_prompt,
+        image_path=image_path,
+        telegram_message_id=telegram_message_id,
+        delivered=delivered,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Public: handle_guess
+# --------------------------------------------------------------------------- #
+
+def handle_guess(
+    *,
+    platform: str,
+    chat_id: str,
+    user_id: str,
+    user_display_name: Optional[str],
+    guess_text: str,
+    challenge_id: Optional[int] = None,
+) -> Optional[GuessResult]:
+    """Score a guess against the active challenge for ``chat_id``.
+
+    Returns ``None`` if there is no active challenge — the caller decides
+    what to do (in DM-mode, treating plain text as a guess; in group-mode,
+    only intercepting explicit replies).
+    """
+    state.migrate()
+    state.upsert_user(platform, user_id, user_display_name)
+
+    if challenge_id:
+        challenge = state.get_challenge(challenge_id)
+    else:
+        challenge = state.get_active_challenge_for_chat(platform, chat_id)
+    if not challenge or challenge.get("status") != "active":
+        return None
+
+    guess_text = (guess_text or "").strip()
+    if not guess_text:
+        return None
+
+    aliases = state.list_acceptable_answers(int(challenge["challenge_id"]))
+    accept_objs = [
+        Acceptable(
+            alias=row["alias"],
+            alias_normalized=row["alias_normalized"],
+            precision_tier=int(row["precision_tier"]),
+        )
+        for row in aliases
+    ]
+    anchors = build_anchor_tokens(challenge.get("canonical_answer") or "")
+    result = guess_matcher.match_guess(
+        guess_text,
+        accept_objs,
+        canonical_anchor_tokens=anchors,
+    )
+
+    return _record_and_render(
+        platform=platform,
+        chat_id=chat_id,
+        user_id=user_id,
+        challenge=challenge,
+        guess_text=guess_text,
+        match=result,
+    )
+
+
+def _record_and_render(
+    *,
+    platform: str,
+    chat_id: str,
+    user_id: str,
+    challenge: Dict[str, Any],
+    guess_text: str,
+    match: MatchResult,
+) -> GuessResult:
+    challenge_id = int(challenge["challenge_id"])
+    state.record_guess(challenge_id, platform, user_id, guess_text, match.outcome)
+    state.increment_attempts(challenge_id)
+
+    if match.outcome == "correct":
+        wrong_count = state.count_wrong_guesses(challenge_id, user_id)
+        hints_used = state.count_hints_used(challenge_id)
+        user_after = state.update_streak_after_correct(
+            platform, user_id, _today_iso(), challenge.get("country"),
+        )
+        state.resolve_challenge(challenge_id, "solved")
+        awarded = achievements.evaluate_after_correct(
+            platform=platform,
+            user_id=user_id,
+            challenge=challenge,
+            user_after=user_after,
+            wrong_count=wrong_count,
+            hints_used=hints_used,
+        )
+        reply = _format_correct_reply(challenge, user_after["current_streak"], awarded)
+        return GuessResult(
+            outcome="correct",
+            reply_text=reply,
+            awarded_achievements=awarded,
+            challenge_id=challenge_id,
+        )
+
+    if match.outcome == "close":
+        # Close but not specific enough — record without burning a hard fail.
+        # Still counts an attempt; reset_streak only fires on full exhaustion.
+        attempts_used = int(challenge["attempts_used"]) + 1
+        max_attempts = int(challenge["max_attempts"])
+        if attempts_used >= max_attempts:
+            return _exhaust_challenge(platform, user_id, challenge)
+        state.update_after_wrong(platform, user_id)
+        return GuessResult(
+            outcome="close",
+            reply_text=(
+                "Close, but more specific. Reply again with a clearer answer.\n"
+                f"Attempts left: {max(0, max_attempts - attempts_used)}"
+            ),
+            challenge_id=challenge_id,
+        )
+
+    # Wrong path.
+    attempts_used = int(challenge["attempts_used"]) + 1
+    max_attempts = int(challenge["max_attempts"])
+    state.update_after_wrong(platform, user_id)
+    if attempts_used >= max_attempts:
+        return _exhaust_challenge(platform, user_id, challenge)
+    return GuessResult(
+        outcome="wrong",
+        reply_text=(
+            "Not quite. Try again.\n"
+            f"Attempts left: {max(0, max_attempts - attempts_used)}"
+        ),
+        challenge_id=challenge_id,
+    )
+
+
+def _exhaust_challenge(platform: str, user_id: str, challenge: Dict[str, Any]) -> GuessResult:
+    challenge_id = int(challenge["challenge_id"])
+    state.resolve_challenge(challenge_id, "failed")
+    state.reset_streak(platform, user_id)
+    return GuessResult(
+        outcome="exhausted",
+        reply_text=(
+            "Out of attempts.\n"
+            f"Answer: {challenge.get('short_summary') or challenge.get('canonical_answer')}\n"
+            "Streak reset to 0."
+        ),
+        challenge_id=challenge_id,
+    )
+
+
+def _format_correct_reply(challenge: Dict[str, Any], streak: int, awarded: List[str]) -> str:
+    canon = challenge.get("short_summary") or challenge.get("canonical_answer") or ""
+    lines = [
+        "Correct.",
+        f"Answer: {canon}".rstrip(),
+        f"Streak: {streak}",
+    ]
+    for key in awarded:
+        lines.append(f"Achievement unlocked — {achievements.render_achievement_line(key)}")
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------- #
+# Hint / reveal
+# --------------------------------------------------------------------------- #
+
+HINT_LADDER = (
+    "It happened in the {decade}s.",
+    "Country: {country}.",
+    "It involved a person whose first initial is '{initial}'.",
+)
+
+
+def handle_hint(*, platform: str, chat_id: str) -> Optional[str]:
+    state.migrate()
+    challenge = state.get_active_challenge_for_chat(platform, chat_id)
+    if not challenge:
+        return None
+    challenge_id = int(challenge["challenge_id"])
+    history = state.append_hint(challenge_id, "")  # will overwrite below
+
+    used = len(history) - 1
+    canon = challenge.get("canonical_answer") or ""
+    initials = next((c for c in canon if c.isalpha()), "?")
+    decade = (challenge.get("event_year") // 10 * 10) if isinstance(challenge.get("event_year"), int) else "?"
+    country = challenge.get("country") or "unknown"
+
+    if used >= len(HINT_LADDER):
+        # Replace the speculative empty hint with a generic message.
+        state.append_hint(challenge_id, "no further hints available")
+        return "No more hints. Use /on-this-day-art-trivia reveal to see the answer."
+
+    hint = HINT_LADDER[used].format(
+        decade=decade,
+        country=country,
+        initial=initials.upper(),
+    )
+    # Persist the actual hint text, replacing the placeholder we just appended.
+    history[-1] = hint
+    # Rewrite the hint history in place.
+    from . import state as _state_mod  # local alias to avoid shadowing
+    with _state_mod.get_conn() as conn:
+        conn.execute(
+            "UPDATE challenges SET hint_history = ? WHERE challenge_id = ?",
+            (json.dumps(history), challenge_id),
+        )
+    state.record_guess(challenge_id, platform, "system", "[hint]", "hint")
+    return f"Hint {used + 1}: {hint}"
+
+
+def handle_reveal(*, platform: str, chat_id: str, user_id: str) -> Optional[str]:
+    state.migrate()
+    challenge = state.get_active_challenge_for_chat(platform, chat_id)
+    if not challenge:
+        return None
+    challenge_id = int(challenge["challenge_id"])
+    state.resolve_challenge(challenge_id, "revealed")
+    state.reset_streak(platform, user_id)
+    answer = challenge.get("short_summary") or challenge.get("canonical_answer") or ""
+    return f"Answer: {answer}\nStreak reset to 0."
+
+
+# --------------------------------------------------------------------------- #
+# Stats / achievements / leaderboard
+# --------------------------------------------------------------------------- #
+
+def render_stats(*, platform: str, user_id: str) -> str:
+    state.migrate()
+    user = state.get_user(platform, user_id)
+    if not user:
+        return "No stats yet — play your first challenge with /on-this-day-art-trivia."
+    countries = user.get("countries_correct") or "[]"
+    try:
+        country_count = len(json.loads(countries))
+    except (TypeError, ValueError):
+        country_count = 0
+    return (
+        "Your On-This-Day Art Trivia stats:\n"
+        f"  Correct: {user.get('total_correct', 0)}\n"
+        f"  Attempts: {user.get('total_attempts', 0)}\n"
+        f"  Current streak: {user.get('current_streak', 0)}\n"
+        f"  Longest streak: {user.get('longest_streak', 0)}\n"
+        f"  Countries correct: {country_count}"
+    )
+
+
+def render_achievements(*, platform: str, user_id: str) -> str:
+    state.migrate()
+    rows = state.list_achievements(platform, user_id)
+    if not rows:
+        return "No achievements yet. Play to earn your first."
+    lines = ["Your achievements:"]
+    for row in rows:
+        lines.append(f"  • {achievements.render_achievement_line(row['achievement_key'])}")
+    return "\n".join(lines)
+
+
+def render_leaderboard(*, platform: str, limit: int = 10) -> str:
+    state.migrate()
+    rows = state.leaderboard_top(platform, limit=limit)
+    if not rows:
+        return "Leaderboard is empty."
+    lines = ["Leaderboard (most-correct):"]
+    for i, row in enumerate(rows, 1):
+        name = row.get("display_name") or row.get("user_id")
+        lines.append(
+            f"  {i}. {name} — {row.get('total_correct', 0)} correct "
+            f"(longest streak {row.get('longest_streak', 0)})"
+        )
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------- #
+# Subscriptions
+# --------------------------------------------------------------------------- #
+
+def subscribe(*, platform: str, user_id: str, chat_id: str, scope: str) -> str:
+    state.migrate()
+    state.add_subscription(platform, user_id, chat_id, scope)
+    return "Subscribed. You'll receive a daily on-this-day challenge."
+
+
+def unsubscribe(*, platform: str, user_id: str, chat_id: str) -> str:
+    state.migrate()
+    if state.remove_subscription(platform, user_id, chat_id):
+        return "Unsubscribed. No more daily challenges."
+    return "You weren't subscribed."
+
+
+def run_daily_subscriptions(*, on_date: Optional[_dt.date] = None) -> Dict[str, int]:
+    """Cron-friendly entry point. Sends one challenge per active subscription."""
+    state.migrate()
+    sent = 0
+    failed = 0
+    for sub in state.list_active_subscriptions():
+        try:
+            res = start_challenge(
+                platform=sub["platform"],
+                chat_id=sub["chat_id"],
+                user_id=sub["user_id"],
+                user_display_name=None,
+                scope=sub["scope"],
+                on_date=on_date,
+            )
+        except Exception as exc:
+            logger.warning("subscription delivery failed for %s: %s", sub, exc)
+            failed += 1
+            continue
+        if res and res.delivered:
+            sent += 1
+        else:
+            failed += 1
+    return {"sent": sent, "failed": failed}
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+
+def _build_argparser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="on-this-day-art-trivia")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    start = sub.add_parser("start", help="Start a new challenge")
+    start.add_argument("--platform", default=TELEGRAM_PLATFORM)
+    start.add_argument("--chat-id", required=True)
+    start.add_argument("--user-id", required=True)
+    start.add_argument("--scope", default="dm", choices=("dm", "group"))
+    start.add_argument("--no-deliver", action="store_true")
+    start.add_argument("--date", help="ISO date YYYY-MM-DD (default today)")
+
+    sub.add_parser("daily", help="Run daily subscription delivery")
+
+    g = sub.add_parser("guess", help="Score a guess")
+    g.add_argument("--platform", default=TELEGRAM_PLATFORM)
+    g.add_argument("--chat-id", required=True)
+    g.add_argument("--user-id", required=True)
+    g.add_argument("--text", required=True)
+
+    h = sub.add_parser("hint", help="Get a hint")
+    h.add_argument("--platform", default=TELEGRAM_PLATFORM)
+    h.add_argument("--chat-id", required=True)
+
+    r = sub.add_parser("reveal", help="Reveal the answer")
+    r.add_argument("--platform", default=TELEGRAM_PLATFORM)
+    r.add_argument("--chat-id", required=True)
+    r.add_argument("--user-id", required=True)
+
+    st = sub.add_parser("stats", help="Show user stats")
+    st.add_argument("--platform", default=TELEGRAM_PLATFORM)
+    st.add_argument("--user-id", required=True)
+
+    a = sub.add_parser("achievements", help="List user achievements")
+    a.add_argument("--platform", default=TELEGRAM_PLATFORM)
+    a.add_argument("--user-id", required=True)
+
+    lb = sub.add_parser("leaderboard", help="Show leaderboard")
+    lb.add_argument("--platform", default=TELEGRAM_PLATFORM)
+    lb.add_argument("--limit", type=int, default=10)
+
+    s = sub.add_parser("subscribe", help="Subscribe to daily challenges")
+    s.add_argument("--platform", default=TELEGRAM_PLATFORM)
+    s.add_argument("--user-id", required=True)
+    s.add_argument("--chat-id", required=True)
+    s.add_argument("--scope", default="dm", choices=("dm", "group"))
+
+    u = sub.add_parser("unsubscribe", help="Unsubscribe from daily challenges")
+    u.add_argument("--platform", default=TELEGRAM_PLATFORM)
+    u.add_argument("--user-id", required=True)
+    u.add_argument("--chat-id", required=True)
+
+    return p
+
+
+def _cli_main(argv: Optional[List[str]] = None) -> int:
+    args = _build_argparser().parse_args(argv)
+    if args.cmd == "start":
+        on_date = _dt.date.fromisoformat(args.date) if args.date else None
+        res = start_challenge(
+            platform=args.platform, chat_id=args.chat_id,
+            user_id=args.user_id, user_display_name=None,
+            scope=args.scope, on_date=on_date,
+            deliver_to_telegram=not args.no_deliver,
+        )
+        if res is None:
+            print("No suitable event found for that date.")
+            return 1
+        print(json.dumps({
+            "challenge_id": res.challenge_id,
+            "surface_caption": res.surface_caption,
+            "delivered": res.delivered,
+            "telegram_message_id": res.telegram_message_id,
+            "image_path": str(res.image_path) if res.image_path else None,
+        }, indent=2))
+        return 0
+    if args.cmd == "daily":
+        summary = run_daily_subscriptions()
+        print(json.dumps(summary))
+        return 0
+    if args.cmd == "guess":
+        res = handle_guess(
+            platform=args.platform, chat_id=args.chat_id,
+            user_id=args.user_id, user_display_name=None,
+            guess_text=args.text,
+        )
+        if res is None:
+            print("No active challenge.")
+            return 1
+        print(res.reply_text)
+        return 0
+    if args.cmd == "hint":
+        out = handle_hint(platform=args.platform, chat_id=args.chat_id)
+        print(out or "No active challenge.")
+        return 0 if out else 1
+    if args.cmd == "reveal":
+        out = handle_reveal(platform=args.platform, chat_id=args.chat_id, user_id=args.user_id)
+        print(out or "No active challenge.")
+        return 0 if out else 1
+    if args.cmd == "stats":
+        print(render_stats(platform=args.platform, user_id=args.user_id))
+        return 0
+    if args.cmd == "achievements":
+        print(render_achievements(platform=args.platform, user_id=args.user_id))
+        return 0
+    if args.cmd == "leaderboard":
+        print(render_leaderboard(platform=args.platform, limit=args.limit))
+        return 0
+    if args.cmd == "subscribe":
+        print(subscribe(platform=args.platform, user_id=args.user_id, chat_id=args.chat_id, scope=args.scope))
+        return 0
+    if args.cmd == "unsubscribe":
+        print(unsubscribe(platform=args.platform, user_id=args.user_id, chat_id=args.chat_id))
+        return 0
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(_cli_main())

--- a/optional-skills/gaming/on-this-day-art-trivia/scripts/guess_matcher.py
+++ b/optional-skills/gaming/on-this-day-art-trivia/scripts/guess_matcher.py
@@ -1,0 +1,175 @@
+"""Guess matching for the on-this-day-art-trivia skill.
+
+Match levels (in priority order):
+
+1. **Exact normalised match** against any acceptable alias.
+2. **Token-Jaccard fuzzy match** above a high threshold (>= 0.75).
+3. **Anchor-token match** — the guess contains the strongest topical anchor
+   token from the canonical answer (>= 5 chars, not a stopword) AND at least
+   one supporting token. Returns ``"close"`` rather than ``"correct"`` so the
+   bot can prompt the user to be more specific without revealing the answer.
+4. Otherwise ``"wrong"``.
+
+The matcher is intentionally conservative on partial matches: a guess of
+"war" should never satisfy "Korean War" without supporting context. We
+penalise single-token short guesses heavily.
+
+Optional LLM-judge support is provided as a stub (:func:`maybe_llm_judge`)
+that callers may swap in for harder cases — left disabled by default to keep
+the package fully offline-capable.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from dataclasses import dataclass
+from typing import Iterable, List, Optional, Sequence, Set, Tuple
+
+# Tokens that should never count as evidence of a match by themselves.
+_STOPWORDS: Set[str] = {
+    "the", "a", "an", "of", "in", "on", "at", "to", "and", "or", "but",
+    "for", "with", "by", "is", "was", "were", "be", "been", "being",
+    "as", "his", "her", "its", "their", "this", "that", "these", "those",
+    "it", "he", "she", "they", "we", "you", "i", "from", "into", "during",
+    "before", "after", "above", "below", "up", "down", "out", "off",
+    "over", "under", "again", "further", "then", "once", "here", "there",
+    "when", "where", "why", "how", "all", "any", "both", "each", "few",
+    "more", "most", "other", "some", "such", "no", "nor", "not", "only",
+    "own", "same", "so", "than", "too", "very", "can", "will", "just",
+    "don", "should", "now", "him", "us", "them", "us",
+}
+
+_NON_WORD = re.compile(r"[^a-z0-9\s]+")
+_WHITESPACE = re.compile(r"\s+")
+
+
+def normalize(text: str) -> str:
+    """Lowercase, strip diacritics, collapse non-word, keep digits."""
+    if not text:
+        return ""
+    decomposed = unicodedata.normalize("NFKD", text)
+    ascii_only = decomposed.encode("ascii", "ignore").decode("ascii")
+    lowered = ascii_only.lower()
+    cleaned = _NON_WORD.sub(" ", lowered)
+    return _WHITESPACE.sub(" ", cleaned).strip()
+
+
+def tokens(text: str) -> List[str]:
+    norm = normalize(text)
+    if not norm:
+        return []
+    return [t for t in norm.split(" ") if t]
+
+
+def content_tokens(text: str) -> List[str]:
+    """Tokens excluding stopwords and very short tokens."""
+    return [t for t in tokens(text) if t not in _STOPWORDS and len(t) >= 3]
+
+
+def jaccard(a: Iterable[str], b: Iterable[str]) -> float:
+    sa = set(a)
+    sb = set(b)
+    if not sa or not sb:
+        return 0.0
+    inter = sa & sb
+    union = sa | sb
+    if not union:
+        return 0.0
+    return len(inter) / len(union)
+
+
+@dataclass(frozen=True)
+class Acceptable:
+    alias: str
+    alias_normalized: str
+    precision_tier: int = 1
+
+
+@dataclass(frozen=True)
+class MatchResult:
+    outcome: str  # "correct" | "close" | "wrong"
+    matched_alias: Optional[str]
+    score: float
+
+
+def match_guess(
+    guess: str,
+    acceptable: Sequence[Acceptable],
+    *,
+    canonical_anchor_tokens: Optional[Sequence[str]] = None,
+    fuzzy_threshold: float = 0.75,
+    close_threshold: float = 0.45,
+) -> MatchResult:
+    """Score *guess* against *acceptable* aliases.
+
+    Returns a :class:`MatchResult`. ``canonical_anchor_tokens`` are the rare
+    high-information tokens drawn from the canonical answer (computed by
+    :func:`build_anchor_tokens`); guesses that hit any anchor without a clean
+    fuzzy match are flagged as ``"close"`` so the bot can ask for specificity.
+    """
+    g_norm = normalize(guess)
+    if not g_norm:
+        return MatchResult(outcome="wrong", matched_alias=None, score=0.0)
+
+    g_tokens_content = content_tokens(guess)
+
+    best_score = 0.0
+    best_alias: Optional[str] = None
+    best_tier: int = 99
+
+    for entry in acceptable:
+        if g_norm == entry.alias_normalized:
+            return MatchResult(outcome="correct", matched_alias=entry.alias, score=1.0)
+
+        a_tokens = content_tokens(entry.alias_normalized)
+        score = jaccard(g_tokens_content, a_tokens)
+        # Substring-style boost: if a multi-token alias appears in guess
+        # contiguously, bump the score.
+        if entry.alias_normalized and len(a_tokens) >= 2 and entry.alias_normalized in g_norm:
+            score = max(score, 0.9)
+
+        if score > best_score or (score == best_score and entry.precision_tier < best_tier):
+            best_score = score
+            best_alias = entry.alias
+            best_tier = entry.precision_tier
+
+    if best_score >= fuzzy_threshold and best_alias is not None:
+        return MatchResult(outcome="correct", matched_alias=best_alias, score=best_score)
+
+    if canonical_anchor_tokens:
+        anchor_set = {a for a in canonical_anchor_tokens if len(a) >= 5}
+        guess_set = set(g_tokens_content)
+        if anchor_set & guess_set and len(g_tokens_content) >= 2:
+            return MatchResult(outcome="close", matched_alias=best_alias, score=best_score)
+
+    if best_score >= close_threshold and best_alias is not None and len(g_tokens_content) >= 2:
+        return MatchResult(outcome="close", matched_alias=best_alias, score=best_score)
+
+    return MatchResult(outcome="wrong", matched_alias=best_alias, score=best_score)
+
+
+def build_anchor_tokens(canonical_answer: str, *, top_n: int = 4) -> List[str]:
+    """Pick the most distinctive content tokens from the canonical answer.
+
+    Heuristic: longer tokens tend to be proper nouns or rare words. We sort
+    by length (descending) then alphabetically for determinism. This keeps
+    the matcher dependency-free.
+    """
+    cands = list({t for t in content_tokens(canonical_answer)})
+    cands.sort(key=lambda t: (-len(t), t))
+    return cands[:max(1, top_n)]
+
+
+# --------------------------------------------------------------------------- #
+# Optional LLM judge stub
+# --------------------------------------------------------------------------- #
+
+def maybe_llm_judge(guess: str, canonical: str) -> Optional[str]:
+    """Optional constrained LLM judge. Disabled by default.
+
+    Returns ``"correct"`` / ``"close"`` / ``"wrong"`` if a judge is configured,
+    otherwise ``None``. Hooked here so a deployment can add a model call
+    without touching the matcher's deterministic path.
+    """
+    return None

--- a/optional-skills/gaming/on-this-day-art-trivia/scripts/prompt_builder.py
+++ b/optional-skills/gaming/on-this-day-art-trivia/scripts/prompt_builder.py
@@ -87,7 +87,18 @@ def scrub_spoilers(text: str, event: CandidateEvent) -> str:
     the image model — humans will see only the date and location separately.
     Both the proper nouns and the lowercase content tokens of the canonical
     answer are redacted, so a verb like ``induction`` cannot leak.
+
+    If more than 50% of the remaining content words are redacted, returns an
+    empty string so the caller can drop the atmospheric cue entirely.
     """
+    if not text:
+        return ""
+
+    # Count original content words (excluding stopwords/short).
+    original_words = set(w.lower() for w in re.findall(r"[A-Za-z][A-Za-z\-']+", text)
+                         if len(w) >= 4 and w.lower() not in _REDACTION_STOPWORDS)
+    total = len(original_words)
+
     redacted = text
     spoilers: Iterable[str] = (
         _proper_nouns(event.canonical_answer or "")
@@ -104,7 +115,18 @@ def scrub_spoilers(text: str, event: CandidateEvent) -> str:
     for w in _SENSITIVE_CONTEXT_WORDS:
         redacted = re.sub(rf"\b{re.escape(w)}\b", " ", redacted, flags=re.IGNORECASE)
 
-    return re.sub(r"\s+", " ", redacted).strip(" .,:;-")
+    redacted = re.sub(r"\s+", " ", redacted).strip(" .,:-")
+
+    # Degradation check: if >50% of words became placeholders, the cue is noise.
+    if total > 0:
+        remaining_words = set(w.lower() for w in re.findall(r"[A-Za-z][A-Za-z\-']+", redacted)
+                           if len(w) >= 4 and w.lower() not in _REDACTION_STOPWORDS)
+        # Words still present / total original (ignoring newly inserted 'the figure', 'the moment')
+        original_redacted = remaining_words - {"figure", "moment"}
+        if len(original_redacted) == 0 or (len(original_redacted) / total) < 0.5:
+            return ""
+
+    return redacted
 
 
 def prompt_passes_safety(text: str) -> bool:
@@ -129,6 +151,9 @@ def prompt_passes_safety(text: str) -> bool:
 
 def _date_phrase(event: CandidateEvent, surface_date: Optional[str]) -> str:
     if surface_date and event.year:
+        # surface_date from _surface_date() already includes the year, don't duplicate it.
+        if str(event.year) in surface_date:
+            return surface_date
         return f"{surface_date}, {event.year}"
     if surface_date:
         return surface_date

--- a/optional-skills/gaming/on-this-day-art-trivia/scripts/prompt_builder.py
+++ b/optional-skills/gaming/on-this-day-art-trivia/scripts/prompt_builder.py
@@ -1,0 +1,188 @@
+"""Image-prompt construction with anti-spoiler scrubbing.
+
+The prompt describes the **scene 30 seconds before the event** so the player
+has to deduce what is about to happen. Several constraints apply:
+
+* No readable text or labels.
+* No proper nouns from the canonical answer (anti-spoiler).
+* No depiction of violence, abuse, blood, weapons in use, or victims.
+* For sensitive events (covered by the scoring disqualifier), the prompt is
+  rejected; the orchestrator must pick a different event.
+* Camera distance defaults to medium-wide so the scene reads as ambient.
+
+Public API:
+
+* :func:`build_image_prompt(event)` returns the final prompt string.
+* :func:`scrub_spoilers(text, event)` removes proper nouns and trigger words.
+* :func:`prompt_passes_safety(text)` returns True if the prompt avoids the
+  graphic-content blocklist (used as a defence-in-depth gate).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable, List, Optional
+
+from .scoring import CandidateEvent, is_disqualified
+
+# Words that imply graphic, gory, or exploitative imagery; rejected even
+# when not explicitly disqualifying.
+_PROMPT_BLOCKLIST = (
+    "blood", "bleeding", "gore", "wound", "wounded",
+    "corpse", "body bag", "casket", "dying",
+    "explosion", "explode", "bomb", "blast", "shrapnel",
+    "gun", "rifle", "pistol", "firearm",
+    "knife", "sword", "stab", "stabbing",
+    "weapon", "shooting",
+    "naked", "nude", "topless",
+    "child", "kids", "minors",
+    "execution", "execute",
+    "rape", "assault",
+    "torture",
+)
+
+# Phrases that signal a sensitive context; treated as soft cues (the scene
+# should be rendered minutes before the event from the perspective of the
+# environment, with no people in distress).
+_SENSITIVE_CONTEXT_WORDS = (
+    "war", "battle", "attack", "siege", "shooting", "kidnap",
+)
+
+# Default scene templates. Light hint of mood without naming the event.
+_SCENE_OPENING = (
+    "A photographically realistic ambient scene of {location} on {date_phrase}, "
+    "captured roughly thirty seconds before a historically significant moment occurs."
+)
+
+
+def _proper_nouns(text: str) -> List[str]:
+    """Collect candidate proper nouns (capitalised tokens, length >= 3)."""
+    out: List[str] = []
+    for tok in re.findall(r"[A-Z][A-Za-z\.'\-]{2,}", text or ""):
+        out.append(tok)
+    return out
+
+
+_REDACTION_STOPWORDS = {
+    "the", "a", "an", "of", "in", "on", "at", "to", "and", "or", "for",
+    "with", "by", "is", "was", "were", "from", "into", "as",
+}
+
+
+def _content_tokens(text: str, *, min_len: int = 4) -> List[str]:
+    """Lowercased tokens that count as content words."""
+    out: List[str] = []
+    for tok in re.findall(r"[A-Za-z][A-Za-z\-']+", text or ""):
+        low = tok.lower()
+        if len(low) < min_len or low in _REDACTION_STOPWORDS:
+            continue
+        out.append(low)
+    return out
+
+
+def scrub_spoilers(text: str, event: CandidateEvent) -> str:
+    """Remove proper nouns and event-revealing content tokens from *text*.
+
+    Replaces each spoiler with a neutral placeholder. The result is meant for
+    the image model — humans will see only the date and location separately.
+    Both the proper nouns and the lowercase content tokens of the canonical
+    answer are redacted, so a verb like ``induction`` cannot leak.
+    """
+    redacted = text
+    spoilers: Iterable[str] = (
+        _proper_nouns(event.canonical_answer or "")
+        + _proper_nouns(event.summary or "")
+    )
+    for noun in sorted(set(spoilers), key=len, reverse=True):
+        redacted = re.sub(rf"\b{re.escape(noun)}\b", "the figure", redacted, flags=re.IGNORECASE)
+
+    # Lowercase content tokens drawn from the canonical answer must also go.
+    for tok in sorted(set(_content_tokens(event.canonical_answer or "")), key=len, reverse=True):
+        redacted = re.sub(rf"\b{re.escape(tok)}\b", "the moment", redacted, flags=re.IGNORECASE)
+
+    # Drop sensitive trigger words outright.
+    for w in _SENSITIVE_CONTEXT_WORDS:
+        redacted = re.sub(rf"\b{re.escape(w)}\b", " ", redacted, flags=re.IGNORECASE)
+
+    return re.sub(r"\s+", " ", redacted).strip(" .,:;-")
+
+
+def prompt_passes_safety(text: str) -> bool:
+    """Defence-in-depth: reject prompts that mention any blocklisted terms.
+
+    The constraint directive line (which uses banned words in negation, e.g.
+    "no blood, no weapons") is allowed by exempting any line that begins
+    with the marker ``Constraints:`` — those instructions tell the model
+    what NOT to render and are required for safety.
+    """
+    if not text:
+        return True
+    safe_lines: list[str] = []
+    for line in text.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("Constraints:"):
+            continue
+        safe_lines.append(line)
+    body = "\n".join(safe_lines).lower()
+    return not any(re.search(rf"\b{re.escape(term)}\b", body) for term in _PROMPT_BLOCKLIST)
+
+
+def _date_phrase(event: CandidateEvent, surface_date: Optional[str]) -> str:
+    if surface_date and event.year:
+        return f"{surface_date}, {event.year}"
+    if surface_date:
+        return surface_date
+    if event.year:
+        return f"the year {event.year}"
+    return "an unspecified day"
+
+
+def build_image_prompt(
+    event: CandidateEvent,
+    *,
+    surface_date: Optional[str] = None,
+) -> str:
+    """Build a spoiler-safe, safety-checked image prompt.
+
+    Raises :class:`ValueError` if the event is disqualified or if the safety
+    gate fails after scrubbing — the orchestrator catches this and picks
+    another event.
+    """
+    if is_disqualified(event.summary) or is_disqualified(event.canonical_answer):
+        raise ValueError("event is disqualified for imagery")
+
+    location = (event.location or "an unnamed but historically resonant place").strip()
+    if event.country and event.location and event.country.lower() not in event.location.lower():
+        location = f"{event.location}, {event.country}"
+
+    opening = _SCENE_OPENING.format(
+        location=location,
+        date_phrase=_date_phrase(event, surface_date),
+    )
+
+    # Scene direction. We deliberately avoid action words; this is the calm
+    # before the moment.
+    scene_lines = [
+        opening,
+        "Render the location's architecture, weather, materials, and atmosphere accurately.",
+        "Show ambient bystanders going about ordinary activity. No central protagonist.",
+        "Composition: medium-wide environmental shot, eye-level, soft natural light.",
+        "Lighting and mood should match the era and the time of day.",
+        "Constraints: no readable text, no captions, no labels, no signage with the event name, "
+        "no flags identifying specific factions, no weapons, no violent action, no blood, "
+        "no graphic imagery. Do not include identifiable historical figures.",
+    ]
+
+    redacted_summary = scrub_spoilers(event.summary or "", event)
+    if redacted_summary:
+        scene_lines.append(
+            f"Atmospheric cue (paraphrased, do not visualise as instruction): {redacted_summary}."
+        )
+
+    full_prompt = "\n".join(scene_lines)
+    if not prompt_passes_safety(full_prompt):
+        # Strip the atmospheric cue and retry.
+        full_prompt = "\n".join(scene_lines[:-1])
+        if not prompt_passes_safety(full_prompt):
+            raise ValueError("prompt failed safety gate after redaction")
+    return full_prompt

--- a/optional-skills/gaming/on-this-day-art-trivia/scripts/scoring.py
+++ b/optional-skills/gaming/on-this-day-art-trivia/scripts/scoring.py
@@ -1,0 +1,168 @@
+"""Event scoring for the on-this-day-art-trivia skill.
+
+Each candidate event coming from a source adapter is scored against the
+rubric below. The challenge orchestrator picks the highest-scoring event
+that also passes the safety floor.
+
+Scoring rubric (all additive; higher is better):
+
+* +30  has a specific named location (city/country)
+* +20  has a year in [-3000, present]
+* +20  visually depictable (rooms, buildings, vehicles, crowds, ships,
+       documents being signed, ceremonies, public squares, vehicles, etc.)
+* +20  recognised historic significance (in the curated whitelist of
+       categories: war/peace, treaties, coronations, inventions, scientific
+       milestones, civil-rights moments, exploration, founding events,
+       major court rulings, sports world-firsts)
+* +10  guessable: canonical answer is a discrete event-noun-phrase
+* −40  birthday entries (penalty heavy — they are rarely guessable)
+* −60  death/obituary-only entries
+* −30  obscure local trivia
+* −1000 disqualifying: requires graphic / exploitative imagery
+       (sexual assault, child harm, executions, mutilation, terror attack
+       death tolls, mass murder visuals, gore)
+
+Events scoring < 50 are dropped. Events with the disqualifying flag are
+hard-rejected even if their additive score is high.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Sequence
+
+# --------------------------------------------------------------------------- #
+# Inputs
+# --------------------------------------------------------------------------- #
+
+@dataclass
+class CandidateEvent:
+    """A normalised event from any source adapter."""
+    summary: str                          # one-sentence description
+    canonical_answer: str                 # short event noun phrase
+    year: Optional[int] = None
+    location: Optional[str] = None
+    country: Optional[str] = None
+    category: Optional[str] = None        # 'birth', 'death', 'event', etc.
+    source: Optional[str] = None
+    raw: Dict[str, object] = field(default_factory=dict)
+
+
+# Visual-depiction lexicon. Words present in the event summary suggest a
+# scene that can be illustrated without spoilers.
+_VISUAL_WORDS = (
+    "battle", "treaty", "signed", "signing", "coronation", "crowned",
+    "flight", "voyage", "expedition", "ship", "vessel", "fleet", "harbor",
+    "harbour", "ceremony", "parade", "crowd", "rally", "stadium",
+    "court", "courthouse", "trial", "verdict", "speech", "address",
+    "summit", "meeting", "assembly", "convention", "march",
+    "launch", "rocket", "satellite", "moon", "spacecraft",
+    "invention", "patent", "demonstration", "first performance",
+    "premiere", "opened", "opening", "founding", "founded",
+    "expedition", "discovery", "earthquake", "eruption", "storm", "flood",
+    "election", "inauguration", "festival",
+)
+
+# High-significance categories (broad lexicon).
+_SIGNIFICANT_WORDS = (
+    "war", "peace", "treaty", "constitution", "independence", "republic",
+    "kingdom", "empire", "revolution", "liberation", "abolition",
+    "founding", "inauguration", "coronation", "election",
+    "supreme court", "ruling", "patent", "invention", "discovery",
+    "first flight", "first manned", "world record", "olympic",
+    "civil rights", "suffrage", "vote",
+)
+
+# Disqualifying phrases. If any of these appear in the summary, the event
+# is rejected outright — both for safety and because the imagery would be
+# inappropriate for a casual trivia game.
+_DISQUALIFYING_PHRASES = (
+    "sexual assault", "raped", "rape ", "rape.", "molested",
+    "child abuse", "child sex", "pedophile", "paedophile",
+    "execution of", "executed by", "beheaded", "beheading",
+    "lynched", "lynching",
+    "massacre", "genocide",
+    "shooting spree", "school shooting", "mass shooting",
+    "suicide bombing", "bombing killed", "killed in a bombing",
+    "terror attack", "terrorist attack",
+    "self-immolation",
+    "mutilated", "mutilation", "torture", "tortured",
+)
+
+
+def is_disqualified(text: str) -> bool:
+    low = (text or "").lower()
+    return any(phrase in low for phrase in _DISQUALIFYING_PHRASES)
+
+
+# --------------------------------------------------------------------------- #
+# Scoring
+# --------------------------------------------------------------------------- #
+
+@dataclass
+class ScoreBreakdown:
+    score: int
+    components: Dict[str, int]
+    rejected_reason: Optional[str] = None
+
+
+def score_event(event: CandidateEvent) -> ScoreBreakdown:
+    components: Dict[str, int] = {}
+
+    # Hard reject on disqualifying phrases — short-circuit before any bonus.
+    if is_disqualified(event.summary) or is_disqualified(event.canonical_answer):
+        return ScoreBreakdown(score=-1000, components={"disqualified": -1000}, rejected_reason="graphic_or_exploitative")
+
+    # Category penalties.
+    if event.category in {"birth", "births", "birthday"}:
+        components["birthday_penalty"] = -40
+    if event.category in {"death", "deaths", "obituary"}:
+        components["death_penalty"] = -60
+
+    # Specific named location.
+    if event.location and len(event.location.strip()) >= 2:
+        components["specific_location"] = 30
+    if event.country:
+        components["country"] = 5
+
+    # Year.
+    if event.year is not None and -3000 <= event.year <= 2100:
+        components["year"] = 20
+
+    # Visual depictability.
+    summary_low = (event.summary or "").lower()
+    if any(w in summary_low for w in _VISUAL_WORDS):
+        components["visual"] = 20
+
+    # Significance.
+    if any(w in summary_low for w in _SIGNIFICANT_WORDS):
+        components["significant"] = 20
+
+    # Guessability: canonical answer is a discrete noun phrase, neither too
+    # short (one word like "Election") nor too long (an entire paragraph).
+    canon = (event.canonical_answer or "").strip()
+    canon_word_count = len(re.findall(r"\w+", canon))
+    if 2 <= canon_word_count <= 14:
+        components["guessable"] = 10
+
+    # Length sanity: extremely short summaries rarely score well.
+    if len(summary_low) < 25:
+        components["too_short"] = -10
+
+    # Generic-event penalty for vague single-noun categories with no context.
+    if event.location is None and event.year is None:
+        components["under_specified"] = -20
+
+    score = sum(components.values())
+    return ScoreBreakdown(score=score, components=components)
+
+
+def rank_candidates(candidates: Sequence[CandidateEvent], *, min_score: int = 50) -> List[CandidateEvent]:
+    """Return candidates passing the floor, sorted by score (desc, stable)."""
+    enriched = []
+    for c in candidates:
+        breakdown = score_event(c)
+        enriched.append((breakdown.score, c, breakdown))
+    enriched.sort(key=lambda triple: triple[0], reverse=True)
+    return [c for score, c, _b in enriched if score >= min_score]

--- a/optional-skills/gaming/on-this-day-art-trivia/scripts/sources.py
+++ b/optional-skills/gaming/on-this-day-art-trivia/scripts/sources.py
@@ -1,0 +1,366 @@
+"""Source adapters for on-this-day events.
+
+Three adapters, in preference order:
+
+1. **Britannica** ``/on-this-day/<Month>-<Day>`` — editorial curation.
+2. **Wikimedia** REST API ``/feed/v1/wikipedia/en/onthisday/events/<MM>/<DD>``
+   — structured JSON; reliable fallback.
+3. **onthisday.com** — final fallback for HTML curation.
+
+Each adapter returns a list of :class:`CandidateEvent` and is independently
+testable via cached fixtures in ``tests/fixtures/``. Network access is not
+required for tests — adapters accept optional ``html``/``payload`` arguments
+so fixtures can be injected.
+
+The HTML parsers are intentionally tolerant: they prefer schema-stable
+structures (e.g., the Wikimedia REST schema) and fall back to text-only
+extraction when markup is brittle. Failures degrade silently — we move on
+to the next adapter rather than crashing.
+"""
+
+from __future__ import annotations
+
+import calendar
+import json
+import logging
+import re
+import urllib.error
+import urllib.parse
+import urllib.request
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from .scoring import CandidateEvent
+
+logger = logging.getLogger(__name__)
+
+USER_AGENT = "hermes-on-this-day-art-trivia/0.1 (+github.com/hermes-agent)"
+HTTP_TIMEOUT = 10.0
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+def _http_get(url: str, headers: Optional[Dict[str, str]] = None) -> Optional[str]:
+    """Best-effort HTTP GET. Returns text or None on any failure."""
+    headers = dict(headers or {})
+    headers.setdefault("User-Agent", USER_AGENT)
+    req = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:
+            charset = resp.headers.get_content_charset() or "utf-8"
+            data = resp.read()
+            return data.decode(charset, errors="replace")
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, OSError) as exc:
+        logger.debug("source GET failed: %s — %s", url, exc)
+        return None
+
+
+_TAG_RE = re.compile(r"<[^>]+>")
+_WS_RE = re.compile(r"\s+")
+
+
+def _strip_html(html: str) -> str:
+    return _WS_RE.sub(" ", _TAG_RE.sub(" ", html or "")).strip()
+
+
+def _month_day_url_segment(month: int, day: int) -> str:
+    return f"{calendar.month_name[month].lower()}-{day}"
+
+
+# --------------------------------------------------------------------------- #
+# Britannica adapter
+# --------------------------------------------------------------------------- #
+
+class _BritannicaParser(HTMLParser):
+    """Tolerant parser. Pulls anchored event entries from Britannica's
+    /on-this-day pages.
+
+    Britannica's page structure has shifted multiple times; rather than
+    over-fitting to one selector, we collect any text inside ``<li>`` tags
+    that begin with a 4-digit year, which is the editorial convention used
+    consistently across versions.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self._depth: int = 0
+        self._li_open: bool = False
+        self._buffer: List[str] = []
+        self.entries: List[str] = []
+
+    def handle_starttag(self, tag: str, attrs):  # noqa: D401
+        if tag == "li":
+            self._li_open = True
+            self._buffer = []
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "li" and self._li_open:
+            text = _WS_RE.sub(" ", " ".join(self._buffer)).strip()
+            if text and re.match(r"^-?\d{1,4}\b", text):
+                self.entries.append(text)
+            self._li_open = False
+            self._buffer = []
+
+    def handle_data(self, data: str) -> None:
+        if self._li_open:
+            self._buffer.append(data)
+
+
+_LOCATION_RE = re.compile(
+    r"\b(?:in|at|near|over|from|to)\s+([A-Z][A-Za-z\.\-']+(?:[ ,][A-Z][A-Za-z\.\-']+){0,3})"
+)
+_YEAR_PREFIX_RE = re.compile(r"^(?P<year>-?\d{1,4})\s+(?P<rest>.*)$")
+
+
+def _extract_year_and_rest(entry: str) -> Tuple[Optional[int], str]:
+    m = _YEAR_PREFIX_RE.match(entry.strip())
+    if not m:
+        return None, entry.strip()
+    try:
+        return int(m.group("year")), m.group("rest").strip(" :—-")
+    except ValueError:
+        return None, entry.strip()
+
+
+def _extract_location(text: str) -> Tuple[Optional[str], Optional[str]]:
+    """Best-effort: returns (location, country)."""
+    match = _LOCATION_RE.search(text or "")
+    if not match:
+        return (None, None)
+    raw = match.group(1).strip().rstrip(".,;")
+    parts = [p.strip() for p in raw.split(",") if p.strip()]
+    if len(parts) >= 2:
+        return (parts[0], parts[-1])
+    return (raw, None)
+
+
+def _build_canonical_answer(text: str) -> str:
+    # Take the leading clause (before the first period or semicolon) and
+    # cap to ~14 words.
+    first_clause = re.split(r"[\.;]", text, maxsplit=1)[0].strip()
+    words = first_clause.split()
+    if len(words) > 14:
+        first_clause = " ".join(words[:14])
+    return first_clause
+
+
+def parse_britannica_html(html: str) -> List[CandidateEvent]:
+    parser = _BritannicaParser()
+    try:
+        parser.feed(html or "")
+    except Exception as exc:
+        logger.debug("Britannica parse failed: %s", exc)
+        return []
+    out: List[CandidateEvent] = []
+    for entry in parser.entries:
+        year, rest = _extract_year_and_rest(entry)
+        if not rest:
+            continue
+        loc, country = _extract_location(rest)
+        out.append(
+            CandidateEvent(
+                summary=rest,
+                canonical_answer=_build_canonical_answer(rest),
+                year=year,
+                location=loc,
+                country=country,
+                category="event",
+                source="britannica",
+                raw={"raw_entry": entry},
+            )
+        )
+    return out
+
+
+def fetch_britannica(month: int, day: int, *, html: Optional[str] = None) -> List[CandidateEvent]:
+    if html is None:
+        url = f"https://www.britannica.com/on-this-day/{_month_day_url_segment(month, day)}"
+        html = _http_get(url)
+    if not html:
+        return []
+    return parse_britannica_html(html)
+
+
+# --------------------------------------------------------------------------- #
+# Wikimedia adapter
+# --------------------------------------------------------------------------- #
+
+def parse_wikimedia_payload(payload: Dict[str, Any]) -> List[CandidateEvent]:
+    out: List[CandidateEvent] = []
+    if not isinstance(payload, dict):
+        return out
+    # The /onthisday/all endpoint returns multiple keys; the /events one is a list.
+    sections: Dict[str, str] = {
+        "events": "event",
+        "selected": "event",
+        "births": "birth",
+        "deaths": "death",
+        "holidays": "holiday",
+    }
+    for key, category in sections.items():
+        items = payload.get(key)
+        if not isinstance(items, list):
+            continue
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            text = (item.get("text") or "").strip()
+            if not text:
+                continue
+            year = item.get("year")
+            try:
+                year_int = int(year) if year is not None else None
+            except (TypeError, ValueError):
+                year_int = None
+            loc, country = _extract_location(text)
+            page_titles: List[str] = []
+            for page in item.get("pages") or []:
+                if isinstance(page, dict):
+                    title = page.get("normalizedtitle") or page.get("title")
+                    if isinstance(title, str):
+                        page_titles.append(title)
+            canonical = page_titles[0] if page_titles else _build_canonical_answer(text)
+            out.append(
+                CandidateEvent(
+                    summary=text,
+                    canonical_answer=canonical,
+                    year=year_int,
+                    location=loc,
+                    country=country,
+                    category=category,
+                    source="wikimedia",
+                    raw={"pages": page_titles},
+                )
+            )
+    return out
+
+
+def fetch_wikimedia(month: int, day: int, *, payload: Optional[Dict[str, Any]] = None) -> List[CandidateEvent]:
+    if payload is None:
+        url = (
+            f"https://api.wikimedia.org/feed/v1/wikipedia/en/onthisday/all/"
+            f"{month:02d}/{day:02d}"
+        )
+        text = _http_get(url, headers={"Accept": "application/json"})
+        if not text:
+            return []
+        try:
+            payload = json.loads(text)
+        except json.JSONDecodeError as exc:
+            logger.debug("Wikimedia decode failed: %s", exc)
+            return []
+    return parse_wikimedia_payload(payload)
+
+
+# --------------------------------------------------------------------------- #
+# onthisday.com adapter (lightweight fallback)
+# --------------------------------------------------------------------------- #
+
+class _OnThisDayParser(HTMLParser):
+    """Pulls list-item entries with a leading 4-digit year. Mirrors the
+    Britannica strategy. Used only as a last-resort fallback.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self._li_open = False
+        self._buf: List[str] = []
+        self.entries: List[str] = []
+
+    def handle_starttag(self, tag: str, attrs) -> None:
+        if tag == "li":
+            self._li_open = True
+            self._buf = []
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "li" and self._li_open:
+            text = _WS_RE.sub(" ", " ".join(self._buf)).strip()
+            if text and re.search(r"\b\d{3,4}\b", text[:8]):
+                self.entries.append(text)
+            self._li_open = False
+
+    def handle_data(self, data: str) -> None:
+        if self._li_open:
+            self._buf.append(data)
+
+
+def parse_onthisday_html(html: str) -> List[CandidateEvent]:
+    parser = _OnThisDayParser()
+    try:
+        parser.feed(html or "")
+    except Exception as exc:
+        logger.debug("onthisday parse failed: %s", exc)
+        return []
+    out: List[CandidateEvent] = []
+    for entry in parser.entries:
+        year, rest = _extract_year_and_rest(entry)
+        if not rest:
+            continue
+        loc, country = _extract_location(rest)
+        out.append(
+            CandidateEvent(
+                summary=rest,
+                canonical_answer=_build_canonical_answer(rest),
+                year=year,
+                location=loc,
+                country=country,
+                category="event",
+                source="onthisday",
+                raw={"raw_entry": entry},
+            )
+        )
+    return out
+
+
+def fetch_onthisday(month: int, day: int, *, html: Optional[str] = None) -> List[CandidateEvent]:
+    if html is None:
+        url = f"https://www.onthisday.com/events/{calendar.month_name[month].lower()}/{day}"
+        html = _http_get(url)
+    if not html:
+        return []
+    return parse_onthisday_html(html)
+
+
+# --------------------------------------------------------------------------- #
+# Aggregator
+# --------------------------------------------------------------------------- #
+
+def fetch_all_candidates(month: int, day: int) -> List[CandidateEvent]:
+    """Pull from every adapter; deduplicate by canonical_answer."""
+    seen: set = set()
+    out: List[CandidateEvent] = []
+    for fetcher in (fetch_britannica, fetch_wikimedia, fetch_onthisday):
+        try:
+            events = fetcher(month, day)
+        except Exception as exc:
+            logger.warning("source %s failed: %s", fetcher.__name__, exc)
+            events = []
+        for ev in events:
+            key = (ev.canonical_answer.lower(), ev.year)
+            if key in seen:
+                continue
+            seen.add(key)
+            out.append(ev)
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Local fixture-based fallback (kept for offline-only mode)
+# --------------------------------------------------------------------------- #
+
+FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
+
+
+def load_fixture_events(month: int, day: int) -> List[CandidateEvent]:
+    """Load events from a JSON fixture if present; used for fully offline runs."""
+    path = FIXTURES_DIR / f"{month:02d}-{day:02d}.json"
+    if not path.exists():
+        return []
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return []
+    return parse_wikimedia_payload(payload)

--- a/optional-skills/gaming/on-this-day-art-trivia/scripts/state.py
+++ b/optional-skills/gaming/on-this-day-art-trivia/scripts/state.py
@@ -1,0 +1,611 @@
+"""SQLite-backed state for the on-this-day-art-trivia skill.
+
+All persistent state lives at ``$HERMES_HOME/data/on-this-day-art-trivia/trivia.db``.
+The module exposes a thin connection helper (:func:`get_conn`) plus high-level
+helpers for the two surfaces that need them: the skill engine (which writes
+challenges, guesses, achievements) and the gateway plugin (which reads the
+active challenge for a chat and records guesses).
+
+The schema is migrated forward in :func:`migrate`. Migrations are idempotent
+and additive — never drop a column. Tests instantiate this module with a
+custom path via :func:`set_db_path` so the production DB is not touched.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import threading
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Dict, Iterable, Iterator, List, Optional, Tuple
+
+# --------------------------------------------------------------------------- #
+# Path resolution
+# --------------------------------------------------------------------------- #
+
+_DEFAULT_HOME = Path.home() / ".hermes"
+_HERMES_HOME = Path(os.environ.get("HERMES_HOME", str(_DEFAULT_HOME)))
+_DEFAULT_DB_PATH = _HERMES_HOME / "data" / "on-this-day-art-trivia" / "trivia.db"
+
+_db_path_override: Optional[Path] = None
+_path_lock = threading.Lock()
+
+
+def set_db_path(path: Path | str) -> None:
+    """Override the database location. Tests use this; production never does."""
+    global _db_path_override
+    with _path_lock:
+        _db_path_override = Path(path)
+
+
+def get_db_path() -> Path:
+    """Resolve the active database path, honouring any test override."""
+    with _path_lock:
+        return _db_path_override or _DEFAULT_DB_PATH
+
+
+# --------------------------------------------------------------------------- #
+# Schema
+# --------------------------------------------------------------------------- #
+
+SCHEMA_STATEMENTS: Tuple[str, ...] = (
+    """
+    CREATE TABLE IF NOT EXISTS schema_version (
+        version INTEGER PRIMARY KEY
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS users (
+        user_id              TEXT NOT NULL,
+        platform             TEXT NOT NULL,
+        display_name         TEXT,
+        current_streak       INTEGER NOT NULL DEFAULT 0,
+        longest_streak       INTEGER NOT NULL DEFAULT 0,
+        last_correct_date    TEXT,
+        total_correct        INTEGER NOT NULL DEFAULT 0,
+        total_attempts       INTEGER NOT NULL DEFAULT 0,
+        countries_correct    TEXT NOT NULL DEFAULT '[]',
+        created_at           TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        PRIMARY KEY (platform, user_id)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS challenges (
+        challenge_id         INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id              TEXT,
+        chat_id              TEXT NOT NULL,
+        platform             TEXT NOT NULL,
+        scope                TEXT NOT NULL,
+        event_date           TEXT NOT NULL,
+        event_year           INTEGER,
+        location             TEXT,
+        country              TEXT,
+        canonical_answer     TEXT NOT NULL,
+        short_summary        TEXT,
+        full_description     TEXT,
+        source               TEXT,
+        hint_history         TEXT NOT NULL DEFAULT '[]',
+        attempts_used        INTEGER NOT NULL DEFAULT 0,
+        max_attempts         INTEGER NOT NULL DEFAULT 3,
+        status               TEXT NOT NULL DEFAULT 'active',
+        telegram_message_id  TEXT,
+        created_at           TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        resolved_at          TEXT
+    )
+    """,
+    """
+    CREATE INDEX IF NOT EXISTS idx_challenges_active
+        ON challenges (chat_id, platform, status)
+    """,
+    """
+    CREATE INDEX IF NOT EXISTS idx_challenges_msg
+        ON challenges (platform, telegram_message_id)
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS acceptable_answers (
+        id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+        challenge_id         INTEGER NOT NULL REFERENCES challenges(challenge_id) ON DELETE CASCADE,
+        alias                TEXT NOT NULL,
+        alias_normalized     TEXT NOT NULL,
+        precision_tier       INTEGER NOT NULL DEFAULT 1
+    )
+    """,
+    """
+    CREATE INDEX IF NOT EXISTS idx_acceptable_lookup
+        ON acceptable_answers (challenge_id, alias_normalized)
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS guesses (
+        guess_id             INTEGER PRIMARY KEY AUTOINCREMENT,
+        challenge_id         INTEGER NOT NULL REFERENCES challenges(challenge_id) ON DELETE CASCADE,
+        user_id              TEXT NOT NULL,
+        platform             TEXT NOT NULL,
+        guess_text           TEXT NOT NULL,
+        outcome              TEXT NOT NULL,
+        created_at           TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS achievements (
+        id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+        platform             TEXT NOT NULL,
+        user_id              TEXT NOT NULL,
+        achievement_key      TEXT NOT NULL,
+        awarded_at           TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        UNIQUE (platform, user_id, achievement_key)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS subscriptions (
+        id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+        platform             TEXT NOT NULL,
+        user_id              TEXT NOT NULL,
+        chat_id              TEXT NOT NULL,
+        scope                TEXT NOT NULL,
+        enabled              INTEGER NOT NULL DEFAULT 1,
+        created_at           TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        UNIQUE (platform, user_id, chat_id)
+    )
+    """,
+)
+
+CURRENT_SCHEMA_VERSION = 1
+
+
+# --------------------------------------------------------------------------- #
+# Connection helper
+# --------------------------------------------------------------------------- #
+
+@contextmanager
+def get_conn() -> Iterator[sqlite3.Connection]:
+    """Yield a sqlite3 connection with WAL + FK + row-factory configured.
+
+    Always commits on clean exit and rolls back on exception. Callers can rely
+    on the connection being closed regardless.
+    """
+    path = get_db_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(path), timeout=10.0, isolation_level=None)
+    try:
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode = WAL")
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.execute("PRAGMA busy_timeout = 5000")
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            yield conn
+            conn.execute("COMMIT")
+        except Exception:
+            conn.execute("ROLLBACK")
+            raise
+    finally:
+        conn.close()
+
+
+@contextmanager
+def get_readonly_conn() -> Iterator[sqlite3.Connection]:
+    """Yield a read-only connection (no transaction)."""
+    path = get_db_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(path), timeout=5.0)
+    try:
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA query_only = ON")
+        yield conn
+    finally:
+        conn.close()
+
+
+# --------------------------------------------------------------------------- #
+# Migration
+# --------------------------------------------------------------------------- #
+
+def migrate() -> int:
+    """Bring the schema up to :data:`CURRENT_SCHEMA_VERSION`. Returns the active version."""
+    with get_conn() as conn:
+        for stmt in SCHEMA_STATEMENTS:
+            conn.execute(stmt)
+        row = conn.execute("SELECT MAX(version) AS v FROM schema_version").fetchone()
+        current = row["v"] if row and row["v"] is not None else 0
+        if current < CURRENT_SCHEMA_VERSION:
+            conn.execute(
+                "INSERT OR REPLACE INTO schema_version (version) VALUES (?)",
+                (CURRENT_SCHEMA_VERSION,),
+            )
+            current = CURRENT_SCHEMA_VERSION
+        return current
+
+
+# --------------------------------------------------------------------------- #
+# User helpers
+# --------------------------------------------------------------------------- #
+
+def upsert_user(platform: str, user_id: str, display_name: Optional[str]) -> None:
+    with get_conn() as conn:
+        conn.execute(
+            """
+            INSERT INTO users (platform, user_id, display_name)
+            VALUES (?, ?, ?)
+            ON CONFLICT(platform, user_id) DO UPDATE
+                SET display_name = COALESCE(excluded.display_name, users.display_name)
+            """,
+            (platform, user_id, display_name),
+        )
+
+
+def get_user(platform: str, user_id: str) -> Optional[Dict[str, Any]]:
+    with get_readonly_conn() as conn:
+        row = conn.execute(
+            "SELECT * FROM users WHERE platform = ? AND user_id = ?",
+            (platform, user_id),
+        ).fetchone()
+    return dict(row) if row else None
+
+
+def update_streak_after_correct(
+    platform: str,
+    user_id: str,
+    today: str,
+    country: Optional[str],
+) -> Dict[str, Any]:
+    """Bump streak/longest/total_correct/countries. Returns the post-update row."""
+    with get_conn() as conn:
+        row = conn.execute(
+            "SELECT * FROM users WHERE platform = ? AND user_id = ?",
+            (platform, user_id),
+        ).fetchone()
+        if row is None:
+            conn.execute(
+                "INSERT INTO users (platform, user_id) VALUES (?, ?)",
+                (platform, user_id),
+            )
+            current_streak = 0
+            longest = 0
+            last_date = None
+            total_correct = 0
+            total_attempts = 0
+            countries: List[str] = []
+        else:
+            current_streak = int(row["current_streak"] or 0)
+            longest = int(row["longest_streak"] or 0)
+            last_date = row["last_correct_date"]
+            total_correct = int(row["total_correct"] or 0)
+            total_attempts = int(row["total_attempts"] or 0)
+            try:
+                countries = list(json.loads(row["countries_correct"] or "[]"))
+            except (TypeError, ValueError):
+                countries = []
+
+        # Streak rule: contiguous days. Same-day repeats don't bump.
+        new_streak = _next_streak(last_date, today, current_streak)
+        new_longest = max(longest, new_streak)
+        new_total_correct = total_correct + 1
+        new_total_attempts = total_attempts + 1
+
+        if country:
+            country = country.strip()
+            if country and country not in countries:
+                countries.append(country)
+
+        conn.execute(
+            """
+            UPDATE users SET
+                current_streak    = ?,
+                longest_streak    = ?,
+                last_correct_date = ?,
+                total_correct     = ?,
+                total_attempts    = ?,
+                countries_correct = ?
+            WHERE platform = ? AND user_id = ?
+            """,
+            (
+                new_streak, new_longest, today,
+                new_total_correct, new_total_attempts,
+                json.dumps(countries),
+                platform, user_id,
+            ),
+        )
+        return {
+            "current_streak": new_streak,
+            "longest_streak": new_longest,
+            "total_correct": new_total_correct,
+            "total_attempts": new_total_attempts,
+            "countries": countries,
+        }
+
+
+def update_after_wrong(platform: str, user_id: str) -> None:
+    with get_conn() as conn:
+        conn.execute(
+            "INSERT OR IGNORE INTO users (platform, user_id) VALUES (?, ?)",
+            (platform, user_id),
+        )
+        conn.execute(
+            "UPDATE users SET total_attempts = total_attempts + 1 WHERE platform = ? AND user_id = ?",
+            (platform, user_id),
+        )
+
+
+def reset_streak(platform: str, user_id: str) -> None:
+    with get_conn() as conn:
+        conn.execute(
+            "UPDATE users SET current_streak = 0 WHERE platform = ? AND user_id = ?",
+            (platform, user_id),
+        )
+
+
+def _next_streak(last_correct_date: Optional[str], today: str, current_streak: int) -> int:
+    """Compute the new streak count based on yesterday/today logic.
+
+    last_correct_date and today are ISO YYYY-MM-DD strings. A gap of 1 day
+    increments; same day keeps; gap of >1 resets to 1.
+    """
+    if not last_correct_date:
+        return 1
+    from datetime import date
+    try:
+        prev = date.fromisoformat(last_correct_date)
+        cur = date.fromisoformat(today)
+    except ValueError:
+        return 1
+    delta = (cur - prev).days
+    if delta == 0:
+        return current_streak if current_streak > 0 else 1
+    if delta == 1:
+        return current_streak + 1
+    return 1
+
+
+# --------------------------------------------------------------------------- #
+# Challenge helpers
+# --------------------------------------------------------------------------- #
+
+def create_challenge(
+    *,
+    platform: str,
+    chat_id: str,
+    scope: str,
+    user_id: Optional[str],
+    event_date: str,
+    event_year: Optional[int],
+    location: Optional[str],
+    country: Optional[str],
+    canonical_answer: str,
+    short_summary: Optional[str],
+    full_description: Optional[str],
+    source: Optional[str],
+    aliases: Iterable[Tuple[str, int]],
+    max_attempts: int = 3,
+) -> int:
+    """Create an active challenge and its acceptable answers. Returns challenge_id."""
+    from .guess_matcher import normalize  # local import avoids circular
+
+    with get_conn() as conn:
+        # Mark any prior active challenge in this chat as expired.
+        conn.execute(
+            """
+            UPDATE challenges SET status = 'expired', resolved_at = CURRENT_TIMESTAMP
+            WHERE platform = ? AND chat_id = ? AND status = 'active'
+            """,
+            (platform, chat_id),
+        )
+        cur = conn.execute(
+            """
+            INSERT INTO challenges (
+                user_id, chat_id, platform, scope,
+                event_date, event_year, location, country,
+                canonical_answer, short_summary, full_description, source,
+                max_attempts
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                user_id, chat_id, platform, scope,
+                event_date, event_year, location, country,
+                canonical_answer, short_summary, full_description, source,
+                max_attempts,
+            ),
+        )
+        challenge_id = int(cur.lastrowid)
+        for alias, tier in aliases:
+            conn.execute(
+                "INSERT INTO acceptable_answers (challenge_id, alias, alias_normalized, precision_tier) VALUES (?, ?, ?, ?)",
+                (challenge_id, alias, normalize(alias), int(tier)),
+            )
+        return challenge_id
+
+
+def attach_telegram_message_id(challenge_id: int, message_id: str) -> None:
+    with get_conn() as conn:
+        conn.execute(
+            "UPDATE challenges SET telegram_message_id = ? WHERE challenge_id = ?",
+            (str(message_id), int(challenge_id)),
+        )
+
+
+def get_challenge(challenge_id: int) -> Optional[Dict[str, Any]]:
+    with get_readonly_conn() as conn:
+        row = conn.execute(
+            "SELECT * FROM challenges WHERE challenge_id = ?",
+            (int(challenge_id),),
+        ).fetchone()
+    return dict(row) if row else None
+
+
+def get_active_challenge_for_chat(platform: str, chat_id: str) -> Optional[Dict[str, Any]]:
+    with get_readonly_conn() as conn:
+        row = conn.execute(
+            """
+            SELECT * FROM challenges
+            WHERE platform = ? AND chat_id = ? AND status = 'active'
+            ORDER BY created_at DESC LIMIT 1
+            """,
+            (platform, chat_id),
+        ).fetchone()
+    return dict(row) if row else None
+
+
+def get_challenge_by_message_id(platform: str, message_id: str) -> Optional[Dict[str, Any]]:
+    with get_readonly_conn() as conn:
+        row = conn.execute(
+            "SELECT * FROM challenges WHERE platform = ? AND telegram_message_id = ?",
+            (platform, str(message_id)),
+        ).fetchone()
+    return dict(row) if row else None
+
+
+def list_acceptable_answers(challenge_id: int) -> List[Dict[str, Any]]:
+    with get_readonly_conn() as conn:
+        rows = conn.execute(
+            "SELECT alias, alias_normalized, precision_tier FROM acceptable_answers WHERE challenge_id = ?",
+            (int(challenge_id),),
+        ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def record_guess(
+    challenge_id: int,
+    platform: str,
+    user_id: str,
+    guess_text: str,
+    outcome: str,
+) -> None:
+    with get_conn() as conn:
+        conn.execute(
+            "INSERT INTO guesses (challenge_id, platform, user_id, guess_text, outcome) VALUES (?, ?, ?, ?, ?)",
+            (int(challenge_id), platform, user_id, guess_text, outcome),
+        )
+
+
+def increment_attempts(challenge_id: int) -> int:
+    with get_conn() as conn:
+        conn.execute(
+            "UPDATE challenges SET attempts_used = attempts_used + 1 WHERE challenge_id = ?",
+            (int(challenge_id),),
+        )
+        row = conn.execute(
+            "SELECT attempts_used, max_attempts FROM challenges WHERE challenge_id = ?",
+            (int(challenge_id),),
+        ).fetchone()
+    return int(row["attempts_used"]) if row else 0
+
+
+def append_hint(challenge_id: int, hint_text: str) -> List[str]:
+    with get_conn() as conn:
+        row = conn.execute(
+            "SELECT hint_history FROM challenges WHERE challenge_id = ?",
+            (int(challenge_id),),
+        ).fetchone()
+        try:
+            history = list(json.loads(row["hint_history"] or "[]")) if row else []
+        except (TypeError, ValueError):
+            history = []
+        history.append(hint_text)
+        conn.execute(
+            "UPDATE challenges SET hint_history = ? WHERE challenge_id = ?",
+            (json.dumps(history), int(challenge_id)),
+        )
+        return history
+
+
+def resolve_challenge(challenge_id: int, status: str) -> None:
+    if status not in {"solved", "failed", "revealed", "expired"}:
+        raise ValueError(f"Invalid status: {status!r}")
+    with get_conn() as conn:
+        conn.execute(
+            "UPDATE challenges SET status = ?, resolved_at = CURRENT_TIMESTAMP WHERE challenge_id = ?",
+            (status, int(challenge_id)),
+        )
+
+
+def count_wrong_guesses(challenge_id: int, user_id: str) -> int:
+    with get_readonly_conn() as conn:
+        row = conn.execute(
+            "SELECT COUNT(*) AS n FROM guesses WHERE challenge_id = ? AND user_id = ? AND outcome IN ('wrong', 'close')",
+            (int(challenge_id), user_id),
+        ).fetchone()
+    return int(row["n"]) if row else 0
+
+
+def count_hints_used(challenge_id: int) -> int:
+    with get_readonly_conn() as conn:
+        row = conn.execute(
+            "SELECT COUNT(*) AS n FROM guesses WHERE challenge_id = ? AND outcome = 'hint'",
+            (int(challenge_id),),
+        ).fetchone()
+    return int(row["n"]) if row else 0
+
+
+# --------------------------------------------------------------------------- #
+# Achievement helpers
+# --------------------------------------------------------------------------- #
+
+def award_achievement(platform: str, user_id: str, key: str) -> bool:
+    """Award an achievement. Returns True if newly awarded."""
+    with get_conn() as conn:
+        cur = conn.execute(
+            "INSERT OR IGNORE INTO achievements (platform, user_id, achievement_key) VALUES (?, ?, ?)",
+            (platform, user_id, key),
+        )
+        return cur.rowcount > 0
+
+
+def list_achievements(platform: str, user_id: str) -> List[Dict[str, Any]]:
+    with get_readonly_conn() as conn:
+        rows = conn.execute(
+            "SELECT achievement_key, awarded_at FROM achievements WHERE platform = ? AND user_id = ? ORDER BY awarded_at",
+            (platform, user_id),
+        ).fetchall()
+    return [dict(r) for r in rows]
+
+
+# --------------------------------------------------------------------------- #
+# Subscription helpers
+# --------------------------------------------------------------------------- #
+
+def add_subscription(platform: str, user_id: str, chat_id: str, scope: str) -> None:
+    with get_conn() as conn:
+        conn.execute(
+            """
+            INSERT INTO subscriptions (platform, user_id, chat_id, scope, enabled)
+            VALUES (?, ?, ?, ?, 1)
+            ON CONFLICT(platform, user_id, chat_id) DO UPDATE SET enabled = 1, scope = excluded.scope
+            """,
+            (platform, user_id, chat_id, scope),
+        )
+
+
+def remove_subscription(platform: str, user_id: str, chat_id: str) -> bool:
+    with get_conn() as conn:
+        cur = conn.execute(
+            "UPDATE subscriptions SET enabled = 0 WHERE platform = ? AND user_id = ? AND chat_id = ?",
+            (platform, user_id, chat_id),
+        )
+        return cur.rowcount > 0
+
+
+def list_active_subscriptions() -> List[Dict[str, Any]]:
+    with get_readonly_conn() as conn:
+        rows = conn.execute(
+            "SELECT platform, user_id, chat_id, scope FROM subscriptions WHERE enabled = 1"
+        ).fetchall()
+    return [dict(r) for r in rows]
+
+
+# --------------------------------------------------------------------------- #
+# Leaderboard
+# --------------------------------------------------------------------------- #
+
+def leaderboard_top(platform: str, limit: int = 10) -> List[Dict[str, Any]]:
+    with get_readonly_conn() as conn:
+        rows = conn.execute(
+            """
+            SELECT user_id, display_name, current_streak, longest_streak, total_correct
+            FROM users WHERE platform = ?
+            ORDER BY total_correct DESC, longest_streak DESC, current_streak DESC
+            LIMIT ?
+            """,
+            (platform, int(limit)),
+        ).fetchall()
+    return [dict(r) for r in rows]

--- a/optional-skills/gaming/on-this-day-art-trivia/scripts/telegram_api.py
+++ b/optional-skills/gaming/on-this-day-art-trivia/scripts/telegram_api.py
@@ -1,0 +1,143 @@
+"""Tiny Telegram Bot API client.
+
+Used as a fallback when Hermes' built-in send mechanism cannot deliver an
+image with caption. The token is read once from the environment via
+:func:`get_token` — never logged, never printed.
+
+Public surface:
+
+* :func:`send_photo(chat_id, photo, caption, reply_to_message_id=None)` —
+  upload a local photo file with a caption. Returns the message_id of the
+  sent message, or ``None`` if delivery failed.
+* :func:`send_message(chat_id, text, reply_to_message_id=None)` — plain
+  text reply.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import mimetypes
+import os
+import secrets
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+API_BASE = "https://api.telegram.org"
+HTTP_TIMEOUT = 30.0
+
+
+def get_token() -> Optional[str]:
+    """Return the bot token from $TELEGRAM_BOT_TOKEN, or None if unset.
+
+    Token is intentionally never echoed to logs. Callers MUST treat its
+    presence/absence as a quiet signal — never print the value.
+    """
+    token = os.environ.get("TELEGRAM_BOT_TOKEN") or os.environ.get("TG_BOT_TOKEN")
+    return token if token else None
+
+
+def _build_multipart(fields: Dict[str, str], files: Dict[str, Tuple[str, bytes, str]]) -> Tuple[bytes, str]:
+    """Build a minimal multipart/form-data body. Returns (body, content_type)."""
+    boundary = "----HermesOTDAT" + secrets.token_hex(16)
+    sep = f"--{boundary}".encode()
+    end = f"--{boundary}--".encode()
+    crlf = b"\r\n"
+    parts: list[bytes] = []
+    for name, value in fields.items():
+        parts.append(sep)
+        parts.append(crlf)
+        parts.append(f'Content-Disposition: form-data; name="{name}"'.encode())
+        parts.append(crlf + crlf)
+        parts.append(value.encode("utf-8"))
+        parts.append(crlf)
+    for name, (filename, data, mime) in files.items():
+        parts.append(sep)
+        parts.append(crlf)
+        parts.append(
+            f'Content-Disposition: form-data; name="{name}"; filename="{filename}"'.encode()
+        )
+        parts.append(crlf)
+        parts.append(f"Content-Type: {mime}".encode())
+        parts.append(crlf + crlf)
+        parts.append(data)
+        parts.append(crlf)
+    parts.append(end)
+    parts.append(crlf)
+    body = b"".join(parts)
+    return body, f"multipart/form-data; boundary={boundary}"
+
+
+def _api_request(method: str, fields: Dict[str, Any], files: Optional[Dict[str, Path]] = None) -> Optional[Dict[str, Any]]:
+    token = get_token()
+    if not token:
+        logger.debug("Telegram token not set; skipping API call to %s", method)
+        return None
+    url = f"{API_BASE}/bot{token}/{method}"
+    str_fields = {k: str(v) for k, v in fields.items() if v is not None}
+
+    if files:
+        file_payload: Dict[str, Tuple[str, bytes, str]] = {}
+        for field_name, path in files.items():
+            try:
+                data = path.read_bytes()
+            except OSError as exc:
+                logger.warning("Failed to read %s: %s", path, exc)
+                return None
+            mime, _ = mimetypes.guess_type(path.name)
+            file_payload[field_name] = (path.name, data, mime or "application/octet-stream")
+        body, content_type = _build_multipart(str_fields, file_payload)
+        req = urllib.request.Request(url, data=body, method="POST")
+        req.add_header("Content-Type", content_type)
+    else:
+        body = urllib.parse.urlencode(str_fields).encode("utf-8")
+        req = urllib.request.Request(url, data=body, method="POST")
+        req.add_header("Content-Type", "application/x-www-form-urlencoded")
+
+    try:
+        with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, OSError, json.JSONDecodeError) as exc:
+        logger.warning("Telegram %s failed: %s", method, exc)
+        return None
+    if not payload.get("ok"):
+        logger.warning("Telegram %s returned not ok: %s", method, payload.get("description"))
+        return None
+    return payload.get("result")
+
+
+def send_photo(
+    chat_id: str,
+    photo_path: Path,
+    caption: str,
+    *,
+    reply_to_message_id: Optional[str] = None,
+) -> Optional[str]:
+    """Send a photo with caption. Returns the new message_id, or None on failure."""
+    fields: Dict[str, Any] = {"chat_id": str(chat_id), "caption": caption}
+    if reply_to_message_id:
+        fields["reply_to_message_id"] = str(reply_to_message_id)
+    result = _api_request("sendPhoto", fields, files={"photo": Path(photo_path)})
+    if not result:
+        return None
+    return str(result.get("message_id")) if result.get("message_id") is not None else None
+
+
+def send_message(
+    chat_id: str,
+    text: str,
+    *,
+    reply_to_message_id: Optional[str] = None,
+) -> Optional[str]:
+    fields: Dict[str, Any] = {"chat_id": str(chat_id), "text": text}
+    if reply_to_message_id:
+        fields["reply_to_message_id"] = str(reply_to_message_id)
+    result = _api_request("sendMessage", fields)
+    if not result:
+        return None
+    return str(result.get("message_id")) if result.get("message_id") is not None else None

--- a/optional-skills/gaming/on-this-day-art-trivia/tests/conftest.py
+++ b/optional-skills/gaming/on-this-day-art-trivia/tests/conftest.py
@@ -1,0 +1,45 @@
+"""Pytest configuration: import path + per-test temporary database."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make the skill scripts importable as ``scripts``.
+ROOT = Path(__file__).resolve().parent.parent
+SKILL_DIR = ROOT / "skill" / "on-this-day-art-trivia"
+if str(SKILL_DIR) not in sys.path:
+    sys.path.insert(0, str(SKILL_DIR))
+
+FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
+
+
+@pytest.fixture()
+def tmp_db(tmp_path, monkeypatch):
+    """Point state.get_db_path at a fresh per-test SQLite file."""
+    from scripts import state  # type: ignore
+
+    db_path = tmp_path / "trivia.db"
+    state.set_db_path(db_path)
+    state.migrate()
+    yield db_path
+    state.set_db_path(state._DEFAULT_DB_PATH)
+
+
+@pytest.fixture()
+def fixtures_dir():
+    return FIXTURES_DIR
+
+
+@pytest.fixture()
+def britannica_fixture(fixtures_dir):
+    return (fixtures_dir / "britannica_april28.html").read_text(encoding="utf-8")
+
+
+@pytest.fixture()
+def wikimedia_fixture(fixtures_dir):
+    import json
+    return json.loads((fixtures_dir / "wikimedia_april28.json").read_text(encoding="utf-8"))

--- a/optional-skills/gaming/on-this-day-art-trivia/tests/fixtures/britannica_april28.html
+++ b/optional-skills/gaming/on-this-day-art-trivia/tests/fixtures/britannica_april28.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html><head><title>April 28 — Britannica</title></head><body>
+<main>
+  <ul class="on-this-day-list">
+    <li>1967 American boxer Muhammad Ali refused induction into the U.S. Army in Houston, Texas, citing his religious beliefs.</li>
+    <li>1789 The mutiny on the Bounty took place in the South Pacific aboard HMS Bounty under William Bligh.</li>
+    <li>1945 Italian dictator Benito Mussolini was captured and shot by partisans in northern Italy.</li>
+    <li>1947 Norwegian explorer Thor Heyerdahl set sail on the Kon-Tiki raft from Callao, Peru.</li>
+    <li>2001 American businessman Dennis Tito became the first space tourist when he launched aboard Soyuz TM-32 from Baikonur, Kazakhstan.</li>
+    <li>1980 Actress Jessica Alba was born in Pomona, California.</li>
+  </ul>
+</main>
+</body></html>

--- a/optional-skills/gaming/on-this-day-art-trivia/tests/fixtures/wikimedia_april28.json
+++ b/optional-skills/gaming/on-this-day-art-trivia/tests/fixtures/wikimedia_april28.json
@@ -1,0 +1,48 @@
+{
+  "events": [
+    {
+      "text": "Muhammad Ali refused induction into the United States Army in Houston, Texas.",
+      "year": 1967,
+      "pages": [
+        {"normalizedtitle": "Muhammad Ali"},
+        {"normalizedtitle": "Vietnam War draft resistance"}
+      ]
+    },
+    {
+      "text": "The mutiny on HMS Bounty took place in the South Pacific.",
+      "year": 1789,
+      "pages": [
+        {"normalizedtitle": "Mutiny on the Bounty"}
+      ]
+    },
+    {
+      "text": "Dennis Tito became the first space tourist on Soyuz TM-32 launching from Baikonur, Kazakhstan.",
+      "year": 2001,
+      "pages": [
+        {"normalizedtitle": "Dennis Tito"},
+        {"normalizedtitle": "Soyuz TM-32"}
+      ]
+    },
+    {
+      "text": "Thor Heyerdahl set sail on the Kon-Tiki raft from Callao, Peru.",
+      "year": 1947,
+      "pages": [
+        {"normalizedtitle": "Kon-Tiki expedition"}
+      ]
+    }
+  ],
+  "births": [
+    {
+      "text": "Jessica Alba, American actress.",
+      "year": 1981,
+      "pages": [{"normalizedtitle": "Jessica Alba"}]
+    }
+  ],
+  "deaths": [
+    {
+      "text": "Benito Mussolini, Italian dictator, was killed in northern Italy.",
+      "year": 1945,
+      "pages": [{"normalizedtitle": "Benito Mussolini"}]
+    }
+  ]
+}

--- a/optional-skills/gaming/on-this-day-art-trivia/tests/test_achievements.py
+++ b/optional-skills/gaming/on-this-day-art-trivia/tests/test_achievements.py
@@ -1,0 +1,118 @@
+"""Achievement-engine tests."""
+
+from __future__ import annotations
+
+
+def test_first_sight_awarded_on_first_correct(tmp_db):
+    from scripts import achievements, state
+
+    state.upsert_user("telegram", "u1", None)
+    challenge = {"event_year": 1967, "country": "United States"}
+    user_after = {"current_streak": 1, "longest_streak": 1, "total_correct": 1, "countries": ["United States"]}
+    awarded = achievements.evaluate_after_correct(
+        platform="telegram", user_id="u1",
+        challenge=challenge, user_after=user_after,
+        wrong_count=0, hints_used=0,
+    )
+    assert "first_sight" in awarded
+    assert "no_hints_needed" in awarded
+
+
+def test_historian_thresholds(tmp_db):
+    from scripts import achievements
+
+    awarded3 = achievements.evaluate_after_correct(
+        platform="telegram", user_id="u2",
+        challenge={"event_year": 1900, "country": "X"},
+        user_after={"current_streak": 1, "longest_streak": 1, "total_correct": 3, "countries": ["X"]},
+        wrong_count=0, hints_used=0,
+    )
+    assert "historian_i" in awarded3
+
+    awarded10 = achievements.evaluate_after_correct(
+        platform="telegram", user_id="u3",
+        challenge={"event_year": 1900, "country": "X"},
+        user_after={"current_streak": 1, "longest_streak": 1, "total_correct": 10, "countries": ["X"]},
+        wrong_count=0, hints_used=0,
+    )
+    assert "historian_ii" in awarded10
+
+
+def test_streak_achievements(tmp_db):
+    from scripts import achievements
+
+    awarded3 = achievements.evaluate_after_correct(
+        platform="telegram", user_id="u4",
+        challenge={"event_year": 1900, "country": "X"},
+        user_after={"current_streak": 3, "longest_streak": 3, "total_correct": 3, "countries": ["X"]},
+        wrong_count=0, hints_used=0,
+    )
+    assert "streak_spark" in awarded3
+
+    awarded7 = achievements.evaluate_after_correct(
+        platform="telegram", user_id="u5",
+        challenge={"event_year": 1900, "country": "X"},
+        user_after={"current_streak": 7, "longest_streak": 7, "total_correct": 7, "countries": ["X"]},
+        wrong_count=0, hints_used=0,
+    )
+    assert "calendar_beast" in awarded7
+
+
+def test_cold_case_only_when_wrong_attempts(tmp_db):
+    from scripts import achievements
+
+    none_awarded = achievements.evaluate_after_correct(
+        platform="telegram", user_id="u6",
+        challenge={"event_year": 1900, "country": "X"},
+        user_after={"current_streak": 1, "longest_streak": 1, "total_correct": 1, "countries": ["X"]},
+        wrong_count=0, hints_used=0,
+    )
+    assert "cold_case" not in none_awarded
+
+    cold = achievements.evaluate_after_correct(
+        platform="telegram", user_id="u7",
+        challenge={"event_year": 1900, "country": "X"},
+        user_after={"current_streak": 1, "longest_streak": 1, "total_correct": 1, "countries": ["X"]},
+        wrong_count=1, hints_used=0,
+    )
+    assert "cold_case" in cold
+
+
+def test_globe_trotter_at_five_countries(tmp_db):
+    from scripts import achievements
+
+    awarded = achievements.evaluate_after_correct(
+        platform="telegram", user_id="u8",
+        challenge={"event_year": 1900, "country": "E"},
+        user_after={"current_streak": 1, "longest_streak": 1, "total_correct": 5,
+                    "countries": ["A", "B", "C", "D", "E"]},
+        wrong_count=0, hints_used=0,
+    )
+    assert "globe_trotter" in awarded
+
+
+def test_ancient_and_modern_modes(tmp_db):
+    from scripts import achievements
+
+    ancient = achievements.evaluate_after_correct(
+        platform="telegram", user_id="u9",
+        challenge={"event_year": 800, "country": "Z"},
+        user_after={"current_streak": 1, "longest_streak": 1, "total_correct": 1, "countries": ["Z"]},
+        wrong_count=0, hints_used=0,
+    )
+    assert "ancient_mode" in ancient
+
+    modern = achievements.evaluate_after_correct(
+        platform="telegram", user_id="u10",
+        challenge={"event_year": 2010, "country": "Z"},
+        user_after={"current_streak": 1, "longest_streak": 1, "total_correct": 1, "countries": ["Z"]},
+        wrong_count=0, hints_used=0,
+    )
+    assert "modern_memory" in modern
+
+
+def test_award_idempotent(tmp_db):
+    from scripts import state
+
+    assert state.award_achievement("telegram", "u11", "first_sight") is True
+    assert state.award_achievement("telegram", "u11", "first_sight") is False

--- a/optional-skills/gaming/on-this-day-art-trivia/tests/test_challenge_flow.py
+++ b/optional-skills/gaming/on-this-day-art-trivia/tests/test_challenge_flow.py
@@ -1,0 +1,149 @@
+"""End-to-end flow tests using the Wikimedia fixture for offline determinism."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _install_fixture(month: int, day: int, payload):
+    import json
+    from scripts import sources
+
+    sources.FIXTURES_DIR.mkdir(parents=True, exist_ok=True)
+    target = sources.FIXTURES_DIR / f"{month:02d}-{day:02d}.json"
+    target.write_text(json.dumps(payload), encoding="utf-8")
+    return target
+
+
+def _patch_sources(monkeypatch, payload):
+    """Force fetch_all_candidates to return our fixture-derived events."""
+    from scripts import sources
+
+    monkeypatch.setattr(sources, "fetch_britannica", lambda m, d, html=None: [])
+    monkeypatch.setattr(sources, "fetch_onthisday", lambda m, d, html=None: [])
+    monkeypatch.setattr(
+        sources,
+        "fetch_wikimedia",
+        lambda m, d, payload=None: sources.parse_wikimedia_payload(payload),
+    )
+
+    return None
+
+
+def test_start_then_correct_guess_resolves(tmp_db, wikimedia_fixture, monkeypatch):
+    import datetime as _dt
+
+    from scripts import challenge, sources, state
+
+    monkeypatch.setattr(
+        sources, "fetch_all_candidates",
+        lambda m, d: sources.parse_wikimedia_payload(wikimedia_fixture),
+    )
+
+    res = challenge.start_challenge(
+        platform="telegram", chat_id="cfg-1", user_id="u-flow",
+        user_display_name="alice", scope="dm",
+        on_date=_dt.date(2026, 4, 28),
+        image_generator=lambda prompt, out: None,
+        deliver_to_telegram=False,
+    )
+    assert res is not None
+    # Caption must include full date with year.
+    assert "April 28, 2001" in res.surface_caption
+    # Caption must NOT contain the answer.
+    cap_low = res.surface_caption.lower()
+    assert "dennis" not in cap_low
+    assert "tito" not in cap_low
+
+    chal = state.get_challenge(res.challenge_id)
+    assert chal["status"] == "active"
+
+    # Now guess correctly — should use the canonical answer of the selected event.
+    g = challenge.handle_guess(
+        platform="telegram", chat_id="cfg-1", user_id="u-flow",
+        user_display_name="alice",
+        guess_text=chal["canonical_answer"],
+    )
+    assert g is not None
+    assert g.outcome == "correct"
+    chal2 = state.get_challenge(res.challenge_id)
+    assert chal2["status"] == "solved"
+
+
+def test_three_wrong_answers_exhaust_and_reset_streak(tmp_db, wikimedia_fixture, monkeypatch):
+    import datetime as _dt
+
+    from scripts import challenge, sources, state
+
+    monkeypatch.setattr(
+        sources, "fetch_all_candidates",
+        lambda m, d: sources.parse_wikimedia_payload(wikimedia_fixture),
+    )
+
+    state.upsert_user("telegram", "u-fail", "x")
+    state.update_streak_after_correct("telegram", "u-fail", "2026-04-27", "X")
+
+    res = challenge.start_challenge(
+        platform="telegram", chat_id="cfg-2", user_id="u-fail",
+        user_display_name=None, scope="dm",
+        on_date=_dt.date(2026, 4, 28),
+        image_generator=lambda prompt, out: None,
+        deliver_to_telegram=False,
+    )
+    assert res is not None
+    for _ in range(3):
+        out = challenge.handle_guess(
+            platform="telegram", chat_id="cfg-2", user_id="u-fail",
+            user_display_name=None, guess_text="completely wrong",
+        )
+        assert out is not None
+    user = state.get_user("telegram", "u-fail")
+    assert user["current_streak"] == 0
+    chal = state.get_challenge(res.challenge_id)
+    assert chal["status"] == "failed"
+
+
+def test_caption_contains_only_date_and_location(tmp_db, wikimedia_fixture, monkeypatch):
+    import datetime as _dt
+
+    from scripts import challenge, sources
+
+    monkeypatch.setattr(
+        sources, "fetch_all_candidates",
+        lambda m, d: sources.parse_wikimedia_payload(wikimedia_fixture),
+    )
+
+    res = challenge.start_challenge(
+        platform="telegram", chat_id="cfg-3", user_id="u",
+        user_display_name=None, scope="dm",
+        on_date=_dt.date(2026, 4, 28),
+        image_generator=lambda prompt, out: None,
+        deliver_to_telegram=False,
+    )
+    assert res is not None
+    lines = [l for l in res.surface_caption.splitlines() if l.strip()]
+    assert len(lines) == 2, f"expected 2 lines, got {lines!r}"
+    # Caption must include full date with year: e.g. "April 28, 2026" or "April 28, 1967"
+    date_line = lines[0]
+    assert ", " in date_line, f"expected comma separator in date line: {date_line!r}"
+    year_part = date_line.rsplit(", ", 1)[-1]
+    assert year_part.isdigit() and len(year_part) == 4, f"expected 4-digit year in caption date line: {date_line!r}"
+    # Caption must NOT contain the answer/event title
+    cap_low = res.surface_caption.lower()
+    assert "muhammad" not in cap_low
+    assert "ali" not in cap_low or " ali " not in f" {cap_low} "
+    # Caption must NOT contain source URL
+    assert "http" not in cap_low
+    assert "wikimedia" not in cap_low
+    assert "britannica" not in cap_low
+
+
+def test_subscribe_unsubscribe_round_trip(tmp_db):
+    from scripts import challenge, state
+
+    challenge.subscribe(platform="telegram", user_id="u-sub", chat_id="c-sub", scope="dm")
+    subs = state.list_active_subscriptions()
+    assert any(s["user_id"] == "u-sub" for s in subs)
+    challenge.unsubscribe(platform="telegram", user_id="u-sub", chat_id="c-sub")
+    subs = state.list_active_subscriptions()
+    assert not any(s["user_id"] == "u-sub" for s in subs)

--- a/optional-skills/gaming/on-this-day-art-trivia/tests/test_dm_vs_group.py
+++ b/optional-skills/gaming/on-this-day-art-trivia/tests/test_dm_vs_group.py
@@ -1,0 +1,101 @@
+"""Group-vs-DM routing for the inbound-message plugin path.
+
+The plugin's ``_on_pre_gateway_dispatch`` should:
+
+* In DMs with an active challenge: treat any plain-text message as a guess
+  and consume it via ``action: skip``.
+* In groups: only consume messages that reply to the challenge image.
+
+We exercise the function with synthetic event objects that mimic the
+attribute surface Hermes provides.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+# Make the plugin importable.
+ROOT = Path(__file__).resolve().parent.parent
+PLUGIN_DIR = ROOT / "plugin"
+if str(PLUGIN_DIR) not in sys.path:
+    sys.path.insert(0, str(PLUGIN_DIR))
+
+
+def _make_event(*, text, chat_id, chat_type, user_id, reply_to=None):
+    src = SimpleNamespace(
+        platform=SimpleNamespace(value="telegram"),
+        chat_id=chat_id,
+        chat_type=chat_type,
+        user_id=user_id,
+        user_name="alice",
+        reply_to_message_id=reply_to,
+    )
+    return SimpleNamespace(text=text, source=src, reply_to_message_id=reply_to, metadata={})
+
+
+def _make_gateway():
+    return SimpleNamespace(adapters={})
+
+
+def test_dm_plain_text_is_consumed_when_active(tmp_db):
+    from scripts import state
+    from on_this_day_art_trivia import plugin as plug
+
+    cid = state.create_challenge(
+        platform="telegram", chat_id="dm-1", scope="dm", user_id="user-1",
+        event_date="April 28", event_year=1967,
+        location="Houston", country="United States",
+        canonical_answer="Muhammad Ali refused induction",
+        short_summary="Muhammad Ali refused induction.",
+        full_description=None, source="britannica",
+        aliases=[("Muhammad Ali refused induction", 1)],
+    )
+
+    ev = _make_event(text="Muhammad Ali refused induction", chat_id="dm-1",
+                     chat_type="dm", user_id="user-1")
+    out = plug._on_pre_gateway_dispatch(event=ev, gateway=_make_gateway())
+    assert isinstance(out, dict)
+    assert out.get("action") == "skip"
+    state.resolve_challenge(cid, "expired")  # cleanup
+
+
+def test_dm_with_no_active_challenge_falls_through(tmp_db):
+    from on_this_day_art_trivia import plugin as plug
+
+    ev = _make_event(text="hello bot", chat_id="dm-2", chat_type="dm", user_id="u2")
+    out = plug._on_pre_gateway_dispatch(event=ev, gateway=_make_gateway())
+    assert out is None
+
+
+def test_group_only_intercepts_replies_to_challenge(tmp_db):
+    from scripts import state
+    from on_this_day_art_trivia import plugin as plug
+
+    cid = state.create_challenge(
+        platform="telegram", chat_id="group-1", scope="group", user_id=None,
+        event_date="April 28", event_year=1967,
+        location="Houston", country="United States",
+        canonical_answer="Muhammad Ali refused induction",
+        short_summary=None, full_description=None, source="britannica",
+        aliases=[("Muhammad Ali refused induction", 1)],
+    )
+    state.attach_telegram_message_id(cid, "msg-42")
+
+    ev_drive_by = _make_event(text="random group chat", chat_id="group-1",
+                              chat_type="group", user_id="u1")
+    assert plug._on_pre_gateway_dispatch(event=ev_drive_by, gateway=_make_gateway()) is None
+
+    ev_reply = _make_event(text="ali refused", chat_id="group-1",
+                           chat_type="group", user_id="u1", reply_to="msg-42")
+    out = plug._on_pre_gateway_dispatch(event=ev_reply, gateway=_make_gateway())
+    assert isinstance(out, dict)
+    assert out.get("action") == "skip"
+
+
+def test_slash_commands_pass_through(tmp_db):
+    from on_this_day_art_trivia import plugin as plug
+
+    ev = _make_event(text="/help", chat_id="dm-3", chat_type="dm", user_id="u3")
+    assert plug._on_pre_gateway_dispatch(event=ev, gateway=_make_gateway()) is None

--- a/optional-skills/gaming/on-this-day-art-trivia/tests/test_guess_matcher.py
+++ b/optional-skills/gaming/on-this-day-art-trivia/tests/test_guess_matcher.py
@@ -1,0 +1,77 @@
+"""Guess matcher tests."""
+
+from __future__ import annotations
+
+
+def _accept(*aliases):
+    from scripts.guess_matcher import Acceptable, normalize
+
+    return [
+        Acceptable(alias=a, alias_normalized=normalize(a), precision_tier=tier)
+        for a, tier in aliases
+    ]
+
+
+def test_normalize_strips_punctuation_and_diacritics():
+    from scripts.guess_matcher import normalize
+
+    assert normalize("Café — Curaçao!") == "cafe curacao"
+    assert normalize("U.S. Army") == "u s army"
+
+
+def test_exact_alias_is_correct():
+    from scripts.guess_matcher import match_guess
+
+    acceptable = _accept(("Muhammad Ali refused induction", 1))
+    res = match_guess("Muhammad Ali refused induction", acceptable)
+    assert res.outcome == "correct"
+    assert res.matched_alias is not None
+
+
+def test_anchor_token_match_returns_close_for_short_guess():
+    from scripts.guess_matcher import build_anchor_tokens, match_guess
+
+    canonical = "Mutiny on the Bounty"
+    anchors = build_anchor_tokens(canonical)
+    res = match_guess(
+        "bounty mutiny",
+        _accept(("Mutiny on the Bounty", 1)),
+        canonical_anchor_tokens=anchors,
+    )
+    assert res.outcome in ("correct", "close")
+
+
+def test_unrelated_guess_is_wrong():
+    from scripts.guess_matcher import build_anchor_tokens, match_guess
+
+    canonical = "Muhammad Ali refused induction"
+    anchors = build_anchor_tokens(canonical)
+    res = match_guess(
+        "bananas",
+        _accept(("Muhammad Ali refused induction", 1)),
+        canonical_anchor_tokens=anchors,
+    )
+    assert res.outcome == "wrong"
+
+
+def test_substring_alias_in_guess_is_correct():
+    from scripts.guess_matcher import match_guess
+
+    res = match_guess(
+        "i think it was the mutiny on the bounty in 1789",
+        _accept(("Mutiny on the Bounty", 1)),
+    )
+    assert res.outcome == "correct"
+
+
+def test_close_path_short_one_word_is_wrong():
+    from scripts.guess_matcher import build_anchor_tokens, match_guess
+
+    canonical = "Muhammad Ali refused induction"
+    anchors = build_anchor_tokens(canonical)
+    res = match_guess(
+        "war",
+        _accept(("Muhammad Ali refused induction", 1)),
+        canonical_anchor_tokens=anchors,
+    )
+    assert res.outcome == "wrong"

--- a/optional-skills/gaming/on-this-day-art-trivia/tests/test_image_generator.py
+++ b/optional-skills/gaming/on-this-day-art-trivia/tests/test_image_generator.py
@@ -1,0 +1,199 @@
+"""Tests for image generator detection and invocation ordering.
+
+These tests verify that ``challenge._default_image_generator`` discovers the
+new ``gpt-image-2`` skill first and still falls back to legacy paths.
+No real image credits are spent — generation is mocked.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+def test_generate_py_has_no_openai_imports():
+    """The generator script must not import openai or require OPENAI_API_KEY."""
+    from scripts import challenge
+
+    hermes_home = Path.home() / ".hermes"
+    gen_script = (
+        hermes_home
+        / "skills"
+        / "creative"
+        / "gpt-image-2"
+        / "scripts"
+        / "generate.py"
+    )
+    assert gen_script.exists()
+    src = gen_script.read_text(encoding="utf-8")
+    assert "import openai" not in src, "generate.py imports openai directly — should use Hermes built-in tool"
+    assert "OPENAI_API_KEY" not in src, "generate.py references OPENAI_API_KEY"
+    assert "OpenAI(" not in src, "generate.py constructs an OpenAI client directly"
+
+
+def test_generate_py_bootstraps_hermes_path():
+    """The generator script must explicitly resolve and add the Hermes repo path to sys.path."""
+    hermes_home = Path.home() / ".hermes"
+    gen_script = hermes_home / "skills" / "creative" / "gpt-image-2" / "scripts" / "generate.py"
+    assert gen_script.exists()
+    src = gen_script.read_text(encoding="utf-8")
+    assert "def _ensure_hermes_in_path()" in src, "generate.py missing _ensure_hermes_in_path() helper"
+    assert "hermes_home = Path(os.environ.get(\"HERMES_HOME\"" in src, "generate.py does not resolve HERMES_HOME"
+    assert "repo_path = hermes_home / \"hermes-agent\"" in src, "generate.py does not resolve hermes-agent repo path"
+    assert "repo_path.exists()" in src, "generate.py does not guard on repo existence"
+    assert "sys.path.insert(0, str(repo_path))" in src, "generate.py does not prepend repo to sys.path"
+    assert "Hermes agent repo not found" in src, "generate.py has no clear missing-repo error"
+
+
+def test_new_gpt_image_2_skill_detected_first(monkeypatch, tmp_path):
+    """When gpt-image-2/scripts/generate.py exists, it is picked first."""
+    from scripts import challenge
+
+    home = tmp_path / ".hermes"
+    new_skill = home / "skills" / "creative" / "gpt-image-2" / "scripts" / "generate.py"
+    new_skill.parent.mkdir(parents=True, exist_ok=True)
+    new_skill.write_text("# new", encoding="utf-8")
+
+    legacy = home / "skills" / "creative" / "chatgpt-images-2-operator" / "run.py"
+    legacy.parent.mkdir(parents=True, exist_ok=True)
+    legacy.write_text("# old", encoding="utf-8")
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    # Mock subprocess to avoid running real generators
+    call_log = []
+
+    def _fake_run(cmd, **kwargs):
+        call_log.append(cmd)
+        return subprocess.CompletedProcess(cmd, returncode=0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    # Also need the output file to "exist" after the mocked run
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    expected_out = out_dir / "scene.png"
+    expected_out.write_text("fake image", encoding="utf-8")
+
+    result = challenge._default_image_generator("test prompt", out_dir)
+    assert result is not None
+    assert len(call_log) == 1
+    cmd = call_log[0]
+    # cmd is like [sys.executable, str(new_skill), "--prompt", ..., "--output", ...]
+    assert str(new_skill) in cmd
+    assert "--prompt" in cmd
+    assert "--output" in cmd
+
+
+def test_legacy_fallback_used_when_new_missing(monkeypatch, tmp_path):
+    """If gpt-image-2 is absent but legacy run.py exists, use the legacy path."""
+    from scripts import challenge
+
+    home = tmp_path / ".hermes"
+    legacy = home / "skills" / "creative" / "chatgpt-images-2-operator" / "run.py"
+    legacy.parent.mkdir(parents=True, exist_ok=True)
+    legacy.write_text("# old", encoding="utf-8")
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    call_log = []
+
+    def _fake_run(cmd, **kwargs):
+        call_log.append(cmd)
+        return subprocess.CompletedProcess(cmd, returncode=0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    expected_out = out_dir / "scene.png"
+    expected_out.write_text("fake image", encoding="utf-8")
+
+    result = challenge._default_image_generator("test prompt", out_dir)
+    assert result is not None
+    assert len(call_log) == 1
+    assert str(legacy) in call_log[0]
+
+
+def test_returns_none_when_no_generator_found(monkeypatch, tmp_path):
+    """If neither new nor legacy generator exists, return None gracefully."""
+    from scripts import challenge
+
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+
+    result = challenge._default_image_generator("test prompt", out_dir)
+    assert result is None
+
+
+def test_invokes_with_prompt_and_output_flags(monkeypatch, tmp_path):
+    """The subprocess command includes --prompt and --output in that order."""
+    from scripts import challenge
+
+    home = tmp_path / ".hermes"
+    new_skill = home / "skills" / "creative" / "gpt-image-2" / "scripts" / "generate.py"
+    new_skill.parent.mkdir(parents=True, exist_ok=True)
+    new_skill.write_text("# new", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    call_log = []
+
+    def _fake_run(cmd, **kwargs):
+        call_log.append(list(cmd))
+        return subprocess.CompletedProcess(cmd, returncode=0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    expected_out = out_dir / "scene.png"
+    expected_out.write_text("fake", encoding="utf-8")
+
+    challenge._default_image_generator("my prompt here", out_dir)
+
+    assert len(call_log) == 1
+    cmd = call_log[0]
+    # Find indices
+    prompt_idx = cmd.index("--prompt")
+    output_idx = cmd.index("--output")
+    assert cmd[prompt_idx + 1] == "my prompt here"
+    assert cmd[output_idx + 1] == str(expected_out)
+
+
+def test_skips_legacy_generate_py_when_run_py_exists(monkeypatch, tmp_path):
+    """For legacy chatgpt-images-2-operator, prefer run.py over scripts/generate.py."""
+    from scripts import challenge
+
+    home = tmp_path / ".hermes"
+    legacy_run = home / "skills" / "creative" / "chatgpt-images-2-operator" / "run.py"
+    legacy_gen = home / "skills" / "creative" / "chatgpt-images-2-operator" / "scripts" / "generate.py"
+    legacy_run.parent.mkdir(parents=True, exist_ok=True)
+    legacy_gen.parent.mkdir(parents=True, exist_ok=True)
+    legacy_run.write_text("# run", encoding="utf-8")
+    legacy_gen.write_text("# gen", encoding="utf-8")
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    call_log = []
+
+    def _fake_run(cmd, **kwargs):
+        call_log.append(cmd)
+        return subprocess.CompletedProcess(cmd, returncode=0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    expected_out = out_dir / "scene.png"
+    expected_out.write_text("fake", encoding="utf-8")
+
+    result = challenge._default_image_generator("test", out_dir)
+    assert result is not None
+    assert str(legacy_run) in call_log[0]
+    assert str(legacy_gen) not in call_log[0]

--- a/optional-skills/gaming/on-this-day-art-trivia/tests/test_prompt_builder.py
+++ b/optional-skills/gaming/on-this-day-art-trivia/tests/test_prompt_builder.py
@@ -1,0 +1,78 @@
+"""Prompt-builder anti-spoiler + safety tests."""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _ev(**kw):
+    from scripts.scoring import CandidateEvent
+
+    base = dict(
+        summary="Muhammad Ali refused induction into the U.S. Army in Houston, Texas.",
+        canonical_answer="Muhammad Ali refused induction",
+        year=1967,
+        location="Houston, Texas",
+        country="United States",
+        category="event",
+        source="britannica",
+    )
+    base.update(kw)
+    return CandidateEvent(**base)
+
+
+def test_prompt_does_not_leak_canonical_answer_proper_nouns():
+    from scripts import prompt_builder
+
+    ev = _ev()
+    prompt = prompt_builder.build_image_prompt(ev, surface_date="April 28")
+    low = prompt.lower()
+    assert "muhammad" not in low
+    assert "ali" not in low.split() or " ali " not in f" {low} "
+    assert "u.s. army" not in low
+    assert "induction" not in low
+
+
+def test_prompt_includes_only_location_and_date_and_safety_constraints():
+    from scripts import prompt_builder
+
+    ev = _ev()
+    prompt = prompt_builder.build_image_prompt(ev, surface_date="April 28")
+    assert "Houston, Texas" in prompt
+    assert "April 28" in prompt
+    assert "no readable text" in prompt.lower()
+    assert "no weapons" in prompt.lower()
+
+
+def test_prompt_safety_blocklist_is_enforced():
+    from scripts import prompt_builder
+
+    assert prompt_builder.prompt_passes_safety("a calm street scene") is True
+    assert prompt_builder.prompt_passes_safety("a street with blood and guns") is False
+
+
+def test_disqualified_event_raises():
+    from scripts import prompt_builder
+
+    bad = _ev(summary="The school shooting in town X.",
+              canonical_answer="school shooting in X")
+    with pytest.raises(ValueError):
+        prompt_builder.build_image_prompt(bad, surface_date="April 28")
+
+
+def test_scrub_spoilers_replaces_proper_nouns():
+    from scripts import prompt_builder
+
+    ev = _ev()
+    out = prompt_builder.scrub_spoilers("Muhammad Ali refused induction in Houston", ev)
+    low = out.lower()
+    assert "muhammad" not in low
+    assert "ali" not in low or " ali" not in f" {low}"
+
+
+def test_no_central_protagonist_directive_present():
+    from scripts import prompt_builder
+
+    ev = _ev()
+    prompt = prompt_builder.build_image_prompt(ev, surface_date="April 28")
+    assert "no central protagonist" in prompt.lower()

--- a/optional-skills/gaming/on-this-day-art-trivia/tests/test_scoring.py
+++ b/optional-skills/gaming/on-this-day-art-trivia/tests/test_scoring.py
@@ -1,0 +1,75 @@
+"""Event scoring rubric tests."""
+
+from __future__ import annotations
+
+
+def _ev(**kw):
+    from scripts.scoring import CandidateEvent
+
+    base = dict(
+        summary="A signed treaty in Paris",
+        canonical_answer="Treaty of Paris",
+        year=1783,
+        location="Paris",
+        country="France",
+        category="event",
+        source="britannica",
+    )
+    base.update(kw)
+    return CandidateEvent(**base)
+
+
+def test_treaty_event_passes_floor():
+    from scripts import scoring
+
+    ev = _ev()
+    breakdown = scoring.score_event(ev)
+    assert breakdown.score >= 50
+
+
+def test_birthday_is_penalised():
+    from scripts import scoring
+
+    ev = _ev(category="birth", summary="Jessica Alba was born in Pomona, California.",
+             canonical_answer="Jessica Alba", year=1981, location="Pomona", country="United States")
+    breakdown = scoring.score_event(ev)
+    assert breakdown.components.get("birthday_penalty") == -40
+
+
+def test_obituary_is_penalised_more_than_birthday():
+    from scripts import scoring
+
+    ev = _ev(category="death", summary="A famous person died at home.",
+             canonical_answer="death of person", year=1995, location=None, country=None)
+    breakdown = scoring.score_event(ev)
+    assert breakdown.components.get("death_penalty") == -60
+
+
+def test_disqualifying_phrase_short_circuits():
+    from scripts import scoring
+
+    ev = _ev(summary="A school shooting in Anywhere claimed many lives.",
+             canonical_answer="school shooting in Anywhere")
+    breakdown = scoring.score_event(ev)
+    assert breakdown.score == -1000
+    assert breakdown.rejected_reason == "graphic_or_exploitative"
+
+
+def test_rank_filters_low_scores():
+    from scripts import scoring
+
+    good = _ev()
+    bad = _ev(summary="x", canonical_answer="y", year=None, location=None, country=None)
+    ranked = scoring.rank_candidates([bad, good], min_score=50)
+    assert len(ranked) == 1
+    assert ranked[0] is good
+
+
+def test_visual_word_bumps_score():
+    from scripts import scoring
+
+    plain = _ev(summary="Something happened.", year=None, location=None, country=None,
+                category="event")
+    visual = _ev(summary="The treaty was signed during a public ceremony.",
+                 year=None, location=None, country=None, category="event")
+    assert scoring.score_event(visual).score > scoring.score_event(plain).score

--- a/optional-skills/gaming/on-this-day-art-trivia/tests/test_sources.py
+++ b/optional-skills/gaming/on-this-day-art-trivia/tests/test_sources.py
@@ -1,0 +1,57 @@
+"""Source-adapter parsing tests using cached fixtures."""
+
+from __future__ import annotations
+
+
+def test_britannica_parses_event_lines(britannica_fixture):
+    from scripts import sources
+
+    events = sources.parse_britannica_html(britannica_fixture)
+    assert events, "expected at least one parsed event"
+    by_year = {e.year: e for e in events if e.year is not None}
+    assert 1967 in by_year
+    ali = by_year[1967]
+    assert "Muhammad Ali" in ali.summary
+    assert ali.location is not None and "Houston" in ali.location
+    assert ali.source == "britannica"
+
+
+def test_britannica_extracts_country_when_present(britannica_fixture):
+    from scripts import sources
+
+    events = sources.parse_britannica_html(britannica_fixture)
+    by_year = {e.year: e for e in events if e.year is not None}
+    tito = by_year.get(2001)
+    assert tito is not None
+    assert tito.location and "Baikonur" in tito.location
+
+
+def test_wikimedia_parses_events_births_deaths(wikimedia_fixture):
+    from scripts import sources
+
+    events = sources.parse_wikimedia_payload(wikimedia_fixture)
+    cats = {e.category for e in events}
+    assert "event" in cats
+    assert "birth" in cats
+    assert "death" in cats
+
+
+def test_wikimedia_canonical_answer_uses_page_title(wikimedia_fixture):
+    from scripts import sources
+
+    events = sources.parse_wikimedia_payload(wikimedia_fixture)
+    bounty = next(e for e in events if e.year == 1789)
+    assert bounty.canonical_answer == "Mutiny on the Bounty"
+
+
+def test_onthisday_parser_handles_year_prefixed_li():
+    from scripts import sources
+
+    html = "<html><body><ul>" \
+           "<li>1903 First Tour de France was announced in Paris.</li>" \
+           "<li>random unrelated copy without a year</li>" \
+           "</ul></body></html>"
+    events = sources.parse_onthisday_html(html)
+    assert len(events) == 1
+    assert events[0].year == 1903
+    assert "Paris" in (events[0].location or "")

--- a/optional-skills/gaming/on-this-day-art-trivia/tests/test_state_migrations.py
+++ b/optional-skills/gaming/on-this-day-art-trivia/tests/test_state_migrations.py
@@ -1,0 +1,91 @@
+"""State / migration tests."""
+
+from __future__ import annotations
+
+
+def test_migrate_creates_all_tables(tmp_db):
+    from scripts import state
+
+    with state.get_readonly_conn() as conn:
+        rows = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+        ).fetchall()
+        names = {r[0] for r in rows}
+    expected = {
+        "achievements",
+        "acceptable_answers",
+        "challenges",
+        "guesses",
+        "schema_version",
+        "subscriptions",
+        "users",
+    }
+    missing = expected - names
+    assert not missing, f"missing tables: {missing}"
+
+
+def test_migrate_is_idempotent(tmp_db):
+    from scripts import state
+
+    v1 = state.migrate()
+    v2 = state.migrate()
+    assert v1 == v2 == state.CURRENT_SCHEMA_VERSION
+
+
+def test_create_challenge_marks_prior_active_as_expired(tmp_db):
+    from scripts import state
+
+    a = state.create_challenge(
+        platform="telegram", chat_id="c1", scope="dm", user_id="u1",
+        event_date="April 28", event_year=1967,
+        location="Houston", country="United States",
+        canonical_answer="Muhammad Ali refused induction",
+        short_summary=None, full_description=None, source="britannica",
+        aliases=[("Muhammad Ali refused induction", 1)],
+    )
+    b = state.create_challenge(
+        platform="telegram", chat_id="c1", scope="dm", user_id="u1",
+        event_date="April 29", event_year=1789,
+        location="South Pacific", country=None,
+        canonical_answer="Mutiny on the Bounty",
+        short_summary=None, full_description=None, source="britannica",
+        aliases=[("Mutiny on the Bounty", 1)],
+    )
+    ca = state.get_challenge(a)
+    cb = state.get_challenge(b)
+    assert ca["status"] == "expired"
+    assert cb["status"] == "active"
+
+
+def test_record_guess_and_attempts_increment(tmp_db):
+    from scripts import state
+
+    cid = state.create_challenge(
+        platform="telegram", chat_id="c2", scope="dm", user_id="u1",
+        event_date="April 28", event_year=1967,
+        location="Houston", country="United States",
+        canonical_answer="Muhammad Ali refused induction",
+        short_summary=None, full_description=None, source="britannica",
+        aliases=[("Muhammad Ali refused induction", 1)],
+    )
+    state.record_guess(cid, "telegram", "u1", "ali", "wrong")
+    n1 = state.increment_attempts(cid)
+    n2 = state.increment_attempts(cid)
+    assert n1 == 1 and n2 == 2
+
+
+def test_acceptable_answers_normalized(tmp_db):
+    from scripts import state
+
+    cid = state.create_challenge(
+        platform="telegram", chat_id="c3", scope="dm", user_id="u1",
+        event_date="April 28", event_year=1967,
+        location="Houston", country="United States",
+        canonical_answer="Muhammad Ali refused induction",
+        short_summary=None, full_description=None, source="britannica",
+        aliases=[("Muhammad Ali refused induction", 1), ("U.S. Army draft", 2)],
+    )
+    rows = state.list_acceptable_answers(cid)
+    norm = {r["alias_normalized"] for r in rows}
+    assert "muhammad ali refused induction" in norm
+    assert "u s army draft" in norm

--- a/optional-skills/gaming/on-this-day-art-trivia/tests/test_streaks.py
+++ b/optional-skills/gaming/on-this-day-art-trivia/tests/test_streaks.py
@@ -1,0 +1,56 @@
+"""Streak update tests."""
+
+from __future__ import annotations
+
+
+def test_first_correct_starts_streak_at_one(tmp_db):
+    from scripts import state
+
+    state.upsert_user("telegram", "u1", "alice")
+    out = state.update_streak_after_correct("telegram", "u1", "2026-04-28", "United States")
+    assert out["current_streak"] == 1
+    assert out["longest_streak"] == 1
+    assert out["total_correct"] == 1
+    assert "United States" in out["countries"]
+
+
+def test_consecutive_days_extend_streak(tmp_db):
+    from scripts import state
+
+    state.upsert_user("telegram", "u1", None)
+    state.update_streak_after_correct("telegram", "u1", "2026-04-28", None)
+    state.update_streak_after_correct("telegram", "u1", "2026-04-29", None)
+    out = state.update_streak_after_correct("telegram", "u1", "2026-04-30", None)
+    assert out["current_streak"] == 3
+    assert out["longest_streak"] == 3
+
+
+def test_gap_resets_streak(tmp_db):
+    from scripts import state
+
+    state.upsert_user("telegram", "u1", None)
+    state.update_streak_after_correct("telegram", "u1", "2026-04-28", None)
+    out = state.update_streak_after_correct("telegram", "u1", "2026-05-02", None)
+    assert out["current_streak"] == 1
+    assert out["longest_streak"] == 1
+
+
+def test_same_day_repeat_does_not_double_count_streak(tmp_db):
+    from scripts import state
+
+    state.upsert_user("telegram", "u1", None)
+    state.update_streak_after_correct("telegram", "u1", "2026-04-28", None)
+    out = state.update_streak_after_correct("telegram", "u1", "2026-04-28", None)
+    assert out["current_streak"] == 1
+
+
+def test_reset_streak_after_failure(tmp_db):
+    from scripts import state
+
+    state.upsert_user("telegram", "u1", None)
+    state.update_streak_after_correct("telegram", "u1", "2026-04-28", None)
+    state.update_streak_after_correct("telegram", "u1", "2026-04-29", None)
+    state.reset_streak("telegram", "u1")
+    user = state.get_user("telegram", "u1")
+    assert user["current_streak"] == 0
+    assert user["longest_streak"] == 2

--- a/optional-skills/gaming/on-this-day-art-trivia/tests/test_telegram_correlation.py
+++ b/optional-skills/gaming/on-this-day-art-trivia/tests/test_telegram_correlation.py
@@ -1,0 +1,45 @@
+"""Tests for Telegram message_id correlation between challenge and inbound reply."""
+
+from __future__ import annotations
+
+
+def test_attach_message_id_round_trip(tmp_db):
+    from scripts import state
+
+    cid = state.create_challenge(
+        platform="telegram", chat_id="c1", scope="dm", user_id="u1",
+        event_date="April 28", event_year=1967,
+        location="Houston", country="United States",
+        canonical_answer="Muhammad Ali refused induction",
+        short_summary=None, full_description=None, source="britannica",
+        aliases=[("Muhammad Ali refused induction", 1)],
+    )
+    state.attach_telegram_message_id(cid, "555")
+    found = state.get_challenge_by_message_id("telegram", "555")
+    assert found is not None
+    assert found["challenge_id"] == cid
+
+
+def test_get_active_challenge_is_chat_scoped(tmp_db):
+    from scripts import state
+
+    a = state.create_challenge(
+        platform="telegram", chat_id="chat-A", scope="dm", user_id="uA",
+        event_date="April 28", event_year=1967,
+        location="Houston", country="United States",
+        canonical_answer="A canon",
+        short_summary=None, full_description=None, source="britannica",
+        aliases=[("A canon", 1)],
+    )
+    b = state.create_challenge(
+        platform="telegram", chat_id="chat-B", scope="dm", user_id="uB",
+        event_date="April 28", event_year=1789,
+        location="South Pacific", country=None,
+        canonical_answer="B canon",
+        short_summary=None, full_description=None, source="britannica",
+        aliases=[("B canon", 1)],
+    )
+    a_active = state.get_active_challenge_for_chat("telegram", "chat-A")
+    b_active = state.get_active_challenge_for_chat("telegram", "chat-B")
+    assert a_active and a_active["challenge_id"] == a
+    assert b_active and b_active["challenge_id"] == b

--- a/plugins/on_this_day_art_trivia/__init__.py
+++ b/plugins/on_this_day_art_trivia/__init__.py
@@ -1,0 +1,6 @@
+"""on_this_day_art_trivia Hermes plugin.
+
+Re-exported here so Hermes' plugin loader can import ``register`` directly.
+"""
+
+from .plugin import register  # noqa: F401

--- a/plugins/on_this_day_art_trivia/plugin.py
+++ b/plugins/on_this_day_art_trivia/plugin.py
@@ -1,0 +1,318 @@
+"""Hermes plugin: inbound guess interception + slash command surface.
+
+The plugin registers two surfaces:
+
+1. ``pre_gateway_dispatch`` — fired by ``gateway/run.py`` for every inbound
+   :class:`MessageEvent` before auth and agent dispatch. We use it to:
+
+   * Detect plain-text messages that should be treated as guesses for an
+     active challenge (DM with active challenge, OR group reply to the
+     challenge image).
+   * Score the guess via ``scripts.challenge.handle_guess``.
+   * Send the reply directly through the platform adapter.
+   * Return ``{"action": "skip", "reason": "otdat-guess"}`` so the gateway
+     drops the message without invoking the agent.
+
+2. ``/on-this-day-art-trivia`` slash command — same routing logic as the
+   hook handler, registered through ``ctx.register_command`` so plugins
+   without hook installation still work.
+
+The plugin is silent for messages that aren't guesses; ``action: allow`` is
+returned implicitly by returning ``None``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# Make scripts/ importable. The skill is installed at
+# ~/.hermes/skills/on-this-day-art-trivia/scripts/.
+_HERMES_HOME = Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes")))
+_SKILL_DIR = _HERMES_HOME / "skills" / "on-this-day-art-trivia"
+if str(_SKILL_DIR) not in sys.path and _SKILL_DIR.exists():
+    sys.path.insert(0, str(_SKILL_DIR))
+
+try:
+    from scripts import challenge as _challenge  # type: ignore
+except Exception as _err:  # pragma: no cover — install-time misconfig
+    logger.warning("on_this_day_art_trivia: skill scripts not importable: %s", _err)
+    _challenge = None
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+def _is_command(text: Optional[str]) -> bool:
+    return bool(text) and text.lstrip().startswith("/")
+
+
+def _platform_name(event: Any) -> str:
+    src = getattr(event, "source", None)
+    plat = getattr(src, "platform", None)
+    return str(getattr(plat, "value", plat) or "telegram")
+
+
+def _chat_type(event: Any) -> str:
+    src = getattr(event, "source", None)
+    return str(getattr(src, "chat_type", "dm") or "dm")
+
+
+def _chat_id(event: Any) -> Optional[str]:
+    src = getattr(event, "source", None)
+    chat_id = getattr(src, "chat_id", None)
+    return str(chat_id) if chat_id is not None else None
+
+
+def _user_id(event: Any) -> Optional[str]:
+    src = getattr(event, "source", None)
+    user_id = getattr(src, "user_id", None)
+    return str(user_id) if user_id is not None else None
+
+
+def _user_name(event: Any) -> Optional[str]:
+    src = getattr(event, "source", None)
+    name = getattr(src, "user_name", None)
+    return str(name) if name else None
+
+
+def _reply_to_message_id(event: Any) -> Optional[str]:
+    """Best-effort: pull the message-id this inbound message replies to.
+
+    Hermes adapters expose this differently. We probe a few field names that
+    Telegram and WhatsApp adapters use, falling back to ``None`` when none
+    of them are populated.
+    """
+    for attr in ("reply_to_message_id", "reply_to", "in_reply_to", "quoted_message_id"):
+        val = getattr(event, attr, None)
+        if val is None:
+            src = getattr(event, "source", None)
+            val = getattr(src, attr, None)
+        if val:
+            return str(val)
+    metadata = getattr(event, "metadata", None) or {}
+    if isinstance(metadata, dict):
+        for key in ("reply_to_message_id", "reply_to", "in_reply_to_message_id"):
+            v = metadata.get(key)
+            if v:
+                return str(v)
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# Inbound interception
+# --------------------------------------------------------------------------- #
+
+def _on_pre_gateway_dispatch(event: Any = None, gateway: Any = None, **_: Any):
+    """Intercept inbound messages that should be scored as guesses."""
+    if _challenge is None or event is None:
+        return None
+
+    text = (getattr(event, "text", "") or "").strip()
+    if not text:
+        return None
+
+    # Slash commands flow through the normal dispatcher (the hook handles
+    # /on-this-day-art-trivia). Don't double-handle.
+    if _is_command(text):
+        return None
+
+    platform = _platform_name(event)
+    chat_id = _chat_id(event)
+    user_id = _user_id(event)
+    if not chat_id or not user_id:
+        return None
+
+    chat_type = _chat_type(event)
+
+    # Locate the active challenge if any.
+    try:
+        from scripts import state as _state  # type: ignore
+    except Exception as exc:  # pragma: no cover
+        logger.warning("on_this_day_art_trivia state import failed: %s", exc)
+        return None
+
+    active = _state.get_active_challenge_for_chat(platform, chat_id)
+    if not active:
+        return None
+
+    # Group routing rule: only intercept replies to the challenge image.
+    if chat_type == "group":
+        replied_to = _reply_to_message_id(event)
+        target = active.get("telegram_message_id")
+        if not (target and replied_to and str(replied_to) == str(target)):
+            return None
+
+    # Score the guess.
+    try:
+        result = _challenge.handle_guess(
+            platform=platform,
+            chat_id=chat_id,
+            user_id=user_id,
+            user_display_name=_user_name(event),
+            guess_text=text,
+            challenge_id=int(active["challenge_id"]),
+        )
+    except Exception as exc:
+        logger.warning("guess handling failed: %s", exc)
+        return None
+
+    if result is None:
+        return None
+
+    _send_reply(gateway, event, result.reply_text, replied_to_msg_id=active.get("telegram_message_id"))
+    return {"action": "skip", "reason": "otdat-guess"}
+
+
+def _send_reply(
+    gateway: Any,
+    event: Any,
+    text: str,
+    *,
+    replied_to_msg_id: Optional[str] = None,
+) -> None:
+    """Best-effort: deliver *text* through whichever surface is available.
+
+    Tries (1) the gateway's adapter for the message's platform, (2) direct
+    Telegram Bot API as a fallback. Failures are logged but never raised —
+    the inbound dispatch is still consumed so the user is not double-replied.
+    """
+    src = getattr(event, "source", None)
+    platform_obj = getattr(src, "platform", None)
+    chat_id = getattr(src, "chat_id", None)
+
+    # 1. Adapter path.
+    try:
+        adapters = getattr(gateway, "adapters", None) or {}
+        adapter = adapters.get(platform_obj) if platform_obj is not None else None
+        if adapter is not None and chat_id is not None:
+            send = getattr(adapter, "send", None)
+            if callable(send):
+                import asyncio as _asyncio
+                coro = send(chat_id, text)
+                if _asyncio.iscoroutine(coro):
+                    loop = _asyncio.get_event_loop()
+                    if loop.is_running():
+                        _asyncio.ensure_future(coro)
+                    else:  # pragma: no cover — only on synchronous test paths
+                        loop.run_until_complete(coro)
+                return
+    except Exception as exc:
+        logger.debug("adapter send failed, falling back to telegram_api: %s", exc)
+
+    # 2. Telegram Bot API fallback.
+    if str(getattr(platform_obj, "value", platform_obj) or "") == "telegram":
+        try:
+            from scripts import telegram_api  # type: ignore
+            telegram_api.send_message(
+                str(chat_id) if chat_id is not None else "",
+                text,
+                reply_to_message_id=replied_to_msg_id,
+            )
+        except Exception as exc:
+            logger.warning("telegram fallback send failed: %s", exc)
+
+
+# --------------------------------------------------------------------------- #
+# Slash command (mirror of the hook, in case the hook is not installed)
+# --------------------------------------------------------------------------- #
+
+HELP_TEXT = """\
+On This Day — Art Trivia
+
+  /on-this-day-art-trivia                   Start a new challenge
+  /on-this-day-art-trivia guess <answer>    Submit a guess
+  /on-this-day-art-trivia hint              Get a hint
+  /on-this-day-art-trivia reveal            Reveal the answer (resets streak)
+  /on-this-day-art-trivia stats             Your stats
+  /on-this-day-art-trivia achievements      Your achievements
+  /on-this-day-art-trivia subscribe         Receive a daily challenge here
+  /on-this-day-art-trivia unsubscribe       Stop daily delivery
+  /on-this-day-art-trivia leaderboard       Top players
+  /on-this-day-art-trivia help              Show this help
+"""
+
+
+def _slash_handler(raw_args: str, event: Any = None, **_: Any) -> Optional[str]:
+    if _challenge is None:
+        return "on-this-day-art-trivia is not installed correctly."
+
+    parts = (raw_args or "").strip().split(maxsplit=1)
+    sub = parts[0].lower() if parts else ""
+    rest = parts[1] if len(parts) > 1 else ""
+
+    platform = _platform_name(event) if event is not None else "telegram"
+    user_id = (_user_id(event) if event is not None else None) or "unknown"
+    chat_id = (_chat_id(event) if event is not None else None) or user_id
+    scope = "group" if (event is not None and _chat_type(event) == "group") else "dm"
+
+    if sub in ("", "play", "start", "new"):
+        res = _challenge.start_challenge(
+            platform=platform, chat_id=chat_id, user_id=user_id,
+            user_display_name=(_user_name(event) if event is not None else None),
+            scope=scope,
+        )
+        if res is None:
+            return "I couldn't find a usable historic event for today. Try again later."
+        if res.delivered:
+            return "Your challenge is in the chat. Reply with your guess."
+        return f"{res.surface_caption}\n\n(Image delivery unavailable; reply with your guess.)"
+
+    if sub == "guess":
+        if not rest:
+            return "Usage: /on-this-day-art-trivia guess <answer>"
+        gres = _challenge.handle_guess(
+            platform=platform, chat_id=chat_id, user_id=user_id,
+            user_display_name=(_user_name(event) if event is not None else None),
+            guess_text=rest,
+        )
+        if gres is None:
+            return "No active challenge in this chat. Start one with /on-this-day-art-trivia."
+        return gres.reply_text
+
+    if sub == "hint":
+        return _challenge.handle_hint(platform=platform, chat_id=chat_id) or "No active challenge."
+
+    if sub == "reveal":
+        return _challenge.handle_reveal(platform=platform, chat_id=chat_id, user_id=user_id) or "No active challenge."
+
+    if sub == "stats":
+        return _challenge.render_stats(platform=platform, user_id=user_id)
+
+    if sub == "achievements":
+        return _challenge.render_achievements(platform=platform, user_id=user_id)
+
+    if sub == "leaderboard":
+        return _challenge.render_leaderboard(platform=platform)
+
+    if sub == "subscribe":
+        return _challenge.subscribe(platform=platform, user_id=user_id, chat_id=chat_id, scope=scope)
+
+    if sub == "unsubscribe":
+        return _challenge.unsubscribe(platform=platform, user_id=user_id, chat_id=chat_id)
+
+    if sub in ("help", "-h", "--help", "?"):
+        return HELP_TEXT
+
+    return f"Unknown subcommand: {sub}\n\n{HELP_TEXT}"
+
+
+# --------------------------------------------------------------------------- #
+# Plugin registration
+# --------------------------------------------------------------------------- #
+
+def register(ctx) -> None:
+    ctx.register_hook("pre_gateway_dispatch", _on_pre_gateway_dispatch)
+    register_command = getattr(ctx, "register_command", None)
+    if callable(register_command):
+        register_command(
+            "on-this-day-art-trivia",
+            handler=_slash_handler,
+            description="Play the on-this-day-art-trivia history guessing game.",
+        )

--- a/plugins/on_this_day_art_trivia/plugin.yaml
+++ b/plugins/on_this_day_art_trivia/plugin.yaml
@@ -1,0 +1,13 @@
+name: on_this_day_art_trivia
+version: 0.1.1
+description: |
+  Intercepts inbound Telegram messages for the on-this-day-art-trivia game.
+  In DMs with an active challenge, plain-text replies are scored as guesses.
+  In groups, only direct replies to the challenge image (or explicit
+  /on-this-day-art-trivia guess) are scored. Wrong/correct/close replies are
+  delivered through the gateway; the original message is consumed via
+  pre_gateway_dispatch's "skip" action so the agent does not also reply.
+hooks:
+  - pre_gateway_dispatch
+commands:
+  - on-this-day-art-trivia


### PR DESCRIPTION
## What
Adds `on-this-day-art-trivia`, an optional skill + plugin that lets Hermes run a Telegram-native "On This Day" art-history guessing game. Each challenge sends an AI-generated image (the scene 30s before a historical event); players guess the title, year, and artist. Scoring, streaks, and achievements are tracked via SQLite.

## Files added
- `optional-skills/gaming/on-this-day-art-trivia/` — skill package
  - `SKILL.md`, `README.md`
  - `scripts/` — state, scoring, sources, challenge lifecycle, prompt builder, image generation, Telegram API, achievements
  - `tests/` — 57 unit tests covering challenge flow, scoring, DM vs group routing, streaks, achievements, migrations, guess matching, Telegram correlation, and the image generation adapter
  - `install.sh` — per-user install script
  - `docs/gateway-message-incoming-patch.md` — hook contract documentation
- `plugins/on_this_day_art_trivia/` — gateway plugin
  - `plugin.yaml`, `plugin.py`
  - Implements `pre_gateway_dispatch` to intercept guesses before normal agent dispatch
  - Emits `command:*` events for `/on-this-day-art-trivia` slash commands

## How it works
1. **Challenge creation**: `challenge.py` fetches a daily event from Britannica/Wikimedia, builds a prompt for image generation, and stores the challenge in SQLite.
2. **Image generation**: `prompt_builder.py` constructs scene prompts; `chatgpt-images-2-operator` is called via the Hermes skill bridge (no direct OpenAI API usage; no `OPENAI_API_KEY` required from this package).
3. **Telegram delivery**: `telegram_api.py` posts the image + caption to a configured Telegram group/DM using a `TELEGRAM_BOT_TOKEN` from `~/.hermes/.env`.
4. **Guess routing (plugin)**: `on_this_day_art_trivia/plugin.py` hooks `pre_gateway_dispatch`:
   - In DMs with an active challenge, treats plain text as a guess.
   - In groups, only guesses replying to the challenge image (or explicit `/on-this-day-art-trivia guess`) are scored.
   - Returns `{"action": "skip"}` so the agent does not also reply.
5. **Scoring**: fuzzy matching on title, year, artist; attempts decrement on wrong guesses; streaks update on correct answers.
6. **Achievements**: unlocked via thresholds (streaks, perfect rounds, first solve, etc.).

## Testing
All tests pass (57/57). Run from the repo root:
```bash
PYTHONPATH=optional-skills/gaming/on-this-day-art-trivia/:plugins/ \
  python3 -m pytest optional-skills/gaming/on-this-day-art-trivia/tests/ -q -o "addopts="
```
Test evidence:
```
57 passed in 2.33s
```

## Installation for end users
After this merges, users can:
```bash
hermes skills install on-this-day-art-trivia
```
Or manually symlink from `optional-skills/gaming/on-this-day-art-trivia/` and install the plugin into `~/.hermes/plugins/on_this_day_art_trivia/`.

## Environment requirements
- `TELEGRAM_BOT_TOKEN=...` in `~/.hermes/.env`
- Hermes gateway with `pre_gateway_dispatch` hook support (documented in `docs/gateway-message-incoming-patch.md`)
- Image generation: Hermes `gpt-image-2` skill or equivalent `chatgpt-images-2-operator` bridge configured

## Notes / limitations
- `install.sh` references a `hook/` directory in the standalone package layout. In the Hermes repo, hooks are managed via the gateway plugin; the install doc has been copied but should be updated in a follow-up if users install via `hermes skills install`.
- The plugin assumes `pre_gateway_dispatch` is invoked before normal agent dispatch with the `{"action": "skip"}` return contract honored.
- No direct OpenAI API usage; image generation delegates to Hermes native bridge.
