### PR TITLE
fix(windows): decode wmic output with explicit encoding to survive non-UTF-8 locales (#17049)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -279,9 +279,11 @@ def _scan_gateway_pids(exclude_pids: set[int], all_profiles: bool = False) -> li
                 ["wmic", "process", "get", "ProcessId,CommandLine", "/FORMAT:LIST"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="ignore",
                 timeout=10,
             )
-            if result.returncode != 0:
+            if result.returncode != 0 or result.stdout is None:
                 return []
             current_cmd = ""
             for line in result.stdout.split("\n"):

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5274,12 +5274,19 @@ def _warn_stale_dashboard_processes() -> None:
 
     try:
         if sys.platform == "win32":
+            # wmic emits text in the system code page (e.g. cp936 on zh-CN
+            # locales), not UTF-8. Without an explicit encoding, Python's
+            # default UTF-8 decoder crashes the subprocess reader thread
+            # with UnicodeDecodeError, leaving result.stdout=None and the
+            # subsequent .split() call crashing `hermes update` with an
+            # AttributeError on Windows non-UTF-8 locales (#17049).
             result = subprocess.run(
                 ["wmic", "process", "get", "ProcessId,CommandLine",
                  "/FORMAT:LIST"],
                 capture_output=True, text=True, timeout=10,
+                encoding="utf-8", errors="ignore",
             )
-            if result.returncode != 0:
+            if result.returncode != 0 or result.stdout is None:
                 return
             current_cmd = ""
             for line in result.stdout.split("\n"):

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5274,12 +5274,13 @@ def _warn_stale_dashboard_processes() -> None:
 
     try:
         if sys.platform == "win32":
-            # wmic emits text in the system code page (e.g. cp936 on zh-CN
-            # locales), not UTF-8. Without an explicit encoding, Python's
-            # default UTF-8 decoder crashes the subprocess reader thread
-            # with UnicodeDecodeError, leaving result.stdout=None and the
-            # subsequent .split() call crashing `hermes update` with an
-            # AttributeError on Windows non-UTF-8 locales (#17049).
+            # wmic may emit text in the system code page (for example cp936
+            # on zh-CN systems), not UTF-8. In text mode, subprocess output
+            # decoding depends on Python's configuration (locale-dependent
+            # by default, or UTF-8 in UTF-8 mode). The important protection
+            # here is errors="ignore": it prevents a reader-thread
+            # UnicodeDecodeError from leaving result.stdout=None and turning
+            # the later .split() into an AttributeError (#17049).
             result = subprocess.run(
                 ["wmic", "process", "get", "ProcessId,CommandLine",
                  "/FORMAT:LIST"],

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -263,6 +263,7 @@ AUTHOR_MAP = {
     "danielrpike9@gmail.com": "Bartok9",
     "skozyuk@cruxexperts.com": "CruxExperts",
     "154585401+LeonSGP43@users.noreply.github.com": "LeonSGP43",
+    "12250313+Kailigithub@users.noreply.github.com": "Kailigithub",
     "mgparkprint@gmail.com": "vlwkaos",
     "tranquil_flow@protonmail.com": "Tranquil-Flow",
     "LyleLengyel@gmail.com": "mcndjxlefnd",

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -175,3 +175,57 @@ class TestWarnStaleDashboardProcesses:
         output = capsys.readouterr().out
         assert "PID 99999" not in output
         assert "PID 12345" in output
+
+
+class TestWindowsWmicEncoding:
+    """Regression tests for #17049 — the Windows wmic branch must not crash
+    `hermes update` on non-UTF-8 system locales (e.g. cp936 on zh-CN).
+    """
+
+    def test_wmic_invoked_with_utf8_ignore_errors(self):
+        """The wmic subprocess.run call must pass encoding='utf-8' and
+        errors='ignore' so the subprocess reader thread cannot raise
+        UnicodeDecodeError on non-UTF-8 wmic output."""
+        with patch("hermes_cli.main.sys") as mock_sys, \
+                patch("subprocess.run") as mock_run:
+            mock_sys.platform = "win32"
+            # Provide a minimal valid wmic /FORMAT:LIST response.
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout=(
+                    "CommandLine=python -m hermes_cli.main dashboard\n"
+                    "ProcessId=12345\n"
+                ),
+                stderr="",
+            )
+            _warn_stale_dashboard_processes()
+
+        assert mock_run.called, "subprocess.run was not invoked"
+        kwargs = mock_run.call_args.kwargs
+        assert kwargs.get("encoding") == "utf-8", (
+            "encoding kwarg must be 'utf-8' so wmic output is decoded "
+            "deterministically rather than via the implicit reader-thread "
+            "default that crashes on non-UTF-8 locales (#17049)."
+        )
+        assert kwargs.get("errors") == "ignore", (
+            "errors kwarg must be 'ignore' so undecodable bytes don't take "
+            "down the reader thread (#17049)."
+        )
+
+    def test_wmic_returns_none_stdout_does_not_crash(self, capsys):
+        """If subprocess.run returns successfully but stdout is None — which
+        is what Python 3.11 leaves behind when the reader thread silently
+        crashed on UnicodeDecodeError before this fix landed — the warning
+        must short-circuit instead of raising AttributeError on
+        ``None.split('\\n')`` and aborting `hermes update` (#17049)."""
+        with patch("hermes_cli.main.sys") as mock_sys, \
+                patch("subprocess.run") as mock_run:
+            mock_sys.platform = "win32"
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout=None, stderr=""
+            )
+            # Must not raise.
+            _warn_stale_dashboard_processes()
+
+        output = capsys.readouterr().out
+        assert "dashboard process" not in output

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -182,13 +182,12 @@ class TestWindowsWmicEncoding:
     `hermes update` on non-UTF-8 system locales (e.g. cp936 on zh-CN).
     """
 
-    def test_wmic_invoked_with_utf8_ignore_errors(self):
+    def test_wmic_invoked_with_utf8_ignore_errors(self, monkeypatch):
         """The wmic subprocess.run call must pass encoding='utf-8' and
         errors='ignore' so the subprocess reader thread cannot raise
         UnicodeDecodeError on non-UTF-8 wmic output."""
-        with patch("hermes_cli.main.sys") as mock_sys, \
-                patch("subprocess.run") as mock_run:
-            mock_sys.platform = "win32"
+        monkeypatch.setattr(sys, "platform", "win32")
+        with patch("subprocess.run") as mock_run:
             # Provide a minimal valid wmic /FORMAT:LIST response.
             mock_run.return_value = MagicMock(
                 returncode=0,
@@ -212,15 +211,14 @@ class TestWindowsWmicEncoding:
             "down the reader thread (#17049)."
         )
 
-    def test_wmic_returns_none_stdout_does_not_crash(self, capsys):
+    def test_wmic_returns_none_stdout_does_not_crash(self, monkeypatch, capsys):
         """If subprocess.run returns successfully but stdout is None — which
         is what Python 3.11 leaves behind when the reader thread silently
         crashed on UnicodeDecodeError before this fix landed — the warning
         must short-circuit instead of raising AttributeError on
         ``None.split('\\n')`` and aborting `hermes update` (#17049)."""
-        with patch("hermes_cli.main.sys") as mock_sys, \
-                patch("subprocess.run") as mock_run:
-            mock_sys.platform = "win32"
+        monkeypatch.setattr(sys, "platform", "win32")
+        with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(
                 returncode=0, stdout=None, stderr=""
             )


### PR DESCRIPTION
`hermes setup` and `hermes update` both scan the Windows process table via `wmic process get ProcessId,CommandLine /FORMAT:LIST` with `text=True` and no explicit encoding. On systems whose default code page is not UTF-8 (e.g. cp936 on zh-CN), the subprocess reader thread crashes with `UnicodeDecodeError`, leaves `result.stdout = None`, and the subsequent `.split("\\n")` aborts both commands with `AttributeError: 'NoneType' object has no attribute 'split'` — exactly the trace in #17049.

This PR closes the bug at both call sites by passing `encoding="utf-8", errors="ignore"` and guarding against `stdout is None`. The parser only matches the ASCII prefixes `CommandLine=` and `ProcessId=`, so dropping undecodable bytes is safe.

## Changes
- `hermes_cli/gateway.py` — `_scan_gateway_pids()` (setup wizard / service detection path).
- `hermes_cli/main.py` — `_warn_stale_dashboard_processes()` (`hermes update` path).
- `tests/hermes_cli/test_update_stale_dashboard.py` — regression tests asserting the encoding kwargs reach `subprocess.run` and that a `None` stdout short-circuits instead of crashing.
- `scripts/release.py` — `AUTHOR_MAP` entry for @Kailigithub.

## Credit
Salvaged from two complementary contributor PRs, both preserved via rebase-merge:
- #17252 @Kailigithub — `_scan_gateway_pids` fix.
- #17123 @briandevans — `_warn_stale_dashboard_processes` fix + regression tests.

(#17271 and #17090 attempted the same fix but bundled unrelated changes; closing those in favor of this PR.)

## Validation
- `tests/hermes_cli/test_update_stale_dashboard.py` — 12/12 pass (10 existing + 2 new).
- `tests/hermes_cli/test_gateway.py` + `test_gateway_service.py` + `test_update_gateway_restart.py` — 169/169 pass.

Closes #17049.