### PR TITLE
fix: harden Telegram lanes and cron no-reply delivery

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -109,10 +109,20 @@ _LEGACY_HOME_TARGET_ENV_VARS = {
 
 from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_run
 
-# Sentinel: when a cron agent has nothing new to report, it can start its
-# response with this marker to suppress delivery.  Output is still saved
-# locally for audit.
+# Sentinels: when a cron agent has nothing new to report, it can include one of
+# these markers to suppress delivery. Output is still saved locally for audit.
 SILENT_MARKER = "[SILENT]"
+NO_REPLY_MARKER = "NO_REPLY"
+
+
+def _should_suppress_delivery(content: str, *, success: bool) -> bool:
+    """Return True when cron output asks the scheduler not to deliver."""
+    normalized = (content or "").strip().upper()
+    if not normalized:
+        return False
+    if NO_REPLY_MARKER in normalized:
+        return True
+    return success and SILENT_MARKER in normalized
 
 # Resolve Hermes home directory (respects HERMES_HOME override)
 _hermes_home = get_hermes_home()
@@ -744,9 +754,9 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
         "the output yourself. Just produce your report/output as your "
         "final response and the system handles the rest. "
         "SILENT: If there is genuinely nothing new to report, respond "
-        "with exactly \"[SILENT]\" (nothing else) to suppress delivery. "
-        "Never combine [SILENT] with content — either report your "
-        "findings normally, or say [SILENT] and nothing more.]\n\n"
+        "with exactly \"[SILENT]\" or \"NO_REPLY\" (nothing else) to suppress delivery. "
+        "Never combine [SILENT] or NO_REPLY with content — either report your "
+        "findings normally, or use one suppression marker and nothing more.]\n\n"
     )
     prompt = cron_hint + prompt
     if skills is None:
@@ -1297,12 +1307,22 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
                     logger.info("Output saved to: %s", output_file)
 
                 # Deliver the final response to the origin/target chat.
-                # If the agent responded with [SILENT], skip delivery (but
-                # output is already saved above).  Failed jobs always deliver.
+                # Suppression markers skip delivery (but output is already saved).
+                # [SILENT] suppresses successful no-op runs; NO_REPLY is explicit
+                # user intent and suppresses any cron message containing it.
                 deliver_content = final_response if success else f"⚠️ Cron job '{job.get('name', job['id'])}' failed:\n{error}"
                 should_deliver = bool(deliver_content)
-                if should_deliver and success and SILENT_MARKER in deliver_content.strip().upper():
-                    logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
+                suppression_content = deliver_content
+                if not success:
+                    suppression_content = "\n".join(
+                        part for part in (deliver_content, final_response, error) if part
+                    )
+                if should_deliver and _should_suppress_delivery(suppression_content, success=success):
+                    logger.info(
+                        "Job '%s': agent returned %s/NO_REPLY suppression marker — skipping delivery",
+                        job["id"],
+                        SILENT_MARKER,
+                    )
                     should_deliver = False
 
                 delivery_error = None

--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -19,6 +19,11 @@ logger = logging.getLogger(__name__)
 DIRECTORY_PATH = get_hermes_home() / "channel_directory.json"
 
 
+def _overrides_path():
+    """Return the optional user-maintained channel directory override path."""
+    return DIRECTORY_PATH.with_name("channel_directory_overrides.json")
+
+
 def _normalize_channel_query(value: str) -> str:
     return value.lstrip("#").strip().lower()
 
@@ -51,6 +56,225 @@ def _session_entry_name(origin: Dict[str, Any]) -> str:
 
     topic_label = origin.get("chat_topic") or f"topic {thread_id}"
     return f"{base_name} / {topic_label}"
+
+
+def _load_channel_overrides() -> Dict[str, List[Dict[str, Any]]]:
+    """Load manually configured channel entries.
+
+    Some platforms (notably Telegram) do not expose a reliable bot-side list of
+    every reachable group. Session history only discovers chats after the bot has
+    spoken there in Hermes. This optional override file lets a user keep a small,
+    machine-readable registry of known lanes without fabricating sessions.
+    """
+    path = _overrides_path()
+    if not path.exists():
+        return {}
+
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+    except Exception as e:
+        logger.debug("Channel directory: failed to read overrides: %s", e)
+        return {}
+
+    platforms = data.get("platforms", data) if isinstance(data, dict) else {}
+    if not isinstance(platforms, dict):
+        return {}
+
+    cleaned: Dict[str, List[Dict[str, Any]]] = {}
+    for platform_name, entries in platforms.items():
+        if not isinstance(platform_name, str) or not isinstance(entries, list):
+            continue
+
+        valid_entries: List[Dict[str, Any]] = []
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            channel_id = str(entry.get("id", "")).strip()
+            name = str(entry.get("name", "")).strip()
+            if not channel_id or not name:
+                continue
+
+            normalized = {k: v for k, v in entry.items() if v is not None}
+            normalized["id"] = channel_id
+            normalized["name"] = name
+            normalized["type"] = str(normalized.get("type") or "channel")
+            valid_entries.append(normalized)
+
+        if valid_entries:
+            cleaned[platform_name.strip().lower()] = valid_entries
+
+    return cleaned
+
+
+def _merge_channel_overrides(directory: Dict[str, Any]) -> Dict[str, Any]:
+    """Merge user-maintained channel overrides into a directory payload."""
+    overrides = _load_channel_overrides()
+    if not overrides:
+        return directory
+
+    platforms = directory.setdefault("platforms", {})
+    if not isinstance(platforms, dict):
+        platforms = {}
+        directory["platforms"] = platforms
+
+    for platform_name, override_entries in overrides.items():
+        existing = platforms.setdefault(platform_name, [])
+        if not isinstance(existing, list):
+            existing = []
+            platforms[platform_name] = existing
+
+        index_by_id = {
+            str(entry.get("id")): idx
+            for idx, entry in enumerate(existing)
+            if isinstance(entry, dict) and entry.get("id") is not None
+        }
+        for override_entry in override_entries:
+            channel_id = override_entry["id"]
+            if channel_id in index_by_id:
+                idx = index_by_id[channel_id]
+                merged = dict(existing[idx])
+                merged.update(override_entry)
+                existing[idx] = merged
+            else:
+                index_by_id[channel_id] = len(existing)
+                existing.append(dict(override_entry))
+
+    return directory
+
+
+def _base_chat_id(channel_id: str) -> str:
+    """Return the Telegram chat id part of a possible chat_id:thread_id entry."""
+    return str(channel_id).split(":", 1)[0]
+
+
+def _telegram_api_chat_id(chat_id: str):
+    """Coerce numeric Telegram ids to int while allowing username-style ids."""
+    text = str(chat_id).strip()
+    return int(text) if text.lstrip("-").isdigit() else text
+
+
+def _enum_value(value: Any) -> str:
+    raw = getattr(value, "value", value)
+    return str(raw or "").lower()
+
+
+def _telegram_chat_type(chat: Any) -> str:
+    chat_type = _enum_value(getattr(chat, "type", ""))
+    if chat_type in {"group", "supergroup"}:
+        return "forum" if bool(getattr(chat, "is_forum", False)) else "group"
+    if chat_type == "private":
+        return "dm"
+    if chat_type == "channel":
+        return "channel"
+    return chat_type or "chat"
+
+
+def _telegram_chat_name(chat: Any, fallback: str) -> str:
+    return str(
+        getattr(chat, "title", None)
+        or getattr(chat, "full_name", None)
+        or getattr(chat, "username", None)
+        or fallback
+    )
+
+
+def _telegram_member_can_send(chat_type: str, member: Any) -> bool:
+    status = _enum_value(getattr(member, "status", ""))
+    if status in {"left", "kicked", "banned"}:
+        return False
+    if status == "restricted":
+        can_send = getattr(member, "can_send_messages", None)
+        return bool(can_send) if can_send is not None else True
+    if chat_type == "channel":
+        if status == "creator":
+            return True
+        return status == "administrator" and getattr(member, "can_post_messages", False) is not False
+    return bool(status)
+
+
+def _sanitize_probe_error(error: Exception) -> str:
+    text = str(error).strip().splitlines()[0] if str(error).strip() else error.__class__.__name__
+    try:
+        from agent.redact import redact_sensitive_text
+        text = redact_sensitive_text(text)
+    except Exception:
+        pass
+    return text[:240]
+
+
+async def _verify_telegram_reachability(adapter: Any, entries: List[Dict[str, Any]]) -> None:
+    """Annotate Telegram entries with non-sending Bot API reachability checks."""
+    bot = getattr(adapter, "_bot", None)
+    if not bot or not entries:
+        return
+
+    checked_at = datetime.now().isoformat()
+    bot_user_id = None
+    try:
+        me = await bot.get_me()
+        bot_user_id = getattr(me, "id", None)
+    except Exception as e:
+        logger.debug("Channel directory: Telegram get_me probe failed: %s", _sanitize_probe_error(e))
+
+    probe_cache: Dict[str, Dict[str, Any]] = {}
+    for entry in entries:
+        if not isinstance(entry, dict) or not entry.get("id"):
+            continue
+        chat_id = _base_chat_id(str(entry["id"]))
+        if chat_id in probe_cache:
+            entry.update(probe_cache[chat_id])
+            continue
+
+        try:
+            chat = await bot.get_chat(_telegram_api_chat_id(chat_id))
+            chat_type = _telegram_chat_type(chat)
+            fields: Dict[str, Any] = {
+                "reachable": True,
+                "reachability_checked_at": checked_at,
+                "reachability_source": "telegram:getChat",
+                "verified_name": _telegram_chat_name(chat, entry.get("name", chat_id)),
+            }
+            if chat_type:
+                fields["type"] = chat_type
+
+            if chat_type == "dm" or bot_user_id is None:
+                fields["can_send_messages"] = True
+            else:
+                member = await bot.get_chat_member(_telegram_api_chat_id(chat_id), bot_user_id)
+                fields["bot_status"] = _enum_value(getattr(member, "status", ""))
+                fields["can_send_messages"] = _telegram_member_can_send(chat_type, member)
+                fields["reachability_source"] = "telegram:getChat+getChatMember"
+
+            entry.update(fields)
+            entry.pop("reachability_error", None)
+            probe_cache[chat_id] = fields
+        except Exception as e:
+            fields = {
+                "reachable": False,
+                "can_send_messages": False,
+                "reachability_checked_at": checked_at,
+                "reachability_source": "telegram:getChat",
+                "reachability_error": _sanitize_probe_error(e),
+            }
+            entry.update(fields)
+            probe_cache[chat_id] = fields
+
+
+def _channel_status_note(channel: Dict[str, Any]) -> str:
+    """Return an optional human-readable delivery status line for a directory entry."""
+    if "reachable" not in channel and "can_send_messages" not in channel:
+        return ""
+    if channel.get("reachable") is False:
+        detail = channel.get("reachability_error") or "bot cannot access this chat"
+        return f"unreachable — {detail}"
+    if channel.get("can_send_messages") is False:
+        status = channel.get("bot_status")
+        return f"reachable, but bot may not be allowed to post{f' ({status})' if status else ''}"
+    if channel.get("reachable") is True:
+        status = channel.get("bot_status")
+        return f"verified sendable{f' ({status})' if status else ''}"
+    return ""
 
 
 # ---------------------------------------------------------------------------
@@ -90,6 +314,17 @@ async def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
         "updated_at": datetime.now().isoformat(),
         "platforms": platforms,
     }
+    directory = _merge_channel_overrides(directory)
+
+    telegram_adapter = adapters.get(Platform.TELEGRAM) if adapters else None
+    if telegram_adapter is not None:
+        try:
+            await _verify_telegram_reachability(
+                telegram_adapter,
+                directory.get("platforms", {}).get("telegram", []),
+            )
+        except Exception as e:
+            logger.debug("Channel directory: Telegram reachability probe failed: %s", e)
 
     try:
         atomic_json_write(DIRECTORY_PATH, directory)
@@ -237,12 +472,12 @@ def _build_from_sessions(platform_name: str) -> List[Dict[str, str]]:
 def load_directory() -> Dict[str, Any]:
     """Load the cached channel directory from disk."""
     if not DIRECTORY_PATH.exists():
-        return {"updated_at": None, "platforms": {}}
+        return _merge_channel_overrides({"updated_at": None, "platforms": {}})
     try:
         with open(DIRECTORY_PATH, encoding="utf-8") as f:
-            return json.load(f)
+            return _merge_channel_overrides(json.load(f))
     except Exception:
-        return {"updated_at": None, "platforms": {}}
+        return _merge_channel_overrides({"updated_at": None, "platforms": {}})
 
 
 def lookup_channel_type(platform_name: str, chat_id: str) -> Optional[str]:
@@ -330,15 +565,24 @@ def format_directory_for_display() -> str:
                 lines.append(f"Discord ({guild_name}):")
                 for ch in sorted(guild_channels, key=lambda c: c["name"]):
                     lines.append(f"  discord:{_channel_target_name(plat_name, ch)}")
+                    status_note = _channel_status_note(ch)
+                    if status_note:
+                        lines.append(f"    status: {status_note}")
             if dms:
                 lines.append("Discord (DMs):")
                 for ch in dms:
                     lines.append(f"  discord:{_channel_target_name(plat_name, ch)}")
+                    status_note = _channel_status_note(ch)
+                    if status_note:
+                        lines.append(f"    status: {status_note}")
             lines.append("")
         else:
             lines.append(f"{plat_name.title()}:")
             for ch in channels:
                 lines.append(f"  {plat_name}:{_channel_target_name(plat_name, ch)}")
+                status_note = _channel_status_note(ch)
+                if status_note:
+                    lines.append(f"    status: {status_note}")
             lines.append("")
 
     lines.append('Use these as the "target" parameter when sending.')

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -7,7 +7,16 @@ from unittest.mock import AsyncMock, patch, MagicMock
 
 import pytest
 
-from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, _send_media_via_adapter, run_job, SILENT_MARKER, _build_job_prompt
+from cron.scheduler import (
+    _resolve_origin,
+    _resolve_delivery_target,
+    _deliver_result,
+    _send_media_via_adapter,
+    run_job,
+    SILENT_MARKER,
+    NO_REPLY_MARKER,
+    _build_job_prompt,
+)
 from tools.env_passthrough import clear_env_passthrough
 from tools.credential_files import clear_credential_files
 
@@ -1343,8 +1352,29 @@ class TestSilentDelivery:
             tick(verbose=False)
         deliver_mock.assert_not_called()
 
-    def test_failed_job_always_delivers(self):
-        """Failed jobs deliver regardless of [SILENT] in output."""
+    def test_no_reply_suppresses_delivery(self):
+        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
+             patch("cron.scheduler.run_job", return_value=(True, "# output", NO_REPLY_MARKER, None)), \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler._deliver_result") as deliver_mock, \
+             patch("cron.scheduler.mark_job_run"):
+            from cron.scheduler import tick
+            tick(verbose=False)
+        deliver_mock.assert_not_called()
+
+    def test_no_reply_inside_response_suppresses_delivery(self):
+        response = "No relevant updates. NO_REPLY"
+        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
+             patch("cron.scheduler.run_job", return_value=(True, "# output", response, None)), \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler._deliver_result") as deliver_mock, \
+             patch("cron.scheduler.mark_job_run"):
+            from cron.scheduler import tick
+            tick(verbose=False)
+        deliver_mock.assert_not_called()
+
+    def test_failed_job_always_delivers_without_no_reply(self):
+        """Failed jobs still deliver unless NO_REPLY is present."""
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
              patch("cron.scheduler.run_job", return_value=(False, "# output", "", "some error")), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
@@ -1353,6 +1383,16 @@ class TestSilentDelivery:
             from cron.scheduler import tick
             tick(verbose=False)
         deliver_mock.assert_called_once()
+
+    def test_failed_job_no_reply_suppresses_delivery(self):
+        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
+             patch("cron.scheduler.run_job", return_value=(False, "# output", NO_REPLY_MARKER, "NO_REPLY")), \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler._deliver_result") as deliver_mock, \
+             patch("cron.scheduler.mark_job_run"):
+            from cron.scheduler import tick
+            tick(verbose=False)
+        deliver_mock.assert_not_called()
 
     def test_output_saved_even_when_delivery_suppressed(self):
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
@@ -1374,6 +1414,7 @@ class TestBuildJobPromptSilentHint:
         job = {"prompt": "Check for updates"}
         result = _build_job_prompt(job)
         assert "[SILENT]" in result
+        assert "NO_REPLY" in result
         assert "Check for updates" in result
 
     def test_hint_present_even_without_prompt(self):

--- a/tests/gateway/test_channel_directory.py
+++ b/tests/gateway/test_channel_directory.py
@@ -15,6 +15,7 @@ from gateway.channel_directory import (
     load_directory,
     _build_from_sessions,
     _build_slack,
+    _verify_telegram_reachability,
     DIRECTORY_PATH,
 )
 
@@ -49,8 +50,125 @@ class TestLoadDirectory:
             result = load_directory()
         assert result["updated_at"] is None
 
+    def test_merges_user_overrides_when_cache_missing(self, tmp_path):
+        cache_file = tmp_path / "channel_directory.json"
+        overrides = tmp_path / "channel_directory_overrides.json"
+        overrides.write_text(json.dumps({
+            "platforms": {
+                "telegram": [
+                    {"id": "-1001", "name": "SageWiz", "type": "group"},
+                ]
+            }
+        }))
+
+        with patch("gateway.channel_directory.DIRECTORY_PATH", cache_file):
+            result = load_directory()
+
+        assert result["platforms"]["telegram"] == [
+            {"id": "-1001", "name": "SageWiz", "type": "group"}
+        ]
+
+    def test_user_overrides_update_existing_entry(self, tmp_path):
+        cache_file = _write_directory(tmp_path, {
+            "telegram": [{"id": "-1001", "name": "Old Name", "type": "group"}]
+        })
+        overrides = tmp_path / "channel_directory_overrides.json"
+        overrides.write_text(json.dumps({
+            "platforms": {
+                "telegram": [
+                    {"id": "-1001", "name": "SageWiz", "type": "group", "source": "override"},
+                ]
+            }
+        }))
+
+        with patch("gateway.channel_directory.DIRECTORY_PATH", cache_file):
+            result = load_directory()
+
+        assert result["platforms"]["telegram"] == [
+            {"id": "-1001", "name": "SageWiz", "type": "group", "source": "override"}
+        ]
+
+
+class TestTelegramReachabilityProbe:
+    def test_marks_group_sendable_without_sending_message(self):
+        bot = SimpleNamespace(
+            get_me=AsyncMock(return_value=SimpleNamespace(id=42)),
+            get_chat=AsyncMock(return_value=SimpleNamespace(type="supergroup", title="SageWiz", is_forum=False)),
+            get_chat_member=AsyncMock(return_value=SimpleNamespace(status="member")),
+        )
+        entries = [{"id": "-1001", "name": "SageWiz", "type": "group"}]
+
+        asyncio.run(_verify_telegram_reachability(SimpleNamespace(_bot=bot), entries))
+
+        assert entries[0]["reachable"] is True
+        assert entries[0]["can_send_messages"] is True
+        assert entries[0]["bot_status"] == "member"
+        assert entries[0]["verified_name"] == "SageWiz"
+        bot.get_chat.assert_awaited_once_with(-1001)
+        bot.get_chat_member.assert_awaited_once_with(-1001, 42)
+
+    def test_marks_unreachable_without_sending_message(self):
+        bot = SimpleNamespace(
+            get_me=AsyncMock(return_value=SimpleNamespace(id=42)),
+            get_chat=AsyncMock(side_effect=RuntimeError("Forbidden: bot is not a member")),
+            get_chat_member=AsyncMock(),
+        )
+        entries = [{"id": "-1002", "name": "Financials", "type": "group"}]
+
+        asyncio.run(_verify_telegram_reachability(SimpleNamespace(_bot=bot), entries))
+
+        assert entries[0]["reachable"] is False
+        assert entries[0]["can_send_messages"] is False
+        assert "Forbidden" in entries[0]["reachability_error"]
+        bot.get_chat.assert_awaited_once_with(-1002)
+        bot.get_chat_member.assert_not_awaited()
+
+    def test_dm_get_chat_success_is_sendable(self):
+        bot = SimpleNamespace(
+            get_me=AsyncMock(return_value=SimpleNamespace(id=42)),
+            get_chat=AsyncMock(return_value=SimpleNamespace(type="private", full_name="SKT Trader")),
+            get_chat_member=AsyncMock(),
+        )
+        entries = [{"id": "7685032119", "name": "SKT Trader", "type": "dm"}]
+
+        asyncio.run(_verify_telegram_reachability(SimpleNamespace(_bot=bot), entries))
+
+        assert entries[0]["reachable"] is True
+        assert entries[0]["can_send_messages"] is True
+        assert entries[0]["type"] == "dm"
+        bot.get_chat_member.assert_not_awaited()
+
 
 class TestBuildChannelDirectoryWrites:
+    def test_build_probes_telegram_overrides_without_sending(self, tmp_path):
+        from gateway.config import Platform
+
+        cache_file = tmp_path / "channel_directory.json"
+        (tmp_path / "channel_directory_overrides.json").write_text(json.dumps({
+            "platforms": {
+                "telegram": [
+                    {"id": "-1001", "name": "SageWiz", "type": "group"},
+                ]
+            }
+        }))
+        bot = SimpleNamespace(
+            get_me=AsyncMock(return_value=SimpleNamespace(id=42)),
+            get_chat=AsyncMock(return_value=SimpleNamespace(type="supergroup", title="SageWiz", is_forum=False)),
+            get_chat_member=AsyncMock(return_value=SimpleNamespace(status="member")),
+        )
+
+        with patch("gateway.channel_directory.DIRECTORY_PATH", cache_file), \
+             patch("gateway.channel_directory._build_from_sessions", return_value=[]):
+            directory = asyncio.run(build_channel_directory({
+                Platform.TELEGRAM: SimpleNamespace(_bot=bot),
+            }))
+
+        entry = directory["platforms"]["telegram"][0]
+        assert entry["name"] == "SageWiz"
+        assert entry["reachable"] is True
+        assert entry["can_send_messages"] is True
+        assert json.loads(cache_file.read_text())["platforms"]["telegram"][0]["reachable"] is True
+
     def test_failed_write_preserves_previous_cache(self, tmp_path, monkeypatch):
         cache_file = _write_directory(tmp_path, {
             "telegram": [{"id": "123", "name": "Alice", "type": "dm"}]
@@ -289,6 +407,25 @@ class TestFormatDirectoryForDisplay:
         assert "telegram:Alice" in result
         assert "telegram:Dev Group" in result
         assert "telegram:Coaching Chat / topic 17585" in result
+
+    def test_telegram_display_keeps_target_line_clean_with_status_note(self, tmp_path):
+        cache_file = _write_directory(tmp_path, {
+            "telegram": [
+                {
+                    "id": "456",
+                    "name": "Dev Group",
+                    "type": "group",
+                    "reachable": True,
+                    "can_send_messages": True,
+                    "bot_status": "member",
+                },
+            ]
+        })
+        with patch("gateway.channel_directory.DIRECTORY_PATH", cache_file):
+            result = format_directory_for_display()
+
+        assert "  telegram:Dev Group (group)\n    status: verified sendable (member)" in result
+        assert "telegram:Dev Group (group) [" not in result
 
     def test_discord_grouped_by_guild(self, tmp_path):
         cache_file = _write_directory(tmp_path, {


### PR DESCRIPTION
## Summary
- Add optional channel directory overrides so known Telegram lanes can resolve even when live discovery is incomplete.
- Add non-sending Telegram `getChat` / `getChatMember` reachability probes and display verified sendable status.
- Treat `NO_REPLY` as an explicit cron delivery suppression marker, including embedded occurrences.

## Verification
- `HERMES_HOME=$TMP_HOME uv run --extra dev python -m pytest tests/cron/test_scheduler.py tests/gateway/test_channel_directory.py -q -o 'addopts='` — 140 passed.
- Ran non-sending Telegram reachability probe against configured lane IDs: all known lanes verified sendable.

## Note
- Full tests currently stop during collection in this checkout because optional/pre-existing deps/modules are unavailable (`acp`, `numpy`) and `tests/gateway/test_session.py` imports a missing `normalize_whatsapp_identifier`; focused affected tests pass.
