### PR TITLE
fix(cron): use last_run_at as croniter base for cron jobs

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -319,7 +319,14 @@ def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None
                 schedule.get("expr"),
             )
             return None
-        cron = croniter(schedule["expr"], now)
+        # Use last_run_at as the croniter base when available, consistent
+        # with interval jobs.  This ensures that after a crash/restart,
+        # the next run is anchored to the actual last execution time
+        # rather than to an arbitrary restart time.
+        base_time = now
+        if last_run_at:
+            base_time = _ensure_aware(datetime.fromisoformat(last_run_at))
+        cron = croniter(schedule["expr"], base_time)
         next_run = cron.get_next(datetime)
         return next_run.isoformat()
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -68,6 +68,7 @@ AUTHOR_MAP = {
     "jefferson@heimdallstrategy.com": "Mind-Dragon",
     "steve.westerhouse@origami-analytics.com": "westers",
     "yeyitech@users.noreply.github.com": "yeyitech",
+    "260878550+beenherebefore@users.noreply.github.com": "beenherebefore",
     "liuhao03@bilibili.com": "liuhao1024",
     "130918800+devorun@users.noreply.github.com": "devorun",
     "surat.s@itm.kmutnb.ac.th": "beesrsj2500",

--- a/tests/cron/test_compute_next_run_last_run_at.py
+++ b/tests/cron/test_compute_next_run_last_run_at.py
@@ -1,0 +1,87 @@
+"""Test that compute_next_run uses last_run_at for cron jobs.
+
+Regression test for: cron jobs computing next_run_at from _hermes_now()
+instead of from last_run_at, making them inconsistent with interval jobs.
+"""
+import pytest
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+pytest.importorskip("croniter")
+
+from cron.jobs import compute_next_run
+
+
+class TestCronComputeNextRunUsesLastRunAt:
+    """compute_next_run MUST use last_run_at as the croniter base for cron jobs,
+    consistent with how interval jobs work."""
+
+    def test_cron_uses_last_run_at_for_every_6h_schedule(self, monkeypatch):
+        """For a schedule like 'every 6 hours', the base time matters.
+        If last_run_at is Apr 6 14:10, next should be Apr 6 18:00.
+        If now is Apr 10 22:00, next should be Apr 11 00:00.
+        compute_next_run must use last_run_at, not now."""
+        morocco = ZoneInfo("Africa/Casablanca")
+
+        # Job last ran April 6 at 14:10
+        last_run = datetime(2026, 4, 6, 14, 10, 0, tzinfo=morocco)
+
+        # But now it's April 10 at 22:00 (e.g., gateway restarted)
+        now = datetime(2026, 4, 10, 22, 0, 0, tzinfo=morocco)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        schedule = {"kind": "cron", "expr": "0 */6 * * *"}  # every 6 hours
+
+        result = compute_next_run(schedule, last_run_at=last_run.isoformat())
+        assert result is not None
+        next_dt = datetime.fromisoformat(result)
+
+        # With last_run_at as base (Apr 6 14:10), next is Apr 6 18:00.
+        # With now as base (Apr 10 22:00), next is Apr 11 00:00.
+        # The fix should use last_run_at, returning Apr 6 18:00
+        # (stale detection in get_due_jobs() fast-forwards from there).
+        assert next_dt.date().isoformat() == "2026-04-06", (
+            f"Expected next run on Apr 6 (from last_run_at), got {next_dt}"
+        )
+        assert next_dt.hour == 18
+
+    def test_cron_without_last_run_at_uses_now(self, monkeypatch):
+        """When last_run_at is NOT provided, compute_next_run falls back to
+        _hermes_now() as the croniter base (existing behavior)."""
+        morocco = ZoneInfo("Africa/Casablanca")
+
+        now = datetime(2026, 4, 10, 22, 0, 0, tzinfo=morocco)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        schedule = {"kind": "cron", "expr": "0 */6 * * *"}
+
+        result = compute_next_run(schedule)
+        assert result is not None
+        next_dt = datetime.fromisoformat(result)
+
+        # Without last_run_at, should compute from now -> Apr 11 00:00
+        assert next_dt.date().isoformat() == "2026-04-11", (
+            f"Expected next run on Apr 11 (from now), got {next_dt}"
+        )
+        assert next_dt.hour == 0
+
+    def test_cron_weekly_consistent_with_interval(self, monkeypatch):
+        """Both cron and interval jobs should anchor to last_run_at when
+        provided, producing consistent behavior after a crash/restart."""
+        morocco = ZoneInfo("Africa/Casablanca")
+
+        last_run = datetime(2026, 4, 6, 14, 10, 0, tzinfo=morocco)
+        now = datetime(2026, 4, 10, 22, 0, 0, tzinfo=morocco)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        cron_schedule = {"kind": "cron", "expr": "0 14 * * 1"}
+        interval_schedule = {"kind": "interval", "minutes": 7 * 24 * 60}
+
+        cron_result = compute_next_run(cron_schedule, last_run_at=last_run.isoformat())
+        interval_result = compute_next_run(interval_schedule, last_run_at=last_run.isoformat())
+
+        # Both should be after last_run_at
+        cron_dt = datetime.fromisoformat(cron_result)
+        interval_dt = datetime.fromisoformat(interval_result)
+        assert cron_dt > last_run, f"Cron next {cron_dt} should be after last_run {last_run}"
+        assert interval_dt > last_run, f"Interval next {interval_dt} should be after last_run {last_run}"


### PR DESCRIPTION
Salvages #9014 from @beenherebefore onto current main.

## Summary
Cron-type schedules now anchor to `last_run_at` after a restart, matching interval-type behavior. Previously, `compute_next_run()` ignored the `last_run_at` parameter for cron schedules and always used `_hermes_now()` — so after a crash/restart the next run was anchored to the arbitrary restart time instead of the actual last execution.

## Changes
- `cron/jobs.py` — 7-line fix in `compute_next_run()`: use `last_run_at` as `croniter` base when provided, fall back to `now` otherwise
- `tests/cron/test_compute_next_run_last_run_at.py` — 3 regression tests (every-6h anchoring, no-last-run fallback, cron/interval parity)
- `scripts/release.py` — AUTHOR_MAP entry for @beenherebefore

## Salvage note
The original PR branch was 2+ weeks stale. Plain cherry-pick would have reverted substantial unrelated work (`_jobs_file_lock` for parallel ticks, `workdir`/`context_from`/`enabled_toolsets` fields, issue #16265's `state=error` recovery path, `atomic_replace` → `os.replace` regression, etc.). Kept just the substantive 7-line fix and ported the regression test to `tests/cron/` (the old `tests/test_cron.py` path no longer exists).

## Validation
| Scenario | Before | After |
|---|---|---|
| `every 6h`, last_run=Apr 6 14:10, now=Apr 10 22:00 | Apr 11 00:00 (from now) | Apr 6 18:00 (from last_run) |
| No `last_run_at` | Apr 11 00:00 | Apr 11 00:00 (unchanged) |

- `tests/cron/test_compute_next_run_last_run_at.py` — 3/3 pass
- `tests/cron/` — 263/263 pass (no regressions)
- E2E: verified `compute_next_run` anchors correctly under both paths with real croniter import

Original PR: #9014