### PR TITLE
fix(wecom/webhook): reuse live WeCom adapter, content-based dedup, auto-YOLO

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -436,6 +436,24 @@ class WebhookAdapter(BasePlatformAdapter):
             )
         self._seen_deliveries[delivery_id] = now
 
+        # ── Content-based dedup ───────────────────────────────────
+        # Some services (e.g. Zentao) send separate webhook events for
+        # operations done at the same time (edit + assign) with different
+        # delivery IDs but identical or near-identical payloads.  Dedup
+        # by route + payload hash within a short window.
+        content_hash = hashlib.sha256(raw_body).hexdigest()[:16]
+        content_key = f"{route_name}:{content_hash}"
+        if content_key in self._seen_deliveries and (now - self._seen_deliveries[content_key]) < 15:
+            logger.info(
+                "[webhook] Skipping content-duplicate for route %s (hash=%s, %.1fs ago)",
+                route_name, content_hash, now - self._seen_deliveries[content_key],
+            )
+            return web.json_response(
+                {"status": "content_duplicate", "delivery_id": delivery_id},
+                status=200,
+            )
+        self._seen_deliveries[content_key] = now
+
         # ── Direct delivery mode (deliver_only) ─────────────────
         # Skip the agent entirely — the rendered prompt IS the message we
         # deliver.  Use case: external services (Supabase, monitoring,
@@ -536,6 +554,17 @@ class WebhookAdapter(BasePlatformAdapter):
             len(prompt),
             delivery_id,
         )
+
+        # Webhook-triggered sessions run autonomously with no user present
+        # to approve dangerous commands.  Auto-enable YOLO for the session.
+        try:
+            from gateway.session import build_session_key
+            _wh_session_key = build_session_key(source)
+            from tools.approval import enable_session_yolo
+            enable_session_yolo(_wh_session_key)
+            logger.info("[webhook] Auto-enabled YOLO for session %s", _wh_session_key)
+        except Exception as _yolo_err:
+            logger.warning("[webhook] Failed to enable YOLO: %s", _yolo_err)
 
         # Non-blocking — return 202 Accepted immediately
         task = asyncio.create_task(self.handle_message(event))

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -594,6 +594,17 @@ def _format_gateway_process_notification(evt: dict) -> "str | None":
     return None
 
 
+# Module-level reference to the active GatewayRunner instance.
+# Used by send_message_tool to reuse live platform adapters (e.g. WeCom)
+# instead of creating throwaway connections that disrupt the main one.
+_active_gateway_runner: Optional["GatewayRunner"] = None
+
+
+def get_active_gateway_runner() -> Optional["GatewayRunner"]:
+    """Return the running GatewayRunner instance, if any."""
+    return _active_gateway_runner
+
+
 class GatewayRunner:
     """
     Main gateway controller.
@@ -617,8 +628,10 @@ class GatewayRunner:
     _session_model_overrides: Dict[str, Dict[str, str]] = {}
     
     def __init__(self, config: Optional[GatewayConfig] = None):
+        global _active_gateway_runner
         self.config = config or load_gateway_config()
         self.adapters: Dict[Platform, BasePlatformAdapter] = {}
+        _active_gateway_runner = self
         self._warn_if_docker_media_delivery_is_risky()
 
         # Load ephemeral config from config.yaml / env vars.

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -328,6 +328,10 @@ def _parse_target_ref(platform_name: str, target_ref: str):
             # Preserve the leading '+' — signal-cli and sms/whatsapp adapters
             # expect E.164 format for direct recipients.
             return target_ref.strip(), None, True
+
+    # WeCom external chat IDs (group chats start with "wr", user IDs are numeric)
+    if platform_name == "wecom" and (target_ref.startswith("wr") or target_ref.startswith("wm") or target_ref.startswith("wk")):
+        return target_ref, None, True
     if target_ref.lstrip("-").isdigit():
         return target_ref, None, True
     # Matrix room IDs (start with !) and user IDs (start with @) are explicit
@@ -1314,7 +1318,30 @@ async def _send_dingtalk(extra, chat_id, message):
 
 
 async def _send_wecom(extra, chat_id, message):
-    """Send via WeCom using the adapter's WebSocket send pipeline."""
+    """Send via WeCom, reusing the gateway's live adapter if available.
+
+    Creating a new WeComAdapter per call is destructive: WeCom only allows
+    one active WebSocket per bot_id, so the new connection kicks the main
+    gateway connection offline (errcode 846609).  We now try the live
+    adapter first and only fall back to a throwaway connection when the
+    gateway isn't running (e.g. CLI mode).
+    """
+    # --- Try the live gateway adapter first (no new WebSocket) ---
+    try:
+        from gateway.run import get_active_gateway_runner
+        from gateway.config import Platform
+        runner = get_active_gateway_runner()
+        if runner:
+            adapter = runner.adapters.get(Platform.WECOM)
+            if adapter and adapter.is_connected:
+                result = await adapter.send(chat_id, message)
+                if result.success:
+                    return {"success": True, "platform": "wecom", "chat_id": chat_id, "message_id": result.message_id}
+                return _error(f"WeCom send failed: {result.error}")
+    except Exception as e:
+        logger.debug("WeCom live-adapter lookup failed, falling back: %s", e)
+
+    # --- Fallback: create a throwaway adapter (CLI mode, no gateway) ---
     try:
         from gateway.platforms.wecom import WeComAdapter, check_wecom_requirements
         if not check_wecom_requirements():


### PR DESCRIPTION
## Problem

### 1. WeCom WebSocket connection disruption (errcode 846609)

When the agent calls `send_message(target='wecom:...')` from a webhook-triggered session, `_send_wecom()` creates a **new** `WeComAdapter` + WebSocket connection every time. WeCom only allows **one active WebSocket per bot_id** — the new connection's `aibot_subscribe` kicks the main gateway connection offline, causing:

- All subsequent webhook deliveries fail with `errcode 846609: aibot websocket not subscribed`
- The main gateway's WeCom connection drops, breaking DM sessions
- Repeated `Connected → Disconnected` cycles as the main connection tries to reconnect but keeps getting kicked

### 2. Duplicate webhook triggers

Some services (e.g. Zentao) fire multiple webhook events for a single user action — for example, "edit + assign" done simultaneously generates two separate POSTs with different delivery IDs but **identical payloads**. The existing delivery-ID-based idempotency check doesn't catch these, resulting in duplicate agent runs (double pipeline triggers, double notifications).

### 3. Webhook sessions block on approval

Webhook-triggered sessions run autonomously with no user present. When the agent executes `terminal` commands (e.g. `curl` to internal APIs), the security scanner flags them and blocks waiting for `/approve` — but nobody is there to approve.

### 4. WeCom external chat ID routing

`send_message` with `target=wecom:wrtP-iDAAA...` (WeCom external group chat ID) fails because `_parse_target_ref()` only accepts numeric chat IDs. WeCom external chat IDs use `wr`/`wm`/`wk` prefixes.

## Solution

### 1. `tools/send_message_tool.py` — Reuse live WeCom adapter

`_send_wecom()` now tries to use the gateway's existing WeCom adapter via `get_active_gateway_runner()` before falling back to creating a throwaway connection. This eliminates the WebSocket contention entirely in gateway mode. CLI mode (no gateway) still works via the fallback path.

### 2. `gateway/platforms/webhook.py` — Content-based dedup

Added SHA-256 payload hash dedup with a 15-second window. Same route + same payload body within 15 seconds → skip the duplicate. Works alongside the existing delivery-ID dedup for webhook retries.

### 3. `gateway/platforms/webhook.py` — Auto-YOLO for webhook sessions

Auto-enable session YOLO mode before dispatching `handle_message()` for webhook-triggered events, allowing autonomous command execution.

### 4. `tools/send_message_tool.py` — WeCom chat ID prefix check

Added prefix check for WeCom external chat IDs (`wr*`, `wm*`, `wk*`) in `_parse_target_ref()`.

### 5. `gateway/run.py` — Module-level gateway runner accessor

Added `_active_gateway_runner` reference and `get_active_gateway_runner()` function, set during `GatewayRunner.__init__()`. This allows tools to access the live gateway adapters without creating new connections.

## Files Changed

- `tools/send_message_tool.py` — WeCom chat ID support + live adapter reuse
- `gateway/platforms/webhook.py` — content dedup + auto-YOLO
- `gateway/run.py` — `get_active_gateway_runner()` accessor
