### PR TITLE
fix(copilot): honor token precedence and derive api_mode per target model

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1113,16 +1113,27 @@ def _upsert_entry(entries: List[PooledCredential], provider: str, source: str, p
 
 
 def _normalize_pool_priorities(provider: str, entries: List[PooledCredential]) -> bool:
-    if provider != "anthropic":
+    if provider == "anthropic":
+        source_rank = {
+            "env:ANTHROPIC_TOKEN": 0,
+            "env:CLAUDE_CODE_OAUTH_TOKEN": 1,
+            "hermes_pkce": 2,
+            "claude_code": 3,
+            "env:ANTHROPIC_API_KEY": 4,
+        }
+    elif provider == "copilot":
+        # Mirror the precedence in hermes_cli/copilot_auth.py:resolve_copilot_token
+        # so a freshly-added COPILOT_GITHUB_TOKEN (e.g. from `hermes model` device
+        # login) outranks an older `gh auth token` for a different account.
+        source_rank = {
+            "env:COPILOT_GITHUB_TOKEN": 0,
+            "env:GH_TOKEN": 1,
+            "env:GITHUB_TOKEN": 2,
+            "gh_cli": 3,
+        }
+    else:
         return False
 
-    source_rank = {
-        "env:ANTHROPIC_TOKEN": 0,
-        "env:CLAUDE_CODE_OAUTH_TOKEN": 1,
-        "hermes_pkce": 2,
-        "claude_code": 3,
-        "env:ANTHROPIC_API_KEY": 4,
-    }
     manual_entries = sorted(
         (entry for entry in entries if _is_manual_source(entry.source)),
         key=lambda entry: entry.priority,

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -149,12 +149,23 @@ def _provider_supports_explicit_api_mode(provider: Optional[str], configured_pro
 def _copilot_runtime_api_mode(model_cfg: Dict[str, Any], api_key: str) -> str:
     configured_provider = str(model_cfg.get("provider") or "").strip().lower()
     configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
-    if configured_mode and _provider_supports_explicit_api_mode("copilot", configured_provider):
-        return configured_mode
-
-    model_name = str(model_cfg.get("default") or "").strip()
+    model_name = str(model_cfg.get("target_model") or model_cfg.get("default") or "").strip()
     if not model_name:
         return "chat_completions"
+
+    # Copilot can serve multiple model families with different API surfaces
+    # under the same provider. Recompute from the active target model instead
+    # of trusting a stale persisted config api_mode from an earlier selection.
+    # Example: gpt-5.4 -> Claude would otherwise stay on Responses API and fail.
+    if configured_mode and _provider_supports_explicit_api_mode("copilot", configured_provider):
+        try:
+            from hermes_cli.models import copilot_model_api_mode
+
+            inferred = copilot_model_api_mode(model_name, api_key=api_key)
+            if inferred:
+                return inferred
+        except Exception:
+            return configured_mode
 
     try:
         from hermes_cli.models import copilot_model_api_mode
@@ -219,7 +230,9 @@ def _resolve_runtime_from_pool_entry(
     elif provider == "nous":
         api_mode = "chat_completions"
     elif provider == "copilot":
-        api_mode = _copilot_runtime_api_mode(model_cfg, getattr(entry, "runtime_api_key", ""))
+        _model_cfg = dict(model_cfg)
+        _model_cfg["target_model"] = effective_model
+        api_mode = _copilot_runtime_api_mode(_model_cfg, getattr(entry, "runtime_api_key", ""))
         base_url = base_url or PROVIDER_REGISTRY["copilot"].inference_base_url
     elif provider == "azure-foundry":
         # Azure Foundry: read api_mode and base_url from config
@@ -1269,7 +1282,9 @@ def resolve_runtime_provider(
         base_url = cfg_base_url or creds.get("base_url", "").rstrip("/")
         api_mode = "chat_completions"
         if provider == "copilot":
-            api_mode = _copilot_runtime_api_mode(model_cfg, creds.get("api_key", ""))
+            _model_cfg = dict(model_cfg)
+            _model_cfg["target_model"] = target_model or model_cfg.get("default", "")
+            api_mode = _copilot_runtime_api_mode(_model_cfg, creds.get("api_key", ""))
         elif provider == "xai":
             api_mode = "codex_responses"
         else:

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -1056,6 +1056,55 @@ def test_load_pool_does_not_seed_copilot_when_no_token(tmp_path, monkeypatch):
     assert pool.entries() == []
 
 
+def test_copilot_pool_prioritizes_env_token_over_gh_cli():
+    """Copilot pool must rank env-var tokens ahead of the gh CLI fallback,
+    mirroring the precedence in ``hermes_cli/copilot_auth.py:resolve_copilot_token``
+    (COPILOT_GITHUB_TOKEN > GH_TOKEN > GITHUB_TOKEN > gh auth token).
+
+    Without this, a ``gh_cli`` entry seeded from a pre-existing
+    ``gh auth login`` (often a different GitHub account) silently
+    outranks the env-var token the user just persisted via
+    ``hermes model`` device-code login, producing wrong-account auth
+    and 400 ``model_not_supported`` at runtime when the gh account
+    lacks Copilot access for the requested model.
+    """
+    from agent.credential_pool import (
+        AUTH_TYPE_API_KEY,
+        PooledCredential,
+        _normalize_pool_priorities,
+    )
+
+    # Realistic ordering: gh_cli was upserted first (priority 0) — the
+    # gh CLI predates the device login.  Normalization must demote it.
+    entries = [
+        PooledCredential(
+            id="gh-cli-entry",
+            provider="copilot",
+            label="account-A",
+            auth_type=AUTH_TYPE_API_KEY,
+            access_token="copilot_api_token_account_A",
+            priority=0,
+            source="gh_cli",
+            base_url="https://api.githubcopilot.com",
+        ),
+        PooledCredential(
+            id="env-entry",
+            provider="copilot",
+            label="COPILOT_GITHUB_TOKEN",
+            auth_type=AUTH_TYPE_API_KEY,
+            access_token="copilot_api_token_account_B",
+            priority=1,
+            source="env:COPILOT_GITHUB_TOKEN",
+            base_url="https://api.githubcopilot.com",
+        ),
+    ]
+
+    _normalize_pool_priorities("copilot", entries)
+
+    by_source = {e.source: e for e in entries}
+    assert by_source["env:COPILOT_GITHUB_TOKEN"].priority < by_source["gh_cli"].priority
+
+
 def test_load_pool_seeds_qwen_oauth_via_cli_tokens(tmp_path, monkeypatch):
     """Qwen OAuth credentials from ~/.qwen/oauth_creds.json should be seeded into the pool."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1312,6 +1312,88 @@ def test_opencode_go_model_derivation_beats_stale_persisted_api_mode(monkeypatch
     assert resolved["api_mode"] == "anthropic_messages"
 
 
+def test_copilot_api_mode_recomputed_for_non_codex_default_model(monkeypatch):
+    """Copilot must re-derive api_mode from the actual model on every
+    resolve, ignoring a stale persisted ``api_mode`` from an earlier
+    setup run.  Mirrors the opencode fix in PR #15106 / #16888 and the
+    cron-side fix in PR #9033.
+
+    Repro: user ran setup while ``model.default = gpt-5.4`` so config
+    has ``api_mode: codex_responses``.  They later switch ``model.default``
+    to ``claude-sonnet-4.6`` (chat_completions).  The persisted api_mode
+    must NOT win — claude-* on Copilot does not speak the Responses API
+    and would return 400 ``model_not_supported``.
+    """
+    cfg = {
+        "provider": "copilot",
+        "default": "claude-sonnet-4.6",
+        "api_mode": "codex_responses",
+        "base_url": "https://api.githubcopilot.com",
+    }
+
+    def _fake_copilot_mode(model_id, *, catalog=None, api_key=None):
+        m = (model_id or "").lower()
+        if m.startswith("gpt-5") and not m.startswith("gpt-5-mini"):
+            return "codex_responses"
+        return "chat_completions"
+
+    monkeypatch.setattr(
+        "hermes_cli.models.copilot_model_api_mode", _fake_copilot_mode
+    )
+
+    mode = rp._copilot_runtime_api_mode(cfg, api_key="gho_fake_token")
+
+    assert mode == "chat_completions"
+
+
+def test_copilot_api_mode_follows_target_model_on_runtime_switch(monkeypatch):
+    """``/model gemini-3.1-pro-preview`` mid-session must resolve to
+    chat_completions even when the persisted config default is gpt-5.4
+    (codex_responses).  The pool-entry resolver threads ``target_model``
+    via ``_model_cfg["target_model"]`` so ``_copilot_runtime_api_mode``
+    sees the model the agent is actually about to dispatch.
+    """
+    from agent.credential_pool import AUTH_TYPE_API_KEY, PooledCredential
+
+    cfg = {
+        "provider": "copilot",
+        "default": "gpt-5.4",
+        "api_mode": "codex_responses",
+        "base_url": "https://api.githubcopilot.com",
+    }
+
+    def _fake_copilot_mode(model_id, *, catalog=None, api_key=None):
+        m = (model_id or "").lower()
+        if m.startswith("gpt-5") and not m.startswith("gpt-5-mini"):
+            return "codex_responses"
+        return "chat_completions"
+
+    monkeypatch.setattr(
+        "hermes_cli.models.copilot_model_api_mode", _fake_copilot_mode
+    )
+
+    entry = PooledCredential(
+        id="env-entry",
+        provider="copilot",
+        label="COPILOT_GITHUB_TOKEN",
+        auth_type=AUTH_TYPE_API_KEY,
+        access_token="copilot_api_token_xyz",
+        priority=0,
+        source="env:COPILOT_GITHUB_TOKEN",
+        base_url="https://api.githubcopilot.com",
+    )
+
+    resolved = rp._resolve_runtime_from_pool_entry(
+        provider="copilot",
+        entry=entry,
+        requested_provider="copilot",
+        model_cfg=cfg,
+        target_model="gemini-3.1-pro-preview",
+    )
+
+    assert resolved["api_mode"] == "chat_completions"
+
+
 def test_named_custom_provider_anthropic_api_mode(monkeypatch):
     """Custom providers should accept api_mode: anthropic_messages."""
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "my-anthropic-proxy")


### PR DESCRIPTION
## What does this PR do?

Fixes two compounding bugs that surface as `HTTP 400 model_not_supported` on Copilot for most non-default-model requests, even when the user's GitHub account does have access to the model in question.

### Bug 1 — Credential pool ignores documented Copilot token precedence

`hermes_cli/copilot_auth.py:resolve_copilot_token` documents the precedence `COPILOT_GITHUB_TOKEN > GH_TOKEN > GITHUB_TOKEN > gh auth token`. That precedence is honored on the **first** `load_pool()` because `_seed_from_singletons` calls `resolve_copilot_token()` directly and seeds a single entry.

But the pool is persisted to `~/.hermes/auth.json`. On subsequent loads, the previously seeded entry (e.g. `gh_cli`) is read back from disk *before* re-seeding runs. If the user later adds a higher-precedence source — for example, by running `hermes model` to log into Copilot via device-code flow, which writes `COPILOT_GITHUB_TOKEN` to `~/.hermes/.env` — the new entry is upserted at the next free priority, *behind* the stale `gh_cli` entry. Subsequent requests authenticate as the wrong GitHub account, and Copilot returns `model_not_supported` for any model the wrong account can't reach.

`_normalize_pool_priorities` is the function that re-ranks pool entries after the load/upsert cycle — but it only special-cased `anthropic`. PR #2647 introduced the function specifically to solve this same bug class (multi-source providers where insertion order doesn't match the user's intended precedence). Copilot acquired multiple credential sources in commit `0bd3f521` (April 2026) without `_normalize_pool_priorities` being extended to match.

### Bug 2 — Copilot `api_mode` not recomputed per target model

Copilot serves different model families through different endpoints under `https://api.githubcopilot.com`:

- `/responses` (`codex_responses`): GPT-5.x non-mini, GPT-5.x-codex
- `/chat/completions`: GPT-5-mini, GPT-4.1, GPT-4o, Gemini
- `/v1/messages` (`anthropic_messages`): Claude

`hermes_cli/models.copilot_model_api_mode()` already encodes this mapping correctly. But `hermes_cli/runtime_provider.py:_copilot_runtime_api_mode` short-circuited on the persisted `model.api_mode` when the configured provider was Copilot. Config written while `model.default = gpt-5.4` records `api_mode: codex_responses`; a later `/model claude-sonnet-4.6` (or any other non-codex Copilot model) was then dispatched to `/responses` and rejected.

PR #15106 fixed the same root cause for opencode-zen / opencode-go by threading `target_model` through `resolve_runtime_provider` and `_resolve_runtime_from_pool_entry`. PR #9033 fixed the equivalent in the cron path. The runtime resolver path for Copilot was missed.

`hermes_cli/model_switch.py:919` already calls `copilot_model_api_mode()` at config-write time, so this fix is defense-in-depth — it covers any path that bypasses the model-switch helper (gateway dispatch, runtime overrides, fresh sessions on stale config).

## Related Issues

No existing issue covers this exact pair. Closely related context:

- PR #2647 — introduced `_normalize_pool_priorities` (the function this PR extends to copilot) and the anthropic precedence ranking
- PR #15106, #16888 — same `target_model` pattern previously applied to opencode-zen / opencode-go
- PR #9033 — equivalent `api_mode` fix for cron
- Commit `0bd3f521` — added Copilot env-var seeding without updating `_normalize_pool_priorities`

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

**`agent/credential_pool.py`** — refactor `_normalize_pool_priorities` to select a per-provider `source_rank` table via `if/elif/else` instead of an early-out on non-anthropic. Adds a `copilot` branch mirroring the precedence in `hermes_cli/copilot_auth.py:resolve_copilot_token`. The existing manual/seeded split, sort, and priority rewrite logic is unchanged and now shared between both providers. Net `+13` lines, zero behavior change for anthropic.

**`hermes_cli/runtime_provider.py`** —
- `_copilot_runtime_api_mode` now reads `target_model` first, falls back to `model.default`, and always invokes `copilot_model_api_mode()` to re-derive from the actual model being dispatched.
- The two pool-resolver call sites (`_resolve_runtime_from_pool_entry` and the explicit-runtime fallback in `resolve_runtime_provider`) thread `target_model` into the `cfg` dict so mid-session `/model` switches see the new model.

**`tests/agent/test_credential_pool.py`** — `test_copilot_pool_prioritizes_env_token_over_gh_cli`. Placed next to the existing `test_load_pool_seeds_copilot_via_gh_auth_token`.

**`tests/hermes_cli/test_runtime_provider_resolution.py`** — `test_copilot_api_mode_recomputed_for_non_codex_default_model`, `test_copilot_api_mode_follows_target_model_on_runtime_switch`. Placed next to the existing `test_opencode_go_model_derivation_beats_stale_persisted_api_mode` which uses the same precedent pattern.

## How to Test

Manual reproduction (requires two GitHub accounts with different Copilot entitlements):

1. `gh auth login` as account A (limited Copilot access — e.g. Individual plan with no Claude/Gemini access).
2. Run `hermes model` and complete OAuth device-code login as account B (Copilot Business / Enterprise with full model access). Verify `~/.hermes/.env` now contains `COPILOT_GITHUB_TOKEN=gho_…`.
3. During interactive setup, set `model.default: gpt-5.4` so `~/.hermes/config.yaml` records `model.api_mode: codex_responses`.
4. **Before this PR:** `hermes chat -q "hi"` against any non-GPT-5 Copilot model (`claude-sonnet-4.6`, `gemini-3.1-pro-preview`, `gpt-5-mini`) returns `400 model_not_supported`. Inspect `~/.hermes/auth.json` and confirm `gh_cli` outranks `env:COPILOT_GITHUB_TOKEN`.
5. **After this PR:** the same calls succeed. Account B's identity is used (Bug 1 fixed) and the request is dispatched to the correct endpoint for the target model (Bug 2 fixed).

Automated:

```
scripts/run_tests.sh tests/agent/test_credential_pool.py \
                     tests/agent/test_credential_pool_routing.py \
                     tests/hermes_cli/test_runtime_provider_resolution.py \
                     tests/hermes_cli/test_copilot_auth.py \
                     tests/hermes_cli/test_model_switch_copilot_api_mode.py
```

→ 187 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate. No existing PR covers either bug. PR #15106 / #9033 are precedents for the Bug 2 pattern; PR #2647 is the precedent for the Bug 1 fix mechanism.
- [x] My PR contains only changes related to this fix
- [x] I've run `scripts/run_tests.sh` on the affected areas — 187 passed
- [x] I've added tests covering both bugs (3 new tests across 2 files)
- [x] I've tested on my platform: macOS 15.x, Python 3.11

### Documentation & Housekeeping

- [x] N/A — no doc changes needed; the precedence is already documented in `hermes_cli/copilot_auth.py:resolve_copilot_token` and the fix makes the runtime match the doc
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow changes
- [x] Cross-platform: pure Python logic, no OS-specific calls
- [x] N/A — no tool schema changes