### PR TITLE
fix(model_tools): cancel coroutine on timeout so worker thread exits + full traceback on tool failure

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -107,17 +107,58 @@ def _run_async(coro):
         loop = None
 
     if loop and loop.is_running():
-        # Inside an async context (gateway, RL env) — run in a fresh thread.
+        # Inside an async context (gateway, RL env) — run in a fresh thread
+        # with its own event loop we own a reference to, so on timeout we
+        # can cancel the task inside that loop (ThreadPoolExecutor.cancel()
+        # only works on not-yet-started futures — it's a no-op on a running
+        # worker, which previously leaked the thread on every 300 s timeout).
         import concurrent.futures
+
+        worker_loop: Optional[asyncio.AbstractEventLoop] = None
+        loop_ready = threading.Event()
+
+        def _run_in_worker():
+            nonlocal worker_loop
+            worker_loop = asyncio.new_event_loop()
+            loop_ready.set()
+            try:
+                asyncio.set_event_loop(worker_loop)
+                return worker_loop.run_until_complete(coro)
+            finally:
+                try:
+                    # Cancel anything still pending (e.g. task cancelled
+                    # externally via call_soon_threadsafe on timeout).
+                    pending = asyncio.all_tasks(worker_loop)
+                    for t in pending:
+                        t.cancel()
+                    if pending:
+                        worker_loop.run_until_complete(
+                            asyncio.gather(*pending, return_exceptions=True)
+                        )
+                except Exception:
+                    pass
+                worker_loop.close()
+
         pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-        future = pool.submit(asyncio.run, coro)
+        future = pool.submit(_run_in_worker)
         try:
             return future.result(timeout=300)
         except concurrent.futures.TimeoutError:
-            future.cancel()
+            # Cancel the coroutine inside its own loop so the worker thread
+            # can wind down instead of running forever.
+            if loop_ready.wait(timeout=1.0) and worker_loop is not None:
+                try:
+                    for t in asyncio.all_tasks(worker_loop):
+                        worker_loop.call_soon_threadsafe(t.cancel)
+                except RuntimeError:
+                    # Loop already closed — nothing to cancel.
+                    pass
             raise
         finally:
-            pool.shutdown(wait=False, cancel_futures=True)
+            # wait=False: don't block the caller on a stuck coroutine. We've
+            # already requested cancellation above; the worker will exit
+            # once the coroutine observes it (usually at the next await).
+            pool.shutdown(wait=False)
 
     # If we're on a worker thread (e.g., parallel tool execution in
     # delegate_task), use a per-thread persistent loop.  This avoids
@@ -737,7 +778,7 @@ def handle_function_call(
 
     except Exception as e:
         error_msg = f"Error executing {function_name}: {str(e)}"
-        logger.error(error_msg)
+        logger.exception(error_msg)
         return json.dumps({"error": error_msg}, ensure_ascii=False)
 
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -58,6 +58,7 @@ AUTHOR_MAP = {
     "johnnncenaaa77@gmail.com": "johnncenae",
     "thomasjhon6666@gmail.com": "ThomassJonax",
     "focusflow.app.help@gmail.com": "yes999zc",
+    "162235745+0z1-ghb@users.noreply.github.com": "0z1-ghb",
     "yes999zc@163.com": "yes999zc",
     "343873859@qq.com": "DrStrangerUJN",
     "uzmpsk.dilekakbas@gmail.com": "dlkakbs",

--- a/tests/test_model_tools_async_bridge.py
+++ b/tests/test_model_tools_async_bridge.py
@@ -199,20 +199,22 @@ class TestRunAsyncWithRunningLoop:
 
     @pytest.mark.asyncio
     async def test_timeout_uses_nonblocking_executor_shutdown(self, monkeypatch):
-        """A timeout in the running-loop branch must not wait for the worker.
+        """A timeout in the running-loop branch must not block the caller.
 
-        ThreadPoolExecutor's context manager performs shutdown(wait=True).
-        If _run_async relies on that path after future.result(timeout=...)
-        times out, the timeout does not bound wall-clock time because the
-        caller still waits for the stuck coroutine's thread to finish.
+        If shutdown ever waits for a stuck worker, a tool coroutine that
+        ignores (or can't observe) cancellation would hang the whole agent.
+        Guard: the caller must raise TimeoutError and pool.shutdown must be
+        called with wait=False. The worker's own event loop handles cleanup
+        (cancellation is scheduled via call_soon_threadsafe before the
+        caller returns).
         """
         import concurrent.futures
         from model_tools import _run_async
 
         events = {
-            "cancelled": False,
             "result_timeout": None,
             "shutdown_calls": [],
+            "submitted_fn": None,
         }
 
         class TimeoutFuture:
@@ -221,7 +223,6 @@ class TestRunAsyncWithRunningLoop:
                 raise concurrent.futures.TimeoutError()
 
             def cancel(self):
-                events["cancelled"] = True
                 return True
 
         class FakeExecutor:
@@ -236,8 +237,10 @@ class TestRunAsyncWithRunningLoop:
                 return False
 
             def submit(self, fn, *args, **kwargs):
-                if args and hasattr(args[0], "close"):
-                    args[0].close()
+                # Record which function got submitted -- should be the
+                # in-function worker wrapper, not bare asyncio.run, so we
+                # know _run_async is using a loop it owns and can cancel.
+                events["submitted_fn"] = getattr(fn, "__name__", repr(fn))
                 return TimeoutFuture()
 
             def shutdown(self, wait=True, cancel_futures=False):
@@ -256,8 +259,82 @@ class TestRunAsyncWithRunningLoop:
             _run_async(_never_finishes())
 
         assert events["result_timeout"] == 300
-        assert events["cancelled"] is True
-        assert events["shutdown_calls"] == [(False, True)]
+        # The worker wrapper creates its own event loop so _run_async can
+        # cancel the task on timeout — this must NOT be bare asyncio.run.
+        assert events["submitted_fn"] != "run", (
+            "_run_async submitted asyncio.run directly — it must submit a "
+            "worker wrapper that owns the event loop so timeouts can cancel "
+            "the task"
+        )
+        # Critical: shutdown must NOT wait. If wait=True, a stuck coroutine
+        # would freeze the caller (converts a thread leak into a hang).
+        assert events["shutdown_calls"], "shutdown was never called"
+        for wait, _cancel in events["shutdown_calls"]:
+            assert wait is False, (
+                f"shutdown called with wait={wait} — a stuck tool coroutine "
+                f"would hang the caller indefinitely"
+            )
+
+    @pytest.mark.asyncio
+    async def test_timeout_cancels_coroutine_in_worker_loop(self, monkeypatch):
+        """On timeout, the worker's event loop must receive a cancel request
+        so the coroutine stops and the thread exits — not leaked.
+
+        Before the fix, future.cancel() on a running ThreadPoolExecutor
+        future is a no-op, so the worker thread kept running the coroutine
+        to completion (leaking one thread per tool-timeout).
+        """
+        from model_tools import _run_async
+
+        # Shrink the 300s internal timeout by patching future.result.
+        # We do this surgically: let everything else run for real so the
+        # worker loop actually exists and can observe cancellation.
+        import concurrent.futures as _cf
+
+        real_pool_cls = _cf.ThreadPoolExecutor
+
+        class FastTimeoutPool(real_pool_cls):
+            def __init__(self, *a, **kw):
+                super().__init__(*a, **kw)
+
+        # Patch future.result to time out after 1s instead of 300s.
+        real_result = _cf.Future.result
+
+        def fast_result(self, timeout=None):
+            return real_result(self, timeout=1.0 if timeout == 300 else timeout)
+
+        monkeypatch.setattr(_cf.Future, "result", fast_result)
+
+        cancel_observed = threading.Event()
+
+        async def _slow_cancellable():
+            try:
+                await asyncio.sleep(60)
+            except asyncio.CancelledError:
+                cancel_observed.set()
+                raise
+
+        import time as _time
+        t0 = _time.time()
+        with pytest.raises(_cf.TimeoutError):
+            _run_async(_slow_cancellable())
+        elapsed = _time.time() - t0
+
+        # Caller must return fast (no hang waiting for the coro).
+        assert elapsed < 3.0, (
+            f"_run_async blocked caller for {elapsed:.1f}s — should return "
+            f"on timeout regardless of whether the coroutine has finished"
+        )
+
+        # Worker thread must cancel the task (not leak).
+        deadline = _time.time() + 5
+        while not cancel_observed.is_set() and _time.time() < deadline:
+            _time.sleep(0.05)
+        assert cancel_observed.is_set(), (
+            "Coroutine never received CancelledError — worker thread leaked "
+            "(ThreadPoolExecutor.cancel() is a no-op on a running future; "
+            "_run_async must cancel the task inside its worker loop)"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Tool timeouts (300s default) no longer leak worker threads, and tool failures now land in errors.log with a full traceback.

Root cause of the leak: `_run_async()`'s running-loop branch bridges sync tool handlers by spawning a worker thread and doing `future.result(timeout=300)`. When a coroutine ran past the timeout, `future.cancel()` was called — but `ThreadPoolExecutor.cancel()` is a no-op on a running future (it only cancels not-yet-started work). `pool.shutdown(wait=False, cancel_futures=True)` let the caller proceed, but the worker thread kept running the coroutine until it returned on its own. Every tool timeout leaked one thread; cumulative in long-lived gateway / RL sessions.

## Changes

- `model_tools.py` `_run_async()`: replace bare `asyncio.run` submit with a worker wrapper that owns its event loop. On timeout, schedule `task.cancel()` on that loop via `call_soon_threadsafe`, then `pool.shutdown(wait=False)` so the caller returns immediately. Coroutine observes `CancelledError` at its next `await` and the worker exits cleanly.
- `model_tools.py` `handle_function_call()`: `logger.error` → `logger.exception` so tool failures produce a full traceback in errors.log.
- `tests/test_model_tools_async_bridge.py`: update `test_timeout_uses_nonblocking_executor_shutdown` to match the new shutdown semantics (must stay `wait=False`; must submit a worker wrapper not bare `asyncio.run`). Add `test_timeout_cancels_coroutine_in_worker_loop` that asserts the coroutine actually sees `CancelledError` on timeout and the caller returns in under 3s.
- `scripts/release.py`: add AUTHOR_MAP entry for @0z1-ghb.

## Why not the original PR's approach

#17420 proposed `pool.shutdown(wait=True)` in both the TimeoutError branch and the `finally`. That converts the leak into a hang: the caller would block indefinitely waiting for the same stuck coroutine that just timed out. E2E-verified: with a coroutine that runs a 30s `time.sleep`, `wait=True` blocks the caller for the full 30s; `wait=False` with in-loop cancel returns in ~1s.

## Validation

Targeted test pass (12/12):

```
scripts/run_tests.sh tests/test_model_tools_async_bridge.py
========================  12 passed, 1 warning in 1.86s  ========================
```

E2E exercised outside the test suite:

| Scenario | Before (leak) | PR #17420 (hang) | This fix |
|---|---|---|---|
| Cancellable coro past timeout | caller returns; worker thread leaks until coro finishes | caller hangs ~= duration of stuck coro | caller returns ~= timeout; coro sees CancelledError; worker exits |
| Uncancellable blocking coro (raw `time.sleep`) | caller returns; worker leaks | caller hangs | caller returns; worker runs to completion (no worse than before, but bounded to that one coro) |

Closes #17420 (issue identified correctly; original fix would have introduced a user-visible hang).

Co-authored-by: 0z! <162235745+0z1-ghb@users.noreply.github.com>