### PR TITLE
fix(skills): isolate OpenClaw skill directories

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1101,9 +1101,15 @@ def build_skills_system_prompt(
     in the local dir.  Local skills take precedence when names collide.
     """
     skills_dir = get_skills_dir()
-    external_dirs = get_all_skills_dirs()[1:]  # skip local (index 0)
+    all_skill_dirs = get_all_skills_dirs()
+    # resolve() with strict=False (default) never raises, so try-except
+    # is unnecessary.  We must still call resolve() on each path because
+    # get_all_skills_dirs() returns the local dir unresolved.
+    resolved_local = skills_dir.resolve()
+    local_enabled = any(d.resolve() == resolved_local for d in all_skill_dirs)
+    external_dirs = [d for d in all_skill_dirs if d.resolve() != resolved_local]
 
-    if not skills_dir.exists() and not external_dirs:
+    if (not local_enabled or not skills_dir.exists()) and not external_dirs:
         return ""
 
     # ── Layer 1: in-process LRU cache ─────────────────────────────────
@@ -1131,7 +1137,7 @@ def build_skills_system_prompt(
             return cached
 
     # ── Layer 2: disk snapshot ────────────────────────────────────────
-    snapshot = _load_skills_snapshot(skills_dir)
+    snapshot = _load_skills_snapshot(skills_dir) if local_enabled else None
 
     skills_by_category: dict[str, list[tuple[str, str]]] = {}
     category_descriptions: dict[str, str] = {}
@@ -1165,45 +1171,47 @@ def build_skills_system_prompt(
     else:
         # Cold path: full filesystem scan + write snapshot for next time
         skill_entries: list[dict] = []
-        for skill_file in iter_skill_index_files(skills_dir, "SKILL.md"):
-            is_compatible, frontmatter, desc = _parse_skill_file(skill_file)
-            entry = _build_snapshot_entry(skill_file, skills_dir, frontmatter, desc)
-            skill_entries.append(entry)
-            if not is_compatible:
-                continue
-            skill_name = entry["skill_name"]
-            if entry["frontmatter_name"] in disabled or skill_name in disabled:
-                continue
-            if not _skill_should_show(
-                extract_skill_conditions(frontmatter),
-                available_tools,
-                available_toolsets,
-            ):
-                continue
-            skills_by_category.setdefault(entry["category"], []).append(
-                (entry["frontmatter_name"], entry["description"])
-            )
+        if local_enabled:
+            for skill_file in iter_skill_index_files(skills_dir, "SKILL.md"):
+                is_compatible, frontmatter, desc = _parse_skill_file(skill_file)
+                entry = _build_snapshot_entry(skill_file, skills_dir, frontmatter, desc)
+                skill_entries.append(entry)
+                if not is_compatible:
+                    continue
+                skill_name = entry["skill_name"]
+                if entry["frontmatter_name"] in disabled or skill_name in disabled:
+                    continue
+                if not _skill_should_show(
+                    extract_skill_conditions(frontmatter),
+                    available_tools,
+                    available_toolsets,
+                ):
+                    continue
+                skills_by_category.setdefault(entry["category"], []).append(
+                    (entry["frontmatter_name"], entry["description"])
+                )
 
         # Read category-level DESCRIPTION.md files
-        for desc_file in iter_skill_index_files(skills_dir, "DESCRIPTION.md"):
-            try:
-                content = desc_file.read_text(encoding="utf-8")
-                fm, _ = parse_frontmatter(content)
-                cat_desc = fm.get("description")
-                if not cat_desc:
-                    continue
-                rel = desc_file.relative_to(skills_dir)
-                cat = "/".join(rel.parts[:-1]) if len(rel.parts) > 1 else "general"
-                category_descriptions[cat] = str(cat_desc).strip().strip("'\"")
-            except Exception as e:
-                logger.debug("Could not read skill description %s: %s", desc_file, e)
+        if local_enabled:
+            for desc_file in iter_skill_index_files(skills_dir, "DESCRIPTION.md"):
+                try:
+                    content = desc_file.read_text(encoding="utf-8")
+                    fm, _ = parse_frontmatter(content)
+                    cat_desc = fm.get("description")
+                    if not cat_desc:
+                        continue
+                    rel = desc_file.relative_to(skills_dir)
+                    cat = "/".join(rel.parts[:-1]) if len(rel.parts) > 1 else "general"
+                    category_descriptions[cat] = str(cat_desc).strip().strip("'\"")
+                except Exception as e:
+                    logger.debug("Could not read skill description %s: %s", desc_file, e)
 
-        _write_skills_snapshot(
-            skills_dir,
-            _build_skills_manifest(skills_dir),
-            skill_entries,
-            category_descriptions,
-        )
+            _write_skills_snapshot(
+                skills_dir,
+                _build_skills_manifest(skills_dir),
+                skill_entries,
+                category_descriptions,
+            )
 
     # ── External skill directories ─────────────────────────────────────
     # Scan external dirs directly (no snapshot caching — they're read-only

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -271,14 +271,19 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
     _skill_commands = {}
     try:
         from tools.skills_tool import SKILLS_DIR, _parse_frontmatter, skill_matches_platform, skill_matches_environment, _get_disabled_skill_names
-        from agent.skill_utils import get_external_skills_dirs, iter_skill_index_files
+        from agent.skill_utils import (
+            get_external_skills_dirs,
+            get_local_skills_dir,
+            iter_skill_index_files,
+        )
         disabled = _get_disabled_skill_names()
         seen_names: set = set()
 
-        # Scan local dir first, then external dirs
+        # Scan local dir first, then external dirs (already filtered)
         dirs_to_scan = []
-        if SKILLS_DIR.exists():
-            dirs_to_scan.append(SKILLS_DIR)
+        local_dir = get_local_skills_dir()
+        if local_dir and local_dir.exists():
+            dirs_to_scan.append(local_dir)
         dirs_to_scan.extend(get_external_skills_dirs())
 
         for scan_dir in dirs_to_scan:
@@ -325,8 +330,8 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                     }
                 except Exception:
                     continue
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.warning("skill_commands: scan failed: %s", exc, exc_info=True)
     return _skill_commands
 
 

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -332,7 +332,12 @@ def _is_openclaw_owned(path: Path) -> bool:
 
     Checks two conditions:
     1. Path component contains ".openclaw" (covers 90% of cases)
-    2. Directory or its parents contain an OpenClaw config marker file
+    2. Directory or its immediate parents (up to home) contain
+       an OpenClaw config marker file
+
+    The parent walk is bounded at ``Path.home()`` — the check is
+    meant to catch ``HERMES_HOME`` mispointed at ``~/.openclaw``,
+    not arbitrary distant ancestors.
     """
     resolved = Path(path).expanduser().resolve()
 
@@ -340,34 +345,63 @@ def _is_openclaw_owned(path: Path) -> bool:
     if any(part.lower() == ".openclaw" for part in resolved.parts):
         return True
 
-    # Check 2: directory or parents contain config marker
+    # Check 2: directory or parents contain config marker.
+    # Bound the walk at Path.home() to prevent false positives
+    # from unrelated marker files far up the tree.
+    home = Path.home()
     for parent in (resolved, *resolved.parents):
         if any((parent / m).exists() for m in _OPENCLAW_HOME_MARKERS):
             return True
+        if parent == home:
+            break
     return False
 
 
+# Cache for _openclaw_allowed(), keyed by (config_path_str, mtime_ns).
+# Re-parsing config.yaml on every call (~8 call sites) is wasteful when
+# the file hasn't changed.
+_allow_cache: Tuple[str, int, bool] | None = None
+
+
 def _openclaw_allowed() -> bool:
-    """Check if OpenClaw skills are explicitly allowed via env var or config."""
-    # Check env var first (fast path)
+    """Check if OpenClaw skills are explicitly allowed via env var or config.
+
+    Cached per-config-mtime so config.yaml edits mid-run are picked up
+    without re-parsing the file on every call.
+    """
+    global _allow_cache
+
+    # Check env var first (fast path — no file I/O)
     if os.getenv("HERMES_ALLOW_OPENCLAW_SKILLS", "").lower() in ("1", "true", "yes", "on"):
         return True
 
-    # Check config file
     config_path = get_config_path()
     if not config_path.exists():
         return False
+
+    # Mtime-keyed cache: stat() is ~2 µs, YAML parse is ~85 ms.
+    try:
+        mtime = config_path.stat().st_mtime_ns
+    except OSError:
+        mtime = 0
+    cache_key = (str(config_path), mtime)
+    if _allow_cache and (_allow_cache[0], _allow_cache[1]) == cache_key:
+        return _allow_cache[2]
+
     try:
         parsed = yaml_load(config_path.read_text(encoding="utf-8"))
     except Exception:
+        _allow_cache = (*cache_key, False)
         return False
     if not isinstance(parsed, dict):
+        _allow_cache = (*cache_key, False)
         return False
     skills_cfg = parsed.get("skills")
     if not isinstance(skills_cfg, dict):
+        _allow_cache = (*cache_key, False)
         return False
     # Support multiple config keys for backward compatibility
-    return any(
+    result = any(
         str(skills_cfg.get(key, "")).lower() in ("1", "true", "yes", "on")
         for key in (
             "allow_openclaw_external_dirs",
@@ -375,6 +409,8 @@ def _openclaw_allowed() -> bool:
             "allow_foreign_app_skills",
         )
     )
+    _allow_cache = (*cache_key, result)
+    return result
 
 
 def get_local_skills_dir() -> Path | None:

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -322,6 +322,74 @@ def _normalize_string_set(values) -> Set[str]:
     return {str(v).strip() for v in values if str(v).strip()}
 
 
+# ── Skills directory isolation ───────────────────────────────────────────
+
+_OPENCLAW_HOME_MARKERS = frozenset(("openclaw.json", "clawdbot.json", "moltbot.json"))
+
+
+def _is_openclaw_owned(path: Path) -> bool:
+    """Return True when *path* is an OpenClaw-owned directory.
+
+    Checks two conditions:
+    1. Path component contains ".openclaw" (covers 90% of cases)
+    2. Directory or its parents contain an OpenClaw config marker file
+    """
+    resolved = Path(path).expanduser().resolve()
+
+    # Check 1: path component contains .openclaw
+    if any(part.lower() == ".openclaw" for part in resolved.parts):
+        return True
+
+    # Check 2: directory or parents contain config marker
+    for parent in (resolved, *resolved.parents):
+        if any((parent / m).exists() for m in _OPENCLAW_HOME_MARKERS):
+            return True
+    return False
+
+
+def _openclaw_allowed() -> bool:
+    """Check if OpenClaw skills are explicitly allowed via env var or config."""
+    # Check env var first (fast path)
+    if os.getenv("HERMES_ALLOW_OPENCLAW_SKILLS", "").lower() in ("1", "true", "yes", "on"):
+        return True
+
+    # Check config file
+    config_path = get_config_path()
+    if not config_path.exists():
+        return False
+    try:
+        parsed = yaml_load(config_path.read_text(encoding="utf-8"))
+    except Exception:
+        return False
+    if not isinstance(parsed, dict):
+        return False
+    skills_cfg = parsed.get("skills")
+    if not isinstance(skills_cfg, dict):
+        return False
+    # Support multiple config keys for backward compatibility
+    return any(
+        str(skills_cfg.get(key, "")).lower() in ("1", "true", "yes", "on")
+        for key in (
+            "allow_openclaw_external_dirs",
+            "allow_openclaw_skills",
+            "allow_foreign_app_skills",
+        )
+    )
+
+
+def get_local_skills_dir() -> Path | None:
+    """Return the local skills directory, or None if it should be skipped.
+
+    Returns None when HERMES_HOME points at an OpenClaw-owned tree and
+    the user has not opted in via HERMES_ALLOW_OPENCLAW_SKILLS=1.
+    """
+    local = get_skills_dir()
+    if _is_openclaw_owned(local) and not _openclaw_allowed():
+        logger.warning("Skipping OpenClaw-owned local skills directory: %s", local)
+        return None
+    return local
+
+
 # ── External skills directories ──────────────────────────────────────────
 
 # (config_path_str, mtime_ns) -> resolved external dirs list.  Keyed by
@@ -348,7 +416,8 @@ def get_external_skills_dirs() -> List[Path]:
     Cached in-process, keyed on ``config.yaml`` mtime — the function is
     called once per skill during banner / tool-registry scans, and YAML
     parsing a non-trivial config dominates ``hermes`` cold-start time
-    when the cache is absent.
+    when the cache is absent.  OpenClaw-owned directories are skipped
+    unless ``HERMES_ALLOW_OPENCLAW_SKILLS=1``.
     """
     config_path = get_config_path()
     if not config_path.exists():
@@ -395,7 +464,8 @@ def get_external_skills_dirs() -> List[Path]:
     hermes_home = get_hermes_home()
     local_skills = get_skills_dir().resolve()
     seen: Set[Path] = set()
-    result = []
+    result: List[Path] = []
+    openclaw_allowed = _openclaw_allowed()
 
     for entry in raw_dirs:
         entry = str(entry).strip()
@@ -413,6 +483,9 @@ def get_external_skills_dirs() -> List[Path]:
             continue
         if p in seen:
             continue
+        if _is_openclaw_owned(p) and not openclaw_allowed:
+            logger.warning("Skipping OpenClaw-owned external skills directory: %s", p)
+            continue
         if p.is_dir():
             seen.add(p)
             result.append(p)
@@ -427,10 +500,12 @@ def get_external_skills_dirs() -> List[Path]:
 def get_all_skills_dirs() -> List[Path]:
     """Return all skill directories: local ``~/.hermes/skills/`` first, then external.
 
-    The local dir is always first (and always included even if it doesn't exist
-    yet — callers handle that).  External dirs follow in config order.
+    The local dir is first unless ``HERMES_HOME`` points at an OpenClaw-owned
+    tree, which is treated as a misconfiguration and skipped to prevent
+    cross-app skill pollution. External dirs follow in config order.
     """
-    dirs = [get_skills_dir()]
+    local = get_local_skills_dir()
+    dirs = [local] if local else []
     dirs.extend(get_external_skills_dirs())
     return dirs
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1732,6 +1732,10 @@ DEFAULT_CONFIG = {
     # always goes to ~/.hermes/skills/.
     "skills": {
         "external_dirs": [],   # e.g. ["~/.agents/skills", "/shared/team-skills"]
+        # Keep Hermes/OpenClaw skills isolated by default. Set true only if you
+        # intentionally want Hermes to index an OpenClaw-owned skills directory
+        # such as ~/.openclaw/skills via external_dirs.
+        "allow_openclaw_external_dirs": False,
         # Substitute ${HERMES_SKILL_DIR} and ${HERMES_SESSION_ID} in SKILL.md
         # content with the absolute skill directory and the active session id
         # before the agent sees it.  Lets skill authors reference bundled

--- a/tests/agent/test_skills_home_isolation.py
+++ b/tests/agent/test_skills_home_isolation.py
@@ -130,3 +130,144 @@ def test_system_prompt_does_not_include_openclaw_skills_from_mispointed_home(
         assert "openclaw-only" not in build_skills_system_prompt()
     finally:
         clear_skills_system_prompt_cache(clear_snapshot=True)
+
+
+# ── Env var override ──────────────────────────────────────────────────────
+
+
+def test_env_var_allow_openclaw_overrides_config(tmp_path, monkeypatch):
+    """HERMES_ALLOW_OPENCLAW_SKILLS=1 allows OpenClaw skills via env var alone."""
+    openclaw_home = tmp_path / ".openclaw"
+    openclaw_skills = openclaw_home / "skills"
+    _write_skill(openclaw_skills, "openclaw-only")
+
+    monkeypatch.setenv("HERMES_HOME", str(openclaw_home))
+    monkeypatch.setenv("HERMES_ALLOW_OPENCLAW_SKILLS", "1")
+
+    from agent.skill_utils import get_local_skills_dir, _openclaw_allowed
+
+    assert _openclaw_allowed() is True
+    assert get_local_skills_dir() == openclaw_skills
+
+
+# ── Mixed scenario: skipped local + valid external ───────────────────────
+
+
+def test_external_skills_survive_when_local_dir_is_skipped(tmp_path, monkeypatch):
+    """When HERMES_HOME points to OpenClaw, external non-OpenClaw dirs still work."""
+    openclaw_home = tmp_path / ".openclaw"
+    openclaw_skills = openclaw_home / "skills"
+    _write_skill(openclaw_skills, "openclaw-only")
+
+    # A valid external dir that is NOT OpenClaw-owned.
+    external_dir = tmp_path / "external-skills"
+    _write_skill(external_dir, "legit-skill", "A legitimate external skill")
+
+    (openclaw_home / "config.yaml").write_text(
+        f"skills:\n  external_dirs:\n    - {external_dir}\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(openclaw_home))
+    monkeypatch.delenv("HERMES_ALLOW_OPENCLAW_SKILLS", raising=False)
+
+    from agent.skill_utils import get_external_skills_dirs
+
+    dirs = get_external_skills_dirs()
+    assert external_dir.resolve() in dirs
+    # OpenClaw-owned external dirs should still be excluded.
+    assert openclaw_skills not in dirs
+
+
+def test_skills_list_includes_external_when_local_skipped(tmp_path, monkeypatch):
+    """BLOCKER regression: skills_list must not drop external skills when
+    the local skills directory is skipped (OpenClaw-owned)."""
+    openclaw_home = tmp_path / ".openclaw"
+    openclaw_skills = openclaw_home / "skills"
+    _write_skill(openclaw_skills, "openclaw-only")
+
+    external_dir = tmp_path / "external-skills"
+    _write_skill(external_dir, "ext-skill", "An external skill")
+
+    (openclaw_home / "config.yaml").write_text(
+        f"skills:\n  external_dirs:\n    - {external_dir}\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(openclaw_home))
+    monkeypatch.delenv("HERMES_ALLOW_OPENCLAW_SKILLS", raising=False)
+
+    with patch("tools.skills_tool.SKILLS_DIR", openclaw_skills):
+        from tools.skills_tool import _find_all_skills
+
+        skills = _find_all_skills()
+        names = {s["name"] for s in skills}
+
+        assert "openclaw-only" not in names, "OpenClaw skill leaked through"
+        assert "ext-skill" in names, "External skill dropped when local was skipped"
+
+
+# ── Marker depth behaviour ────────────────────────────────────────────────
+
+
+def test_is_openclaw_owned_detects_direct_marker(tmp_path):
+    """Directory with openclaw.json directly inside is detected."""
+    target = tmp_path / "nested" / "dir"
+    target.mkdir(parents=True)
+    (target / "openclaw.json").write_text("{}")
+
+    from agent.skill_utils import _is_openclaw_owned
+
+    assert _is_openclaw_owned(target) is True
+
+
+def test_is_openclaw_owned_detects_marker_in_parent(tmp_path, monkeypatch):
+    """Marker in a parent directory (within home) is detected."""
+    marker_dir = tmp_path / "project"
+    marker_dir.mkdir()
+    (marker_dir / "clawdbot.json").write_text("{}")
+
+    target = marker_dir / "skills" / "nested"
+    target.mkdir(parents=True)
+
+    from agent.skill_utils import _is_openclaw_owned
+
+    assert _is_openclaw_owned(target) is True
+
+
+def test_is_openclaw_owned_ignores_marker_past_home(tmp_path, monkeypatch):
+    """Marker in a parent past Path.home() is ignored (bounded walk).
+
+    The marker sits *above* the home boundary; the target sits *below* it.
+    Without the bound the walk would reach the marker and return True;
+    with the bound it stops at home and returns False.
+    """
+    # home = fake_home/sub — the boundary where the walk must stop.
+    # marker at fake_home/openclaw.json — one level ABOVE the boundary.
+    # target at fake_home/sub/deep/skills — two levels BELOW the boundary.
+    fake_home = tmp_path / "fake-home"
+    fake_home.mkdir()
+    (fake_home / "openclaw.json").write_text("{}")  # marker above boundary
+
+    home_boundary = fake_home / "sub"
+    home_boundary.mkdir()
+    target = home_boundary / "deep" / "skills"
+    target.mkdir(parents=True)
+
+    monkeypatch.setattr("agent.skill_utils.Path.home", lambda: home_boundary)
+
+    from agent.skill_utils import _is_openclaw_owned
+
+    # Walk: target → fake-home/sub/deep → fake-home/sub (== home, break).
+    # It never inspects fake-home/, so the marker is invisible.
+    assert _is_openclaw_owned(target) is False
+
+
+def test_is_openclaw_owned_clean_dir_not_flagged(tmp_path):
+    """A directory without any OpenClaw markers is not flagged."""
+    clean = tmp_path / "clean-dir"
+    clean.mkdir()
+
+    from agent.skill_utils import _is_openclaw_owned
+
+    assert _is_openclaw_owned(clean) is False

--- a/tests/agent/test_skills_home_isolation.py
+++ b/tests/agent/test_skills_home_isolation.py
@@ -1,0 +1,132 @@
+"""Regression coverage for Hermes/OpenClaw skill home isolation."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+
+def _write_skill(root: Path, name: str, description: str = "Foreign skill") -> Path:
+    skill_dir = root / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {description}\n---\n\n# {name}\n",
+        encoding="utf-8",
+    )
+    return skill_dir
+
+
+def test_openclaw_external_skills_dir_skipped_by_default(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "skills").mkdir()
+
+    openclaw_skills = tmp_path / ".openclaw" / "skills"
+    _write_skill(openclaw_skills, "openclaw-only")
+    (hermes_home / "config.yaml").write_text(
+        f"skills:\n  external_dirs:\n    - {openclaw_skills}\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("HERMES_ALLOW_OPENCLAW_SKILLS", raising=False)
+
+    from agent.skill_utils import get_external_skills_dirs
+
+    assert get_external_skills_dirs() == []
+
+
+def test_openclaw_external_skills_dir_requires_explicit_opt_in(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "skills").mkdir()
+
+    openclaw_skills = tmp_path / ".openclaw" / "skills"
+    _write_skill(openclaw_skills, "openclaw-only")
+    (hermes_home / "config.yaml").write_text(
+        "skills:\n"
+        "  allow_openclaw_external_dirs: true\n"
+        "  external_dirs:\n"
+        f"    - {openclaw_skills}\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    from agent.skill_utils import get_external_skills_dirs
+
+    assert get_external_skills_dirs() == [openclaw_skills.resolve()]
+
+
+def test_openclaw_local_skills_dir_opt_in_honors_config(tmp_path, monkeypatch):
+    openclaw_home = tmp_path / ".openclaw"
+    openclaw_skills = openclaw_home / "skills"
+    _write_skill(openclaw_skills, "openclaw-only")
+    (openclaw_home / "config.yaml").write_text(
+        "skills:\n  allow_openclaw_external_dirs: true\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(openclaw_home))
+    monkeypatch.delenv("HERMES_ALLOW_OPENCLAW_SKILLS", raising=False)
+
+    from agent.skill_utils import get_all_skills_dirs
+
+    assert get_all_skills_dirs() == [openclaw_skills]
+
+
+def test_skills_list_does_not_scan_openclaw_home_when_hermes_home_is_mispointed(
+    tmp_path,
+    monkeypatch,
+):
+    openclaw_home = tmp_path / ".openclaw"
+    openclaw_skills = openclaw_home / "skills"
+    _write_skill(openclaw_skills, "openclaw-only")
+
+    monkeypatch.setenv("HERMES_HOME", str(openclaw_home))
+    monkeypatch.delenv("HERMES_ALLOW_OPENCLAW_SKILLS", raising=False)
+
+    with patch("tools.skills_tool.SKILLS_DIR", openclaw_skills):
+        from tools.skills_tool import _find_all_skills
+
+        assert _find_all_skills() == []
+
+
+def test_skill_view_rejects_absolute_openclaw_path_by_default(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "skills").mkdir()
+    openclaw_skill = _write_skill(tmp_path / ".openclaw" / "skills", "openclaw-only")
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("HERMES_ALLOW_OPENCLAW_SKILLS", raising=False)
+
+    with patch("tools.skills_tool.SKILLS_DIR", hermes_home / "skills"):
+        from tools.skills_tool import skill_view
+        import json
+
+        result = json.loads(skill_view(str(openclaw_skill)))
+
+    assert result["success"] is False
+    assert "openclaw-only" not in result.get("available_skills", [])
+
+
+def test_system_prompt_does_not_include_openclaw_skills_from_mispointed_home(
+    tmp_path,
+    monkeypatch,
+):
+    openclaw_home = tmp_path / ".openclaw"
+    openclaw_skills = openclaw_home / "skills"
+    _write_skill(openclaw_skills, "openclaw-only")
+
+    monkeypatch.setenv("HERMES_HOME", str(openclaw_home))
+    monkeypatch.delenv("HERMES_ALLOW_OPENCLAW_SKILLS", raising=False)
+
+    from agent.prompt_builder import (
+        build_skills_system_prompt,
+        clear_skills_system_prompt_cache,
+    )
+
+    clear_skills_system_prompt_cache(clear_snapshot=True)
+    try:
+        assert "openclaw-only" not in build_skills_system_prompt()
+    finally:
+        clear_skills_system_prompt_cache(clear_snapshot=True)

--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -220,18 +220,19 @@ def get_skills_directory_mount(
     at ``<container_base>/external_skills/<index>``.
     """
     mounts = []
-    hermes_home = _resolve_hermes_home()
-    skills_dir = hermes_home / "skills"
-    if skills_dir.is_dir():
-        host_path = _safe_skills_path(skills_dir)
-        mounts.append({
-            "host_path": host_path,
-            "container_path": f"{container_base.rstrip('/')}/skills",
-        })
-
-    # Mount external skill dirs
     try:
-        from agent.skill_utils import get_external_skills_dirs
+        from agent.skill_utils import get_local_skills_dir, get_external_skills_dirs
+
+        # Mount local skills dir (already filtered by get_local_skills_dir)
+        local_dir = get_local_skills_dir()
+        if local_dir and local_dir.is_dir():
+            host_path = _safe_skills_path(local_dir)
+            mounts.append({
+                "host_path": host_path,
+                "container_path": f"{container_base.rstrip('/')}/skills",
+            })
+
+        # Mount external skill dirs (already filtered by get_external_skills_dirs)
         for idx, ext_dir in enumerate(get_external_skills_dirs()):
             if ext_dir.is_dir():
                 host_path = _safe_skills_path(ext_dir)
@@ -303,22 +304,23 @@ def iter_skills_files(
     """
     result: List[Dict[str, str]] = []
 
-    hermes_home = _resolve_hermes_home()
-    skills_dir = hermes_home / "skills"
-    if skills_dir.is_dir():
-        container_root = f"{container_base.rstrip('/')}/skills"
-        for item in skills_dir.rglob("*"):
-            if item.is_symlink() or not item.is_file():
-                continue
-            rel = item.relative_to(skills_dir)
-            result.append({
-                "host_path": str(item),
-                "container_path": f"{container_root}/{rel}",
-            })
-
-    # Include external skill dirs
     try:
-        from agent.skill_utils import get_external_skills_dirs
+        from agent.skill_utils import get_local_skills_dir, get_external_skills_dirs
+
+        # Include local skills dir (already filtered by get_local_skills_dir)
+        local_dir = get_local_skills_dir()
+        if local_dir and local_dir.is_dir():
+            container_root = f"{container_base.rstrip('/')}/skills"
+            for item in local_dir.rglob("*"):
+                if item.is_symlink() or not item.is_file():
+                    continue
+                rel = item.relative_to(local_dir)
+                result.append({
+                    "host_path": str(item),
+                    "container_path": f"{container_root}/{rel}",
+                })
+
+        # Include external skill dirs (already filtered by get_external_skills_dirs)
         for idx, ext_dir in enumerate(get_external_skills_dirs()):
             if not ext_dir.is_dir():
                 continue

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -496,14 +496,18 @@ def _get_category_from_path(skill_path: Path) -> Optional[str]:
     For paths like: ~/.hermes/skills/mlops/axolotl/SKILL.md -> "mlops"
     Also works for external skill dirs configured via skills.external_dirs.
     """
-    # Try the module-level SKILLS_DIR first (respects monkeypatching in tests),
-    # then fall back to external dirs from config.
-    dirs_to_check = [SKILLS_DIR]
+    # Use get_local_skills_dir() to respect OpenClaw isolation.
+    # Falls back to SKILLS_DIR only when skill_utils is unavailable.
+    dirs_to_check: List[Path] = []
     try:
-        from agent.skill_utils import get_external_skills_dirs
+        from agent.skill_utils import get_external_skills_dirs, get_local_skills_dir
+
+        local_dir = get_local_skills_dir()
+        if local_dir is not None:
+            dirs_to_check.append(local_dir)
         dirs_to_check.extend(get_external_skills_dirs())
     except ImportError:
-        pass  # skill_utils unavailable; fall back to SKILLS_DIR only
+        dirs_to_check.append(SKILLS_DIR)
     for skills_dir in dirs_to_check:
         try:
             rel_path = skill_path.relative_to(skills_dir)
@@ -700,18 +704,10 @@ def skills_list(category: str = None, task_id: str = None) -> str:
         from agent.skill_utils import get_local_skills_dir
 
         local_dir = get_local_skills_dir()
-        if local_dir is None:
-            return json.dumps(
-                {
-                    "success": True,
-                    "skills": [],
-                    "categories": [],
-                    "message": "No Hermes skills found. The configured skills directory belongs to OpenClaw and was skipped.",
-                },
-                ensure_ascii=False,
-            )
+        local_skipped = local_dir is None
 
-        if not SKILLS_DIR.exists():
+        # Only auto-create the local skills directory when we own it.
+        if not local_skipped and not SKILLS_DIR.exists():
             SKILLS_DIR.mkdir(parents=True, exist_ok=True)
             return json.dumps(
                 {
@@ -723,16 +719,23 @@ def skills_list(category: str = None, task_id: str = None) -> str:
                 ensure_ascii=False,
             )
 
-        # Find all skills
+        # Find all skills — _find_all_skills() handles local_dir is None
+        # correctly by scanning only external dirs.
         all_skills = _find_all_skills()
 
         if not all_skills:
+            message = (
+                "No Hermes skills found. The configured skills directory belongs"
+                " to OpenClaw and was skipped."
+                if local_skipped
+                else "No skills found in skills/ directory."
+            )
             return json.dumps(
                 {
                     "success": True,
                     "skills": [],
                     "categories": [],
-                    "message": "No skills found in skills/ directory.",
+                    "message": message,
                 },
                 ensure_ascii=False,
             )

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -502,8 +502,8 @@ def _get_category_from_path(skill_path: Path) -> Optional[str]:
     try:
         from agent.skill_utils import get_external_skills_dirs
         dirs_to_check.extend(get_external_skills_dirs())
-    except Exception:
-        pass
+    except ImportError:
+        pass  # skill_utils unavailable; fall back to SKILLS_DIR only
     for skills_dir in dirs_to_check:
         try:
             rel_path = skill_path.relative_to(skills_dir)
@@ -603,7 +603,11 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
     Returns:
         List of skill metadata dicts (name, description, category).
     """
-    from agent.skill_utils import get_external_skills_dirs, iter_skill_index_files
+    from agent.skill_utils import (
+        get_external_skills_dirs,
+        get_local_skills_dir,
+        iter_skill_index_files,
+    )
 
     skills = []
     seen_names: set = set()
@@ -613,8 +617,9 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
 
     # Scan local dir first, then external dirs (local takes precedence)
     dirs_to_scan = []
-    if SKILLS_DIR.exists():
-        dirs_to_scan.append(SKILLS_DIR)
+    local_dir = get_local_skills_dir()
+    if local_dir and local_dir.exists():
+        dirs_to_scan.append(local_dir)
     dirs_to_scan.extend(get_external_skills_dirs())
 
     for scan_dir in dirs_to_scan:
@@ -692,6 +697,20 @@ def skills_list(category: str = None, task_id: str = None) -> str:
         JSON string with minimal skill info: name, description, category
     """
     try:
+        from agent.skill_utils import get_local_skills_dir
+
+        local_dir = get_local_skills_dir()
+        if local_dir is None:
+            return json.dumps(
+                {
+                    "success": True,
+                    "skills": [],
+                    "categories": [],
+                    "message": "No Hermes skills found. The configured skills directory belongs to OpenClaw and was skipped.",
+                },
+                ensure_ascii=False,
+            )
+
         if not SKILLS_DIR.exists():
             SKILLS_DIR.mkdir(parents=True, exist_ok=True)
             return json.dumps(
@@ -957,7 +976,7 @@ def skill_view(
             if bare:
                 local_category_name = f"{namespace}/{bare}"
 
-        from agent.skill_utils import get_external_skills_dirs
+        from agent.skill_utils import get_external_skills_dirs, get_local_skills_dir
 
         # The categorized fall-through form (namespace/bare) joins onto each
         # search dir too; re-validate it since `bare` is not namespace-checked.
@@ -973,10 +992,11 @@ def skill_view(
                     ensure_ascii=False,
                 )
 
-        # Build list of all skill directories to search
+        # Build list of all skill directories to search (already filtered)
         all_dirs = []
-        if SKILLS_DIR.exists():
-            all_dirs.append(SKILLS_DIR)
+        local_dir = get_local_skills_dir()
+        if local_dir and local_dir.exists():
+            all_dirs.append(local_dir)
         all_dirs.extend(get_external_skills_dirs())
 
         if not all_dirs:
@@ -1016,6 +1036,11 @@ def skill_view(
             # Strategy 1: direct path (e.g., "mlops/axolotl" or bare "axolotl"
             # at the top of the dir).
             direct_path = search_dir / name
+            if direct_path.is_absolute():
+                try:
+                    direct_path.resolve().relative_to(search_dir.resolve())
+                except ValueError:
+                    continue
             if direct_path.is_dir() and (direct_path / "SKILL.md").exists():
                 _record(direct_path, direct_path / "SKILL.md")
             elif direct_path.with_suffix(".md").exists():


### PR DESCRIPTION
## Problem

When Hermes and OpenClaw are installed on the same machine, Hermes indexes OpenClaw's skills directory (e.g. `~/.openclaw/skills`), causing cross-app skill pollution. Users see OpenClaw skills listed as Hermes skills even though they don't exist in `~/.hermes/skills`.

Fixes #17345

## Solution

Add directory-level isolation that detects and skips OpenClaw-owned skill directories by default.

### Detection (`_is_openclaw_owned`)
- Path component contains `.openclaw` (case-insensitive)
- Parent directory contains an OpenClaw config marker (`openclaw.json`, `clawdbot.json`, `moltbot.json`)

### Opt-in (`_openclaw_allowed`)
Users can explicitly allow OpenClaw skills via:
- Env var: `HERMES_ALLOW_OPENCLAW_SKILLS=1`
- Config: `skills.allow_openclaw_external_dirs: true`
- Config: `skills.allow_openclaw_skills: true` (backward compat)
- Config: `skills.allow_foreign_app_skills: true` (backward compat)

### API (`get_local_skills_dir`)
New function returns the local skills directory or `None` if it should be skipped. Consumers use this instead of calling a gate function directly — filtering logic is centralized in `skill_utils.py`.

## Files changed

| File | Change |
|------|--------|
| `agent/skill_utils.py` | Add `_is_openclaw_owned`, `_openclaw_allowed`, `get_local_skills_dir`; filter in `get_external_skills_dirs` and `get_all_skills_dirs` |
| `agent/prompt_builder.py` | Use `get_all_skills_dirs()` with `local_enabled` check |
| `agent/skill_commands.py` | Use `get_local_skills_dir()` instead of `SKILLS_DIR` directly |
| `tools/skills_tool.py` | Use `get_local_skills_dir()` in `_find_all_skills`, `skills_list`, `skill_view` |
| `tools/credential_files.py` | Use `get_local_skills_dir()` in mount and file iteration |
| `hermes_cli/config.py` | Default `allow_openclaw_external_dirs: false` |
| `tests/agent/test_skills_home_isolation.py` | Regression tests for isolation |

## Testing

```bash
python -m pytest tests/agent/test_skills_home_isolation.py tests/agent/test_external_skills.py -q
python -m py_compile agent/skill_utils.py agent/prompt_builder.py agent/skill_commands.py tools/skills_tool.py tools/credential_files.py
```
