### PR TITLE
fix(voice): add WSL2 PowerShell audio fallback for TTS playback

### DIFF
--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -889,10 +889,8 @@ def play_audio_file(file_path: str) -> bool:
 
     if system == "Darwin":
         players.append(["afplay", file_path])
-
-    # WSL2: route audio through Windows PowerShell SoundPlayer when no Linux
-    # audio devices are available (issue #17573). Convert MP3→WAV via ffmpeg
-    # and save to a Windows-accessible temp path so PowerShell can play it.
+    # WSL2: route audio through Windows PowerShell when Linux audio unavailable
+    # (issue #17573). Detects Windows %%TEMP%% dynamically — no hardcoded paths.
     _is_wsl = False
     try:
         with open("/proc/version") as _fv:
@@ -901,8 +899,6 @@ def play_audio_file(file_path: str) -> bool:
         pass
     if _is_wsl and system == "Linux" and shutil.which("powershell.exe"):
         try:
-            # Detect Windows temp dir dynamically via cmd.exe to avoid
-            # hardcoding a username in the path (user's workaround limitation).
             _win_tmp_raw = subprocess.check_output(
                 ["cmd.exe", "/c", "echo %TEMP%"],
                 stderr=subprocess.DEVNULL, timeout=3,
@@ -917,17 +913,19 @@ def play_audio_file(file_path: str) -> bool:
                     ["wslpath", "-w", _wsl_wav],
                     stderr=subprocess.DEVNULL, timeout=3,
                 ).decode(errors="replace").strip()
-                # Convert to WAV so PowerShell SoundPlayer can handle it
                 ffmpeg_exe = shutil.which("ffmpeg")
-                if ffmpeg_exe:
-                    players.insert(0, [
-                        "sh", "-c",
-                        f"{ffmpeg_exe} -i {shlex.quote(file_path)} -f wav {shlex.quote(_wsl_wav)} "
-                        f"-loglevel quiet -y 2>/dev/null && "
-                        f"powershell.exe -NoProfile -Command "
-                        f""(New-Object Media.SoundPlayer {shlex.quote(_win_wav)}).PlaySync()" && "
-                        f"rm -f {shlex.quote(_wsl_wav)}"
-                    ])
+                if ffmpeg_exe and _win_wav:
+                    _win_wav_safe = _win_wav.replace("'", "''")
+                    _ps_script = "(New-Object Media.SoundPlayer '" + _win_wav_safe + "').PlaySync()"
+                    _ps_cmd = (
+                        shlex.join([ffmpeg_exe, "-i", file_path, "-f", "wav",
+                                    _wsl_wav, "-loglevel", "quiet", "-y"])
+                        + " && "
+                        + shlex.join(["powershell.exe", "-NoProfile", "-Command", _ps_script])
+                        + " && "
+                        + shlex.join(["rm", "-f", _wsl_wav])
+                    )
+                    players.insert(0, ["sh", "-c", _ps_cmd])
         except Exception as _wsl_err:
             logger.debug("WSL PowerShell audio setup failed: %s", _wsl_err)
 

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -13,6 +13,7 @@ import logging
 import os
 import platform
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -888,6 +889,48 @@ def play_audio_file(file_path: str) -> bool:
 
     if system == "Darwin":
         players.append(["afplay", file_path])
+
+    # WSL2: route audio through Windows PowerShell SoundPlayer when no Linux
+    # audio devices are available (issue #17573). Convert MP3→WAV via ffmpeg
+    # and save to a Windows-accessible temp path so PowerShell can play it.
+    _is_wsl = False
+    try:
+        with open("/proc/version") as _fv:
+            _is_wsl = "microsoft" in _fv.read().lower()
+    except OSError:
+        pass
+    if _is_wsl and system == "Linux" and shutil.which("powershell.exe"):
+        try:
+            # Detect Windows temp dir dynamically via cmd.exe to avoid
+            # hardcoding a username in the path (user's workaround limitation).
+            _win_tmp_raw = subprocess.check_output(
+                ["cmd.exe", "/c", "echo %TEMP%"],
+                stderr=subprocess.DEVNULL, timeout=3,
+            ).decode(errors="replace").strip()
+            _win_tmp_wsl = subprocess.check_output(
+                ["wslpath", "-u", _win_tmp_raw],
+                stderr=subprocess.DEVNULL, timeout=3,
+            ).decode(errors="replace").strip()
+            if _win_tmp_wsl:
+                _wsl_wav = os.path.join(_win_tmp_wsl, "hermes-tts.wav")
+                _win_wav = subprocess.check_output(
+                    ["wslpath", "-w", _wsl_wav],
+                    stderr=subprocess.DEVNULL, timeout=3,
+                ).decode(errors="replace").strip()
+                # Convert to WAV so PowerShell SoundPlayer can handle it
+                ffmpeg_exe = shutil.which("ffmpeg")
+                if ffmpeg_exe:
+                    players.insert(0, [
+                        "sh", "-c",
+                        f"{ffmpeg_exe} -i {shlex.quote(file_path)} -f wav {shlex.quote(_wsl_wav)} "
+                        f"-loglevel quiet -y 2>/dev/null && "
+                        f"powershell.exe -NoProfile -Command "
+                        f""(New-Object Media.SoundPlayer {shlex.quote(_win_wav)}).PlaySync()" && "
+                        f"rm -f {shlex.quote(_wsl_wav)}"
+                    ])
+        except Exception as _wsl_err:
+            logger.debug("WSL PowerShell audio setup failed: %s", _wsl_err)
+
     players.append(["ffplay", "-nodisp", "-autoexit", "-loglevel", "quiet", file_path])
     if system == "Linux":
         players.append(["aplay", "-q", file_path])


### PR DESCRIPTION
## Problem

WSL2 does not expose Linux audio devices by default, causing TTS playback to fail silently — files are generated but no sound plays through Windows speakers.

## Fix

When running in WSL2 and `powershell.exe` is available, add a PowerShell SoundPlayer fallback:
1. Detect Windows `%TEMP%` dir dynamically via `cmd.exe` + `wslpath` (no hardcoded username)
2. Convert MP3 → WAV via ffmpeg to a Windows-accessible temp path
3. Play via `PowerShell SoundPlayer.PlaySync()`
4. Clean up temp WAV after playback

Falls back to `ffplay`/`aplay` if PowerShell is unavailable. No new dependencies required.

Fixes #17573