### PR TITLE
fix(security): sanitize MCP server argv to prevent token leaks

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -75,6 +75,57 @@ class TestLoadMCPConfig:
             assert "filesystem" in result
             assert result["filesystem"]["command"] == "npx"
 
+    def test_secret_arg_placeholder_not_interpolated(self, monkeypatch):
+        """Secret-shaped env placeholders in stdio args stay out of argv."""
+        monkeypatch.setenv("EXAMPLE_API_KEY", "test-token-not-real")
+        servers = {
+            "example": {
+                "command": "node",
+                "args": ["server.js", "${EXAMPLE_API_KEY}"],
+            }
+        }
+        with patch("hermes_cli.config.load_config", return_value={"mcp_servers": servers}), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv"):
+            from tools.mcp_tool import _load_mcp_config
+            result = _load_mcp_config()
+
+        assert result["example"]["args"] == ["server.js", "${EXAMPLE_API_KEY}"]
+        assert "test-token-not-real" not in result["example"]["args"]
+
+    def test_non_secret_arg_placeholder_still_interpolates(self, monkeypatch):
+        """Non-secret args interpolation remains backwards-compatible."""
+        monkeypatch.setenv("EXAMPLE_PROJECT", "demo-project")
+        servers = {
+            "example": {
+                "command": "node",
+                "args": ["server.js", "--project", "${EXAMPLE_PROJECT}"],
+            }
+        }
+        with patch("hermes_cli.config.load_config", return_value={"mcp_servers": servers}), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv"):
+            from tools.mcp_tool import _load_mcp_config
+            result = _load_mcp_config()
+
+        assert result["example"]["args"] == ["server.js", "--project", "demo-project"]
+
+    def test_env_block_placeholder_still_interpolates(self, monkeypatch):
+        """Explicit env remains the supported channel for MCP credentials."""
+        monkeypatch.setenv("EXAMPLE_API_KEY", "test-token-not-real")
+        servers = {
+            "example": {
+                "command": "node",
+                "args": ["server.js"],
+                "env": {"EXAMPLE_API_KEY": "${EXAMPLE_API_KEY}"},
+            }
+        }
+        with patch("hermes_cli.config.load_config", return_value={"mcp_servers": servers}), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv"):
+            from tools.mcp_tool import _load_mcp_config
+            result = _load_mcp_config()
+
+        assert result["example"]["env"]["EXAMPLE_API_KEY"] == "test-token-not-real"
+        assert "test-token-not-real" not in result["example"]["args"]
+
     def test_mcp_servers_not_dict_returns_empty(self):
         """mcp_servers set to non-dict value -> empty dict."""
         with patch("hermes_cli.config.load_config", return_value={"mcp_servers": "invalid"}):
@@ -708,6 +759,38 @@ class TestMCPServerTask:
 
         asyncio.run(_test())
 
+    def test_run_stdio_rejects_secret_arg_placeholder_before_spawn(self):
+        """Secret-shaped argv placeholders fail before subprocess params exist."""
+        from tools.mcp_tool import MCPServerTask
+
+        async def _test():
+            server = MCPServerTask("example")
+            with patch("tools.mcp_tool.StdioServerParameters") as mock_params:
+                with pytest.raises(ValueError, match="secret environment placeholder"):
+                    await server._run_stdio({
+                        "command": "node",
+                        "args": ["server.js", "${EXAMPLE_API_KEY}"],
+                    })
+                mock_params.assert_not_called()
+
+        asyncio.run(_test())
+
+    def test_run_stdio_rejects_secret_arg_flag_before_spawn(self):
+        """Secret-bearing argv flags are rejected even with placeholder-free values."""
+        from tools.mcp_tool import MCPServerTask
+
+        async def _test():
+            server = MCPServerTask("example")
+            with patch("tools.mcp_tool.StdioServerParameters") as mock_params:
+                with pytest.raises(ValueError, match="secret-bearing argv flag"):
+                    await server._run_stdio({
+                        "command": "node",
+                        "args": ["server.js", "--api-key", "test-token-not-real"],
+                    })
+                mock_params.assert_not_called()
+
+        asyncio.run(_test())
+
     def test_refresh_tools_deregisters_removed_tools(self):
         """Dynamic refresh removes stale registry entries for deleted tools."""
         from tools.registry import ToolRegistry
@@ -834,6 +917,38 @@ class TestMCPServerTask:
                 assert isinstance(env_arg, dict)
                 assert "PATH" in env_arg
                 assert "HOME" in env_arg
+
+                await server.shutdown()
+
+        asyncio.run(_test())
+
+    def test_explicit_env_reaches_stdio_params_without_argv_leak(self):
+        """Credential env entries are passed via env, never via stdio args."""
+        from tools.mcp_tool import MCPServerTask
+
+        mock_session = MagicMock()
+        mock_session.initialize = AsyncMock()
+        mock_session.list_tools = AsyncMock(
+            return_value=SimpleNamespace(tools=[])
+        )
+
+        p_stdio, p_cs, _, _ = self._mock_stdio_and_session(mock_session)
+
+        async def _test():
+            with patch("tools.mcp_tool.StdioServerParameters") as mock_params, \
+                 p_stdio, p_cs, \
+                 patch.dict("os.environ", {"PATH": "/usr/bin", "HOME": "/home/test"}, clear=False):
+                server = MCPServerTask("srv")
+                await server.start({
+                    "command": "node",
+                    "args": ["server.js"],
+                    "env": {"EXAMPLE_API_KEY": "test-token-not-real"},
+                })
+
+                call_kwargs = mock_params.call_args.kwargs
+                assert call_kwargs["args"] == ["server.js"]
+                assert "test-token-not-real" not in call_kwargs["args"]
+                assert call_kwargs["env"]["EXAMPLE_API_KEY"] == "test-token-not-real"
 
                 await server.shutdown()
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -268,6 +268,28 @@ _CREDENTIAL_PATTERN = re.compile(
     re.IGNORECASE,
 )
 
+_ENV_VAR_REF_PATTERN = re.compile(r"\$\{([^}]+)\}")
+_SECRET_ENV_VAR_NAME_PATTERN = re.compile(
+    r"(?:^|_)(?:API_?KEY|ACCESS_?KEY|AUTH_?TOKEN|BEARER_?TOKEN|"
+    r"CLIENT_?SECRET|CREDENTIALS?|PASSWORD|PASS|PRIVATE_?KEY|SECRET|TOKEN)(?:_|$)"
+    r"|_KEY$",
+    re.IGNORECASE,
+)
+_SECRET_ARG_FLAGS = frozenset({
+    "--access-key",
+    "--access-token",
+    "--api-key",
+    "--apikey",
+    "--auth-token",
+    "--bearer-token",
+    "--client-secret",
+    "--key",
+    "--password",
+    "--private-key",
+    "--secret",
+    "--token",
+})
+
 
 # ---------------------------------------------------------------------------
 # Security helpers
@@ -290,6 +312,45 @@ def _build_safe_env(user_env: Optional[dict]) -> dict:
     if user_env:
         env.update(user_env)
     return env
+
+
+def _is_secret_env_var_name(name: str) -> bool:
+    """Return True for env var names that conventionally carry secrets."""
+    return bool(_SECRET_ENV_VAR_NAME_PATTERN.search(str(name or "")))
+
+
+def _is_mcp_args_path(path: tuple) -> bool:
+    return len(path) >= 3 and path[0] == "mcp_servers" and path[2] == "args"
+
+
+def _stdio_argv_secret_error(args: Optional[list]) -> Optional[str]:
+    """Explain why stdio argv is unsafe, or return None if it is safe."""
+    for raw in args or []:
+        value = str(raw)
+        lowered = value.lower()
+        flag_name = lowered.split("=", 1)[0]
+
+        if flag_name in _SECRET_ARG_FLAGS:
+            return f"secret-bearing argv flag '{flag_name}'"
+
+        for env_name in _ENV_VAR_REF_PATTERN.findall(value):
+            if _is_secret_env_var_name(env_name):
+                return f"secret environment placeholder '${{{env_name}}}'"
+
+        if _CREDENTIAL_PATTERN.search(value):
+            return "credential-shaped argv value"
+
+    return None
+
+
+def _validate_stdio_args_no_secrets(server_name: str, args: Optional[list]) -> None:
+    reason = _stdio_argv_secret_error(args)
+    if reason:
+        raise ValueError(
+            f"MCP server '{server_name}' places a secret in stdio argv ({reason}). "
+            f"Move credentials to mcp_servers.{server_name}.env or another "
+            "non-argv secret channel."
+        )
 
 
 def _sanitize_error(text: str) -> str:
@@ -1068,6 +1129,8 @@ class MCPServerTask:
 
         safe_env = _build_safe_env(user_env)
         command, safe_env = _resolve_stdio_command(command, safe_env)
+
+        _validate_stdio_args_no_secrets(self.name, args)
 
         # Check package against OSV malware database before spawning
         from tools.osv_check import check_package_for_malware
@@ -1896,16 +1959,24 @@ def _interrupted_call_result() -> str:
 # Config loading
 # ---------------------------------------------------------------------------
 
-def _interpolate_env_vars(value):
-    """Recursively resolve ``${VAR}`` placeholders from ``os.environ``."""
+def _interpolate_env_vars(value, _path: tuple = ()):
+    """Recursively resolve ``${VAR}`` placeholders from ``os.environ``.
+
+    Secret-shaped placeholders inside MCP stdio ``args`` are intentionally
+    left unresolved so credentials cannot be copied into child process argv.
+    The stdio launcher rejects those placeholders with an actionable error.
+    """
     if isinstance(value, str):
         def _replace(m):
-            return os.environ.get(m.group(1), m.group(0))
-        return re.sub(r"\$\{([^}]+)\}", _replace, value)
+            env_name = m.group(1)
+            if _is_mcp_args_path(_path) and _is_secret_env_var_name(env_name):
+                return m.group(0)
+            return os.environ.get(env_name, m.group(0))
+        return _ENV_VAR_REF_PATTERN.sub(_replace, value)
     if isinstance(value, dict):
-        return {k: _interpolate_env_vars(v) for k, v in value.items()}
+        return {k: _interpolate_env_vars(v, (*_path, str(k))) for k, v in value.items()}
     if isinstance(value, list):
-        return [_interpolate_env_vars(v) for v in value]
+        return [_interpolate_env_vars(v, (*_path, str(i))) for i, v in enumerate(value)]
     return value
 
 
@@ -1919,6 +1990,8 @@ def _load_mcp_config() -> Dict[str, dict]:
 
     ``${ENV_VAR}`` placeholders in string values are resolved from
     ``os.environ`` (which includes ``~/.hermes/.env`` loaded at startup).
+    Secret-shaped placeholders inside stdio ``args`` are not resolved; use the
+    server's explicit ``env`` block for credentials.
     """
     try:
         from hermes_cli.config import load_config
@@ -1932,7 +2005,10 @@ def _load_mcp_config() -> Dict[str, dict]:
             load_hermes_dotenv()
         except Exception:
             pass
-        return {name: _interpolate_env_vars(cfg) for name, cfg in servers.items()}
+        return {
+            name: _interpolate_env_vars(cfg, ("mcp_servers", str(name)))
+            for name, cfg in servers.items()
+        }
     except Exception as exc:
         logger.debug("Failed to load MCP config: %s", exc)
         return {}


### PR DESCRIPTION
## Summary
- Prevent secret-shaped MCP stdio `args` placeholders from being interpolated into child process argv.
- Fail fast before spawning stdio MCP subprocesses when argv contains secret-bearing flags, secret env placeholders, or credential-shaped values.
- Keep non-secret args interpolation backwards-compatible and preserve explicit `env` interpolation as the supported credential channel.

## Security Impact
This closes a local credential exposure path where MCP server config such as `${EXAMPLE_API_KEY}` in `args` could be resolved into process argv, making the token observable via process inspection. Credentials should be passed through `mcp_servers.<name>.env` or another non-argv secret channel instead.

## Verification
- `scripts/run_tests.sh tests/tools/test_mcp_tool.py` — 188 passed
- `scripts/run_tests.sh tests/hermes_cli/test_mcp_config.py` — 32 passed
- `scripts/run_tests.sh tests/tools/test_mcp_tool_issue_948.py` — 4 passed
- `scripts/run_tests.sh tests/tools/test_mcp_tool.py tests/hermes_cli/test_mcp_config.py tests/tools/test_mcp_tool_issue_948.py` — 224 passed
- `lsp_diagnostics` on `tools/mcp_tool.py` and `tests/tools/test_mcp_tool.py` — clean

## Full Suite Note
I also ran `scripts/run_tests.sh` before pushing. It completed with existing baseline failures unrelated to this patch, including gateway/TUI/transcription/TTS/clipboard failures and an existing MCP structured-content mock issue where origin/main already expects `server._rpc_lock` on mocked MCP servers. The changed files in this PR are limited to MCP stdio argv sanitization and its direct regression tests.