### PR TITLE
fix(run_agent): normalize nested fallback chains to enable cascading provider failover

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -837,6 +837,38 @@ def _pool_may_recover_from_rate_limit(pool) -> bool:
     return len(pool.entries()) > 1
 
 
+def _normalize_fallback_chain(fallback_model: Any) -> List[Dict[str, Any]]:
+    """Return a flat ordered fallback chain from all supported config shapes."""
+    chain: List[Dict[str, Any]] = []
+    seen: set[int] = set()
+
+    def _visit(node: Any) -> None:
+        if isinstance(node, list):
+            for entry in node:
+                _visit(entry)
+            return
+        if not isinstance(node, dict):
+            return
+
+        node_id = id(node)
+        if node_id in seen:
+            return
+        seen.add(node_id)
+
+        if node.get("provider") and node.get("model"):
+            chain.append({
+                key: value
+                for key, value in node.items()
+                if key not in {"fallback_model", "fallback_providers"}
+            })
+
+        _visit(node.get("fallback_providers"))
+        _visit(node.get("fallback_model"))
+
+    _visit(fallback_model)
+    return chain
+
+
 def _qwen_portal_headers() -> dict:
     """Return default HTTP headers required by Qwen Portal API."""
     import platform as _plat
@@ -1490,17 +1522,9 @@ class AIAgent:
         
         # Provider fallback chain — ordered list of backup providers tried
         # when the primary is exhausted (rate-limit, overload, connection
-        # failure).  Supports both legacy single-dict ``fallback_model`` and
-        # new list ``fallback_providers`` format.
-        if isinstance(fallback_model, list):
-            self._fallback_chain = [
-                f for f in fallback_model
-                if isinstance(f, dict) and f.get("provider") and f.get("model")
-            ]
-        elif isinstance(fallback_model, dict) and fallback_model.get("provider") and fallback_model.get("model"):
-            self._fallback_chain = [fallback_model]
-        else:
-            self._fallback_chain = []
+        # failure). Supports legacy single-dict ``fallback_model``, list-based
+        # ``fallback_providers``, and older nested ``fallback_model`` blocks.
+        self._fallback_chain = _normalize_fallback_chain(fallback_model)
         self._fallback_index = 0
         self._fallback_activated = False
         # Legacy attribute kept for backward compat (tests, external callers)

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -81,6 +81,21 @@ class TestFallbackChainInit:
         agent = _make_agent(fallback_model={"model": "gpt-4o"})
         assert agent._fallback_chain == []
 
+    def test_nested_legacy_fallback_model_flattens_chain(self):
+        fbs = {
+            "provider": "groq",
+            "model": "llama-3.3-70b",
+            "fallback_model": {
+                "provider": "mistral",
+                "model": "mistral-large-latest",
+            },
+        }
+        agent = _make_agent(fallback_model=fbs)
+        assert agent._fallback_chain == [
+            {"provider": "groq", "model": "llama-3.3-70b"},
+            {"provider": "mistral", "model": "mistral-large-latest"},
+        ]
+
 
 # ── Chain advancement ─────────────────────────────────────────────────────
 
@@ -155,6 +170,26 @@ class TestFallbackChainAdvancement:
             ]
             assert agent._try_activate_fallback() is True
             assert agent.model == "gpt-4o"
+
+    def test_nested_fallback_cascades_when_first_fallback_fails(self):
+        fbs = {
+            "provider": "groq",
+            "model": "llama-3.3-70b",
+            "fallback_model": {
+                "provider": "mistral",
+                "model": "mistral-large-latest",
+            },
+        }
+        agent = _make_agent(fallback_model=fbs)
+        with patch("agent.auxiliary_client.resolve_provider_client") as mock_rpc:
+            mock_rpc.side_effect = [
+                RuntimeError("HTTP 401 invalid key"),
+                (_mock_client(), "mistral-large-latest"),
+            ]
+            assert agent._try_activate_fallback() is True
+            assert agent.provider == "mistral"
+            assert agent.model == "mistral-large-latest"
+            assert agent._fallback_index == 2
 
     def test_resolves_key_env_for_fallback_provider(self):
         fbs = [


### PR DESCRIPTION
## What does this PR do?

This PR fixes provider fallback handling in `run_agent.py` by normalizing legacy nested `fallback_model` blocks into a single ordered runtime chain. Previously, nested fallback definitions could be skipped during failover, so fallback resolution did not consistently cascade past the first fallback provider. This change ensures fallback resolution is deterministic and traverses the full chain, including the nested case reported in #17485.

## Related Issue

Fixes #17485

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- [run_agent.py](/Users/afurm/Development/hermes-agent/run_agent.py): Added fallback-chain normalization logic to flatten legacy nested `fallback_model` payloads into the runtime fallback chain order, enabling proper cascade behavior.
- [tests/run_agent/test_provider_fallback.py](/Users/afurm/Development/hermes-agent/tests/run_agent/test_provider_fallback.py): Added regression tests for:
  - nested fallback chain normalization
  - cascading fallback when an earlier fallback target raises a 401-like error
- [tests/run_agent/test_fallback_model.py](/Users/afurm/Development/hermes-agent/tests/run_agent/test_fallback_model.py): Kept/verified coverage aligned with the updated normalization behavior and edge cases.

## How to Test

1. Run fallback provider tests:
   - `scripts/run_tests.sh tests/run_agent/test_provider_fallback.py -q`
   - `scripts/run_tests.sh tests/run_agent/test_fallback_model.py -q`
2. Confirm both suites pass:
   - `test_provider_fallback.py`: 21 passed
   - `test_fallback_model.py`: 28 passed
3. Add a provider configuration with a nested fallback chain and simulate a first fallback returning 401-like error; verify the agent continues cascading through the normalized fallback order and does not stop prematurely.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `scripts/run_tests.sh tests/run_agent/test_provider_fallback.py -q` → 21 passed
- `scripts/run_tests.sh tests/run_agent/test_fallback_model.py -q` → 28 passed
