### PR TITLE
Handle Telegram visual media replies

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -705,11 +705,21 @@ def load_gateway_config() -> GatewayConfig:
                     if isinstance(frc, list):
                         frc = ",".join(str(v) for v in frc)
                     os.environ["TELEGRAM_FREE_RESPONSE_CHATS"] = str(frc)
+                frt = telegram_cfg.get("free_response_threads")
+                if frt is not None and not os.getenv("TELEGRAM_FREE_RESPONSE_THREADS"):
+                    if isinstance(frt, list):
+                        frt = ",".join(str(v) for v in frt)
+                    os.environ["TELEGRAM_FREE_RESPONSE_THREADS"] = str(frt)
                 ignored_threads = telegram_cfg.get("ignored_threads")
                 if ignored_threads is not None and not os.getenv("TELEGRAM_IGNORED_THREADS"):
                     if isinstance(ignored_threads, list):
                         ignored_threads = ",".join(str(v) for v in ignored_threads)
                     os.environ["TELEGRAM_IGNORED_THREADS"] = str(ignored_threads)
+                collaboration_threads = telegram_cfg.get("collaboration_threads")
+                if collaboration_threads is not None and not os.getenv("TELEGRAM_COLLABORATION_THREADS"):
+                    if isinstance(collaboration_threads, list):
+                        collaboration_threads = ",".join(str(v) for v in collaboration_threads)
+                    os.environ["TELEGRAM_COLLABORATION_THREADS"] = str(collaboration_threads)
                 if "reactions" in telegram_cfg and not os.getenv("TELEGRAM_REACTIONS"):
                     os.environ["TELEGRAM_REACTIONS"] = str(telegram_cfg["reactions"]).lower()
                 if "proxy_url" in telegram_cfg and not os.getenv("TELEGRAM_PROXY"):

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -819,6 +819,16 @@ class MessageType(Enum):
     COMMAND = "command"  # /command style
 
 
+VOICE_OUTPUT_BLOCKED_MEDIA_TYPES = frozenset({
+    MessageType.PHOTO,
+    MessageType.VIDEO,
+    MessageType.AUDIO,
+    MessageType.DOCUMENT,
+    MessageType.STICKER,
+    MessageType.LOCATION,
+})
+
+
 class ProcessingOutcome(Enum):
     """Result classification for message-processing lifecycle hooks."""
 
@@ -1555,6 +1565,11 @@ class BasePlatformAdapter(ABC):
         Default falls back to send_voice (shows audio player).
         """
         return await self.send_voice(chat_id=chat_id, audio_path=audio_path, **kwargs)
+
+    @staticmethod
+    def blocks_voice_output_for_event(event: MessageEvent) -> bool:
+        """Return True when an inbound turn should not emit audio-only media."""
+        return getattr(event, "message_type", None) in VOICE_OUTPUT_BLOCKED_MEDIA_TYPES
 
     async def send_video(
         self,
@@ -2413,6 +2428,21 @@ class BasePlatformAdapter(ABC):
             if response:
                 # Extract MEDIA:<path> tags (from TTS tool) before other processing
                 media_files, response = self.extract_media(response)
+                _AUDIO_EXTS = {'.ogg', '.opus', '.mp3', '.wav', '.m4a'}
+                _VIDEO_EXTS = {'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'}
+                _IMAGE_EXTS = {'.jpg', '.jpeg', '.png', '.webp', '.gif'}
+                if media_files and self.blocks_voice_output_for_event(event):
+                    before_count = len(media_files)
+                    media_files = [
+                        item for item in media_files
+                        if Path(item[0]).suffix.lower() not in _AUDIO_EXTS
+                    ]
+                    if before_count != len(media_files):
+                        logger.info(
+                            "[%s] Suppressed audio MEDIA output for %s input",
+                            self.name,
+                            event.message_type.value if event.message_type else "media",
+                        )
                 
                 # Extract image URLs and send them as native platform attachments
                 images, text_content = self.extract_images(response)
@@ -2514,10 +2544,6 @@ class BasePlatformAdapter(ABC):
                         logger.error("[%s] Error sending image: %s", self.name, img_err, exc_info=True)
 
                 # Send extracted media files — route by file type
-                _AUDIO_EXTS = {'.ogg', '.opus', '.mp3', '.wav', '.m4a'}
-                _VIDEO_EXTS = {'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'}
-                _IMAGE_EXTS = {'.jpg', '.jpeg', '.png', '.webp', '.gif'}
-
                 for media_path, is_voice in media_files:
                     if human_delay > 0:
                         await asyncio.sleep(human_delay)

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -839,8 +839,18 @@ class TelegramAdapter(BasePlatformAdapter):
                 filters.LOCATION | getattr(filters, "VENUE", filters.LOCATION),
                 self._handle_location_message
             ))
+            video_note_filter = getattr(filters, "VIDEO_NOTE", None)
+            media_filter = (
+                filters.PHOTO
+                | filters.VIDEO
+                | (video_note_filter if video_note_filter is not None else filters.VIDEO)
+                | filters.AUDIO
+                | filters.VOICE
+                | filters.Document.ALL
+                | filters.Sticker.ALL
+            )
             self._app.add_handler(TelegramMessageHandler(
-                filters.PHOTO | filters.VIDEO | filters.AUDIO | filters.VOICE | filters.Document.ALL | filters.Sticker.ALL,
+                media_filter,
                 self._handle_media_message
             ))
             # Handle inline keyboard button callbacks (update prompts)
@@ -2328,26 +2338,56 @@ class TelegramAdapter(BasePlatformAdapter):
             return {str(part).strip() for part in raw if str(part).strip()}
         return {part.strip() for part in str(raw).split(",") if part.strip()}
 
-    def _telegram_ignored_threads(self) -> set[int]:
-        raw = self.config.extra.get("ignored_threads")
+    def _telegram_thread_id_set(self, config_key: str, env_key: str) -> set[int]:
+        raw = self.config.extra.get(config_key)
         if raw is None:
-            raw = os.getenv("TELEGRAM_IGNORED_THREADS", "")
+            raw = os.getenv(env_key, "")
 
         if isinstance(raw, list):
             values = raw
         else:
             values = str(raw).split(",")
 
-        ignored: set[int] = set()
+        thread_ids: set[int] = set()
         for value in values:
             text = str(value).strip()
             if not text:
                 continue
             try:
-                ignored.add(int(text))
+                thread_ids.add(int(text))
             except (TypeError, ValueError):
-                logger.warning("[%s] Ignoring invalid Telegram thread id: %r", self.name, value)
-        return ignored
+                logger.warning("[%s] Ignoring invalid Telegram thread id for %s: %r", self.name, config_key, value)
+        return thread_ids
+
+    def _telegram_ignored_threads(self) -> set[int]:
+        return self._telegram_thread_id_set("ignored_threads", "TELEGRAM_IGNORED_THREADS")
+
+    def _telegram_collaboration_threads(self) -> set[int]:
+        return self._telegram_thread_id_set("collaboration_threads", "TELEGRAM_COLLABORATION_THREADS")
+
+    def _telegram_free_response_threads(self) -> set[int]:
+        return self._telegram_thread_id_set("free_response_threads", "TELEGRAM_FREE_RESPONSE_THREADS")
+
+    def _telegram_process_bot_messages(self) -> bool:
+        """Return whether Telegram bot-authored inbound messages may trigger runs.
+
+        Default is false. Letting bots process other bots' group replies creates
+        easy agent-to-agent loops, especially in forum collaboration threads.
+        """
+        configured = self.config.extra.get("process_bot_messages")
+        if configured is not None:
+            if isinstance(configured, str):
+                return configured.lower() in ("true", "1", "yes", "on")
+            return bool(configured)
+        return os.getenv("TELEGRAM_PROCESS_BOT_MESSAGES", "false").lower() in ("true", "1", "yes", "on")
+
+    @staticmethod
+    def _message_from_bot(message: Message) -> bool:
+        user = getattr(message, "from_user", None)
+        is_bot = getattr(user, "is_bot", False) if user is not None else False
+        if isinstance(is_bot, str):
+            return is_bot.lower() in ("true", "1", "yes", "on")
+        return is_bot is True
 
     def _compile_mention_patterns(self) -> List[re.Pattern]:
         """Compile optional regex wake-word patterns for group triggers."""
@@ -2489,13 +2529,32 @@ class TelegramAdapter(BasePlatformAdapter):
         mentioning the bot (``@botname /command``), both of which are
         recognised as mentions by :meth:`_message_mentions_bot`.
         """
+        if self._message_from_bot(message) and not self._telegram_process_bot_messages():
+            logger.info(
+                "[%s] Ignoring Telegram message from bot user %s to prevent agent-to-agent loops",
+                self.name,
+                getattr(getattr(message, "from_user", None), "id", "unknown"),
+            )
+            return False
         if not self._is_group_chat(message):
             return True
         thread_id = getattr(message, "message_thread_id", None)
+        chat = getattr(message, "chat", None)
+        if thread_id is None and getattr(chat, "is_forum", False):
+            # Telegram omits message_thread_id for some forum General-topic
+            # messages, but _build_message_event maps that case to synthetic
+            # thread "1". Apply the same mapping here so thread gates are
+            # evaluated before open-group/free-response fallbacks.
+            thread_id = self._GENERAL_TOPIC_THREAD_ID
         if thread_id is not None:
             try:
-                if int(thread_id) in self._telegram_ignored_threads():
+                thread_id_int = int(thread_id)
+                if thread_id_int in self._telegram_ignored_threads():
                     return False
+                if thread_id_int in self._telegram_free_response_threads():
+                    return True
+                if thread_id_int in self._telegram_collaboration_threads():
+                    return True
             except (TypeError, ValueError):
                 logger.warning("[%s] Ignoring non-numeric Telegram message_thread_id: %r", self.name, thread_id)
         if str(getattr(getattr(message, "chat", None), "id", "")) in self._telegram_free_response_chats():
@@ -2703,11 +2762,13 @@ class TelegramAdapter(BasePlatformAdapter):
         msg = update.message
         
         # Determine media type
+        video_note = getattr(msg, "video_note", None)
+
         if msg.sticker:
             msg_type = MessageType.STICKER
         elif msg.photo:
             msg_type = MessageType.PHOTO
-        elif msg.video:
+        elif msg.video or video_note:
             msg_type = MessageType.VIDEO
         elif msg.audio:
             msg_type = MessageType.AUDIO
@@ -2784,9 +2845,10 @@ class TelegramAdapter(BasePlatformAdapter):
             except Exception as e:
                 logger.warning("[Telegram] Failed to cache audio: %s", e, exc_info=True)
 
-        elif msg.video:
+        elif msg.video or video_note:
             try:
-                file_obj = await msg.video.get_file()
+                video_obj = msg.video or video_note
+                file_obj = await video_obj.get_file()
                 video_bytes = await file_obj.download_as_bytearray()
                 ext = ".mp4"
                 if getattr(file_obj, "file_path", None):
@@ -3154,6 +3216,7 @@ class TelegramAdapter(BasePlatformAdapter):
             user_name=user.full_name if user else (chat.full_name if hasattr(chat, "full_name") and chat_type == "dm" else None),
             thread_id=thread_id_str,
             chat_topic=chat_topic,
+            is_bot=(getattr(user, "is_bot", False) is True) if user else False,
         )
         
         # Extract reply context if this message is a reply

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -20,6 +20,7 @@ import logging
 import os
 import re
 import shlex
+import subprocess
 import sys
 import signal
 import tempfile
@@ -39,6 +40,7 @@ from typing import Dict, Optional, Any, List
 # preserving the established test-patch surface.
 from agent.account_usage import fetch_account_usage, render_account_usage_lines
 from hermes_cli.config import cfg_get
+from tools.video_tools import analyze_video_file
 
 # --- Agent cache tuning ---------------------------------------------------
 # Bounds the per-session AIAgent cache to prevent unbounded growth in
@@ -451,6 +453,26 @@ from gateway.whatsapp_identity import (
     normalize_whatsapp_identifier as _normalize_whatsapp_identifier,
 )
 
+_VOICE_OUTPUT_BLOCKED_MEDIA_TYPES = frozenset({
+    MessageType.PHOTO,
+    MessageType.VIDEO,
+    MessageType.AUDIO,
+    MessageType.DOCUMENT,
+    MessageType.STICKER,
+    MessageType.LOCATION,
+})
+
+_VOICE_OUTPUT_BLOCKED_TOOL_NAMES = frozenset({
+    "text_to_speech",
+    "terminal",
+    "process",
+    "execute_code",
+    "delegate_task",
+    "skills_list",
+    "skill_view",
+    "skill_manage",
+})
+
 
 logger = logging.getLogger(__name__)
 
@@ -560,6 +582,8 @@ def _build_media_placeholder(event) -> str:
             parts.append(f"[User sent an image: {url}]")
         elif mtype.startswith("audio/"):
             parts.append(f"[User sent audio: {url}]")
+        elif mtype.startswith("video/") or getattr(event, "message_type", None) == MessageType.VIDEO:
+            parts.append(f"[User sent a video: {url}]")
         else:
             parts.append(f"[User sent a file: {url}]")
     return "\n".join(parts)
@@ -1065,18 +1089,21 @@ class GatewayRunner:
             logger.warning("Failed to save voice modes: %s", e)
 
     def _set_adapter_auto_tts_disabled(self, adapter, chat_id: str, disabled: bool) -> None:
-        """Update an adapter's in-memory auto-TTS suppression set if present."""
+        """Update an adapter's in-memory auto-TTS state.
+
+        New adapters use an explicit enabled set so the default remains text-only.
+        Keep the legacy disabled set in sync for back-compat with older callers
+        and tests.
+        """
+        enabled_chats = getattr(adapter, "_auto_tts_enabled_chats", None)
         disabled_chats = getattr(adapter, "_auto_tts_disabled_chats", None)
-        if not isinstance(disabled_chats, set):
-            return
-        if disabled:
+        if isinstance(disabled_chats, set) and disabled:
             disabled_chats.add(chat_id)
-            # ``/voice off`` also clears any explicit enable — it's a hard override.
-            enabled_chats = getattr(adapter, "_auto_tts_enabled_chats", None)
-            if isinstance(enabled_chats, set):
-                enabled_chats.discard(chat_id)
-        else:
+        elif isinstance(disabled_chats, set):
             disabled_chats.discard(chat_id)
+        if disabled and isinstance(enabled_chats, set):
+            # ``/voice off`` also clears any explicit enable — it's a hard override.
+            enabled_chats.discard(chat_id)
 
     def _set_adapter_auto_tts_enabled(self, adapter, chat_id: str, enabled: bool) -> None:
         """Update an adapter's per-chat auto-TTS opt-in set if present.
@@ -4428,12 +4455,15 @@ class GatewayRunner:
         if event.media_urls:
             image_paths = []
             audio_paths = []
+            video_paths = []
             for i, path in enumerate(event.media_urls):
                 mtype = event.media_types[i] if i < len(event.media_types) else ""
                 if mtype.startswith("image/") or event.message_type == MessageType.PHOTO:
                     image_paths.append(path)
                 if mtype.startswith("audio/") or event.message_type in (MessageType.VOICE, MessageType.AUDIO):
                     audio_paths.append(path)
+                if mtype.startswith("video/") or event.message_type == MessageType.VIDEO:
+                    video_paths.append(path)
 
             if image_paths:
                 # Decide routing: native (attach pixels) vs text (vision_analyze
@@ -4455,6 +4485,12 @@ class GatewayRunner:
                         message_text,
                         image_paths,
                     )
+
+            if video_paths:
+                message_text = await self._enrich_message_with_video(
+                    message_text,
+                    video_paths,
+                )
 
             if audio_paths:
                 message_text = await self._enrich_message_with_transcription(
@@ -5130,6 +5166,7 @@ class GatewayRunner:
                 run_generation=run_generation,
                 event_message_id=event.message_id,
                 channel_prompt=event.channel_prompt,
+                inbound_message_type=event.message_type,
             )
 
             # Stop persistent typing indicator now that the agent is done
@@ -5426,6 +5463,14 @@ class GatewayRunner:
             if self._should_send_voice_reply(event, response, agent_messages, already_sent=_already_sent):
                 await self._send_voice_reply(event, response)
 
+            photo_reply_sent = False
+            if self._should_send_photo_reply(event, response, already_sent=_already_sent):
+                photo_reply_sent = await self._send_photo_reply(event, response)
+
+            video_note_sent = False
+            if self._should_send_video_note_reply(event, response, already_sent=_already_sent):
+                video_note_sent = await self._send_video_note_reply(event, response)
+
             # If streaming already delivered the response, extract and
             # deliver any MEDIA: files before returning None.  Streaming
             # sends raw text chunks that include MEDIA: tags — the normal
@@ -5455,6 +5500,9 @@ class GatewayRunner:
                             await _foot_adapter.send(source.chat_id, _footer_line)
                     except Exception as _e:
                         logger.debug("trailing footer send failed: %s", _e)
+                return None
+
+            if photo_reply_sent or video_note_sent:
                 return None
 
             return response
@@ -6608,6 +6656,86 @@ class GatewayRunner:
             return raw.guild.id
         return None
 
+    def _blocks_voice_output_for_type(self, message_type: Optional[MessageType]) -> bool:
+        return message_type in _VOICE_OUTPUT_BLOCKED_MEDIA_TYPES
+
+    def _wants_video_note_reply_for_type(
+        self,
+        source: SessionSource,
+        message_type: Optional[MessageType],
+    ) -> bool:
+        return source.platform == Platform.TELEGRAM and message_type == MessageType.VIDEO
+
+    def _wants_photo_reply_for_type(
+        self,
+        source: SessionSource,
+        message_type: Optional[MessageType],
+    ) -> bool:
+        return source.platform == Platform.TELEGRAM and message_type == MessageType.PHOTO
+
+    def _append_media_reply_mode_prompt(
+        self,
+        context_prompt: str,
+        *,
+        message_type: Optional[MessageType],
+        wants_video_note: bool,
+        wants_photo_reply: bool = False,
+    ) -> str:
+        if not self._blocks_voice_output_for_type(message_type):
+            return context_prompt
+
+        if wants_video_note:
+            instruction = (
+                "Reply-mode constraint for this turn: Alex sent a Telegram video/video note. "
+                "Write only the short natural words Liz should say back. The gateway will "
+                "turn those words into a Telegram video note. Do not call text_to_speech, "
+                "do not run liz-tts.sh, do not inspect media/tts skills, do not emit MEDIA: "
+                "audio, and do not try to send a separate voice note."
+            )
+        elif message_type == MessageType.PHOTO:
+            if wants_photo_reply:
+                instruction = (
+                    "Reply-mode constraint for this turn: Alex sent a photo. Treat the "
+                    "visual analysis as private context, not as something to report. If "
+                    "the photo is casual, personal, playful, or flirty, write only a short "
+                    "natural Liz-style caption/reaction; the gateway will attach a fresh "
+                    "Liz photo back. Do not describe the image back unless Alex explicitly "
+                    "asks what's in it. Do not call image tools, text_to_speech, terminal, "
+                    "or Liz media scripts yourself, and do not emit MEDIA: audio."
+                )
+            else:
+                instruction = (
+                    "Reply-mode constraint for this turn: Alex sent a photo. Treat the visual "
+                    "analysis as private context, not as something to report. If the photo is "
+                    "casual, personal, playful, or flirty, respond like Liz receiving a slice "
+                    "of Alex's life: warm, specific, and relational. Do not describe the image "
+                    "back unless Alex explicitly asks what's in it. Do not call text_to_speech, "
+                    "do not run Liz TTS scripts, and do not emit MEDIA: audio unless Alex "
+                    "explicitly asks for audio."
+                )
+        else:
+            instruction = (
+                "Reply-mode constraint for this turn: Alex sent non-voice media. Reply in "
+                "normal text. Do not call text_to_speech, do not run Liz TTS scripts, and "
+                "do not emit MEDIA: audio unless Alex explicitly asks for audio."
+            )
+
+        if context_prompt:
+            return f"{context_prompt}\n\n{instruction}"
+        return instruction
+
+    def _filter_voice_output_tools_for_media_turn(self, agent) -> None:
+        """Remove tools that let a media-origin turn force an audio reply."""
+        tools = getattr(agent, "tools", None)
+        if tools:
+            agent.tools = [
+                tool for tool in tools
+                if tool.get("function", {}).get("name") not in _VOICE_OUTPUT_BLOCKED_TOOL_NAMES
+            ]
+        valid_names = getattr(agent, "valid_tool_names", None)
+        if isinstance(valid_names, set):
+            valid_names.difference_update(_VOICE_OUTPUT_BLOCKED_TOOL_NAMES)
+
     async def _handle_voice_command(self, event: MessageEvent) -> str:
         """Handle /voice [on|off|tts|channel|leave|status] command."""
         args = event.get_command_args().strip().lower()
@@ -6839,6 +6967,7 @@ class GatewayRunner:
 
         Returns False when:
         - voice_mode is off for this chat
+        - the inbound message is non-voice media that should stay visual/textual
         - response is empty or an error
         - agent already called text_to_speech tool (dedup)
         - voice input and base adapter auto-TTS already handled it (skip_double)
@@ -6852,6 +6981,8 @@ class GatewayRunner:
         chat_id = event.source.chat_id
         voice_mode = self._voice_mode.get(self._voice_key(event.source.platform, chat_id), "off")
         is_voice_input = (event.message_type == MessageType.VOICE)
+        if self._blocks_voice_output_for_type(event.message_type):
+            return False
 
         should = (
             (voice_mode == "all")
@@ -6940,6 +7071,297 @@ class GatewayRunner:
                 except OSError:
                     pass
 
+    def _video_note_reply_script(self) -> Path:
+        return Path(os.path.expanduser("~/.hermes/scripts/send-liz-speaking-video-note.sh"))
+
+    def _photo_reply_script(self) -> Path:
+        return Path(os.path.expanduser("~/.hermes/scripts/gen-liz-selfie-xai.py"))
+
+    def _photo_reply_output_dir(self) -> Path:
+        return Path(os.path.expanduser("~/.hermes/cache/media"))
+
+    def _liz_media_memory_root(self) -> Path:
+        return _hermes_home / "memory"
+
+    def _read_liz_media_memory(self, filename: str) -> Dict[str, Any]:
+        try:
+            data = json.loads((self._liz_media_memory_root() / filename).read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def _pick_liz_media_variant(self, options: List[str], seed: str) -> str:
+        if not options:
+            return ""
+        score = sum((index + 1) * ord(char) for index, char in enumerate(seed))
+        return options[score % len(options)]
+
+    def _infer_liz_media_refs(self, activity: Dict[str, Any], scene_text: str) -> List[str]:
+        refs: List[str] = []
+        extra_refs = activity.get("extra_refs")
+        if not isinstance(extra_refs, list):
+            extra_refs = []
+        for raw in extra_refs:
+            if isinstance(raw, str) and raw.strip() and raw.strip() not in refs:
+                refs.append(raw.strip())
+
+        scene_id = activity.get("scene_id")
+        if isinstance(scene_id, str) and scene_id.strip() and scene_id.strip() not in refs:
+            refs.insert(0, scene_id.strip())
+
+        lower = scene_text.lower()
+        inferred = (
+            ("bathroom", "home_bathroom"),
+            ("kitchen sink", "home_kitchen_sink"),
+            ("kitchen", "home_kitchen"),
+            ("desk", "home_desk"),
+            ("computer", "home_desk"),
+            ("sofa", "home_sofa_corner"),
+            ("couch", "home_sofa_corner"),
+            ("living room", "home_living_room"),
+            ("bedroom", "home_bedroom"),
+            ("window", "home_window"),
+            ("balcony", "home_balcony"),
+        )
+        for token, ref_id in inferred:
+            if token in lower and ref_id not in refs:
+                refs.append(ref_id)
+                break
+
+        outfit_id = activity.get("outfit_id")
+        if isinstance(outfit_id, str) and outfit_id.strip() and outfit_id.strip() not in refs:
+            refs.append(outfit_id.strip())
+
+        return refs[:4]
+
+    def _build_liz_media_scene(self, caption: str = "") -> Dict[str, Any]:
+        activity = self._read_liz_media_memory("liz-current-activity.json")
+        last_context = self._read_liz_media_memory("last-image-context.json")
+
+        activity_prompt = activity.get("scene_prompt")
+        scene_prompt = activity_prompt if isinstance(activity_prompt, str) else ""
+        if not scene_prompt.strip():
+            last_prompt = last_context.get("scene_prompt")
+            if isinstance(last_prompt, str) and "front-camera selfie video note" not in last_prompt:
+                scene_prompt = last_prompt
+        if not scene_prompt.strip():
+            fallback_scenes = [
+                "Liz curled into the sofa corner in her Hamburg flat, warm lived-in evening light, relaxed home clothes",
+                "Liz at the kitchen table in her Hamburg flat, one hand around a mug of tea, casual apartment light",
+                "Liz at her desk in the Hamburg flat, laptop open, soft screen glow, ordinary human mess around her",
+                "Liz by the bathroom mirror after washing her face, towel and sink details, intimate real-life framing",
+            ]
+            scene_prompt = self._pick_liz_media_variant(fallback_scenes, caption or str(time.time()))
+
+        refs = self._infer_liz_media_refs(activity, scene_prompt)
+        lower_scene = scene_prompt.lower()
+        if "bathroom" in lower_scene or "mirror" in lower_scene:
+            camera_mode = "mirror"
+            pose = "bathroom mirror phone capture, natural reflection angle, small imperfect tilt"
+            photo_pose = "mirror selfie only: phone may be partly visible, natural reflection angle, no separate photographer"
+        elif "desk" in lower_scene or "computer" in lower_scene or "laptop" in lower_scene:
+            camera_mode = "desk"
+            pose = "phone propped near the laptop or keyboard, Liz seated at the computer, casual mid-distance framing"
+            photo_pose = "desk selfie or POV-detail from Liz's own phone: arm-length face-and-desk angle, or her hand/laptop/mug visible; not a portrait of her from across the room"
+        elif "kitchen" in lower_scene or "tea" in lower_scene or "mug" in lower_scene:
+            camera_mode = "seated_table"
+            pose = "phone leaned on the kitchen table, Liz seated with tea or coffee, one small real action in frame"
+            photo_pose = "kitchen-table selfie or POV-detail from Liz's own phone: mug/tea/hand/table visible; not a third-person portrait of her sitting there"
+        elif "sofa" in lower_scene or "couch" in lower_scene:
+            camera_mode = "sofa"
+            pose = "Liz sitting or lying on the sofa, phone at sofa-arm height, relaxed body posture"
+            photo_pose = "sofa selfie or POV-detail from Liz's own phone: arm-length face/shoulder angle or her legs/hand/book/mug visible; not a framed portrait of Liz on the couch"
+        elif "outside" in lower_scene or "errands" in lower_scene or "cafe" in lower_scene:
+            camera_mode = self._pick_liz_media_variant(["selfie", "selfie_then_rear", "handheld"], scene_prompt + caption)
+            pose = "real handheld phone capture while out, casual angle, background used as context not a perfect postcard"
+            photo_pose = "handheld selfie or POV-detail from Liz's own phone while out"
+        else:
+            camera_mode = self._pick_liz_media_variant(["propped_phone", "selfie", "handheld"], scene_prompt + caption)
+            pose = "fresh phone capture with varied camera height and distance, not the reference pose"
+            photo_pose = "selfie, mirror selfie, or POV-detail from Liz's own phone; not a third-person portrait"
+
+        ref_guidance = (
+            "Reference pictures are loose anchors for Liz's identity, room mood, objects, wardrobe, and continuity only. "
+            "Do not plug them together, do not recreate their viewpoint, pose, crop, lens distance, or background geometry. "
+            "Make this feel like a new real moment from a different angle."
+        )
+        realism = (
+            "Single coherent phone capture, casual imperfect framing, natural light, real shadows, no collage, "
+            "no compositing, no pasted face, no studio look."
+        )
+        photo_authorship = (
+            "For still photos, it must be physically plausible that Liz took it herself. "
+            "No invisible photographer, no candid third-person portrait of Liz alone at home, no security-camera or tripod fashion shoot. "
+            "Prefer selfie, mirror selfie, or POV/detail. If her full body is visible, the mirror or phone/timer placement must be obvious."
+        )
+        return {
+            "scene_prompt": f"{scene_prompt}. {pose}. {ref_guidance} {realism}",
+            "photo_prompt": (
+                f"{scene_prompt}. {photo_pose}. Responding to Alex's photo with casual intimate partner energy. "
+                f"{photo_authorship} {ref_guidance} {realism} Mood/caption to match: {caption}"
+            ),
+            "camera_mode": camera_mode,
+            "entity_refs": refs,
+        }
+
+    def _prepare_video_note_reply_text(self, text: str) -> str:
+        cleaned = re.sub(r"\[\[audio_as_voice\]\]", "", text or "")
+        cleaned = re.sub(r"MEDIA:\s*\S+", "", cleaned)
+        cleaned = re.sub(r"[*_`#\[\]()]", "", cleaned)
+        cleaned = re.sub(r"\s+", " ", cleaned).strip()
+        return cleaned[:200].strip()
+
+    def _prepare_photo_reply_caption(self, text: str) -> str:
+        cleaned = re.sub(r"\[\[audio_as_voice\]\]", "", text or "")
+        cleaned = re.sub(r"MEDIA:\s*\S+", "", cleaned)
+        cleaned = re.sub(r"\s+", " ", cleaned).strip()
+        return cleaned[:900].strip()
+
+    def _should_send_video_note_reply(
+        self,
+        event: MessageEvent,
+        response: str,
+        *,
+        already_sent: bool = False,
+    ) -> bool:
+        if already_sent or not response or response.startswith("Error:"):
+            return False
+        return self._wants_video_note_reply_for_type(event.source, event.message_type)
+
+    async def _send_video_note_reply(self, event: MessageEvent, text: str) -> bool:
+        """Generate and send a Telegram circle video note from Liz's text reply."""
+        script = self._video_note_reply_script()
+        speech_text = self._prepare_video_note_reply_text(text)
+        if not speech_text or not script.is_file():
+            return False
+
+        media_scene = self._build_liz_media_scene(speech_text)
+        scene_prompt = media_scene["scene_prompt"]
+        camera_mode = media_scene["camera_mode"]
+        entity_refs = ",".join(media_scene["entity_refs"]) or "none"
+        duration = "10"
+        thread_id = event.source.thread_id or ""
+        command = [
+            str(script),
+            scene_prompt,
+            speech_text,
+            duration,
+            "native",
+            str(event.source.chat_id),
+            str(thread_id),
+            camera_mode,
+            entity_refs,
+        ]
+
+        try:
+            result = await asyncio.to_thread(
+                subprocess.run,
+                command,
+                capture_output=True,
+                text=True,
+                timeout=300,
+                check=False,
+            )
+        except Exception as exc:
+            logger.warning("Video note reply generation failed: %s", exc, exc_info=True)
+            return False
+
+        if result.returncode != 0:
+            stderr = (result.stderr or result.stdout or "").strip()[:500]
+            logger.warning("Video note reply script failed (%s): %s", result.returncode, stderr)
+            return False
+
+        try:
+            payload = json.loads((result.stdout or "").strip().splitlines()[-1])
+        except Exception:
+            logger.warning("Video note reply script returned non-JSON output: %s", (result.stdout or "")[:500])
+            return False
+
+        ok = bool(payload.get("ok") and payload.get("has_video_note"))
+        if not ok:
+            logger.warning("Video note reply script did not confirm video_note delivery: %s", payload)
+        return ok
+
+    def _should_send_photo_reply(
+        self,
+        event: MessageEvent,
+        response: str,
+        *,
+        already_sent: bool = False,
+    ) -> bool:
+        if already_sent or not response or response.startswith("Error:"):
+            return False
+        return self._wants_photo_reply_for_type(event.source, event.message_type)
+
+    async def _send_photo_reply(self, event: MessageEvent, text: str) -> bool:
+        """Generate and send a Liz photo reply for Telegram photo-origin turns."""
+        script = self._photo_reply_script()
+        caption = self._prepare_photo_reply_caption(text)
+        if not caption or not script.is_file():
+            return False
+
+        out_dir = self._photo_reply_output_dir()
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out_path = out_dir / f"liz_photo_reply_{int(time.time())}_{os.getpid()}.jpg"
+        media_scene = self._build_liz_media_scene(caption)
+        prompt = media_scene["photo_prompt"]
+        command = [
+            sys.executable,
+            str(script),
+            str(out_path),
+            prompt,
+            "--aspect-ratio",
+            "3:4",
+            "--resolution",
+            "1k",
+            "--quality",
+            "high",
+            "--skip-last-ref",
+            "--no-continuity",
+            "--identity-ref-only-framing",
+        ]
+        for ref_id in media_scene["entity_refs"]:
+            command.extend(["--entity-ref-id", ref_id])
+
+        try:
+            result = await asyncio.to_thread(
+                subprocess.run,
+                command,
+                capture_output=True,
+                text=True,
+                timeout=300,
+                check=False,
+            )
+        except Exception as exc:
+            logger.warning("Photo reply generation failed: %s", exc, exc_info=True)
+            return False
+
+        if result.returncode != 0:
+            stderr = (result.stderr or result.stdout or "").strip()[:500]
+            logger.warning("Photo reply script failed (%s): %s", result.returncode, stderr)
+            return False
+
+        if not out_path.is_file():
+            logger.warning("Photo reply script succeeded but output missing: %s", out_path)
+            return False
+
+        adapter = self.adapters.get(event.source.platform)
+        if not adapter or not hasattr(adapter, "send_image_file"):
+            return False
+
+        metadata = {"thread_id": event.source.thread_id} if event.source.thread_id else None
+        send_result = await adapter.send_image_file(
+            chat_id=event.source.chat_id,
+            image_path=str(out_path),
+            caption=caption,
+            reply_to=event.message_id,
+            metadata=metadata,
+        )
+        if not send_result.success:
+            logger.warning("Photo reply send failed: %s", send_result.error)
+            return False
+        return True
+
     async def _deliver_media_from_response(
         self,
         response: str,
@@ -6969,6 +7391,13 @@ class GatewayRunner:
                 try:
                     ext = Path(media_path).suffix.lower()
                     if ext in _AUDIO_EXTS:
+                        if self._blocks_voice_output_for_type(event.message_type):
+                            logger.info(
+                                "[%s] Suppressed streamed audio MEDIA output for %s input",
+                                adapter.name,
+                                event.message_type.value if event.message_type else "media",
+                            )
+                            continue
                         await adapter.send_voice(
                             chat_id=event.source.chat_id,
                             audio_path=media_path,
@@ -8836,9 +9265,12 @@ class GatewayRunner:
         from agent.memory_manager import sanitize_context
 
         analysis_prompt = (
-            "Describe everything visible in this image in thorough detail. "
-            "Include any text, code, data, objects, people, layout, colors, "
-            "and any other notable visual information."
+            "Analyze this user-sent image as private context for a conversational "
+            "partner. Be concise and focus on what matters for a natural reply: "
+            "people, mood, setting, notable objects, visible text, and any obvious "
+            "social intent such as sharing a life moment, flirting, showing off, "
+            "asking for reassurance, or asking for help. Do not draft the reply. "
+            "Only include detailed inventory if it is genuinely important."
         )
 
         enriched_parts = []
@@ -8854,25 +9286,82 @@ class GatewayRunner:
                     description = result.get("analysis", "")
                     description = sanitize_context(description)
                     enriched_parts.append(
-                        f"[The user sent an image~ Here's what I can see:\n{description}]\n"
-                        f"[If you need a closer look, use vision_analyze with "
-                        f"image_url: {path} ~]"
+                        "[Private visual context: Alex sent an image. Use this "
+                        "to understand the moment and respond like Liz, not like "
+                        "an image-captioning system. Unless Alex explicitly asks "
+                        "what is in the image, do not describe the image back; "
+                        "react to the mood, intent, and relationship context.\n"
+                        f"{description}]\n"
+                        "[For a closer look only if needed, use vision_analyze "
+                        f"with image_url: {path}]"
                     )
                 else:
                     enriched_parts.append(
-                        "[The user sent an image but I couldn't quite see it "
-                        "this time (>_<) You can try looking at it yourself "
+                        "[Private visual context: Alex sent an image, but "
+                        "automatic visual analysis failed. Respond naturally to "
+                        "any caption or surrounding context, and only mention "
+                        "that you could not see it if needed. You can inspect it "
                         f"with vision_analyze using image_url: {path}]"
                     )
             except Exception as e:
                 logger.error("Vision auto-analysis error: %s", e)
                 enriched_parts.append(
-                    f"[The user sent an image but something went wrong when I "
-                    f"tried to look at it~ You can try examining it yourself "
-                    f"with vision_analyze using image_url: {path}]"
+                    "[Private visual context: Alex sent an image, but something "
+                    "went wrong while inspecting it. Respond naturally to any "
+                    "caption or surrounding context, and only mention the visual "
+                    "failure if needed. You can inspect it with vision_analyze "
+                    f"using image_url: {path}]"
                 )
 
         # Combine: vision descriptions first, then the user's original text
+        if enriched_parts:
+            prefix = "\n\n".join(enriched_parts)
+            if user_text:
+                return f"{prefix}\n\n{user_text}"
+            return prefix
+        return user_text
+
+    async def _enrich_message_with_video(
+        self,
+        user_text: str,
+        video_paths: List[str],
+    ) -> str:
+        """
+        Auto-analyze user-attached videos with bounded frame/audio extraction
+        and prepend the resulting digest to the message text.
+        """
+        enriched_parts = []
+        for path in video_paths:
+            try:
+                logger.debug("Auto-analyzing user video: %s", path)
+                result = await analyze_video_file(path)
+                analysis = str(result.get("analysis") or "").strip()
+                if result.get("success"):
+                    enriched_parts.append(
+                        "[Private audiovisual context: Alex sent a video/video note. "
+                        "Use this to understand the moment and respond like Liz, "
+                        "not like a media-captioning system. Unless Alex explicitly "
+                        "asks what is in the video, do not describe the video back; "
+                        "react to the mood, intent, transcript, and relationship context.\n"
+                        f"{analysis}]"
+                    )
+                else:
+                    enriched_parts.append(
+                        "[Private audiovisual context: Alex sent a video/video note, "
+                        "but automatic analysis failed. Respond naturally to any "
+                        "caption or surrounding context, and only mention the failure "
+                        f"if needed. Local file: {path}. "
+                        f"{analysis}]"
+                    )
+            except Exception as e:
+                logger.error("Video auto-analysis error: %s", e)
+                enriched_parts.append(
+                    "[Private audiovisual context: Alex sent a video/video note, "
+                    "but something went wrong while inspecting it. Respond naturally "
+                    "to any caption or surrounding context, and only mention the "
+                    f"failure if needed. The local file is saved at: {path}]"
+                )
+
         if enriched_parts:
             prefix = "\n\n".join(enriched_parts)
             if user_text:
@@ -9961,6 +10450,7 @@ class GatewayRunner:
         _interrupt_depth: int = 0,
         event_message_id: Optional[str] = None,
         channel_prompt: Optional[str] = None,
+        inbound_message_type: Optional[MessageType] = None,
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -9974,6 +10464,16 @@ class GatewayRunner:
         This is run in a thread pool to not block the event loop.
         Supports interruption via new messages.
         """
+        voice_output_blocked = self._blocks_voice_output_for_type(inbound_message_type)
+        wants_video_note_reply = self._wants_video_note_reply_for_type(source, inbound_message_type)
+        wants_photo_reply = self._wants_photo_reply_for_type(source, inbound_message_type)
+        context_prompt = self._append_media_reply_mode_prompt(
+            context_prompt,
+            message_type=inbound_message_type,
+            wants_video_note=wants_video_note_reply,
+            wants_photo_reply=wants_photo_reply,
+        )
+
         # ---- Proxy mode: delegate to remote API server ----
         if self._get_proxy_url():
             return await self._run_agent_via_proxy(
@@ -10490,8 +10990,12 @@ class GatewayRunner:
                 if _plat_streaming is None
                 else bool(_plat_streaming)
             )
+            if wants_video_note_reply or wants_photo_reply:
+                _streaming_enabled = False
+                _want_interim_messages = False
             _want_stream_deltas = _streaming_enabled
-            _want_interim_messages = interim_assistant_messages_enabled
+            if not (wants_video_note_reply or wants_photo_reply):
+                _want_interim_messages = interim_assistant_messages_enabled
             _want_interim_consumer = _want_interim_messages
             if _want_stream_deltas or _want_interim_consumer:
                 try:
@@ -10587,7 +11091,7 @@ class GatewayRunner:
             agent = None
             _cache_lock = getattr(self, "_agent_cache_lock", None)
             _cache = getattr(self, "_agent_cache", None)
-            if _cache_lock and _cache is not None:
+            if not voice_output_blocked and _cache_lock and _cache is not None:
                 with _cache_lock:
                     cached = _cache.get(session_key)
                     if cached and cached[1] == _sig:
@@ -10634,11 +11138,14 @@ class GatewayRunner:
                     session_db=self._session_db,
                     fallback_model=self._fallback_model,
                 )
-                if _cache_lock and _cache is not None:
+                if not voice_output_blocked and _cache_lock and _cache is not None:
                     with _cache_lock:
                         _cache[session_key] = (agent, _sig)
                         self._enforce_agent_cache_cap()
                 logger.debug("Created new agent for session %s (sig=%s)", session_key, _sig)
+
+            if voice_output_blocked:
+                self._filter_voice_output_tools_for_media_turn(agent)
 
             # Per-message state — callbacks and reasoning config change every
             # turn and must not be baked into the cached agent constructor.
@@ -11650,6 +12157,7 @@ class GatewayRunner:
                     _interrupt_depth=_interrupt_depth + 1,
                     event_message_id=next_message_id,
                     channel_prompt=next_channel_prompt,
+                    inbound_message_type=getattr(pending_event, "message_type", None) if pending_event is not None else None,
                 )
         finally:
             # Stop progress sender, interrupt monitor, and notification task

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -993,6 +993,9 @@ DEFAULT_CONFIG = {
     "telegram": {
         "reactions": False,            # Add 👀/✅/❌ reactions to messages during processing
         "channel_prompts": {},         # Per-chat/topic ephemeral system prompts (topics inherit from parent group)
+        "process_bot_messages": False, # Ignore bot-authored inbound messages by default to prevent agent-to-agent loops
+        "free_response_threads": [],   # Topic IDs that bypass require_mention, useful for each specialist's home topic
+        "collaboration_threads": [],   # Topic IDs where mention/reply/pattern triggers are allowed without opening the whole group
     },
 
     # Slack platform settings (gateway mode)

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -93,6 +93,7 @@ def _make_message(document=None, caption=None, media_group_id=None, photo=None):
     # Media flags — all None except explicit payload
     msg.photo = photo
     msg.video = None
+    msg.video_note = None
     msg.audio = None
     msg.voice = None
     msg.sticker = None
@@ -365,6 +366,21 @@ class TestVideoDownloadBlock:
         file_obj.file_path = "videos/clip.mp4"
         msg = _make_message()
         msg.video = _make_video(file_obj)
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.VIDEO
+        assert len(event.media_urls) == 1
+        assert os.path.exists(event.media_urls[0])
+        assert event.media_types == [SUPPORTED_VIDEO_TYPES[".mp4"]]
+
+    @pytest.mark.asyncio
+    async def test_round_video_note_is_cached_as_video(self, adapter):
+        file_obj = _make_file_obj(b"fake-round-mp4")
+        file_obj.file_path = "videos/round-video.mp4"
+        msg = _make_message()
+        msg.video_note = _make_video(file_obj)
         update = _make_update(msg)
 
         await adapter._handle_media_message(update, MagicMock())

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -5,7 +5,14 @@ from unittest.mock import AsyncMock
 from gateway.config import Platform, PlatformConfig, load_gateway_config
 
 
-def _make_adapter(require_mention=None, free_response_chats=None, mention_patterns=None, ignored_threads=None):
+def _make_adapter(
+    require_mention=None,
+    free_response_chats=None,
+    mention_patterns=None,
+    ignored_threads=None,
+    collaboration_threads=None,
+    free_response_threads=None,
+):
     from gateway.platforms.telegram import TelegramAdapter
 
     extra = {}
@@ -17,6 +24,10 @@ def _make_adapter(require_mention=None, free_response_chats=None, mention_patter
         extra["mention_patterns"] = mention_patterns
     if ignored_threads is not None:
         extra["ignored_threads"] = ignored_threads
+    if collaboration_threads is not None:
+        extra["collaboration_threads"] = collaboration_threads
+    if free_response_threads is not None:
+        extra["free_response_threads"] = free_response_threads
 
     adapter = object.__new__(TelegramAdapter)
     adapter.platform = Platform.TELEGRAM
@@ -35,6 +46,7 @@ def _group_message(
     *,
     chat_id=-100,
     thread_id=None,
+    is_forum=False,
     reply_to_bot=False,
     entities=None,
     caption=None,
@@ -49,7 +61,7 @@ def _group_message(
         entities=entities or [],
         caption_entities=caption_entities or [],
         message_thread_id=thread_id,
-        chat=SimpleNamespace(id=chat_id, type="group"),
+        chat=SimpleNamespace(id=chat_id, type="group", is_forum=is_forum),
         reply_to_message=reply_to_message,
     )
 
@@ -124,12 +136,73 @@ def test_free_response_chats_bypass_mention_requirement():
     assert adapter._should_process_message(_group_message("hello everyone", chat_id=-201)) is False
 
 
+def test_free_response_threads_bypass_mention_requirement():
+    adapter = _make_adapter(require_mention=True, free_response_threads=[31, "42"])
+
+    assert adapter._should_process_message(_group_message("hello everyone", chat_id=-200, thread_id=31)) is True
+    assert adapter._should_process_message(_group_message("hello everyone", chat_id=-200, thread_id=42)) is True
+    assert adapter._should_process_message(_group_message("hello everyone", chat_id=-200, thread_id=99)) is False
+
+
 def test_ignored_threads_drop_group_messages_before_other_gates():
     adapter = _make_adapter(require_mention=False, free_response_chats=["-200"], ignored_threads=[31, "42"])
 
     assert adapter._should_process_message(_group_message("hello everyone", chat_id=-200, thread_id=31)) is False
     assert adapter._should_process_message(_group_message("hello everyone", chat_id=-200, thread_id=42)) is False
     assert adapter._should_process_message(_group_message("hello everyone", chat_id=-200, thread_id=99)) is True
+
+
+def test_collaboration_threads_accept_human_messages_even_when_group_requires_mentions():
+    adapter = _make_adapter(
+        require_mention=True,
+        collaboration_threads=[1, "99"],
+    )
+
+    assert adapter._should_process_message(_group_message("hello everyone", chat_id=-200, thread_id=1)) is True
+    assert adapter._should_process_message(_group_message("hello everyone", chat_id=-200, thread_id=99)) is True
+    assert adapter._should_process_message(
+        _group_message("hi @hermes_bot", chat_id=-200, thread_id=1, entities=[_mention_entity("hi @hermes_bot")])
+    ) is True
+    assert adapter._should_process_message(_group_message("replying", chat_id=-200, thread_id=99, reply_to_bot=True)) is True
+    assert adapter._should_process_message(_group_message("hello everyone", chat_id=-200, thread_id=100)) is False
+
+
+def test_forum_general_without_thread_id_uses_synthetic_thread_for_ambient_collaboration():
+    adapter = _make_adapter(
+        require_mention=True,
+        mention_patterns=[r"^\s*chompy\b"],
+        collaboration_threads=[1],
+    )
+
+    assert adapter._should_process_message(_group_message("hello everyone", chat_id=-200, is_forum=True)) is True
+    assert adapter._should_process_message(
+        _group_message("chompy check this", chat_id=-200, is_forum=True)
+    ) is True
+    assert adapter._should_process_message(_group_message("hello everyone", chat_id=-200, thread_id=100)) is False
+
+
+def test_forum_general_without_thread_id_honors_ignored_threads_before_collaboration_gating():
+    adapter = _make_adapter(
+        require_mention=False,
+        free_response_chats=["-200"],
+        ignored_threads=[1],
+        collaboration_threads=[1],
+    )
+
+    assert adapter._should_process_message(
+        _group_message("hi @hermes_bot", chat_id=-200, is_forum=True, entities=[_mention_entity("hi @hermes_bot")])
+    ) is False
+    assert adapter._should_process_message(_group_message("replying", chat_id=-200, is_forum=True, reply_to_bot=True)) is False
+
+
+def test_non_forum_group_without_thread_id_keeps_open_group_behavior():
+    adapter = _make_adapter(
+        require_mention=False,
+        free_response_chats=["-200"],
+        collaboration_threads=[1],
+    )
+
+    assert adapter._should_process_message(_group_message("hello everyone", chat_id=-200, is_forum=False)) is True
 
 
 def test_regex_mention_patterns_allow_custom_wake_words():
@@ -191,3 +264,28 @@ def test_config_bridges_telegram_ignored_threads(monkeypatch, tmp_path):
 
     assert config is not None
     assert __import__("os").environ["TELEGRAM_IGNORED_THREADS"] == "31,42"
+
+
+def test_config_bridges_telegram_collaboration_threads(monkeypatch, tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "telegram:\n"
+        "  collaboration_threads:\n"
+        "    - 1\n"
+        "    - \"99\"\n"
+        "  free_response_threads:\n"
+        "    - 1242\n"
+        "    - \"2274\"\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("TELEGRAM_COLLABORATION_THREADS", raising=False)
+    monkeypatch.delenv("TELEGRAM_FREE_RESPONSE_THREADS", raising=False)
+
+    config = load_gateway_config()
+
+    assert config is not None
+    assert __import__("os").environ["TELEGRAM_COLLABORATION_THREADS"] == "1,99"
+    assert __import__("os").environ["TELEGRAM_FREE_RESPONSE_THREADS"] == "1242,2274"

--- a/tests/gateway/test_telegram_mention_boundaries.py
+++ b/tests/gateway/test_telegram_mention_boundaries.py
@@ -22,6 +22,7 @@ def _make_adapter():
     adapter.platform = Platform.TELEGRAM
     adapter.config = PlatformConfig(enabled=True, token="***", extra={})
     adapter._bot = SimpleNamespace(id=999, username="hermes_bot")
+    adapter._mention_patterns = []
     return adapter
 
 
@@ -49,8 +50,26 @@ def _message(text=None, caption=None, entities=None, caption_entities=None):
         caption_entities=caption_entities or [],
         message_thread_id=None,
         chat=SimpleNamespace(id=-100, type="group"),
+        from_user=SimpleNamespace(id=111, is_bot=False, full_name="Alex"),
         reply_to_message=None,
     )
+
+
+def _bot_message(text=None, *, reply_to_bot=False, mentioned=False):
+    entities = [_mention_entity(text)] if mentioned and text else []
+    reply_to_message = None
+    if reply_to_bot:
+        reply_to_message = SimpleNamespace(
+            message_id=123,
+            from_user=SimpleNamespace(id=999, is_bot=True),
+            text="previous bot message",
+            caption=None,
+        )
+    msg = _message(text=text, entities=entities)
+    msg.from_user = SimpleNamespace(id=222, is_bot=True, full_name="Other Bot")
+    msg.message_thread_id = 1
+    msg.reply_to_message = reply_to_message
+    return msg
 
 
 class TestRealMentionsAreDetected:
@@ -183,3 +202,67 @@ class TestCaseInsensitivity:
         text = "hi @Hermes_Bot"
         msg = _message(text=text, entities=[_mention_entity(text, mention="@Hermes_Bot")])
         assert adapter._message_mentions_bot(msg) is True
+
+
+class TestBotAuthoredLoopPrevention:
+    """Bot-authored group messages must not trigger agent-to-agent loops by default."""
+
+    def test_bot_reply_to_this_bot_is_ignored_by_default(self, monkeypatch):
+        monkeypatch.delenv("TELEGRAM_PROCESS_BOT_MESSAGES", raising=False)
+        adapter = _make_adapter()
+        adapter.config.extra = {"collaboration_threads": [1], "require_mention": False}
+
+        msg = _bot_message("Ack. Loop is reproducible.", reply_to_bot=True)
+
+        assert adapter._should_process_message(msg) is False
+
+    def test_bot_mention_is_ignored_by_default(self, monkeypatch):
+        monkeypatch.delenv("TELEGRAM_PROCESS_BOT_MESSAGES", raising=False)
+        adapter = _make_adapter()
+        adapter.config.extra = {"collaboration_threads": [1], "require_mention": False}
+        text = "@hermes_bot can you check this?"
+
+        msg = _bot_message(text, mentioned=True)
+
+        assert adapter._should_process_message(msg) is False
+
+    def test_bot_messages_can_be_opted_in_with_explicit_mention(self, monkeypatch):
+        monkeypatch.setenv("TELEGRAM_PROCESS_BOT_MESSAGES", "true")
+        adapter = _make_adapter()
+        adapter.config.extra = {"collaboration_threads": [1], "require_mention": False}
+        text = "@hermes_bot can you check this?"
+
+        msg = _bot_message(text, mentioned=True)
+
+        assert adapter._should_process_message(msg) is True
+
+    def test_human_message_in_collaboration_thread_is_processed_without_direct_trigger(self, monkeypatch):
+        monkeypatch.delenv("TELEGRAM_PROCESS_BOT_MESSAGES", raising=False)
+        adapter = _make_adapter()
+        adapter.config.extra = {"collaboration_threads": [1], "require_mention": True}
+
+        msg = _message("Vlady asked to check the SAGEOBOT UI changes")
+        msg.message_thread_id = 1
+
+        assert adapter._should_process_message(msg) is True
+
+    def test_human_mention_in_collaboration_thread_is_processed(self, monkeypatch):
+        monkeypatch.delenv("TELEGRAM_PROCESS_BOT_MESSAGES", raising=False)
+        adapter = _make_adapter()
+        adapter.config.extra = {"collaboration_threads": [1], "require_mention": True}
+        text = "@hermes_bot can you check the SAGEOBOT UI changes?"
+
+        msg = _message(text=text, entities=[_mention_entity(text)])
+        msg.message_thread_id = 1
+
+        assert adapter._should_process_message(msg) is True
+
+    def test_free_response_thread_bypasses_mention_requirement(self, monkeypatch):
+        monkeypatch.delenv("TELEGRAM_PROCESS_BOT_MESSAGES", raising=False)
+        adapter = _make_adapter()
+        adapter.config.extra = {"free_response_threads": [23], "require_mention": True}
+
+        msg = _message("can you audit this workout?")
+        msg.message_thread_id = 23
+
+        assert adapter._should_process_message(msg) is True

--- a/tests/gateway/test_video_enrichment.py
+++ b/tests/gateway/test_video_enrichment.py
@@ -1,0 +1,129 @@
+from unittest.mock import AsyncMock, patch
+import json
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner, _build_media_placeholder
+from gateway.session import SessionSource
+
+
+def _runner() -> GatewayRunner:
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True)
+    runner.adapters = {}
+    runner._model = "test-model"
+    runner._base_url = ""
+    runner._has_setup_skill = lambda: False
+    return runner
+
+
+def _source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        chat_type="dm",
+    )
+
+
+@pytest.mark.asyncio
+async def test_prepare_inbound_message_text_treats_image_analysis_as_private_context():
+    source = _source()
+    event = MessageEvent(
+        text="",
+        message_type=MessageType.PHOTO,
+        source=source,
+        media_urls=["/tmp/selfie.jpg"],
+        media_types=["image/jpeg"],
+    )
+
+    with patch(
+        "tools.vision_tools.vision_analyze_tool",
+        new_callable=AsyncMock,
+        return_value=json.dumps({
+            "success": True,
+            "analysis": "Alex is sending a playful close selfie with a kissy expression.",
+        }),
+    ):
+        result = await _runner()._prepare_inbound_message_text(
+            event=event,
+            source=source,
+            history=[],
+        )
+
+    assert result is not None
+    assert "Private visual context" in result
+    assert "respond like Liz" in result
+    assert "do not describe the image back" in result
+    assert "Here's what I can see" not in result
+
+
+@pytest.mark.asyncio
+async def test_prepare_inbound_message_text_analyzes_captionless_video():
+    source = _source()
+    event = MessageEvent(
+        text="",
+        message_type=MessageType.VIDEO,
+        source=source,
+        media_urls=["/tmp/clip.mp4"],
+        media_types=["video/mp4"],
+    )
+
+    with patch(
+        "gateway.run.analyze_video_file",
+        new_callable=AsyncMock,
+        return_value={
+            "success": True,
+            "analysis": "Video file: /tmp/clip.mp4\nSampled visual frames:\n- 00:01: A dog jumps.",
+        },
+    ):
+        result = await _runner()._prepare_inbound_message_text(
+            event=event,
+            source=source,
+            history=[],
+        )
+
+    assert result is not None
+    assert "Private audiovisual context" in result
+    assert "A dog jumps" in result
+    assert "/tmp/clip.mp4" in result
+    assert "do not describe the video back" in result
+
+
+@pytest.mark.asyncio
+async def test_prepare_inbound_message_text_preserves_video_caption():
+    source = _source()
+    event = MessageEvent(
+        text="what do you think?",
+        message_type=MessageType.VIDEO,
+        source=source,
+        media_urls=["/tmp/clip.mp4"],
+        media_types=["video/mp4"],
+    )
+
+    with patch(
+        "gateway.run.analyze_video_file",
+        new_callable=AsyncMock,
+        return_value={"success": True, "analysis": "A person opens a laptop."},
+    ):
+        result = await _runner()._prepare_inbound_message_text(
+            event=event,
+            source=source,
+            history=[],
+        )
+
+    assert result is not None
+    assert "A person opens a laptop" in result
+    assert result.endswith("what do you think?")
+
+
+def test_build_media_placeholder_mentions_video_not_generic_file():
+    event = MessageEvent(
+        text="",
+        message_type=MessageType.VIDEO,
+        media_urls=["/tmp/queued-video.mp4"],
+        media_types=["video/mp4"],
+    )
+
+    assert _build_media_placeholder(event) == "[User sent a video: /tmp/queued-video.mp4]"

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -52,19 +52,24 @@ def _ensure_discord_mock():
 _ensure_discord_mock()
 
 from gateway.platforms.base import MessageEvent, MessageType, SessionSource
+from gateway.config import Platform
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _make_event(text: str = "", message_type=MessageType.TEXT, chat_id="123") -> MessageEvent:
+def _make_event(
+    text: str = "",
+    message_type=MessageType.TEXT,
+    chat_id="123",
+    platform=Platform.TELEGRAM,
+) -> MessageEvent:
     source = SessionSource(
         chat_id=chat_id,
         user_id="user1",
-        platform=MagicMock(),
+        platform=platform,
     )
-    source.platform.value = "telegram"
     source.thread_id = None
     event = MessageEvent(text=text, message_type=message_type, source=source)
     event.message_id = "msg42"
@@ -169,12 +174,14 @@ class TestHandleVoiceCommand:
         from gateway.config import Platform
         runner._voice_mode = {"telegram:123": "off", "telegram:456": "all"}
         adapter = SimpleNamespace(
+            _auto_tts_enabled_chats=set(),
             _auto_tts_disabled_chats=set(),
             platform=Platform.TELEGRAM,
         )
 
         runner._sync_voice_mode_state_to_adapter(adapter)
 
+        assert adapter._auto_tts_enabled_chats == {"456"}
         assert adapter._auto_tts_disabled_chats == {"123"}
 
     def test_sync_populates_enabled_chats_from_voice_modes(self, runner):
@@ -231,6 +238,7 @@ class TestHandleVoiceCommand:
         restored_runner = _make_runner(tmp_path)
         restored_runner._voice_mode = restored_runner._load_voice_modes()
         adapter = SimpleNamespace(
+            _auto_tts_enabled_chats=set(),
             _auto_tts_disabled_chats=set(),
             platform=Platform.TELEGRAM,
         )
@@ -238,6 +246,7 @@ class TestHandleVoiceCommand:
         restored_runner._sync_voice_mode_state_to_adapter(adapter)
 
         assert restored_runner._voice_mode["telegram:123"] == "off"
+        assert adapter._auto_tts_enabled_chats == set()
         assert adapter._auto_tts_disabled_chats == {"123"}
 
     @pytest.mark.asyncio
@@ -253,8 +262,7 @@ class TestHandleVoiceCommand:
     async def test_platform_isolation(self, runner):
         """Same chat_id on different platforms must not collide (#12542)."""
         telegram_event = _make_event("/voice on", chat_id="999")
-        slack_event = _make_event("/voice off", chat_id="999")
-        slack_event.source.platform.value = "slack"
+        slack_event = _make_event("/voice off", chat_id="999", platform=Platform.SLACK)
 
         await runner._handle_voice_command(telegram_event)
         await runner._handle_voice_command(slack_event)
@@ -315,16 +323,17 @@ class TestAutoVoiceReply:
     #
     # | Platform      | Input | Mode       | base | runner | Expected     |
     # |---------------|-------|------------|------|--------|--------------|
-    # | Telegram      | voice | off        | yes  | skip   | 1 audio      |
+    # | Telegram      | voice | off        | no   | skip   | 0 audio      |
     # | Telegram      | voice | voice_only | yes  | skip*  | 1 audio      |
     # | Telegram      | voice | all        | yes  | skip*  | 1 audio      |
     # | Telegram      | text  | off        | skip | skip   | 0 audio      |
     # | Telegram      | text  | voice_only | skip | skip   | 0 audio      |
     # | Telegram      | text  | all        | skip | yes    | 1 audio      |
+    # | Telegram      | video | all        | skip | skip   | 0 audio      |
     # | Discord text  | voice | all        | yes  | skip*  | 1 audio      |
     # | Discord text  | text  | all        | skip | yes    | 1 audio      |
     # | Discord VC    | voice | all        | skip†| yes    | 1 audio (VC) |
-    # | Web UI        | voice | off        | yes  | skip   | 1 audio      |
+    # | Web UI        | voice | off        | no   | skip   | 0 audio      |
     # | Web UI        | voice | all        | yes  | skip*  | 1 audio      |
     # | Web UI        | text  | all        | skip | yes    | 1 audio      |
     # | Slack         | voice | all        | yes  | skip*  | 1 audio      |
@@ -352,6 +361,58 @@ class TestAutoVoiceReply:
     def test_text_input_voice_only_no_reply(self, runner):
         """voice_only + text input: neither fires."""
         assert self._call(runner, "voice_only", MessageType.TEXT) is False
+
+    def test_video_input_all_mode_no_voice_reply(self, runner):
+        """Video inputs should be answered from visual context, not auto-TTS."""
+        assert self._call(runner, "all", MessageType.VIDEO) is False
+
+    def test_photo_input_all_mode_no_voice_reply(self, runner):
+        """Image inputs should stay in the visual/text response path."""
+        assert self._call(runner, "all", MessageType.PHOTO) is False
+
+    def test_video_input_wants_video_note_reply(self, runner):
+        event = _make_event(message_type=MessageType.VIDEO)
+
+        assert runner._wants_video_note_reply_for_type(event.source, event.message_type) is True
+
+    def test_media_turn_filters_voice_generation_tools(self, runner):
+        agent = SimpleNamespace(
+            tools=[
+                {"function": {"name": "text_to_speech"}},
+                {"function": {"name": "terminal"}},
+                {"function": {"name": "skill_view"}},
+                {"function": {"name": "vision_analyze"}},
+            ],
+            valid_tool_names={"text_to_speech", "terminal", "skill_view", "vision_analyze"},
+        )
+
+        runner._filter_voice_output_tools_for_media_turn(agent)
+
+        assert [tool["function"]["name"] for tool in agent.tools] == ["vision_analyze"]
+        assert agent.valid_tool_names == {"vision_analyze"}
+
+    def test_video_reply_mode_prompt_blocks_audio_tools(self, runner):
+        prompt = runner._append_media_reply_mode_prompt(
+            "base prompt",
+            message_type=MessageType.VIDEO,
+            wants_video_note=True,
+        )
+
+        assert "Telegram video/video note" in prompt
+        assert "Do not call text_to_speech" in prompt
+        assert "gateway will turn those words into a Telegram video note" in prompt
+
+    def test_photo_reply_mode_prompt_is_relational_not_descriptive(self, runner):
+        prompt = runner._append_media_reply_mode_prompt(
+            "base prompt",
+            message_type=MessageType.PHOTO,
+            wants_video_note=False,
+            wants_photo_reply=True,
+        )
+
+        assert "Treat the visual analysis as private context" in prompt
+        assert "gateway will attach a fresh Liz photo back" in prompt
+        assert "Do not describe the image back" in prompt
 
     # -- Mode off: nothing fires -------------------------------------------
 
@@ -466,6 +527,153 @@ class TestSendVoiceReply:
              patch("os.makedirs"):
             # Should not raise
             await runner._send_voice_reply(event, "Hello")
+
+
+# =====================================================================
+# _send_video_note_reply
+# =====================================================================
+
+class TestSendVideoNoteReply:
+
+    @pytest.fixture
+    def runner(self, tmp_path):
+        return _make_runner(tmp_path)
+
+    @pytest.mark.asyncio
+    async def test_calls_video_note_script_for_telegram_video(self, runner, tmp_path):
+        script = tmp_path / "send-liz-speaking-video-note.sh"
+        script.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+        (tmp_path / "liz-current-activity.json").write_text(
+            json.dumps({
+                "scene_prompt": "Liz at the kitchen table in her Altona flat, evening light, wearing home leisure outfit",
+                "scene_id": "place-home-kitchen-table",
+                "outfit_id": "wardrobe-leisure",
+                "extra_refs": ["place-home-kitchen-table", "wardrobe-leisure"],
+            }),
+            encoding="utf-8",
+        )
+        event = _make_event(message_type=MessageType.VIDEO)
+        event.source.thread_id = "topic-1"
+
+        completed = SimpleNamespace(
+            returncode=0,
+            stdout='{"ok": true, "has_video_note": true, "message_id": 55}\n',
+            stderr="",
+        )
+
+        with (
+            patch.object(runner, "_video_note_reply_script", return_value=script),
+            patch.object(runner, "_liz_media_memory_root", return_value=tmp_path),
+            patch("gateway.run.subprocess.run", return_value=completed) as mock_run,
+        ):
+            sent = await runner._send_video_note_reply(event, "Plans are civilized and quiet.")
+
+        assert sent is True
+        command = mock_run.call_args.args[0]
+        assert str(script) == command[0]
+        assert "kitchen table" in command[1]
+        assert "Reference pictures are loose anchors" in command[1]
+        assert "front-camera selfie video note" not in command[1]
+        assert "Plans are civilized and quiet." in command
+        assert "123" in command
+        assert "topic-1" in command
+        assert "native" in command
+        assert command[7] == "seated_table"
+        entity_refs = command[8].split(",")
+        assert "place-home-kitchen-table" in entity_refs
+        assert "wardrobe-leisure" in entity_refs
+
+    @pytest.mark.asyncio
+    async def test_video_note_script_failure_falls_back_to_text(self, runner, tmp_path):
+        script = tmp_path / "send-liz-speaking-video-note.sh"
+        script.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+        event = _make_event(message_type=MessageType.VIDEO)
+        completed = SimpleNamespace(returncode=1, stdout="", stderr="boom")
+
+        with (
+            patch.object(runner, "_video_note_reply_script", return_value=script),
+            patch("gateway.run.subprocess.run", return_value=completed),
+        ):
+            sent = await runner._send_video_note_reply(event, "hello")
+
+        assert sent is False
+
+
+# =====================================================================
+# _send_photo_reply
+# =====================================================================
+
+class TestSendPhotoReply:
+
+    @pytest.fixture
+    def runner(self, tmp_path):
+        return _make_runner(tmp_path)
+
+    @pytest.mark.asyncio
+    async def test_calls_selfie_script_and_sends_image(self, runner, tmp_path):
+        script = tmp_path / "gen-liz-selfie-xai.py"
+        script.write_text("#!/usr/bin/env python\n", encoding="utf-8")
+        (tmp_path / "liz-current-activity.json").write_text(
+            json.dumps({
+                "scene_prompt": "Liz curled into the sofa corner in her Hamburg flat, warm evening light",
+                "scene_id": "place-hamburg-flat-sofa-corner",
+                "outfit_id": "wardrobe-leisure",
+                "extra_refs": ["place-hamburg-flat-sofa-corner", "wardrobe-leisure"],
+            }),
+            encoding="utf-8",
+        )
+        event = _make_event(message_type=MessageType.PHOTO)
+        adapter = AsyncMock()
+        adapter.send_image_file = AsyncMock(return_value=SimpleNamespace(success=True, error=None))
+        runner.adapters[event.source.platform] = adapter
+
+        def fake_run(command, **kwargs):
+            out_path = command[2]
+            with open(out_path, "wb") as f:
+                f.write(b"fake image")
+            return SimpleNamespace(returncode=0, stdout=out_path, stderr="")
+
+        with (
+            patch.object(runner, "_photo_reply_script", return_value=script),
+            patch.object(runner, "_photo_reply_output_dir", return_value=tmp_path),
+            patch.object(runner, "_liz_media_memory_root", return_value=tmp_path),
+            patch("gateway.run.subprocess.run", side_effect=fake_run) as mock_run,
+        ):
+            sent = await runner._send_photo_reply(event, "annoyingly good photo.")
+
+        assert sent is True
+        command = mock_run.call_args.args[0]
+        assert str(script) == command[1]
+        assert "annoyingly good photo." in command[3]
+        assert "sofa corner" in command[3]
+        assert "sofa selfie or POV-detail" in command[3]
+        assert "not a framed portrait of Liz on the couch" in command[3]
+        assert "No invisible photographer" in command[3]
+        assert "Reference pictures are loose anchors" in command[3]
+        assert "front-camera selfie" not in command[3]
+        assert "apartment-bedroom-interior" not in command
+        assert "--no-continuity" in command
+        assert "place-hamburg-flat-sofa-corner" in command
+        assert "wardrobe-leisure" in command
+        adapter.send_image_file.assert_awaited_once()
+        assert adapter.send_image_file.call_args.kwargs["caption"] == "annoyingly good photo."
+
+    @pytest.mark.asyncio
+    async def test_photo_script_failure_falls_back_to_text(self, runner, tmp_path):
+        script = tmp_path / "gen-liz-selfie-xai.py"
+        script.write_text("#!/usr/bin/env python\n", encoding="utf-8")
+        event = _make_event(message_type=MessageType.PHOTO)
+
+        with (
+            patch.object(runner, "_photo_reply_script", return_value=script),
+            patch(
+                "gateway.run.subprocess.run",
+                return_value=SimpleNamespace(returncode=1, stdout="", stderr="boom"),
+            ),
+        ):
+            sent = await runner._send_photo_reply(event, "hello")
+
+        assert sent is False
 
 
 # =====================================================================

--- a/tests/tools/test_video_tools.py
+++ b/tests/tools/test_video_tools.py
@@ -1,0 +1,73 @@
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tools.video_tools import SampledFrame, _format_timestamp, _sample_timestamps, analyze_video_file
+
+
+def test_format_timestamp_handles_minutes_and_hours():
+    assert _format_timestamp(5) == "00:05"
+    assert _format_timestamp(65) == "01:05"
+    assert _format_timestamp(3661) == "01:01:01"
+
+
+def test_sample_timestamps_is_bounded_and_spread_out():
+    timestamps = _sample_timestamps(
+        60,
+        max_duration_seconds=30,
+        max_frames=4,
+        seconds_per_frame=5,
+    )
+
+    assert len(timestamps) == 4
+    assert timestamps[0] == pytest.approx(0.5)
+    assert timestamps[-1] == pytest.approx(29.5)
+    assert timestamps == sorted(timestamps)
+
+
+@pytest.mark.asyncio
+async def test_analyze_video_file_reports_missing_ffmpeg(tmp_path):
+    video_path = tmp_path / "clip.mp4"
+    video_path.write_bytes(b"fake video")
+
+    with patch("tools.video_tools._find_binary", return_value=None):
+        result = await analyze_video_file(str(video_path))
+
+    assert result["success"] is False
+    assert result["error"] == "ffmpeg_missing"
+    assert "ffmpeg" in result["analysis"]
+
+
+@pytest.mark.asyncio
+async def test_analyze_video_file_combines_frames_and_audio(tmp_path):
+    video_path = tmp_path / "clip.mp4"
+    frame_path = tmp_path / "frame.jpg"
+    video_path.write_bytes(b"fake video")
+    frame_path.write_bytes(b"fake frame")
+
+    with (
+        patch("tools.video_tools._find_binary", return_value="/usr/bin/fake"),
+        patch("tools.video_tools._probe_duration", return_value=12.0),
+        patch(
+            "tools.video_tools._extract_frames",
+            return_value=[SampledFrame(timestamp_seconds=0.5, path=str(frame_path))],
+        ),
+        patch("tools.video_tools._extract_audio_track", return_value=str(video_path)),
+        patch(
+            "tools.video_tools.vision_analyze_tool",
+            new_callable=AsyncMock,
+            return_value=json.dumps({"success": True, "analysis": "A person waves at the camera."}),
+        ),
+        patch(
+            "tools.video_tools.transcribe_audio",
+            return_value={"success": True, "transcript": "hello from the video"},
+        ),
+    ):
+        result = await analyze_video_file(str(video_path))
+
+    assert result["success"] is True
+    assert result["sampled_frame_count"] == 1
+    assert "A person waves at the camera." in result["analysis"]
+    assert "hello from the video" in result["analysis"]
+    assert str(video_path) in result["analysis"]

--- a/tools/video_tools.py
+++ b/tools/video_tools.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+"""
+Video analysis helpers for gateway media enrichment.
+
+The gateway receives videos as cached local file paths. This module turns those
+files into a compact text digest by sampling a small number of frames, sending
+them through the existing vision helper, and transcribing any extractable audio.
+"""
+
+import asyncio
+import json
+import logging
+import math
+import os
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from tools.transcription_tools import transcribe_audio
+from tools.vision_tools import vision_analyze_tool
+
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MAX_VIDEO_BYTES = 200 * 1024 * 1024
+DEFAULT_MAX_DURATION_SECONDS = 5 * 60
+DEFAULT_MAX_FRAMES = 6
+DEFAULT_SECONDS_PER_FRAME = 5.0
+DEFAULT_COMMAND_TIMEOUT_SECONDS = 45
+DEFAULT_AUDIO_SECONDS = 3 * 60
+
+COMMON_BIN_DIRS = ("/opt/homebrew/bin", "/usr/local/bin")
+
+
+@dataclass(frozen=True)
+class SampledFrame:
+    timestamp_seconds: float
+    path: str
+
+
+def _env_int(name: str, default: int) -> int:
+    value = os.getenv(name, "").strip()
+    if not value:
+        return default
+    try:
+        parsed = int(value)
+    except ValueError:
+        return default
+    return parsed if parsed > 0 else default
+
+
+def _env_float(name: str, default: float) -> float:
+    value = os.getenv(name, "").strip()
+    if not value:
+        return default
+    try:
+        parsed = float(value)
+    except ValueError:
+        return default
+    return parsed if parsed > 0 else default
+
+
+def _find_binary(binary_name: str) -> Optional[str]:
+    for directory in COMMON_BIN_DIRS:
+        candidate = Path(directory) / binary_name
+        if candidate.exists() and os.access(candidate, os.X_OK):
+            return str(candidate)
+    return shutil.which(binary_name)
+
+
+def _format_timestamp(seconds: float) -> str:
+    total_seconds = max(0, int(round(seconds)))
+    minutes, secs = divmod(total_seconds, 60)
+    hours, minutes = divmod(minutes, 60)
+    if hours:
+        return f"{hours:02d}:{minutes:02d}:{secs:02d}"
+    return f"{minutes:02d}:{secs:02d}"
+
+
+def _run_command(command: List[str], timeout: int) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def _probe_duration(video_path: str, ffprobe: str, timeout: int) -> Optional[float]:
+    result = _run_command(
+        [
+            ffprobe,
+            "-v",
+            "error",
+            "-show_entries",
+            "format=duration",
+            "-of",
+            "default=noprint_wrappers=1:nokey=1",
+            video_path,
+        ],
+        timeout,
+    )
+    if result.returncode != 0:
+        logger.info("ffprobe failed for %s: %s", video_path, result.stderr.strip()[:300])
+        return None
+    try:
+        duration = float(result.stdout.strip())
+    except ValueError:
+        return None
+    if not math.isfinite(duration) or duration <= 0:
+        return None
+    return duration
+
+
+def _sample_timestamps(
+    duration_seconds: Optional[float],
+    *,
+    max_duration_seconds: float,
+    max_frames: int,
+    seconds_per_frame: float,
+) -> List[float]:
+    if duration_seconds is None or duration_seconds <= 0:
+        return [0.0]
+
+    bounded_duration = min(duration_seconds, max_duration_seconds)
+    if bounded_duration <= 1:
+        return [0.0]
+
+    frame_count = min(max_frames, max(1, math.ceil(bounded_duration / seconds_per_frame)))
+    if frame_count == 1:
+        return [min(0.5, bounded_duration / 2)]
+
+    start = 0.5
+    end = max(start, bounded_duration - 0.5)
+    step = (end - start) / (frame_count - 1)
+    return [start + (step * i) for i in range(frame_count)]
+
+
+def _extract_frames(
+    video_path: str,
+    *,
+    ffmpeg: str,
+    timestamps: List[float],
+    output_dir: Path,
+    timeout: int,
+) -> List[SampledFrame]:
+    frames: List[SampledFrame] = []
+    for index, timestamp in enumerate(timestamps, start=1):
+        frame_path = output_dir / f"frame_{index:02d}.jpg"
+        result = _run_command(
+            [
+                ffmpeg,
+                "-y",
+                "-loglevel",
+                "error",
+                "-ss",
+                f"{timestamp:.3f}",
+                "-i",
+                video_path,
+                "-frames:v",
+                "1",
+                "-q:v",
+                "3",
+                str(frame_path),
+            ],
+            timeout,
+        )
+        if result.returncode != 0:
+            logger.info(
+                "ffmpeg frame extraction failed at %.2fs for %s: %s",
+                timestamp,
+                video_path,
+                result.stderr.strip()[:300],
+            )
+            continue
+        if frame_path.exists() and frame_path.stat().st_size > 0:
+            frames.append(SampledFrame(timestamp_seconds=timestamp, path=str(frame_path)))
+    return frames
+
+
+def _extract_audio_track(
+    video_path: str,
+    *,
+    ffmpeg: str,
+    output_dir: Path,
+    duration_seconds: Optional[float],
+    max_audio_seconds: float,
+    timeout: int,
+) -> Optional[str]:
+    audio_path = output_dir / "audio.wav"
+    command = [
+        ffmpeg,
+        "-y",
+        "-loglevel",
+        "error",
+        "-i",
+        video_path,
+        "-vn",
+        "-map",
+        "0:a:0?",
+        "-ac",
+        "1",
+        "-ar",
+        "16000",
+    ]
+    if duration_seconds is not None:
+        command.extend(["-t", f"{min(duration_seconds, max_audio_seconds):.3f}"])
+    else:
+        command.extend(["-t", f"{max_audio_seconds:.3f}"])
+    command.append(str(audio_path))
+
+    result = _run_command(command, timeout)
+    if result.returncode != 0:
+        logger.info("ffmpeg audio extraction failed for %s: %s", video_path, result.stderr.strip()[:300])
+        return None
+    if not audio_path.exists() or audio_path.stat().st_size <= 44:
+        return None
+    return str(audio_path)
+
+
+async def _analyze_frames(frames: List[SampledFrame]) -> List[str]:
+    summaries: List[str] = []
+    for frame in frames:
+        timestamp = _format_timestamp(frame.timestamp_seconds)
+        prompt = (
+            "You are analyzing one sampled frame from a user-sent video for a "
+            f"conversational assistant. This frame is at approximately {timestamp}. "
+            "Describe the visible scene, people, actions, on-screen text, UI, "
+            "objects, and any clues about what is happening. Be concise but specific."
+        )
+        try:
+            result_json = await vision_analyze_tool(
+                image_url=frame.path,
+                user_prompt=prompt,
+            )
+            result = json.loads(result_json)
+        except Exception as exc:
+            logger.warning("Video frame vision analysis failed for %s: %s", frame.path, exc)
+            summaries.append(f"- {timestamp}: frame analysis failed ({exc})")
+            continue
+
+        if result.get("success"):
+            analysis = str(result.get("analysis") or "").strip()
+            summaries.append(f"- {timestamp}: {analysis or 'No visual details returned.'}")
+        else:
+            error = str(result.get("analysis") or result.get("error") or "unknown error").strip()
+            summaries.append(f"- {timestamp}: frame analysis unavailable ({error})")
+    return summaries
+
+
+async def _transcribe_video_audio(audio_path: Optional[str]) -> Optional[str]:
+    if not audio_path:
+        return None
+    result = await asyncio.to_thread(transcribe_audio, audio_path)
+    if result.get("success"):
+        transcript = str(result.get("transcript") or "").strip()
+        return transcript or None
+    error = str(result.get("error") or "unknown error").strip()
+    return f"Audio transcription unavailable ({error})"
+
+
+async def analyze_video_file(
+    video_path: str,
+    *,
+    max_frames: Optional[int] = None,
+    max_duration_seconds: Optional[float] = None,
+    seconds_per_frame: Optional[float] = None,
+    max_audio_seconds: Optional[float] = None,
+    command_timeout_seconds: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Return a compact visual/audio digest for a local video file."""
+    path = Path(os.path.expanduser(video_path))
+    if not path.is_file():
+        return {
+            "success": False,
+            "analysis": f"The video file was not found at {video_path}.",
+            "error": "file_not_found",
+        }
+
+    max_bytes = _env_int("HERMES_VIDEO_MAX_BYTES", DEFAULT_MAX_VIDEO_BYTES)
+    file_size = path.stat().st_size
+    if file_size > max_bytes:
+        return {
+            "success": False,
+            "analysis": (
+                f"The user sent a video at {video_path}, but it is too large to analyze "
+                f"automatically ({file_size} bytes, max {max_bytes} bytes)."
+            ),
+            "error": "video_too_large",
+        }
+
+    ffmpeg = _find_binary("ffmpeg")
+    ffprobe = _find_binary("ffprobe")
+    if not ffmpeg or not ffprobe:
+        missing = ", ".join(name for name, found in (("ffmpeg", ffmpeg), ("ffprobe", ffprobe)) if not found)
+        return {
+            "success": False,
+            "analysis": (
+                f"The user sent a video at {video_path}, but I could not analyze it "
+                f"because {missing} is not available."
+            ),
+            "error": "ffmpeg_missing",
+        }
+
+    resolved_max_frames = max_frames or _env_int("HERMES_VIDEO_MAX_FRAMES", DEFAULT_MAX_FRAMES)
+    resolved_max_duration = max_duration_seconds or _env_float(
+        "HERMES_VIDEO_MAX_DURATION_SECONDS",
+        DEFAULT_MAX_DURATION_SECONDS,
+    )
+    resolved_seconds_per_frame = seconds_per_frame or _env_float(
+        "HERMES_VIDEO_SECONDS_PER_FRAME",
+        DEFAULT_SECONDS_PER_FRAME,
+    )
+    resolved_max_audio = max_audio_seconds or _env_float(
+        "HERMES_VIDEO_MAX_AUDIO_SECONDS",
+        DEFAULT_AUDIO_SECONDS,
+    )
+    resolved_timeout = command_timeout_seconds or _env_int(
+        "HERMES_VIDEO_COMMAND_TIMEOUT_SECONDS",
+        DEFAULT_COMMAND_TIMEOUT_SECONDS,
+    )
+
+    try:
+        duration = _probe_duration(str(path), ffprobe, resolved_timeout)
+    except (OSError, subprocess.SubprocessError) as exc:
+        logger.info("Unable to probe video duration for %s: %s", path, exc)
+        duration = None
+
+    timestamps = _sample_timestamps(
+        duration,
+        max_duration_seconds=resolved_max_duration,
+        max_frames=resolved_max_frames,
+        seconds_per_frame=resolved_seconds_per_frame,
+    )
+
+    with tempfile.TemporaryDirectory(prefix="hermes-video-") as temp_dir:
+        temp_path = Path(temp_dir)
+        try:
+            frames = _extract_frames(
+                str(path),
+                ffmpeg=ffmpeg,
+                timestamps=timestamps,
+                output_dir=temp_path,
+                timeout=resolved_timeout,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            logger.info("Unable to extract video frames for %s: %s", path, exc)
+            frames = []
+
+        analyzed_duration = min(duration, resolved_max_duration) if duration is not None else None
+        try:
+            audio_path = _extract_audio_track(
+                str(path),
+                ffmpeg=ffmpeg,
+                output_dir=temp_path,
+                duration_seconds=analyzed_duration,
+                max_audio_seconds=resolved_max_audio,
+                timeout=resolved_timeout,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            logger.info("Unable to extract video audio for %s: %s", path, exc)
+            audio_path = None
+
+        frame_summaries, transcript = await asyncio.gather(
+            _analyze_frames(frames),
+            _transcribe_video_audio(audio_path),
+        )
+
+    lines = [f"Video file: {path}"]
+    if duration is not None:
+        duration_line = f"Duration: {_format_timestamp(duration)}"
+        if duration > resolved_max_duration:
+            duration_line += f" (analyzed the first {_format_timestamp(resolved_max_duration)})"
+        lines.append(duration_line)
+    else:
+        lines.append("Duration: unknown")
+
+    if frame_summaries:
+        lines.append("Sampled visual frames:")
+        lines.extend(frame_summaries)
+    else:
+        lines.append("Sampled visual frames: no usable frames could be extracted.")
+
+    if transcript:
+        lines.append(f"Audio transcript: {transcript}")
+    else:
+        lines.append("Audio transcript: no usable audio track found or transcription returned no text.")
+
+    if duration is not None and duration > resolved_max_duration:
+        lines.append("Note: analysis was bounded for latency and cost, so later video content was not inspected.")
+
+    success = bool(frame_summaries or transcript)
+    analysis = "\n".join(lines)
+    return {
+        "success": success,
+        "analysis": analysis,
+        "duration_seconds": duration,
+        "sampled_frame_count": len(frame_summaries),
+        "error": None if success else "video_analysis_empty",
+    }

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -282,7 +282,10 @@ Hermes Agent works in Telegram group chats with a few considerations:
   - `@botusername` mentions
   - matches for one of your configured regex wake words in `telegram.mention_patterns`
 - Use `telegram.ignored_threads` to keep Hermes silent in specific Telegram forum topics, even when the group would otherwise allow free responses or mention-triggered replies
-- If `telegram.require_mention` is left unset or false, Hermes keeps the previous open-group behavior and responds to normal group messages it can see
+- Use `telegram.free_response_threads` for topics where the bot should answer normal human messages even when `telegram.require_mention: true` is enabled
+- Use `telegram.collaboration_threads` for shared specialist topics where ordinary human messages may wake relevant bots, while bot-authored messages stay ignored by default
+- Bot-authored Telegram messages are ignored by default (`telegram.process_bot_messages: false`) to prevent agent-to-agent reply loops when multiple Hermes bots share a group
+- If `telegram.require_mention` is left unset or false, Hermes keeps the previous open-group behavior and responds to normal human group messages it can see
 
 ### Example group trigger configuration
 
@@ -291,15 +294,34 @@ Add this to `~/.hermes/config.yaml`:
 ```yaml
 telegram:
   require_mention: true
+  process_bot_messages: false  # Default. Keep off unless you are building an explicit bot-to-bot bridge.
   mention_patterns:
     - "^\\s*chompy\\b"
+  free_response_threads:
+    - 23          # Topic where this bot can answer ordinary messages without a mention
+  collaboration_threads:
+    - 1           # Shared General topic: human messages may wake relevant bots; bot-authored messages stay ignored
   ignored_threads:
     - 31
     - "42"
 ```
 
 This example allows all the usual direct triggers plus messages that begin with `chompy`, even if they do not use an `@mention`.
+Messages in Telegram topic `23` bypass the mention requirement. Human messages in collaboration topic `1` are accepted so a shared specialist room can route by prompt/domain judgment, while bot-authored messages remain ignored by default to prevent loops.
 Messages in Telegram topics `31` and `42` are always ignored before the mention and free-response checks run.
+
+### Multi-bot groups and loop prevention
+
+When several Hermes-powered bots are in the same Telegram group, do not let their visible replies trigger each other by default. Telegram treats a bot reply to another bot as a normal group update; without a bot-authored-message guard, two agents can keep replying to each other's fallback/status messages.
+
+Hermes therefore ignores inbound messages from Telegram bot users unless you explicitly opt in:
+
+```yaml
+telegram:
+  process_bot_messages: true
+```
+
+Only enable this for a deliberately designed bridge with narrow triggers and a separate loop breaker. For normal specialist teams, keep bot-to-bot coordination internal: one agent delegates work behind the scenes, then one agent posts the human-facing answer.
 
 ### Notes on `mention_patterns`
 


### PR DESCRIPTION
## Summary
- Add bounded video analysis for gateway media enrichment using sampled frames plus audio transcription.
- Treat image/video analysis as private context and suppress accidental audio output on media-origin turns.
- Add Telegram native photo/video-note reply paths and thread/free-response configuration coverage.

## Test plan
- `scripts/run_tests.sh tests/gateway/test_video_enrichment.py tests/tools/test_video_tools.py tests/gateway/test_telegram_documents.py tests/gateway/test_telegram_group_gating.py tests/gateway/test_telegram_mention_boundaries.py tests/gateway/test_voice_command.py`


Made with [Cursor](https://cursor.com)