### PR TITLE
feat: add voice.enabled config to persist voice mode across sessions

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -756,6 +756,25 @@ stt:
   #   model: "voxtral-mini-latest"  # voxtral-mini-latest | voxtral-mini-2602
 
 # =============================================================================
+# Voice Mode (CLI)
+# =============================================================================
+# CLI voice mode: speak your input via microphone, get spoken responses via TTS.
+# Unlike STT (which transcribes voice messages from messaging platforms), this
+# enables voice interaction directly in the terminal.
+#
+# Set `enabled: true` to start every CLI session with voice mode on, so you
+# don't need to type `/voice on` each time.
+#
+# voice:
+#   enabled: false           # Start sessions with voice mode enabled
+#   record_key: "ctrl+b"     # Keyboard shortcut to start/stop recording
+#   max_recording_seconds: 120
+#   auto_tts: true           # Automatically speak responses aloud
+#   beep_enabled: true       # Play audio cues on record start/stop
+#   silence_threshold: 200   # RMS level below which audio is considered silence
+#   silence_duration: 3.0    # Seconds of silence before auto-stopping recording
+
+# =============================================================================
 # Response Pacing (Messaging Platforms)
 # =============================================================================
 # Add human-like delays between message chunks.

--- a/cli.py
+++ b/cli.py
@@ -2145,8 +2145,8 @@ class HermesCLI:
 
         # Voice mode state (also reinitialized inside run() for interactive TUI).
         self._voice_lock = threading.Lock()
-        self._voice_mode = False
-        self._voice_tts = False
+        self._voice_mode = CLI_CONFIG.get("voice", {}).get("enabled", False)
+        self._voice_tts = CLI_CONFIG.get("voice", {}).get("auto_tts", False)
         self._voice_recorder = None
         self._voice_recording = False
         self._voice_processing = False
@@ -9423,8 +9423,8 @@ class HermesCLI:
 
         # Voice mode state (protected by _voice_lock for cross-thread access)
         self._voice_lock = threading.Lock()
-        self._voice_mode = False        # Whether voice mode is enabled
-        self._voice_tts = False         # Whether TTS output is enabled
+        self._voice_mode = CLI_CONFIG.get("voice", {}).get("enabled", False)  # Whether voice mode is enabled
+        self._voice_tts = CLI_CONFIG.get("voice", {}).get("auto_tts", False)  # Whether TTS output is enabled
         self._voice_recorder = None     # AudioRecorder instance (lazy init)
         self._voice_recording = False   # Whether currently recording
         self._voice_processing = False  # Whether STT is in progress

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -812,6 +812,7 @@ DEFAULT_CONFIG = {
     },
 
     "voice": {
+        "enabled": False,
         "record_key": "ctrl+b",
         "max_recording_seconds": 120,
         "auto_tts": False,

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -160,6 +160,47 @@ class TestSingleQueryState:
         assert hasattr(cli, "_pending_input")
 
 
+class TestVoiceConfigPersistence:
+    """voice.enabled and voice.auto_tts should initialize _voice_mode and _voice_tts."""
+
+    def test_voice_mode_defaults_to_false(self):
+        """When no voice config, voice mode is off (backward compat)."""
+        cli = _make_cli()
+        assert cli._voice_mode is False
+
+    def test_voice_tts_defaults_to_false(self):
+        """When no voice config, TTS is off (backward compat)."""
+        cli = _make_cli()
+        assert cli._voice_tts is False
+
+    def test_voice_enabled_true_activates_voice_mode(self):
+        """voice.enabled: true should set _voice_mode to True at init."""
+        cli = _make_cli(config_overrides={"voice": {"enabled": True}})
+        assert cli._voice_mode is True
+
+    def test_voice_auto_tts_true_activates_tts(self):
+        """voice.auto_tts: true should set _voice_tts to True at init."""
+        cli = _make_cli(config_overrides={"voice": {"enabled": True, "auto_tts": True}})
+        assert cli._voice_tts is True
+
+    def test_voice_enabled_false_keeps_voice_off(self):
+        """Explicit voice.enabled: false should keep voice mode off."""
+        cli = _make_cli(config_overrides={"voice": {"enabled": False}})
+        assert cli._voice_mode is False
+
+    def test_voice_enabled_without_auto_tts(self):
+        """voice.enabled: true without auto_tts should enable voice but not TTS."""
+        cli = _make_cli(config_overrides={"voice": {"enabled": True}})
+        assert cli._voice_mode is True
+        assert cli._voice_tts is False
+
+    def test_voice_config_nested_get_fallback(self):
+        """Missing voice key in config should not crash -- safe nested .get()."""
+        cli = _make_cli(config_overrides={"agent": {}})
+        assert cli._voice_mode is False
+        assert cli._voice_tts is False
+
+
 class TestHistoryDisplay:
     def test_history_numbers_only_visible_messages_and_summarizes_tools(self, capsys):
         cli = _make_cli()


### PR DESCRIPTION
## What does this PR do?

Adds a `voice.enabled` config option so users can start every CLI session with voice mode on, without needing to type `/voice on` each time. Also initializes `_voice_tts` from config so `auto_tts` takes effect at startup -- matching the behavior of `_enable_voice_mode()`.

Voice mode (`_voice_mode`) is hardcoded to `False` on every new session. Other features like `stt.enabled`, `memory.enabled`, and `compression.enabled` all have config-level toggles, but voice mode does not.

## Related Issue

<!-- No existing issue filed for this. -->
Fixes #

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/config.py` (line 815): Added `enabled: False` to the voice defaults
- `cli.py` (line 2148, 9426): Changed `_voice_mode` initialization from hardcoded `False` to `CLI_CONFIG.get("voice", {}).get("enabled", False)`
- `cli.py` (line 2149, 9427): Changed `_voice_tts` initialization from hardcoded `False` to `CLI_CONFIG.get("voice", {}).get("auto_tts", False)` so TTS auto-activates at startup when configured, matching `_enable_voice_mode()` behavior
- `cli-config.yaml.example` (line 757): Documented the full `voice:` section for new users
- `tests/cli/test_cli_init.py`: Added 7 new tests covering `voice.enabled` and `voice.auto_tts` config initialization

## How to Test

1. Add `voice.enabled: true` and `auto_tts: true` to `~/.hermes/config.yaml` under the `voice:` section
2. Start Hermes: `hermes`
3. Verify the status bar shows `🎤 Voice mode (TTS enabled)` immediately on startup without needing `/voice on`
4. Speak into microphone using the configured record key (default: `Ctrl+B`)
5. Verify the agent transcribes your input and speaks the response
6. Test with `voice.enabled: false` (or remove the key) -- verify voice mode is off by default (existing behavior preserved)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/cli/ -q` and all 577 CLI tests pass (7 new tests added)
- [x] I've added tests for my changes — `TestVoiceConfigPersistence` class with 7 tests
- [x] I've tested on my platform: macOS 26.3.1 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) -- N/A, config-only change
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows -- N/A
- [x] I've considered cross-platform impact (Windows, macOS) -- no platform-specific code; changes are pure dict `.get()` lookups
- [x] I've updated tool descriptions/schemas if I changed tool behavior -- N/A

## Screenshots / Logs

<!-- N/A -- no visual changes, config-only feature. -->