### PR TITLE
chore(release): add dusterbloom to AUTHOR_MAP

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -857,6 +857,7 @@ AUTHOR_MAP = {
     "nfb0408@163.com": "ningfangbin",
     "164839249+Joseph19820124@users.noreply.github.com": "Joseph19820124",
     "rugved@lmstudio.ai": "rugvedS07",
+<<<<<<< HEAD
     "44333070+Heltman@users.noreply.github.com": "Heltman",
     # v0.12.0 additions
     "ching@kachingappz.com": "ching-kaching",
@@ -901,6 +902,7 @@ AUTHOR_MAP = {
     "promptsiren@gmail.com": "firefly",  # PR #18123 salvage of #16660 (ContextVars)
     "wtyopenclaw@gmail.com": "WuTianyi123",  # PR #20275 salvage of #13723 (feishu markdown)
     # pander: empty email, salvaged via PR #19665 from #16126 by @ms-alan
+    "giuseppe.littera@gmail.com": "dusterbloom",
 }
 
 


### PR DESCRIPTION
The `check-attribution` CI workflow fails on all my open PRs because my email (`giuseppe.littera@gmail.com`) is not in `scripts/release.py`'s `AUTHOR_MAP`.

This one-line addition maps it to my GitHub username `dusterbloom`, unblocking the CI check for my contributions.