### PR TITLE
fix(agent): preserve custom codex provider aliases

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1935,6 +1935,7 @@ def resolve_provider_client(
     """
     _validate_proxy_env_urls()
     # Normalise aliases
+    requested_provider = (provider or "").strip()
     provider = _normalize_aux_provider(provider)
 
     def _needs_codex_wrap(client_obj, base_url_str: str, model_str: str) -> bool:
@@ -1986,6 +1987,98 @@ def resolve_provider_client(
             client_obj, final_model_str, api_key_str, base_url_str, api_mode,
         )
 
+    def _resolve_named_custom(provider_name: str):
+        """Resolve user-defined providers before built-in aliases win.
+
+        A saved custom provider can legitimately be named the same as a
+        convenient alias such as ``codex``.  The raw provider string must get a
+        chance to match config before the normalized ``openai-codex`` branch
+        looks for OAuth credentials.
+        """
+        try:
+            from hermes_cli.runtime_provider import _get_named_custom_provider
+            custom_entry = _get_named_custom_provider(provider_name)
+            if not custom_entry:
+                return None
+            custom_base = custom_entry.get("base_url", "").strip()
+            custom_key = custom_entry.get("api_key", "").strip()
+            custom_key_env = custom_entry.get("key_env", "").strip()
+            if not custom_key and custom_key_env:
+                custom_key = os.getenv(custom_key_env, "").strip()
+            custom_key = custom_key or "no-key-required"
+            # An explicit per-task api_mode override (from _resolve_task_provider_model)
+            # wins; otherwise fall back to what the provider entry declared.
+            entry_api_mode = (api_mode or custom_entry.get("api_mode") or "").strip()
+            if custom_base:
+                final_model = _normalize_resolved_model(
+                    model
+                    or custom_entry.get("model")
+                    or (main_runtime.get("model") if main_runtime else None)
+                    or _read_main_model()
+                    or "gpt-4o-mini",
+                    provider_name,
+                )
+                # anthropic_messages talks to the /anthropic surface directly;
+                # OpenAI-wire paths (chat_completions / codex_responses) need the
+                # /v1 equivalent.  Rewrite only on the OpenAI-wire path so the
+                # Anthropic fallback SDK still sees the original URL.
+                if entry_api_mode == "anthropic_messages":
+                    openai_base = custom_base
+                else:
+                    openai_base = _to_openai_base_url(custom_base)
+                _clean_base2, _dq2 = _extract_url_query_params(openai_base)
+                _extra2 = {"default_query": _dq2} if _dq2 else {}
+                logger.debug(
+                    "resolve_provider_client: named custom provider %r (%s, api_mode=%s)",
+                    provider_name, final_model, entry_api_mode or "chat_completions")
+                # anthropic_messages: route through the Anthropic Messages API
+                # via AnthropicAuxiliaryClient. Mirrors the anonymous-custom
+                # branch in _try_custom_endpoint(). See #15033.
+                if entry_api_mode == "anthropic_messages":
+                    try:
+                        from agent.anthropic_adapter import build_anthropic_client
+                        real_client = build_anthropic_client(custom_key, custom_base)
+                    except ImportError:
+                        logger.warning(
+                            "Named custom provider %r declares api_mode="
+                            "anthropic_messages but the anthropic SDK is not "
+                            "installed — falling back to OpenAI-wire.",
+                            provider_name,
+                        )
+                        # Fallback went OpenAI-wire after all — redo the query
+                        # extraction against the rewritten /v1 URL.
+                        _fallback_base = _to_openai_base_url(custom_base)
+                        _fb_clean, _fb_dq = _extract_url_query_params(_fallback_base)
+                        _fb_extra = {"default_query": _fb_dq} if _fb_dq else {}
+                        client = OpenAI(api_key=custom_key, base_url=_fb_clean, **_fb_extra)
+                        return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+                                else (client, final_model))
+                    sync_anthropic = AnthropicAuxiliaryClient(
+                        real_client, final_model, custom_key, custom_base, is_oauth=False,
+                    )
+                    if async_mode:
+                        return AsyncAnthropicAuxiliaryClient(sync_anthropic), final_model
+                    return sync_anthropic, final_model
+                client = OpenAI(api_key=custom_key, base_url=_clean_base2, **_extra2)
+                # codex_responses or inherited auto-detect (via _wrap_if_needed).
+                # _wrap_if_needed reads the closed-over `api_mode` (the task-level
+                # override). Named-provider entry api_mode=codex_responses also
+                # flows through here.
+                if entry_api_mode == "codex_responses" and not isinstance(
+                    client, CodexAuxiliaryClient
+                ):
+                    client = CodexAuxiliaryClient(client, final_model)
+                else:
+                    client = _wrap_if_needed(client, final_model, openai_base, custom_key)
+                return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+                        else (client, final_model))
+            logger.warning(
+                "resolve_provider_client: named custom provider %r has no base_url",
+                provider_name)
+            return None, None
+        except ImportError:
+            return None
+
     # ── Auto: try all providers in priority order ────────────────────
     if provider == "auto":
         client, resolved = _resolve_auto(main_runtime=main_runtime)
@@ -2033,6 +2126,13 @@ def resolve_provider_client(
         final_model = _normalize_resolved_model(model or default, provider)
         return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                 else (client, final_model))
+
+    # Named custom providers must be resolved before built-in aliases such as
+    # ``codex`` route to OAuth-backed providers.  Using the raw request keeps
+    # explicit namespaced providers (``custom:codex``) authoritative.
+    named_custom = _resolve_named_custom(requested_provider)
+    if named_custom is not None:
+        return named_custom
 
     # ── OpenAI Codex (OAuth → Responses API) ─────────────────────────
     if provider == "openai-codex":
@@ -2111,88 +2211,9 @@ def resolve_provider_client(
         return None, None
 
     # ── Named custom providers (config.yaml providers dict / custom_providers list) ───
-    try:
-        from hermes_cli.runtime_provider import _get_named_custom_provider
-        custom_entry = _get_named_custom_provider(provider)
-        if custom_entry:
-            custom_base = custom_entry.get("base_url", "").strip()
-            custom_key = custom_entry.get("api_key", "").strip()
-            custom_key_env = custom_entry.get("key_env", "").strip()
-            if not custom_key and custom_key_env:
-                custom_key = os.getenv(custom_key_env, "").strip()
-            custom_key = custom_key or "no-key-required"
-            # An explicit per-task api_mode override (from _resolve_task_provider_model)
-            # wins; otherwise fall back to what the provider entry declared.
-            entry_api_mode = (api_mode or custom_entry.get("api_mode") or "").strip()
-            if custom_base:
-                final_model = _normalize_resolved_model(
-                    model
-                    or custom_entry.get("model")
-                    or (main_runtime.get("model") if main_runtime else None)
-                    or _read_main_model()
-                    or "gpt-4o-mini",
-                    provider,
-                )
-                # anthropic_messages talks to the /anthropic surface directly;
-                # OpenAI-wire paths (chat_completions / codex_responses) need the
-                # /v1 equivalent.  Rewrite only on the OpenAI-wire path so the
-                # Anthropic fallback SDK still sees the original URL.
-                if entry_api_mode == "anthropic_messages":
-                    openai_base = custom_base
-                else:
-                    openai_base = _to_openai_base_url(custom_base)
-                _clean_base2, _dq2 = _extract_url_query_params(openai_base)
-                _extra2 = {"default_query": _dq2} if _dq2 else {}
-                logger.debug(
-                    "resolve_provider_client: named custom provider %r (%s, api_mode=%s)",
-                    provider, final_model, entry_api_mode or "chat_completions")
-                # anthropic_messages: route through the Anthropic Messages API
-                # via AnthropicAuxiliaryClient. Mirrors the anonymous-custom
-                # branch in _try_custom_endpoint(). See #15033.
-                if entry_api_mode == "anthropic_messages":
-                    try:
-                        from agent.anthropic_adapter import build_anthropic_client
-                        real_client = build_anthropic_client(custom_key, custom_base)
-                    except ImportError:
-                        logger.warning(
-                            "Named custom provider %r declares api_mode="
-                            "anthropic_messages but the anthropic SDK is not "
-                            "installed — falling back to OpenAI-wire.",
-                            provider,
-                        )
-                        # Fallback went OpenAI-wire after all — redo the query
-                        # extraction against the rewritten /v1 URL.
-                        _fallback_base = _to_openai_base_url(custom_base)
-                        _fb_clean, _fb_dq = _extract_url_query_params(_fallback_base)
-                        _fb_extra = {"default_query": _fb_dq} if _fb_dq else {}
-                        client = OpenAI(api_key=custom_key, base_url=_fb_clean, **_fb_extra)
-                        return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
-                                else (client, final_model))
-                    sync_anthropic = AnthropicAuxiliaryClient(
-                        real_client, final_model, custom_key, custom_base, is_oauth=False,
-                    )
-                    if async_mode:
-                        return AsyncAnthropicAuxiliaryClient(sync_anthropic), final_model
-                    return sync_anthropic, final_model
-                client = OpenAI(api_key=custom_key, base_url=_clean_base2, **_extra2)
-                # codex_responses or inherited auto-detect (via _wrap_if_needed).
-                # _wrap_if_needed reads the closed-over `api_mode` (the task-level
-                # override). Named-provider entry api_mode=codex_responses also
-                # flows through here.
-                if entry_api_mode == "codex_responses" and not isinstance(
-                    client, CodexAuxiliaryClient
-                ):
-                    client = CodexAuxiliaryClient(client, final_model)
-                else:
-                    client = _wrap_if_needed(client, final_model, openai_base, custom_key)
-                return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
-                        else (client, final_model))
-            logger.warning(
-                "resolve_provider_client: named custom provider %r has no base_url",
-                provider)
-            return None, None
-    except ImportError:
-        pass
+    named_custom = _resolve_named_custom(provider)
+    if named_custom is not None:
+        return named_custom
 
     # ── API-key providers from PROVIDER_REGISTRY ─────────────────────
     try:

--- a/tests/agent/test_auxiliary_named_custom_providers.py
+++ b/tests/agent/test_auxiliary_named_custom_providers.py
@@ -162,6 +162,62 @@ class TestResolveProviderClientNamedCustom:
         assert client is not None
         # no-key-required should be used
 
+    def test_named_custom_codex_wins_over_builtin_alias(self, tmp_path):
+        """A saved provider named codex should not be rewritten to openai-codex."""
+        _write_config(tmp_path, {
+            "model": {"default": "gpt-5.4", "provider": "codex"},
+            "custom_providers": [
+                {
+                    "name": "codex",
+                    "base_url": "http://127.0.0.1:8317/api/provider/codex",
+                    "api_key": "ccs-internal-managed",
+                    "model": "gpt-5.4",
+                },
+            ],
+        })
+        from agent.auxiliary_client import resolve_provider_client
+
+        client, model = resolve_provider_client("codex")
+
+        assert client is not None
+        assert model == "gpt-5.4"
+        assert "127.0.0.1:8317" in str(client.base_url)
+
+    def test_custom_prefixed_codex_preserves_custom_namespace(self, tmp_path):
+        """custom:codex is an explicit custom provider, not a Codex OAuth alias."""
+        _write_config(tmp_path, {
+            "model": {"default": "gpt-5.4", "provider": "custom:codex"},
+            "custom_providers": [
+                {
+                    "name": "codex",
+                    "base_url": "http://127.0.0.1:8317/api/provider/codex",
+                    "api_key": "ccs-internal-managed",
+                    "model": "gpt-5.4",
+                },
+            ],
+        })
+        from agent.auxiliary_client import resolve_provider_client
+
+        client, model = resolve_provider_client("custom:codex")
+
+        assert client is not None
+        assert model == "gpt-5.4"
+        assert "127.0.0.1:8317" in str(client.base_url)
+
+    def test_codex_alias_still_uses_builtin_without_custom_provider(self, tmp_path):
+        _write_config(tmp_path, {
+            "model": {"default": "gpt-5.4", "provider": "openai-codex"},
+        })
+        mock_client = MagicMock()
+        with patch("agent.auxiliary_client._try_codex",
+                   return_value=(mock_client, "gpt-5.2-codex")):
+            from agent.auxiliary_client import resolve_provider_client
+
+            client, model = resolve_provider_client("codex")
+
+        assert client is mock_client
+        assert model == "gpt-5.2-codex"
+
     def test_nonexistent_named_custom_falls_through(self, tmp_path):
         _write_config(tmp_path, {
             "model": {"default": "test"},


### PR DESCRIPTION
## What does this PR do?

Fixes auxiliary provider resolution when a user-defined provider is named `codex`.

Before this change, `resolve_provider_client()` normalized aliases before checking named custom providers:

```text
custom:codex -> codex -> openai-codex
codex        -> openai-codex
```

That meant a configured local/custom endpoint named `codex` was bypassed and Hermes tried to find OpenAI Codex OAuth credentials instead. This PR gives the raw requested provider name a chance to resolve against `providers:` / `custom_providers:` before the built-in `codex -> openai-codex` alias wins.

The existing alias behavior is preserved when no custom provider named `codex` exists.

## Related Issue

Fixes #17488

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/auxiliary_client.py`
  - Preserve the raw requested provider string in `resolve_provider_client()`.
  - Resolve named custom providers with that raw name before built-in aliases route to OAuth-backed providers.
  - Keep the normalized-provider custom lookup so existing named-provider behavior remains intact.
- `tests/agent/test_auxiliary_named_custom_providers.py`
  - Add regression coverage for a custom provider named `codex`.
  - Add coverage for explicit `custom:codex`.
  - Add coverage that bare `codex` still resolves to built-in `openai-codex` when no custom provider shadows it.

## How to Test

1. Configure a custom provider named `codex`:

   ```yaml
   model:
     default: gpt-5.4
     provider: codex

   custom_providers:
     - name: codex
       base_url: http://127.0.0.1:8317/api/provider/codex
       api_key: ccs-internal-managed
       model: gpt-5.4
   ```

2. Resolve an auxiliary client for `codex`.

3. Confirm it uses the configured custom endpoint instead of the built-in `openai-codex` OAuth path.

Automated checks run:

```bash
PYTHONPATH=/private/tmp/hermes-agent-pr /Users/ansel/.hermes/hermes-agent/venv/bin/python -m pytest tests/agent/test_auxiliary_named_custom_providers.py tests/agent/test_auxiliary_client.py::TestNormalizeAuxProvider tests/agent/test_auxiliary_client.py::TestTryPaymentFallback -q
# 35 passed

PYTHONPATH=/private/tmp/hermes-agent-pr /Users/ansel/.hermes/hermes-agent/venv/bin/python -m pytest tests/agent/test_auxiliary_client.py -q
# 110 passed

git diff --check
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A.

## Screenshots / Logs

N/A. This is provider-resolution logic covered by unit tests.

