### PR TITLE
chore(dingtalk): gateway infra — HOME_CHANNEL injection, guard script, misc config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,5 @@ mini-swe-agent/
 result
 website/static/api/skills-index.json
 models-dev-upstream/
+
+.claude

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -507,6 +507,22 @@ def load_gateway_config() -> GatewayConfig:
             with open(config_yaml_path, encoding="utf-8") as f:
                 yaml_cfg = yaml.safe_load(f) or {}
 
+            # Hydrate top-level UPPERCASE_HOME_CHANNEL keys from config.yaml
+            # into os.environ so `_apply_env_overrides` picks them up on boot.
+            # Without this, /sethome-written yaml entries get orphaned across
+            # gateway restarts (yaml survives, process env does not), which
+            # makes onboarding prompts and home-channel routing flap between
+            # sessions.  Env var (if already set) takes precedence.
+            for _k, _v in yaml_cfg.items():
+                if (
+                    isinstance(_k, str)
+                    and _k.endswith("_HOME_CHANNEL")
+                    and _k.isupper()
+                    and _v
+                    and not os.getenv(_k)
+                ):
+                    os.environ[_k] = str(_v)
+
             # Map config.yaml keys → GatewayConfig.from_dict() schema.
             # Each key overwrites whatever gateway.json may have set.
             sr = yaml_cfg.get("session_reset")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5047,6 +5047,17 @@ class GatewayRunner:
         if not history and source.platform and source.platform != Platform.LOCAL and source.platform != Platform.WEBHOOK:
             platform_name = source.platform.value
             env_key = f"{platform_name.upper()}_HOME_CHANNEL"
+            # Platform display-name overrides for mixed-case brands where
+            # naive .title() reads awkwardly ("Dingtalk" → "DingTalk").
+            _display_overrides = {
+                "dingtalk": "DingTalk",
+                "feishu": "Feishu",
+                "wecom": "WeCom",
+                "qqbot": "QQ",
+                "bluebubbles": "BlueBubbles",
+                "homeassistant": "Home Assistant",
+            }
+            display_name = _display_overrides.get(platform_name, platform_name.title())
             if not os.getenv(env_key):
                 adapter = self.adapters.get(source.platform)
                 if adapter:
@@ -5060,7 +5071,7 @@ class GatewayRunner:
                     )
                     await adapter.send(
                         source.chat_id,
-                        f"📬 No home channel is set for {platform_name.title()}. "
+                        f"📬 No home channel is set for {display_name}. "
                         f"A home channel is where Hermes delivers cron job results "
                         f"and cross-platform messages.\n\n"
                         f"Type {sethome_cmd} to make this chat your home channel, "

--- a/hermes_cli/dingtalk_auth.py
+++ b/hermes_cli/dingtalk_auth.py
@@ -29,7 +29,7 @@ REGISTRATION_BASE_URL = os.environ.get(
     "DINGTALK_REGISTRATION_BASE_URL", "https://oapi.dingtalk.com"
 ).rstrip("/")
 
-REGISTRATION_SOURCE = os.environ.get("DINGTALK_REGISTRATION_SOURCE", "openClaw")
+REGISTRATION_SOURCE = os.environ.get("DINGTALK_REGISTRATION_SOURCE", "DING_DWS_CLAW")
 
 
 # ── API helpers ────────────────────────────────────────────────────────────

--- a/scripts/gateway_guard.sh
+++ b/scripts/gateway_guard.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOG_DIR="${ROOT_DIR}/logs"
+PID_FILE="${LOG_DIR}/gateway-guard.pid"
+RUN_LOG="${LOG_DIR}/gateway-guard.log"
+
+mkdir -p "${LOG_DIR}"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/gateway_guard.sh <start|stop|restart|status|logs>
+
+start   Start gateway in background with auto-restart loop
+stop    Stop background guard process
+restart Restart guard process
+status  Show whether guard is running
+logs    Follow logs
+EOF
+}
+
+is_running() {
+  if [[ -f "${PID_FILE}" ]]; then
+    local pid
+    pid="$(cat "${PID_FILE}")"
+    if [[ -n "${pid}" ]] && kill -0 "${pid}" 2>/dev/null; then
+      return 0
+    fi
+  fi
+  return 1
+}
+
+start_guard() {
+  if is_running; then
+    echo "gateway guard is already running (pid: $(cat "${PID_FILE}"))"
+    exit 0
+  fi
+
+  (
+    cd "${ROOT_DIR}"
+    while true; do
+      echo "===== $(date '+%F %T') gateway start =====" >> "${RUN_LOG}"
+      if command -v caffeinate >/dev/null 2>&1; then
+        caffeinate -dimsu venv/bin/python -m hermes_cli.main gateway run --replace -v >> "${RUN_LOG}" 2>&1
+      else
+        venv/bin/python -m hermes_cli.main gateway run --replace -v >> "${RUN_LOG}" 2>&1
+      fi
+      code=$?
+      echo "===== $(date '+%F %T') gateway exited code=${code}, restart in 5s =====" >> "${RUN_LOG}"
+      sleep 5
+    done
+  ) &
+
+  echo $! > "${PID_FILE}"
+  echo "gateway guard started (pid: $(cat "${PID_FILE}"))"
+  echo "log file: ${RUN_LOG}"
+}
+
+stop_guard() {
+  if ! is_running; then
+    echo "gateway guard is not running"
+    rm -f "${PID_FILE}"
+    exit 0
+  fi
+
+  local pid
+  pid="$(cat "${PID_FILE}")"
+  kill "${pid}" 2>/dev/null || true
+  sleep 1
+  if kill -0 "${pid}" 2>/dev/null; then
+    kill -9 "${pid}" 2>/dev/null || true
+  fi
+  rm -f "${PID_FILE}"
+  echo "gateway guard stopped"
+}
+
+status_guard() {
+  if is_running; then
+    echo "gateway guard is running (pid: $(cat "${PID_FILE}"))"
+  else
+    echo "gateway guard is not running"
+  fi
+}
+
+logs_guard() {
+  touch "${RUN_LOG}"
+  tail -f "${RUN_LOG}"
+}
+
+main() {
+  if [[ $# -lt 1 ]]; then
+    usage
+    exit 1
+  fi
+
+  case "${1}" in
+    start) start_guard ;;
+    stop) stop_guard ;;
+    restart) stop_guard; start_guard ;;
+    status) status_guard ;;
+    logs) logs_guard ;;
+    *) usage; exit 1 ;;
+  esac
+}
+
+main "$@"

--- a/tests/hermes_cli/test_dingtalk_auth.py
+++ b/tests/hermes_cli/test_dingtalk_auth.py
@@ -214,4 +214,4 @@ class TestConfigOverrides:
         import importlib
         import hermes_cli.dingtalk_auth as mod
         importlib.reload(mod)
-        assert mod.REGISTRATION_SOURCE == "openClaw"
+        assert mod.REGISTRATION_SOURCE == "DING_DWS_CLAW"


### PR DESCRIPTION
## Summary

Infrastructure and configuration improvements for DingTalk gateway deployments.

## Changes

- `gateway/config.py`: inject HOME_CHANNEL from DINGTALK_HOME_CHANNEL / FEISHU_HOME_CHANNEL env vars when config.yaml doesn't define one
- `gateway/run.py`: add platform display name overrides (DingTalk, WeCom, etc.)
- `hermes_cli/dingtalk_auth.py`: change REGISTRATION_SOURCE default from "openClaw" to "DING_DWS_CLAW"
- `scripts/gateway_guard.sh`: new auto-restart supervisor script for production deployments
- `.gitignore`: add `.claude` to ignore list
- `tests/hermes_cli/test_dingtalk_auth.py`: update assertion for new default

## Related

Part of the DingTalk adapter enhancement series — see #12769 for the umbrella PR.