### PR TITLE
fix(auxiliary): pass original URL to _wrap_if_needed for anthropic detection

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2092,7 +2092,10 @@ def resolve_provider_client(
                     is_agent_turn=True, is_vision=is_vision
                 )
             client = OpenAI(api_key=custom_key, base_url=_clean_base, **extra)
-            client = _wrap_if_needed(client, final_model, custom_base, custom_key)
+            # Pass original URL for anthropic detection (not the rewritten /v1 one).
+            # _maybe_wrap_anthropic checks _endpoint_speaks_anthropic_messages(base_url)
+            # which looks for /anthropic suffix — rewritten URL loses that signal.
+            client = _wrap_if_needed(client, final_model, explicit_base_url, custom_key)
             return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                     else (client, final_model))
         # Try custom first, then codex, then API-key providers


### PR DESCRIPTION
## Summary
Pass the original URL to _wrap_if_needed so that the auxiliary URL wrapper can properly detect the provider (Anthropic, etc.) from the URL path before wrapping.

Closes #17076

## Testing
- [ ] Unit tests pass
- [ ] Manual verification with auxiliary URL endpoint