### PR TITLE
fix(gateway): delete partial message after fallback send on flood control

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -640,6 +640,7 @@ class GatewayStreamConsumer:
         safe_limit = max(500, raw_limit - 100)
         chunks = self._split_text_chunks(continuation, safe_limit)
 
+        stale_message_id = self._message_id  # partial message to clean up
         last_message_id: Optional[str] = None
         last_successful_chunk = ""
         sent_any_chunk = False
@@ -686,6 +687,16 @@ class GatewayStreamConsumer:
             # Each fallback chunk is a fresh platform message — notify
             # so any stale tool-progress bubble gets closed off.
             self._notify_new_message()
+
+        # Remove the frozen partial message so the user only sees the
+        # complete fallback response.  Best-effort — if the delete fails
+        # (e.g. flood control still active, or bot lacks permission), the
+        # partial message remains but at least the full answer was delivered.
+        if stale_message_id and stale_message_id != last_message_id:
+            try:
+                await self.adapter.delete_message(self.chat_id, stale_message_id)
+            except Exception:
+                pass
 
         self._message_id = last_message_id
         self._already_sent = True


### PR DESCRIPTION
## What does this PR do?

When Telegram flood control triggers 3+ consecutive edit failures during streaming, the stream consumer enters fallback mode and sends the complete response as a new message. This leaves the user seeing two messages: a frozen partial (often with cursor ▉) and the full duplicate.

After the fallback chunks are sent successfully, this PR deletes the original partial message so the user only sees one complete response.

## Related Issue

Fixes #16668

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/stream_consumer.py`: in `_send_fallback_final()`, save the stale message ID before the send loop, then delete it after all fallback chunks succeed. The delete is best-effort — if it fails (flood control still active, missing permissions, already deleted), the full answer is still delivered.

## How to Test

1. Configure Telegram bot with streaming enabled
2. Send a message that produces a long response
3. Simulate flood control (high-frequency edits in a busy group)
4. Before fix: user sees [partial frozen message] + [complete duplicate]
5. After fix: partial message is deleted, user sees only the complete response

## Design Decisions

- **Best-effort delete**: the delete itself may be rate-limited by Telegram. The comment in code acknowledges this. The fix improves the common case (delete succeeds) without making the worst case worse (delete fails → same behavior as before this PR).
- **`except Exception: pass`**: matches the existing error handling pattern in this file (e.g., `_try_strip_cursor`). A failed delete should never crash the response delivery.
- **Scope**: only the happy-path exit of `_send_fallback_final()` gets the delete. Early-return error paths (partial chunk failure) are left unchanged to avoid adding complexity to already-complex error handling.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] Cross-platform: `delete_message` is defined on the base adapter; non-Telegram platforms that don't implement it return False (no crash)