### PR TITLE
feat: add x402 wallet and payments skill

### DIFF
--- a/skills/payments/x402/SKILL.md
+++ b/skills/payments/x402/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: x402
+description: "Use when paying for, discovering, or building x402 paid APIs (USDC on Base via the awal wallet). Covers wallet auth, funding, bazaar search, paid requests, and monetizing your own endpoints."
+version: 1.0.0
+author: Hermes Agent (ported from coinbase/agentic-wallet-skills)
+license: MIT
+user-invocable: true
+disable-model-invocation: false
+allowed-tools: ["Bash(npx awal@latest status*)", "Bash(npx awal@latest auth *)", "Bash(npx awal@latest balance*)", "Bash(npx awal@latest address*)", "Bash(npx awal@latest show*)", "Bash(npx awal@latest x402 *)", "Bash(npm *)", "Bash(node *)", "Bash(curl *)", "Bash(mkdir *)"]
+metadata:
+  hermes:
+    tags: [x402, payments, usdc, base, wallet, awal, coinbase]
+    related_skills: []
+---
+
+# x402 Payments (awal wallet)
+
+## Overview
+
+x402 is an HTTP-native payment protocol: when a client hits a protected endpoint without paying, the server returns HTTP 402 with payment requirements; the client signs a USDC payment and retries with a payment header; a facilitator verifies and settles. Payments are USDC on Base, per-request, with no accounts, API keys, or subscriptions.
+
+This skill wraps Coinbase's `awal` CLI and bundles five workflows: wallet auth, funding, bazaar discovery, making paid requests, and monetizing your own API. The typical consumer flow is **find → check → pay**:
+
+1. **Find** a service via the bazaar (`npx awal@latest x402 bazaar search …`)
+2. **Check** its requirements (`npx awal@latest x402 details <url>`)
+3. **Pay** to call it (`npx awal@latest x402 pay <url> …`)
+
+## When to Use
+
+- User wants to call a paid API endpoint or use an x402 service
+- User wants to browse / search the x402 bazaar for available paid services
+- User wants to fund the wallet with USDC, sign in, or check balance
+- User wants to build and deploy a paid API of their own
+- A wallet operation fails with "Not authenticated" or "Insufficient balance"
+- You don't have a clear tool for the task — search the bazaar to see if a paid service exists
+
+**Don't use for:**
+
+- Trading / swapping tokens (out of scope; not ported here)
+- Sending USDC peer-to-peer (out of scope; not ported here)
+- Onchain SQL data queries (out of scope; not ported here)
+- Anything not involving USDC-on-Base or the x402 protocol
+
+## Sub-Topics
+
+| Goal                                | Reference                          |
+| ----------------------------------- | ---------------------------------- |
+| Sign in / wallet authentication     | `references/authenticate.md`       |
+| Top up the wallet (USDC onramp)     | `references/fund.md`               |
+| Discover paid APIs in the bazaar    | `references/search-bazaar.md`      |
+| Call a paid API endpoint            | `references/pay.md`                |
+| Build & deploy a paid API server    | `references/monetize.md`           |
+
+## Quick Status Check
+
+Always start here when the wallet state is uncertain:
+
+```bash
+npx awal@latest status
+```
+
+Displays server health, authentication status, and wallet address. If it reports not authenticated, see `references/authenticate.md`. If balance is too low for a paid request, see `references/fund.md`.
+
+## USDC Atomic Units
+
+x402 prices and `--max-amount` flags use USDC atomic units (6 decimals):
+
+| Atomic Units | USD   |
+| ------------ | ----- |
+| 1000000      | $1.00 |
+| 100000       | $0.10 |
+| 50000        | $0.05 |
+| 10000        | $0.01 |
+
+Always single-quote dollar amounts in bash to prevent variable expansion: `'$1.00'`, never `$1.00`.
+
+## Common Pitfalls
+
+1. **Forgetting to single-quote `$` amounts in bash.** `price: $1.00` becomes `price: .00` after shell expansion. Always wrap dollar amounts in single quotes.
+2. **Calling pay before authenticating.** `x402 pay` requires an authed wallet. Run `npx awal@latest status` first; if not signed in, see `references/authenticate.md`.
+3. **Calling pay with insufficient balance.** Check with `npx awal@latest balance`; top up via `references/fund.md`.
+4. **Treating upstream version pins as authoritative.** The Coinbase docs use `awal@2.8.2`; this skill standardizes on `awal@latest` so users get current behavior. Don't paste old version-pinned commands from outside docs without converting.
+5. **Confusing the consumer and producer flows.** `pay.md` calls someone else's paid API; `monetize.md` exposes one of your own. They share the wallet but serve opposite roles.
+
+## Verification Checklist
+
+- [ ] `npx awal@latest status` shows authenticated and a wallet address
+- [ ] `npx awal@latest balance` shows enough USDC for the intended call (consumer flow)
+- [ ] For paid requests: `x402 details <url>` returns valid payment requirements before `x402 pay`
+- [ ] For monetization: `curl -i http://localhost:<port>/<route>` returns HTTP 402 with payment requirements; `npx awal@latest x402 pay http://localhost:<port>/<route>` returns 200
+- [ ] Dollar amounts in any custom bash invocations are single-quoted
+
+## Further Reading
+
+For anything not covered in this skill or its references — newer `awal` CLI flags, deeper SDK reference, alternate facilitators, broader CDP / agentic-wallet documentation — fetch the official CDP `llms.txt` index and follow the relevant link:
+
+```
+https://docs.cdp.coinbase.com/llms.txt
+```

--- a/skills/payments/x402/SKILL.md
+++ b/skills/payments/x402/SKILL.md
@@ -21,7 +21,7 @@ x402 is an HTTP-native payment protocol: when a client hits a protected endpoint
 
 This skill wraps Coinbase's `awal` CLI and bundles five workflows: wallet auth, funding, bazaar discovery, making paid requests, and monetizing your own API. The typical consumer flow is **find → check → pay**:
 
-1. **Find** a service via the bazaar (`npx awal@latest x402 bazaar search …`)
+1. **Find** a service in `references/services-catalog.md` (curated) or via `npx awal@latest x402 bazaar search …` (live)
 2. **Check** its requirements (`npx awal@latest x402 details <url>`)
 3. **Pay** to call it (`npx awal@latest x402 pay <url> …`)
 
@@ -45,9 +45,9 @@ This skill wraps Coinbase's `awal` CLI and bundles five workflows: wallet auth, 
 
 | Goal                                | Reference                          |
 | ----------------------------------- | ---------------------------------- |
+| Discover services / known catalog   | `references/search-bazaar.md`      |
 | Sign in / wallet authentication     | `references/authenticate.md`       |
 | Top up the wallet (USDC onramp)     | `references/fund.md`               |
-| Discover paid APIs in the bazaar    | `references/search-bazaar.md`      |
 | Call a paid API endpoint            | `references/pay.md`                |
 | Build & deploy a paid API server    | `references/monetize.md`           |
 

--- a/skills/payments/x402/references/authenticate.md
+++ b/skills/payments/x402/references/authenticate.md
@@ -1,0 +1,80 @@
+# Authenticating with the Payments Wallet
+
+When the wallet is not signed in (detected via `npx awal@latest status` or when wallet operations fail with authentication errors), use the `npx awal@latest` CLI to authenticate.
+
+If you have access to email, you can authenticate the wallet yourself, otherwise you'll need to ask your human to give you an email address and to tell you the OTP code they receive.
+
+## Authentication Flow
+
+Authentication uses a two-step email OTP process:
+
+### Step 1: Initiate login
+
+```bash
+npx awal@latest auth login <email>
+```
+
+This sends a 6-digit verification code to the email and outputs a `flowId`.
+
+### Step 2: Verify OTP
+
+```bash
+npx awal@latest auth verify <otp>
+```
+
+Use the 6-digit code from the user's email to complete authentication. The flow ID from step 1 is saved automatically to a local file — you do not pass it as an argument. If you have the ability to access the user's email, you can read the OTP code, or you can ask your human for the code.
+
+## Input Validation
+
+Before constructing the command, validate all user-provided values to prevent shell injection:
+
+- **email**: Must match a standard email format (`^[^\s;|&`]+@[^\s;|&`]+$`). Reject if it contains spaces, semicolons, pipes, backticks, or other shell metacharacters.
+- **otp**: Must be exactly 6 digits (`^\d{6}$`).
+
+Do not pass unvalidated user input into the command.
+
+## Checking Authentication Status
+
+```bash
+npx awal@latest status
+```
+
+Displays wallet server health and authentication status including wallet address.
+
+## Example Session
+
+```bash
+# Check current status
+npx awal@latest status
+
+# Start login (sends OTP to email)
+npx awal@latest auth login user@example.com
+# Output: flowId: abc123...
+
+# After user receives code, verify (flow ID saved automatically)
+npx awal@latest auth verify 123456
+
+# Confirm authentication
+npx awal@latest status
+```
+
+## Available CLI Commands
+
+| Command                             | Purpose                                |
+| ----------------------------------- | -------------------------------------- |
+| `npx awal@latest status`            | Check server health and auth status    |
+| `npx awal@latest auth login <email>`| Send OTP code to email, returns flowId |
+| `npx awal@latest auth verify <otp>` | Complete authentication with OTP code  |
+| `npx awal@latest balance`           | Get USDC wallet balance                |
+| `npx awal@latest address`           | Get wallet address                     |
+| `npx awal@latest show`              | Open the wallet companion window       |
+
+## JSON Output
+
+All commands support `--json` for machine-readable output:
+
+```bash
+npx awal@latest status --json
+npx awal@latest auth login user@example.com --json
+npx awal@latest auth verify <otp> --json
+```

--- a/skills/payments/x402/references/fund.md
+++ b/skills/payments/x402/references/fund.md
@@ -1,0 +1,66 @@
+# Funding the Wallet
+
+Use the wallet companion app to fund the wallet with USDC via Coinbase Onramp. This supports multiple payment methods including Apple Pay, debit cards, bank transfers, and funding from a Coinbase account.
+
+## Confirm wallet is initialized and authed
+
+```bash
+npx awal@latest status
+```
+
+If the wallet is not authenticated, see `authenticate.md`.
+
+## Opening the Funding Interface
+
+```bash
+npx awal@latest show
+```
+
+This opens the wallet companion window where users can:
+
+1. Select a preset amount ($10, $20, $50) or enter a custom amount
+2. Choose their preferred payment method
+3. Complete the purchase through Coinbase Pay
+
+## Payment Methods
+
+| Method    | Description                                    |
+| --------- | ---------------------------------------------- |
+| Apple Pay | Fast checkout with Apple Pay (where available) |
+| Coinbase  | Transfer from existing Coinbase account        |
+| Card      | Debit card payment                             |
+| Bank      | ACH bank transfer                              |
+
+## Alternative
+
+You can also ask your human to send USDC on Base to your wallet address. Get the address with:
+
+```bash
+npx awal@latest address
+```
+
+## Prerequisites
+
+- Must be authenticated (`npx awal@latest status` to check)
+- Coinbase Onramp is available in supported regions (US, etc.)
+
+## Flow
+
+1. Run `npx awal@latest show` to open the wallet UI
+2. Instruct the user to click the Fund button
+3. User selects amount and payment method in the UI
+4. User completes payment through Coinbase Pay (opens in browser)
+5. USDC is deposited to the wallet once payment confirms
+
+## Checking Balance After Funding
+
+```bash
+npx awal@latest balance
+```
+
+## Notes
+
+- Funding goes through Coinbase's regulated onramp
+- Processing time varies by payment method (instant for card/Apple Pay, 1-3 days for bank)
+- Funds are deposited as USDC on Base network
+- If funding is not available, users can also send USDC on Base directly to the wallet address

--- a/skills/payments/x402/references/monetize.md
+++ b/skills/payments/x402/references/monetize.md
@@ -1,0 +1,399 @@
+# Build an x402 Payment Server
+
+Create an Express server that charges USDC for API access using the x402 payment protocol. Callers pay per-request in USDC on Base — no accounts, API keys, or subscriptions needed. Your service is automatically discoverable by other agents via the x402 Bazaar.
+
+## How It Works
+
+x402 is an HTTP-native payment protocol. When a client hits a protected endpoint without paying, the server returns HTTP 402 with payment requirements. The client signs a USDC payment and retries with a payment header. The facilitator verifies and settles the payment, and the server returns the response. Services register with the x402 Bazaar so other agents can discover and pay for them automatically.
+
+## Confirm wallet is initialized and authed
+
+```bash
+npx awal@latest status
+```
+
+If the wallet is not authenticated, see `authenticate.md`.
+
+## Step 1: Get the Payment Address
+
+Run this to get the wallet address that will receive payments:
+
+```bash
+npx awal@latest address
+```
+
+Use this address as the `payTo` value.
+
+## Step 2: Set Up the Project
+
+```bash
+mkdir x402-server && cd x402-server
+npm init -y
+npm install express @x402/express @x402/core @x402/evm @x402/extensions
+```
+
+Create `index.js`:
+
+```js
+const express = require("express");
+const { paymentMiddleware } = require("@x402/express");
+const { x402ResourceServer, HTTPFacilitatorClient } = require("@x402/core/server");
+const { ExactEvmScheme } = require("@x402/evm/exact/server");
+
+const app = express();
+app.use(express.json());
+
+const PAY_TO = "<address from step 1>";
+
+// Create facilitator client and x402 resource server
+const facilitator = new HTTPFacilitatorClient({ url: "https://x402.org/facilitator" });
+const server = new x402ResourceServer(facilitator);
+server.register("eip155:8453", new ExactEvmScheme());
+
+// x402 payment middleware — protects routes below
+app.use(
+  paymentMiddleware(
+    {
+      "GET /api/example": {
+        accepts: {
+          scheme: "exact",
+          price: "$0.01",
+          network: "eip155:8453",
+          payTo: PAY_TO,
+        },
+        description: "Description of what this endpoint returns",
+        mimeType: "application/json",
+      },
+    },
+    server,
+  ),
+);
+
+// Protected endpoint
+app.get("/api/example", (req, res) => {
+  res.json({ data: "This costs $0.01 per request" });
+});
+
+app.listen(3000, () => console.log("Server running on port 3000"));
+```
+
+## Step 3: Run It
+
+```bash
+node index.js
+```
+
+Test with curl — you should get a 402 response with payment requirements:
+
+```bash
+curl -i http://localhost:3000/api/example
+```
+
+## API Reference
+
+### paymentMiddleware(routes, server)
+
+Creates Express middleware that enforces x402 payments.
+
+| Parameter | Type                 | Description                                           |
+| --------- | -------------------- | ----------------------------------------------------- |
+| `routes`  | object               | Route config mapping route patterns to payment config |
+| `server`  | x402ResourceServer   | Pre-configured x402 resource server instance          |
+
+### x402ResourceServer
+
+Created with a facilitator client. Register payment schemes and extensions before passing to middleware.
+
+```js
+const { x402ResourceServer, HTTPFacilitatorClient } = require("@x402/core/server");
+const { ExactEvmScheme } = require("@x402/evm/exact/server");
+
+const facilitator = new HTTPFacilitatorClient({ url: "https://x402.org" });
+const server = new x402ResourceServer(facilitator);
+server.register("eip155:8453", new ExactEvmScheme());
+```
+
+| Method                      | Description                                               |
+| --------------------------- | --------------------------------------------------------- |
+| `register(network, scheme)` | Register a payment scheme for a CAIP-2 network identifier |
+
+### Route Config
+
+Each key in the routes object is `"METHOD /path"`. The value is a config object:
+
+```js
+{
+  "GET /api/data": {
+    accepts: {
+      scheme: "exact",
+      price: "$0.05",
+      network: "eip155:8453",
+      payTo: "0x...",
+    },
+    description: "Human-readable description of the endpoint",
+    mimeType: "application/json",
+    extensions: {
+      ...declareDiscoveryExtension({
+        output: {
+          example: { result: "example response" },
+          schema: {
+            properties: {
+              result: { type: "string" },
+            },
+          },
+        },
+      }),
+    },
+  },
+}
+```
+
+### Accepts Config Fields
+
+The `accepts` field can be a single object or an array (for multiple payment options):
+
+| Field     | Type   | Description                                       |
+| --------- | ------ | ------------------------------------------------- |
+| `scheme`  | string | Payment scheme: `"exact"`                         |
+| `price`   | string | USDC price (e.g. `"$0.01"`, `"$1.00"`)            |
+| `network` | string | CAIP-2 network identifier (e.g. `"eip155:8453"`)  |
+| `payTo`   | string | Ethereum address (0x...) to receive USDC payments |
+
+### Route-Level Fields
+
+| Field         | Type            | Description                                |
+| ------------- | --------------- | ------------------------------------------ |
+| `accepts`     | object or array | Payment requirements (single or multiple)  |
+| `description` | string?         | What this endpoint does (shown to clients) |
+| `mimeType`    | string?         | MIME type of the response                  |
+| `extensions`  | object?         | Extensions config (e.g. Bazaar discovery)  |
+
+### Discovery Extension
+
+The `declareDiscoveryExtension` function registers your endpoint with the x402 Bazaar so other agents can discover it:
+
+```js
+const { declareDiscoveryExtension } = require("@x402/extensions/bazaar");
+
+extensions: {
+  ...declareDiscoveryExtension({
+    output: {
+      example: { /* example response body */ },
+      schema: {
+        properties: {
+          /* JSON schema of the response */
+        },
+      },
+    },
+  }),
+}
+```
+
+| Field            | Type   | Description                                |
+| ---------------- | ------ | ------------------------------------------ |
+| `output.example` | object | Example response body for the endpoint     |
+| `output.schema`  | object | JSON schema describing the response format |
+
+### Supported Networks
+
+| Network        | Description                      |
+| -------------- | -------------------------------- |
+| `eip155:8453`  | Base mainnet (real USDC)         |
+| `eip155:84532` | Base Sepolia testnet (test USDC) |
+
+## Patterns
+
+### Multiple endpoints with different prices
+
+```js
+app.use(
+  paymentMiddleware(
+    {
+      "GET /api/cheap": {
+        accepts: {
+          scheme: "exact",
+          price: "$0.001",
+          network: "eip155:8453",
+          payTo: PAY_TO,
+        },
+        description: "Inexpensive data lookup",
+      },
+      "GET /api/expensive": {
+        accepts: {
+          scheme: "exact",
+          price: "$1.00",
+          network: "eip155:8453",
+          payTo: PAY_TO,
+        },
+        description: "Premium data access",
+      },
+      "POST /api/query": {
+        accepts: {
+          scheme: "exact",
+          price: "$0.25",
+          network: "eip155:8453",
+          payTo: PAY_TO,
+        },
+        description: "Run a custom query",
+      },
+    },
+    server,
+  ),
+);
+
+app.get("/api/cheap", (req, res) => { /* ... */ });
+app.get("/api/expensive", (req, res) => { /* ... */ });
+app.post("/api/query", (req, res) => { /* ... */ });
+```
+
+### Wildcard routes
+
+```js
+app.use(
+  paymentMiddleware(
+    {
+      "GET /api/*": {
+        accepts: {
+          scheme: "exact",
+          price: "$0.05",
+          network: "eip155:8453",
+          payTo: PAY_TO,
+        },
+        description: "API access",
+      },
+    },
+    server,
+  ),
+);
+
+app.get("/api/users", (req, res) => { /* ... */ });
+app.get("/api/posts", (req, res) => { /* ... */ });
+```
+
+### Health check (no payment)
+
+Register free endpoints before the payment middleware:
+
+```js
+app.get("/health", (req, res) => res.json({ status: "ok" }));
+
+// Payment middleware only applies to routes registered after it
+app.use(paymentMiddleware({ /* ... */ }, server));
+app.get("/api/data", (req, res) => { /* ... */ });
+```
+
+### POST with body and discovery extension
+
+```js
+app.use(
+  paymentMiddleware(
+    {
+      "POST /api/analyze": {
+        accepts: {
+          scheme: "exact",
+          price: "$0.10",
+          network: "eip155:8453",
+          payTo: PAY_TO,
+        },
+        description: "Analyze text sentiment",
+        mimeType: "application/json",
+        extensions: {
+          ...declareDiscoveryExtension({
+            output: {
+              example: { sentiment: "positive", score: 0.95 },
+              schema: {
+                properties: {
+                  sentiment: { type: "string" },
+                  score: { type: "number" },
+                },
+              },
+            },
+          }),
+        },
+      },
+    },
+    server,
+  ),
+);
+
+app.post("/api/analyze", (req, res) => {
+  const { text } = req.body;
+  // ... your logic
+  res.json({ sentiment: "positive", score: 0.95 });
+});
+```
+
+### Multiple payment options per endpoint
+
+Accept payments on multiple networks for the same endpoint:
+
+```js
+"GET /api/data": {
+  accepts: [
+    {
+      scheme: "exact",
+      price: "$0.01",
+      network: "eip155:8453",
+      payTo: EVM_ADDRESS,
+    },
+    {
+      scheme: "exact",
+      price: "$0.01",
+      network: "eip155:84532",
+      payTo: EVM_ADDRESS,
+    },
+  ],
+  description: "Data endpoint accepting Base mainnet or testnet",
+}
+```
+
+### Using the CDP facilitator (authenticated)
+
+For production use with the Coinbase facilitator (supports mainnet):
+
+```bash
+npm install @coinbase/x402
+```
+
+```js
+const { facilitator } = require("@coinbase/x402");
+const { HTTPFacilitatorClient } = require("@x402/core/server");
+
+const facilitatorClient = new HTTPFacilitatorClient(facilitator);
+const server = new x402ResourceServer(facilitatorClient);
+server.register("eip155:8453", new ExactEvmScheme());
+```
+
+This requires `CDP_API_KEY_ID` and `CDP_API_KEY_SECRET` environment variables. Get these from https://portal.cdp.coinbase.com.
+
+## Testing with the pay flow
+
+Once the server is running, use the pay commands (see `pay.md`) to test:
+
+```bash
+# Check the endpoint's payment requirements
+npx awal@latest x402 details http://localhost:3000/api/example
+
+# Make a paid request
+npx awal@latest x402 pay http://localhost:3000/api/example
+```
+
+## Pricing Guidelines
+
+| Use Case               | Suggested Price |
+| ---------------------- | --------------- |
+| Simple data lookup     | $0.001 - $0.01  |
+| API proxy / enrichment | $0.01 - $0.10   |
+| Compute-heavy query    | $0.10 - $0.50   |
+| AI inference           | $0.05 - $1.00   |
+
+## Checklist
+
+- [ ] Get wallet address with `npx awal@latest address`
+- [ ] Install `express`, `@x402/express`, `@x402/core`, `@x402/evm`, and `@x402/extensions`
+- [ ] Create `x402ResourceServer` with facilitator client and register `ExactEvmScheme` for `eip155:8453`
+- [ ] Define routes with prices, descriptions, and discovery extensions (Bazaar auto-registers when routes declare it)
+- [ ] Register payment middleware before protected routes
+- [ ] Keep health/status endpoints before payment middleware
+- [ ] Test with `curl` (should get 402) and `npx awal@latest x402 pay` (should get 200)
+- [ ] Announce your service so other agents can find and use it

--- a/skills/payments/x402/references/pay.md
+++ b/skills/payments/x402/references/pay.md
@@ -1,0 +1,66 @@
+# Making Paid x402 Requests
+
+Use the `npx awal@latest x402 pay` command to call paid API endpoints with automatic USDC payment on Base.
+
+## Confirm wallet is initialized and authed
+
+```bash
+npx awal@latest status
+```
+
+If the wallet is not authenticated, see `authenticate.md`.
+
+## Command Syntax
+
+```bash
+npx awal@latest x402 pay <url> [-X <method>] [-d <json>] [-q <params>] [-h <json>] [--max-amount <n>] [--json]
+```
+
+## Options
+
+| Option                  | Description                                        |
+| ----------------------- | -------------------------------------------------- |
+| `-X, --method <method>` | HTTP method (default: GET)                         |
+| `-d, --data <json>`     | Request body as JSON string                        |
+| `-q, --query <params>`  | Query parameters as JSON string                    |
+| `-h, --headers <json>`  | Custom HTTP headers as JSON string                 |
+| `--max-amount <amount>` | Max payment in USDC atomic units (1000000 = $1.00) |
+| `--correlation-id <id>` | Group related operations                           |
+| `--json`                | Output as JSON                                     |
+
+The USDC atomic-unit conversion table lives in `../SKILL.md` (`## USDC Atomic Units`). **Always single-quote `$` amounts** to prevent bash variable expansion (e.g. `'$1.00'`, not `$1.00`).
+
+## Input Validation
+
+Before constructing the command, validate all user-provided values to prevent shell injection:
+
+- **url**: Must be a valid URL starting with `https://` or `http://`. Reject if it contains spaces, semicolons, pipes, backticks, or shell metacharacters.
+- **data (-d)**: Must be valid JSON. Always wrap in single quotes to prevent shell expansion.
+- **max-amount**: Must be a positive integer (`^\d+$`).
+
+Do not pass unvalidated user input into the command.
+
+## Examples
+
+```bash
+# Make a GET request (auto-pays)
+npx awal@latest x402 pay https://example.com/api/weather
+
+# Make a POST request with body
+npx awal@latest x402 pay https://example.com/api/sentiment -X POST -d '{"text": "I love this product"}'
+
+# Limit max payment to $0.10
+npx awal@latest x402 pay https://example.com/api/data --max-amount 100000
+```
+
+## Prerequisites
+
+- Must be authenticated (`npx awal@latest status` to check; see `authenticate.md`)
+- Wallet must have sufficient USDC balance (`npx awal@latest balance` to check)
+- If you don't know the endpoint URL, use `search-bazaar.md` to find services first
+
+## Error Handling
+
+- "Not authenticated" — Run `npx awal@latest auth login <email>`; see `authenticate.md`
+- "No X402 payment requirements found" — URL may not be an x402 endpoint; use `search-bazaar.md` to find valid endpoints
+- "Insufficient balance" — Fund wallet with USDC; see `fund.md`

--- a/skills/payments/x402/references/search-bazaar.md
+++ b/skills/payments/x402/references/search-bazaar.md
@@ -1,0 +1,78 @@
+# Searching the x402 Bazaar
+
+Use the `npx awal@latest x402` commands to discover and inspect paid API endpoints available on the x402 bazaar marketplace. No authentication or balance is required for searching.
+
+## Commands
+
+### Search the Bazaar
+
+Find paid services by keyword using CDP's vector search:
+
+```bash
+npx awal@latest x402 bazaar search <query> [-k <n>] [--network <network>] [--scheme <scheme>] [--max-price <price>] [--json]
+```
+
+| Option                | Description                                                          |
+| --------------------- | -------------------------------------------------------------------- |
+| `-k, --top <n>`       | Number of results, 1–20 (default: 20)                                |
+| `--network <name>`    | Filter by chain (base, base-sepolia, polygon, solana, solana-devnet) |
+| `--scheme <scheme>`   | Filter by payment scheme: `exact` or `upto`                          |
+| `--max-price <price>` | Maximum price in USD (e.g. `0.01`)                                   |
+| `--asset <address>`   | Filter by payment asset address                                      |
+| `--pay-to <address>`  | Filter by recipient wallet address                                   |
+| `--extensions <type>` | Filter by extension type (e.g. `outputSchema`, `bazaar`)             |
+| `--json`              | Output as JSON                                                       |
+
+### List Bazaar Resources
+
+Browse all available resources:
+
+```bash
+npx awal@latest x402 bazaar list [--network <network>] [--full] [--refresh] [--json]
+```
+
+| Option             | Description                                                          |
+| ------------------ | -------------------------------------------------------------------- |
+| `--network <name>` | Filter by chain (base, base-sepolia, polygon, solana, solana-devnet) |
+| `--full`           | Show complete details including schemas                              |
+| `--refresh`        | Re-fetch resource index from CDP API                                 |
+| `--json`           | Output as JSON                                                       |
+
+### Discover Payment Requirements
+
+Inspect an endpoint's x402 payment requirements without paying:
+
+```bash
+npx awal@latest x402 details <url> [--json]
+```
+
+Auto-detects the correct HTTP method (GET, POST, PUT, DELETE, PATCH) by trying each until it gets a 402 response, then displays price, accepted payment schemes, network, and input/output schemas.
+
+## Examples
+
+```bash
+# Search for weather-related paid APIs
+npx awal@latest x402 bazaar search "weather"
+
+# Search with more results
+npx awal@latest x402 bazaar search "sentiment analysis" -k 10
+
+# Browse all bazaar resources with full details
+npx awal@latest x402 bazaar list --full
+
+# Check what an endpoint costs
+npx awal@latest x402 details https://example.com/api/weather
+```
+
+## Prerequisites
+
+- No authentication needed for search, list, or details commands
+
+## Next Steps
+
+Once you've found a service you want to use, see `pay.md` to make a paid request.
+
+## Error Handling
+
+- "CDP API returned 429" — Rate limited; cached data will be used if available
+- "No X402 payment requirements found" — URL may not be an x402 endpoint

--- a/skills/payments/x402/references/search-bazaar.md
+++ b/skills/payments/x402/references/search-bazaar.md
@@ -1,12 +1,42 @@
-# Searching the x402 Bazaar
+# Discovering & Browsing x402 Services
 
-Use the `npx awal@latest x402` commands to discover and inspect paid API endpoints available on the x402 bazaar marketplace. No authentication or balance is required for searching.
+Two complementary ways to find services: the **agentic.market REST API** (structured, filterable, no CLI needed) and the **awal bazaar CLI** (vector search, richer schemas). Use whichever fits the context, or combine them.
 
-## Commands
+---
 
-### Search the Bazaar
+## agentic.market REST API
 
-Find paid services by keyword using CDP's vector search:
+No authentication or wallet required.
+
+### List all services
+
+```bash
+curl https://api.agentic.market/v1/services
+```
+
+Returns a complete directory of registered x402 services with endpoint URLs, methods, prices, and categories.
+
+### Search by name or keyword
+
+```bash
+curl 'https://api.agentic.market/v1/services/search?q={query}'
+```
+
+Examples:
+
+```bash
+curl 'https://api.agentic.market/v1/services/search?q=flight'
+curl 'https://api.agentic.market/v1/services/search?q=crypto+price'
+curl 'https://api.agentic.market/v1/services/search?q=web+scraping'
+```
+
+---
+
+## awal Bazaar CLI
+
+Vector search across the CDP bazaar — finds services by semantic meaning, not just keyword match. Also the only way to inspect per-endpoint payment requirements without making a request.
+
+### Search the bazaar
 
 ```bash
 npx awal@latest x402 bazaar search <query> [-k <n>] [--network <network>] [--scheme <scheme>] [--max-price <price>] [--json]
@@ -23,9 +53,7 @@ npx awal@latest x402 bazaar search <query> [-k <n>] [--network <network>] [--sch
 | `--extensions <type>` | Filter by extension type (e.g. `outputSchema`, `bazaar`)             |
 | `--json`              | Output as JSON                                                       |
 
-### List Bazaar Resources
-
-Browse all available resources:
+### List all bazaar resources
 
 ```bash
 npx awal@latest x402 bazaar list [--network <network>] [--full] [--refresh] [--json]
@@ -38,41 +66,272 @@ npx awal@latest x402 bazaar list [--network <network>] [--full] [--refresh] [--j
 | `--refresh`        | Re-fetch resource index from CDP API                                 |
 | `--json`           | Output as JSON                                                       |
 
-### Discover Payment Requirements
-
-Inspect an endpoint's x402 payment requirements without paying:
+### Inspect payment requirements
 
 ```bash
 npx awal@latest x402 details <url> [--json]
 ```
 
-Auto-detects the correct HTTP method (GET, POST, PUT, DELETE, PATCH) by trying each until it gets a 402 response, then displays price, accepted payment schemes, network, and input/output schemas.
+Auto-detects the correct HTTP method by trying each until it gets a 402 response, then displays price, accepted payment schemes, network, and input/output schemas.
 
-## Examples
+---
+
+## When to use which
+
+| Situation | Use |
+|-----------|-----|
+| Need to enumerate or filter the full service list | agentic.market REST API |
+| Know a category / keyword, want ranked results | Either (try REST first; fall back to bazaar for semantic search) |
+| Want to verify an endpoint exists and see its price before paying | `awal x402 details <url>` |
+| Need input/output schema for a specific endpoint | `awal x402 details <url>` |
+| Searching for something niche (no exact keyword match) | `awal x402 bazaar search` (semantic) |
+
+---
+
+## Known Services Catalog
+
+Use this as a first lookup — if the endpoint you need is listed here, skip discovery and go straight to `pay.md`. All prices are USDC per request. Endpoints marked ✓ have been live-tested.
+
+### Quick-Pick by Use Case
+
+| I need…                         | Provider            | Price         |
+| ------------------------------- | ------------------- | ------------- |
+| Web search                      | Exa                 | $0.001–$0.007 |
+| Web search with LLM answer      | Perplexity          | $0.01–$0.10   |
+| Computational / math            | Wolfram Alpha       | $0.01–$0.02   |
+| Web scraping                    | Firecrawl           | $0.01         |
+| Browser automation              | Browserbase         | $0.002        |
+| LLM inference (cheap)           | Venice.ai           | $0.001        |
+| Audio transcription             | Deepgram            | $0.01–$1.00   |
+| Flight / hotel search + booking | Amadeus             | $0.002–$0.09  |
+| Live flight tracking            | FlightAware         | $0.04–$0.12   |
+| Restaurant / attraction data    | Tripadvisor         | $0.01         |
+| Email / messaging               | AgentMail           | Free          |
+| Image generation                | Run402              | $0.03         |
+| Blockchain RPC                  | Alchemy / QuickNode | Free–$10      |
+| Subgraph queries                | The Graph           | Free          |
+| Crypto spot prices (BTC, ETH…)  | CoinMarketCap ✓     | $0.01         |
+| Crypto spot prices (cheap)      | Zapper / CoinStats  | $0.001        |
+| Onchain token price by address  | CoinGecko           | $0.01         |
+| DeFi portfolio / wallet balance | Zapper              | $0.001–$0.002 |
+| Wallet analytics / SQL          | Allium              | $0.01–$0.03   |
+| Historical price on exchange    | CoinStats           | $0.001        |
+| Deep crypto research / AI       | Messari             | $0.10–$0.55   |
+
+### Search & Web
+
+**Exa** — AI-native web search with content retrieval.
+
+| Endpoint | Method | Price |
+|----------|--------|-------|
+| `https://api.exa.ai/search` | POST | $0.007 |
+| `https://api.exa.ai/contents` | POST | $0.001 |
 
 ```bash
-# Search for weather-related paid APIs
-npx awal@latest x402 bazaar search "weather"
-
-# Search with more results
-npx awal@latest x402 bazaar search "sentiment analysis" -k 10
-
-# Browse all bazaar resources with full details
-npx awal@latest x402 bazaar list --full
-
-# Check what an endpoint costs
-npx awal@latest x402 details https://example.com/api/weather
+npx awal@latest x402 pay 'https://api.exa.ai/search' -X POST \
+  --max-amount 7000 \
+  --data '{"query":"latest AI news","numResults":5}'
 ```
 
-## Prerequisites
+**Perplexity** — Web search with LLM-synthesized answers (Sonar models).
 
-- No authentication needed for search, list, or details commands
+| Endpoint | Method | Price | Notes |
+|----------|--------|-------|-------|
+| `https://pplx.x402.paysponge.com/search` | POST | $0.01 | Basic search |
+| `https://pplx.x402.paysponge.com/v1/sonar` | POST | $0.10 | Sonar model |
+| `https://pplx.x402.paysponge.com/v1/agent` | POST | $0.01 | Agentic search |
 
-## Next Steps
+**Wolfram Alpha** — Computational intelligence: math, science, unit conversion, data lookup.
 
-Once you've found a service you want to use, see `pay.md` to make a paid request.
+| Endpoint | Method | Price | Notes |
+|----------|--------|-------|-------|
+| `https://wolframalpha.x402.paysponge.com/v1/result` | GET | $0.01 | Simple text answer |
+| `https://wolframalpha.x402.paysponge.com/v2/query` | GET | $0.02 | Full structured result |
+
+**Firecrawl** (via Heurist) — Web scraping and crawling.
+
+| Endpoint | Method | Price |
+|----------|--------|-------|
+| `https://mesh.heurist.xyz/x402/agents/.../firecrawl_web_search` | POST | $0.01 |
+| `https://mesh.heurist.xyz/x402/agents/.../firecrawl_scrape_url` | POST | $0.01 |
+
+Run `npx awal@latest x402 bazaar search "firecrawl"` to resolve the full endpoint URL.
+
+**Browserbase** — Cloud browser sessions for dynamic page rendering.
+
+| Endpoint | Method | Price |
+|----------|--------|-------|
+| `https://x402.browserbase.com/browser/session/create` | POST | $0.002 |
+
+### LLM Inference
+
+**Venice.ai** (Anthropic / OpenAI / DeepSeek) — On-demand LLM calls without managing API keys.
+
+| Endpoint | Method | Price | Notes |
+|----------|--------|-------|-------|
+| `https://api.venice.ai/api/v1/chat/completions` | POST | $0.001 | Chat (OpenAI-compatible) |
+| `https://api.venice.ai/api/v1/responses` | POST | $0.001 | Responses API |
+| `https://api.venice.ai/api/v1/audio/speech` | POST | $0.001 | TTS |
+| `https://api.venice.ai/api/v1/audio/transcriptions` | POST | $0.001 | STT |
+| `https://api.venice.ai/api/v1/images/generations` | POST | $0.001 | Image gen |
+
+**Parallel** — Search and long-running agentic tasks.
+
+| Endpoint | Method | Price |
+|----------|--------|-------|
+| `https://parallelmpp.dev/api/search` | POST | $0.01 |
+| `https://parallelmpp.dev/api/task` | POST | $0.30 |
+
+### Media & Audio
+
+**Deepgram** — Audio transcription, TTS, and text intelligence.
+
+| Endpoint | Method | Price | Notes |
+|----------|--------|-------|-------|
+| `https://deepgram.x402.paysponge.com/v1/listen` | POST | $1.00 | Speech-to-text |
+| `https://deepgram.x402.paysponge.com/v1/speak` | POST | $0.01 | Text-to-speech |
+| `https://deepgram.x402.paysponge.com/v1/read` | POST | $0.01 | Text intelligence |
+
+### Travel
+
+**Amadeus** — Flight and hotel search and booking.
+
+| Endpoint | Method | Price | Notes |
+|----------|--------|-------|-------|
+| `https://stabletravel.dev/api/flights/search` | GET/POST | $0.05 | Search flights |
+| `https://stabletravel.dev/api/flights/book` | POST | $0.09 | Book a flight |
+| `https://stabletravel.dev/api/hotels/search` | GET | $0.03 | Search hotels |
+| `https://stabletravel.dev/api/hotels/book` | POST | $0.002 | Book a hotel |
+
+**FlightAware** — Live flight tracking and historical flight data.
+
+| Endpoint | Method | Price |
+|----------|--------|-------|
+| `https://stabletravel.dev/api/flightaware/flights/search` | GET | $0.10 |
+| `https://stabletravel.dev/api/flightaware/airports/{id}/flights` | GET | $0.04 |
+| `https://stabletravel.dev/api/flightaware/history/flights/{id}/track` | GET | $0.12 |
+
+### Location & Places
+
+**Tripadvisor** — Location details and search for restaurants, hotels, and attractions.
+
+| Endpoint | Method | Price |
+|----------|--------|-------|
+| `https://tripadvisor.x402.paysponge.com/api/v1/location/:locationId/details` | GET | $0.01 |
+| `https://tripadvisor.x402.paysponge.com/api/v1/location/search` | GET | $0.01 |
+
+### Social & Communication
+
+**AgentMail** — 90+ email and messaging operations, all free.
+
+```bash
+npx awal@latest x402 bazaar search "agentmail"
+```
+
+### Compute & Infra
+
+**Run402** — Code execution tiers and image generation.
+
+| Endpoint | Method | Price |
+|----------|--------|-------|
+| `https://api.run402.com/tiers/v1/prototype` | POST | $0.10 |
+| `https://api.run402.com/tiers/v1/hobby` | POST | $5.00 |
+| `https://api.run402.com/generate-image/v1` | POST | $0.03 |
+
+**Bankr** — Wallet transfers and agent task prompting, all free.
+
+| Endpoint | Method | Price |
+|----------|--------|-------|
+| `https://llm.bankr.bot/v1/chat/completions` | POST | Free |
+| `https://api.bankr.bot/wallet/transfer` | POST | Free |
+| `https://api.bankr.bot/agent/prompt` | POST | Free |
+| `https://api.bankr.bot/token-launches/deploy` | POST | Free |
+
+### Blockchain & Onchain
+
+**Alchemy** — NFT data, token balances, and EVM RPC, all free.
+
+| Endpoint | Method | Price |
+|----------|--------|-------|
+| `https://x402.alchemy.com/{chainNetwork}/v2` | POST | Free |
+| `https://x402.alchemy.com/{chainNetwork}/nft/v3/getNFTsForOwner` | GET | Free |
+| `https://x402.alchemy.com/data/v1/assets/tokens/by-address` | POST | Free |
+
+**The Graph** — Subgraph and deployment queries, free.
+
+| Endpoint | Method | Price |
+|----------|--------|-------|
+| `https://gateway.thegraph.com/api/x402/subgraphs/id/{id}` | POST | Free |
+| `https://gateway.thegraph.com/api/x402/deployments/id/{id}` | POST | Free |
+
+**QuickNode** — 80+ blockchain RPC proxies, $0.00–$10.00 depending on network and call type.
+
+```bash
+npx awal@latest x402 bazaar search "quicknode"
+```
+
+### Crypto Market Data
+
+**CoinMarketCap ✓** — Crypto quotes, DEX data, and listings.
+
+| Endpoint | Method | Price | Notes |
+|----------|--------|-------|-------|
+| `https://pro-api.coinmarketcap.com/x402/v3/cryptocurrency/quotes/latest` | GET | $0.01 | Query: `symbol=BTC,ETH`, `convert=USD` |
+| `https://pro-api.coinmarketcap.com/x402/v1/dex/search` | GET | $0.01 | DEX token/pair search |
+
+```bash
+npx awal@latest x402 pay 'https://pro-api.coinmarketcap.com/x402/v3/cryptocurrency/quotes/latest' \
+  --max-amount 10000 \
+  --query '{"symbol":"BTC,ETH","convert":"USD"}'
+```
+
+**CoinGecko** — Spot prices, onchain token prices, trending pools.
+
+| Endpoint | Method | Price | Notes |
+|----------|--------|-------|-------|
+| `https://pro-api.coingecko.com/api/v3/x402/simple/price` | GET | $0.01 | Query: `ids=bitcoin,ethereum`, `vs_currencies=usd` |
+| `https://pro-api.coingecko.com/api/v3/x402/onchain/networks/{network_id}/tokens/{contract_address}` | GET | $0.01 | Replace path params |
+
+**CoinStats** — Historical price at a specific exchange and timestamp.
+
+| Endpoint | Method | Price | Notes |
+|----------|--------|-------|-------|
+| `https://x402.coinstats.app/coins/price/exchange` | GET | $0.001 | Query: `exchange`, `from`, `to`, `timestamp` (unix) |
+
+```bash
+npx awal@latest x402 pay 'https://x402.coinstats.app/coins/price/exchange' \
+  --max-amount 1000 \
+  --query '{"exchange":"binance","from":"bitcoin","to":"usd","timestamp":"1700000000"}'
+```
+
+**Zapper** — Token prices, portfolio totals, DeFi balances.
+
+| Endpoint | Method | Price |
+|----------|--------|-------|
+| `https://public.zapper.xyz/x402/token-price` | GET | $0.001125 |
+| `https://public.zapper.xyz/x402/portfolio-totals` | GET | $0.001875 |
+| `https://public.zapper.xyz/x402/defi-balances` | GET | $0.001125 |
+
+**Allium** — Onchain token prices and wallet analytics with SQL-level access.
+
+| Endpoint | Method | Price | Notes |
+|----------|--------|-------|-------|
+| `https://agents.allium.so/api/v1/developer/prices` | POST | $0.02 | Token price lookup |
+| `https://agents.allium.so/api/v1/developer/wallet/balances` | POST | $0.03 | Wallet balance |
+| `https://agents.allium.so/api/v1/explorer/queries/run-async` | POST | $0.01 | Custom SQL query |
+
+**Messari** — Crypto research, AI chat, asset metrics, and signal intelligence.
+
+| Endpoint | Method | Price | Notes |
+|----------|--------|-------|-------|
+| `https://api.messari.io/ai/v2/chat/completions` | POST | $0.25 | LLM with crypto context |
+| `https://api.messari.io/metrics/v2/assets/details` | GET | $0.10 | Asset fundamentals |
+| `https://api.messari.io/signal/v1/assets` | GET | $0.55 | Signal intelligence |
+
+---
 
 ## Error Handling
 
-- "CDP API returned 429" — Rate limited; cached data will be used if available
-- "No X402 payment requirements found" — URL may not be an x402 endpoint
+- "CDP API returned 429" — Rate limited on the bazaar CLI; cached data will be used if available
+- "No X402 payment requirements found" — URL is not an x402 endpoint; verify via `curl -i <url>`
+- Empty results from agentic.market search — try a broader keyword or use `bazaar search` for semantic matching


### PR DESCRIPTION
## What does this PR do?                                                                               
                                                
  Adds a new bundled skill `skills/payments/x402` that consolidates the x402-related skills from         
  [coinbase/agentic-wallet-skills](https://github.com/coinbase/agentic-wallet-skills/tree/main/skills)
  into a single hermes-style skill. One router `SKILL.md` plus 5 topic refs cover wallet auth, USDC      
  funding, bazaar discovery, paid requests, and monetizing endpoints. Out-of-scope upstream skills
  (`send-usdc`, `trade`, `query-onchain-data`) are intentionally not ported.                
                                      
  ## Related Issue

  Fixes #N/A                                                                                             
   
  ## Type of Change                                                                                      
                                                
  - [x] 🎯 New skill (bundled or hub)                                                                    
                                      
  ## Changes Made                                                                                        
                                                
  - New `skills/payments/` category                                                         
  - `skills/payments/x402/SKILL.md` — router + overview, USDC table, pitfalls, pointer to
  https://docs.cdp.coinbase.com/llms.txt                                                                 
  - `skills/payments/x402/references/{authenticate,fund,search-bazaar,pay,monetize}.md` — one ref per
  upstream skill                                                                                         
  - All `npx awal@2.8.2` invocations swapped to `npx awal@latest`
                                                                                                         
  ## How to Test                                                                                         
                                                                                                         
  1. `ls skills/payments/x402/` — shows `SKILL.md` and `references/` with 5 files                        
  2. `grep -rn 'awal@2\.8\.2' skills/payments/x402/` — only hit is the intentional pitfall mention in
  `SKILL.md`                                                                                             
  3. `hermes --toolsets skills -q "Use the x402 skill to find a paid weather API and check what it
  costs"` — agent loads SKILL.md, follows Sub-Topics → `search-bazaar.md`, runs `npx awal@latest x402    
  bazaar search "weather"` then `x402 details <url>`
                                                                                                         
  ## Checklist                                                                                           
                                                                                            
  ### Code                                                                                               
                                                
  - [x] Read Contributing Guide                                                                          
  - [x] Conventional Commits          
  - [x] Searched existing PRs                                                                            
  - [x] PR scoped to this change only                                                                    
  - [x] Tested on macOS 15 (Darwin 25.4.0)                                                               
  - N/A `pytest` / new tests — docs-only addition, no code paths touched                                 
                                                                                                         
  ### Documentation & Housekeeping                                                                       
                                                                                                         
  - N/A README/docs/cli-config/CONTRIBUTING/tool-schemas updates — skill is self-documenting via SKILL.md
   + refs; no code, config, or tool changes                                                 
  - [x] Cross-platform: only uses `npx`, `node`, `npm`, `curl`; no shell-specific syntax                 
                                                                                                         
  ## For New Skills                                                                                      
                                                                                                         
  - [x] Broadly useful — x402 is a standard HTTP payment protocol relevant to any agent calling paid APIs
   or monetizing endpoints                                                                  
  - [x] SKILL.md follows standard format (Overview, When to Use, Sub-Topics, Pitfalls, Verification,     
  Further Reading)                                                                                       
  - [x] No new bundled deps — `awal` is fetched on-demand via `npx`                         
  - [ ] End-to-end `hermes` run — not executed; no authed awal wallet in dev env