### PR TITLE
fix(agent): pad reasoning_content on DeepSeek/Kimi tool-call turns

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -8456,12 +8456,6 @@ class AIAgent:
             raw_reasoning_content = getattr(assistant_message, "reasoning_content", None)
             if raw_reasoning_content is not None:
                 msg["reasoning_content"] = _sanitize_surrogates(raw_reasoning_content)
-            elif msg.get("tool_calls") and self._needs_deepseek_tool_reasoning():
-                # DeepSeek thinking mode requires reasoning_content on every
-                # assistant tool-call message. Without it, replaying the
-                # persisted message causes HTTP 400. Include empty string
-                # as a defensive compatibility fallback (refs #15250).
-                msg["reasoning_content"] = ""
 
         # Additive fallback (refs #16844, #16884). Streaming-only providers
         # (glm, MiniMax, gpt-5.x via aigw, Anthropic via openai-compat shims)
@@ -8567,7 +8561,31 @@ class AIAgent:
                 tool_calls.append(tc_dict)
             msg["tool_calls"] = tool_calls
 
+        # Strict echo-back providers (DeepSeek v4 thinking, Kimi/Moonshot
+        # thinking) reject any subsequent request whose history contains an
+        # assistant tool-call message without reasoning_content. The earlier
+        # SDK-attribute and streaming-text branches cover the common cases;
+        # this pad fills the gap when the SDK attribute is absent or null
+        # AND streaming captured no reasoning text. Refs #15250, #17400.
+        if (
+            assistant_message.tool_calls
+            and "reasoning_content" not in msg
+            and self._needs_thinking_reasoning_pad()
+        ):
+            msg["reasoning_content"] = ""
+
         return msg
+
+    def _needs_thinking_reasoning_pad(self) -> bool:
+        """Return True when the active provider enforces reasoning_content echo-back.
+
+        DeepSeek v4 thinking and Kimi/Moonshot thinking both reject replays of
+        assistant tool-call messages that omit ``reasoning_content``.
+        """
+        return (
+            self._needs_deepseek_tool_reasoning()
+            or self._needs_kimi_tool_reasoning()
+        )
 
     def _needs_kimi_tool_reasoning(self) -> bool:
         """Return True when the current provider is Kimi / Moonshot thinking mode.
@@ -8611,10 +8629,7 @@ class AIAgent:
             api_msg["reasoning_content"] = existing
             return
 
-        needs_thinking_pad = (
-            self._needs_kimi_tool_reasoning()
-            or self._needs_deepseek_tool_reasoning()
-        )
+        needs_thinking_pad = self._needs_thinking_reasoning_pad()
 
         # 2. Cross-provider poisoned history (#15748): on DeepSeek/Kimi,
         # if the source turn has tool_calls AND a 'reasoning' field but no

--- a/tests/run_agent/test_deepseek_reasoning_content_echo.py
+++ b/tests/run_agent/test_deepseek_reasoning_content_echo.py
@@ -23,9 +23,14 @@ Refs #15250 / #15353.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 from run_agent import AIAgent
+
+
+_ATTR_ABSENT = object()
 
 
 def _make_agent(provider: str = "", model: str = "", base_url: str = "") -> AIAgent:
@@ -33,7 +38,32 @@ def _make_agent(provider: str = "", model: str = "", base_url: str = "") -> AIAg
     agent.provider = provider
     agent.model = model
     agent.base_url = base_url
+    # Defaults so _build_assistant_message and _extract_reasoning don't
+    # AttributeError on object.__new__-created instances.
+    agent.verbose_logging = False
+    agent.reasoning_callback = None
+    agent.stream_delta_callback = None
+    agent._stream_callback = None
     return agent
+
+
+def _sdk_tool_call(call_id: str = "c1", name: str = "terminal", arguments: str = "{}"):
+    """Minimal SDK-shaped tool_call object that satisfies the builder's iteration."""
+    return SimpleNamespace(
+        id=call_id,
+        call_id=call_id,
+        type="function",
+        function=SimpleNamespace(name=name, arguments=arguments),
+        extra_content=None,
+    )
+
+
+def _build_sdk_message(reasoning_content=_ATTR_ABSENT, **extra):
+    """SDK-shaped assistant message; ``reasoning_content`` defaults to absent."""
+    kwargs = {"content": "", **extra}
+    if reasoning_content is not _ATTR_ABSENT:
+        kwargs["reasoning_content"] = reasoning_content
+    return SimpleNamespace(**kwargs)
 
 
 class TestNeedsDeepSeekToolReasoning:
@@ -226,6 +256,95 @@ class TestCopyReasoningContentForApi:
         api_msg: dict = {}
         agent._copy_reasoning_content_for_api(source, api_msg)
         assert "reasoning_content" not in api_msg
+
+
+_EXPECT_NOT_PRESENT = object()
+
+
+class TestBuildAssistantMessagePadsStrictProviders:
+    """Regression for #17400: _build_assistant_message must pin reasoning_content
+    on tool-call turns when the active provider enforces echo-back, regardless
+    of whether the SDK exposed reasoning_content as None, omitted it entirely,
+    or returned an empty thinking block.
+
+    Prior to the fix, the pad branch was guarded by ``msg.get("tool_calls")``,
+    which was always falsy because tool_calls were assigned later in the same
+    method. Persisted history accumulated assistant tool-call turns with no
+    reasoning_content; the next replay 400'd on DeepSeek/Kimi.
+    """
+
+    @pytest.mark.parametrize(
+        "provider,model,base_url,sdk_reasoning_content,expected",
+        [
+            pytest.param(
+                "deepseek", "deepseek-v4-pro", "",
+                None, "",
+                id="deepseek-attr-none",
+            ),
+            pytest.param(
+                "deepseek", "deepseek-v4-pro", "",
+                _ATTR_ABSENT, "",
+                id="deepseek-attr-absent",
+            ),
+            pytest.param(
+                "kimi-coding", "kimi-k2.6", "",
+                None, "",
+                id="kimi-attr-none",
+            ),
+            pytest.param(
+                "custom", "kimi-k2", "https://api.moonshot.ai/v1",
+                _ATTR_ABSENT, "",
+                id="moonshot-base-url",
+            ),
+            pytest.param(
+                "openrouter", "anthropic/claude-sonnet-4.6", "https://openrouter.ai/api/v1",
+                _ATTR_ABSENT, _EXPECT_NOT_PRESENT,
+                id="openrouter-no-pad",
+            ),
+        ],
+    )
+    def test_tool_call_reasoning_content_pad(
+        self, provider, model, base_url, sdk_reasoning_content, expected,
+    ) -> None:
+        agent = _make_agent(provider=provider, model=model, base_url=base_url)
+        msg_in = _build_sdk_message(
+            reasoning_content=sdk_reasoning_content,
+            tool_calls=[_sdk_tool_call()],
+        )
+        msg = agent._build_assistant_message(msg_in, finish_reason="tool_calls")
+        if expected is _EXPECT_NOT_PRESENT:
+            assert "reasoning_content" not in msg
+        else:
+            assert msg["reasoning_content"] == expected
+
+    def test_deepseek_tool_call_preserves_real_reasoning_content(self) -> None:
+        agent = _make_agent(provider="deepseek", model="deepseek-v4-pro")
+        msg_in = _build_sdk_message(
+            reasoning_content="actual chain of thought",
+            tool_calls=[_sdk_tool_call()],
+        )
+        msg = agent._build_assistant_message(msg_in, finish_reason="tool_calls")
+        assert msg["reasoning_content"] == "actual chain of thought"
+
+    def test_deepseek_text_only_turn_not_padded_by_tool_call_branch(self) -> None:
+        """Plain-text turns rely on _copy_reasoning_content_for_api at replay
+        time, not on this builder's tool-call pad."""
+        agent = _make_agent(provider="deepseek", model="deepseek-v4-pro")
+        msg_in = SimpleNamespace(content="hello", tool_calls=None)
+        msg = agent._build_assistant_message(msg_in, finish_reason="stop")
+        assert "tool_calls" not in msg
+        assert "reasoning_content" not in msg
+
+    def test_deepseek_streamed_reasoning_text_promoted_over_pad(self) -> None:
+        """When ``.reasoning`` carries streamed thinking, it must be promoted
+        to reasoning_content rather than overwritten with the empty pad."""
+        agent = _make_agent(provider="deepseek", model="deepseek-v4-pro")
+        msg_in = _build_sdk_message(
+            reasoning="streamed thoughts",
+            tool_calls=[_sdk_tool_call()],
+        )
+        msg = agent._build_assistant_message(msg_in, finish_reason="tool_calls")
+        assert msg["reasoning_content"] == "streamed thoughts"
 
 
 class TestNeedsKimiToolReasoning:


### PR DESCRIPTION
## What does this PR do?

The defensive branch in `_build_assistant_message` that was supposed to pin `reasoning_content=""` on DeepSeek thinking-mode tool-call turns never actually fired. It was gated on `msg.get("tool_calls")` — but `tool_calls` doesn't get added to `msg` until ~60 lines later in the same method, so the check was always falsy. Whenever DeepSeek returned `reasoning_content=None` on a tool-call turn (which happens intermittently in long sessions) and streaming captured no reasoning text, the message got persisted bare. The next replay 400'd:

> Error from provider (DeepSeek): The reasoning_content in the thinking mode must be passed back to the API.

The same defect is reachable on Kimi/Moonshot thinking — same enforcement, no separate ticket but the shape's identical.

The fix replaces the dead `elif` with a single post-`tool_calls` pad that fires when:

- `assistant_message.tool_calls` is truthy (reading the SDK source of truth, not a not-yet-populated dict key, which is what caused the original bug); **and**
- `reasoning_content` isn't already set by an earlier branch (so we never clobber legitimate reasoning); **and**
- the active provider enforces echo-back.

Pulled the predicate into a new `_needs_thinking_reasoning_pad()` helper so `_copy_reasoning_content_for_api` shares it instead of re-inlining `kimi or deepseek`.

## Related Issue

Fixes #17400

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `run_agent.py`: removed the dead pad branch in `_build_assistant_message`; added the unified post-`tool_calls` pad covering DeepSeek and Kimi/Moonshot; extracted `_needs_thinking_reasoning_pad()` and reused it in `_copy_reasoning_content_for_api`.
- `tests/run_agent/test_deepseek_reasoning_content_echo.py`: new `TestBuildAssistantMessagePadsStrictProviders` class — one parametrized test covering five provider/attribute combos (deepseek with `reasoning_content=None`, deepseek without the attribute at all, kimi-coding, custom-provider via `api.moonshot.ai`, plus an openrouter case to confirm we don't pad needlessly), and three standalone tests for "real reasoning preserved", "text-only turn untouched", "streamed reasoning wins over the empty pad". Folded the new helper's defaults into the existing `_make_agent` so the file doesn't end up with two parallel agent factories.

## How to Test

1. `pytest tests/run_agent/test_deepseek_reasoning_content_echo.py -q` — 31 pass.
2. To confirm the new tests actually exercise the fix and not just pass trivially: `git stash` the change to `run_agent.py`, re-run the file, and 4 of the 8 new cases fail (the four that hit the previously-dead pad). Pop the stash; they pass again.
3. Wider sweep: `pytest tests/run_agent/ -q` — 1164 passed, 7 unrelated skips.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the relevant test slice (`tests/run_agent/`) and all tests pass — 1164 passed, 7 unrelated skips. Skipped the full `tests/` suite as the change is contained.
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.4, arm64)

### Documentation & Housekeeping

- [x] Documentation updates — N/A (internal builder logic, no public surface change)
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered — pure Python message-builder logic, no platform-specific paths
- [x] Tool descriptions/schemas — N/A