### PR TITLE
feat(feishu): allow disabling group mention requirement

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1336,6 +1336,11 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         feishu_verification_token = os.getenv("FEISHU_VERIFICATION_TOKEN", "")
         if feishu_verification_token:
             config.platforms[Platform.FEISHU].extra["verification_token"] = feishu_verification_token
+        for require_mention_var in ("FEISHU_REQUIRE_MENTION", "HERMES_FEISHU_REQUIRE_MENTION"):
+            feishu_require_mention = os.getenv(require_mention_var)
+            if feishu_require_mention is not None:
+                config.platforms[Platform.FEISHU].extra["require_mention"] = feishu_require_mention
+                break
         feishu_home = os.getenv("FEISHU_HOME_CHANNEL")
         if feishu_home:
             config.platforms[Platform.FEISHU].home_channel = HomeChannel(

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -365,6 +365,7 @@ class FeishuAdapterSettings:
     verification_token: str
     group_policy: str
     allowed_group_users: frozenset[str]
+    require_mention: bool
     # Bot's own open_id (app-scoped) — returned by /bot/v3/info.  Used only for
     # @mention matching: Feishu puts this value in mentions[].id.open_id when
     # a user @-mentions the bot in a group chat.
@@ -389,7 +390,6 @@ class FeishuAdapterSettings:
     default_group_policy: str = ""
     group_rules: Dict[str, FeishuGroupRule] = field(default_factory=dict)
     allow_bots: str = "none"  # "none" | "mentions" | "all"
-    require_mention: bool = True
 
 
 @dataclass
@@ -536,6 +536,29 @@ def _coerce_int(value: Any, default: Optional[int] = None, min_value: int = 0) -
 def _coerce_required_int(value: Any, default: int, min_value: int = 0) -> int:
     parsed = _coerce_int(value, default=default, min_value=min_value)
     return default if parsed is None else parsed
+
+
+def _coerce_bool(value: Any, default: bool = True) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        if value in (0, 1):
+            return bool(value)
+        return default
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "1", "yes", "on"}:
+            return True
+        if normalized in {"false", "0", "no", "off"}:
+            return False
+    return default
+
+
+def _first_env_value(*names: str) -> Optional[str]:
+    for name in names:
+        if name in os.environ:
+            return os.environ[name]
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -1433,6 +1456,10 @@ class FeishuAdapter(BasePlatformAdapter):
 
         # Default group policy (for groups not in group_rules)
         default_group_policy = str(extra.get("default_group_policy", "")).strip().lower()
+        require_mention = extra.get("require_mention", True)
+        require_mention_env = _first_env_value("FEISHU_REQUIRE_MENTION", "HERMES_FEISHU_REQUIRE_MENTION")
+        if require_mention_env is not None:
+            require_mention = require_mention_env
 
         # Env-only so adapter and gateway auth bypass share one source; yaml
         # feishu.allow_bots is bridged to this env var at config load.
@@ -1459,6 +1486,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 for item in os.getenv("FEISHU_ALLOWED_USERS", "").split(",")
                 if item.strip()
             ),
+            require_mention=_coerce_bool(require_mention, default=True),
             bot_open_id=os.getenv("FEISHU_BOT_OPEN_ID", "").strip(),
             bot_user_id=os.getenv("FEISHU_BOT_USER_ID", "").strip(),
             bot_name=os.getenv("FEISHU_BOT_NAME", "").strip(),
@@ -1501,9 +1529,6 @@ class FeishuAdapter(BasePlatformAdapter):
             default_group_policy=default_group_policy,
             group_rules=group_rules,
             allow_bots=allow_bots,
-            require_mention=_to_boolean(
-                extra.get("require_mention", os.getenv("FEISHU_REQUIRE_MENTION", "true"))
-            ),
         )
 
     def _apply_settings(self, settings: FeishuAdapterSettings) -> None:
@@ -1515,6 +1540,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._verification_token = settings.verification_token
         self._group_policy = settings.group_policy
         self._allowed_group_users = set(settings.allowed_group_users)
+        self._require_mention = settings.require_mention
         self._admins = set(settings.admins)
         self._default_group_policy = settings.default_group_policy or settings.group_policy
         self._group_rules = settings.group_rules
@@ -3800,6 +3826,14 @@ class FeishuAdapter(BasePlatformAdapter):
         return bool(sender_ids and (sender_ids & self._allowed_group_users))
 
     # --- Mention detection ----------------------------------------------------
+
+    def _should_accept_group_message(self, message: Any, sender_id: Any, chat_id: str = "") -> bool:
+        """Apply group policy, then optionally require an explicit @mention."""
+        if not self._allow_group_message(sender_id, chat_id):
+            return False
+        if not self._require_mention_for(chat_id):
+            return True
+        return self._mentions_self(message)
 
     def _mentions_self(self, message: Any) -> bool:
         # @_all is Feishu's @everyone placeholder.

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -53,6 +53,19 @@ class TestConfigEnvOverrides(unittest.TestCase):
     @patch.dict(os.environ, {
         "FEISHU_APP_ID": "cli_xxx",
         "FEISHU_APP_SECRET": "secret_xxx",
+        "FEISHU_REQUIRE_MENTION": "false",
+    }, clear=False)
+    def test_feishu_require_mention_config_loaded_from_env(self):
+        from gateway.config import GatewayConfig, Platform, _apply_env_overrides
+
+        config = GatewayConfig()
+        _apply_env_overrides(config)
+
+        self.assertEqual(config.platforms[Platform.FEISHU].extra["require_mention"], "false")
+
+    @patch.dict(os.environ, {
+        "FEISHU_APP_ID": "cli_xxx",
+        "FEISHU_APP_SECRET": "secret_xxx",
         "FEISHU_HOME_CHANNEL": "oc_xxx",
     }, clear=False)
     def test_feishu_home_channel_loaded(self):
@@ -450,6 +463,22 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
         self.assertEqual(info["type"], "group")
 
 class TestAdapterModule(unittest.TestCase):
+    @patch.dict(os.environ, {}, clear=True)
+    def test_load_settings_defaults_to_requiring_group_mentions(self):
+        from gateway.platforms.feishu import FeishuAdapter
+
+        settings = FeishuAdapter._load_settings({})
+
+        self.assertTrue(settings.require_mention)
+
+    @patch.dict(os.environ, {"HERMES_FEISHU_REQUIRE_MENTION": "off"}, clear=True)
+    def test_load_settings_accepts_hermes_require_mention_env(self):
+        from gateway.platforms.feishu import FeishuAdapter
+
+        settings = FeishuAdapter._load_settings({"require_mention": True})
+
+        self.assertFalse(settings.require_mention)
+
     def test_load_settings_uses_sdk_defaults_for_invalid_ws_reconnect_values(self):
         from gateway.platforms.feishu import FeishuAdapter
 
@@ -762,17 +791,109 @@ class TestAdapterBehavior(unittest.TestCase):
         adapter._handle_message_with_guards.assert_awaited_once()
 
     @patch.dict(os.environ, {"FEISHU_GROUP_POLICY": "open"}, clear=True)
-    def test_group_message_requires_mentions_even_when_policy_open(self):
+    def test_group_message_requires_mention_by_default_after_policy_passes(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter
 
         adapter = FeishuAdapter(PlatformConfig())
+        adapter._bot_open_id = "ou_bot"
         message = SimpleNamespace(mentions=[])
         sender_id = SimpleNamespace(open_id="ou_any", user_id=None)
         self.assertFalse(_admits_group(adapter, message, sender_id, ""))
 
-        message_with_mention = SimpleNamespace(mentions=[SimpleNamespace(key="@_user_1")])
-        self.assertFalse(_admits_group(adapter, message_with_mention, sender_id, ""))
+        message_with_key_only_mention = SimpleNamespace(mentions=[SimpleNamespace(key="@_user_1")])
+        self.assertFalse(_admits_group(adapter, message_with_key_only_mention, sender_id, ""))
+
+        message_with_mention = SimpleNamespace(
+            mentions=[SimpleNamespace(id=SimpleNamespace(open_id="ou_bot", user_id=None))]
+        )
+        self.assertTrue(adapter._should_accept_group_message(message_with_mention, sender_id, ""))
+
+    @patch.dict(os.environ, {"FEISHU_GROUP_POLICY": "open"}, clear=True)
+    def test_group_message_accepts_unmentioned_when_require_mention_disabled_after_policy_passes(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig(extra={"require_mention": False}))
+        message = SimpleNamespace(mentions=[])
+        sender_id = SimpleNamespace(open_id="ou_any", user_id=None)
+
+        self.assertTrue(adapter._should_accept_group_message(message, sender_id, ""))
+
+    @patch.dict(
+        os.environ,
+        {
+            "FEISHU_GROUP_POLICY": "allowlist",
+            "FEISHU_ALLOWED_USERS": "ou_allowed",
+        },
+        clear=True,
+    )
+    def test_group_message_blocked_sender_remains_blocked_when_require_mention_disabled(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig(extra={"require_mention": False}))
+        message = SimpleNamespace(mentions=[])
+
+        self.assertFalse(
+            adapter._should_accept_group_message(
+                message,
+                SimpleNamespace(open_id="ou_blocked", user_id=None),
+                "",
+            )
+        )
+
+    @patch.dict(
+        os.environ,
+        {
+            "FEISHU_GROUP_POLICY": "open",
+            "FEISHU_REQUIRE_MENTION": "false",
+        },
+        clear=True,
+    )
+    def test_group_message_env_disables_require_mention(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+
+        self.assertTrue(
+            adapter._should_accept_group_message(
+                SimpleNamespace(mentions=[]),
+                SimpleNamespace(open_id="ou_any", user_id=None),
+                "",
+            )
+        )
+
+    @patch.dict(os.environ, {"FEISHU_GROUP_POLICY": "open", "FEISHU_REQUIRE_MENTION": "bogus"}, clear=True)
+    def test_group_message_invalid_env_falls_back_to_requiring_mention(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig(extra={"require_mention": False}))
+
+        self.assertFalse(
+            adapter._should_accept_group_message(
+                SimpleNamespace(mentions=[]),
+                SimpleNamespace(open_id="ou_any", user_id=None),
+                "",
+            )
+        )
+
+    @patch.dict(os.environ, {"FEISHU_GROUP_POLICY": "open"}, clear=True)
+    def test_group_message_invalid_config_falls_back_to_requiring_mention(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig(extra={"require_mention": "bogus"}))
+
+        self.assertFalse(
+            adapter._should_accept_group_message(
+                SimpleNamespace(mentions=[]),
+                SimpleNamespace(open_id="ou_any", user_id=None),
+                "",
+            )
+        )
 
     @patch.dict(os.environ, {"FEISHU_GROUP_POLICY": "open"}, clear=True)
     def test_group_message_with_other_user_mention_is_rejected_when_bot_identity_unknown(self):
@@ -861,6 +982,40 @@ class TestAdapterBehavior(unittest.TestCase):
             _admits_group(adapter,
                 message,
                 SimpleNamespace(open_id="ou_charlie", user_id=None),
+                "oc_chat_a",
+            )
+        )
+
+    @patch.dict(os.environ, {"FEISHU_GROUP_POLICY": "open"}, clear=True)
+    def test_per_group_allowlist_is_honored_when_require_mention_disabled(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        config = PlatformConfig(
+            extra={
+                "require_mention": False,
+                "group_rules": {
+                    "oc_chat_a": {
+                        "policy": "allowlist",
+                        "allowlist": ["ou_alice"],
+                    }
+                },
+            }
+        )
+        adapter = FeishuAdapter(config)
+        message = SimpleNamespace(mentions=[])
+
+        self.assertTrue(
+            adapter._should_accept_group_message(
+                message,
+                SimpleNamespace(open_id="ou_alice", user_id=None),
+                "oc_chat_a",
+            )
+        )
+        self.assertFalse(
+            adapter._should_accept_group_message(
+                message,
+                SimpleNamespace(open_id="ou_bob", user_id=None),
                 "oc_chat_a",
             )
         )

--- a/website/docs/user-guide/messaging/feishu.md
+++ b/website/docs/user-guide/messaging/feishu.md
@@ -155,6 +155,8 @@ FEISHU_ALLOWED_USERS=ou_xxx,ou_yyy
 
 If you leave the allowlist empty, anyone who can reach the bot may be able to use it. In group chats, the allowlist is checked against the sender's open_id before the message is processed.
 
+Group messages require an explicit `@`-mention by default, after the group policy/allowlist check passes. To let allowed group users trigger the bot without an `@`-mention, set `FEISHU_REQUIRE_MENTION=false` or configure `platforms.feishu.extra.require_mention: false`.
+
 ### Webhook Encryption Key
 
 When running in webhook mode, set an encryption key to enable signature verification of inbound webhook payloads:
@@ -492,6 +494,7 @@ Inbound messages are deduplicated using message IDs with a 24-hour TTL. The dedu
 | `FEISHU_ENCRYPT_KEY` | — | _(empty)_ | Encrypt key for webhook signature verification |
 | `FEISHU_VERIFICATION_TOKEN` | — | _(empty)_ | Verification token for webhook payload auth |
 | `FEISHU_GROUP_POLICY` | — | `allowlist` | Group message policy: `open`, `allowlist`, `disabled` |
+| `FEISHU_REQUIRE_MENTION` / `HERMES_FEISHU_REQUIRE_MENTION` | — | `true` | Require group messages to @mention the bot after group policy passes |
 | `FEISHU_BOT_OPEN_ID` | — | _(empty)_ | Bot's open_id (for @mention detection) |
 | `FEISHU_BOT_USER_ID` | — | _(empty)_ | Bot's user_id (for @mention detection) |
 | `FEISHU_BOT_NAME` | — | _(empty)_ | Bot's display name (for @mention detection) |


### PR DESCRIPTION
## What does this PR do?

Adds a Feishu/Lark option to let allowed group messages trigger the bot without an explicit `@` mention.

The default behavior is unchanged: group messages still require an `@` mention unless this option is explicitly disabled.

The safety gate is preserved. Feishu group policy / allowlist checks still run first, so disabling mention requirements does not make every group user able to trigger the bot.

Supported configuration:

```yaml
platforms:
  feishu:
    extra:
      require_mention: false
```

Supported environment variables:

```bash
FEISHU_REQUIRE_MENTION=false
# or
HERMES_FEISHU_REQUIRE_MENTION=false
```

Accepted boolean values: `true/false`, `1/0`, `yes/no`, `on/off`. Invalid values fall back to the safer default: requiring mentions.

Feishu/Lark apps still need permission to receive group messages that do not mention the bot; this option only controls Hermes-side filtering after Feishu delivers the event.

## Related Issue

Fixes #10275
Fixes #9835

Related / overlapping PRs: #15525 and #12887.

This PR keeps the change intentionally small: it preserves the group policy / allowlist gate before bypassing mention matching, supports both config and env vars, keeps the safe default enabled, documents the option, and includes directed unit tests.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/config.py`
  - Loads `FEISHU_REQUIRE_MENTION` / `HERMES_FEISHU_REQUIRE_MENTION` into Feishu platform extra config.
- `gateway/platforms/feishu.py`
  - Adds `require_mention` setting with safe default `true`.
  - Applies group policy / allowlist first, then optionally skips mention matching.
  - Keeps `@_all` and bot mention behavior unchanged when mention requirement is enabled.
- `tests/gateway/test_feishu.py`
  - Adds coverage for default behavior, config/env overrides, invalid fallback, blocked sender behavior, and per-group allowlist behavior.
- `website/docs/user-guide/messaging/feishu.md`
  - Documents the new option and env vars.

## How to Test

```bash
python -m py_compile gateway/config.py gateway/platforms/feishu.py
python -m pytest tests/gateway/test_feishu.py -q -o 'addopts='
git diff --check origin/main..HEAD
```

Result locally:

```text
198 passed, 4 warnings
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu/Linux, Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — Feishu gateway config only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
