### PR TITLE
fix(gateway): allow fast mode for fallback models

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7400,8 +7400,19 @@ class GatewayRunner:
 
         user_config = _load_gateway_config()
         model = _resolve_gateway_model(user_config)
-        if not model_supports_fast_mode(model):
-            return "⚡ /fast is only available for OpenAI models that support Priority Processing."
+
+        candidate_models = [model]
+        fallback_config = user_config.get("fallback_providers") or user_config.get("fallback_model") or []
+        if isinstance(fallback_config, dict):
+            fallback_config = [fallback_config]
+        if isinstance(fallback_config, list):
+            candidate_models.extend(
+                str(entry.get("model") or "")
+                for entry in fallback_config
+                if isinstance(entry, dict)
+            )
+        if not any(model_supports_fast_mode(candidate) for candidate in candidate_models):
+            return "⚡ /fast is only available for OpenAI/Anthropic models that support fast mode."
 
         def _save_config_key(key_path: str, value):
             """Save a dot-separated key to config.yaml."""

--- a/run_agent.py
+++ b/run_agent.py
@@ -7510,6 +7510,18 @@ class AIAgent:
                     provider=self.provider,
                 )
 
+            # Recompute fast/priority request overrides after fallback swaps the
+            # active model. A turn can start on a non-fast primary (e.g. GLM)
+            # and later fall back to a fast-capable model (e.g. GPT-5.x). In
+            # that case the per-turn request_overrides were computed for the
+            # primary and would otherwise omit service_tier/speed on fallback.
+            if getattr(self, "service_tier", None):
+                try:
+                    from hermes_cli.models import resolve_fast_mode_overrides
+                    self.request_overrides = resolve_fast_mode_overrides(fb_model) or {}
+                except Exception:
+                    self.request_overrides = {}
+
             self._emit_status(
                 f"🔄 Primary model failed — switching to fallback: "
                 f"{fb_model} via {fb_provider}"

--- a/tests/gateway/test_fast_command_fallback.py
+++ b/tests/gateway/test_fast_command_fallback.py
@@ -1,0 +1,106 @@
+"""Tests for gateway /fast handling with fallback providers."""
+
+from types import SimpleNamespace
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.platforms.base import MessageEvent
+
+
+class _DummyPath:
+    def __truediv__(self, _name):
+        return self
+
+    def exists(self):
+        return False
+
+
+class _DummyCompressor:
+    def update_model(self, **kwargs):
+        self.kwargs = kwargs
+
+
+def _make_runner():
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._service_tier = None
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_fast_command_allows_fast_capable_fallback(monkeypatch):
+    """A non-fast primary should not block /fast when fallbacks include GPT/Claude."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", _DummyPath())
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {
+        "model": {"default": "glm-5.1"},
+        "fallback_providers": [
+            {"provider": "cliproxy", "model": "gpt-5.5"},
+        ],
+    })
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda _cfg=None: "glm-5.1")
+    monkeypatch.setattr(gateway_run.GatewayRunner, "_load_service_tier", staticmethod(lambda: None))
+
+    saved = {}
+    monkeypatch.setattr(gateway_run, "atomic_yaml_write", lambda _path, cfg: saved.update(cfg))
+
+    runner = _make_runner()
+    event = MessageEvent(text="/fast fast")
+
+    response = await runner._handle_fast_command(event)
+
+    assert "Priority Processing: **FAST**" in response
+    assert saved["agent"]["service_tier"] == "fast"
+
+
+def test_fallback_activation_recomputes_fast_request_overrides(monkeypatch):
+    """Fallback to a fast-capable model should refresh request_overrides."""
+    from run_agent import AIAgent
+
+    agent = object.__new__(AIAgent)
+    agent.service_tier = "priority"
+    agent.request_overrides = {}
+    agent._fallback_chain = [{
+        "provider": "custom",
+        "model": "gpt-5.5",
+        "base_url": "https://example.test/v1",
+        "api_key": "test-key",
+    }]
+    agent._fallback_index = 0
+    agent._fallback_activated = False
+    agent._primary_runtime = {"provider": "opencode-go"}
+    agent._rate_limited_until = 0
+    agent.model = "glm-5.1"
+    agent.provider = "opencode-go"
+    agent.base_url = "https://primary.test/v1"
+    agent.api_key = "primary-key"
+    agent.api_mode = "chat_completions"
+    agent._api_mode_explicit = False
+    agent._credential_pool = None
+    agent._client_kwargs = {}
+    agent.client = SimpleNamespace(api_key="primary-key")
+    agent.context_compressor = _DummyCompressor()
+    agent._config_context_length = 128000
+    agent.quiet_mode = True
+    agent._force_ascii_payload = False
+    agent._emit_status = lambda *_args, **_kwargs: None
+    agent._ensure_lmstudio_runtime_loaded = lambda: None
+    agent._replace_primary_openai_client = lambda **_kwargs: None
+    agent._anthropic_prompt_cache_policy = lambda **_kwargs: (False, False)
+    agent._provider_model_requires_responses_api = lambda *_args, **_kwargs: False
+    agent._is_azure_openai_url = lambda *_args, **_kwargs: False
+    agent._is_direct_openai_url = lambda *_args, **_kwargs: False
+
+    import agent.auxiliary_client as auxiliary_client
+
+    monkeypatch.setattr(
+        auxiliary_client,
+        "resolve_provider_client",
+        lambda *_args, **_kwargs: (
+            SimpleNamespace(api_key="fallback-key", base_url="https://example.test/v1"),
+            "gpt-5.5",
+        ),
+    )
+
+    assert agent._try_activate_fallback() is True
+    assert agent.model == "gpt-5.5"
+    assert agent.request_overrides == {"service_tier": "priority"}


### PR DESCRIPTION
## Summary
- allow the gateway `/fast` command when a configured fallback provider uses a fast-capable OpenAI/Anthropic model, even if the primary model is not fast-capable
- recompute fast/priority request overrides after provider fallback activates so `service_tier`/`speed` applies to the active fallback model
- add regression tests for gateway `/fast` fallback handling and fallback override recomputation

## Test Plan
- `python -m py_compile gateway/run.py run_agent.py tests/gateway/test_fast_command_fallback.py`
- `python -m pytest tests/gateway/test_fast_command_fallback.py tests/run_agent/test_provider_parity.py::TestBuildApiKwargsChatCompletionsServiceTier -q -o 'addopts='`
