### PR TITLE
fix: lazy import platform adapters in send_message to prevent cross-platform import pollution

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -1621,3 +1621,48 @@ class TestForumProbeCache:
         assert result2["success"] is True
         # Only one session opened (thread creation) — no probe session this time
         # (verified by not raising from our side_effect exhaustion)
+
+
+class TestLazyPlatformImports:
+    """Regression: _send_to_platform must not eagerly import all platform adapters."""
+
+    def test_send_to_platform_does_not_import_slack_for_feishu(self, tmp_path):
+        """Sending to Feishu must not trigger a Slack/Discord/Telegram import.
+
+        Previously _send_to_platform imported SlackAdapter, DiscordAdapter,
+        TelegramAdapter, and FeishuAdapter unconditionally at the top of the
+        function.  A broken or unavailable Slack dependency would then crash
+        *every* send — even to completely unrelated platforms like Feishu.
+
+        Regression test for the ``cannot import name
+        'is_host_excluded_by_no_proxy' from 'gateway.platforms.base'`` error
+        that occurred because ``slack.py`` had a side-effect import that
+        polluted ``sys.modules`` with a partially-loaded base module.
+        """
+        # Simulate: Slack import fails, but Feishu should still work.
+        import_error = ImportError("slack_bolt not installed")
+
+        feishu_cfg = SimpleNamespace(enabled=True, token="t", extra={})
+        pconfig = SimpleNamespace(platforms={Platform.FEISHU: feishu_cfg})
+
+        fake_result = {"success": True, "platform": "feishu"}
+
+        # Patch Slack import to fail — the old code would crash here even for
+        # Feishu sends because it imported SlackAdapter unconditionally.
+        with patch.dict("sys.modules", {"gateway.platforms.slack": None}):
+            with patch(
+                "tools.send_message_tool._send_feishu",
+                new_callable=AsyncMock,
+                return_value=fake_result,
+            ) as feishu_mock:
+                result = _run_async_immediately(
+                    _send_to_platform(
+                        Platform.FEISHU,
+                        feishu_cfg,
+                        "oc_test123",
+                        "hello",
+                    )
+                )
+
+        assert result == fake_result
+        feishu_mock.assert_called_once()

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -438,40 +438,40 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     """
     from gateway.config import Platform
     from gateway.platforms.base import BasePlatformAdapter, utf16_len
-    from gateway.platforms.discord import DiscordAdapter
-    from gateway.platforms.slack import SlackAdapter
-
-    # Telegram adapter import is optional (requires python-telegram-bot)
-    try:
-        from gateway.platforms.telegram import TelegramAdapter
-        _telegram_available = True
-    except ImportError:
-        _telegram_available = False
-
-    # Feishu adapter import is optional (requires lark-oapi)
-    try:
-        from gateway.platforms.feishu import FeishuAdapter
-        _feishu_available = True
-    except ImportError:
-        _feishu_available = False
 
     media_files = media_files or []
 
+    # --- Per-platform adapter imports (lazy: only import what we need) ---
     if platform == Platform.SLACK and message:
         try:
+            from gateway.platforms.slack import SlackAdapter
             slack_adapter = SlackAdapter.__new__(SlackAdapter)
             message = slack_adapter.format_message(message)
         except Exception:
             logger.debug("Failed to apply Slack mrkdwn formatting in _send_to_platform", exc_info=True)
 
-    # Platform message length limits (from adapter class attributes)
-    _MAX_LENGTHS = {
-        Platform.TELEGRAM: TelegramAdapter.MAX_MESSAGE_LENGTH if _telegram_available else 4096,
-        Platform.DISCORD: DiscordAdapter.MAX_MESSAGE_LENGTH,
-        Platform.SLACK: SlackAdapter.MAX_MESSAGE_LENGTH,
-    }
-    if _feishu_available:
-        _MAX_LENGTHS[Platform.FEISHU] = FeishuAdapter.MAX_MESSAGE_LENGTH
+    # Platform message length limits (from adapter class attributes).
+    # Each adapter is imported on demand so a broken/unavailable platform
+    # never blocks sending to a different one.
+    _MAX_LENGTHS: dict = {}
+    if platform == Platform.TELEGRAM:
+        try:
+            from gateway.platforms.telegram import TelegramAdapter
+            _MAX_LENGTHS[Platform.TELEGRAM] = TelegramAdapter.MAX_MESSAGE_LENGTH
+        except ImportError:
+            _MAX_LENGTHS[Platform.TELEGRAM] = 4096
+    elif platform == Platform.DISCORD:
+        from gateway.platforms.discord import DiscordAdapter
+        _MAX_LENGTHS[Platform.DISCORD] = DiscordAdapter.MAX_MESSAGE_LENGTH
+    elif platform == Platform.SLACK:
+        from gateway.platforms.slack import SlackAdapter
+        _MAX_LENGTHS[Platform.SLACK] = SlackAdapter.MAX_MESSAGE_LENGTH
+    elif platform == Platform.FEISHU:
+        try:
+            from gateway.platforms.feishu import FeishuAdapter
+            _MAX_LENGTHS[Platform.FEISHU] = FeishuAdapter.MAX_MESSAGE_LENGTH
+        except ImportError:
+            pass
 
     # Smart-chunk the message to fit within platform limits.
     # For short messages or platforms without a known limit this is a no-op.


### PR DESCRIPTION
## Summary

Previously, `_send_to_platform()` unconditionally imported ALL platform adapters (Slack, Discord, Telegram, Feishu) at the top of the function. This caused a cascading failure: if any single adapter had an import error (e.g., Slack's `is_host_excluded_by_no_proxy`), it would crash `send_message` for ALL platforms, including ones that worked fine.

## Changes

- Changed platform adapter imports from eager (all-at-once) to **lazy (on-demand)** — only the adapter for the target platform gets imported
- Added graceful fallbacks for optional adapters (Telegram, Feishu)
- Added regression test verifying Feishu sends don't trigger Slack imports

## Impact

- Feishu sends never trigger Slack imports (and vice versa)
- A broken/unavailable platform adapter only affects that specific platform
- Import errors are caught per-platform with graceful fallbacks

## Test Plan

- [x] 88 tests passed
- [x] Regression test added for Feishu/Slack import isolation
- [x] Verified Feishu sends work correctly after fix

## Related

This fixes the root cause of the Feishu send_message failure documented in session 20260429_051703_688e8047.