### PR TITLE
fix(tools): replace deprecated asyncio.get_event_loop() in browser_cdp_tool

### DIFF
--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -132,9 +132,9 @@ async def _cdp_call(
                     }
                 )
             )
-            deadline = asyncio.get_event_loop().time() + timeout
+            deadline = asyncio.get_running_loop().time() + timeout
             while True:
-                remaining = deadline - asyncio.get_event_loop().time()
+                remaining = deadline - asyncio.get_running_loop().time()
                 if remaining <= 0:
                     raise TimeoutError(
                         f"Timed out attaching to target {target_id}"
@@ -166,9 +166,9 @@ async def _cdp_call(
             req["sessionId"] = session_id
         await ws.send(json.dumps(req))
 
-        deadline = asyncio.get_event_loop().time() + timeout
+        deadline = asyncio.get_running_loop().time() + timeout
         while True:
-            remaining = deadline - asyncio.get_event_loop().time()
+            remaining = deadline - asyncio.get_running_loop().time()
             if remaining <= 0:
                 raise TimeoutError(
                     f"Timed out waiting for response to {method}"


### PR DESCRIPTION
## Summary

Python 3.12 deprecates `asyncio.get_event_loop()` when called inside a running coroutine; `asyncio.get_running_loop()` is the documented replacement.

All four sites in `tools/browser_cdp_tool.py` sit inside `async def _cdp_call` and only use the loop to read monotonic time for a per-call deadline (`loop.time()`). `.time()` semantics are identical between the two, so the switch is a drop-in.

## Why

Matches the sweep already started in #12014 (`hermes_cli/web_server.py`) and #12017 (`environments/agent_loop.py`, `environments/benchmarks/terminalbench_2/terminalbench2_env.py`), continuing the 3.10+ deprecation cleanup. `browser_cdp_tool.py` was the last remaining file with these calls on current `main`.

## Changes

```
-            deadline = asyncio.get_event_loop().time() + timeout
+            deadline = asyncio.get_running_loop().time() + timeout
             while True:
-                remaining = deadline - asyncio.get_event_loop().time()
+                remaining = deadline - asyncio.get_running_loop().time()
```

4 line edits in one file, inside `async def _cdp_call`. No behavior change, no new imports, no test impact.

## Verified

- `grep -n asyncio.get_event_loop tools/browser_cdp_tool.py` → empty after patch
- All 4 sites sit inside the single `async def _cdp_call` body (lines 94–189)