### PR TITLE
fix(cli): preserve model-specific api_mode across credential refresh

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3253,7 +3253,13 @@ class HermesCLI:
             or resolved_acp_args != self.acp_args
         )
         self.provider = resolved_provider
-        self.api_mode = resolved_api_mode
+        # Preserve model-specific api_mode set by the /model command.
+        # resolve_runtime_provider() defaults to "chat_completions" for
+        # most providers, but some models require "anthropic_messages"
+        # (e.g. kimi-for-coding). Only overwrite when the resolver
+        # returns a non-default transport or we're already at default.
+        if self.api_mode == "chat_completions" or resolved_api_mode != "chat_completions":
+            self.api_mode = resolved_api_mode
         self.acp_command = resolved_acp_command
         self.acp_args = resolved_acp_args
         self._credential_pool = resolved_credential_pool


### PR DESCRIPTION
## Problem

`_ensure_runtime_credentials()` unconditionally overwrites `self.api_mode` with `resolve_runtime_provider()`s return value on every turn. The resolver defaults to `"chat_completions"` for most providers, but some models require `"anthropic_messages"` (e.g. kimi-for-coding).

When a user runs `/model kimi-for-coding`, it correctly sets `api_mode="anthropic_messages"`. But on the **next** turn, `_ensure_runtime_credentials()` resets it back to `"chat_completions"`, causing a 404 error (OpenAI-format traffic sent to an Anthropic-format endpoint).

## Repro

1. Start a session with any provider
2. `/model kimi-for-coding`
3. Send a message → works
4. Send a second message → **404 error**

## Root Cause

`resolve_runtime_provider()` always returns an `api_mode` (defaulting to `"chat_completions"`), so the fallback `runtime.get("api_mode", self.api_mode)` never uses `self.api_mode`. The `/model` commands correctly set transport is unconditionally overwritten.

## Fix

Only overwrite `self.api_mode` when:
- We are already at the default (`"chat_completions"`) — nothing to preserve
- The resolver returns a non-default value — it has important info

This preserves model-specific transport modes set by `/model` while still allowing the resolver to communicate non-default transports.

## Related

Fixes #17574