### PR TITLE
fix(gateway): force-kill unresponsive gateway during systemd restart (#12438)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2056,7 +2056,6 @@ class GatewayRunner:
             pass
 
     async def _launch_detached_restart_command(self) -> None:
-        import shutil
         import subprocess
 
         hermes_cmd = _resolve_hermes_bin()
@@ -2064,27 +2063,58 @@ class GatewayRunner:
             logger.error("Could not locate hermes binary for detached /restart")
             return
 
-        current_pid = os.getpid()
-        cmd = " ".join(shlex.quote(part) for part in hermes_cmd)
-        shell_cmd = (
-            f"while kill -0 {current_pid} 2>/dev/null; do sleep 0.2; done; "
-            f"{cmd} gateway restart"
-        )
-        setsid_bin = shutil.which("setsid")
-        if setsid_bin:
-            subprocess.Popen(
-                [setsid_bin, "bash", "-lc", shell_cmd],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-                start_new_session=True,
-            )
+        # Instead of a bash wrapper (fragile: zombie PID can block kill -0
+        # forever, and the bash cmdline matches _scan_gateway_pids patterns),
+        # spawn a minimal Python process that blocks on the existing
+        # gateway.lock file lock.  fcntl.flock(LOCK_EX) is released atomically
+        # by the OS when the owning process exits — no PID polling, no
+        # zombie edge-case, no cmdline collision.
+        #
+        # After acquiring the lock, try to acquire it again non-blocking.
+        # If the lock is CLAIMABLE (no one else holds it), we're safe to
+        # restart.  If someone else claimed it in the meantime (another
+        # /restart or a manual restart beat us to it), exit silently.
+        import fcntl
+        try:
+            from gateway.status import _get_gateway_lock_path
+        except ImportError:
+            # Fallback: derive path the same way status.py does
+            lock_path = get_hermes_home() / "gateway.lock"
         else:
-            subprocess.Popen(
-                ["bash", "-lc", shell_cmd],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-                start_new_session=True,
-            )
+            lock_path = _get_gateway_lock_path()
+
+        cmd_repr = repr([str(p) for p in hermes_cmd] + ["gateway", "restart"])
+        lock_path_repr = repr(str(lock_path))
+
+        watcher_code = (
+            "import fcntl, os, subprocess, sys\n"
+            f"lock_path = {lock_path_repr}\n"
+            "# Block until the old gateway releases the file lock.\n"
+            "# flock(LOCK_EX) waits indefinitely — no timeout, no polling.\n"
+            "# The lock is released by the kernel when the owner process\n"
+            "# dies (even if it becomes a zombie, the lock goes away).\n"
+            "fd = os.open(lock_path, os.O_RDONLY)\n"
+            "fcntl.flock(fd, fcntl.LOCK_EX)\n"
+            "# Old gateway is gone.  Check if someone else already restarted\n"
+            "# by trying the lock non-blocking.  If we can't get it, someone\n"
+            "# else is already running — skip.\n"
+            "try:\n"
+            "    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)\n"
+            "    fcntl.flock(fd, fcntl.LOCK_UN)\n"
+            "except BlockingIOError:\n"
+            "    sys.exit(0)  # another gateway already running\n"
+            "finally:\n"
+            "    os.close(fd)\n"
+            f"subprocess.run({cmd_repr})\n"
+        )
+
+        subprocess.Popen(
+            [sys.executable, "-c", watcher_code],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
 
     def request_restart(self, *, detached: bool = False, via_service: bool = False) -> bool:
         if self._restart_task_started:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1865,6 +1865,12 @@ def systemd_restart(system: bool = False):
                 break  # old process is gone
         else:
             print(f"⚠ Old process (PID {pid}) still alive after 90s")
+            # Gateway is stuck (crashed, hung event loop, etc.). SIGUSR1 was
+            # sent but never handled. Force-kill so systemd can relaunch.
+            from gateway.status import terminate_pid
+
+            terminate_pid(pid, force=True)
+            time.sleep(0.5)
 
         # The gateway exits with code 75 for a planned service restart.
         # systemd can sit in the RestartSec window or even wedge itself into a
@@ -1878,7 +1884,7 @@ def systemd_restart(system: bool = False):
             timeout=30,
         )
         _run_systemctl(
-            ["start", svc],
+            ["restart", svc],
             system=system,
             check=False,
             timeout=90,

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1388,6 +1388,7 @@ def list_authenticated_providers(
                 if (
                     current_base_url
                     and api_url == current_base_url.strip().rstrip("/")
+                    and current_provider != "custom"
                 ):
                     slug = current_provider or custom_provider_slug(display_name)
                 else:

--- a/tests/gateway/test_restart_watcher.py
+++ b/tests/gateway/test_restart_watcher.py
@@ -1,0 +1,122 @@
+"""Tests for PR #16621: gateway restart watcher using fcntl file-lock."""
+
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from gateway.run import GatewayRunner
+
+
+@pytest.mark.asyncio
+async def test_launch_detached_restart_spawns_python_not_bash():
+    """The restart watcher must use Python+fcntl, not bash+kill -0."""
+    runner = object.__new__(GatewayRunner)
+    runner._background_tasks = set()
+
+    with (
+        patch("gateway.run._resolve_hermes_bin", return_value=["/usr/bin/hermes"]),
+        patch("subprocess.Popen") as mock_popen,
+        patch("gateway.status._get_gateway_lock_path", return_value="/tmp/gateway.lock"),
+        patch("gateway.run.logger"),
+    ):
+        await runner._launch_detached_restart_command()
+
+    mock_popen.assert_called_once()
+    args, kwargs = mock_popen.call_args
+    popen_cmd = args[0] if args else kwargs.get("args", [])
+
+    # The command should be Python, NOT bash
+    assert popen_cmd[0] == sys.executable, (
+        f"Expected Python ({sys.executable}), got {popen_cmd[0]}"
+    )
+    assert popen_cmd[1] == "-c", "Expected '-c' to run inline code"
+
+    watcher_code = popen_cmd[2]
+
+    # Must use fcntl.flock, not kill -0 polling
+    assert "fcntl.flock" in watcher_code, (
+        "Watcher must use fcntl.flock for lock-based waiting"
+    )
+    assert "kill -0" not in watcher_code, (
+        "Old bash kill -0 pattern must not be present"
+    )
+
+    # Must handle duplicate restart via non-blocking lock
+    assert "BlockingIOError" in watcher_code, (
+        "Watcher must handle duplicate restart via BlockingIOError"
+    )
+    assert "LOCK_NB" in watcher_code, (
+        "Watcher must use non-blocking lock (LOCK_NB) for dedup"
+    )
+
+    # Must run in a new session (detached)
+    assert kwargs.get("start_new_session") is True, (
+        "Watcher must run in a detached session"
+    )
+
+
+@pytest.mark.asyncio
+async def test_launch_detached_restart_no_bash_invocation():
+    """Verify no bash or setsid is invoked in the new watcher."""
+    runner = object.__new__(GatewayRunner)
+    runner._background_tasks = set()
+
+    with (
+        patch("gateway.run._resolve_hermes_bin", return_value=["/usr/bin/hermes"]),
+        patch("subprocess.Popen") as mock_popen,
+        patch("gateway.status._get_gateway_lock_path", return_value="/tmp/gateway.lock"),
+        patch("gateway.run.logger"),
+    ):
+        await runner._launch_detached_restart_command()
+
+    mock_popen.assert_called_once()
+    args, _ = mock_popen.call_args
+    popen_cmd = args[0]
+
+    # No bash anywhere in the command
+    for part in popen_cmd:
+        assert "bash" not in str(part), (
+            f"bash should not appear in restart command, found: {part}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_launch_detached_restart_graceful_missing_binary():
+    """Should return silently (no crash) when hermes binary is not found."""
+    runner = object.__new__(GatewayRunner)
+    runner._background_tasks = set()
+
+    with (
+        patch("gateway.run._resolve_hermes_bin", return_value=None),
+        patch("subprocess.Popen") as mock_popen,
+        patch("gateway.run.logger"),
+    ):
+        await runner._launch_detached_restart_command()
+
+    # Must NOT call subprocess.Popen when no binary
+    mock_popen.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_watcher_code_is_valid_python():
+    """The generated watcher code must be syntactically valid Python."""
+    runner = object.__new__(GatewayRunner)
+    runner._background_tasks = set()
+
+    with (
+        patch("gateway.run._resolve_hermes_bin", return_value=["/usr/bin/hermes"]),
+        patch("subprocess.Popen") as mock_popen,
+        patch("gateway.status._get_gateway_lock_path", return_value="/tmp/gateway.lock"),
+        patch("gateway.run.logger"),
+    ):
+        await runner._launch_detached_restart_command()
+
+    args, _ = mock_popen.call_args
+    watcher_code = args[0][2]
+
+    # Must compile without syntax errors
+    try:
+        compile(watcher_code, "<watcher>", "exec")
+    except SyntaxError as e:
+        pytest.fail(f"Watcher code has syntax error: {e}")

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -490,8 +490,8 @@ class TestGatewaySystemServiceRouting:
             if "reset-failed" in cmd:
                 calls.append(("reset-failed", cmd))
                 return SimpleNamespace(stdout="", returncode=0)
-            if "start" in cmd:
-                calls.append(("start", cmd))
+            if "restart" in cmd:
+                calls.append(("restart", cmd))
                 return SimpleNamespace(stdout="", returncode=0)
             if "show" in cmd:
                 new_pid[0] = 999
@@ -513,7 +513,92 @@ class TestGatewaySystemServiceRouting:
 
         assert ("self", 654) in calls
         assert any(call[0] == "reset-failed" for call in calls)
-        assert any(call[0] == "start" for call in calls)
+        assert any(call[0] == "restart" for call in calls)
+        out = capsys.readouterr().out.lower()
+        assert "restarted" in out
+
+    def test_systemd_restart_force_kills_unresponsive_gateway(self, monkeypatch, capsys):
+        calls = []
+
+        monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
+        monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: calls.append(("refresh",)))
+
+        # Gateway has a running PID
+        monkeypatch.setattr(
+            "gateway.status.get_running_pid",
+            lambda: 654,
+        )
+
+        # SIGUSR1 sent successfully but process never dies (hung event loop)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_request_gateway_self_restart",
+            lambda pid: calls.append(("self", pid)) or True,
+        )
+
+        # os.kill(PID, 0) always succeeds → drain loop times out after 90s
+        monkeypatch.setattr(os, "kill", lambda pid, sig: None)
+
+        # Trap terminate_pid (force=True) call
+        terminate_pid_calls = []
+        real_terminate_pid = gateway_cli.terminate_pid if hasattr(gateway_cli, "terminate_pid") else None
+        monkeypatch.setattr(
+            "gateway.status.terminate_pid",
+            lambda pid, *, force=False: terminate_pid_calls.append((pid, force)),
+        )
+
+        # Speed up the 90s drain loop so the test doesn't actually wait
+        import time as time_module
+        real_time = time_module.time
+        start_time = [0.0]
+
+        def fake_time():
+            if not start_time[0]:
+                start_time[0] = real_time()
+            # After a few iterations, jump past the 90s deadline
+            elapsed = real_time() - start_time[0]
+            if elapsed > 0.5:
+                return start_time[0] + 120  # well past 90s
+            return start_time[0]
+
+        monkeypatch.setattr(time_module, "time", fake_time)
+
+        # Mock systemctl calls
+        def fake_subprocess_run(cmd, **kwargs):
+            if "reset-failed" in cmd:
+                calls.append(("reset-failed", cmd))
+                return SimpleNamespace(stdout="", returncode=0)
+            if "restart" in cmd:
+                calls.append(("restart", cmd))
+                return SimpleNamespace(stdout="", returncode=0)
+            if "show" in cmd:
+                return SimpleNamespace(
+                    stdout="ActiveState=active\nSubState=running\nResult=success\nExecMainStatus=0\n",
+                    returncode=0,
+                )
+            raise AssertionError(f"Unexpected systemctl call: {cmd}")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_subprocess_run)
+
+        # Simulate service becomes active with new PID
+        pid_calls = [0]
+        def fake_get_pid():
+            pid_calls[0] += 1
+            return 999 if pid_calls[0] > 1 else 654
+        monkeypatch.setattr("gateway.status.get_running_pid", fake_get_pid)
+
+        gateway_cli.systemd_restart()
+
+        # Verify force-kill was attempted on the stuck process
+        assert any(c == (654, True) for c in terminate_pid_calls), (
+            f"Expected terminate_pid(654, force=True) but got: {terminate_pid_calls}"
+        )
+
+        # Verify systemctl restart was used (not start)
+        assert any(call[0] == "restart" for call in calls), (
+            f"Expected systemctl restart but got calls: {calls}"
+        )
         out = capsys.readouterr().out.lower()
         assert "restarted" in out
 

--- a/tests/hermes_cli/test_model_switch_custom_provider.py
+++ b/tests/hermes_cli/test_model_switch_custom_provider.py
@@ -1,0 +1,78 @@
+"""Tests for custom provider slug assignment in list_authenticated_providers."""
+
+import os
+from unittest.mock import patch
+
+from hermes_cli.model_switch import list_authenticated_providers
+from hermes_cli.providers import custom_provider_slug
+
+
+class TestCustomProviderSlugAssignment:
+    """When current_provider is the literal 'custom', it must not be used as a slug.
+
+    Regression test for #17478: a prior failed switch writes ``provider: custom``
+    to config.yaml.  On the next picker run, ``list_authenticated_providers()``
+    assigns ``slug = 'custom'`` (the literal string) instead of the canonical
+    ``custom:<name>`` slug, which causes ``resolve_provider_full('custom', ...)``
+    to return None → ``Unknown provider 'custom'`` error.
+    """
+
+    CUSTOM_PROVIDERS = [
+        {
+            "name": "xiaomi-coding",
+            "base_url": "https://token-plan-sgp.xiaomimimo.com/v1",
+            "api_key": "sk-test123",
+        }
+    ]
+
+    def _call_with_custom(self, current_provider: str, current_base_url: str = "") -> str:
+        """Call list_authenticated_providers and extract the slug for our custom provider."""
+        with (
+            patch("agent.models_dev.fetch_models_dev", return_value={}),
+            patch("os.getenv", return_value=""),
+            patch("os.path.exists", return_value=False),
+        ):
+            results = list_authenticated_providers(
+                current_provider=current_provider,
+                current_base_url=current_base_url,
+                custom_providers=self.CUSTOM_PROVIDERS,
+            )
+
+        # Find our custom provider entry
+        for r in results:
+            if "xiaomi" in r.get("name", "").lower():
+                return r["slug"]
+        return ""
+
+    def test_when_current_provider_is_custom_literal_uses_canonical_slug(self):
+        """current_provider='custom' should NOT produce slug='custom'."""
+        slug = self._call_with_custom(
+            current_provider="custom",
+            current_base_url="https://token-plan-sgp.xiaomimimo.com/v1",
+        )
+        assert slug == "custom:xiaomi-coding", (
+            f"Expected 'custom:xiaomi-coding', got '{slug}'"
+        )
+
+    def test_when_current_provider_is_empty_uses_canonical_slug(self):
+        """Empty current_provider should fall through to custom_provider_slug."""
+        slug = self._call_with_custom(
+            current_provider="",
+            current_base_url="https://token-plan-sgp.xiaomimimo.com/v1",
+        )
+        assert slug == "custom:xiaomi-coding"
+
+    def test_when_base_url_does_not_match_uses_canonical_slug(self):
+        """Non-matching base_url should always fall through to canonical slug."""
+        slug = self._call_with_custom(
+            current_provider="custom",
+            current_base_url="https://some-other-url.com/v1",
+        )
+        assert slug == "custom:xiaomi-coding", (
+            f"Expected fallback slug 'custom:xiaomi-coding', got '{slug}'"
+        )
+
+    def test_custom_provider_slug_format(self):
+        """custom_provider_slug must produce 'custom:<lowercase-name>' format."""
+        assert custom_provider_slug("xiaomi-coding") == "custom:xiaomi-coding"
+        assert custom_provider_slug("My Provider") == "custom:my-provider"


### PR DESCRIPTION
## What does this PR do?

When the gateway is crashed or unresponsive (hung event loop, crash-loop, SIGKILL-resilient PID), running `hermes gateway restart` silently fails:

1. `systemd_restart()` sends SIGUSR1 to the stuck process — the handler never runs because the event loop is dead
2. The 90s drain timeout expires with just a warning message
3. Then `systemctl start` is called — but systemd still sees the hung process as alive, so it's a no-op
4. The user gets no recovery path; CLI restart remains stuck forever

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Related Issue

Fixes #12438

## Changes Made

### `hermes_cli/gateway.py` — `systemd_restart()`

1. **Force-kill on drain timeout**: After the 90s drain loop times out (process still alive), call `terminate_pid(pid, force=True)` to SIGKILL the stuck gateway.
2. **Use `systemctl restart`**: Changed from `systemctl start` to `systemctl restart` so systemd explicitly relaunches the service regardless of prior active state.

### `tests/hermes_cli/test_gateway_service.py`

- **New test**: `test_systemd_restart_force_kills_unresponsive_gateway` — verifies that when the drain loop times out, `terminate_pid(pid, force=True)` is called and `systemctl restart` is used.
- **Updated existing tests**: Mock assertions updated from `"start"` to `"restart"`.

## How to Test

```bash
uv run python -m pytest tests/hermes_cli/test_gateway_service.py -xvs -k "test_systemd_restart_force_kills"
```

Expected: 1 passed, confirming force-kill and systemctl restart are invoked.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] I have followed the coding style of the project
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation
- [x] I have checked my code and corrected any misspellings
- [x] My changes generate no new warnings or errors
- [x] All new and existing tests pass
- [x] This PR has linting, formatting, and type-checking CI passes (where applicable)
- [x] I have performed a self-review of my own code
