### PR TITLE
feat(cli): set terminal tab title from session title via OSC 0

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -90,6 +90,7 @@ def auto_title_session(
     assistant_response: str,
     failure_callback: Optional[FailureCallback] = None,
     main_runtime: dict = None,
+    on_title=None,
 ) -> None:
     """Generate and set a session title if one doesn't already exist.
 
@@ -119,6 +120,11 @@ def auto_title_session(
     try:
         session_db.set_session_title(session_id, title)
         logger.debug("Auto-generated session title: %s", title)
+        if on_title:
+            try:
+                on_title(title)
+            except Exception:
+                pass
     except Exception as e:
         logger.debug("Failed to set auto-generated title: %s", e)
 
@@ -131,6 +137,7 @@ def maybe_auto_title(
     conversation_history: list,
     failure_callback: Optional[FailureCallback] = None,
     main_runtime: dict = None,
+    on_title=None,
 ) -> None:
     """Fire-and-forget title generation after the first exchange.
 
@@ -152,7 +159,7 @@ def maybe_auto_title(
     thread = threading.Thread(
         target=auto_title_session,
         args=(session_db, session_id, user_message, assistant_response),
-        kwargs={"failure_callback": failure_callback, "main_runtime": main_runtime},
+        kwargs={"failure_callback": failure_callback, "main_runtime": main_runtime, "on_title": on_title},
         daemon=True,
         name="auto-title",
     )

--- a/cli.py
+++ b/cli.py
@@ -3498,6 +3498,7 @@ class HermesCLI:
                 try:
                     self._session_db.set_session_title(self.session_id, self._pending_title)
                     _cprint(f"  Session title applied: {self._pending_title}")
+                    self._set_terminal_title(self._pending_title)
                     self._pending_title = None
                 except (ValueError, Exception) as e:
                     _cprint(f"  Could not apply pending title: {e}")
@@ -4117,6 +4118,11 @@ class HermesCLI:
             output.flush()
             return
         sys.stdout.write(seq)
+        sys.stdout.flush()
+
+    def _set_terminal_title(self, title: str) -> None:
+        """Set the terminal tab/window title via OSC 0 escape sequence."""
+        sys.stdout.write(f"\x1b]0;Hermes: {title}\x07")
         sys.stdout.flush()
 
     def _handle_copy_command(self, cmd_original: str) -> None:
@@ -4899,6 +4905,8 @@ class HermesCLI:
                 self.agent._invalidate_system_prompt()
 
         title_part = f" \"{session_meta['title']}\"" if session_meta.get("title") else ""
+        if session_meta.get("title"):
+            self._set_terminal_title(session_meta["title"])
         msg_count = len([m for m in self.conversation_history if m.get("role") == "user"])
         if self.conversation_history:
             _cprint(
@@ -6137,6 +6145,7 @@ class HermesCLI:
                             try:
                                 if self._session_db.set_session_title(self.session_id, new_title):
                                     _cprint(f"  Session title set: {new_title}")
+                                    self._set_terminal_title(new_title)
                                 else:
                                     _cprint("  Session not found in database.")
                             except ValueError as e:
@@ -8844,6 +8853,7 @@ class HermesCLI:
                             "api_key": self.api_key,
                             "api_mode": self.api_mode,
                         },
+                        on_title=self._set_terminal_title,
                     )
                 except Exception:
                     pass
@@ -9256,6 +9266,14 @@ class HermesCLI:
         if self._resumed:
             if self._preload_resumed_session():
                 self._display_resumed_history()
+                # Set terminal title from loaded session if it has one
+                if self._session_db:
+                    try:
+                        t = self._session_db.get_session_title(self.session_id)
+                        if t:
+                            self._set_terminal_title(t)
+                    except Exception:
+                        pass
 
         try:
             from hermes_cli.skin_engine import get_active_skin


### PR DESCRIPTION
## Summary

When running multiple Hermes sessions in separate terminal tabs (e.g. Ghostty, iTerm2, Kitty), every tab shows the generic title `Hermes`. This PR makes each tab reflect the actual session title, so users can distinguish sessions at a glance.

## What changes

**`agent/title_generator.py`**
- Added an optional `on_title` callback parameter to `auto_title_session` and `maybe_auto_title`
- After a title is successfully saved to the DB, the callback is invoked with the new title string
- The callback is forwarded through the background thread kwargs so the thread result reaches the CLI

**`cli.py`**
- Added `HermesCLI._set_terminal_title(title)` — emits the standard OSC 0 escape sequence `ESC]0;Hermes: <title>BEL` to stdout, which all modern terminals interpret as a tab/window title update
- Wired it into all 5 title-setting paths:
  1. **Auto-title after first exchange** — passed as `on_title` callback to `maybe_auto_title` so the background thread updates the tab once the LLM-generated title is ready
  2. **`/title` command** — immediately updates the tab after saving a manually set title
  3. **Pending title flush** — updates the tab when a `/title` set before the first message is finally committed to the DB on session creation
  4. **`/resume` command** — sets the tab title when switching to an existing titled session mid-conversation
  5. **Startup `--continue` resume** — fetches and sets the tab title immediately on launch when loading an existing session

## Behaviour

- New session: tab shows `Hermes` → switches to `Hermes: <generated title>` a few seconds after the first exchange
- `hermes -c "my project"`: tab shows `Hermes: my project` immediately on startup
- `/title My Project`: tab updates instantly
- All OSC sequences go to `sys.stdout` directly — same approach as the existing `_write_osc52_clipboard` helper

## Compatibility

OSC 0 is supported by virtually all modern terminal emulators (Ghostty, iTerm2, Kitty, GNOME Terminal, Windows Terminal, WezTerm, Alacritty, xterm). There is no visible side-effect in terminals that don't support it (the sequence is silently ignored).