### PR TITLE
fix: handle EXDEV in atomic_replace for cross-device memory writes

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,6 @@
 """Shared utility functions for hermes-agent."""
 
+import errno
 import json
 import logging
 import os
@@ -78,7 +79,14 @@ def atomic_replace(tmp_path: Union[str, Path], target: Union[str, Path]) -> str:
     """
     target_str = str(target)
     real_path = os.path.realpath(target_str) if os.path.islink(target_str) else target_str
-    os.replace(str(tmp_path), real_path)
+    try:
+        os.replace(str(tmp_path), real_path)
+    except OSError as exc:
+        if exc.errno == getattr(errno, "EXDEV", 18):
+            import shutil
+            shutil.move(str(tmp_path), real_path)
+        else:
+            raise
     return real_path
 
 


### PR DESCRIPTION
## What does this PR do?

`atomic_replace()` in `utils.py` uses `os.replace()` which fails with EXDEV (errno 18) when the temp file and resolved target path are on different filesystems. This breaks the memory tool for users with Docker volumes, NFS mounts, or symlinked memory directories.

The fix tries `os.replace()` first (preserves atomicity on same filesystem), then falls back to `shutil.move()` on EXDEV.

## Related Issue

Fixes #17313

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `utils.py`: wrap `os.replace()` in try/except, catch `errno.EXDEV`, fall back to `shutil.move()` (+6 lines)

## How to Test

1. Create a symlink from `~/.hermes/memories/MEMORY.md` to a path on a different filesystem (e.g., a mounted Docker volume or NFS share)
2. Run any memory write operation (e.g., `fact_store(action="add", ...)`)
3. Before fix: `[Errno 18] Invalid cross-device link`
4. After fix: write succeeds silently

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] Cross-platform: fix uses `errno.EXDEV` (POSIX-standard) and `shutil.move()` (cross-platform)