### PR TITLE
fix(utils): fall back when atomic_replace crosses filesystems (#17313)

### DIFF
--- a/tests/test_atomic_replace_symlinks.py
+++ b/tests/test_atomic_replace_symlinks.py
@@ -265,3 +265,81 @@ def test_atomic_replace_exdev_cleans_sibling_on_replace_failure(
     assert excinfo.value.errno == errno.EACCES
     leftovers = sorted(p.name for p in tmp_path.iterdir() if p.name.startswith(".atomic_xdev_"))
     assert leftovers == [], f"sibling temp not cleaned up: {leftovers}"
+
+
+def test_atomic_replace_exdev_fsyncs_sibling_temp(tmp_path: Path, monkeypatch) -> None:
+    """The cross-device fallback must ``fsync`` the sibling temp before
+    swapping it in, otherwise the durability promise that callers like
+    ``atomic_json_write`` paid for on the original temp is silently lost
+    when EXDEV fires (the sibling is a fresh ``shutil.copyfile`` whose
+    pages are not yet flushed).
+    """
+    target = tmp_path / "real.yaml"
+    target.write_text("old\n", encoding="utf-8")
+
+    tmp = _write_tmp(tmp_path, "fresh-after-xdev\n")
+    monkeypatch.setattr("utils.os.replace", _exdev_once(os.replace))
+
+    real_fsync = os.fsync
+    fsynced_paths: list[str] = []
+
+    def _spy_fsync(fd):
+        try:
+            # /proc/self/fd is Linux-only — we use os.fstat to get the
+            # device/inode and resolve back via tmp_path scan rather than
+            # /proc, which is portable to macOS test runners.
+            st = os.fstat(fd)
+        except OSError:
+            return real_fsync(fd)
+        for p in tmp_path.iterdir():
+            try:
+                if p.stat().st_ino == st.st_ino:
+                    fsynced_paths.append(p.name)
+                    break
+            except OSError:
+                continue
+        return real_fsync(fd)
+
+    monkeypatch.setattr("utils.os.fsync", _spy_fsync)
+    atomic_replace(tmp, target)
+
+    assert any(name.startswith(".atomic_xdev_") for name in fsynced_paths), (
+        f"sibling temp must be fsynced before the swap; saw fsync on: {fsynced_paths}"
+    )
+    assert target.read_text(encoding="utf-8") == "fresh-after-xdev\n"
+
+
+def test_atomic_replace_exdev_dir_fsync_failure_is_swallowed(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Directory ``fsync`` is a best-effort durability barrier — not all
+    platforms / filesystems support it (Windows raises, some FUSE mounts
+    raise EINVAL).  The fallback must still complete the swap even when
+    the directory fsync raises ``OSError``."""
+    target = tmp_path / "real.yaml"
+    target.write_text("old\n", encoding="utf-8")
+
+    tmp = _write_tmp(tmp_path, "fresh-with-dir-fsync-fail\n")
+    monkeypatch.setattr("utils.os.replace", _exdev_once(os.replace))
+
+    real_fsync = os.fsync
+    real_dir_str = os.path.realpath(str(tmp_path))
+
+    def _fsync_fail_on_dir(fd):
+        try:
+            st = os.fstat(fd)
+        except OSError:
+            return real_fsync(fd)
+        # Directory fd: raise to simulate Windows / FUSE.
+        try:
+            dir_st = os.stat(real_dir_str)
+        except OSError:
+            return real_fsync(fd)
+        if st.st_ino == dir_st.st_ino:
+            raise OSError(errno.EINVAL, "directory fsync unsupported")
+        return real_fsync(fd)
+
+    monkeypatch.setattr("utils.os.fsync", _fsync_fail_on_dir)
+    # Must not raise — the swap is the contract, dir fsync is a bonus.
+    atomic_replace(tmp, target)
+    assert target.read_text(encoding="utf-8") == "fresh-with-dir-fsync-fail\n"

--- a/tests/test_atomic_replace_symlinks.py
+++ b/tests/test_atomic_replace_symlinks.py
@@ -12,6 +12,7 @@ the codebase were migrated to the helper; these tests pin that invariant.
 """
 from __future__ import annotations
 
+import errno
 import json
 import os
 import sys
@@ -158,3 +159,109 @@ def test_atomic_replace_broken_symlink_creates_target(tmp_path: Path) -> None:
     assert link.is_symlink(), "symlink must be preserved"
     assert missing.exists(), "real target should now exist"
     assert missing.read_text(encoding="utf-8") == "created-through-link\n"
+
+
+# ─── Cross-device fallback (GitHub #17313) ───────────────────────────────────
+
+
+def _exdev_once(real_replace):
+    """Return a replacement for os.replace that raises EXDEV exactly once.
+
+    Simulates a cross-filesystem move on the first call (the original tmp →
+    real target swap) and lets the fallback's same-filesystem replace
+    succeed by delegating to the real ``os.replace`` thereafter.
+    """
+    state = {"raised": False}
+
+    def _replace(src, dst):
+        if not state["raised"]:
+            state["raised"] = True
+            raise OSError(errno.EXDEV, "Invalid cross-device link", src)
+        return real_replace(src, dst)
+
+    return _replace
+
+
+def test_atomic_replace_recovers_from_exdev(tmp_path: Path, monkeypatch) -> None:
+    """First os.replace raises EXDEV; helper must copy onto a sibling temp
+    in the real target's directory and atomically replace there."""
+    target = tmp_path / "real.yaml"
+    target.write_text("old\n", encoding="utf-8")
+
+    tmp = _write_tmp(tmp_path, "fresh-after-xdev\n")
+    monkeypatch.setattr("utils.os.replace", _exdev_once(os.replace))
+
+    returned = atomic_replace(tmp, target)
+
+    assert Path(returned) == target
+    assert target.read_text(encoding="utf-8") == "fresh-after-xdev\n"
+    assert not tmp.exists(), "original temp must be cleaned up after fallback"
+    # No leftover sibling temps from the fallback.
+    leftovers = sorted(p.name for p in tmp_path.iterdir() if p.name.startswith(".atomic_xdev_"))
+    assert leftovers == [], f"unexpected sibling temps: {leftovers}"
+
+
+def test_atomic_replace_exdev_with_symlink_preserves_link(tmp_path: Path, monkeypatch) -> None:
+    """Cross-device swap through a symlink keeps the symlink and writes the
+    real file. Mirrors the #17313 reporter's setup where ~/.hermes/memories/
+    is symlinked into a vault on a separate mount."""
+    real = tmp_path / "real.md"
+    link = tmp_path / "link.md"
+    real.write_text("old\n", encoding="utf-8")
+    link.symlink_to(real)
+
+    tmp = _write_tmp(tmp_path, "fresh-via-symlink\n")
+    monkeypatch.setattr("utils.os.replace", _exdev_once(os.replace))
+
+    returned = atomic_replace(tmp, link)
+
+    assert link.is_symlink(), "symlink must survive cross-device swap"
+    assert Path(returned) == real
+    assert real.read_text(encoding="utf-8") == "fresh-via-symlink\n"
+    assert link.read_text(encoding="utf-8") == "fresh-via-symlink\n"
+    assert not tmp.exists()
+
+
+def test_atomic_replace_propagates_non_exdev_oserror(tmp_path: Path, monkeypatch) -> None:
+    """Only EXDEV triggers the fallback — every other OSError must propagate."""
+    target = tmp_path / "real.yaml"
+    target.write_text("untouched\n", encoding="utf-8")
+
+    tmp = _write_tmp(tmp_path, "ignored\n")
+
+    def _disk_full(_src, _dst):
+        raise OSError(errno.ENOSPC, "No space left on device")
+
+    monkeypatch.setattr("utils.os.replace", _disk_full)
+
+    with pytest.raises(OSError) as excinfo:
+        atomic_replace(tmp, target)
+    assert excinfo.value.errno == errno.ENOSPC
+    assert target.read_text(encoding="utf-8") == "untouched\n"
+
+
+def test_atomic_replace_exdev_cleans_sibling_on_replace_failure(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """If the fallback's same-filesystem replace itself fails, the sibling
+    temp must be cleaned up rather than leaked into the real directory."""
+    target = tmp_path / "real.yaml"
+    target.write_text("untouched\n", encoding="utf-8")
+
+    tmp = _write_tmp(tmp_path, "ignored\n")
+
+    state = {"calls": 0}
+
+    def _replace(_src, _dst):
+        state["calls"] += 1
+        if state["calls"] == 1:
+            raise OSError(errno.EXDEV, "Invalid cross-device link")
+        raise OSError(errno.EACCES, "Permission denied")
+
+    monkeypatch.setattr("utils.os.replace", _replace)
+
+    with pytest.raises(OSError) as excinfo:
+        atomic_replace(tmp, target)
+    assert excinfo.value.errno == errno.EACCES
+    leftovers = sorted(p.name for p in tmp_path.iterdir() if p.name.startswith(".atomic_xdev_"))
+    assert leftovers == [], f"sibling temp not cleaned up: {leftovers}"

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -1,6 +1,8 @@
 """Tests for tools/memory_tool.py — MemoryStore, security scanning, and tool dispatcher."""
 
+import errno
 import json
+import os
 import pytest
 from pathlib import Path
 
@@ -255,3 +257,56 @@ class TestMemoryToolDispatcher:
     def test_remove_requires_old_text(self, store):
         result = json.loads(memory_tool(action="remove", store=store))
         assert result["success"] is False
+
+
+# =========================================================================
+# Cross-device write (GitHub #17313)
+# =========================================================================
+
+class TestMemoryToolCrossDeviceWrite:
+    """Reporter setup: ~/.hermes/memories is a symlink (or otherwise sits on a
+    different filesystem) from where the temp file lands, so the original
+    ``os.replace`` raised EXDEV and the write surfaced as
+    ``Failed to write memory file ...: [Errno 18] Invalid cross-device link``.
+
+    The fix in ``utils.atomic_replace`` now copies onto a sibling temp on the
+    real target's filesystem and atomically replaces there — these tests pin
+    the memory tool's reliance on that behavior so the bug doesn't regress."""
+
+    def test_write_succeeds_when_first_replace_raises_exdev(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+
+        real_replace = os.replace
+        state = {"raised": False}
+
+        def _replace(src, dst):
+            if not state["raised"]:
+                state["raised"] = True
+                raise OSError(errno.EXDEV, "Invalid cross-device link", src)
+            return real_replace(src, dst)
+
+        monkeypatch.setattr("utils.os.replace", _replace)
+
+        store = MemoryStore()
+        store.load_from_disk()
+        store.add("memory", "fact persisted across cross-device move")
+
+        # Reload from disk to confirm content was actually persisted, not just
+        # held in memory.
+        reloaded = MemoryStore()
+        reloaded.load_from_disk()
+        assert "fact persisted across cross-device move" in reloaded.memory_entries
+
+        # Cross-device fallback should not leave behind sibling temps in the
+        # memories dir.
+        leftovers = sorted(
+            p.name for p in tmp_path.iterdir() if p.name.startswith(".atomic_xdev_")
+        )
+        assert leftovers == [], f"unexpected sibling temps: {leftovers}"
+
+        # Original `.mem_*.tmp` should also be cleaned up (the fallback unlinks
+        # it after copying onto the sibling).
+        mem_temps = sorted(
+            p.name for p in tmp_path.iterdir() if p.name.startswith(".mem_")
+        )
+        assert mem_temps == [], f"original mem temp not cleaned up: {mem_temps}"

--- a/utils.py
+++ b/utils.py
@@ -1,8 +1,10 @@
 """Shared utility functions for hermes-agent."""
 
+import errno
 import json
 import logging
 import os
+import shutil
 import stat
 import tempfile
 from pathlib import Path
@@ -73,12 +75,45 @@ def atomic_replace(tmp_path: Union[str, Path], target: Union[str, Path]) -> str:
     and non-existent paths the behavior is identical to a plain
     ``os.replace`` call.
 
+    When ``tmp_path`` and the resolved real target sit on different
+    filesystems (Docker bind mounts, NAS volumes, custom vault mounts —
+    common when ``~/.hermes`` is a symlink to a managed location), the
+    initial ``os.replace`` raises ``OSError`` with ``errno == EXDEV``.
+    In that case the helper falls back to copying the temp content onto
+    a sibling temp file in the real target's directory and atomically
+    replacing within that filesystem, so the swap remains atomic on the
+    target side even though the original move crossed devices
+    (GitHub #17313).
+
     Returns the resolved real path used for the replace, so callers that
     need to re-apply permissions can target it instead of the symlink.
     """
     target_str = str(target)
     real_path = os.path.realpath(target_str) if os.path.islink(target_str) else target_str
-    os.replace(str(tmp_path), real_path)
+    tmp_str = str(tmp_path)
+    try:
+        os.replace(tmp_str, real_path)
+    except OSError as exc:
+        if exc.errno != errno.EXDEV:
+            raise
+        real_dir = os.path.dirname(real_path) or "."
+        sibling_fd, sibling_tmp = tempfile.mkstemp(
+            dir=real_dir, prefix=".atomic_xdev_", suffix=".tmp"
+        )
+        try:
+            os.close(sibling_fd)
+            shutil.copyfile(tmp_str, sibling_tmp)
+            os.replace(sibling_tmp, real_path)
+        except BaseException:
+            try:
+                os.unlink(sibling_tmp)
+            except OSError:
+                pass
+            raise
+        try:
+            os.unlink(tmp_str)
+        except OSError:
+            pass
     return real_path
 
 

--- a/utils.py
+++ b/utils.py
@@ -85,6 +85,16 @@ def atomic_replace(tmp_path: Union[str, Path], target: Union[str, Path]) -> str:
     target side even though the original move crossed devices
     (GitHub #17313).
 
+    The fallback path also ``fsync``s the sibling temp file before the
+    swap and ``fsync``s the destination directory after, matching the
+    durability guarantees that ``atomic_json_write`` / ``atomic_yaml_write``
+    / ``MemoryStore._write_file`` already provide on the non-EXDEV path
+    (those callers ``fsync`` their original temp file before calling
+    here, but ``shutil.copyfile`` to the sibling skips that — without
+    re-syncing, a crash in the cross-device window could leave the
+    destination with a copied-but-unflushed file even though the
+    pre-fallback durability promise was satisfied).
+
     Returns the resolved real path used for the replace, so callers that
     need to re-apply permissions can target it instead of the symlink.
     """
@@ -103,6 +113,14 @@ def atomic_replace(tmp_path: Union[str, Path], target: Union[str, Path]) -> str:
         try:
             os.close(sibling_fd)
             shutil.copyfile(tmp_str, sibling_tmp)
+            # fsync the copied temp before swap so the cross-device
+            # fallback preserves the durability the caller already paid
+            # for on the original temp.
+            sync_fd = os.open(sibling_tmp, os.O_RDONLY)
+            try:
+                os.fsync(sync_fd)
+            finally:
+                os.close(sync_fd)
             os.replace(sibling_tmp, real_path)
         except BaseException:
             try:
@@ -110,6 +128,20 @@ def atomic_replace(tmp_path: Union[str, Path], target: Union[str, Path]) -> str:
             except OSError:
                 pass
             raise
+        # fsync the destination directory so the rename itself is
+        # durable — best-effort: not all platforms / filesystems
+        # support directory fsync (Windows raises, some FUSE mounts
+        # raise EINVAL); silently ignore those.
+        try:
+            dir_fd = os.open(real_dir, os.O_RDONLY)
+            try:
+                os.fsync(dir_fd)
+            except OSError:
+                pass
+            finally:
+                os.close(dir_fd)
+        except OSError:
+            pass
         try:
             os.unlink(tmp_str)
         except OSError:


### PR DESCRIPTION
## Summary

- `atomic_replace` now falls back to a sibling-temp + same-fs replace when `os.replace` raises `OSError(EXDEV)`, so symlink-following writes survive when the resolved real path is on a different filesystem than the caller's temp.
- Fixes the memory tool's `[Errno 18] Invalid cross-device link` failure on Docker / NAS / managed-vault setups (#17313). Same fix transparently covers every other call site already routed through `atomic_replace` — `tools/skill_manager_tool.py`, `tools/skills_sync.py`, `utils.atomic_json_write`, and `utils.atomic_yaml_write`.

## The bug

`utils.atomic_replace` was introduced in #16743 to keep symlinked deployment files (e.g. `~/.hermes/config.yaml` → a profile package) intact across atomic writes. It calls `os.path.realpath(target)` and then `os.replace(tmp, real_path)`.

When the symlink crosses a filesystem boundary — common in #17313's setup, where `~/.hermes/memories/MEMORY.md` is symlinked into `/opt/hermes-vault/hermes-memory/` on a separate mount — the temp file lives on one device while the real file lives on another. `os.replace` cannot move inodes between filesystems, so it raises `OSError(EXDEV)`:

```
Failed to write memory file /root/.hermes/memories/MEMORY.md:
  [Errno 18] Invalid cross-device link:
  /root/.hermes/memories/.mem_wre8n6ee.tmp -> /opt/hermes-vault/hermes-memory/MEMORY.md
```

Every call site that reaches `atomic_replace` through a symlink to a different mount hits the same path: memory writes, skill manager edits, JSON/YAML config writes.

## The fix

Catch `OSError(errno=EXDEV)` from the inner `os.replace` and:

1. `tempfile.mkstemp` a sibling temp in the **real** target's directory (same filesystem as the destination).
2. `shutil.copyfile` the original temp's content onto the sibling.
3. `os.replace(sibling_tmp, real_path)` — now within a single filesystem, so the swap is atomic from any reader's perspective.
4. `os.unlink` the original cross-device temp.

If the inner `os.replace` itself fails, the sibling temp is cleaned up before re-raising, so we don't leak `.atomic_xdev_*.tmp` files into the user's vault.

Same-filesystem writes hit the original fast path unchanged. Only `EXDEV` triggers the fallback — every other `OSError` propagates exactly as before, preserving existing error-handling tests in `tests/gateway/test_weixin.py` (which monkeypatch `utils.os.replace` to raise non-EXDEV errors).

## Contract Protected

`atomic_replace(tmp, target)` invariant: writes the contents of `tmp` to the real file behind `target`, atomically from a reader's perspective, regardless of which filesystem `tmp` was created on.

| Input scenario                         | Pre-fix behavior                  | Post-fix behavior                     |
|----------------------------------------|-----------------------------------|---------------------------------------|
| Same-fs, regular file                  | Atomic `os.replace`               | Atomic `os.replace` (unchanged)       |
| Same-fs, symlinked target              | Atomic `os.replace` on real path  | Atomic `os.replace` on real path (unchanged) |
| **Cross-fs, symlinked target**         | **`OSError(EXDEV)` propagates**   | **Atomic replace via sibling temp**   |
| Inner replace fails (e.g. `EACCES`)    | n/a (only triggered by fallback)  | Sibling temp unlinked, original error re-raised |
| `OSError != EXDEV` from `os.replace`   | Propagates                        | Propagates (unchanged)                |

## Test plan

- [x] `tests/test_atomic_replace_symlinks.py` — 4 new cases on the helper:
  - `test_atomic_replace_recovers_from_exdev` — reporter's exact error path
  - `test_atomic_replace_exdev_with_symlink_preserves_link` — symlink + cross-fs, link survives
  - `test_atomic_replace_propagates_non_exdev_oserror` — non-EXDEV `OSError` still raises
  - `test_atomic_replace_exdev_cleans_sibling_on_replace_failure` — no leftover `.atomic_xdev_*` on inner-replace failure
- [x] `tests/tools/test_memory_tool.py::TestMemoryToolCrossDeviceWrite` — integration: `MemoryStore.add` round-trips through disk when the first `os.replace` raises `EXDEV`, with no leftover `.mem_*.tmp` or `.atomic_xdev_*.tmp` in the memories dir.
- [x] Adjacent suites confirmed clean: `test_atomic_replace_symlinks.py` (16 tests, all pass), `tests/tools/test_memory_tool.py` (30 tests), `tests/hermes_cli/test_config.py` (52 tests, exercises `atomic_yaml_write`), `tests/gateway/test_weixin.py` (42 tests, mocks `utils.os.replace` with non-EXDEV errors).
- [x] **Regression guard**: 4 of the 5 new tests fail on clean `origin/main` (`58a6171bf`) with the reporter's exact error: `RuntimeError: Failed to write memory file …: [Errno 18] Invalid cross-device link`. The fifth (non-EXDEV propagation) passes on baseline because that path was already correct.

## Related

- Fixes #17313
- Builds on #16743 (introduced `atomic_replace` symlink-following) — that PR made the helper symlink-aware but didn't account for the symlink resolving to a different filesystem.
- No active competing PR. No prior closed PR by me on `atomic_replace` / EXDEV / memory-tool atomic-write paths.