### PR TITLE
fix(telegram): stop large videos from triggering infinite model fallback (#17302)

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2699,9 +2699,21 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         if not self._should_process_message(update.message):
             return
-        
+
         msg = update.message
-        
+
+        # Optional: skip videos entirely when the operator opts in. Telegram
+        # Bot API caps `getFile` downloads at 20 MB, so video handling is
+        # routinely impractical in groups; this gate lets a deployment turn
+        # video processing off without code changes (closes #17302 follow-up).
+        if self.config.extra.get("ignore_videos", False):
+            doc_mime = (msg.document.mime_type or "") if msg.document else ""
+            if msg.video or (msg.document and doc_mime.startswith("video/")):
+                logger.info(
+                    "[Telegram] Ignoring video message (ignore_videos=true)"
+                )
+                return
+
         # Determine media type
         if msg.sticker:
             msg_type = MessageType.STICKER
@@ -2785,6 +2797,23 @@ class TelegramAdapter(BasePlatformAdapter):
                 logger.warning("[Telegram] Failed to cache audio: %s", e, exc_info=True)
 
         elif msg.video:
+            # Telegram Bot API caps file downloads at 20 MB; bail early with a
+            # user-visible message instead of a blank event so the agent
+            # doesn't churn the model-fallback chain (#17302).
+            MAX_VIDEO_BYTES = 20 * 1024 * 1024
+            video_size = getattr(msg.video, "file_size", None)
+            if not video_size or video_size > MAX_VIDEO_BYTES:
+                event.text = (
+                    "⚠️ This video can't be processed: Telegram's Bot API "
+                    "limits file downloads to 20 MB. Please send a shorter "
+                    "clip or upload it elsewhere and share the link."
+                )
+                logger.info(
+                    "[Telegram] Video too large or unverifiable: %s bytes",
+                    video_size,
+                )
+                await self.handle_message(event)
+                return
             try:
                 file_obj = await msg.video.get_file()
                 video_bytes = await file_obj.download_as_bytearray()
@@ -2799,7 +2828,22 @@ class TelegramAdapter(BasePlatformAdapter):
                 event.media_types = [SUPPORTED_VIDEO_TYPES.get(ext, "video/mp4")]
                 logger.info("[Telegram] Cached user video at %s", cached_path)
             except Exception as e:
-                logger.warning("[Telegram] Failed to cache video: %s", e, exc_info=True)
+                # Detect the post-API-version-bump "File is too big" error that
+                # Telegram raises even when file_size looked OK at message time
+                # (e.g. forwarded videos). Surface a friendly text instead of
+                # forwarding an empty event to the agent (#17302).
+                if "File is too big" in str(e):
+                    event.text = (
+                        "⚠️ This video exceeds Telegram's 20 MB Bot API "
+                        "download limit and can't be processed."
+                    )
+                    logger.info(
+                        "[Telegram] Telegram refused video download (too big): %s", e
+                    )
+                else:
+                    logger.warning(
+                        "[Telegram] Failed to cache video: %s", e, exc_info=True
+                    )
 
         # Download document files to cache for agent processing
         elif msg.document:
@@ -2822,6 +2866,25 @@ class TelegramAdapter(BasePlatformAdapter):
                     ext = video_mime_to_ext.get(doc.mime_type, "")
 
                 if ext in SUPPORTED_VIDEO_TYPES:
+                    # Same 20 MB Bot API cap as inline videos (#17302). Without
+                    # this check, get_file() raises BadRequest("File is too
+                    # big"), control falls through to handle_message() with a
+                    # blank event, and the agent burns through every fallback
+                    # model trying to respond to nothing.
+                    MAX_VIDEO_DOC_BYTES = 20 * 1024 * 1024
+                    if not doc.file_size or doc.file_size > MAX_VIDEO_DOC_BYTES:
+                        event.text = (
+                            "⚠️ This video document is too large for the "
+                            "Telegram Bot API (20 MB limit). Please share a "
+                            "shorter clip or a link."
+                        )
+                        event.message_type = MessageType.VIDEO
+                        logger.info(
+                            "[Telegram] Video document too large: %s bytes",
+                            doc.file_size,
+                        )
+                        await self.handle_message(event)
+                        return
                     file_obj = await doc.get_file()
                     video_bytes = await file_obj.download_as_bytearray()
                     cached_path = cache_video_from_bytes(bytes(video_bytes), ext=ext)
@@ -2883,7 +2946,22 @@ class TelegramAdapter(BasePlatformAdapter):
                         )
 
             except Exception as e:
-                logger.warning("[Telegram] Failed to cache document: %s", e, exc_info=True)
+                # Telegram's API can refuse downloads after the fact with
+                # "File is too big" even when file_size looked acceptable
+                # (forwards, edited messages, etc.). Don't fall through to
+                # handle_message() with a blank event — that's what triggers
+                # the model-fallback storm in #17302.
+                if "File is too big" in str(e):
+                    event.text = (
+                        "⚠️ This file exceeds Telegram's 20 MB Bot API "
+                        "download limit and can't be processed."
+                    )
+                    logger.info(
+                        "[Telegram] Telegram refused document download (too big): %s",
+                        e,
+                    )
+                else:
+                    logger.warning("[Telegram] Failed to cache document: %s", e, exc_info=True)
 
         media_group_id = getattr(msg, "media_group_id", None)
         if media_group_id:

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -118,9 +118,10 @@ def _make_update(msg):
     return update
 
 
-def _make_video(file_obj=None):
+def _make_video(file_obj=None, file_size=1024):
     video = MagicMock()
     video.get_file = AsyncMock(return_value=file_obj or _make_file_obj(b"video-bytes"))
+    video.file_size = file_size
     return video
 
 
@@ -387,6 +388,124 @@ class TestVideoDownloadBlock:
         assert len(event.media_urls) == 1
         assert os.path.exists(event.media_urls[0])
         assert event.media_types == [SUPPORTED_VIDEO_TYPES[".mp4"]]
+
+    # ----- #17302 regression: large videos must not silently fall through -----
+
+    @pytest.mark.asyncio
+    async def test_oversize_native_video_short_circuits_with_friendly_text(self, adapter):
+        """Native videos > 20 MB must reach handle_message() with a user-visible
+        text, not an empty event that triggers the model fallback storm (#17302)."""
+        msg = _make_message()
+        # 25 MB — over the 20 MB Bot API cap.
+        msg.video = _make_video(file_size=25 * 1024 * 1024)
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+        event = adapter.handle_message.call_args[0][0]
+        assert event.text and "20 MB" in event.text
+        assert not event.media_urls  # nothing was downloaded
+        # Crucially: get_file() was never called — the early gate caught it.
+        msg.video.get_file.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unverifiable_native_video_size_short_circuits(self, adapter):
+        """file_size=None must be treated like 'too large' (security parity with documents)."""
+        msg = _make_message()
+        msg.video = _make_video(file_size=None)
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+        event = adapter.handle_message.call_args[0][0]
+        assert event.text and "20 MB" in event.text
+        msg.video.get_file.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_oversize_video_document_short_circuits(self, adapter):
+        """Video sent as a document and > 20 MB must also short-circuit (#17302)."""
+        doc = _make_document(
+            file_name="huge.mp4",
+            mime_type="video/mp4",
+            file_size=25 * 1024 * 1024,
+        )
+        msg = _make_message(document=doc)
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.VIDEO
+        assert event.text and "20 MB" in event.text
+        # get_file() must NOT be called — that's what threw BadRequest in #17302.
+        doc.get_file.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_native_video_get_file_too_big_does_not_send_blank_event(self, adapter):
+        """Even when file_size lies (forwarded videos), if Telegram raises
+        'File is too big' inside get_file(), the event must carry a friendly
+        text — NOT a blank one that triggers infinite model fallback (#17302)."""
+        # Pretend file_size is fine (5 MB), but get_file() blows up.
+        from telegram.error import BadRequest  # type: ignore[attr-defined]
+        boom = AsyncMock(side_effect=Exception("BadRequest: File is too big"))
+        video = MagicMock()
+        video.file_size = 5 * 1024 * 1024
+        video.get_file = boom
+        msg = _make_message()
+        msg.video = video
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+        event = adapter.handle_message.call_args[0][0]
+        assert event.text and "20 MB" in event.text
+        assert not event.media_urls
+
+    @pytest.mark.asyncio
+    async def test_video_document_get_file_too_big_does_not_send_blank_event(self, adapter):
+        """Same as above but for videos sent as documents."""
+        # file_size lies; get_file() raises File is too big.
+        doc = MagicMock()
+        doc.file_name = "forwarded.mp4"
+        doc.mime_type = "video/mp4"
+        doc.file_size = 5 * 1024 * 1024  # Looks fine.
+        doc.get_file = AsyncMock(side_effect=Exception("BadRequest: File is too big"))
+        msg = _make_message(document=doc)
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+        event = adapter.handle_message.call_args[0][0]
+        assert event.text and "20 MB" in event.text
+        assert not event.media_urls
+
+    @pytest.mark.asyncio
+    async def test_ignore_videos_config_skips_native_video(self, adapter):
+        """With telegram.extra.ignore_videos=true, video messages are dropped (#17302)."""
+        adapter.config.extra["ignore_videos"] = True
+        msg = _make_message()
+        msg.video = _make_video(file_size=1024)
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+        adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_ignore_videos_config_skips_video_documents(self, adapter):
+        """With telegram.extra.ignore_videos=true, video-as-document is also dropped."""
+        adapter.config.extra["ignore_videos"] = True
+        doc = _make_document(file_name="clip.mp4", mime_type="video/mp4", file_size=1024)
+        msg = _make_message(document=doc)
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+        adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_ignore_videos_does_not_block_pdfs(self, adapter):
+        """ignore_videos must NOT touch non-video media."""
+        adapter.config.extra["ignore_videos"] = True
+        doc = _make_document(file_name="report.pdf", file_size=1024)
+        msg = _make_message(document=doc)
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+        adapter.handle_message.assert_called_once()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #17302.

## Summary

When a Telegram video > 20 MB hits the bot, `getFile()` raises `BadRequest("File is too big")`. The current handler catches the exception, logs a warning, and **falls through to `handle_message(event)` with an effectively empty event** — the agent then burns through every fallback model (15+ retries in the reporter's logs) trying to respond to nothing.

This PR fixes it with three layered defenses, mirroring the size-check pattern that the non-video document branch already uses:

### 1. Pre-check `file_size` before downloading
Both the native `msg.video` branch and the video-as-document branch now verify `file_size <= 20 MB` *before* calling `get_file()`. Oversize / unverifiable videos short-circuit with a user-visible message ("Telegram's Bot API limits file downloads to 20 MB…") and `message_type=VIDEO`. The agent gets a meaningful event instead of a blank one.

### 2. Trap "File is too big" inside the `except` block
For forwarded-video / edited-message edge cases where `file_size` lies, the BadRequest is now caught at runtime and `event.text` is set to an explanatory message instead of being left blank. This is the surgical fix that prevents the fallback storm even when the pre-check is bypassed.

### 3. Optional opt-out: `telegram.extra.ignore_videos: true`
When set, video messages (native and `video/*` MIME documents) are dropped at the top of `_handle_media_message`, before any work is done. Other media (PDFs, photos, voice, audio) is unaffected.

## Why not the issue's exact diff
The issue's proposed diff calls `self._send_safe_message(...)` which doesn't exist in this codebase (only `self._bot.send_message(...)` does). I kept the spirit of the suggestion — the friendly text message — but routed it through the existing `event.text` + `handle_message()` path that the document handler already uses for "Unsupported document type" and "too large or unverifiable", so the fix is consistent with the surrounding code rather than introducing a new send pattern.

## Tests
Added 8 new tests in `tests/gateway/test_telegram_documents.py::TestVideoDownloadBlock`:

- `test_oversize_native_video_short_circuits_with_friendly_text`
- `test_unverifiable_native_video_size_short_circuits` (parity with the existing document `file_size=None` security fix)
- `test_oversize_video_document_short_circuits`
- `test_native_video_get_file_too_big_does_not_send_blank_event`
- `test_video_document_get_file_too_big_does_not_send_blank_event`
- `test_ignore_videos_config_skips_native_video`
- `test_ignore_videos_config_skips_video_documents`
- `test_ignore_videos_does_not_block_pdfs`

The existing `_make_video()` helper now defaults `file_size=1024` so the prior happy-path test still passes through the new gate.

```
$ python -m pytest tests/gateway/test_telegram_documents.py -q
............................................                          [100%]
44 passed in 3.50s
```

`python3 -c "import ast; ast.parse(open('gateway/platforms/telegram.py').read())"` clean.

## Out of scope
The reporter's `_send_safe_message` reply-via-Telegram pattern is more invasive than needed; the agent-event path is sufficient and consistent with how the document handler already communicates blocked uploads. Happy to add a direct reply if maintainers prefer it.