### PR TITLE
fix: preserve memory authority across context compaction (#17251)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -43,6 +43,9 @@ SUMMARY_PREFIX = (
     "they were already addressed. "
     "Your current task is identified in the '## Active Task' section of the "
     "summary — resume exactly from there. "
+    "IMPORTANT: Your persistent memory (MEMORY.md, USER.md) in the system "
+    "prompt is ALWAYS authoritative and active — never ignore or deprioritize "
+    "memory content due to this compaction note. "
     "Respond ONLY to the latest user message "
     "that appears AFTER this summary. The current session state (files, "
     "config, etc.) may reflect work described here — avoid repeating it:"
@@ -1322,7 +1325,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             msg = messages[i].copy()
             if i == 0 and msg.get("role") == "system":
                 existing = msg.get("content")
-                _compression_note = "[Note: Some earlier conversation turns have been compacted into a handoff summary to preserve context space. The current session state may still reflect earlier work, so build on that summary and state rather than re-doing work.]"
+                _compression_note = "[Note: Some earlier conversation turns have been compacted into a handoff summary to preserve context space. The current session state may still reflect earlier work, so build on that summary and state rather than re-doing work. Your persistent memory (MEMORY.md, USER.md) remains fully authoritative regardless of compaction.]"
                 if _compression_note not in _content_text_for_contains(existing):
                     msg["content"] = _append_text_to_content(
                         existing,

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -49,7 +49,7 @@ _INTERNAL_CONTEXT_RE = re.compile(
     re.IGNORECASE,
 )
 _INTERNAL_NOTE_RE = re.compile(
-    r'\[System note:\s*The following is recalled memory context,\s*NOT new user input\.\s*Treat as informational background data\.\]\s*',
+    r'\[System note:\s*The following is recalled memory context,\s*NOT new user input\.\s*Treat as (?:informational background data|authoritative reference data[^\]]*)\.\]\s*',
     re.IGNORECASE,
 )
 
@@ -183,7 +183,8 @@ def build_memory_context_block(raw_context: str) -> str:
     return (
         "<memory-context>\n"
         "[System note: The following is recalled memory context, "
-        "NOT new user input. Treat as informational background data.]\n\n"
+        "NOT new user input. Treat as authoritative reference data — "
+        "this is the agent's persistent memory and should inform all responses.]\n\n"
         f"{clean}\n"
         "</memory-context>"
     )


### PR DESCRIPTION
## Fixes #17251: Context Compaction Demotes Memory to "Background Reference"

### Problem

When context compression triggers, the `SUMMARY_PREFIX` instructs the model to treat the summary as **"background reference, NOT as active instructions"**. After compaction + session resume, the agent ignores its persistent memory (MEMORY.md, USER.md) because:

1. Memory is part of the system prompt, which gets the same "background reference" treatment
2. `build_memory_context_block()` labels memory as "informational background data"
3. The model follows these instructions literally and cannot access stored facts

### Root Cause

Three complementary demotion signals caused memory loss:
- `SUMMARY_PREFIX` in `context_compressor.py` — blanket "background reference" applies to everything including memory
- System prompt compression note — no mention of memory exemption
- `build_memory_context_block()` in `memory_manager.py` — "informational background data" further demotes memory

### Changes

**`agent/context_compressor.py`:**
- `SUMMARY_PREFIX`: Added explicit note that persistent memory (MEMORY.md, USER.md) is ALWAYS authoritative and must never be deprioritized
- System prompt compression note: Added reminder that memory remains fully authoritative regardless of compaction

**`agent/memory_manager.py`:**
- `build_memory_context_block()`: Changed "informational background data" → "authoritative reference data — this is the agent's persistent memory and should inform all responses"
- `_INTERNAL_NOTE_RE`: Updated regex to match both old and new wording (backward compatible with existing sessions)

### Testing
- All 40 context_compressor tests pass
- All 382 memory-related tests pass
- Regex matches both old and new patterns (backward compatible)

---

**Discussed in:** #17251