### PR TITLE
fix(mcp): detect TimeoutError as stale session in StreamableHTTP transport

### DIFF
--- a/tests/tools/test_mcp_tool_session_expired.py
+++ b/tests/tools/test_mcp_tool_session_expired.py
@@ -74,10 +74,20 @@ def test_is_session_expired_rejects_interrupted_error():
 
 
 def test_is_session_expired_rejects_empty_message():
-    """Bare exceptions with no message shouldn't match."""
+    """Bare exceptions with no message shouldn't match — unless they are
+    TimeoutError, which signals a stale session (see #XXXX)."""
     from tools.mcp_tool import _is_session_expired_error
     assert _is_session_expired_error(RuntimeError("")) is False
     assert _is_session_expired_error(Exception()) is False
+
+
+def test_is_session_expired_detects_timeout_error():
+    """TimeoutError on an MCP tool call signals a stale transport session.
+    When the SSE stream disconnects, subsequent calls to the old session
+    hang until the tool-call timeout fires.  Reconnecting is the right fix."""
+    from tools.mcp_tool import _is_session_expired_error
+    assert _is_session_expired_error(TimeoutError()) is True
+    assert _is_session_expired_error(TimeoutError("timed out")) is True
 
 
 # ---------------------------------------------------------------------------

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1678,9 +1678,24 @@ def _is_session_expired_error(exc: BaseException) -> bool:
     needed is a transport reconnect — tear down and rebuild the
     ``streamablehttp_client`` + ``ClientSession`` pair, which is
     exactly what ``MCPServerTask._reconnect_event`` triggers.
+
+    **2026-04-30**: Also treat ``TimeoutError`` as a session-expiry
+    signal.  When a StreamableHTTP server closes the GET SSE stream
+    (idle timeout, server restart), subsequent tool calls on the stale
+    session hang until the tool-call timeout fires with an empty
+    message.  The transport reconnect path is the correct recovery
+    because the access token is still valid — only the server-side
+    session state needs rebuilding.
     """
     if isinstance(exc, InterruptedError):
         return False
+    # TimeoutError (builtin in 3.11+, concurrent.futures.TimeoutError
+    # before that) on an MCP tool call strongly suggests a stale
+    # session — the server-side session was garbage-collected while
+    # the GET SSE stream was disconnected.  Reconnecting the transport
+    # is the correct recovery path.
+    if isinstance(exc, TimeoutError):
+        return True
     # Exception messages vary across SDK versions + server
     # implementations, so match on a small allow-list of stable
     # substrings rather than exception type.  Kept narrow to avoid


### PR DESCRIPTION
## Problem

MCP tools connected via StreamableHTTP transport (e.g. `actual-mcp-server`) consistently time out with an empty error message (`"call failed: "`), even though direct HTTP POSTs to the same endpoint work fine.

**Root cause**: When the server closes the GET SSE long-poll stream after idle timeout (`~60s`), the python-sdk transport reconnects with a **new** session ID. But tool calls queued on the **old** session hang until the 120s `tool_timeout` fires. `TimeoutError` has an empty `str()`, so `_is_session_expired_error()` returns `False`, and the transport reconnect path is never triggered.

### Evidence from agent.log

```
18:00:19  MCP server actual-mcp: registered 66 tools
18:05:19  GET stream disconnected, reconnecting in 1000ms...
23:41:11  ERROR: actual_accounts_list call failed:        ← empty error
23:49:24  GET stream disconnected...
23:53:43  ERROR: actual_accounts_list call failed:        ← empty error
```

## Fix

`_is_session_expired_error()` now returns `True` for `TimeoutError`, triggering the existing `_handle_session_expired_and_retry()` path (transport reconnect + single retry). This is the same mechanism already used for `"Invalid or expired session"` text markers.

### Changes

- `tools/mcp_tool.py`: Add `isinstance(exc, TimeoutError)` check before the text-marker matching
- `tests/tools/test_mcp_tool_session_expired.py`: Added `test_is_session_expired_detects_timeout_error()`. All 17 tests pass.

### What this fixes

```
Before:
  GET stream disconnect → tool call timeout → "call failed: " → dead

After:
  GET stream disconnect → tool call timeout → reconnect + retry → success
```

## Testing

```bash
pytest tests/tools/test_mcp_tool_session_expired.py -v
# 17 passed in 3.01s
```

The fix is narrow: it only affects `_is_session_expired_error()` which is guarded by `_handle_session_expired_and_retry()` — a path that already tears down and rebuilds the transport. No new failure modes are introduced.