### PR TITLE
feat(update): skip npm ci when node_modules already matches lockfile (#17268)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -832,64 +832,69 @@ def _print_tui_exit_summary(session_id: Optional[str], active_session_file: Opti
 _NPM_LOCK_RUNTIME_KEYS = frozenset({"ideallyInert"})
 
 
-def _tui_need_npm_install(root: Path) -> bool:
-    """True when @hermes/ink is missing or node_modules is behind package-lock.json.
+def _npm_install_in_sync(root: Path) -> bool:
+    """True when ``node_modules/.package-lock.json`` matches ``package-lock.json``.
 
-    Compares ``package-lock.json`` against ``node_modules/.package-lock.json``
-    (npm's hidden lockfile) by **content**, not mtime: git checkouts and npm
-    rewrites can bump the root lockfile's timestamp even when installed deps
-    already match, which used to trigger a spurious "Installing TUI
-    dependencies" on every launch.
+    Compares the committed lockfile against npm's hidden lockfile by
+    **content**, not mtime: git checkouts and npm rewrites can bump the root
+    lockfile's timestamp even when installed deps already match, which used
+    to trigger spurious reinstalls on every launch / update.
 
     For each entry in the root lock's ``packages`` map:
-      - missing from hidden lock → reinstall (unless the entry is marked
+      - missing from hidden lock → out of sync (unless the entry is marked
         ``optional`` or ``peer``, which npm may intentionally skip per platform)
       - present but with differing fields (excluding npm-written runtime
-        annotations like ``ideallyInert``) → reinstall
+        annotations like ``ideallyInert``) → out of sync
 
     Extra entries that exist only in the hidden lock are ignored — stale
     transitives left over from a removed dependency don't break runtime and
     we'd rather not force a reinstall for them. Falls back to mtime
     comparison if either lockfile is unparseable.
+
+    Returns ``False`` when either lockfile is absent: a missing
+    ``package-lock.json`` means we cannot prove sync, and a missing hidden
+    lockfile means ``node_modules`` was never populated. Callers that want
+    to treat "no lockfile committed" as "skip install" must guard for that
+    case before calling.
     """
+    lock = root / "package-lock.json"
+    marker = root / "node_modules" / ".package-lock.json"
+    if not lock.is_file() or not marker.is_file():
+        return False
+
+    try:
+        wanted = json.loads(lock.read_text(encoding="utf-8")).get("packages") or {}
+        installed = json.loads(marker.read_text(encoding="utf-8")).get("packages") or {}
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return marker.stat().st_mtime >= lock.stat().st_mtime
+
+    def comparable(pkg: dict) -> dict:
+        return {k: v for k, v in pkg.items() if k not in _NPM_LOCK_RUNTIME_KEYS}
+
+    for name, pkg in wanted.items():
+        if not name or not isinstance(pkg, dict):
+            continue
+
+        if name not in installed:
+            if pkg.get("optional") or pkg.get("peer"):
+                continue
+            return False
+
+        if isinstance(installed[name], dict) and comparable(pkg) != comparable(installed[name]):
+            return False
+
+    return True
+
+
+def _tui_need_npm_install(root: Path) -> bool:
+    """True when @hermes/ink is missing or node_modules is behind package-lock.json."""
     ink = root / "node_modules" / "@hermes" / "ink" / "package.json"
     if not ink.is_file():
         return True
     lock = root / "package-lock.json"
     if not lock.is_file():
         return False
-    marker = root / "node_modules" / ".package-lock.json"
-    if not marker.is_file():
-        return True
-
-    # Compare lockfile contents, not mtimes: git checkouts and npm rewrites
-    # can bump the root lockfile timestamp even when installed deps already
-    # match. Fall back to mtime when either file is unparseable.
-    try:
-        wanted = json.loads(lock.read_text(encoding="utf-8")).get("packages") or {}
-        installed = json.loads(marker.read_text(encoding="utf-8")).get("packages") or {}
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
-        return lock.stat().st_mtime > marker.stat().st_mtime
-
-    def comparable(pkg: dict) -> dict:
-        return {k: v for k, v in pkg.items() if k not in _NPM_LOCK_RUNTIME_KEYS}
-
-    for name, pkg in wanted.items():
-        if not name:
-            continue
-
-        if not isinstance(pkg, dict):
-            continue
-
-        if name not in installed:
-            if pkg.get("optional") or pkg.get("peer"):
-                continue
-            return True
-
-        if isinstance(installed[name], dict) and comparable(pkg) != comparable(installed[name]):
-            return True
-
-    return False
+    return not _npm_install_in_sync(root)
 
 
 def _find_bundled_tui(tui_dir: Path) -> Optional[Path]:
@@ -6026,6 +6031,15 @@ def _update_node_dependencies() -> None:
     print("→ Updating Node.js dependencies...")
     for label, path in paths:
         if not (path / "package.json").exists():
+            continue
+
+        # `npm ci` deletes and re-installs node_modules from scratch even
+        # when the committed lockfile already matches what's installed,
+        # which is the slow path on metered or restricted networks (#17268).
+        # Skip when the hidden lockfile already records the same package
+        # tree — npm's own freshness check is the source of truth.
+        if _npm_install_in_sync(path):
+            print(f"  ✓ {label} (already in sync with lockfile)")
             continue
 
         result = _run_npm_install_deterministic(

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -863,9 +863,21 @@ def _npm_install_in_sync(root: Path) -> bool:
         return False
 
     try:
-        wanted = json.loads(lock.read_text(encoding="utf-8")).get("packages") or {}
-        installed = json.loads(marker.read_text(encoding="utf-8")).get("packages") or {}
+        lock_doc = json.loads(lock.read_text(encoding="utf-8"))
+        marker_doc = json.loads(marker.read_text(encoding="utf-8"))
     except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return marker.stat().st_mtime >= lock.stat().st_mtime
+
+    # `json.loads` may return any JSON value; npm lockfiles are always a top-
+    # level object with a dict-shaped `packages` map. Anything else is a
+    # corrupted lockfile — treat it like an unparseable file rather than
+    # crashing `hermes update` with an AttributeError when we call `.get` /
+    # `.items` below.
+    if not isinstance(lock_doc, dict) or not isinstance(marker_doc, dict):
+        return marker.stat().st_mtime >= lock.stat().st_mtime
+    wanted = lock_doc.get("packages") or {}
+    installed = marker_doc.get("packages") or {}
+    if not isinstance(wanted, dict) or not isinstance(installed, dict):
         return marker.stat().st_mtime >= lock.stat().st_mtime
 
     def comparable(pkg: dict) -> dict:

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -106,11 +106,14 @@ class TestCmdUpdateBranchFallback:
         pull_cmds = [c for c in commands if "pull" in c]
         assert len(pull_cmds) == 0
 
+    @patch("hermes_cli.main._npm_install_in_sync", return_value=False)
     @patch("shutil.which")
     @patch("subprocess.run")
     def test_update_refreshes_repo_and_tui_node_dependencies(
-        self, mock_run, mock_which, mock_args
+        self, mock_run, mock_which, _mock_in_sync, mock_args
     ):
+        # Force the install path regardless of whether the dev machine's
+        # node_modules already matches package-lock.json (#17268).
         mock_which.side_effect = {"uv": "/usr/bin/uv", "npm": "/usr/bin/npm"}.get
         mock_run.side_effect = _make_run_side_effect(
             branch="main", verify_ok=True, commit_count="1"

--- a/tests/hermes_cli/test_update_node_dependencies_skip.py
+++ b/tests/hermes_cli/test_update_node_dependencies_skip.py
@@ -1,0 +1,185 @@
+"""`hermes update` skips `npm ci` when node_modules is already in sync (#17268).
+
+`_npm_install_in_sync(root)` decides whether the committed `package-lock.json`
+already matches `node_modules/.package-lock.json` (npm's hidden lockfile);
+when it does, `_update_node_dependencies()` must not call `npm ci` at all,
+because `npm ci` deletes and re-installs `node_modules` from scratch even
+on a no-op update — the slow path on metered or restricted networks.
+"""
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def main_mod():
+    import hermes_cli.main as m
+
+    return m
+
+
+def _write_lock(root: Path, packages: dict) -> None:
+    (root / "package-lock.json").write_text(json.dumps({"packages": packages}))
+
+
+def _write_marker(root: Path, packages: dict) -> None:
+    nm = root / "node_modules"
+    nm.mkdir(parents=True, exist_ok=True)
+    (nm / ".package-lock.json").write_text(json.dumps({"packages": packages}))
+
+
+# ---------------------------------------------------------------------------
+# _npm_install_in_sync — pure lockfile comparison
+# ---------------------------------------------------------------------------
+
+
+def test_in_sync_when_lock_and_marker_match(tmp_path: Path, main_mod) -> None:
+    pkg = {"node_modules/foo": {"version": "1.0.0"}}
+    _write_lock(tmp_path, pkg)
+    _write_marker(tmp_path, pkg)
+    assert main_mod._npm_install_in_sync(tmp_path) is True
+
+
+def test_out_of_sync_when_marker_missing(tmp_path: Path, main_mod) -> None:
+    _write_lock(tmp_path, {"node_modules/foo": {"version": "1.0.0"}})
+    assert main_mod._npm_install_in_sync(tmp_path) is False
+
+
+def test_out_of_sync_when_lockfile_missing(tmp_path: Path, main_mod) -> None:
+    _write_marker(tmp_path, {"node_modules/foo": {"version": "1.0.0"}})
+    assert main_mod._npm_install_in_sync(tmp_path) is False
+
+
+def test_out_of_sync_when_required_package_missing_from_marker(tmp_path: Path, main_mod) -> None:
+    _write_lock(
+        tmp_path,
+        {
+            "node_modules/foo": {"version": "1.0.0"},
+            "node_modules/bar": {"version": "1.0.0"},
+        },
+    )
+    _write_marker(tmp_path, {"node_modules/foo": {"version": "1.0.0"}})
+    assert main_mod._npm_install_in_sync(tmp_path) is False
+
+
+def test_in_sync_when_only_optional_or_peer_packages_missing(tmp_path: Path, main_mod) -> None:
+    _write_lock(
+        tmp_path,
+        {
+            "node_modules/foo": {"version": "1.0.0"},
+            "node_modules/optional-only": {"version": "1.0.0", "optional": True},
+            "node_modules/peer-only": {"version": "1.0.0", "peer": True},
+        },
+    )
+    _write_marker(tmp_path, {"node_modules/foo": {"version": "1.0.0"}})
+    assert main_mod._npm_install_in_sync(tmp_path) is True
+
+
+def test_in_sync_ignores_npm_runtime_annotations(tmp_path: Path, main_mod) -> None:
+    _write_lock(tmp_path, {"node_modules/foo": {"version": "1.0.0"}})
+    _write_marker(
+        tmp_path,
+        {"node_modules/foo": {"version": "1.0.0", "ideallyInert": True}},
+    )
+    assert main_mod._npm_install_in_sync(tmp_path) is True
+
+
+def test_out_of_sync_when_versions_differ(tmp_path: Path, main_mod) -> None:
+    _write_lock(tmp_path, {"node_modules/foo": {"version": "1.0.0"}})
+    _write_marker(tmp_path, {"node_modules/foo": {"version": "1.1.0"}})
+    assert main_mod._npm_install_in_sync(tmp_path) is False
+
+
+def test_falls_back_to_mtime_when_unparseable(tmp_path: Path, main_mod) -> None:
+    (tmp_path / "package-lock.json").write_text("not json")
+    nm = tmp_path / "node_modules"
+    nm.mkdir(parents=True, exist_ok=True)
+    (nm / ".package-lock.json").write_text("also not json")
+    # Marker newer → in sync (no install needed).
+    os.utime(tmp_path / "package-lock.json", (100, 100))
+    os.utime(nm / ".package-lock.json", (200, 200))
+    assert main_mod._npm_install_in_sync(tmp_path) is True
+    # Lock newer → out of sync.
+    os.utime(tmp_path / "package-lock.json", (300, 300))
+    os.utime(nm / ".package-lock.json", (200, 200))
+    assert main_mod._npm_install_in_sync(tmp_path) is False
+
+
+# ---------------------------------------------------------------------------
+# _update_node_dependencies — does not call npm when in sync (#17268)
+# ---------------------------------------------------------------------------
+
+
+def _seed_repo_root_and_tui(tmp_path: Path, *, in_sync: bool) -> Path:
+    """Populate tmp_path so it looks like both repo root and ui-tui/.
+
+    `_update_node_dependencies()` consults `PROJECT_ROOT` (repo root) and
+    `PROJECT_ROOT / "ui-tui"`. We only seed the repo-root path here; the
+    ui-tui path is left without a `package.json` so the loop short-circuits
+    on the second iteration. That keeps the test focused on the skip
+    decision for one location.
+    """
+    (tmp_path / "package.json").write_text("{}")
+    pkg = {"node_modules/foo": {"version": "1.0.0"}}
+    _write_lock(tmp_path, pkg)
+    if in_sync:
+        _write_marker(tmp_path, pkg)
+    return tmp_path
+
+
+def test_update_skips_npm_call_when_in_sync(tmp_path: Path, main_mod, capsys) -> None:
+    _seed_repo_root_and_tui(tmp_path, in_sync=True)
+
+    npm_path = "/fake/npm"
+    runner = MagicMock()
+    with patch.object(main_mod.shutil, "which", return_value=npm_path), \
+        patch.object(main_mod, "PROJECT_ROOT", tmp_path), \
+        patch.object(main_mod, "_run_npm_install_deterministic", runner):
+        main_mod._update_node_dependencies()
+
+    out = capsys.readouterr().out
+    assert "Updating Node.js dependencies" in out
+    assert "already in sync with lockfile" in out
+    runner.assert_not_called()
+
+
+def test_update_calls_npm_when_marker_missing(tmp_path: Path, main_mod, capsys) -> None:
+    _seed_repo_root_and_tui(tmp_path, in_sync=False)
+
+    npm_path = "/fake/npm"
+    runner = MagicMock(return_value=MagicMock(returncode=0, stderr=""))
+    with patch.object(main_mod.shutil, "which", return_value=npm_path), \
+        patch.object(main_mod, "PROJECT_ROOT", tmp_path), \
+        patch.object(main_mod, "_run_npm_install_deterministic", runner):
+        main_mod._update_node_dependencies()
+
+    out = capsys.readouterr().out
+    assert "already in sync" not in out
+    runner.assert_called_once()
+    args, kwargs = runner.call_args
+    assert args[0] == npm_path
+    assert args[1] == tmp_path
+
+
+def test_update_calls_npm_when_lockfile_diverges(tmp_path: Path, main_mod) -> None:
+    _seed_repo_root_and_tui(tmp_path, in_sync=True)
+    # Mutate the lockfile to add a required package the marker doesn't have.
+    _write_lock(
+        tmp_path,
+        {
+            "node_modules/foo": {"version": "1.0.0"},
+            "node_modules/bar": {"version": "1.0.0"},
+        },
+    )
+
+    runner = MagicMock(return_value=MagicMock(returncode=0, stderr=""))
+    with patch.object(main_mod.shutil, "which", return_value="/fake/npm"), \
+        patch.object(main_mod, "PROJECT_ROOT", tmp_path), \
+        patch.object(main_mod, "_run_npm_install_deterministic", runner):
+        main_mod._update_node_dependencies()
+
+    runner.assert_called_once()

--- a/tests/hermes_cli/test_update_node_dependencies_skip.py
+++ b/tests/hermes_cli/test_update_node_dependencies_skip.py
@@ -109,6 +109,36 @@ def test_falls_back_to_mtime_when_unparseable(tmp_path: Path, main_mod) -> None:
     assert main_mod._npm_install_in_sync(tmp_path) is False
 
 
+def test_falls_back_to_mtime_when_packages_is_not_a_dict(tmp_path: Path, main_mod) -> None:
+    """Corrupted lockfile where `packages` is a list/string must not crash.
+
+    `json.loads(...).get("packages")` returns whatever happens to be there.
+    A real npm lockfile always pins it to a dict, but a hand-edited or
+    truncated file can leave it as a list — and we must not blow up
+    `hermes update` with `AttributeError: 'list' object has no attribute 'items'`.
+    """
+    nm = tmp_path / "node_modules"
+    nm.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "package-lock.json").write_text(json.dumps({"packages": ["not", "a", "dict"]}))
+    (nm / ".package-lock.json").write_text(json.dumps({"packages": {"node_modules/foo": {"version": "1.0.0"}}}))
+    os.utime(tmp_path / "package-lock.json", (100, 100))
+    os.utime(nm / ".package-lock.json", (200, 200))
+    # Falls back to mtime: marker newer than lock → in sync.
+    assert main_mod._npm_install_in_sync(tmp_path) is True
+
+
+def test_falls_back_to_mtime_when_top_level_is_not_an_object(tmp_path: Path, main_mod) -> None:
+    """Top-level JSON value is a list/string instead of an object → no crash."""
+    nm = tmp_path / "node_modules"
+    nm.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "package-lock.json").write_text(json.dumps(["unexpected", "shape"]))
+    (nm / ".package-lock.json").write_text(json.dumps({"packages": {}}))
+    os.utime(tmp_path / "package-lock.json", (300, 300))
+    os.utime(nm / ".package-lock.json", (200, 200))
+    # Falls back to mtime: lock newer than marker → out of sync.
+    assert main_mod._npm_install_in_sync(tmp_path) is False
+
+
 # ---------------------------------------------------------------------------
 # _update_node_dependencies — does not call npm when in sync (#17268)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `hermes update` ran `npm ci` unconditionally in the repo root and `ui-tui/` on every run, even when nothing had changed
- `npm ci` deletes `node_modules` and re-installs from scratch — the slow path on metered or restricted networks (#17268 reports 30–60s+ stalls)
- Skip the call when `package-lock.json` content already matches `node_modules/.package-lock.json` (npm's hidden lockfile)

## The bug

`_update_node_dependencies()` in `hermes_cli/main.py` always called `_run_npm_install_deterministic` for every directory with a `package.json`. There was no \"is anything actually out of date?\" check before paying the `npm ci` cost — which is high precisely because `npm ci` is intentionally destructive (it removes `node_modules` first), so even a no-op update pays for a full registry handshake plus a clean re-install.

The TUI launcher already had a content-based lockfile comparison in `_tui_need_npm_install`, but it was scoped to the TUI's `@hermes/ink` presence guard and never called from the update path.

## The fix

Extract the lockfile-content comparison into `_npm_install_in_sync(root)`:

- Compares `package-lock.json` against `node_modules/.package-lock.json` (npm's hidden lockfile) by **content**, not mtime — so git checkouts and npm rewrites that bump lockfile timestamps don't cause spurious reinstalls
- Returns `True` only when every required (non-optional, non-peer) entry in the committed lockfile matches the hidden lockfile, ignoring npm-written runtime annotations like `ideallyInert`
- Returns `False` when either lockfile is missing (defensive default — let the existing install path handle bootstrap and recovery)
- Falls back to mtime comparison if either file is unparseable

`_update_node_dependencies()` calls the helper before each install and prints `\"✓ {label} (already in sync with lockfile)\"` when skipping. `_tui_need_npm_install` is now a thin wrapper around the helper plus its existing `@hermes/ink` presence guard — all 9 of its existing tests still pass unchanged, so the launcher's behaviour is preserved.

## Test plan
- [x] **Focused regression** — [tests/hermes_cli/test_update_node_dependencies_skip.py](https://github.com/NousResearch/hermes-agent/blob/feat/update-skip-npm-when-lockfile-matches-17268/tests/hermes_cli/test_update_node_dependencies_skip.py) covers:
  - In-sync match (skip)
  - Missing marker / missing lockfile (run install)
  - Required package missing from marker (run install)
  - Optional/peer-only divergence (skip)
  - npm runtime annotations ignored (skip)
  - Version mismatch (run install)
  - Unparseable JSON → mtime fallback (newer marker = skip; newer lock = install)
  - End-to-end: `_update_node_dependencies` does NOT call `_run_npm_install_deterministic` when in sync; DOES call it when marker missing or packages diverge
- [x] **Adjacent suite** — `tests/hermes_cli/test_tui_npm_install.py` (refactored function, all 9 tests pass unchanged); `tests/hermes_cli/test_cmd_update.py::test_update_refreshes_repo_and_tui_node_dependencies` updated to patch `_npm_install_in_sync` so the npm-call assertion runs regardless of whether the dev machine's `node_modules` happens to already match
- [x] **Regression guard** — removing the `_npm_install_in_sync` short-circuit from `_update_node_dependencies` makes `test_update_skips_npm_call_when_in_sync` fail with the expected \"npm install failed in repo root\" output instead of \"already in sync with lockfile\". Restoring the fix flips it back to passing.

## Contract Protected

| Aspect | Behaviour |
|---|---|
| Both lockfiles match (required entries) | Skip `npm ci`, print `(already in sync with lockfile)` |
| Hidden lockfile missing (fresh checkout) | Run install — node_modules was never populated |
| Committed lockfile missing | Run install — defensive default; `_run_npm_install_deterministic` falls back to `npm install` |
| Required package missing from hidden lock | Run install |
| Required package version differs | Run install |
| Only optional/peer packages differ | Skip — npm intentionally skips these per platform |
| Either lockfile unparseable | Fall back to mtime: install only if committed lockfile is newer |

Fixes #17268