### PR TITLE
chore: add alexzhu0 to AUTHOR_MAP

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -106,3 +106,4 @@ xinbenlv <zzn+pa@zzn.im> <zzn+pa@zzn.im>
 SaulJWu <saul.jj.wu@gmail.com> <saul.jj.wu@gmail.com>
 angelos <angelos@oikos.lan.home.malaiwah.com> <angelos@oikos.lan.home.malaiwah.com>
 MestreY0d4-Uninter <241404605+MestreY0d4-Uninter@users.noreply.github.com> <MestreY0d4-Uninter@users.noreply.github.com>
+alexzhu0 <178769291+alexzhu0@users.noreply.github.com> <alexazzjjtt@163.com>


### PR DESCRIPTION
## Summary

Adds a .mailmap entry so `git shortlog -sn` attributes my three merged commits to my GitHub profile rather than counting `Alexazhu <alexazzjjtt@163.com>` as a separate contributor.

## Commits already on `main` (verified 2026-04-29)

| commit | title | landed via |
|---|---|---|
| `64a136821` | fix(tools): keep SSH ControlMaster socket path under macOS 104-byte limit | #12958 (salvage) |
| `15050fd96` | fix(mcp_oauth): raise RuntimeError instead of asserting OAuth port is set | solo cherry-pick |
| `fbbcfa24c` | fix(matrix): preserve exception tracebacks on E2EE and auth failures | #16821 (matrix salvage batch) |

All three are authored as `Alexazhu <alexazzjjtt@163.com>`; this PR canonicalizes to `alexzhu0 <178769291+alexzhu0@users.noreply.github.com>`, matching the pattern used for Teknium / Sertug17 / MestreY0d4-Uninter.

## Verify

    git shortlog -sne main | grep alexzhu0

…should show all three commits grouped under `alexzhu0` after this lands.