### PR TITLE
fix(anthropic): narrow dot→hyphen normalization to Claude models only (#17171)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1076,9 +1076,12 @@ def normalize_model_name(model: str, preserve_dots: bool = False) -> str:
         # These must not be converted to hyphens.  See issue #12295.
         if _is_bedrock_model_id(model):
             return model
-        # OpenRouter uses dots for version separators (claude-opus-4.6),
-        # Anthropic uses hyphens (claude-opus-4-6). Convert dots to hyphens.
-        model = model.replace(".", "-")
+        # Only convert dots to hyphens for Anthropic/Claude models.
+        # Non-Anthropic models (gpt-5.4, gemini-2.5, etc.) use dots
+        # as part of their canonical names.  See issue #17171.
+        _lower = model.lower()
+        if _lower.startswith("claude-") or _lower.startswith("anthropic/"):
+            model = model.replace(".", "-")
     return model
 
 


### PR DESCRIPTION
Salvage of #17290 by @vominh1919 onto current main.

## Summary
The Anthropic adapter no longer hyphen-mangles non-Claude model names. `gpt-5.4` routed through the Anthropic adapter now reaches the wire as `gpt-5.4` instead of `gpt-5-4`.

## Root cause
`normalize_model_name()` in `agent/anthropic_adapter.py` unconditionally did `model.replace('.', '-')` on every non-Bedrock model. This is only correct for Anthropic's own `claude-*` IDs — any other model ID with dots (`gpt-5.4`, `gemini-2.5-pro`, `z-ai/glm-5.1`, `qwen3.5-plus`) got mangled when it landed on this code path (e.g. a custom `anthropic_messages` endpoint, or a webui session where provider auto-detection falls back to Anthropic without inferring openai-codex from `gpt-*`).

## Fix
Guard the replacement with a Claude/Anthropic prefix check (case-insensitive). Everything else passes through unchanged. Bedrock guard unchanged.

## Validation
| Input | Before | After |
|---|---|---|
| `claude-opus-4.6` | `claude-opus-4-6` ✓ | `claude-opus-4-6` ✓ |
| `anthropic/claude-sonnet-4.5` | `claude-sonnet-4-5` ✓ | `claude-sonnet-4-5` ✓ |
| `gpt-5.4` | `gpt-5-4` ✗ | `gpt-5.4` ✓ |
| `gemini-2.5-pro` | `gemini-2-5-pro` ✗ | `gemini-2.5-pro` ✓ |
| `z-ai/glm-5.1` | `z-ai/glm-5-1` ✗ | `z-ai/glm-5.1` ✓ |
| `us.anthropic.claude-sonnet-4-6` | preserved ✓ | preserved ✓ |

`tests/agent/test_anthropic_adapter.py`: 138/138 pass.

Fixes #17171
Fixes #13061
Related: #16417 (partial — helps non-Claude IDs on custom anthropic_messages endpoints; does not help Claude IDs whose upstream wants the dot form)