### PR TITLE
fix(usage_pricing): add MiniMax-M2.7 pricing for minimax and minimax-cn

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -359,6 +359,25 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         source_url="https://aws.amazon.com/bedrock/pricing/",
         pricing_version="bedrock-pricing-2026-04",
     ),
+    # MiniMax
+    (
+        "minimax",
+        "minimax-m2.7",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.30"),
+        output_cost_per_million=Decimal("1.20"),
+        source="official_docs_snapshot",
+        pricing_version="minimax-pricing-2026-04",
+    ),
+    (
+        "minimax-cn",
+        "minimax-m2.7",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.30"),
+        output_cost_per_million=Decimal("1.20"),
+        source="official_docs_snapshot",
+        pricing_version="minimax-pricing-2026-04",
+    ),
 }
 
 
@@ -400,6 +419,8 @@ def resolve_billing_route(
         return BillingRoute(provider="anthropic", model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
     if provider_name == "openai":
         return BillingRoute(provider="openai", model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
+    if provider_name in {"minimax", "minimax-cn"}:
+        return BillingRoute(provider=provider_name, model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
     if provider_name in {"custom", "local"} or (base and "localhost" in base):
         return BillingRoute(provider=provider_name or "custom", model=model, base_url=base_url or "", billing_mode="unknown")
     return BillingRoute(provider=provider_name or "unknown", model=model.split("/")[-1] if model else "", base_url=base_url or "", billing_mode="unknown")


### PR DESCRIPTION
Salvage of #17408 — pricing commit only.

Fixes #16825. Sessions using MiniMax-M2.7 via `minimax` or `minimax-cn` showed `estimated_cost_usd=0.0` / `cost_status='unknown'`. Adds `official_docs_snapshot` entries ($0.30/M input, $1.20/M output, per https://platform.minimax.io/docs/guides/pricing-paygo) for both providers and an explicit `resolve_billing_route()` branch so both resolve to `billing_mode='official_docs_snapshot'` instead of falling through to `unknown`.

Original PR #17408 bundled 5 additional unrelated commits (approval.py run_in_terminal fix, skill description cap change, ⚕→☤ symbol rebrand, claw migration hint, `hermes update --check`) — two of which already landed on main (#10318, #16911 respectively). Only the in-scope pricing commit (33d6995cd) is salvaged here; @Feranmi10's authorship is preserved.

## Validation
E2E tested with real imports of `resolve_billing_route` + `_lookup_official_docs_pricing`: both case-variants (`MiniMax-M2.7`, `minimax-m2.7`) × both providers (`minimax`, `minimax-cn`) return $0.30/$1.20 via `official_docs_snapshot`. Unknown minimax models still route cleanly with no entry. `tests/agent/test_usage_pricing.py` — 9/9 passing.