### PR TITLE
fix(security): apply ACL checks to QQBot guild messages and guild DMs to prevent allowlist bypass

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -976,6 +976,18 @@ class QQAdapter(BasePlatformAdapter):
         if not channel_id:
             return
 
+        # Apply group_policy ACL — guild channels are group-like contexts.
+        # Without this check any member of any guild the bot is in could
+        # bypass the configured allowlist.
+        guild_id = str(d.get("guild_id", ""))
+        author_id = str(author.get("id", ""))
+        if not self._is_group_allowed(guild_id or channel_id, author_id):
+            logger.debug(
+                "[%s] Guild message blocked by ACL: channel=%s user=%s",
+                self._log_tag, channel_id, author_id,
+            )
+            return
+
         member = d.get("member") if isinstance(d.get("member"), dict) else {}
         nick = str(member.get("nick", "")) or str(author.get("username", ""))
 
@@ -1030,6 +1042,17 @@ class QQAdapter(BasePlatformAdapter):
         """Handle a guild DM message event."""
         guild_id = str(d.get("guild_id", ""))
         if not guild_id:
+            return
+
+        # Apply dm_policy ACL — guild DMs were previously unauthenticated.
+        # Without this check any member of any guild the bot is in could
+        # bypass the configured allowlist via direct messages.
+        author_id = str(author.get("id", ""))
+        if not self._is_dm_allowed(author_id):
+            logger.debug(
+                "[%s] Guild DM blocked by ACL: guild=%s user=%s",
+                self._log_tag, guild_id, author_id,
+            )
             return
 
         text = content


### PR DESCRIPTION
## What does this PR do?

The QQBot adapter (`gateway/platforms/qqbot/adapter.py`) applies access
control to two of its four message handlers, but **not the other two**:

| Handler | Event | ACL Check | Status |
|---|---|---|---|
| `_handle_c2c_message` | C2C_MESSAGE_CREATE | `_is_dm_allowed()` | ✅ |
| `_handle_group_message` | GROUP_AT_MESSAGE_CREATE | `_is_group_allowed()` | ✅ |
| `_handle_guild_message` | GUILD_AT_MESSAGE_CREATE | **NONE** | ❌ |
| `_handle_dm_message` | DIRECT_MESSAGE_CREATE | **NONE** | ❌ |

This means the configured `dm_policy` and `group_policy` allowlists
can be completely bypassed via guild channels or guild DMs.

## Attack scenario

Operator deploys with this config:

```yaml
platforms:
  qq:
    extra:
      dm_policy: "allowlist"
      allow_from: ["authorized_user_openid"]
      group_policy: "allowlist"
      group_allow_from: ["authorized_group_openid"]
```

The operator believes only authorized users can interact with the bot.
However:

1. `C2C_MESSAGE_CREATE` → `_is_dm_allowed()` → **rejected** ✓
2. `GUILD_AT_MESSAGE_CREATE` → no ACL → **accepted** ✗
3. `DIRECT_MESSAGE_CREATE` (guild DM) → no ACL → **accepted** ✗

Any member of any guild the bot is in can bypass the allowlist via
guild channels or direct messages.

## Fix

### `_handle_guild_message`

Apply `_is_group_allowed()` — guild channels are group-like contexts:

```python
guild_id = str(d.get("guild_id", ""))
author_id = str(author.get("id", ""))
if not self._is_group_allowed(guild_id or channel_id, author_id):
    logger.debug("[%s] Guild message blocked by ACL: ...", ...)
    return
```

### `_handle_dm_message`

Apply `_is_dm_allowed()` — guild DMs are user-level interactions:

```python
author_id = str(author.get("id", ""))
if not self._is_dm_allowed(author_id):
    logger.debug("[%s] Guild DM blocked by ACL: ...", ...)
    return
```

## Type of Change

- [x] 🔒 Security fix (HIGH — authorization bypass / ACL circumvention)

## Checklist

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Mirrors existing ACL patterns from C2C and Group handlers
- [x] No behavior change when no allowlist is configured
- [x] Backward compatible — same `dm_policy`/`group_policy` config options