### PR TITLE
fix(cli): guard setup-hermes prompts for non-interactive environments

### DIFF
--- a/setup-hermes.sh
+++ b/setup-hermes.sh
@@ -51,6 +51,46 @@ get_command_link_display_dir() {
     fi
 }
 
+prompt_yes_no() {
+    local question="$1"
+    local default="$2"
+    local prompt_suffix
+    local answer=""
+
+    case "$default" in
+        [nN]|[nN][oO]|0|false|FALSE)
+            prompt_suffix="[y/N]"
+            ;;
+        *)
+            prompt_suffix="[Y/n]"
+            ;;
+    esac
+
+    if [ -t 0 ]; then
+        read -r -p "$question $prompt_suffix " answer || answer=""
+    elif [ -r /dev/tty ] && [ -w /dev/tty ]; then
+        printf "%s %s " "$question" "$prompt_suffix" > /dev/tty
+        IFS= read -r answer < /dev/tty || answer=""
+    else
+        return 1
+    fi
+
+    answer="${answer#"${answer%%[![:space:]]*}"}"
+    answer="${answer%"${answer##*[![:space:]]}"}"
+
+    if [ -z "$answer" ]; then
+        case "$default" in
+            [nN]|[nN][oO]|0|false|FALSE) return 1 ;;
+            *) return 0 ;;
+        esac
+    fi
+
+    case "$answer" in
+        [yY]|[yY][eE][sS]) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
 echo ""
 echo -e "${CYAN}⚕ Hermes Agent Setup${NC}"
 echo ""
@@ -220,9 +260,7 @@ if command -v rg &> /dev/null; then
     echo -e "${GREEN}✓${NC} ripgrep found"
 else
     echo -e "${YELLOW}⚠${NC} ripgrep not found (file search will use grep fallback)"
-    read -p "Install ripgrep for faster search? [Y/n] " -n 1 -r
-    echo
-    if [[ $REPLY =~ ^[Yy]$ ]] || [[ -z $REPLY ]]; then
+    if prompt_yes_no "Install ripgrep for faster search?" yes; then
         INSTALLED=false
 
         if is_termux; then
@@ -390,9 +428,7 @@ echo "  hermes doctor        # Diagnose issues"
 echo ""
 
 # Ask if they want to run setup wizard now
-read -p "Would you like to run the setup wizard now? [Y/n] " -n 1 -r
-echo
-if [[ $REPLY =~ ^[Yy]$ ]] || [[ -z $REPLY ]]; then
+if prompt_yes_no "Would you like to run the setup wizard now?" yes; then
     echo ""
     # Run directly with venv Python (no activation needed)
     "$SCRIPT_DIR/venv/bin/python" -m hermes_cli.main setup

--- a/tests/hermes_cli/test_setup_hermes_script.py
+++ b/tests/hermes_cli/test_setup_hermes_script.py
@@ -19,3 +19,16 @@ def test_setup_hermes_script_has_termux_path():
     assert "constraints-termux.txt" in content
     assert "$PREFIX/bin" in content
     assert "Skipping tinker-atropos on Termux" in content
+
+
+def test_setup_script_uses_tty_safe_yes_no_prompt():
+    content = SETUP_SCRIPT.read_text(encoding="utf-8")
+
+    assert "prompt_yes_no()" in content
+    assert (
+        'prompt_yes_no "Install ripgrep for faster search?" yes' in content
+    )
+    assert (
+        'prompt_yes_no "Would you like to run the setup wizard now?" yes' in content
+    )
+    assert "read -p" not in content


### PR DESCRIPTION
## What does this PR do?

This PR fixes `setup-hermes.sh` to avoid failing in non-interactive environments.

The script currently used `read -p` directly for interactive questions, which can hit EOF and abort under CI/container/non-interactive execution (`set -e`), even when the user requested a headless install flow. This patch adds a small helper to detect non-interactive stdin and safely skip prompts, preserving interactive behavior while preventing EOF crashes.

## Related Issue

Fixes #17579

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `setup-hermes.sh`
  - Added `prompt_yes_no()` helper to centralize prompt handling.
  - Replaced direct `read -p` usage in the two installer prompts with `prompt_yes_no()`.
  - In non-interactive mode, prompts now return a safe default without calling `read`, preventing EOF-related exits.
- `tests/hermes_cli/test_setup_hermes_script.py`
  - Added regression checks ensuring `prompt_yes_no()` exists and is used.
  - Added assertions that interactive `read -p` usages are no longer present for these prompts.

## How to Test

1. Shell syntax check:
   - `bash -n setup-hermes.sh`
2. Run focused regression tests:
   - `scripts/run_tests.sh tests/hermes_cli/test_setup_hermes_script.py`
3. Validate non-interactive safety manually:
   - `./setup-hermes.sh </dev/null`
   - Ensure installer no longer fails on interactive prompts and exits cleanly through non-interactive path behavior.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->
- [ ] N/A

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `scripts/run_tests.sh tests/hermes_cli/test_setup_hermes_script.py` (pass)
