### PR TITLE
fix(webui): save session to active profile directory instead of default

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4157,6 +4157,16 @@ class AIAgent:
         if not messages:
             return
 
+        # Re-derive logs_dir from the current HERMES_HOME so that session
+        # files land in the active profile's directory even when the profile
+        # was switched after this agent was created (issue #16582).
+        current_home = get_hermes_home()
+        current_logs_dir = current_home / "sessions"
+        if current_logs_dir != self.logs_dir:
+            self.logs_dir = current_logs_dir
+            self.logs_dir.mkdir(parents=True, exist_ok=True)
+            self.session_log_file = self.logs_dir / f"session_{self.session_id}.json"
+
         try:
             # Clean assistant content for session logs
             cleaned = []


### PR DESCRIPTION
## What does this PR do?

When the active profile is switched at runtime (e.g. via the WebUI agent dropdown), the running agent kept writing session JSON files into the **original** profile's `sessions/` directory. Root cause: `logs_dir` was cached at agent construction time and never re-evaluated.

This PR makes `_save_session_log()` re-derive `logs_dir` from the current `HERMES_HOME` on every save. The fix is a no-op when the profile hasn't changed (the common case), so there's no overhead for single-profile users.

## Related Issue

Fixes #16582

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Re-derive `logs_dir` from `get_hermes_home()` inside `_save_session_log()` (`run_agent.py`) instead of relying on the value cached when the agent was constructed
- When the resolved path differs from `self.logs_dir`, update `self.logs_dir` and `self.session_log_file`, creating the directory as needed

## How to Test

1. Start the gateway with active profile `awen`
2. Open the WebUI, switch active profile to `ayan` via the agent dropdown, send a message — verify the session JSON is written to `~/.hermes/profiles/ayan/sessions/`
3. Verify normal single-profile usage is unaffected (session files still go to `HERMES_HOME/sessions/`) and compression-triggered session rotation still works correctly with the updated `logs_dir`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- N/A — behavior change is internal file-path resolution; no UI/log output affected. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
