### PR TITLE
fix(metadata): resolve context_length for custom:xxx providers via URL inference

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1355,7 +1355,7 @@ def get_model_context_length(
     # (e.g. claude-opus-4.6 is 1M on Anthropic but 128K on GitHub Copilot).
     # If provider is generic (openrouter/custom/empty), try to infer from URL.
     effective_provider = provider
-    if not effective_provider or effective_provider in ("openrouter", "custom"):
+    if not effective_provider or effective_provider in ("openrouter", "custom") or effective_provider.startswith("custom:"):
         if base_url:
             inferred = _infer_provider_from_url(base_url)
             if inferred:


### PR DESCRIPTION
## What does this PR do?

When a provider is configured as `custom:xxx` (e.g. `custom:glmcode`, `custom:deepseek`), the URL inference step in `get_model_context_length()` is skipped. The condition only checks for exact match on `"openrouter"` / `"custom"`, not the `"custom:"` prefix namespace.

This causes fallback to hardcoded `DEFAULT_CONTEXT_LENGTHS` which may be inaccurate.

**Example:** `glm-5.1` via `custom:glmcode` resolves to **202,752** (hardcoded `"glm"` family fallback) instead of the correct **200,000** from models.dev (confirmed against [official docs](https://docs.bigmodel.cn/cn/guide/models/text/glm-5.1) stating 200K context window).

Fix: also trigger URL inference when `provider.startswith("custom:")`, allowing the existing `_infer_provider_from_url()` → `lookup_models_dev_context()` path to resolve the correct context length.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/model_metadata.py` L1358: added `or effective_provider.startswith("custom:")` to the URL inference condition

## How to Test
