### PR TITLE
fix(core): resolve thread leak, lost traceback, and type violation

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -260,7 +260,7 @@ def redact_sensitive_text(text: str) -> str:
     Disabled when security.redact_secrets is false in config.yaml.
     """
     if text is None:
-        return None
+        return ""
     if not isinstance(text, str):
         text = str(text)
     if not text:

--- a/model_tools.py
+++ b/model_tools.py
@@ -114,9 +114,10 @@ def _run_async(coro):
             return future.result(timeout=300)
         except concurrent.futures.TimeoutError:
             future.cancel()
+            pool.shutdown(wait=True)
             raise
         finally:
-            pool.shutdown(wait=False, cancel_futures=True)
+            pool.shutdown(wait=True)
 
     # If we're on a worker thread (e.g., parallel tool execution in
     # delegate_task), use a per-thread persistent loop.  This avoids
@@ -584,7 +585,7 @@ def handle_function_call(
 
     except Exception as e:
         error_msg = f"Error executing {function_name}: {str(e)}"
-        logger.error(error_msg)
+        logger.exception(error_msg)
         return json.dumps({"error": error_msg}, ensure_ascii=False)
 
 


### PR DESCRIPTION
## Overview
This PR addresses three distinct bugs in the core tool execution and redaction paths:

1. A **ThreadPoolExecutor thread leak** in `_run_coro_in_fresh_thread` where timed-out coroutines continued running in orphaned threads.
2. A **lost traceback** in `handle_function_call` where `logger.error()` discarded the full stack trace.
3. A **type contract violation** in `redact_sensitive_text` where `None` was returned despite a `-> str` annotation.

## Key Changes

- **`model_tools.py`** — Changed `pool.shutdown(wait=False, cancel_futures=True)` to `pool.shutdown(wait=True)`. The previous `wait=False` caused worker threads to be orphaned on timeout, leaking threads on every timeout event.

- **`model_tools.py`** — Replaced `logger.error()` with `logger.exception()`. Ensures full traceback is written to `errors.log` when a tool handler raises an unexpected exception.

- **`agent/redact.py`** — Changed `return None` to `return ""`. The function signature declares `-> str`, so returning `None` violated the type contract and could cause `AttributeError` in callers.

## Impact
- **Resource stability**: Eliminates cumulative thread leaks in long-running gateway/RL sessions.
- **Debuggability**: Tool failures now produce actionable stack traces.
- **Type safety**: `redact_sensitive_text` now honors its type contract.

All changes are backward-compatible.