### PR TITLE
fix(weixin): route send_message media uploads through a fresh aiohttp session

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -2030,22 +2030,28 @@ async def send_weixin_direct(
 
     live_adapter = _LIVE_ADAPTERS.get(resolved_token)
     send_session = getattr(live_adapter, '_send_session', None)
-    if live_adapter is not None and send_session is not None and not send_session.closed:
+    has_media = bool(media_files)
+
+    # Reuse the live adapter only for text-only sends. Its _send_session
+    # was created inside the long-poll reader task; using it for file
+    # uploads from a different task (e.g. the tool-call task that runs
+    # send_message) trips aiohttp's "Timeout context manager should be
+    # used inside a task" check in the upload code path (the 120-second
+    # upload timeout is the trigger).  Text sends go through a much
+    # shorter request timeout and have not reproduced the failure.
+    # See #17347 for the full reproduction and logs.
+    if (
+        live_adapter is not None
+        and send_session is not None
+        and not send_session.closed
+        and not has_media
+    ):
         last_result: Optional[SendResult] = None
         cleaned = live_adapter.format_message(message)
         if cleaned:
             last_result = await live_adapter.send(chat_id, cleaned)
             if not last_result.success:
                 return {"error": f"Weixin send failed: {last_result.error}"}
-
-        for media_path, _is_voice in media_files or []:
-            ext = Path(media_path).suffix.lower()
-            if ext in {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp"}:
-                last_result = await live_adapter.send_image_file(chat_id, media_path)
-            else:
-                last_result = await live_adapter.send_document(chat_id, media_path)
-            if not last_result.success:
-                return {"error": f"Weixin media send failed: {last_result.error}"}
 
         return {
             "success": True,
@@ -2055,6 +2061,10 @@ async def send_weixin_direct(
             "context_token_used": bool(context_token),
         }
 
+    # Fresh-session path: own task, own aiohttp session.  Covers media
+    # sends unconditionally (so the cross-task timeout bug in #17347
+    # cannot fire) and the adapter-unavailable case (cron delivery before
+    # the gateway is fully up, stand-alone tool invocations, etc.)
     async with aiohttp.ClientSession(trust_env=True, connector=_make_ssl_connector()) as session:
         adapter = WeixinAdapter(
             PlatformConfig(


### PR DESCRIPTION
Closes #17347.

## Symptom

`send_message` tool call to a Weixin chat with a `.docx` / image attachment fails 5/5 times with:

```
WARNING [Weixin] send chunk failed to=…: Timeout context manager should be used inside a task
ERROR   [Weixin] send failed to=…: Timeout context manager should be used inside a task
```

Text replies through the same platform continue to work — only tool-initiated media sends break.

## Root cause

`send_weixin_direct` (`gateway/platforms/weixin.py:2005`) optimistically reuses the live long-poll adapter's `_send_session` when that adapter is running:

```python
live_adapter = _LIVE_ADAPTERS.get(resolved_token)
send_session = getattr(live_adapter, '_send_session', None)
if live_adapter is not None and send_session is not None and not send_session.closed:
    # reuse for text AND media
```

That `_send_session` was created inside the long-poll reader task. Reusing it from the tool-call task works for short request timeouts (the text-send path uses `API_TIMEOUT_MS` ≈ 8 s), but the **120-second upload-CDN timeout** in `_upload_ciphertext`:

```python
timeout = aiohttp.ClientTimeout(total=120)
async with session.post(upload_url, data=ciphertext, …, timeout=timeout) as response:
```

trips aiohttp's `asyncio.current_task()` check inside the session's timeout handler when the session crosses task boundaries.

Text sends work because their timer registers and tears down within the same tool-call task turn; the 120 s upload timer spans enough turns that the task-binding check fails.

## Fix

Reuse the live adapter **only when `media_files` is empty**. Any media send falls through to the existing fresh-session path (the same `aiohttp.ClientSession` that cron delivery and adapter-unavailable tool calls already use), so the upload runs in the tool-call task's own session and the timeout-context check sees a valid current task.

```diff
-if live_adapter is not None and send_session is not None and not send_session.closed:
+has_media = bool(media_files)
+if (
+    live_adapter is not None
+    and send_session is not None
+    and not send_session.closed
+    and not has_media
+):
     # text-only reuse, preserved to keep the common-case perf
```

Text-only behavior is preserved byte-for-byte. The adapter-unavailable branch (cron / standalone) already fell through to the fresh-session path, so its behavior also unchanged.

## Not in scope

- Doesn't restructure the live adapter's internal task model. That may be the right long-term fix (own task for each send op), but it's a bigger change and this one-line gate unblocks the user-visible bug first.
- Doesn't add a regression test — the bug requires a live weixin account + CDN flight to reproduce.  Adding a mock-aiohttp test that hits the same `asyncio.current_task()` branch is possible but significantly more scaffolding than the fix; happy to add in a follow-up if preferred.

## File

- `gateway/platforms/weixin.py`: +20 / -10