### PR TITLE
fix(auxiliary): preserve original base URL before OpenAI rewrite for …

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1052,12 +1052,11 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
             if not api_key:
                 continue
 
-            base_url = _to_openai_base_url(
-                _pool_runtime_base_url(entry, pconfig.inference_base_url) or pconfig.inference_base_url
-            )
+            provider_url = _pool_runtime_base_url(entry, pconfig.inference_base_url) or pconfig.inference_base_url
+            base_url = _to_openai_base_url(provider_url)
             model = _API_KEY_PROVIDER_AUX_MODELS.get(provider_id)
             if model is None:
-                continue  # skip provider if we don't know a valid aux model
+                continue
             logger.debug("Auxiliary text client: %s (%s) via pool", pconfig.name, model)
             if provider_id == "gemini":
                 from agent.gemini_native_adapter import GeminiNativeClient, is_native_gemini_base_url
@@ -1072,7 +1071,7 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
 
                 extra["default_headers"] = copilot_default_headers()
             _client = OpenAI(api_key=api_key, base_url=base_url, **extra)
-            _client = _maybe_wrap_anthropic(_client, model, api_key, base_url)
+            _client = _maybe_wrap_anthropic(_client, model, api_key, provider_url)
             return _client, model
 
         creds = resolve_api_key_provider_credentials(provider_id)
@@ -1080,12 +1079,11 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
         if not api_key:
             continue
 
-        base_url = _to_openai_base_url(
-            str(creds.get("base_url", "")).strip().rstrip("/") or pconfig.inference_base_url
-        )
+        provider_url = str(creds.get("base_url", "")).strip().rstrip("/") or pconfig.inference_base_url
+        base_url = _to_openai_base_url(provider_url)
         model = _API_KEY_PROVIDER_AUX_MODELS.get(provider_id)
         if model is None:
-            continue  # skip provider if we don't know a valid aux model
+            continue
         logger.debug("Auxiliary text client: %s (%s)", pconfig.name, model)
         if provider_id == "gemini":
             from agent.gemini_native_adapter import GeminiNativeClient, is_native_gemini_base_url
@@ -1100,7 +1098,7 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
 
             extra["default_headers"] = copilot_default_headers()
         _client = OpenAI(api_key=api_key, base_url=base_url, **extra)
-        _client = _maybe_wrap_anthropic(_client, model, api_key, base_url)
+        _client = _maybe_wrap_anthropic(_client, model, api_key, provider_url)
         return _client, model
 
     return None, None


### PR DESCRIPTION
 Fixes MiniMax (and all other /anthropic-based providers) returning a plain OpenAI client instead of AnthropicAuxiliaryClient when used as an auxiliary/vision backend.
    
Root cause: _to_openai_base_url() rewrites /anthropic → /v1 so the OpenAI SDK hits the right endpoint. But _maybe_wrap_anthropic() then receives the rewritten /v1 URL and fails its endswith("/anthropic") check — leaving the client as plain OpenAI → 404 on every request.
    
Fix: Save the original base URL before rewriting, pass the original to _maybe_wrap_anthropic() so detection works correctly.
    
    
    
## Type of Change
    
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
    
## Changes Made
    
- agent/auxiliary_client.py — _resolve_api_key_provider(): two call sites now preserve original_base_url before passing to _maybe_wrap_anthropic() (pool credentials path + direct credentials path)
    
    
    
## How to Test
    
1. Set AUXILIARY_TEXT_MODEL=minimax-video-01 (or any MiniMax provider) as the auxiliary model
2. Trigger an auxiliary task (vision or large context summarization)
3. Verify response is returned (not a 404) and AnthropicAuxiliaryClient is used
4. Run: python -m pytest tests/agent/test_auxiliary_transport_autodetect.py tests/agent/test_minimax_auxiliary_url.py -q → all 30 pass
    
    
    
## Checklist
    
- [x] My commit messages follow Conventional Commits (fix(auxiliary):)
- [x] No unrelated commits in this PR
- [x] Tests added/passing (30 tests)
