### PR TITLE
fix(weixin): schedule direct sends on adapter loop

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1142,6 +1142,7 @@ class WeixinAdapter(BasePlatformAdapter):
         self._poll_session: Optional[aiohttp.ClientSession] = None
         self._send_session: Optional[aiohttp.ClientSession] = None
         self._poll_task: Optional[asyncio.Task] = None
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._dedup = MessageDeduplicator(ttl_seconds=MESSAGE_DEDUP_TTL_SECONDS)
 
         self._account_id = str(extra.get("account_id") or os.getenv("WEIXIN_ACCOUNT_ID", "")).strip()
@@ -1215,6 +1216,7 @@ class WeixinAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.debug("[%s] Token lock unavailable (non-fatal): %s", self.name, exc)
 
+        self._loop = asyncio.get_running_loop()
         self._poll_session = aiohttp.ClientSession(trust_env=True, connector=_make_ssl_connector())
         self._send_session = aiohttp.ClientSession(trust_env=True, connector=_make_ssl_connector())
         self._token_store.restore(self._account_id)
@@ -2030,30 +2032,50 @@ async def send_weixin_direct(
 
     live_adapter = _LIVE_ADAPTERS.get(resolved_token)
     send_session = getattr(live_adapter, '_send_session', None)
-    if live_adapter is not None and send_session is not None and not send_session.closed:
-        last_result: Optional[SendResult] = None
-        cleaned = live_adapter.format_message(message)
-        if cleaned:
-            last_result = await live_adapter.send(chat_id, cleaned)
-            if not last_result.success:
-                return {"error": f"Weixin send failed: {last_result.error}"}
+    adapter_loop = getattr(live_adapter, '_loop', None)
+    current_loop: Optional[asyncio.AbstractEventLoop]
+    try:
+        current_loop = asyncio.get_running_loop()
+    except RuntimeError:
+        current_loop = None
+    if (
+        live_adapter is not None
+        and send_session is not None
+        and not send_session.closed
+        and adapter_loop is not None
+        and adapter_loop.is_running()
+        and not adapter_loop.is_closed()
+    ):
+        async def _send_via_live_adapter() -> Dict[str, Any]:
+            last_result: Optional[SendResult] = None
+            cleaned = live_adapter.format_message(message)
+            if cleaned:
+                last_result = await live_adapter.send(chat_id, cleaned)
+                if not last_result.success:
+                    return {"error": f"Weixin send failed: {last_result.error}"}
 
-        for media_path, _is_voice in media_files or []:
-            ext = Path(media_path).suffix.lower()
-            if ext in {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp"}:
-                last_result = await live_adapter.send_image_file(chat_id, media_path)
-            else:
-                last_result = await live_adapter.send_document(chat_id, media_path)
-            if not last_result.success:
-                return {"error": f"Weixin media send failed: {last_result.error}"}
+            for media_path, _is_voice in media_files or []:
+                ext = Path(media_path).suffix.lower()
+                if ext in {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp"}:
+                    last_result = await live_adapter.send_image_file(chat_id, media_path)
+                else:
+                    last_result = await live_adapter.send_document(chat_id, media_path)
+                if not last_result.success:
+                    return {"error": f"Weixin media send failed: {last_result.error}"}
 
-        return {
-            "success": True,
-            "platform": "weixin",
-            "chat_id": chat_id,
-            "message_id": last_result.message_id if last_result else None,
-            "context_token_used": bool(context_token),
-        }
+            return {
+                "success": True,
+                "platform": "weixin",
+                "chat_id": chat_id,
+                "message_id": last_result.message_id if last_result else None,
+                "context_token_used": bool(context_token),
+            }
+
+        if current_loop is adapter_loop:
+            return await _send_via_live_adapter()
+
+        future = asyncio.run_coroutine_threadsafe(_send_via_live_adapter(), adapter_loop)
+        return await asyncio.wrap_future(future)
 
     async with aiohttp.ClientSession(trust_env=True, connector=_make_ssl_connector()) as session:
         adapter = WeixinAdapter(

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -5,7 +5,7 @@ import base64
 import json
 import os
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from gateway.config import PlatformConfig
 from gateway.config import GatewayConfig, HomeChannel, Platform, _apply_env_overrides
@@ -307,6 +307,69 @@ class TestWeixinSendMessageIntegration:
             "hello",
             media_files=[("/tmp/demo.png", False)],
         )
+
+    def test_send_weixin_direct_schedules_live_adapter_send_on_adapter_loop(self, tmp_path, monkeypatch):
+        """Direct sends must use the live adapter's loop for aiohttp sessions.
+
+        Cron/send_message can call send_weixin_direct from a different worker
+        loop than the gateway adapter loop. The live adapter's aiohttp sessions
+        are bound to the adapter loop, so using them on the caller's loop can
+        raise "Timeout context manager should be used inside a task".
+        """
+
+        adapter_loop = MagicMock()
+        adapter_loop.is_running.return_value = True
+        adapter_loop.is_closed.return_value = False
+        caller_loop = asyncio.new_event_loop()
+        adapter = _make_adapter()
+        adapter._send_session = MagicMock(closed=False)
+        adapter._loop = adapter_loop
+        adapter.format_message = MagicMock(return_value="hello")
+        adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="msg-1"))
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setitem(weixin._LIVE_ADAPTERS, "bot-token", adapter)
+
+        async def _call_direct():
+            return await weixin.send_weixin_direct(
+                extra={"account_id": "bot-account"},
+                token="bot-token",
+                chat_id="wxid_test123",
+                message="hello",
+            )
+
+        try:
+            with patch("gateway.platforms.weixin.asyncio.run_coroutine_threadsafe") as schedule_mock:
+                scheduled_coro = None
+
+                def _schedule(coro, loop):
+                    nonlocal scheduled_coro
+                    scheduled_coro = coro
+                    assert loop is adapter_loop
+                    import concurrent.futures
+                    future = concurrent.futures.Future()
+                    future.set_result(
+                        {
+                            "success": True,
+                            "platform": "weixin",
+                            "chat_id": "wxid_test123",
+                            "message_id": "msg-1",
+                            "context_token_used": False,
+                        }
+                    )
+                    return future
+
+                schedule_mock.side_effect = _schedule
+                result = caller_loop.run_until_complete(_call_direct())
+
+            assert result["success"] is True
+            schedule_mock.assert_called_once()
+            adapter.send.assert_not_awaited()
+            assert scheduled_coro is not None
+            scheduled_coro.close()
+        finally:
+            weixin._LIVE_ADAPTERS.pop("bot-token", None)
+            caller_loop.close()
 
 
 class TestWeixinChunkDelivery:


### PR DESCRIPTION
## Summary
- record the Weixin adapter's owning asyncio event loop when it connects
- route live-adapter direct sends back onto that adapter loop instead of using its aiohttp session from the caller loop
- add regression coverage for cron/send_message direct sends from a different loop

## Why this is needed
`send_weixin_direct()` is used by one-shot delivery paths such as `send_message` and cron delivery. When a live Weixin adapter is available, it reuses that adapter so outbound delivery can keep the adapter's context-token and media behavior.

The live adapter's `_send_session` is an `aiohttp.ClientSession` created during `WeixinAdapter.connect()`, so it belongs to the gateway adapter's asyncio event loop. Cron/tool delivery can call `send_weixin_direct()` from a different worker thread/event loop. Before this change, that path directly awaited `live_adapter.send(...)` from the caller loop, which can use the live adapter's aiohttp session on the wrong loop.

That cross-loop aiohttp session access can fail with event-loop/task errors such as:

```text
Timeout context manager should be used inside a task
```

In practice, this can make a scheduled job complete successfully but fail when delivering the result to Weixin.

## Implementation details
This PR stores the adapter's loop at connect time:

```python
self._loop = asyncio.get_running_loop()
```

Then, when `send_weixin_direct()` finds a live adapter with an open send session:

- if the caller is already on the adapter loop, it sends directly as before
- if the caller is on another loop, it schedules the send coroutine onto the adapter loop with `asyncio.run_coroutine_threadsafe(...)` and awaits the wrapped future
- if there is no usable live adapter loop, the existing standalone one-shot session fallback remains available

This preserves live adapter reuse while avoiding cross-loop use of the adapter's `aiohttp.ClientSession`.

## Test Plan
- `/home/tonyxu/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_weixin.py::TestWeixinSendMessageIntegration::test_send_weixin_direct_schedules_live_adapter_send_on_adapter_loop tests/gateway/test_weixin.py::TestWeixinSendMessageIntegration::test_send_to_platform_routes_weixin_media_to_native_helper -q -o 'addopts='`
- `/home/tonyxu/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_weixin.py -q -o 'addopts='`

Results:
- targeted tests: `2 passed, 2 warnings`
- full Weixin adapter test file: `50 passed, 2 warnings`
