### PR TITLE
fix(gateway): queue follow-ups unless explicitly stopped

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -913,6 +913,8 @@ _PLAINTEXT_GATEWAY_RESTART_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"^(?:please\s+)?restart\s+hermes[.!?\s]*$", re.IGNORECASE),
 )
 
+_PLAINTEXT_GATEWAY_STOP_PATTERN = re.compile(r"^stop[.!?\s]*$", re.IGNORECASE)
+
 
 def coerce_plaintext_gateway_command(event: "MessageEvent") -> None:
     """Rewrite a tiny set of DM plaintext admin phrases into slash commands.
@@ -922,8 +924,10 @@ def coerce_plaintext_gateway_command(event: "MessageEvent") -> None:
     currently running agent and leave the gateway stuck in ``draining`` while it
     waits for that same agent to finish.
 
-    Scope is intentionally narrow: DM text messages only, exact restart-style
-    phrases only. Group chats keep natural-language semantics.
+    Scope is intentionally narrow: DM text messages only. ``stop`` is exact
+    (apart from whitespace/punctuation/case) so normal sentences like ``don't
+    stop`` or ``stop after this`` remain user input and are not treated as an
+    interrupt. Group chats keep natural-language semantics.
     """
     try:
         if event is None or event.message_type != MessageType.TEXT:
@@ -933,6 +937,9 @@ def coerce_plaintext_gateway_command(event: "MessageEvent") -> None:
             return
         source = getattr(event, "source", None)
         if getattr(source, "chat_type", None) != "dm":
+            return
+        if _PLAINTEXT_GATEWAY_STOP_PATTERN.match(text):
+            event.text = "/stop"
             return
         for pattern in _PLAINTEXT_GATEWAY_RESTART_PATTERNS:
             if pattern.match(text):
@@ -2311,11 +2318,16 @@ class BasePlatformAdapter(ABC):
                 merge_pending_message_event(self._pending_messages, session_key, event)
                 return  # Don't interrupt now - will run after current task completes
 
-            # Default behavior for non-photo follow-ups: interrupt the running agent
-            logger.debug("[%s] New message while session %s is active — triggering interrupt", self.name, session_key)
-            self._pending_messages[session_key] = event
-            # Signal the interrupt (the processing task checks this)
-            self._active_sessions[session_key].set()
+            # Default behavior for follow-ups: queue behind the running agent.
+            # Explicit session-control commands such as /stop still bypass above;
+            # ordinary extra messages should not interrupt long tool runs.
+            logger.debug("[%s] New message while session %s is active — queueing without interrupt", self.name, session_key)
+            merge_pending_message_event(
+                self._pending_messages,
+                session_key,
+                event,
+                merge_text=event.message_type == MessageType.TEXT,
+            )
             return  # Don't process now - will be handled after current task finishes
         
         # Mark session as active BEFORE spawning background task to close

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -784,7 +784,7 @@ class GatewayRunner:
     # Class-level defaults so partial construction in tests doesn't
     # blow up on attribute access.
     _running_agents_ts: Dict[str, float] = {}
-    _busy_input_mode: str = "interrupt"
+    _busy_input_mode: str = "queue"
     _restart_drain_timeout: float = DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
     _exit_code: Optional[int] = None
     _draining: bool = False
@@ -1677,7 +1677,7 @@ class GatewayRunner:
 
     @staticmethod
     def _load_busy_input_mode() -> str:
-        """Load gateway drain-time busy-input behavior from config/env."""
+        """Load active-session follow-up behavior from config/env."""
         mode = os.getenv("HERMES_GATEWAY_BUSY_INPUT_MODE", "").strip().lower()
         if not mode:
             try:
@@ -1693,7 +1693,9 @@ class GatewayRunner:
             return "queue"
         if mode == "steer":
             return "steer"
-        return "interrupt"
+        if mode == "interrupt":
+            return "interrupt"
+        return "queue"
 
     @staticmethod
     def _load_restart_drain_timeout() -> float:

--- a/tests/gateway/test_session_race_guard.py
+++ b/tests/gateway/test_session_race_guard.py
@@ -14,7 +14,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig
-from gateway.platforms.base import MessageEvent, MessageType, merge_pending_message_event
+from gateway.platforms.base import (
+    MessageEvent,
+    MessageType,
+    coerce_plaintext_gateway_command,
+    merge_pending_message_event,
+)
 from gateway.run import GatewayRunner, _AGENT_PENDING_SENTINEL
 from gateway.session import SessionSource, build_session_key
 
@@ -265,6 +270,63 @@ async def test_recent_telegram_followups_append_in_pending_queue():
     fake_agent.interrupt.assert_not_called()
     adapter = runner.adapters[Platform.TELEGRAM]
     assert adapter._pending_messages[session_key].text == "part one\npart two"
+
+
+@pytest.mark.asyncio
+async def test_default_busy_policy_queues_later_followup_without_interrupt():
+    """Default policy should queue follow-ups, not interrupt active work."""
+    runner = _make_runner()
+    event = _make_event(text="later follow-up")
+    session_key = build_session_key(event.source)
+
+    fake_agent = MagicMock()
+    fake_agent.get_activity_summary.return_value = {"seconds_since_activity": 99}
+    runner._running_agents[session_key] = fake_agent
+    import time as _time
+    runner._running_agents_ts[session_key] = _time.time() - 99
+
+    result = await runner._handle_message(event)
+
+    assert result is None
+    fake_agent.interrupt.assert_not_called()
+    adapter = runner.adapters[Platform.TELEGRAM]
+    assert adapter._pending_messages[session_key].text == "later follow-up"
+
+
+@pytest.mark.asyncio
+async def test_configured_interrupt_mode_still_interrupts_running_agent():
+    """Explicit interrupt mode remains available for users who opt into it."""
+    runner = _make_runner()
+    runner._busy_input_mode = "interrupt"
+    event = _make_event(text="interrupting follow-up")
+    session_key = build_session_key(event.source)
+
+    fake_agent = MagicMock()
+    fake_agent.get_activity_summary.return_value = {"seconds_since_activity": 99}
+    runner._running_agents[session_key] = fake_agent
+
+    result = await runner._handle_message(event)
+
+    assert result is None
+    fake_agent.interrupt.assert_called_once_with("interrupting follow-up")
+    assert runner._pending_messages[session_key] == "interrupting follow-up"
+
+
+def test_plaintext_stop_dm_is_exact_interrupt_command():
+    stop_event = _make_event(text="  Stop!  ")
+    coerce_plaintext_gateway_command(stop_event)
+    assert stop_event.text == "/stop"
+
+    stop_after_event = _make_event(text="stop after this")
+    coerce_plaintext_gateway_command(stop_after_event)
+    assert stop_after_event.text == "stop after this"
+
+    group_source = SessionSource(
+        platform=Platform.TELEGRAM, chat_id="g1", chat_type="group", user_id="u1"
+    )
+    group_event = MessageEvent(text="stop", message_type=MessageType.TEXT, source=group_source)
+    coerce_plaintext_gateway_command(group_event)
+    assert group_event.text == "stop"
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- default active-session follow-ups now queue behind the current run instead of interrupting it
- preserve explicit interrupt behavior for /stop and opt-in busy_input_mode: interrupt
- coerce bare plaintext `stop` to `/stop` only for exact DM messages, avoiding accidental group or sentence interruptions

## Test Plan
- [x] `python -m pytest tests/gateway/test_session_race_guard.py -q`
- [x] static diff scan for secrets/injection patterns
- [x] independent review pass

## Privacy
- Only repo source/test files are included
- No local config, logs, personal paths, tokens, or credentials are included