### PR TITLE
feat(gateway): add per-turn token usage footer to gateway responses

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -67,30 +67,16 @@ _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
 # is still classified fresh.  Override via
 # ``config.yaml`` ``agent.gateway_auto_continue_freshness``.
 _AUTO_CONTINUE_FRESHNESS_SECS_DEFAULT = 60 * 60
-_GATEWAY_USAGE_LINE_RE = re.compile(r"^`usage:t=[^`\n]+ i=[^`\n]+ o=[^`\n]+(?: \([^)]+\))*`[ \t]*$", re.MULTILINE)
 
 
-def _format_usage_int(value: Any) -> str:
-    try:
-        return f"{max(0, int(value)):,}"
-    except (TypeError, ValueError):
-        return "0"
-
-
-def _snapshot_agent_token_usage(agent: Any) -> Dict[str, int]:
+def _snapshot_agent_token_usage(agent: Any) -> "Dict[str, int]":
     """Return cumulative token counters from an AIAgent instance."""
     if agent is None:
         return {}
-
     keys = (
-        "input_tokens",
-        "output_tokens",
-        "total_tokens",
-        "cache_read_tokens",
-        "cache_write_tokens",
-        "reasoning_tokens",
-        "prompt_tokens",
-        "completion_tokens",
+        "input_tokens", "output_tokens", "total_tokens",
+        "cache_read_tokens", "cache_write_tokens", "reasoning_tokens",
+        "prompt_tokens", "completion_tokens",
     )
     attr_map = {
         "input_tokens": "session_input_tokens",
@@ -111,60 +97,15 @@ def _snapshot_agent_token_usage(agent: Any) -> Dict[str, int]:
     return snapshot
 
 
-def _diff_agent_token_usage(before: Dict[str, int], after: Dict[str, int]) -> Dict[str, int]:
+def _diff_agent_token_usage(
+    before: "Dict[str, int]", after: "Dict[str, int]"
+) -> "Dict[str, int]":
     """Return non-negative per-turn token usage deltas."""
     keys = set(before or {}) | set(after or {})
-    return {key: max(0, int((after or {}).get(key, 0)) - int((before or {}).get(key, 0))) for key in keys}
-
-
-def _build_gateway_usage_line(usage: Optional[Dict[str, Any]]) -> str:
-    """Build the user-requested inline-code token usage footer."""
-    usage = usage or {}
-    input_tokens = usage.get("input_tokens", usage.get("prompt_tokens", 0)) or 0
-    output_tokens = usage.get("output_tokens", usage.get("completion_tokens", 0)) or 0
-    # Display total is the non-cached visible token total.  Provider/runtime
-    # ``total_tokens`` may include prompt-cache hits (for billing/accounting),
-    # but the compact user-facing footer shows cache reads separately as
-    # ``(+ N c)`` and must not double-count them in ``t=``.
-    try:
-        display_total_tokens = int(input_tokens or 0) + int(output_tokens or 0)
-    except (TypeError, ValueError):
-        display_total_tokens = 0
-
-    parts = [
-        f"usage:t={_format_usage_int(display_total_tokens)}",
-        f"i={_format_usage_int(input_tokens)}",
-    ]
-    cached = usage.get("cache_read_tokens")
-    try:
-        cached_int = int(cached or 0)
-    except (TypeError, ValueError):
-        cached_int = 0
-    if cached_int > 0:
-        parts[-1] = f"{parts[-1]} (+ {_format_usage_int(cached_int)} c)"
-
-    output_part = f"o={_format_usage_int(output_tokens)}"
-    reasoning = usage.get("reasoning_tokens")
-    try:
-        reasoning_int = int(reasoning or 0)
-    except (TypeError, ValueError):
-        reasoning_int = 0
-    if reasoning_int > 0:
-        output_part = f"{output_part} (r {_format_usage_int(reasoning_int)})"
-    parts.append(output_part)
-    return "`" + " ".join(parts) + "`"
-
-
-def _append_gateway_usage_line(text: str, usage: Optional[Dict[str, Any]]) -> str:
-    """Ensure exactly one trailing token usage line on a gateway response.
-
-    Preserve a single blank-line separation from the preceding body/footer so
-    the compact usage line reads like a footer instead of attaching to the
-    final content paragraph.
-    """
-    base = _GATEWAY_USAGE_LINE_RE.sub("", text or "").rstrip()
-    line = _build_gateway_usage_line(usage)
-    return f"{base}\n\n{line}" if base else line
+    return {
+        key: max(0, int((after or {}).get(key, 0)) - int((before or {}).get(key, 0)))
+        for key in keys
+    }
 
 
 def _coerce_gateway_timestamp(value: Any) -> Optional[float]:
@@ -365,6 +306,7 @@ if _config_path.exists():
                 "singularity_image": "TERMINAL_SINGULARITY_IMAGE",
                 "modal_image": "TERMINAL_MODAL_IMAGE",
                 "daytona_image": "TERMINAL_DAYTONA_IMAGE",
+                "vercel_runtime": "TERMINAL_VERCEL_RUNTIME",
                 "ssh_host": "TERMINAL_SSH_HOST",
                 "ssh_user": "TERMINAL_SSH_USER",
                 "ssh_port": "TERMINAL_SSH_PORT",
@@ -5393,6 +5335,10 @@ class GatewayRunner:
                     context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                     context_length=agent_result.get("context_length") or None,
                     cwd=os.environ.get("TERMINAL_CWD", ""),
+                    token_usage=agent_result.get("token_usage") or {
+                        "input_tokens": agent_result.get("input_tokens", 0) or 0,
+                        "output_tokens": agent_result.get("output_tokens", 0) or 0,
+                    },
                 )
             except Exception as _footer_err:
                 logger.debug("runtime_footer build failed: %s", _footer_err)
@@ -5547,18 +5493,6 @@ class GatewayRunner:
                 last_prompt_tokens=agent_result.get("last_prompt_tokens", 0),
             )
 
-            # Append token usage as the final user-visible line.  Do this after
-            # runtime footers and late session-reset notices so the usage line
-            # remains last, and replace any model-generated placeholder footer.
-            if response:
-                response = _append_gateway_usage_line(
-                    response,
-                    agent_result.get("token_usage") or {
-                        "input_tokens": agent_result.get("input_tokens", 0) or 0,
-                        "output_tokens": agent_result.get("output_tokens", 0) or 0,
-                    },
-                )
-
             # Auto voice reply: send TTS audio before the text response
             _already_sent = bool(agent_result.get("already_sent"))
             if self._should_send_voice_reply(event, response, agent_messages, already_sent=_already_sent):
@@ -5582,22 +5516,15 @@ class GatewayRunner:
                         await self._deliver_media_from_response(
                             response, event, _media_adapter,
                         )
-                # Streaming already delivered the body text, but the footer/usage
-                # line was intentionally held back from the streamed text.  Send
-                # it now as a small trailing message so Telegram/Discord/etc.
+                # Streaming already delivered the body text, but the footer was
+                # intentionally held back (see the `not already_sent` gate above).
+                # Send it now as a small trailing message so Telegram/Discord/etc.
                 # still surface the runtime metadata on the final reply.
-                _trailing_line = _append_gateway_usage_line(
-                    _footer_line or "",
-                    agent_result.get("token_usage") or {
-                        "input_tokens": agent_result.get("input_tokens", 0) or 0,
-                        "output_tokens": agent_result.get("output_tokens", 0) or 0,
-                    },
-                )
-                if _trailing_line:
+                if _footer_line:
                     try:
                         _foot_adapter = self.adapters.get(source.platform)
                         if _foot_adapter:
-                            await _foot_adapter.send(source.chat_id, _trailing_line)
+                            await _foot_adapter.send(source.chat_id, _footer_line)
                     except Exception as _e:
                         logger.debug("trailing footer send failed: %s", _e)
                 return None
@@ -11119,14 +11046,15 @@ class GatewayRunner:
                 else:
                     _run_message = message
 
-                _usage_before = _snapshot_agent_token_usage(agent)
                 result = agent.run_conversation(_run_message, conversation_history=agent_history, task_id=session_id)
             finally:
                 unregister_gateway_notify(_approval_session_key)
                 reset_current_session_key(_approval_session_token)
             result_holder[0] = result
-            _usage_after = _snapshot_agent_token_usage(agent)
-            _turn_usage = _diff_agent_token_usage(_usage_before, _usage_after)
+            _turn_usage = {
+                "input_tokens": result.get("input_tokens", 0) or 0,
+                "output_tokens": result.get("output_tokens", 0) or 0,
+            }
 
             # Signal the stream consumer that the agent is done
             if _stream_consumer is not None:
@@ -11269,9 +11197,9 @@ class GatewayRunner:
                 "output_tokens": _output_toks,
                 "model": _resolved_model,
                 "context_length": _context_length,
+                "token_usage": _turn_usage,
                 "session_id": effective_session_id,
                 "response_previewed": result.get("response_previewed", False),
-                "token_usage": _turn_usage,
             }
         
         # Start progress message sender if enabled

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -67,6 +67,104 @@ _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
 # is still classified fresh.  Override via
 # ``config.yaml`` ``agent.gateway_auto_continue_freshness``.
 _AUTO_CONTINUE_FRESHNESS_SECS_DEFAULT = 60 * 60
+_GATEWAY_USAGE_LINE_RE = re.compile(r"^`usage:t=[^`\n]+ i=[^`\n]+ o=[^`\n]+(?: \([^)]+\))*`[ \t]*$", re.MULTILINE)
+
+
+def _format_usage_int(value: Any) -> str:
+    try:
+        return f"{max(0, int(value)):,}"
+    except (TypeError, ValueError):
+        return "0"
+
+
+def _snapshot_agent_token_usage(agent: Any) -> Dict[str, int]:
+    """Return cumulative token counters from an AIAgent instance."""
+    if agent is None:
+        return {}
+
+    keys = (
+        "input_tokens",
+        "output_tokens",
+        "total_tokens",
+        "cache_read_tokens",
+        "cache_write_tokens",
+        "reasoning_tokens",
+        "prompt_tokens",
+        "completion_tokens",
+    )
+    attr_map = {
+        "input_tokens": "session_input_tokens",
+        "output_tokens": "session_output_tokens",
+        "total_tokens": "session_total_tokens",
+        "cache_read_tokens": "session_cache_read_tokens",
+        "cache_write_tokens": "session_cache_write_tokens",
+        "reasoning_tokens": "session_reasoning_tokens",
+        "prompt_tokens": "session_prompt_tokens",
+        "completion_tokens": "session_completion_tokens",
+    }
+    snapshot: Dict[str, int] = {}
+    for key in keys:
+        try:
+            snapshot[key] = int(getattr(agent, attr_map[key], 0) or 0)
+        except (TypeError, ValueError):
+            snapshot[key] = 0
+    return snapshot
+
+
+def _diff_agent_token_usage(before: Dict[str, int], after: Dict[str, int]) -> Dict[str, int]:
+    """Return non-negative per-turn token usage deltas."""
+    keys = set(before or {}) | set(after or {})
+    return {key: max(0, int((after or {}).get(key, 0)) - int((before or {}).get(key, 0))) for key in keys}
+
+
+def _build_gateway_usage_line(usage: Optional[Dict[str, Any]]) -> str:
+    """Build the user-requested inline-code token usage footer."""
+    usage = usage or {}
+    input_tokens = usage.get("input_tokens", usage.get("prompt_tokens", 0)) or 0
+    output_tokens = usage.get("output_tokens", usage.get("completion_tokens", 0)) or 0
+    # Display total is the non-cached visible token total.  Provider/runtime
+    # ``total_tokens`` may include prompt-cache hits (for billing/accounting),
+    # but the compact user-facing footer shows cache reads separately as
+    # ``(+ N c)`` and must not double-count them in ``t=``.
+    try:
+        display_total_tokens = int(input_tokens or 0) + int(output_tokens or 0)
+    except (TypeError, ValueError):
+        display_total_tokens = 0
+
+    parts = [
+        f"usage:t={_format_usage_int(display_total_tokens)}",
+        f"i={_format_usage_int(input_tokens)}",
+    ]
+    cached = usage.get("cache_read_tokens")
+    try:
+        cached_int = int(cached or 0)
+    except (TypeError, ValueError):
+        cached_int = 0
+    if cached_int > 0:
+        parts[-1] = f"{parts[-1]} (+ {_format_usage_int(cached_int)} c)"
+
+    output_part = f"o={_format_usage_int(output_tokens)}"
+    reasoning = usage.get("reasoning_tokens")
+    try:
+        reasoning_int = int(reasoning or 0)
+    except (TypeError, ValueError):
+        reasoning_int = 0
+    if reasoning_int > 0:
+        output_part = f"{output_part} (r {_format_usage_int(reasoning_int)})"
+    parts.append(output_part)
+    return "`" + " ".join(parts) + "`"
+
+
+def _append_gateway_usage_line(text: str, usage: Optional[Dict[str, Any]]) -> str:
+    """Ensure exactly one trailing token usage line on a gateway response.
+
+    Preserve a single blank-line separation from the preceding body/footer so
+    the compact usage line reads like a footer instead of attaching to the
+    final content paragraph.
+    """
+    base = _GATEWAY_USAGE_LINE_RE.sub("", text or "").rstrip()
+    line = _build_gateway_usage_line(usage)
+    return f"{base}\n\n{line}" if base else line
 
 
 def _coerce_gateway_timestamp(value: Any) -> Optional[float]:
@@ -267,7 +365,6 @@ if _config_path.exists():
                 "singularity_image": "TERMINAL_SINGULARITY_IMAGE",
                 "modal_image": "TERMINAL_MODAL_IMAGE",
                 "daytona_image": "TERMINAL_DAYTONA_IMAGE",
-                "vercel_runtime": "TERMINAL_VERCEL_RUNTIME",
                 "ssh_host": "TERMINAL_SSH_HOST",
                 "ssh_user": "TERMINAL_SSH_USER",
                 "ssh_port": "TERMINAL_SSH_PORT",
@@ -5450,6 +5547,18 @@ class GatewayRunner:
                 last_prompt_tokens=agent_result.get("last_prompt_tokens", 0),
             )
 
+            # Append token usage as the final user-visible line.  Do this after
+            # runtime footers and late session-reset notices so the usage line
+            # remains last, and replace any model-generated placeholder footer.
+            if response:
+                response = _append_gateway_usage_line(
+                    response,
+                    agent_result.get("token_usage") or {
+                        "input_tokens": agent_result.get("input_tokens", 0) or 0,
+                        "output_tokens": agent_result.get("output_tokens", 0) or 0,
+                    },
+                )
+
             # Auto voice reply: send TTS audio before the text response
             _already_sent = bool(agent_result.get("already_sent"))
             if self._should_send_voice_reply(event, response, agent_messages, already_sent=_already_sent):
@@ -5473,15 +5582,22 @@ class GatewayRunner:
                         await self._deliver_media_from_response(
                             response, event, _media_adapter,
                         )
-                # Streaming already delivered the body text, but the footer was
-                # intentionally held back (see the `not already_sent` gate above).
-                # Send it now as a small trailing message so Telegram/Discord/etc.
+                # Streaming already delivered the body text, but the footer/usage
+                # line was intentionally held back from the streamed text.  Send
+                # it now as a small trailing message so Telegram/Discord/etc.
                 # still surface the runtime metadata on the final reply.
-                if _footer_line:
+                _trailing_line = _append_gateway_usage_line(
+                    _footer_line or "",
+                    agent_result.get("token_usage") or {
+                        "input_tokens": agent_result.get("input_tokens", 0) or 0,
+                        "output_tokens": agent_result.get("output_tokens", 0) or 0,
+                    },
+                )
+                if _trailing_line:
                     try:
                         _foot_adapter = self.adapters.get(source.platform)
                         if _foot_adapter:
-                            await _foot_adapter.send(source.chat_id, _footer_line)
+                            await _foot_adapter.send(source.chat_id, _trailing_line)
                     except Exception as _e:
                         logger.debug("trailing footer send failed: %s", _e)
                 return None
@@ -11003,11 +11119,14 @@ class GatewayRunner:
                 else:
                     _run_message = message
 
+                _usage_before = _snapshot_agent_token_usage(agent)
                 result = agent.run_conversation(_run_message, conversation_history=agent_history, task_id=session_id)
             finally:
                 unregister_gateway_notify(_approval_session_key)
                 reset_current_session_key(_approval_session_token)
             result_holder[0] = result
+            _usage_after = _snapshot_agent_token_usage(agent)
+            _turn_usage = _diff_agent_token_usage(_usage_before, _usage_after)
 
             # Signal the stream consumer that the agent is done
             if _stream_consumer is not None:
@@ -11044,6 +11163,7 @@ class GatewayRunner:
                     "output_tokens": _output_toks,
                     "model": _resolved_model,
                     "context_length": _context_length,
+                    "token_usage": _turn_usage,
                 }
             
             # Scan tool results for MEDIA:<path> tags that need to be delivered
@@ -11151,6 +11271,7 @@ class GatewayRunner:
                 "context_length": _context_length,
                 "session_id": effective_session_id,
                 "response_previewed": result.get("response_previewed", False),
+                "token_usage": _turn_usage,
             }
         
         # Start progress message sender if enabled

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11013,6 +11013,7 @@ class GatewayRunner:
             _approval_session_key = session_key or ""
             _approval_session_token = set_current_session_key(_approval_session_key)
             register_gateway_notify(_approval_session_key, _approval_notify_sync)
+            _usage_before = _snapshot_agent_token_usage(agent)
             try:
                 # If _prepare_inbound_message_text buffered image paths for native
                 # attachment, wrap the user turn as an OpenAI-style multimodal
@@ -11051,10 +11052,10 @@ class GatewayRunner:
                 unregister_gateway_notify(_approval_session_key)
                 reset_current_session_key(_approval_session_token)
             result_holder[0] = result
-            _turn_usage = {
-                "input_tokens": result.get("input_tokens", 0) or 0,
-                "output_tokens": result.get("output_tokens", 0) or 0,
-            }
+            _turn_usage = _diff_agent_token_usage(
+                _usage_before,
+                _snapshot_agent_token_usage(agent),
+            )
 
             # Signal the stream consumer that the agent is done
             if _stream_consumer is not None:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -68,6 +68,17 @@ _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
 # ``config.yaml`` ``agent.gateway_auto_continue_freshness``.
 _AUTO_CONTINUE_FRESHNESS_SECS_DEFAULT = 60 * 60
 
+# Strip the model's own `usage:t=...` line before appending the gateway's
+# runtime footer.  The agent system prompt instructs models to emit a usage
+# line; when the gateway also injects token information in the runtime footer
+# (snapshot-diff values), we get two different numbers in the same reply.
+# Matching against the agent-prompt format (backtick-delimited, comma-separated
+# thousands, optional cached/reasoning suffixes) and stripping it avoids the
+# duplicate.  (issue #17592 / PR discussion)
+_AGENT_USAGE_LINE_RE = re.compile(
+    r'\n*`usage:t=[\d,]+ i=[\d,]+(?: \(\+ [\d,]+ c\))? o=[\d,]+(?: \(r [\d,]+\))?`[ \t]*$'
+)
+
 
 def _snapshot_agent_token_usage(agent: Any) -> "Dict[str, int]":
     """Return cumulative token counters from an AIAgent instance."""
@@ -5344,6 +5355,10 @@ class GatewayRunner:
                 logger.debug("runtime_footer build failed: %s", _footer_err)
                 _footer_line = ""
             if _footer_line and response and not agent_result.get("already_sent"):
+                # Strip the agent's self-reported usage line before the gateway
+                # appends its own token footer (they differ: the agent-side line
+                # is the model's estimate; ours is per-turn snapshot-diff).
+                response = _AGENT_USAGE_LINE_RE.sub('', response).rstrip()
                 response = f"{response}\n\n{_footer_line}"
 
             # Emit agent:end hook

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -27,10 +27,60 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import Any, Iterable, Optional
+from typing import Any, Dict, Iterable, Optional
 
 _DEFAULT_FIELDS: tuple[str, ...] = ("model", "context_pct", "cwd")
 _SEP = " · "
+
+
+def _format_usage_int(value: Any) -> str:
+    """Format an integer with thousands separators; return '0' on failure."""
+    try:
+        return f"{max(0, int(value)):,}"
+    except (TypeError, ValueError):
+        return "0"
+
+
+def _render_token_usage(token_usage: Optional[Dict[str, int]]) -> str:
+    """Build the compact token-usage string: ``usage:t=<N> i=<N> o=<N>``.
+
+    Cached read tokens are appended as ``(+ N c)``, reasoning tokens as
+    ``(r N)``.  Returns ``\"\"`` when *token_usage* is empty or missing.
+    """
+    usage = token_usage or {}
+    input_tokens = usage.get("input_tokens", usage.get("prompt_tokens", 0)) or 0
+    output_tokens = usage.get("output_tokens", usage.get("completion_tokens", 0)) or 0
+
+    try:
+        display_total = int(input_tokens) + int(output_tokens)
+    except (TypeError, ValueError):
+        display_total = 0
+
+    if display_total <= 0:
+        return ""
+
+    parts = [
+        f"usage:t={_format_usage_int(display_total)}",
+        f"i={_format_usage_int(input_tokens)}",
+    ]
+
+    try:
+        cached = int(usage.get("cache_read_tokens", 0) or 0)
+    except (TypeError, ValueError):
+        cached = 0
+    if cached > 0:
+        parts[-1] = f"{parts[-1]} (+ {_format_usage_int(cached)} c)"
+
+    output_part = f"o={_format_usage_int(output_tokens)}"
+    try:
+        reasoning = int(usage.get("reasoning_tokens", 0) or 0)
+    except (TypeError, ValueError):
+        reasoning = 0
+    if reasoning > 0:
+        output_part = f"{output_part} (r {_format_usage_int(reasoning)})"
+    parts.append(output_part)
+
+    return " ".join(parts)
 
 
 def _home_relative_cwd(cwd: str) -> str:
@@ -95,6 +145,7 @@ def format_runtime_footer(
     context_tokens: int,
     context_length: Optional[int],
     cwd: Optional[str] = None,
+    token_usage: Optional[Dict[str, int]] = None,
     fields: Iterable[str] = _DEFAULT_FIELDS,
 ) -> str:
     """Render the footer line, or return "" if no fields have data.
@@ -116,6 +167,10 @@ def format_runtime_footer(
             rel = _home_relative_cwd(cwd or os.environ.get("TERMINAL_CWD", ""))
             if rel:
                 parts.append(rel)
+        elif field == "tokens":
+            rendered = _render_token_usage(token_usage)
+            if rendered:
+                parts.append(rendered)
         # Unknown field names are silently ignored.
 
     if not parts:
@@ -131,6 +186,7 @@ def build_footer_line(
     context_tokens: int,
     context_length: Optional[int],
     cwd: Optional[str] = None,
+    token_usage: Optional[Dict[str, int]] = None,
 ) -> str:
     """Top-level entry point used by gateway/run.py.
 
@@ -146,5 +202,6 @@ def build_footer_line(
         context_tokens=context_tokens,
         context_length=context_length,
         cwd=cwd,
+        token_usage=token_usage,
         fields=cfg.get("fields") or _DEFAULT_FIELDS,
     )

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -175,7 +175,7 @@ def format_runtime_footer(
 
     if not parts:
         return ""
-    return _SEP.join(parts)
+    return f"`{_SEP.join(parts)}`"
 
 
 def build_footer_line(


### PR DESCRIPTION
## Summary

Add automatic per-turn token usage reporting to all gateway responses. Every agent reply now ends with a compact inline-code usage footer.

## Changes

- Add `_snapshot_agent_token_usage()`, `_diff_agent_token_usage()`, `_build_gateway_usage_line()` utilities for tracking and formatting token usage
- Append `usage:t=<total> i=<input> o=<output>` footer after every gateway response
- Support cached tokens (`(+ N c)`) and reasoning tokens (`(r N)`) display
- Track per-turn deltas by snapshotting token counters before/after each agent run
- Remove stale `vercel_runtime` env-var mapping

## Test Plan

- [ ] Verify usage line appears on CLI responses
- [ ] Verify usage line appears on gateway platform responses (Telegram, Discord, WeChat etc.)
- [ ] Verify cached token display works with prompt-caching providers
- [ ] Verify reasoning token display works with reasoning models