### PR TITLE
feat(custom-endpoint): support Anthropic Messages protocol for custom endpoints

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2745,7 +2745,7 @@ def _model_flow_custom(config):
     current_url = get_env_value("OPENAI_BASE_URL") or ""
     current_key = get_env_value("OPENAI_API_KEY") or ""
 
-    print("Custom OpenAI-compatible endpoint configuration:")
+    print("Custom endpoint configuration (OpenAI / Anthropic compatible):")
     if current_url:
         print(f"  Current URL: {current_url}")
     if current_key:
@@ -2831,6 +2831,44 @@ def _model_flow_custom(config):
             else:
                 print(f"  If /v1 should not be in the base URL, try: {suggested}")
 
+    # Select API protocol — auto-detect from URL, then let user confirm/choose
+    from hermes_cli.runtime_provider import _detect_api_mode_for_url
+
+    detected_mode = _detect_api_mode_for_url(effective_url)
+    api_mode = None
+    try:
+        if detected_mode:
+            mode_label = "Anthropic Messages" if detected_mode == "anthropic_messages" else (
+                "Codex Responses" if detected_mode == "codex_responses" else detected_mode
+            )
+            print(f"\n  Auto-detected API protocol: {mode_label}")
+            confirm = input(f"  Use {mode_label}? [Y/n]: ").strip().lower()
+            if confirm in ("", "y", "yes"):
+                api_mode = detected_mode
+            else:
+                detected_mode = None  # fall through to manual selection
+        if not detected_mode:
+            print("\n  Select API protocol:")
+            print("    1. OpenAI Chat Completions (default)")
+            print("    2. Anthropic Messages")
+            proto_pick = input("  Choice [1-2] (1): ").strip()
+            if proto_pick == "2":
+                api_mode = "anthropic_messages"
+            else:
+                api_mode = "chat_completions"
+    except (KeyboardInterrupt, EOFError):
+        print("\nCancelled.")
+        return
+
+    # Auto-strip /v1 for Anthropic protocol — the SDK appends /v1/messages itself
+    if api_mode == "anthropic_messages" and effective_url.rstrip("/").endswith("/v1"):
+        import re as _re
+        effective_url = _re.sub(r"/v1/?$", "", effective_url)
+        if base_url:
+            base_url = effective_url
+        print(f"  Note: stripped /v1 from URL (Anthropic SDK adds /v1/messages automatically)")
+        print(f"  Updated URL: {effective_url}")
+
     # Select model — use probe results when available, fall back to manual input
     model_name = ""
     detected_models = probe.get("models") or []
@@ -2894,7 +2932,10 @@ def _model_flow_custom(config):
         model["base_url"] = effective_url
         if effective_key:
             model["api_key"] = effective_key
-        model.pop("api_mode", None)  # let runtime auto-detect from URL
+        if api_mode and api_mode != "chat_completions":
+            model["api_mode"] = api_mode
+        else:
+            model.pop("api_mode", None)
         save_config(cfg)
         deactivate_provider()
 
@@ -2917,7 +2958,10 @@ def _model_flow_custom(config):
         _caller_model["base_url"] = effective_url
         if effective_key:
             _caller_model["api_key"] = effective_key
-        _caller_model.pop("api_mode", None)
+        if api_mode and api_mode != "chat_completions":
+            _caller_model["api_mode"] = api_mode
+        else:
+            _caller_model.pop("api_mode", None)
         config["model"] = _caller_model
         print("Endpoint saved. Use `/model` in chat or `hermes model` to set a model.")
 
@@ -2928,6 +2972,7 @@ def _model_flow_custom(config):
         model_name or "",
         context_length=context_length,
         name=display_name,
+        api_mode=api_mode,
     )
 
 
@@ -2966,7 +3011,7 @@ def _custom_provider_api_key_config_value(provider_info, resolved_api_key=""):
 
 
 def _save_custom_provider(
-    base_url, api_key="", model="", context_length=None, name=None
+    base_url, api_key="", model="", context_length=None, name=None, api_mode=None
 ):
     """Save a custom endpoint to custom_providers in config.yaml.
 
@@ -2990,6 +3035,9 @@ def _save_custom_provider(
             if model and entry.get("model") != model:
                 entry["model"] = model
                 changed = True
+            if api_mode and entry.get("api_mode") != api_mode:
+                entry["api_mode"] = api_mode
+                changed = True
             if model and context_length:
                 models_cfg = entry.get("models", {})
                 if not isinstance(models_cfg, dict):
@@ -3009,6 +3057,8 @@ def _save_custom_provider(
     entry = {"name": name, "base_url": base_url}
     if api_key:
         entry["api_key"] = api_key
+    if api_mode:
+        entry["api_mode"] = api_mode
     if model:
         entry["model"] = model
     if model and context_length:

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -926,20 +926,9 @@ def switch_model(
     if not api_mode:
         api_mode = determine_api_mode(target_provider, base_url)
 
-    # OpenCode base URLs end with /v1 for OpenAI-compatible models, but the
-    # Anthropic SDK prepends its own /v1/messages to the base_url.  Strip the
-    # trailing /v1 so the SDK constructs the correct path (e.g.
-    # https://opencode.ai/zen/go/v1/messages instead of .../v1/v1/messages).
-    # Mirrors the same logic in hermes_cli.runtime_provider.resolve_runtime_provider;
-    # without it, /model switches into an anthropic_messages-routed OpenCode
-    # model (e.g. `/model minimax-m2.7` on opencode-go, `/model claude-sonnet-4-6`
-    # on opencode-zen) hit a double /v1 and returned OpenCode's website 404 page.
-    if (
-        api_mode == "anthropic_messages"
-        and target_provider in {"opencode-zen", "opencode-go"}
-        and isinstance(base_url, str)
-        and base_url
-    ):
+    # The Anthropic SDK prepends /v1/messages to the base_url — strip
+    # trailing /v1 to avoid .../v1/v1/messages (404).
+    if api_mode == "anthropic_messages" and isinstance(base_url, str) and base_url:
         base_url = re.sub(r"/v1/?$", "", base_url)
 
     # --- Get capabilities (legacy) ---

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -598,10 +598,13 @@ def resolve_custom_provider(
         if requested not in {display_name.lower(), slug}:
             continue
 
+        entry_api_mode = (entry.get("api_mode") or "").strip().lower()
+        transport = "anthropic_messages" if entry_api_mode == "anthropic_messages" else "openai_chat"
+
         return ProviderDef(
             id=slug,
             name=display_name,
-            transport="openai_chat",
+            transport=transport,
             api_key_env_vars=(),
             base_url=api_url,
             is_aggregator=False,

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -86,6 +86,18 @@ def _detect_api_mode_for_url(base_url: str) -> Optional[str]:
     return None
 
 
+def _strip_v1_for_anthropic(api_mode: str, base_url: str) -> str:
+    """Strip trailing /v1 when using the Anthropic Messages protocol.
+
+    The Anthropic SDK prepends its own /v1/messages to the base_url.
+    If the user-provided base_url already ends with /v1, the SDK would
+    construct .../v1/v1/messages (404).  Strip /v1 so the path is correct.
+    """
+    if api_mode == "anthropic_messages" and base_url:
+        return re.sub(r"/v1/?$", "", base_url)
+    return base_url
+
+
 def _auto_detect_local_model(base_url: str) -> str:
     """Query a local server for its model name when only one model is loaded."""
     if not base_url:
@@ -278,12 +290,9 @@ def _resolve_runtime_from_pool_entry(
             if detected:
                 api_mode = detected
 
-    # OpenCode base URLs end with /v1 for OpenAI-compatible models, but the
-    # Anthropic SDK prepends its own /v1/messages to the base_url.  Strip the
-    # trailing /v1 so the SDK constructs the correct path (e.g.
-    # https://opencode.ai/zen/go/v1/messages instead of .../v1/v1/messages).
-    if api_mode == "anthropic_messages" and provider in ("opencode-zen", "opencode-go"):
-        base_url = re.sub(r"/v1/?$", "", base_url)
+    # The Anthropic SDK prepends /v1/messages to the base_url — strip
+    # trailing /v1 to avoid .../v1/v1/messages (404).
+    base_url = _strip_v1_for_anthropic(api_mode, base_url)
 
     return {
         "provider": provider,
@@ -523,11 +532,16 @@ def _resolve_named_custom_runtime(
     ]
     api_key = next((candidate for candidate in api_key_candidates if has_usable_secret(candidate)), "")
 
+    api_mode = (
+        custom_provider.get("api_mode")
+        or _detect_api_mode_for_url(base_url)
+        or "chat_completions"
+    )
+    base_url = _strip_v1_for_anthropic(api_mode, base_url)
+
     result = {
         "provider": "custom",
-        "api_mode": custom_provider.get("api_mode")
-        or _detect_api_mode_for_url(base_url)
-        or "chat_completions",
+        "api_mode": api_mode,
         "base_url": base_url,
         "api_key": api_key or "no-key-required",
         "source": f"custom_provider:{custom_provider.get('name', requested_provider)}",
@@ -633,11 +647,16 @@ def _resolve_openrouter_runtime(
     if effective_provider == "custom" and not api_key and not _is_openrouter_url:
         api_key = "no-key-required"
 
+    api_mode = (
+        _parse_api_mode(model_cfg.get("api_mode"))
+        or _detect_api_mode_for_url(base_url)
+        or "chat_completions"
+    )
+    base_url = _strip_v1_for_anthropic(api_mode, base_url)
+
     return {
         "provider": effective_provider,
-        "api_mode": _parse_api_mode(model_cfg.get("api_mode"))
-        or _detect_api_mode_for_url(base_url)
-        or "chat_completions",
+        "api_mode": api_mode,
         "base_url": base_url,
         "api_key": api_key,
         "source": source,
@@ -861,10 +880,11 @@ def _resolve_explicit_runtime(
                 if detected:
                     api_mode = detected
 
+        base_url = _strip_v1_for_anthropic(api_mode, base_url.rstrip("/"))
         return {
             "provider": provider,
             "api_mode": api_mode,
-            "base_url": base_url.rstrip("/"),
+            "base_url": base_url,
             "api_key": api_key,
             "source": "explicit",
             "requested_provider": requested_provider,
@@ -1283,9 +1303,7 @@ def resolve_runtime_provider(
                 detected = _detect_api_mode_for_url(base_url)
                 if detected:
                     api_mode = detected
-        # Strip trailing /v1 for OpenCode Anthropic models (see comment above).
-        if api_mode == "anthropic_messages" and provider in ("opencode-zen", "opencode-go"):
-            base_url = re.sub(r"/v1/?$", "", base_url)
+        base_url = _strip_v1_for_anthropic(api_mode, base_url)
         return {
             "provider": provider,
             "api_mode": api_mode,


### PR DESCRIPTION
## Summary

- Add **API protocol selection** (OpenAI / Anthropic) to the `hermes model` custom endpoint setup wizard, with auto-detection from URL patterns (e.g. `/anthropic` suffix)
- **Persist `api_mode`** in `custom_providers` config entries so the protocol choice survives across sessions
- **Read `api_mode`** from `custom_providers` in `resolve_custom_provider()` instead of hardcoding `openai_chat` transport
- **Generalize `/v1` auto-stripping** for Anthropic protocol to all providers (previously only applied to OpenCode) — the Anthropic SDK appends `/v1/messages` automatically, so a base_url ending in `/v1` would produce `.../v1/v1/messages` (HTTP 404)

## Motivation

The custom endpoint setup wizard only offered "OpenAI-compatible" endpoints. Users who needed the Anthropic Messages protocol (e.g. MiniMax `/anthropic`, LiteLLM proxies, custom gateways) had to manually edit `config.yaml` to add `api_mode: anthropic_messages`. This PR makes that a first-class option in the interactive setup flow.

Closes #12137, closes #6209

## Test plan

- [ ] `hermes model` → Custom endpoint → enter an Anthropic-protocol URL (e.g. `https://api.minimaxi.com/anthropic`) → verify auto-detection prompts "Anthropic Messages"
- [ ] `hermes model` → Custom endpoint → enter a plain URL → verify manual protocol selection appears
- [ ] Select Anthropic Messages with a `/v1`-suffixed URL → verify `/v1` is auto-stripped with a note printed
- [ ] Check `~/.hermes/config.yaml` → `custom_providers` entry has `api_mode: anthropic_messages`
- [ ] Check `model.api_mode` is correctly set in config
- [ ] `/model` in-chat switch to a custom Anthropic endpoint → verify no `/v1/v1/messages` 404
- [ ] Existing OpenAI-compatible custom endpoints continue to work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)