### PR TITLE
fix: spawn OpenRouter pre-warm thread only once per process

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -323,6 +323,12 @@ _PATH_SCOPED_TOOLS = frozenset({"read_file", "write_file", "patch"})
 # Maximum number of concurrent worker threads for parallel tool execution.
 _MAX_TOOL_WORKERS = 8
 
+# Guard so the OpenRouter metadata pre-warm thread is only spawned once per
+# process, not once per AIAgent instantiation.  Without this, long-running
+# gateway processes leak one OS thread per incoming message and eventually
+# exhaust the system thread limit (RuntimeError: can't start new thread).
+_openrouter_prewarm_done = threading.Event()
+
 # Patterns that indicate a terminal command may modify/delete files.
 _DESTRUCTIVE_PATTERNS = re.compile(
     r"""(?:^|\s|&&|\|\||;|`)(?:
@@ -1102,10 +1108,17 @@ class AIAgent:
         # Pre-warm OpenRouter model metadata cache in a background thread.
         # fetch_model_metadata() is cached for 1 hour; this avoids a blocking
         # HTTP request on the first API response when pricing is estimated.
-        if self.provider == "openrouter" or self._is_openrouter_url():
+        # Use a process-level Event so this thread is only spawned once — a new
+        # AIAgent is created for every gateway request, so without the guard
+        # each message leaks one OS thread and the process eventually exhausts
+        # the system thread limit (RuntimeError: can't start new thread).
+        if (self.provider == "openrouter" or self._is_openrouter_url()) and \
+                not _openrouter_prewarm_done.is_set():
+            _openrouter_prewarm_done.set()
             threading.Thread(
-                target=lambda: fetch_model_metadata(),
+                target=fetch_model_metadata,
                 daemon=True,
+                name="openrouter-prewarm",
             ).start()
 
         self.tool_progress_callback = tool_progress_callback


### PR DESCRIPTION
## What changed and why

`AIAgent.__init__()` unconditionally spawned a daemon thread to pre-warm the OpenRouter model metadata cache on every instantiation. In gateway mode a new `AIAgent` is created for every incoming message, leaking one OS thread per request. After ~1 000 messages the process exhausts the Linux default thread limit and raises `RuntimeError: can't start new thread` — the gateway becomes completely unresponsive until restarted.

**Fix:** add a module-level `threading.Event` (`_openrouter_prewarm_done`) that is set before the thread starts. All subsequent `AIAgent` instantiations skip the spawn. `fetch_model_metadata()` is already cached for 1 hour so a single background call per process is sufficient.

## How to test

1. Run the gateway in Telegram (or any adapter) with an OpenRouter model
2. Send ~1 000+ messages without restarting
3. **Before fix:** gateway crashes with `RuntimeError: can't start new thread`
4. **After fix:** gateway remains stable indefinitely

Quick synthetic check:
```python
import threading
before = threading.active_count()
for _ in range(100):
    agent = AIAgent(model='openrouter/...', ...)  # simulate gateway
after = threading.active_count()
assert after - before <= 2  # only 1 prewarm thread spawned, not 100
```

## Platforms tested

- Linux (Docker / Hetzner VPS) — confirmed fix resolves the production crash after 3 days uptime

## Related issues

Related to #8043 (persistent resource accumulation in long-running gateway)