### PR TITLE
feat: add auth credential switching

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1043,6 +1043,62 @@ class CredentialPool:
             self._current_id = None
         return removed
 
+    def activate_index(self, index: int) -> Optional[PooledCredential]:
+        """Make the credential at 1-based *index* the preferred pool entry.
+
+        Selection is priority-ordered for the default fill_first strategy and
+        priority is also the tie-breaker for least_used leases.  Persisting the
+        target at priority 0 gives `hermes auth switch` a stable "active"
+        meaning without deleting or rewriting the other credentials.
+        """
+        if index < 1 or index > len(self._entries):
+            return None
+        selected = self._entries[index - 1]
+        reordered = [selected] + [entry for entry in self._entries if entry.id != selected.id]
+        self._entries = [
+            replace(entry, priority=new_priority)
+            for new_priority, entry in enumerate(reordered)
+        ]
+        self._current_id = selected.id
+        self._persist()
+        active = self.current() or self._entries[0]
+        if self.provider == "openai-codex":
+            self._sync_codex_active_entry_to_auth_store(active)
+        return active
+
+    def _sync_codex_active_entry_to_auth_store(self, entry: PooledCredential) -> None:
+        """Mirror the selected Codex pool credential into providers.openai-codex.
+
+        Runtime normally resolves OpenAI Codex from the credential pool, but
+        several fallback/status paths still read the singleton auth store.  Keep
+        that singleton aligned with the explicit active choice.
+        """
+        if self.provider != "openai-codex" or entry.auth_type != AUTH_TYPE_OAUTH:
+            return
+        if not entry.access_token:
+            return
+        try:
+            with _auth_store_lock():
+                auth_store = _load_auth_store()
+                state = _load_provider_state(auth_store, "openai-codex")
+                if not isinstance(state, dict):
+                    state = {}
+                tokens = state.get("tokens")
+                if not isinstance(tokens, dict):
+                    tokens = {}
+                tokens["access_token"] = entry.access_token
+                if entry.refresh_token:
+                    tokens["refresh_token"] = entry.refresh_token
+                state["tokens"] = tokens
+                if entry.base_url:
+                    state["base_url"] = entry.base_url
+                if entry.last_refresh:
+                    state["last_refresh"] = entry.last_refresh
+                _save_provider_state(auth_store, "openai-codex", state)
+                _save_auth_store(auth_store)
+        except Exception as exc:
+            logger.debug("Failed to sync active Codex credential to auth store: %s", exc)
+
     def resolve_target(self, target: Any) -> Tuple[Optional[int], Optional[PooledCredential], Optional[str]]:
         raw = str(target or "").strip()
         if not raw:
@@ -1316,21 +1372,68 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
         # existing Codex CLI credentials get a one-time, explicit prompt
         # via `hermes auth openai-codex`.
         if isinstance(tokens, dict) and tokens.get("access_token"):
-            active_sources.add("device_code")
-            changed |= _upsert_entry(
-                entries,
-                provider,
-                "device_code",
-                {
-                    "source": "device_code",
-                    "auth_type": AUTH_TYPE_OAUTH,
-                    "access_token": tokens.get("access_token", ""),
-                    "refresh_token": tokens.get("refresh_token"),
-                    "base_url": "https://chatgpt.com/backend-api/codex",
-                    "last_refresh": state.get("last_refresh"),
-                    "label": label_from_token(tokens.get("access_token", ""), "device_code"),
-                },
+            token_access = tokens.get("access_token", "")
+            token_refresh = tokens.get("refresh_token")
+            # If the singleton state points at an already-pooled credential
+            # (for example after an explicit switch), update that entry in
+            # place instead of creating a second synthetic device_code row.
+            matching_entry = next(
+                (
+                    entry
+                    for entry in entries
+                    if entry.access_token == token_access
+                    or (token_refresh and entry.refresh_token == token_refresh)
+                ),
+                None,
             )
+            if matching_entry is not None:
+                active_sources.add(matching_entry.source)
+                # Drop any older synthetic singleton row for the same Codex
+                # account. This keeps an explicit manual pool entry from
+                # being duplicated as a generic `device_code` entry on the
+                # next load_pool() after switching.
+                before_count = len(entries)
+                entries[:] = [
+                    entry
+                    for entry in entries
+                    if not (
+                        entry.source == "device_code"
+                        and entry.id != matching_entry.id
+                        and (
+                            entry.access_token == token_access
+                            or (token_refresh and entry.refresh_token == token_refresh)
+                        )
+                    )
+                ]
+                if len(entries) != before_count:
+                    changed = True
+                field_updates: Dict[str, Any] = {}
+                if matching_entry.base_url != "https://chatgpt.com/backend-api/codex":
+                    field_updates["base_url"] = "https://chatgpt.com/backend-api/codex"
+                if state.get("last_refresh") and matching_entry.last_refresh != state.get("last_refresh"):
+                    field_updates["last_refresh"] = state.get("last_refresh")
+                if field_updates:
+                    for idx, entry in enumerate(entries):
+                        if entry.id == matching_entry.id:
+                            entries[idx] = replace(entry, **field_updates)
+                            changed = True
+                            break
+            else:
+                active_sources.add("device_code")
+                changed |= _upsert_entry(
+                    entries,
+                    provider,
+                    "device_code",
+                    {
+                        "source": "device_code",
+                        "auth_type": AUTH_TYPE_OAUTH,
+                        "access_token": token_access,
+                        "refresh_token": token_refresh,
+                        "base_url": "https://chatgpt.com/backend-api/codex",
+                        "last_refresh": state.get("last_refresh"),
+                        "label": label_from_token(token_access, "device_code"),
+                    },
+                )
 
     return changed, active_sources
 

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -363,6 +363,24 @@ def auth_list_command(args) -> None:
         print()
 
 
+def auth_switch_command(args) -> None:
+    provider = _normalize_provider(getattr(args, "provider", ""))
+    target = getattr(args, "target", None)
+    pool = load_pool(provider)
+    index, matched, error = pool.resolve_target(target)
+    if matched is None or index is None:
+        raise SystemExit(f"{error} Provider: {provider}.")
+    active = pool.activate_index(index)
+    if active is None:
+        raise SystemExit(f'No credential matching "{target}" for provider {provider}.')
+    print(f"Switched {provider} active credential to #{1} ({active.label})")
+    strategy = get_pool_strategy(provider)
+    if strategy in {STRATEGY_ROUND_ROBIN, STRATEGY_RANDOM}:
+        print(
+            f"Note: {provider} uses {strategy}; explicit active ordering may be overridden by that selection strategy."
+        )
+
+
 def auth_remove_command(args) -> None:
     provider = _normalize_provider(getattr(args, "provider", ""))
     target = getattr(args, "target", None)
@@ -639,6 +657,9 @@ def auth_command(args) -> None:
         return
     if action == "remove":
         auth_remove_command(args)
+        return
+    if action == "switch":
+        auth_switch_command(args)
         return
     if action == "reset":
         auth_reset_command(args)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8489,6 +8489,13 @@ For more help on a command:
     auth_remove.add_argument(
         "target", help="Credential index, entry id, or exact label"
     )
+    auth_switch = auth_subparsers.add_parser(
+        "switch", help="Make a pooled credential the active/default entry"
+    )
+    auth_switch.add_argument("provider", help="Provider id")
+    auth_switch.add_argument(
+        "target", help="Credential index, entry id, or exact label"
+    )
     auth_reset = auth_subparsers.add_parser(
         "reset", help="Clear exhaustion status for all credentials for a provider"
     )

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -363,6 +363,133 @@ def test_auth_remove_accepts_label_target(tmp_path, monkeypatch):
     assert entries[0]["label"] == "work-account"
 
 
+def test_auth_switch_reorders_provider_pool(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr(
+        "agent.credential_pool._seed_from_singletons",
+        lambda provider, entries: (False, set()),
+    )
+    monkeypatch.setattr(
+        "agent.credential_pool._seed_from_env",
+        lambda provider, entries: (False, set()),
+    )
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openrouter": [
+                    {
+                        "id": "cred-1",
+                        "label": "work-key",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "sk-work",
+                    },
+                    {
+                        "id": "cred-2",
+                        "label": "personal-key",
+                        "auth_type": "api_key",
+                        "priority": 1,
+                        "source": "manual",
+                        "access_token": "sk-personal",
+                    },
+                ]
+            },
+        },
+    )
+
+    from hermes_cli.auth_commands import auth_switch_command
+
+    class _Args:
+        provider = "openrouter"
+        target = "personal-key"
+
+    auth_switch_command(_Args())
+    out = capsys.readouterr().out
+    assert "Switched openrouter active credential" in out
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    entries = payload["credential_pool"]["openrouter"]
+    assert [entry["label"] for entry in entries] == ["personal-key", "work-key"]
+    assert [entry["priority"] for entry in entries] == [0, 1]
+
+
+def test_auth_switch_syncs_codex_singleton(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": "token-work",
+                        "refresh_token": "refresh-work",
+                    },
+                    "base_url": "https://chatgpt.com/backend-api/codex",
+                    "last_refresh": "2026-03-23T09:00:00Z",
+                }
+            },
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "cred-1",
+                        "label": "work-account",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "manual:device_code",
+                        "access_token": "token-work",
+                        "refresh_token": "refresh-work",
+                        "base_url": "https://chatgpt.com/backend-api/codex",
+                        "last_refresh": "2026-03-23T09:00:00Z",
+                    },
+                    {
+                        "id": "cred-2",
+                        "label": "personal-account",
+                        "auth_type": "oauth",
+                        "priority": 1,
+                        "source": "manual:device_code",
+                        "access_token": "token-personal",
+                        "refresh_token": "refresh-personal",
+                        "base_url": "https://chatgpt.com/backend-api/codex",
+                        "last_refresh": "2026-03-23T10:00:00Z",
+                    },
+                ]
+            },
+        },
+    )
+
+    from hermes_cli.auth_commands import auth_switch_command
+    from agent.credential_pool import load_pool
+
+    class _Args:
+        provider = "openai-codex"
+        target = "personal-account"
+
+    auth_switch_command(_Args())
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    singleton = payload["providers"]["openai-codex"]
+    assert singleton["tokens"]["access_token"] == "token-personal"
+    assert singleton["tokens"]["refresh_token"] == "refresh-personal"
+    assert singleton["last_refresh"] == "2026-03-23T10:00:00Z"
+
+    # Reloading the pool after switching should keep the selected pooled entry
+    # aligned with providers.openai-codex without creating an extra synthetic
+    # singleton-derived device_code entry.
+    pool = load_pool("openai-codex")
+    entries = pool.entries()
+    assert [entry.label for entry in entries] == ["personal-account", "work-account"]
+    assert [entry.source for entry in entries] == ["manual:device_code", "manual:device_code"]
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    persisted = payload["credential_pool"]["openai-codex"]
+    assert len(persisted) == 2
+    assert all(entry["source"] != "device_code" for entry in persisted)
+
+
 def test_auth_remove_prefers_exact_numeric_label_over_index(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary

Adds `hermes auth switch <provider> <target>` for making a pooled credential the active/default credential for any provider with entries in Hermes' credential pool.

The command reorders the selected provider's credential pool so the chosen credential becomes priority `0`, preserving existing priority-based selection behavior used by the default/fill-first flow and priority tie-breaks.

For `openai-codex`, switching also keeps the selected pooled OAuth credential synchronized with the existing `providers.openai-codex` auth state, because some Codex paths still read that singleton state. This keeps Codex switching consistent across both auth-store representations.

## Details

- Adds `CredentialPool.activate_index()`
- Adds `hermes auth switch <provider> <target>`
- Supports target resolution by:
  - 1-based index
  - credential id
  - exact label
- Keeps non-selected credentials in the pool and reindexes priorities
- Warns when a provider uses `round_robin` or `random`, since explicit active ordering may be overridden by that selection strategy
- Keeps Codex pool state and singleton auth state aligned without creating duplicate singleton-derived pool entries on reload

## Test Plan

- [x] `python -m pytest -q tests/hermes_cli/test_auth_commands.py::test_auth_switch_reorders_provider_pool tests/hermes_cli/test_auth_commands.py::test_auth_switch_syncs_codex_singleton`
- [x] `python -m pytest -q tests/hermes_cli/test_auth_commands.py`
- [x] `python -m pytest -q tests/hermes_cli/test_runtime_provider_resolution.py`
- [x] `git diff --check origin/main...HEAD`
