### PR TITLE
fix(compressor): shrink protect_first_n on recompaction (#17344)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -49,6 +49,14 @@ SUMMARY_PREFIX = (
 )
 LEGACY_SUMMARY_PREFIX = "[CONTEXT SUMMARY]:"
 
+# Sentinel appended to the system prompt the first time a session is
+# compacted. Detection of this string in messages[0] tells subsequent
+# compactions “this is a re-compaction” — see
+# ``ContextCompressor._is_recompaction``. (issue #17344)
+_COMPRESSION_NOTE_SENTINEL = (
+    "earlier conversation turns have been compacted into a handoff summary"
+)
+
 # Minimum tokens for the summary output
 _MIN_SUMMARY_TOKENS = 2000
 # Proportion of compressed content to allocate for summary
@@ -1217,6 +1225,26 @@ The user has requested that this compaction PRIORITISE preserving all informatio
     # ContextEngine: manual /compress preflight
     # ------------------------------------------------------------------
 
+    def _is_recompaction(self, messages: List[Dict[str, Any]]) -> bool:
+        """True when ``messages[0]`` is a system prompt that already carries
+        our compaction note — i.e. this is at least the second compaction
+        in this session's lifetime.
+
+        Used by :meth:`compress` to shrink ``protect_first_n`` so the
+        stale first user exchange isn't re-anchored across every cycle.
+        See issue #17344.
+        """
+        if not messages:
+            return False
+        first = messages[0]
+        if not isinstance(first, dict) or first.get("role") != "system":
+            return False
+        try:
+            text = _content_text_for_contains(first.get("content"))
+        except Exception:
+            return False
+        return _COMPRESSION_NOTE_SENTINEL in (text or "")
+
     def has_content_to_compress(self, messages: List[Dict[str, Any]]) -> bool:
         """Return True if there is a non-empty middle region to compact.
 
@@ -1259,8 +1287,26 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         self._last_aux_model_failure_error = None
         self._last_aux_model_failure_model = None
         n_messages = len(messages)
+        # Recompaction detection (#17344): if the system prompt already
+        # carries our compaction note from a previous run, the original
+        # ``[user1, assistant1]`` exchange is no longer a meaningful head
+        # — it just anchors a stale request the model keeps trying to
+        # re-execute on every cycle. Drop ``protect_first_n`` to 1 (system
+        # only) so the old first exchange flows into the summariser pool
+        # alongside everything else, where the structured ``## Active
+        # Task`` framing replaces it as the steering signal.
+        effective_protect_first_n = self.protect_first_n
+        if self._is_recompaction(messages) and self.protect_first_n > 1:
+            effective_protect_first_n = 1
+            if not self.quiet_mode:
+                logger.info(
+                    "Recompaction detected (system has prior compaction note); "
+                    "shrinking protect_first_n %d -> 1 so the stale first exchange "
+                    "is summarised instead of re-anchored (#17344)",
+                    self.protect_first_n,
+                )
         # Only need head + 3 tail messages minimum (token budget decides the real tail size)
-        _min_for_compress = self.protect_first_n + 3 + 1
+        _min_for_compress = effective_protect_first_n + 3 + 1
         if n_messages <= _min_for_compress:
             if not self.quiet_mode:
                 logger.warning(
@@ -1280,7 +1326,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             logger.info("Pre-compression: pruned %d old tool result(s)", pruned_count)
 
         # Phase 2: Determine boundaries
-        compress_start = self.protect_first_n
+        compress_start = effective_protect_first_n
         compress_start = self._align_boundary_forward(messages, compress_start)
 
         # Use token-budget tail protection instead of fixed message count

--- a/tests/agent/test_context_compressor_recompaction.py
+++ b/tests/agent/test_context_compressor_recompaction.py
@@ -1,0 +1,234 @@
+"""Regression test for issue #17344: recompaction must not keep re-anchoring
+the original first user exchange across every cycle.
+
+Pre-fix, ``protect_first_n=3`` preserved ``[system, user1, assistant1]``
+on every compaction. After 6 compactions the head still contained the
+*original* user1 \u2014 and the model, presented with a stale user-role
+message right next to the handoff summary, would re-execute it as if it
+were active.
+
+Fix: when the system prompt already carries the compaction note from a
+previous run, ``protect_first_n`` is shrunk to 1 (system only) for that
+compaction, so the stale exchange flows into the summariser pool where
+the structured ``## Active Task`` section replaces it as the steering
+signal.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from agent.context_compressor import (
+    ContextCompressor,
+    _COMPRESSION_NOTE_SENTINEL,
+)
+
+
+def _make_compressor(protect_first_n: int = 3):
+    with patch(
+        "agent.context_compressor.get_model_context_length",
+        return_value=100_000,
+    ):
+        return ContextCompressor(
+            model="test/model",
+            threshold_percent=0.85,
+            protect_first_n=protect_first_n,
+            protect_last_n=2,
+            quiet_mode=True,
+        )
+
+
+class TestIsRecompaction:
+    """Sentinel detection: cheap, side-effect-free, and conservative."""
+
+    def test_fresh_system_prompt_is_not_recompaction(self):
+        c = _make_compressor()
+        msgs = [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Original first request"},
+            {"role": "assistant", "content": "Sure."},
+        ]
+        assert c._is_recompaction(msgs) is False
+
+    def test_system_prompt_with_compaction_note_is_recompaction(self):
+        c = _make_compressor()
+        msgs = [
+            {
+                "role": "system",
+                "content": (
+                    "You are a helpful assistant.\n\n"
+                    "[Note: Some earlier conversation turns have been "
+                    "compacted into a handoff summary to preserve context "
+                    "space.]"
+                ),
+            },
+            {"role": "user", "content": "u1"},
+        ]
+        assert c._is_recompaction(msgs) is True
+
+    def test_empty_messages_safe(self):
+        c = _make_compressor()
+        assert c._is_recompaction([]) is False
+
+    def test_non_system_first_message_is_not_recompaction(self):
+        c = _make_compressor()
+        msgs = [
+            {"role": "user", "content": _COMPRESSION_NOTE_SENTINEL},
+        ]
+        assert c._is_recompaction(msgs) is False
+
+    def test_multimodal_system_content_is_inspected(self):
+        c = _make_compressor()
+        msgs = [
+            {
+                "role": "system",
+                "content": [
+                    {"type": "text", "text": "You are a helpful assistant."},
+                    {
+                        "type": "text",
+                        "text": (
+                            "[Note: Some earlier conversation turns have "
+                            "been compacted into a handoff summary.]"
+                        ),
+                    },
+                ],
+            },
+        ]
+        assert c._is_recompaction(msgs) is True
+
+    def test_garbage_content_does_not_raise(self):
+        c = _make_compressor()
+        msgs = [{"role": "system", "content": object()}]
+        # Must not raise; should default to False.
+        assert c._is_recompaction(msgs) is False
+
+
+class TestRecompactionShrinksProtectFirstN:
+    """Behaviour test: on recompaction the head shrinks to {system}, so the
+    stale first exchange is summarised instead of re-anchored."""
+
+    def _build_session(self, n_middle: int = 30, recompacted: bool = False):
+        system_text = "You are a helpful assistant."
+        if recompacted:
+            system_text += (
+                "\n\n[Note: Some earlier conversation turns have been "
+                "compacted into a handoff summary to preserve context "
+                "space.]"
+            )
+        msgs = [{"role": "system", "content": system_text}]
+        # First exchange: this is what we want demoted on recompaction.
+        msgs.append({"role": "user", "content": "ORIGINAL_FIRST_REQUEST"})
+        msgs.append({"role": "assistant", "content": "Sure, started on it."})
+        for i in range(n_middle):
+            role = "user" if i % 2 == 0 else "assistant"
+            msgs.append({"role": role, "content": f"middle-msg-{i} " * 80})
+        # Latest user message anchors the tail.
+        msgs.append({"role": "user", "content": "LATEST_USER_REQUEST"})
+        return msgs
+
+    def test_first_compaction_preserves_first_exchange_in_head(self):
+        c = _make_compressor(protect_first_n=3)
+        msgs = self._build_session(recompacted=False)
+        with patch.object(c, "_generate_summary", return_value="SUMMARY_BODY"):
+            out = c.compress(msgs, current_tokens=80_000)
+        # Head: [system, user(ORIGINAL_FIRST_REQUEST), assistant(...)]
+        assert out[0]["role"] == "system"
+        assert out[1]["role"] == "user"
+        assert "ORIGINAL_FIRST_REQUEST" in out[1]["content"]
+        assert out[2]["role"] == "assistant"
+
+    def test_recompaction_demotes_first_exchange_to_summary(self):
+        c = _make_compressor(protect_first_n=3)
+        msgs = self._build_session(recompacted=True)
+        with patch.object(c, "_generate_summary", return_value="SUMMARY_BODY"):
+            out = c.compress(msgs, current_tokens=80_000)
+        # Head: [system] only \u2014 the original first exchange must NOT be
+        # sitting at messages[1] anymore.
+        assert out[0]["role"] == "system"
+        # No preserved-head user message carrying ORIGINAL_FIRST_REQUEST.
+        head_user_texts = [
+            (m.get("content") if isinstance(m.get("content"), str) else "")
+            for m in out[:2]
+            if isinstance(m, dict) and m.get("role") == "user"
+        ]
+        assert all(
+            "ORIGINAL_FIRST_REQUEST" not in (t or "") for t in head_user_texts
+        ), (
+            "Recompaction must drop the stale first user exchange from the "
+            "preserved head; otherwise the model keeps re-executing it. "
+            f"head_user_texts={head_user_texts}"
+        )
+
+    def test_recompaction_preserves_latest_user_message_in_tail(self):
+        c = _make_compressor(protect_first_n=3)
+        msgs = self._build_session(recompacted=True)
+        with patch.object(c, "_generate_summary", return_value="SUMMARY_BODY"):
+            out = c.compress(msgs, current_tokens=80_000)
+        # Latest user request must still be reachable (not summarised away).
+        last_text = (
+            out[-1].get("content")
+            if isinstance(out[-1].get("content"), str)
+            else ""
+        )
+        # The TODO snapshot may append an extra user message; scan the tail.
+        tail_text = "".join(
+            (m.get("content") or "") if isinstance(m.get("content"), str) else ""
+            for m in out[-5:]
+            if isinstance(m, dict)
+        )
+        assert "LATEST_USER_REQUEST" in tail_text
+
+    def test_recompaction_keeps_protect_first_n_attribute_unchanged(self):
+        # The shrink is per-call; the configured value must not mutate so
+        # subsequent fresh sessions still get the default head.
+        c = _make_compressor(protect_first_n=3)
+        msgs = self._build_session(recompacted=True)
+        with patch.object(c, "_generate_summary", return_value="SUMMARY_BODY"):
+            c.compress(msgs, current_tokens=80_000)
+        assert c.protect_first_n == 3
+
+    def test_protect_first_n_one_no_op_for_recompaction(self):
+        # When the compressor is already configured with protect_first_n=1
+        # the shrink branch should be a no-op (no further shrinking needed).
+        c = _make_compressor(protect_first_n=1)
+        msgs = self._build_session(recompacted=True)
+        with patch.object(c, "_generate_summary", return_value="SUMMARY_BODY"):
+            out = c.compress(msgs, current_tokens=80_000)
+        # Still produces a valid compressed transcript.
+        assert out[0]["role"] == "system"
+        assert len(out) >= 3  # system + summary + at least one tail message
+
+
+class TestRecompactionMinForCompressGate:
+    """``_min_for_compress`` early-return must scale with the *effective*
+    head size on recompaction, otherwise small recompacted sessions would
+    skip compression entirely."""
+
+    def test_recompaction_can_compress_small_session(self):
+        c = _make_compressor(protect_first_n=3)
+        # 1 system + 2 first-exchange + 4 middle + 1 latest = 8 messages.
+        # Default protect_first_n=3 \u2192 _min_for_compress = 7, which is < 8 so
+        # compression DOES run, but the effective shrink to 1 makes
+        # _min_for_compress = 5, leaving more room to summarise.
+        system_text = (
+            "You are a helpful assistant.\n\n"
+            "[Note: Some earlier conversation turns have been compacted "
+            "into a handoff summary.]"
+        )
+        msgs = [
+            {"role": "system", "content": system_text},
+            {"role": "user", "content": "ORIGINAL"},
+            {"role": "assistant", "content": "ack"},
+            {"role": "user", "content": "m1 " * 200},
+            {"role": "assistant", "content": "m2 " * 200},
+            {"role": "user", "content": "m3 " * 200},
+            {"role": "assistant", "content": "m4 " * 200},
+            {"role": "user", "content": "LATEST"},
+        ]
+        with patch.object(c, "_generate_summary", return_value="SUMMARY_BODY"):
+            out = c.compress(msgs, current_tokens=80_000)
+        # ORIGINAL must be summarised away (not in preserved head).
+        head = out[:2]
+        for m in head:
+            text = m.get("content") if isinstance(m.get("content"), str) else ""
+            assert "ORIGINAL" not in text


### PR DESCRIPTION
Closes #17344.

## Bug
Reporter traced a **6-session compression chain** in which every child session carried the *identical* original first user request — as if no progress had been made. After resume (or on new sessions opened post-compression), the model re-executes the original first task instead of continuing from the handoff summary's `## Active Task`.

## Root cause
`ContextCompressor` protects `protect_first_n=3` messages at the head — `[system, user1, assistant1]`. On every cycle that head is preserved verbatim:

```
[system + compaction note, user1 (ORIGINAL), assistant1, summary, …tail…, latest_user]
```

`SUMMARY_PREFIX` says "resume from `## Active Task`," but `user1 (ORIGINAL)` is sitting right next to it as a still-prominent user-role message. The model latches onto the first plausible unanswered request and re-executes it — structured summary prose loses against direct attention on a user message. After 6 cycles that same `user1` has been re-anchored 6 times.

## Fix
On the **second and subsequent** compactions — detected by checking whether `messages[0]` (the system prompt) already carries the compaction note we appended last time — shrink `protect_first_n` to **1** for that call. The original `[user1, assistant1]` then flow into the summariser pool, and the structured `## Active Task` section becomes the sole steering signal as designed.

The shrink is **per-call**; `self.protect_first_n` is left untouched so fresh sessions continue to use the configured default.

```python
effective_protect_first_n = self.protect_first_n
if self._is_recompaction(messages) and self.protect_first_n > 1:
    effective_protect_first_n = 1
```

### Detection signal
Reuses the existing compaction note already written to the system prompt on first compaction. A new `_COMPRESSION_NOTE_SENTINEL` constant captures a stable substring (`"earlier conversation turns have been compacted into a handoff summary"`) so PR #17301 — which expands the note text — will not break detection. New helper `ContextCompressor._is_recompaction(messages)` does the lookup with no I/O, returns `False` on malformed input, and handles multimodal system content via the existing `_content_text_for_contains()` helper.

## Why not just strengthen `SUMMARY_PREFIX`?
The prefix already says *"Respond ONLY to the latest user message that appears AFTER this summary."* Stronger prose helps marginally but cannot compete with structural attention on a head-preserved user message. The reporter explicitly noted: *"the model responds as if the session had just started."* That's an architectural problem, not a wording problem.

## Coordination with PR #17301 / #17251
**PR #17301** (open, by @HiddenPuppy) addresses a sibling problem: `SUMMARY_PREFIX` over-applies "background reference" framing to memory and skills. Both fixes stem from the same root concern (compaction handoff misinterpreted by the model) but are orthogonal — #17301 carves out exceptions inside `SUMMARY_PREFIX` text; this PR shrinks `protect_first_n` on recompaction. They **compose cleanly**; merge order doesn't matter.

## Out of scope
The reporter also flagged `parent_session_id = NULL` observations on chained sessions. That's a separate DB-write concern — `run_agent.py:8891` explicitly passes `parent_session_id=old_session_id` and `resolve_resume_session_id` (#15000) handles chain-walking. If NULL is observed it's likely a different write-path failure and deserves its own bug. This PR stays focused on the message-level fix that unbreaks the user-visible "restarts first task" behaviour.

## Tests
**`TestIsRecompaction` (6 cases)** — sentinel detection edge cases:
- `test_fresh_system_prompt_is_not_recompaction`
- `test_system_prompt_with_compaction_note_is_recompaction`
- `test_empty_messages_safe`
- `test_non_system_first_message_is_not_recompaction`
- `test_multimodal_system_content_is_inspected`
- `test_garbage_content_does_not_raise`

**`TestRecompactionShrinksProtectFirstN` (5 cases)** — behavioural:
- `test_first_compaction_preserves_first_exchange_in_head` (control)
- `test_recompaction_demotes_first_exchange_to_summary` (the bug)
- `test_recompaction_preserves_latest_user_message_in_tail`
- `test_recompaction_keeps_protect_first_n_attribute_unchanged`
- `test_protect_first_n_one_no_op_for_recompaction`

**`TestRecompactionMinForCompressGate` (1 case)** — `_min_for_compress` early-return uses the *effective* (post-shrink) head count.

```
$ python -m pytest tests/agent/test_context_compressor.py \
                   tests/agent/test_context_compressor_recompaction.py \
                   tests/run_agent/test_compression_boundary_hook.py \
                   tests/run_agent/test_compression_persistence.py \
                   tests/run_agent/test_413_compression.py -q
99 passed in 8.26s
```

87 pre-existing + 12 new, zero regressions.