### PR TITLE
fix(auth): resolve Codex usage credentials from auth fallbacks

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -84,6 +84,9 @@ def _model_switch_skew_guard() -> Optional[str]:
     )
 
 
+_USAGE_ACCOUNT_PROVIDERS = ("openai-codex", "anthropic")
+
+
 class GatewaySlashCommandsMixin:
     """In-session slash-command handlers for GatewayRunner."""
 
@@ -3977,6 +3980,17 @@ class GatewaySlashCommandsMixin:
                 persisted = {}
             provider = provider or persisted.get("billing_provider")
             base_url = base_url or persisted.get("billing_base_url")
+
+        if not provider:
+            try:
+                from hermes_cli.auth import read_credential_pool
+
+                for candidate in _USAGE_ACCOUNT_PROVIDERS:
+                    if read_credential_pool(candidate):
+                        provider = candidate
+                        break
+            except Exception:
+                pass
 
         # Fetch account usage off the event loop so slow provider APIs don't
         # block the gateway. Failures are non-fatal -- account_lines stays [].

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -3229,18 +3229,67 @@ def _print_loopback_ssh_hint(redirect_uri: str, *, docs_url: str | None = None) 
 # where one app's refresh invalidates the other's session.
 # =============================================================================
 
+def _codex_state_from_auth_store(auth_store: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    providers = auth_store.get("providers")
+    if isinstance(providers, dict):
+        state = providers.get("openai-codex")
+        if isinstance(state, dict) and state:
+            with_source = dict(state)
+            with_source.setdefault("source", "hermes-auth-store")
+            return with_source
+
+    pool = auth_store.get("credential_pool")
+    if not isinstance(pool, dict):
+        pool = {}
+    entries = pool.get("openai-codex")
+    if not isinstance(entries, list):
+        entries = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("auth_type") != "oauth":
+            continue
+        access_token = entry.get("access_token")
+        if not isinstance(access_token, str) or not access_token.strip():
+            continue
+        reset_at = entry.get("last_error_reset_at")
+        if isinstance(reset_at, (int, float)) and reset_at > time.time():
+            continue
+        return {
+            "tokens": {
+                "access_token": access_token,
+                "refresh_token": entry.get("refresh_token"),
+                "id_token": entry.get("id_token"),
+                "account_id": entry.get("account_id"),
+            },
+            "last_refresh": entry.get("last_refresh"),
+            "base_url": entry.get("base_url"),
+            "source": "credential_pool",
+        }
+    return None
+
+
 def _read_codex_tokens(*, _lock: bool = True) -> Dict[str, Any]:
     """Read Codex OAuth tokens from Hermes auth store (~/.hermes/auth.json).
-    
+
     Returns dict with 'tokens' (access_token, refresh_token) and 'last_refresh'.
     Raises AuthError if no Codex tokens are stored.
+
+    Hermes may store Codex OAuth credentials in either the legacy
+    providers.openai-codex slot or the newer credential_pool.openai-codex
+    slot.  The pool fallback keeps legacy readers working for credentials
+    added through `hermes auth add openai-codex --type oauth`. In profile
+    mode, the global-root auth store is used as a read-only fallback when
+    the profile has no local Codex credentials.
     """
     if _lock:
         with _auth_store_lock():
             auth_store = _load_auth_store()
     else:
         auth_store = _load_auth_store()
-    state = _load_provider_state(auth_store, "openai-codex")
+    state = _codex_state_from_auth_store(auth_store)
+    if not state:
+        state = _codex_state_from_auth_store(_load_global_auth_store())
     if not state:
         raise AuthError(
             "No Codex credentials stored. Run `hermes auth` to authenticate.",
@@ -3275,6 +3324,8 @@ def _read_codex_tokens(*, _lock: bool = True) -> Dict[str, Any]:
     return {
         "tokens": tokens,
         "last_refresh": state.get("last_refresh"),
+        "base_url": state.get("base_url"),
+        "source": state.get("source"),
     }
 
 
@@ -3738,6 +3789,7 @@ def resolve_codex_runtime_credentials(
 
     base_url = (
         os.getenv("HERMES_CODEX_BASE_URL", "").strip().rstrip("/")
+        or str(data.get("base_url") or "").strip().rstrip("/")
         or DEFAULT_CODEX_BASE_URL
     )
 
@@ -3745,7 +3797,7 @@ def resolve_codex_runtime_credentials(
         "provider": "openai-codex",
         "base_url": base_url,
         "api_key": access_token,
-        "source": "hermes-auth-store",
+        "source": data.get("source") or "hermes-auth-store",
         "last_refresh": data.get("last_refresh"),
         "auth_mode": "chatgpt",
     }

--- a/tests/gateway/test_usage_command.py
+++ b/tests/gateway/test_usage_command.py
@@ -244,6 +244,51 @@ class TestUsageAccountSection:
         assert "📊 **Session Info**" in result
         assert "📈 **Account limits**" in result
 
+    @pytest.mark.asyncio
+    async def test_usage_command_probes_credential_pool_without_agent_or_billing_row(self, monkeypatch):
+        runner = _make_runner(SK)
+        runner._session_db = MagicMock()
+        runner._session_db.get_session.return_value = {}
+        session_entry = MagicMock()
+        session_entry.session_id = "sess-empty"
+        runner.session_store.get_or_create_session.return_value = session_entry
+        runner.session_store.load_transcript.return_value = []
+
+        calls = []
+
+        async def _fake_to_thread(fn, *args, **kwargs):
+            calls.append({"args": args, "kwargs": kwargs})
+            return fn(*args, **kwargs)
+
+        monkeypatch.setattr("gateway.run.asyncio.to_thread", _fake_to_thread)
+        monkeypatch.setattr(
+            "gateway.slash_commands.fetch_account_usage",
+            lambda provider, base_url=None, api_key=None: object(),
+        )
+        monkeypatch.setattr(
+            "gateway.slash_commands.render_account_usage_lines",
+            lambda snapshot, markdown=False: [
+                "📈 **Account limits**",
+                "Provider: openai-codex (Pro)",
+            ],
+        )
+        monkeypatch.setattr("agent.account_usage.nous_credits_lines", lambda markdown=False: [])
+        monkeypatch.setattr(
+            "hermes_cli.auth.read_credential_pool",
+            lambda provider_id=None: [{
+                "auth_type": "oauth",
+                "access_token": "pool-access-token",
+                "refresh_token": "pool-refresh-token",
+            }] if provider_id == "openai-codex" else [],
+        )
+
+        event = MagicMock()
+        result = await runner._handle_usage_command(event)
+
+        account_call = next(c for c in calls if c["args"] == ("openai-codex",))
+        assert account_call["kwargs"] == {"base_url": None, "api_key": None}
+        assert "📈 **Account limits**" in result
+
 
 class TestUsageContextBreakdown:
     """The /usage output includes the per-category context breakdown."""

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -72,6 +72,76 @@ def test_read_codex_tokens_missing(tmp_path, monkeypatch):
     assert exc.value.code == "codex_auth_missing"
 
 
+def test_read_codex_tokens_falls_back_to_credential_pool(tmp_path, monkeypatch):
+    """Codex OAuth added through the pool must be visible to legacy readers."""
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "auth.json").write_text(json.dumps({
+        "version": 1,
+        "providers": {},
+        "credential_pool": {
+            "openai-codex": [{
+                "auth_type": "oauth",
+                "access_token": "pool-access-token",
+                "refresh_token": "pool-refresh-token",
+                "account_id": "acct_123",
+                "last_refresh": "2026-04-24T12:00:00Z",
+                "base_url": "https://custom.example/codex",
+            }],
+        },
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    data = _read_codex_tokens()
+
+    assert data["tokens"]["access_token"] == "pool-access-token"
+    assert data["tokens"]["refresh_token"] == "pool-refresh-token"
+    assert data["tokens"]["account_id"] == "acct_123"
+    assert data["last_refresh"] == "2026-04-24T12:00:00Z"
+    assert data["base_url"] == "https://custom.example/codex"
+
+
+def test_resolve_codex_runtime_credentials_uses_pool_base_url(tmp_path, monkeypatch):
+    """Runtime credential resolution should preserve Codex pool base_url."""
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "auth.json").write_text(json.dumps({
+        "version": 1,
+        "providers": {},
+        "credential_pool": {
+            "openai-codex": [{
+                "auth_type": "oauth",
+                "access_token": "pool-access-token",
+                "refresh_token": "pool-refresh-token",
+                "base_url": "https://custom.example/codex",
+            }],
+        },
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("HERMES_CODEX_BASE_URL", raising=False)
+
+    creds = resolve_codex_runtime_credentials()
+
+    assert creds["base_url"] == "https://custom.example/codex"
+
+
+def test_read_codex_tokens_ignores_malformed_credential_pool(tmp_path, monkeypatch):
+    """Malformed pool data should raise the normal auth-missing error, not crash."""
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "auth.json").write_text(json.dumps({
+        "version": 1,
+        "providers": {},
+        "credential_pool": {"openai-codex": "not-a-list"},
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    with pytest.raises(AuthError) as exc:
+        _read_codex_tokens()
+
+    assert exc.value.code == "codex_auth_missing"
+
+
 def test_resolve_codex_runtime_credentials_missing_access_token(tmp_path, monkeypatch):
     hermes_home = tmp_path / "hermes"
     _setup_hermes_auth(hermes_home, access_token="")

--- a/tests/hermes_cli/test_auth_profile_fallback.py
+++ b/tests/hermes_cli/test_auth_profile_fallback.py
@@ -149,6 +149,35 @@ def test_per_provider_shadowing_is_independent(profile_env):
     assert [e["id"] for e in ant_entries] == ["glob-ant"]
 
 
+def test_profile_read_codex_tokens_falls_back_to_global_pool(profile_env):
+    """Legacy Codex token readers should honor the same profile fallback as credential pools."""
+    from hermes_cli.auth import _read_codex_tokens
+
+    _write(profile_env["global"] / "auth.json", _make_auth_store(pool={
+        "openai-codex": [{
+            "id": "global-codex",
+            "label": "global-codex",
+            "auth_type": "oauth",
+            "priority": 0,
+            "source": "manual:device_code",
+            "access_token": "global-access-token",
+            "refresh_token": "global-refresh-token",
+            "account_id": "acct_global",
+            "last_refresh": "2026-05-11T00:00:00Z",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+        }],
+    }))
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={}))
+
+    data = _read_codex_tokens()
+
+    assert data["tokens"]["access_token"] == "global-access-token"
+    assert data["tokens"]["refresh_token"] == "global-refresh-token"
+    assert data["tokens"]["account_id"] == "acct_global"
+    assert data["last_refresh"] == "2026-05-11T00:00:00Z"
+    assert data["base_url"] == "https://chatgpt.com/backend-api/codex"
+
+
 def test_missing_global_auth_file_is_safe(profile_env):
     """Profile processes that never had a global auth.json still work."""
     from hermes_cli.auth import read_credential_pool


### PR DESCRIPTION
## Summary
- allows Codex token readers used by `/usage` to resolve OAuth credentials from `credential_pool.openai-codex` when the legacy `providers.openai-codex` block is absent
- keeps profile-local auth authoritative, with the global root auth store as a read-only fallback only when no local provider/pool credentials are present
- preserves Codex pool `base_url` and source provenance metadata during runtime credential resolution
- lets gateway `/usage` probe account-usage-capable credential pools when no live/cached agent or billing row has identified a provider yet

Fixes #15167.
Related: #15173.

## Latest main refresh
- Base: `355af2c20` (`origin/main`)
- Head: `4962d8477e69f5c0b4408da0bcef91f19cbba736`
- Rebuilt as one clean commit on latest main.
- Semantic conflict resolved: latest main had moved Codex pool fallback into the shared token reader, so this refresh preserves latest-main reader behavior while carrying `source` provenance forward, avoiding global auth fallback shadowing of local pool credentials, and skipping pool entries still in an exhaustion cooldown.

## Test Plan
- `git diff --check`
- `/home/ubuntu/.hermes/hermes-agent/.venv/bin/python -m pytest -o addopts='' tests/hermes_cli/test_auth_codex_provider.py tests/hermes_cli/test_auth_profile_fallback.py tests/gateway/test_usage_command.py -q`

Focused result: `53 passed in 0.57s`.
