### PR TITLE
test(gateway): cover Feishu bot group session rebuilds

### DIFF
--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1820,6 +1820,44 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(event.source.chat_type, "group")
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_process_inbound_group_message_marks_other_bot_sender(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._dispatch_inbound_event = AsyncMock()
+        adapter.get_chat_info = AsyncMock(
+            return_value={"chat_id": "oc_group", "name": "Ops Group", "type": "group"}
+        )
+        adapter._resolve_sender_profile = AsyncMock(
+            return_value={"user_id": "u_peer_bot", "user_name": "Peer Bot", "user_id_alt": None}
+        )
+        message = SimpleNamespace(
+            chat_id="oc_group",
+            thread_id=None,
+            message_type="text",
+            content='{"text":"@Hermes continue"}',
+            message_id="om_group_bot_text",
+        )
+        sender_id = SimpleNamespace(open_id="ou_peer_bot", user_id="u_peer_bot", union_id=None)
+        data = SimpleNamespace(event=SimpleNamespace(message=message))
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=data,
+                message=message,
+                sender_id=sender_id,
+                chat_type="group",
+                message_id="om_group_bot_text",
+                is_bot=True,
+            )
+        )
+
+        event = adapter._dispatch_inbound_event.await_args.args[0]
+        self.assertTrue(event.source.is_bot)
+        self.assertEqual(event.source.user_id, "u_peer_bot")
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_process_inbound_message_fetches_reply_to_text(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter

--- a/tests/gateway/test_feishu_bot_auth_bypass.py
+++ b/tests/gateway/test_feishu_bot_auth_bypass.py
@@ -1,18 +1,14 @@
-"""Regression guard for Feishu bot-sender authorization bypass.
-
-Mirrors tests/gateway/test_discord_bot_auth_bypass.py for Platform.FEISHU.
-Without the bypass in gateway/run.py, Feishu bot senders admitted by the
-adapter would be rejected at _is_user_authorized with "Unauthorized user"
-— same class of bug as Discord #4466.
-"""
+"""Regression guards for Feishu bot-sender authorization bypass."""
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta
 from types import SimpleNamespace
 
 import pytest
 
-from gateway.session import Platform, SessionSource
+from gateway.config import GatewayConfig, SessionResetPolicy
+from gateway.session import Platform, SessionSource, SessionStore
 
 
 @pytest.fixture(autouse=True)
@@ -111,3 +107,20 @@ def test_feishu_bot_bypass_does_not_leak_to_other_platforms(monkeypatch):
         is_bot=True,
     )
     assert runner._is_user_authorized(telegram_bot) is False
+
+
+def test_authorized_feishu_bot_source_can_idle_reset_group_session(tmp_path):
+    config = GatewayConfig(default_reset_policy=SessionResetPolicy(mode="idle", idle_minutes=1))
+    config.group_sessions_per_user = False
+    store = SessionStore(sessions_dir=tmp_path, config=config)
+    source = _make_feishu_bot_source("ou_peer_bot")
+
+    entry = store.get_or_create_session(source)
+    entry.updated_at = datetime.now() - timedelta(minutes=5)
+    store._save()
+
+    rebuilt = store.get_or_create_session(source)
+
+    assert rebuilt.was_auto_reset is True
+    assert rebuilt.auto_reset_reason == "idle"
+    assert rebuilt.session_id != entry.session_id


### PR DESCRIPTION
## Summary
- add coverage that Feishu inbound group messages preserve `SessionSource.is_bot` for peer bot senders
- add a regression guard proving an authorized Feishu bot source can rebuild an idle-reset group session

## Why
Fixes #17525. After rebasing onto current `main`, the gateway authorization implementation for `FEISHU_ALLOW_BOTS` is already present; this PR keeps the issue-backed regression coverage that proves the bot-origin group session rebuild path stays working.

## Scope
This intentionally leaves gateway authorization behavior unchanged and avoids touching unrelated platform/session code.

## Verification
- `scripts/run_tests.sh tests/gateway/test_feishu.py::TestAdapterBehavior::test_process_inbound_group_message_marks_other_bot_sender tests/gateway/test_feishu_bot_auth_bypass.py`
- `git diff --check origin/main...HEAD`
