### PR TITLE
feat: add voice.enabled config to persist voice mode across sessions

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -756,6 +756,25 @@ stt:
   #   model: "voxtral-mini-latest"  # voxtral-mini-latest | voxtral-mini-2602
 
 # =============================================================================
+# Voice Mode (CLI)
+# =============================================================================
+# CLI voice mode: speak your input via microphone, get spoken responses via TTS.
+# Unlike STT (which transcribes voice messages from messaging platforms), this
+# enables voice interaction directly in the terminal.
+#
+# Set `enabled: true` to start every CLI session with voice mode on, so you
+# don't need to type `/voice on` each time.
+#
+# voice:
+#   enabled: false           # Start sessions with voice mode enabled
+#   record_key: "ctrl+b"     # Keyboard shortcut to start/stop recording
+#   max_recording_seconds: 120
+#   auto_tts: true           # Automatically speak responses aloud
+#   beep_enabled: true       # Play audio cues on record start/stop
+#   silence_threshold: 200   # RMS level below which audio is considered silence
+#   silence_duration: 3.0    # Seconds of silence before auto-stopping recording
+
+# =============================================================================
 # Response Pacing (Messaging Platforms)
 # =============================================================================
 # Add human-like delays between message chunks.

--- a/cli.py
+++ b/cli.py
@@ -2145,7 +2145,7 @@ class HermesCLI:
 
         # Voice mode state (also reinitialized inside run() for interactive TUI).
         self._voice_lock = threading.Lock()
-        self._voice_mode = False
+        self._voice_mode = CLI_CONFIG.get("voice", {}).get("enabled", False)
         self._voice_tts = False
         self._voice_recorder = None
         self._voice_recording = False
@@ -9423,7 +9423,7 @@ class HermesCLI:
 
         # Voice mode state (protected by _voice_lock for cross-thread access)
         self._voice_lock = threading.Lock()
-        self._voice_mode = False        # Whether voice mode is enabled
+        self._voice_mode = CLI_CONFIG.get("voice", {}).get("enabled", False)  # Whether voice mode is enabled
         self._voice_tts = False         # Whether TTS output is enabled
         self._voice_recorder = None     # AudioRecorder instance (lazy init)
         self._voice_recording = False   # Whether currently recording

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -812,6 +812,7 @@ DEFAULT_CONFIG = {
     },
 
     "voice": {
+        "enabled": False,             # Start CLI sessions with voice mode on
         "record_key": "ctrl+b",
         "max_recording_seconds": 120,
         "auto_tts": False,


### PR DESCRIPTION
Superseded by #17594 which includes the `_voice_tts` fix on top of this change.