### PR TITLE
feat(curator): hide stale skills and revalidate negative claims

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -24,6 +24,8 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
+import shutil
 import tempfile
 import threading
 from datetime import datetime, timedelta, timezone
@@ -40,6 +42,9 @@ DEFAULT_INTERVAL_HOURS = 24 * 7  # 7 days
 DEFAULT_MIN_IDLE_HOURS = 2
 DEFAULT_STALE_AFTER_DAYS = 30
 DEFAULT_ARCHIVE_AFTER_DAYS = 90
+DEFAULT_NEGATIVE_CLAIM_TTL_DAYS = 30
+DEFAULT_NEGATIVE_CLAIM_CONFIDENCE_THRESHOLD = 0.6
+DEFAULT_NEGATIVE_CLAIM_MAX_PER_RUN = 10
 
 
 # ---------------------------------------------------------------------------
@@ -55,6 +60,7 @@ def _default_state() -> Dict[str, Any]:
         "last_run_at": None,
         "last_run_duration_seconds": None,
         "last_run_summary": None,
+        "last_report_path": None,
         "paused": False,
         "run_count": 0,
     }
@@ -164,6 +170,40 @@ def get_archive_after_days() -> int:
         return DEFAULT_ARCHIVE_AFTER_DAYS
 
 
+def get_revalidate_negative_claims() -> bool:
+    cfg = _load_config()
+    return bool(cfg.get("revalidate_negative_claims", True))
+
+
+def get_negative_claim_ttl_days() -> int:
+    cfg = _load_config()
+    try:
+        return int(cfg.get("negative_claim_ttl_days", DEFAULT_NEGATIVE_CLAIM_TTL_DAYS))
+    except (TypeError, ValueError):
+        return DEFAULT_NEGATIVE_CLAIM_TTL_DAYS
+
+
+def get_negative_claim_confidence_threshold() -> float:
+    cfg = _load_config()
+    try:
+        return float(
+            cfg.get(
+                "negative_claim_confidence_threshold",
+                DEFAULT_NEGATIVE_CLAIM_CONFIDENCE_THRESHOLD,
+            )
+        )
+    except (TypeError, ValueError):
+        return DEFAULT_NEGATIVE_CLAIM_CONFIDENCE_THRESHOLD
+
+
+def get_negative_claim_max_per_run() -> int:
+    cfg = _load_config()
+    try:
+        return int(cfg.get("negative_claim_max_per_run", DEFAULT_NEGATIVE_CLAIM_MAX_PER_RUN))
+    except (TypeError, ValueError):
+        return DEFAULT_NEGATIVE_CLAIM_MAX_PER_RUN
+
+
 # ---------------------------------------------------------------------------
 # Idle / interval check
 # ---------------------------------------------------------------------------
@@ -250,6 +290,105 @@ def apply_automatic_transitions(now: Optional[datetime] = None) -> Dict[str, int
             # Skill got used again after being marked stale — reactivate.
             _u.set_state(name, _u.STATE_ACTIVE)
             counts["reactivated"] += 1
+
+    return counts
+
+
+# ---------------------------------------------------------------------------
+# Negative claim revalidation (deterministic, no LLM)
+# ---------------------------------------------------------------------------
+
+_COMMAND_UNAVAILABLE_PATTERNS = (
+    re.compile(r"(?:`([^`]+)`|\b([A-Za-z0-9_.+-]+)\b)\s+command\s+(?:is\s+)?unavailable", re.I),
+    re.compile(r"command\s+(?:`([^`]+)`|\b([A-Za-z0-9_.+-]+)\b)\s+(?:is\s+)?unavailable", re.I),
+    re.compile(r"(?:`([^`]+)`|\b([A-Za-z0-9_.+-]+)\b)\s+(?:is\s+)?not\s+(?:installed|available|found)", re.I),
+)
+
+
+def _extract_unavailable_command(summary: str) -> Optional[str]:
+    text = summary or ""
+    for pat in _COMMAND_UNAVAILABLE_PATTERNS:
+        m = pat.search(text)
+        if not m:
+            continue
+        cmd = next((g for g in m.groups() if g), "").strip()
+        if cmd and cmd.lower() not in {"the", "a", "an", "this", "that"}:
+            return cmd
+    return None
+
+
+def _probe_negative_claim(row: Dict[str, Any]) -> Dict[str, Any]:
+    """Probe one due negative claim using deterministic checks only.
+
+    Returns a dict with status, confidence, summary, and kind. Unknown claim
+    shapes are marked uncertain rather than patched or treated as disproven.
+    """
+    summary = str(row.get("negative_claim_summary") or "")
+    cmd = _extract_unavailable_command(summary)
+    if cmd:
+        found = shutil.which(cmd)
+        if found:
+            return {
+                "status": "disproven",
+                "confidence": 0.2,
+                "summary": f"Revalidated: command '{cmd}' is now available at {found}.",
+                "kind": "command_available",
+            }
+        return {
+            "status": "refreshed",
+            "confidence": row.get("negative_claim_confidence"),
+            "summary": f"Revalidated: command '{cmd}' is still unavailable.",
+            "kind": "command_missing",
+        }
+
+    return {
+        "status": "uncertain",
+        "confidence": row.get("negative_claim_confidence"),
+        "summary": f"Needs manual review: no deterministic probe for claim: {summary}",
+        "kind": "unprobeable",
+    }
+
+
+def revalidate_negative_claims(now: Optional[datetime] = None) -> Dict[str, int]:
+    """Revalidate due negative/environment-dependent claims.
+
+    This pass is intentionally conservative: it only updates sidecar metadata
+    based on deterministic probes. It does not edit SKILL.md content; a later
+    phase can use the report output to drive safe patches when evidence is
+    positive.
+    """
+    if not get_revalidate_negative_claims():
+        return {"checked": 0, "disproven": 0, "refreshed": 0, "uncertain": 0, "skipped": 0}
+
+    if now is None:
+        now = datetime.now(timezone.utc)
+    due = skill_usage.due_negative_claims(
+        now=now,
+        limit=get_negative_claim_max_per_run(),
+        min_confidence=get_negative_claim_confidence_threshold(),
+    )
+    counts = {"checked": 0, "disproven": 0, "refreshed": 0, "uncertain": 0, "skipped": 0}
+    ttl_days = get_negative_claim_ttl_days()
+
+    for row in due:
+        name = row.get("name")
+        if not name:
+            counts["skipped"] += 1
+            continue
+        result = _probe_negative_claim(row)
+        status = str(result.get("status") or "uncertain")
+        counts["checked"] += 1
+        if status not in ("disproven", "refreshed", "uncertain"):
+            status = "uncertain"
+        counts[status] += 1
+        skill_usage.update_negative_claim_revalidation(
+            str(name),
+            status=status,
+            confidence=result.get("confidence"),
+            summary=result.get("summary"),
+            ttl_days=ttl_days,
+            now=now,
+        )
 
     return counts
 
@@ -379,12 +518,16 @@ def _write_run_report(
     before_names: Set[str],
     after_report: List[Dict[str, Any]],
     llm_meta: Dict[str, Any],
+    negative_counts: Optional[Dict[str, int]] = None,
 ) -> Optional[Path]:
     """Write run.json + REPORT.md under logs/curator/{YYYYMMDD-HHMMSS}/.
 
     Returns the report directory path on success, None if the write
     couldn't happen (caller logs and continues — reporting is best-effort).
     """
+    if negative_counts is None:
+        negative_counts = {"checked": 0, "disproven": 0, "refreshed": 0, "uncertain": 0, "skipped": 0}
+
     root = _reports_root()
     try:
         root.mkdir(parents=True, exist_ok=True)
@@ -432,6 +575,7 @@ def _write_run_report(
         "model": llm_meta.get("model", ""),
         "provider": llm_meta.get("provider", ""),
         "auto_transitions": auto_counts,
+        "negative_claim_revalidation": negative_counts,
         "counts": {
             "before": len(before_names),
             "after": len(after_names),
@@ -499,6 +643,16 @@ def _render_report_markdown(p: Dict[str, Any]) -> str:
     lines.append(f"- marked stale: {auto.get('marked_stale', 0)}")
     lines.append(f"- archived: {auto.get('archived', 0)}")
     lines.append(f"- reactivated: {auto.get('reactivated', 0)}")
+    lines.append("")
+
+    # Negative claim revalidation (pure, no LLM)
+    neg = p.get("negative_claim_revalidation") or {}
+    lines.append("## Negative claim revalidation (pure, no LLM)\n")
+    lines.append(f"- checked: {neg.get('checked', 0)}")
+    lines.append(f"- disproven: {neg.get('disproven', 0)}")
+    lines.append(f"- refreshed: {neg.get('refreshed', 0)}")
+    lines.append(f"- uncertain: {neg.get('uncertain', 0)}")
+    lines.append(f"- skipped: {neg.get('skipped', 0)}")
     lines.append("")
 
     # LLM pass numbers
@@ -607,6 +761,7 @@ def run_curator_review(
     """
     start = datetime.now(timezone.utc)
     counts = apply_automatic_transitions(now=start)
+    negative_counts = revalidate_negative_claims(now=start)
 
     auto_summary_parts = []
     if counts["marked_stale"]:
@@ -615,6 +770,14 @@ def run_curator_review(
         auto_summary_parts.append(f"{counts['archived']} archived")
     if counts["reactivated"]:
         auto_summary_parts.append(f"{counts['reactivated']} reactivated")
+    if negative_counts.get("checked"):
+        auto_summary_parts.append(
+            "negative claims: "
+            f"{negative_counts.get('checked', 0)} checked, "
+            f"{negative_counts.get('disproven', 0)} disproven, "
+            f"{negative_counts.get('refreshed', 0)} refreshed, "
+            f"{negative_counts.get('uncertain', 0)} uncertain"
+        )
     auto_summary = ", ".join(auto_summary_parts) if auto_summary_parts else "no changes"
 
     # Persist state before the LLM pass so a crash mid-review still records
@@ -683,6 +846,7 @@ def run_curator_review(
                 elapsed_seconds=elapsed,
                 auto_counts=counts,
                 auto_summary=auto_summary,
+                negative_counts=negative_counts,
                 before_report=before_report,
                 before_names=before_names,
                 after_report=after_report,
@@ -710,6 +874,7 @@ def run_curator_review(
     return {
         "started_at": start.isoformat(),
         "auto_transitions": counts,
+        "negative_claim_revalidation": negative_counts,
         "summary_so_far": auto_summary,
     }
 

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -530,6 +530,47 @@ def _build_skills_manifest(skills_dir: Path) -> dict[str, list[int]]:
     return manifest
 
 
+def _skill_usage_signature(skills_dir: Path) -> tuple[int, int] | None:
+    """Return a cheap signature for lifecycle metadata that affects prompts."""
+    usage_path = skills_dir / ".usage.json"
+    try:
+        st = usage_path.stat()
+    except OSError:
+        return None
+    return (st.st_mtime_ns, st.st_size)
+
+
+def _hide_stale_from_prompt_enabled() -> bool:
+    """Whether curator.hide_stale_from_prompt is enabled in config.yaml."""
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+    except Exception as exc:
+        logger.debug("Could not load curator prompt-filter config: %s", exc)
+        return False
+    cur = cfg.get("curator") if isinstance(cfg, dict) else None
+    if not isinstance(cur, dict):
+        return False
+    return bool(cur.get("hide_stale_from_prompt", False))
+
+
+def _skill_hidden_by_curator(
+    skill_name: str,
+    frontmatter_name: str,
+    hide_stale_from_prompt: bool,
+) -> bool:
+    """Return True when curator lifecycle metadata should hide a skill entry."""
+    if not hide_stale_from_prompt:
+        return False
+    try:
+        from tools.skill_usage import should_hide_from_prompt
+        names = {n for n in (skill_name, frontmatter_name) if n}
+        return any(should_hide_from_prompt(n) for n in names)
+    except Exception as exc:
+        logger.debug("Could not apply curator skill prompt filter: %s", exc)
+        return False
+
+
 def _load_skills_snapshot(skills_dir: Path) -> Optional[dict]:
     """Load the disk snapshot if it exists and its manifest still matches."""
     snapshot_path = _skills_prompt_snapshot_path()
@@ -685,6 +726,8 @@ def build_skills_system_prompt(
         or ""
     )
     disabled = get_disabled_skill_names()
+    hide_stale_from_prompt = _hide_stale_from_prompt_enabled()
+    usage_signature = _skill_usage_signature(skills_dir) if hide_stale_from_prompt else None
     cache_key = (
         str(skills_dir.resolve()),
         tuple(str(d) for d in external_dirs),
@@ -692,6 +735,8 @@ def build_skills_system_prompt(
         tuple(sorted(str(ts) for ts in (available_toolsets or set()))),
         _platform_hint,
         tuple(sorted(disabled)),
+        hide_stale_from_prompt,
+        usage_signature,
     )
     with _SKILLS_PROMPT_CACHE_LOCK:
         cached = _SKILLS_PROMPT_CACHE.get(cache_key)
@@ -718,6 +763,12 @@ def build_skills_system_prompt(
                 continue
             if frontmatter_name in disabled or skill_name in disabled:
                 continue
+            if _skill_hidden_by_curator(
+                skill_name,
+                frontmatter_name,
+                hide_stale_from_prompt,
+            ):
+                continue
             if not _skill_should_show(
                 entry.get("conditions") or {},
                 available_tools,
@@ -741,7 +792,14 @@ def build_skills_system_prompt(
             if not is_compatible:
                 continue
             skill_name = entry["skill_name"]
-            if entry["frontmatter_name"] in disabled or skill_name in disabled:
+            frontmatter_name = entry["frontmatter_name"]
+            if frontmatter_name in disabled or skill_name in disabled:
+                continue
+            if _skill_hidden_by_curator(
+                skill_name,
+                frontmatter_name,
+                hide_stale_from_prompt,
+            ):
                 continue
             if not _skill_should_show(
                 extract_skill_conditions(frontmatter),
@@ -797,6 +855,12 @@ def build_skills_system_prompt(
                 if frontmatter_name in seen_skill_names:
                     continue
                 if frontmatter_name in disabled or skill_name in disabled:
+                    continue
+                if _skill_hidden_by_curator(
+                    skill_name,
+                    frontmatter_name,
+                    hide_stale_from_prompt,
+                ):
                     continue
                 if not _skill_should_show(
                     extract_skill_conditions(frontmatter),

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -949,6 +949,13 @@ DEFAULT_CONFIG = {
         # When true, skills in the stale lifecycle state are omitted from the
         # default prompt-time skills index. Pinned stale skills stay visible.
         "hide_stale_from_prompt": False,
+        # Revalidate negative / environment-dependent skill claims such as
+        # "X command unavailable" after their TTL expires. The first pass only
+        # tracks metadata; the curator revalidation pass consumes these values.
+        "revalidate_negative_claims": True,
+        "negative_claim_ttl_days": 30,
+        "negative_claim_confidence_threshold": 0.6,
+        "negative_claim_max_per_run": 10,
         # Optional per-task override for the curator's aux model. Leave null
         # to use Hermes' main auxiliary client resolution.
         "auxiliary": {

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -946,6 +946,9 @@ DEFAULT_CONFIG = {
         # Archive a skill (move to skills/.archive/) after this many days
         # without use. Archived skills are recoverable — no auto-deletion.
         "archive_after_days": 90,
+        # When true, skills in the stale lifecycle state are omitted from the
+        # default prompt-time skills index. Pinned stale skills stay visible.
+        "hide_stale_from_prompt": False,
         # Optional per-task override for the curator's aux model. Leave null
         # to use Hermes' main auxiliary client resolution.
         "auxiliary": {

--- a/tests/agent/test_curator.py
+++ b/tests/agent/test_curator.py
@@ -66,6 +66,10 @@ def test_curator_defaults(curator_env):
     assert c.get_min_idle_hours() == 2
     assert c.get_stale_after_days() == 30
     assert c.get_archive_after_days() == 90
+    assert c.get_revalidate_negative_claims() is True
+    assert c.get_negative_claim_ttl_days() == 30
+    assert c.get_negative_claim_confidence_threshold() == 0.6
+    assert c.get_negative_claim_max_per_run() == 10
 
 
 def test_curator_config_overrides(curator_env, monkeypatch):
@@ -75,11 +79,19 @@ def test_curator_config_overrides(curator_env, monkeypatch):
         "min_idle_hours": 0.5,
         "stale_after_days": 7,
         "archive_after_days": 60,
+        "revalidate_negative_claims": False,
+        "negative_claim_ttl_days": 45,
+        "negative_claim_confidence_threshold": 0.75,
+        "negative_claim_max_per_run": 3,
     })
     assert c.get_interval_hours() == 12
     assert c.get_min_idle_hours() == 0.5
     assert c.get_stale_after_days() == 7
     assert c.get_archive_after_days() == 60
+    assert c.get_revalidate_negative_claims() is False
+    assert c.get_negative_claim_ttl_days() == 45
+    assert c.get_negative_claim_confidence_threshold() == 0.75
+    assert c.get_negative_claim_max_per_run() == 3
 
 
 # ---------------------------------------------------------------------------
@@ -249,6 +261,70 @@ def test_bundled_skill_not_touched_by_transitions(curator_env):
 
 
 # ---------------------------------------------------------------------------
+# Negative claim revalidation pass
+# ---------------------------------------------------------------------------
+
+def test_revalidate_negative_claims_disproves_available_command(curator_env, monkeypatch):
+    c = curator_env["curator"]
+    u = curator_env["usage"]
+    now = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    u.mark_negative_claim("cmd-skill", "foo command unavailable", confidence=0.9, ttl_days=1, now=now)
+    monkeypatch.setattr(c.shutil, "which", lambda cmd: "/usr/bin/foo" if cmd == "foo" else None)
+
+    counts = c.revalidate_negative_claims(now=now + timedelta(days=2))
+
+    rec = u.get_record("cmd-skill")
+    assert counts["checked"] == 1
+    assert counts["disproven"] == 1
+    assert rec["negative_claim_status"] == "disproven"
+    assert rec["negative_claim_confidence"] < 0.6
+    assert "available" in rec["negative_claim_summary"]
+
+
+def test_revalidate_negative_claims_refreshes_still_missing_command(curator_env, monkeypatch):
+    c = curator_env["curator"]
+    u = curator_env["usage"]
+    now = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    u.mark_negative_claim("cmd-skill", "bar command unavailable", confidence=0.9, ttl_days=1, now=now)
+    monkeypatch.setattr(c.shutil, "which", lambda cmd: None)
+
+    counts = c.revalidate_negative_claims(now=now + timedelta(days=2))
+
+    rec = u.get_record("cmd-skill")
+    assert counts["checked"] == 1
+    assert counts["refreshed"] == 1
+    assert rec["negative_claim_status"] == "refreshed"
+    assert "still unavailable" in rec["negative_claim_summary"]
+
+
+def test_revalidate_negative_claims_marks_unprobeable_claim_uncertain(curator_env):
+    c = curator_env["curator"]
+    u = curator_env["usage"]
+    now = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    u.mark_negative_claim("vague-skill", "some provider might be flaky", confidence=0.9, ttl_days=1, now=now)
+
+    counts = c.revalidate_negative_claims(now=now + timedelta(days=2))
+
+    rec = u.get_record("vague-skill")
+    assert counts["checked"] == 1
+    assert counts["uncertain"] == 1
+    assert rec["negative_claim_status"] == "uncertain"
+
+
+def test_revalidate_negative_claims_respects_disabled_config(curator_env, monkeypatch):
+    c = curator_env["curator"]
+    u = curator_env["usage"]
+    now = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    u.mark_negative_claim("cmd-skill", "foo command unavailable", confidence=0.9, ttl_days=1, now=now)
+    monkeypatch.setattr(c, "_load_config", lambda: {"revalidate_negative_claims": False})
+
+    counts = c.revalidate_negative_claims(now=now + timedelta(days=2))
+
+    assert counts["checked"] == 0
+    assert u.get_record("cmd-skill")["negative_claim_status"] == "active"
+
+
+# ---------------------------------------------------------------------------
 # run_curator_review orchestration
 # ---------------------------------------------------------------------------
 
@@ -263,6 +339,40 @@ def test_run_review_records_state(curator_env):
     assert state["last_run_at"] is not None
     assert state["run_count"] >= 1
     assert state["last_run_summary"] is not None
+
+
+def test_run_review_applies_negative_claim_revalidation(curator_env, monkeypatch):
+    c = curator_env["curator"]
+    u = curator_env["usage"]
+    skills_dir = curator_env["home"] / "skills"
+    _write_skill(skills_dir, "cmd-skill")
+    now = datetime.now(timezone.utc) - timedelta(days=3)
+    u.mark_negative_claim("cmd-skill", "foo command unavailable", confidence=0.9, ttl_days=1, now=now)
+    monkeypatch.setattr(c.shutil, "which", lambda cmd: None)
+
+    result = c.run_curator_review(synchronous=True)
+
+    assert result["negative_claim_revalidation"]["checked"] == 1
+    assert u.get_record("cmd-skill")["negative_claim_status"] == "refreshed"
+    assert "negative" in c.load_state()["last_run_summary"]
+
+
+def test_run_review_report_includes_negative_claim_revalidation(curator_env, monkeypatch):
+    c = curator_env["curator"]
+    u = curator_env["usage"]
+    skills_dir = curator_env["home"] / "skills"
+    _write_skill(skills_dir, "cmd-skill")
+    now = datetime.now(timezone.utc) - timedelta(days=3)
+    u.mark_negative_claim("cmd-skill", "foo command unavailable", confidence=0.9, ttl_days=1, now=now)
+    monkeypatch.setattr(c.shutil, "which", lambda cmd: None)
+
+    c.run_curator_review(synchronous=True)
+
+    report_path = Path(c.load_state()["last_report_path"])
+    payload = json.loads((report_path / "run.json").read_text(encoding="utf-8"))
+    report_md = (report_path / "REPORT.md").read_text(encoding="utf-8")
+    assert payload["negative_claim_revalidation"]["checked"] == 1
+    assert "Negative claim revalidation" in report_md
 
 
 def test_run_review_synchronous_invokes_llm_stub(curator_env, monkeypatch):

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -372,6 +372,72 @@ class TestBuildSkillsSystemPrompt:
         second = build_skills_system_prompt()
         assert "cached-skill" not in second
 
+    def test_hides_stale_skills_from_prompt_when_curator_flag_enabled(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            "curator:\n  hide_stale_from_prompt: true\n"
+        )
+        skills_root = tmp_path / "skills" / "tools"
+        for name in ("active-skill", "stale-skill", "pinned-stale-skill"):
+            skill_dir = skills_root / name
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text(
+                f"---\nname: {name}\ndescription: {name} description\n---\n"
+            )
+        (tmp_path / "skills" / ".usage.json").write_text(
+            """
+{
+  "stale-skill": {"state": "stale", "pinned": false},
+  "pinned-stale-skill": {"state": "stale", "pinned": true}
+}
+""".strip()
+        )
+
+        result = build_skills_system_prompt()
+
+        assert "    - active-skill:" in result
+        assert "    - stale-skill:" not in result
+        assert "    - pinned-stale-skill:" in result
+
+    def test_keeps_stale_skills_visible_when_curator_flag_disabled(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            "curator:\n  hide_stale_from_prompt: false\n"
+        )
+        skill_dir = tmp_path / "skills" / "tools" / "stale-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: stale-skill\ndescription: Stale but visible\n---\n"
+        )
+        (tmp_path / "skills" / ".usage.json").write_text(
+            '{"stale-skill": {"state": "stale", "pinned": false}}'
+        )
+
+        result = build_skills_system_prompt()
+
+        assert "stale-skill" in result
+
+    def test_rebuilds_prompt_when_skill_usage_state_changes(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            "curator:\n  hide_stale_from_prompt: true\n"
+        )
+        skill_dir = tmp_path / "skills" / "tools" / "transitions-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: transitions-skill\ndescription: Changes state\n---\n"
+        )
+
+        first = build_skills_system_prompt()
+        assert "transitions-skill" in first
+
+        (tmp_path / "skills" / ".usage.json").write_text(
+            '{"transitions-skill": {"state": "stale", "pinned": false}}'
+        )
+
+        second = build_skills_system_prompt()
+        assert "transitions-skill" not in second
+
     def test_includes_setup_needed_skills(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         monkeypatch.delenv("MISSING_API_KEY_XYZ", raising=False)

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -71,6 +71,13 @@ class TestLoadConfigDefaults:
             assert config["terminal"]["backend"] == "local"
             assert config["display"]["interim_assistant_messages"] is True
 
+    def test_curator_defaults_include_negative_claim_revalidation_settings(self):
+        curator = DEFAULT_CONFIG["curator"]
+        assert curator["revalidate_negative_claims"] is True
+        assert curator["negative_claim_ttl_days"] == 30
+        assert curator["negative_claim_confidence_threshold"] == 0.6
+        assert curator["negative_claim_max_per_run"] == 10
+
     def test_legacy_root_level_max_turns_migrates_to_agent_config(self, tmp_path):
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
             config_path = tmp_path / "config.yaml"

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -485,6 +485,40 @@ class TestSkillManageDispatcher:
         result = json.loads(raw)
         assert result["success"] is True
 
+    def test_create_records_negative_claim_metadata(self, tmp_path, monkeypatch):
+        import tools.skill_usage as usage
+        monkeypatch.setattr(usage, "_skills_dir", lambda: tmp_path)
+        content = VALID_SKILL_CONTENT + "\nNote: `foo` command is unavailable on CI.\n"
+
+        with _skill_dir(tmp_path):
+            raw = skill_manage(action="create", name="test-skill", content=content)
+
+        result = json.loads(raw)
+        rec = usage.get_record("test-skill")
+        assert result["success"] is True
+        assert rec["negative_claim_status"] == "active"
+        assert rec["negative_claim_summary"] == "`foo` command is unavailable on CI."
+        assert rec["negative_claims"][0]["subject"] == "foo"
+
+    def test_patch_records_new_negative_claim_metadata(self, tmp_path, monkeypatch):
+        import tools.skill_usage as usage
+        monkeypatch.setattr(usage, "_skills_dir", lambda: tmp_path)
+
+        with _skill_dir(tmp_path):
+            skill_manage(action="create", name="test-skill", content=VALID_SKILL_CONTENT)
+            raw = skill_manage(
+                action="patch",
+                name="test-skill",
+                old_string="Step 1: Do the thing.",
+                new_string="Step 1: Do the thing.\n\nWarning: bar command unavailable in old containers.",
+            )
+
+        result = json.loads(raw)
+        rec = usage.get_record("test-skill")
+        assert result["success"] is True
+        assert rec["negative_claim_summary"] == "Warning: bar command unavailable in old containers."
+        assert rec["negative_claims"][0]["subject"] == "bar"
+
 
 class TestSecurityScanGate:
     """_security_scan_skill is gated by skills.guard_agent_created config flag."""

--- a/tests/tools/test_skill_usage.py
+++ b/tests/tools/test_skill_usage.py
@@ -83,6 +83,7 @@ def test_get_record_missing_returns_empty_record(skills_home):
     assert rec["negative_claim_revalidation_due_at"] is None
     assert rec["negative_claim_summary"] is None
     assert rec["negative_claim_status"] is None
+    assert rec["negative_claims"] == []
 
 
 def test_get_record_backfills_missing_keys(skills_home):
@@ -148,6 +149,37 @@ def test_bumps_do_not_corrupt_other_skills(skills_home):
 # ---------------------------------------------------------------------------
 # Negative / environment-dependent claim metadata
 # ---------------------------------------------------------------------------
+
+def test_extract_negative_claims_from_text_detects_command_claims(skills_home):
+    from tools.skill_usage import extract_negative_claims_from_text
+
+    claims = extract_negative_claims_from_text(
+        "If setup fails, note that `foo` command is unavailable on CI.\n"
+        "The browser tool works normally."
+    )
+
+    assert len(claims) == 1
+    assert claims[0]["kind"] == "command_unavailable"
+    assert claims[0]["subject"] == "foo"
+    assert "foo" in claims[0]["text"]
+    assert claims[0]["id"]
+
+
+def test_mark_negative_claim_stores_per_claim_list_without_duplicates(skills_home):
+    from datetime import datetime, timezone
+    from tools.skill_usage import get_record, mark_negative_claim
+
+    now = datetime(2026, 4, 29, 12, 0, tzinfo=timezone.utc)
+    mark_negative_claim("cmd-skill", "foo command unavailable", confidence=0.8, ttl_days=7, now=now)
+    mark_negative_claim("cmd-skill", "foo command unavailable", confidence=0.8, ttl_days=7, now=now)
+
+    rec = get_record("cmd-skill")
+    assert len(rec["negative_claims"]) == 1
+    claim = rec["negative_claims"][0]
+    assert claim["kind"] == "command_unavailable"
+    assert claim["status"] == "active"
+    assert claim["next_revalidate_at"] == "2026-05-06T12:00:00+00:00"
+
 
 def test_mark_negative_claim_records_summary_confidence_and_due_time(skills_home):
     from datetime import datetime, timezone

--- a/tests/tools/test_skill_usage.py
+++ b/tests/tools/test_skill_usage.py
@@ -77,6 +77,12 @@ def test_get_record_missing_returns_empty_record(skills_home):
     assert rec["state"] == "active"
     assert rec["pinned"] is False
     assert rec["archived_at"] is None
+    assert rec["negative_claim_confidence"] is None
+    assert rec["negative_claim_ttl_days"] is None
+    assert rec["negative_claim_last_revalidated_at"] is None
+    assert rec["negative_claim_revalidation_due_at"] is None
+    assert rec["negative_claim_summary"] is None
+    assert rec["negative_claim_status"] is None
 
 
 def test_get_record_backfills_missing_keys(skills_home):
@@ -137,6 +143,86 @@ def test_bumps_do_not_corrupt_other_skills(skills_home):
     assert get_record("skill-a")["view_count"] == 2
     assert get_record("skill-a")["use_count"] == 0
     assert get_record("skill-b")["use_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Negative / environment-dependent claim metadata
+# ---------------------------------------------------------------------------
+
+def test_mark_negative_claim_records_summary_confidence_and_due_time(skills_home):
+    from datetime import datetime, timezone
+    from tools.skill_usage import mark_negative_claim, get_record
+
+    now = datetime(2026, 4, 29, 12, 0, tzinfo=timezone.utc)
+    mark_negative_claim(
+        "browser-skill",
+        summary="browser tools do not work in this environment",
+        confidence=0.8,
+        ttl_days=14,
+        now=now,
+    )
+
+    rec = get_record("browser-skill")
+    assert rec["negative_claim_summary"] == "browser tools do not work in this environment"
+    assert rec["negative_claim_confidence"] == 0.8
+    assert rec["negative_claim_ttl_days"] == 14
+    assert rec["negative_claim_status"] == "active"
+    assert rec["negative_claim_last_revalidated_at"] is None
+    assert rec["negative_claim_revalidation_due_at"] == "2026-05-13T12:00:00+00:00"
+
+
+def test_due_negative_claims_returns_only_due_active_claims(skills_home):
+    from datetime import datetime, timezone
+    from tools.skill_usage import (
+        due_negative_claims,
+        mark_negative_claim,
+        update_negative_claim_revalidation,
+    )
+
+    now = datetime(2026, 4, 29, 12, 0, tzinfo=timezone.utc)
+    mark_negative_claim("due", "command unavailable", ttl_days=1, now=now)
+    mark_negative_claim("future", "browser unavailable", ttl_days=10, now=now)
+    mark_negative_claim("disproven", "old false claim", ttl_days=1, now=now)
+    update_negative_claim_revalidation(
+        "disproven",
+        status="disproven",
+        now=now,
+    )
+
+    later = datetime(2026, 5, 1, 12, 0, tzinfo=timezone.utc)
+    due = due_negative_claims(now=later)
+
+    assert [row["name"] for row in due] == ["due"]
+    assert due[0]["negative_claim_summary"] == "command unavailable"
+
+
+def test_update_negative_claim_revalidation_refreshes_status_and_next_due(skills_home):
+    from datetime import datetime, timezone
+    from tools.skill_usage import (
+        get_record,
+        mark_negative_claim,
+        update_negative_claim_revalidation,
+    )
+
+    start = datetime(2026, 4, 29, 12, 0, tzinfo=timezone.utc)
+    checked = datetime(2026, 5, 2, 9, 30, tzinfo=timezone.utc)
+    mark_negative_claim("cmd-skill", "foo command unavailable", ttl_days=7, now=start)
+    update_negative_claim_revalidation(
+        "cmd-skill",
+        status="refreshed",
+        confidence=0.6,
+        summary="foo command still unavailable",
+        ttl_days=30,
+        now=checked,
+    )
+
+    rec = get_record("cmd-skill")
+    assert rec["negative_claim_status"] == "refreshed"
+    assert rec["negative_claim_confidence"] == 0.6
+    assert rec["negative_claim_summary"] == "foo command still unavailable"
+    assert rec["negative_claim_ttl_days"] == 30
+    assert rec["negative_claim_last_revalidated_at"] == "2026-05-02T09:30:00+00:00"
+    assert rec["negative_claim_revalidation_due_at"] == "2026-06-01T09:30:00+00:00"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_skill_usage.py
+++ b/tests/tools/test_skill_usage.py
@@ -181,6 +181,25 @@ def test_set_pinned(skills_home):
     assert get_record("x")["pinned"] is False
 
 
+def test_should_hide_from_prompt_only_for_unpinned_stale(skills_home):
+    from tools.skill_usage import (
+        set_pinned,
+        set_state,
+        should_hide_from_prompt,
+        STATE_ACTIVE,
+        STATE_STALE,
+    )
+
+    set_state("active", STATE_ACTIVE)
+    set_state("stale", STATE_STALE)
+    set_state("pinned-stale", STATE_STALE)
+    set_pinned("pinned-stale", True)
+
+    assert should_hide_from_prompt("active") is False
+    assert should_hide_from_prompt("stale") is True
+    assert should_hide_from_prompt("pinned-stale") is False
+
+
 def test_forget_removes_record(skills_home):
     from tools.skill_usage import bump_view, forget, load_usage
     bump_view("x")

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -72,6 +72,32 @@ def _guard_agent_created_enabled() -> bool:
         return False
 
 
+def _record_negative_claims_from_text(skill_name: str, text: str) -> None:
+    """Best-effort curator telemetry for negative/environment-dependent claims."""
+    if not text:
+        return
+    try:
+        from hermes_cli.config import load_config
+        from tools.skill_usage import extract_negative_claims_from_text, mark_negative_claim
+        claims = extract_negative_claims_from_text(text)
+        if not claims:
+            return
+        try:
+            ttl_days = int(cfg_get(load_config(), "curator", "negative_claim_ttl_days", default=30))
+        except Exception:
+            ttl_days = 30
+        # Record each extracted claim; mark_negative_claim deduplicates by claim id.
+        for claim in claims:
+            mark_negative_claim(
+                skill_name,
+                claim.get("text", ""),
+                confidence=0.8,
+                ttl_days=ttl_days,
+            )
+    except Exception:
+        logger.debug("Failed to record negative claim metadata for %s", skill_name, exc_info=True)
+
+
 def _security_scan_skill(skill_dir: Path) -> Optional[str]:
     """Scan a skill directory after write. Returns error string if blocked, else None.
 
@@ -712,6 +738,21 @@ def skill_manage(
                 forget(name)
         except Exception:
             pass
+        # Negative/environment-dependent claim telemetry. Best-effort and
+        # sidecar-only: never rewrite SKILL.md content or fail the user action.
+        try:
+            if action in ("create", "edit"):
+                _record_negative_claims_from_text(name, content or "")
+            elif action == "patch":
+                existing = _find_skill(name)
+                if existing:
+                    target = existing["path"] / (file_path or "SKILL.md")
+                    if target.exists() and target.is_file():
+                        _record_negative_claims_from_text(name, target.read_text(encoding="utf-8"))
+            elif action == "write_file":
+                _record_negative_claims_from_text(name, file_content or "")
+        except Exception:
+            logger.debug("Negative claim telemetry failed for %s", name, exc_info=True)
 
     return json.dumps(result, ensure_ascii=False)
 

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -22,9 +22,11 @@ Lifecycle states:
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
+import re
 import tempfile
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -184,6 +186,7 @@ def _empty_record() -> Dict[str, Any]:
         "negative_claim_revalidation_due_at": None,
         "negative_claim_summary": None,
         "negative_claim_status": None,
+        "negative_claims": [],
     }
 
 
@@ -319,6 +322,54 @@ def _parse_iso(ts: Optional[str]) -> Optional[datetime]:
     return _ensure_aware(dt)
 
 
+_NEGATIVE_COMMAND_PATTERNS = (
+    re.compile(r"(?:`([^`]+)`|\b([A-Za-z0-9_.+-]+)\b)\s+command\s+(?:is\s+)?unavailable[^.\n]*(?:[.])?", re.I),
+    re.compile(r"command\s+(?:`([^`]+)`|\b([A-Za-z0-9_.+-]+)\b)\s+(?:is\s+)?unavailable[^.\n]*(?:[.])?", re.I),
+    re.compile(r"(?:`([^`]+)`|\b([A-Za-z0-9_.+-]+)\b)\s+(?:is\s+)?not\s+(?:installed|available|found)[^.\n]*(?:[.])?", re.I),
+)
+
+
+def _claim_id(kind: str, subject: str, text: str) -> str:
+    basis = f"{kind}\0{subject.lower()}\0{text.strip().lower()}"
+    return hashlib.sha256(basis.encode("utf-8")).hexdigest()[:16]
+
+
+def extract_negative_claims_from_text(text: str) -> List[Dict[str, Any]]:
+    """Extract deterministic negative/environment-dependent claims from text.
+
+    This first-pass detector intentionally recognizes only high-confidence
+    command-availability claims. Unknown or ambiguous text is left for manual
+    review rather than guessed.
+    """
+    claims: List[Dict[str, Any]] = []
+    seen: Set[str] = set()
+    source = text or ""
+    for pat in _NEGATIVE_COMMAND_PATTERNS:
+        for match in pat.finditer(source):
+            subject = next((g for g in match.groups() if g), "").strip()
+            if not subject or subject.lower() in {"the", "a", "an", "this", "that", "is"}:
+                continue
+            line_start = source.rfind("\n", 0, match.start()) + 1
+            line_end = source.find("\n", match.end())
+            if line_end == -1:
+                line_end = len(source)
+            claim_text = source[line_start:line_end].strip()
+            if claim_text.lower().startswith("note:"):
+                claim_text = claim_text.split(":", 1)[1].strip()
+            claim_text = claim_text.rstrip(".") + "." if claim_text else claim_text
+            cid = _claim_id("command_unavailable", subject, claim_text)
+            if cid in seen:
+                continue
+            seen.add(cid)
+            claims.append({
+                "id": cid,
+                "kind": "command_unavailable",
+                "subject": subject,
+                "text": claim_text,
+            })
+    return claims
+
+
 def mark_negative_claim(
     skill_name: str,
     summary: str,
@@ -326,26 +377,42 @@ def mark_negative_claim(
     ttl_days: Optional[int] = None,
     now: Optional[datetime] = None,
 ) -> None:
-    """Record that a skill contains a negative / environment-dependent claim.
-
-    The sidecar stores coarse per-skill metadata for the first lifecycle pass.
-    Future revisions can expand this to a per-claim list without rewriting
-    SKILL.md on every use.
-    """
+    """Record that a skill contains a negative / environment-dependent claim."""
     when = _ensure_aware(now)
     try:
         ttl = int(ttl_days) if ttl_days is not None else None
     except (TypeError, ValueError):
         ttl = None
     due = (when + timedelta(days=ttl)).isoformat() if ttl is not None else None
+    clean_summary = str(summary or "").strip() or None
+    extracted = extract_negative_claims_from_text(clean_summary or "")
+    if not extracted and clean_summary:
+        cid = _claim_id("other", "", clean_summary)
+        extracted = [{"id": cid, "kind": "other", "subject": "", "text": clean_summary}]
 
     def _apply(rec: Dict[str, Any]) -> None:
-        rec["negative_claim_summary"] = str(summary or "").strip() or None
+        rec["negative_claim_summary"] = clean_summary
         rec["negative_claim_confidence"] = confidence
         rec["negative_claim_ttl_days"] = ttl
         rec["negative_claim_last_revalidated_at"] = None
         rec["negative_claim_revalidation_due_at"] = due
         rec["negative_claim_status"] = "active"
+        existing = rec.get("negative_claims") if isinstance(rec.get("negative_claims"), list) else []
+        by_id = {str(c.get("id")): c for c in existing if isinstance(c, dict) and c.get("id")}
+        for claim in extracted:
+            cid = str(claim.get("id") or "")
+            if not cid:
+                continue
+            by_id[cid] = {
+                **by_id.get(cid, {}),
+                **claim,
+                "confidence": confidence,
+                "ttl_days": ttl,
+                "status": "active",
+                "last_revalidated_at": None,
+                "next_revalidate_at": due,
+            }
+        rec["negative_claims"] = list(by_id.values())
 
     _mutate(skill_name, _apply)
 

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -26,7 +26,7 @@ import json
 import logging
 import os
 import tempfile
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
@@ -178,6 +178,12 @@ def _empty_record() -> Dict[str, Any]:
         "state": STATE_ACTIVE,
         "pinned": False,
         "archived_at": None,
+        "negative_claim_confidence": None,
+        "negative_claim_ttl_days": None,
+        "negative_claim_last_revalidated_at": None,
+        "negative_claim_revalidation_due_at": None,
+        "negative_claim_summary": None,
+        "negative_claim_status": None,
     }
 
 
@@ -289,6 +295,129 @@ def bump_patch(skill_name: str) -> None:
         rec["patch_count"] = int(rec.get("patch_count") or 0) + 1
         rec["last_patched_at"] = _now_iso()
     _mutate(skill_name, _apply)
+
+
+# ---------------------------------------------------------------------------
+# Negative / environment-dependent claim metadata
+# ---------------------------------------------------------------------------
+
+def _ensure_aware(dt: Optional[datetime]) -> datetime:
+    if dt is None:
+        return datetime.now(timezone.utc)
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _parse_iso(ts: Optional[str]) -> Optional[datetime]:
+    if not ts:
+        return None
+    try:
+        dt = datetime.fromisoformat(str(ts))
+    except (TypeError, ValueError):
+        return None
+    return _ensure_aware(dt)
+
+
+def mark_negative_claim(
+    skill_name: str,
+    summary: str,
+    confidence: Optional[float] = None,
+    ttl_days: Optional[int] = None,
+    now: Optional[datetime] = None,
+) -> None:
+    """Record that a skill contains a negative / environment-dependent claim.
+
+    The sidecar stores coarse per-skill metadata for the first lifecycle pass.
+    Future revisions can expand this to a per-claim list without rewriting
+    SKILL.md on every use.
+    """
+    when = _ensure_aware(now)
+    try:
+        ttl = int(ttl_days) if ttl_days is not None else None
+    except (TypeError, ValueError):
+        ttl = None
+    due = (when + timedelta(days=ttl)).isoformat() if ttl is not None else None
+
+    def _apply(rec: Dict[str, Any]) -> None:
+        rec["negative_claim_summary"] = str(summary or "").strip() or None
+        rec["negative_claim_confidence"] = confidence
+        rec["negative_claim_ttl_days"] = ttl
+        rec["negative_claim_last_revalidated_at"] = None
+        rec["negative_claim_revalidation_due_at"] = due
+        rec["negative_claim_status"] = "active"
+
+    _mutate(skill_name, _apply)
+
+
+def update_negative_claim_revalidation(
+    skill_name: str,
+    status: str,
+    confidence: Optional[float] = None,
+    summary: Optional[str] = None,
+    ttl_days: Optional[int] = None,
+    now: Optional[datetime] = None,
+) -> None:
+    """Update revalidation metadata after a negative claim has been checked."""
+    when = _ensure_aware(now)
+    valid_statuses = {"active", "refreshed", "disproven", "uncertain"}
+    next_status = status if status in valid_statuses else "uncertain"
+
+    def _apply(rec: Dict[str, Any]) -> None:
+        rec["negative_claim_status"] = next_status
+        rec["negative_claim_last_revalidated_at"] = when.isoformat()
+        if confidence is not None:
+            rec["negative_claim_confidence"] = confidence
+        if summary is not None:
+            rec["negative_claim_summary"] = str(summary).strip() or None
+        current_ttl = rec.get("negative_claim_ttl_days")
+        try:
+            ttl = int(ttl_days if ttl_days is not None else current_ttl)
+        except (TypeError, ValueError):
+            ttl = None
+        rec["negative_claim_ttl_days"] = ttl
+        rec["negative_claim_revalidation_due_at"] = (
+            (when + timedelta(days=ttl)).isoformat() if ttl is not None else None
+        )
+
+    _mutate(skill_name, _apply)
+
+
+def due_negative_claims(
+    now: Optional[datetime] = None,
+    limit: Optional[int] = None,
+    min_confidence: float = 0.0,
+) -> List[Dict[str, Any]]:
+    """Return negative claims whose TTL has expired and need revalidation."""
+    when = _ensure_aware(now)
+    rows: List[Dict[str, Any]] = []
+    for name, rec in load_usage().items():
+        if not isinstance(rec, dict):
+            continue
+        status = rec.get("negative_claim_status")
+        if status in (None, "disproven"):
+            continue
+        due = _parse_iso(rec.get("negative_claim_revalidation_due_at"))
+        if due is None or due > when:
+            continue
+        try:
+            confidence = float(rec.get("negative_claim_confidence") or 0.0)
+        except (TypeError, ValueError):
+            confidence = 0.0
+        if confidence < min_confidence:
+            continue
+        base = _empty_record()
+        base.update(rec)
+        rows.append({"name": str(name), **base})
+
+    rows.sort(key=lambda row: (row.get("negative_claim_revalidation_due_at") or "", row["name"]))
+    if limit is not None:
+        try:
+            n = max(0, int(limit))
+            rows = rows[:n]
+        except (TypeError, ValueError):
+            pass
+    return rows
 
 
 def set_state(skill_name: str, state: str) -> None:

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -311,6 +311,21 @@ def set_pinned(skill_name: str, pinned: bool) -> None:
     _mutate(skill_name, _apply)
 
 
+def should_hide_from_prompt(skill_name: str) -> bool:
+    """Return True when *skill_name* should be omitted from prompt-time indexes.
+
+    Stale skills may be hidden from the default skills prompt when the curator
+    config enables that policy, but pinned skills remain visible so users can
+    protect rare-but-important workflows from recency-based deprioritization.
+    This helper is deliberately config-free; callers decide whether the policy
+    is enabled and use this only for the lifecycle-state check.
+    """
+    if not skill_name:
+        return False
+    rec = get_record(skill_name)
+    return rec.get("state") == STATE_STALE and not bool(rec.get("pinned"))
+
+
 def forget(skill_name: str) -> None:
     """Drop a skill's usage entry entirely. Called when the skill is deleted."""
     if not skill_name:


### PR DESCRIPTION
## Summary

Completes the remaining skill lifecycle pieces called out in #7816 / comment 4341335259:

- add `curator.hide_stale_from_prompt` and filter stale skills out of the prompt-time skills index when enabled
- keep pinned stale skills visible so rare-but-important workflows are not hidden
- include `.usage.json` lifecycle metadata in the skills prompt cache key when stale filtering is enabled
- add sidecar metadata for negative / environment-dependent claims
- add deterministic negative-claim revalidation for simple command-unavailable claims
- include negative-claim revalidation counts in curator run reports

## Details

### Stale prompt filtering

`curator.hide_stale_from_prompt` defaults to `false` for a conservative rollout. When set to `true`, stale skills are omitted from the default skills system prompt, while pinned stale skills remain visible. Direct `skill_view` access remains available.

### Negative claim metadata

Adds coarse per-skill sidecar fields:

- `negative_claim_confidence`
- `negative_claim_ttl_days`
- `negative_claim_last_revalidated_at`
- `negative_claim_revalidation_due_at`
- `negative_claim_summary`
- `negative_claim_status`

Helpers added in `tools/skill_usage.py`:

- `mark_negative_claim(...)`
- `due_negative_claims(...)`
- `update_negative_claim_revalidation(...)`

### Revalidation pass

The curator now runs a conservative deterministic revalidation pass before the LLM consolidation pass. The first supported probe is command availability claims such as “foo command unavailable,” checked via `shutil.which()`.

Statuses:

- `disproven` — command is now available
- `refreshed` — command is still unavailable
- `uncertain` — no deterministic probe is available

This intentionally updates only sidecar metadata. It does not auto-edit `SKILL.md` content yet; that can be a follow-up once the metadata/reporting loop is proven safe.

## Tests

Ran:

```bash
pytest tests/agent/test_curator_reports.py tests/agent/test_curator.py tests/tools/test_skill_usage.py tests/hermes_cli/test_config.py tests/agent/test_prompt_builder.py -q
```

Result:

```text
254 passed, 1 skipped
```

Also ran `git diff --check` successfully.

Closes the remaining `hide_stale_from_prompt` and negative-claim revalidation portions of #7816.
