### PR TITLE
fix(gateway): add per-platform connect timeout to prevent blocking (#17242)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2453,7 +2453,9 @@ class GatewayRunner:
             adapter.set_session_store(self.session_store)
             adapter.set_busy_session_handler(self._handle_active_session_busy_message)
             
-            # Try to connect
+            # Try to connect — wrap in a per-platform timeout so one
+            # slow/hanging platform cannot block initialization of others
+            # (e.g., Telegram retrying 8×15s blocks Feishu startup).
             logger.info("Connecting to %s...", platform.value)
             self._update_platform_runtime_status(
                 platform.value,
@@ -2461,8 +2463,12 @@ class GatewayRunner:
                 error_code=None,
                 error_message=None,
             )
+            _platform_connect_timeout = 90  # seconds — generous for slow networks
             try:
-                success = await adapter.connect()
+                success = await asyncio.wait_for(
+                    adapter.connect(),
+                    timeout=_platform_connect_timeout,
+                )
                 if success:
                     self.adapters[platform] = adapter
                     self._sync_voice_mode_state_to_adapter(adapter)
@@ -2523,6 +2529,26 @@ class GatewayRunner:
                             "attempts": 1,
                             "next_retry": time.monotonic() + 30,
                         }
+            except asyncio.TimeoutError:
+                logger.error(
+                    "✗ %s connect timed out after %ds",
+                    platform.value, _platform_connect_timeout,
+                )
+                await self._safe_adapter_disconnect(adapter, platform)
+                self._update_platform_runtime_status(
+                    platform.value,
+                    platform_state="retrying",
+                    error_code="TIMEOUT",
+                    error_message=f"connect timed out after {_platform_connect_timeout}s",
+                )
+                startup_retryable_errors.append(
+                    f"{platform.value}: connect timed out after {_platform_connect_timeout}s"
+                )
+                self._failed_platforms[platform] = {
+                    "config": platform_config,
+                    "attempts": 1,
+                    "next_retry": time.monotonic() + 30,
+                }
             except Exception as e:
                 logger.error("✗ %s error: %s", platform.value, e)
                 # Same defensive cleanup path for exceptions — an adapter


### PR DESCRIPTION
## Fixes #17242: Platform initialization failure blocks other platforms

### Problem

When multiple messaging platforms are configured (e.g., Telegram + Feishu/Lark), if one platform's `connect()` call hangs or takes very long, it blocks initialization of all subsequent platforms.

**Real-world scenario:** Telegram's retry loop (8 attempts × 15s exponential backoff = up to 120s) can prevent Feishu from ever starting — common in regions where Telegram is network-restricted.

### Root Cause

The startup loop in `GatewayRunner.start()` iterates platforms sequentially and awaits each `adapter.connect()` without a timeout:

```python
for platform, platform_config in self.config.platforms.items():
    success = await adapter.connect()  # can hang indefinitely
```

### Fix

Wrap each platform's `connect()` call in `asyncio.wait_for()` with a 90-second timeout:

```python
_platform_connect_timeout = 90  # seconds
success = await asyncio.wait_for(adapter.connect(), timeout=_platform_connect_timeout)
```

On timeout:
- The platform is logged as timed out
- Resources are cleaned up via `_safe_adapter_disconnect()`
- The platform is queued for background reconnection (just like other transient failures)
- The next platform starts immediately

### Why 90 seconds?

- Telegram's 8-retry loop can take up to ~120s in the worst case
- 90s is generous enough for slow networks but prevents indefinite blocking
- The timeout is applied per-platform, so total startup time = min(90s, connect_time) × num_platforms

### Testing
- Syntax verified with `ast.parse()`
- Timeout handler is consistent with existing error handling (same cleanup, same reconnection queue)

---

**Discussed in:** #17242