### PR TITLE
fix(agent): preserve slash model names for custom provider on cache hits

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2802,19 +2802,21 @@ def _is_openrouter_client(client: Any) -> bool:
     return False
 
 
-def _cached_client_accepts_slash_models(client: Any, cached_default: Optional[str]) -> bool:
+def _cached_client_accepts_slash_models(client: Any, cached_default: Optional[str], provider: str = "") -> bool:
     """Best-effort check for cached clients that accept ``vendor/model`` IDs."""
+    if provider == "custom":
+        return True
     if _is_openrouter_client(client):
         return True
     return bool(cached_default and "/" in cached_default)
 
 
-def _compat_model(client: Any, model: Optional[str], cached_default: Optional[str]) -> Optional[str]:
+def _compat_model(client: Any, model: Optional[str], cached_default: Optional[str], provider: str = "") -> Optional[str]:
     """Keep slash-bearing model IDs only for cached clients that support them.
 
     Mirrors the guard in resolve_provider_client() which is skipped on cache hits.
     """
-    if model and "/" in model and not _cached_client_accepts_slash_models(client, cached_default):
+    if model and "/" in model and not _cached_client_accepts_slash_models(client, cached_default, provider):
         return cached_default
     return model or cached_default
 
@@ -2879,13 +2881,13 @@ def _get_cached_client(
                     and not cached_loop.is_closed()
                 )
                 if loop_ok:
-                    effective = _compat_model(cached_client, model, cached_default)
+                    effective = _compat_model(cached_client, model, cached_default, provider)
                     return cached_client, effective
                 # Stale — evict and fall through to create a new client.
                 _force_close_async_httpx(cached_client)
                 del _client_cache[cache_key]
             else:
-                effective = _compat_model(cached_client, model, cached_default)
+                effective = _compat_model(cached_client, model, cached_default, provider)
                 return cached_client, effective
     # Build outside the lock
     client, default_model = resolve_provider_client(


### PR DESCRIPTION
## What does this PR do?

When a custom provider uses a HuggingFace-style model name like `google/gemma-4-31b-it`, the model name is correctly preserved through `normalize_model_for_provider()`. However, on subsequent requests that hit the client cache, `_compat_model()` strips the `google/` prefix because the cached client isn't recognized as slash-model-compatible.

This PR passes `provider` into the compat check and short-circuits for `"custom"` — custom providers always accept whatever model format the underlying API expects.

## Related Issue

Fixes #15516

Follow-up to the closed #17410 — @teknium1 pointed out the truncation wasn't in `model_normalize.py` but somewhere else in the pipeline. This is the actual location: the client cache compatibility layer in `auxiliary_client.py`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py`:
  - `_cached_client_accepts_slash_models()`: add `provider` param, return True for `"custom"`
  - `_compat_model()`: pass `provider` through
  - Two call sites in `_get_cached_client()`: pass `provider` arg

## How to Test

1. Configure `provider: "custom"`, `model: "google/gemma-4-31b-it"`, `base_url: "http://localhost/v1"`
2. Send two consecutive requests (second hits cache)
3. Before fix: second request sends truncated model `gemma-4-31b-it`
4. After fix: both requests send full model `google/gemma-4-31b-it`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix