### PR TITLE
fix(run_agent): consolidate duplicate memory tool handlers

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2280,29 +2280,13 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
             )
     elif function_name == "memory":
         def _execute(next_args: dict) -> Any:
-            target = next_args.get("target", "memory")
-            operations = next_args.get("operations")
-            from tools.memory_tool import memory_tool as _memory_tool
-            result = _memory_tool(
-                action=next_args.get("action"),
-                target=target,
-                content=next_args.get("content"),
-                old_text=next_args.get("old_text"),
-                operations=operations,
-                store=agent._memory_store,
+            from agent import memory_tool_dispatch
+            result = memory_tool_dispatch.dispatch_memory_tool(
+                agent,
+                next_args,
+                task_id=effective_task_id,
+                tool_call_id=tool_call_id,
             )
-            # Mirror successful built-in memory writes to external providers.
-            # All gating/op-expansion lives behind the manager interface
-            # (MemoryManager.notify_memory_tool_write).
-            if agent._memory_manager:
-                agent._memory_manager.notify_memory_tool_write(
-                    result,
-                    next_args,
-                    build_metadata=lambda: agent._build_memory_write_metadata(
-                        task_id=effective_task_id,
-                        tool_call_id=tool_call_id,
-                    ),
-                )
             return _finish_agent_tool(result, next_args)
     elif agent._memory_manager and agent._memory_manager.has_tool(function_name):
         def _execute(next_args: dict) -> Any:

--- a/agent/memory_tool_dispatch.py
+++ b/agent/memory_tool_dispatch.py
@@ -1,0 +1,44 @@
+"""Shared built-in memory tool dispatch.
+
+Both direct agent invocation and sequential tool execution call this operation.
+Path-specific middleware, result formatting, display, and persistence stay with
+their respective callers.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+
+def dispatch_memory_tool(
+    agent: Any,
+    function_args: dict[str, Any],
+    *,
+    task_id: Optional[str] = None,
+    tool_call_id: Optional[str] = None,
+) -> Any:
+    """Execute one built-in memory call and notify external providers.
+
+    ``MemoryManager.notify_memory_tool_write`` remains the sole authority for
+    committed-write gating, batch expansion, and add/replace/remove mirroring.
+    """
+    from tools.memory_tool import memory_tool
+
+    result = memory_tool(
+        action=function_args.get("action"),
+        target=function_args.get("target", "memory"),
+        content=function_args.get("content"),
+        old_text=function_args.get("old_text"),
+        operations=function_args.get("operations"),
+        store=agent._memory_store,
+    )
+    if agent._memory_manager:
+        agent._memory_manager.notify_memory_tool_write(
+            result,
+            function_args,
+            build_metadata=lambda: agent._build_memory_write_metadata(
+                task_id=task_id,
+                tool_call_id=tool_call_id,
+            ),
+        )
+    return result

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1283,30 +1283,13 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 agent._vprint(f"  {_get_cute_tool_message_impl('session_search', function_args, tool_duration, result=function_result)}")
         elif function_name == "memory":
             def _execute(next_args: dict) -> Any:
-                target = next_args.get("target", "memory")
-                operations = next_args.get("operations")
-                from tools.memory_tool import memory_tool as _memory_tool
-                result = _memory_tool(
-                    action=next_args.get("action"),
-                    target=target,
-                    content=next_args.get("content"),
-                    old_text=next_args.get("old_text"),
-                    operations=operations,
-                    store=agent._memory_store,
+                from agent import memory_tool_dispatch
+                return memory_tool_dispatch.dispatch_memory_tool(
+                    agent,
+                    next_args,
+                    task_id=effective_task_id,
+                    tool_call_id=getattr(tool_call, "id", None),
                 )
-                # Mirror successful built-in memory writes to external
-                # providers. All gating/op-expansion lives behind the manager
-                # interface (MemoryManager.notify_memory_tool_write).
-                if agent._memory_manager:
-                    agent._memory_manager.notify_memory_tool_write(
-                        result,
-                        next_args,
-                        build_metadata=lambda: agent._build_memory_write_metadata(
-                            task_id=effective_task_id,
-                            tool_call_id=getattr(tool_call, "id", None),
-                        ),
-                    )
-                return result
             function_result, function_args = _run_agent_tool_execution_middleware(
                 agent,
                 function_name=function_name,

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2282,6 +2282,131 @@ class TestExecuteToolCalls:
         assert metadata["tool_call_id"] == "mem-1"
         assert messages[-1]["tool_call_id"] == "mem-1"
 
+    def test_memory_paths_use_shared_dispatch(self, agent, monkeypatch):
+        """Direct and sequential execution must route through one memory operation."""
+        from agent import memory_tool_dispatch
+
+        calls = []
+
+        def fake_dispatch(current_agent, args, *, task_id=None, tool_call_id=None):
+            calls.append((current_agent, args, task_id, tool_call_id))
+            return json.dumps({"success": True, "path": len(calls)})
+
+        monkeypatch.setattr(memory_tool_dispatch, "dispatch_memory_tool", fake_dispatch)
+        args = {"action": "add", "target": "memory", "content": "shared fact"}
+
+        direct = agent._invoke_tool(
+            "memory", args, "task-direct", tool_call_id="mem-direct"
+        )
+
+        tc = _mock_tool_call(
+            name="memory", arguments=json.dumps(args), call_id="mem-sequential"
+        )
+        messages = []
+        agent._execute_tool_calls_sequential(
+            _mock_assistant_msg(content="", tool_calls=[tc]),
+            messages,
+            "task-sequential",
+        )
+
+        assert json.loads(direct)["path"] == 1
+        assert json.loads(messages[-1]["content"])["path"] == 2
+        assert [(task_id, tool_call_id) for _, _, task_id, tool_call_id in calls] == [
+            ("task-direct", "mem-direct"),
+            ("task-sequential", "mem-sequential"),
+        ]
+
+    @pytest.mark.parametrize("path", ["direct", "sequential"])
+    def test_memory_paths_forward_batch_and_mirror_committed_writes(
+        self, agent, path
+    ):
+        operations = [
+            {"action": "replace", "old_text": "old", "content": "updated"},
+            {"action": "remove", "old_text": "obsolete"},
+            {"action": "add", "content": "new fact"},
+        ]
+        args = {"target": "user", "operations": operations}
+        mirrored = []
+
+        class FakeMemoryManager(MemoryManager):
+            def has_tool(self, tool_name):
+                return False
+
+            def on_memory_write(self, action, target, content, metadata=None):
+                mirrored.append((action, target, content, dict(metadata or {})))
+
+        agent._memory_manager = FakeMemoryManager()
+        agent._memory_store = object()
+
+        with patch(
+            "tools.memory_tool.memory_tool",
+            return_value=json.dumps({"success": True}),
+        ) as memory_tool:
+            if path == "direct":
+                result = agent._invoke_tool(
+                    "memory", args, "task-1", tool_call_id="mem-1"
+                )
+                assert json.loads(result)["success"] is True
+            else:
+                tc = _mock_tool_call(
+                    name="memory", arguments=json.dumps(args), call_id="mem-1"
+                )
+                messages = []
+                agent._execute_tool_calls_sequential(
+                    _mock_assistant_msg(content="", tool_calls=[tc]),
+                    messages,
+                    "task-1",
+                )
+                assert json.loads(messages[-1]["content"])["success"] is True
+
+        assert memory_tool.call_args.kwargs["operations"] == operations
+        assert [(a, t, c) for a, t, c, _ in mirrored] == [
+            ("replace", "user", "updated"),
+            ("remove", "user", ""),
+            ("add", "user", "new fact"),
+        ]
+        assert all(metadata["tool_call_id"] == "mem-1" for *_, metadata in mirrored)
+
+    @pytest.mark.parametrize("path", ["direct", "sequential"])
+    @pytest.mark.parametrize(
+        "tool_result",
+        [
+            json.dumps({"success": False, "error": "write failed"}),
+            json.dumps({"success": True, "staged": True, "pending_id": "p1"}),
+        ],
+        ids=["failed", "staged"],
+    )
+    def test_memory_paths_do_not_mirror_uncommitted_writes(
+        self, agent, path, tool_result
+    ):
+        mirrored = []
+
+        class FakeMemoryManager(MemoryManager):
+            def has_tool(self, tool_name):
+                return False
+
+            def on_memory_write(self, action, target, content, metadata=None):
+                mirrored.append((action, target, content, metadata))
+
+        agent._memory_manager = FakeMemoryManager()
+        agent._memory_store = object()
+        args = {"action": "add", "target": "memory", "content": "candidate"}
+
+        with patch("tools.memory_tool.memory_tool", return_value=tool_result):
+            if path == "direct":
+                agent._invoke_tool("memory", args, "task-1", tool_call_id="mem-1")
+            else:
+                tc = _mock_tool_call(
+                    name="memory", arguments=json.dumps(args), call_id="mem-1"
+                )
+                agent._execute_tool_calls_sequential(
+                    _mock_assistant_msg(content="", tool_calls=[tc]),
+                    [],
+                    "task-1",
+                )
+
+        assert mirrored == []
+
     def test_keyboard_interrupt_emits_cancelled_post_tool_hook(self, agent, monkeypatch):
         tc = _mock_tool_call(name="web_search", arguments='{"q":"test"}', call_id="c1")
         mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])


### PR DESCRIPTION
## Summary

Centralize built-in memory tool execution across the direct and sequential agent paths. Both paths now call one shared operation while retaining their path-specific middleware, display, persistence, and result handling.

## Change

- Add `agent/memory_tool_dispatch.py` as the shared built-in memory operation.
- Route `agent/agent_runtime_helpers.py` and `agent/tool_executor.py` through it.
- Preserve `operations` forwarding.
- Preserve committed-write gating, batch expansion, and external-provider mirroring through `MemoryManager.notify_memory_tool_write()`.
- Add behavior coverage for both execution paths, including batch, failed, and staged writes.

The concurrent executor already delegates agent-owned tools through the direct `_invoke_tool` path, so it reaches the same shared memory operation without adding a third dispatch site.

## Why

The direct and sequential paths previously duplicated the `memory_tool()` call and the external-memory notification bridge. Keeping this logic in one operation prevents future memory-tool parameters or bridge changes from drifting between execution paths.

## Test plan

- [x] `scripts/run_tests.sh tests/run_agent/test_run_agent.py tests/agent/test_memory_write_bridge.py tests/agent/test_memory_provider.py` — 533 passed
- [x] New behavior tests cover shared dispatch, batch forwarding/mirroring, failed writes, and staged writes across direct and sequential paths
- [x] `ruff check .`
- [x] `python -m py_compile agent/memory_tool_dispatch.py agent/agent_runtime_helpers.py agent/tool_executor.py tests/run_agent/test_run_agent.py`
- [x] `python scripts/check-windows-footguns.py --all`
- [x] `git diff --check`

## Risk

Low. This is a focused refactor with no intended behavior change. Path-specific middleware, display, persistence, and result formatting remain in their existing callers, while committed-write gating and batch mirroring remain owned by `MemoryManager.notify_memory_tool_write()`.
