### PR TITLE
fix(cron): clear auto-delivery thread context between jobs

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -860,6 +860,13 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         chat_id=str(origin["chat_id"]) if origin else "",
         chat_name=origin.get("chat_name", "") if origin else "",
     )
+    _cron_delivery_vars = (
+        "HERMES_CRON_AUTO_DELIVER_PLATFORM",
+        "HERMES_CRON_AUTO_DELIVER_CHAT_ID",
+        "HERMES_CRON_AUTO_DELIVER_THREAD_ID",
+    )
+    for _var_name in _cron_delivery_vars:
+        _VAR_MAP[_var_name].set("")
 
     # Per-job working directory.  When set (and validated at create/update
     # time), we point TERMINAL_CWD at it so:
@@ -898,8 +905,11 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         if delivery_target:
             _VAR_MAP["HERMES_CRON_AUTO_DELIVER_PLATFORM"].set(delivery_target["platform"])
             _VAR_MAP["HERMES_CRON_AUTO_DELIVER_CHAT_ID"].set(str(delivery_target["chat_id"]))
-            if delivery_target.get("thread_id") is not None:
-                _VAR_MAP["HERMES_CRON_AUTO_DELIVER_THREAD_ID"].set(str(delivery_target["thread_id"]))
+            _VAR_MAP["HERMES_CRON_AUTO_DELIVER_THREAD_ID"].set(
+                ""
+                if delivery_target.get("thread_id") is None
+                else str(delivery_target["thread_id"])
+            )
 
         model = job.get("model") or os.getenv("HERMES_MODEL") or ""
 
@@ -1185,6 +1195,8 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 os.environ["TERMINAL_CWD"] = _prior_terminal_cwd
         # Clean up ContextVar session/delivery state for this job.
         clear_session_vars(_ctx_tokens)
+        for _var_name in _cron_delivery_vars:
+            _VAR_MAP[_var_name].set("")
         if _session_db:
             try:
                 _session_db.end_session(_cron_session_id, "cron_complete")

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1027,6 +1027,80 @@ class TestRunJobSessionPersistence:
         assert os.getenv("HERMES_CRON_AUTO_DELIVER_THREAD_ID") is None
         fake_db.close.assert_called_once()
 
+    def test_run_job_clears_stale_auto_delivery_thread_id_between_jobs(self, tmp_path, monkeypatch):
+        jobs = [
+            {
+                "id": "threaded-job",
+                "name": "threaded",
+                "prompt": "hello",
+                "deliver": "telegram:-1001:42",
+            },
+            {
+                "id": "threadless-job",
+                "name": "threadless",
+                "prompt": "hello again",
+                "deliver": "telegram:-2002",
+            },
+        ]
+        fake_db = MagicMock()
+        seen = []
+
+        monkeypatch.delenv("HERMES_CRON_AUTO_DELIVER_PLATFORM", raising=False)
+        monkeypatch.delenv("HERMES_CRON_AUTO_DELIVER_CHAT_ID", raising=False)
+        monkeypatch.delenv("HERMES_CRON_AUTO_DELIVER_THREAD_ID", raising=False)
+
+        class FakeAgent:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def run_conversation(self, *args, **kwargs):
+                from gateway.session_context import get_session_env
+
+                seen.append(
+                    {
+                        "platform": get_session_env("HERMES_CRON_AUTO_DELIVER_PLATFORM") or None,
+                        "chat_id": get_session_env("HERMES_CRON_AUTO_DELIVER_CHAT_ID") or None,
+                        "thread_id": get_session_env("HERMES_CRON_AUTO_DELIVER_THREAD_ID") or None,
+                    }
+                )
+                return {"final_response": "ok"}
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent", FakeAgent):
+            for job in jobs:
+                success, output, final_response, error = run_job(job)
+                assert success is True
+                assert error is None
+                assert final_response == "ok"
+                assert "ok" in output
+
+        assert seen == [
+            {
+                "platform": "telegram",
+                "chat_id": "-1001",
+                "thread_id": "42",
+            },
+            {
+                "platform": "telegram",
+                "chat_id": "-2002",
+                "thread_id": None,
+            },
+        ]
+        assert os.getenv("HERMES_CRON_AUTO_DELIVER_PLATFORM") is None
+        assert os.getenv("HERMES_CRON_AUTO_DELIVER_CHAT_ID") is None
+        assert os.getenv("HERMES_CRON_AUTO_DELIVER_THREAD_ID") is None
+        assert fake_db.close.call_count == 2
+
 
 class TestRunJobConfigLogging:
     """Verify that config.yaml parse failures are logged, not silently swallowed."""


### PR DESCRIPTION
## Summary

This fixes a cron state-isolation bug where HERMES_CRON_AUTO_DELIVER_THREAD_ID could leak from one job into the next job in the same process context.

The bug showed up when a job with a threaded delivery target ran before a job without a thread target. In that case, the second job could still observe the previous job's thread id.

## Problem

run_job() stores cron auto-delivery routing information in ContextVars so concurrent jobs do not clobber each other through process-global environment state.

However, the thread id had two gaps:

- HERMES_CRON_AUTO_DELIVER_THREAD_ID was only set when the resolved delivery target had a non-None thread id.
- The cron auto-delivery ContextVars were not explicitly cleared at job teardown.

That meant a threaded job could leave behind a stale thread id, and a later threadless job in the same execution context could still see it.

This is especially risky because tools/send_message_tool.py reads these values to detect cron auto-delivery duplicate targets.

## Root cause

The cron auto-delivery routing state was only partially normalized per job.

Platform and chat id were set when a delivery target existed, but thread id was conditionally skipped for threadless targets. Since the cron delivery ContextVars were also not cleared in the finally path, old values could survive into the next job.

## Fix

This change makes cron auto-delivery routing state fully per-job by:

- Clearing all cron auto-delivery ContextVars at the start of run_job()
- Explicitly setting HERMES_CRON_AUTO_DELIVER_THREAD_ID to "" when the resolved target has no thread id
- Clearing the same cron auto-delivery ContextVars again during job teardown

This keeps the routing state deterministic for both threaded and threadless jobs.

## Tests

Added a regression test that runs two cron jobs back-to-back in the same process:

- first job delivers to telegram:-1001:42
- second job delivers to telegram:-2002

The test verifies that the second job sees:

- platform = telegram
- chat_id = -2002
- thread_id = None

and not the stale "42" from the first job.

Verified with:

uv run pytest -n 4 -o "addopts=" tests/cron/test_scheduler.py -k auto_delivery

Result:

- test_run_job_sets_auto_delivery_env_from_dotenv_home_channel passed
- test_run_job_clears_stale_auto_delivery_thread_id_between_jobs passed