### PR TITLE
fix(copilot-acp): handle reasoning-only responses when tool permission denied

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -464,7 +464,7 @@ class CopilotACPClient:
 
         next_id = 0
 
-        def _request(method: str, params: dict[str, Any], *, text_parts: list[str] | None = None, reasoning_parts: list[str] | None = None) -> Any:
+        def _request(method: str, params: dict[str, Any], *, text_parts: list[str] | None = None, reasoning_parts: list[str] | None = None, prompt_completed: threading.Event | None = None) -> Any:
             nonlocal next_id
             next_id += 1
             request_id = next_id
@@ -492,6 +492,7 @@ class CopilotACPClient:
                     cwd=self._acp_cwd,
                     text_parts=text_parts,
                     reasoning_parts=reasoning_parts,
+                    prompt_completed=prompt_completed,
                 ):
                     continue
 
@@ -540,6 +541,7 @@ class CopilotACPClient:
 
             text_parts: list[str] = []
             reasoning_parts: list[str] = []
+            prompt_completed = threading.Event()
             _request(
                 "session/prompt",
                 {
@@ -553,8 +555,15 @@ class CopilotACPClient:
                 },
                 text_parts=text_parts,
                 reasoning_parts=reasoning_parts,
+                prompt_completed=prompt_completed,
             )
-            return "".join(text_parts), "".join(reasoning_parts)
+            text_result = "".join(text_parts)
+            reasoning_result = "".join(reasoning_parts)
+            # Fallback: if no text was produced but reasoning was, return reasoning as text.
+            # This handles permission-denied scenarios where Copilot returns only reasoning.
+            if not text_result and reasoning_result:
+                return reasoning_result, reasoning_result
+            return text_result, reasoning_result
         finally:
             self.close()
 
@@ -566,6 +575,7 @@ class CopilotACPClient:
         cwd: str,
         text_parts: list[str] | None,
         reasoning_parts: list[str] | None,
+        prompt_completed: threading.Event | None = None,
     ) -> bool:
         method = msg.get("method")
         if not isinstance(method, str):
@@ -579,6 +589,10 @@ class CopilotACPClient:
             chunk_text = ""
             if isinstance(content, dict):
                 chunk_text = str(content.get("text") or "")
+            if kind == "end_turn":
+                if prompt_completed is not None:
+                    prompt_completed.set()
+                return True
             if kind == "agent_message_chunk" and chunk_text and text_parts is not None:
                 text_parts.append(chunk_text)
             elif kind == "agent_thought_chunk" and chunk_text and reasoning_parts is not None:

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -201,3 +201,173 @@ def test_run_prompt_passes_home_when_parent_env_is_clean(monkeypatch, tmp_path):
 
     assert "env" in captured["kwargs"]
     assert captured["kwargs"]["env"]["HOME"]
+
+
+# ── Permission-denied / reasoning-only response tests (PR fix) ─────────────
+
+import threading
+import queue
+
+
+def _make_acp_server(messages: list[dict]) -> io.StringIO:
+    """Build a fake ACP server stdin buffer that yields `messages` as JSON lines."""
+    buf = io.StringIO("\n".join(json.dumps(m) for m in messages) + "\n")
+    return buf
+
+
+class ReasoningOnlyResponseTests(unittest.TestCase):
+    """Tests for the fix: return reasoning content when no text is produced."""
+
+    def setUp(self) -> None:
+        self.client = CopilotACPClient(acp_cwd="/tmp")
+
+    def _make_fake_proc(self, stdout_lines: list[str]) -> "_FakeProc":
+        class _FakeProc:
+            def __init__(self, lines):
+                self.stdin = io.StringIO()
+                self._lines = iter(lines)
+                self.stdout = self
+                self.stderr = io.StringIO()
+                self._rc = None
+
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                return next(self._lines)
+
+            def poll(self):
+                return self._rc
+
+            def terminate(self):
+                self._rc = -15
+
+            def wait(self, timeout=None):
+                return self._rc
+
+            def kill(self):
+                self._rc = -9
+
+        return _FakeProc(stdout_lines)
+
+    def test_end_turn_sets_prompt_completed(self) -> None:
+        """_handle_server_message should set prompt_completed on end_turn."""
+        completed = threading.Event()
+        msg = {
+            "method": "session/update",
+            "params": {
+                "update": {
+                    "sessionUpdate": "end_turn",
+                    "content": {},
+                }
+            },
+        }
+        process = _FakeProcess()
+        handled = self.client._handle_server_message(
+            msg,
+            process=process,
+            cwd="/tmp",
+            text_parts=[],
+            reasoning_parts=[],
+            prompt_completed=completed,
+        )
+        self.assertTrue(handled)
+        self.assertTrue(completed.is_set(), "prompt_completed should be set after end_turn")
+
+    def test_end_turn_without_completed_event_is_safe(self) -> None:
+        """_handle_server_message should not raise if prompt_completed is None."""
+        msg = {
+            "method": "session/update",
+            "params": {
+                "update": {
+                    "sessionUpdate": "end_turn",
+                    "content": {},
+                }
+            },
+        }
+        process = _FakeProcess()
+        handled = self.client._handle_server_message(
+            msg,
+            process=process,
+            cwd="/tmp",
+            text_parts=[],
+            reasoning_parts=[],
+            prompt_completed=None,
+        )
+        self.assertTrue(handled)
+
+    def test_thought_chunks_collected(self) -> None:
+        """agent_thought_chunk messages should be collected into reasoning_parts."""
+        reasoning_parts: list[str] = []
+        msg = {
+            "method": "session/update",
+            "params": {
+                "update": {
+                    "sessionUpdate": "agent_thought_chunk",
+                    "content": {"text": "I am thinking..."},
+                }
+            },
+        }
+        process = _FakeProcess()
+        self.client._handle_server_message(
+            msg,
+            process=process,
+            cwd="/tmp",
+            text_parts=[],
+            reasoning_parts=reasoning_parts,
+        )
+        self.assertEqual(reasoning_parts, ["I am thinking..."])
+
+    def test_reasoning_fallback_when_no_text(self) -> None:
+        """If text_result is empty but reasoning_result has content, reasoning is returned as text."""
+        import subprocess
+        from unittest.mock import patch as _patch2, MagicMock
+
+        # Simulate a sequence: initialize response, session/new response, thought chunks, end_turn
+        server_messages = [
+            # initialize response
+            json.dumps({"jsonrpc": "2.0", "id": 1, "result": {"protocolVersion": 1}}),
+            # session/new response
+            json.dumps({"jsonrpc": "2.0", "id": 2, "result": {"sessionId": "sess-001"}}),
+            # session/request_permission (triggers cancellation)
+            json.dumps({
+                "jsonrpc": "2.0",
+                "id": None,
+                "method": "session/request_permission",
+                "params": {"permission": "fs"},
+            }),
+            # reasoning-only response (no agent_message_chunk)
+            json.dumps({
+                "method": "session/update",
+                "params": {"update": {"sessionUpdate": "agent_thought_chunk", "content": {"text": "I cannot access that file."}}},
+            }),
+            json.dumps({
+                "method": "session/update",
+                "params": {"update": {"sessionUpdate": "end_turn", "content": {}}},
+            }),
+            # session/prompt response
+            json.dumps({"jsonrpc": "2.0", "id": 3, "result": {}}),
+        ]
+
+        fake_stdout = io.StringIO("\n".join(server_messages) + "\n")
+        fake_stdin = io.StringIO()
+
+        mock_proc = MagicMock()
+        mock_proc.stdin = fake_stdin
+        mock_proc.stdout = fake_stdout
+        mock_proc.stderr = io.StringIO()
+        mock_proc.poll.return_value = None
+
+        def fake_popen(cmd, **kwargs):
+            return mock_proc
+
+        with _patch2("agent.copilot_acp_client.subprocess.Popen", side_effect=fake_popen):
+            text, reasoning = self.client._run_prompt("test prompt", timeout_seconds=5)
+
+        # With the fix: text should be the reasoning content (fallback)
+        self.assertIn("I cannot access that file.", text)
+        self.assertNotEqual(text, "", "text should not be empty when reasoning content exists")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION

When Copilot CLI (ACP mode) denies tool permissions, it returns only `agent_thought_chunk` events with reasoning content but no `agent_message_chunk` text. This causes Hermes to return empty responses, triggering retry loops that eventually deliver '(empty)' to the user.

## Changes

- Add `end_turn` signal handling to properly detect when `session/prompt` completes
- Return reasoning content as text response when no text is produced
- This prevents the '(empty)' output and avoids unnecessary retry loops

## Why This Is Better Than PR #17285

PR #17285 proposes sending a follow-up message after a thought-only turn. This treats the symptom (empty response) rather than the cause (not returning reasoning content when text is empty).

This fix:
- **Addresses the root cause**: Returns reasoning content when no text is produced
- **No retry loop needed**: The response is valid on the first try
- **Follows ACP spec**: Properly handles `end_turn` signals
- **Backwards compatible**: Doesn't change the API, just improves response handling

## Related

- PR #17285 (workaround approach)
- Issue #16282 (ACP harness support)
- Issue #4543 (Copilot ACP breaks toolcalls)
- Issue #13248 (Empty-response retry loop)
- Issue #15213 (reasoning_content budget issues)
