### PR TITLE
fix(gateway): preserve reasoning fields in session transcript append

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1012,13 +1012,17 @@ class SessionStore:
         # Write to SQLite (unless the agent already handled it)
         if self._db and not skip_db:
             try:
+                role = message.get("role", "unknown")
                 self._db.append_message(
                     session_id=session_id,
-                    role=message.get("role", "unknown"),
+                    role=role,
                     content=message.get("content"),
                     tool_name=message.get("tool_name"),
                     tool_calls=message.get("tool_calls"),
                     tool_call_id=message.get("tool_call_id"),
+                    reasoning=message.get("reasoning") if role == "assistant" else None,
+                    reasoning_details=message.get("reasoning_details") if role == "assistant" else None,
+                    codex_reasoning_items=message.get("codex_reasoning_items") if role == "assistant" else None,
                 )
             except Exception as e:
                 logger.debug("Session DB operation failed: %s", e)


### PR DESCRIPTION
## Summary

`append_to_transcript()` was dropping `reasoning`, `reasoning_details`, and `codex_reasoning_items` when writing assistant messages to SQLite. 

## Problem

This caused DeepSeek v4 pro thinking mode to fail with 400:
```
Error code: 400 - {"error": {"message": "The reasoning_content in the thinking mode must be passed back to the API."}}
```

The stored messages lacked reasoning context needed for multi-turn reasoning continuity. When the gateway reloads a session and replays messages to the API, assistant messages with tool_calls had no reasoning_content field, violating the requirement that reasoning-aware models need their previous reasoning passed back.

## Root Cause

`append_to_transcript()` only passed `role/content/tool_name/tool_calls/tool_call_id` to `append_message()`, omitting the three reasoning fields. In contrast, both `rewrite_transcript()` and the agent's `_flush_messages_to_session_db()` already included these fields.

## Fix

Add `reasoning`, `reasoning_details`, and `codex_reasoning_items` to the `append_message()` call in `append_to_transcript()`, matching the behavior of `rewrite_transcript()`.

## Test Plan

- [x] Verified fix resolves DeepSeek v4 pro thinking mode multi-turn error
- [x] Reasoning fields now persist through SQLite in gateway sessions