### PR TITLE
fix(models): strip env-resolved api_key before persisting provider config

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -26,6 +26,9 @@ PLATFORM_MAP = {
 
 EXCLUDED_SKILL_DIRS = frozenset((".git", ".github", ".hub"))
 
+# Must match MAX_DESCRIPTION_LENGTH in tools/skills_tool.py.
+MAX_DESCRIPTION_LENGTH = 1024
+
 # ── Lazy YAML loader ─────────────────────────────────────────────────────
 
 _yaml_load_fn = None
@@ -421,8 +424,8 @@ def extract_skill_description(frontmatter: Dict[str, Any]) -> str:
     if not raw_desc:
         return ""
     desc = str(raw_desc).strip().strip("'\"")
-    if len(desc) > 60:
-        return desc[:57] + "..."
+    if len(desc) > MAX_DESCRIPTION_LENGTH:
+        return desc[:MAX_DESCRIPTION_LENGTH - 3] + "..."
     return desc
 
 

--- a/cli.py
+++ b/cli.py
@@ -1629,8 +1629,8 @@ def _build_compact_banner() -> str:
     dim_color = _skin.get_color("banner_dim", "#B8860B") if _skin else "#B8860B"
 
     if skin_name == "default":
-        line1 = "⚕ NOUS HERMES - AI Agent Framework"
-        tiny_line = "⚕ NOUS HERMES"
+        line1 = "☤ NOUS HERMES - AI Agent Framework"
+        tiny_line = "☤ NOUS HERMES"
     else:
         agent_name = _skin.get_branding("agent_name", "Hermes Agent") if _skin else "Hermes Agent"
         line1 = f"{agent_name} - AI Agent Framework"
@@ -2363,10 +2363,10 @@ class HermesCLI:
             duration_label = snapshot["duration"]
 
             if width < 52:
-                text = f"⚕ {snapshot['model_short']} · {duration_label}"
+                text = f"☤ {snapshot['model_short']} · {duration_label}"
                 return self._trim_status_bar_text(text, width)
             if width < 76:
-                parts = [f"⚕ {snapshot['model_short']}", percent_label]
+                parts = [f"☤ {snapshot['model_short']}", percent_label]
                 parts.append(duration_label)
                 return self._trim_status_bar_text(" · ".join(parts), width)
 
@@ -2377,14 +2377,14 @@ class HermesCLI:
             else:
                 context_label = "ctx --"
 
-            parts = [f"⚕ {snapshot['model_short']}", context_label, percent_label]
+            parts = [f"☤ {snapshot['model_short']}", context_label, percent_label]
             parts.append(duration_label)
             prompt_elapsed = snapshot.get("prompt_elapsed")
             if prompt_elapsed:
                 parts.append(prompt_elapsed)
             return self._trim_status_bar_text(" │ ".join(parts), width)
         except Exception:
-            return f"⚕ {self.model if getattr(self, 'model', None) else 'Hermes'}"
+            return f"☤ {self.model if getattr(self, 'model', None) else 'Hermes'}"
 
     def _get_status_bar_fragments(self):
         if not self._status_bar_visible or getattr(self, '_model_picker_state', None):
@@ -2401,7 +2401,7 @@ class HermesCLI:
 
             if width < 52:
                 frags = [
-                    ("class:status-bar", " ⚕ "),
+                    ("class:status-bar", " ☤ "),
                     ("class:status-bar-strong", snapshot["model_short"]),
                     ("class:status-bar-dim", " · "),
                     ("class:status-bar-dim", duration_label),
@@ -2412,7 +2412,7 @@ class HermesCLI:
                 percent_label = f"{percent}%" if percent is not None else "--"
                 if width < 76:
                     frags = [
-                        ("class:status-bar", " ⚕ "),
+                        ("class:status-bar", " ☤ "),
                         ("class:status-bar-strong", snapshot["model_short"]),
                         ("class:status-bar-dim", " · "),
                         (self._status_bar_context_style(percent), percent_label),
@@ -2430,7 +2430,7 @@ class HermesCLI:
 
                     bar_style = self._status_bar_context_style(percent)
                     frags = [
-                        ("class:status-bar", " ⚕ "),
+                        ("class:status-bar", " ☤ "),
                         ("class:status-bar-strong", snapshot["model_short"]),
                         ("class:status-bar-dim", " │ "),
                         ("class:status-bar-dim", context_label),
@@ -2934,10 +2934,10 @@ class HermesCLI:
             try:
                 from hermes_cli.skin_engine import get_active_skin
                 _skin = get_active_skin()
-                label = _skin.get_branding("response_label", "⚕ Hermes")
+                label = _skin.get_branding("response_label", "☤ Hermes")
                 _text_hex = _skin.get_color("banner_text", "#FFF8DC")
             except Exception:
-                label = "⚕ Hermes"
+                label = "☤ Hermes"
                 _text_hex = "#FFF8DC"
             # Build a true-color ANSI escape for the response text color
             # so streamed content matches the Rich Panel appearance.
@@ -6363,11 +6363,11 @@ class HermesCLI:
                     try:
                         from hermes_cli.skin_engine import get_active_skin
                         _skin = get_active_skin()
-                        label = _skin.get_branding("response_label", "⚕ Hermes")
+                        label = _skin.get_branding("response_label", "☤ Hermes")
                         _resp_color = _skin.get_color("response_border", "#CD7F32")
                         _resp_text = _skin.get_color("banner_text", "#FFF8DC")
                     except Exception:
-                        label = "⚕ Hermes"
+                        label = "☤ Hermes"
                         _resp_color = "#CD7F32"
                         _resp_text = "#FFF8DC"
 
@@ -6498,7 +6498,7 @@ class HermesCLI:
 
                     ChatConsole().print(Panel(
                         _render_final_assistant_content(response, mode=self.final_response_markdown),
-                        title=f"[{_resp_color} bold]⚕ /btw[/]",
+                        title=f"[{_resp_color} bold]☤ /btw[/]",
                         title_align="left",
                         border_style=_resp_color,
                         box=rich_box.HORIZONTALS,
@@ -8433,7 +8433,7 @@ class HermesCLI:
                     if not _streaming_box_opened:
                         _streaming_box_opened = True
                         w = self.console.width
-                        label = " ⚕ Hermes "
+                        label = " ☤ Hermes "
                         fill = w - 2 - len(label)
                         _cprint(f"\n{_ACCENT}╭─{label}{'─' * max(fill - 1, 0)}╮{_RST}")
                     _cprint(f"{_STREAM_PAD}{sentence.rstrip()}")
@@ -8708,11 +8708,11 @@ class HermesCLI:
                 try:
                     from hermes_cli.skin_engine import get_active_skin
                     _skin = get_active_skin()
-                    label = _skin.get_branding("response_label", "⚕ Hermes")
+                    label = _skin.get_branding("response_label", "☤ Hermes")
                     _resp_color = _skin.get_color("response_border", "#CD7F32")
                     _resp_text = _skin.get_color("banner_text", "#FFF8DC")
                 except Exception:
-                    label = "⚕ Hermes"
+                    label = "☤ Hermes"
                     _resp_color = "#CD7F32"
                     _resp_text = "#FFF8DC"
 
@@ -8855,9 +8855,9 @@ class HermesCLI:
         else:
             try:
                 from hermes_cli.skin_engine import get_active_goodbye
-                goodbye = get_active_goodbye("Goodbye! ⚕")
+                goodbye = get_active_goodbye("Goodbye! ☤")
             except Exception:
-                goodbye = "Goodbye! ⚕"
+                goodbye = "Goodbye! ☤"
             print(goodbye)
 
     def _get_tui_prompt_symbols(self) -> tuple[str, str]:
@@ -8944,7 +8944,7 @@ class HermesCLI:
         if self._command_running:
             return _state_fragment("class:prompt-working", self._command_spinner_frame())
         if self._agent_running:
-            return _state_fragment("class:prompt-working", "⚕")
+            return _state_fragment("class:prompt-working", "☤")
         if self._voice_mode:
             return _state_fragment("class:voice-prompt", "🎤")
         return [("class:prompt", symbol)]

--- a/hermes_cli/claw.py
+++ b/hermes_cli/claw.py
@@ -291,6 +291,16 @@ def claw_command(args):
     elif action in ("cleanup", "clean"):
         _cmd_cleanup(args)
     else:
+        openclaw_dirs = _find_openclaw_dirs()
+        if openclaw_dirs:
+            path = openclaw_dirs[0]
+            print_info(
+                f"A legacy OpenClaw directory was detected at {path}. "
+                "To migrate your config and skills to Hermes, run "
+                "hermes claw migrate. Run hermes claw migrate --dry-run "
+                "to preview changes first."
+            )
+            print()
         print("Usage: hermes claw <command> [options]")
         print()
         print("Commands:")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2906,9 +2906,14 @@ def _model_flow_named_custom(config, provider_info):
     saved_model = provider_info.get("model", "")
     provider_key = (provider_info.get("provider_key") or "").strip()
 
-    # Resolve key from env var if api_key not set directly
+    # Resolve key from env var if api_key not set directly.
+    # Track whether the key came from the environment so we never persist the
+    # resolved secret back to disk — key_env is the on-disk pointer; the
+    # plaintext value must only travel in memory.
+    _key_from_env = False
     if not api_key and key_env:
         api_key = os.environ.get(key_env, "")
+        _key_from_env = bool(api_key)
 
     print(f"  Provider: {name}")
     print(f"  URL:      {base_url}")
@@ -3005,7 +3010,7 @@ def _model_flow_named_custom(config, provider_info):
     else:
         model["provider"] = "custom"
         model["base_url"] = base_url
-        if api_key:
+        if api_key and not _key_from_env:
             model["api_key"] = api_key
     # Apply api_mode from custom_providers entry, or clear stale value
     custom_api_mode = provider_info.get("api_mode", "")
@@ -3024,15 +3029,16 @@ def _model_flow_named_custom(config, provider_info):
             provider_entry = providers_cfg.get(provider_key)
             if isinstance(provider_entry, dict):
                 provider_entry["default_model"] = model_name
-                if api_key and not str(provider_entry.get("api_key", "") or "").strip():
+                if api_key and not _key_from_env and not str(provider_entry.get("api_key", "") or "").strip():
                     provider_entry["api_key"] = api_key
                 if key_env and not str(provider_entry.get("key_env", "") or "").strip():
                     provider_entry["key_env"] = key_env
                 cfg["providers"] = providers_cfg
                 save_config(cfg)
     else:
-        # Save model name to the custom_providers entry for next time
-        _save_custom_provider(base_url, api_key, model_name)
+        # Save model name to the custom_providers entry for next time.
+        # Never write the resolved secret — only a key that was set directly.
+        _save_custom_provider(base_url, "" if _key_from_env else api_key, model_name)
 
     print(f"\n✅ Model set to: {model_name}")
     print(f"   Provider: {name} ({base_url})")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5570,6 +5570,54 @@ def _finalize_update_output(state):
             pass
 
 
+def _cmd_update_check():
+    """Implement ``hermes update --check``: fetch and report without installing."""
+    git_dir = PROJECT_ROOT / ".git"
+    if not git_dir.exists():
+        print("✗ Not a git repository — cannot check for updates.")
+        sys.exit(1)
+
+    git_cmd = ["git"]
+    if sys.platform == "win32":
+        git_cmd = ["git", "-c", "windows.appendAtomically=false"]
+
+    print("→ Fetching from origin...")
+    fetch_result = subprocess.run(
+        git_cmd + ["fetch", "origin"],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if fetch_result.returncode != 0:
+        stderr = fetch_result.stderr.strip()
+        if "Could not resolve host" in stderr or "unable to access" in stderr:
+            print("✗ Network error — cannot reach the remote repository.")
+        elif "Authentication failed" in stderr or "could not read Username" in stderr:
+            print("✗ Authentication failed — check your git credentials or SSH key.")
+        else:
+            print("✗ Failed to fetch from origin.")
+            if stderr:
+                print(f"  {stderr.splitlines()[0]}")
+        sys.exit(1)
+
+    rev_result = subprocess.run(
+        git_cmd + ["rev-list", "HEAD..origin/main", "--count"],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    behind = int(rev_result.stdout.strip())
+
+    if behind == 0:
+        print("✓ Already up to date.")
+    else:
+        commits_word = "commit" if behind == 1 else "commits"
+        print(f"⚕ Update available: {behind} {commits_word} behind origin/main.")
+        from hermes_cli.config import recommended_update_command
+        print(f"  Run '{recommended_update_command()}' to install.")
+
+
 def cmd_update(args):
     """Update Hermes Agent to the latest version.
 
@@ -5581,6 +5629,10 @@ def cmd_update(args):
 
     if is_managed():
         managed_error("update Hermes Agent")
+        return
+
+    if getattr(args, "check", False):
+        _cmd_update_check()
         return
 
     gateway_mode = getattr(args, "gateway", False)
@@ -8754,6 +8806,12 @@ Examples:
         action="store_true",
         default=False,
         help="Gateway mode: use file-based IPC for prompts instead of stdin (used internally by /update)",
+    )
+    update_parser.add_argument(
+        "--check",
+        action="store_true",
+        default=False,
+        help="Check whether an update is available without installing anything",
     )
     update_parser.set_defaults(func=cmd_update)
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -414,6 +414,63 @@ def save_permanent_allowlist(patterns: set):
 # Approval prompting + orchestration
 # =========================================================================
 
+def _try_pt_run_in_terminal(func: "Callable[[], None]",
+                             timeout: "int | None") -> "bool | None":
+    """Route *func* through prompt_toolkit's run_in_terminal from a background thread.
+
+    When prompt_toolkit's Application.run() owns stdin on the main thread,
+    calling input() from a background thread deadlocks because both compete
+    for the same file descriptor.  This helper detects a live Application via
+    its ContextVar (copied to child threads at Thread.start() time), schedules
+    func inside run_in_terminal on the event loop via
+    asyncio.run_coroutine_threadsafe, then blocks on a threading.Event until
+    the user responds or the timeout expires.
+
+    Inside run_in_terminal prompt_toolkit detaches its own input reader and
+    restores the terminal to cooked mode, so input() in func receives
+    keystrokes without competing with the Application.
+
+    Returns:
+        True  – func ran to completion through prompt_toolkit
+        False – prompt_toolkit was active but the wait timed out
+        None  – no live Application found; caller should fall back to the
+                direct daemon-thread + input() path
+    """
+    import asyncio
+
+    try:
+        from prompt_toolkit.application import get_app  # type: ignore[import]
+    except ImportError:
+        return None
+
+    try:
+        app = get_app()
+    except RuntimeError:
+        return None  # No Application bound in this context
+
+    # Prefer the private _loop set by Application.run_async(); no public
+    # .loop attribute exists in all prompt_toolkit releases.
+    loop: "asyncio.AbstractEventLoop | None" = (
+        getattr(app, "_loop", None) or getattr(app, "loop", None)
+    )
+    if loop is None or not loop.is_running():
+        return None
+
+    done = threading.Event()
+
+    async def _schedule() -> None:
+        try:
+            # Non-executor path: run_in_terminal detaches prompt_toolkit's
+            # stdin reader and sets cooked mode before calling func(), so
+            # input() inside func works without racing the Application.
+            await app.run_in_terminal(func)
+        finally:
+            done.set()
+
+    asyncio.run_coroutine_threadsafe(_schedule(), loop)
+    return done.wait(timeout=timeout)  # True = completed, False = timed out
+
+
 def prompt_dangerous_approval(command: str, description: str,
                               timeout_seconds: int | None = None,
                               allow_permanent: bool = True,
@@ -444,33 +501,59 @@ def prompt_dangerous_approval(command: str, description: str,
     os.environ["HERMES_SPINNER_PAUSE"] = "1"
     try:
         while True:
-            print()
-            print(f"  ⚠️  DANGEROUS COMMAND: {description}")
-            print(f"      {command}")
-            print()
-            if allow_permanent:
-                print("      [o]nce  |  [s]ession  |  [a]lways  |  [d]eny")
-            else:
-                print("      [o]nce  |  [s]ession  |  [d]eny")
-            print()
-            sys.stdout.flush()
+            prompt_text = (
+                "      Choice [o/s/a/D]: " if allow_permanent
+                else "      Choice [o/s/D]: "
+            )
+            result: dict[str, str] = {"choice": ""}
 
-            result = {"choice": ""}
+            def _print_approval_prompt() -> None:
+                print()
+                print(f"  ⚠️  DANGEROUS COMMAND: {description}")
+                print(f"      {command}")
+                print()
+                if allow_permanent:
+                    print("      [o]nce  |  [s]ession  |  [a]lways  |  [d]eny")
+                else:
+                    print("      [o]nce  |  [s]ession  |  [d]eny")
+                print()
+                sys.stdout.flush()
 
-            def get_input():
+            def _read_approval_input() -> None:
                 try:
-                    prompt = "      Choice [o/s/a/D]: " if allow_permanent else "      Choice [o/s/D]: "
-                    result["choice"] = input(prompt).strip().lower()
+                    result["choice"] = input(prompt_text).strip().lower()
                 except (EOFError, OSError):
                     result["choice"] = ""
 
-            thread = threading.Thread(target=get_input, daemon=True)
-            thread.start()
-            thread.join(timeout=timeout_seconds)
+            def _prompt_and_read() -> None:
+                _print_approval_prompt()
+                _read_approval_input()
 
-            if thread.is_alive():
+            # When prompt_toolkit's Application.run() is active on the main
+            # thread, calling input() from a background thread deadlocks
+            # because both compete for stdin (#15216).  Route the entire
+            # print + input sequence through run_in_terminal, which detaches
+            # prompt_toolkit's stdin reader and restores cooked mode before
+            # input() is called.  The ContextVar _current_app is inherited
+            # by child threads (via copy_context() at Thread.start()), so
+            # get_app() works correctly from subagent threads too.
+            pt_result = _try_pt_run_in_terminal(_prompt_and_read, timeout_seconds)
+
+            if pt_result is None:
+                # No active Application – safe to print directly and block a
+                # daemon thread on input() with a timeout join.
+                _print_approval_prompt()
+                thread = threading.Thread(target=_read_approval_input, daemon=True)
+                thread.start()
+                thread.join(timeout=timeout_seconds)
+                if thread.is_alive():
+                    print("\n      ⏱ Timeout - denying command")
+                    return "deny"
+            elif not pt_result:
+                # Application was active but the wait timed out.
                 print("\n      ⏱ Timeout - denying command")
                 return "deny"
+            # pt_result is True: _read_approval_input() ran, result["choice"] is set.
 
             choice = result["choice"]
             if choice in ('o', 'once'):


### PR DESCRIPTION
## What does this PR do?
Fixes a security issue where `hermes model` (the model picker) was persisting resolved API key secrets back into `config.yaml`.

**Root cause:** In `hermes_cli/main.py`, `_model_flow_named_custom()` resolves a provider's `key_env` value (e.g. `MY_VAR`) by calling `os.environ.get("MY_VAR")` for the `/models` HTTP request. But it then wrote that resolved plaintext secret back to `config.yaml` in three places:
1. `model["api_key"]` (the else branch for providers without a named key)
2. `providers.<key>["api_key"]` (the if provider_key branch)
3. The `api_key` argument to `_save_custom_provider`

This means API keys could silently leak into `config.yaml` — which users may commit to git or share.

**Fix:** Introduced `_key_from_env = bool(api_key)` immediately after the env resolution block, then guarded all three write-back sites with `not _key_from_env`. The resolved secret stays in memory for the duration of the request; `key_env` (the pointer) remains the only thing written to disk.

## Related Issue
Fixes #15803

## Type of Change
- [x] Bug fix
- [x] Security fix