### PR TITLE
fix(execute_code): forward docker_forward_env into container_config

### DIFF
--- a/tests/tools/test_code_execution_docker_forward_env.py
+++ b/tests/tools/test_code_execution_docker_forward_env.py
@@ -1,0 +1,101 @@
+"""Regression test for docker_forward_env / docker_env wiring through
+the execute_code → _get_or_create_env → _create_environment path.
+
+Mirrors the test_parse_env_var.py boundary check for the terminal_tool
+path. Without these keys in container_config, env vars listed in
+``terminal.docker_forward_env`` (or set in ``terminal.docker_env``) are
+silently dropped when ``execute_code`` provisions a Docker sandbox —
+even though they reach the same ``_DockerEnvironment`` constructor
+correctly via the terminal_tool code path.
+"""
+
+from unittest.mock import patch
+
+import tools.code_execution_tool as _ce_mod
+import tools.terminal_tool as _tt_mod
+
+
+def _make_env_config(forward_env, docker_env=None):
+    """Build a minimal env-config dict matching _get_env_config()'s shape."""
+    return {
+        "env_type": "docker",
+        "docker_image": "python:3.11",
+        "cwd": "/root",
+        "timeout": 60,
+        "lifetime_seconds": 300,
+        "container_cpu": 1,
+        "container_memory": 5120,
+        "container_disk": 51200,
+        "container_persistent": True,
+        "docker_volumes": [],
+        "docker_forward_env": forward_env,
+        "docker_env": docker_env or {},
+    }
+
+
+def test_get_or_create_env_passes_docker_forward_env_to_container_config():
+    """execute_code's container_config must include docker_forward_env."""
+    captured = {}
+
+    def fake_create(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    with patch.object(_tt_mod, "_get_env_config",
+                      return_value=_make_env_config(["GITHUB_TOKEN", "NPM_TOKEN"])), \
+         patch.object(_tt_mod, "_create_environment", side_effect=fake_create), \
+         patch.object(_tt_mod, "_active_environments", {}), \
+         patch.object(_tt_mod, "_task_env_overrides", {}):
+        _ce_mod._get_or_create_env("task-forward-env")
+
+    assert captured["container_config"]["docker_forward_env"] == ["GITHUB_TOKEN", "NPM_TOKEN"]
+
+
+def test_get_or_create_env_passes_docker_env_to_container_config():
+    """execute_code's container_config must include docker_env."""
+    captured = {}
+
+    def fake_create(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    with patch.object(_tt_mod, "_get_env_config",
+                      return_value=_make_env_config([], docker_env={"FOO": "bar"})), \
+         patch.object(_tt_mod, "_create_environment", side_effect=fake_create), \
+         patch.object(_tt_mod, "_active_environments", {}), \
+         patch.object(_tt_mod, "_task_env_overrides", {}):
+        _ce_mod._get_or_create_env("task-docker-env")
+
+    assert captured["container_config"]["docker_env"] == {"FOO": "bar"}
+
+
+def test_get_or_create_env_defaults_when_keys_absent():
+    """When config omits the keys entirely, sensible empty defaults flow through."""
+    captured = {}
+
+    def fake_create(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    sparse_cfg = {
+        "env_type": "docker",
+        "docker_image": "python:3.11",
+        "cwd": "/root",
+        "timeout": 60,
+        "lifetime_seconds": 300,
+        "container_cpu": 1,
+        "container_memory": 5120,
+        "container_disk": 51200,
+        "container_persistent": True,
+        "docker_volumes": [],
+        # docker_forward_env / docker_env intentionally omitted
+    }
+
+    with patch.object(_tt_mod, "_get_env_config", return_value=sparse_cfg), \
+         patch.object(_tt_mod, "_create_environment", side_effect=fake_create), \
+         patch.object(_tt_mod, "_active_environments", {}), \
+         patch.object(_tt_mod, "_task_env_overrides", {}):
+        _ce_mod._get_or_create_env("task-defaults")
+
+    assert captured["container_config"]["docker_forward_env"] == []
+    assert captured["container_config"]["docker_env"] == {}

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -507,6 +507,8 @@ def _get_or_create_env(task_id: str):
                 "vercel_runtime": config.get("vercel_runtime", ""),
                 "docker_volumes": config.get("docker_volumes", []),
                 "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
+                "docker_forward_env": config.get("docker_forward_env", []),
+                "docker_env": config.get("docker_env", {}),
             }
 
         ssh_config = None


### PR DESCRIPTION
## What does this PR do?

`tools/code_execution_tool.py:_get_or_create_env()` builds the `container_config` dict that's passed to `_create_environment()`, but it omits `docker_forward_env` and `docker_env`. Env vars listed in `terminal.docker_forward_env` (config.yaml) are silently dropped whenever a Docker sandbox is provisioned for `execute_code`. Since most agent shell work now flows through `execute_code` rather than the older terminal/file tool paths, real-world CLIs that depend on credentials (himalaya, vercel, gh, firebase, …) fail with "no credentials" errors inside the sandbox even when the agent's whitelist explicitly names the right vars.

The terminal_tool path was fixed by #14235 and the file_tools path by #12900. `code_execution_tool.py` re-implements the `container_config` assembly in its own `_get_or_create_env()` and was missed by both. PR #8320 originally caught all three call sites in one diff but went DIRTY once the other two merged independently and was incorrectly closed as a duplicate of #14235 — this PR carries forward its surviving third chunk.

> Note on `docker_env`: the corresponding config-bridging in `cli.py` is still missing (tracked in #16214), so `terminal.docker_env` values won't actually reach `_get_env_config()` until that lands. Including the key here keeps shape parity with the merged `terminal_tool.py` change so the wiring is in place once #16214 lands.

## Related Issue

Fixes #12534

Refs #5722, #16214, #8320

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/code_execution_tool.py` — add `docker_forward_env` and `docker_env` to the `container_config` dict in `_get_or_create_env()`, matching the shape that #14235 already merged into `terminal_tool.py` and #12900 merged into `file_tools.py`.
- `tests/tools/test_code_execution_docker_forward_env.py` — new file. Three regression tests that mock `_create_environment` and assert both keys flow through, plus a defaults case. Verified to **fail** (KeyError on `container_config["docker_forward_env"]`/`["docker_env"]`) without the fix and **pass** with it.

## How to Test

1. Set up a Docker-backend config:

   ```yaml
   # ~/.hermes/config.yaml
   terminal:
     backend: docker
     docker_forward_env:
       - GITHUB_TOKEN
   ```

   ```
   # ~/.hermes/.env
   GITHUB_TOKEN=ghp_xxxxxxxxxxxxx
   ```

2. Restart the gateway so the new container is provisioned with the corrected wiring.

3. Inside an agent session, have the model use `execute_code` to run:

   ```bash
   printenv GITHUB_TOKEN | wc -c
   ```

   - **Before the fix:** prints `0` (var empty in sandbox).
   - **After the fix:** prints the actual token length.

4. Run the new regression suite directly:

   ```
   pytest tests/tools/test_code_execution_docker_forward_env.py -v
   ```

   3 tests should pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(execute_code):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) — closest are merged #14235 and #12900 (sister tools, not this path) and the now-DIRTY #8320 (originally caught all three sites, only the code_execution_tool chunk remained unmerged)
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/tools/test_code_execution_docker_forward_env.py tests/tools/test_parse_env_var.py tests/tools/test_docker_environment.py -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.x / Colima

### Documentation & Housekeeping

- [x] Documentation — **N/A** (no user-facing surface change; the `docker_forward_env` config key is already documented and was already supposed to work via this path)
- [x] `cli-config.yaml.example` — **N/A** (key already present)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — **N/A**
- [x] Cross-platform — **N/A** (only affects the Docker backend code path; no OS-specific code touched)
- [x] Tool descriptions / schemas — **N/A**

## Screenshots / Logs

End-to-end verification with `himalaya` (Gmail IMAP CLI) inside `execute_code` after the fix:

```
$ hermes chat -q "Use execute_code to run: printenv EMAIL_PASSWORD | wc -c. Print verbatim." -Q
19

$ hermes chat -q "Use execute_code to run: himalaya envelope list -a default 2>&1 | head -3. Print verbatim." -Q
| ID | FLAGS | SUBJECT  | FROM   | DATE                   |
|----|-------|----------|--------|------------------------|
| 7  |       | Re: Hello| elliot | 2026-04-28 15:10-07:00 |
```

Without the fix, `printenv EMAIL_PASSWORD | wc -c` returns `0` and himalaya fails with `cannot get imap password from global keyring` / `command printenv EMAIL_PASSWORD returned non-zero exit status code 1`.