### PR TITLE
fix(auxiliary): preserve raw_base_url for Anthropic SDK wrapping in resolve_provider_client

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2213,9 +2213,8 @@ def resolve_provider_client(
                          provider, ", ".join(tried_sources))
             return None, None
 
-        base_url = _to_openai_base_url(
-            str(creds.get("base_url", "")).strip().rstrip("/") or pconfig.inference_base_url
-        )
+        raw_base_url = (str(creds.get("base_url", "")).strip().rstrip("/") or pconfig.inference_base_url)
+        base_url = _to_openai_base_url(raw_base_url)
 
         default_model = _API_KEY_PROVIDER_AUX_MODELS.get(provider, "")
         final_model = _normalize_resolved_model(model or default_model, provider)
@@ -2264,7 +2263,10 @@ def resolve_provider_client(
         # Anthropic-wire endpoints (Kimi Coding Plan api.kimi.com/coding,
         # /anthropic-suffixed gateways) so named providers like kimi-coding
         # land on the right transport without needing per-provider branches.
-        client = _wrap_if_needed(client, final_model, base_url, api_key)
+        # Pass raw_base_url (pre-conversion) so _maybe_wrap_anthropic gets the
+        # original /anthropic suffix for URL detection and Anthropic SDK construction.
+        # The OpenAI client above already uses the /v1-converted base_url.
+        client = _wrap_if_needed(client, final_model, raw_base_url, api_key)
 
         logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
         return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode


### PR DESCRIPTION
## Problem

After #17308 (f3371c39) threaded `main_runtime` through to `auto_title_session`, title generation started returning HTTP 404 for users on `minimax-cn` (and any other provider whose `inference_base_url` ends with `/anthropic`).

**Root cause chain:**

1. `resolve_api_key_provider_credentials("minimax-cn")` returns `base_url = "https://api.minimaxi.com/anthropic"`
2. `_to_openai_base_url()` converts it to `"https://api.minimaxi.com/v1"` (correct for the OpenAI SDK client)
3. `_wrap_if_needed` is called with this already-converted `/v1` URL
4. Because `main_runtime` now carries `api_mode="anthropic_messages"`, `_maybe_wrap_anthropic` decides to wrap → calls `build_anthropic_client(key, "https://api.minimaxi.com/v1")`
5. The Anthropic SDK appends `/v1/messages` → actual request hits `https://api.minimaxi.com/v1/messages` → **404**

The correct endpoint is `https://api.minimaxi.com/anthropic/v1/messages`.

## Fix

Preserve `raw_base_url` (pre-`_to_openai_base_url` conversion) and pass it to `_wrap_if_needed`, so `_maybe_wrap_anthropic` receives the original `/anthropic`-suffixed URL for both:
- endpoint detection (`_endpoint_speaks_anthropic_messages`)
- Anthropic SDK client construction (`build_anthropic_client`)

The OpenAI client continues to use the `/v1`-converted `base_url`.

## Affected providers

All API-key providers whose `inference_base_url` ends with `/anthropic` when a `main_runtime` with `api_mode=anthropic_messages` is available: `minimax`, `minimax-cn`, and any compatible third-party gateway.