### PR TITLE
fix(gateway): load WhatsApp home channel from env overrides

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -940,7 +940,14 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         if Platform.WHATSAPP not in config.platforms:
             config.platforms[Platform.WHATSAPP] = PlatformConfig()
         config.platforms[Platform.WHATSAPP].enabled = True
-    
+    whatsapp_home = os.getenv("WHATSAPP_HOME_CHANNEL")
+    if whatsapp_home and Platform.WHATSAPP in config.platforms:
+        config.platforms[Platform.WHATSAPP].home_channel = HomeChannel(
+            platform=Platform.WHATSAPP,
+            chat_id=whatsapp_home,
+            name=os.getenv("WHATSAPP_HOME_CHANNEL_NAME", "Home"),
+        )
+
     # Slack
     slack_token = os.getenv("SLACK_BOT_TOKEN")
     if slack_token:

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -456,6 +456,15 @@ class TestHomeChannelEnvOverrides:
                 ("C123", "Ops"),
             ),
             (
+                Platform.WHATSAPP,
+                PlatformConfig(enabled=True),
+                {
+                    "WHATSAPP_HOME_CHANNEL": "1234567890@lid",
+                    "WHATSAPP_HOME_CHANNEL_NAME": "Owner DM",
+                },
+                ("1234567890@lid", "Owner DM"),
+            ),
+            (
                 Platform.SIGNAL,
                 PlatformConfig(
                     enabled=True,


### PR DESCRIPTION
## Summary

Load `WHATSAPP_HOME_CHANNEL` and `WHATSAPP_HOME_CHANNEL_NAME` into `GatewayConfig` during env override application.

Before this change, WhatsApp only honored `WHATSAPP_ENABLED` in `gateway/config.py`, but did not map the home-channel env vars into `PlatformConfig.home_channel`. That meant WhatsApp could be enabled while `config.get_home_channel(Platform.WHATSAPP)` still returned `None`, unlike the other messaging platforms.

## Fix

- add WhatsApp home-channel env override handling in `gateway/config.py`
- add a regression case to `TestHomeChannelEnvOverrides` in `tests/gateway/test_config.py`

## Why this matters

Several gateway paths use `config.get_home_channel(...)` as the source of truth for delivery/context behavior. Without this mapping, WhatsApp home-channel state could be present in env but effectively invisible to those code paths after config load.

## Testing

Ran targeted gateway config tests:

- `tests/gateway/test_config.py`

Result:

- `33 passed, 0 failed`
