### PR TITLE
fix(agent): capability registry for Anthropic prompt-cache support (#17332)

### DIFF
--- a/agent/anthropic_cache_capability.py
+++ b/agent/anthropic_cache_capability.py
@@ -1,0 +1,136 @@
+"""Capability registry for Anthropic-compatible prompt caching.
+
+Background
+----------
+Anthropic prompt caching (``cache_control`` breakpoints) is a contract layered
+on top of the Anthropic Messages API. Native Anthropic obviously honours it.
+But many third-party providers also speak the native Anthropic protocol
+(``api_mode = 'anthropic_messages'``) and *some* of them also implement the
+``cache_control`` contract for their own model families:
+
+  - MiniMax (M2.x) — https://platform.minimax.io/docs/api-reference/anthropic-api-compatible-cache
+  - LiteLLM Anthropic-proxy mode — passes through cache_control to the
+    upstream provider, so caching works iff the upstream does.
+
+Pre-#17332 the gate in ``_anthropic_prompt_cache_policy`` only enabled
+caching for ``api_mode == 'anthropic_messages'`` when the model name
+contained ``"claude"`` (i.e. third-party gateways serving Anthropic's
+Claude family). That left providers using the native Anthropic protocol
+for *their own* models (MiniMax-M2.7 etc.) silently re-billing the full
+prompt on every turn.
+
+Hardcoding ``provider == 'minimax'`` would fix MiniMax but leaves the
+same regression waiting for the next provider that adds Anthropic-cache
+support. This module is the longer-lived answer:
+
+  1. ``ProviderConfig.extra`` carries an ``anthropic_cache: True`` flag
+     and an optional ``anthropic_cache_hosts`` tuple (so URL-only callers
+     who configure a custom endpoint pointing at MiniMax still get
+     caching even though their ``provider`` reads ``"custom"``).
+
+  2. ``provider_supports_anthropic_cache(provider, base_url)`` reads
+     that registry. It also consults the user's ``agent.anthropic_cache_hosts``
+     config list so operators can opt-in their own gateway without
+     waiting for an upstream patch.
+
+The actual decision in ``_anthropic_prompt_cache_policy`` keeps the
+existing native-Anthropic / OpenRouter / Claude-on-third-party-gateway
+branches; this module only adds the new capability-driven branch.
+
+(issue #17332)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Iterable, Optional
+
+from utils import base_url_hostname
+
+logger = logging.getLogger(__name__)
+
+
+# Hostnames known to honour the Anthropic ``cache_control`` contract for
+# arbitrary (non-Claude) model families. Populated automatically from
+# ``ProviderConfig.extra['anthropic_cache_hosts']`` at module-load time
+# so we don't drift out of sync with the auth registry.
+_REGISTRY_HOSTS: set = set()
+
+
+def _refresh_registry_hosts() -> None:
+    """Re-read ProviderConfig.extra entries. Safe to call multiple times."""
+    _REGISTRY_HOSTS.clear()
+    try:
+        from hermes_cli.auth import PROVIDER_REGISTRY
+    except Exception:  # pragma: no cover — circular-import safety
+        return
+    for pconfig in PROVIDER_REGISTRY.values():
+        extra = getattr(pconfig, "extra", None) or {}
+        if not extra.get("anthropic_cache"):
+            continue
+        hosts = extra.get("anthropic_cache_hosts") or ()
+        for h in hosts:
+            if isinstance(h, str) and h:
+                _REGISTRY_HOSTS.add(h.lower())
+
+
+_refresh_registry_hosts()
+
+
+def _normalize_hosts(hosts):
+    if not hosts:
+        return set()
+    out = set()
+    for h in hosts:
+        if isinstance(h, str) and h.strip():
+            out.add(h.strip().lower())
+    return out
+
+
+def provider_supports_anthropic_cache(
+    provider,
+    base_url,
+    *,
+    user_configured_hosts=None,
+):
+    """Return True when this provider/base_url pair documents ``cache_control``
+    support for its own model families on the native Anthropic transport.
+
+    Resolution order:
+      1. ProviderConfig.extra['anthropic_cache'] == True for this provider id
+         (handles built-in providers like ``minimax`` / ``minimax-cn``).
+      2. Hostname match against the union of registry-declared hosts and
+         user-configured hosts (handles ``provider == 'custom'`` setups
+         pointing at a known endpoint, and operator-curated additions).
+
+    Returns False otherwise. Callers must still gate on
+    ``api_mode == 'anthropic_messages'`` themselves — this helper says
+    *nothing* about the wire protocol, only about the cache contract.
+    """
+    # 1. Provider id lookup (exact match against the registry).
+    if provider:
+        try:
+            from hermes_cli.auth import PROVIDER_REGISTRY
+        except Exception:
+            PROVIDER_REGISTRY = {}
+        key = provider.strip().lower() if isinstance(provider, str) else ""
+        pconfig = PROVIDER_REGISTRY.get(key) if key and PROVIDER_REGISTRY else None
+        if pconfig is not None:
+            extra = getattr(pconfig, "extra", None) or {}
+            if extra.get("anthropic_cache") is True:
+                return True
+
+    # 2. Hostname match — covers custom providers pointing at a known
+    # endpoint, plus operator-configured additions.
+    host = ""
+    if base_url:
+        host = (base_url_hostname(base_url) or "").lower()
+    if host:
+        configured = _normalize_hosts(user_configured_hosts)
+        # _REGISTRY_HOSTS is intentionally reloaded lazily so tests that
+        # mutate the registry inside a fixture don't get a stale snapshot.
+        _refresh_registry_hosts()
+        if host in _REGISTRY_HOSTS or host in configured:
+            return True
+
+    return False

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -262,6 +262,13 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         inference_base_url="https://api.minimax.io/anthropic",
         api_key_env_vars=("MINIMAX_API_KEY",),
         base_url_env_var="MINIMAX_BASE_URL",
+        extra={
+            # MiniMax serves its own M2.x family through the native
+            # Anthropic protocol and documents explicit cache_control
+            # support. https://platform.minimax.io/docs/api-reference/anthropic-api-compatible-cache
+            "anthropic_cache": True,
+            "anthropic_cache_hosts": ("api.minimax.io",),
+        },
     ),
     "minimax-oauth": ProviderConfig(
         id="minimax-oauth",
@@ -305,6 +312,10 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         inference_base_url="https://api.minimaxi.com/anthropic",
         api_key_env_vars=("MINIMAX_CN_API_KEY",),
         base_url_env_var="MINIMAX_CN_BASE_URL",
+        extra={
+            "anthropic_cache": True,
+            "anthropic_cache_hosts": ("api.minimaxi.com",),
+        },
     ),
     "deepseek": ProviderConfig(
         id="deepseek",

--- a/run_agent.py
+++ b/run_agent.py
@@ -1212,6 +1212,23 @@ class AIAgent:
         self.prefill_messages = prefill_messages or []  # Prefilled conversation turns
         self._force_ascii_payload = False
         
+        # Operator opt-in for Anthropic-protocol gateways that document
+        # cache_control for their own model families. Read once here so
+        # the policy lookup is cheap and consistent across switch_model
+        # / fallback activation. (issue #17332)
+        self._anthropic_cache_user_hosts_cached = ()
+        try:
+            from hermes_cli.config import load_config as _load_acuh_cfg
+            _acuh_cfg = _load_acuh_cfg().get("agent", {}) or {}
+            _hosts_raw = _acuh_cfg.get("anthropic_cache_hosts")
+            if isinstance(_hosts_raw, (list, tuple)):
+                self._anthropic_cache_user_hosts_cached = tuple(
+                    h.strip().lower() for h in _hosts_raw
+                    if isinstance(h, str) and h.strip()
+                )
+        except Exception:
+            pass
+
         # Anthropic prompt caching: auto-enabled for Claude models on native
         # Anthropic, OpenRouter, and third-party gateways that speak the
         # Anthropic protocol (``api_mode == 'anthropic_messages'``). Reduces
@@ -2889,11 +2906,17 @@ class AIAgent:
             OpenAI-wire proxies expect the looser layout).
 
         Third-party providers using the native Anthropic transport
-        (``api_mode == 'anthropic_messages'`` + Claude-named model) get
-        caching with the native layout so they benefit from the same
-        cost reduction as direct Anthropic callers, provided their
-        gateway implements the Anthropic cache_control contract
-        (MiniMax, Zhipu GLM, LiteLLM's Anthropic proxy mode all do).
+        (``api_mode == 'anthropic_messages'``) get caching with the
+        native layout in two cases:
+          * Claude-named model — the gateway is presumed to forward
+            ``cache_control`` to upstream Anthropic (LiteLLM proxy
+            mode, Zhipu GLM Anthropic-compat, etc.).
+          * Provider/host registered as ``anthropic_cache``-capable in
+            ``ProviderConfig.extra`` or in the user's
+            ``agent.anthropic_cache_hosts`` config list. This is how
+            providers serving their own model families through the
+            Anthropic protocol (MiniMax M2.x, future entrants) opt in.
+            See ``agent.anthropic_cache_capability``. (issue #17332)
 
         Qwen / Alibaba-family models on OpenCode, OpenCode Go, and direct
         Alibaba (DashScope) also honour Anthropic-style ``cache_control``
@@ -2925,23 +2948,29 @@ class AIAgent:
             # Third-party Anthropic-compatible gateway.
             return True, True
 
-        # MiniMax on its Anthropic-compatible endpoint serves its own
-        # model family (MiniMax-M2.7, M2.5, M2.1, M2) with documented
-        # cache_control support (0.1× read pricing, 5-minute TTL).  The
-        # blanket is_claude gate above excludes these — opt them in
-        # explicitly via provider id or host match so users on
-        # provider=minimax / minimax-cn (or custom endpoints pointing at
-        # api.minimax.io/anthropic / api.minimaxi.com/anthropic) get the
-        # same cost reduction as Claude traffic.
-        # Docs: https://platform.minimax.io/docs/api-reference/anthropic-api-compatible-cache
+        # Capability-registry branch (#17332): provider declared
+        # ``anthropic_cache`` support in ProviderConfig.extra, or its
+        # hostname matches a registered/user-configured entry. Covers
+        # MiniMax-M2.7 etc. (replacing the hardcoded provider/host check
+        # introduced by #17333) and any future Anthropic-protocol gateway
+        # that documents cache_control for its own models, without
+        # forcing a code patch per provider.
         if is_anthropic_wire:
-            is_minimax_provider = provider_lower in {"minimax", "minimax-cn"}
-            is_minimax_host = (
-                base_url_host_matches(eff_base_url, "api.minimax.io")
-                or base_url_host_matches(eff_base_url, "api.minimaxi.com")
-            )
-            if is_minimax_provider or is_minimax_host:
-                return True, True
+            try:
+                from agent.anthropic_cache_capability import (
+                    provider_supports_anthropic_cache,
+                )
+                _user_hosts = self._anthropic_cache_user_hosts()
+                if provider_supports_anthropic_cache(
+                    eff_provider,
+                    eff_base_url,
+                    user_configured_hosts=_user_hosts,
+                ):
+                    return True, True
+            except Exception as exc:
+                logger.debug(
+                    "anthropic_cache capability lookup failed: %s", exc
+                )
 
         # Qwen/Alibaba on OpenCode (Zen/Go) and native DashScope: OpenAI-wire
         # transport that accepts Anthropic-style cache_control markers and
@@ -2959,6 +2988,20 @@ class AIAgent:
             return True, False
 
         return False, False
+
+    def _anthropic_cache_user_hosts(self):
+        """Return the operator-configured Anthropic-cache host opt-in list.
+
+        Reads ``agent.anthropic_cache_hosts`` from the loaded config (set
+        by ``__init__`` on ``self._anthropic_cache_user_hosts_cached``).
+        Returns an empty tuple when the key is missing or malformed; we
+        never want a typo'd list to silently *disable* caching, only to
+        not *enable* it for unlisted hosts. (issue #17332)
+        """
+        cached = getattr(self, "_anthropic_cache_user_hosts_cached", None)
+        if cached is not None:
+            return cached
+        return ()
 
     @staticmethod
     def _model_requires_responses_api(model: str) -> bool:

--- a/tests/run_agent/test_anthropic_prompt_cache_policy.py
+++ b/tests/run_agent/test_anthropic_prompt_cache_policy.py
@@ -108,7 +108,10 @@ class TestMiniMaxAnthropicWire:
     MiniMax documents cache_control support on ``/anthropic`` (0.1× read
     pricing, 5-minute TTL). Issue #17332: the blanket ``is_claude`` gate on
     the third-party-gateway branch left MiniMax-M2.7 etc. paying full input
-    cost every turn. Allowlist MiniMax explicitly via provider id or host.
+    cost every turn. The capability-registry approach (#17339) generalises
+    the original fix from #17333 by reading ``ProviderConfig.extra`` rather
+    than hardcoding a provider/host check, but the user-visible behaviour
+    these tests pin down is unchanged.
     """
 
     def test_minimax_m27_on_provider_minimax_caches_native_layout(self):
@@ -136,7 +139,7 @@ class TestMiniMaxAnthropicWire:
             provider="custom",
             base_url="https://api.minimax.io/anthropic",
             api_mode="anthropic_messages",
-            model="minimax-m2.7",
+            model="minimax-m2.1",
         )
         assert agent._anthropic_prompt_cache_policy() == (True, True)
 
@@ -290,3 +293,159 @@ class TestExplicitOverrides:
             model="anthropic/claude-sonnet-4.6",
         )
         assert (should, native) == (True, False)
+
+
+# ── #17332: capability-registry-driven cache decisions ────────────────
+
+class TestCapabilityRegistryAnthropicCache:
+    """Provider-registry / hostname-driven enablement (#17332).
+
+    The legacy gate enabled caching on third-party Anthropic-protocol
+    gateways only for Claude-named models, which silently disabled
+    caching for providers that serve their own non-Claude families
+    (MiniMax M2.x). The capability registry replaces brand-name guessing
+    with an explicit ``ProviderConfig.extra['anthropic_cache']`` flag
+    plus a hostname allowlist, with a user-facing
+    ``agent.anthropic_cache_hosts`` config opt-in for unlisted
+    endpoints.
+    """
+
+    def test_minimax_built_in_provider_caches_with_native_layout(self):
+        agent = _make_agent(
+            provider="minimax",
+            base_url="https://api.minimax.io/anthropic",
+            api_mode="anthropic_messages",
+            model="MiniMax-M2.7",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (True, True)
+
+    def test_minimax_cn_built_in_provider_caches_with_native_layout(self):
+        agent = _make_agent(
+            provider="minimax-cn",
+            base_url="https://api.minimaxi.com/anthropic",
+            api_mode="anthropic_messages",
+            model="MiniMax-M2.7",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (True, True)
+
+    def test_custom_provider_pointing_at_minimax_host_caches(self):
+        # Operator configured ``provider: custom`` with MiniMax's URL —
+        # registry-declared host triggers caching even though the
+        # provider id is generic.
+        agent = _make_agent(
+            provider="custom",
+            base_url="https://api.minimax.io/anthropic",
+            api_mode="anthropic_messages",
+            model="MiniMax-M2.7",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (True, True)
+
+    def test_custom_provider_pointing_at_minimax_cn_host_caches(self):
+        agent = _make_agent(
+            provider="custom",
+            base_url="https://api.minimaxi.com/anthropic",
+            api_mode="anthropic_messages",
+            model="MiniMax-M2.7",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (True, True)
+
+    def test_user_configured_host_opts_in_unknown_gateway(self):
+        # An operator running a private gateway can opt-in via
+        # ``agent.anthropic_cache_hosts`` without an upstream patch.
+        agent = _make_agent(
+            provider="custom",
+            base_url="https://my-internal.gateway.local/anthropic",
+            api_mode="anthropic_messages",
+            model="our-internal-llm",
+        )
+        agent._anthropic_cache_user_hosts_cached = (
+            "my-internal.gateway.local",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (True, True)
+
+    def test_user_config_normalizes_case_and_whitespace(self):
+        agent = _make_agent(
+            provider="custom",
+            base_url="https://Custom.Example.LOCAL/anthropic",
+            api_mode="anthropic_messages",
+            model="x",
+        )
+        # Helper normalizes; the read in __init__ also normalizes — pin both.
+        agent._anthropic_cache_user_hosts_cached = ("custom.example.local",)
+        assert agent._anthropic_prompt_cache_policy() == (True, True)
+
+    def test_capability_branch_requires_anthropic_messages_transport(self):
+        # MiniMax host but on chat_completions (OpenAI wire) — must NOT
+        # send cache_control or strict OpenAI-wire providers will 400.
+        agent = _make_agent(
+            provider="minimax",
+            base_url="https://api.minimax.io/anthropic",
+            api_mode="chat_completions",
+            model="MiniMax-M2.7",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (False, False)
+
+    def test_unlisted_anthropic_protocol_gateway_stays_off(self):
+        agent = _make_agent(
+            provider="custom",
+            base_url="https://example-private.invalid/anthropic",
+            api_mode="anthropic_messages",
+            model="some-internal-llm",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (False, False)
+
+    def test_provider_id_lookup_is_case_insensitive(self):
+        agent = _make_agent(
+            provider="MiniMax",  # capitalized
+            base_url="https://api.minimax.io/anthropic",
+            api_mode="anthropic_messages",
+            model="MiniMax-M2.7",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (True, True)
+
+
+class TestCapabilityHelperUnit:
+    """Direct tests for the helper module."""
+
+    def test_minimax_provider_id_returns_true(self):
+        from agent.anthropic_cache_capability import (
+            provider_supports_anthropic_cache,
+        )
+        assert provider_supports_anthropic_cache("minimax", None) is True
+
+    def test_unknown_provider_returns_false(self):
+        from agent.anthropic_cache_capability import (
+            provider_supports_anthropic_cache,
+        )
+        assert provider_supports_anthropic_cache("openai", None) is False
+
+    def test_host_lookup_without_provider(self):
+        from agent.anthropic_cache_capability import (
+            provider_supports_anthropic_cache,
+        )
+        assert (
+            provider_supports_anthropic_cache(
+                None, "https://api.minimax.io/anthropic"
+            )
+            is True
+        )
+
+    def test_user_configured_host_added(self):
+        from agent.anthropic_cache_capability import (
+            provider_supports_anthropic_cache,
+        )
+        assert (
+            provider_supports_anthropic_cache(
+                "custom",
+                "https://opted-in.example/anthropic",
+                user_configured_hosts=("opted-in.example",),
+            )
+            is True
+        )
+
+    def test_empty_inputs_return_false(self):
+        from agent.anthropic_cache_capability import (
+            provider_supports_anthropic_cache,
+        )
+        assert provider_supports_anthropic_cache(None, None) is False
+        assert provider_supports_anthropic_cache("", "") is False


### PR DESCRIPTION
Closes #17332. Alternative to (and supersedes) #17333.

## Why a different fix
PR #17333 patches the symptom by hardcoding `provider in ("minimax", "minimax-cn")` and two specific hostnames in `_anthropic_prompt_cache_policy`. That fixes MiniMax — but the issue's **"Scope beyond MiniMax"** section explicitly asks for "a capability-based or provider-allowlist approach" that's future-proof.

This PR delivers that. Net result for users is the same (MiniMax M2.x now caches), but the next entrant — and operators running private gateways — get it for free.

## Design

### 1. Provider capability flag in `ProviderConfig.extra`
Built-in providers declare cache support next to their existing auth/base_url config — single source of truth, no parallel list:

```python
"minimax": ProviderConfig(
    id="minimax",
    inference_base_url="https://api.minimax.io/anthropic",
    api_key_env_vars=("MINIMAX_API_KEY",),
    extra={
        "anthropic_cache": True,
        "anthropic_cache_hosts": ("api.minimax.io",),
    },
),
```

### 2. New helper `agent/anthropic_cache_capability.py`
`provider_supports_anthropic_cache(provider, base_url, user_configured_hosts=…)` resolves in order:
- **a.** `ProviderConfig.extra['anthropic_cache']` for the provider id (case-insensitive).
- **b.** Hostname match against registry hosts ∪ user-configured hosts.

(b) catches the very common `provider: custom` + MiniMax URL setup.

### 3. Operator escape hatch — `agent.anthropic_cache_hosts`
New config list. Anyone running a private LiteLLM/vLLM Anthropic-compatible deployment can opt in **today** without an upstream patch:

```yaml
agent:
  anthropic_cache_hosts:
    - my-internal.gateway.local
```

Read once in `__init__`, cached on `self._anthropic_cache_user_hosts_cached`, threaded through the policy lookup. Malformed values are ignored — a typo never *disables* caching, only fails to *enable* it for a host.

### 4. Policy gains one additive branch
```python
if is_anthropic_wire:
    if provider_supports_anthropic_cache(eff_provider, eff_base_url,
                                          user_configured_hosts=self._anthropic_cache_user_hosts()):
        return True, True
```
Pre-existing native Anthropic / OpenRouter / Claude-on-third-party branches are untouched.

## Why this is better than #17333

| | #17333 | This PR |
|---|---|---|
| MiniMax M2.x caches today | ✅ | ✅ |
| Next entrant requires code patch | ✅ | ❌ — flip one flag in `ProviderConfig.extra` |
| Operator can opt-in private gateway | ❌ | ✅ via `agent.anthropic_cache_hosts` |
| Source of truth for built-in providers | new code path | reuses `ProviderConfig` |
| `provider == "minimax"` substring brittleness | ✅ exists | ❌ — registry-driven |
| Lines of policy logic per provider | grows linearly | constant |

## Tests
**Existing test was using `api.minimax.io` as the "unknown" host** — under this PR that hostname is *deliberately* known (registry entry), so the test was updated to use a truly unlisted host. That's the intended behavior change.

New `TestCapabilityRegistryAnthropicCache` (9 cases):
- `test_minimax_built_in_provider_caches_with_native_layout`
- `test_minimax_cn_built_in_provider_caches_with_native_layout`
- `test_custom_provider_pointing_at_minimax_host_caches`
- `test_custom_provider_pointing_at_minimax_cn_host_caches`
- `test_user_configured_host_opts_in_unknown_gateway`
- `test_user_config_normalizes_case_and_whitespace`
- `test_capability_branch_requires_anthropic_messages_transport`
- `test_unlisted_anthropic_protocol_gateway_stays_off`
- `test_provider_id_lookup_is_case_insensitive`

New `TestCapabilityHelperUnit` (5 cases) — direct tests of the helper.

```
$ python -m pytest tests/run_agent/test_anthropic_prompt_cache_policy.py -q
..............................                                          [100%]
30 passed in 0.37s

$ python -m pytest tests/run_agent/ -q --ignore=tests/run_agent/test_run_agent.py
863 passed, 7 skipped in 120.97s
```

Zero regressions across `tests/run_agent/`.