### PR TITLE
fix(yuanbao): track reconnect-backoff task to prevent GC mid-flight

### DIFF
--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -3174,7 +3174,10 @@ class ConnectionManager:
     def schedule_reconnect(self) -> None:
         """Schedule a reconnect only if running and not already reconnecting."""
         if self._adapter._running and not self._reconnecting:
-            asyncio.create_task(self._reconnect_with_backoff())
+            self._adapter._track_task(asyncio.create_task(
+                self._reconnect_with_backoff(),
+                name=f"yuanbao-reconnect-{self._adapter.name}",
+            ))
 
     async def _reconnect_with_backoff(self) -> bool:
         """Reconnect with exponential backoff (1s, 2s, 4s, … up to 60s)."""


### PR DESCRIPTION
## Summary

`ConnectionManager.schedule_reconnect` in `gateway/platforms/yuanbao.py` fires `asyncio.create_task(self._reconnect_with_backoff())` without retaining a reference to the resulting Task. Per [Python's asyncio docs](https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task):

> Important: Save a reference to the result of this function, to avoid a task disappearing mid-execution.

Under memory pressure the reconnect loop could be garbage-collected mid-execution, leaving the adapter in a permanently disconnected state with no error surfaced.

## Fix

Route the task through the existing `YuanbaoAdapter._track_task` helper (defined at line 4505) — same pattern already used at lines 1919 and 3135. The helper holds a strong reference in `self._background_tasks` and auto-discards via `add_done_callback`, avoiding the leak at completion time.

```diff
 def schedule_reconnect(self) -> None:
     if self._adapter._running and not self._reconnecting:
-        asyncio.create_task(self._reconnect_with_backoff())
+        self._adapter._track_task(asyncio.create_task(
+            self._reconnect_with_backoff(),
+            name=f"yuanbao-reconnect-{self._adapter.name}",
+        ))
```

4-line diff, one file, no new imports. Same bug class as #11997 / #11998 / #12000 / #12001 / #12006 from the earlier gateway-platform task-tracking sweep — this was the last yuanbao site still using bare `create_task`.