### PR TITLE
feat(delegate): add inception prompting to child agent system prompts

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -93,6 +93,28 @@ class TestChildSystemPrompt(unittest.TestCase):
         prompt = _build_child_system_prompt("Do something", "  ")
         self.assertNotIn("CONTEXT", prompt)
 
+    def test_inception_prompting_directives_present(self):
+        prompt = _build_child_system_prompt("Refactor the auth module")
+        self.assertIn("Do not ask questions", prompt)
+        self.assertIn("Do not restate or paraphrase", prompt)
+        self.assertIn("it seems fine", prompt)
+        self.assertIn("fails twice", prompt)
+
+    def test_inception_prompting_role_anchor(self):
+        prompt = _build_child_system_prompt("Fix the bug")
+        self.assertIn("executing a delegated task", prompt)
+        self.assertNotIn("focused subagent working on", prompt)
+
+    def test_inception_prompting_with_context(self):
+        prompt = _build_child_system_prompt("Fix the bug", "Error in line 42")
+        self.assertIn("Do not ask questions", prompt)
+        self.assertIn("CONTEXT", prompt)
+
+    def test_inception_prompting_orchestrator_role(self):
+        prompt = _build_child_system_prompt("Coordinate the refactor", role="orchestrator")
+        self.assertIn("Do not ask questions", prompt)
+        self.assertIn("Subagent Spawning", prompt)
+
 
 class TestStripBlockedTools(unittest.TestCase):
     def test_removes_blocked_toolsets(self):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -570,7 +570,11 @@ def _build_child_system_prompt(
     max_spawn_depth: int = 2,
     child_depth: int = 1,
 ) -> str:
-    """Build a focused system prompt for a child agent.
+    """Build a hardened system prompt for a child agent.
+
+    Injects inception-prompting directives (role-anchoring, anti-echo,
+    output format enforcement, convergence pressure) to prevent role-flip,
+    instruction echoing, flake replies, and infinite retry loops.
 
     When role='orchestrator', appends a delegation-capability block
     modeled on OpenClaw's buildSubagentSystemPrompt (canSpawn branch at
@@ -579,7 +583,14 @@ def _build_child_system_prompt(
     the LLM doesn't confabulate nesting capabilities that don't exist.
     """
     parts = [
-        "You are a focused subagent working on a specific delegated task.",
+        "You are a subagent executing a delegated task. Do the work directly.",
+        "",
+        "## Execution Rules",
+        "",
+        "- Do not ask questions, request clarification, or suggest the parent do the work instead.",
+        "- Do not restate or paraphrase the task — perform it using your tools and report concrete results.",
+        '- Your response must include specific findings, file paths, code snippets, or other concrete artifacts. Vague summaries like \"it seems fine\" or \"further investigation needed\" are not acceptable.',
+        "- If an approach fails twice, try a fundamentally different approach rather than retrying the same thing.",
         "",
         f"YOUR TASK:\n{goal}",
     ]


### PR DESCRIPTION
## Summary
Implements Phase 1 of #375: inception prompting for child agent system prompts.

---

## Root cause
Sub-agents spawned via `delegate_task` exhibit four failure modes documented in CAMEL-AI's NeurIPS 2023 research: role-flipping (agent asks the parent to do the work instead), instruction echoing (agent restates the task without performing it), flake replies ("it seems fine", "further investigation needed"), and infinite retry loops (same broken approach repeated until iterations run out).

---

## Fix
Added four inception-prompting directives to `_build_child_system_prompt()` in `tools/delegate_tool.py`: role-anchoring ("Do the work directly"), anti-echo ("Do not restate or paraphrase the task"), output format enforcement (requires concrete findings, file paths, code snippets, bans vague summaries), and convergence pressure ("If an approach fails twice, try a fundamentally different approach").

---

## What changed
* `tools/delegate_tool.py`: replaced opening prompt line and added Execution Rules block in `_build_child_system_prompt()`
* `tools/delegate_tool.py`: updated docstring to reflect hardened behavior
* `tests/tools/test_delegate.py`: added 4 tests to `TestChildSystemPrompt` covering all four directives

---

## What is not affected
* `delegate_task` call signature: unchanged, zero API changes
* Orchestrator role: inception directives apply to all roles including orchestrator
* Batch mode: all child agents in a batch receive hardened prompts

---

## Behavioral change
Sub-agent prompts are now hardened. Agents will no longer ask questions, restate tasks, or return vague summaries. This change directly addresses the failure modes described in #375 Phase 1.

---

## Observed behavior
After this change, two delegate_task runs were verified:

1. File listing task: sub-agent returned concrete file paths, line counts, and per-file descriptions across 6 tool calls with no role-flip, no echo, and no vague summaries.

2. Refactoring recommendations task ("What files should I refactor?"): sub-agent read all 5 project files, returned a prioritized list with exact file paths, line numbers, and specific issues ("Massive duplication", "Thread-unsafe cache", "Dead parameters") with a suggested order of work. No role-flip, no echo, no flake replies, no scope creep.

---

## Tests
3 existing + 4 new = 7 total, all pass.
* `test_inception_prompting_directives_present` - all four directives present in every child prompt
* `test_inception_prompting_role_anchor` - role anchor present, old phrasing absent
* `test_inception_prompting_with_context` - directives present even when context is provided
* `test_inception_prompting_orchestrator_role` - directives present for orchestrator role too

---

This is a prerequisite for the simplify skill (#379): hardened sub-agent prompts directly address the timeout and quality issues observed in parallel review agents.

Phase 2 (enhanced guard rails for multi-agent workflows) and Phase 3 (adaptive prompting) are planned as follow-up PRs.

Part of #375 (Phase 1/3)