### PR TITLE
fix(cli): resolve runtime credentials for current model

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3182,6 +3182,7 @@ class HermesCLI:
                 requested=self.requested_provider,
                 explicit_api_key=self._explicit_api_key,
                 explicit_base_url=self._explicit_base_url,
+                target_model=self.model,
             )
         except Exception as exc:
             _primary_exc = exc
@@ -3197,7 +3198,10 @@ class HermesCLI:
                     if not _fb_provider or not _fb_model:
                         continue
                     try:
-                        runtime = resolve_runtime_provider(requested=_fb_provider)
+                        runtime = resolve_runtime_provider(
+                            requested=_fb_provider,
+                            target_model=_fb_model,
+                        )
                         logger.warning(
                             "Primary provider auth failed (%s). Falling through to fallback: %s/%s",
                             _primary_exc, _fb_provider, _fb_model,

--- a/tests/cli/test_runtime_credentials.py
+++ b/tests/cli/test_runtime_credentials.py
@@ -1,0 +1,63 @@
+from types import SimpleNamespace
+
+from cli import HermesCLI
+
+
+def _runtime_cli_stub(**overrides):
+    attrs = {
+        "requested_provider": "kimi-coding",
+        "_explicit_api_key": None,
+        "_explicit_base_url": None,
+        "_fallback_model": [],
+        "api_mode": "chat_completions",
+        "provider": "kimi-coding",
+        "acp_command": None,
+        "acp_args": [],
+        "_credential_pool": None,
+        "_provider_source": None,
+        "api_key": "old-key",
+        "base_url": "https://old.example/v1",
+        "model": "kimi-for-coding",
+        "agent": object(),
+        "_active_agent_route_signature": ("stale",),
+        "_normalize_model_for_provider": lambda provider: False,
+    }
+    attrs.update(overrides)
+    return SimpleNamespace(**attrs)
+
+
+def test_ensure_runtime_credentials_resolves_for_current_model(monkeypatch):
+    """Mid-session /model choices must drive runtime api_mode resolution."""
+    calls = []
+
+    def fake_resolve_runtime_provider(**kwargs):
+        calls.append(kwargs)
+        return {
+            "api_key": "new-key",
+            "base_url": "https://api.kimi.com/coding",
+            "provider": "kimi-coding",
+            "api_mode": "anthropic_messages",
+            "credential_pool": None,
+            "source": "test",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        fake_resolve_runtime_provider,
+    )
+
+    cli = _runtime_cli_stub()
+
+    assert HermesCLI._ensure_runtime_credentials(cli) is True
+
+    assert calls == [
+        {
+            "requested": "kimi-coding",
+            "explicit_api_key": None,
+            "explicit_base_url": None,
+            "target_model": "kimi-for-coding",
+        }
+    ]
+    assert cli.api_mode == "anthropic_messages"
+    assert cli.agent is None
+    assert cli._active_agent_route_signature is None


### PR DESCRIPTION
## Summary
- Pass the current CLI model into runtime credential resolution.
- Keep fallback credential resolution aligned with the fallback model being selected.
- Add regression coverage for mid-session `/model` switches that require a non-default `api_mode`.

## Root cause
`HermesCLI._ensure_runtime_credentials()` re-resolved provider credentials without passing the active model. Providers whose transport depends on the selected model could therefore recompute `api_mode` from stale persisted config instead of the current `/model` selection.

## Fix
Forward `target_model=self.model` during normal runtime resolution and `target_model=_fb_model` when falling through to an auth fallback.

## Regression coverage
Added `tests/cli/test_runtime_credentials.py` to assert that `_ensure_runtime_credentials()` passes the active model to `resolve_runtime_provider()` and invalidates the cached agent when routing changes.

## Testing
- `scripts/run_tests.sh tests/cli/test_runtime_credentials.py -q`
- `scripts/run_tests.sh tests/cli/test_runtime_credentials.py tests/hermes_cli/test_runtime_provider_resolution.py -q`

Closes #17574
