### PR TITLE
fix(hindsight): flush buffered turns + drop stale prefetch on session switch

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1447,6 +1447,16 @@ class HindsightMemoryProvider(MemoryProvider):
         batching must start from zero so an in-flight retain doesn't flush
         under the wrong ``_document_id``.
 
+        Before clearing, flush any buffered turns under the *old*
+        ``_document_id``. Users who set ``retain_every_n_turns > 1`` would
+        otherwise silently lose whatever's in ``_session_turns`` at the
+        moment of switch — the same data-loss class as the shutdown race,
+        just at a different lifecycle event.
+
+        Also wait for any in-flight prefetch from the old session and drop
+        its cached result; otherwise the new session's first ``prefetch()``
+        could read stale recall text from before the switch.
+
         ``parent_session_id`` is recorded for lineage tags on future retains.
         ``reset`` is accepted but not needed for Hindsight's state model —
         buffer clearing is correct for every session switch, not only /reset.
@@ -1454,6 +1464,70 @@ class HindsightMemoryProvider(MemoryProvider):
         new_id = str(new_session_id or "").strip()
         if not new_id:
             return
+
+        # 1. Flush any buffered turns under the OLD identifiers. Snapshot
+        # everything before mutating self._* so metadata + tags + doc_id
+        # all reference the old session consistently.
+        if self._session_turns:
+            old_turns = list(self._session_turns)
+            old_session_id = self._session_id
+            old_document_id = self._document_id
+            old_parent_session_id = self._parent_session_id
+            old_turn_index = self._turn_index
+            old_metadata = self._build_metadata(
+                message_count=len(old_turns) * 2,
+                turn_index=old_turn_index,
+            )
+            old_lineage_tags: list[str] = []
+            if old_session_id:
+                old_lineage_tags.append(f"session:{old_session_id}")
+            if old_parent_session_id:
+                old_lineage_tags.append(f"parent:{old_parent_session_id}")
+            old_content = "[" + ",".join(old_turns) + "]"
+
+            def _flush():
+                try:
+                    item = self._build_retain_kwargs(
+                        old_content,
+                        context=self._retain_context,
+                        metadata=old_metadata,
+                        tags=old_lineage_tags or None,
+                    )
+                    item.pop("bank_id", None)
+                    item.pop("retain_async", None)
+                    logger.debug(
+                        "Hindsight flush-on-switch: bank=%s, doc=%s, num_turns=%d",
+                        self._bank_id, old_document_id, len(old_turns),
+                    )
+                    self._run_hindsight_operation(
+                        lambda client: client.aretain_batch(
+                            bank_id=self._bank_id,
+                            items=[item],
+                            document_id=old_document_id,
+                            retain_async=self._retain_async,
+                        )
+                    )
+                except Exception as e:
+                    logger.warning("Hindsight flush-on-switch failed: %s", e, exc_info=True)
+
+            # Match sync_turn's serialization — wait for any prior retain
+            # thread to finish before spawning the flush, so writes
+            # against the old document arrive in order.
+            if self._sync_thread and self._sync_thread.is_alive():
+                self._sync_thread.join(timeout=5.0)
+            self._sync_thread = threading.Thread(
+                target=_flush, daemon=True, name="hindsight-flush-on-switch"
+            )
+            self._sync_thread.start()
+
+        # 2. Drain any in-flight prefetch from the old session and drop
+        # its cached result so the new session doesn't see stale recall.
+        if self._prefetch_thread and self._prefetch_thread.is_alive():
+            self._prefetch_thread.join(timeout=3.0)
+        with self._prefetch_lock:
+            self._prefetch_result = ""
+
+        # 3. Now rotate to the new session.
         if parent_session_id:
             self._parent_session_id = str(parent_session_id).strip()
         self._session_id = new_id

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1510,15 +1510,16 @@ class HindsightMemoryProvider(MemoryProvider):
                 except Exception as e:
                     logger.warning("Hindsight flush-on-switch failed: %s", e, exc_info=True)
 
-            # Match sync_turn's serialization — wait for any prior retain
-            # thread to finish before spawning the flush, so writes
-            # against the old document arrive in order.
-            if self._sync_thread and self._sync_thread.is_alive():
-                self._sync_thread.join(timeout=5.0)
-            self._sync_thread = threading.Thread(
-                target=_flush, daemon=True, name="hindsight-flush-on-switch"
-            )
-            self._sync_thread.start()
+            # Route the flush through the same writer queue sync_turn
+            # uses. That serializes it behind any still-queued retains
+            # from the old session (FIFO by document_id), avoids racing
+            # two threads on aretain_batch against the same document, and
+            # keeps shutdown's drain semantics intact. Skip enqueue if
+            # shutdown has already fired — the writer is draining/gone.
+            if not self._shutting_down.is_set():
+                self._ensure_writer()
+                self._register_atexit()
+                self._retain_queue.put(_flush)
 
         # 2. Drain any in-flight prefetch from the old session and drop
         # its cached result so the new session doesn't see stale recall.

--- a/tests/agent/test_memory_session_switch.py
+++ b/tests/agent/test_memory_session_switch.py
@@ -205,6 +205,7 @@ def _make_hindsight_provider():
     bypassing __init__ and seeding the attributes on_session_switch
     reads/writes. This keeps the test hermetic.
     """
+    import threading
     hindsight_mod = pytest.importorskip("plugins.memory.hindsight")
     provider = object.__new__(hindsight_mod.HindsightMemoryProvider)
     provider._session_id = "old-sid"
@@ -213,6 +214,33 @@ def _make_hindsight_provider():
     provider._session_turns = ["turn-1", "turn-2"]
     provider._turn_counter = 2
     provider._turn_index = 2
+    # Attrs read by _build_metadata / _build_retain_kwargs when the
+    # buffer-flush path on session switch fires. Empty strings keep the
+    # metadata minimal but well-formed.
+    provider._retain_source = ""
+    provider._platform = ""
+    provider._user_id = ""
+    provider._user_name = ""
+    provider._chat_id = ""
+    provider._chat_name = ""
+    provider._chat_type = ""
+    provider._thread_id = ""
+    provider._agent_identity = ""
+    provider._agent_workspace = ""
+    provider._retain_tags = []
+    provider._retain_context = "test-context"
+    provider._retain_async = False
+    provider._bank_id = "test-bank"
+    # Prefetch state the switch path drains/clears.
+    provider._prefetch_thread = None
+    provider._prefetch_lock = threading.Lock()
+    provider._prefetch_result = ""
+    # Sync thread tracking — flush spawn target.
+    provider._sync_thread = None
+    # Stub the network-touching helper so the spawned flush thread is a
+    # no-op in unit tests. Real plugin behavior is covered by the
+    # mock-client tests in tests/plugins/memory/test_hindsight_provider.py.
+    provider._run_hindsight_operation = lambda _op: None
     return provider
 
 

--- a/tests/agent/test_memory_session_switch.py
+++ b/tests/agent/test_memory_session_switch.py
@@ -235,11 +235,21 @@ def _make_hindsight_provider():
     provider._prefetch_thread = None
     provider._prefetch_lock = threading.Lock()
     provider._prefetch_result = ""
-    # Sync thread tracking — flush spawn target.
+    # Sync thread tracking (legacy alias at the writer).
     provider._sync_thread = None
-    # Stub the network-touching helper so the spawned flush thread is a
-    # no-op in unit tests. Real plugin behavior is covered by the
-    # mock-client tests in tests/plugins/memory/test_hindsight_provider.py.
+    # Writer queue infra the flush-on-switch path enqueues onto. We stub
+    # _ensure_writer / _register_atexit so no real thread is spawned;
+    # tests exercising flush delivery live in
+    # tests/plugins/memory/test_hindsight_provider.py where the full
+    # writer-queue wiring is in place.
+    import queue as _queue
+    provider._retain_queue = _queue.Queue()
+    provider._shutting_down = threading.Event()
+    provider._atexit_registered = True
+    provider._ensure_writer = lambda: None
+    provider._register_atexit = lambda: None
+    # Stub the network-touching helper so any enqueued flush closure is
+    # a no-op if ever drained in a unit test.
     provider._run_hindsight_operation = lambda _op: None
     return provider
 

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -928,6 +928,95 @@ class TestShutdownRace:
 
 
 # ---------------------------------------------------------------------------
+# on_session_switch — flush + prefetch reset behavior
+# ---------------------------------------------------------------------------
+
+
+class TestSessionSwitchBufferFlush:
+    def test_buffered_turns_flushed_before_clear(self, provider_with_config):
+        """retain_every_n_turns > 1 must not silently drop partial buffers
+        on session switch. Whatever's in _session_turns at switch time
+        should land in the OLD document under the OLD session id."""
+        p = provider_with_config(retain_every_n_turns=3, retain_async=False)
+        old_doc = p._document_id
+
+        # Two turns buffered, no retain yet (boundary is at turn 3).
+        p.sync_turn("turn1-user", "turn1-asst")
+        p.sync_turn("turn2-user", "turn2-asst")
+        assert p._sync_thread is None
+        p._client.aretain_batch.assert_not_called()
+
+        # Switch — flush should fire under OLD document_id.
+        p.on_session_switch("new-sid", parent_session_id="test-session", reset=True)
+        if p._sync_thread:
+            p._sync_thread.join(timeout=5.0)
+
+        p._client.aretain_batch.assert_called_once()
+        kw = p._client.aretain_batch.call_args.kwargs
+        assert kw["document_id"] == old_doc
+        item = kw["items"][0]
+        # Both buffered turns must be present in the flushed payload.
+        content = json.loads(item["content"])
+        flat = json.dumps(content)
+        assert "turn1-user" in flat
+        assert "turn2-user" in flat
+        # Old session id must appear in lineage tags / metadata.
+        assert "session:test-session" in item["tags"]
+        assert item["metadata"]["session_id"] == "test-session"
+
+        # And the new session must start with a clean slate.
+        assert p._session_id == "new-sid"
+        assert p._session_turns == []
+        assert p._turn_counter == 0
+        assert p._document_id != old_doc
+        assert p._document_id.startswith("new-sid-")
+
+    def test_no_flush_when_buffer_empty(self, provider):
+        """Switch with no buffered turns must not fire a spurious retain."""
+        provider.on_session_switch("new-sid")
+        if provider._sync_thread:
+            provider._sync_thread.join(timeout=5.0)
+        provider._client.aretain_batch.assert_not_called()
+        assert provider._session_id == "new-sid"
+
+    def test_prefetch_result_cleared_on_switch(self, provider):
+        """Stale recall text from the old session must not leak into the
+        next session's first prefetch read."""
+        provider._prefetch_result = "old-session recall: User likes Rust"
+        provider.on_session_switch("new-sid")
+        assert provider._prefetch_result == ""
+        # And subsequent prefetch() should now report empty, not the leftover.
+        assert provider.prefetch("anything") == ""
+
+    def test_in_flight_prefetch_thread_drained_on_switch(self, provider, monkeypatch):
+        """on_session_switch must wait for an in-flight prefetch from the
+        old session to settle before clearing _prefetch_result, otherwise
+        the thread can race and re-populate the field after the clear."""
+        import threading
+        import time as _time
+
+        gate = threading.Event()
+        finished = threading.Event()
+
+        def _slow_prefetch():
+            gate.wait(timeout=5.0)
+            with provider._prefetch_lock:
+                provider._prefetch_result = "old-session recall"
+            finished.set()
+
+        provider._prefetch_thread = threading.Thread(target=_slow_prefetch, daemon=True)
+        provider._prefetch_thread.start()
+
+        # Release the prefetch worker so it writes _prefetch_result, then
+        # call on_session_switch — it must join the thread before clearing.
+        gate.set()
+        provider.on_session_switch("new-sid")
+
+        assert finished.is_set(), "switch returned before prefetch thread settled"
+        assert provider._prefetch_result == ""
+
+
+# ---------------------------------------------------------------------------
 # System prompt tests
 # ---------------------------------------------------------------------------
 

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -940,16 +940,17 @@ class TestSessionSwitchBufferFlush:
         p = provider_with_config(retain_every_n_turns=3, retain_async=False)
         old_doc = p._document_id
 
-        # Two turns buffered, no retain yet (boundary is at turn 3).
+        # Two turns buffered, no retain yet (boundary is at turn 3). The
+        # writer hasn't been started either — sync_turn's early return
+        # skips _ensure_writer when no retain is due.
         p.sync_turn("turn1-user", "turn1-asst")
         p.sync_turn("turn2-user", "turn2-asst")
         assert p._sync_thread is None
         p._client.aretain_batch.assert_not_called()
 
-        # Switch — flush should fire under OLD document_id.
+        # Switch — flush should fire under OLD document_id via the writer queue.
         p.on_session_switch("new-sid", parent_session_id="test-session", reset=True)
-        if p._sync_thread:
-            p._sync_thread.join(timeout=5.0)
+        p._retain_queue.join()
 
         p._client.aretain_batch.assert_called_once()
         kw = p._client.aretain_batch.call_args.kwargs
@@ -974,8 +975,8 @@ class TestSessionSwitchBufferFlush:
     def test_no_flush_when_buffer_empty(self, provider):
         """Switch with no buffered turns must not fire a spurious retain."""
         provider.on_session_switch("new-sid")
-        if provider._sync_thread:
-            provider._sync_thread.join(timeout=5.0)
+        # Nothing enqueued — join is immediate.
+        provider._retain_queue.join()
         provider._client.aretain_batch.assert_not_called()
         assert provider._session_id == "new-sid"
 
@@ -1014,6 +1015,61 @@ class TestSessionSwitchBufferFlush:
 
         assert finished.is_set(), "switch returned before prefetch thread settled"
         assert provider._prefetch_result == ""
+
+    def test_flush_serializes_behind_pending_retains_via_writer_queue(
+        self, provider_with_config
+    ):
+        """The flush closure must ride the same _retain_queue sync_turn
+        uses, so it lands FIFO behind any still-queued old-session
+        retains rather than racing them on a separate thread.
+
+        Regression guard: an earlier draft spawned a raw threading.Thread
+        for flush, overwriting _sync_thread and racing the writer against
+        the same document_id.
+        """
+        import threading as _threading
+
+        p = provider_with_config(retain_every_n_turns=2, retain_async=False)
+
+        # Block the first writer job until we've enqueued the flush
+        # behind it. This proves ordering — the flush MUST wait.
+        gate = _threading.Event()
+        call_order: list[str] = []
+
+        def _aretain_batch_tracking(**kw):
+            idx = kw["items"][0]["metadata"].get("turn_index", "")
+            call_order.append(str(idx))
+            if idx == "2":
+                # First retain blocks until we've enqueued the flush.
+                gate.wait(timeout=5.0)
+
+        p._client.aretain_batch = AsyncMock(side_effect=_aretain_batch_tracking)
+
+        # Turn 1+2 → boundary hit → retain enqueued (will block).
+        p.sync_turn("turn1-user", "turn1-asst")
+        p.sync_turn("turn2-user", "turn2-asst")
+
+        # One more buffered turn so flush has something to land.
+        p.sync_turn("turn3-user", "turn3-asst")
+
+        # Switch while the first retain is still blocked on `gate`.
+        p.on_session_switch("new-sid", parent_session_id="test-session")
+
+        # Release the first retain. Flush must have been enqueued
+        # BEHIND it, and run second.
+        gate.set()
+        p._retain_queue.join()
+
+        # The flush carries all buffered turns; sync_turn's retain #2
+        # carried the batch at boundary time. Two distinct calls.
+        assert p._client.aretain_batch.call_count == 2
+        # First call landed while buffer was [t1, t2]; flush landed
+        # after we added t3. So the second call must be strictly after.
+        assert call_order[0] == "2"
+        # Flush retain has turn_index matching the buffered count at
+        # switch time (3 turns accumulated, _turn_index was set to 3
+        # by the last sync_turn).
+        assert call_order[1] == "3"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Salvage of #17447 (@nicoloboschi) — same fix, same tests, + one follow-up: route the flush through the existing writer queue instead of a raw thread.

## Summary
`HindsightMemoryProvider.on_session_switch` was silently losing partial batches and leaking prior-session recall across `/reset`, `/resume`, `/branch`, `/new`, and context compression. This PR flushes buffered turns under the OLD `document_id` with OLD lineage before rotation, drains in-flight prefetch, and clears `_prefetch_result`.

## Bugs fixed (from #17447)
1. **Data loss when `retain_every_n_turns > 1`** — `on_session_switch` cleared `_session_turns` without flushing. Any in-flight batch disappeared at session switch time. Same data-loss class as the shutdown race, different lifecycle event. Reproduced on current main via bare-object repro: `_session_turns=['a','b']` → `on_session_switch('new')` → buffer is `[]` with zero flush.
2. **Stale prefetch leak across switch** — if `queue_prefetch` ran in the old session and `prefetch()` hadn't consumed the result, the new session's first `prefetch()` returned text mined from the prior session's bank.

## Follow-up in this salvage (second commit)
Nicolò's original fix spawned a raw `threading.Thread` for the flush, overwriting `self._sync_thread` (which is aliased to the long-lived writer thread). Two issues:

1. **No serialization with the writer queue.** `sync_turn` enqueues retains on `_retain_queue` drained by the long-lived `_writer_thread`. The raw-thread flush ran concurrently with the writer — two threads could call `aretain_batch` against the same `document_id`.
2. **Broken pre-spawn join.** The `self._sync_thread.join(timeout=5.0)` before spawn tried to join the long-lived writer, which never exits on its own, so it always timed out and never actually serialized anything.

Fix: enqueue the flush closure on `_retain_queue` via `_ensure_writer()` + `put()`, the same path `sync_turn` uses. Natural FIFO ordering behind any pending retains, no new thread, no broken join. Shutdown-aware (`if not self._shutting_down.is_set()`) so it can't enqueue during teardown.

## Tests
- 4 tests from Nicolò — buffer flushed under OLD doc/lineage, no spurious retain on empty buffer, `_prefetch_result` cleared, in-flight prefetch drained.
- 1 new regression guard — `test_flush_serializes_behind_pending_retains_via_writer_queue` blocks the writer mid-retain with an Event and proves the flush lands FIFO behind the pending retain rather than racing it.
- **103/103 passing** on `tests/plugins/memory/test_hindsight_provider.py` + `tests/agent/test_memory_session_switch.py`.
- E2E against the worktree: bare-object repro against patched code → flush enqueued on writer queue with OLD `document_id` and `session:old` lineage tag; stale prefetch cleared; rotation completes.

## Commits
- `c3bbdc23d` — original fix (authored by @nicoloboschi, cherry-picked)
- `177a6905e` — follow-up: route flush through writer queue

Closes #17447.