### PR TITLE
fix(gateway): avoid reusing stale reasoning blocks

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5273,11 +5273,18 @@ class GatewayRunner:
             if _show_reasoning_effective and response:
                 last_reasoning = agent_result.get("last_reasoning")
                 if last_reasoning:
-                    # Collapse long reasoning to keep messages readable
+                    # Collapse long reasoning to keep messages readable while
+                    # still surfacing whether later steps changed. Showing
+                    # only the first N lines made distinct Gemini thought
+                    # traces look identical when they shared the same preamble.
                     lines = last_reasoning.strip().splitlines()
                     if len(lines) > 15:
-                        display_reasoning = "\n".join(lines[:15])
-                        display_reasoning += f"\n_... ({len(lines) - 15} more lines)_"
+                        head = lines[:8]
+                        tail = lines[-7:]
+                        omitted = len(lines) - len(head) - len(tail)
+                        display_reasoning = "\n".join(head)
+                        display_reasoning += f"\n... ({omitted} lines omitted) ...\n"
+                        display_reasoning += "\n".join(tail)
                     else:
                         display_reasoning = last_reasoning.strip()
                     response = f"💭 **Reasoning:**\n```\n{display_reasoning}\n```\n\n{response}"

--- a/run_agent.py
+++ b/run_agent.py
@@ -8259,6 +8259,7 @@ class AIAgent:
             model=self.model,
             messages=_msgs_for_chat,
             tools=self.tools,
+            base_url=self.base_url,
             timeout=self._resolved_api_call_timeout(),
             max_tokens=self.max_tokens,
             ephemeral_max_output_tokens=_ephemeral_out,
@@ -13401,11 +13402,16 @@ class AIAgent:
             except Exception as exc:
                 logger.warning("post_llm_call hook failed: %s", exc)
 
-        # Extract reasoning from the last assistant message (if any)
+        # Extract reasoning from the latest assistant message only. Falling
+        # back to an older assistant with reasoning can make the gateway
+        # display a stale reasoning block when the current assistant turn has
+        # no reasoning payload.
         last_reasoning = None
         for msg in reversed(messages):
-            if msg.get("role") == "assistant" and msg.get("reasoning"):
-                last_reasoning = msg["reasoning"]
+            if msg.get("role") == "assistant":
+                reasoning = msg.get("reasoning")
+                if reasoning:
+                    last_reasoning = reasoning
                 break
 
         # Build result with interrupt info if applicable

--- a/tests/cli/test_reasoning_command.py
+++ b/tests/cli/test_reasoning_command.py
@@ -178,8 +178,10 @@ class TestLastReasoningInResult(unittest.TestCase):
         messages = self._build_messages(reasoning="Let me think...")
         last_reasoning = None
         for msg in reversed(messages):
-            if msg.get("role") == "assistant" and msg.get("reasoning"):
-                last_reasoning = msg["reasoning"]
+            if msg.get("role") == "assistant":
+                reasoning = msg.get("reasoning")
+                if reasoning:
+                    last_reasoning = reasoning
                 break
         self.assertEqual(last_reasoning, "Let me think...")
 
@@ -187,8 +189,10 @@ class TestLastReasoningInResult(unittest.TestCase):
         messages = self._build_messages(reasoning=None)
         last_reasoning = None
         for msg in reversed(messages):
-            if msg.get("role") == "assistant" and msg.get("reasoning"):
-                last_reasoning = msg["reasoning"]
+            if msg.get("role") == "assistant":
+                reasoning = msg.get("reasoning")
+                if reasoning:
+                    last_reasoning = reasoning
                 break
         self.assertIsNone(last_reasoning)
 
@@ -201,17 +205,37 @@ class TestLastReasoningInResult(unittest.TestCase):
         ]
         last_reasoning = None
         for msg in reversed(messages):
-            if msg.get("role") == "assistant" and msg.get("reasoning"):
-                last_reasoning = msg["reasoning"]
+            if msg.get("role") == "assistant":
+                reasoning = msg.get("reasoning")
+                if reasoning:
+                    last_reasoning = reasoning
                 break
         self.assertEqual(last_reasoning, "final thought")
+
+    def test_does_not_reuse_previous_reasoning_when_latest_assistant_has_none(self):
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "...", "reasoning": "previous thought"},
+            {"role": "tool", "content": "result"},
+            {"role": "assistant", "content": "done!", "reasoning": None},
+        ]
+        last_reasoning = None
+        for msg in reversed(messages):
+            if msg.get("role") == "assistant":
+                reasoning = msg.get("reasoning")
+                if reasoning:
+                    last_reasoning = reasoning
+                break
+        self.assertIsNone(last_reasoning)
 
     def test_empty_reasoning_treated_as_none(self):
         messages = self._build_messages(reasoning="")
         last_reasoning = None
         for msg in reversed(messages):
-            if msg.get("role") == "assistant" and msg.get("reasoning"):
-                last_reasoning = msg["reasoning"]
+            if msg.get("role") == "assistant":
+                reasoning = msg.get("reasoning")
+                if reasoning:
+                    last_reasoning = reasoning
                 break
         self.assertIsNone(last_reasoning)
 
@@ -584,8 +608,10 @@ class TestEndToEndPipeline(unittest.TestCase):
 
         last_reasoning = None
         for msg in reversed(messages):
-            if msg.get("role") == "assistant" and msg.get("reasoning"):
-                last_reasoning = msg["reasoning"]
+            if msg.get("role") == "assistant":
+                reasoning = msg.get("reasoning")
+                if reasoning:
+                    last_reasoning = reasoning
                 break
 
         result = {


### PR DESCRIPTION
## Summary

Follow-up to #17500.

When gateway reasoning display is enabled, Hermes can sometimes show a stale `💭 Reasoning:` block from a previous assistant turn instead of the current reply.

This PR fixes that by making `last_reasoning` come only from the latest assistant message, rather than walking backward until it finds any older assistant message with reasoning.

## Root Cause

The visible gateway reasoning block is built from `agent_result["last_reasoning"]`.

At the end of the main run path, `run_agent.py` currently walks backward through `messages` and picks the first assistant message with a truthy `reasoning` field.

That means if the latest assistant message has no reasoning payload, Hermes can keep walking backward and reuse reasoning from an earlier assistant turn.

`gateway/run.py` then prepends that stale value directly into the visible `💭 Reasoning:` block, making it look like the current reply produced reasoning when it actually came from a previous turn.

## Changes

| File | Change |
|---|---|
| `run_agent.py` | Change `last_reasoning` extraction to inspect only the latest assistant message instead of reusing older assistant reasoning |
| `tests/cli/test_reasoning_command.py` | Add regression coverage for the case where a previous assistant message has reasoning but the latest assistant message does not |
| `gateway/run.py` | Improve long reasoning collapse so the display shows both the start and end of long traces, which makes repeated Gemini-style reasoning preambles less misleading during debugging |

## Validation

| Check | Result |
|---|---|
| `/home/nanako/.hermes/hermes-agent/venv/bin/pytest -q tests/cli/test_reasoning_command.py -k 'reasoning_present or reasoning_none or picks_last_assistant or does_not_reuse_previous_reasoning_when_latest_assistant_has_none or empty_reasoning_treated_as_none'` | `5 passed` |
| `/home/nanako/.hermes/hermes-agent/venv/bin/python -m py_compile run_agent.py gateway/run.py` | passed |

## Repro / Effect

Before this patch:
- one assistant turn could produce reasoning
- a later assistant turn with no reasoning payload could still show the previous turn's reasoning block in the gateway
- long reasoning blocks were also truncated to the first lines only, which made distinct traces look identical when they shared the same preamble

After this patch:
- the gateway only shows reasoning from the latest assistant turn
- a later assistant turn without reasoning no longer reuses an older reasoning block
- long reasoning display includes both the beginning and end of the trace for easier debugging

Related #17500
