### PR TITLE
fix: close file descriptor in LocalEnvironment._update_cwd

### DIFF
--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -296,7 +296,8 @@ class LocalEnvironment(BaseEnvironment):
     def _update_cwd(self, result: dict):
         """Read CWD from temp file (local-only, no round-trip needed)."""
         try:
-            cwd_path = open(self._cwd_file).read().strip()
+            with open(self._cwd_file) as f:
+                cwd_path = f.read().strip()
             if cwd_path:
                 self.cwd = cwd_path
         except (OSError, FileNotFoundError):


### PR DESCRIPTION
## Problem

`LocalEnvironment._update_cwd()` uses a bare `open(self._cwd_file).read()` call that never closes the file descriptor. This method runs on **every terminal command execution**, so the fd leaks accumulate over time in long sessions.

## Fix

Use a `with` statement so the fd is released promptly.

```python
# Before
cwd_path = open(self._cwd_file).read().strip()

# After
with open(self._cwd_file) as f:
    cwd_path = f.read().strip()
```

## Impact

Prevents file descriptor exhaustion in long-running sessions with many terminal commands.

---

*Standalone resubmission of the fd-leak fix from #15552 (1 file, 2 lines changed).*