### PR TITLE
Add project-local skill discovery

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -669,10 +669,15 @@ def build_skills_system_prompt(
     are read-only — they appear in the index but new skills are always created
     in the local dir.  Local skills take precedence when names collide.
     """
-    skills_dir = get_skills_dir()
-    external_dirs = get_all_skills_dirs()[1:]  # skip local (index 0)
+    # Skill roots are ordered by lookup precedence: project-local (if any),
+    # global ~/.hermes/skills, then configured external dirs.  Snapshot only
+    # the first/root-most directory to preserve the existing single-snapshot
+    # format; remaining roots are scanned directly with duplicate suppression.
+    all_skill_dirs = get_all_skills_dirs()
+    skills_dir = all_skill_dirs[0] if all_skill_dirs else get_skills_dir()
+    external_dirs = all_skill_dirs[1:]
 
-    if not skills_dir.exists() and not external_dirs:
+    if not skills_dir.exists() and not any(d.exists() for d in external_dirs):
         return ""
 
     # ── Layer 1: in-process LRU cache ─────────────────────────────────

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -8,6 +8,7 @@ tool registration or provider resolution.
 import logging
 import os
 import re
+import subprocess
 import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
@@ -168,7 +169,76 @@ def _normalize_string_set(values) -> Set[str]:
     return {str(v).strip() for v in values if str(v).strip()}
 
 
-# ── External skills directories ──────────────────────────────────────────
+# ── Skill directory discovery ────────────────────────────────────────────
+
+
+def _resolve_cwd(cwd: Optional[os.PathLike | str] = None) -> Path:
+    """Return the session working directory used for project-local discovery."""
+    raw_cwd = (
+        cwd
+        or os.getenv("TERMINAL_CWD")
+        or os.getenv("HERMES_CWD")
+        or os.getcwd()
+    )
+    return Path(raw_cwd).expanduser().resolve()
+
+
+def _find_project_root(cwd: Optional[os.PathLike | str] = None) -> Path:
+    """Find the nearest git root for cwd, falling back to cwd/parents."""
+    cwd_path = _resolve_cwd(cwd)
+    try:
+        proc = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=str(cwd_path),
+            text=True,
+            capture_output=True,
+            timeout=2,
+            check=False,
+        )
+        if proc.returncode == 0 and proc.stdout.strip():
+            return Path(proc.stdout.strip()).resolve()
+    except Exception:
+        pass
+
+    for candidate in (cwd_path, *cwd_path.parents):
+        if (candidate / ".git").exists():
+            return candidate
+    return cwd_path
+
+
+def get_project_skills_dirs(cwd: Optional[os.PathLike | str] = None) -> List[Path]:
+    """Return project-local skill directories for the current project.
+
+    Discovery is based on the current session working directory (``TERMINAL_CWD``
+    first, then ``HERMES_CWD``, then ``os.getcwd()``) or an explicit ``cwd``.
+    A git root is used when available.  Existing directories are returned in
+    precedence order before global/external skills:
+
+    1. ``<project-root>/.hermes/skills``
+    2. ``<project-root>/.ai/skills``
+    """
+    root = _find_project_root(cwd)
+    global_skills = get_skills_dir().resolve()
+    candidates = [root / ".hermes" / "skills", root / ".ai" / "skills"]
+    result: List[Path] = []
+    seen: Set[Path] = set()
+    for candidate in candidates:
+        path = candidate.resolve()
+        if path == global_skills or path in seen or not path.is_dir():
+            continue
+        seen.add(path)
+        result.append(path)
+    return result
+
+
+def get_project_skills_base_dir(cwd: Optional[os.PathLike | str] = None) -> Path:
+    """Return the default writable project-local skills root for the CWD.
+
+    The directory may not exist yet; callers that create project-local skills can
+    create it on demand.  Discovery still uses :func:`get_project_skills_dirs`
+    so empty/non-existent project skill roots do not pollute listings.
+    """
+    return (_find_project_root(cwd) / ".hermes" / "skills").resolve()
 
 
 def get_external_skills_dirs() -> List[Path]:
@@ -232,14 +302,22 @@ def get_external_skills_dirs() -> List[Path]:
     return result
 
 
-def get_all_skills_dirs() -> List[Path]:
-    """Return all skill directories: local ``~/.hermes/skills/`` first, then external.
+def get_all_skills_dirs(cwd: Optional[os.PathLike | str] = None) -> List[Path]:
+    """Return skill roots in precedence order: project-local, global, external.
 
-    The local dir is always first (and always included even if it doesn't exist
-    yet — callers handle that).  External dirs follow in config order.
+    Project-local directories are discovered dynamically from the session CWD so
+    switching projects changes the visible skills without editing global config.
+    The global ``~/.hermes/skills`` dir is always included; external dirs follow
+    in config order.  Duplicates are removed after resolving symlinks.
     """
-    dirs = [get_skills_dir()]
-    dirs.extend(get_external_skills_dirs())
+    dirs: List[Path] = []
+    seen: Set[Path] = set()
+    for skills_dir in [*get_project_skills_dirs(cwd), get_skills_dir(), *get_external_skills_dirs()]:
+        resolved = skills_dir.resolve()
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        dirs.append(skills_dir)
     return dirs
 
 

--- a/tests/agent/test_external_skills.py
+++ b/tests/agent/test_external_skills.py
@@ -1,6 +1,7 @@
 """Tests for external skill directories (skills.external_dirs config)."""
 
 import json
+import logging
 import os
 from pathlib import Path
 from unittest.mock import patch
@@ -104,6 +105,26 @@ class TestGetAllSkillsDirs:
         assert result[1] == external_skills_dir.resolve()
 
 
+
+
+class TestProjectLocalSkillsDirs:
+    def test_project_skills_precede_global_and_external(self, hermes_home, external_skills_dir, tmp_path):
+        project = tmp_path / "project"
+        project_skills = project / ".hermes" / "skills"
+        project_skills.mkdir(parents=True)
+        (project / ".git").mkdir()
+        (hermes_home / "config.yaml").write_text(
+            f"skills:\n  external_dirs:\n    - {external_skills_dir}\n"
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
+            from agent.skill_utils import get_all_skills_dirs, get_project_skills_dirs
+
+            assert get_project_skills_dirs(cwd=project / "subdir") == [project_skills.resolve()]
+            result = get_all_skills_dirs(cwd=project / "subdir")
+
+        assert result == [project_skills.resolve(), hermes_home / "skills", external_skills_dir.resolve()]
+
 class TestExternalSkillsInFindAll:
     def test_external_skills_found(self, hermes_home, external_skills_dir):
         (hermes_home / "config.yaml").write_text(
@@ -140,6 +161,36 @@ class TestExternalSkillsInFindAll:
         assert len(matching) == 1
         assert matching[0]["description"] == "Local version"
 
+    def test_project_local_takes_precedence_over_global_and_external(self, hermes_home, external_skills_dir, tmp_path):
+        project = tmp_path / "project"
+        project_skills = project / ".hermes" / "skills"
+        project_skill = project_skills / "project-skill"
+        project_skill.mkdir(parents=True)
+        (project / ".git").mkdir()
+        (project_skill / "SKILL.md").write_text(
+            "---\nname: shared-skill\ndescription: Project version\n---\n\nProject.\n"
+        )
+        local_skills = hermes_home / "skills"
+        global_skill = local_skills / "shared-skill"
+        global_skill.mkdir(parents=True)
+        (global_skill / "SKILL.md").write_text(
+            "---\nname: shared-skill\ndescription: Global version\n---\n\nGlobal.\n"
+        )
+        (hermes_home / "config.yaml").write_text(
+            f"skills:\n  external_dirs:\n    - {external_skills_dir}\n"
+        )
+
+        with (
+            patch.dict(os.environ, {"HERMES_HOME": str(hermes_home), "TERMINAL_CWD": str(project)}),
+            patch("tools.skills_tool.SKILLS_DIR", local_skills),
+        ):
+            from tools.skills_tool import _find_all_skills
+            skills = _find_all_skills()
+
+        matching = [s for s in skills if s["name"] == "shared-skill"]
+        assert len(matching) == 1
+        assert matching[0]["description"] == "Project version"
+
 
 class TestExternalSkillView:
     def test_skill_view_finds_external(self, hermes_home, external_skills_dir):
@@ -155,3 +206,26 @@ class TestExternalSkillView:
             result = json.loads(skill_view("my-external-skill"))
         assert result["success"] is True
         assert "external things" in result["content"]
+
+    def test_skill_view_finds_project_local_before_global(self, hermes_home, tmp_path, caplog):
+        project = tmp_path / "project"
+        project_skills = project / ".hermes" / "skills"
+        project_skill = project_skills / "project-only"
+        project_skill.mkdir(parents=True)
+        (project / ".git").mkdir()
+        (project_skill / "SKILL.md").write_text(
+            "---\nname: project-only\ndescription: Project-only skill\n---\n\nProject local content.\n"
+        )
+
+        caplog.set_level(logging.WARNING, logger="tools.skills_tool")
+        with (
+            patch.dict(os.environ, {"HERMES_HOME": str(hermes_home), "TERMINAL_CWD": str(project)}),
+            patch("tools.skills_tool.SKILLS_DIR", hermes_home / "skills"),
+        ):
+            from tools.skills_tool import skill_view
+            result = json.loads(skill_view("project-only"))
+
+        assert result["success"] is True
+        assert "Project local content" in result["content"]
+        assert "outside the trusted skills directory" not in caplog.text
+

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -428,6 +428,29 @@ class TestBuildSkillsSystemPrompt:
         result = build_skills_system_prompt()
         assert "backend-skill" in result
 
+    def test_project_local_skills_precede_global_in_prompt(self, monkeypatch, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        project = tmp_path / "project"
+        project_skill = project / ".hermes" / "skills" / "shared-skill"
+        global_skill = hermes_home / "skills" / "shared-skill"
+        project_skill.mkdir(parents=True)
+        global_skill.mkdir(parents=True)
+        (project / ".git").mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("TERMINAL_CWD", str(project))
+        (project_skill / "SKILL.md").write_text(
+            "---\nname: shared-skill\ndescription: Project prompt version\n---\n"
+        )
+        (global_skill / "SKILL.md").write_text(
+            "---\nname: shared-skill\ndescription: Global prompt version\n---\n"
+        )
+
+        result = build_skills_system_prompt()
+
+        assert "shared-skill" in result
+        assert "Project prompt version" in result
+        assert "Global prompt version" not in result
+
 
 class TestBuildNousSubscriptionPrompt:
     def test_includes_active_subscription_features(self, monkeypatch):

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -196,6 +196,46 @@ class TestCreateSkill:
         assert result["success"] is True
         assert (tmp_path / "my-skill" / "SKILL.md").exists()
 
+    def test_create_with_project_scope_writes_to_project_skills(self, monkeypatch, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        global_skills = hermes_home / "skills"
+        global_skills.mkdir(parents=True)
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / ".git").mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("TERMINAL_CWD", str(project))
+
+        with patch("tools.skill_manager_tool.SKILLS_DIR", global_skills):
+            result = _create_skill("my-skill", VALID_SKILL_CONTENT, scope="project")
+
+        assert result["success"] is True
+        assert result["scope"] == "project"
+        assert (project / ".hermes" / "skills" / "my-skill" / "SKILL.md").exists()
+        assert not (global_skills / "my-skill" / "SKILL.md").exists()
+
+    def test_patch_project_local_skill_is_writable(self, monkeypatch, tmp_path):
+        hermes_home = tmp_path / "hermes-home"
+        global_skills = hermes_home / "skills"
+        global_skills.mkdir(parents=True)
+        project = tmp_path / "project"
+        project_skill = project / ".hermes" / "skills" / "my-skill"
+        project_skill.mkdir(parents=True)
+        (project / ".git").mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("TERMINAL_CWD", str(project))
+        (project_skill / "SKILL.md").write_text(VALID_SKILL_CONTENT)
+
+        with patch("tools.skill_manager_tool.SKILLS_DIR", global_skills):
+            result = _patch_skill(
+                "my-skill",
+                old_string="Step 1: Do the thing.",
+                new_string="Step 1: Do the project thing.",
+            )
+
+        assert result["success"] is True
+        assert "Do the project thing" in (project_skill / "SKILL.md").read_text()
+
     def test_create_with_category(self, tmp_path):
         with _skill_dir(tmp_path):
             result = _create_skill("my-skill", VALID_SKILL_CONTENT, category="devops")

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -40,7 +40,7 @@ import shutil
 import tempfile
 from pathlib import Path
 from hermes_constants import get_hermes_home, display_hermes_home
-from typing import Dict, Any, Optional, Tuple
+from typing import Dict, Any, List, Optional, Tuple
 
 from utils import atomic_replace
 from hermes_cli.config import cfg_get
@@ -101,7 +101,7 @@ def _security_scan_skill(skill_dir: Path) -> Optional[str]:
 import yaml
 
 
-# All skills live in ~/.hermes/skills/ (single source of truth)
+# Default global skills directory. Project-local roots are discovered dynamically.
 HERMES_HOME = get_hermes_home()
 SKILLS_DIR = HERMES_HOME / "skills"
 
@@ -110,10 +110,11 @@ MAX_DESCRIPTION_LENGTH = 1024
 
 
 def _containing_skills_root(skill_path: Path) -> Path:
-    """Return the skills root directory (local or external_dirs entry) that
-    contains ``skill_path``.  Falls back to the local ``SKILLS_DIR`` if no
-    match is found (defensive — callers should have located the skill via
-    ``_find_skill`` first).
+    """Return the skills root directory that contains ``skill_path``.
+
+    This includes the global skills directory, project-local skill roots, and
+    configured external_dirs as returned by ``get_all_skills_dirs()``.  It falls
+    back to the global ``SKILLS_DIR`` defensively when no root matches.
     """
     from agent.skill_utils import get_all_skills_dirs
 
@@ -156,7 +157,6 @@ def _pinned_guard(name: str) -> Optional[str]:
     except Exception:
         logger.debug("pinned-guard lookup failed for %s", name, exc_info=True)
     return None
-
 
 MAX_SKILL_CONTENT_CHARS = 100_000   # ~36k tokens at 2.75 chars/token
 MAX_SKILL_FILE_BYTES = 1_048_576    # 1 MiB per supporting file
@@ -265,11 +265,20 @@ def _validate_content_size(content: str, label: str = "SKILL.md") -> Optional[st
     return None
 
 
-def _resolve_skill_dir(name: str, category: str = None) -> Path:
-    """Build the directory path for a new skill, optionally under a category."""
+def _resolve_skill_dir(name: str, category: str = None, scope: str = "global") -> Path:
+    """Build the directory path for a new skill under the requested scope."""
+    if scope == "global":
+        root = SKILLS_DIR
+    elif scope == "project":
+        from agent.skill_utils import get_project_skills_base_dir
+        root = get_project_skills_base_dir()
+        if root == SKILLS_DIR.resolve():
+            root = SKILLS_DIR
+    else:
+        raise ValueError("scope must be 'global' or 'project'")
     if category:
-        return SKILLS_DIR / category / name
-    return SKILLS_DIR / name
+        return root / category / name
+    return root / name
 
 
 def _find_skill(name: str) -> Optional[Dict[str, Any]]:
@@ -365,7 +374,7 @@ def _atomic_write_text(file_path: Path, content: str, encoding: str = "utf-8") -
 # Core actions
 # =============================================================================
 
-def _create_skill(name: str, content: str, category: str = None) -> Dict[str, Any]:
+def _create_skill(name: str, content: str, category: str = None, scope: str = "global") -> Dict[str, Any]:
     """Create a new user skill with SKILL.md content."""
     # Validate name
     err = _validate_name(name)
@@ -375,6 +384,9 @@ def _create_skill(name: str, content: str, category: str = None) -> Dict[str, An
     err = _validate_category(category)
     if err:
         return {"success": False, "error": err}
+
+    if scope not in {"global", "project"}:
+        return {"success": False, "error": "scope must be 'global' or 'project'."}
 
     # Validate content
     err = _validate_frontmatter(content)
@@ -394,7 +406,7 @@ def _create_skill(name: str, content: str, category: str = None) -> Dict[str, An
         }
 
     # Create the skill directory
-    skill_dir = _resolve_skill_dir(name, category)
+    skill_dir = _resolve_skill_dir(name, category, scope)
     skill_dir.mkdir(parents=True, exist_ok=True)
 
     # Write SKILL.md atomically
@@ -410,8 +422,9 @@ def _create_skill(name: str, content: str, category: str = None) -> Dict[str, An
     result = {
         "success": True,
         "message": f"Skill '{name}' created.",
-        "path": str(skill_dir.relative_to(SKILLS_DIR)),
+        "path": str(skill_dir),
         "skill_md": str(skill_md),
+        "scope": scope,
     }
     if category:
         result["category"] = category
@@ -571,9 +584,9 @@ def _delete_skill(name: str) -> Dict[str, Any]:
     skills_root = _containing_skills_root(skill_dir)
     shutil.rmtree(skill_dir)
 
-    # Clean up empty category directories (don't remove the skills root itself)
+    # Clean up empty category directories (don't remove the containing skills root itself)
     parent = skill_dir.parent
-    if parent != skills_root and parent.exists() and not any(parent.iterdir()):
+    if parent.resolve() != skills_root.resolve() and parent.exists() and not any(parent.iterdir()):
         parent.rmdir()
 
     return {
@@ -699,6 +712,7 @@ def skill_manage(
     old_string: str = None,
     new_string: str = None,
     replace_all: bool = False,
+    scope: str = "global",
 ) -> str:
     """
     Manage user-created skills. Dispatches to the appropriate action handler.
@@ -708,7 +722,7 @@ def skill_manage(
     if action == "create":
         if not content:
             return tool_error("content is required for 'create'. Provide the full SKILL.md text (frontmatter + body).", success=False)
-        result = _create_skill(name, content, category)
+        result = _create_skill(name, content, category, scope)
 
     elif action == "edit":
         if not content:
@@ -770,7 +784,7 @@ SKILL_MANAGE_SCHEMA = {
     "description": (
         "Manage skills (create, update, delete). Skills are your procedural "
         "memory — reusable approaches for recurring task types. "
-        f"New skills go to {display_hermes_home()}/skills/; existing skills can be modified wherever they live.\n\n"
+        f"New skills go to {display_hermes_home()}/skills/ by default; pass scope='project' to create under the current project's .hermes/skills/. Existing skills can be modified wherever they live.\n\n"
         "Actions: create (full SKILL.md + optional category), "
         "patch (old_string/new_string — preferred for fixes), "
         "edit (full SKILL.md rewrite — major overhauls only), "
@@ -839,6 +853,15 @@ SKILL_MANAGE_SCHEMA = {
                     "Only used with 'create'."
                 )
             },
+            "scope": {
+                "type": "string",
+                "enum": ["global", "project"],
+                "description": (
+                    "Where to create a new skill. 'global' (default) writes to "
+                    f"{display_hermes_home()}/skills/. 'project' writes to the current "
+                    "project's .hermes/skills/ directory. Only used with 'create'."
+                )
+            },
             "file_path": {
                 "type": "string",
                 "description": (
@@ -874,6 +897,7 @@ registry.register(
         file_content=args.get("file_content"),
         old_string=args.get("old_string"),
         new_string=args.get("new_string"),
-        replace_all=args.get("replace_all", False)),
+        replace_all=args.get("replace_all", False),
+        scope=args.get("scope", "global")),
     emoji="📝",
 )

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -450,12 +450,13 @@ def _get_category_from_path(skill_path: Path) -> Optional[str]:
     For paths like: ~/.hermes/skills/mlops/axolotl/SKILL.md -> "mlops"
     Also works for external skill dirs configured via skills.external_dirs.
     """
-    # Try the module-level SKILLS_DIR first (respects monkeypatching in tests),
-    # then fall back to external dirs from config.
+    # Try all active skill roots in lookup precedence order (project-local,
+    # global, then external).  The module-level SKILLS_DIR fallback preserves
+    # test monkeypatch compatibility.
     dirs_to_check = [SKILLS_DIR]
     try:
-        from agent.skill_utils import get_external_skills_dirs
-        dirs_to_check.extend(get_external_skills_dirs())
+        from agent.skill_utils import get_all_skills_dirs
+        dirs_to_check = [*get_all_skills_dirs(), SKILLS_DIR]
     except Exception:
         pass
     for skills_dir in dirs_to_check:
@@ -557,7 +558,7 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
     Returns:
         List of skill metadata dicts (name, description, category).
     """
-    from agent.skill_utils import get_external_skills_dirs, iter_skill_index_files
+    from agent.skill_utils import get_all_skills_dirs, iter_skill_index_files
 
     skills = []
     seen_names: set = set()
@@ -565,11 +566,17 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
     # Load disabled set once (not per-skill)
     disabled = set() if skip_disabled else _get_disabled_skill_names()
 
-    # Scan local dir first, then external dirs (local takes precedence)
+    # Scan project-local, global, then external dirs (earlier roots win).
+    # Append module-level SKILLS_DIR to preserve tests/legacy callers that
+    # monkeypatch tools.skills_tool.SKILLS_DIR directly.
     dirs_to_scan = []
-    if SKILLS_DIR.exists():
-        dirs_to_scan.append(SKILLS_DIR)
-    dirs_to_scan.extend(get_external_skills_dirs())
+    seen_dirs: set[Path] = set()
+    for candidate in [*get_all_skills_dirs(), SKILLS_DIR]:
+        resolved = candidate.resolve()
+        if resolved in seen_dirs or not candidate.exists():
+            continue
+        seen_dirs.add(resolved)
+        dirs_to_scan.append(candidate)
 
     for scan_dir in dirs_to_scan:
         for skill_md in iter_skill_index_files(scan_dir, "SKILL.md"):
@@ -931,13 +938,18 @@ def skill_view(
             # Plugin itself not found — fall through to flat-tree scan
             # which will return a normal "not found" with suggestions.
 
-        from agent.skill_utils import get_external_skills_dirs
+        from agent.skill_utils import get_all_skills_dirs
 
-        # Build list of all skill directories to search
+        # Build list of all active skill directories to search. Append module-level
+        # SKILLS_DIR for tests/legacy callers that monkeypatch it directly.
         all_dirs = []
-        if SKILLS_DIR.exists():
-            all_dirs.append(SKILLS_DIR)
-        all_dirs.extend(get_external_skills_dirs())
+        seen_dirs: set[Path] = set()
+        for candidate in [*get_all_skills_dirs(), SKILLS_DIR]:
+            resolved = candidate.resolve()
+            if resolved in seen_dirs or not candidate.exists():
+                continue
+            seen_dirs.add(resolved)
+            all_dirs.append(candidate)
 
         if not all_dirs:
             return json.dumps(
@@ -1010,14 +1022,16 @@ def skill_view(
                 ensure_ascii=False,
             )
 
-        # Security: warn if skill is loaded from outside trusted directories
-        # (local skills dir + configured external_dirs are all trusted)
+        # Security: warn if skill is loaded from outside trusted directories.
+        # Active skill roots (project-local, global, and configured external_dirs)
+        # are trusted; arbitrary fallback paths still warn.
         _outside_skills_dir = True
-        _trusted_dirs = [SKILLS_DIR.resolve()]
+        _trusted_dirs = []
         try:
-            _trusted_dirs.extend(d.resolve() for d in all_dirs[1:])
+            _trusted_dirs = [d.resolve() for d in all_dirs]
+            _trusted_dirs.append(SKILLS_DIR.resolve())
         except Exception:
-            pass
+            _trusted_dirs = [SKILLS_DIR.resolve()]
         for _td in _trusted_dirs:
             try:
                 skill_md.resolve().relative_to(_td)


### PR DESCRIPTION
# PR: Add project-local skill discovery

## Title
Add project-local skill discovery

## Summary
- Discover project-local skills from the current git root before global and external skill directories.
- Support project-scoped skill management with `skill_manage(..., scope="project")`, writing to `<project>/.hermes/skills/`.
- Make `skills_list`, `skill_view`, and prompt skill snapshots respect project-local precedence while preserving legacy `SKILLS_DIR` monkeypatch compatibility.
- Treat project-local skill roots as trusted in `skill_view` security checks.
- Add regression tests for project-local discovery, prompt precedence, and project-scoped skill creation.

## Motivation
Project-specific skills should live with the project that owns them instead of permanently polluting the global `~/.hermes/skills/` index and every agent prompt. This change enables repositories to carry their own `.hermes/skills/` or `.ai/skills/` directories, loaded only when the active working directory belongs to that project.

## Implementation Notes
- `agent/skill_utils.py`
  - Adds CWD resolution from explicit argument, `TERMINAL_CWD`, `HERMES_CWD`, then `os.getcwd()`.
  - Finds the project root via `git rev-parse --show-toplevel`, falling back to walking parent directories for `.git`.
  - Adds project skill roots: `<git-root>/.hermes/skills` and `<git-root>/.ai/skills`.
  - Orders all skill directories as project-local, global, then configured external dirs.
- `tools/skills_tool.py`
  - Uses `get_all_skills_dirs()` for discovery and view lookup.
  - Keeps a module-level `SKILLS_DIR` fallback for older tests/callers that monkeypatch it directly.
  - Updates trusted-root checks so active project-local directories do not trigger false security warnings.
- `tools/skill_manager_tool.py`
  - Adds `scope="global" | "project"` for create operations.
  - Allows patch/delete/edit/write-file lookup across both project-local and global roots.
- `agent/prompt_builder.py`
  - Builds skill prompt snapshots from the highest-priority active skill root instead of assuming only global/external roots.

## Test Plan
Passed locally:

```bash
venv/bin/python -m pytest -n 0 tests/tools/test_skills_tool.py tests/tools/test_skill_view_path_check.py tests/tools/test_skill_view_traversal.py tests/tools/test_skill_manager_tool.py tests/agent/test_external_skills.py tests/agent/test_prompt_builder.py tests/agent/test_skill_commands.py tests/tools/test_skill_size_limits.py -q
# 331 passed, 2 skipped in 5.22s

venv/bin/python -m py_compile agent/skill_utils.py agent/prompt_builder.py tools/skills_tool.py tools/skill_manager_tool.py
```

Also passed a smoke test using temporary `HERMES_HOME` and temporary git project:

```json
{"created": true, "project_skill_exists": true, "prompt_has_skill": true, "scope": "project", "viewed": true}
```

Known local note:
- Full `pytest -q` in this environment hit `Too many open files` from the repository's broad parallel/default test behavior, so the relevant skill/prompt test surface was rerun serially with `-n 0` and passed.
- `git diff --check` returns status 2 with no diagnostic output under this local Git 2.50.1 setup; no whitespace issue was reported.

## Commit
`5113a4ad2 Add project-local skill discovery`

## Patch File
`/Users/dujiao/.hermes/pr-prep/0001-project-local-skill-discovery.patch`

## Manual PR Commands
If you have a fork:

```bash
cd /Users/dujiao/.hermes/hermes-agent
git remote add fork https://github.com/<your-user>/hermes-agent.git  # if not already added
git push -u fork feat/project-local-skills
```

Then open:

```text
https://github.com/NousResearch/hermes-agent/compare/main...<your-user>:hermes-agent:feat/project-local-skills?expand=1
```

If using GitHub CLI after login:

```bash
gh auth login
gh repo fork NousResearch/hermes-agent --remote --push --branch feat/project-local-skills
gh pr create --repo NousResearch/hermes-agent --base main --head <your-user>:feat/project-local-skills --title "Add project-local skill discovery" --body-file /Users/dujiao/.hermes/pr-prep/project-local-skills-pr.md
```
