### PR TITLE
fix(local): recover when persistent_shell cwd is deleted (#17558)

### DIFF
--- a/tests/tools/test_local_env_cwd_recovery.py
+++ b/tests/tools/test_local_env_cwd_recovery.py
@@ -43,25 +43,53 @@ class TestResolveSafeCwd:
         monkeypatch.setattr(os.path, "isdir", lambda p: False)
         assert _resolve_safe_cwd("/no/such/dir") == tempfile.gettempdir()
 
+    def test_returns_root_when_only_root_exists(self, monkeypatch):
+        """If every ancestor except the filesystem root is gone, the root
+        itself is still a valid recovery target — don't skip it just because
+        ``os.path.dirname('/') == '/'`` is the loop's exit condition."""
+        sep = os.path.sep
+        monkeypatch.setattr(os.path, "isdir", lambda p: p == sep)
+        assert _resolve_safe_cwd("/no/such/deep/dir") == sep
+
 
 def _fake_interrupt():
     return threading.Event()
 
 
-def _make_fake_popen(captured: dict):
+def _make_fake_popen(captured: dict, fds: list):
+    """Build a fake ``Popen`` whose ``stdout`` exposes a real OS file
+    descriptor so ``BaseEnvironment._wait_for_process`` can call
+    ``select.select([fd], ...)`` and ``os.read(fd, ...)`` against it without
+    tripping ``TypeError: fileno() returned a non-integer`` from a MagicMock
+    ``fileno()`` (or worse, accidentally reading from the test runner's own
+    stdout).
+
+    The pipe's write end is closed immediately so the drain loop sees EOF on
+    the first iteration.  Every fd handed out is appended to ``fds`` so the
+    caller can clean up after the test.
+    """
     def fake_popen(cmd, **kwargs):
         captured["cwd"] = kwargs.get("cwd")
         captured["env"] = kwargs.get("env", {})
+        read_fd, write_fd = os.pipe()
+        os.close(write_fd)
+        stdout = os.fdopen(read_fd, "rb", buffering=0)
+        fds.append(stdout)
         proc = MagicMock()
         proc.poll.return_value = 0
         proc.returncode = 0
-        proc.stdout = MagicMock(
-            __iter__=lambda s: iter([]),
-            __next__=lambda s: (_ for _ in ()).throw(StopIteration),
-        )
+        proc.stdout = stdout
         proc.stdin = MagicMock()
         return proc
     return fake_popen
+
+
+def _close_fds(fds):
+    for f in fds:
+        try:
+            f.close()
+        except Exception:
+            pass
 
 
 class TestRunBashCwdRecovery:
@@ -82,11 +110,15 @@ class TestRunBashCwdRecovery:
         assert env.cwd == str(wedged) and not os.path.isdir(env.cwd)
 
         captured = {}
-        with patch("tools.environments.local._find_bash", return_value="/bin/bash"), \
-             patch("subprocess.Popen", side_effect=_make_fake_popen(captured)), \
-             patch("tools.terminal_tool._interrupt_event", _fake_interrupt()), \
-             caplog.at_level("WARNING", logger="tools.environments.local"):
-            env.execute("echo hello")
+        fds: list = []
+        try:
+            with patch("tools.environments.local._find_bash", return_value="/bin/bash"), \
+                 patch("subprocess.Popen", side_effect=_make_fake_popen(captured, fds)), \
+                 patch("tools.terminal_tool._interrupt_event", _fake_interrupt()), \
+                 caplog.at_level("WARNING", logger="tools.environments.local"):
+                env.execute("echo hello")
+        finally:
+            _close_fds(fds)
 
         # Popen must have been handed a real, existing directory.
         assert captured["cwd"] == str(tmp_path)
@@ -103,11 +135,15 @@ class TestRunBashCwdRecovery:
             env = LocalEnvironment(cwd=str(tmp_path), timeout=10)
 
         captured = {}
-        with patch("tools.environments.local._find_bash", return_value="/bin/bash"), \
-             patch("subprocess.Popen", side_effect=_make_fake_popen(captured)), \
-             patch("tools.terminal_tool._interrupt_event", _fake_interrupt()), \
-             caplog.at_level("WARNING", logger="tools.environments.local"):
-            env.execute("echo hello")
+        fds: list = []
+        try:
+            with patch("tools.environments.local._find_bash", return_value="/bin/bash"), \
+                 patch("subprocess.Popen", side_effect=_make_fake_popen(captured, fds)), \
+                 patch("tools.terminal_tool._interrupt_event", _fake_interrupt()), \
+                 caplog.at_level("WARNING", logger="tools.environments.local"):
+                env.execute("echo hello")
+        finally:
+            _close_fds(fds)
 
         assert captured["cwd"] == str(tmp_path)
         assert env.cwd == str(tmp_path)

--- a/tests/tools/test_local_env_cwd_recovery.py
+++ b/tests/tools/test_local_env_cwd_recovery.py
@@ -1,0 +1,151 @@
+"""Tests for LocalEnvironment recovery when ``self.cwd`` is deleted.
+
+When a tool call inside the persistent terminal session ``rm -rf``'s its own
+working directory, the next ``subprocess.Popen(..., cwd=self.cwd)`` would
+otherwise raise ``FileNotFoundError`` before bash starts, wedging every
+subsequent terminal/file-tool call until the gateway restarts.
+
+Regression coverage for https://github.com/NousResearch/hermes-agent/issues/17558.
+"""
+
+import os
+import shutil
+import tempfile
+import threading
+from unittest.mock import MagicMock, patch
+
+from tools.environments.local import (
+    LocalEnvironment,
+    _resolve_safe_cwd,
+)
+
+
+class TestResolveSafeCwd:
+    """Pure-function unit tests for the recovery helper."""
+
+    def test_returns_cwd_when_directory_exists(self, tmp_path):
+        path = str(tmp_path)
+        assert _resolve_safe_cwd(path) == path
+
+    def test_walks_up_to_first_existing_ancestor(self, tmp_path):
+        nested = tmp_path / "child" / "grandchild"
+        nested.mkdir(parents=True)
+        deleted = str(nested)
+        shutil.rmtree(tmp_path / "child")
+
+        # The deepest existing ancestor on the path is tmp_path itself.
+        assert _resolve_safe_cwd(deleted) == str(tmp_path)
+
+    def test_falls_back_when_path_is_empty(self):
+        assert _resolve_safe_cwd("") == tempfile.gettempdir()
+
+    def test_returns_tempdir_when_nothing_on_path_exists(self, monkeypatch):
+        monkeypatch.setattr(os.path, "isdir", lambda p: False)
+        assert _resolve_safe_cwd("/no/such/dir") == tempfile.gettempdir()
+
+
+def _fake_interrupt():
+    return threading.Event()
+
+
+def _make_fake_popen(captured: dict):
+    def fake_popen(cmd, **kwargs):
+        captured["cwd"] = kwargs.get("cwd")
+        captured["env"] = kwargs.get("env", {})
+        proc = MagicMock()
+        proc.poll.return_value = 0
+        proc.returncode = 0
+        proc.stdout = MagicMock(
+            __iter__=lambda s: iter([]),
+            __next__=lambda s: (_ for _ in ()).throw(StopIteration),
+        )
+        proc.stdin = MagicMock()
+        return proc
+    return fake_popen
+
+
+class TestRunBashCwdRecovery:
+    """End-to-end recovery: deleted ``self.cwd`` must not crash Popen."""
+
+    def test_recovers_when_cwd_deleted_after_init(self, tmp_path, caplog):
+        """Reproduces the wedge from #17558: cwd was valid when the
+        snapshot was taken, but a subsequent command deleted it before the
+        next ``Popen``."""
+        wedged = tmp_path / "wedge-repro"
+        wedged.mkdir()
+
+        with patch.object(LocalEnvironment, "init_session", autospec=True, return_value=None):
+            env = LocalEnvironment(cwd=str(wedged), timeout=10)
+
+        # The previous tool call deleted the working directory.
+        shutil.rmtree(wedged)
+        assert env.cwd == str(wedged) and not os.path.isdir(env.cwd)
+
+        captured = {}
+        with patch("tools.environments.local._find_bash", return_value="/bin/bash"), \
+             patch("subprocess.Popen", side_effect=_make_fake_popen(captured)), \
+             patch("tools.terminal_tool._interrupt_event", _fake_interrupt()), \
+             caplog.at_level("WARNING", logger="tools.environments.local"):
+            env.execute("echo hello")
+
+        # Popen must have been handed a real, existing directory.
+        assert captured["cwd"] == str(tmp_path)
+        assert os.path.isdir(captured["cwd"])
+
+        # ``self.cwd`` is updated so the next call doesn't re-warn.
+        assert env.cwd == str(tmp_path)
+
+        # The warning surfaces the wedge so it isn't silently masked.
+        assert any("missing on disk" in rec.message for rec in caplog.records)
+
+    def test_no_warning_when_cwd_still_exists(self, tmp_path, caplog):
+        with patch.object(LocalEnvironment, "init_session", autospec=True, return_value=None):
+            env = LocalEnvironment(cwd=str(tmp_path), timeout=10)
+
+        captured = {}
+        with patch("tools.environments.local._find_bash", return_value="/bin/bash"), \
+             patch("subprocess.Popen", side_effect=_make_fake_popen(captured)), \
+             patch("tools.terminal_tool._interrupt_event", _fake_interrupt()), \
+             caplog.at_level("WARNING", logger="tools.environments.local"):
+            env.execute("echo hello")
+
+        assert captured["cwd"] == str(tmp_path)
+        assert env.cwd == str(tmp_path)
+        assert not any("missing on disk" in rec.message for rec in caplog.records)
+
+
+class TestUpdateCwdRejectsMissingPaths:
+    """``_update_cwd`` must not propagate a deleted path back into ``self.cwd``."""
+
+    def test_skips_assignment_when_marker_path_missing(self, tmp_path):
+        original = tmp_path / "starting"
+        original.mkdir()
+
+        with patch.object(LocalEnvironment, "init_session", autospec=True, return_value=None):
+            env = LocalEnvironment(cwd=str(original), timeout=10)
+
+        # Simulate the stale-marker case: the prior command's ``pwd -P`` left
+        # a path in the cwd file, but that path has since been deleted.
+        deleted = tmp_path / "wedge-repro"
+        with open(env._cwd_file, "w") as f:
+            f.write(str(deleted))
+
+        env._update_cwd({"output": "", "returncode": 0})
+
+        assert env.cwd == str(original)
+
+    def test_accepts_assignment_when_marker_path_exists(self, tmp_path):
+        original = tmp_path / "starting"
+        original.mkdir()
+        new_dir = tmp_path / "next"
+        new_dir.mkdir()
+
+        with patch.object(LocalEnvironment, "init_session", autospec=True, return_value=None):
+            env = LocalEnvironment(cwd=str(original), timeout=10)
+
+        with open(env._cwd_file, "w") as f:
+            f.write(str(new_dir))
+
+        env._update_cwd({"output": "", "returncode": 0})
+
+        assert env.cwd == str(new_dir)

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1,5 +1,6 @@
 """Local execution environment — spawn-per-call with session snapshot."""
 
+import logging
 import os
 import platform
 import shutil
@@ -10,6 +11,30 @@ import tempfile
 from tools.environments.base import BaseEnvironment, _pipe_stdin
 
 _IS_WINDOWS = platform.system() == "Windows"
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_safe_cwd(cwd: str) -> str:
+    """Return ``cwd`` if it exists as a directory, else the nearest existing
+    ancestor.  Falls back to ``tempfile.gettempdir()`` only if walking up the
+    path can't find any existing directory (effectively never on a healthy
+    filesystem, but cheap belt-and-braces).
+
+    Used by ``_run_bash`` to recover when the configured cwd is gone — most
+    commonly because a previous tool call deleted its own working directory
+    (issue #17558).  Without this guard, ``subprocess.Popen(..., cwd=...)``
+    raises ``FileNotFoundError`` before bash starts, wedging every subsequent
+    terminal call until the gateway restarts.
+    """
+    if cwd and os.path.isdir(cwd):
+        return cwd
+    parent = os.path.dirname(cwd) if cwd else ""
+    while parent and parent != os.path.dirname(parent):
+        if os.path.isdir(parent):
+            return parent
+        parent = os.path.dirname(parent)
+    return tempfile.gettempdir()
 
 
 # Hermes-internal env vars that should NOT leak into terminal subprocesses.
@@ -357,6 +382,21 @@ class LocalEnvironment(BaseEnvironment):
         args = [bash, "-l", "-c", cmd_string] if login else [bash, "-c", cmd_string]
         run_env = _make_run_env(self.env)
 
+        # Recover when the cwd has been deleted out from under us — usually by
+        # a previous tool call that ran ``rm -rf`` on its own working dir
+        # (issue #17558).  Popen would otherwise raise FileNotFoundError on
+        # the cwd before bash starts, wedging every subsequent call until the
+        # gateway restarts.
+        safe_cwd = _resolve_safe_cwd(self.cwd)
+        if safe_cwd != self.cwd:
+            logger.warning(
+                "LocalEnvironment cwd %r is missing on disk; "
+                "falling back to %r so terminal commands keep working.",
+                self.cwd,
+                safe_cwd,
+            )
+            self.cwd = safe_cwd
+
         proc = subprocess.Popen(
             args,
             text=True,
@@ -394,11 +434,17 @@ class LocalEnvironment(BaseEnvironment):
                 pass
 
     def _update_cwd(self, result: dict):
-        """Read CWD from temp file (local-only, no round-trip needed)."""
+        """Read CWD from temp file (local-only, no round-trip needed).
+
+        Skip the assignment when the path no longer exists as a directory —
+        ``pwd -P`` on a deleted cwd can leave a stale value in the marker
+        file, and propagating it would re-wedge the next ``Popen``.  The
+        ``_run_bash`` recovery path will resolve a safe fallback if needed.
+        """
         try:
             with open(self._cwd_file) as f:
                 cwd_path = f.read().strip()
-            if cwd_path:
+            if cwd_path and os.path.isdir(cwd_path):
                 self.cwd = cwd_path
         except (OSError, FileNotFoundError):
             pass

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -30,10 +30,15 @@ def _resolve_safe_cwd(cwd: str) -> str:
     if cwd and os.path.isdir(cwd):
         return cwd
     parent = os.path.dirname(cwd) if cwd else ""
-    while parent and parent != os.path.dirname(parent):
+    while parent:
         if os.path.isdir(parent):
             return parent
-        parent = os.path.dirname(parent)
+        next_parent = os.path.dirname(parent)
+        if next_parent == parent:
+            # Reached the filesystem root and it doesn't exist either —
+            # genuinely nothing to fall back to except the temp dir.
+            break
+        parent = next_parent
     return tempfile.gettempdir()
 
 


### PR DESCRIPTION
## Summary
- Recover gracefully in `LocalEnvironment._run_bash` when `self.cwd` no longer exists on disk, so a single `rm -rf` on the cwd can no longer wedge every subsequent tool call until the gateway restarts.
- Reject stale paths in `LocalEnvironment._update_cwd` so the marker-file write from a `pwd -P` against a deleted cwd doesn't get propagated back into `self.cwd`.

Fixes #17558.

## The bug
With `terminal.persistent_shell: true` (the default), a single agent command can permanently break the LocalEnvironment for the rest of the gateway's lifetime:

```
mkdir -p /tmp/wedge-repro
cd /tmp/wedge-repro
rm -rf /tmp/wedge-repro
pwd
```

After `rm -rf`, `self.cwd` still holds `/tmp/wedge-repro` from the prior `_update_cwd`. The next call hits `subprocess.Popen(args, ..., cwd=self.cwd)`, which raises `FileNotFoundError: [Errno 2] No such file or directory: '/tmp/wedge-repro'` **before bash even starts**. There is no path forward — every subsequent terminal/file-tool call fails the same way until the gateway is restarted.

## The fix
1. **`_run_bash` — recover before `Popen`.** A new `_resolve_safe_cwd(cwd)` helper returns `cwd` when it exists, otherwise the nearest existing ancestor (with `tempfile.gettempdir()` as a final guard). When the resolved path differs from `self.cwd`, log a `WARNING` ("LocalEnvironment cwd %r is missing on disk; falling back to %r ...") and update `self.cwd` so the next call doesn't re-warn. The wedge becomes a recoverable, observable event instead of a silent gateway-wide break.
2. **`_update_cwd` — refuse to store missing paths.** `pwd -P` against a deleted cwd can leave stale text in the marker file. Adding `os.path.isdir(cwd_path)` to the existing truthy guard means we only adopt a new cwd that actually exists. The `_run_bash` recovery still handles paths that disappear *between* calls; this guard prevents propagating known-bad values *during* the same call.

The maintainer-flagged anti-pattern of "silently fall back to `$HOME` so commands run in the wrong project dir" (closed PR #13165) is avoided two ways: the warning makes the fallback visible, and the ancestor walk lands the recovery near the original cwd (e.g. `/tmp` when `/tmp/wedge-repro` was deleted) rather than $HOME.

## Test plan
- [x] Focused regression: `tests/tools/test_local_env_cwd_recovery.py` (8 cases)
  - `_resolve_safe_cwd` unit tests: returns existing cwd, walks up to ancestor, handles empty path, falls back to tempdir when nothing exists.
  - `_run_bash` E2E: wedge scenario recovers (Popen receives existing dir, `self.cwd` updated, warning logged); no spurious warning when cwd still exists.
  - `_update_cwd` defense in depth: refuses missing path in marker file; still accepts valid replacement.
- [x] Adjacent suite: 68 passes across `tests/tools/test_local_env_blocklist.py`, `test_local_tempdir.py`, `test_local_shell_init.py`, `test_local_background_child_hang.py`, `test_base_environment.py` (one local-env-specific failure in `test_local_interrupt_cleanup.py::test_wait_for_process_kills_subprocess_on_keyboardinterrupt` reproduces on clean `origin/main` — baseline, unrelated).
- [x] Regression guard: with the recovery block in `_run_bash` neutralized AND the `_update_cwd` guard reverted, `test_recovers_when_cwd_deleted_after_init` and `test_skips_assignment_when_marker_path_missing` both fail; restoring both fixes flips them to passing.

## Related
- Fixes #17558.
- Issue references #6607 (same root-cause class in `checkpoint_manager._run_git`) and #4982 (same class in `cli.py` via `os.getcwd()`); this PR is intentionally scoped to the `tools/environments/local.py` execution path. The other call sites can be addressed in follow-ups now that the helper exists.
- #17342 (hypen-o, open) targets `_update_cwd` for a different scenario (Windows POSIX-path overwrite). Orthogonal — different surface, no overlap.
- Closed PR #13165 (tangyuanjc, 2026-04-29) tried to silently fall back to `$HOME` at config-resolution time; the maintainer rejected it because it masked bad project config. This PR's fallback is at runtime (after the cwd was valid), is logged at WARNING, and lands in the closest existing ancestor rather than `$HOME` — so it surfaces the wedge instead of hiding it.