### PR TITLE
fix(nix): refresh stale npmDepsHash for hermes-tui

### DIFF
--- a/nix/tui.nix
+++ b/nix/tui.nix
@@ -4,7 +4,7 @@ let
   src = ../ui-tui;
   npmDeps = pkgs.fetchNpmDeps {
     inherit src;
-    hash = "sha256-Chz+NW9NXqboXHOa6PKwf5bhAkkcFtKNhvKWwg2XSPc=";
+    hash = "sha256-a/HGI9OgVcTnZrMXA7xFMGnFoVxyHe95fulVz+WNYB0=";
   };
 
   npm = hermesNpmLib.mkNpmPassthru { folder = "ui-tui"; attr = "tui"; pname = "hermes-tui"; };


### PR DESCRIPTION
The `npmDepsHash` in `nix/tui.nix` went stale after #17175 merged with an updated `ui-tui/package-lock.json`.

The auto-fix workflow (#16285) triggered but **cannot push to main** due to branch protection rules (`GH013: Changes must be made through a pull request`). The GitHub App token isn't exempted from the ruleset — so the auto-fix mechanism is currently non-functional regardless of trigger timing.

This PR manually applies the correct hash from the nix build error:
```
specified: sha256-Chz+NW9NXqboXHOa6PKwf5bhAkkcFtKNhvKWwg2XSPc=
      got: sha256-a/HGI9OgVcTnZrMXA7xFMGnFoVxyHe95fulVz+WNYB0=
```

**Note:** The auto-fix workflow from #16285 needs its GitHub App added to the branch protection bypass list, otherwise it will keep failing on every future hash drift.