### PR TITLE
fix(agent): preserve full model name when provider is explicitly custom

### DIFF
--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -102,7 +102,6 @@ _MATCHING_PREFIX_STRIP_PROVIDERS: frozenset[str] = frozenset({
     "xiaomi",
     "arcee",
     "ollama-cloud",
-    "custom",
 })
 
 # Providers whose APIs require lowercase model IDs.  Xiaomi's


### PR DESCRIPTION
## Summary

When provider is explicitly set to `custom` in config, model names containing
slashes (e.g. `google/gemma-4-31b-it`, HuggingFace-style `org/model`) were
passed through `_strip_matching_provider_prefix()` because `"custom"` was
listed in `_MATCHING_PREFIX_STRIP_PROVIDERS`. While the prefix-matching logic
itself wouldn't strip a non-matching prefix like `google`, the inclusion of
`custom` in this set was architecturally wrong — custom endpoints are opaque
and the model name should always pass through verbatim.

This removes `"custom"` from `_MATCHING_PREFIX_STRIP_PROVIDERS` so the
`custom` provider falls through to the "Custom & all others: pass through
as-is" path (line 458), which is what the code's own documentation promises.

- Removes `"custom"` from `_MATCHING_PREFIX_STRIP_PROVIDERS` in
  `hermes_cli/model_normalize.py`
- Slash-bearing model names like `google/gemma-4-31b-it` now reach the custom
  endpoint unmodified
- Other providers (zai, xiaomi, ollama-cloud, etc.) are unaffected

Fixes #15516

## Test plan

- [ ] `normalize_model_for_provider("google/gemma-4-31b-it", "custom")` returns
  `"google/gemma-4-31b-it"` (not `"gemma-4-31b-it"`)
- [ ] `normalize_model_for_provider("my-model", "custom")` still returns
  `"my-model"`
- [ ] `normalize_model_for_provider("zai/glm-5.1", "zai")` still strips to
  `"glm-5.1"` (other direct providers unaffected)
- [ ] Existing `test_model_normalize.py` suite passes