### PR TITLE
feat(cli): mark latest session with ★ in /resume and sessions list

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4664,8 +4664,16 @@ class HermesCLI:
         print()
         print(f"  {'Title':<32} {'Preview':<40} {'Last Active':<13} {'ID'}")
         print(f"  {'─' * 32} {'─' * 40} {'─' * 13} {'─' * 24}")
-        for session in sessions:
-            title = (session.get("title") or "—")[:30]
+        for idx, session in enumerate(sessions):
+            raw_title = session.get("title") or "—"
+            # First row is the most-recently-active session (list_sessions_rich
+            # sorts by last_active DESC).  Mark it so users can spot the
+            # resume-what-I-was-just-doing target without eyeballing
+            # timestamps.  See #17352.
+            if idx == 0:
+                title = f"★ {raw_title[:28]}"
+            else:
+                title = raw_title[:30]
             preview = (session.get("preview") or "")[:38]
             last_active = _relative_time(session.get("last_active"))
             print(f"  {title:<32} {preview:<40} {last_active:<13} {session['id']}")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9614,20 +9614,29 @@ Examples:
             else:
                 print(f"{'Preview':<50} {'Last Active':<13} {'Src':<6} {'ID'}")
                 print("─" * 95)
-            for s in sessions:
+            for idx, s in enumerate(sessions):
                 last_active = _relative_time(s.get("last_active"))
                 preview = (
                     s.get("preview", "")[:38]
                     if has_titles
                     else s.get("preview", "")[:48]
                 )
+                # The first row is the most recently active session
+                # (list_sessions_rich sorts by last_active DESC).  Mark it so
+                # users can spot the "resume my most recent conversation"
+                # target immediately.  See #17352.
+                is_latest = (idx == 0)
                 if has_titles:
-                    title = (s.get("title") or "—")[:30]
+                    raw_title = s.get("title") or "—"
+                    title = (f"★ {raw_title[:28]}" if is_latest
+                             else raw_title[:30])
                     sid = s["id"]
                     print(f"{title:<32} {preview:<40} {last_active:<13} {sid}")
                 else:
+                    prefix = "★ " if is_latest else "  "
                     sid = s["id"]
-                    print(f"{preview:<50} {last_active:<13} {s['source']:<6} {sid}")
+                    marked_preview = f"{prefix}{preview[:48]}"[:50]
+                    print(f"{marked_preview:<50} {last_active:<13} {s['source']:<6} {sid}")
 
         elif action == "export":
             if args.session_id:


### PR DESCRIPTION
Closes #17352.

## Summary

The `/resume` inline picker and `hermes sessions list` already show a `Last Active` timestamp column, but users still had to eyeball timestamps to pick their most-recent conversation. Since `list_sessions_rich` sorts by `last_active DESC`, the first row is *always* the most-recently-active session — so prefix it with a ★ so users can spot their resume-what-I-was-just-doing target in one glance.

## Before

```
  Title                            Preview                                  Last Active   ID
  Alpha project                    Working on pr-cli                        0d ago        sess-xxxx-yyyy-zz-01
  —                                No title here                            1d ago        sess-xxxx-yyyy-zz-02
  Gamma                            Another                                  2d ago        sess-xxxx-yyyy-zz-03
```

## After

```
  Title                            Preview                                  Last Active   ID
  ★ Alpha project                  Working on pr-cli                        0d ago        sess-xxxx-yyyy-zz-01
  —                                No title here                            1d ago        sess-xxxx-yyyy-zz-02
  Gamma                            Another                                  2d ago        sess-xxxx-yyyy-zz-03
```

## Scope

Two surfaces, two display-only changes:
- `cli.py::_show_recent_sessions` — inline list shown mid-chat by `/resume` (no args) and `/history` (when empty)
- `hermes_cli/main.py` — `hermes sessions list` CLI command, both titled and preview-only layouts

Column widths preserved: `★ ` consumes 2 chars from the 32-wide title column (title content truncated from 30 → 28 chars on the starred row only). Last Active / ID columns unchanged.

## Not in scope

- The curses picker `_session_browse_picker` already highlights the cursor row; a marker would be redundant with the active-selection colorway.
- No change to `db.list_sessions_rich` ordering; the fix relies on the existing DESC sort.