### PR TITLE
fix(api-server): preserve tool_call_id in conversation_history

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2406,7 +2406,10 @@ class APIServerAdapter(BasePlatformAdapter):
                         _openai_error(f"conversation_history[{i}] must have 'role' and 'content' fields"),
                         status=400,
                     )
-                conversation_history.append({"role": str(entry["role"]), "content": str(entry["content"])})
+                msg_entry = dict(entry)
+                msg_entry["role"] = str(entry["role"])
+                msg_entry["content"] = str(entry["content"])
+                conversation_history.append(msg_entry)
             if previous_response_id:
                 logger.debug("Both conversation_history and previous_response_id provided; using conversation_history")
 
@@ -2432,7 +2435,10 @@ class APIServerAdapter(BasePlatformAdapter):
                             part.get("text", "") for part in content
                             if isinstance(part, dict) and part.get("type") == "text"
                         )
-                    conversation_history.append({"role": msg["role"], "content": str(content)})
+                    msg_entry = dict(msg)
+                    msg_entry["role"] = msg["role"]
+                    msg_entry["content"] = str(content)
+                    conversation_history.append(msg_entry)
 
         session_id = body.get("session_id") or stored_session_id or run_id
         ephemeral_system_prompt = instructions


### PR DESCRIPTION
## Problem

When sending follow-up messages via the Hermes Web UI through the API Server, DeepSeek (and other strict OpenAI-format providers) returns a 400 error:
```
messages[3]: missing field `tool_call_id`
```

## Root Cause

`_handle_runs()` in `gateway/platforms/api_server.py` reconstructs `conversation_history` messages with only `role` and `content` fields, dropping `tool_call_id`, `tool_calls`, and other metadata.

This affects two code paths:
1. Explicit `conversation_history` from request body (web UI) [line 2409]
2. Multi-message `input` array mode [line 2438]

## Fix

Copy all fields from the incoming message dict instead of creating a new dict with only `role` + `content`. This preserves `tool_call_id` and other metadata while still ensuring `role`/`content` values are stringified.

## Related

Fixes tool-calling conversations via Hermes Web UI when using providers that enforce the OpenAI message schema strictly (DeepSeek, OpenAI, etc.).