### PR TITLE
docs(anthropic): correct OAuth scope to Max plan + extra usage credits only

### DIFF
--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -70,7 +70,7 @@ Good defaults:
 |----------|-----------|---------------|
 | **Nous Portal** | Subscription-based, zero-config | OAuth login via `hermes model` |
 | **OpenAI Codex** | ChatGPT OAuth, uses Codex models | Device code auth via `hermes model` |
-| **Anthropic** | Claude models directly — Pro/Max subscription (uses your included Claude Code usage) or API key | `hermes model` → OAuth login, or an Anthropic API key |
+| **Anthropic** | Claude models directly — Max plan + extra usage credits (OAuth), or API key for pay-per-token | `hermes model` → OAuth login (requires Max + extra credits), or an Anthropic API key |
 | **OpenRouter** | Multi-provider routing across many models | Enter your API key |
 | **Z.AI** | GLM / Zhipu-hosted models | Set `GLM_API_KEY` / `ZAI_API_KEY` |
 | **Kimi / Moonshot** | Moonshot-hosted coding and chat models | Set `KIMI_API_KEY` |

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -18,7 +18,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **OpenAI Codex** | `hermes model` (ChatGPT OAuth, uses Codex models) |
 | **GitHub Copilot** | `hermes model` (OAuth device code flow, `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, or `gh auth token`) |
 | **GitHub Copilot ACP** | `hermes model` (spawns local `copilot --acp --stdio`) |
-| **Anthropic** | `hermes model` (Claude Pro/Max subscription via OAuth — uses your included Claude Code usage; also supports Anthropic API key or manual setup-token) |
+| **Anthropic** | `hermes model` (Claude Max + extra usage credits via OAuth; also supports Anthropic API key or manual setup-token — see note below) |
 | **OpenRouter** | `OPENROUTER_API_KEY` in `~/.hermes/.env` |
 | **AI Gateway** | `AI_GATEWAY_API_KEY` in `~/.hermes/.env` (provider: `ai-gateway`) |
 | **z.ai / GLM** | `GLM_API_KEY` in `~/.hermes/.env` (provider: `zai`) |
@@ -158,10 +158,10 @@ If you're trying to switch to a provider you haven't set up yet (e.g. you only h
 
 Use Claude models directly through the Anthropic API — no OpenRouter proxy needed. Supports three auth methods:
 
-:::info Claude Pro / Max subscription usage
-When you authenticate via `hermes model` → Anthropic OAuth (or via `hermes auth add anthropic --type oauth`), Hermes consumes the **extra usage included with your Claude Pro or Max subscription** — the same quota Claude Code uses. This is per Anthropic's policy: requests identified as Claude Code route against your subscription's included Claude Code usage before any overage billing. You do not need an Anthropic API key or pay-per-token credits for this path — your Pro/Max plan covers it.
+:::caution Requires Claude Max "extra usage" credits
+When you authenticate via `hermes model` → Anthropic OAuth (or via `hermes auth add anthropic --type oauth`), Hermes routes as Claude Code against your Anthropic account. **It only works if you're on a Claude Max plan and have purchased extra usage credits.** The base Max plan allowance (the usage included in Claude Code by default) is not consumed by Hermes — only the extra/overage credits you've added on top are. Claude Pro subscribers cannot use this path.
 
-If you use an `ANTHROPIC_API_KEY` instead, requests are billed pay-per-token against that key's organization (standard API pricing, independent of your Pro/Max subscription).
+If you don't have Max + extra credits, use an `ANTHROPIC_API_KEY` instead — requests are billed pay-per-token against that key's organization (standard API pricing, independent of any Claude subscription).
 :::
 
 ```bash

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -89,7 +89,7 @@ All variables go in `~/.hermes/.env`. You can also set them with `hermes config 
 
 ## Provider Auth (OAuth)
 
-For native Anthropic auth, Hermes prefers Claude Code's own credential files when they exist because those credentials can refresh automatically. OAuth-authenticated Anthropic requests draw from the **extra Claude Code usage included with your Claude Pro or Max subscription** — no separate API key or per-token billing. Environment variables such as `ANTHROPIC_TOKEN` remain useful as manual overrides, but they are no longer the preferred path for Claude Pro/Max login.
+For native Anthropic auth, Hermes prefers Claude Code's own credential files when they exist because those credentials can refresh automatically. **OAuth against Anthropic requires a Claude Max plan with purchased extra usage credits** — Hermes routes as Claude Code, which only draws from the Max plan's extra/overage credits, not the base Max allowance, and does not work on Claude Pro. Without Max + extra credits, use an API key instead. Environment variables such as `ANTHROPIC_TOKEN` remain useful as manual overrides, but they are no longer the preferred path for Claude Max login.
 
 | Variable | Description |
 |----------|-------------|

--- a/website/docs/user-guide/features/credential-pools.md
+++ b/website/docs/user-guide/features/credential-pools.md
@@ -40,7 +40,7 @@ hermes auth add openrouter --api-key sk-or-v1-your-second-key
 # Add a second Anthropic key
 hermes auth add anthropic --type api-key --api-key sk-ant-api03-your-second-key
 
-# Add an Anthropic OAuth credential (uses your Claude Pro/Max subscription's included Claude Code usage)
+# Add an Anthropic OAuth credential (requires Claude Max plan + extra usage credits)
 hermes auth add anthropic --type oauth
 # Opens browser for OAuth login
 ```


### PR DESCRIPTION
Corrects #17399, which overstated what Anthropic OAuth actually works with in Hermes.

## The correct story
- Anthropic OAuth only works if you're on a **Claude Max plan**.
- It only consumes the **extra usage credits** you've explicitly purchased on top of Max — the base Max allowance included in Claude Code by default is **not** consumed by Hermes.
- Claude Pro subscribers cannot use this path.
- Users without Max + extra credits must use an `ANTHROPIC_API_KEY` (pay-per-token, standard API pricing).

## Files touched
- `website/docs/integrations/providers.md` — rewrote the admonition in the Anthropic (Native) section (now `:::caution`), updated provider-table row.
- `website/docs/user-guide/features/credential-pools.md` — OAuth command comment.
- `website/docs/reference/environment-variables.md` — Provider Auth (OAuth) intro.
- `website/docs/getting-started/quickstart.md` — provider-picker table row.

4 files, +7/-7.
