### PR TITLE
Fix backup hangs on live browser profile files

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -13,6 +13,7 @@ import logging
 import os
 import shutil
 import sqlite3
+import stat
 import sys
 import tempfile
 import time
@@ -37,6 +38,7 @@ _EXCLUDED_DIRS = {
     ".git",             # nested git dirs (profiles shouldn't have these, but safety)
     "node_modules",     # js deps if website/ somehow leaks in
     "backups",          # prior auto-backups — don't nest backups exponentially
+    "browser-cdp-profile",  # live Chrome profile — contains sockets and locked SQLite DBs
     "checkpoints",      # session-local trajectory caches — regenerated per-session,
                         # session-hash-keyed so they don't port to another machine anyway
 }
@@ -80,6 +82,19 @@ def _should_exclude(rel_path: Path) -> bool:
         return True
 
     return False
+
+
+def _is_backupable_file(path: Path) -> bool:
+    """Return True only for regular files.
+
+    ``zipfile.write()`` follows symlinks. Runtime browser profiles can contain
+    symlinks to Unix sockets such as ``SingletonSocket``; following those can
+    block forever. Skip all symlinks and other special files.
+    """
+    try:
+        return stat.S_ISREG(path.lstat().st_mode)
+    except OSError:
+        return False
 
 
 # ---------------------------------------------------------------------------
@@ -171,6 +186,9 @@ def run_backup(args) -> None:
             rel = fpath.relative_to(hermes_root)
 
             if _should_exclude(rel):
+                continue
+
+            if not _is_backupable_file(fpath):
                 continue
 
             # Skip the output zip itself if it happens to be inside hermes root
@@ -722,6 +740,9 @@ def _write_full_zip_backup(out_path: Path, hermes_root: Path) -> Optional[Path]:
                     continue
 
                 if _should_exclude(rel):
+                    continue
+
+                if not _is_backupable_file(fpath):
                     continue
 
                 # Skip the output zip itself if it already exists inside root.

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -103,6 +103,12 @@ class TestShouldExclude:
         from hermes_cli.backup import _should_exclude
         assert _should_exclude(Path("backups/pre-update-2026-04-27-063400.zip"))
 
+    def test_excludes_browser_cdp_profile(self):
+        """Live browser profiles contain sockets and locked SQLite DBs."""
+        from hermes_cli.backup import _should_exclude
+        assert _should_exclude(Path("browser-cdp-profile/SingletonSocket"))
+        assert _should_exclude(Path("browser-cdp-profile/Default/History"))
+
     def test_excludes_sqlite_sidecars(self):
         """SQLite WAL/SHM/journal sidecars must not ship alongside the
         safe-copied .db — pairing a fresh snapshot with stale sidecar state
@@ -238,6 +244,43 @@ class TestBackup:
             names = zf.namelist()
             pid_files = [n for n in names if n.endswith(".pid")]
             assert pid_files == []
+
+    def test_excludes_symlinks(self, tmp_path, monkeypatch):
+        """Backup skips symlinks instead of following targets."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        _make_hermes_tree(hermes_home)
+        real_file = hermes_home / "real.txt"
+        real_file.write_text("real\n")
+        link = hermes_home / "linked.txt"
+        try:
+            link.symlink_to(real_file)
+        except OSError as exc:
+            pytest.skip(f"symlinks unavailable in test environment: {exc}")
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        out_zip = tmp_path / "backup.zip"
+        args = Namespace(output=str(out_zip))
+
+        from hermes_cli.backup import run_backup
+        run_backup(args)
+
+        with zipfile.ZipFile(out_zip, "r") as zf:
+            names = zf.namelist()
+            assert "real.txt" in names
+            assert "linked.txt" not in names
+
+    @pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="mkfifo unavailable")
+    def test_rejects_special_files(self, tmp_path):
+        """Backup file filter rejects FIFOs/sockets and other special files."""
+        from hermes_cli.backup import _is_backupable_file
+
+        fifo = tmp_path / "pipe"
+        os.mkfifo(fifo)
+
+        assert not _is_backupable_file(fifo)
 
     def test_default_output_path(self, tmp_path, monkeypatch):
         """When no output path given, zip goes to ~/hermes-backup-*.zip."""


### PR DESCRIPTION
## Summary
- skip symlinks and non-regular filesystem entries while collecting backup files
- exclude the live `browser-cdp-profile/` Chrome profile from backups
- add regressions for symlink, special-file, and browser profile exclusion

## Root Cause
The backup path walked live runtime data under `~/.hermes/browser-cdp-profile`. Chrome keeps socket-like symlinks and locked SQLite databases there. `zipfile.write()` follows symlinks and SQLite backup can stall on live Chrome DB locks, so backups could appear stuck after progress output stopped.

## Validation
- `/home/lost9999/.hermes/hermes-agent/venv/bin/pytest tests/hermes_cli/test_backup.py -q` -> 96 passed
- `python -m hermes_cli.main backup --output /tmp/hermes-backup-pr-test.zip` completed
- `unzip -tq /tmp/hermes-backup-pr-test.zip` -> no errors
