### PR TITLE
fix: repair GLM env sanitization

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3678,59 +3678,102 @@ def load_env() -> Dict[str, str]:
             if line and not line.startswith('#') and '=' in line:
                 key, _, value = line.partition('=')
                 env_vars[key.strip()] = value.strip().strip('"\'')
-    
+
+        env_vars = _sanitize_loaded_env_vars(env_vars)
+
     return env_vars
 
 
 def _sanitize_env_lines(lines: list) -> list:
     """Fix corrupted .env lines before reading or writing.
 
-    Handles two known corruption patterns:
+    Handles three known corruption patterns:
     1. Concatenated KEY=VALUE pairs on a single line (missing newline between
-       entries, e.g. ``ANTHROPIC_API_KEY=sk-...OPENAI_BASE_URL=https://...``).
-    2. Stale ``KEY=***`` placeholder entries left by incomplete setup runs.
+       entries, e.g. ``ANTHROPIC_API_KEY=sk-...OPENAI_BASE_URL=...``).
+    2. Split GLM keys across lines (``G`` on one line followed by ``LM_*`` on the next).
+    3. Stale ``KEY=***`` placeholder entries left by incomplete setup runs.
 
     Uses a known-keys set (OPTIONAL_ENV_VARS + _EXTRA_ENV_KEYS) so we only
     split on real Hermes env var names, avoiding false positives from values
     that happen to contain uppercase text with ``=``.
     """
-    # Build the known keys set lazily from OPTIONAL_ENV_VARS + extras.
-    # Done inside the function so OPTIONAL_ENV_VARS is guaranteed to be defined.
     known_keys = set(OPTIONAL_ENV_VARS.keys()) | _EXTRA_ENV_KEYS
 
     sanitized: list[str] = []
-    for line in lines:
-        raw = line.rstrip("\r\n")
+    i = 0
+    while i < len(lines):
+        raw = lines[i].rstrip("\r\n")
         stripped = raw.strip()
+
+        # Repair split GLM keys: previous line is literal 'G', next line starts with LM_...
+        if stripped == "G" and i + 1 < len(lines):
+            next_raw = lines[i + 1].rstrip("\r\n")
+            next_stripped = next_raw.strip()
+            if next_stripped.startswith("LM_API_KEY="):
+                sanitized.append("GLM_API_KEY=" + next_stripped[len("LM_API_KEY="):] + "\n")
+                i += 2
+                continue
+            if next_stripped.startswith("LM_BASE_URL="):
+                sanitized.append("GLM_BASE_URL=" + next_stripped[len("LM_BASE_URL="):] + "\n")
+                i += 2
+                continue
 
         # Preserve blank lines and comments
         if not stripped or stripped.startswith("#"):
             sanitized.append(raw + "\n")
+            i += 1
             continue
 
-        # Detect concatenated KEY=VALUE pairs on one line.
-        # Search for known KEY= patterns at any position in the line.
-        split_positions = []
+        matches: list[tuple[int, str]] = []
         for key_name in known_keys:
             needle = key_name + "="
             idx = stripped.find(needle)
             while idx >= 0:
-                split_positions.append(idx)
-                idx = stripped.find(needle, idx + len(needle))
+                matches.append((idx, needle))
+                idx = stripped.find(needle, idx + 1)
 
-        if len(split_positions) > 1:
-            split_positions.sort()
-            # Deduplicate (shouldn't happen, but be safe)
-            split_positions = sorted(set(split_positions))
-            for i, pos in enumerate(split_positions):
-                end = split_positions[i + 1] if i + 1 < len(split_positions) else len(stripped)
-                part = stripped[pos:end].strip()
-                if part:
-                    sanitized.append(part + "\n")
+        if matches:
+            # Prefer longest key at each position, then drop overlapping substring matches
+            best_by_pos: dict[int, str] = {}
+            for pos, needle in matches:
+                if pos not in best_by_pos or len(needle) > len(best_by_pos[pos]):
+                    best_by_pos[pos] = needle
+
+            ordered = sorted(best_by_pos.items(), key=lambda x: x[0])
+            final_positions: list[int] = []
+            covered_until = -1
+            for pos, needle in ordered:
+                if pos < covered_until:
+                    continue
+                final_positions.append(pos)
+                covered_until = pos + len(needle)
+
+            if len(final_positions) > 1:
+                for idx, pos in enumerate(final_positions):
+                    end = final_positions[idx + 1] if idx + 1 < len(final_positions) else len(stripped)
+                    part = stripped[pos:end].strip()
+                    if part:
+                        sanitized.append(part + "\n")
+            else:
+                sanitized.append(stripped + "\n")
         else:
             sanitized.append(stripped + "\n")
 
+        i += 1
+
     return sanitized
+
+
+def _sanitize_loaded_env_vars(env_vars: Dict[str, str]) -> Dict[str, str]:
+    """Normalize env vars after line parsing for known split-key corruption cases."""
+    normalized = dict(env_vars)
+    if "GLM_API_KEY" not in normalized and "LM_API_KEY" in normalized:
+        normalized["GLM_API_KEY"] = normalized.pop("LM_API_KEY")
+    if "GLM_BASE_URL" not in normalized and "LM_BASE_URL" in normalized:
+        normalized["GLM_BASE_URL"] = normalized.pop("LM_BASE_URL")
+    return normalized
+
+
 
 
 def sanitize_env_file() -> int:

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -353,6 +353,81 @@ class TestSanitizeEnvLines:
             assert "OPENROUTER_API_KEY=val\n" in content
             assert "FIRECRAWL_API_KEY=val2\n" in content
 
+    def test_glm_api_key_intact_line_preserved(self):
+        """Intact GLM_API_KEY= line should remain GLM_API_KEY, not become LM_API_KEY."""
+        lines = ["GLM_API_KEY=zai-xxx123\n"]
+        result = _sanitize_env_lines(lines)
+        assert result == ["GLM_API_KEY=zai-xxx123\n"]
+
+    def test_glm_base_url_intact_line_preserved(self):
+        """Intact GLM_BASE_URL= line should remain GLM_BASE_URL, not become LM_BASE_URL."""
+        lines = ["GLM_BASE_URL=https://api.example.com\n"]
+        result = _sanitize_env_lines(lines)
+        assert result == ["GLM_BASE_URL=https://api.example.com\n"]
+
+    def test_split_g_lm_api_key_repaired(self):
+        """Split 'G' + 'LM_API_KEY=...' corruption repairs to GLM_API_KEY."""
+        lines = ["G\n", "LM_API_KEY=zai-xxx123\n"]
+        result = _sanitize_env_lines(lines)
+        assert result == ["GLM_API_KEY=zai-xxx123\n"]
+
+    def test_split_g_lm_base_url_repaired(self):
+        """Split 'G' + 'LM_BASE_URL=...' corruption repairs to GLM_BASE_URL."""
+        lines = ["G\n", "LM_BASE_URL=https://api.example.com\n"]
+        result = _sanitize_env_lines(lines)
+        assert result == ["GLM_BASE_URL=https://api.example.com\n"]
+
+    def test_glm_and_lm_concatenated_splits_correctly(self):
+        """GLM_API_KEY=... followed by LM_BASE_URL=... should split correctly."""
+        lines = ["GLM_API_KEY=zai-xxxLM_BASE_URL=https://example.com\n"]
+        result = _sanitize_env_lines(lines)
+        assert result == [
+            "GLM_API_KEY=zai-xxx\n",
+            "LM_BASE_URL=https://example.com\n",
+        ]
+
+    def test_lm_studio_key_preserved(self):
+        """Intact LM_API_KEY= line should remain LM_API_KEY."""
+        lines = ["LM_API_KEY=lm-studio-token\n"]
+        result = _sanitize_env_lines(lines)
+        assert result == ["LM_API_KEY=lm-studio-token\n"]
+
+    def test_lm_studio_base_url_preserved(self):
+        """Intact LM_BASE_URL= line should remain LM_BASE_URL."""
+        lines = ["LM_BASE_URL=http://localhost:1234\n"]
+        result = _sanitize_env_lines(lines)
+        assert result == ["LM_BASE_URL=http://localhost:1234\n"]
+
+    def test_load_env_returns_glm_not_lm(self, tmp_path):
+        """load_env() should return GLM_* for valid GLM_* entries."""
+        env_file = tmp_path / ".env"
+        env_file.write_text(
+            "GLM_API_KEY=zai-xxx123\n"
+            "GLM_BASE_URL=https://api.example.com\n"
+        )
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            result = load_env()
+            assert result["GLM_API_KEY"] == "zai-xxx123"
+            assert result["GLM_BASE_URL"] == "https://api.example.com"
+            assert "LM_API_KEY" not in result
+            assert "LM_BASE_URL" not in result
+
+    def test_load_env_repairs_split_glm_keys(self, tmp_path):
+        """load_env() should repair split GLM keys and not surface LM_* aliases."""
+        env_file = tmp_path / ".env"
+        env_file.write_text(
+            "G\n"
+            "LM_API_KEY=zai-xxx123\n"
+            "G\n"
+            "LM_BASE_URL=https://api.example.com\n"
+        )
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            result = load_env()
+            assert result["GLM_API_KEY"] == "zai-xxx123"
+            assert result["GLM_BASE_URL"] == "https://api.example.com"
+            assert "LM_API_KEY" not in result
+            assert "LM_BASE_URL" not in result
+
     def test_sanitize_env_file_noop_on_clean_file(self, tmp_path):
         """No changes when file is already clean."""
         env_file = tmp_path / ".env"


### PR DESCRIPTION
## Bug Description
Hermes could report `Z.AI/GLM` as not configured even when `~/.hermes/.env` had already been manually repaired to valid `GLM_API_KEY=...` and `GLM_BASE_URL=...` lines.

## Root Cause
`hermes_cli.config._sanitize_env_lines()` handled same-line concatenated env corruption, but did not handle the cross-line split-key corruption pattern:

```env
G
LM_API_KEY=...
G
LM_BASE_URL=...
```

That left `load_env()` / `get_env_value()` surfacing `LM_*` instead of `GLM_*`. There was also a substring-collision risk where `LM_*` could be falsely matched inside `GLM_*` during sanitization logic changes.

## Fix
- repair split `G` + `LM_API_KEY` / `LM_BASE_URL` pairs back into `GLM_*`
- preserve existing concatenated-key splitting behavior
- avoid `LM_*` vs `GLM_*` substring collision during sanitization
- normalize parsed env vars after load so repaired GLM keys surface as `GLM_*`
- add focused regression coverage for sanitizer and `load_env()` behavior

## How to Verify
1. Create a temporary `.env` with valid `GLM_API_KEY` and `GLM_BASE_URL` lines and confirm `load_env()` returns `GLM_*` only.
2. Create a temporary `.env` with the split corruption form (`G` + `LM_*`) and confirm `load_env()` repairs it to `GLM_*`.
3. Run the focused config regression tests.

## Test Plan
- [x] Added regression test for this bug
- [x] Existing targeted tests still pass
- [x] Manual verification of the fix

Verification run:
- `python -m pytest tests/hermes_cli/test_config.py -q`

## Risk Assessment
Low — scoped to Hermes env sanitization / parsing for a known corruption class, with targeted regression tests covering both the repaired GLM path and pre-existing concatenated-line behavior.
