### PR TITLE
fix(web): allow WebSocket connections from remote clients when --insecure is used

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2388,7 +2388,7 @@ async def pty_ws(ws: WebSocket) -> None:
         return
 
     client_host = ws.client.host if ws.client else ""
-    if client_host and client_host not in _LOOPBACK_HOSTS:
+    if client_host and client_host not in _LOOPBACK_HOSTS and not getattr(app.state, "allow_public", False):
         await ws.close(code=4403)
         return
 
@@ -2496,7 +2496,7 @@ async def gateway_ws(ws: WebSocket) -> None:
         return
 
     client_host = ws.client.host if ws.client else ""
-    if client_host and client_host not in _LOOPBACK_HOSTS:
+    if client_host and client_host not in _LOOPBACK_HOSTS and not getattr(app.state, "allow_public", False):
         await ws.close(code=4403)
         return
 
@@ -2529,7 +2529,7 @@ async def pub_ws(ws: WebSocket) -> None:
         return
 
     client_host = ws.client.host if ws.client else ""
-    if client_host and client_host not in _LOOPBACK_HOSTS:
+    if client_host and client_host not in _LOOPBACK_HOSTS and not getattr(app.state, "allow_public", False):
         await ws.close(code=4403)
         return
 
@@ -2559,7 +2559,7 @@ async def events_ws(ws: WebSocket) -> None:
         return
 
     client_host = ws.client.host if ws.client else ""
-    if client_host and client_host not in _LOOPBACK_HOSTS:
+    if client_host and client_host not in _LOOPBACK_HOSTS and not getattr(app.state, "allow_public", False):
         await ws.close(code=4403)
         return
 
@@ -3157,6 +3157,7 @@ def start_server(
     # PTY child uses to publish events to the dashboard sidebar.
     app.state.bound_host = host
     app.state.bound_port = port
+    app.state.allow_public = allow_public
 
     if open_browser:
         import webbrowser


### PR DESCRIPTION
## Problem

When using `hermes dashboard --insecure --host 0.0.0.0`, the HTTP page loads fine over Tailscale/remote connections, but the WebSocket endpoints (`/api/pty`, `/api/ws`, `/api/pub`, `/api/events`) still rejected non-loopback clients with code 4403 (Forbidden).

This caused "Session ended" errors in the Chat tab when accessing the dashboard remotely via Tailscale, even though `--insecure` was passed.

## Root Cause

In `hermes_cli/web_server.py`:
- Line 3131: `allow_public: bool = False` is set when `--insecure` is used
- Lines 2391, 2499, 2532, 2562: WebSocket handlers check `_LOOPBACK_HOSTS` unconditionally
- `allow_public` was NOT stored in `app.state` for WebSocket handlers to check

## Fix

1. Store `allow_public` in `app.state` in `start_server()` (line 3158)
2. Check `app.state.allow_public` before rejecting non-loopback clients in all 4 WebSocket handlers

## Changes

- Added `app.state.allow_public = allow_public` in `start_server()`
- Updated WebSocket loopback check in `pty_ws()`, `gateway_ws()`, `pub_ws()`, `events_ws()` to skip the check when `allow_public` is True

## Security Note

This fix only affects connections when `--insecure` is explicitly used. The default behavior (loopback-only) remains unchanged for security.

## Testing

Tested locally with `hermes dashboard --no-open --tui --host 0.0.0.0 --insecure` over Tailscale - WebSocket Chat tab now works correctly from remote clients.