### PR TITLE
fix(codex): normalize oversized Responses item IDs for replay safety

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -169,6 +169,26 @@ def _split_responses_tool_id(raw_id: Any) -> tuple[Optional[str], Optional[str]]
     return value, None
 
 
+def _normalize_responses_item_id(raw_id: Any, *, prefix: str = "msg") -> Optional[str]:
+    """Normalize Responses item IDs to API-safe length (<=64) deterministically."""
+    if not isinstance(raw_id, str):
+        return None
+    value = raw_id.strip()
+    if not value:
+        return None
+    if len(value) <= 64:
+        return value
+    digest = hashlib.sha256(value.encode("utf-8", errors="replace")).hexdigest()
+    max_body = 64 - (len(prefix) + 1)
+    shortened = digest[:max_body]
+    logger.warning(
+        "Responses item id too long (%d chars); normalized to %s_* hash.",
+        len(value),
+        prefix,
+    )
+    return f"{prefix}_{shortened}"
+
+
 def _derive_responses_function_call_id(
     call_id: str,
     response_item_id: Optional[str] = None,
@@ -328,9 +348,9 @@ def _chat_messages_to_responses_input(messages: List[Dict[str, Any]]) -> List[Di
                             "status": _normalize_responses_message_status(raw_item.get("status")),
                             "content": normalized_content_parts,
                         }
-                        item_id = raw_item.get("id")
-                        if isinstance(item_id, str) and item_id.strip():
-                            replay_item["id"] = item_id.strip()
+                        item_id = _normalize_responses_item_id(raw_item.get("id"), prefix="msg")
+                        if item_id:
+                            replay_item["id"] = item_id
                         phase = raw_item.get("phase")
                         if isinstance(phase, str) and phase.strip():
                             replay_item["phase"] = phase.strip()
@@ -859,8 +879,8 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
                     "status": _normalize_responses_message_status(item_status),
                     "content": [{"type": "output_text", "text": message_text}],
                 }
-                item_id = getattr(item, "id", None)
-                if isinstance(item_id, str) and item_id:
+                item_id = _normalize_responses_item_id(getattr(item, "id", None), prefix="msg")
+                if item_id:
                     raw_message_item["id"] = item_id
                 if normalized_phase:
                     raw_message_item["phase"] = normalized_phase
@@ -875,8 +895,8 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
             encrypted = getattr(item, "encrypted_content", None)
             if isinstance(encrypted, str) and encrypted:
                 raw_item = {"type": "reasoning", "encrypted_content": encrypted}
-                item_id = getattr(item, "id", None)
-                if isinstance(item_id, str) and item_id:
+                item_id = _normalize_responses_item_id(getattr(item, "id", None), prefix="r")
+                if item_id:
                     raw_item["id"] = item_id
                 # Capture summary — required by the API when replaying reasoning items
                 summary = getattr(item, "summary", None)


### PR DESCRIPTION
## Problem

The OpenAI Responses API requires `input[].id` to be ≤ 64 characters. During session resume, Hermes replays assistant message items and reasoning items from stored `codex_message_items` / `codex_reasoning_items`. Some provider-generated IDs (e.g., from Codex Responses) can exceed this limit — observed at 416 characters — causing:

```
Error code: 400 - Invalid 'input[8].id': string too long. Expected max 64, got 416
```

This prevents session resumption. The TUI shows only `ready` and the conversation cannot continue.

## Root Cause

The replay path in `_chat_messages_to_responses_input` and `_normalize_codex_response` passes through the raw `id` from stored message/response items without length validation. Unlike `function_call.id` (which has `_derive_responses_function_call_id` with `[:48]` truncation via `fc_` prefix), **message item IDs and reasoning item IDs** have no length enforcement.

## Fix

Add `_normalize_responses_item_id(raw_id, prefix)` that:

- **Passes through** IDs ≤ 64 chars unchanged (zero impact for normal IDs)
- **Hashes** oversized IDs deterministically via SHA-256, keeping the prefix intact (`msg_*` for message items, `r_*` for reasoning items)
- Logs a warning so oversized IDs are visible in logs

The hash is **deterministic** (same input → same output), so prompt cache behavior is preserved across resume attempts — only the first normalization causes a cache miss.

Applied at three replay points:
1. Assistant message item IDs in `_chat_messages_to_responses_input` (replay `codex_message_items`)
2. Message item IDs in `_normalize_codex_response` (store `message_items_raw`)
3. Reasoning item IDs in `_normalize_codex_response` (store `reasoning_items_raw`)

## Validation

- `python3 -m py_compile agent/codex_responses_adapter.py` ✅
- Session that previously failed with 400 error now resumes successfully ✅
- No content loss — only the ID changes; conversation and phase data are preserved

## Related

- #9107 addresses a different set of Codex Responses issues (turn-boundary output extraction, function_call pairing, `previous_response_id` threading) but does not handle the 64-char ID limit