### PR TITLE
docs(run_agent): note xiaomi/MiMo empirical exclusion from reasoning whitelist (#17314)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -8271,6 +8271,20 @@ class AIAgent:
         OpenRouter forwards unknown extra_body fields to upstream providers.
         Some providers/routes reject `reasoning` with 400s, so gate it to
         known reasoning-capable model families and direct Nous Portal.
+
+        Empirically excluded providers (do NOT add to the whitelist without
+        re-testing server-side behavior):
+
+        * **xiaomi / MiMo (`mimo-v2.5-pro`):** the schema accepts
+          ``reasoning_effort`` at validation (rejects ``xhigh`` with
+          ``Input should be 'low', 'medium' or 'high'``), but the four
+          documented levels (``none``/``low``/``medium``/``high``) produce
+          statistically indistinguishable reasoning depth and accuracy on
+          AIME-class problems (4 efforts × N=5 on AIME 2025 II P2,
+          all Mann-Whitney U pairwise p > 0.1, 100% accuracy across all
+          20 trials; tested 2026-04-29 — see #17314 for the full
+          characterization). Forwarding the field to MiMo would just ship
+          a no-op, so the conservative default is correct here.
         """
         if base_url_host_matches(self._base_url_lower, "nousresearch.com"):
             return True


### PR DESCRIPTION
Closes #17314 (the suggested follow-up #1 — inline doc).

## Summary

#17314 empirically established that xiaomi/MiMo (`mimo-v2.5-pro`) accepts `reasoning_effort` at the schema layer but produces **statistically indistinguishable** reasoning depth, length, and accuracy across `none` / `low` / `medium` / `high` (4 efforts × N=5 on AIME 2025 II P2; Mann-Whitney U pairwise p > 0.1 on every pair; 100% accuracy on all 20 trials; identical solution paths in inspected `reasoning_content`).

The conservative default in `_supports_reasoning_extra_body()` — *not* whitelisting xiaomi — is therefore correct. Forwarding the field would just ship a no-op.

This PR adds a docstring note documenting the empirical test so a future PR doesn't "complete the list" by adding xiaomi without first re-verifying server-side behavior.

## Changes
- `run_agent.py`: extended `_supports_reasoning_extra_body()` docstring with an "Empirically excluded providers" section noting the xiaomi/MiMo result, the test methodology, and the link back to #17314.
- No code-path changes. No behavior changes. AST-parses clean.

## Not included (intentional)
The issue's optional follow-up #2 — surfacing a startup warning when `agent.reasoning_effort` is set in `config.yaml` for a provider that won't forward it — is broader-scope (touches every excluded provider, not just xiaomi) and is left as a separate optional follow-up so this PR stays a minimal, mergeable doc-only change.

## Tests
- `python3 -c "import ast; ast.parse(open('run_agent.py').read())"` clean.
- Docs-only change; no functional test surface.