### PR TITLE
feat(tts): add Gradium provider

### DIFF
--- a/agent/tts_registry.py
+++ b/agent/tts_registry.py
@@ -53,6 +53,7 @@ _BUILTIN_NAMES = frozenset({
     "xai",
     "mistral",
     "gemini",
+    "gradium",
     "neutts",
     "kittentts",
     "piper",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2141,7 +2141,7 @@ DEFAULT_CONFIG = {
     # Gemini 32000, Edge 5000, Mistral 4000, NeuTTS/KittenTTS 2000).
     "tts": {
         # Set explicitly to pin a backend:
-        # "edge" (free) | "elevenlabs" (premium) | "openai" | "xai" | "minimax" | "mistral" | "gemini" | "deepinfra" | "neutts" (local) | "kittentts" (local) | "piper" (local)
+        # "edge" (free) | "elevenlabs" (premium) | "openai" | "xai" | "minimax" | "mistral" | "gemini" | "deepinfra" | "gradium" | "neutts" (local) | "kittentts" (local) | "piper" (local)
         "provider": "edge",
         "edge": {
             "voice": "en-US-AriaNeural",
@@ -2215,6 +2215,10 @@ DEFAULT_CONFIG = {
             "model": "",  # empty = first tts-tagged model from the live catalog
             "voice": "default",
             # "base_url": "",  # override DEEPINFRA_BASE_URL for TTS only
+        },
+        "gradium": {
+            "voice_id": "YTpq7expH9539ERJ",  # default english voice id
+            "model": "default",
         },
     },
 
@@ -4142,6 +4146,13 @@ OPTIONAL_ENV_VARS = {
         "prompt": "ElevenLabs API key",
         "url": "https://elevenlabs.io/",
         "tools": ["elevenlabs_tts", "voice_transcription"],
+        "password": True,
+        "category": "tool",
+    },
+    "GRADIUM_API_KEY": {
+        "description": "Gradium API key for text-to-speech",
+        "prompt": "Gradium API key",
+        "url": "https://gradium.ai/",
         "password": True,
         "category": "tool",
     },

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -526,6 +526,8 @@ def _print_setup_summary(config: dict, hermes_home):
         tool_status.append(("Text-to-Speech (Mistral Voxtral)", True, None))
     elif tts_provider == "gemini" and (get_env_value("GEMINI_API_KEY") or get_env_value("GOOGLE_API_KEY")):
         tool_status.append(("Text-to-Speech (Google Gemini)", True, None))
+    elif tts_provider == "gradium" and get_env_value("GRADIUM_API_KEY"):
+        tool_status.append(("Text-to-Speech (Gradium)", True, None))
     elif tts_provider == "neutts":
         try:
             neutts_ok = importlib.util.find_spec("neutts") is not None
@@ -946,6 +948,7 @@ def _setup_tts_provider(config: dict):
         "minimax": "MiniMax TTS",
         "mistral": "Mistral Voxtral TTS",
         "gemini": "Google Gemini TTS",
+        "gradium": "Gradium TTS",
         "neutts": "NeuTTS",
         "kittentts": "KittenTTS",
     }
@@ -970,11 +973,12 @@ def _setup_tts_provider(config: dict):
             "MiniMax TTS (high quality with voice cloning, needs API key)",
             "Mistral Voxtral TTS (multilingual, native Opus, needs API key)",
             "Google Gemini TTS (30 prebuilt voices, prompt-controllable, needs API key)",
+            "Gradium TTS (multilingual, needs API key)",
             "NeuTTS (local on-device, free, ~300MB model download)",
             "KittenTTS (local on-device, free, lightweight ~25-80MB ONNX)",
         ]
     )
-    providers.extend(["edge", "elevenlabs", "openai", "xai", "minimax", "mistral", "gemini", "neutts", "kittentts"])
+    providers.extend(["edge", "elevenlabs", "openai", "xai", "minimax", "mistral", "gemini", "gradium", "neutts", "kittentts"])
     choices.append(f"Keep current ({current_label})")
     keep_current_idx = len(choices) - 1
     idx = prompt_choice("Select TTS provider:", choices, keep_current_idx)
@@ -1134,6 +1138,18 @@ def _setup_tts_provider(config: dict):
             if api_key:
                 save_env_value("GEMINI_API_KEY", api_key)
                 print_success("Gemini TTS API key saved")
+            else:
+                print_warning("No API key provided. Falling back to Edge TTS.")
+                selected = "edge"
+
+    elif selected == "gradium":
+        existing = get_env_value("GRADIUM_API_KEY")
+        if not existing:
+            print()
+            api_key = prompt("Gradium API key for TTS", password=True)
+            if api_key:
+                save_env_value("GRADIUM_API_KEY", api_key)
+                print_success("Gradium TTS API key saved")
             else:
                 print_warning("No API key provided. Falling back to Edge TTS.")
                 selected = "edge"

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -382,6 +382,15 @@ TOOL_CATEGORIES = {
                 ],
                 "tts_provider": "deepinfra",
             },
+            {
+                "name": "Gradium",
+                "badge": "paid",
+                "tag": "Multilingual TTS, needs API key + 'gradium' pip package",
+                "env_vars": [
+                    {"key": "GRADIUM_API_KEY", "prompt": "Gradium API key", "url": "https://studio.gradium.ai/platform/api-keys"},
+                ],
+                "tts_provider": "gradium",
+            },
         ],
     },
     "web": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,6 +169,7 @@ matrix = ["mautrix[encryption]==0.21.0", "aiosqlite==0.22.1", "asyncpg==0.31.0",
 wecom = ["defusedxml==0.7.1"]
 cli = ["simple-term-menu==1.6.6"]
 tts-premium = ["elevenlabs==1.59.0"]
+tts-gradium = ["gradium==0.6.0"]
 voice = [
   # Local STT pulls in wheel-only transitive deps (ctranslate2, onnxruntime).
   "faster-whisper==1.2.1",

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -68,6 +68,7 @@ def test_lazy_installable_extras_excluded_from_all():
         "honcho", "hindsight",
         "supermemory", "mem0",
         "mistral",  # mistralai — Voxtral STT/TTS, lazy-installed (stt.mistral / tts.mistral)
+        "tts-gradium",  # gradium — Gradium TTS, lazy-installed (tts.gradium)
     }
     all_extra_specs = optional_dependencies["all"]
     for extra in lazy_covered_extras:

--- a/tests/tools/test_tts_gradium.py
+++ b/tests/tools/test_tts_gradium.py
@@ -1,0 +1,203 @@
+"""Tests for the Gradium TTS provider in tools/tts_tool.py."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    for key in ("GRADIUM_API_KEY", "HERMES_SESSION_PLATFORM"):
+        monkeypatch.delenv(key, raising=False)
+
+
+def _minimal_wav_bytes() -> bytes:
+    """Return a tiny but well-formed WAV (44-byte header + 1 sample of silence)."""
+    import struct
+    pcm = b"\x00\x00"
+    fmt_chunk = struct.pack("<4sIHHIIHH", b"fmt ", 16, 1, 1, 8000, 16000, 2, 16)
+    data_chunk = struct.pack("<4sI", b"data", len(pcm)) + pcm
+    riff = struct.pack("<4sI4s", b"RIFF", 4 + len(fmt_chunk) + len(data_chunk), b"WAVE")
+    return riff + fmt_chunk + data_chunk
+
+
+@pytest.fixture
+def mock_gradium_module():
+    """Stub the gradium SDK so tests don't need the real package."""
+    fake_client = MagicMock()
+    fake_client.tts = AsyncMock(return_value=MagicMock(raw_data=_minimal_wav_bytes()))
+    fake_client_cls = MagicMock(return_value=fake_client)
+    fake_client_module = MagicMock(GradiumClient=fake_client_cls)
+    fake_module = MagicMock(client=fake_client_module)
+    with patch.dict(
+        "sys.modules",
+        {"gradium": fake_module, "gradium.client": fake_client_module},
+    ):
+        yield fake_client
+
+
+class TestGenerateGradiumTts:
+    def test_missing_api_key_raises_value_error(self, tmp_path, mock_gradium_module):
+        from tools.tts_tool import _generate_gradium_tts
+
+        with pytest.raises(ValueError, match="GRADIUM_API_KEY"):
+            _generate_gradium_tts("Hello", str(tmp_path / "out.wav"), {})
+
+    def test_writes_wav_directly(self, tmp_path, mock_gradium_module, monkeypatch):
+        from tools.tts_tool import _generate_gradium_tts
+
+        monkeypatch.setenv("GRADIUM_API_KEY", "test-key")
+        out = tmp_path / "out.wav"
+
+        result = _generate_gradium_tts("Hello", str(out), {})
+
+        assert result == str(out)
+        assert out.read_bytes() == _minimal_wav_bytes()
+        mock_gradium_module.tts.assert_awaited_once()
+
+    def test_default_voice_and_model_used_when_absent(
+        self, tmp_path, mock_gradium_module, monkeypatch
+    ):
+        from tools.tts_tool import (
+            DEFAULT_GRADIUM_TTS_MODEL,
+            DEFAULT_GRADIUM_TTS_VOICE_ID,
+            _generate_gradium_tts,
+        )
+
+        monkeypatch.setenv("GRADIUM_API_KEY", "test-key")
+        _generate_gradium_tts("Hi", str(tmp_path / "out.wav"), {})
+
+        call_kwargs = mock_gradium_module.tts.await_args.kwargs
+        assert call_kwargs["setup"]["voice_id"] == DEFAULT_GRADIUM_TTS_VOICE_ID
+        assert call_kwargs["setup"]["model_name"] == DEFAULT_GRADIUM_TTS_MODEL
+        assert call_kwargs["setup"]["output_format"] == "wav"
+        assert call_kwargs["text"] == "Hi"
+
+    @pytest.mark.parametrize(
+        "extension, expected_format",
+        [(".wav", "wav"), (".ogg", "opus"), (".mp3", "wav")],
+    )
+    def test_output_format_picked_from_extension(
+        self, tmp_path, mock_gradium_module, monkeypatch, extension, expected_format
+    ):
+        """`.ogg` → opus (native), `.wav` → wav, anything else → wav + transcode."""
+        from tools.tts_tool import _generate_gradium_tts
+
+        monkeypatch.setenv("GRADIUM_API_KEY", "test-key")
+        # For .mp3 we go through ffmpeg; mock ffmpeg out so the test doesn't
+        # depend on it being installed.
+        with patch("tools.tts_tool.shutil.which", return_value=None):
+            _generate_gradium_tts("Hi", str(tmp_path / f"out{extension}"), {})
+
+        call_kwargs = mock_gradium_module.tts.await_args.kwargs
+        assert call_kwargs["setup"]["output_format"] == expected_format
+
+    def test_voice_and_model_from_config_override_defaults(
+        self, tmp_path, mock_gradium_module, monkeypatch
+    ):
+        from tools.tts_tool import _generate_gradium_tts
+
+        monkeypatch.setenv("GRADIUM_API_KEY", "test-key")
+        config = {"gradium": {"voice_id": "custom-voice", "model": "premium"}}
+        _generate_gradium_tts("Hi", str(tmp_path / "out.wav"), config)
+
+        call_kwargs = mock_gradium_module.tts.await_args.kwargs
+        assert call_kwargs["setup"]["voice_id"] == "custom-voice"
+        assert call_kwargs["setup"]["model_name"] == "premium"
+
+    def test_empty_audio_raises(self, tmp_path, mock_gradium_module, monkeypatch):
+        from tools.tts_tool import _generate_gradium_tts
+
+        monkeypatch.setenv("GRADIUM_API_KEY", "test-key")
+        mock_gradium_module.tts.return_value = MagicMock(raw_data=b"")
+
+        with pytest.raises(RuntimeError, match="empty audio"):
+            _generate_gradium_tts("Hi", str(tmp_path / "out.wav"), {})
+
+    def test_api_error_sanitized(self, tmp_path, mock_gradium_module, monkeypatch):
+        from tools.tts_tool import _generate_gradium_tts
+
+        monkeypatch.setenv("GRADIUM_API_KEY", "test-key")
+        mock_gradium_module.tts.side_effect = RuntimeError("secret-key-in-error")
+
+        with pytest.raises(RuntimeError, match="RuntimeError") as exc_info:
+            _generate_gradium_tts("Hi", str(tmp_path / "out.wav"), {})
+        assert "secret-key-in-error" not in str(exc_info.value)
+
+
+class TestTtsDispatcherGradium:
+    def test_dispatcher_routes_to_gradium(
+        self, tmp_path, mock_gradium_module, monkeypatch
+    ):
+        import json
+
+        from tools.tts_tool import text_to_speech_tool
+
+        monkeypatch.setenv("GRADIUM_API_KEY", "test-key")
+        out = str(tmp_path / "out.wav")
+        with patch("tools.tts_tool._load_tts_config", return_value={"provider": "gradium"}):
+            result = json.loads(text_to_speech_tool("Hello", output_path=out))
+
+        assert result["success"] is True
+        assert result["provider"] == "gradium"
+        mock_gradium_module.tts.assert_awaited_once()
+
+    def test_dispatcher_returns_error_when_sdk_not_installed(self, tmp_path, monkeypatch):
+        import json
+
+        from tools.tts_tool import text_to_speech_tool
+
+        monkeypatch.setenv("GRADIUM_API_KEY", "test-key")
+        with patch(
+            "tools.tts_tool._import_gradium", side_effect=ImportError("no module")
+        ), patch("tools.tts_tool._load_tts_config", return_value={"provider": "gradium"}):
+            result = json.loads(
+                text_to_speech_tool("Hello", output_path=str(tmp_path / "out.wav"))
+            )
+
+        assert result["success"] is False
+        assert "gradium" in result["error"]
+
+
+class TestImportGradiumLazyInstall:
+    def test_calls_ensure_before_import(self, mock_gradium_module):
+        from tools.tts_tool import _import_gradium
+
+        with patch("tools.lazy_deps.ensure") as mock_ensure:
+            _import_gradium()
+
+        mock_ensure.assert_called_once_with("tts.gradium", prompt=False)
+
+    def test_feature_unavailable_becomes_import_error(self, mock_gradium_module):
+        from tools.lazy_deps import FeatureUnavailable
+        from tools.tts_tool import _import_gradium
+
+        unavailable = FeatureUnavailable(
+            "tts.gradium", ("gradium==0.6.0",), "pip install failed"
+        )
+        with patch("tools.lazy_deps.ensure", side_effect=unavailable):
+            with pytest.raises(ImportError, match="pip install failed"):
+                _import_gradium()
+
+
+class TestCheckTtsRequirementsGradium:
+    def test_gradium_sdk_and_key_returns_true(self, mock_gradium_module, monkeypatch):
+        from tools.tts_tool import check_tts_requirements
+
+        monkeypatch.setenv("GRADIUM_API_KEY", "test-key")
+        with patch("tools.tts_tool._load_tts_config", return_value={"provider": "gradium"}):
+            assert check_tts_requirements() is True
+
+    def test_gradium_key_missing_returns_false(self, mock_gradium_module):
+        from tools.tts_tool import check_tts_requirements
+
+        with patch("tools.tts_tool._load_tts_config", return_value={"provider": "gradium"}):
+            assert check_tts_requirements() is False
+
+    def test_gradium_sdk_missing_returns_false(self, monkeypatch):
+        from tools.tts_tool import check_tts_requirements
+
+        monkeypatch.setenv("GRADIUM_API_KEY", "test-key")
+        with patch("tools.tts_tool._import_gradium", side_effect=ImportError), \
+             patch("tools.tts_tool._load_tts_config", return_value={"provider": "gradium"}):
+            assert check_tts_requirements() is False

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -126,6 +126,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     "tts.mistral": ("mistralai==2.4.8",),
     "tts.edge": ("edge-tts==7.2.7",),
     "tts.elevenlabs": ("elevenlabs==1.59.0",),
+    "tts.gradium": ("gradium==0.6.0",),
 
     # ─── Speech-to-text providers ──────────────────────────────────────────
     "stt.mistral": ("mistralai==2.4.8",),

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -9,6 +9,7 @@ Built-in TTS providers:
 - MiniMax TTS: High-quality with voice cloning, needs MINIMAX_API_KEY
 - Mistral (Voxtral TTS): Multilingual, native Opus, needs MISTRAL_API_KEY
 - Google Gemini TTS: Controllable, 30 prebuilt voices, needs GEMINI_API_KEY
+- Gradium TTS: API-based multilingual TTS, needs GRADIUM_API_KEY
 - xAI TTS: Grok voices, uses xAI Grok OAuth credentials or XAI_API_KEY
 - NeuTTS (local, free, no API key): On-device TTS via neutts
 - KittenTTS (local, free, no API key): On-device 25MB model
@@ -163,6 +164,25 @@ def _import_piper():
     return PiperVoice
 
 
+def _import_gradium():
+    """Lazy import gradium. Returns the module or raises ImportError.
+
+    Calls :func:`tools.lazy_deps.ensure` first so the ``gradium`` SDK gets
+    installed on demand if the user picked Gradium as their TTS provider
+    but never ran the post-setup hook (e.g. enabled it by editing config.yaml
+    directly). Mirrors the ElevenLabs/Mistral lazy-import paths.
+    """
+    try:
+        from tools.lazy_deps import ensure
+        ensure("tts.gradium", prompt=False)
+    except ImportError:
+        pass
+    except Exception as e:  # FeatureUnavailable or any unexpected error
+        raise ImportError(str(e))
+    import gradium
+    return gradium
+
+
 # ===========================================================================
 # Defaults
 # ===========================================================================
@@ -207,6 +227,8 @@ DEFAULT_GEMINI_AUDIO_TAGS = False
 GEMINI_AUDIO_TAG_REWRITE_TASK = "tts_audio_tags"
 # Base URL now resolved via hermes_cli.models.deepinfra_base_url (shared).
 DEFAULT_DEEPINFRA_TTS_VOICE = "default"
+DEFAULT_GRADIUM_TTS_MODEL = "default"
+DEFAULT_GRADIUM_TTS_VOICE_ID = "YTpq7expH9539ERJ"
 # PCM output specs for Gemini TTS (fixed by the API)
 GEMINI_TTS_SAMPLE_RATE = 24000
 GEMINI_TTS_CHANNELS = 1
@@ -236,6 +258,7 @@ PROVIDER_MAX_TEXT_LENGTH: Dict[str, int] = {
     "neutts": 2000,       # local model, quality falls off on long text
     "kittentts": 2000,    # local 25MB model
     "piper": 5000,        # local VITS model, phoneme-based; practical cap
+    "gradium": 4000,      # per Gradium API guidance
 }
 
 # ElevenLabs caps vary by model_id. https://elevenlabs.io/docs/overview/models
@@ -401,6 +424,7 @@ BUILTIN_TTS_PROVIDERS = frozenset({
     "xai",
     "mistral",
     "gemini",
+    "gradium",
     "neutts",
     "kittentts",
     "piper",
@@ -1949,6 +1973,105 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
 
 
 # ===========================================================================
+# Provider: Gradium TTS
+# ===========================================================================
+async def _gradium_tts_async(
+    api_key: str,
+    text: str,
+    voice_id: str,
+    model_name: str,
+    output_format: str,
+) -> bytes:
+    """Call Gradium's async TTS endpoint and return raw audio bytes."""
+    gradium = _import_gradium()
+    client = gradium.client.GradiumClient(api_key=api_key)
+    result = await client.tts(
+        setup={
+            "model_name": model_name,
+            "voice_id": voice_id,
+            "output_format": output_format,
+        },
+        text=text,
+    )
+    return result.raw_data
+
+
+def _generate_gradium_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+    """Generate audio using Gradium TTS.
+
+    Gradium can emit `wav` or `opus` natively (also `pcm` and a few rates),
+    we pick the format from the requested file extension. `.ogg` gets Opus
+    directly (no ffmpeg pass needed for Telegram voice bubbles). For `.mp3`
+    or any other extension Gradium doesn't natively produce, we fall back
+    to requesting WAV and ffmpeg-converting.
+    """
+    api_key = (get_env_value("GRADIUM_API_KEY") or "").strip()
+    if not api_key:
+        raise ValueError("GRADIUM_API_KEY not set.")
+
+    gr_config = tts_config.get("gradium", {})
+    voice_id = str(gr_config.get("voice_id") or DEFAULT_GRADIUM_TTS_VOICE_ID).strip()
+    model_name = str(gr_config.get("model") or DEFAULT_GRADIUM_TTS_MODEL).strip()
+
+    lower = output_path.lower()
+    if lower.endswith(".ogg"):
+        output_format = "opus"
+    elif lower.endswith(".wav"):
+        output_format = "wav"
+    else:
+        # Gradium does not produce mp3 natively, request wav and transcode.
+        output_format = "wav"
+
+    try:
+        audio_bytes = asyncio.run(
+            _gradium_tts_async(api_key, text, voice_id, model_name, output_format)
+        )
+    except ValueError:
+        raise
+    except Exception as e:
+        logger.error("Gradium TTS failed: %s", e, exc_info=True)
+        raise RuntimeError(f"Gradium TTS failed: {type(e).__name__}") from e
+
+    if not audio_bytes:
+        raise RuntimeError("Gradium TTS returned empty audio data")
+
+    # Native-format fast path: extension matches what we asked for.
+    if (lower.endswith(".ogg") and output_format == "opus") or (
+        lower.endswith(".wav") and output_format == "wav"
+    ):
+        with open(output_path, "wb") as f:
+            f.write(audio_bytes)
+        return output_path
+
+    # Fallback: stage WAV and ffmpeg-convert to the requested extension (.mp3, …).
+    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+        tmp.write(audio_bytes)
+        wav_path = tmp.name
+
+    try:
+        ffmpeg = shutil.which("ffmpeg")
+        if ffmpeg:
+            cmd = [ffmpeg, "-i", wav_path, "-y", "-loglevel", "error", output_path]
+            result = subprocess.run(cmd, capture_output=True, timeout=30)
+            if result.returncode != 0:
+                stderr = result.stderr.decode("utf-8", errors="ignore")[:300]
+                raise RuntimeError(f"ffmpeg conversion failed: {stderr}")
+        else:
+            logger.warning(
+                "ffmpeg not found; writing raw WAV to %s (extension may be misleading)",
+                output_path,
+            )
+            shutil.copyfile(wav_path, output_path)
+    finally:
+        try:
+            os.remove(wav_path)
+        except OSError:
+            pass
+
+    return output_path
+
+
+# ===========================================================================
 # NeuTTS (local, on-device TTS via neutts_cli)
 # ===========================================================================
 
@@ -2369,7 +2492,7 @@ def text_to_speech_tool(
             file_path = out_dir / f"tts_{timestamp}.{fmt}"
         # Use .ogg for Telegram with providers that support native Opus output,
         # otherwise fall back to .mp3 (Edge TTS will attempt ffmpeg conversion later).
-        elif want_opus and provider in {"openai", "elevenlabs", "mistral", "gemini"}:
+        elif want_opus and provider in {"openai", "elevenlabs", "mistral", "gemini", "gradium"}:
             file_path = out_dir / f"tts_{timestamp}.ogg"
         else:
             file_path = out_dir / f"tts_{timestamp}.mp3"
@@ -2459,6 +2582,18 @@ def text_to_speech_tool(
         elif provider == "gemini":
             logger.info("Generating speech with Google Gemini TTS...")
             _generate_gemini_tts(text, file_str, tts_config)
+
+        elif provider == "gradium":
+            try:
+                _import_gradium()
+            except ImportError:
+                return json.dumps({
+                    "success": False,
+                    "error": "Gradium provider selected but 'gradium' package not installed. "
+                             "Run: pip install 'hermes-agent[tts-gradium]'"
+                }, ensure_ascii=False)
+            logger.info("Generating speech with Gradium TTS...")
+            _generate_gradium_tts(text, file_str, tts_config)
 
         elif provider == "neutts":
             if not _check_neutts_available():
@@ -2568,7 +2703,7 @@ def text_to_speech_tool(
             if opus_path:
                 file_str = opus_path
                 voice_compatible = True
-        elif provider in {"elevenlabs", "openai", "mistral", "gemini"}:
+        elif provider in {"elevenlabs", "openai", "mistral", "gemini", "gradium"}:
             voice_compatible = want_opus and file_str.endswith(".ogg")
 
         file_size = os.path.getsize(file_str)
@@ -2667,6 +2802,12 @@ def check_tts_requirements() -> bool:
         return _check_kittentts_available()
     if provider == "piper":
         return _check_piper_available()
+    if provider == "gradium":
+        try:
+            _import_gradium()
+        except ImportError:
+            return False
+        return bool(get_env_value("GRADIUM_API_KEY"))
 
     try:
         from agent.tts_registry import get_provider
@@ -2967,6 +3108,8 @@ if __name__ == "__main__":
     )
     print(f"  MiniMax:    {'API key set' if get_env_value('MINIMAX_API_KEY') else 'not set (MINIMAX_API_KEY)'}")
     print(f"  Piper:      {'installed' if _check_piper_available() else 'not installed (pip install piper-tts)'}")
+    print(f"  Gradium:    {'installed' if _check(_import_gradium, 'gradium') else 'not installed (pip install gradium)'}")
+    print(f"    API Key:  {'set' if get_env_value('GRADIUM_API_KEY') else 'not set'}")
     print(f"  ffmpeg:     {'✅ found' if _has_ffmpeg() else '❌ not found (needed for Telegram Opus)'}")
     print(f"\n  Output dir: {DEFAULT_OUTPUT_DIR}")
 

--- a/uv.lock
+++ b/uv.lock
@@ -1407,6 +1407,19 @@ wheels = [
 ]
 
 [[package]]
+name = "gradium"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8c/a1/ed6ed1efbae0bf8c858290866ffcf93f0cabea8db5c7a3544e04ea3c46e5/gradium-0.6.0.tar.gz", hash = "sha256:da911914060916a3bf2693bf8a0aa9661b5326f8a3b46d7cc00721d58f93d734", size = 1322858, upload-time = "2026-06-23T11:53:28.909Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/0c/7c46c148feddfc2ad8089156872349054ec868f99eb66edda35c7c5c2697/gradium-0.6.0-py3-none-any.whl", hash = "sha256:929953f0ed3e6816cc0c48c3e741ca6700624694c9ab1098570e39288aa0b73d", size = 25540, upload-time = "2026-06-23T11:53:20.99Z" },
+]
+
+[[package]]
 name = "greenlet"
 version = "3.5.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1707,6 +1720,9 @@ termux-all = [
     { name = "starlette" },
     { name = "uvicorn", extra = ["standard"] },
 ]
+tts-gradium = [
+    { name = "gradium" },
+]
 tts-premium = [
     { name = "elevenlabs" },
 ]
@@ -1770,6 +1786,7 @@ requires-dist = [
     { name = "google-auth", marker = "extra == 'vertex'", specifier = "==2.55.1" },
     { name = "google-auth-httplib2", marker = "extra == 'google'", specifier = "==0.3.1" },
     { name = "google-auth-oauthlib", marker = "extra == 'google'", specifier = "==1.3.1" },
+    { name = "gradium", marker = "extra == 'tts-gradium'", specifier = "==0.6.0" },
     { name = "hermes-agent", extras = ["acp"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["acp"], marker = "extra == 'termux'" },
     { name = "hermes-agent", extras = ["cli"], marker = "extra == 'all'" },
@@ -1855,7 +1872,7 @@ requires-dist = [
     { name = "websockets", specifier = "==15.0.1" },
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = "==1.2.4" },
 ]
-provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "cli", "tts-premium", "voice", "honcho", "supermemory", "mem0", "vision", "pty", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "bedrock", "vertex", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
+provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "cli", "tts-premium", "tts-gradium", "voice", "honcho", "supermemory", "mem0", "vision", "pty", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "bedrock", "vertex", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
 
 [[package]]
 name = "hf-xet"

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -154,6 +154,7 @@ For native Anthropic auth, Hermes prefers Claude Code's own credential files whe
 | `KREA_API_KEY` | Krea API key for Krea 2 image generation ([krea.ai](https://krea.ai/)) |
 | `GROQ_API_KEY` | Groq Whisper STT API key ([groq.com](https://groq.com/)) |
 | `ELEVENLABS_API_KEY` | ElevenLabs premium TTS voices ([elevenlabs.io](https://elevenlabs.io/)) |
+| `GRADIUM_API_KEY` | Gradium multilingual TTS ([gradium.ai](https://gradium.ai/)) |
 | `STT_GROQ_MODEL` | Override the Groq STT model (default: `whisper-large-v3-turbo`) |
 | `GROQ_BASE_URL` | Override the Groq OpenAI-compatible STT endpoint |
 | `STT_OPENAI_MODEL` | Override the OpenAI STT model (default: `whisper-1`) |

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1434,7 +1434,7 @@ tool_loop_guardrails:
 
 ```yaml
 tts:
-  provider: "edge"              # "edge" | "elevenlabs" | "openai" | "minimax" | "mistral" | "gemini" | "xai" | "neutts"
+  provider: "edge"              # "edge" | "elevenlabs" | "openai" | "minimax" | "mistral" | "gemini" | "xai" | "gradium" | "neutts"
   speed: 1.0                    # Global speed multiplier (fallback for all providers)
   edge:
     voice: "en-US-AriaNeural"   # 322 voices, 74 languages
@@ -1464,6 +1464,9 @@ tts:
     sample_rate: 24000
     bit_rate: 128000            # MP3 bitrate
     # base_url: "https://api.x.ai/v1"
+  gradium:
+    voice_id: "YTpq7expH9539ERJ"  # Default English voice; browse more at https://studio.gradium.ai
+    model: "default"              # Gradium model name
   neutts:
     ref_audio: ''
     ref_text: ''

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -25,6 +25,7 @@ Convert text to speech with ten providers:
 | **Mistral (Voxtral TTS)** | Excellent | Paid | `MISTRAL_API_KEY` |
 | **Google Gemini TTS** | Excellent | Free tier | `GEMINI_API_KEY` |
 | **xAI TTS** | Excellent | Paid | `XAI_API_KEY` |
+| **Gradium TTS** | Excellent | Paid | `GRADIUM_API_KEY` |
 | **NeuTTS** | Good | Free (local) | None needed |
 | **KittenTTS** | Good | Free (local) | None needed |
 | **Piper** | Good | Free (local) | None needed |
@@ -43,7 +44,7 @@ Convert text to speech with ten providers:
 ```yaml
 # In ~/.hermes/config.yaml
 tts:
-  provider: "edge"              # "edge" | "elevenlabs" | "openai" | "minimax" | "mistral" | "gemini" | "xai" | "neutts" | "kittentts" | "piper"
+  provider: "edge"              # "edge" | "elevenlabs" | "openai" | "minimax" | "mistral" | "gemini" | "xai" | "gradium" | "neutts" | "kittentts" | "piper"
   speed: 1.0                    # Global speed multiplier (provider-specific settings override this)
   edge:
     voice: "en-US-AriaNeural"   # 322 voices, 74 languages
@@ -76,6 +77,9 @@ tts:
     sample_rate: 24000          # 22050 / 24000 (default) / 44100 / 48000
     bit_rate: 128000            # MP3 bitrate; only applies when codec=mp3
     # base_url: "https://api.x.ai/v1"   # Override via XAI_BASE_URL env var
+  gradium:
+    voice_id: "YTpq7expH9539ERJ"   # Default English voice; browse more at https://studio.gradium.ai
+    model: "default"               # Gradium model name
   neutts:
     ref_audio: ''
     ref_text: ''
@@ -169,7 +173,7 @@ Only positive integers are honored. Zero, negative, non-numeric, or boolean valu
 
 Telegram voice bubbles require Opus/OGG audio format:
 
-- **OpenAI, ElevenLabs, and Mistral** produce Opus natively — no extra setup
+- **OpenAI, ElevenLabs, Mistral, and Gradium** produce Opus natively — no extra setup
 - **Edge TTS** (default) outputs MP3 and needs **ffmpeg** to convert:
 - **MiniMax TTS** outputs MP3 and needs **ffmpeg** to convert for Telegram voice bubbles
 - **Google Gemini TTS** outputs raw PCM and uses **ffmpeg** to encode Opus directly for Telegram voice bubbles
@@ -192,7 +196,7 @@ sudo dnf install ffmpeg
 Without ffmpeg, Edge TTS, MiniMax TTS, NeuTTS, KittenTTS, and Piper audio are sent as regular audio files (playable, but shown as a rectangular player instead of a voice bubble).
 
 :::tip
-If you want voice bubbles without installing ffmpeg, switch to the OpenAI, ElevenLabs, or Mistral provider.
+If you want voice bubbles without installing ffmpeg, switch to the OpenAI, ElevenLabs, Mistral, or Gradium provider.
 :::
 
 ### xAI Custom Voices (voice cloning)


### PR DESCRIPTION
## What does this PR do?

Adds [Gradium](https://gradium.ai/) as a new TTS provider. Gradium is a paid multilingual TTS API which gives users another high-quality voice option alongside the existing ElevenLabs / OpenAI / MiniMax / Mistral / Gemini choices, with native Opus output for Telegram voice messages (no ffmpeg pass needed for `.ogg`).

The integration follows the existing TTS provider pattern: an optional dependency (`hermes-agent[tts-gradium]`), a `GRADIUM_API_KEY` env var, defaults in `config.yaml`, a setup-wizard branch, and tools-config exposure.

## Related Issue

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/tts_tool.py`: new `_generate_gradium_tts()` provider, lazy `_import_gradium()`, dispatch branch in `text_to_speech_tool()`, contribution to `check_tts_requirements()` and the `__main__` diagnostics block. `.ogg` requests get native Opus from Gradium, `.wav` is written directly, other extensions (e.g. `.mp3`) stage a WAV and ffmpeg-transcode.
- `hermes_cli/config.py`: `tts.gradium` defaults (`voice_id`, `model`), updated provider-comment list, and `GRADIUM_API_KEY` entry in `OPTIONAL_ENV_VARS`.
- `hermes_cli/setup.py`: Gradium branch in `_setup_tts_provider()` (provider list, label, API-key prompt, fallback to Edge if skipped) and a status row in `_print_setup_summary()`.
- `hermes_cli/tools_config.py`: Gradium entry under the TTS category for the curses tools menu.
- `pyproject.toml`: new `tts-gradium` extra (`gradium>=0.5.11`), wired into the `all` extra.
- `tests/tools/test_tts_gradium.py`: unit tests covering missing-API-key error, native WAV write path, default voice/model, and the SDK call surface (gradium module is stubbed via `sys.modules`, so the real package is not required to run).

## How to Test

1. `uv pip install -e ".[all,dev]"` (or `.[tts-gradium]` for the minimal install) and `echo "GRADIUM_API_KEY=..." >> ~/.hermes/.env`.
2. Set `tts.provider: gradium` in `~/.hermes/config.yaml` (or run `hermes setup` and pick "Gradium TTS").
3. Run `python -m tools.tts_tool` to confirm the diagnostics block reports `Gradium: installed` and `API Key: set`.
4. From a chat: ask the agent to speak something. Verify:
   - A `.mp3` is produced when not on Telegram (WAV → ffmpeg conversion).
   - On Telegram (`HERMES_SESSION_PLATFORM=telegram`), a `.ogg` is produced via native Opus and is voice-bubble compatible.
5. `scripts/run_tests.sh tests/tools/test_tts_gradium.py`, all four tests pass without the real `gradium` package installed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(tts): add Gradium provider`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh` and all tests pass
- [x] I've added tests for my changes (`tests/tools/test_tts_gradium.py`)
- [x] I've tested on my platform: Ubuntu 22.04 (Linux 5.15)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — the webpage in `website/docs/user-guide/features/tts.md`, module docstring in `tools/tts_tool.py` and provider-list comments in `hermes_cli/config.py`
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (defaults live in `DEFAULT_CONFIG` in `hermes_cli/config.py`; the example file does not enumerate every TTS provider block)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A (additive provider, follows the existing pattern)
- [x] I've considered cross-platform impact — N/A from a code path perspective (no `termios`/`fcntl`/`os.setsid` usage; ffmpeg is already an existing soft dependency for the other providers)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no schema change to `text_to_speech_tool`; provider is selected via config)