### PR TITLE
acp_adapter: render `todo` tool as a live markdown checklist

### DIFF
--- a/acp_adapter/tools.py
+++ b/acp_adapter/tools.py
@@ -41,6 +41,8 @@ TOOL_KIND_MAP: Dict[str, ToolKind] = {
     "browser_press": "execute",
     "browser_back": "execute",
     "browser_get_images": "read",
+    # Planning / task tracking
+    "todo": "think",
     # Agent internals
     "delegate_task": "execute",
     "vision_analyze": "read",
@@ -94,7 +96,50 @@ def build_tool_title(tool_name: str, args: Dict[str, Any]) -> str:
         return "execute code"
     if tool_name == "vision_analyze":
         return f"analyze image: {args.get('question', '?')[:50]}"
+    if tool_name == "todo":
+        todos = args.get("todos") or []
+        if not todos:
+            return "todo: read list"
+        in_progress = next(
+            (t.get("content", "") for t in todos if str(t.get("status", "")).lower() == "in_progress"),
+            None,
+        )
+        if in_progress:
+            label = in_progress[:57] + "..." if len(in_progress) > 60 else in_progress
+            return f"todo: {label}"
+        return f"todo: update ({len(todos)} item{'s' if len(todos) != 1 else ''})"
     return tool_name
+
+
+def _render_todo_markdown(todos: List[Dict[str, Any]], merge: bool = False) -> str:
+    """Render a todo list as a GFM checklist with status icons.
+
+    Status mapping (renders well in Zed/VS Code/JetBrains ACP clients):
+      - completed   -> [x] ~~text~~
+      - in_progress -> [ ] **text** ▶
+      - cancelled   -> [x] ~~text~~ (cancelled)
+      - pending     -> [ ] text
+    """
+    if not todos:
+        return "_(empty todo list)_"
+
+    lines: List[str] = []
+    for item in todos:
+        if not isinstance(item, dict):
+            continue
+        status = str(item.get("status", "pending")).strip().lower()
+        content = str(item.get("content", "")).strip() or "_(no description)_"
+        if status == "completed":
+            lines.append(f"- [x] ~~{content}~~")
+        elif status == "in_progress":
+            lines.append(f"- [ ] **{content}** ▶")
+        elif status == "cancelled":
+            lines.append(f"- [x] ~~{content}~~ _(cancelled)_")
+        else:
+            lines.append(f"- [ ] {content}")
+
+    header = "**Todos** _(merge)_" if merge else "**Todos**"
+    return header + "\n" + "\n".join(lines)
 
 
 def _build_patch_mode_content(patch_text: str) -> List[Any]:
@@ -258,6 +303,28 @@ def _build_tool_complete_content(
         except Exception:
             pass
 
+    if tool_name == "todo":
+        # The todo tool returns the full current list as JSON.
+        # Re-render as a markdown checklist so ACP clients show a live list,
+        # not a raw JSON blob.
+        try:
+            parsed = json.loads(result) if result else None
+            todos: List[Dict[str, Any]] = []
+            if isinstance(parsed, list):
+                todos = parsed
+            elif isinstance(parsed, dict):
+                # Common shapes: {"todos": [...]}, {"items": [...]}, {"list": [...]}
+                for key in ("todos", "items", "list"):
+                    if isinstance(parsed.get(key), list):
+                        todos = parsed[key]
+                        break
+            if todos:
+                markdown = _render_todo_markdown(todos)
+                return [acp.tool_content(acp.text_block(markdown))]
+        except (ValueError, TypeError):
+            pass
+        # Fall through to plain text if parsing fails
+
     return [acp.tool_content(acp.text_block(display_result))]
 
 
@@ -320,6 +387,16 @@ def build_tool_start(
         pattern = arguments.get("pattern", "")
         target = arguments.get("target", "content")
         content = [acp.tool_content(acp.text_block(f"Searching for '{pattern}' ({target})"))]
+        return acp.start_tool_call(
+            tool_call_id, title, kind=kind, content=content, locations=locations,
+            raw_input=arguments,
+        )
+
+    if tool_name == "todo":
+        todos = arguments.get("todos") or []
+        merge = bool(arguments.get("merge", False))
+        markdown = _render_todo_markdown(todos, merge=merge)
+        content = [acp.tool_content(acp.text_block(markdown))]
         return acp.start_tool_call(
             tool_call_id, title, kind=kind, content=content, locations=locations,
             raw_input=arguments,

--- a/tests/acp/test_tools.py
+++ b/tests/acp/test_tools.py
@@ -4,6 +4,7 @@ import pytest
 
 from acp_adapter.tools import (
     TOOL_KIND_MAP,
+    _render_todo_markdown,
     build_tool_complete,
     build_tool_start,
     build_tool_title,
@@ -274,3 +275,107 @@ class TestExtractLocations:
         args = {"command": "echo hi"}
         locs = extract_locations(args)
         assert locs == []
+
+
+# ---------------------------------------------------------------------------
+# todo tool rendering
+# ---------------------------------------------------------------------------
+
+
+class TestTodoRendering:
+    def test_todo_in_kind_map(self):
+        assert TOOL_KIND_MAP.get("todo") == "think"
+
+    def test_title_read_when_no_todos(self):
+        assert build_tool_title("todo", {}) == "todo: read list"
+
+    def test_title_uses_in_progress_item(self):
+        todos = [
+            {"id": "1", "content": "done thing", "status": "completed"},
+            {"id": "2", "content": "active task", "status": "in_progress"},
+            {"id": "3", "content": "later", "status": "pending"},
+        ]
+        assert build_tool_title("todo", {"todos": todos}) == "todo: active task"
+
+    def test_title_falls_back_to_count(self):
+        todos = [
+            {"id": "1", "content": "a", "status": "pending"},
+            {"id": "2", "content": "b", "status": "pending"},
+        ]
+        assert build_tool_title("todo", {"todos": todos}) == "todo: update (2 items)"
+
+    def test_render_empty(self):
+        assert _render_todo_markdown([]) == "_(empty todo list)_"
+
+    def test_render_all_statuses(self):
+        out = _render_todo_markdown([
+            {"id": "a", "content": "shipped", "status": "completed"},
+            {"id": "b", "content": "writing", "status": "in_progress"},
+            {"id": "c", "content": "next", "status": "pending"},
+            {"id": "d", "content": "abandoned", "status": "cancelled"},
+        ])
+        assert "**Todos**" in out
+        assert "- [x] ~~shipped~~" in out
+        assert "- [ ] **writing** ▶" in out
+        assert "- [ ] next" in out
+        assert "- [x] ~~abandoned~~ _(cancelled)_" in out
+
+    def test_render_merge_header(self):
+        out = _render_todo_markdown(
+            [{"id": "x", "content": "y", "status": "pending"}], merge=True
+        )
+        assert out.startswith("**Todos** _(merge)_")
+
+    def test_build_tool_start_renders_markdown(self):
+        todos = [{"id": "1", "content": "do it", "status": "in_progress"}]
+        ev = build_tool_start("tc-test", "todo", {"todos": todos})
+        # Walk into ACP content blocks and confirm checklist markdown landed there.
+        text_blocks = []
+
+        def _collect(obj):
+            if isinstance(obj, dict):
+                if obj.get("type") == "text" and "text" in obj:
+                    text_blocks.append(obj["text"])
+                for v in obj.values():
+                    _collect(v)
+            elif isinstance(obj, list):
+                for item in obj:
+                    _collect(item)
+            elif hasattr(obj, "model_dump"):
+                _collect(obj.model_dump())
+            elif hasattr(obj, "__dict__"):
+                _collect(vars(obj))
+
+        _collect(ev)
+        joined = "\n".join(text_blocks)
+        assert "- [ ] **do it** ▶" in joined
+        assert '"todos"' not in joined  # not the JSON fallback
+
+    def test_build_tool_complete_parses_json_result(self):
+        # The todo tool returns a JSON array as its tool result string.
+        import json as _json
+        result = _json.dumps([
+            {"id": "1", "content": "alpha", "status": "completed"},
+            {"id": "2", "content": "beta", "status": "in_progress"},
+        ])
+        ev = build_tool_complete("tc-test", "todo", result=result)
+        text_blocks = []
+
+        def _collect(obj):
+            if isinstance(obj, dict):
+                if obj.get("type") == "text" and "text" in obj:
+                    text_blocks.append(obj["text"])
+                for v in obj.values():
+                    _collect(v)
+            elif isinstance(obj, list):
+                for item in obj:
+                    _collect(item)
+            elif hasattr(obj, "model_dump"):
+                _collect(obj.model_dump())
+            elif hasattr(obj, "__dict__"):
+                _collect(vars(obj))
+
+        _collect(ev)
+        joined = "\n".join(text_blocks)
+        assert "- [x] ~~alpha~~" in joined
+        assert "- [ ] **beta** ▶" in joined


### PR DESCRIPTION
## Summary

The ACP adapter has per-tool renderers for `patch`, `write_file`, `terminal`, `read_file`, `search_files`, etc., but no branch for the `todo` tool. As a result, todo lists fall through to the generic JSON fallback, and ACP clients (Zed, VS Code, JetBrains via `claude-code-acp`-style integrations) render them as a raw JSON code block instead of a live, scannable checklist.

**Before** (Zed):
```json
{
  "todos": [
    {"id": "1", "content": "fork repo", "status": "completed"},
    {"id": "2", "content": "write patch", "status": "in_progress"},
    {"id": "3", "content": "open PR", "status": "pending"}
  ]
}
```

**After** (rendered as markdown by the client):
> **Todos**
> - [x] ~~fork repo~~
> - [ ] **write patch** ▶
> - [ ] open PR

## Changes

- `"todo" → "think"` in `TOOL_KIND_MAP` so clients group it with planning kinds.
- New `_render_todo_markdown(todos, merge=False)` helper — GFM checklist with status icons:
  - `completed` → `- [x] ~~text~~`
  - `in_progress` → `- [ ] **text** ▶`
  - `cancelled` → `- [x] ~~text~~ _(cancelled)_`
  - `pending` → `- [ ] text`
- `build_tool_title("todo", args)` — uses the current `in_progress` item if present, else item count, else `"read list"` for empty calls.
- `build_tool_start` — `todo` branch emits the rendered checklist.
- `_build_tool_complete_content` — re-parses the JSON tool result (which the `todo` tool returns) and re-renders, so the **persisted** card in the client stays a checklist instead of reverting to JSON when the call completes.

## Tests

`tests/acp/test_tools.py` adds a `TestTodoRendering` class covering:
- kind map entry
- title selection (in-progress / count / read)
- empty list / all four statuses / merge header
- end-to-end assertion that `build_tool_start` and `build_tool_complete` emit the markdown checklist (not the JSON fallback) into ACP `text_block` content

```
$ pytest tests/acp/test_tools.py -q
.........................................                                [100%]
41 passed in 4.77s
```

(32 previously passing tests + 9 new.)

## Compatibility

- Pure addition — no existing renderer changed.
- Non-`todo` tool calls hit zero new code paths.
- Falls through to the generic content path if the tool result isn't parseable as a list / `{todos|items|list: [...]}`, so anything custom keeps working.