### PR TITLE
Enforce subtractive toolset filtration in tool resolution logic

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -15,10 +15,10 @@ Usage:
 
 import logging
 import os
-import platform
-import shutil
-import json
 import re
+import shutil
+import sys
+import json
 import concurrent.futures
 import base64
 import atexit

--- a/cli.py
+++ b/cli.py
@@ -15,9 +15,8 @@ Usage:
 
 import logging
 import os
-import re
+import platform
 import shutil
-import sys
 import json
 import re
 import concurrent.futures
@@ -597,6 +596,7 @@ def load_cli_config() -> Dict[str, Any]:
 
 # Load configuration at module startup
 CLI_CONFIG = load_cli_config()
+
 
 # Initialize centralized logging early — agent.log + errors.log in ~/.hermes/logs/.
 # This ensures CLI sessions produce a log trail even before AIAgent is instantiated.
@@ -1998,6 +1998,8 @@ class HermesCLI:
         
         # Parse and validate toolsets
         self.enabled_toolsets = toolsets
+        self.disabled_toolsets = CLI_CONFIG["agent"].get("disabled_toolsets") or []
+
         if toolsets and "all" not in toolsets and "*" not in toolsets:
             # Validate each toolset — MCP server names are resolved via
             # live registry aliases (registered during discover_mcp_tools),
@@ -3446,6 +3448,7 @@ class HermesCLI:
                 credential_pool=runtime.get("credential_pool"),
                 max_iterations=self.max_turns,
                 enabled_toolsets=self.enabled_toolsets,
+                disabled_toolsets=self.disabled_toolsets,
                 verbose_logging=self.verbose,
                 quiet_mode=not self.verbose,
                 ephemeral_system_prompt=self.system_prompt if self.system_prompt else None,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -451,6 +451,7 @@ DEFAULT_CONFIG = {
         # remains available as a tool regardless of this setting — the routing
         # only controls how inbound user images are presented.
         "image_input_mode": "auto",
+        "disabled_toolsets": [],
     },
     
     "terminal": {

--- a/model_tools.py
+++ b/model_tools.py
@@ -23,6 +23,8 @@ Public API (signatures preserved from the original 2,400-line version):
 import json
 import asyncio
 import logging
+import os
+import sys
 import threading
 import time
 from typing import Dict, Any, List, Optional, Tuple
@@ -307,12 +309,17 @@ def _compute_tool_definitions(
             else:
                 if not quiet_mode:
                     print(f"⚠️  Unknown toolset: {toolset_name}")
-
-    elif disabled_toolsets:
+    else:
+        # Default: start with everything
         from toolsets import get_all_toolsets
         for ts_name in get_all_toolsets():
             tools_to_include.update(resolve_toolset(ts_name))
 
+    # Always apply disabled toolsets as a subtraction step at the end.
+    # This ensures that even if a composite toolset (like hermes-cli)
+    # is enabled, any tools belonging to a disabled toolset are strictly
+    # stripped out. See issue #15291.
+    if disabled_toolsets:
         for toolset_name in disabled_toolsets:
             if validate_toolset(toolset_name):
                 resolved = resolve_toolset(toolset_name)
@@ -327,10 +334,6 @@ def _compute_tool_definitions(
             else:
                 if not quiet_mode:
                     print(f"⚠️  Unknown toolset: {toolset_name}")
-    else:
-        from toolsets import get_all_toolsets
-        for ts_name in get_all_toolsets():
-            tools_to_include.update(resolve_toolset(ts_name))
 
     # Plugin-registered tools are now resolved through the normal toolset
     # path — validate_toolset() / resolve_toolset() / get_all_toolsets()


### PR DESCRIPTION
### Problem

Composite toolsets (like browser or hermes-cli) were able to bypass the disabled_toolsets filter because the resolution logic used a mutually exclusive if/elif check. If an enabled toolset added a tool (e.g., web_search), the "disabled" logic was never triggered for that session. Additionally, the disabled_toolsets setting in config.yaml was not being correctly propagated to the agent.

### Solution

- Strict Subtraction: Refactored model_tools._compute_tool_definitions to use a two-phase resolution process. It now gathers all tools from enabled sets first, and then strictly performs a difference_update using all tools from the disabled sets. This ensures that "disabled" always beats "enabled".

- Config Bridge: Updated HermesCLI to read disabled_toolsets from the global config and pass them to the AIAgent during initialization.

- Schema Support: Added the disabled_toolsets key to the default configuration schema to ensure persistence.

###  Verification Results

- Verified that with agent.disabled_toolsets: ["web"], the web_search tool is strictly absent from the final tool list, even when the browser toolset is active.

verified with `hermes chat --verbose`


fix  #17309 