### PR TITLE
fix: prevent bare 'custom' slug in model.provider (#17478)

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1467,7 +1467,14 @@ def list_authenticated_providers(
                     current_base_url
                     and api_url == current_base_url.strip().rstrip("/")
                 ):
-                    slug = current_provider or custom_provider_slug(display_name)
+                    # Guard against bare "custom" slug left by a prior
+                    # failed switch — always resolve to the canonical
+                    # custom:<name> form.  (GH #17478)
+                    slug = (
+                        current_provider
+                        if current_provider and current_provider != "custom"
+                        else custom_provider_slug(display_name)
+                    )
                 else:
                     slug = custom_provider_slug(display_name)
                 groups[group_key] = {

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -580,6 +580,12 @@ def resolve_custom_provider(
     if not requested:
         return None
 
+    # If the stored provider is the bare string "custom" (corrupt state
+    # from a prior model-switch bug), fall back to the first custom
+    # provider entry so existing configs self-heal.  (GH #17478)
+    bare_custom_fallback = requested == "custom"
+    first_valid = None
+
     for entry in custom_providers:
         if not isinstance(entry, dict):
             continue
@@ -594,6 +600,10 @@ def resolve_custom_provider(
         if not display_name or not api_url:
             continue
 
+        # Stash the first valid entry for bare-"custom" fallback
+        if first_valid is None:
+            first_valid = (display_name, api_url)
+
         slug = custom_provider_slug(display_name)
         if requested not in {display_name.lower(), slug}:
             continue
@@ -604,6 +614,21 @@ def resolve_custom_provider(
             transport="openai_chat",
             api_key_env_vars=(),
             base_url=api_url,
+            is_aggregator=False,
+            auth_type="api_key",
+            source="user-config",
+        )
+
+    # Self-heal: bare "custom" matched nothing — return first valid entry
+    if bare_custom_fallback and first_valid:
+        dname, aurl = first_valid
+        slug = custom_provider_slug(dname)
+        return ProviderDef(
+            id=slug,
+            name=dname,
+            transport="openai_chat",
+            api_key_env_vars=(),
+            base_url=aurl,
             is_aggregator=False,
             auth_type="api_key",
             source="user-config",


### PR DESCRIPTION
## Problem

When using `hermes model` interactive picker to switch to a `custom_providers` entry, the CLI can write the literal string `custom` to `model.provider` in config.yaml instead of the actual provider name (e.g. `xiaomi-coding`).

This causes every subsequent session to fail with:
```
Unknown provider "custom". Check hermes model for available providers.
```

Root cause: in `list_authenticated_providers()` (model_switch.py:1466-1472), when `current_provider` is already `"custom"` from a prior failed switch and `current_base_url` matches, slug gets set to the literal `"custom"`. Then `resolve_provider_full("custom")` finds no match since the canonical slug is `custom:xiaomi-coding`.

## Fix (2 files, +33/-1)

**hermes_cli/model_switch.py** — Slug assignment guards against bare `"custom"`:
- If `current_provider` is `"custom"`, fall back to `custom_provider_slug(display_name)` which produces the canonical `custom:<name>` form

**hermes_cli/providers.py** — Self-healing fallback in `resolve_custom_provider()`:
- When `requested == "custom"` matches nothing by name or slug, fall back to the first valid `custom_providers` entry so corrupted configs auto-recover

## Testing

9/9 test cases pass:
- Normal resolution by name and slug
- Bare `"custom"` self-heals to first entry
- Unknown provider returns None
- Slug assignment handles bug case, normal case, None case, and URL mismatch

Closes #17478