### PR TITLE
feat(gateway): add busy_ack_enabled config option to suppress ack messages

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -357,6 +357,8 @@ if _config_path.exists():
         if _display_cfg and isinstance(_display_cfg, dict):
             if "busy_input_mode" in _display_cfg and "HERMES_GATEWAY_BUSY_INPUT_MODE" not in os.environ:
                 os.environ["HERMES_GATEWAY_BUSY_INPUT_MODE"] = str(_display_cfg["busy_input_mode"])
+            if "busy_ack_enabled" in _display_cfg and "HERMES_GATEWAY_BUSY_ACK_ENABLED" not in os.environ:
+                os.environ["HERMES_GATEWAY_BUSY_ACK_ENABLED"] = str(_display_cfg["busy_ack_enabled"])
         # Timezone: bridge config.yaml → HERMES_TIMEZONE env var.
         # HERMES_TIMEZONE from .env takes precedence (already in os.environ).
         _tz_cfg = _cfg.get("timezone", "")
@@ -1885,6 +1887,12 @@ class GatewayRunner:
             return True  # interrupt sent (if not queue), ack already delivered recently
 
         self._busy_ack_ts[session_key] = now
+
+        # Check if busy ack is disabled — skip sending but still process the input
+        busy_ack_enabled = os.environ.get("HERMES_GATEWAY_BUSY_ACK_ENABLED", "true").lower() == "true"
+        if not busy_ack_enabled:
+            logger.debug("Busy ack suppressed for session %s", session_key)
+            return True  # input still processed, just no ack sent
 
         # Build a status-rich acknowledgment
         status_parts = []


### PR DESCRIPTION
## Summary

When a user sends a message while the gateway is busy processing, an acknowledgment message is sent (e.g., "⚡ Interrupting current task..."). This can be spammy for users who send rapid messages like voice input.

Add  config option (default:  for backward compatibility) to allow users to suppress these busy-input acknowledgment messages.

## Changes

- Add config loading for  in 
- Add guard in  to skip sending ack when disabled
- Log at DEBUG level when ack is suppressed

## Config



## How to test

1. Run a long terminal command (e.g., )
2. Send a message while it\'s running
3. Verify you get the ack message (default behavior)
4. Add  to config.yaml
5. Restart gateway
6. Repeat test - verify NO ack message is sent

## Related

- Fixes #17457