### PR TITLE
fix: resolve cron script paths from shared Hermes root

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -34,7 +34,7 @@ from typing import List, Optional
 # the module) fail with ModuleNotFoundError for hermes_time et al.
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from hermes_constants import get_hermes_home
+from hermes_constants import get_default_hermes_root, get_hermes_home
 from hermes_cli.config import load_config
 from hermes_time import now as _hermes_now
 
@@ -547,23 +547,22 @@ def _get_script_timeout() -> int:
 def _run_job_script(script_path: str) -> tuple[bool, str]:
     """Execute a cron job's data-collection script and capture its output.
 
-    Scripts must reside within HERMES_HOME/scripts/.  Both relative and
-    absolute paths are resolved and validated against this directory to
-    prevent arbitrary script execution via path traversal or absolute
-    path injection.
+    Scripts must reside within the shared Hermes root ``scripts/`` directory.
+    Both relative and absolute paths are resolved and validated against this
+    directory to prevent arbitrary script execution via path traversal or
+    absolute path injection.
 
     Args:
-        script_path: Path to a Python script.  Relative paths are resolved
-            against HERMES_HOME/scripts/.  Absolute and ~-prefixed paths
-            are also validated to ensure they stay within the scripts dir.
+        script_path: Path to a Python script. Relative paths are resolved
+            against the shared Hermes root ``scripts/`` directory. Absolute
+            and ``~``-prefixed paths are also validated to ensure they stay
+            within that directory.
 
     Returns:
         (success, output) — on failure *output* contains the error message so the
         LLM can report the problem to the user.
     """
-    from hermes_constants import get_hermes_home
-
-    scripts_dir = get_hermes_home() / "scripts"
+    scripts_dir = get_default_hermes_root() / "scripts"
     scripts_dir.mkdir(parents=True, exist_ok=True)
     scripts_dir_resolved = scripts_dir.resolve()
 
@@ -574,7 +573,7 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
         path = (scripts_dir / raw).resolve()
 
     # Guard against path traversal, absolute path injection, and symlink
-    # escape — scripts MUST reside within HERMES_HOME/scripts/.
+    # escape — scripts MUST reside within the shared Hermes root scripts/.
     try:
         path.relative_to(scripts_dir_resolved)
     except ValueError:

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -91,6 +91,24 @@ class TestJobScriptField:
 class TestRunJobScript:
     """Test the _run_job_script() function."""
 
+    def test_profile_mode_relative_script_resolves_from_shared_root_scripts(self, tmp_path, monkeypatch):
+        from cron.scheduler import _run_job_script
+
+        hermes_root = tmp_path / ".hermes"
+        profile_home = hermes_root / "profiles" / "ceo"
+        shared_scripts = hermes_root / "scripts"
+        (profile_home / "cron" / "output").mkdir(parents=True)
+        shared_scripts.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        script = shared_scripts / "shared.py"
+        script.write_text('print("shared root works")\n')
+
+        success, output = _run_job_script("shared.py")
+        assert success is True
+        assert output == "shared root works"
+
     def test_successful_script(self, cron_env):
         from cron.scheduler import _run_job_script
 
@@ -410,6 +428,27 @@ class TestScriptPathContainment:
 
 class TestCronjobToolScriptValidation:
     """Test API-boundary validation of cron script paths in cronjob_tools."""
+
+    def test_profile_mode_relative_script_uses_shared_root_scripts_dir(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        hermes_root = tmp_path / ".hermes"
+        profile_home = hermes_root / "profiles" / "ceo"
+        shared_scripts = hermes_root / "scripts"
+        (profile_home / "cron" / "output").mkdir(parents=True)
+        shared_scripts.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        from tools.cronjob_tools import cronjob
+
+        result = json.loads(cronjob(
+            action="create",
+            schedule="every 1h",
+            prompt="Monitor things",
+            script="shared.py",
+        ))
+        assert result["success"] is True
+        assert result["job"]["script"] == "shared.py"
 
     def test_create_with_absolute_script_rejected(self, cron_env, monkeypatch):
         monkeypatch.setenv("HERMES_INTERACTIVE", "1")

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -174,32 +174,33 @@ def _normalize_deliver_param(value: Any) -> Optional[str]:
 def _validate_cron_script_path(script: Optional[str]) -> Optional[str]:
     """Validate a cron job script path at the API boundary.
 
-    Scripts must be relative paths that resolve within HERMES_HOME/scripts/.
-    Absolute paths and ~ expansion are rejected to prevent arbitrary script
-    execution via prompt injection.
+    Scripts must be relative paths that resolve within the shared Hermes
+    root ``scripts/`` directory. Absolute paths and ``~`` expansion are
+    rejected to prevent arbitrary script execution via prompt injection.
 
     Returns an error string if blocked, else None (valid).
     """
     if not script or not script.strip():
         return None  # empty/None = clearing the field, always OK
 
-    from hermes_constants import get_hermes_home
+    from hermes_constants import get_default_hermes_root
 
     raw = script.strip()
 
     # Reject absolute paths and ~ expansion at the API boundary.
-    # Only relative paths within ~/.hermes/scripts/ are allowed.
+    # Only relative paths within the shared Hermes root scripts/ dir are allowed.
     if raw.startswith(("/", "~")) or (len(raw) >= 2 and raw[1] == ":"):
         return (
-            f"Script path must be relative to ~/.hermes/scripts/. "
+            f"Script path must be relative to the shared Hermes scripts directory "
+            f"({get_default_hermes_root() / 'scripts'}). "
             f"Got absolute or home-relative path: {raw!r}. "
-            f"Place scripts in ~/.hermes/scripts/ and use just the filename."
+            f"Place scripts there and use just the filename."
         )
 
     # Validate containment after resolution
     from tools.path_security import validate_within_dir
 
-    scripts_dir = get_hermes_home() / "scripts"
+    scripts_dir = get_default_hermes_root() / "scripts"
     scripts_dir.mkdir(parents=True, exist_ok=True)
     containment_error = validate_within_dir(scripts_dir / raw, scripts_dir)
     if containment_error:


### PR DESCRIPTION
## Summary
- resolve cron job scripts against the shared Hermes root scripts directory instead of profile-local HERMES_HOME/scripts
- align cronjob script-path validation with the shared scripts root
- add regression coverage for profile-mode relative scripts

## Test Plan
- ./venv/bin/python -m pytest -q tests/cron/test_cron_script.py tests/test_hermes_constants.py