### PR TITLE
Fix curator LLM review to honor curator-specific auxiliary model config

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -759,8 +759,20 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
         from hermes_cli.runtime_provider import resolve_runtime_provider
         _cfg = load_config()
         _m = _cfg.get("model", {}) if isinstance(_cfg.get("model"), dict) else {}
+        _curator_cfg = (
+            _cfg.get("curator", {}) if isinstance(_cfg, dict) else {}
+        )
+        _curator_aux_cfg = (
+            _curator_cfg.get("auxiliary", {}) if isinstance(_curator_cfg, dict) else {}
+        )
         _provider = _m.get("provider") or "auto"
         _model_name = _m.get("default") or _m.get("model") or ""
+        _aux_provider = _curator_aux_cfg.get("provider")
+        _aux_model = _curator_aux_cfg.get("model")
+        if _aux_provider:
+            _provider = _aux_provider
+        if _aux_model:
+            _model_name = _aux_model
         _rp = resolve_runtime_provider(
             requested=_provider, target_model=_model_name
         )

--- a/tests/agent/test_curator.py
+++ b/tests/agent/test_curator.py
@@ -82,6 +82,110 @@ def test_curator_config_overrides(curator_env, monkeypatch):
     assert c.get_archive_after_days() == 60
 
 
+def test_run_llm_review_uses_curator_auxiliary_config(monkeypatch, curator_env):
+    c = curator_env["curator"]
+
+    calls = {}
+    resolved = {}
+    importlib.reload(c)
+
+    def fake_load_config():
+        return {
+            "model": {
+                "provider": "main-provider",
+                "default": "main-model",
+            },
+            "curator": {
+                "auxiliary": {
+                    "provider": "aux-provider",
+                    "model": "aux-model",
+                }
+            },
+        }
+
+    def fake_resolve_runtime_provider(requested, target_model=None, explicit_api_key=None, explicit_base_url=None):
+        calls.update({
+            "requested": requested,
+            "target_model": target_model,
+            "explicit_api_key": explicit_api_key,
+            "explicit_base_url": explicit_base_url,
+        })
+        return {
+            "provider": "resolved-provider",
+            "api_mode": "chat_completions",
+            "base_url": "https://example.test",
+            "api_key": "k",
+            "requested_provider": requested,
+        }
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            resolved.update(kwargs)
+
+        def run_conversation(self, user_message):
+            return {"final_response": "curator summary"}
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr("hermes_cli.config.load_config", fake_load_config)
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", fake_resolve_runtime_provider)
+    monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+
+    result = c._run_llm_review("hello")
+
+    assert calls["requested"] == "aux-provider"
+    assert calls["target_model"] == "aux-model"
+    assert resolved["provider"] == "resolved-provider"
+    assert resolved["model"] == "aux-model"
+    assert result["model"] == "aux-model"
+    assert result["provider"] == "resolved-provider"
+
+
+def test_run_llm_review_uses_main_config_when_curator_auxiliary_missing(monkeypatch, curator_env):
+    c = curator_env["curator"]
+
+    calls = {}
+    importlib.reload(c)
+
+    def fake_load_config():
+        return {"model": {"provider": "main-provider", "default": "main-model"}}
+
+    def fake_resolve_runtime_provider(requested, target_model=None, explicit_api_key=None, explicit_base_url=None):
+        calls.update({
+            "requested": requested,
+            "target_model": target_model,
+            "explicit_api_key": explicit_api_key,
+            "explicit_base_url": explicit_base_url,
+        })
+        return {
+            "provider": "resolved-main",
+            "api_mode": "chat_completions",
+            "base_url": "https://example.test",
+            "api_key": "k",
+            "requested_provider": requested,
+        }
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            calls["agent_kwargs"] = kwargs
+
+        def run_conversation(self, user_message):
+            return {"final_response": "curator summary"}
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr("hermes_cli.config.load_config", fake_load_config)
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", fake_resolve_runtime_provider)
+    monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+
+    c._run_llm_review("hello")
+
+    assert calls["requested"] == "main-provider"
+    assert calls["target_model"] == "main-model"
+    assert calls["agent_kwargs"]["provider"] == "resolved-main"
+    assert calls["agent_kwargs"]["model"] == "main-model"
 # ---------------------------------------------------------------------------
 # should_run_now
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

This PR fixes the curator background review fork so it honors curator-specific auxiliary model settings in `curator.auxiliary`.

Before this change, curator review always resolved its fork runtime from the main `model.*` config, so it ignored `curator.auxiliary.provider` and `curator.auxiliary.model` even when users had explicitly configured a dedicated auxiliary backend.

The fix updates runtime resolution in [`agent/curator.py`](/Users/afurm/Development/hermes-agent/agent/curator.py) to prefer curator overrides when present and fall back to `model.*` only when curator-specific values are not set.

I also added regression tests in [`tests/agent/test_curator.py`](/Users/afurm/Development/hermes-agent/tests/agent/test_curator.py) to cover both:

- curator auxiliary override is used,
- and fallback to main model config when curator auxiliary config is missing.

## Related Issue

Fixes #17572

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- [`agent/curator.py`](/Users/afurm/Development/hermes-agent/agent/curator.py): In `_run_llm_review()`, read `curator.auxiliary` and prefer `curator.auxiliary.provider` and `curator.auxiliary.model` when resolving runtime. Falls back to `model.provider` / `model.default` when curator-specific overrides are absent.
- [`tests/agent/test_curator.py`](/Users/afurm/Development/hermes-agent/tests/agent/test_curator.py): Added regression tests:
  - `test_run_llm_review_uses_curator_auxiliary_config`
  - `test_run_llm_review_uses_main_config_when_curator_auxiliary_missing`

## How to Test

1. Configure main model and curator auxiliary settings to different values in `~/.hermes/config.yaml` (or through CLI config tooling):
   - `model.provider`/`model.default` for primary model
   - `curator.auxiliary.provider`/`curator.auxiliary.model` for curator overrides
2. Run:
   - `scripts/run_tests.sh tests/agent/test_curator.py -k "run_llm_review_uses_curator_auxiliary"`
   - `scripts/run_tests.sh tests/agent/test_curator.py -k "run_llm_review_uses_main_config"`
3. Confirm tests pass and verify curator metadata in the run summary now reflects curator-specific model/provider when configured.

## Checklist

### Code

- [x] I’ve read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [ ] I’ve run `pytest tests/ -q` and all tests pass
- [x] I’ve added tests for my changes
- [x] I’ve tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I’ve updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I’ve updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I’ve updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I’ve considered cross-platform impact (Windows, macOS, Linux) — or N/A
- [ ] I’ve updated tool descriptions/schemas if I changed tool behavior — or N/A

