### PR TITLE
fix(agent): enable prompt caching for MiniMax own models on anthropic_messages transport

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,12 +67,10 @@
 # =============================================================================
 # MiniMax provides access to MiniMax models (global endpoint)
 # Get your key at: https://www.minimax.io
-# MINIMAX_API_KEY=
-# MINIMAX_BASE_URL=https://api.minimax.io/v1  # Override default base URL
+# MINIMAX_API_KEY=*** MINIMAX_BASE_URL=https://api.minimax.io/anthropic  # Anthropic-compatible endpoint (required for prompt caching)
 
 # MiniMax China endpoint (for users in mainland China)
-# MINIMAX_CN_API_KEY=
-# MINIMAX_CN_BASE_URL=https://api.minimaxi.com/v1  # Override default base URL
+# MINIMAX_CN_API_KEY=*** MINIMAX_CN_BASE_URL=https://api.minimaxi.com/anthropic  # Anthropic-compatible endpoint (required for prompt caching)
 
 # =============================================================================
 # LLM PROVIDER (OpenCode Zen)

--- a/run_agent.py
+++ b/run_agent.py
@@ -1037,6 +1037,17 @@ class AIAgent:
             # use a URL convention ending in /anthropic. Auto-detect these so the
             # Anthropic Messages API adapter is used instead of chat completions.
             self.api_mode = "anthropic_messages"
+        elif self.provider in ("minimax", "minimax-cn"):
+            # MiniMax serves its own models through an Anthropic-compatible endpoint.
+            # Default to anthropic_messages so prompt caching and other Anthropic
+            # features work out of the box.  Mirrors the runtime_provider.py logic.
+            self.api_mode = "anthropic_messages"
+            if not self.base_url:
+                self.base_url = (
+                    "https://api.minimax.io/anthropic"
+                    if self.provider == "minimax"
+                    else "https://api.minimaxi.com/anthropic"
+                )
         elif self.provider == "bedrock" or (
             self._base_url_hostname.startswith("bedrock-runtime.")
             and base_url_host_matches(self._base_url_lower, "amazonaws.com")

--- a/run_agent.py
+++ b/run_agent.py
@@ -2777,11 +2777,13 @@ class AIAgent:
             OpenAI-wire proxies expect the looser layout).
 
         Third-party providers using the native Anthropic transport
-        (``api_mode == 'anthropic_messages'`` + Claude-named model) get
-        caching with the native layout so they benefit from the same
-        cost reduction as direct Anthropic callers, provided their
-        gateway implements the Anthropic cache_control contract
-        (MiniMax, Zhipu GLM, LiteLLM's Anthropic proxy mode all do).
+        (``api_mode == 'anthropic_messages'``) get caching with the
+        native layout when the model is Claude-named or the provider
+        is a known Anthropic-compatible gateway that documents
+        ``cache_control`` support for its own models (MiniMax).
+        LiteLLM proxies and Zhipu GLM also implement the contract
+        but are only enabled for Claude-named models until they
+        document cache support for their own model families.
 
         Qwen / Alibaba-family models on OpenCode, OpenCode Go, and direct
         Alibaba (DashScope) also honour Anthropic-style ``cache_control``
@@ -2811,6 +2813,17 @@ class AIAgent:
             return True, False
         if is_anthropic_wire and is_claude:
             # Third-party Anthropic-compatible gateway.
+            return True, True
+
+        # MiniMax and MiniMax-CN use the native Anthropic protocol for
+        # their own models (MiniMax-M2.7, etc.) and document explicit
+        # cache_control support on their Anthropic-compatible endpoints.
+        # https://platform.minimax.io/docs/api-reference/anthropic-api-compatible-cache
+        provider_is_minimax = provider_lower in ("minimax", "minimax-cn")
+        is_minimax_endpoint = base_url_hostname(eff_base_url) in (
+            "api.minimax.io", "api.minimaxi.com"
+        )
+        if is_anthropic_wire and (provider_is_minimax or is_minimax_endpoint):
             return True, True
 
         # Qwen/Alibaba on OpenCode (Zen/Go) and native DashScope: OpenAI-wire

--- a/tests/agent/test_minimax_provider.py
+++ b/tests/agent/test_minimax_provider.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import patch
 
+from run_agent import AIAgent
+
 
 class TestMinimaxContextLengths:
     """Verify context length entries match official docs (204,800 for all models).
@@ -328,7 +330,6 @@ class TestMinimaxSwitchModelCredentialGuard:
         from unittest.mock import patch, MagicMock
 
         with patch("run_agent.AIAgent.__init__", return_value=None):
-            from run_agent import AIAgent
             agent = AIAgent.__new__(AIAgent)
             agent.provider = "anthropic"
             agent.model = "claude-sonnet-4"
@@ -359,3 +360,98 @@ class TestMinimaxSwitchModelCredentialGuard:
             # The key passed to build_anthropic_client should be the MiniMax key
             build_args = mock_build.call_args
             assert build_args[0][0] == "mm-key-123"
+
+
+class TestMinimaxAgentInitDefaults:
+    """Verify AIAgent.__init__ defaults MiniMax to anthropic_messages + correct base_url."""
+
+    def test_minimax_defaults_to_anthropic_messages_and_global_url(self):
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="minimax-key-1234",
+                provider="minimax",
+                model="MiniMax-M2.7",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+        assert agent.api_mode == "anthropic_messages"
+        assert agent.base_url == "https://api.minimax.io/anthropic"
+        assert agent.provider == "minimax"
+
+    def test_minimax_cn_defaults_to_anthropic_messages_and_china_url(self):
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="minimax-cn-key-5678",
+                provider="minimax-cn",
+                model="MiniMax-M2.7",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+        assert agent.api_mode == "anthropic_messages"
+        assert agent.base_url == "https://api.minimaxi.com/anthropic"
+        assert agent.provider == "minimax-cn"
+
+    def test_minimax_explicit_base_url_not_overwritten(self):
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="minimax-key-1234",
+                provider="minimax",
+                base_url="https://custom.minimax.example.com/anthropic",
+                model="MiniMax-M2.7",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+        assert agent.api_mode == "anthropic_messages"
+        assert agent.base_url == "https://custom.minimax.example.com/anthropic"
+
+    def test_minimax_explicit_api_mode_chat_completions_allowed(self):
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="minimax-key-1234",
+                provider="minimax",
+                api_mode="chat_completions",
+                base_url="https://api.minimax.io/v1",
+                model="MiniMax-M2.7",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+        assert agent.api_mode == "chat_completions"
+        # explicit base_url should be preserved
+        assert agent.base_url == "https://api.minimax.io/v1"
+
+    def test_minimax_prompt_caching_enabled_by_default(self):
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="minimax-key-1234",
+                provider="minimax",
+                model="MiniMax-M2.7",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+        assert agent._use_prompt_caching is True
+        assert agent._use_native_cache_layout is True

--- a/tests/run_agent/test_anthropic_prompt_cache_policy.py
+++ b/tests/run_agent/test_anthropic_prompt_cache_policy.py
@@ -123,6 +123,30 @@ class TestThirdPartyAnthropicGateway:
         assert should is True
         assert native is True
 
+    def test_minimax_own_model_with_empty_base_url_caches_by_provider_name(self):
+        # When AIAgent.__init__ is fixed to default base_url for minimax,
+        # this tests the policy directly even before base_url is set.
+        agent = _make_agent(
+            provider="minimax",
+            base_url="",
+            api_mode="anthropic_messages",
+            model="MiniMax-M2.7",
+        )
+        should, native = agent._anthropic_prompt_cache_policy()
+        assert should is True
+        assert native is True
+
+    def test_minimax_cn_own_model_with_empty_base_url_caches_by_provider_name(self):
+        agent = _make_agent(
+            provider="minimax-cn",
+            base_url="",
+            api_mode="anthropic_messages",
+            model="MiniMax-M2.7",
+        )
+        should, native = agent._anthropic_prompt_cache_policy()
+        assert should is True
+        assert native is True
+
     def test_third_party_without_claude_name_does_not_cache(self):
         # A generic provider exposing e.g. GLM via anthropic_messages transport
         # — we don't know whether it supports cache_control for its own models,

--- a/tests/run_agent/test_anthropic_prompt_cache_policy.py
+++ b/tests/run_agent/test_anthropic_prompt_cache_policy.py
@@ -89,14 +89,49 @@ class TestThirdPartyAnthropicGateway:
         assert should is True, "Third-party Anthropic gateway with Claude must cache"
         assert native is True, "Third-party Anthropic gateway uses native cache_control layout"
 
-    def test_third_party_without_claude_name_does_not_cache(self):
-        # A provider exposing e.g. GLM via anthropic_messages transport — we
-        # don't know whether it supports cache_control, so stay conservative.
+    def test_minimax_own_model_caches_with_native_layout(self):
+        agent = _make_agent(
+            provider="minimax",
+            base_url="https://api.minimax.io/anthropic",
+            api_mode="anthropic_messages",
+            model="MiniMax-M2.7",
+        )
+        should, native = agent._anthropic_prompt_cache_policy()
+        assert should is True
+        assert native is True
+
+    def test_minimax_cn_own_model_caches_with_native_layout(self):
+        agent = _make_agent(
+            provider="minimax-cn",
+            base_url="https://api.minimaxi.com/anthropic",
+            api_mode="anthropic_messages",
+            model="MiniMax-M2.7",
+        )
+        should, native = agent._anthropic_prompt_cache_policy()
+        assert should is True
+        assert native is True
+
+    def test_minimax_custom_endpoint_by_url_caches(self):
+        # Custom provider config pointing at MiniMax's Anthropic endpoint.
         agent = _make_agent(
             provider="custom",
             base_url="https://api.minimax.io/anthropic",
             api_mode="anthropic_messages",
-            model="minimax-m2.7",
+            model="MiniMax-M2.7",
+        )
+        should, native = agent._anthropic_prompt_cache_policy()
+        assert should is True
+        assert native is True
+
+    def test_third_party_without_claude_name_does_not_cache(self):
+        # A generic provider exposing e.g. GLM via anthropic_messages transport
+        # — we don't know whether it supports cache_control for its own models,
+        # so stay conservative.
+        agent = _make_agent(
+            provider="custom",
+            base_url="https://api.glm.ai/anthropic",
+            api_mode="anthropic_messages",
+            model="glm-5",
         )
         assert agent._anthropic_prompt_cache_policy() == (False, False)
 


### PR DESCRIPTION
Closes #17332

PR #12846 enabled Anthropic prompt caching for third-party gateways,
but gated it on `is_claude`, which excluded providers like MiniMax
that serve their own model families (MiniMax-M2.7, etc.) through the
native Anthropic protocol.

MiniMax documents full `cache_control` support on its
`/anthropic` endpoints (global and China). This patch adds MiniMax
detection to `_anthropic_prompt_cache_policy()` using:

- Built-in provider id (`minimax`, `minimax-cn`), or
- Known Anthropic-compatible hostname (`api.minimax.io`,
  `api.minimaxi.com`)

Both paths receive the native `cache_control` layout, consistent with
how Hermes already treats native Anthropic and Claude-on-third-party
gateways.

Tests: 3 new cases, 19 total in the policy suite.

Refs: #8294 (related, but only covered Claude-named models on
third-party gateways).