### PR TITLE
fix(weixin): recognize ret=-2 errmsg='unknown error' as stale-session signal (#17228)

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -92,6 +92,18 @@ SESSION_EXPIRED_ERRCODE = -14
 RATE_LIMIT_ERRCODE = -2  # iLink frequency limit — backoff and retry
 MESSAGE_DEDUP_TTL_SECONDS = 300
 
+
+def _is_stale_session_ret(
+    ret: "Optional[int]", errcode: "Optional[int]", errmsg: "Optional[str]",
+) -> bool:
+    """True when iLink returns ret=-2 / errcode=-2 with 'unknown error',
+    which is a stale-session signal (same as errcode=-14) rather than
+    a genuine rate limit."""
+    if ret != RATE_LIMIT_ERRCODE and errcode != RATE_LIMIT_ERRCODE:
+        return False
+    return (errmsg or "").lower() == "unknown error"
+
+
 MEDIA_IMAGE = 1
 MEDIA_VIDEO = 2
 MEDIA_FILE = 3
@@ -1254,7 +1266,8 @@ class WeixinAdapter(BasePlatformAdapter):
                 ret = response.get("ret", 0)
                 errcode = response.get("errcode", 0)
                 if ret not in (0, None) or errcode not in (0, None):
-                    if ret == SESSION_EXPIRED_ERRCODE or errcode == SESSION_EXPIRED_ERRCODE:
+                    if (ret == SESSION_EXPIRED_ERRCODE or errcode == SESSION_EXPIRED_ERRCODE
+                            or _is_stale_session_ret(ret, errcode, response.get("errmsg"))):
                         logger.error("[%s] Session expired; pausing for 10 minutes", self.name)
                         await asyncio.sleep(600)
                         consecutive_failures = 0
@@ -1519,6 +1532,7 @@ class WeixinAdapter(BasePlatformAdapter):
                         is_session_expired = (
                             ret == SESSION_EXPIRED_ERRCODE
                             or errcode == SESSION_EXPIRED_ERRCODE
+                            or _is_stale_session_ret(ret, errcode, resp.get("errmsg"))
                         )
                         # Session expired — strip token and retry once
                         if is_session_expired and not retried_without_token and context_token:

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -758,3 +758,33 @@ class TestWeixinVoiceSending:
         assert voice_item["encode_type"] == 6
         assert voice_item["sample_rate"] == 24000
         assert voice_item["bits_per_sample"] == 16
+
+
+class TestIsStaleSessionRet:
+    """Regression test for #17228: distinguish stale-session ret=-2 from rate-limit ret=-2."""
+
+    def test_ret_minus_2_with_unknown_error_is_stale(self):
+        assert weixin._is_stale_session_ret(-2, None, "unknown error") is True
+
+    def test_errcode_minus_2_with_unknown_error_is_stale(self):
+        assert weixin._is_stale_session_ret(None, -2, "unknown error") is True
+
+    def test_unknown_error_case_insensitive(self):
+        assert weixin._is_stale_session_ret(-2, None, "Unknown Error") is True
+
+    def test_ret_minus_2_with_freq_limit_is_not_stale(self):
+        # Genuine rate limit — must NOT be treated as stale session.
+        assert weixin._is_stale_session_ret(-2, None, "freq limit") is False
+
+    def test_ret_minus_2_with_no_errmsg_is_not_stale(self):
+        assert weixin._is_stale_session_ret(-2, None, None) is False
+        assert weixin._is_stale_session_ret(-2, None, "") is False
+
+    def test_errcode_minus_14_is_not_matched_here(self):
+        # -14 is handled by the separate SESSION_EXPIRED_ERRCODE path; the
+        # helper only disambiguates -2 from a genuine rate limit.
+        assert weixin._is_stale_session_ret(-14, None, "session expired") is False
+
+    def test_success_codes_are_not_stale(self):
+        assert weixin._is_stale_session_ret(0, 0, "") is False
+        assert weixin._is_stale_session_ret(None, None, "unknown error") is False


### PR DESCRIPTION
## Summary

Weixin cron pushes to inactive chats now recover by stripping the stale `context_token` and retrying tokenless, instead of being silently dropped.

Root cause: iLink returns `ret=-2 errmsg="unknown error"` for a stale `context_token` (same condition as `errcode=-14`), but the adapter was treating all `ret=-2` as a rate limit and exhausting retries with the same bad token. Genuine rate limits are `ret=-2` with a different errmsg (e.g. `"freq limit"`) — the two share a code but are distinguishable by errmsg.

## Changes

- `gateway/platforms/weixin.py`: new `_is_stale_session_ret(ret, errcode, errmsg)` helper that matches `-2` **only** when `errmsg == "unknown error"`. Wired into both `_send_text_chunk` (send path) and the poll loop. Genuine rate-limit `-2` still takes the existing backoff path.
- `tests/gateway/test_weixin.py`: 7-case truth table for the helper — covers stale/rate-limit disambiguation, case-insensitivity, empty errmsg, and non-match on `-14`.

## Validation

| Scenario | Before | After |
|---|---|---|
| `ret=-2 errmsg="unknown error"` (stale token) | Rate-limit backoff, retries fail, push dropped | Strip `context_token`, retry tokenless, push succeeds |
| `ret=-2 errmsg="freq limit"` (genuine rate limit) | Backoff + retry (correct) | Backoff + retry (unchanged) |
| `errcode=-14` (documented session expired) | Session-expired path (correct) | Session-expired path (unchanged) |

`tests/gateway/test_weixin.py`: 49 passed.

## Credit

Salvaged from #17287 by @vominh1919 — original commit preserved via cherry-pick. Also closes #16465 by @Grey0202 (submitted first, same root cause, different implementation — blanket `-2` matching which would have masked genuine rate limits).

Closes #17228.