### PR TITLE
chore(delegate): remove unused sys import and fix bare f-string

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -11,7 +11,6 @@ Run with:  python -m pytest tests/test_delegate.py -v
 
 import json
 import os
-import sys
 import threading
 import time
 import unittest

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1194,7 +1194,7 @@ def _dump_subagent_timeout_diagnostic(
         def _w(line: str = "") -> None:
             lines.append(line)
 
-        _w(f"# Subagent timeout diagnostic — issue #14726")
+        _w("# Subagent timeout diagnostic — issue #14726")
         _w(f"# Generated: {_dt.datetime.now().isoformat()}")
         _w("")
         _w("## Timeout")


### PR DESCRIPTION
## Summary
Removes two ruff warnings missed in #17010.

---

## What changed
* `tests/tools/test_delegate.py`: removed unused `import sys` (F401)
* `tools/delegate_tool.py`: removed bare `f` prefix from string without placeholders in `_dump_subagent_timeout_diagnostic` (F541)

---

## Validation

Both warnings confirmed present on upstream main after #17010 - missed in that cleanup pass.

```bash
ruff check --select F401,F541 tools/delegate_tool.py tests/tools/test_delegate.py
# All checks passed!
```

Part of the ruff cleanup started in #17010.