### PR TITLE
feat(honcho): add context injection section controls

### DIFF
--- a/optional-skills/autonomous-ai-agents/honcho/SKILL.md
+++ b/optional-skills/autonomous-ai-agents/honcho/SKILL.md
@@ -54,7 +54,10 @@ hermes honcho status    # shows resolved config, connection test, peer info
 
 ### Base Context Injection
 
-When Honcho injects context into the system prompt (in `hybrid` or `context` recall modes), it assembles the base context block in this order:
+In `hybrid` or `context` recall modes, Honcho assembles the base context block
+below and appends it to the current user message only at API-call time. The
+stored conversation and system prompt are not mutated, preserving prompt-cache
+reuse.
 
 1. **Session summary** -- a short digest of the current session so far (placed first so the model has immediate conversational continuity)
 2. **User representation** -- Honcho's accumulated model of the user (preferences, facts, patterns)
@@ -88,7 +91,7 @@ keeping Honcho active:
 
 All five keys default to `true`. Host config overrides root config per key;
 unknown keys are ignored. This only controls which base-context sections are
-formatted into automatic injection. It does not disable Honcho tools, message
+formatted into automatic user-message context. It does not disable Honcho tools, message
 saving, dialectic supplements, or necessarily underlying prefetch calls. Use
 `recallMode: "tools"` when you want no automatic injection.
 
@@ -99,7 +102,7 @@ Honcho automatically selects between two prompt strategies:
 | Condition | Strategy | What happens |
 |-----------|----------|--------------|
 | No prior session or empty representation | **Cold start** | Lightweight intro prompt; skips summary injection; encourages the model to learn about the user |
-| Existing representation and/or session history | **Warm start** | Full base context injection (summary → representation → card); richer system prompt |
+| Existing representation and/or session history | **Warm start** | Full base context (summary → representation → card) appended to the API request |
 
 You do not need to configure this -- it is automatic based on session state.
 
@@ -355,8 +358,8 @@ Use AI peer targeting to build and query the agent's own self-knowledge:
 
 ### When NOT to call tools
 
-In `hybrid` and `context` modes, base context (user representation + card + session summary) is auto-injected before every turn. Do not re-fetch what was already injected. Call tools only when:
-- You need something the injected context doesn't have
+In `hybrid` and `context` modes, base context (user representation + card + session summary) is appended to the current user message at API-call time. Do not re-fetch what was already provided. Call tools only when:
+- You need something the automatic context does not include
 - The user explicitly asks you to recall or check memory
 - You're writing a conclusion about something new
 
@@ -412,7 +415,7 @@ Honcho sanitizes the `memory-context` block before injection to prevent prompt i
 - Strips XML/HTML tags from user-authored conclusions
 - Normalizes whitespace and control characters
 - Truncates individual conclusions that exceed `messageMaxChars`
-- Escapes delimiter sequences that could break the system prompt structure
+- Escapes delimiter sequences that could break the appended context structure
 
 This fix addresses edge cases where raw user conclusions containing markup or special characters could corrupt the injected context block.
 
@@ -434,7 +437,7 @@ Observation config is synced from the server on each session init. Start a new s
 Messages over `messageMaxChars` (default 25k) are automatically chunked with `[continued]` markers. If you're hitting this often, check if tool results or skill content is inflating message size.
 
 ### Context injection too large
-If you see warnings about context budget exceeded, lower `contextTokens` or reduce `dialecticDepth`. The session summary is trimmed first when the budget is tight.
+If context is too large, lower `contextTokens` or reduce `dialecticDepth`. The assembled context makes a best-effort cut at a nearby word boundary, but hard-cuts when none is found near the budget; no individual section is preserved preferentially.
 
 ### Session summary missing
 Session summary requires at least one prior turn in the current Honcho session. On cold start (new session, no history), the summary is omitted and Honcho uses the cold-start prompt strategy instead.

--- a/optional-skills/autonomous-ai-agents/honcho/SKILL.md
+++ b/optional-skills/autonomous-ai-agents/honcho/SKILL.md
@@ -58,9 +58,39 @@ When Honcho injects context into the system prompt (in `hybrid` or `context` rec
 
 1. **Session summary** -- a short digest of the current session so far (placed first so the model has immediate conversational continuity)
 2. **User representation** -- Honcho's accumulated model of the user (preferences, facts, patterns)
-3. **AI peer card** -- the identity card for this Hermes profile's AI peer
+3. **User peer card** -- key facts about the user peer
+4. **AI representation** -- Honcho's accumulated model of this Hermes profile's AI peer
+5. **AI peer card** -- the identity card for this Hermes profile's AI peer
 
 The session summary is generated automatically by Honcho at the start of each turn (when a prior session exists). It gives the model a warm start without replaying full history.
+
+Use `contextInjection` to hide individual formatted base-context sections while
+keeping Honcho active:
+
+```json
+{
+  "contextInjection": {
+    "sessionSummary": true,
+    "userRepresentation": true,
+    "userPeerCard": true,
+    "aiRepresentation": false,
+    "aiPeerCard": false
+  },
+  "hosts": {
+    "hermes.coder": {
+      "contextInjection": {
+        "sessionSummary": false
+      }
+    }
+  }
+}
+```
+
+All five keys default to `true`. Host config overrides root config per key;
+unknown keys are ignored. This only controls which base-context sections are
+formatted into automatic injection. It does not disable Honcho tools, message
+saving, dialectic supplements, or necessarily underlying prefetch calls. Use
+`recallMode: "tools"` when you want no automatic injection.
 
 ### Cold / Warm Prompt Selection
 
@@ -367,12 +397,13 @@ Config file: `$HERMES_HOME/honcho.json` (profile-local) or `~/.honcho/config.jso
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `contextTokens` | uncapped | Max tokens for the combined base context injection (summary + representation + card). Opt-in cap — omit to leave uncapped, set to an integer to bound injection size. |
+| `contextTokens` | uncapped | Max tokens for the combined base context injection. Opt-in cap — omit to leave uncapped, set to an integer to bound injection size. |
+| `contextInjection` | all `true` | Per-section controls for formatted base-context injection: `sessionSummary`, `userRepresentation`, `userPeerCard`, `aiRepresentation`, `aiPeerCard` |
 | `injectionFrequency` | `every-turn` | `every-turn` or `first-turn` |
 | `contextCadence` | `1` | Min turns between context API calls |
 | `dialecticCadence` | `2` | Min turns between dialectic LLM calls (recommended 1–5) |
 
-The `contextTokens` budget is enforced at injection time. If the session summary + representation + card exceed the budget, Honcho trims the summary first, then the representation, preserving the card. This prevents context blowup in long sessions.
+The `contextTokens` budget is enforced at injection time and prevents context blowup in long sessions.
 
 ### Memory-context sanitization
 

--- a/plugins/memory/honcho/README.md
+++ b/plugins/memory/honcho/README.md
@@ -37,6 +37,13 @@ Two independent layers, each on its own cadence:
 4. **AI Self-Representation** — Honcho's model of the AI peer
 5. **AI Identity Card** — AI peer facts
 
+`contextInjection` can hide individual base-context sections from the formatted
+injection block. All sections default to `true` for backward compatibility.
+This only controls which base-context sections are formatted into the automatic
+prompt injection; it does not disable Honcho tools, message saving, dialectic
+supplements, or necessarily the underlying prefetch API calls. To disable all
+automatic injection, use `recallMode: "tools"`.
+
 **Layer 2 — Dialectic supplement** (fired every `dialecticCadence` turns):
 Multi-pass `.chat()` reasoning about the user, appended after base context.
 
@@ -132,8 +139,33 @@ For every key, resolution order is: **host block > root > env var > default**.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `recallMode` | string | `"hybrid"` | `"hybrid"` (auto-inject + tools), `"context"` (auto-inject only, tools hidden), `"tools"` (tools only, no injection). Legacy `"auto"` → `"hybrid"` |
+| `contextInjection` | object | all `true` | Per-section controls for formatted base-context injection: `sessionSummary`, `userRepresentation`, `userPeerCard`, `aiRepresentation`, `aiPeerCard` |
 | `observationMode` | string | `"directional"` | Preset: `"directional"` (all on) or `"unified"` (shared pool). Use `observation` object for granular control |
 | `observation` | object | — | Per-peer observation config (see Observation section) |
+
+Example:
+
+```json
+{
+  "contextInjection": {
+    "sessionSummary": true,
+    "userRepresentation": true,
+    "userPeerCard": true,
+    "aiRepresentation": false,
+    "aiPeerCard": false
+  },
+  "hosts": {
+    "hermes.coder": {
+      "contextInjection": {
+        "sessionSummary": false
+      }
+    }
+  }
+}
+```
+
+Host blocks override root `contextInjection` per key. Unknown keys are ignored,
+and omitted keys inherit from the host/root/default chain.
 
 ### Write Behavior
 
@@ -225,7 +257,7 @@ Host key is derived from the active Hermes profile: `hermes` (default) or `herme
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `contextCadence` | int | `1` | Minimum turns between base context refreshes (session summary + representation + card) |
+| `contextCadence` | int | `1` | Minimum turns between base context refreshes |
 | `dialecticCadence` | int | `1` | Minimum turns between dialectic `.chat()` firings |
 | `injectionFrequency` | string | `"every-turn"` | `"every-turn"` or `"first-turn"` (inject context on the first user message only, skip from turn 2 onward) |
 | `reasoningLevelCap` | string | — | Hard cap on reasoning level: `"minimal"`, `"low"`, `"medium"`, `"high"` |

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -468,26 +468,30 @@ class HonchoMemoryProvider(MemoryProvider):
     def _format_first_turn_context(self, ctx: dict) -> str:
         """Format the prefetch context dict into a readable system prompt block."""
         parts = []
+        context_injection = getattr(self._config, "context_injection", None) or {}
+
+        def enabled(section: str) -> bool:
+            return context_injection.get(section, True)
 
         # Session summary — session-scoped context, placed first for relevance
         summary = ctx.get("summary", "")
-        if summary:
+        if summary and enabled("sessionSummary"):
             parts.append(f"## Session Summary\n{summary}")
 
         rep = ctx.get("representation", "")
-        if rep:
+        if rep and enabled("userRepresentation"):
             parts.append(f"## User Representation\n{rep}")
 
         card = ctx.get("card", "")
-        if card:
+        if card and enabled("userPeerCard"):
             parts.append(f"## User Peer Card\n{card}")
 
         ai_rep = ctx.get("ai_representation", "")
-        if ai_rep:
+        if ai_rep and enabled("aiRepresentation"):
             parts.append(f"## AI Self-Representation\n{ai_rep}")
 
         ai_card = ctx.get("ai_card", "")
-        if ai_card:
+        if ai_card and enabled("aiPeerCard"):
             parts.append(f"## AI Identity Card\n{ai_card}")
 
         if not parts:

--- a/plugins/memory/honcho/cli.py
+++ b/plugins/memory/honcho/cli.py
@@ -45,7 +45,8 @@ def clone_honcho_for_profile(profile_name: str) -> bool:
     for key in ("recallMode", "writeFrequency", "sessionStrategy",
                 "sessionPeerPrefix", "contextTokens", "dialecticReasoningLevel",
                 "dialecticDynamic", "dialecticMaxChars", "messageMaxChars",
-                "dialecticMaxInputChars", "saveMessages", "observation"):
+                "dialecticMaxInputChars", "saveMessages", "observation",
+                "contextInjection"):
         val = default_block.get(key)
         if val is not None:
             new_block[key] = val
@@ -111,7 +112,7 @@ def cmd_enable(args) -> None:
         for key in ("recallMode", "writeFrequency", "sessionStrategy",
                     "contextTokens", "dialecticReasoningLevel", "dialecticDynamic",
                     "dialecticMaxChars", "messageMaxChars", "dialecticMaxInputChars",
-                    "saveMessages", "observation"):
+                    "saveMessages", "observation", "contextInjection"):
             val = default_block.get(key)
             if val is not None and key not in block:
                 block[key] = val

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -82,6 +82,13 @@ def resolve_config_path() -> Path:
 
 _RECALL_MODE_ALIASES = {"auto": "hybrid"}
 _VALID_RECALL_MODES = {"hybrid", "context", "tools"}
+_CONTEXT_INJECTION_DEFAULTS = {
+    "sessionSummary": True,
+    "userRepresentation": True,
+    "userPeerCard": True,
+    "aiRepresentation": True,
+    "aiPeerCard": True,
+}
 
 
 def _normalize_recall_mode(val: str) -> str:
@@ -119,6 +126,22 @@ def _parse_int_config(host_val, root_val, default: int) -> int:
             except (ValueError, TypeError):
                 pass
     return default
+
+
+def _parse_context_injection(host_val, root_val) -> dict[str, bool]:
+    """Resolve section-level base-context injection flags.
+
+    Root values override defaults. Host values override root per key.
+    Unknown keys and non-dict blocks are ignored.
+    """
+    resolved = dict(_CONTEXT_INJECTION_DEFAULTS)
+    for block in (root_val, host_val):
+        if not isinstance(block, dict):
+            continue
+        for key in _CONTEXT_INJECTION_DEFAULTS:
+            if key in block:
+                resolved[key] = bool(block[key])
+    return resolved
 
 
 def _parse_dialectic_depth(host_val, root_val) -> int:
@@ -266,6 +289,10 @@ class HonchoClientConfig:
     write_frequency: str | int = "async"
     # Prefetch budget (None = no cap; set to an integer to bound auto-injected context)
     context_tokens: int | None = None
+    # Section-level controls for formatted base context injection.
+    context_injection: dict[str, bool] = field(
+        default_factory=lambda: dict(_CONTEXT_INJECTION_DEFAULTS)
+    )
     # Dialectic (peer.chat) settings
     # reasoning_level: "minimal" | "low" | "medium" | "high" | "max"
     dialectic_reasoning_level: str = "low"
@@ -463,6 +490,10 @@ class HonchoClientConfig:
             context_tokens=_parse_context_tokens(
                 host_block.get("contextTokens"),
                 raw.get("contextTokens"),
+            ),
+            context_injection=_parse_context_injection(
+                host_block.get("contextInjection"),
+                raw.get("contextInjection"),
             ),
             dialectic_reasoning_level=(
                 host_block.get("dialecticReasoningLevel")

--- a/tests/honcho_plugin/test_cli.py
+++ b/tests/honcho_plugin/test_cli.py
@@ -154,3 +154,55 @@ class TestCmdStatus:
         out = capsys.readouterr().out
         assert "FAILED (Invalid API key)" in out
         assert "Connection... OK" not in out
+
+
+class TestProfileContextInjectionInheritance:
+    def test_clone_inherits_context_injection(self, monkeypatch):
+        import plugins.memory.honcho.cli as honcho_cli
+
+        cfg = {
+            "apiKey": "test-key",
+            "hosts": {
+                "hermes": {
+                    "contextInjection": {
+                        "sessionSummary": False,
+                        "aiPeerCard": False,
+                    },
+                },
+            },
+        }
+        monkeypatch.setattr(honcho_cli, "_read_config", lambda: cfg)
+        monkeypatch.setattr(honcho_cli, "_write_config", lambda written: None)
+        monkeypatch.setattr(honcho_cli, "_ensure_peer_exists", lambda host: True)
+
+        assert honcho_cli.clone_honcho_for_profile("coder") is True
+        assert cfg["hosts"]["hermes.coder"]["contextInjection"] == {
+            "sessionSummary": False,
+            "aiPeerCard": False,
+        }
+
+    def test_enable_inherits_context_injection_for_new_profile_block(self, monkeypatch):
+        import plugins.memory.honcho.cli as honcho_cli
+
+        cfg = {
+            "hosts": {
+                "hermes": {
+                    "contextInjection": {
+                        "userRepresentation": False,
+                        "aiRepresentation": False,
+                    },
+                },
+            },
+        }
+        monkeypatch.setattr(honcho_cli, "_read_config", lambda: cfg)
+        monkeypatch.setattr(honcho_cli, "_host_key", lambda: "hermes.coder")
+        monkeypatch.setattr(honcho_cli, "_write_config", lambda written: None)
+        monkeypatch.setattr(honcho_cli, "_ensure_peer_exists", lambda host: True)
+        monkeypatch.setattr(honcho_cli, "_config_path", lambda: "honcho.json")
+
+        honcho_cli.cmd_enable(SimpleNamespace())
+
+        assert cfg["hosts"]["hermes.coder"]["contextInjection"] == {
+            "userRepresentation": False,
+            "aiRepresentation": False,
+        }

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -988,6 +988,35 @@ class TestBaseContextSummary:
         assert "AI Self-Representation" not in formatted
         assert "AI Identity Card" in formatted
 
+    def test_formatter_uses_context_injection_from_temp_config(self, tmp_path):
+        """Resolved config flags control the provider's formatted context."""
+        import json
+        from plugins.memory.honcho.client import HonchoClientConfig
+
+        config_path = tmp_path / "honcho.json"
+        config_path.write_text(json.dumps({
+            "contextInjection": {
+                "sessionSummary": False,
+                "aiPeerCard": False,
+            },
+        }))
+        provider = HonchoMemoryProvider()
+        provider._config = HonchoClientConfig.from_global_config(config_path=config_path)
+
+        formatted = provider._format_first_turn_context({
+            "summary": "summary",
+            "representation": "user representation",
+            "card": "user card",
+            "ai_representation": "ai representation",
+            "ai_card": "ai card",
+        })
+
+        assert "Session Summary" not in formatted
+        assert "AI Identity Card" not in formatted
+        assert "User Representation" in formatted
+        assert "User Peer Card" in formatted
+        assert "AI Self-Representation" in formatted
+
     def test_formatter_all_disabled_returns_empty_string(self):
         """If every supplied base context section is disabled, nothing is injected."""
         from plugins.memory.honcho.client import HonchoClientConfig

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -941,6 +941,95 @@ class TestBaseContextSummary:
         formatted = provider._format_first_turn_context(ctx)
         assert "Session Summary" not in formatted
 
+    def test_formatter_default_includes_all_provided_sections(self):
+        """Default formatter behavior includes every supplied base context section."""
+        provider = HonchoMemoryProvider()
+        ctx = {
+            "summary": "summary",
+            "representation": "user representation",
+            "card": "user card",
+            "ai_representation": "ai representation",
+            "ai_card": "ai card",
+        }
+
+        formatted = provider._format_first_turn_context(ctx)
+
+        assert "## Session Summary\nsummary" in formatted
+        assert "## User Representation\nuser representation" in formatted
+        assert "## User Peer Card\nuser card" in formatted
+        assert "## AI Self-Representation\nai representation" in formatted
+        assert "## AI Identity Card\nai card" in formatted
+
+    def test_formatter_omits_disabled_sections(self):
+        """Configured false flags remove only those base context sections."""
+        from plugins.memory.honcho.client import HonchoClientConfig
+
+        provider = HonchoMemoryProvider()
+        provider._config = HonchoClientConfig(context_injection={
+            "sessionSummary": True,
+            "userRepresentation": False,
+            "userPeerCard": True,
+            "aiRepresentation": False,
+            "aiPeerCard": True,
+        })
+        ctx = {
+            "summary": "summary",
+            "representation": "user representation",
+            "card": "user card",
+            "ai_representation": "ai representation",
+            "ai_card": "ai card",
+        }
+
+        formatted = provider._format_first_turn_context(ctx)
+
+        assert "Session Summary" in formatted
+        assert "User Representation" not in formatted
+        assert "User Peer Card" in formatted
+        assert "AI Self-Representation" not in formatted
+        assert "AI Identity Card" in formatted
+
+    def test_formatter_all_disabled_returns_empty_string(self):
+        """If every supplied base context section is disabled, nothing is injected."""
+        from plugins.memory.honcho.client import HonchoClientConfig
+
+        provider = HonchoMemoryProvider()
+        provider._config = HonchoClientConfig(context_injection={
+            "sessionSummary": False,
+            "userRepresentation": False,
+            "userPeerCard": False,
+            "aiRepresentation": False,
+            "aiPeerCard": False,
+        })
+        ctx = {
+            "summary": "summary",
+            "representation": "user representation",
+            "card": "user card",
+            "ai_representation": "ai representation",
+            "ai_card": "ai card",
+        }
+
+        assert provider._format_first_turn_context(ctx) == ""
+
+    def test_missing_config_context_injection_preserves_old_behavior(self):
+        """Missing config/context_injection should behave like all sections enabled."""
+        provider = HonchoMemoryProvider()
+        provider._config = SimpleNamespace()
+        ctx = {
+            "summary": "summary",
+            "representation": "user representation",
+            "card": "user card",
+            "ai_representation": "ai representation",
+            "ai_card": "ai card",
+        }
+
+        formatted = provider._format_first_turn_context(ctx)
+
+        assert "Session Summary" in formatted
+        assert "User Representation" in formatted
+        assert "User Peer Card" in formatted
+        assert "AI Self-Representation" in formatted
+        assert "AI Identity Card" in formatted
+
 
 class TestDialecticDepth:
     """Tests for the dialecticDepth multi-pass system."""

--- a/tests/test_honcho_client_config.py
+++ b/tests/test_honcho_client_config.py
@@ -103,3 +103,114 @@ class TestHonchoClientConfigAutoEnable:
 
         assert cfg.api_key == "fallback-key"
         assert cfg.enabled is True  # from_env() sets enabled=True
+
+
+class TestHonchoClientConfigContextInjection:
+    """Test section-level Honcho base context injection config."""
+
+    def test_defaults_all_sections_enabled(self):
+        cfg = HonchoClientConfig()
+
+        assert cfg.context_injection == {
+            "sessionSummary": True,
+            "userRepresentation": True,
+            "userPeerCard": True,
+            "aiRepresentation": True,
+            "aiPeerCard": True,
+        }
+
+    def test_root_level_partial_override(self, tmp_path):
+        config_path = tmp_path / "config.json"
+        config_path.write_text(json.dumps({
+            "contextInjection": {
+                "sessionSummary": False,
+                "aiPeerCard": False,
+            },
+        }))
+
+        cfg = HonchoClientConfig.from_global_config(config_path=config_path)
+
+        assert cfg.context_injection["sessionSummary"] is False
+        assert cfg.context_injection["aiPeerCard"] is False
+        assert cfg.context_injection["userRepresentation"] is True
+        assert cfg.context_injection["userPeerCard"] is True
+        assert cfg.context_injection["aiRepresentation"] is True
+
+    def test_host_level_per_key_override_over_root(self, tmp_path):
+        config_path = tmp_path / "config.json"
+        config_path.write_text(json.dumps({
+            "contextInjection": {
+                "sessionSummary": False,
+                "userRepresentation": False,
+                "aiPeerCard": False,
+            },
+            "hosts": {
+                "hermes": {
+                    "contextInjection": {
+                        "sessionSummary": True,
+                    },
+                },
+            },
+        }))
+
+        cfg = HonchoClientConfig.from_global_config(config_path=config_path)
+
+        assert cfg.context_injection["sessionSummary"] is True
+        assert cfg.context_injection["userRepresentation"] is False
+        assert cfg.context_injection["aiPeerCard"] is False
+
+    def test_host_false_overrides_root_true(self, tmp_path):
+        config_path = tmp_path / "config.json"
+        config_path.write_text(json.dumps({
+            "contextInjection": {
+                "userPeerCard": True,
+            },
+            "hosts": {
+                "hermes": {
+                    "contextInjection": {
+                        "userPeerCard": False,
+                    },
+                },
+            },
+        }))
+
+        cfg = HonchoClientConfig.from_global_config(config_path=config_path)
+
+        assert cfg.context_injection["userPeerCard"] is False
+
+    def test_unknown_keys_ignored(self, tmp_path):
+        config_path = tmp_path / "config.json"
+        config_path.write_text(json.dumps({
+            "contextInjection": {
+                "sessionSummary": False,
+                "futureSection": False,
+            },
+            "hosts": {
+                "hermes": {
+                    "contextInjection": {
+                        "anotherUnknown": False,
+                    },
+                },
+            },
+        }))
+
+        cfg = HonchoClientConfig.from_global_config(config_path=config_path)
+
+        assert "futureSection" not in cfg.context_injection
+        assert "anotherUnknown" not in cfg.context_injection
+        assert cfg.context_injection["sessionSummary"] is False
+
+    def test_non_dict_root_and_host_ignored(self, tmp_path):
+        config_path = tmp_path / "config.json"
+        config_path.write_text(json.dumps({
+            "contextInjection": False,
+            "hosts": {
+                "hermes": {
+                    "contextInjection": ["sessionSummary"],
+                },
+            },
+        }))
+
+        cfg = HonchoClientConfig.from_global_config(config_path=config_path)
+
+        assert all(cfg.context_injection.values())

--- a/website/docs/user-guide/features/honcho.md
+++ b/website/docs/user-guide/features/honcho.md
@@ -54,12 +54,16 @@ Get an API key at [honcho.dev](https://honcho.dev).
 
 ### Two-Layer Context Injection
 
-Every turn (in `hybrid` or `context` mode), Honcho assembles two layers of context injected into the system prompt:
+Every turn (in `hybrid` or `context` mode), Honcho assembles two layers of
+context that are appended to the current user message only at API-call time.
+The stored conversation and system prompt are not mutated, preserving
+prompt-cache reuse:
 
 1. **Base context** — session summary, user representation, user peer card, AI self-representation, and AI identity card. Refreshed on `contextCadence`. This is the "who is this user" layer.
 2. **Dialectic supplement** — LLM-synthesized reasoning about the user's current state and needs. Refreshed on `dialecticCadence`. This is the "what matters right now" layer.
 
-Both layers are concatenated and truncated to the `contextTokens` budget (if set).
+Both layers are concatenated and truncated to the `contextTokens` budget (if set)
+before being appended to the API request.
 
 ### Cold/Warm Prompt Selection
 
@@ -110,14 +114,15 @@ Honcho is configured in `~/.honcho/config.json` (global) or `$HERMES_HOME/honcho
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `contextTokens` | `null` (uncapped) | Token budget for auto-injected context per turn. Set to an integer (e.g. 1200) to cap. Truncates at word boundaries |
+| `contextTokens` | `null` (uncapped) | Token budget for automatic context per turn. Set to an integer (e.g. 1200) to cap. Makes a best-effort cut at a nearby word boundary, otherwise hard-cuts |
+| `contextInjection` | all `true` | Per-section controls for formatted base-context injection: `sessionSummary`, `userRepresentation`, `userPeerCard`, `aiRepresentation`, `aiPeerCard` |
 | `contextCadence` | `1` | Minimum turns between `context()` API calls (base layer refresh) |
 | `dialecticCadence` | `2` | Minimum turns between `peer.chat()` LLM calls (dialectic layer). Recommended 1–5. In `tools` mode, irrelevant — model calls explicitly |
 | `dialecticDepth` | `1` | Number of `.chat()` passes per dialectic invocation. Clamped to 1–3 |
 | `dialecticDepthLevels` | `null` | Optional array of reasoning levels per pass, e.g. `["minimal", "low", "medium"]`. Overrides proportional defaults |
 | `dialecticReasoningLevel` | `'low'` | Base reasoning level: `minimal`, `low`, `medium`, `high`, `max` |
 | `dialecticDynamic` | `true` | When `true`, model can override reasoning level per-call via tool param |
-| `dialecticMaxChars` | `600` | Max chars of dialectic result injected into system prompt |
+| `dialecticMaxChars` | `600` | Max chars of dialectic result appended to the API request |
 | `recallMode` | `'hybrid'` | `hybrid` (auto-inject + tools), `context` (inject only), `tools` (tools only) |
 | `writeFrequency` | `'async'` | When to flush messages: `async` (background thread), `turn` (sync), `session` (batch on end), or integer N |
 | `saveMessages` | `true` | Whether to persist messages to Honcho API |
@@ -133,9 +138,32 @@ Honcho is configured in `~/.honcho/config.json` (global) or `$HERMES_HOME/honcho
 - `global` — single session across all directories.
 
 **Recall mode** controls how memory flows into conversations:
-- `hybrid` — context auto-injected into system prompt AND tools available (model decides when to query).
+- `hybrid` — context appended to the current user message at API-call time AND tools available (model decides when to query).
 - `context` — auto-injection only, tools hidden.
 - `tools` — tools only, no auto-injection. Agent must explicitly call `honcho_reasoning`, `honcho_search`, etc.
+
+**Context injection sections** can be disabled individually without disabling
+Honcho, its tools, message saving, or dialectic supplements. All sections default
+to `true`; host-level values override root-level values per key. Enabled sections
+are appended to the current user message at API-call time. For example:
+
+```json
+{
+  "contextInjection": {
+    "aiRepresentation": false,
+    "aiPeerCard": false
+  },
+  "hosts": {
+    "hermes.coder": {
+      "contextInjection": {
+        "sessionSummary": false
+      }
+    }
+  }
+}
+```
+
+Use `recallMode: "tools"` to disable automatic injection entirely.
 
 **Settings per recall mode:**
 

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -55,6 +55,13 @@ AI-native cross-session user modeling with dialectic reasoning, session-scoped c
 
 **Architecture:** Two-layer context injection — a base layer (session summary + representation + peer card, refreshed on `contextCadence`) plus a dialectic supplement (LLM reasoning, refreshed on `dialecticCadence`). The dialectic automatically selects cold-start prompts (general user facts) vs. warm prompts (session-scoped context) based on whether base context exists.
 
+Use `contextInjection` to hide individual formatted base-context sections:
+`sessionSummary`, `userRepresentation`, `userPeerCard`, `aiRepresentation`,
+and `aiPeerCard`. All default to `true`; host blocks override root config per
+key. This does not disable Honcho tools, message saving, dialectic supplements,
+or necessarily underlying prefetch calls. Use `recallMode: "tools"` for no
+automatic injection.
+
 **Three orthogonal config knobs** control cost and depth independently:
 
 - `contextCadence` — how often the base layer refreshes (API call frequency)
@@ -81,6 +88,7 @@ hermes memory setup        # select "honcho"
 | `aiPeer` | host key | AI peer identity (one per profile) |
 | `workspace` | host key | Shared workspace ID |
 | `contextTokens` | `null` (uncapped) | Token budget for auto-injected context per turn. Truncates at word boundaries |
+| `contextInjection` | all `true` | Per-section controls for formatted base-context injection |
 | `contextCadence` | `1` | Minimum turns between `context()` API calls (base layer refresh) |
 | `dialecticCadence` | `2` | Minimum turns between `peer.chat()` LLM calls. Recommended 1–5. Only applies to `hybrid`/`context` modes |
 | `dialecticDepth` | `1` | Number of `.chat()` passes per dialectic invocation. Clamped 1–3. Pass 0: cold/warm prompt, pass 1: self-audit, pass 2: reconciliation |
@@ -104,6 +112,13 @@ hermes memory setup        # select "honcho"
 ```json
 {
   "apiKey": "your-key-from-app.honcho.dev",
+  "contextInjection": {
+    "sessionSummary": true,
+    "userRepresentation": true,
+    "userPeerCard": true,
+    "aiRepresentation": false,
+    "aiPeerCard": false
+  },
   "hosts": {
     "hermes": {
       "enabled": true,

--- a/website/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-honcho.md
+++ b/website/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-honcho.md
@@ -69,13 +69,46 @@ hermes honcho status    # shows resolved config, connection test, peer info
 
 ### Base Context Injection
 
-When Honcho injects context into the system prompt (in `hybrid` or `context` recall modes), it assembles the base context block in this order:
+In `hybrid` or `context` recall modes, Honcho assembles the base context block
+below and appends it to the current user message only at API-call time. The
+stored conversation and system prompt are not mutated, preserving prompt-cache
+reuse.
 
 1. **Session summary** -- a short digest of the current session so far (placed first so the model has immediate conversational continuity)
 2. **User representation** -- Honcho's accumulated model of the user (preferences, facts, patterns)
-3. **AI peer card** -- the identity card for this Hermes profile's AI peer
+3. **User peer card** -- key facts about the user peer
+4. **AI representation** -- Honcho's accumulated model of this Hermes profile's AI peer
+5. **AI peer card** -- the identity card for this Hermes profile's AI peer
 
 The session summary is generated automatically by Honcho at the start of each turn (when a prior session exists). It gives the model a warm start without replaying full history.
+
+Use `contextInjection` to hide individual formatted base-context sections while
+keeping Honcho active:
+
+```json
+{
+  "contextInjection": {
+    "sessionSummary": true,
+    "userRepresentation": true,
+    "userPeerCard": true,
+    "aiRepresentation": false,
+    "aiPeerCard": false
+  },
+  "hosts": {
+    "hermes.coder": {
+      "contextInjection": {
+        "sessionSummary": false
+      }
+    }
+  }
+}
+```
+
+All five keys default to `true`. Host config overrides root config per key;
+unknown keys are ignored. This only controls which base-context sections are
+formatted into automatic user-message context. It does not disable Honcho tools, message
+saving, dialectic supplements, or necessarily underlying prefetch calls. Use
+`recallMode: "tools"` when you want no automatic injection.
 
 ### Cold / Warm Prompt Selection
 
@@ -84,7 +117,7 @@ Honcho automatically selects between two prompt strategies:
 | Condition | Strategy | What happens |
 |-----------|----------|--------------|
 | No prior session or empty representation | **Cold start** | Lightweight intro prompt; skips summary injection; encourages the model to learn about the user |
-| Existing representation and/or session history | **Warm start** | Full base context injection (summary → representation → card); richer system prompt |
+| Existing representation and/or session history | **Warm start** | Full base context (summary → representation → card) appended to the API request |
 
 You do not need to configure this -- it is automatic based on session state.
 
@@ -340,8 +373,8 @@ Use AI peer targeting to build and query the agent's own self-knowledge:
 
 ### When NOT to call tools
 
-In `hybrid` and `context` modes, base context (user representation + card + session summary) is auto-injected before every turn. Do not re-fetch what was already injected. Call tools only when:
-- You need something the injected context doesn't have
+In `hybrid` and `context` modes, base context (user representation + card + session summary) is appended to the current user message at API-call time. Do not re-fetch what was already provided. Call tools only when:
+- You need something the automatic context does not include
 - The user explicitly asks you to recall or check memory
 - You're writing a conclusion about something new
 
@@ -382,12 +415,13 @@ Config file: `$HERMES_HOME/honcho.json` (profile-local) or `~/.honcho/config.jso
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `contextTokens` | uncapped | Max tokens for the combined base context injection (summary + representation + card). Opt-in cap — omit to leave uncapped, set to an integer to bound injection size. |
+| `contextTokens` | uncapped | Max tokens for the combined base context injection. Opt-in cap — omit to leave uncapped, set to an integer to bound injection size. |
+| `contextInjection` | all `true` | Per-section controls for formatted base-context injection: `sessionSummary`, `userRepresentation`, `userPeerCard`, `aiRepresentation`, `aiPeerCard` |
 | `injectionFrequency` | `every-turn` | `every-turn` or `first-turn` |
 | `contextCadence` | `1` | Min turns between context API calls |
 | `dialecticCadence` | `2` | Min turns between dialectic LLM calls (recommended 1–5) |
 
-The `contextTokens` budget is enforced at injection time. If the session summary + representation + card exceed the budget, Honcho trims the summary first, then the representation, preserving the card. This prevents context blowup in long sessions.
+The `contextTokens` budget is enforced at injection time and prevents context blowup in long sessions.
 
 ### Memory-context sanitization
 
@@ -396,7 +430,7 @@ Honcho sanitizes the `memory-context` block before injection to prevent prompt i
 - Strips XML/HTML tags from user-authored conclusions
 - Normalizes whitespace and control characters
 - Truncates individual conclusions that exceed `messageMaxChars`
-- Escapes delimiter sequences that could break the system prompt structure
+- Escapes delimiter sequences that could break the appended context structure
 
 This fix addresses edge cases where raw user conclusions containing markup or special characters could corrupt the injected context block.
 
@@ -418,7 +452,7 @@ Observation config is synced from the server on each session init. Start a new s
 Messages over `messageMaxChars` (default 25k) are automatically chunked with `[continued]` markers. If you're hitting this often, check if tool results or skill content is inflating message size.
 
 ### Context injection too large
-If you see warnings about context budget exceeded, lower `contextTokens` or reduce `dialecticDepth`. The session summary is trimmed first when the budget is tight.
+If context is too large, lower `contextTokens` or reduce `dialecticDepth`. The assembled context makes a best-effort cut at a nearby word boundary, but hard-cuts when none is found near the budget; no individual section is preserved preferentially.
 
 ### Session summary missing
 Session summary requires at least one prior turn in the current Honcho session. On cold start (new session, no history), the summary is omitted and Honcho uses the cold-start prompt strategy instead.


### PR DESCRIPTION
## What does this PR do?

Adds `contextInjection` controls for the Honcho memory provider so users can choose which base-context sections are formatted into the auto-injected prompt.

This is useful for `hybrid` / `context` recall modes where users want automatic Honcho context, but do not want every session/user/AI representation block injected into the model context on every refresh.

The new config is backward compatible: all sections default to `true`, preserving existing behavior.

Example:

```json
{
  "contextInjection": {
    "sessionSummary": true,
    "userRepresentation": false,
    "userPeerCard": true,
    "aiRepresentation": false,
    "aiPeerCard": false
  }
}
```

`contextInjection` can be configured at the root or under `hosts.<host>`. Host values override root values per key.

This only controls formatted base-context injection. It does not disable Honcho tools, message saving, dialectic supplements, or necessarily underlying prefetch calls. Users who want no automatic injection should continue to use `recallMode: "tools"`.

## Related Issue

Resolves #17412

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/memory/honcho/client.py`
  - Adds `contextInjection` defaults and parsing.
  - Supports root + host-level config with host per-key overrides.
  - Ignores unknown keys and non-object values safely.
- `plugins/memory/honcho/__init__.py`
  - Applies section-level gates when formatting first-turn/base Honcho context.
- `tests/test_honcho_client_config.py`
  - Adds config parsing coverage.
- `tests/honcho_plugin/test_session.py`
  - Adds formatter behavior coverage.
- Honcho docs updated with config examples and semantics.

## How to Test

```bash
python -m py_compile plugins/memory/honcho/client.py plugins/memory/honcho/__init__.py
python -m pytest tests/honcho_plugin tests/test_honcho_client_config.py -q -o 'addopts='
git diff --check origin/main..HEAD
```

Result locally:

```text
283 passed, 1 warning
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu/Linux, Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — config parsing / prompt formatting only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
