### PR TITLE
fix(install): promote croniter to a core dependency

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -313,9 +313,10 @@ def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None
     elif schedule["kind"] == "cron":
         if not HAS_CRONITER:
             logger.warning(
-                "Cannot compute next run for cron schedule %r: 'croniter' "
-                "is not installed. Install the 'cron' extra (pip install "
-                "'hermes-agent[cron]') to re-enable recurring cron jobs.",
+                "Cannot compute next run for cron schedule %r: 'croniter' is "
+                "not installed. croniter is a core dependency as of v0.9.x; "
+                "reinstall hermes-agent or run 'pip install croniter' in your "
+                "runtime env.",
                 schedule.get("expr"),
             )
             return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,8 @@ dependencies = [
   "firecrawl-py>=4.16.0,<5",
   "parallel-web>=0.4.2,<1",
   "fal-client>=0.13.1,<1",
+  # Cron scheduler (built-in feature — scheduled cron/interval jobs use croniter).
+  "croniter>=6.0.0,<7",
   # Text-to-speech (Edge TTS is free, no API key needed)
   "edge-tts>=7.2.7,<8",
   # Skills Hub (GitHub App JWT auth — optional, only needed for bot identity)
@@ -42,7 +44,7 @@ daytona = ["daytona>=0.148.0,<1"]
 vercel = ["vercel>=0.5.7,<0.6.0"]
 dev = ["debugpy>=1.8.0,<2", "pytest>=9.0.2,<10", "pytest-asyncio>=1.3.0,<2", "pytest-xdist>=3.0,<4", "mcp>=1.2.0,<2", "ty>=0.0.1a29,<0.0.22", "ruff"]
 messaging = ["python-telegram-bot[webhooks]>=22.6,<23", "discord.py[voice]>=2.7.1,<3", "aiohttp>=3.13.3,<4", "slack-bolt>=1.18.0,<2", "slack-sdk>=3.27.0,<4", "qrcode>=7.0,<8"]
-cron = ["croniter>=6.0.0,<7"]
+cron = []  # croniter is now a core dependency; this extra kept for back-compat
 slack = ["slack-bolt>=1.18.0,<2", "slack-sdk>=3.27.0,<4"]
 matrix = ["mautrix[encryption]>=0.20,<1", "Markdown>=3.6,<4", "aiosqlite>=0.20", "asyncpg>=0.29", "aiohttp-socks>=0.10,<1"]
 cli = ["simple-term-menu>=1.0,<2"]

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -69,6 +69,7 @@ AUTHOR_MAP = {
     "steve.westerhouse@origami-analytics.com": "westers",
     "yeyitech@users.noreply.github.com": "yeyitech",
     "260878550+beenherebefore@users.noreply.github.com": "beenherebefore",
+    "79389617+txbxxx@users.noreply.github.com": "txbxxx",
     "liuhao03@bilibili.com": "liuhao1024",
     "130918800+devorun@users.noreply.github.com": "devorun",
     "surat.s@itm.kmutnb.ac.th": "beesrsj2500",


### PR DESCRIPTION
Salvages #17234 from @txbxxx with a corrected premise.

## Summary
`pip install hermes-agent` (no extras) now yields a working cron scheduler out of the box. Previously, plain installs left `HAS_CRONITER=False`, so any recurring cron/interval schedule silently returned `next_run_at=None` and only surfaced as a `state=error` message on tick — bad first-run UX for a feature that ships in the core CLI, gateway ticker, and `cronjob` agent tool.

## Changes
- `pyproject.toml` — `croniter>=6.0.0,<7` moved into core `dependencies`
- `pyproject.toml` — `cron = []` kept as empty passthrough so existing `hermes-agent[cron]` installs and the `[all]`/`[termux]` extras continue to resolve
- `cron/jobs.py` — update the now-stale `compute_next_run()` warning message (no longer tells users to install the `[cron]` extra)
- `scripts/release.py` — AUTHOR_MAP entry for @txbxxx

## Salvage note
The original PR claimed `[cron]` wasn't included in `[all]`, but it is (`pyproject.toml` line 112 on main), so the stated failure mode ("hermes update strips croniter") doesn't happen via `[all]`. But the deeper UX argument is right: cron is a built-in first-class feature, not an optional integration like `modal` or `matrix`, and should work on a bare install. croniter is a tiny pure-Python dep (~60KB, zero native extensions). Kept the `[cron]` extra as an empty passthrough for back-compat.

Also: the original PR branch was severely stale (would have reverted the entire `minimax-oauth` feature landed this morning, plus nix workflow hardening, anthropic adapter lazy-load, lmstudio provider, BOOT.md hook, and dozens more unrelated changes). Rebuilt the fix directly on current main.

## Validation
| Install path | Before | After |
|---|---|---|
| `pip install hermes-agent` (no extras) | `HAS_CRONITER=False`, schedules silently broken | `HAS_CRONITER=True`, schedules work |
| `pip install 'hermes-agent[cron]'` | works (legacy extra) | works (empty extra, croniter from core) |
| `pip install 'hermes-agent[all]'` | works | works |

- Throwaway venv + `pip install -e .` (no extras) → `HAS_CRONITER=True`, `compute_next_run({'kind':'cron','expr':'*/5 * * * *'})` → valid ISO timestamp
- Throwaway venv + `pip install -e '.[cron]'` → still resolves cleanly, croniter present via core
- `tests/cron/` — 263/263 pass

Original PR: #17234