### PR TITLE
fix(model_switch): use live API discovery for openai-codex in gateway/Telegram picker

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1207,7 +1207,7 @@ def list_authenticated_providers(
         if not has_creds:
             continue
 
-        if hermes_slug in {"copilot", "copilot-acp"}:
+        if hermes_slug in {"copilot", "copilot-acp", "openai-codex"}:
             model_ids = provider_model_ids(hermes_slug)
         # For aws_sdk providers (bedrock), use live discovery so the list
         # reflects the active region (eu.*, ap.*) not the static us.* list.


### PR DESCRIPTION
## Problem

Models available to a user's OpenAI Codex account (e.g. `gpt-5.5`) appear in the CLI model picker but **not** in the Telegram/gateway picker.

## Root Cause

`list_authenticated_providers()` — used by the gateway/Telegram model picker — falls through to the static curated list for `openai-codex`:

```python
# model_switch.py (before)
if hermes_slug in {"copilot", "copilot-acp"}:
    model_ids = provider_model_ids(hermes_slug)
else:
    model_ids = curated.get(hermes_slug, [])  # ← openai-codex lands here
```

The CLI path calls `provider_model_ids("openai-codex")` which performs a live OAuth-authenticated fetch via `get_codex_model_ids(access_token=...)`, so new models appear there immediately. The gateway never makes that call.

The comment in `models.py` line ~1903 even states the intention:
> *"Pass the live OAuth access token so the picker matches whatever ChatGPT lists for this account right now"*

…but this was only wired up for the CLI path.

## Fix

Add `"openai-codex"` to the set of providers that use `provider_model_ids()` for live discovery — consistent with how `copilot` and `copilot-acp` are already handled:

```python
if hermes_slug in {"copilot", "copilot-acp", "openai-codex"}:
    model_ids = provider_model_ids(hermes_slug)
```

`provider_model_ids("openai-codex")` already falls back to the hardcoded catalog if no token is available or the endpoint is unreachable, so this is safe.

## Testing

- With a Codex account that has access to `gpt-5.5`: confirm the model appears in the Telegram picker after this change
- With no Codex credentials: confirm the static fallback list is still returned