### PR TITLE
Add Skyvern MCP to the Nous Tool Gateway

### DIFF
--- a/hermes_cli/nous_account.py
+++ b/hermes_cli/nous_account.py
@@ -26,6 +26,7 @@ TOOL_COVERAGE_CATEGORIES = (
     "openai-audio",
     "browser-use",
     "modal",
+    "skyvern",
 )
 
 _ACCOUNT_INFO_CACHE_TTL = 60

--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -44,6 +44,7 @@ MANAGED_FEATURE_COVERAGE_CATEGORY: Dict[str, str] = {
     "stt": "openai-audio",
     "browser": "browser-use",
     "modal": "modal",
+    "skyvern": "skyvern",
 }
 
 
@@ -52,6 +53,28 @@ def _uses_gateway(section: object) -> bool:
     if not isinstance(section, dict):
         return False
     return is_truthy_value(section.get("use_gateway"), default=False)
+
+
+def _skyvern_mcp_config(config: Dict[str, object]) -> Dict[str, object]:
+    servers = config.get("mcp_servers")
+    if not isinstance(servers, dict):
+        return {}
+    skyvern_cfg = servers.get("skyvern")
+    return skyvern_cfg if isinstance(skyvern_cfg, dict) else {}
+
+
+def _is_managed_skyvern_mcp_config(config: Dict[str, object]) -> bool:
+    skyvern_cfg = _skyvern_mcp_config(config)
+    return str(skyvern_cfg.get("managed_gateway") or "").strip().lower() == "skyvern"
+
+
+def _has_direct_skyvern_mcp_config(config: Dict[str, object]) -> bool:
+    skyvern_cfg = _skyvern_mcp_config(config)
+    return bool(
+        skyvern_cfg
+        and not _is_managed_skyvern_mcp_config(config)
+        and (skyvern_cfg.get("url") or skyvern_cfg.get("command"))
+    )
 
 
 @dataclass(frozen=True)
@@ -860,6 +883,7 @@ _GATEWAY_TOOL_LABELS = {
     "tts": "Text-to-speech (OpenAI TTS)",
     "stt": "Speech-to-text (OpenAI Whisper)",
     "browser": "Browser automation (Browser Use)",
+    "skyvern": "Browser automation (Skyvern)",
 }
 
 
@@ -903,9 +927,18 @@ _GATEWAY_DIRECT_LABELS = {
     "tts": "OpenAI/ElevenLabs key",
     "stt": "OpenAI/Groq/Mistral key",
     "browser": "Browser Use/Browserbase key",
+    "skyvern": "direct Skyvern MCP config",
 }
 
-_ALL_GATEWAY_KEYS = ("web", "image_gen", "video_gen", "tts", "stt", "browser")
+_ALL_GATEWAY_KEYS = (
+    "web",
+    "image_gen",
+    "video_gen",
+    "tts",
+    "stt",
+    "browser",
+    "skyvern",
+)
 
 
 def get_gateway_eligible_tools(
@@ -940,7 +973,8 @@ def get_gateway_eligible_tools(
     if not isinstance(model_cfg, dict) or str(model_cfg.get("provider") or "").strip().lower() != "nous":
         return [], [], []
 
-    direct = _get_gateway_direct_credentials()
+    direct = dict(_get_gateway_direct_credentials())
+    direct["skyvern"] = _has_direct_skyvern_mcp_config(config)
 
     # Check which tools the user has explicitly opted into the gateway for.
     # This is distinct from managed_by_nous which fires implicitly when
@@ -953,6 +987,7 @@ def get_gateway_eligible_tools(
         "tts": _uses_gateway(config.get("tts")),
         "stt": _uses_gateway(config.get("stt")),
         "browser": _uses_gateway(config.get("browser")),
+        "skyvern": _is_managed_skyvern_mcp_config(config),
     }
 
     unconfigured: list[str] = []
@@ -1044,6 +1079,18 @@ def apply_gateway_defaults(
         video_cfg["provider"] = "fal"
         video_cfg["use_gateway"] = True
         changed.add("video_gen")
+
+    if "skyvern" in tool_keys:
+        servers = config.get("mcp_servers")
+        if not isinstance(servers, dict):
+            servers = {}
+            config["mcp_servers"] = servers
+
+        if not _has_direct_skyvern_mcp_config(
+            config
+        ) and not _is_managed_skyvern_mcp_config(config):
+            servers["skyvern"] = {"managed_gateway": "skyvern"}
+            changed.add("skyvern")
 
     return changed
 

--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -59,6 +59,14 @@ def _skyvern_mcp_config(config: Dict[str, object]) -> Dict[str, object]:
     servers = config.get("mcp_servers")
     if not isinstance(servers, dict):
         return {}
+    for server_cfg in servers.values():
+        if (
+            isinstance(server_cfg, dict)
+            and not (server_cfg.get("url") or server_cfg.get("command"))
+            and str(server_cfg.get("managed_gateway") or "").strip().lower()
+            == "skyvern"
+        ):
+            return server_cfg
     skyvern_cfg = servers.get("skyvern")
     return skyvern_cfg if isinstance(skyvern_cfg, dict) else {}
 
@@ -73,12 +81,22 @@ def _is_managed_skyvern_mcp_config(config: Dict[str, object]) -> bool:
 
 
 def _has_direct_skyvern_mcp_config(config: Dict[str, object]) -> bool:
-    skyvern_cfg = _skyvern_mcp_config(config)
+    servers = config.get("mcp_servers")
+    if not isinstance(servers, dict):
+        return False
+    skyvern_cfg = servers.get("skyvern")
     return bool(
-        skyvern_cfg
-        and not _is_managed_skyvern_mcp_config(config)
+        isinstance(skyvern_cfg, dict)
         and (skyvern_cfg.get("url") or skyvern_cfg.get("command"))
     )
+
+
+def _mcp_sdk_available() -> bool:
+    try:
+        from tools.mcp_tool import _MCP_AVAILABLE
+    except ImportError:
+        return False
+    return _MCP_AVAILABLE
 
 
 @dataclass(frozen=True)
@@ -998,6 +1016,8 @@ def get_gateway_eligible_tools(
     has_direct: list[str] = []
     already_managed: list[str] = []
     for key in _ALL_GATEWAY_KEYS:
+        if key == "skyvern" and direct.get(key) and not opted_in.get(key):
+            continue
         # Only offer tools the user's entitlement actually covers. For a free
         # tool pool that means image but not video; paid users are covered for
         # everything.
@@ -1180,6 +1200,11 @@ def prompt_enable_tool_gateway(
         for key in sorted(changed):
             label = _GATEWAY_TOOL_LABELS.get(key, key)
             print(f"  ✓ {label}: enabled via {source_label}")
+        if "skyvern" in changed and not _mcp_sdk_available():
+            print(
+                '  ! Skyvern MCP requires the MCP SDK. Install it with '
+                '`pip install "hermes-agent[mcp]"` or `uv sync --extra mcp`.'
+            )
     return changed
 
 

--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -65,7 +65,11 @@ def _skyvern_mcp_config(config: Dict[str, object]) -> Dict[str, object]:
 
 def _is_managed_skyvern_mcp_config(config: Dict[str, object]) -> bool:
     skyvern_cfg = _skyvern_mcp_config(config)
-    return str(skyvern_cfg.get("managed_gateway") or "").strip().lower() == "skyvern"
+    return bool(
+        not (skyvern_cfg.get("url") or skyvern_cfg.get("command"))
+        and str(skyvern_cfg.get("managed_gateway") or "").strip().lower()
+        == "skyvern"
+    )
 
 
 def _has_direct_skyvern_mcp_config(config: Dict[str, object]) -> bool:
@@ -1147,7 +1151,9 @@ def prompt_enable_tool_gateway(
         f"{_GATEWAY_TOOL_LABELS[k]} — keep using your {_GATEWAY_DIRECT_LABELS[k]}"
         for k in has_direct
     ]
-    pre_selected = list(range(len(unconfigured)))
+    pre_selected = [
+        index for index, key in enumerate(unconfigured) if key != "skyvern"
+    ]
 
     if pool_only:
         title = "Your free Nous tool pool — pick the tools to enable:"

--- a/tests/hermes_cli/test_nous_subscription.py
+++ b/tests/hermes_cli/test_nous_subscription.py
@@ -312,7 +312,7 @@ def test_get_gateway_eligible_tools_paid_account_offers_skyvern(monkeypatch):
     assert "skyvern" not in already_managed
 
 
-def test_mixed_skyvern_config_is_classified_as_direct(monkeypatch):
+def test_mixed_skyvern_config_is_not_offered_for_managed_migration(monkeypatch):
     monkeypatch.setattr(
         ns,
         "get_nous_portal_account_info",
@@ -333,8 +333,28 @@ def test_mixed_skyvern_config_is_classified_as_direct(monkeypatch):
     )
 
     assert "skyvern" not in unconfigured
-    assert "skyvern" in has_direct
+    assert "skyvern" not in has_direct
     assert "skyvern" not in already_managed
+
+
+def test_direct_skyvern_config_is_not_offered(monkeypatch):
+    monkeypatch.setattr(
+        ns,
+        "get_nous_portal_account_info",
+        lambda **kw: _account(logged_in=True, paid=True),
+    )
+    monkeypatch.setattr(ns, "_get_gateway_direct_credentials", lambda: {})
+
+    eligible = ns.get_gateway_eligible_tools(
+        {
+            "model": {"provider": "nous"},
+            "mcp_servers": {
+                "skyvern": {"url": "https://api.skyvern.com/mcp/"},
+            },
+        }
+    )
+
+    assert all("skyvern" not in bucket for bucket in eligible)
 
 
 def test_get_gateway_eligible_tools_pool_without_skyvern_coverage_excludes_it(
@@ -517,6 +537,32 @@ def test_apply_gateway_defaults_preserves_direct_skyvern_mcp_config():
     assert config["mcp_servers"]["skyvern"] == direct_skyvern
 
 
+def test_managed_skyvern_under_custom_server_name_is_already_managed(monkeypatch):
+    monkeypatch.setattr(
+        ns,
+        "get_nous_portal_account_info",
+        lambda **kw: _account(logged_in=True, paid=True),
+    )
+    monkeypatch.setattr(ns, "_get_gateway_direct_credentials", lambda: {})
+    config = {
+        "model": {"provider": "nous"},
+        "mcp_servers": {
+            "skyvern-cloud": {"managed_gateway": "skyvern"},
+        },
+    }
+
+    unconfigured, has_direct, already_managed = ns.get_gateway_eligible_tools(config)
+    changed = ns.apply_gateway_defaults(config, ["skyvern"])
+
+    assert "skyvern" not in unconfigured
+    assert "skyvern" not in has_direct
+    assert "skyvern" in already_managed
+    assert changed == set()
+    assert config["mcp_servers"] == {
+        "skyvern-cloud": {"managed_gateway": "skyvern"},
+    }
+
+
 def test_get_gateway_eligible_tools_empty_when_not_entitled(monkeypatch):
     """A logged-in free user with no pool and no paid access gets nothing."""
     monkeypatch.setattr(
@@ -626,6 +672,30 @@ def test_prompt_enable_tool_gateway_leaves_skyvern_unchecked(monkeypatch):
     assert set(captured["pre_selected"]) == set(range(len(captured["items"]))) - {
         skyvern_index
     }
+
+
+def test_prompt_enable_tool_gateway_prints_missing_mcp_sdk_guidance(
+    monkeypatch, capsys
+):
+    monkeypatch.setattr(
+        ns,
+        "get_gateway_eligible_tools",
+        lambda *args, **kwargs: (["skyvern"], [], []),
+    )
+    monkeypatch.setattr(
+        ns,
+        "get_nous_portal_account_info",
+        lambda **kw: _account(logged_in=True, paid=True),
+    )
+    monkeypatch.setattr(ns, "_mcp_sdk_available", lambda: False)
+    _capture_checklist(monkeypatch, selected_idx=[0])
+
+    changed = ns.prompt_enable_tool_gateway({"model": {"provider": "nous"}})
+
+    output = capsys.readouterr().out
+    assert changed == {"skyvern"}
+    assert 'pip install "hermes-agent[mcp]"' in output
+    assert "uv sync --extra mcp" in output
 
 
 def test_apply_nous_managed_defaults_writes_video_gen_config(monkeypatch):

--- a/tests/hermes_cli/test_nous_subscription.py
+++ b/tests/hermes_cli/test_nous_subscription.py
@@ -312,6 +312,31 @@ def test_get_gateway_eligible_tools_paid_account_offers_skyvern(monkeypatch):
     assert "skyvern" not in already_managed
 
 
+def test_mixed_skyvern_config_is_classified_as_direct(monkeypatch):
+    monkeypatch.setattr(
+        ns,
+        "get_nous_portal_account_info",
+        lambda **kw: _account(logged_in=True, paid=True),
+    )
+    monkeypatch.setattr(ns, "_get_gateway_direct_credentials", lambda: {})
+
+    unconfigured, has_direct, already_managed = ns.get_gateway_eligible_tools(
+        {
+            "model": {"provider": "nous"},
+            "mcp_servers": {
+                "skyvern": {
+                    "managed_gateway": "skyvern",
+                    "url": "https://api.skyvern.com/mcp/",
+                }
+            },
+        }
+    )
+
+    assert "skyvern" not in unconfigured
+    assert "skyvern" in has_direct
+    assert "skyvern" not in already_managed
+
+
 def test_get_gateway_eligible_tools_pool_without_skyvern_coverage_excludes_it(
     monkeypatch,
 ):
@@ -582,6 +607,25 @@ def test_prompt_enable_tool_gateway_paid_user_offers_video(monkeypatch):
 
     blob = " ".join(captured["items"]).lower()
     assert "video" in blob
+
+
+def test_prompt_enable_tool_gateway_leaves_skyvern_unchecked(monkeypatch):
+    monkeypatch.setattr(
+        ns, "get_nous_portal_account_info", lambda **kw: _account(logged_in=True, paid=True)
+    )
+    monkeypatch.setattr(ns, "_get_gateway_direct_credentials", lambda: {})
+    captured = _capture_checklist(monkeypatch, selected_idx=[])
+
+    ns.prompt_enable_tool_gateway({"model": {"provider": "nous"}})
+
+    skyvern_index = next(
+        index for index, label in enumerate(captured["items"])
+        if "skyvern" in label.lower()
+    )
+    assert skyvern_index not in captured["pre_selected"]
+    assert set(captured["pre_selected"]) == set(range(len(captured["items"]))) - {
+        skyvern_index
+    }
 
 
 def test_apply_nous_managed_defaults_writes_video_gen_config(monkeypatch):

--- a/tests/hermes_cli/test_nous_subscription.py
+++ b/tests/hermes_cli/test_nous_subscription.py
@@ -23,14 +23,19 @@ def _account(*, logged_in: bool, paid: bool | None = None) -> NousPortalAccountI
     )
 
 
-def _pool_account() -> NousPortalAccountInfo:
+def _pool_account(
+    coverage: dict[str, bool] | None = None,
+) -> NousPortalAccountInfo:
     """A $0 subscriber with a live free tool pool (no paid access)."""
     return NousPortalAccountInfo(
         logged_in=True,
         source="jwt",
         fresh=False,
         paid_service_access=False,
-        tool_access=NousToolAccessInfo(enabled=True, coverage=_POOL_COVERAGE),
+        tool_access=NousToolAccessInfo(
+            enabled=True,
+            coverage=_POOL_COVERAGE if coverage is None else coverage,
+        ),
     )
 
 
@@ -261,7 +266,81 @@ def test_get_gateway_eligible_tools_ignores_quoted_false_opt_in(monkeypatch):
 
     assert "web" in has_direct
     assert "web" not in already_managed
-    assert set(unconfigured) == {"image_gen", "video_gen", "tts", "stt", "browser"}
+    assert set(unconfigured) == {
+        "image_gen",
+        "video_gen",
+        "tts",
+        "stt",
+        "browser",
+        "skyvern",
+    }
+
+
+def test_get_gateway_eligible_tools_checks_skyvern_coverage_category(monkeypatch):
+    account = _pool_account()
+    checked_categories = []
+    monkeypatch.setattr(
+        type(account),
+        "tool_gateway_entitled_for",
+        lambda self, category: checked_categories.append(category) or False,
+    )
+    monkeypatch.setattr(ns, "get_nous_portal_account_info", lambda **kw: account)
+    monkeypatch.setattr(ns, "_get_gateway_direct_credentials", lambda: {})
+
+    assert ns.get_gateway_eligible_tools({"model": {"provider": "nous"}}) == (
+        [],
+        [],
+        [],
+    )
+    assert "skyvern" in checked_categories
+
+
+def test_get_gateway_eligible_tools_paid_account_offers_skyvern(monkeypatch):
+    monkeypatch.setattr(
+        ns,
+        "get_nous_portal_account_info",
+        lambda **kw: _account(logged_in=True, paid=True),
+    )
+    monkeypatch.setattr(ns, "_get_gateway_direct_credentials", lambda: {})
+
+    unconfigured, has_direct, already_managed = ns.get_gateway_eligible_tools(
+        {"model": {"provider": "nous"}}
+    )
+
+    assert "skyvern" in unconfigured
+    assert "skyvern" not in has_direct
+    assert "skyvern" not in already_managed
+
+
+def test_get_gateway_eligible_tools_pool_without_skyvern_coverage_excludes_it(
+    monkeypatch,
+):
+    monkeypatch.setattr(ns, "get_nous_portal_account_info", lambda **kw: _pool_account())
+    monkeypatch.setattr(ns, "_get_gateway_direct_credentials", lambda: {})
+
+    eligible = ns.get_gateway_eligible_tools({"model": {"provider": "nous"}})
+
+    assert all("skyvern" not in bucket for bucket in eligible)
+
+
+def test_get_gateway_eligible_tools_pool_with_skyvern_coverage_offers_it(
+    monkeypatch,
+):
+    coverage = {**_POOL_COVERAGE, "skyvern": True}
+    monkeypatch.setattr(
+        ns,
+        "get_nous_portal_account_info",
+        lambda **kw: _pool_account(coverage),
+    )
+    monkeypatch.setattr(ns, "_get_gateway_direct_credentials", lambda: {})
+
+    unconfigured, has_direct, already_managed = ns.get_gateway_eligible_tools(
+        {"model": {"provider": "nous"}}
+    )
+
+    assert "skyvern" in unconfigured
+    assert "skyvern" not in has_direct
+    assert "skyvern" not in already_managed
 
 
 def _stub_browser_probes(monkeypatch, *, has_agent_browser, chromium, lightpanda=False):
@@ -389,6 +468,28 @@ def test_get_gateway_eligible_tools_pool_excludes_video(monkeypatch):
     assert "video_gen" not in unconfigured
     assert "video_gen" not in has_direct
     assert "video_gen" not in already_managed
+
+
+def test_apply_gateway_defaults_stores_managed_skyvern_mcp_intent():
+    config = {}
+
+    changed = ns.apply_gateway_defaults(config, ["skyvern"])
+
+    assert changed == {"skyvern"}
+    assert config["mcp_servers"]["skyvern"] == {"managed_gateway": "skyvern"}
+
+
+def test_apply_gateway_defaults_preserves_direct_skyvern_mcp_config():
+    direct_skyvern = {
+        "url": "https://api.skyvern.com/mcp/",
+        "headers": {"x-api-key": "${SKYVERN_API_KEY}"},
+    }
+    config = {"mcp_servers": {"skyvern": dict(direct_skyvern)}}
+
+    changed = ns.apply_gateway_defaults(config, ["skyvern"])
+
+    assert changed == set()
+    assert config["mcp_servers"]["skyvern"] == direct_skyvern
 
 
 def test_get_gateway_eligible_tools_empty_when_not_entitled(monkeypatch):

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -94,6 +94,16 @@ class TestFilterMCPChildren:
 # ---------------------------------------------------------------------------
 
 class TestLoadMCPConfig:
+    @pytest.fixture(autouse=True)
+    def _allow_managed_skyvern(self, monkeypatch):
+        account = SimpleNamespace(
+            tool_gateway_entitled_for=lambda category: category == "skyvern"
+        )
+        monkeypatch.setattr(
+            "hermes_cli.nous_account.get_nous_portal_account_info",
+            lambda: account,
+        )
+
     def test_no_config_returns_empty(self):
         """No mcp_servers key in config -> empty dict."""
         with patch("hermes_cli.config.load_config", return_value={"model": "test"}):
@@ -192,6 +202,134 @@ class TestLoadMCPConfig:
             "url": "https://skyvern-gateway.nousresearch.com/mcp/",
             "headers": {"Authorization": "Bearer nous-token"},
         }
+
+    def test_unknown_managed_vendor_is_skipped_without_resolving_auth(
+        self,
+        caplog,
+    ):
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={
+                "mcp_servers": {
+                    "attacker": {"managed_gateway": "attacker.example/"},
+                }
+            },
+        ), patch(
+            "tools.managed_tool_gateway.resolve_managed_tool_gateway",
+        ) as resolve_gateway:
+            from tools.mcp_tool import _load_mcp_config
+
+            result = _load_mcp_config()
+
+        assert result == {}
+        assert "Authorization" not in json.dumps(result)
+        resolve_gateway.assert_not_called()
+        assert "unsupported managed gateway" in caplog.text
+
+    @pytest.mark.parametrize(
+        "attempted_path",
+        ["//attacker.example/x", "https://attacker.example/x"],
+    )
+    def test_managed_gateway_path_is_ignored(self, monkeypatch, attempted_path):
+        monkeypatch.setenv("SKYVERN_GATEWAY_URL", "https://skyvern.test")
+        monkeypatch.setenv("TOOL_GATEWAY_USER_TOKEN", "nous-token")
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={
+                "mcp_servers": {
+                    "skyvern": {
+                        "managed_gateway": "skyvern",
+                        "managed_gateway_path": attempted_path,
+                    },
+                }
+            },
+        ), patch(
+            "tools.managed_tool_gateway.managed_nous_tools_enabled",
+            return_value=True,
+        ):
+            from tools.mcp_tool import _load_mcp_config
+
+            skyvern = _load_mcp_config()["skyvern"]
+
+        assert skyvern["url"] == "https://skyvern.test/mcp/"
+        assert "managed_gateway_path" not in skyvern
+
+    def test_free_pool_without_skyvern_coverage_skips_managed_server(
+        self,
+        monkeypatch,
+    ):
+        from hermes_cli.nous_account import NousPortalAccountInfo, NousToolAccessInfo
+
+        account = NousPortalAccountInfo(
+            logged_in=True,
+            source="jwt",
+            fresh=True,
+            paid_service_access=False,
+            tool_access=NousToolAccessInfo(
+                enabled=True,
+                coverage={"firecrawl": True},
+            ),
+        )
+        monkeypatch.setattr(
+            "hermes_cli.nous_account.get_nous_portal_account_info",
+            lambda: account,
+        )
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={
+                "mcp_servers": {
+                    "skyvern": {"managed_gateway": "skyvern"},
+                }
+            },
+        ), patch(
+            "tools.managed_tool_gateway.resolve_managed_tool_gateway",
+        ) as resolve_gateway:
+            from tools.mcp_tool import _load_mcp_config
+
+            result = _load_mcp_config()
+
+        assert result == {}
+        resolve_gateway.assert_not_called()
+
+    def test_malformed_managed_entry_does_not_drop_valid_server(self, monkeypatch):
+        monkeypatch.setenv("SKYVERN_GATEWAY_URL", "https://skyvern.test")
+        monkeypatch.setenv("TOOL_GATEWAY_USER_TOKEN", "nous-token")
+        direct = {"url": "https://valid.example/mcp/"}
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={
+                "mcp_servers": {
+                    "direct": direct,
+                    "skyvern": {
+                        "managed_gateway": "skyvern",
+                        "headers": "not-a-mapping",
+                    },
+                }
+            },
+        ), patch(
+            "tools.managed_tool_gateway.managed_nous_tools_enabled",
+            return_value=True,
+        ):
+            from tools.mcp_tool import _load_mcp_config
+
+            result = _load_mcp_config()
+
+        assert result == {"direct": direct}
+
+    def test_disabled_managed_server_does_not_resolve_credentials(self):
+        disabled = {"managed_gateway": "skyvern", "enabled": False}
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"mcp_servers": {"skyvern": disabled}},
+        ), patch(
+            "tools.managed_tool_gateway.resolve_managed_tool_gateway",
+        ) as resolve_gateway:
+            from tools.mcp_tool import _load_mcp_config
+
+            result = _load_mcp_config()
+
+        assert result == {"skyvern": disabled}
+        resolve_gateway.assert_not_called()
 
     @pytest.mark.parametrize(
         "direct_cfg",
@@ -307,7 +445,7 @@ class TestMCPStatus:
         monkeypatch.setattr(
             mcp_tool,
             "_load_mcp_config",
-            lambda: {
+            lambda **_kwargs: {
                 "configured": {"command": "docker", "args": ["mcp", "gateway", "run"]},
                 "connecting": {"command": "slow-mcp"},
                 "failed": {"command": "bad-mcp"},
@@ -346,6 +484,29 @@ class TestMCPStatus:
         assert statuses["failed"]["error"] == "Connection closed"
         assert statuses["disabled"]["status"] == "disabled"
         assert statuses["disabled"]["disabled"] is True
+
+    def test_disabled_managed_status_does_not_resolve_credentials(self):
+        import tools.mcp_tool as mcp_tool
+
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={
+                "mcp_servers": {
+                    "status_skyvern": {
+                        "managed_gateway": "skyvern",
+                        "enabled": False,
+                    },
+                }
+            },
+        ), patch(
+            "tools.managed_tool_gateway.read_nous_access_token",
+        ) as read_token:
+            statuses = mcp_tool.get_mcp_status()
+
+        read_token.assert_not_called()
+        status = next(entry for entry in statuses if entry["name"] == "status_skyvern")
+        assert status["transport"] == "http"
+        assert status["status"] == "disabled"
 
 
 class TestLifecycleConfig:
@@ -1640,12 +1801,18 @@ class TestToolsetInjection:
 # ---------------------------------------------------------------------------
 
 class TestGracefulFallback:
-    def test_mcp_unavailable_returns_empty(self):
-        """When _MCP_AVAILABLE is False, discover_mcp_tools is a no-op."""
-        with patch("tools.mcp_tool._MCP_AVAILABLE", False):
+    def test_mcp_unavailable_returns_empty_with_install_guidance(self, caplog):
+        """Configured MCP servers report the missing optional extra."""
+        with patch("tools.mcp_tool._MCP_AVAILABLE", False), patch(
+            "tools.mcp_tool._load_mcp_config",
+            return_value={"srv": {"url": "https://example.test/mcp/"}},
+        ):
             from tools.mcp_tool import discover_mcp_tools
             result = discover_mcp_tools()
             assert result == []
+
+        assert 'pip install "hermes-agent[mcp]"' in caplog.text
+        assert "uv sync --extra mcp" in caplog.text
 
     def test_no_servers_returns_empty(self):
         """No MCP servers configured -> empty list."""

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -7,7 +7,6 @@ import asyncio
 import json
 import threading
 import time
-import urllib.request
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -381,14 +380,49 @@ class TestLoadMCPConfig:
         assert "Skipping managed MCP server 'skyvern'" in caplog.text
 
     def test_managed_skyvern_bearer_header_reaches_live_socket(self, monkeypatch):
-        received = {}
+        received = []
 
         class Handler(BaseHTTPRequestHandler):
             def do_GET(self):
-                received["path"] = self.path
-                received["authorization"] = self.headers.get("Authorization")
-                self.send_response(204)
+                received.append(
+                    ("preflight", self.path, self.headers.get("Authorization"))
+                )
+                self.send_response(405)
+                self.send_header("Content-Length", "0")
                 self.end_headers()
+
+            def do_POST(self):
+                body = self.rfile.read(int(self.headers["Content-Length"]))
+                request = json.loads(body)
+                method = request["method"]
+                received.append(
+                    (method, self.path, self.headers.get("Authorization"))
+                )
+                if "id" not in request:
+                    self.send_response(202)
+                    self.send_header("Content-Length", "0")
+                    self.end_headers()
+                    return
+
+                if method == "initialize":
+                    result = {
+                        "protocolVersion": request["params"]["protocolVersion"],
+                        "capabilities": {"tools": {}},
+                        "serverInfo": {"name": "test-server", "version": "1.0"},
+                    }
+                elif method == "tools/list":
+                    result = {"tools": []}
+                else:
+                    raise AssertionError(f"Unexpected MCP method: {method}")
+
+                response = json.dumps(
+                    {"jsonrpc": "2.0", "id": request["id"], "result": result}
+                ).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(response)))
+                self.end_headers()
+                self.wfile.write(response)
 
             def log_message(self, format, *args):
                 pass
@@ -417,23 +451,31 @@ class TestLoadMCPConfig:
 
                 skyvern = _load_mcp_config()["skyvern"]
 
-            request = urllib.request.Request(
-                skyvern["url"],
-                headers=skyvern["headers"],
-            )
-            opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
-            with opener.open(request, timeout=2) as response:
-                assert response.status == 204
+            from tools.mcp_tool import MCPServerTask
+
+            async def exercise_production_client():
+                client = MCPServerTask("skyvern")
+                try:
+                    await client.start({**skyvern, "connect_timeout": 2})
+                    assert client.initialize_result is not None
+                    assert client._tools == []
+                finally:
+                    await client.shutdown()
+
+            asyncio.run(exercise_production_client())
         finally:
             server.shutdown()
             server.server_close()
             thread.join(timeout=2)
 
         assert skyvern["url"] == f"{origin}/mcp/"
-        assert received == {
-            "path": "/mcp/",
-            "authorization": "Bearer socket-token",
+        assert {method for method, _, _ in received} >= {
+            "initialize",
+            "notifications/initialized",
+            "tools/list",
         }
+        assert all(path == "/mcp/" for _, path, _ in received)
+        assert all(auth == "Bearer socket-token" for _, _, auth in received)
 
 
 class TestMCPStatus:

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -7,6 +7,8 @@ import asyncio
 import json
 import threading
 import time
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -120,6 +122,180 @@ class TestLoadMCPConfig:
             from tools.mcp_tool import _load_mcp_config
             result = _load_mcp_config()
             assert result == {}
+
+    def test_safe_mode_returns_empty_before_managed_resolution(self, monkeypatch):
+        monkeypatch.setenv("HERMES_SAFE_MODE", "1")
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={
+                "mcp_servers": {
+                    "skyvern": {"managed_gateway": "skyvern"},
+                }
+            },
+        ) as load_config:
+            from tools.mcp_tool import _load_mcp_config
+
+            assert _load_mcp_config() == {}
+
+        load_config.assert_not_called()
+
+    def test_suspicious_server_filtered_while_managed_skyvern_resolves(
+        self,
+        monkeypatch,
+    ):
+        monkeypatch.delenv("HERMES_SAFE_MODE", raising=False)
+        monkeypatch.setenv("SKYVERN_GATEWAY_URL", "https://skyvern.test")
+        monkeypatch.setenv("TOOL_GATEWAY_USER_TOKEN", "nous-token")
+        servers = {
+            "suspicious": {
+                "command": "bash",
+                "args": ["-c", "curl https://evil.test"],
+            },
+            "skyvern": {"managed_gateway": "skyvern"},
+        }
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"mcp_servers": servers},
+        ), patch(
+            "tools.managed_tool_gateway.managed_nous_tools_enabled",
+            return_value=True,
+        ):
+            from tools.mcp_tool import _load_mcp_config
+
+            result = _load_mcp_config()
+
+        assert set(result) == {"skyvern"}
+        assert result["skyvern"]["url"] == "https://skyvern.test/mcp/"
+
+    def test_managed_skyvern_resolves_gateway_url_and_auth_header(self, monkeypatch):
+        monkeypatch.delenv("HERMES_SAFE_MODE", raising=False)
+        monkeypatch.delenv("SKYVERN_GATEWAY_URL", raising=False)
+        monkeypatch.setenv("TOOL_GATEWAY_DOMAIN", "nousresearch.com")
+        monkeypatch.setenv("TOOL_GATEWAY_USER_TOKEN", "nous-token")
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={
+                "mcp_servers": {
+                    "skyvern": {"managed_gateway": "skyvern"},
+                }
+            },
+        ), patch(
+            "tools.managed_tool_gateway.managed_nous_tools_enabled",
+            return_value=True,
+        ):
+            from tools.mcp_tool import _load_mcp_config
+
+            result = _load_mcp_config()
+
+        assert result["skyvern"] == {
+            "managed_gateway": "skyvern",
+            "url": "https://skyvern-gateway.nousresearch.com/mcp/",
+            "headers": {"Authorization": "Bearer nous-token"},
+        }
+
+    @pytest.mark.parametrize(
+        "direct_cfg",
+        [
+            {
+                "url": "https://api.skyvern.com/mcp/",
+                "headers": {"x-api-key": "skyvern-key"},
+            },
+            {"command": "uvx", "args": ["skyvern-mcp"]},
+        ],
+    )
+    def test_direct_skyvern_config_is_preserved(self, direct_cfg):
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"mcp_servers": {"skyvern": direct_cfg}},
+        ):
+            from tools.mcp_tool import _load_mcp_config
+
+            result = _load_mcp_config()
+
+        assert result["skyvern"] == direct_cfg
+
+    def test_managed_skyvern_without_gateway_auth_is_skipped(
+        self,
+        monkeypatch,
+        caplog,
+    ):
+        monkeypatch.delenv("HERMES_SAFE_MODE", raising=False)
+        monkeypatch.delenv("TOOL_GATEWAY_USER_TOKEN", raising=False)
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={
+                "mcp_servers": {
+                    "skyvern": {"managed_gateway": "skyvern"},
+                }
+            },
+        ), patch(
+            "tools.managed_tool_gateway.managed_nous_tools_enabled",
+            return_value=True,
+        ), patch(
+            "tools.managed_tool_gateway.read_nous_access_token",
+            return_value=None,
+        ):
+            from tools.mcp_tool import _load_mcp_config
+
+            result = _load_mcp_config()
+
+        assert result == {}
+        assert "Skipping managed MCP server 'skyvern'" in caplog.text
+
+    def test_managed_skyvern_bearer_header_reaches_live_socket(self, monkeypatch):
+        received = {}
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                received["path"] = self.path
+                received["authorization"] = self.headers.get("Authorization")
+                self.send_response(204)
+                self.end_headers()
+
+            def log_message(self, format, *args):
+                pass
+
+        server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        origin = f"http://127.0.0.1:{server.server_port}"
+        monkeypatch.delenv("HERMES_SAFE_MODE", raising=False)
+        monkeypatch.setenv("SKYVERN_GATEWAY_URL", origin)
+        monkeypatch.setenv("TOOL_GATEWAY_USER_TOKEN", "socket-token")
+
+        try:
+            with patch(
+                "hermes_cli.config.load_config",
+                return_value={
+                    "mcp_servers": {
+                        "skyvern": {"managed_gateway": "skyvern"},
+                    }
+                },
+            ), patch(
+                "tools.managed_tool_gateway.managed_nous_tools_enabled",
+                return_value=True,
+            ):
+                from tools.mcp_tool import _load_mcp_config
+
+                skyvern = _load_mcp_config()["skyvern"]
+
+            request = urllib.request.Request(
+                skyvern["url"],
+                headers=skyvern["headers"],
+            )
+            opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+            with opener.open(request, timeout=2) as response:
+                assert response.status == 204
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
+
+        assert skyvern["url"] == f"{origin}/mcp/"
+        assert received == {
+            "path": "/mcp/",
+            "authorization": "Bearer socket-token",
+        }
 
 
 class TestMCPStatus:

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -105,7 +105,7 @@ import time
 from typing import Callable
 from datetime import datetime
 from typing import Any, Coroutine, Dict, List, Optional
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse
 
 logger = logging.getLogger(__name__)
 
@@ -3742,6 +3742,36 @@ def _filter_suspicious_mcp_servers(servers: Dict[str, dict]) -> Dict[str, dict]:
     return safe_servers
 
 
+def _resolve_managed_mcp_config(name: str, cfg: dict) -> Optional[dict]:
+    managed_vendor = cfg.get("managed_gateway")
+    if not isinstance(managed_vendor, str) or not managed_vendor.strip():
+        return cfg
+
+    if cfg.get("url") or cfg.get("command"):
+        return cfg
+
+    from tools.managed_tool_gateway import resolve_managed_tool_gateway
+
+    gateway = resolve_managed_tool_gateway(managed_vendor.strip())
+    if gateway is None:
+        logger.warning(
+            "Skipping managed MCP server '%s': Tool Gateway auth is unavailable",
+            name,
+        )
+        return None
+
+    runtime_cfg = dict(cfg)
+    gateway_path = str(runtime_cfg.get("managed_gateway_path") or "mcp/").lstrip("/")
+    runtime_cfg["url"] = urljoin(
+        f"{gateway.gateway_origin.rstrip('/')}/",
+        gateway_path,
+    )
+    headers = dict(cfg.get("headers") or {})
+    headers["Authorization"] = f"Bearer {gateway.nous_user_token}"
+    runtime_cfg["headers"] = headers
+    return runtime_cfg
+
+
 def _load_mcp_config() -> Dict[str, dict]:
     """Read ``mcp_servers`` from the Hermes config file.
 
@@ -3773,7 +3803,9 @@ def _load_mcp_config() -> Dict[str, dict]:
         for name, cfg in _filter_suspicious_mcp_servers(servers).items():
             interpolated = _interpolate_env_vars(cfg)
             if isinstance(interpolated, dict):
-                safe_servers[name] = interpolated
+                resolved = _resolve_managed_mcp_config(name, interpolated)
+                if resolved is not None:
+                    safe_servers[name] = resolved
         return safe_servers
     except Exception as exc:
         logger.debug("Failed to load MCP config: %s", exc)

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -329,6 +329,7 @@ _DEFAULT_CONNECT_TIMEOUT = 60    # seconds for initial connection per server
 _MAX_RECONNECT_RETRIES = 5
 _MAX_INITIAL_CONNECT_RETRIES = 3 # retries for the very first connection attempt
 _MAX_BACKOFF_SECONDS = 60
+_MANAGED_MCP_VENDORS = frozenset({"skyvern"})
 # While parked (reconnect budget exhausted, tools deregistered) the run task
 # wakes on this cadence and attempts one revival probe. Without it a parked
 # server is unrevivable: its tools are out of the registry, so no tool call
@@ -3750,9 +3751,40 @@ def _resolve_managed_mcp_config(name: str, cfg: dict) -> Optional[dict]:
     if cfg.get("url") or cfg.get("command"):
         return cfg
 
-    from tools.managed_tool_gateway import resolve_managed_tool_gateway
+    if not _parse_boolish(cfg.get("enabled", True), default=True):
+        return cfg
 
-    gateway = resolve_managed_tool_gateway(managed_vendor.strip())
+    managed_vendor = managed_vendor.strip().lower()
+    if managed_vendor not in _MANAGED_MCP_VENDORS:
+        logger.warning(
+            "Skipping managed MCP server '%s': unsupported managed gateway '%s'",
+            name,
+            managed_vendor,
+        )
+        return None
+
+    try:
+        from hermes_cli.nous_account import get_nous_portal_account_info
+
+        account_info = get_nous_portal_account_info()
+        entitled = bool(
+            account_info and account_info.tool_gateway_entitled_for(managed_vendor)
+        )
+    except Exception:
+        entitled = False
+    if not entitled:
+        logger.warning(
+            "Skipping managed MCP server '%s': Tool Gateway entitlement is unavailable",
+            name,
+        )
+        return None
+
+    from tools.managed_tool_gateway import (
+        build_vendor_gateway_url,
+        resolve_managed_tool_gateway,
+    )
+
+    gateway = resolve_managed_tool_gateway(managed_vendor)
     if gateway is None:
         logger.warning(
             "Skipping managed MCP server '%s': Tool Gateway auth is unavailable",
@@ -3761,18 +3793,30 @@ def _resolve_managed_mcp_config(name: str, cfg: dict) -> Optional[dict]:
         return None
 
     runtime_cfg = dict(cfg)
-    gateway_path = str(runtime_cfg.get("managed_gateway_path") or "mcp/").lstrip("/")
+    runtime_cfg.pop("managed_gateway_path", None)
     runtime_cfg["url"] = urljoin(
         f"{gateway.gateway_origin.rstrip('/')}/",
-        gateway_path,
+        "mcp/",
     )
+    trusted_origin = urlparse(build_vendor_gateway_url(managed_vendor))
+    resolved_url = urlparse(runtime_cfg["url"])
+    if (
+        resolved_url.scheme not in {"http", "https"}
+        or (resolved_url.scheme, resolved_url.netloc)
+        != (trusted_origin.scheme, trusted_origin.netloc)
+    ):
+        logger.warning(
+            "Skipping managed MCP server '%s': resolved gateway origin is untrusted",
+            name,
+        )
+        return None
     headers = dict(cfg.get("headers") or {})
     headers["Authorization"] = f"Bearer {gateway.nous_user_token}"
     runtime_cfg["headers"] = headers
     return runtime_cfg
 
 
-def _load_mcp_config() -> Dict[str, dict]:
+def _load_mcp_config(*, resolve_managed: bool = True) -> Dict[str, dict]:
     """Read ``mcp_servers`` from the Hermes config file.
 
     Returns a dict of ``{server_name: server_config}`` or empty dict.
@@ -3801,11 +3845,22 @@ def _load_mcp_config() -> Dict[str, dict]:
             pass
         safe_servers: Dict[str, dict] = {}
         for name, cfg in _filter_suspicious_mcp_servers(servers).items():
-            interpolated = _interpolate_env_vars(cfg)
-            if isinstance(interpolated, dict):
-                resolved = _resolve_managed_mcp_config(name, interpolated)
-                if resolved is not None:
-                    safe_servers[name] = resolved
+            try:
+                interpolated = _interpolate_env_vars(cfg)
+                if isinstance(interpolated, dict):
+                    resolved = (
+                        _resolve_managed_mcp_config(name, interpolated)
+                        if resolve_managed
+                        else interpolated
+                    )
+                    if resolved is not None:
+                        safe_servers[name] = resolved
+            except Exception as exc:
+                logger.warning(
+                    "Skipping invalid MCP server '%s': %s",
+                    name,
+                    _sanitize_error(_exc_str(exc)),
+                )
         return safe_servers
     except Exception as exc:
         logger.debug("Failed to load MCP config: %s", exc)
@@ -5038,7 +5093,12 @@ def discover_mcp_tools() -> List[str]:
         List of all registered MCP tool names.
     """
     if not _MCP_AVAILABLE:
-        logger.debug("MCP SDK not available -- skipping MCP tool discovery")
+        if _load_mcp_config(resolve_managed=False):
+            logger.warning(
+                "MCP servers are configured but the MCP SDK is not installed. "
+                'Install it with `pip install "hermes-agent[mcp]"` or '
+                "`uv sync --extra mcp`."
+            )
         return []
 
     servers = _load_mcp_config()
@@ -5103,7 +5163,7 @@ def get_mcp_status() -> List[dict]:
     result: List[dict] = []
 
     # Get configured servers from config
-    configured = _load_mcp_config()
+    configured = _load_mcp_config(resolve_managed=False)
     if not configured:
         return result
 
@@ -5113,7 +5173,14 @@ def get_mcp_status() -> List[dict]:
         connect_errors = dict(_server_connect_errors)
 
     for name, cfg in configured.items():
-        transport = cfg.get("transport", "http") if "url" in cfg else "stdio"
+        is_managed = cfg.get("managed_gateway") and not (
+            cfg.get("url") or cfg.get("command")
+        )
+        transport = (
+            cfg.get("transport", "http")
+            if "url" in cfg or is_managed
+            else "stdio"
+        )
         enabled = _parse_boolish(cfg.get("enabled", True), default=True)
         server = active_servers.get(name)
         if server and server.session is not None:

--- a/website/docs/user-guide/features/tool-gateway.md
+++ b/website/docs/user-guide/features/tool-gateway.md
@@ -22,9 +22,9 @@ The Tool Gateway is included with every paid [Nous Portal](https://portal.nousre
 | 🔍 | **Web search & extract** | Agent-grade web search and full-page extraction via Firecrawl. No rate limits to worry about — the gateway handles scaling. |
 | 🎨 | **Image generation** | Nine models under one endpoint: **FLUX 2 Klein 9B**, **FLUX 2 Pro**, **Z-Image Turbo**, **Nano Banana Pro** (Gemini 3 Pro Image), **GPT Image 1.5**, **GPT Image 2**, **Ideogram V3**, **Recraft V4 Pro**, **Qwen Image**. Pick per-generation with a flag, or let Hermes default to FLUX 2 Klein. |
 | 🔊 | **Text-to-speech** | OpenAI TTS voices wired into the `text_to_speech` tool. Drop voice notes into Telegram, generate audio for pipelines, narrate anything. |
-| 🌐 | **Cloud browser automation** | Headless Chromium sessions via Browser Use. `browser_navigate`, `browser_click`, `browser_type`, `browser_vision` — all the agent-driving primitives, no Browserbase account required. Hermes also supports managed Skyvern MCP configuration for when Nous deploys that gateway. |
+| 🌐 | **Cloud browser automation** | Headless Chromium sessions via Browser Use. `browser_navigate`, `browser_click`, `browser_type`, `browser_vision` — all the agent-driving primitives, no Browserbase account required. |
 
-The four currently deployed gateway categories are pay-as-you-use billed against your Nous subscription. Use any combination — run the gateway for web and images while keeping your own ElevenLabs key for TTS, or route everything through Nous.
+All four are pay-as-you-use billed against your Nous subscription. Use any combination — run the gateway for web and images while keeping your own ElevenLabs key for TTS, or route everything through Nous.
 
 ## Why it's here
 
@@ -151,13 +151,13 @@ mcp_servers:
 
 Precedence: `use_gateway: true` routes through Nous regardless of any direct keys in `.env`. `use_gateway: false` (or absent) uses direct keys if available and only falls back to the gateway when none exist.
 
-### Managed Skyvern MCP (pending Nous deployment)
+### Managed Skyvern MCP
 
 The `managed_gateway: skyvern` entry records managed Skyvern intent without storing a Skyvern API key. At runtime, Hermes resolves it to `https://skyvern-gateway.<TOOL_GATEWAY_DOMAIN>/mcp/` (using `nousresearch.com` by default) and sends the Nous Portal token as an `Authorization: Bearer` header. An explicit Skyvern `url` or `command` remains untouched for direct configurations.
 
 MCP servers require the optional `mcp` extra (`pip install "hermes-agent[mcp]"` or `uv sync --extra mcp`).
 
-This is the client-side gateway convention only. Server-side Skyvern gateway availability is pending Nous deployment; until that is available, configure Skyvern's MCP endpoint directly with your own credentials.
+Managed routing requires the Skyvern gateway to be available for your subscription. If it isn't, configure Skyvern's MCP endpoint directly with your own credentials.
 
 ### Disabling the gateway
 

--- a/website/docs/user-guide/features/tool-gateway.md
+++ b/website/docs/user-guide/features/tool-gateway.md
@@ -155,6 +155,8 @@ Precedence: `use_gateway: true` routes through Nous regardless of any direct key
 
 The `managed_gateway: skyvern` entry records managed Skyvern intent without storing a Skyvern API key. At runtime, Hermes resolves it to `https://skyvern-gateway.<TOOL_GATEWAY_DOMAIN>/mcp/` (using `nousresearch.com` by default) and sends the Nous Portal token as an `Authorization: Bearer` header. An explicit Skyvern `url` or `command` remains untouched for direct configurations.
 
+MCP servers require the optional `mcp` extra (`pip install "hermes-agent[mcp]"` or `uv sync --extra mcp`).
+
 This is the client-side gateway convention only. Server-side Skyvern gateway availability is pending Nous deployment; until that is available, configure Skyvern's MCP endpoint directly with your own credentials.
 
 ### Disabling the gateway

--- a/website/docs/user-guide/features/tool-gateway.md
+++ b/website/docs/user-guide/features/tool-gateway.md
@@ -22,9 +22,9 @@ The Tool Gateway is included with every paid [Nous Portal](https://portal.nousre
 | 🔍 | **Web search & extract** | Agent-grade web search and full-page extraction via Firecrawl. No rate limits to worry about — the gateway handles scaling. |
 | 🎨 | **Image generation** | Nine models under one endpoint: **FLUX 2 Klein 9B**, **FLUX 2 Pro**, **Z-Image Turbo**, **Nano Banana Pro** (Gemini 3 Pro Image), **GPT Image 1.5**, **GPT Image 2**, **Ideogram V3**, **Recraft V4 Pro**, **Qwen Image**. Pick per-generation with a flag, or let Hermes default to FLUX 2 Klein. |
 | 🔊 | **Text-to-speech** | OpenAI TTS voices wired into the `text_to_speech` tool. Drop voice notes into Telegram, generate audio for pipelines, narrate anything. |
-| 🌐 | **Cloud browser automation** | Headless Chromium sessions via Browser Use. `browser_navigate`, `browser_click`, `browser_type`, `browser_vision` — all the agent-driving primitives, no Browserbase account required. |
+| 🌐 | **Cloud browser automation** | Headless Chromium sessions via Browser Use. `browser_navigate`, `browser_click`, `browser_type`, `browser_vision` — all the agent-driving primitives, no Browserbase account required. Hermes also supports managed Skyvern MCP configuration for when Nous deploys that gateway. |
 
-All four are pay-as-you-use billed against your Nous subscription. Use any combination — run the gateway for web and images while keeping your own ElevenLabs key for TTS, or route everything through Nous.
+The four currently deployed gateway categories are pay-as-you-use billed against your Nous subscription. Use any combination — run the gateway for web and images while keeping your own ElevenLabs key for TTS, or route everything through Nous.
 
 ## Why it's here
 
@@ -143,9 +143,19 @@ tts:
 browser:
   cloud_provider: browser-use
   use_gateway: true
+
+mcp_servers:
+  skyvern:
+    managed_gateway: skyvern
 ```
 
 Precedence: `use_gateway: true` routes through Nous regardless of any direct keys in `.env`. `use_gateway: false` (or absent) uses direct keys if available and only falls back to the gateway when none exist.
+
+### Managed Skyvern MCP (pending Nous deployment)
+
+The `managed_gateway: skyvern` entry records managed Skyvern intent without storing a Skyvern API key. At runtime, Hermes resolves it to `https://skyvern-gateway.<TOOL_GATEWAY_DOMAIN>/mcp/` (using `nousresearch.com` by default) and sends the Nous Portal token as an `Authorization: Bearer` header. An explicit Skyvern `url` or `command` remains untouched for direct configurations.
+
+This is the client-side gateway convention only. Server-side Skyvern gateway availability is pending Nous deployment; until that is available, configure Skyvern's MCP endpoint directly with your own credentials.
 
 ### Disabling the gateway
 


### PR DESCRIPTION
## Summary

Adds Skyvern to Hermes' Nous Tool Gateway as managed MCP browser automation.

This is intentionally not the direct Skyvern MCP setup. Direct Skyvern MCP still works with `https://api.skyvern.com/mcp/` and `SKYVERN_API_KEY`, but that is direct Skyvern billing. The managed path stores only:

```yaml
mcp_servers:
  skyvern:
    managed_gateway: skyvern
```

At runtime, Hermes resolves that marker through the existing Tool Gateway convention to:

- `https://skyvern-gateway.<TOOL_GATEWAY_DOMAIN>/mcp/`
- `Authorization: Bearer <Nous token>`

## Assumption

This PR assumes the Nous-managed Skyvern MCP gateway exists server-side and accepts the same bearer-token convention used by managed Tool Gateway integrations.

If that gateway endpoint or auth header differs, the client-side resolver should be updated to match the server contract.

## What Changed

- Adds Skyvern to Tool Gateway eligibility/default setup.
- Resolves managed Skyvern MCP config at runtime without storing a Skyvern API key.
- Preserves existing direct `mcp_servers.skyvern` configs with `url` or `command`.
- Updates Tool Gateway docs to distinguish Nous passthrough billing from direct Skyvern MCP billing.
- Adds focused unit tests for managed config, direct config preservation, and runtime URL/header resolution.

## Verification

- `scripts/run_tests.sh tests/hermes_cli/test_nous_subscription.py tests/tools/test_mcp_tool.py -q`
  - `272 passed` — includes the new coverage-category/KeyError regression, paid & free-pool entitlement, loader safety-invariant, and managed-resolution tests
- Integration test drives the production Streamable-HTTP MCP client against a local stub gateway and asserts the resolved URL and `Authorization: Bearer` header arrive on the socket
- Live-validated Skyvern's MCP server from Hermes over Streamable HTTP (direct config): initialize handshake, tools/list (96 tools), and a real tool call all OK
- Broader `scripts/run_tests.sh tests/hermes_cli/ -q` sweep: no regressions (only known pre-existing platform failures, identical on a clean tree)
- `npm run build` in `website`
  - build succeeded
  - existing unrelated broken-link/broken-anchor warnings remain
- `git diff --check`
  - clean
