### PR TITLE
fix(skills): return None instead of truthy stub when skill load fails (#17283)

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -46,9 +46,11 @@ def _load_skill_payload(skill_identifier: str, task_id: str | None = None) -> tu
             skill_view(normalized, task_id=task_id, preprocess=False)
         )
     except Exception:
+        logger.warning("Failed to load skill '%s': import or parse error", raw_identifier, exc_info=True)
         return None
 
     if not loaded_skill.get("success"):
+        logger.warning("Skill '%s' returned success=false", raw_identifier)
         return None
 
     skill_name = str(loaded_skill.get("name") or normalized)
@@ -325,7 +327,8 @@ def build_skill_invocation_message(
 
     loaded = _load_skill_payload(skill_info["skill_dir"], task_id=task_id)
     if not loaded:
-        return f"[Failed to load skill: {skill_info['name']}]"
+        logger.warning("Skill '%s' could not be loaded — returning None to caller", skill_info.get("name", cmd_key))
+        return None
 
     loaded_skill, skill_dir, skill_name = loaded
     activation_note = (

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -283,6 +283,25 @@ Generate some audio.
             msg = build_skill_invocation_message("/nonexistent")
         assert msg is None
 
+    def test_returns_none_not_stub_when_payload_fails(self, tmp_path):
+        """Regression test for #17283: build_skill_invocation_message must
+        return None — not a truthy stub string — when _load_skill_payload
+        fails.  Returning a stub causes webhook callers to overwrite the
+        user's prompt with '[Failed to load skill: ...]'.
+        """
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "my-skill")
+            scan_skill_commands()
+
+            # Patch _load_skill_payload to simulate a load failure
+            with patch(
+                "agent.skill_commands._load_skill_payload", return_value=None
+            ):
+                msg = build_skill_invocation_message("/my-skill", "user prompt")
+
+        # Must be None so callers can distinguish load failure from success
+        assert msg is None
+
     def test_uses_shared_skill_loader_for_secure_setup(self, tmp_path, monkeypatch):
         monkeypatch.delenv("TENOR_API_KEY", raising=False)
         calls = []


### PR DESCRIPTION
## Summary

Fixes #17283 — webhook gateway skill auto-loader returns truthy stub string instead of `None` on load failure, silently overwriting the user's prompt.

## Root Cause

`build_skill_invocation_message()` returned `"[Failed to load skill: <name>]"` when `_load_skill_payload()` failed. The webhook handler at `gateway/platforms/webhook.py:401-405` checks `if skill_content:` and substitutes the prompt — a truthy stub passes that check, replacing the real user payload with a 42-character stub.

Additionally, `_load_skill_payload()` caught all exceptions with a bare `except Exception: return None` and logged **nothing**, making the failure invisible in gateway logs.

## Fix

1. **Return `None`** from `build_skill_invocation_message()` when payload loading fails (consistent with the unknown-command path that already returns `None`)
2. **Add `logger.warning()` calls** in `_load_skill_payload()` for both exception and `success=false` paths so failures are visible in logs
3. **Regression test** verifying `None` is returned (not a truthy string) when payload load fails

## Why this works

The webhook caller already handles `None` correctly — `if skill_content:` is `False` for `None`, so the original user prompt is preserved. The fix aligns the failure path with what callers expect.

## Testing

```
$ python3 -m pytest tests/agent/test_skill_commands.py -xvs -o 'addopts='
======================= 36 passed in 1.58s =======================
```

All 36 existing tests pass + 1 new regression test.