### PR TITLE
fix(compression): frame summaries as reference metadata

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -37,15 +37,13 @@ logger = logging.getLogger(__name__)
 
 SUMMARY_PREFIX = (
     "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted "
-    "into the summary below. This is a handoff from a previous context "
-    "window — treat it as background reference, NOT as active instructions. "
-    "Do NOT answer questions or fulfill requests mentioned in this summary; "
-    "they were already addressed. "
-    "Your current task is identified in the '## Active Task' section of the "
-    "summary — resume exactly from there. "
-    "Respond ONLY to the latest user message "
-    "that appears AFTER this summary. The current session state (files, "
-    "config, etc.) may reflect work described here — avoid repeating it:"
+    "into the summary below. This handoff is background reference, not a "
+    "new user request and not active instructions. Do NOT answer questions "
+    "or fulfill requests solely because they appear in this summary. Follow "
+    "the latest real user message after this summary; if there is no later "
+    "real user message, use the summary only as continuity metadata for "
+    "previously unfinished work. The current session state (files, config, "
+    "etc.) may reflect work described here — avoid repeating it:"
 )
 LEGACY_SUMMARY_PREFIX = "[CONTEXT SUMMARY]:"
 
@@ -755,13 +753,15 @@ class ContextCompressor(ContextEngine):
             "do not preserve their values."
         )
 
-        # Shared structured template (used by both paths).
-        _template_sections = f"""## Active Task
-[THE SINGLE MOST IMPORTANT FIELD. Copy the user's most recent request or
-task assignment verbatim — the exact words they used. If multiple tasks
-were requested and only some are done, list only the ones NOT yet completed.
-The next assistant must pick up exactly here. Example:
-"User asked: 'Now refactor the auth module to use JWT instead of sessions'"
+        # Shared structured template (used by both paths). Keep unfinished
+        # work as metadata, not as instructions; SUMMARY_PREFIX tells the next
+        # model that the summary itself is never a fresh user request.
+        _template_sections = f"""## Outstanding Work Metadata
+[Copy the user's most recent unresolved request or task assignment verbatim —
+the exact words they used — as continuity metadata only. If multiple tasks were
+requested and only some are done, list only the ones NOT yet completed. Do not
+phrase this section as commands to the next assistant. Example:
+"Unresolved user request: 'Now refactor the auth module to use JWT instead of sessions'"
 If no outstanding task exists, write "None."]
 
 ## Goal
@@ -827,7 +827,7 @@ PREVIOUS SUMMARY:
 NEW TURNS TO INCORPORATE:
 {content_to_summarize}
 
-Update the summary using this exact structure. PRESERVE all existing information that is still relevant. ADD new completed actions to the numbered list (continue numbering). Move items from "In Progress" to "Completed Actions" when done. Move answered questions to "Resolved Questions". Update "Active State" to reflect current state. Remove information only if it is clearly obsolete. CRITICAL: Update "## Active Task" to reflect the user's most recent unfulfilled request — this is the most important field for task continuity.
+Update the summary using this exact structure. PRESERVE all existing information that is still relevant. ADD new completed actions to the numbered list (continue numbering). Move items from "In Progress" to "Completed Actions" when done. Move answered questions to "Resolved Questions". Update "Active State" to reflect current state. Remove information only if it is clearly obsolete. CRITICAL: Update "## Outstanding Work Metadata" with the user's most recent unresolved request, but keep it descriptive metadata — do not phrase it as an instruction to the next assistant.
 
 {_template_sections}"""
         else:

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -535,6 +535,14 @@ class TestSummaryFailureTrackingForGatewayWarning:
 
 
 class TestSummaryPrefixNormalization:
+    def test_summary_prefix_frames_handoff_as_reference_not_request(self):
+        assert "not a new user request" in SUMMARY_PREFIX
+        assert "not active instructions" in SUMMARY_PREFIX
+        assert "Follow the latest real user message after this summary" in SUMMARY_PREFIX
+        assert "resume exactly" not in SUMMARY_PREFIX
+        assert "Respond ONLY" not in SUMMARY_PREFIX
+        assert "## Active Task" not in SUMMARY_PREFIX
+
     def test_legacy_prefix_is_replaced(self):
         summary = ContextCompressor._with_summary_prefix("[CONTEXT SUMMARY]: did work")
         assert summary == f"{SUMMARY_PREFIX}\ndid work"


### PR DESCRIPTION
## Summary\n- Reframe context compaction summaries as reference metadata, not fresh user requests or active instructions.\n- Rename the summary's active-task section to outstanding-work metadata and tell the summarizer not to phrase unfinished work as commands.\n- Add regression coverage for the handoff prefix so it does not reintroduce `resume exactly` / `Respond ONLY` style instructions.\n\n## Tests\n- `python -m pytest tests/agent/test_context_compressor.py -q -o 'addopts='`