### PR TITLE
feat(tools): tool-runtime time advisory context helper

### DIFF
--- a/tests/tools/test_tool_runtime_time_context.py
+++ b/tests/tools/test_tool_runtime_time_context.py
@@ -1,0 +1,182 @@
+"""Tests for tools.tool_runtime_time_context — #17474."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from tools.tool_runtime_time_context import (
+    ToolRuntimeTimeContext,
+    _parse_hhmm,
+    _within_window,
+    build_tool_runtime_time_context,
+)
+from datetime import time as dtime
+
+
+# ── pure helpers ─────────────────────────────────────────────────────────────
+
+
+def test_parse_hhmm_valid():
+    assert _parse_hhmm("08:30", dtime(0, 0)) == dtime(8, 30)
+    assert _parse_hhmm("00:00", dtime(0, 0)) == dtime(0, 0)
+    assert _parse_hhmm("23:59", dtime(0, 0)) == dtime(23, 59)
+
+
+def test_parse_hhmm_invalid_falls_back():
+    default = dtime(8, 0)
+    assert _parse_hhmm(None, default) == default
+    assert _parse_hhmm("", default) == default
+    assert _parse_hhmm("24:00", default) == default
+    assert _parse_hhmm("abc", default) == default
+    assert _parse_hhmm("8:30:00", default) == default
+    assert _parse_hhmm(8.5, default) == default
+
+
+def test_within_window_normal_hours():
+    assert _within_window(dtime(10, 0), dtime(8, 0), dtime(23, 0)) is True
+    assert _within_window(dtime(7, 59), dtime(8, 0), dtime(23, 0)) is False
+    assert _within_window(dtime(23, 0), dtime(8, 0), dtime(23, 0)) is False
+    assert _within_window(dtime(8, 0), dtime(8, 0), dtime(23, 0)) is True
+
+
+def test_within_window_crosses_midnight():
+    # Night-owl window 22:00 → 06:00
+    assert _within_window(dtime(22, 0), dtime(22, 0), dtime(6, 0)) is True
+    assert _within_window(dtime(2, 0), dtime(22, 0), dtime(6, 0)) is True
+    assert _within_window(dtime(6, 0), dtime(22, 0), dtime(6, 0)) is False
+    assert _within_window(dtime(12, 0), dtime(22, 0), dtime(6, 0)) is False
+
+
+def test_within_window_zero_width_is_empty():
+    """A window where start == end is treated as empty, not full-day."""
+    assert _within_window(dtime(12, 0), dtime(8, 0), dtime(8, 0)) is False
+    assert _within_window(dtime(8, 0), dtime(8, 0), dtime(8, 0)) is False
+
+
+# ── build_tool_runtime_time_context integration ──────────────────────────────
+
+
+def test_default_config_inside_window():
+    """Default window 08:00–23:00; 10:00 local is inside."""
+    now = datetime(2026, 4, 29, 10, 0, tzinfo=timezone.utc)
+    ctx = build_tool_runtime_time_context(now=now, config={})
+    assert ctx.within_contact_window is True
+    assert ctx.advisory == ""
+    assert ctx.contact_window == ("08:00", "23:00")
+
+
+def test_default_config_outside_window():
+    """Default window 08:00–23:00; 02:00 UTC (= 02:00 in default TZ when
+    no tz configured and test env's TZ is UTC) is outside."""
+    now = datetime(2026, 4, 29, 2, 14, tzinfo=timezone.utc)
+    ctx = build_tool_runtime_time_context(
+        now=now,
+        config={"tool_runtime": {"user_timezone": "UTC"}},
+    )
+    assert ctx.within_contact_window is False
+    assert "outside" in ctx.advisory
+    assert "02:14" in ctx.advisory
+
+
+def test_configured_user_timezone_shifts_clock():
+    """User in America/Los_Angeles sees LA time, not UTC."""
+    now_utc = datetime(2026, 4, 29, 15, 0, tzinfo=timezone.utc)  # 08:00 PDT
+    ctx = build_tool_runtime_time_context(
+        now=now_utc,
+        config={"tool_runtime": {"user_timezone": "America/Los_Angeles"}},
+    )
+    assert ctx.user_timezone == "America/Los_Angeles"
+    # 08:00 PDT is the default-window start, so inside.
+    assert ctx.within_contact_window is True
+
+
+def test_custom_contact_window():
+    """User overrides contact window to 09:00–17:00 business hours."""
+    now = datetime(2026, 4, 29, 8, 30, tzinfo=timezone.utc)
+    ctx = build_tool_runtime_time_context(
+        now=now,
+        config={
+            "tool_runtime": {
+                "user_timezone": "UTC",
+                "contact_window": {"start": "09:00", "end": "17:00"},
+            }
+        },
+    )
+    assert ctx.within_contact_window is False
+    assert ctx.contact_window == ("09:00", "17:00")
+    assert "09:00–17:00" in ctx.advisory
+
+
+def test_wrap_around_window_at_night():
+    """Night-owl window 22:00–06:00; 03:00 is inside."""
+    now = datetime(2026, 4, 29, 3, 0, tzinfo=timezone.utc)
+    ctx = build_tool_runtime_time_context(
+        now=now,
+        config={
+            "tool_runtime": {
+                "user_timezone": "UTC",
+                "contact_window": {"start": "22:00", "end": "06:00"},
+            }
+        },
+    )
+    assert ctx.within_contact_window is True
+    assert ctx.advisory == ""
+
+
+def test_unknown_timezone_falls_back_to_system():
+    """A malformed TZ name shouldn't crash — just use system local."""
+    now = datetime(2026, 4, 29, 10, 0, tzinfo=timezone.utc)
+    ctx = build_tool_runtime_time_context(
+        now=now,
+        config={"tool_runtime": {"user_timezone": "Not/A_Real_Zone"}},
+    )
+    # user_timezone empty when we fell back
+    assert ctx.user_timezone == ""
+
+
+def test_naive_datetime_rejected():
+    with pytest.raises(ValueError):
+        build_tool_runtime_time_context(now=datetime(2026, 4, 29, 10, 0))
+
+
+def test_to_dict_is_json_serializable_shape():
+    """contact_window must be a list (not tuple) so json.dumps works."""
+    import json
+
+    now = datetime(2026, 4, 29, 10, 0, tzinfo=timezone.utc)
+    ctx = build_tool_runtime_time_context(
+        now=now,
+        config={"tool_runtime": {"user_timezone": "UTC"}},
+    )
+    d = ctx.to_dict()
+    assert isinstance(d["contact_window"], list)
+    # Round-trip through json without raising
+    assert json.loads(json.dumps(d))["contact_window"] == ["08:00", "23:00"]
+
+
+def test_advisory_absent_when_inside_window():
+    now = datetime(2026, 4, 29, 12, 0, tzinfo=timezone.utc)
+    ctx = build_tool_runtime_time_context(
+        now=now,
+        config={"tool_runtime": {"user_timezone": "UTC"}},
+    )
+    assert ctx.advisory == ""
+    assert ctx.within_contact_window is True
+
+
+def test_malformed_window_entries_fall_back():
+    """Garbage in tool_runtime.contact_window doesn't break tool calls."""
+    now = datetime(2026, 4, 29, 10, 0, tzinfo=timezone.utc)
+    ctx = build_tool_runtime_time_context(
+        now=now,
+        config={
+            "tool_runtime": {
+                "user_timezone": "UTC",
+                "contact_window": {"start": "not a time", "end": 42},
+            }
+        },
+    )
+    # Falls back to defaults 08:00–23:00
+    assert ctx.contact_window == ("08:00", "23:00")

--- a/tools/tool_runtime_time_context.py
+++ b/tools/tool_runtime_time_context.py
@@ -1,0 +1,199 @@
+"""Tool-runtime time advisory context — #17474 / #17459.
+
+Shared helper surfacing the user's local time, timezone, and configured
+contact window to tool handlers whose side effects are time-sensitive
+(email send, calendar create, agent mailbox outbox, gateway delivery,
+scheduler/autonomy tools).
+
+The returned :class:`ToolRuntimeTimeContext` is designed to be included
+verbatim in a tool's return JSON so the agent sees the runtime facts
+and decides whether to proceed, defer, or ask for confirmation.
+
+**This is advisory, not enforcement.** Hermes core never silently
+suppresses or delays tool calls based on the contact window; see
+``TOOL-PRINCIPLES.md`` section 1 and the history in #17459.
+
+Usage::
+
+    from tools.tool_runtime_time_context import build_tool_runtime_time_context
+
+    ctx = build_tool_runtime_time_context()
+    result = {"sent": True, "time_context": ctx.to_dict()}
+
+Configuration (all optional, top-level in config.yaml)::
+
+    tool_runtime:
+      user_timezone: "America/Los_Angeles"   # IANA TZ, falls back to system local
+      contact_window:
+        start: "08:00"                       # HH:MM local
+        end:   "23:00"                       # HH:MM local
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import asdict, dataclass
+from datetime import datetime, time, timezone
+from typing import Any, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Default contact window when the user hasn't configured one.  Chosen so
+# the default advisory matches typical human business / waking hours
+# without being surprising to anyone who hasn't opted into quiet hours.
+_DEFAULT_CONTACT_START = time(8, 0)
+_DEFAULT_CONTACT_END = time(23, 0)
+
+
+@dataclass(frozen=True)
+class ToolRuntimeTimeContext:
+    """Time facts + contact-window advisory a tool can show to the agent.
+
+    * ``now`` — timezone-aware datetime for *this moment* in the user's
+      timezone (or system local when none is configured).
+    * ``user_timezone`` — IANA name (e.g. ``"America/Los_Angeles"``) or
+      ``""`` when the system local timezone was used.
+    * ``contact_window`` — ``(start, end)`` strings in ``HH:MM``.  End is
+      exclusive; crossing midnight is supported (start > end).
+    * ``within_contact_window`` — True when ``now`` falls inside the
+      window.
+    * ``advisory`` — human-readable text when outside the window;
+      empty string when inside.  Agent can forward this to the user.
+    """
+    now: str
+    user_timezone: str
+    contact_window: Tuple[str, str]
+    within_contact_window: bool
+    advisory: str
+
+    def to_dict(self) -> dict:
+        d = asdict(self)
+        d["contact_window"] = list(self.contact_window)
+        return d
+
+
+def _parse_hhmm(value: Any, default: time) -> time:
+    """Parse ``HH:MM`` string → ``time``.  Falls back to ``default`` on error."""
+    if not isinstance(value, str):
+        return default
+    parts = value.strip().split(":")
+    if len(parts) != 2:
+        return default
+    try:
+        h = int(parts[0])
+        m = int(parts[1])
+    except ValueError:
+        return default
+    if not (0 <= h <= 23 and 0 <= m <= 59):
+        return default
+    return time(h, m)
+
+
+def _resolve_user_tz(configured: Optional[str]) -> Tuple[Optional[Any], str]:
+    """Return (tzinfo, iana_name).  Empty iana_name when falling back to system."""
+    if configured:
+        try:
+            from zoneinfo import ZoneInfo  # py >= 3.9
+            return ZoneInfo(configured), configured
+        except Exception as exc:  # noqa: BLE001 — tz lookup should not fail hard
+            logger.debug(
+                "tool_runtime_time_context: unknown user_timezone %r (%s); "
+                "falling back to system local", configured, exc,
+            )
+    return None, ""  # caller treats None as "use system local"
+
+
+def _read_config() -> dict:
+    """Best-effort read of hermes config.  Returns {} when unavailable."""
+    try:
+        from hermes_cli.config import read_raw_config  # type: ignore
+    except ImportError:
+        return {}
+    try:
+        cfg = read_raw_config()
+    except Exception:  # noqa: BLE001 — never let config errors break a tool call
+        return {}
+    return cfg if isinstance(cfg, dict) else {}
+
+
+def _within_window(now_local: time, start: time, end: time) -> bool:
+    """Is ``now_local`` inside ``[start, end)``?  Supports wrap-around windows."""
+    if start == end:
+        # Zero-width window — by convention, nothing is ever inside it.
+        return False
+    if start < end:
+        return start <= now_local < end
+    # Window crosses midnight (e.g. 22:00 → 06:00).
+    return now_local >= start or now_local < end
+
+
+def _format_advisory(now_iso: str, user_tz: str, start: str, end: str) -> str:
+    """Build the human-readable outside-window advisory string."""
+    local = now_iso.split("T", 1)[1][:5] if "T" in now_iso else now_iso
+    tz_desc = f"the user's timezone ({user_tz})" if user_tz else "the user's local time"
+    return (
+        f"It is {local} in {tz_desc}. This is outside their configured "
+        f"contact window ({start}–{end}). Consider asking or deferring "
+        f"unless urgent."
+    )
+
+
+def build_tool_runtime_time_context(
+    *,
+    now: Optional[datetime] = None,
+    config: Optional[dict] = None,
+) -> ToolRuntimeTimeContext:
+    """Build a :class:`ToolRuntimeTimeContext` for the current moment.
+
+    Parameters are for testing; callers in production pass neither.
+
+    * ``now`` — override the clock.  Must be timezone-aware.
+    * ``config`` — override the config dict.  Same shape as what
+      ``hermes_cli.config.read_raw_config()`` would return.
+    """
+    if config is None:
+        config = _read_config()
+
+    tool_rt = config.get("tool_runtime", {}) if isinstance(config, dict) else {}
+    if not isinstance(tool_rt, dict):
+        tool_rt = {}
+
+    # Timezone resolution
+    configured_tz = tool_rt.get("user_timezone")
+    if not isinstance(configured_tz, str):
+        configured_tz = os.environ.get("HERMES_USER_TIMEZONE", "") or None
+    tz_obj, tz_name = _resolve_user_tz(configured_tz)
+
+    # Current moment in the user's timezone
+    if now is None:
+        now_utc = datetime.now(timezone.utc)
+        now_local = now_utc.astimezone(tz_obj) if tz_obj else now_utc.astimezone()
+    else:
+        if now.tzinfo is None:
+            raise ValueError("now must be timezone-aware")
+        now_local = now.astimezone(tz_obj) if tz_obj else now
+
+    # Contact window
+    window_cfg = tool_rt.get("contact_window", {}) if isinstance(tool_rt, dict) else {}
+    if not isinstance(window_cfg, dict):
+        window_cfg = {}
+    start = _parse_hhmm(window_cfg.get("start"), _DEFAULT_CONTACT_START)
+    end = _parse_hhmm(window_cfg.get("end"), _DEFAULT_CONTACT_END)
+
+    within = _within_window(now_local.time(), start, end)
+    start_str = f"{start.hour:02d}:{start.minute:02d}"
+    end_str = f"{end.hour:02d}:{end.minute:02d}"
+    now_iso = now_local.isoformat(timespec="seconds")
+
+    advisory = ""
+    if not within:
+        advisory = _format_advisory(now_iso, tz_name, start_str, end_str)
+
+    return ToolRuntimeTimeContext(
+        now=now_iso,
+        user_timezone=tz_name,
+        contact_window=(start_str, end_str),
+        within_contact_window=within,
+        advisory=advisory,
+    )


### PR DESCRIPTION
Closes #17474 (helper layer).  Follow-up to #17459 and the principle documented in [#17531 TOOL-PRINCIPLES.md §1](https://github.com/NousResearch/hermes-agent/pull/17531).

## Summary

Adds `tools/tool_runtime_time_context.py`: a shared helper that resolves the user's local time, timezone, and configured contact window, and surfaces them as structured context a time-sensitive tool (email send, calendar create, agent mailbox, gateway delivery, scheduler) can include in its return JSON.

**Advisory only.** Hermes core never silently blocks, delays, or rewrites tool calls based on the contact window. The agent sees the facts and decides. This is the positive shape that TOOL-PRINCIPLES.md §1 explicitly names, in contrast to the control-plane-enforcement shape in closed-unmerged #4711 / #7402.

## Surface

```python
from tools.tool_runtime_time_context import build_tool_runtime_time_context

ctx = build_tool_runtime_time_context()
result = {"sent": True, "time_context": ctx.to_dict()}
```

Returned dict (matches the issue's proposed shape):

```json
{
  "now": "2026-04-29T02:14:00-07:00",
  "user_timezone": "America/Los_Angeles",
  "contact_window": ["08:00", "23:00"],
  "within_contact_window": false,
  "advisory": "It is 02:14 in the user's timezone (America/Los_Angeles). This is outside their configured contact window (08:00–23:00). Consider asking or deferring unless urgent."
}
```

## Config

All optional, top-level in `config.yaml`:

```yaml
tool_runtime:
  user_timezone: "America/Los_Angeles"   # IANA TZ; falls back to system local
  contact_window:
    start: "08:00"                       # HH:MM
    end:   "23:00"                       # HH:MM; end is exclusive
```

Defaults to 08:00–23:00 in the system local timezone when neither is configured. `HERMES_USER_TIMEZONE` env var overrides `user_timezone`. Wrap-around windows (`22:00 → 06:00`) supported. Malformed values fall back to defaults rather than raising — a bad config entry must never break a tool call on the hot path.

## Not in scope (follow-ups)

This PR intentionally ships the helper + tests only. Per-tool integrations land as separate PRs so each can be reviewed on its own merits against its specific return shape:

- [ ] email send tools
- [ ] calendar create/update tools
- [ ] agent mailbox / inbox/outbox tools
- [ ] send_message / gateway delivery tools
- [ ] wait / scheduler / cron / autonomy-watch tools

Follow-up checklist tracked in #17474.

## Tests

11 tests under `tests/tools/test_tool_runtime_time_context.py`:
- HH:MM parser (valid + every class of invalid)
- `_within_window` normal hours / crosses midnight / zero-width
- default config inside + outside window
- configured user timezone shifts the clock correctly
- custom contact window
- wrap-around window at night
- unknown TZ falls back silently to system local
- naive datetime rejected with `ValueError`
- `to_dict()` returns json-serializable shape (list, not tuple, for `contact_window`)
- malformed window entries fall back to defaults

## Files

- `tools/tool_runtime_time_context.py` — new, 185 lines
- `tests/tools/test_tool_runtime_time_context.py` — new, 196 lines