### PR TITLE
fix(gateway): refresh idle runtime status heartbeat

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -48,6 +48,7 @@ from hermes_cli.config import cfg_get
 _AGENT_CACHE_MAX_SIZE = 128
 _AGENT_CACHE_IDLE_TTL_SECS = 3600.0  # evict agents idle for >1h
 _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
+_RUNTIME_STATUS_HEARTBEAT_SECS = 60.0
 # Only auto-continue interrupted gateway turns while the interruption is fresh.
 # Stale tool-tail/resume markers can otherwise revive an unrelated old task
 # after a gateway restart when the user's next message starts new work.
@@ -962,6 +963,7 @@ class GatewayRunner:
 
         # Track background tasks to prevent garbage collection mid-execution
         self._background_tasks: set = set()
+        self._runtime_status_heartbeat_task: Optional[asyncio.Task] = None
 
 
     def _warn_if_docker_media_delivery_is_risky(self) -> None:
@@ -1526,6 +1528,34 @@ class GatewayRunner:
             )
         except Exception:
             pass
+
+    def _track_background_task(self, task: asyncio.Task) -> None:
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+
+    def _start_runtime_status_heartbeat(self) -> None:
+        task = getattr(self, "_runtime_status_heartbeat_task", None)
+        if task is not None and not task.done():
+            return
+        task = asyncio.create_task(self._runtime_status_heartbeat())
+        self._runtime_status_heartbeat_task = task
+        self._track_background_task(task)
+
+    async def _runtime_status_heartbeat(
+        self,
+        interval: float = _RUNTIME_STATUS_HEARTBEAT_SECS,
+    ) -> None:
+        """Keep gateway_state.json fresh while the gateway is idle."""
+        while self._running:
+            await asyncio.sleep(interval)
+            if not self._running:
+                break
+            try:
+                self._update_runtime_status("running")
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.warning("Runtime status heartbeat failed: %s", exc)
     
     @staticmethod
     def _load_prefill_messages() -> List[Dict[str, Any]]:
@@ -2314,8 +2344,7 @@ class GatewayRunner:
             await self.stop(restart=True, detached_restart=detached, service_restart=via_service)
 
         task = asyncio.create_task(_run_restart())
-        self._background_tasks.add(task)
-        task.add_done_callback(self._background_tasks.discard)
+        self._track_background_task(task)
         return True
 
     async def start(self) -> bool:
@@ -2600,6 +2629,7 @@ class GatewayRunner:
         
         self._running = True
         self._update_runtime_status("running")
+        self._start_runtime_status_heartbeat()
         
         # Emit gateway:startup hook
         hook_count = len(self.hooks.loaded_hooks)
@@ -3114,6 +3144,7 @@ class GatewayRunner:
                     continue
                 _task.cancel()
             self._background_tasks.clear()
+            self._runtime_status_heartbeat_task = None
 
             self.adapters.clear()
             self._running_agents.clear()
@@ -7127,8 +7158,7 @@ class GatewayRunner:
         _task = asyncio.create_task(
             self._run_background_task(prompt, source, task_id)
         )
-        self._background_tasks.add(_task)
-        _task.add_done_callback(self._background_tasks.discard)
+        self._track_background_task(_task)
 
         preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
         return f'🔄 Background task started: "{preview}"\nTask ID: {task_id}\nYou can keep chatting — results will appear when done.'

--- a/tests/gateway/test_runner_startup_failures.py
+++ b/tests/gateway/test_runner_startup_failures.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 from unittest.mock import AsyncMock
 
@@ -61,6 +63,81 @@ class _SuccessfulAdapter(BasePlatformAdapter):
 
     async def get_chat_info(self, chat_id):
         return {"id": chat_id}
+
+
+@pytest.mark.asyncio
+async def test_runtime_status_heartbeat_refreshes_idle_gateway(monkeypatch, tmp_path):
+    """Regression: idle gateways must keep gateway_state.json freshness current."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config = GatewayConfig(sessions_dir=tmp_path / "sessions")
+    runner = GatewayRunner(config)
+    calls = []
+    monkeypatch.setattr(runner, "_update_runtime_status", lambda state=None, reason=None: calls.append(state))
+
+    runner._running = True
+    task = asyncio.create_task(runner._runtime_status_heartbeat(interval=0.01))
+    await asyncio.sleep(0.035)
+    runner._running = False
+    await asyncio.wait_for(task, timeout=0.1)
+
+    assert calls
+    assert all(state == "running" for state in calls)
+
+
+@pytest.mark.asyncio
+async def test_runtime_status_heartbeat_survives_transient_status_update_error(monkeypatch, tmp_path):
+    """A transient write failure must not permanently kill the heartbeat."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config = GatewayConfig(sessions_dir=tmp_path / "sessions")
+    runner = GatewayRunner(config)
+    attempts = 0
+    calls = []
+
+    def update(state=None, reason=None):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise OSError("temporary status write failure")
+        calls.append(state)
+
+    monkeypatch.setattr(runner, "_update_runtime_status", update)
+
+    runner._running = True
+    task = asyncio.create_task(runner._runtime_status_heartbeat(interval=0.01))
+    await asyncio.sleep(0.04)
+    runner._running = False
+    await asyncio.wait_for(task, timeout=0.1)
+
+    assert attempts >= 2
+    assert calls
+    assert all(state == "running" for state in calls)
+
+
+@pytest.mark.asyncio
+async def test_runtime_status_heartbeat_start_is_idempotent_and_stop_clears_task(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(enabled=False, token="***")
+        },
+        sessions_dir=tmp_path / "sessions",
+    )
+    runner = GatewayRunner(config)
+
+    ok = await runner.start()
+    assert ok is True
+    first = runner._runtime_status_heartbeat_task
+    assert first is not None
+    assert first in runner._background_tasks
+
+    runner._start_runtime_status_heartbeat()
+    assert runner._runtime_status_heartbeat_task is first
+
+    await runner.stop()
+    await asyncio.sleep(0)
+
+    assert runner._runtime_status_heartbeat_task is None
+    assert first.cancelled() or first.done()
 
 
 @pytest.mark.asyncio

--- a/ui-tui/package-lock.json
+++ b/ui-tui/package-lock.json
@@ -124,7 +124,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -500,6 +499,31 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1676,7 +1700,6 @@
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -1687,7 +1710,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1698,7 +1720,6 @@
       "integrity": "sha512-eSkwoemjo76bdXl2MYqtxg51HNwUSkWfODUOQ3PaTLZGh9uIWWFZIjyjaJnex7wXDu+TRx+ATsnSxdN9YWfRTQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.58.1",
@@ -1728,7 +1749,6 @@
       "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.1",
         "@typescript-eslint/types": "8.58.1",
@@ -2046,7 +2066,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2449,7 +2468,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3185,7 +3203,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3317,7 +3334,6 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -4226,7 +4242,6 @@
       "resolved": "https://registry.npmjs.org/ink-text-input/-/ink-text-input-6.0.0.tgz",
       "integrity": "sha512-Fw64n7Yha5deb1rHY137zHTAbSTNelUKuB5Kkk2HACXEtwIHBCf9OH2tP/LQ9fRYTl1F0dZgbW0zPnZk6FA9Lw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chalk": "^5.3.0",
         "type-fest": "^4.18.2"
@@ -5663,7 +5678,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5773,7 +5787,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6598,7 +6611,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -6725,7 +6737,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6835,7 +6846,6 @@
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -7251,7 +7261,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## Summary
- Add a periodic runtime-status heartbeat for idle gateways so `gateway_state.json` stays fresh while the gateway is running but inactive.
- Track and clean up the heartbeat task with the existing gateway background-task lifecycle.
- Keep the UI/TUI npm lockfile refresh as a separate commit for review clarity.

## Verification
- `.venv/bin/python -m pytest tests/gateway/test_runner_startup_failures.py -q`
- `.venv/bin/python -m pytest tests/gateway/test_runner_startup_failures.py tests/gateway/test_status.py tests/hermes_cli/test_gateway_runtime_health.py -q`
- `.venv/bin/python -m pytest tests/gateway/test_gateway_shutdown.py tests/gateway/test_shutdown_cache_cleanup.py tests/gateway/test_restart_drain.py -q`
- `.venv/bin/python -m py_compile gateway/run.py gateway/status.py tests/gateway/test_runner_startup_failures.py`
- Clean PR branch focused suite: `46 passed, 9 warnings`; shutdown/restart suite: `31 passed, 1 warning`
- `git diff --check`

## Notes
- This clean PR branch intentionally excludes the unrelated local preservation commit `26cdbb939`.
- Secret scan only flagged the existing test placeholder token style (`"***"`), not a real credential.
