### PR TITLE
fix(memory): warn when holographic memory lacks numpy

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2473,6 +2473,17 @@ def run_doctor(args):
             _provider = load_memory_provider(_active_memory_provider)
             if _provider and _provider.is_available():
                 check_ok(f"{_active_memory_provider} provider active")
+                if _active_memory_provider == "holographic":
+                    try:
+                        from plugins.memory.holographic import holographic as _holographic_hrr
+                        if not getattr(_holographic_hrr, "_HAS_NUMPY", False):
+                            check_warn(
+                                "Holographic memory degraded",
+                                "numpy not installed; HRR semantic retrieval disabled",
+                            )
+                            issues.append("Holographic memory provider is missing numpy")
+                    except Exception as _e:
+                        check_warn("Holographic numpy check failed", str(_e))
             elif _provider:
                 check_warn(f"{_active_memory_provider} configured but not available", "run: hermes memory status")
             else:

--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -25,11 +25,19 @@ from typing import Any, Dict, List
 from agent.memory_provider import MemoryProvider
 from tools.registry import tool_error
 from utils import is_truthy_value
+from . import holographic as hrr
 from .store import MemoryStore
 from .retrieval import FactRetriever
 from hermes_cli.config import cfg_get
 
 logger = logging.getLogger(__name__)
+
+_NUMPY_DEGRADED_MESSAGE = (
+    "Holographic memory is running in degraded mode because numpy is not installed; "
+    "HRR semantic retrieval, related/reason/contradict operations, and contradiction "
+    "detection are disabled or fall back to FTS5 keyword search. Install numpy in the "
+    "Hermes environment to enable full holographic memory."
+)
 
 
 # ---------------------------------------------------------------------------
@@ -121,6 +129,7 @@ class HolographicMemoryProvider(MemoryProvider):
         self._store = None
         self._retriever = None
         self._min_trust = float(self._config.get("min_trust_threshold", 0.3))
+        self._warned_numpy_degraded = False
 
     @property
     def name(self) -> str:
@@ -171,6 +180,10 @@ class HolographicMemoryProvider(MemoryProvider):
         hrr_dim = int(self._config.get("hrr_dim", 1024))
         hrr_weight = float(self._config.get("hrr_weight", 0.3))
         temporal_decay = int(self._config.get("temporal_decay_half_life", 0))
+
+        if not hrr._HAS_NUMPY and not self._warned_numpy_degraded:
+            logger.warning(_NUMPY_DEGRADED_MESSAGE)
+            self._warned_numpy_degraded = True
 
         self._store = MemoryStore(db_path=db_path, default_trust=default_trust, hrr_dim=hrr_dim)
         self._retriever = FactRetriever(

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -1,6 +1,7 @@
 """Tests for the memory provider interface, manager, and builtin provider."""
 
 import json
+import logging
 import threading
 import time
 import pytest
@@ -493,6 +494,27 @@ class TestPluginMemoryDiscovery:
         """load_memory_provider returns None for unknown names."""
         from plugins.memory import load_memory_provider
         assert load_memory_provider("nonexistent_provider") is None
+
+    def test_holographic_warns_when_numpy_missing(self, monkeypatch, tmp_path, caplog):
+        """Holographic provider should not silently hide degraded HRR mode."""
+        from plugins.memory.holographic import HolographicMemoryProvider
+        from plugins.memory.holographic import holographic as hrr
+
+        monkeypatch.setattr(hrr, "_HAS_NUMPY", False)
+        provider = HolographicMemoryProvider(config={"db_path": str(tmp_path / "memory.db")})
+
+        with caplog.at_level(logging.WARNING, logger="plugins.memory.holographic"):
+            provider.initialize("session-1")
+            provider.initialize("session-2")
+
+        messages = [
+            record.getMessage()
+            for record in caplog.records
+            if "degraded mode" in record.getMessage()
+        ]
+        assert len(messages) == 1
+        assert "numpy is not installed" in messages[0]
+        assert "HRR semantic retrieval" in messages[0]
 
 
 class TestUserInstalledProviderDiscovery:

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -347,6 +347,16 @@ class TestDoctorMemoryProviderSection:
         assert "Memory Provider" in out
         assert "Built-in memory active" not in out
 
+    def test_holographic_provider_warns_when_numpy_missing(self, monkeypatch, tmp_path):
+        from plugins.memory.holographic import holographic as hrr
+
+        monkeypatch.setattr(hrr, "_HAS_NUMPY", False)
+        out = self._run_doctor_and_capture(monkeypatch, tmp_path, provider="holographic")
+
+        assert "holographic provider active" in out
+        assert "Holographic memory degraded" in out
+        assert "numpy not installed" in out
+
 
 def test_run_doctor_termux_treats_docker_and_browser_warnings_as_expected(monkeypatch, tmp_path):
     helper = TestDoctorMemoryProviderSection()


### PR DESCRIPTION
## Summary

- warn once when the holographic memory provider initializes without `numpy`, instead of silently degrading HRR-backed retrieval
- surface the same degraded state in `hermes doctor` when `memory.provider: holographic` is active
- add focused regression coverage for provider initialization and doctor diagnostics

## Why

Fixes #17350. Without `numpy`, holographic memory still registers and stores facts, but semantic HRR behavior is disabled or downgraded: `probe` / `related` / `reason` fall back to keyword search, and `contradict` returns no results. Users had no visible signal that this was happening.

## Testing

- `./.venv/bin/python -m pytest -o addopts='' tests/agent/test_memory_provider.py::TestPluginMemoryDiscovery::test_holographic_warns_when_numpy_missing tests/hermes_cli/test_doctor.py::TestDoctorMemoryProviderSection::test_holographic_provider_warns_when_numpy_missing -q`
- `./.venv/bin/python -m pytest -o addopts='' tests/agent/test_memory_provider.py -q`
- `./.venv/bin/python -m pytest -o addopts='' tests/hermes_cli/test_doctor.py -q`
- `./.venv/bin/python -m py_compile plugins/memory/holographic/__init__.py hermes_cli/doctor.py tests/agent/test_memory_provider.py tests/hermes_cli/test_doctor.py`

Note: running `tests/agent/test_memory_provider.py tests/hermes_cli/test_doctor.py` together still exposes an existing order-dependent failure in two Honcho doctor tests that monkeypatch `plugins.memory.honcho` after `plugins.memory` has already been imported. Each file passes independently.
