### PR TITLE
fix(gateway): preserve tool_call_id in api_server conversation history

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1744,7 +1744,16 @@ class APIServerAdapter(BasePlatformAdapter):
                     entry_content = _normalize_multimodal_content(entry["content"])
                 except ValueError as exc:
                     return _multimodal_validation_error(exc, param=f"conversation_history[{i}].content")
-                conversation_history.append({"role": str(entry["role"]), "content": entry_content})
+                msg = {"role": str(entry["role"]), "content": entry_content}
+                # Preserve tool_call_id for tool messages — required by strict providers
+                if entry.get("tool_call_id"):
+                    msg["tool_call_id"] = entry["tool_call_id"]
+                # Preserve tool_calls for assistant messages
+                if entry.get("tool_calls"):
+                    msg["tool_calls"] = entry["tool_calls"]
+                if entry.get("name"):
+                    msg["name"] = entry["name"]
+                conversation_history.append(msg)
             if previous_response_id:
                 logger.debug("Both conversation_history and previous_response_id provided; using conversation_history")
 
@@ -2406,7 +2415,16 @@ class APIServerAdapter(BasePlatformAdapter):
                         _openai_error(f"conversation_history[{i}] must have 'role' and 'content' fields"),
                         status=400,
                     )
-                conversation_history.append({"role": str(entry["role"]), "content": str(entry["content"])})
+                msg = {"role": str(entry["role"]), "content": str(entry["content"])}
+                # Preserve tool_call_id for tool messages — required by strict providers
+                if entry.get("tool_call_id"):
+                    msg["tool_call_id"] = entry["tool_call_id"]
+                # Preserve tool_calls for assistant messages
+                if entry.get("tool_calls"):
+                    msg["tool_calls"] = entry["tool_calls"]
+                if entry.get("name"):
+                    msg["name"] = entry["name"]
+                conversation_history.append(msg)
             if previous_response_id:
                 logger.debug("Both conversation_history and previous_response_id provided; using conversation_history")
 
@@ -2432,7 +2450,16 @@ class APIServerAdapter(BasePlatformAdapter):
                             part.get("text", "") for part in content
                             if isinstance(part, dict) and part.get("type") == "text"
                         )
-                    conversation_history.append({"role": msg["role"], "content": str(content)})
+                    msg_out = {"role": msg["role"], "content": str(content)}
+                    # Preserve tool_call_id for tool messages — required by strict providers
+                    if msg.get("tool_call_id"):
+                        msg_out["tool_call_id"] = msg["tool_call_id"]
+                    # Preserve tool_calls for assistant messages
+                    if msg.get("tool_calls"):
+                        msg_out["tool_calls"] = msg["tool_calls"]
+                    if msg.get("name"):
+                        msg_out["name"] = msg["name"]
+                    conversation_history.append(msg_out)
 
         session_id = body.get("session_id") or stored_session_id or run_id
         ephemeral_system_prompt = instructions


### PR DESCRIPTION
## What does this PR do?

Fix a bug where `api_server.py` strips `tool_call_id`, `tool_calls`, and `name` fields when reconstructing conversation history. This causes strict providers (xiaomimimo, stepfun) to return HTTP 400 "tool_call_id is required" for API clients that send conversation history with tool messages.

## Related Issue

Fixes #16800

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/api_server.py`: Preserve `tool_call_id`, `tool_calls`, and `name` fields in conversation history reconstruction at three locations (lines 1747, 2409, 2435)

## Root Cause

The API server's `/v1/runs` and `/v1/responses` handlers reconstruct conversation history by only keeping `role` and `content` fields, discarding `tool_call_id`, `tool_calls`, and `name`. When API clients (including third-party WebUIs like hermes-web-ui) send follow-up messages with full conversation history, strict providers reject the request because tool messages lack the required `tool_call_id` field.

The gateway's `run.py` already has correct logic to preserve these fields (lines 10737-10743), but `api_server.py` was missing this handling when rebuilding conversation history from client requests.

## Impact

- Affects all API clients that send `conversation_history` via `/v1/runs` or `/v1/responses`
- Does NOT affect CLI sessions (they use a different code path in `gateway/run.py`)
- Strict providers (xiaomimimo, stepfun) will reject requests with HTTP 400
- Tolerant providers (deepseek) may work but with degraded functionality

## Evidence

### Error Log
```
2026-04-29 18:36:08,891 ERROR [eph_mojx6dbl_itkoil] root: Non-retryable client error: 
Error code: 400 - {'error': {'code': '400', 'message': 'Param Incorrect', 
'param': '`tool_call_id` is not set', 'type': ''}}
```

### Session Analysis
- Failed session: `eph_mojx6dbl_itkoil` (platform=api_server) — 7/7 tool messages missing `tool_call_id`
- Success session: `20260429_183619_6f3307` (platform=cli) — 0/13 tool messages missing

### Comparison
| Session | Platform | tool_call_id | Result |
|---------|----------|--------------|--------|
| eph_mojx6dbl_itkoil | api_server | All missing | ❌ 400 error |
| 20260429_183619_6f3307 | cli | All present | ✅ Success |

Both sessions use the same provider (`mimo-v2.5-pro`), confirming this is an API server issue, not a provider issue.

## How to Test

1. Start Hermes gateway
2. Use an API client (e.g., hermes-web-ui) to create a conversation with tool calls
3. Send a follow-up message in the same conversation
4. Verify no "tool_call_id is required" error
5. Check that CLI sessions still work normally

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (no dedicated api_server tests exist)
- [ ] I've added tests for my changes

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture — or N/A
- [x] I've considered cross-platform impact — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A