### PR TITLE
fix(send_message): native Slack media uploads for cross-channel/DM sends (#17261)

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -1621,3 +1621,314 @@ class TestForumProbeCache:
         assert result2["success"] is True
         # Only one session opened (thread creation) — no probe session this time
         # (verified by not raising from our side_effect exhaustion)
+
+
+# ---------------------------------------------------------------------------
+# Slack native media delivery via send_message tool
+# ---------------------------------------------------------------------------
+
+
+class TestSendSlackMedia:
+    """`_send_slack` uploads files via slack_sdk's files_upload_v2 when given media."""
+
+    def _install_slack_sdk_mock(self, monkeypatch, upload_mock):
+        """Inject a MagicMock slack_sdk.web.async_client + slack_sdk.errors."""
+        slack_sdk = MagicMock()
+
+        class FakeAsyncWebClient:
+            def __init__(self, token=None):
+                self.token = token
+                self.files_upload_v2 = upload_mock
+
+        slack_sdk.web.async_client.AsyncWebClient = FakeAsyncWebClient
+
+        class FakeSlackApiError(Exception):
+            def __init__(self, message="", response=None):
+                super().__init__(message)
+                self.response = response
+
+        slack_sdk.errors.SlackApiError = FakeSlackApiError
+
+        monkeypatch.setitem(sys.modules, "slack_sdk", slack_sdk)
+        monkeypatch.setitem(sys.modules, "slack_sdk.web", slack_sdk.web)
+        monkeypatch.setitem(sys.modules, "slack_sdk.web.async_client", slack_sdk.web.async_client)
+        monkeypatch.setitem(sys.modules, "slack_sdk.errors", slack_sdk.errors)
+        return FakeAsyncWebClient, FakeSlackApiError
+
+    def test_single_image_upload_uses_files_upload_v2(self, monkeypatch, tmp_path):
+        from tools.send_message_tool import _send_slack
+
+        img = tmp_path / "photo.png"
+        img.write_bytes(b"fake png content")
+
+        upload = AsyncMock(return_value={
+            "ok": True,
+            "files": [{"id": "F12345", "name": "photo.png"}],
+        })
+        self._install_slack_sdk_mock(monkeypatch, upload)
+
+        result = asyncio.run(
+            _send_slack("xoxb-tok", "C123", "here you go", media_files=[(str(img), False)])
+        )
+
+        assert result["success"] is True
+        assert result["platform"] == "slack"
+        assert result["chat_id"] == "C123"
+        assert result["message_id"] == "F12345"
+        upload.assert_awaited_once()
+        kwargs = upload.await_args.kwargs
+        assert kwargs["channel"] == "C123"
+        assert kwargs["file"] == str(img)
+        assert kwargs["filename"] == "photo.png"
+        # Caption must be carried into the upload as initial_comment, otherwise
+        # the user's text is dropped.
+        assert kwargs["initial_comment"] == "here you go"
+        # No thread_id was passed → no thread_ts kwarg should appear.
+        assert "thread_ts" not in kwargs
+
+    def test_thread_id_is_forwarded_as_thread_ts(self, monkeypatch, tmp_path):
+        from tools.send_message_tool import _send_slack
+
+        doc = tmp_path / "report.pdf"
+        doc.write_bytes(b"%PDF-1.4 fake")
+
+        upload = AsyncMock(return_value={"ok": True, "files": [{"id": "F1"}]})
+        self._install_slack_sdk_mock(monkeypatch, upload)
+
+        result = asyncio.run(
+            _send_slack(
+                "xoxb-tok", "C99", "see attached",
+                media_files=[(str(doc), False)],
+                thread_id="1700000000.000123",
+            )
+        )
+
+        assert result["success"] is True
+        kwargs = upload.await_args.kwargs
+        assert kwargs["thread_ts"] == "1700000000.000123"
+
+    def test_multiple_files_only_first_carries_caption(self, monkeypatch, tmp_path):
+        """Caption is attached to the first upload only — subsequent uploads
+        in the same call must not duplicate it as their initial_comment."""
+        from tools.send_message_tool import _send_slack
+
+        a = tmp_path / "a.png"
+        a.write_bytes(b"a")
+        b = tmp_path / "b.pdf"
+        b.write_bytes(b"%PDF b")
+
+        upload = AsyncMock(return_value={"ok": True, "files": [{"id": "F"}]})
+        self._install_slack_sdk_mock(monkeypatch, upload)
+
+        result = asyncio.run(
+            _send_slack(
+                "tok", "C1", "summary",
+                media_files=[(str(a), False), (str(b), False)],
+            )
+        )
+
+        assert result["success"] is True
+        assert upload.await_count == 2
+        first_kwargs = upload.await_args_list[0].kwargs
+        second_kwargs = upload.await_args_list[1].kwargs
+        assert first_kwargs["initial_comment"] == "summary"
+        assert second_kwargs["initial_comment"] == ""
+
+    def test_missing_media_file_returns_error(self, monkeypatch, tmp_path):
+        from tools.send_message_tool import _send_slack
+
+        upload = AsyncMock()
+        self._install_slack_sdk_mock(monkeypatch, upload)
+
+        result = asyncio.run(
+            _send_slack("tok", "C1", "msg", media_files=[(str(tmp_path / "missing.png"), False)])
+        )
+        assert "error" in result
+        assert "Media file not found" in result["error"]
+        upload.assert_not_awaited()
+
+    def test_slack_api_error_is_surfaced(self, monkeypatch, tmp_path):
+        """SlackApiError from the SDK must surface as a structured error, not an exception."""
+        from tools.send_message_tool import _send_slack
+
+        img = tmp_path / "x.png"
+        img.write_bytes(b"x")
+
+        # Configure the mock to raise SlackApiError on the first call.
+        # The error class is also returned from _install so we can construct it.
+        upload = AsyncMock()
+        _, FakeSlackApiError = self._install_slack_sdk_mock(monkeypatch, upload)
+
+        class FakeResp(dict):
+            pass
+
+        upload.side_effect = FakeSlackApiError(
+            "channel_not_found", response=FakeResp(error="channel_not_found")
+        )
+
+        result = asyncio.run(
+            _send_slack("tok", "Cbad", "hi", media_files=[(str(img), False)])
+        )
+
+        assert "error" in result
+        assert "channel_not_found" in result["error"]
+
+    def test_text_only_path_does_not_import_slack_sdk(self, monkeypatch):
+        """Regression: text-only sends must continue to use aiohttp + chat.postMessage,
+        NOT touch slack_sdk. This guards against the new media branch leaking into
+        the text-only path."""
+        from tools.send_message_tool import _send_slack
+
+        # Purposely DO NOT install slack_sdk — if the text-only path tries to
+        # import it the test should still pass (proving the import is gated
+        # on media_files being truthy).
+        monkeypatch.delitem(sys.modules, "slack_sdk", raising=False)
+        monkeypatch.delitem(sys.modules, "slack_sdk.web", raising=False)
+        monkeypatch.delitem(sys.modules, "slack_sdk.web.async_client", raising=False)
+        monkeypatch.delitem(sys.modules, "slack_sdk.errors", raising=False)
+
+        # Stub the aiohttp.ClientSession so we don't actually hit Slack.
+        resp = MagicMock()
+        resp.json = AsyncMock(return_value={"ok": True, "ts": "111.222"})
+        resp.__aenter__ = AsyncMock(return_value=resp)
+        resp.__aexit__ = AsyncMock(return_value=None)
+        session = MagicMock()
+        session.post = MagicMock(return_value=resp)
+        session.__aenter__ = AsyncMock(return_value=session)
+        session.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("aiohttp.ClientSession", return_value=session):
+            result = asyncio.run(_send_slack("tok", "C1", "just text"))
+
+        assert result["success"] is True
+        assert result["message_id"] == "111.222"
+        # slack_sdk must NOT have been imported by the text-only path.
+        assert "slack_sdk.web.async_client" not in sys.modules
+
+
+class TestSendToPlatformSlackMedia:
+    """`_send_to_platform` routes Slack media through the new media branch (#17261)."""
+
+    def test_media_present_uses_send_slack_with_media(self, monkeypatch, tmp_path):
+        """When media_files is non-empty for SLACK, _send_to_platform calls _send_slack
+        with media_files attached on the last chunk — not the warning-and-drop path."""
+        _ensure_slack_mock(monkeypatch)
+        import gateway.platforms.slack as slack_mod
+        monkeypatch.setattr(slack_mod, "SLACK_AVAILABLE", True)
+
+        img = tmp_path / "shot.png"
+        img.write_bytes(b"img")
+
+        send_mock = AsyncMock(return_value={
+            "success": True, "platform": "slack", "chat_id": "C42", "message_id": "F1",
+        })
+
+        with patch("tools.send_message_tool._send_slack", send_mock):
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.SLACK,
+                    SimpleNamespace(enabled=True, token="xoxb", extra={}),
+                    "C42",
+                    "look",
+                    media_files=[(str(img), False)],
+                )
+            )
+
+        assert result["success"] is True
+        # The new media branch returns last_result directly — so the success
+        # path does NOT inject a "MEDIA attachments were omitted" warning.
+        assert "warnings" not in result
+        send_mock.assert_awaited_once()
+        kwargs = send_mock.await_args.kwargs
+        assert kwargs["media_files"] == [(str(img), False)]
+
+    def test_media_attaches_only_to_last_chunk(self, monkeypatch, tmp_path):
+        """Long Slack messages chunk to MAX_MESSAGE_LENGTH; media_files must
+        attach to the FINAL chunk only so we don't upload duplicates per-chunk."""
+        _ensure_slack_mock(monkeypatch)
+        import gateway.platforms.slack as slack_mod
+        monkeypatch.setattr(slack_mod, "SLACK_AVAILABLE", True)
+
+        img = tmp_path / "shot.png"
+        img.write_bytes(b"img")
+
+        # Slack MAX_MESSAGE_LENGTH is 39000 — build something well over that
+        # to force chunking through BasePlatformAdapter.truncate_message.
+        long_msg = ("word " * 9000).strip()
+        assert len(long_msg) > 39000
+
+        call_log = []
+
+        async def fake_send(token, chat_id, message, media_files=None, thread_id=None):
+            call_log.append(media_files or [])
+            return {
+                "success": True, "platform": "slack", "chat_id": chat_id,
+                "message_id": str(len(call_log)),
+            }
+
+        with patch("tools.send_message_tool._send_slack", fake_send):
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.SLACK,
+                    SimpleNamespace(enabled=True, token="xoxb", extra={}),
+                    "C7",
+                    long_msg,
+                    media_files=[(str(img), False)],
+                )
+            )
+
+        assert result["success"] is True
+        assert len(call_log) >= 2  # message was chunked
+        assert all(c == [] for c in call_log[:-1])
+        assert call_log[-1] == [(str(img), False)]
+
+    def test_text_only_slack_still_uses_text_branch(self, monkeypatch):
+        """Regression: a text-only Slack send (media_files empty) must NOT enter
+        the new media branch — it should hit the existing chat.postMessage path."""
+        _ensure_slack_mock(monkeypatch)
+        import gateway.platforms.slack as slack_mod
+        monkeypatch.setattr(slack_mod, "SLACK_AVAILABLE", True)
+
+        send_mock = AsyncMock(return_value={"success": True, "message_id": "1"})
+
+        with patch("tools.send_message_tool._send_slack", send_mock):
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.SLACK,
+                    SimpleNamespace(enabled=True, token="xoxb", extra={}),
+                    "C1",
+                    "plain text",
+                    media_files=[],
+                )
+            )
+
+        assert result["success"] is True
+        send_mock.assert_awaited_once()
+        # Old text-only branch passes positional args only — no media_files kwarg.
+        assert send_mock.await_args.kwargs == {}
+
+    def test_warning_message_lists_slack_as_supported(self, monkeypatch):
+        """When media is dropped on a non-supporting platform, the warning text
+        must list slack as one of the supported platforms (regression for
+        https://github.com/NousResearch/hermes-agent/issues/17261)."""
+        # Pick a platform without media support, e.g. WHATSAPP.
+        _ensure_slack_mock(monkeypatch)
+
+        send_whatsapp = AsyncMock(return_value={"success": True, "message_id": "w1"})
+
+        with patch("tools.send_message_tool._send_whatsapp", send_whatsapp):
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.WHATSAPP,
+                    SimpleNamespace(enabled=True, token="tok", extra={}),
+                    "1234567890",
+                    "with file please",
+                    media_files=[("/fake/x.png", False)],
+                )
+            )
+
+        assert result["success"] is True
+        warnings = result.get("warnings") or []
+        assert warnings, "expected a 'MEDIA attachments were omitted' warning"
+        # The warning text must mention slack now that we support it.
+        assert "slack" in warnings[0]

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -382,6 +382,7 @@ class TestSendToPlatformChunking:
             "***",
             "C123",
             "*hello* from <https://example.com|Hermes>",
+            thread_id=None,
         )
 
     def test_slack_bold_italic_formatted_before_send(self, monkeypatch):
@@ -1773,6 +1774,90 @@ class TestSendSlackMedia:
         assert "error" in result
         assert "channel_not_found" in result["error"]
 
+    def test_proxy_resolved_via_slack_helpers_is_applied_to_client(self, monkeypatch, tmp_path):
+        """Media path must apply SlackAdapter._resolve_slack_proxy_url to the
+        AsyncWebClient (regression for Copilot finding on the original PR —
+        without this, uploads fail in proxied environments while text-only
+        chat.postMessage works because aiohttp uses resolve_proxy_url())."""
+        from tools.send_message_tool import _send_slack
+
+        img = tmp_path / "shot.png"
+        img.write_bytes(b"x")
+
+        # Capture the AsyncWebClient instance so we can inspect proxy state.
+        captured_clients = []
+        upload = AsyncMock(return_value={"ok": True, "files": [{"id": "F1"}]})
+
+        class FakeAsyncWebClient:
+            def __init__(self, token=None):
+                self.token = token
+                self.proxy = None  # SlackAdapter sets via .proxy attribute
+                self.files_upload_v2 = upload
+                captured_clients.append(self)
+
+        slack_sdk = MagicMock()
+        slack_sdk.web.async_client.AsyncWebClient = FakeAsyncWebClient
+
+        class FakeSlackApiError(Exception):
+            def __init__(self, message="", response=None):
+                super().__init__(message)
+                self.response = response
+
+        slack_sdk.errors.SlackApiError = FakeSlackApiError
+        monkeypatch.setitem(sys.modules, "slack_sdk", slack_sdk)
+        monkeypatch.setitem(sys.modules, "slack_sdk.web", slack_sdk.web)
+        monkeypatch.setitem(sys.modules, "slack_sdk.web.async_client", slack_sdk.web.async_client)
+        monkeypatch.setitem(sys.modules, "slack_sdk.errors", slack_sdk.errors)
+
+        # Force the SlackAdapter helpers to surface a proxy URL.
+        with patch("gateway.platforms.slack._resolve_slack_proxy_url", return_value="http://proxy.example:8080"):
+            result = asyncio.run(
+                _send_slack("xoxb", "C1", "hi", media_files=[(str(img), False)])
+            )
+
+        assert result["success"] is True
+        assert len(captured_clients) == 1
+        assert captured_clients[0].proxy == "http://proxy.example:8080"
+
+    def test_no_proxy_resolved_does_not_set_client_proxy(self, monkeypatch, tmp_path):
+        """When _resolve_slack_proxy_url returns None (no proxy / NO_PROXY hit),
+        the client's .proxy attribute must be left untouched (None), not coerced."""
+        from tools.send_message_tool import _send_slack
+
+        img = tmp_path / "shot.png"
+        img.write_bytes(b"x")
+
+        captured_clients = []
+        upload = AsyncMock(return_value={"ok": True, "files": [{"id": "F1"}]})
+
+        class FakeAsyncWebClient:
+            def __init__(self, token=None):
+                self.token = token
+                self.proxy = "preset_sentinel"
+                self.files_upload_v2 = upload
+                captured_clients.append(self)
+
+        slack_sdk = MagicMock()
+        slack_sdk.web.async_client.AsyncWebClient = FakeAsyncWebClient
+
+        class FakeSlackApiError(Exception):
+            pass
+
+        slack_sdk.errors.SlackApiError = FakeSlackApiError
+        monkeypatch.setitem(sys.modules, "slack_sdk", slack_sdk)
+        monkeypatch.setitem(sys.modules, "slack_sdk.web", slack_sdk.web)
+        monkeypatch.setitem(sys.modules, "slack_sdk.web.async_client", slack_sdk.web.async_client)
+        monkeypatch.setitem(sys.modules, "slack_sdk.errors", slack_sdk.errors)
+
+        with patch("gateway.platforms.slack._resolve_slack_proxy_url", return_value=None):
+            result = asyncio.run(
+                _send_slack("xoxb", "C1", "hi", media_files=[(str(img), False)])
+            )
+
+        assert result["success"] is True
+        # Sentinel must remain untouched — _apply_slack_proxy was not called.
+        assert captured_clients[0].proxy == "preset_sentinel"
+
     def test_text_only_path_does_not_import_slack_sdk(self, monkeypatch):
         """Regression: text-only sends must continue to use aiohttp + chat.postMessage,
         NOT touch slack_sdk. This guards against the new media branch leaking into
@@ -1904,8 +1989,36 @@ class TestSendToPlatformSlackMedia:
 
         assert result["success"] is True
         send_mock.assert_awaited_once()
-        # Old text-only branch passes positional args only — no media_files kwarg.
-        assert send_mock.await_args.kwargs == {}
+        # Text-only branch should not carry a media_files kwarg (that's the
+        # signal that distinguishes it from the new media branch). thread_id
+        # is allowed (it just defaults to None when not provided by caller).
+        called_kwargs = send_mock.await_args.kwargs
+        assert "media_files" not in called_kwargs
+
+    def test_text_only_slack_forwards_thread_id(self, monkeypatch):
+        """Text-only Slack sends must forward thread_id (regression for Copilot
+        finding on the original PR — without this, _send_to_platform's thread_id
+        is silently dropped for Slack unless media is present)."""
+        _ensure_slack_mock(monkeypatch)
+        import gateway.platforms.slack as slack_mod
+        monkeypatch.setattr(slack_mod, "SLACK_AVAILABLE", True)
+
+        send_mock = AsyncMock(return_value={"success": True, "message_id": "1"})
+
+        with patch("tools.send_message_tool._send_slack", send_mock):
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.SLACK,
+                    SimpleNamespace(enabled=True, token="xoxb", extra={}),
+                    "C1",
+                    "thread reply",
+                    thread_id="1700000000.000999",
+                )
+            )
+
+        assert result["success"] is True
+        send_mock.assert_awaited_once()
+        assert send_mock.await_args.kwargs.get("thread_id") == "1700000000.000999"
 
     def test_warning_message_lists_slack_as_supported(self, monkeypatch):
         """When media is dropped on a non-supporting platform, the warning text

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -523,6 +523,27 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             last_result = result
         return last_result
 
+    # --- Slack: native files_upload_v2 when media attachments are present ---
+    # Without this branch, cross-channel/DM Slack sends (which never enter the
+    # in-thread BasePlatformAdapter media pipeline) would drop attachments and
+    # surface the "MEDIA attachments were omitted for slack" warning, even
+    # though SlackAdapter exposes full media support via files_upload_v2.
+    if platform == Platform.SLACK and media_files:
+        last_result = None
+        for i, chunk in enumerate(chunks):
+            is_last = (i == len(chunks) - 1)
+            result = await _send_slack(
+                pconfig.token,
+                chat_id,
+                chunk,
+                media_files=media_files if is_last else [],
+                thread_id=thread_id,
+            )
+            if isinstance(result, dict) and result.get("error"):
+                return result
+            last_result = result
+        return last_result
+
     # --- Matrix: use the native adapter helper when media is present ---
     if platform == Platform.MATRIX and media_files:
         last_result = None
@@ -560,7 +581,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if media_files and not message.strip():
         return {
             "error": (
-                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal and yuanbao; "
+                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, slack and yuanbao; "
                 f"target {platform.value} had only media attachments"
             )
         }
@@ -568,7 +589,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if media_files:
         warning = (
             f"MEDIA attachments were omitted for {platform.value}; "
-            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal and yuanbao"
+            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, slack and yuanbao"
         )
 
     last_result = None
@@ -963,12 +984,86 @@ async def _send_discord(token, chat_id, message, thread_id=None, media_files=Non
         return _error(f"Discord send failed: {e}")
 
 
-async def _send_slack(token, chat_id, message):
-    """Send via Slack Web API."""
+async def _send_slack(token, chat_id, message, media_files=None, thread_id=None):
+    """Send via Slack Web API.
+
+    Text-only sends use chat.postMessage. When ``media_files`` is non-empty,
+    each file is uploaded with ``files_upload_v2`` via the slack_sdk async
+    client (matching SlackAdapter.send_image_file/send_voice/send_video/
+    send_document) so that cross-channel and DM sends through the
+    ``send_message`` tool deliver attachments natively instead of dropping
+    them with the "MEDIA attachments were omitted" warning.
+    """
+    media_files = media_files or []
     try:
         import aiohttp
     except ImportError:
         return {"error": "aiohttp not installed. Run: pip install aiohttp"}
+
+    if media_files:
+        try:
+            from slack_sdk.web.async_client import AsyncWebClient
+            from slack_sdk.errors import SlackApiError
+        except ImportError:
+            return {"error": "slack_sdk not installed. Run: pip install 'hermes-agent[slack]'"}
+
+        client = AsyncWebClient(token=token)
+        last_result = None
+        text_consumed = False
+        try:
+            for media_path, _is_voice in media_files:
+                if not os.path.exists(media_path):
+                    return _error(f"Media file not found: {media_path}")
+
+                # Attach the text as initial_comment on the first upload only;
+                # subsequent uploads in the same call should not duplicate it.
+                initial_comment = "" if text_consumed else (message or "")
+                upload_kwargs = {
+                    "channel": chat_id,
+                    "file": media_path,
+                    "filename": os.path.basename(media_path),
+                    "initial_comment": initial_comment,
+                }
+                if thread_id:
+                    upload_kwargs["thread_ts"] = thread_id
+                try:
+                    result = await client.files_upload_v2(**upload_kwargs)
+                except SlackApiError as exc:
+                    resp = getattr(exc, "response", None)
+                    err = None
+                    if resp is not None:
+                        try:
+                            err = resp.get("error")
+                        except Exception:
+                            err = None
+                    return _error(f"Slack files_upload_v2 error: {err or exc}")
+
+                text_consumed = True
+                # files_upload_v2's response wraps a "files" list; surface the
+                # first file id as the message_id, mirroring the chat.postMessage
+                # path's "ts" — gives callers something stable to log/correlate.
+                msg_id = None
+                try:
+                    files_list = result.get("files") or []
+                except Exception:
+                    files_list = []
+                if files_list:
+                    first = files_list[0]
+                    if isinstance(first, dict):
+                        msg_id = first.get("id")
+                last_result = {
+                    "success": True,
+                    "platform": "slack",
+                    "chat_id": chat_id,
+                    "message_id": msg_id,
+                }
+
+            # If only media was sent and no text consumed (shouldn't happen),
+            # last_result is the final upload's result.
+            return last_result or {"success": True, "platform": "slack", "chat_id": chat_id}
+        except Exception as e:
+            return _error(f"Slack send failed: {e}")
+
     try:
         from gateway.platforms.base import resolve_proxy_url, proxy_kwargs_for_aiohttp
         _proxy = resolve_proxy_url()
@@ -977,6 +1072,8 @@ async def _send_slack(token, chat_id, message):
         headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30), **_sess_kw) as session:
             payload = {"channel": chat_id, "text": message, "mrkdwn": True}
+            if thread_id:
+                payload["thread_ts"] = thread_id
             async with session.post(url, headers=headers, json=payload, **_req_kw) as resp:
                 data = await resp.json()
                 if data.get("ok"):

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -595,7 +595,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     last_result = None
     for chunk in chunks:
         if platform == Platform.SLACK:
-            result = await _send_slack(pconfig.token, chat_id, chunk)
+            result = await _send_slack(pconfig.token, chat_id, chunk, thread_id=thread_id)
         elif platform == Platform.WHATSAPP:
             result = await _send_whatsapp(pconfig.extra, chat_id, chunk)
         elif platform == Platform.SIGNAL:
@@ -1008,6 +1008,23 @@ async def _send_slack(token, chat_id, message, media_files=None, thread_id=None)
             return {"error": "slack_sdk not installed. Run: pip install 'hermes-agent[slack]'"}
 
         client = AsyncWebClient(token=token)
+        # Apply the same proxy that SlackAdapter uses (NO_PROXY-aware,
+        # http(s)-only). Without this, media uploads fail in proxied
+        # environments even though text-only chat.postMessage works
+        # because the aiohttp path goes through resolve_proxy_url().
+        try:
+            from gateway.platforms.slack import (
+                _apply_slack_proxy,
+                _resolve_slack_proxy_url,
+            )
+            _slack_proxy = _resolve_slack_proxy_url()
+            if _slack_proxy:
+                _apply_slack_proxy(client, _slack_proxy)
+        except ImportError:
+            # SlackAdapter unavailable (no slack_bolt) is fine — we already
+            # have slack_sdk; just skip proxy configuration in that case.
+            pass
+
         last_result = None
         text_consumed = False
         try:


### PR DESCRIPTION
## Summary

- Cross-channel `send_message` to Slack drops MEDIA attachments and emits *"MEDIA attachments were omitted for slack…"* even though SlackAdapter has full media support via `files_upload_v2`. This PR adds the missing media branch.
- `_send_slack` now uploads files through `slack_sdk.web.async_client.AsyncWebClient.files_upload_v2` when `media_files` is non-empty, with `thread_ts` forwarded for in-thread cross-channel sends.
- The "supported platforms" warning + media-only-no-text error now list slack.

Fixes #17261.

## The bug

Reporter (#17261) traced it: `BasePlatformAdapter._process_message_background` (in-thread agent replies) dispatches MEDIA tags through the SlackAdapter's `send_image_file` / `send_voice` / `send_video` / `send_document` (all call `files_upload_v2`). The `send_message` *tool* — used for cross-channel and DM sends — has its own hand-rolled per-platform helpers in `tools/send_message_tool.py` and just lacked a Slack-with-media branch:

- `_send_to_platform` had `if platform == Platform.TELEGRAM` / `DISCORD` / `MATRIX and media_files` / `SIGNAL and media_files` branches that pass `media_files` through to platform-specific helpers.
- Slack fell through to the generic "non-media platforms" block (`tools/send_message_tool.py:580`), which surfaced the warning at `tools/send_message_tool.py:589-593` and called `_send_slack(token, chat_id, chunk)` — text only.

So the result the user saw — *"send works in thread, fails when DMing or sending to another channel"* — matches the code path exactly.

## The fix

Two-part surgical change in [tools/send_message_tool.py](tools/send_message_tool.py):

1. **`_send_to_platform` — add a Slack media branch** (mirrors the existing Telegram / Discord branches). Media attaches to the **last chunk only** so we don't upload duplicates per-chunk on long messages:

   ```python
   if platform == Platform.SLACK and media_files:
       last_result = None
       for i, chunk in enumerate(chunks):
           is_last = (i == len(chunks) - 1)
           result = await _send_slack(
               pconfig.token, chat_id, chunk,
               media_files=media_files if is_last else [],
               thread_id=thread_id,
           )
           ...
   ```

2. **`_send_slack` — extend signature** to `(token, chat_id, message, media_files=None, thread_id=None)`. When `media_files` is empty, behavior is unchanged (still uses aiohttp + `chat.postMessage`). When media is present, it uses `slack_sdk.web.async_client.AsyncWebClient(token=token).files_upload_v2(...)` per file, with the message text carried as `initial_comment` on the **first** upload only (so multi-file sends don't duplicate the caption). `thread_id` becomes `thread_ts` so the upload lands in the right thread when one is specified.

3. The "MEDIA attachments were omitted" warning + the media-only-no-text error were updated to list `slack` as supported.

Approach choice: directly using `AsyncWebClient(token=...)` mirrors the one-shot HTTP/SDK style of the other senders in this file. Going through `_send_yuanbao`-style "fetch the running gateway adapter" would couple the cross-channel send to the gateway's lifecycle (vs. a clean, restartable HTTP/SDK call) and didn't seem worth the indirection — `SlackAdapter._upload_file` itself is just a wrapper around the same `files_upload_v2` API call. The `SlackAdapter` is **untouched**.

## Test plan

- [x] **Focused regression** — 10 new tests across two classes:
  - `TestSendSlackMedia` (6): single image, `thread_ts` forwarding, multi-file caption-on-first-only invariant, missing-file error, `SlackApiError` surfacing, and a regression that the text-only path does **not** import `slack_sdk` (gates the dep behind `media_files`).
  - `TestSendToPlatformSlackMedia` (4): media branch routing, last-chunk-only attachment for chunked messages over Slack's 39000-char `MAX_MESSAGE_LENGTH`, text-only Slack still hits `chat.postMessage`, and the warning text now lists slack.
- [x] **Adjacent suite** — `tests/tools/test_send_message_tool.py` (97/97 pass, all preexisting Slack tests still green) and `tests/gateway/test_slack*.py` (228/228 pass).
- [x] **Regression guard** — with `tools/send_message_tool.py` reverted to `58a6171bf` (current `origin/main`) but the new tests in place, three representative new tests fail (`test_single_image_upload_uses_files_upload_v2`, `test_media_present_uses_send_slack_with_media`, `test_warning_message_lists_slack_as_supported`); restoring the fix makes them pass.

## Related

Fixes #17261.