### PR TITLE
fix(delegate): honor runtime default model during provider resolution

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -786,6 +786,26 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertEqual(creds["api_mode"], "chat_completions")
         mock_resolve.assert_called_once_with(requested="openrouter")
 
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_provider_resolution_uses_runtime_model_when_config_model_missing(self, mock_resolve):
+        """Named providers should propagate their runtime default model to children."""
+        mock_resolve.return_value = {
+            "provider": "custom",
+            "base_url": "https://my-server.example/v1",
+            "api_key": "sk-test-key",
+            "api_mode": "chat_completions",
+            "model": "server-default-model",
+        }
+        parent = _make_mock_parent(depth=0)
+        cfg = {"provider": "custom:my-server", "model": ""}
+
+        creds = _resolve_delegation_credentials(cfg, parent)
+
+        self.assertEqual(creds["model"], "server-default-model")
+        self.assertEqual(creds["provider"], "custom")
+        self.assertEqual(creds["base_url"], "https://my-server.example/v1")
+        mock_resolve.assert_called_once_with(requested="custom:my-server")
+
     def test_direct_endpoint_uses_configured_base_url_and_api_key(self):
         parent = _make_mock_parent(depth=0)
         cfg = {

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2309,7 +2309,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
         )
 
     return {
-        "model": configured_model,
+        "model": configured_model or runtime.get("model") or None,
         "provider": runtime.get("provider"),
         "base_url": runtime.get("base_url"),
         "api_key": api_key,


### PR DESCRIPTION
**Summary**

This fixes a bug in `delegate_task` where a delegated provider override could lose the runtime resolver's default model.

When `delegation.provider` was set but `delegation.model` was left empty, the child agent did not use the provider's resolved default model. Instead, it fell back to the parent model, which could send the wrong model slug to the delegated endpoint.

---

**Problem**

The delegation credential path already calls `resolve_runtime_provider()` when `delegation.provider` is configured. That resolver may return a runtime-specific model, especially for named custom providers or provider-specific defaults.

Before this change, `_resolve_delegation_credentials()` discarded `runtime["model"]` and only returned the explicitly configured `delegation.model` value. In practice that meant:

- `delegation.provider` is set  
- `delegation.model` is empty  
- `resolve_runtime_provider()` returns a default model  
- the child agent still inherits the parent model instead of using the resolved model  

This can cause delegated runs to target the right provider/base_url but the wrong model.

---

**Fix**

Use the resolved runtime model as the fallback model for delegated provider overrides.

Behavior is now:

- if `delegation.model` is explicitly set, keep using it  
- otherwise, if `resolve_runtime_provider()` returns `runtime["model"]`, use that  
- otherwise, preserve the existing inheritance behavior  

This keeps the change narrow and only affects the provider-override path.

---

**Tests**

Added a regression test:

`tests/tools/test_delegate.py::TestDelegationCredentialResolution::test_provider_resolution_uses_runtime_model_when_config_model_missing`

The test covers this case:

- `delegation.provider = "custom:my-server"`  
- `delegation.model = ""`  
- `resolve_runtime_provider()` returns `model = "server-default-model"`  

**Expected result:**

the delegated child uses `"server-default-model"`

---

**Validation**

The new targeted regression test passed with:

uv run pytest tests/tools/test_delegate.py::TestDelegationCredentialResolution::test_provider_resolution_uses_runtime_model_when_config_model_missing