### PR TITLE
fix: warn when holographic memory degrades due to missing numpy

### DIFF
--- a/plugins/memory/holographic/holographic.py
+++ b/plugins/memory/holographic/holographic.py
@@ -30,6 +30,13 @@ try:
 except ImportError:
     _HAS_NUMPY = False
 
+if not _HAS_NUMPY:
+    logging.getLogger(__name__).warning(
+        "numpy is not installed — holographic memory (HRR) is disabled. "
+        "Retrieval will degrade to FTS5 keyword-only search. "
+        "Install numpy to enable vector-symbolic retrieval: pip install numpy"
+    )
+
 logger = logging.getLogger(__name__)
 
 _TWO_PI = 2.0 * math.pi

--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -6,9 +6,12 @@ Jaccard similarity reranking and trust-weighted scoring.
 
 from __future__ import annotations
 
+import logging
 import math
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from .store import MemoryStore
@@ -37,6 +40,11 @@ class FactRetriever:
 
         # Auto-redistribute weights if numpy unavailable
         if hrr_weight > 0 and not hrr._HAS_NUMPY:
+            logger.warning(
+                "numpy unavailable — HRR weight (%.1f) redistributed to "
+                "FTS5 (0.6) + Jaccard (0.4). Search quality will be reduced.",
+                hrr_weight,
+            )
             fts_weight = 0.6
             jaccard_weight = 0.4
             hrr_weight = 0.0


### PR DESCRIPTION
## What does this PR do?

When `numpy` is not installed, the holographic memory plugin silently degrades all HRR-based semantic search to FTS5 keyword matching. No warning is logged, no error is raised. Users have no way to know their memory is running in degraded mode.

This PR adds init-time warnings so the degradation is visible.

## Related Issue

Fixes #17350

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/holographic/holographic.py`: add `logging.warning()` when numpy import fails and `_HAS_NUMPY` is set to False
- `plugins/memory/holographic/retrieval.py`: add `logger.warning()` in `FactRetriever.__init__()` when HRR weight is redistributed to zero

No warnings in per-query methods (`probe`, `related`, `reason`, `contradict`) to avoid log spam — init-time warnings are sufficient.

## How to Test

1. Uninstall numpy from the Hermes venv: `pip uninstall numpy`
2. Configure `memory.provider: holographic`
3. Start Hermes
4. Before fix: no indication of degraded mode
5. After fix: warning logged at startup: "numpy not installed — HRR semantic search disabled, falling back to FTS5 keyword matching"

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix