### PR TITLE
docs(onboarding): lead OpenClaw residue banner with migrate, warn cleanup breaks OpenClaw

### DIFF
--- a/agent/onboarding.py
+++ b/agent/onboarding.py
@@ -98,17 +98,19 @@ def tool_progress_hint_cli() -> str:
 def openclaw_residue_hint_cli() -> str:
     """Banner shown the first time Hermes starts and finds ``~/.openclaw/``.
 
-    OpenClaw-era config, memory, and skill paths in ``~/.openclaw/`` will
-    otherwise attract the agent (memory entries like ``~/.openclaw/config.yaml``
-    get carried forward and the agent dutifully reads them). ``hermes claw
-    cleanup`` renames the directory so the agent stops finding it.
+    Points users at ``hermes claw migrate`` (non-destructive port of config,
+    memory, and skills) first. ``hermes claw cleanup`` is mentioned as the
+    follow-up step for users who have already migrated and want to archive
+    the old directory — with a warning that archiving breaks OpenClaw.
     """
     return (
-        "Heads up — an OpenClaw workspace was detected at ~/.openclaw/.\n"
-        "After migrating, the agent can still get confused and read that "
-        "directory's config/memory instead of Hermes's.\n"
-        "Run `hermes claw cleanup` to archive it (rename → .openclaw.pre-migration). "
-        "This tip only shows once; rerun it any time with `hermes claw cleanup`."
+        "A legacy OpenClaw directory was detected at ~/.openclaw/.\n"
+        "To port your config, memory, and skills over to Hermes, run "
+        "`hermes claw migrate`.\n"
+        "If you've already migrated and want to archive the old directory, "
+        "run `hermes claw cleanup` (renames it to ~/.openclaw.pre-migration — "
+        "OpenClaw will stop working after this).\n"
+        "This tip only shows once."
     )
 
 

--- a/tests/agent/test_onboarding.py
+++ b/tests/agent/test_onboarding.py
@@ -205,10 +205,21 @@ class TestDetectOpenclawResidue:
 
 
 class TestOpenclawResidueHint:
-    def test_hint_mentions_cleanup_command(self):
+    def test_hint_mentions_migrate_command(self):
+        # `migrate` is the non-destructive path — should lead the banner.
         msg = openclaw_residue_hint_cli()
-        assert "hermes claw cleanup" in msg
+        assert "hermes claw migrate" in msg
         assert "~/.openclaw" in msg
+
+    def test_hint_mentions_cleanup_command(self):
+        # `cleanup` is mentioned as the follow-up archive step.
+        assert "hermes claw cleanup" in openclaw_residue_hint_cli()
+
+    def test_hint_warns_cleanup_breaks_openclaw(self):
+        # Archiving the directory breaks OpenClaw for users still running it —
+        # the banner must flag that side effect.
+        msg = openclaw_residue_hint_cli().lower()
+        assert "openclaw will stop working" in msg or "stop working" in msg
 
     def test_hint_not_empty(self):
         assert openclaw_residue_hint_cli().strip()


### PR DESCRIPTION
## Summary
Reword the `~/.openclaw/` detection banner (added in #16327) so it leads with `hermes claw migrate` (the non-destructive path) and warns that `hermes claw cleanup` archives the directory — breaking OpenClaw for users still running it.

## Changes
- `agent/onboarding.py`: rewrite `openclaw_residue_hint_cli()`. Drops the anthropomorphic framing ("the agent can still get confused", "dutifully reads", "instead of Hermes's") and adds the missing `hermes claw migrate` callout.
- `tests/agent/test_onboarding.py`: add assertions that the banner mentions `hermes claw migrate` and warns that cleanup makes OpenClaw stop working; keep the existing `hermes claw cleanup` / `~/.openclaw` / non-empty checks.

## Before → After

Before:
```
Heads up — an OpenClaw workspace was detected at ~/.openclaw/.
After migrating, the agent can still get confused and read that directory's config/memory instead of Hermes's.
Run `hermes claw cleanup` to archive it (rename → .openclaw.pre-migration). This tip only shows once; rerun it any time with `hermes claw cleanup`.
```

After:
```
A legacy OpenClaw directory was detected at ~/.openclaw/.
To port your config, memory, and skills over to Hermes, run `hermes claw migrate`.
If you've already migrated and want to archive the old directory, run `hermes claw cleanup` (renames it to ~/.openclaw.pre-migration — OpenClaw will stop working after this).
This tip only shows once.
```

## Validation
- `scripts/run_tests.sh tests/agent/test_onboarding.py` — 33/33 pass (includes the new migrate / stop-working assertions).

Closes #16629