### PR TITLE
fix(skills): exclude .archive from skill index walk

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -234,7 +234,7 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
 
         for scan_dir in dirs_to_scan:
             for skill_md in iter_skill_index_files(scan_dir, "SKILL.md"):
-                if any(part in ('.git', '.github', '.hub') for part in skill_md.parts):
+                if any(part in ('.git', '.github', '.hub', '.archive') for part in skill_md.parts):
                     continue
                 try:
                     content = skill_md.read_text(encoding='utf-8')

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -24,7 +24,7 @@ PLATFORM_MAP = {
     "windows": "win32",
 }
 
-EXCLUDED_SKILL_DIRS = frozenset((".git", ".github", ".hub"))
+EXCLUDED_SKILL_DIRS = frozenset((".git", ".github", ".hub", ".archive"))
 
 # ── Lazy YAML loader ─────────────────────────────────────────────────────
 
@@ -440,7 +440,7 @@ def extract_skill_description(frontmatter: Dict[str, Any]) -> str:
 def iter_skill_index_files(skills_dir: Path, filename: str):
     """Walk skills_dir yielding sorted paths matching *filename*.
 
-    Excludes ``.git``, ``.github``, ``.hub`` directories.
+    Excludes ``.git``, ``.github``, ``.hub``, ``.archive`` directories.
     """
     matches = []
     for root, dirs, files in os.walk(skills_dir, followlinks=True):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -621,7 +621,7 @@ def _check_unavailable_skill(command_name: str) -> str | None:
             if not skills_dir.exists():
                 continue
             for skill_md in skills_dir.rglob("SKILL.md"):
-                if any(part in ('.git', '.github', '.hub') for part in skill_md.parts):
+                if any(part in ('.git', '.github', '.hub', '.archive') for part in skill_md.parts):
                     continue
                 name = skill_md.parent.name.lower().replace("_", "-")
                 if name == normalized and name in disabled:


### PR DESCRIPTION
## Summary

Archived skills (moved to `~/.hermes/skills/.archive/` by the skill curator) were still being surfaced in the `<available_skills>` system prompt under a fake `.archive` category, causing the agent to load and try to use deprecated skills.

I hit this in practice — the agent indexed and attempted to load `linkedin-camofox-scraping` from `.archive/` even though that skill had been merged into `camofox-browser/references/linkedin-scraping.md` two weeks ago.

## Root cause

`iter_skill_index_files()` in `agent/skill_utils.py` walks `skills_dir` and excludes `.git/.github/.hub` but not `.archive`. The same exclusion tuple is hardcoded in two other walkers:
- `gateway/run.py` (skill-disable resolver)
- `agent/skill_commands.py` (slash-command scanner)

## Fix

Add `.archive` to `EXCLUDED_SKILL_DIRS` and the two inline tuples.

```diff
-EXCLUDED_SKILL_DIRS = frozenset((".git", ".github", ".hub"))
+EXCLUDED_SKILL_DIRS = frozenset((".git", ".github", ".hub", ".archive"))
```

## Verification

- Existing tests pass: `pytest tests/agent/test_curator.py tests/tools/test_skill_usage.py` → 66 passed
- Manual verification: `iter_skill_index_files()` finds 105 skills, 0 from `.archive` (was previously surfacing 4 archived skills as a bogus category)

## Notes

The curator already correctly archives skills *into* `.archive/` (`tools/skill_usage.py:53`). This PR closes the loop on the read side so they actually stay hidden from the model.

Future cleanup (out of scope): the three places that hardcode this tuple should probably all reference `EXCLUDED_SKILL_DIRS` instead. Left as-is to keep the diff minimal.
