### PR TITLE
fix(tui): persist global details mode sections

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -879,6 +879,36 @@ def test_config_set_statusbar_survives_non_dict_display(tmp_path, monkeypatch):
     assert saved["display"]["tui_statusbar"] == "bottom"
 
 
+def test_config_set_details_mode_pins_all_sections(tmp_path, monkeypatch):
+    import yaml
+
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(
+        yaml.safe_dump(
+            {"display": {"sections": {"tools": "expanded", "activity": "hidden"}}}
+        )
+    )
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "config.set",
+            "params": {"key": "details_mode", "value": "collapsed"},
+        }
+    )
+
+    assert resp["result"] == {"key": "details_mode", "value": "collapsed"}
+    saved = yaml.safe_load(cfg_path.read_text())
+    assert saved["display"]["details_mode"] == "collapsed"
+    assert saved["display"]["sections"] == {
+        "thinking": "collapsed",
+        "tools": "collapsed",
+        "subagents": "collapsed",
+        "activity": "collapsed",
+    }
+
+
 def test_config_set_section_writes_per_section_override(tmp_path, monkeypatch):
     import yaml
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3130,7 +3130,15 @@ def _(rid, params: dict) -> dict:
         allowed_dm = frozenset({"hidden", "collapsed", "expanded"})
         if nv not in allowed_dm:
             return _err(rid, 4002, f"unknown details_mode: {value}")
-        _write_config_key("display.details_mode", nv)
+        cfg = _load_cfg()
+        display = cfg.get("display") if isinstance(cfg.get("display"), dict) else {}
+        sections = display.get("sections") if isinstance(display.get("sections"), dict) else {}
+        display["details_mode"] = nv
+        for section in ("thinking", "tools", "subagents", "activity"):
+            sections[section] = nv
+        display["sections"] = sections
+        cfg["display"] = display
+        _save_cfg(cfg)
         return _ok(rid, {"key": key, "value": nv})
 
     if key.startswith("details_mode."):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -128,6 +128,8 @@ _cfg_path = None
 _SLASH_WORKER_TIMEOUT_S = max(
     5.0, float(os.environ.get("HERMES_TUI_SLASH_TIMEOUT_S", "45") or 45)
 )
+_DETAIL_SECTION_NAMES = ("thinking", "tools", "subagents", "activity")
+_DETAIL_MODES = frozenset({"hidden", "collapsed", "expanded"})
 
 # ── Async RPC dispatch (#12546) ──────────────────────────────────────
 # A handful of handlers block the dispatcher loop in entry.py for seconds
@@ -3127,14 +3129,13 @@ def _(rid, params: dict) -> dict:
 
     if key == "details_mode":
         nv = str(value or "").strip().lower()
-        allowed_dm = frozenset({"hidden", "collapsed", "expanded"})
-        if nv not in allowed_dm:
+        if nv not in _DETAIL_MODES:
             return _err(rid, 4002, f"unknown details_mode: {value}")
         cfg = _load_cfg()
         display = cfg.get("display") if isinstance(cfg.get("display"), dict) else {}
         sections = display.get("sections") if isinstance(display.get("sections"), dict) else {}
         display["details_mode"] = nv
-        for section in ("thinking", "tools", "subagents", "activity"):
+        for section in _DETAIL_SECTION_NAMES:
             sections[section] = nv
         display["sections"] = sections
         cfg["display"] = display
@@ -3143,11 +3144,11 @@ def _(rid, params: dict) -> dict:
 
     if key.startswith("details_mode."):
         # Per-section override: `details_mode.<section>` writes to
-        # `display.sections.<section>`.  Empty value clears the override
-        # and lets the section fall back to the global details_mode.
+        # `display.sections.<section>`. Empty value clears the explicit
+        # override and lets frontend resolution apply built-in section defaults
+        # before the global details_mode.
         section = key.split(".", 1)[1]
-        allowed_sections = frozenset({"thinking", "tools", "subagents", "activity"})
-        if section not in allowed_sections:
+        if section not in _DETAIL_SECTION_NAMES:
             return _err(rid, 4002, f"unknown section: {section}")
 
         cfg = _load_cfg()
@@ -3164,8 +3165,7 @@ def _(rid, params: dict) -> dict:
             _save_cfg(cfg)
             return _ok(rid, {"key": key, "value": ""})
 
-        allowed_dm = frozenset({"hidden", "collapsed", "expanded"})
-        if nv not in allowed_dm:
+        if nv not in _DETAIL_MODES:
             return _err(rid, 4002, f"unknown details_mode: {value}")
 
         sections_cfg[section] = nv

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -141,6 +141,12 @@ describe('createSlashHandler', () => {
     expect(createSlashHandler(ctx)('/details toggle')).toBe(true)
     expect(getUiState().detailsMode).toBe('expanded')
     expect(getUiState().detailsModeCommandOverride).toBe(true)
+    expect(getUiState().sections).toEqual({
+      thinking: 'expanded',
+      tools: 'expanded',
+      subagents: 'expanded',
+      activity: 'expanded'
+    })
     expect(ctx.gateway.rpc).toHaveBeenCalledWith('config.set', {
       key: 'details_mode',
       value: 'expanded'

--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -266,7 +266,9 @@ export const coreCommands: SlashCommand[] = [
         return transcript.sys(DETAILS_USAGE)
       }
 
-      patchUiState({ detailsMode: next, detailsModeCommandOverride: true })
+      const sections = Object.fromEntries(SECTION_NAMES.map(section => [section, next]))
+
+      patchUiState({ detailsMode: next, detailsModeCommandOverride: true, sections })
       gateway.rpc<ConfigSetResponse>('config.set', { key: 'details_mode', value: next }).catch(() => {})
       transcript.sys(`details: ${next}`)
     }


### PR DESCRIPTION
## Summary
- Make global `/details <mode>` pin every detail section in live TUI state.
- Persist matching `display.sections.*` values so config sync does not restore built-in section defaults.
- Cover frontend slash handling and gateway config persistence.

## Test plan
- `npm test -- src/__tests__/createSlashHandler.test.ts src/__tests__/details.test.ts src/__tests__/useConfigSync.test.ts`
- `npm run type-check`
- `scripts/run_tests.sh tests/test_tui_gateway_server.py::test_config_set_details_mode_pins_all_sections tests/test_tui_gateway_server.py::test_config_set_section_writes_per_section_override tests/test_tui_gateway_server.py::test_config_set_section_clears_override_on_empty_value`
- PTY smoke: `hermes --tui --dev` reached ready prompt on `bb/tui-details-persist`