### PR TITLE
docs: move cargo bancario to plan de cuentas

### DIFF
--- a/knowledge-base/contabilidad/plan-de-cuentas/cargo-bancario.md
+++ b/knowledge-base/contabilidad/plan-de-cuentas/cargo-bancario.md
@@ -1,0 +1,6 @@
+Es una cuenta contable de Gasto. Generalmente entran los siguientes tipos de gastos acá:
+- Comisiones SWIFT.
+- Spread/Comisión al convertir dinero de una moneada a otra.
+- Comisiones de mantención de cuentas corrientes.
+- Comisiones de mantención de tarjetas de crédito.
+- Impuestos, cargos o comisiones cobrados por el banco sobre sus productos financieros; no necesariamente corresponden a líneas de sobregiro, aunque esa es una posibilidad.


### PR DESCRIPTION
## Summary
- Moves `cargo-bancario.md` into `knowledge-base/contabilidad/plan-de-cuentas/`.

## Source of truth
- Requested by Borja in Slack.
- File found locally at `knowledge-base/contabilidad/diccionario/cargo-bancario.md` before the move.

## Notes
- cc @Borjampm
