### PR TITLE
Fix delegate_task model/provider precedence and expose per-task overrides

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -68,6 +68,8 @@ class TestDelegateRequirements(unittest.TestCase):
         self.assertIn("goal", props)
         self.assertIn("tasks", props)
         self.assertIn("context", props)
+        self.assertIn("model", props)
+        self.assertIn("provider", props)
         self.assertIn("toolsets", props)
         # max_iterations is intentionally NOT exposed to the model — it's
         # config-authoritative via delegation.max_iterations so users get
@@ -1146,6 +1148,114 @@ class TestDelegationProviderIntegration(unittest.TestCase):
             # But provider/base_url/api_key should inherit from parent
             self.assertEqual(kwargs["provider"], parent.provider)
             self.assertEqual(kwargs["base_url"], parent.base_url)
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_top_level_model_provider_overrides(self, mock_resolve, mock_cfg):
+        """Top-level model/provider args should be applied before fallback to config."""
+        mock_cfg.return_value = {
+            "max_iterations": 45,
+            "model": "delegation-model",
+            "provider": "openrouter",
+        }
+
+        def _resolve(cfg, parent_agent):
+            return {
+                "model": cfg.get("model"),
+                "provider": cfg.get("provider"),
+                "base_url": f"https://{cfg.get('provider')}.example.com/v1"
+                if cfg.get("provider")
+                else parent_agent.base_url,
+                "api_key": "resolved-key",
+                "api_mode": "chat_completions",
+                "command": None,
+                "args": [],
+            }
+
+        mock_resolve.side_effect = _resolve
+        parent = _make_mock_parent(depth=0)
+
+        with patch("tools.delegate_tool._build_child_agent") as mock_build, \
+             patch("tools.delegate_tool._run_single_child") as mock_run:
+            mock_child = MagicMock()
+            mock_build.return_value = mock_child
+            mock_run.return_value = {
+                "task_index": 0,
+                "status": "completed",
+                "summary": "done",
+                "api_calls": 1,
+                "duration_seconds": 1.0,
+            }
+
+            delegate_task(
+                goal="Top-level override test",
+                model="top-model",
+                provider="custom-provider",
+                parent_agent=parent,
+            )
+
+            _, kwargs = mock_build.call_args
+            self.assertEqual(kwargs["model"], "top-model")
+            self.assertEqual(kwargs["override_provider"], "custom-provider")
+            self.assertEqual(kwargs["override_base_url"], "https://custom-provider.example.com/v1")
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_per_task_model_provider_override(self, mock_resolve, mock_cfg):
+        """Per-task model/provider overrides should outrank top-level overrides."""
+        mock_cfg.return_value = {
+            "max_iterations": 45,
+            "model": "delegation-model",
+            "provider": "openrouter",
+        }
+
+        def _resolve(cfg, parent_agent):
+            return {
+                "model": cfg.get("model"),
+                "provider": cfg.get("provider"),
+                "base_url": f"https://{cfg.get('provider')}.example.com/v1"
+                if cfg.get("provider")
+                else parent_agent.base_url,
+                "api_key": "resolved-key",
+                "api_mode": "chat_completions",
+                "command": None,
+                "args": [],
+            }
+
+        mock_resolve.side_effect = _resolve
+        parent = _make_mock_parent(depth=0)
+
+        with patch("tools.delegate_tool._build_child_agent") as mock_build, \
+             patch("tools.delegate_tool._run_single_child") as mock_run:
+            mock_child = MagicMock()
+            mock_build.return_value = mock_child
+            mock_run.return_value = {
+                "task_index": 0,
+                "status": "completed",
+                "summary": "done",
+                "api_calls": 1,
+                "duration_seconds": 1.0,
+            }
+
+            delegate_task(
+                tasks=[
+                    {"goal": "Task A", "model": "task-model-a", "provider": "openrouter"},
+                    {"goal": "Task B", "model": "task-model-b", "provider": "copilot-acp"},
+                ],
+                model="top-model",
+                provider="top-provider",
+                parent_agent=parent,
+            )
+
+            self.assertEqual(mock_build.call_count, 2)
+            first = mock_build.call_args_list[0].kwargs
+            second = mock_build.call_args_list[1].kwargs
+            self.assertEqual(first["model"], "task-model-a")
+            self.assertEqual(first["override_provider"], "openrouter")
+            self.assertEqual(second["model"], "task-model-b")
+            self.assertEqual(second["override_provider"], "copilot-acp")
+            self.assertEqual(first["override_base_url"], "https://openrouter.example.com/v1")
+            self.assertEqual(second["override_base_url"], "https://copilot-acp.example.com/v1")
 
 
 class TestChildCredentialPoolResolution(unittest.TestCase):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1815,6 +1815,8 @@ def delegate_task(
     toolsets: Optional[List[str]] = None,
     tasks: Optional[List[Dict[str, Any]]] = None,
     max_iterations: Optional[int] = None,
+    model: Optional[str] = None,
+    provider: Optional[str] = None,
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
     role: Optional[str] = None,
@@ -1881,13 +1883,17 @@ def delegate_task(
         )
     effective_max_iter = default_max_iter
 
-    # Resolve delegation credentials (provider:model pair).
-    # When delegation.provider is configured, this resolves the full credential
-    # bundle (base_url, api_key, api_mode) via the same runtime provider system
-    # used by CLI/gateway startup.  When unconfigured, returns None values so
-    # children inherit from the parent.
+    # Resolve delegation credentials (provider:model pair) with top-level
+    # model/provider overrides applied before task-level overrides.
+    # Delegation config still acts as the default fallback if no top-level
+    # override is supplied.
     try:
-        creds = _resolve_delegation_credentials(cfg, parent_agent)
+        top_level_cfg = dict(cfg)
+        if model is not None:
+            top_level_cfg["model"] = model
+        if provider is not None:
+            top_level_cfg["provider"] = provider
+        creds_default = _resolve_delegation_credentials(top_level_cfg, parent_agent)
     except ValueError as exc:
         return tool_error(str(exc))
 
@@ -1942,26 +1948,42 @@ def delegate_task(
             # Per-task role beats top-level; normalise again so unknown
             # per-task values warn and degrade to leaf uniformly.
             effective_role = _normalize_role(t.get("role") or top_role)
+            task_cfg = None
+            if (
+                "model" in t
+                or "provider" in t
+            ):
+                task_cfg = dict(top_level_cfg)
+                if "model" in t:
+                    task_cfg["model"] = t.get("model")
+                if "provider" in t:
+                    task_cfg["provider"] = t.get("provider")
+                try:
+                    task_creds = _resolve_delegation_credentials(task_cfg, parent_agent)
+                except ValueError as exc:
+                    return tool_error(str(exc))
+            else:
+                task_creds = creds_default
             child = _build_child_agent(
                 task_index=i,
                 goal=t["goal"],
                 context=t.get("context"),
                 toolsets=t.get("toolsets") or toolsets,
-                model=creds["model"],
+                model=task_creds["model"],
                 max_iterations=effective_max_iter,
                 task_count=n_tasks,
                 parent_agent=parent_agent,
-                override_provider=creds["provider"],
-                override_base_url=creds["base_url"],
-                override_api_key=creds["api_key"],
-                override_api_mode=creds["api_mode"],
+                override_provider=task_creds["provider"],
+                override_base_url=task_creds["base_url"],
+                override_api_key=task_creds["api_key"],
+                override_api_mode=task_creds["api_mode"],
                 override_acp_command=t.get("acp_command")
                 or acp_command
-                or creds.get("command"),
+                or task_creds.get("command"),
                 override_acp_args=(
                     task_acp_args
                     if task_acp_args is not None
-                    else (acp_args if acp_args is not None else creds.get("args"))
+                    else (acp_args if acp_args is not None else task_creds.get("args"))
                 ),
                 role=effective_role,
             )
@@ -2446,6 +2468,22 @@ DELEGATE_TASK_SCHEMA = {
                             "items": {"type": "string"},
                             "description": f"Toolsets for this specific task. Available: {_TOOLSET_LIST_STR}. Use 'web' for network access, 'terminal' for shell, 'browser' for web interaction.",
                         },
+                        "model": {
+                            "type": "string",
+                            "description": (
+                                "Per-task model override. "
+                                "Priority: task.model > top-level model > "
+                                "delegation.model > parent model."
+                            ),
+                        },
+                        "provider": {
+                            "type": "string",
+                            "description": (
+                                "Per-task provider override. "
+                                "Priority: task.provider > top-level provider > "
+                                "delegation.provider > parent provider."
+                            ),
+                        },
                         "acp_command": {
                             "type": "string",
                             "description": "Per-task ACP command override (e.g. 'claude'). Overrides the top-level acp_command for this task only.",
@@ -2502,6 +2540,20 @@ DELEGATE_TASK_SCHEMA = {
                     "Only used when acp_command is set. Example: ['--acp', '--stdio', '--model', 'claude-opus-4-6']"
                 ),
             },
+            "model": {
+                "type": "string",
+                "description": (
+                    "Optional top-level model override for all tasks. "
+                    "Priority: top-level model > delegation.model > parent model."
+                ),
+            },
+            "provider": {
+                "type": "string",
+                "description": (
+                    "Optional top-level provider override for all tasks. "
+                    "Priority: top-level provider > delegation.provider > parent provider."
+                ),
+            },
         },
         "required": [],
     },
@@ -2521,6 +2573,8 @@ registry.register(
         toolsets=args.get("toolsets"),
         tasks=args.get("tasks"),
         max_iterations=args.get("max_iterations"),
+        model=args.get("model"),
+        provider=args.get("provider"),
         acp_command=args.get("acp_command"),
         acp_args=args.get("acp_args"),
         role=args.get("role"),


### PR DESCRIPTION
## What does this PR do?

Fix delegation so `delegate_task` consistently applies model/provider override precedence across top-level and per-task configuration, and forwards the resolved credentials to child agents. This resolves cases where users pass `model`/`provider` but child tasks still use unintended defaults.

Also updates the tool schema and tests to document and verify the new behavior.

## Related Issue

Fixes #10995

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added optional top-level `model` and `provider` args to `delegate_task` in [tools/delegate_tool.py](/Users/afurm/Development/hermes-agent/tools/delegate_tool.py).
- Applied precedence handling so delegation credentials resolve in this order:
  - task-level `model`/`provider`
  - top-level `model`/`provider`
  - `delegation.model`/`delegation.provider` from config
  - parent agent fallback
- Passed resolved per-task credentials into child construction (`model`, `override_provider`, `override_base_url`, `override_api_key`, `override_api_mode`) in [tools/delegate_tool.py](/Users/afurm/Development/hermes-agent/tools/delegate_tool.py).
- Extended `DELEGATE_TASK_SCHEMA` with:
  - top-level `model`, `provider`
  - per-task `tasks[].model`, `tasks[].provider`
  - precedence descriptions for both levels.
- Added regression/integration coverage in [tests/tools/test_delegate.py](/Users/afurm/Development/hermes-agent/tests/tools/test_delegate.py):
  - `TestDelegateRequirements.test_schema_valid` now checks new schema fields.
  - `test_top_level_model_provider_overrides` validates top-level propagation.
  - `test_per_task_model_provider_override` validates per-task precedence over top-level values.

## How to Test

1. Run focused tests:
   - `scripts/run_tests.sh tests/tools/test_delegate.py`
2. Run the targeted new tests:
   - `scripts/run_tests.sh -k "model_provider_override"`
3. Optional: execute a delegation call manually with mixed config and task-level values and verify child creation uses task-level values where provided, then top-level values, then config fallback.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: 

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior
