### PR TITLE
fix(file-ops): skip ts/tsx auto-lint when project tsconfig.json exists

### DIFF
--- a/tests/tools/test_file_operations_edge_cases.py
+++ b/tests/tools/test_file_operations_edge_cases.py
@@ -147,6 +147,54 @@ class TestCheckLintBracePaths:
         assert result.success is False
         assert "SyntaxError" in result.output
 
+    def test_typescript_with_tsconfig_skipped(self, ops):
+        """TS file with an ancestor tsconfig.json should be skipped (single-file
+        tsc ignores tsconfig and produces noise)."""
+        with patch.object(ops, "_exec") as mock_exec, \
+             patch.object(ops, "_has_command", return_value=True):
+            # Ancestor walk returns a tsconfig path
+            mock_exec.return_value = MagicMock(
+                exit_code=0, stdout="/repo/tsconfig.json\n"
+            )
+            result = ops._check_lint("/repo/src/foo.ts")
+
+        assert result.skipped is True
+        assert "tsconfig.json" in result.message
+        # Should not have invoked tsc — the only _exec call is the ancestor walk
+        assert mock_exec.call_count == 1
+        assert "npx tsc" not in mock_exec.call_args_list[0].args[0]
+
+    def test_typescript_without_tsconfig_runs_lint(self, ops):
+        """Orphan .ts file (no ancestor tsconfig) still gets a syntax check."""
+        calls = []
+
+        def fake_exec(command, *args, **kwargs):
+            calls.append(command)
+            if "tsconfig.json" in command:
+                # No tsconfig found
+                return MagicMock(exit_code=0, stdout="")
+            # tsc invocation
+            return MagicMock(exit_code=0, stdout="")
+
+        with patch.object(ops, "_exec", side_effect=fake_exec), \
+             patch.object(ops, "_has_command", return_value=True):
+            result = ops._check_lint("/tmp/orphan.ts")
+
+        assert result.success is True
+        assert any("tsc" in c for c in calls)
+
+    def test_tsx_with_tsconfig_skipped(self, ops):
+        """Same as .ts: .tsx files should also be skipped when tsconfig exists."""
+        with patch.object(ops, "_exec") as mock_exec, \
+             patch.object(ops, "_has_command", return_value=True):
+            mock_exec.return_value = MagicMock(
+                exit_code=0, stdout="/repo/tsconfig.json\n"
+            )
+            result = ops._check_lint("/repo/src/Component.tsx")
+
+        assert result.skipped is True
+        assert "tsconfig.json" in result.message
+
 
 # =========================================================================
 # Pagination bounds

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -262,6 +262,7 @@ LINTERS = {
     '.py': 'python -m py_compile {file} 2>&1',
     '.js': 'node --check {file} 2>&1',
     '.ts': 'npx tsc --noEmit {file} 2>&1',
+    '.tsx': 'npx tsc --noEmit --jsx preserve {file} 2>&1',
     '.go': 'go vet {file} 2>&1',
     '.rs': 'rustfmt --check {file} 2>&1',
 }
@@ -864,7 +865,30 @@ class ShellFileOperations(FileOperations):
         
         if ext not in LINTERS:
             return LintResult(skipped=True, message=f"No linter for {ext} files")
-        
+
+        # TypeScript: `tsc --noEmit <file>` ignores the nearest tsconfig.json
+        # entirely, which produces a wall of bogus errors for any file that
+        # relies on path aliases, ambient types, JSX, decorators, lib settings,
+        # etc. Single-file type-checking just isn't meaningful in a project.
+        # If we detect an ancestor tsconfig.json, skip auto-lint and let the
+        # caller run the project's own type-check. (Orphan .ts files with no
+        # tsconfig still get the single-file check below.)
+        if ext in ('.ts', '.tsx'):
+            dir_arg = self._escape_shell_arg(os.path.dirname(os.path.abspath(path)) or '.')
+            tsconfig_check = self._exec(
+                f"d={dir_arg}; "
+                f"while [ \"$d\" != \"/\" ] && [ -n \"$d\" ]; do "
+                f"  if [ -f \"$d/tsconfig.json\" ]; then echo \"$d/tsconfig.json\"; break; fi; "
+                f"  d=$(dirname \"$d\"); "
+                f"done"
+            )
+            tsconfig_path = tsconfig_check.stdout.strip() if tsconfig_check.exit_code == 0 else ""
+            if tsconfig_path:
+                return LintResult(
+                    skipped=True,
+                    message=f"project-managed (found {tsconfig_path}); skipped single-file tsc"
+                )
+
         # Check if linter command is available
         linter_cmd = LINTERS[ext]
         # Extract the base command (first word)


### PR DESCRIPTION
## Problem

Single-file `npx tsc --noEmit <file>` ignores the nearest `tsconfig.json` entirely. After every patch to a TypeScript file in a real project, the auto-lint produces a wall of bogus errors because path aliases, ambient types, JSX, decorators, and lib settings are all unresolved. The lint signal in the patch tool result becomes pure noise.

## Fix

Walk ancestors for `tsconfig.json` before invoking tsc:

- **Project file (tsconfig found):** skip with `project-managed (found …/tsconfig.json); skipped single-file tsc`. Caller is expected to run the project's own type-check.
- **Orphan `.ts` (no tsconfig):** keep the existing single-file syntax check.

Also adds `.tsx` to `LINTERS` with the same handling.

## Tests

Adds three tests to `tests/tools/test_file_operations_edge_cases.py`:
- `.ts` with ancestor tsconfig → skipped, tsc not invoked
- `.ts` orphan → tsc still runs
- `.tsx` with ancestor tsconfig → skipped

```
21 passed in 3.06s
```
(One unrelated pre-existing failure in `test_mcp_dynamic_discovery.py` confirmed on `origin/main`.)