### PR TITLE
fix(api-server): use session-scoped task IDs for tool isolation

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2351,10 +2351,11 @@ class APIServerAdapter(BasePlatformAdapter):
             )
             if agent_ref is not None:
                 agent_ref[0] = agent
+            effective_task_id = session_id or str(uuid.uuid4())
             result = agent.run_conversation(
                 user_message=user_message,
                 conversation_history=conversation_history,
-                task_id="default",
+                task_id=effective_task_id,
             )
             usage = {
                 "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
@@ -2551,10 +2552,11 @@ class APIServerAdapter(BasePlatformAdapter):
                 )
                 self._active_run_agents[run_id] = agent
                 def _run_sync():
+                    effective_task_id = session_id or run_id
                     r = agent.run_conversation(
                         user_message=user_message,
                         conversation_history=conversation_history,
-                        task_id="default",
+                        task_id=effective_task_id,
                     )
                     u = {
                         "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -333,6 +333,36 @@ def auth_adapter():
 
 
 # ---------------------------------------------------------------------------
+# Adapter internals
+# ---------------------------------------------------------------------------
+
+
+class TestAgentExecution:
+    @pytest.mark.asyncio
+    async def test_run_agent_uses_session_id_as_task_id(self, adapter):
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = {"final_response": "ok"}
+        mock_agent.session_prompt_tokens = 1
+        mock_agent.session_completion_tokens = 2
+        mock_agent.session_total_tokens = 3
+
+        with patch.object(adapter, "_create_agent", return_value=mock_agent):
+            result, usage = await adapter._run_agent(
+                user_message="hello",
+                conversation_history=[],
+                session_id="session-123",
+            )
+
+        assert result == {"final_response": "ok"}
+        assert usage == {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3}
+        mock_agent.run_conversation.assert_called_once_with(
+            user_message="hello",
+            conversation_history=[],
+            task_id="session-123",
+        )
+
+
+# ---------------------------------------------------------------------------
 # /health endpoint
 # ---------------------------------------------------------------------------
 

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -253,10 +253,7 @@ class TestRunStatus:
                     await asyncio.sleep(0.05)
 
                 mock_agent.run_conversation.assert_called_once()
-                # task_id stays "default" so the Runs API shares one sandbox
-                # container with CLI/gateway; session_id is surfaced in status
-                # for external UIs to correlate runs with their own session IDs.
-                assert mock_agent.run_conversation.call_args.kwargs["task_id"] == "default"
+                assert mock_agent.run_conversation.call_args.kwargs["task_id"] == "space-session"
                 assert status["session_id"] == "space-session"
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fix API server run isolation by passing session-scoped `task_id` values into `agent.run_conversation()` instead of hardcoding `"default"`.

Previously, API server requests shared the same task identity for tool/runtime isolation, which could cause separate sessions or runs to reuse the same terminal/browser/process state. This change aligns task isolation with the session identity already tracked by the API server.

## Changes

- use `session_id` as the `task_id` in the shared API server agent execution path
- use `session_id` (or `run_id` fallback) as the `task_id` for `/v1/runs`
- add regression coverage for `_run_agent()` task propagation
- update `/v1/runs` test expectations to verify session-scoped task IDs

## Why

The API server already creates and tracks per-session identities, but tool execution was still routed through `task_id="default"`. That collapsed runtime isolation across otherwise distinct API conversations.

## Testing

- `tests/gateway/test_api_server.py::TestAgentExecution::test_run_agent_uses_session_id_as_task_id`
- `tests/gateway/test_api_server.py`
- `tests/gateway/test_api_server_runs.py::TestRunStatus::test_status_reflects_explicit_session_id`
