### PR TITLE
fix(agent): cascade nested fallback_model chains

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -83,6 +83,39 @@ class _OpenAIProxy:
 
 OpenAI = _OpenAIProxy()
 
+
+def _normalize_fallback_chain(fallback_model: Any) -> List[Dict[str, Any]]:
+    """Flatten supported fallback config shapes into an ordered provider chain.
+
+    The canonical config is ``fallback_providers: [ ... ]``. Older examples
+    used a single ``fallback_model`` dict, and some users nested another
+    ``fallback_model`` inside that dict to express a second fallback. Preserve
+    that legacy shape so a failed first fallback can still cascade.
+    """
+    chain: List[Dict[str, Any]] = []
+
+    def _append(entry: Any) -> None:
+        if not isinstance(entry, dict):
+            return
+        if entry.get("provider") and entry.get("model"):
+            chain.append(entry)
+        nested = entry.get("fallback_model")
+        if nested is not None:
+            if isinstance(nested, list):
+                for item in nested:
+                    _append(item)
+            else:
+                _append(nested)
+
+    if isinstance(fallback_model, list):
+        for item in fallback_model:
+            _append(item)
+    else:
+        _append(fallback_model)
+
+    return chain
+
+
 # Load .env from ~/.hermes/.env first, then project root as dev fallback.
 # User-managed env files should override stale shell exports on restart.
 from hermes_cli.env_loader import load_hermes_dotenv
@@ -1497,15 +1530,7 @@ class AIAgent:
         # when the primary is exhausted (rate-limit, overload, connection
         # failure).  Supports both legacy single-dict ``fallback_model`` and
         # new list ``fallback_providers`` format.
-        if isinstance(fallback_model, list):
-            self._fallback_chain = [
-                f for f in fallback_model
-                if isinstance(f, dict) and f.get("provider") and f.get("model")
-            ]
-        elif isinstance(fallback_model, dict) and fallback_model.get("provider") and fallback_model.get("model"):
-            self._fallback_chain = [fallback_model]
-        else:
-            self._fallback_chain = []
+        self._fallback_chain = _normalize_fallback_chain(fallback_model)
         self._fallback_index = 0
         self._fallback_activated = False
         # Legacy attribute kept for backward compat (tests, external callers)

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -61,6 +61,48 @@ class TestFallbackChainInit:
         assert len(agent._fallback_chain) == 2
         assert agent._fallback_model == fbs[0]
 
+    def test_nested_legacy_fallback_model_flattens_to_chain(self):
+        fbs = {
+            "provider": "groq",
+            "model": "llama-3.3-70b-versatile",
+            "fallback_model": {
+                "provider": "mistral",
+                "model": "mistral-large-latest",
+            },
+        }
+        agent = _make_agent(fallback_model=fbs)
+        assert agent._fallback_chain == [
+            {
+                "provider": "groq",
+                "model": "llama-3.3-70b-versatile",
+                "fallback_model": {
+                    "provider": "mistral",
+                    "model": "mistral-large-latest",
+                },
+            },
+            {"provider": "mistral", "model": "mistral-large-latest"},
+        ]
+        assert agent._fallback_model == fbs
+
+    def test_list_entry_nested_fallback_model_flattens_to_chain(self):
+        fbs = [
+            {
+                "provider": "groq",
+                "model": "llama-3.3-70b-versatile",
+                "fallback_model": {
+                    "provider": "mistral",
+                    "model": "mistral-large-latest",
+                },
+            },
+            {"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},
+        ]
+        agent = _make_agent(fallback_model=fbs)
+        assert [entry["provider"] for entry in agent._fallback_chain] == [
+            "groq",
+            "mistral",
+            "openrouter",
+        ]
+
     def test_invalid_entries_filtered(self):
         fbs = [
             {"provider": "openai", "model": "gpt-4o"},
@@ -115,6 +157,26 @@ class TestFallbackChainAdvancement:
             assert agent.model == "gpt-4o"
             assert agent._try_activate_fallback() is True
             assert agent.model == "glm-4.7"
+            assert agent._fallback_index == 2
+
+    def test_nested_legacy_fallback_cascades_to_second_provider(self):
+        fbs = {
+            "provider": "groq",
+            "model": "llama-3.3-70b-versatile",
+            "fallback_model": {
+                "provider": "mistral",
+                "model": "mistral-large-latest",
+            },
+        }
+        agent = _make_agent(fallback_model=fbs)
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(_mock_client(), "resolved"),
+        ):
+            assert agent._try_activate_fallback() is True
+            assert agent.model == "llama-3.3-70b-versatile"
+            assert agent._try_activate_fallback() is True
+            assert agent.model == "mistral-large-latest"
             assert agent._fallback_index == 2
 
     def test_all_exhausted_returns_false(self):


### PR DESCRIPTION
## Summary

Fixes #17485.

Legacy configs can express multi-level provider failover by nesting `fallback_model` blocks. Hermes only kept the first dict in `_fallback_chain`, so after fallback 1 failed with a non-retryable/auth error, the retry loop had no second provider to activate and aborted despite the nested fallback config.

This normalizes fallback config into an ordered chain before agent startup:

- keeps the canonical list-form `fallback_providers` / list `fallback_model` behavior
- preserves single-dict `fallback_model` behavior
- flattens nested legacy `fallback_model` entries so fallback 1 can cascade to fallback 2

## Verification

- `scripts/run_tests.sh tests/run_agent/test_provider_fallback.py` (22 passed)
- `git diff --check`

## Scope

This only changes fallback-chain normalization and focused fallback tests. It does not alter provider-specific auth refresh, retry classification, or the canonical fallback command/config storage format.
