### PR TITLE
fix(hindsight): add circuit breaker to prevent session freeze on daemon failure

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -36,6 +36,7 @@ import logging
 import os
 import queue
 import threading
+import time
 
 from datetime import datetime, timezone
 from typing import Any, Dict, List
@@ -58,6 +59,8 @@ _DEFAULT_IDLE_TIMEOUT = 300  # seconds — Hindsight embedded daemon default
 # overwrites prior turns server-side, so we keep the per-process
 # unique document_id fallback for older APIs.
 _MIN_VERSION_FOR_UPDATE_MODE_APPEND = "0.5.0"
+_CIRCUIT_BREAKER_THRESHOLD = 3  # consecutive failures before opening circuit
+_CIRCUIT_BREAKER_COOLDOWN = 60.0  # seconds before half-open retry
 _VALID_BUDGETS = {"low", "mid", "high"}
 _PROVIDER_DEFAULT_MODELS = {
     "openai": "gpt-4o-mini",
@@ -556,6 +559,8 @@ class HindsightMemoryProvider(MemoryProvider):
         # Legacy alias — older tests/callers reference _sync_thread directly.
         # Points at _writer_thread once the writer is running.
         self._sync_thread = None
+        self._circuit_breaker_failures = 0
+        self._circuit_breaker_open_until = 0.0
         self._session_id = ""
         self._parent_session_id = ""
         self._document_id = ""
@@ -914,6 +919,17 @@ class HindsightMemoryProvider(MemoryProvider):
         """Schedule *coro* on the shared loop using the configured timeout."""
         return _run_sync(coro, timeout=self._timeout)
 
+    def _check_circuit_breaker(self):
+        """Fast-fail if the embedded daemon has failed repeatedly."""
+        if self._circuit_breaker_failures >= _CIRCUIT_BREAKER_THRESHOLD:
+            if time.monotonic() < self._circuit_breaker_open_until:
+                raise RuntimeError(
+                    "Hindsight circuit breaker open: embedded daemon failed %d consecutive times; "
+                    "will retry after cooldown" % self._circuit_breaker_failures
+                )
+            # Cooldown elapsed — half-open: allow one attempt
+            self._circuit_breaker_failures = 0
+
     def _is_retriable_embedded_connection_error(self, exc: Exception) -> bool:
         """Return True for stale embedded-daemon connection failures."""
         if self._mode != "local_embedded":
@@ -926,6 +942,8 @@ class HindsightMemoryProvider(MemoryProvider):
                 "connection refused",
                 "connect call failed",
                 "clientconnectorerror",
+                "failed to start daemon",
+                "after it has been closed",
             )
         )
 
@@ -998,20 +1016,32 @@ class HindsightMemoryProvider(MemoryProvider):
 
     def _run_hindsight_operation(self, operation):
         """Run an async Hindsight client operation, retrying once after idle shutdown."""
+        self._check_circuit_breaker()
         client = self._get_client()
         try:
-            return self._run_sync(operation(client))
+            result = self._run_sync(operation(client))
+            self._circuit_breaker_failures = 0
+            return result
         except Exception as exc:
             if not self._is_retriable_embedded_connection_error(exc):
+                self._circuit_breaker_failures += 1
+                self._circuit_breaker_open_until = time.monotonic() + _CIRCUIT_BREAKER_COOLDOWN
                 raise
             logger.info(
                 "Hindsight embedded daemon appears unreachable; recreating client and retrying once: %s",
                 exc,
             )
             self._client = None
-            client = self._get_client()
-            self._client = client
-            return self._run_sync(operation(client))
+            try:
+                client = self._get_client()
+                self._client = client
+                result = self._run_sync(operation(client))
+                self._circuit_breaker_failures = 0
+                return result
+            except Exception:
+                self._circuit_breaker_failures += 1
+                self._circuit_breaker_open_until = time.monotonic() + _CIRCUIT_BREAKER_COOLDOWN
+                raise
 
     def _probe_url(self) -> str:
         """Return the URL to probe /version on.
@@ -1417,6 +1447,10 @@ class HindsightMemoryProvider(MemoryProvider):
         if self._shutting_down.is_set():
             logger.debug("sync_turn: skipped (shutting down)")
             return
+        if (self._circuit_breaker_failures >= _CIRCUIT_BREAKER_THRESHOLD
+                and time.monotonic() < self._circuit_breaker_open_until):
+            logger.debug("sync_turn: skipped (circuit breaker open)")
+            return
 
         if session_id:
             self._session_id = str(session_id).strip()
@@ -1454,6 +1488,7 @@ class HindsightMemoryProvider(MemoryProvider):
         retain_context = self._retain_context
 
         def _do_retain() -> None:
+            self._check_circuit_breaker()
             item = self._build_retain_kwargs(
                 content,
                 context=retain_context,

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -172,6 +172,7 @@ AUTHOR_MAP = {
     # Moonshot schema anyOf+enum salvage (May 2026)
     "git@local.invalid": "hendrixfreire",
     "1060770+benjaminsehl@users.noreply.github.com": "benjaminsehl",
+    "kagura.agent.ai@gmail.com": "kagura-agent",
     "nerijusn76@gmail.com": "Nerijusas",
     "itonov@proton.me": "Ito-69",
     "glesstech@gmail.com": "georgeglessner",

--- a/tests/plugins/memory/test_hindsight_circuit_breaker.py
+++ b/tests/plugins/memory/test_hindsight_circuit_breaker.py
@@ -1,0 +1,91 @@
+"""Tests for Hindsight circuit breaker behaviour."""
+
+import json
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from plugins.memory.hindsight import (
+    HindsightMemoryProvider,
+    _CIRCUIT_BREAKER_COOLDOWN,
+    _CIRCUIT_BREAKER_THRESHOLD,
+)
+
+
+@pytest.fixture()
+def provider(tmp_path, monkeypatch):
+    """Create a local_embedded provider with a mock client."""
+    config = {
+        "mode": "local_embedded",
+        "bank_id": "test-bank",
+        "budget": "mid",
+        "memory_mode": "hybrid",
+    }
+    config_path = tmp_path / "hindsight" / "config.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(json.dumps(config))
+    monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr("plugins.memory.hindsight._check_local_runtime", lambda: (True, ""))
+
+    p = HindsightMemoryProvider()
+    p.initialize(session_id="test-session", hermes_home=str(tmp_path), platform="cli")
+
+    client = MagicMock()
+    client.aretain = AsyncMock(return_value=SimpleNamespace(ok=True))
+    client.arecall = AsyncMock(
+        return_value=SimpleNamespace(results=[SimpleNamespace(text="m1")])
+    )
+    client.aretain_batch = AsyncMock()
+    client.aclose = AsyncMock()
+    p._client = client
+    return p
+
+
+class TestCircuitBreaker:
+
+    def test_opens_after_threshold_failures(self, provider):
+        # Use a non-retriable error so each call increments the counter directly
+        provider._client.arecall = AsyncMock(side_effect=RuntimeError("database migration failed"))
+
+        for _ in range(_CIRCUIT_BREAKER_THRESHOLD):
+            with pytest.raises(RuntimeError, match="database migration failed"):
+                provider._run_hindsight_operation(lambda c: c.arecall(bank_id="b", query="q"))
+
+        with pytest.raises(RuntimeError, match="circuit breaker open"):
+            provider._run_hindsight_operation(lambda c: c.arecall(bank_id="b", query="q"))
+
+    def test_resets_after_cooldown(self, provider):
+        provider._circuit_breaker_failures = _CIRCUIT_BREAKER_THRESHOLD
+        provider._circuit_breaker_open_until = time.monotonic() - 1  # expired
+
+        result = provider._run_hindsight_operation(lambda c: c.arecall(bank_id="b", query="q"))
+        assert result.results
+        assert provider._circuit_breaker_failures == 0
+
+    def test_success_resets_counter(self, provider):
+        provider._circuit_breaker_failures = 2
+
+        provider._run_hindsight_operation(lambda c: c.arecall(bank_id="b", query="q"))
+        assert provider._circuit_breaker_failures == 0
+
+    def test_sync_turn_skips_when_circuit_open(self, provider):
+        provider._circuit_breaker_failures = _CIRCUIT_BREAKER_THRESHOLD
+        provider._circuit_breaker_open_until = time.monotonic() + 300
+        provider._auto_retain = True
+        provider._retain_every_n_turns = 1
+
+        provider.sync_turn("hello", "world")
+        if provider._sync_thread:
+            provider._sync_thread.join(timeout=5.0)
+
+        provider._client.aretain_batch.assert_not_called()
+
+    def test_retriable_errors_include_daemon_markers(self, provider):
+        assert provider._is_retriable_embedded_connection_error(
+            RuntimeError("Failed to start daemon on port 9999")
+        )
+        assert provider._is_retriable_embedded_connection_error(
+            RuntimeError("Cannot use HindsightEmbedded after it has been closed")
+        )


### PR DESCRIPTION
## Summary

Fixes #17403.

When the embedded Hindsight daemon fails to start (e.g., database migration error), every tool call (`hindsight_retain`, `hindsight_recall`, `hindsight_reflect`) and every background `sync_turn` blocks for ~177 seconds waiting for the daemon startup timeout. With no circuit breaker, this repeats on every interaction, making the session appear frozen.

## Changes

**Circuit breaker in `_run_hindsight_operation()`** (`plugins/memory/hindsight/__init__.py`):
- Tracks consecutive operation failures
- After 3 consecutive failures (`_CIRCUIT_BREAKER_THRESHOLD`), raises immediately with a descriptive error instead of blocking
- Resets after a 60s cooldown (`_CIRCUIT_BREAKER_COOLDOWN`) — half-open state allows one retry
- Resets to 0 on any successful operation

**Expanded `_is_retriable_embedded_connection_error()`**:
- Added `'failed to start daemon'` and `'after it has been closed'` markers
- This allows a single client-recreation retry before the circuit opens (matching existing idle-shutdown recovery pattern)

**`sync_turn` protection**:
- Checks circuit breaker before spawning retain thread
- Prevents accumulation of blocked daemon threads

## Testing

- 5 new tests in `tests/plugins/memory/test_hindsight_circuit_breaker.py`:
  - Circuit opens after threshold failures
  - Circuit resets after cooldown (half-open)
  - Success resets failure counter
  - `sync_turn` skips when circuit is open
  - New retriable error markers recognized
- All 132 existing `tests/plugins/memory/` tests pass

## Behaviour

| State | Before | After |
|-------|--------|-------|
| Daemon broken, 1st call | Blocks ~177s, raises | Blocks ~177s, raises |
| Daemon broken, 2nd call | Blocks ~177s, raises | Blocks ~177s, raises |
| Daemon broken, 3rd call | Blocks ~177s, raises | Blocks ~177s, raises (opens circuit) |
| Daemon broken, 4th+ call | Blocks ~177s, raises | **Raises immediately** (~0ms) |
| After 60s cooldown | Blocks ~177s (repeat) | Allows one retry (half-open) |
| Daemon recovers | N/A | Counter resets to 0, normal operation |