### PR TITLE
feat: expose cache usage to context engines

### DIFF
--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -71,7 +71,12 @@ class ContextEngine(ABC):
     def update_from_response(self, usage: Dict[str, Any]) -> None:
         """Update tracked token usage from an API response.
 
-        Called after every LLM call with the usage dict from the response.
+        Called after every LLM call with a normalized usage dict. The legacy
+        keys ``prompt_tokens``, ``completion_tokens``, and ``total_tokens`` are
+        always present. Newer hosts may also include canonical buckets such as
+        ``input_tokens``, ``output_tokens``, ``cache_read_tokens``,
+        ``cache_write_tokens``, and ``reasoning_tokens``. Engines should treat
+        those fields as optional for compatibility with older hosts.
         """
 
     @abstractmethod

--- a/run_agent.py
+++ b/run_agent.py
@@ -161,7 +161,7 @@ from agent.context_compressor import ContextCompressor
 from agent.subdirectory_hints import SubdirectoryHintTracker
 from agent.prompt_caching import apply_anthropic_cache_control
 from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt, build_environment_hints, load_soul_md, TOOL_USE_ENFORCEMENT_GUIDANCE, TOOL_USE_ENFORCEMENT_MODELS, GOOGLE_MODEL_OPERATIONAL_GUIDANCE, OPENAI_MODEL_EXECUTION_GUIDANCE
-from agent.usage_pricing import estimate_usage_cost, normalize_usage
+from agent.usage_pricing import CanonicalUsage, estimate_usage_cost, normalize_usage
 from agent.codex_responses_adapter import (
     _derive_responses_function_call_id as _codex_derive_responses_function_call_id,
     _deterministic_call_id as _codex_deterministic_call_id,
@@ -192,6 +192,24 @@ from agent.trajectory import (
 from utils import atomic_json_write, base_url_host_matches, base_url_hostname, env_var_enabled, normalize_proxy_url
 from hermes_cli.config import cfg_get
 
+
+
+def _build_context_engine_usage_dict(canonical_usage: CanonicalUsage) -> dict[str, int]:
+    """Build the usage payload passed to context engines.
+
+    Keep the legacy token keys while also exposing canonical cache buckets for
+    engines that can make better policy decisions with them.
+    """
+    return {
+        "prompt_tokens": canonical_usage.prompt_tokens,
+        "completion_tokens": canonical_usage.output_tokens,
+        "total_tokens": canonical_usage.total_tokens,
+        "input_tokens": canonical_usage.input_tokens,
+        "output_tokens": canonical_usage.output_tokens,
+        "cache_read_tokens": canonical_usage.cache_read_tokens,
+        "cache_write_tokens": canonical_usage.cache_write_tokens,
+        "reasoning_tokens": canonical_usage.reasoning_tokens,
+    }
 
 
 class _SafeWriter:
@@ -13166,11 +13184,7 @@ class AIAgent:
                         prompt_tokens = canonical_usage.prompt_tokens
                         completion_tokens = canonical_usage.output_tokens
                         total_tokens = canonical_usage.total_tokens
-                        usage_dict = {
-                            "prompt_tokens": prompt_tokens,
-                            "completion_tokens": completion_tokens,
-                            "total_tokens": total_tokens,
-                        }
+                        usage_dict = _build_context_engine_usage_dict(canonical_usage)
                         self.context_compressor.update_from_response(usage_dict)
 
                         # Cache discovered context length after successful call.

--- a/tests/run_agent/test_context_engine_usage.py
+++ b/tests/run_agent/test_context_engine_usage.py
@@ -1,0 +1,36 @@
+from agent.usage_pricing import CanonicalUsage
+from run_agent import _build_context_engine_usage_dict
+
+
+def test_context_engine_usage_dict_exposes_canonical_cache_fields():
+    usage = CanonicalUsage(
+        input_tokens=600,
+        output_tokens=120,
+        cache_read_tokens=400,
+        cache_write_tokens=50,
+        reasoning_tokens=30,
+    )
+
+    payload = _build_context_engine_usage_dict(usage)
+
+    assert payload == {
+        "prompt_tokens": 1050,
+        "completion_tokens": 120,
+        "total_tokens": 1170,
+        "input_tokens": 600,
+        "output_tokens": 120,
+        "cache_read_tokens": 400,
+        "cache_write_tokens": 50,
+        "reasoning_tokens": 30,
+    }
+
+
+def test_context_engine_usage_dict_keeps_zero_cache_fields_present():
+    usage = CanonicalUsage(input_tokens=600, output_tokens=120)
+
+    payload = _build_context_engine_usage_dict(usage)
+
+    assert "cache_read_tokens" in payload
+    assert "cache_write_tokens" in payload
+    assert payload["cache_read_tokens"] == 0
+    assert payload["cache_write_tokens"] == 0


### PR DESCRIPTION
## Summary

This PR forwards the canonical usage buckets that Hermes already computes to the active context engine.

The existing usage keys remain present: `prompt_tokens`, `completion_tokens`, and `total_tokens`.

Context engines can now also read `input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_write_tokens`, and `reasoning_tokens` when those values are available from the provider usage object.

## Why

Hermes already normalizes provider usage into canonical usage fields, including cache read and cache write buckets. External context engines should be able to make decisions and report status from that same usage data instead of only receiving legacy aggregate token fields.

This keeps the host contract generic. It does not add or vendor any external context-engine implementation.

Existing engines stay compatible because the legacy fields are still sent with the same names and meanings.

## Validation

- `./scripts/run_tests.sh -n 0 tests/run_agent/test_context_engine_usage.py tests/run_agent/test_plugin_context_engine_init.py -q --tb=short`, `4 passed`
- `python -m compileall -q run_agent.py agent/context_engine.py tests/run_agent/test_context_engine_usage.py`
- `git diff --check origin/main...HEAD`
- read-only audit of the rebuilt branch found no stale baseline, CI, or unrelated files in the PR diff

## Notes

- Rebuilt on current `main` after #21012 so the old shared baseline commit is no longer part of this PR.
- No external context-engine implementation is vendored or bundled.
