### PR TITLE
fix(whatsapp): correct platform markdown guidance

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -296,8 +296,13 @@ DEVELOPER_ROLE_MODELS = ("gpt-5", "codex")
 
 PLATFORM_HINTS = {
     "whatsapp": (
-        "You are on a text messaging communication platform, WhatsApp. "
-        "Please do not use markdown as it does not render. "
+        "You are on WhatsApp. Standard markdown is automatically converted "
+        "to WhatsApp-compatible formatting before delivery. Supported: '- ' "
+        "bullet lists, **bold** or __bold__, _italic_, ~~strikethrough~~, "
+        "`inline code`, ```code blocks```, and [links](url). Single "
+        "asterisks render as WhatsApp bold, so use _underscores_ when you "
+        "need italic. Markdown headers are converted to bold labels, but "
+        "prefer short labeled bullets for mobile reading. Avoid pipe tables. "
         "You can send media files natively: to deliver a file to the user, "
         "include MEDIA:/absolute/path/to/file in your response. The file "
         "will be sent as a native WhatsApp attachment — images (.jpg, .png, "

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -807,6 +807,23 @@ class TestPromptBuilderConstants:
         # check that this test is calibrated correctly).
         assert "include MEDIA:" in PLATFORM_HINTS["telegram"]
 
+    def test_whatsapp_hint_uses_supported_markdown_subset(self):
+        hint = PLATFORM_HINTS["whatsapp"]
+        lowered = hint.lower()
+        assert "do not use markdown" not in lowered
+        assert "standard markdown is automatically converted" in lowered
+        assert "'- '" in hint
+        assert "**bold**" in hint
+        assert "__bold__" in hint
+        assert "_italic_" in hint
+        assert "~~strikethrough~~" in hint
+        assert "[links](url)" in hint
+        assert "single asterisks render as whatsapp bold" in lowered
+        assert "markdown headers are converted to bold labels" in lowered
+        assert "do not use **double" not in lowered
+        assert "pipe tables" in lowered
+        assert "include MEDIA:" in hint
+
     def test_platform_hints_mattermost(self):
         hint = PLATFORM_HINTS["mattermost"]
         assert "Mattermost" in hint
@@ -1086,6 +1103,4 @@ class TestOpenAIModelExecutionGuidance:
 # =========================================================================
 # Budget warning history stripping
 # =========================================================================
-
-
 


### PR DESCRIPTION
## What does this PR do?

Updates the WhatsApp platform hint so Hermes no longer tells the agent to avoid markdown on WhatsApp.

WhatsApp supports a markdown subset, and the old hint caused models to avoid useful formatting like `- ` bullets, producing harder-to-read mobile replies. The new guidance documents the supported WhatsApp formatting style and keeps the existing native media instructions.

## Related Issue

Fixes #12224

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `agent/prompt_builder.py` to replace the stale WhatsApp “do not use markdown” instruction with WhatsApp-specific formatting guidance.
- Added a regression test in `tests/agent/test_prompt_builder.py` to ensure the WhatsApp hint keeps supported markdown guidance and media instructions.

## How to Test

1. `scripts/run_tests.sh tests/agent/test_prompt_builder.py::TestPromptBuilderConstants::test_whatsapp_hint_uses_supported_markdown_subset -q`
2. `scripts/run_tests.sh tests/agent/test_prompt_builder.py -q`
3. `git diff --check`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — prompt text only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Targeted validation passed:

- `scripts/run_tests.sh tests/agent/test_prompt_builder.py::TestPromptBuilderConstants::test_whatsapp_hint_uses_supported_markdown_subset -q`
- `scripts/run_tests.sh tests/agent/test_prompt_builder.py -q` — 116 passed, 1 skipped
- `git diff --check`
