### PR TITLE
feat(cron): add cron.show_job_id to drop (job_id:) line from delivery wrapper

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -364,20 +364,27 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 
     # Optionally wrap the content with a header/footer so the user knows this
     # is a cron delivery.  Wrapping is on by default; set cron.wrap_response: false
-    # in config.yaml for clean output.
+    # in config.yaml for clean output.  The (job_id: ...) line inside the
+    # wrapper can be hidden independently via cron.show_job_id: false (default
+    # true) for users who want to keep the human-friendly header/footer but
+    # find the bare job id reads as debug noise in chat.
     wrap_response = True
+    show_job_id = True
     try:
         user_cfg = load_config()
-        wrap_response = user_cfg.get("cron", {}).get("wrap_response", True)
+        cron_cfg = user_cfg.get("cron", {})
+        wrap_response = cron_cfg.get("wrap_response", True)
+        show_job_id = cron_cfg.get("show_job_id", True)
     except Exception:
         pass
 
     if wrap_response:
         task_name = job.get("name", job["id"])
         job_id = job.get("id", "")
+        job_id_line = f"(job_id: {job_id})\n" if show_job_id else ""
         delivery_content = (
             f"Cronjob Response: {task_name}\n"
-            f"(job_id: {job_id})\n"
+            f"{job_id_line}"
             f"-------------\n\n"
             f"{content}\n\n"
             f"To stop or manage this job, send me a new message (e.g. \"stop reminder {task_name}\")."

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -369,6 +369,34 @@ class TestDeliverResultWrapping:
         sent_content = send_mock.call_args.kwargs.get("content") or send_mock.call_args[0][-1]
         assert "Cronjob Response: abc-123" in sent_content
 
+    def test_delivery_omits_job_id_when_show_job_id_false(self):
+        """When cron.show_job_id is false, wrapper retains header/footer but drops the (job_id:) line."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("cron.scheduler.load_config", return_value={"cron": {"show_job_id": False}}):
+            job = {
+                "id": "test-job",
+                "name": "daily-report",
+                "deliver": "origin",
+                "origin": {"platform": "telegram", "chat_id": "123"},
+            }
+            _deliver_result(job, "Here is today's summary.")
+
+        send_mock.assert_called_once()
+        sent_content = send_mock.call_args.kwargs.get("content") or send_mock.call_args[0][-1]
+        assert "Cronjob Response: daily-report" in sent_content
+        assert "(job_id:" not in sent_content
+        assert "-------------" in sent_content
+        assert "Here is today's summary." in sent_content
+        assert "To stop or manage this job" in sent_content
+
     def test_delivery_skips_wrapping_when_config_disabled(self):
         """When cron.wrap_response is false, deliver raw content without header/footer."""
         from gateway.config import Platform

--- a/website/docs/developer-guide/cron-internals.md
+++ b/website/docs/developer-guide/cron-internals.md
@@ -188,6 +188,7 @@ For Telegram topics, use the format `telegram:<chat_id>:<thread_id>` (e.g., `tel
 
 By default (`cron.wrap_response: true`), cron deliveries are wrapped with:
 - A header identifying the cron job name and task
+- A `(job_id: <id>)` line below the header (can be hidden with `cron.show_job_id: false` while keeping the rest of the wrapper)
 - A footer noting the agent cannot see the delivered message in conversation
 
 The `[SILENT]` prefix in a cron response suppresses delivery entirely — useful for jobs that only need to write to files or perform side effects.

--- a/website/docs/guides/cron-troubleshooting.md
+++ b/website/docs/guides/cron-troubleshooting.md
@@ -97,6 +97,13 @@ cron:
   wrap_response: false
 ```
 
+To keep the wrapper but hide just the `(job_id: …)` line (useful when the job id reads as noise in chat but the header/footer are still wanted), set `cron.show_job_id: false`:
+
+```yaml
+cron:
+  show_job_id: false
+```
+
 ---
 
 ## Skill Loading Failures

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -261,6 +261,14 @@ cron:
   wrap_response: false
 ```
 
+To keep the human-friendly header and footer but drop the bare `(job_id: …)` line (which can read as debug noise in chat), set `cron.show_job_id` to `false`:
+
+```yaml
+# ~/.hermes/config.yaml
+cron:
+  show_job_id: false
+```
+
 ### Silent suppression
 
 If the agent's final response starts with `[SILENT]`, delivery is suppressed entirely. The output is still saved locally for audit (in `~/.hermes/cron/output/`), but no message is sent to the delivery target.


### PR DESCRIPTION
## Summary

Add `cron.show_job_id` (default `true`) so operators can drop the `(job_id: <id>)` line from cron delivery wrappers without losing the helpful `Cronjob Response: …` header and the `to stop or manage` footer.

## Why

Today the only knob is `cron.wrap_response: false`, which strips the entire wrapper. Some operators want to keep the human-friendly header and footer but find the bare `(job_id: …)` line reads as debug noise in chat (Mattermost, Telegram, Discord, Slack, WhatsApp, etc — every adapter except yuanbao, which has its own per-platform stripper). This PR adds a finer-grained switch.

## Behavior

- `cron.show_job_id: true` (default) — unchanged from today.
- `cron.show_job_id: false` — wrapper still appears, but the `(job_id: <id>)` line is omitted.

## How to test

```yaml
# ~/.hermes/config.yaml
cron:
  show_job_id: false
```

Trigger any cron job that delivers to a chat platform; the message keeps `Cronjob Response: <name>` and the footer but no longer has the job-id line.

## Tests

- New unit test: `tests/cron/test_scheduler.py::TestDeliverResultWrapping::test_delivery_omits_job_id_when_show_job_id_false`
- Existing wrapping tests unchanged and still pass (`pytest tests/cron/` — 264 passing locally).

## Docs

Updated `website/docs/user-guide/features/cron.md`, `website/docs/guides/cron-troubleshooting.md`, and `website/docs/developer-guide/cron-internals.md` to mention the new flag alongside the existing `wrap_response` examples.

## Yuanbao note (transparency)

`gateway/platforms/yuanbao.py::strip_cron_wrapper` uses the `\n(job_id: ` substring as a sentinel to confirm a cron wrapper before stripping it. With `show_job_id: false`, that sentinel is absent, so yuanbao no longer auto-strips the header/footer in that specific combo. This matches user expectation: someone who flips `show_job_id: false` is opting into seeing the header/footer, and yuanbao users who want the entire wrapper stripped already have today's default behavior. Left untouched in this PR — happy to follow up with a stronger sentinel (e.g. keying on `Cronjob Response:` prefix + divider) if preferred.

## Platforms tested

Linux (Debian-based, Python 3.11), `pytest tests/cron/` — all 264 tests pass.