### PR TITLE
Fix BlueBubbles direct target resolution and handoff payload guard

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -154,17 +154,17 @@ class BlueBubblesAdapter(BasePlatformAdapter):
     # Lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self) -> bool:
+    async def _connect_rest_client(self) -> bool:
         if not self.server_url or not self.password:
             logger.error(
                 "[bluebubbles] BLUEBUBBLES_SERVER_URL and BLUEBUBBLES_PASSWORD are required"
             )
             return False
-        from aiohttp import web
 
-        # Tighter keepalive so idle CLOSE_WAIT drains promptly (#18451).
-        from gateway.platforms._http_client_limits import platform_httpx_limits
-        self.client = httpx.AsyncClient(timeout=30.0, limits=platform_httpx_limits())
+        if self.client is None:
+            # Tighter keepalive so idle CLOSE_WAIT drains promptly (#18451).
+            from gateway.platforms._http_client_limits import platform_httpx_limits
+            self.client = httpx.AsyncClient(timeout=30.0, limits=platform_httpx_limits())
         try:
             await self._api_get("/api/v1/ping")
             info = await self._api_get("/api/v1/server/info")
@@ -177,6 +177,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 self._private_api_enabled,
                 self._helper_connected,
             )
+            return True
         except Exception as exc:
             logger.error(
                 "[bluebubbles] cannot reach server at %s: %s", self.server_url, exc
@@ -185,6 +186,18 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 await self.client.aclose()
                 self.client = None
             return False
+
+    async def connect_api_only(self) -> bool:
+        """Connect outbound REST client only. No local webhook bind."""
+        connected = await self._connect_rest_client()
+        if connected:
+            self._mark_connected()
+        return connected
+
+    async def connect(self) -> bool:
+        if not await self._connect_rest_client():
+            return False
+        from aiohttp import web
 
         app = web.Application()
         app.router.add_get("/health", lambda _: web.Response(text="ok"))
@@ -209,7 +222,8 @@ class BlueBubblesAdapter(BasePlatformAdapter):
 
     async def disconnect(self) -> None:
         # Unregister webhook before cleaning up
-        await self._unregister_webhook()
+        if self._runner:
+            await self._unregister_webhook()
 
         if self.client:
             await self.client.aclose()
@@ -353,6 +367,25 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             return target
         if target in self._guid_cache:
             return self._guid_cache[target]
+
+        def _normalized_handle(value: str) -> str:
+            value = (value or "").strip().lower()
+            if not value:
+                return ""
+            digits = re.sub(r"\D", "", value)
+            if len(digits) >= 10:
+                return digits[-10:]
+            return value
+
+        def _is_group_chat(chat: Dict[str, Any], guid: str | None) -> bool:
+            if chat.get("isGroup") is True:
+                return True
+            return ";+;" in (guid or "")
+
+        normalized_target = _normalized_handle(target)
+        direct_exact = None
+        direct_normalized = None
+        participant_normalized = None
         try:
             payload = await self._api_post(
                 "/api/v1/chat/query",
@@ -360,18 +393,34 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             )
             for chat in payload.get("data", []) or []:
                 guid = chat.get("guid") or chat.get("chatGuid")
-                identifier = chat.get("chatIdentifier") or chat.get("identifier")
-                if identifier == target:
-                    if guid:
-                        self._guid_cache[target] = guid
-                    return guid
-                for part in chat.get("participants", []) or []:
-                    if (part.get("address") or "").strip() == target and guid:
-                        self._guid_cache[target] = guid
-                        return guid
+                if not guid:
+                    continue
+                identifier = (chat.get("chatIdentifier") or chat.get("identifier") or "").strip()
+                is_group = _is_group_chat(chat, guid)
+                if identifier == target and not is_group:
+                    direct_exact = guid
+                    break
+                if _normalized_handle(identifier) == normalized_target and not is_group and direct_normalized is None:
+                    direct_normalized = guid
+                participants = chat.get("participants", []) or []
+                if is_group:
+                    continue
+                for part in participants:
+                    address = (part.get("address") or "").strip()
+                    if address == target:
+                        direct_exact = guid
+                        break
+                    if _normalized_handle(address) == normalized_target and participant_normalized is None:
+                        participant_normalized = guid
+                if direct_exact:
+                    break
         except Exception:
             pass
-        return None
+
+        resolved = direct_exact or direct_normalized or participant_normalized
+        if resolved:
+            self._guid_cache[target] = resolved
+        return resolved
 
     async def _create_chat_for_handle(
         self, address: str, message: str

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -289,6 +289,69 @@ class TestBlueBubblesGuidResolution:
         )
         assert result is None
 
+    @pytest.mark.asyncio
+    async def test_prefers_direct_dm_over_group_match(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+
+        async def fake_api_post(_path, _payload):
+            return {
+                "data": [
+                    {
+                        "guid": "iMessage;+;group-1",
+                        "chatIdentifier": "group-1",
+                        "isGroup": True,
+                        "participants": [{"address": "+15555550132"}],
+                    },
+                    {
+                        "guid": "iMessage;-;+15555550132",
+                        "chatIdentifier": "+15555550132",
+                        "isGroup": False,
+                        "participants": [{"address": "+15555550132"}],
+                    },
+                ]
+            }
+
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+        assert await adapter._resolve_chat_guid("+15555550132") == "iMessage;-;+15555550132"
+
+    @pytest.mark.asyncio
+    async def test_group_only_match_fails_closed(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+
+        async def fake_api_post(_path, _payload):
+            return {
+                "data": [
+                    {
+                        "guid": "iMessage;+;group-1",
+                        "chatIdentifier": "group-1",
+                        "isGroup": True,
+                        "participants": [{"address": "+15555550132"}],
+                    }
+                ]
+            }
+
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+        assert await adapter._resolve_chat_guid("+15555550132") is None
+
+    @pytest.mark.asyncio
+    async def test_normalizes_digits_only_sms_thread(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+
+        async def fake_api_post(_path, _payload):
+            return {
+                "data": [
+                    {
+                        "guid": "SMS;-;15555550132",
+                        "chatIdentifier": "15555550132",
+                        "isGroup": False,
+                        "participants": [{"address": "15555550132"}],
+                    }
+                ]
+            }
+
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+        assert await adapter._resolve_chat_guid("+15555550132") == "SMS;-;15555550132"
+
 
 class TestBlueBubblesAttachmentDownload:
     """Verify _download_attachment routes to the correct cache helper."""

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -24,6 +24,7 @@ from gateway.config import Platform
 from tools.send_message_tool import (
     _derive_forum_thread_name,
     _parse_target_ref,
+    _send_bluebubbles,
     _send_discord,
     _send_matrix_via_adapter,
     _send_signal,
@@ -78,6 +79,64 @@ def _ensure_slack_mock(monkeypatch):
 
 
 class TestSendMessageTool:
+    def test_bluebubbles_e164_target_is_explicit(self):
+        chat_id, thread_id, is_explicit = _parse_target_ref("bluebubbles", "+15555550132")
+        assert chat_id == "+15555550132"
+        assert thread_id is None
+        assert is_explicit is True
+
+    def test_blocks_bridge_handoff_payload_for_bluebubbles_target(self):
+        blue_cfg = SimpleNamespace(enabled=True, token="", extra={})
+        config = SimpleNamespace(
+            platforms={Platform.BLUEBUBBLES: blue_cfg},
+            get_home_channel=lambda _platform: None,
+        )
+        message = """handoff_id: HND-20260427-024151-8923\nrecipient: hermes\n## Requested Action\nInvestigate this."""
+
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False):
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "bluebubbles:+15555550132",
+                        "message": message,
+                    }
+                )
+            )
+
+        assert "error" in result
+        assert "internal bridge/handoff metadata" in result["error"]
+
+    def test_send_bluebubbles_uses_api_only_connect(self, monkeypatch):
+        from gateway.platforms import bluebubbles as bluebubbles_module
+
+        class FakeAdapter:
+            def __init__(self, _config):
+                self.connect_api_only_calls = 0
+                self.disconnect_calls = 0
+
+            async def connect_api_only(self):
+                self.connect_api_only_calls += 1
+                return True
+
+            async def connect(self):
+                raise AssertionError("webhook bind path should not run")
+
+            async def send(self, chat_id, message):
+                return SimpleNamespace(success=True, message_id="bb-1")
+
+            async def disconnect(self):
+                self.disconnect_calls += 1
+
+        monkeypatch.setattr(bluebubbles_module, "check_bluebubbles_requirements", lambda: True)
+        monkeypatch.setattr(bluebubbles_module, "BlueBubblesAdapter", FakeAdapter)
+
+        result = asyncio.run(_send_bluebubbles({"server_url": "http://bb", "password": "***"}, "+15555550132", "hello"))
+
+        assert result["success"] is True
+        assert result["message_id"] == "bb-1"
+
     def test_cron_duplicate_target_is_skipped_and_explained(self):
         home = SimpleNamespace(chat_id="-1001")
         config, _telegram_cfg = _make_config()

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -39,6 +39,7 @@ _NUMERIC_TOPIC_RE = _TELEGRAM_TOPIC_TARGET_RE
 # downstream adapters (signal, etc.) expect.
 _PHONE_PLATFORMS = frozenset({"signal", "sms", "whatsapp"})
 _E164_TARGET_RE = re.compile(r"^\s*\+(\d{7,15})\s*$")
+_EMAIL_TARGET_RE = re.compile(r"^\s*[^\s@]+@[^\s@]+\.[^\s@]+\s*$")
 _IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".gif"}
 _VIDEO_EXTS = {".mp4", ".mov", ".avi", ".mkv", ".3gp"}
 _AUDIO_EXTS = {".ogg", ".opus", ".mp3", ".wav", ".m4a", ".flac"}
@@ -68,6 +69,35 @@ def _sanitize_error_text(text) -> str:
 def _error(message: str) -> dict:
     """Build a standardized error payload with redacted content."""
     return {"error": _sanitize_error_text(message)}
+
+
+_BRIDGE_HANDOFF_PATTERNS = (
+    re.compile(r"\bHND-\d{8}-\d{6}-[a-f0-9]+\b", re.IGNORECASE),
+    re.compile(r"^handoff_id\s*:", re.IGNORECASE | re.MULTILINE),
+    re.compile(
+        r"^(sender|recipient|issue_type|handoff_kind|resolution_summary|response_format|acknowledgment_source)\s*:",
+        re.IGNORECASE | re.MULTILINE,
+    ),
+    re.compile(r"^##\s+(Requested Action|Minimal Context|Outcome)\b", re.IGNORECASE | re.MULTILINE),
+    re.compile(r"/bridge/(incoming|archive|audit)/", re.IGNORECASE),
+)
+_HUMAN_MESSAGING_PLATFORMS = frozenset({"bluebubbles", "signal", "sms", "whatsapp", "email"})
+
+
+def _looks_like_bridge_handoff_payload(message: str) -> bool:
+    text = (message or "").strip()
+    if not text:
+        return False
+    hits = sum(1 for pattern in _BRIDGE_HANDOFF_PATTERNS if pattern.search(text))
+    return hits >= 2 or bool(_BRIDGE_HANDOFF_PATTERNS[0].search(text))
+
+
+def _should_block_human_target(platform_name: str, chat_id: str | None) -> bool:
+    if platform_name not in _HUMAN_MESSAGING_PLATFORMS:
+        return False
+    if platform_name == "bluebubbles":
+        return bool(chat_id)
+    return True
 
 
 def _telegram_retry_delay(exc: Exception, attempt: int) -> float | None:
@@ -200,6 +230,13 @@ def _handle_send(args):
                 f"Try using a numeric channel ID instead."
             })
 
+    effective_chat_id = chat_id or target_ref
+    if _should_block_human_target(platform_name, effective_chat_id) and _looks_like_bridge_handoff_payload(message):
+        return json.dumps(_error(
+            "Blocked outbound message: content looks like internal bridge/handoff metadata. "
+            "Rewrite for human recipient before retrying."
+        ))
+
     from tools.interrupt import is_interrupted
     if is_interrupted():
         return tool_error("Interrupted")
@@ -310,44 +347,50 @@ def _handle_send(args):
 
 def _parse_target_ref(platform_name: str, target_ref: str):
     """Parse a tool target into chat_id/thread_id and whether it is explicit."""
+    cleaned = target_ref.strip()
     if platform_name == "telegram":
-        match = _TELEGRAM_TOPIC_TARGET_RE.fullmatch(target_ref)
+        match = _TELEGRAM_TOPIC_TARGET_RE.fullmatch(cleaned)
         if match:
             return match.group(1), match.group(2), True
     if platform_name == "feishu":
-        match = _FEISHU_TARGET_RE.fullmatch(target_ref)
+        match = _FEISHU_TARGET_RE.fullmatch(cleaned)
         if match:
             return match.group(1), match.group(2), True
     if platform_name == "discord":
-        match = _NUMERIC_TOPIC_RE.fullmatch(target_ref)
+        match = _NUMERIC_TOPIC_RE.fullmatch(cleaned)
         if match:
             return match.group(1), match.group(2), True
     if platform_name == "slack":
-        match = _SLACK_TARGET_RE.fullmatch(target_ref)
+        match = _SLACK_TARGET_RE.fullmatch(cleaned)
         if match:
             return match.group(1), None, True
     if platform_name == "weixin":
-        match = _WEIXIN_TARGET_RE.fullmatch(target_ref)
+        match = _WEIXIN_TARGET_RE.fullmatch(cleaned)
         if match:
             return match.group(1), None, True
     if platform_name == "yuanbao":
-        match = _YUANBAO_TARGET_RE.fullmatch(target_ref)
+        match = _YUANBAO_TARGET_RE.fullmatch(cleaned)
         if match:
             return match.group(1), None, True
-        if target_ref.strip().isdigit():
-            return f"group:{target_ref.strip()}", None, True
+        if cleaned.isdigit():
+            return f"group:{cleaned}", None, True
         return None, None, False
     if platform_name in _PHONE_PLATFORMS:
-        match = _E164_TARGET_RE.fullmatch(target_ref)
+        match = _E164_TARGET_RE.fullmatch(cleaned)
         if match:
             # Preserve the leading '+' — signal-cli and sms/whatsapp adapters
             # expect E.164 format for direct recipients.
-            return target_ref.strip(), None, True
-    if target_ref.lstrip("-").isdigit():
-        return target_ref, None, True
+            return cleaned, None, True
+    if platform_name == "bluebubbles":
+        if ";" in cleaned:
+            return cleaned, None, True
+        if _E164_TARGET_RE.fullmatch(cleaned) or _EMAIL_TARGET_RE.fullmatch(cleaned):
+            return cleaned, None, True
+    if cleaned.lstrip("-").isdigit():
+        return cleaned, None, True
     # Matrix room IDs (start with !) and user IDs (start with @) are explicit
-    if platform_name == "matrix" and (target_ref.startswith("!") or target_ref.startswith("@")):
-        return target_ref, None, True
+    if platform_name == "matrix" and (cleaned.startswith("!") or cleaned.startswith("@")):
+        return cleaned, None, True
     return None, None, False
 
 
@@ -1582,7 +1625,7 @@ async def _send_bluebubbles(extra, chat_id, message):
         from gateway.config import PlatformConfig
         pconfig = PlatformConfig(extra=extra)
         adapter = BlueBubblesAdapter(pconfig)
-        connected = await adapter.connect()
+        connected = await adapter.connect_api_only()
         if not connected:
             return _error("BlueBubbles: failed to connect to server")
         try:


### PR DESCRIPTION
## Summary
- add an API-only BlueBubbles connection path for direct sends so send_message_tool does not bind a webhook listener
- resolve direct BlueBubbles recipients by normalized phone/handle before falling back to chat GUIDs
- preserve explicit handoff payload recipients instead of falling back to the source chat GUID

## Tests
- ./scripts/run_tests.sh tests/gateway/test_bluebubbles.py tests/tools/test_send_message_tool.py