### PR TITLE
fix(auxiliary): explicit_base_url path now respects api_mode=anthropic_messages

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2175,7 +2175,12 @@ def resolve_provider_client(
     # ── Custom endpoint (OPENAI_BASE_URL + OPENAI_API_KEY) ───────────
     if provider == "custom":
         if explicit_base_url:
-            custom_base = _to_openai_base_url(explicit_base_url).strip()
+            # anthropic_messages must preserve the original URL intact; the
+            # /anthropic → /v1 rewrite only applies to OpenAI-wire clients.
+            if api_mode == "anthropic_messages":
+                custom_base = str(explicit_base_url or "").strip().rstrip("/")
+            else:
+                custom_base = _to_openai_base_url(explicit_base_url).strip()
             custom_key = (
                 (explicit_api_key or "").strip()
                 or os.getenv("OPENAI_API_KEY", "").strip()
@@ -2191,6 +2196,30 @@ def resolve_provider_client(
                 model or (main_runtime.get("model") if main_runtime else None) or "gpt-4o-mini",
                 provider,
             )
+            # anthropic_messages: route directly through AnthropicAuxiliaryClient.
+            # Mirrors _try_custom_endpoint() and the named custom provider branch.
+            if api_mode == "anthropic_messages":
+                try:
+                    from agent.anthropic_adapter import build_anthropic_client
+                    real_client = build_anthropic_client(custom_key, custom_base)
+                except ImportError:
+                    logger.warning(
+                        "resolve_provider_client: explicit_base_url with "
+                        "api_mode=anthropic_messages but the anthropic SDK is not "
+                        "installed — falling back to OpenAI-wire."
+                    )
+                    _fb_base = _to_openai_base_url(explicit_base_url).strip()
+                    _fb_clean, _fb_dq = _extract_url_query_params(_fb_base)
+                    _fb_extra = {"default_query": _fb_dq} if _fb_dq else {}
+                    client = OpenAI(api_key=custom_key, base_url=_fb_clean, **_fb_extra)
+                    return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+                            else (client, final_model))
+                sync_client = AnthropicAuxiliaryClient(
+                    real_client, final_model, custom_key, custom_base, is_oauth=False,
+                )
+                if async_mode:
+                    return AsyncAnthropicAuxiliaryClient(sync_client), final_model
+                return sync_client, final_model
             extra = {}
             _clean_base, _dq = _extract_url_query_params(custom_base)
             if _dq:

--- a/tests/agent/test_auxiliary_client_anthropic_custom.py
+++ b/tests/agent/test_auxiliary_client_anthropic_custom.py
@@ -105,3 +105,102 @@ def test_custom_endpoint_chat_completions_still_uses_openai_wire():
     assert client is not None
     assert model == "my-model"
     assert not isinstance(client, AnthropicAuxiliaryClient)
+
+
+# ── explicit_base_url + api_mode=anthropic_messages (path 3) ────────────────
+
+
+def test_explicit_base_url_anthropic_messages_builds_anthropic_wrapper():
+    """explicit_base_url + api_mode=anthropic_messages → AnthropicAuxiliaryClient."""
+    from agent.auxiliary_client import resolve_provider_client, AnthropicAuxiliaryClient
+
+    fake_anthropic = MagicMock(name="anthropic_client")
+    with patch(
+        "agent.anthropic_adapter.build_anthropic_client",
+        return_value=fake_anthropic,
+    ):
+        client, model = resolve_provider_client(
+            "custom",
+            model="claude-sonnet-4-6",
+            explicit_base_url="https://api.minimax.io/anthropic",
+            explicit_api_key="minimax-key",
+            api_mode="anthropic_messages",
+        )
+
+    assert isinstance(client, AnthropicAuxiliaryClient), (
+        f"Expected AnthropicAuxiliaryClient, got {type(client).__name__}"
+    )
+    assert model == "claude-sonnet-4-6"
+    assert client.api_key == "minimax-key"
+    # URL must NOT be rewritten from /anthropic to /v1
+    assert client.base_url == "https://api.minimax.io/anthropic"
+
+
+def test_explicit_base_url_anthropic_messages_url_not_mangled():
+    """/anthropic suffix must be preserved, not rewritten to /v1."""
+    from agent.auxiliary_client import resolve_provider_client, AnthropicAuxiliaryClient
+
+    captured = {}
+
+    def fake_build(api_key, base_url, **_):
+        captured["base_url"] = base_url
+        return MagicMock(name="anthropic_client")
+
+    with patch("agent.anthropic_adapter.build_anthropic_client", side_effect=fake_build):
+        client, _ = resolve_provider_client(
+            "custom",
+            explicit_base_url="https://api.minimax.io/anthropic",
+            explicit_api_key="k",
+            api_mode="anthropic_messages",
+        )
+
+    assert captured.get("base_url") == "https://api.minimax.io/anthropic", (
+        f"build_anthropic_client received mangled URL: {captured.get('base_url')!r}"
+    )
+
+
+def test_explicit_base_url_anthropic_messages_falls_back_when_sdk_missing():
+    """Graceful degradation when anthropic SDK is absent."""
+    from agent.auxiliary_client import resolve_provider_client, AnthropicAuxiliaryClient
+
+    with patch(
+        "agent.anthropic_adapter.build_anthropic_client",
+        side_effect=ImportError("no anthropic"),
+    ), patch("agent.auxiliary_client.OpenAI") as mock_openai:
+        mock_openai.return_value = MagicMock()
+        client, model = resolve_provider_client(
+            "custom",
+            model="some-model",
+            explicit_base_url="https://api.minimax.io/anthropic",
+            explicit_api_key="k",
+            api_mode="anthropic_messages",
+        )
+
+    assert client is not None
+    assert not isinstance(client, AnthropicAuxiliaryClient)
+    # Fallback must use the /v1-rewritten URL for OpenAI-wire
+    call_kwargs = mock_openai.call_args
+    used_base = call_kwargs.kwargs.get("base_url") or (
+        call_kwargs.args[1] if len(call_kwargs.args) > 1 else None
+    )
+    assert used_base is not None
+    assert "/anthropic" not in str(used_base), (
+        f"Fallback OpenAI client should use rewritten URL, got {used_base!r}"
+    )
+
+
+def test_explicit_base_url_chat_completions_still_uses_openai_wire():
+    """Regression: explicit_base_url without api_mode stays on OpenAI-wire."""
+    from agent.auxiliary_client import resolve_provider_client, AnthropicAuxiliaryClient
+
+    with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+        mock_openai.return_value = MagicMock()
+        client, model = resolve_provider_client(
+            "custom",
+            model="gpt-4o-mini",
+            explicit_base_url="https://api.example.com/v1",
+            explicit_api_key="k",
+        )
+
+    assert client is not None
+    assert not isinstance(client, AnthropicAuxiliaryClient)


### PR DESCRIPTION
## What changed and why

When `resolve_provider_client()` was called with both `explicit_base_url` and `api_mode=anthropic_messages`, the URL was silently mangled: `_to_openai_base_url()` rewrote any `/anthropic` suffix to `/v1` before `AnthropicAuxiliaryClient` was constructed, so the Anthropic SDK hit the wrong endpoint surface (e.g. `https://api.minimax.io/v1/messages` instead of `https://api.minimax.io/anthropic/messages`).

PR #7648 fixed this for paths 1 (_try_custom_endpoint) and 2 (named custom providers). This PR fixes the remaining path 3 — the `explicit_base_url` branch — by adding an explicit early-return for `api_mode=anthropic_messages` that:
1. Skips the `/anthropic → /v1` URL rewrite (needed only for OpenAI-wire).
2. Builds `AnthropicAuxiliaryClient` directly, matching the other two paths.
3. Falls back gracefully to OpenAI-wire (with the rewritten URL) when the `anthropic` SDK is not installed.

Per the collaborator comment on #7661 (alt-glitch, 2026-04-29) mapping the three code paths.

## How to test

```bash
pytest tests/agent/test_auxiliary_client_anthropic_custom.py -v
```

New tests:
- `test_explicit_base_url_anthropic_messages_builds_anthropic_wrapper` — correct wrapper type returned
- `test_explicit_base_url_anthropic_messages_url_not_mangled` — `/anthropic` suffix preserved
- `test_explicit_base_url_anthropic_messages_falls_back_when_sdk_missing` — graceful OpenAI-wire fallback
- `test_explicit_base_url_chat_completions_still_uses_openai_wire` — regression: default path unchanged

## What platforms tested on

macOS Darwin 24.6.0, Python 3.x

Fixes #7661

<!-- autocontrib:worker-id=issue-followup-2e4ac62b kind=pr-open -->