### PR TITLE
fix(gateway/wecom): support WeCom external chat IDs and auto-YOLO for webhook sessions

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -537,6 +537,17 @@ class WebhookAdapter(BasePlatformAdapter):
             delivery_id,
         )
 
+        # Webhook-triggered sessions run autonomously with no user present
+        # to approve dangerous commands.  Auto-enable YOLO for the session.
+        try:
+            from gateway.session import build_session_key
+            _wh_session_key = build_session_key(source)
+            from tools.approval import enable_session_yolo
+            enable_session_yolo(_wh_session_key)
+            logger.info("[webhook] Auto-enabled YOLO for session %s", _wh_session_key)
+        except Exception as _yolo_err:
+            logger.warning("[webhook] Failed to enable YOLO: %s", _yolo_err)
+
         # Non-blocking — return 202 Accepted immediately
         task = asyncio.create_task(self.handle_message(event))
         self._background_tasks.add(task)

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -328,6 +328,9 @@ def _parse_target_ref(platform_name: str, target_ref: str):
             # Preserve the leading '+' — signal-cli and sms/whatsapp adapters
             # expect E.164 format for direct recipients.
             return target_ref.strip(), None, True
+    # WeCom external chat IDs (group chats start with "wr", user IDs are numeric)
+    if platform_name == "wecom" and (target_ref.startswith("wr") or target_ref.startswith("wm") or target_ref.startswith("wk")):
+        return target_ref, None, True
     if target_ref.lstrip("-").isdigit():
         return target_ref, None, True
     # Matrix room IDs (start with !) and user IDs (start with @) are explicit


### PR DESCRIPTION
## Problem

### 1. WeCom group chat delivery fails
`send_message` with `target=wecom:wrtP-iDAAAzoD57vOF3pjEVgsY6NPpmA` (a WeCom external group chat ID) fails because `_parse_target_ref()` only accepts numeric chat IDs. WeCom external chat IDs start with `wr`/`wm`/`wk` prefixes.

### 2. Webhook-triggered sessions block on approval
Webhook sessions run autonomously with no user present. When the agent executes `terminal` commands (e.g. `curl` to internal APIs), the security scanner flags them as dangerous and blocks waiting for `/approve` — but there is nobody to approve. The approval message gets delivered to the webhook target (e.g. a group chat) where it cannot be actioned.

## Solution

### 1. `tools/send_message_tool.py`
Add a prefix check for WeCom external chat IDs (`wr*`, `wm*`, `wk*`) before the numeric-only `isdigit()` fallback.

### 2. `gateway/platforms/webhook.py`
Auto-enable session YOLO mode before dispatching `handle_message()` for webhook-triggered events. This allows the agent to execute commands without blocking on approval prompts, which is the expected behavior for autonomous webhook handlers.

## Changes
- `tools/send_message_tool.py`: +3 lines (WeCom prefix check)
- `gateway/platforms/webhook.py`: +11 lines (auto-YOLO for webhook sessions)