### PR TITLE
fix(plugins): stop firing pre_tool_call hook twice per tool execution

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -668,6 +668,13 @@ def handle_function_call(
         # Check plugin hooks for a block directive (unless caller already
         # checked — e.g. run_agent._invoke_tool passes skip=True to
         # avoid double-firing the hook).
+        #
+        # Single-fire contract: pre_tool_call fires exactly once per tool
+        # execution. get_pre_tool_call_block_message() internally calls
+        # invoke_hook("pre_tool_call", ...) and returns the first block
+        # directive (if any), so observer plugins see the hook on that same
+        # pass. When skip=True, the caller already fired it — do nothing
+        # here.
         if not skip_pre_tool_call_hook:
             block_message: Optional[str] = None
             try:
@@ -684,21 +691,6 @@ def handle_function_call(
 
             if block_message is not None:
                 return json.dumps({"error": block_message}, ensure_ascii=False)
-        else:
-            # Still fire the hook for observers — just don't check for blocking
-            # (the caller already did that).
-            try:
-                from hermes_cli.plugins import invoke_hook
-                invoke_hook(
-                    "pre_tool_call",
-                    tool_name=function_name,
-                    args=function_args,
-                    task_id=task_id or "",
-                    session_id=session_id or "",
-                    tool_call_id=tool_call_id or "",
-                )
-            except Exception:
-                pass
 
         # Notify the read-loop tracker when a non-read/search tool runs,
         # so the *consecutive* counter resets (reads after other work are fine).

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -193,8 +193,15 @@ class TestPreToolCallBlocking:
         result = json.loads(handle_function_call("read_file", {"path": "test.txt"}, task_id="t1"))
         assert result == {"ok": True}
 
-    def test_skip_flag_prevents_double_block_check(self, monkeypatch):
-        """When skip_pre_tool_call_hook=True, blocking is not checked (caller did it)."""
+    def test_skip_flag_prevents_double_fire(self, monkeypatch):
+        """When skip_pre_tool_call_hook=True, the hook does not fire again.
+
+        The caller (e.g. run_agent._invoke_tool) has already called
+        get_pre_tool_call_block_message(), which fires the hook once.
+        handle_function_call must NOT fire it a second time — that was
+        the classic double-fire bug where observer hooks logged every
+        tool call twice.
+        """
         hook_calls = []
 
         def fake_invoke_hook(hook_name, **kwargs):
@@ -208,10 +215,58 @@ class TestPreToolCallBlocking:
         handle_function_call("web_search", {"q": "test"}, task_id="t1",
                              skip_pre_tool_call_hook=True)
 
-        # Hook still fires for observer notification, but get_pre_tool_call_block_message
-        # is not called — invoke_hook fires directly in the skip=True branch.
-        assert "pre_tool_call" in hook_calls
+        # Single-fire contract: when skip=True the caller already fired
+        # pre_tool_call, so handle_function_call must not fire it again.
+        assert hook_calls.count("pre_tool_call") == 0, (
+            f"pre_tool_call fired {hook_calls.count('pre_tool_call')} times "
+            f"with skip_pre_tool_call_hook=True; expected 0 "
+            f"(caller already fired it). hook_calls={hook_calls}"
+        )
+        # post_tool_call and transform_tool_result still fire — only the
+        # pre-call block-check path is suppressed by the skip flag.
         assert "post_tool_call" in hook_calls
+        assert "transform_tool_result" in hook_calls
+
+    def test_run_agent_pattern_fires_pre_tool_call_exactly_once(self, monkeypatch):
+        """End-to-end regression for the double-fire bug.
+
+        Mirrors run_agent._invoke_tool: first calls
+        get_pre_tool_call_block_message() (which fires the hook as part of
+        its block-directive poll), then calls
+        handle_function_call(skip_pre_tool_call_hook=True).  The plugin
+        hook MUST fire exactly once across both calls — not twice as it
+        did before the fix (observer plugins were seeing every tool
+        execution logged twice).
+        """
+        from hermes_cli.plugins import get_pre_tool_call_block_message
+
+        hook_calls = []
+
+        def fake_invoke_hook(hook_name, **kwargs):
+            hook_calls.append(hook_name)
+            return []
+
+        monkeypatch.setattr("hermes_cli.plugins.invoke_hook", fake_invoke_hook)
+        monkeypatch.setattr("model_tools.registry.dispatch",
+                            lambda *a, **kw: json.dumps({"ok": True}))
+
+        # Step 1: caller checks for a block directive (this fires pre_tool_call once).
+        block = get_pre_tool_call_block_message(
+            "web_search", {"q": "test"}, task_id="t1",
+        )
+        assert block is None
+
+        # Step 2: caller dispatches with skip=True so the hook isn't re-fired.
+        handle_function_call(
+            "web_search", {"q": "test"}, task_id="t1",
+            skip_pre_tool_call_hook=True,
+        )
+
+        assert hook_calls.count("pre_tool_call") == 1, (
+            f"pre_tool_call fired {hook_calls.count('pre_tool_call')} times "
+            f"across the run_agent (block-check + dispatch) path; "
+            f"expected exactly 1. hook_calls={hook_calls}"
+        )
 
 
 # =========================================================================


### PR DESCRIPTION
## Summary
pre_tool_call now fires exactly once per tool execution.

Previously, every tool call routed through the main agent loop fired pre_tool_call twice. Community plugin authors with observer/audit hooks saw each tool invocation logged twice with identical timestamps.

## Root cause
`run_agent._invoke_tool` pre-checks for a block directive via `get_pre_tool_call_block_message()`, then dispatches with `handle_function_call(skip_pre_tool_call_hook=True)` specifically to avoid double-firing. But `handle_function_call` had an `else:` branch (added in eabc0a2f6) that fired `invoke_hook("pre_tool_call", ...)` again "for observers" — without noticing that `get_pre_tool_call_block_message()` itself calls `invoke_hook("pre_tool_call", ...)` as part of its poll. So the "observer" pass was redundant and produced the double-fire.

## Changes
- `model_tools.py`: delete the `else:` branch that re-fired the hook when skip=True.
- `tests/test_model_tools.py`: renamed `test_skip_flag_prevents_double_block_check` → `test_skip_flag_prevents_double_fire`, now asserts `hook_calls.count("pre_tool_call") == 0` in the skip=True path (was merely checking presence).
- `tests/test_model_tools.py`: new `test_run_agent_pattern_fires_pre_tool_call_exactly_once` — end-to-end regression that mirrors the run_agent call sequence and asserts the hook fires exactly once across block-check + dispatch.

## Single-fire contract
|  | Before | After |
|---|---|---|
| `handle_function_call(skip=False)` | 1 fire | 1 fire |
| `run_agent._invoke_tool` → `handle_function_call(skip=True)` | 2 fires | 1 fire |

## Validation
- `tests/test_model_tools.py` — 24/24 pass (including the 2 new/tightened ones).
- `tests/hermes_cli/test_plugins.py` + `tests/test_transform_tool_result_hook.py` + `tests/agent/test_shell_hooks.py` + `tests/plugins/test_langfuse_plugin.py` + `tests/hermes_cli/test_hooks_cli.py` — 137/137 pass.

Reported on Discord by Norbert, surfaced by Gille [NOUS].