### PR TITLE
fix: use non-blocking subprocess for gateway detached restart

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2281,9 +2281,17 @@ class GatewayRunner:
 
         current_pid = os.getpid()
         cmd = " ".join(shlex.quote(part) for part in hermes_cmd)
+        log_path = _hermes_home / "logs" / "gateway.log"
+        # Use ``gateway run --replace`` instead of ``gateway restart`` to
+        # avoid the CLI restart handler which calls run_gateway() in the
+        # foreground and blocks the detached subprocess forever.  The
+        # ``--replace`` flag ensures any lingering gateway process is killed
+        # before the new one starts.  ``nohup ... &`` daemonizes the new
+        # gateway so it survives after this subprocess exits.
         shell_cmd = (
             f"while kill -0 {current_pid} 2>/dev/null; do sleep 0.2; done; "
-            f"{cmd} gateway restart"
+            f"nohup {cmd} gateway run --replace"
+            f" >> {shlex.quote(str(log_path))} 2>&1 &"
         )
         setsid_bin = shutil.which("setsid")
         if setsid_bin:

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -169,7 +169,7 @@ async def test_launch_detached_restart_command_uses_setsid(monkeypatch):
     assert len(popen_calls) == 1
     cmd, kwargs = popen_calls[0]
     assert cmd[:2] == ["/usr/bin/setsid", "bash"]
-    assert "gateway restart" in cmd[-1]
+    assert "gateway run --replace" in cmd[-1]
     assert "kill -0 321" in cmd[-1]
     assert kwargs["start_new_session"] is True
     assert kwargs["stdout"] is subprocess.DEVNULL


### PR DESCRIPTION
## Summary

Previously, `_launch_detached_restart_command()` used a blocking call to `hermes gateway restart` which hung forever because the CLI restart handler calls `run_gateway()` in the foreground. This meant the detached subprocess would block indefinitely, and the gateway would never actually restart.

## Changes

- Changed from blocking `hermes gateway restart` to non-blocking `hermes gateway run --replace`
- Added proper daemonization with output redirected to `gateway.log`
- `--replace` flag ensures any lingering gateway process is killed before starting

## Impact

- `/restart` command now works reliably
- Gateway actually restarts instead of hanging forever
- systemd can properly manage the gateway lifecycle

## Test Plan

- [x] 120 tests passed
- [x] Verified `/restart` command works correctly
- [x] Confirmed gateway process restarts and comes back up

## Related

This fixes the gateway restart reliability issue documented in session 20260429_051703_688e8047.