### PR TITLE
Fix Codex auxiliary fallback model drift (`gpt-5.2-codex` → `gpt-5.4`)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -8,7 +8,7 @@ Resolution order for text tasks (auto mode):
   1. OpenRouter  (OPENROUTER_API_KEY)
   2. Nous Portal (~/.hermes/auth.json active provider)
   3. Custom endpoint (config.yaml model.base_url + OPENAI_API_KEY)
-  4. Codex OAuth (Responses API via chatgpt.com with gpt-5.3-codex,
+  4. Codex OAuth (Responses API via chatgpt.com with gpt-5.4,
      wrapped to look like a chat.completions client)
   5. Native Anthropic
   6. Direct API-key providers (z.ai/GLM, Kimi/Moonshot, MiniMax, MiniMax-CN)
@@ -18,7 +18,7 @@ Resolution order for vision/multimodal tasks (auto mode):
   1. Selected main provider, if it is one of the supported vision backends below
   2. OpenRouter
   3. Nous Portal
-  4. Codex OAuth (gpt-5.3-codex supports vision via Responses API)
+  4. Codex OAuth (gpt-5.4 supports vision via Responses API)
   5. Native Anthropic
   6. Custom endpoint (for local vision models: Qwen-VL, LLaVA, Pixtral, etc.)
   7. None
@@ -278,10 +278,9 @@ _AUTH_JSON_PATH = get_hermes_home() / "auth.json"
 
 # Codex fallback: uses the Responses API (the only endpoint the Codex
 # OAuth token can access) with a fast model for auxiliary tasks.
-# ChatGPT-backed Codex accounts currently reject gpt-5.3-codex for these
-# auxiliary flows, while gpt-5.2-codex remains broadly available and supports
-# vision via Responses.
-_CODEX_AUX_MODEL = "gpt-5.2-codex"
+# ChatGPT-backed Codex accounts currently accept gpt-5.4 on the Responses
+# endpoint, and this model remains broadly available for auxiliary flows.
+_CODEX_AUX_MODEL = "gpt-5.4"
 _CODEX_AUX_BASE_URL = "https://chatgpt.com/backend-api/codex"
 
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -21,6 +21,7 @@ from agent.auxiliary_client import (
     _is_payment_error,
     _normalize_aux_provider,
     _try_payment_fallback,
+    _CODEX_AUX_MODEL,
     _resolve_auto,
 )
 
@@ -272,7 +273,7 @@ class TestTryCodex:
             client, model = _try_codex()
 
         assert client is not None
-        assert model == "gpt-5.2-codex"
+        assert model == _CODEX_AUX_MODEL
         assert mock_openai.call_args.kwargs["api_key"] == "codex-auth-token"
         assert mock_openai.call_args.kwargs["base_url"] == "https://chatgpt.com/backend-api/codex"
 
@@ -514,7 +515,7 @@ class TestGetTextAuxiliaryClient:
         from agent.auxiliary_client import CodexAuxiliaryClient
 
         assert isinstance(client, CodexAuxiliaryClient)
-        assert model == "gpt-5.2-codex"
+        assert model == _CODEX_AUX_MODEL
 
     def test_returns_none_when_nothing_available(self, monkeypatch):
         monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
@@ -836,11 +837,11 @@ class TestTryPaymentFallback:
         with patch("agent.auxiliary_client._try_openrouter", return_value=(None, None)), \
              patch("agent.auxiliary_client._try_nous", return_value=(None, None)), \
              patch("agent.auxiliary_client._try_custom_endpoint", return_value=(None, None)), \
-             patch("agent.auxiliary_client._try_codex", return_value=(mock_codex, "gpt-5.2-codex")), \
+             patch("agent.auxiliary_client._try_codex", return_value=(mock_codex, _CODEX_AUX_MODEL)), \
              patch("agent.auxiliary_client._read_main_provider", return_value="openrouter"):
             client, model, label = _try_payment_fallback("openrouter")
         assert client is mock_codex
-        assert model == "gpt-5.2-codex"
+        assert model == _CODEX_AUX_MODEL
         assert label == "openai-codex"
 
 
@@ -1360,14 +1361,14 @@ class TestAuxiliaryAuthRefreshRetry:
         with (
             patch(
                 "agent.auxiliary_client.resolve_vision_provider_client",
-                side_effect=[("openai-codex", failing_client, "gpt-5.2-codex"), ("openai-codex", fresh_client, "gpt-5.2-codex")],
+                side_effect=[("openai-codex", failing_client, _CODEX_AUX_MODEL), ("openai-codex", fresh_client, _CODEX_AUX_MODEL)],
             ),
             patch("agent.auxiliary_client._refresh_provider_credentials", return_value=True) as mock_refresh,
         ):
             resp = call_llm(
                 task="vision",
                 provider="openai-codex",
-                model="gpt-5.2-codex",
+                model=_CODEX_AUX_MODEL,
                 messages=[{"role": "user", "content": "hi"}],
             )
 
@@ -1384,14 +1385,14 @@ class TestAuxiliaryAuthRefreshRetry:
         fresh_client.chat.completions.create.return_value = _DummyResponse("fresh-non-vision")
 
         with (
-            patch("agent.auxiliary_client._resolve_task_provider_model", return_value=("openai-codex", "gpt-5.2-codex", None, None, None)),
-            patch("agent.auxiliary_client._get_cached_client", side_effect=[(stale_client, "gpt-5.2-codex"), (fresh_client, "gpt-5.2-codex")]),
+            patch("agent.auxiliary_client._resolve_task_provider_model", return_value=("openai-codex", _CODEX_AUX_MODEL, None, None, None)),
+            patch("agent.auxiliary_client._get_cached_client", side_effect=[(stale_client, _CODEX_AUX_MODEL), (fresh_client, _CODEX_AUX_MODEL)]),
             patch("agent.auxiliary_client._refresh_provider_credentials", return_value=True) as mock_refresh,
         ):
             resp = call_llm(
                 task="compression",
                 provider="openai-codex",
-                model="gpt-5.2-codex",
+                model=_CODEX_AUX_MODEL,
                 messages=[{"role": "user", "content": "hi"}],
             )
 
@@ -1439,14 +1440,14 @@ class TestAuxiliaryAuthRefreshRetry:
         with (
             patch(
                 "agent.auxiliary_client.resolve_vision_provider_client",
-                side_effect=[("openai-codex", failing_client, "gpt-5.2-codex"), ("openai-codex", fresh_client, "gpt-5.2-codex")],
+                side_effect=[("openai-codex", failing_client, _CODEX_AUX_MODEL), ("openai-codex", fresh_client, _CODEX_AUX_MODEL)],
             ),
             patch("agent.auxiliary_client._refresh_provider_credentials", return_value=True) as mock_refresh,
         ):
             resp = await async_call_llm(
                 task="vision",
                 provider="openai-codex",
-                model="gpt-5.2-codex",
+                model=_CODEX_AUX_MODEL,
                 messages=[{"role": "user", "content": "hi"}],
             )
 


### PR DESCRIPTION
## What does this PR do?

This PR updates Hermes-Agent’s Codex auxiliary fallback model to a currently supported Codex model so ChatGPT-account users can continue to use auxiliary features (compression, vision extraction, etc.) when payment/credit fallbacks are triggered.

Problem resolved:
- `_CODEX_AUX_MODEL` was still pinned to `gpt-5.2-codex`, which is rejected by ChatGPT-account Codex backends.
- This caused auxiliary calls routed through `_try_payment_fallback` to fail with HTTP 400 “model is not supported” and pause retry logic in long sessions.

This update also removes brittle test coupling by asserting against `_CODEX_AUX_MODEL` instead of hardcoded strings.

## Related Issue

Fixes [#17533](https://github.com/NousResearch/hermes-agent/issues/17533)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/auxiliary_client.py`
  - Update `_CODEX_AUX_MODEL` from `"gpt-5.2-codex"` to `"gpt-5.4"`.
  - Refresh nearby inline comments describing current Codex fallback model behavior.
  - Keep selection logic intact (`_try_codex` and auxiliary provider chain unchanged).
- `tests/agent/test_auxiliary_client.py`
  - Import `_CODEX_AUX_MODEL` in tests.
  - Replace hardcoded `"gpt-5.2-codex"` assertions with `_CODEX_AUX_MODEL` for resilient assertions.

## How to Test

1. Run focused tests:
   - `scripts/run_tests.sh tests/agent/test_auxiliary_client.py -k codex`
2. Add temporary logging/trace in a ChatGPT-account Codex environment and trigger an auxiliary fallback path (for example: force payment-fallback path and call compression/vision auxiliary task).
3. Confirm no `"model is not supported"` errors for Codex auxiliary calls and that fallback returns a successful response.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Please include auxiliary fallback logs showing successful Codex responses with `gpt-5.4` if CI/manual verification is run in a ChatGPT-account Codex environment.
