### PR TITLE
fix(weixin): prevent cross-event-loop aiohttp session reuse in send_weixin_direct

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -2030,7 +2030,21 @@ async def send_weixin_direct(
 
     live_adapter = _LIVE_ADAPTERS.get(resolved_token)
     send_session = getattr(live_adapter, '_send_session', None)
-    if live_adapter is not None and send_session is not None and not send_session.closed:
+    # Verify the live adapter's session is on the CURRENT event loop.
+    # When called via _run_async (send_message tool from gateway), we run
+    # in a new thread with a fresh event loop — the main loop's aiohttp
+    # session cannot be reused (causes "Timeout context manager should be
+    # used inside a task" errors).
+    _session_on_current_loop = False
+    if send_session is not None and not send_session.closed:
+        try:
+            _current_loop = asyncio.get_running_loop()
+            _session_loop = getattr(send_session, '_loop', None)
+            # aiohttp >=3.9 stores the loop; if same object, safe to reuse
+            _session_on_current_loop = (_session_loop is None or _session_loop is _current_loop)
+        except RuntimeError:
+            pass
+    if live_adapter is not None and send_session is not None and not send_session.closed and _session_on_current_loop:
         last_result: Optional[SendResult] = None
         cleaned = live_adapter.format_message(message)
         if cleaned:


### PR DESCRIPTION
## Problem

`send_message` tool fails on WeChat platform with:

```
Timeout context manager should be used inside a task
```

## Root Cause

An **async event loop conflict** between the gateway's main event loop and `send_message` tool's execution context:

1. The WeChat adapter's `aiohttp.ClientSession` is created on the **gateway's main event loop** (long-running process).
2. `send_message` is a **synchronous tool** that bridges to async via `_run_async()` (in `model_tools.py`), which spawns a **new thread with a fresh event loop** using `asyncio.run()`.
3. `send_weixin_direct()` then tries to **reuse the main loop's aiohttp session** (`_LIVE_ADAPTERS` cache) from this new thread/loop.
4. Cross-event-loop usage of `aiohttp.ClientTimeout` causes the timeout context manager error.

## Fix

Add an event loop compatibility check before reusing the live adapter's session. When the session's event loop doesn't match the current one, fall through to create a fresh `aiohttp.ClientSession` on the current loop.

```python
# Before:
if live_adapter is not None and send_session is not None and not send_session.closed:

# After:
_session_on_current_loop = False
if send_session is not None and not send_session.closed:
    try:
        _current_loop = asyncio.get_running_loop()
        _session_loop = getattr(send_session, '_loop', None)
        _session_on_current_loop = (_session_loop is None or _session_loop is _current_loop)
    except RuntimeError:
        pass
if live_adapter is not None and send_session is not None and not send_session.closed and _session_on_current_loop:
```

## Testing

- Verified `send_message` to WeChat returns `{"success": true}` after gateway restart.
- Multiple subsequent sends (text messages and file attachments) all succeeded.

## Impact

Minimal — only affects the code path when the session is on a different event loop. When on the same loop (the common case), behavior is unchanged.