### PR TITLE
fix(agent): preserve explicit custom:codex auxiliary routing

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -155,6 +155,11 @@ def _normalize_aux_provider(provider: Optional[str]) -> str:
         if not suffix:
             return "custom"
         normalized = suffix
+        # Keep explicit custom routing for colliding names like "codex".
+        # Without this, "custom:codex" is rewritten to the built-in
+        # "openai-codex" provider and cannot resolve the user-defined endpoint.
+        if normalized == "codex":
+            return "custom:codex"
     if normalized == "codex":
         return "openai-codex"
     if normalized == "main":

--- a/tests/agent/test_auxiliary_named_custom_providers.py
+++ b/tests/agent/test_auxiliary_named_custom_providers.py
@@ -66,6 +66,10 @@ class TestNormalizeVisionProvider:
         from agent.auxiliary_client import _normalize_vision_provider
         assert _normalize_vision_provider("codex") == "openai-codex"
 
+    def test_explicit_custom_codex_is_preserved(self):
+        from agent.auxiliary_client import _normalize_vision_provider
+        assert _normalize_vision_provider("custom:codex") == "custom:codex"
+
     def test_auto_unchanged(self):
         from agent.auxiliary_client import _normalize_vision_provider
         assert _normalize_vision_provider("auto") == "auto"
@@ -173,6 +177,19 @@ class TestResolveProviderClientNamedCustom:
         # "coffee" doesn't exist in custom_providers
         client, model = resolve_provider_client("coffee", "test")
         assert client is None
+
+    def test_custom_prefixed_codex_named_provider(self, tmp_path):
+        _write_config(tmp_path, {
+            "model": {"default": "test"},
+            "custom_providers": [
+                {"name": "codex", "base_url": "http://codex.local/v1", "api_key": "k"},
+            ],
+        })
+        from agent.auxiliary_client import resolve_provider_client
+        client, model = resolve_provider_client("custom:codex", "my-model")
+        assert client is not None
+        assert model == "my-model"
+        assert "codex.local" in str(client.base_url)
 
 
 class TestResolveProviderClientModelNormalization:


### PR DESCRIPTION
Avoid rewriting `custom:codex` to the built-in `openai-codex` alias in auxiliary provider normalization so named custom providers can be resolved reliably. Add regression tests for normalization and end-to-end custom provider client resolution.

Made-with: Cursor

## What does this PR do?

This PR fixes an auxiliary provider normalization bug where `custom:codex` was incorrectly rewritten to the built-in `openai-codex` alias.  
That rewrite prevented users from targeting a named custom provider literally called `codex`.

The fix preserves explicit `custom:codex` routing while keeping the existing `codex -> openai-codex` alias behavior for non-custom paths.  
This is a minimal, targeted change with regression coverage to prevent future breakage.

## Related Issue

Fixes #17488

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `agent/auxiliary_client.py`:
  - In `_normalize_aux_provider(...)`, preserve explicit `custom:codex` instead of rewriting it to `openai-codex`.
  - Keep existing alias mapping for bare `codex` unchanged.
- Updated `tests/agent/test_auxiliary_named_custom_providers.py`:
  - Added regression test to assert `custom:codex` normalization is preserved.
  - Added end-to-end resolution test for `resolve_provider_client("custom:codex", ...)` against a named custom provider.

## How to Test

1. Run:
   ```bash
   pytest tests/agent/test_auxiliary_named_custom_providers.py -q -n 4