### PR TITLE
fix(security): route-bound auth_format pins the webhook authentication scheme

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -9,6 +9,11 @@ Configuration lives in config.yaml under platforms.webhook.extra.routes.
 Each route defines:
   - events: which event types to accept (header-based filtering)
   - secret: HMAC secret for signature validation (REQUIRED)
+  - auth_format: pin the route to one authentication scheme ("github" =
+    body-bound HMAC via X-Hub-Signature-256 only, "gitlab" = plain
+    X-Gitlab-Token only). Default "auto" selects the scheme from request
+    headers, which lets the sender choose the weakest accepted scheme —
+    pin routes that need body integrity.
   - prompt: template string formatted with the webhook payload
   - skills: optional list of skills to load for the agent
   - deliver: where to send the response (github_comment, telegram, etc.)
@@ -80,6 +85,11 @@ _BUILTIN_DELIVER_PLATFORMS = {
 DEFAULT_HOST = "0.0.0.0"
 DEFAULT_PORT = 8644
 _INSECURE_NO_AUTH = "INSECURE_NO_AUTH"
+# Valid values for a route's optional `auth_format` field. "auto" (default)
+# selects the scheme from the request headers — legacy behavior. Pinning
+# "github" or "gitlab" binds the route to that single scheme so a sender
+# cannot pick a weaker one via headers.
+_AUTH_FORMATS = ("auto", "github", "gitlab")
 _DYNAMIC_ROUTES_FILENAME = "webhook_subscriptions.json"
 _RATE_WINDOW_SECONDS = 60.0
 # Hostnames/IP literals that only serve connections originating on the same
@@ -196,6 +206,16 @@ class WebhookAdapter(BasePlatformAdapter):
                     f"but is bound to non-loopback host '{self._host}'. "
                     f"INSECURE_NO_AUTH is for local testing only. "
                     f"Refusing to start to prevent accidental exposure."
+                )
+
+            # auth_format pins the route to a single authentication scheme;
+            # catch typos at startup rather than silently rejecting every
+            # request at runtime (the validator fails closed on unknowns).
+            auth_format = route.get("auth_format", "auto")
+            if auth_format not in _AUTH_FORMATS:
+                raise ValueError(
+                    f"[webhook] Route '{name}' has invalid auth_format "
+                    f"'{auth_format}'. Valid values: {', '.join(_AUTH_FORMATS)}."
                 )
             # deliver_only routes bypass the agent — the POST body becomes a
             # direct push notification via the configured delivery target.
@@ -532,7 +552,10 @@ class WebhookAdapter(BasePlatformAdapter):
                 status=403,
             )
         if secret != _INSECURE_NO_AUTH:
-            if not self._validate_signature(request, raw_body, secret):
+            auth_format = route_config.get("auth_format", "auto")
+            if not self._validate_signature(
+                request, raw_body, secret, auth_format
+            ):
                 logger.warning(
                     "[webhook] Invalid signature for route %s", route_name
                 )
@@ -893,9 +916,47 @@ class WebhookAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     def _validate_signature(
-        self, request: "web.Request", body: bytes, secret: str
+        self,
+        request: "web.Request",
+        body: bytes,
+        secret: str,
+        auth_format: str = "auto",
     ) -> bool:
-        """Validate webhook signature (GitHub, GitLab, Svix, generic HMAC-SHA256)."""
+        """Validate webhook signature (GitHub, GitLab, Svix, generic HMAC-SHA256).
+
+        ``auth_format`` binds a route to a single authentication scheme.
+        Under the default ``"auto"`` the scheme is selected from the request
+        headers (legacy behavior) — which means the SENDER picks the scheme:
+        a caller who knows the shared secret can downgrade a route that
+        expects body-bound HMAC integrity to the raw ``X-Gitlab-Token``
+        string comparison (which authenticates the caller but not the body).
+        Routes that need body integrity should pin ``auth_format: github``;
+        GitLab routes should pin ``auth_format: gitlab``.
+        """
+        # Route-bound scheme: only the pinned scheme's credential is
+        # consulted; any other header (present or not) cannot authenticate.
+        if auth_format == "gitlab":
+            gl_token = request.headers.get("X-Gitlab-Token", "")
+            if not gl_token:
+                return False
+            return hmac.compare_digest(gl_token, secret)
+        if auth_format == "github":
+            gh_sig = request.headers.get("X-Hub-Signature-256", "")
+            if not gh_sig:
+                return False
+            expected = "sha256=" + hmac.new(
+                secret.encode(), body, hashlib.sha256
+            ).hexdigest()
+            return hmac.compare_digest(gh_sig, expected)
+        if auth_format != "auto":
+            # Unknown value (connect() validates static routes, but fail
+            # closed here too so handler reuse can't skip that check).
+            logger.warning(
+                "[webhook] Unknown auth_format %r; rejecting request",
+                auth_format,
+            )
+            return False
+
         def _header(name: str) -> str:
             return (
                 request.headers.get(name, "")
@@ -930,6 +991,9 @@ class WebhookAdapter(BasePlatformAdapter):
             return hmac.compare_digest(gh_sig, expected)
 
         # GitLab: X-Gitlab-Token = <plain secret>
+        # NOTE: authenticates the caller but does NOT bind the body. Routes
+        # that need body integrity must pin `auth_format: github` — under
+        # "auto" a sender who knows the secret can always choose this branch.
         gl_token = request.headers.get("X-Gitlab-Token", "")
         if gl_token:
             return hmac.compare_digest(gl_token, secret)

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -453,6 +453,156 @@ class TestValidateSignature:
         assert adapter._validate_signature(req, body, secret) is True
 
 
+class TestAuthFormatPinning:
+    """Route-bound authentication-format selection via `auth_format`.
+
+    Under the default "auto", the validator picks the scheme from request
+    headers — so a sender who knows the shared secret can downgrade an
+    HMAC route to the raw X-Gitlab-Token comparison (authenticates the
+    caller, but not the body). Pinning `auth_format` on the route closes
+    that: only the pinned scheme's credential is consulted.
+    """
+
+    def test_github_pinned_rejects_valid_gitlab_token(self):
+        """The downgrade attack: a correct GitLab token + non-empty JSON
+        body must NOT authenticate against an HMAC-pinned route."""
+        adapter = _make_adapter()
+        secret = "shared-secret"
+        body = b'{"action": "opened", "injected": "attacker-controlled"}'
+        req = _mock_request(headers={"X-Gitlab-Token": secret})
+        assert (
+            adapter._validate_signature(req, body, secret, auth_format="github")
+            is False
+        )
+
+    def test_github_pinned_accepts_valid_hmac(self):
+        adapter = _make_adapter()
+        secret = "shared-secret"
+        body = b'{"action": "opened"}'
+        sig = _github_signature(body, secret)
+        req = _mock_request(headers={"X-Hub-Signature-256": sig})
+        assert (
+            adapter._validate_signature(req, body, secret, auth_format="github")
+            is True
+        )
+
+    def test_github_pinned_ignores_gitlab_token_next_to_valid_hmac(self):
+        """A stray X-Gitlab-Token must not disturb a valid pinned HMAC."""
+        adapter = _make_adapter()
+        secret = "shared-secret"
+        body = b'{"action": "opened"}'
+        sig = _github_signature(body, secret)
+        req = _mock_request(headers={
+            "X-Hub-Signature-256": sig,
+            "X-Gitlab-Token": "whatever",
+        })
+        assert (
+            adapter._validate_signature(req, body, secret, auth_format="github")
+            is True
+        )
+
+    def test_gitlab_pinned_accepts_correct_token(self):
+        adapter = _make_adapter()
+        secret = "gl-token-value"
+        req = _mock_request(headers={"X-Gitlab-Token": secret})
+        assert (
+            adapter._validate_signature(req, b"{}", secret, auth_format="gitlab")
+            is True
+        )
+
+    def test_gitlab_pinned_rejects_wrong_token(self):
+        adapter = _make_adapter()
+        req = _mock_request(headers={"X-Gitlab-Token": "wrong"})
+        assert (
+            adapter._validate_signature(req, b"{}", "correct", auth_format="gitlab")
+            is False
+        )
+
+    def test_gitlab_pinned_rejects_hmac_signature(self):
+        """A gitlab-pinned route must not accept HMAC (or any other) scheme."""
+        adapter = _make_adapter()
+        secret = "shared-secret"
+        body = b'{"action": "opened"}'
+        sig = _github_signature(body, secret)
+        req = _mock_request(headers={"X-Hub-Signature-256": sig})
+        assert (
+            adapter._validate_signature(req, body, secret, auth_format="gitlab")
+            is False
+        )
+
+    def test_unpinned_route_keeps_legacy_gitlab_behavior(self):
+        """No auth_format on the route → header-driven selection unchanged
+        (mirrors test_validate_gitlab_token, including an empty-ish body)."""
+        adapter = _make_adapter()
+        secret = "gl-token-value"
+        req = _mock_request(headers={"X-Gitlab-Token": secret})
+        assert adapter._validate_signature(req, b"{}", secret) is True
+
+    def test_unknown_auth_format_fails_closed(self):
+        adapter = _make_adapter()
+        secret = "gl-token-value"
+        req = _mock_request(headers={"X-Gitlab-Token": secret})
+        assert (
+            adapter._validate_signature(req, b"{}", secret, auth_format="nope")
+            is False
+        )
+
+    @pytest.mark.asyncio
+    async def test_handler_uses_route_auth_format(self):
+        """End-to-end: the handler reads auth_format from the route config —
+        a valid GitLab token 401s on a github-pinned route, while a valid
+        HMAC signature on the same route is dispatched."""
+        secret = "shared-secret"
+        routes = {
+            "gh": {
+                "secret": secret,
+                "auth_format": "github",
+                "prompt": "PR: {action}",
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        body = json.dumps({"action": "opened"}).encode()
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/gh",
+                data=body,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Gitlab-Token": secret,
+                },
+            )
+            assert resp.status == 401, (
+                "valid GitLab token must not authenticate a github-pinned route"
+            )
+
+            resp = await cli.post(
+                "/webhooks/gh",
+                data=body,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Hub-Signature-256": _github_signature(body, secret),
+                },
+            )
+            assert resp.status == 202
+
+    @pytest.mark.asyncio
+    async def test_connect_rejects_invalid_auth_format(self):
+        """A typo'd auth_format fails at startup, not silently at runtime."""
+        routes = {
+            "gh": {
+                "secret": "s3cret",
+                "auth_format": "githab",
+                "prompt": "x",
+            }
+        }
+        adapter = _make_adapter(routes=routes, host="127.0.0.1")
+        with pytest.raises(ValueError, match="auth_format"):
+            await adapter.connect()
+
+
 # ===================================================================
 # Prompt rendering
 # ===================================================================

--- a/website/docs/user-guide/messaging/webhooks.md
+++ b/website/docs/user-guide/messaging/webhooks.md
@@ -291,6 +291,35 @@ platforms:
           deliver: "log"
 ```
 
+### Pinning the authentication format (`auth_format`)
+
+By default (`auth_format: auto`) the gateway selects the authentication
+scheme from the request headers: a GitHub-style HMAC signature
+(`X-Hub-Signature-256`), a GitLab plain token (`X-Gitlab-Token`), Svix, or
+the generic HMAC signatures. This means the *sender* picks the scheme — a
+caller who knows the shared secret can authenticate an HMAC route with a
+plain `X-Gitlab-Token` header instead, which verifies the caller but does
+**not** bind the request body.
+
+Set the optional `auth_format` field to pin a route to a single scheme:
+
+```yaml
+routes:
+  github-pr:
+    secret: "github-webhook-secret"
+    auth_format: "github"   # only body-bound HMAC (X-Hub-Signature-256)
+    # ...
+  gitlab-mr:
+    secret: "your-gitlab-secret-token"
+    auth_format: "gitlab"   # only the plain X-Gitlab-Token header
+    # ...
+```
+
+Valid values: `auto` (default, header-driven selection), `github`
+(body-bound HMAC only), `gitlab` (plain token only). On a pinned route,
+credentials for any other scheme are rejected. Pin `auth_format: github`
+on any route where the payload contents must be tamper-proof.
+
 ---
 
 ## Delivery Options {#delivery-options}


### PR DESCRIPTION
## What does this PR do?

Closes a header-driven authentication-downgrade hole in the generic webhook adapter.

`_validate_signature()` selects the authentication scheme from the **request headers**: whichever recognised header the sender supplies decides how the request is validated. A sender who knows the shared secret can therefore authenticate a route that expects body-bound HMAC integrity (`X-Hub-Signature-256`) by sending the plain `X-Gitlab-Token` header instead — the raw token comparison verifies the caller but places no integrity binding on the body, so arbitrary payloads validate.

An earlier revision of this PR added an empty-body guard to the GitLab branch. Review (sweeper) correctly pointed out it does not stop the attack — any non-empty body still passes — because the root cause is that the *sender* picks the scheme. That guard is removed.

## Fix: route-bound authentication-format selection

New optional per-route `auth_format` field:

| Value | Behavior |
|-------|----------|
| `auto` (default) | Header-driven selection — legacy behavior, byte-for-byte unchanged |
| `github` | Only body-bound HMAC (`X-Hub-Signature-256`) is consulted; `X-Gitlab-Token` (or anything else) cannot authenticate |
| `gitlab` | Only the plain `X-Gitlab-Token` header is consulted; HMAC and other schemes are rejected |

- Unknown `auth_format` values are rejected at startup (`connect()` raises `ValueError`) and fail closed at runtime.
- `auth_format: auto` (or omitting the field) preserves existing behavior exactly, so current deployments are unaffected.

## Tests (`tests/gateway/test_webhook_adapter.py`)

- **Downgrade regression:** correct GitLab token + non-empty JSON body against a `github`-pinned route → rejected (unit + end-to-end through the HTTP handler, which 401s the token and 202s a valid HMAC on the same route)
- `gitlab`-pinned route: correct token accepted, wrong token rejected, HMAC signature rejected
- Unpinned route: legacy header-driven behavior unchanged (mirrors the existing GitLab token test)
- Unknown `auth_format`: fails closed at runtime, rejected at startup

## Docs

`website/docs/user-guide/messaging/webhooks.md` documents the field, the downgrade risk under `auto`, and when to pin.

## Type of Change

- [x] 🔒 Security fix