### PR TITLE
fix(gemini): nest OpenAI-compat thinking config under google

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -101,6 +101,14 @@ from utils import base_url_host_matches, base_url_hostname, normalize_proxy_env_
 logger = logging.getLogger(__name__)
 
 
+def _safe_isinstance(obj: Any, maybe_type: Any) -> bool:
+    """Return False instead of raising when a patched symbol is not a type."""
+    try:
+        return isinstance(obj, maybe_type)
+    except TypeError:
+        return False
+
+
 def _extract_url_query_params(url: str):
     """Extract query params from URL, return (clean_url, default_query dict or None)."""
     parsed = urlparse(url)
@@ -843,20 +851,20 @@ def _maybe_wrap_anthropic(
     - The ``anthropic`` SDK is not installed (falls back to OpenAI wire).
     """
     # Already wrapped — don't double-wrap.
-    if isinstance(client_obj, AnthropicAuxiliaryClient):
+    if _safe_isinstance(client_obj, AnthropicAuxiliaryClient):
         return client_obj
     # Other specialized adapters we should never re-dispatch.
-    if isinstance(client_obj, CodexAuxiliaryClient):
+    if _safe_isinstance(client_obj, CodexAuxiliaryClient):
         return client_obj
     try:
         from agent.gemini_native_adapter import GeminiNativeClient
-        if isinstance(client_obj, GeminiNativeClient):
+        if _safe_isinstance(client_obj, GeminiNativeClient):
             return client_obj
     except ImportError:
         pass
     try:
         from agent.copilot_acp_client import CopilotACPClient
-        if isinstance(client_obj, CopilotACPClient):
+        if _safe_isinstance(client_obj, CopilotACPClient):
             return client_obj
     except ImportError:
         pass

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -20,12 +20,7 @@ from agent.transports.types import NormalizedResponse, ToolCall, Usage
 
 
 def _build_gemini_thinking_config(model: str, reasoning_config: dict | None) -> dict | None:
-    """Translate Hermes/OpenRouter-style reasoning config to Gemini thinkingConfig.
-
-    Gemini native/cloud-code adapters do not read ``extra_body.reasoning``.
-    They only inspect ``extra_body.thinking_config`` / ``thinkingConfig`` and
-    then request thought parts with ``includeThoughts`` enabled.
-    """
+    """Translate Hermes/OpenRouter-style reasoning config to Gemini thinkingConfig."""
     if reasoning_config is None or not isinstance(reasoning_config, dict):
         return None
 
@@ -69,6 +64,30 @@ def _build_gemini_thinking_config(model: str, reasoning_config: dict | None) -> 
             )
 
     return thinking_config
+
+
+def _snake_case_gemini_thinking_config(config: dict | None) -> dict | None:
+    """Convert Gemini thinking config keys to the OpenAI-compat field names."""
+    if not isinstance(config, dict) or not config:
+        return None
+
+    translated: Dict[str, Any] = {}
+    if isinstance(config.get("includeThoughts"), bool):
+        translated["include_thoughts"] = config["includeThoughts"]
+    if isinstance(config.get("thinkingLevel"), str) and config["thinkingLevel"].strip():
+        translated["thinking_level"] = config["thinkingLevel"].strip().lower()
+    if isinstance(config.get("thinkingBudget"), (int, float)):
+        translated["thinking_budget"] = int(config["thinkingBudget"])
+    return translated or None
+
+
+def _is_gemini_openai_compat_base_url(base_url: Any) -> bool:
+    normalized = str(base_url or "").strip().rstrip("/").lower()
+    if not normalized:
+        return False
+    if "generativelanguage.googleapis.com" not in normalized:
+        return False
+    return normalized.endswith("/openai")
 
 
 class ChatCompletionsTransport(ProviderTransport):
@@ -309,6 +328,7 @@ class ChatCompletionsTransport(ProviderTransport):
         is_nous = params.get("is_nous", False)
         is_github_models = params.get("is_github_models", False)
         provider_name = str(params.get("provider_name") or "").strip().lower()
+        base_url = params.get("base_url")
 
         provider_prefs = params.get("provider_preferences")
         if provider_prefs and is_openrouter:
@@ -362,7 +382,19 @@ class ChatCompletionsTransport(ProviderTransport):
         if is_qwen:
             extra_body["vl_high_resolution_images"] = True
 
-        if provider_name in {"gemini", "google-gemini-cli"}:
+        if provider_name == "gemini":
+            raw_thinking_config = _build_gemini_thinking_config(model, reasoning_config)
+            if _is_gemini_openai_compat_base_url(base_url):
+                thinking_config = _snake_case_gemini_thinking_config(raw_thinking_config)
+                if thinking_config:
+                    openai_compat_extra = extra_body.get("extra_body", {})
+                    google_extra = openai_compat_extra.get("google", {})
+                    google_extra["thinking_config"] = thinking_config
+                    openai_compat_extra["google"] = google_extra
+                    extra_body["extra_body"] = openai_compat_extra
+            elif raw_thinking_config:
+                extra_body["thinking_config"] = raw_thinking_config
+        elif provider_name == "google-gemini-cli":
             thinking_config = _build_gemini_thinking_config(model, reasoning_config)
             if thinking_config:
                 extra_body["thinking_config"] = thinking_config

--- a/run_agent.py
+++ b/run_agent.py
@@ -8234,6 +8234,7 @@ class AIAgent:
             model=self.model,
             messages=_msgs_for_chat,
             tools=self.tools,
+            base_url=self.base_url,
             timeout=self._resolved_api_call_timeout(),
             max_tokens=self.max_tokens,
             ephemeral_max_output_tokens=_ephemeral_out,

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -122,21 +122,25 @@ class TestChatCompletionsBuildKwargs:
         )
         assert kw["extra_body"]["think"] is False
 
-    def test_gemini_without_explicit_reasoning_config_keeps_existing_behavior(self, transport):
+    def test_gemini_native_without_explicit_reasoning_config_keeps_existing_behavior(self, transport):
         msgs = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(
             model="gemini-3-flash-preview",
             messages=msgs,
             provider_name="gemini",
+            base_url="https://generativelanguage.googleapis.com/v1beta",
         )
         assert "thinking_config" not in kw.get("extra_body", {})
+        assert "google" not in kw.get("extra_body", {})
+        assert "extra_body" not in kw.get("extra_body", {})
 
-    def test_gemini_flash_reasoning_maps_to_thinking_config(self, transport):
+    def test_gemini_native_flash_reasoning_maps_to_top_level_thinking_config(self, transport):
         msgs = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(
             model="gemini-3-flash-preview",
             messages=msgs,
             provider_name="gemini",
+            base_url="https://generativelanguage.googleapis.com/v1beta",
             reasoning_config={"enabled": True, "effort": "high"},
         )
         assert kw["extra_body"]["thinking_config"] == {
@@ -144,52 +148,85 @@ class TestChatCompletionsBuildKwargs:
             "thinkingLevel": "high",
         }
 
-    def test_gemini_25_reasoning_only_enables_visible_thoughts(self, transport):
+    def test_gemini_openai_compat_flash_reasoning_maps_to_nested_google_thinking_config(self, transport):
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gemini-3-flash-preview",
+            messages=msgs,
+            provider_name="gemini",
+            base_url="https://generativelanguage.googleapis.com/v1beta/openai",
+            reasoning_config={"enabled": True, "effort": "high"},
+        )
+        assert "thinking_config" not in kw["extra_body"]
+        assert kw["extra_body"]["extra_body"]["google"]["thinking_config"] == {
+            "include_thoughts": True,
+            "thinking_level": "high",
+        }
+
+    def test_gemini_native_25_reasoning_only_enables_visible_thoughts(self, transport):
         msgs = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(
             model="gemini-2.5-flash",
             messages=msgs,
             provider_name="gemini",
+            base_url="https://generativelanguage.googleapis.com/v1beta",
             reasoning_config={"enabled": True, "effort": "high"},
         )
         assert kw["extra_body"]["thinking_config"] == {
             "includeThoughts": True,
         }
 
-    def test_gemini_pro_reasoning_clamps_to_supported_levels(self, transport):
+    def test_gemini_openai_compat_pro_reasoning_clamps_to_supported_levels(self, transport):
         msgs = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(
             model="google/gemini-3.1-pro-preview",
             messages=msgs,
             provider_name="gemini",
+            base_url="https://generativelanguage.googleapis.com/v1beta/openai",
             reasoning_config={"enabled": True, "effort": "medium"},
         )
-        assert kw["extra_body"]["thinking_config"] == {
-            "includeThoughts": True,
-            "thinkingLevel": "low",
+        assert kw["extra_body"]["extra_body"]["google"]["thinking_config"] == {
+            "include_thoughts": True,
+            "thinking_level": "low",
         }
 
-    def test_gemini_disabled_reasoning_hides_thoughts(self, transport):
+    def test_gemini_native_disabled_reasoning_hides_thoughts(self, transport):
         msgs = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(
             model="gemini-3-flash-preview",
             messages=msgs,
             provider_name="gemini",
+            base_url="https://generativelanguage.googleapis.com/v1beta",
             reasoning_config={"enabled": False},
         )
         assert kw["extra_body"]["thinking_config"] == {
             "includeThoughts": False,
         }
 
-    def test_gemini_xhigh_clamps_to_high(self, transport):
+    def test_gemini_openai_compat_xhigh_clamps_to_high(self, transport):
         msgs = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(
             model="gemini-3-flash-preview",
             messages=msgs,
             provider_name="gemini",
+            base_url="https://generativelanguage.googleapis.com/v1beta/openai",
             reasoning_config={"enabled": True, "effort": "xhigh"},
         )
-        assert kw["extra_body"]["thinking_config"]["thinkingLevel"] == "high"
+        assert kw["extra_body"]["extra_body"]["google"]["thinking_config"]["thinking_level"] == "high"
+
+    def test_google_gemini_cli_keeps_top_level_thinking_config(self, transport):
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gemini-3-flash-preview",
+            messages=msgs,
+            provider_name="google-gemini-cli",
+            reasoning_config={"enabled": True, "effort": "high"},
+        )
+        assert kw["extra_body"]["thinking_config"] == {
+            "includeThoughts": True,
+            "thinkingLevel": "high",
+        }
+        assert "google" not in kw["extra_body"]
 
     def test_gemini_flash_minimal_clamps_to_low(self, transport):
         # Gemini 3 Flash documents low/medium/high; "minimal" isn't accepted,
@@ -199,11 +236,12 @@ class TestChatCompletionsBuildKwargs:
             model="gemini-3-flash-preview",
             messages=msgs,
             provider_name="gemini",
+            base_url="https://generativelanguage.googleapis.com/v1beta/openai",
             reasoning_config={"enabled": True, "effort": "minimal"},
         )
-        assert kw["extra_body"]["thinking_config"] == {
-            "includeThoughts": True,
-            "thinkingLevel": "low",
+        assert kw["extra_body"]["extra_body"]["google"]["thinking_config"] == {
+            "include_thoughts": True,
+            "thinking_level": "low",
         }
 
     def test_max_tokens_with_fn(self, transport):

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -144,6 +144,36 @@ class TestBuildApiKwargsOpenRouter:
         assert messages[1]["tool_calls"][0]["response_item_id"] == "fc_123"
         assert "codex_reasoning_items" in messages[1]
 
+    def test_gemini_native_passes_base_url_for_top_level_thinking_config(self, monkeypatch):
+        agent = _make_agent(
+            monkeypatch,
+            "gemini",
+            base_url="https://generativelanguage.googleapis.com/v1beta",
+            model="gemini-3-flash-preview",
+        )
+        agent.reasoning_config = {"enabled": True, "effort": "high"}
+        kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
+        assert kwargs["extra_body"]["thinking_config"] == {
+            "includeThoughts": True,
+            "thinkingLevel": "high",
+        }
+        assert "extra_body" not in kwargs["extra_body"]
+
+    def test_gemini_openai_compat_passes_base_url_for_nested_google_thinking_config(self, monkeypatch):
+        agent = _make_agent(
+            monkeypatch,
+            "gemini",
+            base_url="https://generativelanguage.googleapis.com/v1beta/openai",
+            model="gemini-3.1-pro-preview",
+        )
+        agent.reasoning_config = {"enabled": True, "effort": "high"}
+        kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
+        assert "thinking_config" not in kwargs["extra_body"]
+        assert kwargs["extra_body"]["extra_body"]["google"]["thinking_config"] == {
+            "include_thoughts": True,
+            "thinking_level": "high",
+        }
+
     def test_should_sanitize_tool_calls_codex_vs_chat(self, monkeypatch):
         """Codex API should NOT sanitize, all other APIs should sanitize."""
         # Codex mode should NOT need sanitization


### PR DESCRIPTION
## Summary

Follow-up to #16999.

The merged Gemini reasoning bridge fixed the missing Discord `💭 Reasoning:` block, but a reported regression showed that some `provider: gemini` requests still hit the official Gemini OpenAI-compat endpoint (`https://generativelanguage.googleapis.com/v1beta/openai`) and fail with HTTP 400 if Hermes sends the wrong thinking payload shape.

This PR fixes that without regressing the default native Gemini path.

## Root Cause

The right split is not just `provider: gemini` vs `google-gemini-cli`.
It is the actual Gemini route:

- native Gemini route (`https://generativelanguage.googleapis.com/v1beta`) uses `GeminiNativeClient`, which still expects top-level `extra_body["thinking_config"]`
- official Gemini OpenAI-compat route (`.../v1beta/openai`) needs a nested OpenAI-compat kwargs shape so the wire JSON becomes `extra_body.google.thinking_config`
- `google-gemini-cli` keeps the adapter-friendly top-level `thinking_config`

There was also one more plumbing bug in the chat-completions path: `run_agent.py::_build_api_kwargs()` was not passing `base_url` into `ChatCompletionsTransport.build_kwargs()`, so route detection inside the transport always saw `None` and could never select the OpenAI-compat Gemini shape.

If Hermes sends the OpenAI-compat route the wrong shape, the endpoint rejects it with HTTP 400 (`Unknown name "thinking_config"` / `Unknown name "google"`).

## Changes

| File | Change |
|---|---|
| `agent/transports/chat_completions.py` | Split Gemini thinking-config shaping by actual route, not just provider name |
| `agent/transports/chat_completions.py` | Keep native Gemini (`.../v1beta`) on top-level `extra_body["thinking_config"]` for `GeminiNativeClient` compatibility |
| `agent/transports/chat_completions.py` | For official Gemini OpenAI-compat (`.../v1beta/openai`), emit nested kwargs under `extra_body["extra_body"]["google"]["thinking_config"]` so the OpenAI SDK produces wire-level `extra_body.google.thinking_config` |
| `run_agent.py` | Pass `base_url=self.base_url` into `ChatCompletionsTransport.build_kwargs()` so Gemini route detection can distinguish native vs OpenAI-compat |
| `tests/agent/transports/test_chat_completions.py` | Add / update coverage for native Gemini, official OpenAI-compat Gemini, `google-gemini-cli`, and the Flash `minimal -> low` clamp case |
| `tests/run_agent/test_provider_parity.py` | Add run-agent-level regression coverage to verify `_build_api_kwargs()` forwards `base_url` and produces the correct Gemini thinking-config shape for both routes |
| `agent/auxiliary_client.py` | Use a safe `isinstance` guard for specialized client wrappers so Gemini route-selection tests that patch client classes with mocks do not fail with `TypeError` |

## Validation

| Check | Result |
|---|---|
| `/home/nanako/.hermes/hermes-agent/venv/bin/pytest -q tests/agent/transports/test_chat_completions.py` | `56 passed` |
| `/home/nanako/.hermes/hermes-agent/venv/bin/pytest -q tests/agent/test_gemini_cloudcode.py -k thinking_config_normalization` | `1 passed` |
| `/home/nanako/.hermes/hermes-agent/venv/bin/pytest -q tests/hermes_cli/test_gemini_provider.py -k non_native_base_url` | `1 passed` |
| `/home/nanako/.hermes/hermes-agent/venv/bin/pytest -q tests/agent/transports/test_chat_completions.py tests/run_agent/test_provider_parity.py -k 'gemini and thinking_config'` | `5 passed` |
| `/home/nanako/.hermes/hermes-agent/venv/bin/ruff check agent/transports/chat_completions.py tests/agent/transports/test_chat_completions.py` | passed |
| `/home/nanako/.hermes/hermes-agent/venv/bin/python -m py_compile agent/auxiliary_client.py agent/transports/chat_completions.py run_agent.py` | passed |
| Native smoke (`provider: gemini`, base URL `.../v1beta`) | top-level `thinking_config` still emitted |
| Live official OpenAI-compat smoke (`provider: gemini`, model `gemini-3.1-pro-preview`, endpoint `.../v1beta/openai`) | passed; no HTTP 400 |

## Repro / Effect

Before this patch:
- native Gemini path worked with top-level `thinking_config`
- OpenAI-compat Gemini path could fail with HTTP 400 if given the same shape
- even after transport-level route splitting, `_build_api_kwargs()` still needed to pass `base_url` through or the transport could not detect the OpenAI-compat route

After this patch:
- native Gemini path stays unchanged
- official OpenAI-compat Gemini path gets the documented nested shape
- `run_agent.py` correctly forwards `base_url` so the route split actually takes effect at runtime
- `google-gemini-cli` stays unchanged

Related #16941
Follow-up to #16999
