### PR TITLE
fix(setup): keep max turns in config

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1643,7 +1643,7 @@ def setup_terminal_backend(config: dict):
 def _apply_default_agent_settings(config: dict):
     """Apply recommended defaults for all agent settings without prompting."""
     config.setdefault("agent", {})["max_turns"] = 90
-    save_env_value("HERMES_MAX_ITERATIONS", "90")
+    remove_env_value("HERMES_MAX_ITERATIONS")
 
     config.setdefault("display", {})["tool_progress"] = "all"
 
@@ -1673,9 +1673,9 @@ def setup_agent_settings(config: dict):
     print()
 
     # ── Max Iterations ──
-    current_max = get_env_value("HERMES_MAX_ITERATIONS") or str(
-        cfg_get(config, "agent", "max_turns", default=90)
-    )
+    agent_cfg = config.get("agent") if isinstance(config.get("agent"), dict) else {}
+    config_max = agent_cfg.get("max_turns")
+    current_max = str(config_max if config_max else (get_env_value("HERMES_MAX_ITERATIONS") or 90))
     print_info("Maximum tool-calling iterations per conversation.")
     print_info("Higher = more complex tasks, but costs more tokens.")
     print_info(
@@ -1686,9 +1686,9 @@ def setup_agent_settings(config: dict):
     try:
         max_iter = int(max_iter_str)
         if max_iter > 0:
-            save_env_value("HERMES_MAX_ITERATIONS", str(max_iter))
             config.setdefault("agent", {})["max_turns"] = max_iter
             config.pop("max_turns", None)
+            remove_env_value("HERMES_MAX_ITERATIONS")
             print_success(f"Max iterations set to {max_iter}")
     except ValueError:
         print_warning("Invalid number, keeping current value")

--- a/tests/hermes_cli/test_setup_agent_settings.py
+++ b/tests/hermes_cli/test_setup_agent_settings.py
@@ -3,8 +3,8 @@
 from hermes_cli.setup import setup_agent_settings
 
 
-def test_setup_agent_settings_uses_displayed_max_iterations_value(tmp_path, monkeypatch, capsys):
-    """The helper text should match the value shown in the prompt."""
+def test_setup_agent_settings_prefers_config_max_turns_over_stale_env(tmp_path, monkeypatch, capsys):
+    """The wizard should not surface stale HERMES_MAX_ITERATIONS when config has max_turns."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 
     config = {
@@ -14,16 +14,47 @@ def test_setup_agent_settings_uses_displayed_max_iterations_value(tmp_path, monk
         "session_reset": {"mode": "both", "idle_minutes": 1440, "at_hour": 4},
     }
 
-    prompt_answers = iter(["60", "all", "0.5"])
+    prompt_answers = iter(["90", "all", "0.5"])
+    removed_env = []
 
     monkeypatch.setattr("hermes_cli.setup.get_env_value", lambda key: "60" if key == "HERMES_MAX_ITERATIONS" else "")
     monkeypatch.setattr("hermes_cli.setup.prompt", lambda *args, **kwargs: next(prompt_answers))
     monkeypatch.setattr("hermes_cli.setup.prompt_choice", lambda *args, **kwargs: 4)
     monkeypatch.setattr("hermes_cli.setup.save_env_value", lambda *args, **kwargs: None)
+    monkeypatch.setattr("hermes_cli.setup.remove_env_value", lambda key: removed_env.append(key))
+    monkeypatch.setattr("hermes_cli.setup.save_config", lambda *args, **kwargs: None)
+
+    setup_agent_settings(config)
+
+    out = capsys.readouterr().out
+    assert "Press Enter to keep 90." in out
+    assert "Press Enter to keep 60." not in out
+    assert removed_env == ["HERMES_MAX_ITERATIONS"]
+
+
+def test_setup_agent_settings_uses_legacy_env_when_config_missing(tmp_path, monkeypatch, capsys):
+    """Legacy env-only installs still get their current max-iteration value as the default."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    config = {
+        "display": {"tool_progress": "all"},
+        "compression": {"threshold": 0.50},
+        "session_reset": {"mode": "both", "idle_minutes": 1440, "at_hour": 4},
+    }
+
+    prompt_answers = iter(["60", "all", "0.5"])
+    removed_env = []
+
+    monkeypatch.setattr("hermes_cli.setup.get_env_value", lambda key: "60" if key == "HERMES_MAX_ITERATIONS" else "")
+    monkeypatch.setattr("hermes_cli.setup.prompt", lambda *args, **kwargs: next(prompt_answers))
+    monkeypatch.setattr("hermes_cli.setup.prompt_choice", lambda *args, **kwargs: 4)
+    monkeypatch.setattr("hermes_cli.setup.save_env_value", lambda *args, **kwargs: None)
+    monkeypatch.setattr("hermes_cli.setup.remove_env_value", lambda key: removed_env.append(key))
     monkeypatch.setattr("hermes_cli.setup.save_config", lambda *args, **kwargs: None)
 
     setup_agent_settings(config)
 
     out = capsys.readouterr().out
     assert "Press Enter to keep 60." in out
-    assert "Default is 90" not in out
+    assert config["agent"]["max_turns"] == 60
+    assert removed_env == ["HERMES_MAX_ITERATIONS"]


### PR DESCRIPTION
## Summary
- Keeps `agent.max_turns` as the setup wizard source of truth instead of dual-writing `HERMES_MAX_ITERATIONS`.
- Clears the legacy `HERMES_MAX_ITERATIONS` entry when setup writes max turns, preventing stale env values from shadowing config in env-only paths.
- Preserves legacy env-only installs by using `HERMES_MAX_ITERATIONS` as the default only when config has no `agent.max_turns`.

## Root cause
The setup wizard read `HERMES_MAX_ITERATIONS` before `agent.max_turns` and wrote updates to both `.env` and `config.yaml`. That allowed an old env value to remain as a hidden second source of truth after users edited config only.

## Fix
Prefer `agent.max_turns` in setup defaults and remove `HERMES_MAX_ITERATIONS` after writing max turns to config.

## Regression coverage
- Added coverage for a stale `HERMES_MAX_ITERATIONS` not overriding configured `agent.max_turns` in the setup wizard.
- Added coverage that legacy env-only configurations still use the env value as their initial default and migrate it into config.

## Testing
- `scripts/run_tests.sh tests/hermes_cli/test_setup_agent_settings.py -q`
- `scripts/run_tests.sh tests/hermes_cli/test_setup.py::test_vercel_setup_prefills_project_and_team_from_link_file -q`
- `scripts/run_tests.sh tests/hermes_cli/test_setup_agent_settings.py tests/hermes_cli/test_setup_reconfigure.py tests/hermes_cli/test_setup_noninteractive.py -q`

Closes #17534
