### PR TITLE
fix: resolve Slack user IDs to DM channels in standalone cron delivery

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -881,6 +881,159 @@ class TestParseTargetRefSlack:
         assert _parse_target_ref("telegram", "C0B0QV5434G")[2] is False
 
 
+class TestSendSlackUserDm:
+    """_send_slack resolves user IDs (U...) to DM channels via conversations.open."""
+
+    @staticmethod
+    def _build_conversations_open_response(ok=True, channel_id="D1234567890"):
+        """Build a mock response for conversations.open."""
+        resp = MagicMock()
+        resp.status = 200
+        resp.json = AsyncMock(return_value={"ok": ok, "channel": {"id": channel_id}} if ok else {"ok": False, "error": "user_not_found"})
+        resp.__aenter__ = AsyncMock(return_value=resp)
+        resp.__aexit__ = AsyncMock(return_value=None)
+        return resp
+
+    @staticmethod
+    def _build_post_message_response(ok=True):
+        """Build a mock response for chat.postMessage."""
+        resp = MagicMock()
+        resp.status = 200
+        resp.json = AsyncMock(return_value={"ok": ok, "ts": "1234567890.123456"} if ok else {"ok": False, "error": "channel_not_found"})
+        resp.__aenter__ = AsyncMock(return_value=resp)
+        resp.__aexit__ = AsyncMock(return_value=None)
+        return resp
+
+    def _build_session_sequence(self, *responses):
+        """Build a session that returns given responses for sequential POST calls."""
+        session = MagicMock()
+        session.__aenter__ = AsyncMock(return_value=session)
+        session.__aexit__ = AsyncMock(return_value=None)
+        session.post = MagicMock(side_effect=list(responses))
+        return session
+
+    def test_sends_to_user_id_resolves_dm(self):
+        """Sending to a user ID (U...) calls conversations.open then chat.postMessage with the DM channel."""
+        from tools.send_message_tool import _send_slack
+
+        open_resp = self._build_conversations_open_response(channel_id="D999888777")
+        post_resp = self._build_post_message_response()
+        session = self._build_session_sequence(open_resp, post_resp)
+
+        with patch("aiohttp.ClientSession", return_value=session):
+            result = asyncio.run(_send_slack("xoxb-token", "U1234567890", "Hello via DM resolution"))
+
+        assert result["success"] is True
+        assert result["chat_id"] == "D999888777"
+        # Verify conversations.open was called first
+        open_call_url = session.post.call_args_list[0].args[0]
+        assert "conversations.open" in open_call_url
+        open_payload = session.post.call_args_list[0].kwargs["json"]
+        assert open_payload == {"users": "U1234567890"}
+        # Verify chat.postMessage was called with the resolved DM channel
+        post_call_url = session.post.call_args_list[1].args[0]
+        assert "chat.postMessage" in post_call_url
+        post_payload = session.post.call_args_list[1].kwargs["json"]
+        assert post_payload["channel"] == "D999888777"
+
+    def test_channel_id_skips_resolution(self):
+        """Channel IDs (C..., G..., D...) go directly to chat.postMessage without conversations.open."""
+        from tools.send_message_tool import _send_slack
+
+        post_resp = self._build_post_message_response()
+        session = self._build_session_sequence(post_resp)
+
+        with patch("aiohttp.ClientSession", return_value=session):
+            result = asyncio.run(_send_slack("xoxb-token", "C1234567890", "Hello channel"))
+
+        assert result["success"] is True
+        assert result["chat_id"] == "C1234567890"
+        # Only one POST call — no conversations.open
+        assert session.post.call_count == 1
+        call_url = session.post.call_args.args[0]
+        assert "chat.postMessage" in call_url
+
+    def test_private_channel_skips_resolution(self):
+        """Private channel IDs (G...) go directly to chat.postMessage."""
+        from tools.send_message_tool import _send_slack
+
+        post_resp = self._build_post_message_response()
+        session = self._build_session_sequence(post_resp)
+
+        with patch("aiohttp.ClientSession", return_value=session):
+            result = asyncio.run(_send_slack("xoxb-token", "G1234567890", "Hello private channel"))
+
+        assert result["success"] is True
+        assert result["chat_id"] == "G1234567890"
+        assert session.post.call_count == 1
+
+    def test_existing_dm_channel_skips_resolution(self):
+        """Existing DM IDs (D...) go directly to chat.postMessage."""
+        from tools.send_message_tool import _send_slack
+
+        post_resp = self._build_post_message_response()
+        session = self._build_session_sequence(post_resp)
+
+        with patch("aiohttp.ClientSession", return_value=session):
+            result = asyncio.run(_send_slack("xoxb-token", "D1234567890", "Hello existing DM"))
+
+        assert result["success"] is True
+        assert result["chat_id"] == "D1234567890"
+        assert session.post.call_count == 1
+
+    def test_user_id_resolution_failure_returns_error(self):
+        """When conversations.open fails, _send_slack returns an error without calling chat.postMessage."""
+        from tools.send_message_tool import _send_slack, _slack_dm_cache
+
+        _slack_dm_cache.clear()
+
+        open_resp = self._build_conversations_open_response(ok=False)
+        session = self._build_session_sequence(open_resp)
+
+        with patch("aiohttp.ClientSession", return_value=session):
+            result = asyncio.run(_send_slack("xoxb-token", "U9999999999", "Hello"))
+
+        assert "error" in result
+        assert "user ID resolution failed" in result["error"]
+        # Only conversations.open was called, not chat.postMessage
+        assert session.post.call_count == 1
+        open_call_url = session.post.call_args.args[0]
+        assert "conversations.open" in open_call_url
+
+    def test_user_id_resolution_cached(self):
+        """User ID -> DM channel resolution is cached; second send skips conversations.open."""
+        from tools.send_message_tool import _send_slack, _slack_dm_cache
+
+        _slack_dm_cache.clear()
+
+        # First send: conversations.open + chat.postMessage
+        open_resp = self._build_conversations_open_response(channel_id="D555444333")
+        post_resp1 = self._build_post_message_response()
+        session1 = self._build_session_sequence(open_resp, post_resp1)
+
+        with patch("aiohttp.ClientSession", return_value=session1):
+            result1 = asyncio.run(_send_slack("xoxb-token", "U1112223334", "First message"))
+
+        assert result1["success"] is True
+        assert result1["chat_id"] == "D555444333"
+        assert session1.post.call_count == 2  # conversations.open + chat.postMessage
+
+        # Second send: only chat.postMessage (cache hit)
+        post_resp2 = self._build_post_message_response()
+        session2 = self._build_session_sequence(post_resp2)
+
+        with patch("aiohttp.ClientSession", return_value=session2):
+            result2 = asyncio.run(_send_slack("xoxb-token", "U1112223334", "Second message"))
+
+        assert result2["success"] is True
+        assert result2["chat_id"] == "D555444333"
+        assert session2.post.call_count == 1  # Only chat.postMessage
+        post_call_url = session2.post.call_args.args[0]
+        assert "chat.postMessage" in post_call_url
+
+        _slack_dm_cache.clear()
+
+
 class TestSendDiscordThreadId:
     """_send_discord uses thread_id when provided."""
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -27,6 +27,9 @@ _FEISHU_TARGET_RE = re.compile(r"^\s*((?:oc|ou|on|chat|open)_[-A-Za-z0-9]+)(?::(
 # conversations.open to obtain a D... ID. Without this gate, Slack IDs fall
 # through to channel-name resolution, which only matches by name and fails.
 _SLACK_TARGET_RE = re.compile(r"^\s*([CGD][A-Z0-9]{8,})\s*$")
+# Cache for Slack user ID -> DM conversation ID resolution.
+# Keyed by "{token}:{user_id}" to support multi-workspace setups.
+_slack_dm_cache: Dict[str, str] = {}
 _WEIXIN_TARGET_RE = re.compile(r"^\s*((?:wxid|gh|v\d+|wm|wb)_[A-Za-z0-9_-]+|[A-Za-z0-9._-]+@chatroom|filehelper)\s*$")
 _YUANBAO_TARGET_RE = re.compile(r"^\s*((?:group|direct):[^:]+)\s*$")
 # Discord snowflake IDs are numeric, same regex pattern as Telegram topic targets.
@@ -980,13 +983,60 @@ async def _send_discord(token, chat_id, message, thread_id=None, media_files=Non
         return _error(f"Discord send failed: {e}")
 
 
+async def _resolve_slack_user_dm(token: str, user_id: str) -> Optional[str]:
+    """Resolve a Slack user ID (U...) to a DM conversation ID (D...) via conversations.open.
+
+    Results are cached per (token, user_id) pair to avoid redundant API calls.
+    Returns None if resolution fails.
+    """
+    cache_key = f"{token}:{user_id}"
+    if cache_key in _slack_dm_cache:
+        return _slack_dm_cache[cache_key]
+
+    try:
+        import aiohttp
+    except ImportError:
+        return None
+    try:
+        from gateway.platforms.base import resolve_proxy_url, proxy_kwargs_for_aiohttp
+        _proxy = resolve_proxy_url()
+        _sess_kw, _req_kw = proxy_kwargs_for_aiohttp(_proxy)
+        url = "https://slack.com/api/conversations.open"
+        headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=15), **_sess_kw) as session:
+            payload = {"users": user_id}
+            async with session.post(url, headers=headers, json=payload, **_req_kw) as resp:
+                data = await resp.json()
+                if data.get("ok") and data.get("channel", {}).get("id"):
+                    channel_id = data["channel"]["id"]
+                    _slack_dm_cache[cache_key] = channel_id
+                    return channel_id
+                logger.warning("Slack conversations.open failed for %s: %s", user_id, data.get("error", "unknown"))
+                return None
+    except Exception as e:
+        logger.warning("Slack conversations.open exception for %s: %s", user_id, e)
+        return None
+
+
 async def _send_slack(token, chat_id, message):
-    """Send via Slack Web API."""
+    """Send via Slack Web API.
+
+    Supports both Slack conversation IDs (C..., G..., D...) and user IDs (U...).
+    User IDs are automatically resolved to DM conversation IDs via
+    conversations.open and cached to avoid redundant API calls.
+    """
     try:
         import aiohttp
     except ImportError:
         return {"error": "aiohttp not installed. Run: pip install aiohttp"}
     try:
+        # Resolve Slack user IDs (U...) to DM conversation IDs (D...)
+        if chat_id.startswith("U"):
+            resolved = await _resolve_slack_user_dm(token, chat_id)
+            if resolved is None:
+                return _error(f"Slack user ID resolution failed for {chat_id}")
+            chat_id = resolved
+
         from gateway.platforms.base import resolve_proxy_url, proxy_kwargs_for_aiohttp
         _proxy = resolve_proxy_url()
         _sess_kw, _req_kw = proxy_kwargs_for_aiohttp(_proxy)


### PR DESCRIPTION
## Summary

The `_send_slack` function in the cron scheduler's standalone delivery path directly passes `chat_id` to Slack's `chat.postMessage` API. This works for channel IDs (`C...`, `G...`, `D...`) but **fails for user IDs (`U...`)** because `chat.postMessage` requires a conversation ID, not a user ID.

This is a gap between the live SlackAdapter path (which already resolves user IDs via `conversations.open`) and the standalone cron delivery path (which uses raw `aiohttp`).

## Changes

- **New `_resolve_slack_user_dm()` helper** — calls Slack's `conversations.open` API to obtain a DM channel ID (`D...`) from a user ID (`U...`)
- **Module-level cache `_slack_dm_cache`** — caches resolved DM channels per `(token, user_id)` pair to avoid redundant API calls
- **Modified `_send_slack()`** — auto-detects user IDs (starts with `"U"`) and resolves them before posting; channel IDs (`C...`, `G...`, `D...`) are sent directly as before
- **6 new tests** covering: user ID resolution, channel passthrough, private channel, existing DM, resolution failure, and cache behavior

## Test plan

- [x] All 93 existing tests pass
- [x] 6 new tests added for the DM resolution feature
- [x] Manual testing on local cron jobs delivering to `slack:U074PGC4MDM`

## Notes

The live gateway path (`SlackAdapter`) already handles user ID resolution via `conversations.open`. This PR adds equivalent logic to the standalone cron delivery path which was overlooked when the cron delivery system was refactored to use raw HTTP calls instead of `slack_sdk`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)