### PR TITLE
feat(yuanbao): wire native text + media delivery into send_message

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -556,6 +556,21 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             last_result = result
         return last_result
 
+    # --- Yuanbao: native media attachment support via running gateway adapter ---
+    if platform == Platform.YUANBAO and media_files:
+        last_result = None
+        for i, chunk in enumerate(chunks):
+            is_last = (i == len(chunks) - 1)
+            result = await _send_yuanbao(
+                chat_id,
+                chunk,
+                media_files=media_files if is_last else None,
+            )
+            if isinstance(result, dict) and result.get("error"):
+                return result
+            last_result = result
+        return last_result
+
     # --- Non-media platforms ---
     if media_files and not message.strip():
         return {
@@ -599,6 +614,8 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             result = await _send_bluebubbles(pconfig.extra, chat_id, chunk)
         elif platform == Platform.QQBOT:
             result = await _send_qqbot(pconfig, chat_id, chunk)
+        elif platform == Platform.YUANBAO:
+            result = await _send_yuanbao(chat_id, chunk)
         else:
             result = {"error": f"Direct sending not yet implemented for {platform.value}"}
 


### PR DESCRIPTION
## Summary
Wires the existing `_send_yuanbao()` helper into `_send_to_platform()` so `send_message` targeting yuanbao actually works — both text-only and media-attached chunks.

Before this, `_send_yuanbao()` already accepted `media_files=` and the user-facing error strings already claimed yuanbao was supported, but no dispatch branch actually routed to it. Text-only yuanbao sends fell through to `"Direct sending not yet implemented"`.

## Changes
- `tools/send_message_tool.py`: yuanbao media-chunk branch (mirrors Signal/Matrix — attachments on the final chunk only) + `elif Platform.YUANBAO` dispatch in the non-media loop.

## Validation
| | Before | After |
|---|---|---|
| `send_message target="yuanbao:..."` text | `{error: "Direct sending not yet implemented for yuanbao"}` | routes to `_send_yuanbao` |
| `send_message` with `media_files` | silently omitted (despite advertised support) | attached on final chunk |
| `py_compile` | — | OK |

Salvage of #17411 by @loongzhao. SKILL.md description change and redundant `website/sidebars.ts` entry (already on main) dropped; indentation + trailing-whitespace cleaned up.
