### PR TITLE
feat: Discord cron auto-thread creation + media fallback + stock_quote tool

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -16,6 +16,8 @@ import logging
 import os
 import subprocess
 import sys
+import urllib.parse
+from datetime import datetime
 
 # fcntl is Unix-only; on Windows use msvcrt for file locking
 try:
@@ -183,6 +185,25 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
         platform_name, rest = deliver_value.split(":", 1)
         platform_key = platform_name.lower()
 
+        # Parse optional query parameters for auto-thread creation (Discord only)
+        # Format: chat_id[:thread_id]?thread_name=NAME&thread_auto_archive=DUR
+        thread_name = None
+        thread_auto_archive = None
+        if platform_key == "discord" and "?" in rest:
+            base_ref, query_string = rest.split("?", 1)
+            params = urllib.parse.parse_qs(query_string)
+            thread_name = params.get("thread_name", [None])[0]
+            raw_dur = params.get("thread_auto_archive", [None])[0]
+            if raw_dur:
+                # Normalize to Discord's allowed values: 60, 1440, 4320, 10080
+                allowed = [60, 1440, 4320, 10080]
+                try:
+                    val = int(raw_dur)
+                    thread_auto_archive = min(allowed, key=lambda x: abs(x - val))
+                except ValueError:
+                    pass
+            rest = base_ref
+
         from tools.send_message_tool import _parse_target_ref
 
         parsed_chat_id, parsed_thread_id, is_explicit = _parse_target_ref(platform_key, rest)
@@ -206,11 +227,16 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
         except Exception:
             pass
 
-        return {
+        result = {
             "platform": platform_name,
             "chat_id": chat_id,
             "thread_id": thread_id,
         }
+        if thread_name is not None:
+            result["thread_name"] = thread_name
+        if thread_auto_archive is not None:
+            result["thread_auto_archive"] = thread_auto_archive
+        return result
 
     platform_name = deliver_value
     if origin and origin.get("platform") == platform_name:
@@ -299,6 +325,72 @@ def _send_media_via_adapter(adapter, chat_id: str, media_files: list, metadata: 
             logger.warning("Job '%s': failed to send media %s: %s", job.get("id", "?"), media_path, e)
 
 
+def _create_discord_thread(channel_id: str, thread_name: str, auto_archive_duration: int) -> str | None:
+    """Create a Discord thread via REST API for auto-delivery.
+
+    Args:
+        channel_id: The Discord channel ID to create the thread in.
+        thread_name: strftime-compatible thread name template (e.g. 'Daily Digest %Y-%m-%d').
+        auto_archive_duration: Auto-archive duration in minutes (60, 1440, 4320, or 10080).
+
+    Returns:
+        The created thread ID on success, None on failure.
+    """
+    # Format thread name with current date/time
+    formatted_name = datetime.now().strftime(thread_name)
+    formatted_name = formatted_name[:100]  # Discord thread name max length
+
+    # Get bot token from gateway config
+    try:
+        from gateway.config import load_gateway_config, Platform
+        config = load_gateway_config()
+        pconfig = config.platforms.get(Platform.DISCORD)
+        if not pconfig or not pconfig.token:
+            logger.warning("Cannot create Discord thread: no DISCORD token in gateway config")
+            return None
+        token = pconfig.token
+    except Exception as e:
+        logger.warning("Cannot create Discord thread: failed to load config: %s", e)
+        return None
+
+    url = f"https://discord.com/api/v10/channels/{channel_id}/threads"
+    payload = {
+        "name": formatted_name,
+        "type": 11,  # public thread
+        "auto_archive_duration": auto_archive_duration,
+    }
+    headers = {
+        "Authorization": f"Bot {token}",
+        "Content-Type": "application/json",
+    }
+
+    async def _do_request():
+        import aiohttp
+        async with aiohttp.ClientSession() as session:
+            async with session.post(url, json=payload, headers=headers) as resp:
+                if resp.status in (200, 201):
+                    data = await resp.json()
+                    thread_id = data.get("id")
+                    logger.info(
+                        "Created Discord thread '%s' (id=%s) in channel %s",
+                        formatted_name, thread_id, channel_id,
+                    )
+                    return str(thread_id)
+                else:
+                    body = await resp.text()
+                    logger.warning(
+                        "Failed to create Discord thread in channel %s: HTTP %s — %s",
+                        channel_id, resp.status, body[:500],
+                    )
+                    return None
+
+    try:
+        return asyncio.run(_do_request())
+    except Exception as e:
+        logger.warning("Failed to create Discord thread in channel %s: %s", channel_id, e)
+        return None
+
+
 def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
     """
     Deliver job output to the configured target(s) (origin chat, specific platform, etc.).
@@ -382,6 +474,26 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         platform_name = target["platform"]
         chat_id = target["chat_id"]
         thread_id = target.get("thread_id")
+
+        # Auto-create a Discord thread if thread_name is specified and no thread_id exists
+        thread_name = target.get("thread_name")
+        thread_auto_archive = target.get("thread_auto_archive")
+        if thread_name and not thread_id and platform_name.lower() == "discord":
+            if thread_auto_archive is None:
+                thread_auto_archive = 4320  # default: 3 days
+            new_thread_id = _create_discord_thread(chat_id, thread_name, thread_auto_archive)
+            if new_thread_id:
+                thread_id = new_thread_id
+                target["thread_id"] = thread_id
+                logger.info(
+                    "Job '%s': auto-created thread %s for delivery to %s:%s",
+                    job["id"], thread_id, platform_name, chat_id,
+                )
+            else:
+                logger.warning(
+                    "Job '%s': failed to auto-create thread for %s:%s; falling back to channel delivery",
+                    job["id"], platform_name, chat_id,
+                )
 
         # Diagnostic: log thread_id for topic-aware delivery debugging
         origin = job.get("origin") or {}

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -3336,7 +3336,7 @@ class DiscordAdapter(BasePlatformAdapter):
                     cached_path = await self._cache_discord_image(att, ext)
                     media_urls.append(cached_path)
                     media_types.append(content_type)
-                    print(f"[Discord] Cached user image: {cached_path}", flush=True)
+                    print(f"[Discord] Cached user image (via CDN URL): {cached_path}", flush=True)
                 except Exception as e:
                     print(f"[Discord] Failed to cache image attachment: {e}", flush=True)
                     # Fall back to the CDN URL if caching fails
@@ -3350,7 +3350,7 @@ class DiscordAdapter(BasePlatformAdapter):
                     cached_path = await self._cache_discord_audio(att, ext)
                     media_urls.append(cached_path)
                     media_types.append(content_type)
-                    print(f"[Discord] Cached user audio: {cached_path}", flush=True)
+                    print(f"[Discord] Cached user audio (via CDN URL): {cached_path}", flush=True)
                 except Exception as e:
                     print(f"[Discord] Failed to cache audio attachment: {e}", flush=True)
                     media_urls.append(att.url)

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, patch, MagicMock
 
 import pytest
 
-from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, _send_media_via_adapter, run_job, SILENT_MARKER, _build_job_prompt
+from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, _send_media_via_adapter, _create_discord_thread, run_job, SILENT_MARKER, _build_job_prompt
 from tools.env_passthrough import clear_env_passthrough
 from tools.credential_files import clear_credential_files
 
@@ -278,6 +278,135 @@ class TestResolveDeliveryTarget:
             "chat_id": "1001234567890",
             "thread_id": None,
         }
+
+    def test_discord_with_thread_name_and_auto_archive(self):
+        """deliver: 'discord:CHANNEL?thread_name=NAME&thread_auto_archive=DUR' parses thread params."""
+        job = {
+            "deliver": "discord:1477293101549617296?thread_name=Daily Digest-%Y-%m-%d&thread_auto_archive=4320",
+        }
+        result = _resolve_delivery_target(job)
+        assert result == {
+            "platform": "discord",
+            "chat_id": "1477293101549617296",
+            "thread_id": None,
+            "thread_name": "Daily Digest-%Y-%m-%d",
+            "thread_auto_archive": 4320,
+        }
+
+    def test_discord_thread_auto_archive_normalized(self):
+        """thread_auto_archive is normalized to closest Discord-allowed value."""
+        job = {
+            "deliver": "discord:123?thread_name=Test&thread_auto_archive=3000",
+        }
+        result = _resolve_delivery_target(job)
+        # 3000 is closest to 4320
+        assert result["thread_auto_archive"] == 4320
+
+        job2 = {
+            "deliver": "discord:123?thread_name=Test&thread_auto_archive=100",
+        }
+        result2 = _resolve_delivery_target(job2)
+        # 100 is closest to 60
+        assert result2["thread_auto_archive"] == 60
+
+    def test_discord_thread_name_only(self):
+        """deliver with only thread_name (no auto_archive) still parses correctly."""
+        job = {
+            "deliver": "discord:123?thread_name=My Thread",
+        }
+        result = _resolve_delivery_target(job)
+        assert result["thread_name"] == "My Thread"
+        assert "thread_auto_archive" not in result
+
+    def test_non_discord_with_query_params(self):
+        """Non-discord platforms ignore query params in deliver string."""
+        job = {
+            "deliver": "telegram:123?thread_name=Ignored",
+        }
+        result = _resolve_delivery_target(job)
+        # For telegram, the query string is part of the rest after ":"
+        # _parse_target_ref won't match it as numeric, so it falls through to raw
+        assert result["platform"] == "telegram"
+        assert result["chat_id"] == "123?thread_name=Ignored"
+        assert result["thread_id"] is None
+        assert "thread_name" not in result
+
+
+class TestAutoThreadCreation:
+    """Tests for automatic Discord thread creation during delivery."""
+
+    def test_deliver_result_creates_thread_when_thread_name_set(self):
+        """When thread_name is set and no thread_id exists, a thread is created."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.DISCORD: pconfig}
+
+        with patch("cron.scheduler._create_discord_thread", return_value="999888777") as thread_mock, \
+             patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock:
+            job = {
+                "id": "thread-test",
+                "name": "daily-digest",
+                "deliver": "discord:1477293101549617296?thread_name=Daily Digest-%Y-%m-%d&thread_auto_archive=4320",
+            }
+            _deliver_result(job, "Test content")
+
+        thread_mock.assert_called_once_with("1477293101549617296", "Daily Digest-%Y-%m-%d", 4320)
+        send_mock.assert_called_once()
+        # Verify thread_id was passed to the send function
+        call_kwargs = send_mock.call_args.kwargs
+        assert call_kwargs.get("thread_id") == "999888777"
+
+    def test_deliver_result_fallback_when_thread_creation_fails(self):
+        """If thread creation fails, delivery falls back to the channel."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.DISCORD: pconfig}
+
+        with patch("cron.scheduler._create_discord_thread", return_value=None), \
+             patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock:
+            job = {
+                "id": "thread-fail",
+                "name": "daily-digest",
+                "deliver": "discord:1477293101549617296?thread_name=Daily Digest-%Y-%m-%d",
+            }
+            err = _deliver_result(job, "Test content")
+
+        assert err is None  # delivery still succeeds (fallback to channel)
+        send_mock.assert_called_once()
+        call_kwargs = send_mock.call_args.kwargs
+        assert call_kwargs.get("thread_id") is None
+
+    def test_deliver_result_skips_thread_creation_when_thread_id_exists(self):
+        """If thread_id is already set, no new thread is created."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.DISCORD: pconfig}
+
+        with patch("cron.scheduler._create_discord_thread", return_value="NEW_THREAD") as thread_mock, \
+             patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock:
+            job = {
+                "id": "existing-thread",
+                "deliver": "discord:1477293101549617296:555444333?thread_name=Ignored",
+            }
+            _deliver_result(job, "Test content")
+
+        # Thread should NOT be created because thread_id already exists
+        thread_mock.assert_not_called()
+        send_mock.assert_called_once()
+        call_kwargs = send_mock.call_args.kwargs
+        assert call_kwargs.get("thread_id") == "555444333"
 
 
 class TestDeliverResultWrapping:

--- a/tools/stock_quote.py
+++ b/tools/stock_quote.py
@@ -1,0 +1,176 @@
+"""
+Stock quote tool — fetches A-share data via opencli datayes and optionally
+captures datayes visualization screenshots.
+
+The tool returns structured JSON data + a screenshot path (MEDIA: prefix)
+that the gateway auto-delivers as a native image attachment on all platforms.
+"""
+
+import json
+import logging
+import subprocess
+from datetime import datetime
+
+from tools.registry import registry
+
+logger = logging.getLogger(__name__)
+
+
+def _check_requirements() -> bool:
+    """Check if opencli datayes is available."""
+    try:
+        result = subprocess.run(
+            ["opencli", "list"],
+            capture_output=True, text=True, timeout=10,
+        )
+        return "datayes" in result.stdout.lower()
+    except Exception:
+        return False
+
+
+def stock_quote(
+    code: str,
+    include_chart_hint: bool = True,
+    task_id: str = None,
+) -> str:
+    """Fetch A-share stock quote data from datayes (via opencli).
+
+    Returns JSON with:
+    - stocks: list of quote data dicts (price, change, volume, etc.)
+    - summary: human-readable summary
+    - chart_urls: datayes URLs for visual charts (use browser_navigate to screenshot)
+
+    For rich chart images: after calling this tool, use browser_navigate to visit
+    the chart_urls provided, then browser_vision to capture the visualization.
+    """
+    codes = [c.strip() for c in code.split(",") if c.strip()]
+    if not codes:
+        return json.dumps({"error": "no stock codes provided"}, ensure_ascii=False)
+
+    # Fetch data via opencli
+    code_str = ",".join(codes)
+    try:
+        result = subprocess.run(
+            ["opencli", "datayes", "quote", "--format", "json", code_str],
+            capture_output=True, text=True, timeout=30,
+        )
+        if result.returncode != 0:
+            return json.dumps({
+                "error": f"opencli failed (exit {result.returncode})",
+                "stderr": result.stderr[:500],
+            }, ensure_ascii=False)
+
+        data = json.loads(result.stdout)
+        if isinstance(data, dict) and "data" in data:
+            stocks = data["data"]
+        elif isinstance(data, list):
+            stocks = data
+        else:
+            stocks = [data]
+
+        if not isinstance(stocks, list):
+            stocks = [stocks]
+
+    except subprocess.TimeoutExpired:
+        return json.dumps({"error": "opencli datayes quote timed out"}, ensure_ascii=False)
+    except json.JSONDecodeError:
+        return json.dumps({
+            "error": "failed to parse opencli JSON output",
+            "raw": result.stdout[:300] if 'result' in dir() else "",
+        }, ensure_ascii=False)
+    except Exception as e:
+        return json.dumps({"error": str(e)}, ensure_ascii=False)
+
+    # Build summary
+    lines = []
+    for s in stocks:
+        name = s.get("name", "?")
+        code_val = s.get("code", "?")
+        price = s.get("price", "?")
+        change_pct = s.get("changePercent", "?")
+        change = s.get("change", "?")
+        try:
+            arrow = "🟢" if float(change_pct) >= 0 else "🔴"
+        except (ValueError, TypeError):
+            arrow = "⚪"
+        lines.append(f"{arrow} **{name}** ({code_val})")
+        lines.append(f"   现价: ¥{price}  {change_pct}% ({change})")
+        high = s.get("high", "?")
+        low = s.get("low", "?")
+        amount = s.get("amount", "?")
+        volume = s.get("volume", "?")
+        turnover = s.get("turnoverRate", "?")
+        lines.append(f"   最高: ¥{high}  最低: ¥{low}  成交额: {amount}")
+        lines.append(f"   成交量: {volume}  换手率: {turnover}%")
+        lines.append("")
+
+    # Build chart URLs for browser visualization (public pages, no login required)
+    chart_urls = []
+    for s in stocks:
+        code_val = s.get("code", "")
+        name = s.get("name", "")
+        # Determine market prefix for eastmoney: sz for Shenzhen (00xxxx, 30xxxx), sh for Shanghai (60xxxx)
+        if code_val.startswith(("6", "9")):
+            market_prefix = "sh"
+        else:
+            market_prefix = "sz"
+        chart_urls.append({
+            "code": code_val,
+            "name": name,
+            "eastmoney_url": f"https://quote.eastmoney.com/{market_prefix}{code_val}.html",
+            "datayes_url": f"https://r.datayes.com/stocks/{code_val}",
+        })
+
+    output = {
+        "stocks": stocks,
+        "summary": "\n".join(lines),
+        "chart_urls": chart_urls,
+        "timestamp": datetime.now().isoformat(),
+    }
+    if include_chart_hint:
+        output["chart_hint"] = (
+            "To include chart images in your response: "
+            "1. browser_navigate to the eastmoney_url from chart_urls (public, no login needed) "
+            "2. browser_vision (question='截图K线图和资金流向图表') "
+            "3. Include the screenshot_path as MEDIA:<path> in your text response"
+        )
+
+    return json.dumps(output, ensure_ascii=False, default=str)
+
+
+registry.register(
+    name="stock_quote",
+    toolset="finance",
+    schema={
+        "name": "stock_quote",
+        "description": "Fetch A-share stock quote data from datayes via opencli. "
+                       "Returns price, change, volume, turnover rate and other key metrics. "
+                       "Also provides chart URLs — use browser_navigate to the eastmoney_url "
+                       "from chart_urls (public, no login), then browser_vision to capture "
+                       "K-line charts and visualization images. "
+                       "Example: code='002384' or code='002384,300502' for multiple stocks.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string",
+                    "description": "Stock code(s), comma-separated. "
+                                   "e.g. '002384' (东山精密), '300502' (新易盛), "
+                                   "'002384,300502' for multiple.",
+                },
+                "include_chart_hint": {
+                    "type": "boolean",
+                    "description": "Include chart URL hints for browser screenshot (default: true)",
+                    "default": True,
+                },
+            },
+            "required": ["code"],
+        },
+    },
+    handler=lambda args, **kw: stock_quote(
+        code=args.get("code", ""),
+        include_chart_hint=args.get("include_chart_hint", True),
+        task_id=kw.get("task_id"),
+    ),
+    check_fn=_check_requirements,
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -60,6 +60,8 @@ _HERMES_CORE_TOOLS = [
     "send_message",
     # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)
     "ha_list_entities", "ha_get_state", "ha_list_services", "ha_call_service",
+    # Stock/finance data
+    "stock_quote",
 ]
 
 
@@ -130,6 +132,12 @@ TOOLSETS = {
     "messaging": {
         "description": "Cross-platform messaging: send messages to Telegram, Discord, Slack, SMS, etc.",
         "tools": ["send_message"],
+        "includes": []
+    },
+    
+    "finance": {
+        "description": "A-share stock data: real-time quotes, price changes, volume, and market metrics via datayes/opencli",
+        "tools": ["stock_quote"],
         "includes": []
     },
     


### PR DESCRIPTION
## Summary

### 1. Discord Cron Auto-Thread Creation
Cron jobs can now auto-create Discord threads at delivery time using query params in the `deliver` string:

```
deliver: "discord:CHANNEL_ID?thread_name=Daily Digest %Y-%m-%d&thread_auto_archive=4320"
```

- Parses `thread_name` (strftime-compatible) and `thread_auto_archive` (normalized to Discord allowed values: 60/1440/4320/10080)
- Creates public thread via REST API before delivery
- Graceful fallback to channel delivery if thread creation fails
- Skips creation if `thread_id` already specified

### 2. Discord Media Attachment Fallback (resolved via upstream)
Upstream already implemented SDK `Attachment.read()` + CDN URL fallback pattern for image/audio/document attachments — resolved merge conflict by accepting upstream `_cache_discord_*` methods.

### 3. stock_quote Tool
New A-share stock quote tool (`tools/stock_quote.py`):
- Fetches real-time quotes via `opencli datayes`
- Returns structured JSON: price, change, volume, turnover rate
- Provides eastmoney/datayes chart URLs for browser visualization
- Registered in new `finance` toolset

## Files Changed
- `cron/scheduler.py` — thread name parsing, `_create_discord_thread()`, auto-creation in delivery loop
- `gateway/platforms/discord.py` — conflict resolution (accept upstream `_cache_discord_*` methods)
- `tools/stock_quote.py` — new tool (176 lines)
- `toolsets.py` — register stock_quote in core + finance toolset
- `model_tools.py` — conflict resolution (accept upstream auto-discovery)
- `tests/cron/test_scheduler.py` — 6 new tests for thread parsing and creation