### PR TITLE
fix(transport): omit thinking_config for Gemma on the gemini provider (#17426)

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -29,6 +29,18 @@ def _build_gemini_thinking_config(model: str, reasoning_config: dict | None) -> 
     if reasoning_config is None or not isinstance(reasoning_config, dict):
         return None
 
+    normalized_model = (model or "").strip().lower()
+    if normalized_model.startswith("google/"):
+        normalized_model = normalized_model.split("/", 1)[1]
+
+    # ``thinking_config`` is a Gemini-only request parameter. The same
+    # ``gemini`` provider also serves Gemma (and historically PaLM/Bard);
+    # those reject the field with HTTP 400 "Unknown name 'thinking_config':
+    # Cannot find field" — including the polite ``{"includeThoughts": False}``
+    # form. Omit the field entirely on non-Gemini models. (#17426)
+    if not normalized_model.startswith("gemini"):
+        return None
+
     if reasoning_config.get("enabled") is False:
         # Gemini can hide thought parts even when internal thinking still
         # happens; omit thinkingLevel to avoid model-specific validation quirks.
@@ -39,9 +51,6 @@ def _build_gemini_thinking_config(model: str, reasoning_config: dict | None) -> 
         return {"includeThoughts": False}
 
     thinking_config: Dict[str, Any] = {"includeThoughts": True}
-    normalized_model = (model or "").strip().lower()
-    if normalized_model.startswith("google/"):
-        normalized_model = normalized_model.split("/", 1)[1]
 
     # Gemini 2.5 accepts thinkingBudget; don't guess a budget from Hermes'
     # coarse effort levels. ``includeThoughts`` alone is enough to surface

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -206,6 +206,46 @@ class TestChatCompletionsBuildKwargs:
             "thinkingLevel": "low",
         }
 
+    def test_gemma_does_not_receive_thinking_config(self, transport):
+        # The `gemini` provider also serves Gemma (e.g. `gemma-4-31b-it`),
+        # but Gemma rejects `thinking_config` with HTTP 400 (#17426). Even
+        # when Hermes has reasoning enabled, the field must be omitted for
+        # non-Gemini models on this provider.
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gemma-4-31b-it",
+            messages=msgs,
+            provider_name="gemini",
+            reasoning_config={"enabled": True, "effort": "high"},
+        )
+        assert "thinking_config" not in kw.get("extra_body", {})
+
+    def test_gemma_disabled_reasoning_still_omits_thinking_config(self, transport):
+        # The `Unknown name 'thinking_config': Cannot find field` rejection
+        # fires even on `{"includeThoughts": False}` — the entire field must
+        # be absent, not just disabled. (#17426)
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gemma-4-31b-it",
+            messages=msgs,
+            provider_name="gemini",
+            reasoning_config={"enabled": False},
+        )
+        assert "thinking_config" not in kw.get("extra_body", {})
+
+    def test_google_prefixed_gemma_also_omits_thinking_config(self, transport):
+        # OpenRouter-style `google/gemma-...` IDs hit the same provider path
+        # and must also omit `thinking_config`. The existing `google/`
+        # prefix-stripping must not accidentally classify Gemma as Gemini.
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="google/gemma-4-31b-it",
+            messages=msgs,
+            provider_name="gemini",
+            reasoning_config={"enabled": True, "effort": "medium"},
+        )
+        assert "thinking_config" not in kw.get("extra_body", {})
+
     def test_max_tokens_with_fn(self, transport):
         msgs = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(


### PR DESCRIPTION
## Summary
- Hermes was sending `extra_body.thinking_config` for **every** chat call routed through the `gemini` provider — including Gemma (`gemma-4-31b-it`), PaLM, and any other non-Gemini Google model on the same endpoint
- Those models reject the field at the API edge: `HTTP 400 — Unknown name \"thinking_config\": Cannot find field`
- Result: Gemma users on the `gemini` provider exit immediately on every chat (#17426)

## The bug

[chat_completions.py:365-368](https://github.com/NousResearch/hermes-agent/blob/main/agent/transports/chat_completions.py#L365-L368) builds `thinking_config` whenever `provider_name in {\"gemini\", \"google-gemini-cli\"}`:

\`\`\`python
if provider_name in {\"gemini\", \"google-gemini-cli\"}:
    thinking_config = _build_gemini_thinking_config(model, reasoning_config)
    if thinking_config:
        extra_body[\"thinking_config\"] = thinking_config
\`\`\`

The helper unconditionally returned a dict — never `None` — for any model under those providers. So `extra_body[\"thinking_config\"]` was always set, including for Gemma. The Gemini API's strict request validator rejects unknown fields, even the polite `{\"includeThoughts\": False}` shape.

The reporter's payload:

\`\`\`
provider:    gemini
model:       gemma-4-31b-it
→ HTTP 400: 'Invalid JSON payload received. Unknown name \"thinking_config\": Cannot find field.'
\`\`\`

## The fix

`_build_gemini_thinking_config()` now mirrors the same family-detection pattern it already uses for Gemini-2.5 vs Gemini-3 clamping: normalise the model id, strip an OpenRouter-style `google/` prefix, and short-circuit to `None` when the result doesn't start with `gemini`.

We return `None` rather than `{\"includeThoughts\": False}` because the API rejects the field **name** itself — there is no \"off\" shape that's safe.

The Gemini guard fires after the `google/` strip, so:
- `gemini-2.5-flash` → still gets `thinking_config`
- `gemini-3-flash-preview` → still gets `thinking_config`
- `google/gemini-3.1-pro-preview` → still gets `thinking_config` (existing behaviour preserved)
- `gemma-4-31b-it` → no `thinking_config`
- `google/gemma-4-31b-it` → no `thinking_config`

## Test plan
- [x] **Focused regression**: 3 new cases in `tests/agent/transports/test_chat_completions.py`:
  - `test_gemma_does_not_receive_thinking_config` — reasoning enabled, high effort → field absent
  - `test_gemma_disabled_reasoning_still_omits_thinking_config` — `enabled: False` → field absent (proves the omit-not-disable contract)
  - `test_google_prefixed_gemma_also_omits_thinking_config` — OpenRouter-style id → field absent
- [x] **Adjacent suite**: existing 5 Gemini cases (\`test_gemini_*_reasoning_*\`, \`test_gemini_25_*\`, \`test_gemini_pro_*\`, etc.) all still pass — the new guard only kicks in for non-Gemini models
- [x] **Regression guard**: stashing the `chat_completions.py` change makes both Gemma tests fail at \`assert \"thinking_config\" not in kw.get(\"extra_body\", {})\` (the field is present); restoring the fix flips them back to passing
- [x] Full file run: \`pytest tests/agent/transports/test_chat_completions.py\` → **57 passed**

## Contract Protected

| Model | Provider | reasoning_config | thinking_config sent? |
|---|---|---|---|
| `gemini-2.5-flash` | gemini | enabled | ✅ yes |
| `gemini-3-flash-preview` | gemini | enabled | ✅ yes (with `thinkingLevel`) |
| `gemini-3-flash-preview` | gemini | disabled | ✅ yes (`includeThoughts: False`) |
| `google/gemini-3.1-pro-preview` | gemini | enabled | ✅ yes (with clamped level) |
| `gemma-4-31b-it` | gemini | enabled | ❌ omitted (#17426) |
| `gemma-4-31b-it` | gemini | disabled | ❌ omitted |
| `google/gemma-4-31b-it` | gemini | enabled | ❌ omitted |

Fixes #17426