### PR TITLE
fix: use non-empty reasoning_content placeholder for DeepSeek V4 Pro thinking mode

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -8372,9 +8372,9 @@ class AIAgent:
             elif msg.get("tool_calls") and self._needs_deepseek_tool_reasoning():
                 # DeepSeek thinking mode requires reasoning_content on every
                 # assistant tool-call message. Without it, replaying the
-                # persisted message causes HTTP 400. Include empty string
-                # as a defensive compatibility fallback (refs #15250).
-                msg["reasoning_content"] = ""
+                # persisted message causes HTTP 400. Use non-empty placeholder
+                # — empty string is rejected by DeepSeek V4 Pro (refs #15250).
+                msg["reasoning_content"] = " "
 
         # Additive fallback (refs #16844, #16884). Streaming-only providers
         # (glm, MiniMax, gpt-5.x via aigw, Anthropic via openai-compat shims)
@@ -8558,12 +8558,12 @@ class AIAgent:
             return
 
         # 4. DeepSeek / Kimi thinking mode: all assistant messages need
-        # reasoning_content. Inject "" to satisfy the provider's requirement
-        # when no explicit reasoning content is present. Covers both
-        # tool-call turns (already-poisoned history with no reasoning at all)
-        # and plain text turns.
+        # reasoning_content. Inject a non-empty placeholder to satisfy the
+        # provider's requirement when no explicit reasoning content is present.
+        # DeepSeek V4 Pro rejects empty string with HTTP 400:
+        # "The reasoning content in the thinking mode must be passed back to the API."
         if needs_thinking_pad:
-            api_msg["reasoning_content"] = ""
+            api_msg["reasoning_content"] = " "
             return
 
         # 5. reasoning_content was present but not a string (e.g. None after


### PR DESCRIPTION
## Problem

DeepSeek V4 Pro thinking mode (`reasoning_effort ≠ none`) returns HTTP 400
on multi-turn conversations with tool calls:

> The reasoning content in the thinking mode must be passed back to the API.

## Root Cause

Two fallback paths inject an empty string `""` for `reasoning_content`:

- `_build_assistant_message()` — new tool-call assistant messages without reasoning
- `_copy_reasoning_content_for_api()` — replaying historical messages without reasoning

DeepSeek V4 Pro rejects empty string values. Older DeepSeek models tolerate it.

## Fix

Change the placeholder from `""` to `" "` (single space) in both locations.
Non-empty value satisfies V4 Pro validation. No behavioral change —
these paths only execute when reasoning content is genuinely absent.

## Tested

- `deepseek-v4-pro` + `reasoning_effort=xhigh` + 4-round tool-call chain ✓
- No 400 errors in multi-turn conversation