### PR TITLE
[codex] fix gateway service restart exit

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12167,6 +12167,14 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         pass
 
     if runner.exit_code is not None:
+        if runner.exit_code == GATEWAY_SERVICE_RESTART_EXIT_CODE:
+            # Planned service restarts must actually terminate the process so
+            # launchd/systemd can spawn a fresh gateway.  A normal SystemExit
+            # can leave the interpreter alive when non-daemon worker threads
+            # survive a drain timeout, which strands the gateway with all
+            # platforms disconnected but the launchd job still "running".
+            logging.shutdown()
+            os._exit(runner.exit_code)
         raise SystemExit(runner.exit_code)
 
     # When a signal (SIGTERM/SIGINT) caused the shutdown and it wasn't a


### PR DESCRIPTION
## Summary

- force planned gateway service restarts to terminate the process with the configured restart exit code
- flush logging before the hard exit so process supervisors can spawn a clean replacement process

## Root cause

The gateway restart path can stop platform and API services, then raise SystemExit with GATEWAY_SERVICE_RESTART_EXIT_CODE. In a threaded shutdown case, surviving non-daemon worker threads can keep the Python interpreter alive after services are already disconnected. Supervisors such as launchd or systemd then see the old process as still running and never start a fresh gateway, leaving the service unavailable while the process appears alive.

## Validation

- parsed gateway/run.py with Python ast.parse
- verified the patched gateway restarts cleanly under a process supervisor