### PR TITLE
fix(browser): SIGKILL Chrome descendants when reaping orphaned daemons

### DIFF
--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -807,6 +807,103 @@ def _write_owner_pid(socket_dir: str, session_name: str) -> None:
                      session_name, exc)
 
 
+def _descendant_pids(pid: int) -> set[int]:
+    """Return every descendant PID of ``pid`` (not ``pid`` itself).
+
+    Order of preference:
+      1. psutil (cross-platform, most reliable)
+      2. Linux ``/proc/*/status`` PPid walk
+      3. empty set (caller falls back to signalling ``pid`` only)
+
+    Used by the orphan reaper to SIGKILL Chrome renderers / helpers that
+    agent-browser's daemon spawned.  Without this, a SIGTERM to the
+    daemon leaves the Chrome children pinned at 100% CPU as init-reparented
+    orphans (#17388).
+    """
+    # psutil first — handles macOS / Windows / Linux uniformly
+    try:
+        import psutil  # type: ignore[import-not-found]
+
+        try:
+            return {c.pid for c in psutil.Process(pid).children(recursive=True)}
+        except psutil.NoSuchProcess:
+            return set()
+    except ImportError:
+        pass
+
+    # Linux fallback: walk /proc
+    try:
+        all_pids = [int(p) for p in os.listdir("/proc") if p.isdigit()]
+    except OSError:
+        return set()
+
+    ppid_map: dict[int, int] = {}
+    for p in all_pids:
+        try:
+            with open(f"/proc/{p}/status") as fh:
+                for line in fh:
+                    if line.startswith("PPid:"):
+                        ppid_map[p] = int(line.split()[1])
+                        break
+        except (OSError, ValueError):
+            continue
+
+    descendants: set[int] = set()
+    stack = [pid]
+    while stack:
+        parent = stack.pop()
+        for child, pp in ppid_map.items():
+            if pp == parent and child not in descendants:
+                descendants.add(child)
+                stack.append(child)
+    return descendants
+
+
+def _kill_browser_tree(daemon_pid: int, *, session_name: str = "") -> int:
+    """SIGTERM the agent-browser daemon and everything it spawned.
+
+    Collects the full descendant PID set BEFORE signalling so reparented
+    Chrome helpers are captured — once the daemon exits, init may become
+    the parent of stragglers and the tree walk would miss them.
+
+    Returns the number of descendants that survived the SIGTERM and
+    had to be SIGKILL'd.  Failure to signal any individual pid is
+    silently ignored (ProcessLookupError / PermissionError / OSError);
+    the caller logs the overall outcome.
+    """
+    descendants = _descendant_pids(daemon_pid)
+
+    try:
+        os.kill(daemon_pid, signal.SIGTERM)
+    except (ProcessLookupError, PermissionError, OSError):
+        pass
+
+    if not descendants:
+        return 0
+
+    # Chrome renderers + GPU helpers sometimes ignore SIGTERM.  Give them
+    # a short grace period, then SIGKILL anything still running — these
+    # are the "100% CPU zombie" processes described in #17388.
+    time.sleep(0.5)
+    killed = 0
+    for dpid in descendants:
+        try:
+            os.kill(dpid, 0)  # existence check
+        except (ProcessLookupError, PermissionError, OSError):
+            continue
+        try:
+            os.kill(dpid, signal.SIGKILL)
+            killed += 1
+        except (ProcessLookupError, PermissionError, OSError):
+            pass
+    if killed:
+        logger.info(
+            "Force-killed %d lingering browser descendants (daemon=%d session=%s)",
+            killed, daemon_pid, session_name or "?",
+        )
+    return killed
+
+
 def _reap_orphaned_browser_sessions():
     """Scan for orphaned agent-browser daemon processes from previous runs.
 
@@ -912,8 +1009,11 @@ def _reap_orphaned_browser_sessions():
             continue
 
         # Daemon is alive and its owner is dead (or legacy + untracked).  Reap.
+        # Use _kill_browser_tree so we also SIGKILL any Chrome renderers
+        # / GPU helpers that agent-browser spawned — otherwise they'd be
+        # reparented to init and keep running at 100% CPU (#17388).
         try:
-            os.kill(daemon_pid, signal.SIGTERM)
+            _kill_browser_tree(daemon_pid, session_name=session_name)
             logger.info("Reaped orphaned browser daemon PID %d (session %s)",
                         daemon_pid, session_name)
             reaped += 1


### PR DESCRIPTION
Closes #17388.

## Symptom

`hermes-agent` launches `agent-browser` (headless Chrome) for a task, the task completes, hermes dies/crashes/restarts — and days later, Chrome's renderer / GPU / helper processes are still running at 100% CPU. Reporter observed 7 Chrome processes consuming ~580% CPU for 3+ days after the owning hermes process was gone.

## Root cause

`_reap_orphaned_browser_sessions()` in `tools/browser_tool.py` detects dead-owner daemons correctly, but when it reaps them it only sends `SIGTERM` to the daemon PID itself:

```python
os.kill(daemon_pid, signal.SIGTERM)
```

The daemon spawned Chrome; Chrome spawned its renderer / GPU / network / storage helpers as its own children. When the daemon dies:
- helpers that respect SIGTERM come down with it
- helpers that ignore SIGTERM (renderers in certain states, stuck GPU helpers) get reparented to init and keep running forever

The reporter's table showed exactly that shape — GPU helper + 4 renderers + Network helper + Storage helper, each eating a whole CPU.

## Fix

Add `_descendant_pids(pid)` and `_kill_browser_tree(daemon_pid)`:

- `_descendant_pids` walks the full process tree using psutil (cross-platform); falls back to a Linux `/proc/*/status` PPid walk when psutil is absent; returns empty set otherwise (caller degrades gracefully to the old SIGTERM-only behavior).
- `_kill_browser_tree`:
  1. **Collects descendants BEFORE signalling** — once the daemon exits, init reparents helpers and the tree walk would miss them.
  2. `SIGTERM` daemon.
  3. Sleep 0.5s for graceful shutdown.
  4. `SIGKILL` any descendant still alive.

`_reap_orphaned_browser_sessions` now calls `_kill_browser_tree` instead of raw `os.kill`. Logs both the reap count and the force-kill straggler count so this class of bug becomes visible in `journalctl -u hermes-gateway` going forward.

## Not in scope

- Doesn't add a regression test. Simulating a dead-owner + live-descendants scenario requires forking real processes in CI; the existing `_reap_orphaned_browser_sessions` path has no unit tests for similar reasons. Happy to add an integration test in a follow-up if preferred.
- Doesn't touch the agent-browser daemon's own shutdown semantics. The daemon does have `AGENT_BROWSER_IDLE_TIMEOUT_MS` self-termination (#24), but that's the happy path; this PR covers the unhappy path where the owner crashed before idle fires.

## File

- `tools/browser_tool.py`: +101 / -1