### PR TITLE
feat(skills): allow locking skills against agent edits

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -566,3 +566,136 @@ class TestSecurityScanGate:
 
         with patch("hermes_cli.config.load_config", side_effect=RuntimeError("boom")):
             assert _guard_agent_created_enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# Skill protection / locking
+# ---------------------------------------------------------------------------
+
+
+LOCKED_SKILL_CONTENT = """\
+---
+name: locked-skill
+description: A locked skill that cannot be auto-edited.
+locked: true
+---
+
+# Locked Skill
+
+Step 1: Do the thing.
+"""
+
+
+class TestSkillProtection:
+    """Skills can be locked from agent edits via two independent layers:
+    frontmatter `locked: true` and the `skills.protected` config glob list."""
+
+    def test_frontmatter_locked_blocks_patch(self, tmp_path):
+        with _skill_dir(tmp_path), \
+             patch("hermes_cli.config.load_config", return_value={}):
+            _create_skill("locked-skill", LOCKED_SKILL_CONTENT)
+            result = _patch_skill("locked-skill", "Do the thing.", "Do something else.")
+        assert result["success"] is False
+        assert "locked" in result["error"].lower()
+
+    def test_frontmatter_locked_blocks_edit(self, tmp_path):
+        with _skill_dir(tmp_path), \
+             patch("hermes_cli.config.load_config", return_value={}):
+            _create_skill("locked-skill", LOCKED_SKILL_CONTENT)
+            result = _edit_skill("locked-skill", VALID_SKILL_CONTENT_2)
+        assert result["success"] is False
+        assert "locked" in result["error"].lower()
+
+    def test_frontmatter_locked_blocks_delete(self, tmp_path):
+        with _skill_dir(tmp_path), \
+             patch("hermes_cli.config.load_config", return_value={}):
+            _create_skill("locked-skill", LOCKED_SKILL_CONTENT)
+            result = _delete_skill("locked-skill")
+        assert result["success"] is False
+        assert "locked" in result["error"].lower()
+        # Skill still exists on disk
+        assert (tmp_path / "locked-skill" / "SKILL.md").exists()
+
+    def test_frontmatter_locked_blocks_write_file(self, tmp_path):
+        with _skill_dir(tmp_path), \
+             patch("hermes_cli.config.load_config", return_value={}):
+            _create_skill("locked-skill", LOCKED_SKILL_CONTENT)
+            result = _write_file("locked-skill", "references/note.md", "hello")
+        assert result["success"] is False
+        assert "locked" in result["error"].lower()
+
+    def test_frontmatter_locked_blocks_remove_file(self, tmp_path):
+        # Need to seed a supporting file outside the lock check, so create
+        # the skill unlocked first, add the file, then re-write SKILL.md
+        # with locked: true.
+        with _skill_dir(tmp_path), \
+             patch("hermes_cli.config.load_config", return_value={}):
+            _create_skill("locked-skill", VALID_SKILL_CONTENT)
+            _write_file("locked-skill", "references/note.md", "hello")
+            (tmp_path / "locked-skill" / "SKILL.md").write_text(
+                LOCKED_SKILL_CONTENT, encoding="utf-8"
+            )
+            result = _remove_file("locked-skill", "references/note.md")
+        assert result["success"] is False
+        assert "locked" in result["error"].lower()
+        assert (tmp_path / "locked-skill" / "references" / "note.md").exists()
+
+    def test_readonly_alias_also_blocks(self, tmp_path):
+        readonly_content = LOCKED_SKILL_CONTENT.replace("locked: true", "readonly: true")
+        with _skill_dir(tmp_path), \
+             patch("hermes_cli.config.load_config", return_value={}):
+            _create_skill("locked-skill", readonly_content)
+            result = _patch_skill("locked-skill", "Do the thing.", "Do something else.")
+        assert result["success"] is False
+        assert "locked" in result["error"].lower()
+
+    def test_unlocked_skill_can_be_patched(self, tmp_path):
+        with _skill_dir(tmp_path), \
+             patch("hermes_cli.config.load_config", return_value={}):
+            _create_skill("free-skill", VALID_SKILL_CONTENT)
+            result = _patch_skill("free-skill", "Do the thing.", "Do something else.")
+        assert result["success"] is True
+
+    def test_config_protected_blocks_by_name(self, tmp_path):
+        with _skill_dir(tmp_path), \
+             patch("hermes_cli.config.load_config",
+                   return_value={"skills": {"protected": ["important"]}}):
+            _create_skill("important", VALID_SKILL_CONTENT)
+            result = _patch_skill("important", "Do the thing.", "Do something else.")
+        assert result["success"] is False
+        assert "protected" in result["error"].lower()
+        assert "important" in result["error"]
+
+    def test_config_protected_blocks_by_glob(self, tmp_path):
+        with _skill_dir(tmp_path), \
+             patch("hermes_cli.config.load_config",
+                   return_value={"skills": {"protected": ["creative/*"]}}):
+            _create_skill("art-bot", VALID_SKILL_CONTENT, category="creative")
+            result = _delete_skill("art-bot")
+        assert result["success"] is False
+        assert "creative/*" in result["error"]
+
+    def test_config_protected_no_match(self, tmp_path):
+        with _skill_dir(tmp_path), \
+             patch("hermes_cli.config.load_config",
+                   return_value={"skills": {"protected": ["other-skill"]}}):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            result = _patch_skill("my-skill", "Do the thing.", "Do something else.")
+        assert result["success"] is True
+
+    def test_config_protected_handles_load_error(self, tmp_path):
+        """If load_config raises, the layer-2 check is skipped silently."""
+        with _skill_dir(tmp_path), \
+             patch("hermes_cli.config.load_config", side_effect=RuntimeError("boom")):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            result = _patch_skill("my-skill", "Do the thing.", "Do something else.")
+        assert result["success"] is True
+
+    def test_create_not_blocked_by_protection(self, tmp_path):
+        """Creating a brand-new skill is never blocked, even if its name
+        matches a `skills.protected` glob — the lock only guards modification."""
+        with _skill_dir(tmp_path), \
+             patch("hermes_cli.config.load_config",
+                   return_value={"skills": {"protected": ["my-skill"]}}):
+            result = _create_skill("my-skill", VALID_SKILL_CONTENT)
+        assert result["success"] is True

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -118,6 +118,60 @@ def _is_local_skill(skill_path: Path) -> bool:
         return True
     except ValueError:
         return False
+
+
+def _is_skill_protected(name: str, skill_dir: Path) -> Optional[str]:
+    """Return an error message if the skill is locked, else None.
+
+    Two independent layers (either one blocks):
+
+    1. Frontmatter ``locked: true`` (or ``readonly: true``) in SKILL.md —
+       authored by the skill owner, travels with the skill.
+    2. ``skills.protected`` config: a list of fnmatch globs matched against
+       both the skill name and its path relative to SKILLS_DIR — set by
+       the user to protect skills they didn't author.
+    """
+    # Layer 1: frontmatter flag
+    skill_md = skill_dir / "SKILL.md"
+    if skill_md.exists():
+        try:
+            from agent.skill_utils import parse_frontmatter
+            fm, _ = parse_frontmatter(skill_md.read_text(encoding="utf-8"))
+            if isinstance(fm, dict) and (fm.get("locked") or fm.get("readonly")):
+                return (
+                    f"Skill '{name}' is locked (frontmatter `locked: true`). "
+                    f"Remove that field from {skill_md} manually if you really "
+                    f"need to modify it."
+                )
+        except Exception:
+            pass
+
+    # Layer 2: config glob list
+    try:
+        import fnmatch
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        patterns = (cfg.get("skills", {}) or {}).get("protected", []) or []
+        if patterns:
+            try:
+                rel = str(skill_dir.resolve().relative_to(SKILLS_DIR.resolve()))
+            except ValueError:
+                rel = name
+            for pat in patterns:
+                if not isinstance(pat, str):
+                    continue
+                if fnmatch.fnmatch(name, pat) or fnmatch.fnmatch(rel, pat):
+                    return (
+                        f"Skill '{name}' is protected by `skills.protected` "
+                        f"config (matched pattern '{pat}'). Remove the entry "
+                        f"with `hermes config` if you really need to modify it."
+                    )
+    except Exception:
+        pass
+
+    return None
+
+
 MAX_SKILL_CONTENT_CHARS = 100_000   # ~36k tokens at 2.75 chars/token
 MAX_SKILL_FILE_BYTES = 1_048_576    # 1 MiB per supporting file
 
@@ -399,6 +453,10 @@ def _edit_skill(name: str, content: str) -> Dict[str, Any]:
     if not _is_local_skill(existing["path"]):
         return {"success": False, "error": f"Skill '{name}' is in an external directory and cannot be modified. Copy it to your local skills directory first."}
 
+    err = _is_skill_protected(name, existing["path"])
+    if err:
+        return {"success": False, "error": err}
+
     skill_md = existing["path"] / "SKILL.md"
     # Back up original content for rollback
     original_content = skill_md.read_text(encoding="utf-8") if skill_md.exists() else None
@@ -441,6 +499,10 @@ def _patch_skill(
 
     if not _is_local_skill(existing["path"]):
         return {"success": False, "error": f"Skill '{name}' is in an external directory and cannot be modified. Copy it to your local skills directory first."}
+
+    err = _is_skill_protected(name, existing["path"])
+    if err:
+        return {"success": False, "error": err}
 
     skill_dir = existing["path"]
 
@@ -524,6 +586,10 @@ def _delete_skill(name: str) -> Dict[str, Any]:
     if not _is_local_skill(existing["path"]):
         return {"success": False, "error": f"Skill '{name}' is in an external directory and cannot be deleted."}
 
+    err = _is_skill_protected(name, existing["path"])
+    if err:
+        return {"success": False, "error": err}
+
     skill_dir = existing["path"]
     shutil.rmtree(skill_dir)
 
@@ -569,6 +635,10 @@ def _write_file(name: str, file_path: str, file_content: str) -> Dict[str, Any]:
     if not _is_local_skill(existing["path"]):
         return {"success": False, "error": f"Skill '{name}' is in an external directory and cannot be modified. Copy it to your local skills directory first."}
 
+    err = _is_skill_protected(name, existing["path"])
+    if err:
+        return {"success": False, "error": err}
+
     target, err = _resolve_skill_target(existing["path"], file_path)
     if err:
         return {"success": False, "error": err}
@@ -605,6 +675,10 @@ def _remove_file(name: str, file_path: str) -> Dict[str, Any]:
 
     if not _is_local_skill(existing["path"]):
         return {"success": False, "error": f"Skill '{name}' is in an external directory and cannot be modified."}
+
+    err = _is_skill_protected(name, existing["path"])
+    if err:
+        return {"success": False, "error": err}
 
     skill_dir = existing["path"]
 
@@ -735,6 +809,9 @@ SKILL_MANAGE_SCHEMA = {
         "Update when: instructions stale/wrong, OS-specific failures, "
         "missing steps or pitfalls found during use. "
         "If you used a skill and hit issues not covered by it, patch it immediately.\n\n"
+        "Skills with `locked: true` (or `readonly: true`) in their frontmatter, "
+        "or matching the `skills.protected` config glob list, cannot be edited, "
+        "patched, deleted, or written to — do not retry, just respect the lock.\n\n"
         "After difficult/iterative tasks, offer to save as a skill. "
         "Skip for simple one-offs. Confirm with user before creating/deleting.\n\n"
         "Good skills: trigger conditions, numbered steps with exact commands, "


### PR DESCRIPTION
## Summary

Adds two independent layers to prevent `skill_manage` from auto-editing skills the user wants to keep stable. Either layer blocks `edit` / `patch` / `delete` / `write_file` / `remove_file` with a clear error message; `create` is never blocked.

### Layer 1 — Frontmatter flag (per-skill, travels with the skill)

\`\`\`yaml
---
name: my-precious-skill
description: ...
locked: true   # or 'readonly: true'
---
\`\`\`

### Layer 2 — Config glob list (user-side, in \`~/.hermes/config.yaml\`)

\`\`\`yaml
skills:
  protected:
    - my-precious-skill
    - \"creative/*\"
\`\`\`

Patterns are matched (via \`fnmatch\`) against both the bare skill name and its path relative to \`SKILLS_DIR\`, so category-level globs work.

## Why

Today the only protection in \`skill_manage\` is \`_is_local_skill()\`, which gates skills outside \`~/.hermes/skills/\`. There's no way to keep a *local* skill from being silently rewritten by the agent during \"auto-optimization\" turns. This adds an opt-in lock for skills the user wants to freeze.

## Implementation

- New helper \`_is_skill_protected(name, skill_dir)\` in \`tools/skill_manager_tool.py\`.
- Inserted after \`_is_local_skill\` checks in 5 mutating handlers.
- Schema description updated so the model respects the lock instead of retrying.
- Both layers fail-open on unexpected errors (e.g. malformed config), so existing skills never get accidentally bricked.

## Tests

\`tests/tools/test_skill_manager_tool.py\` adds a \`TestSkillProtection\` class with 12 cases covering both layers, the \`readonly\` alias, glob matching, fail-open on config errors, and the \"create is never blocked\" invariant.

\`\`\`
$ venv/bin/python -m pytest tests/tools/test_skill_manager_tool.py -q
72 passed in 6.04s
\`\`\`

## Backward compatibility

Fully backward compatible — skills without \`locked\`/\`readonly\` frontmatter and configs without \`skills.protected\` behave exactly as before.