### PR TITLE
fix(cli): extend memory reset to clear state.db conversation history

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9339,9 +9339,10 @@ Examples:
     )
     _reset_parser.add_argument(
         "--target",
-        choices=["all", "memory", "user"],
+        choices=["all", "memory", "user", "conversations", "everything"],
         default="all",
-        help="Which store to reset: 'all' (default), 'memory', or 'user'",
+        help="Which store to reset: 'all' (default), 'memory', 'user', "
+             "'conversations' (state.db only), or 'everything'",
     )
 
     def cmd_memory(args):
@@ -9358,31 +9359,71 @@ Examples:
             print("  Saved to config.yaml\n")
         elif sub == "reset":
             from hermes_constants import get_hermes_home, display_hermes_home
+            import sqlite3 as _sqlite3
 
-            mem_dir = get_hermes_home() / "memories"
+            hermes_home = get_hermes_home()
+            mem_dir = hermes_home / "memories"
             target = getattr(args, "target", "all")
-            files_to_reset = []
-            if target in ("all", "memory"):
-                files_to_reset.append(("MEMORY.md", "agent notes"))
-            if target in ("all", "user"):
-                files_to_reset.append(("USER.md", "user profile"))
 
-            # Check what exists
+            # Determine what to reset
+            reset_files = target in ("all", "memory", "user", "everything")
+            reset_db = target in ("conversations", "everything")
+
+            # Build file list
+            files_to_reset = []
+            if reset_files:
+                if target in ("all", "memory", "everything"):
+                    files_to_reset.append(("MEMORY.md", "agent notes"))
+                if target in ("all", "user", "everything"):
+                    files_to_reset.append(("USER.md", "user profile"))
+
             existing = [
                 (f, desc) for f, desc in files_to_reset if (mem_dir / f).exists()
             ]
-            if not existing:
+
+            # Check DB
+            db_path = hermes_home / "state.db"
+            db_exists = reset_db and db_path.exists()
+            db_msg_count = 0
+            if db_exists:
+                _conn = None
+                try:
+                    _conn = _sqlite3.connect(str(db_path))
+                    result = _conn.execute(
+                        "SELECT name FROM sqlite_master "
+                        "WHERE type='table' AND name='messages'"
+                    ).fetchone()
+                    if result:
+                        db_msg_count = _conn.execute(
+                            "SELECT COUNT(*) FROM messages"
+                        ).fetchone()[0]
+                except Exception:
+                    db_exists = False
+                finally:
+                    if _conn:
+                        _conn.close()
+
+            # If nothing to reset, bail out
+            if not existing and not db_exists:
                 print(
-                    f"\n  Nothing to reset — no memory files found in {display_hermes_home()}/memories/\n"
+                    f"\n  Nothing to reset — no memory files or conversation "
+                    f"history found.\n"
                 )
                 return
 
-            print(f"\n  This will permanently erase the following memory files:")
+            # Show what will be reset
+            print(f"\n  This will permanently erase:")
             for f, desc in existing:
                 path = mem_dir / f
                 size = path.stat().st_size
                 print(f"    ◆ {f} ({desc}) — {size:,} bytes")
+            if db_exists:
+                print(
+                    f"    ◆ state.db (conversation history) — "
+                    f"{db_msg_count:,} messages"
+                )
 
+            # Confirmation
             if not getattr(args, "yes", False):
                 try:
                     answer = input("\n  Type 'yes' to confirm: ").strip().lower()
@@ -9393,14 +9434,45 @@ Examples:
                     print("  Cancelled.\n")
                     return
 
+            # Delete files
             for f, desc in existing:
                 (mem_dir / f).unlink()
                 print(f"  ✓ Deleted {f} ({desc})")
 
+            # Clear state.db
+            if db_exists:
+                conn = _sqlite3.connect(str(db_path))
+                try:
+                    conn.execute("PRAGMA foreign_keys = OFF")
+                    tables = conn.execute(
+                        "SELECT name FROM sqlite_master "
+                        "WHERE type='table' AND NOT name LIKE 'sqlite_%'"
+                    ).fetchall()
+                    total_deleted = 0
+                    for (table,) in tables:
+                        cursor = conn.execute(f"DELETE FROM {table}")
+                        total_deleted += cursor.rowcount
+                    conn.execute("PRAGMA foreign_keys = ON")
+                    conn.commit()
+                    print(
+                        f"  ✓ Cleared state.db "
+                        f"({total_deleted:,} rows across {len(tables)} tables)"
+                    )
+                except Exception as e:
+                    print(f"  ✗ Failed to clear state.db: {e}")
+                finally:
+                    conn.close()
+
+            # Summary
             print(
-                f"\n  Memory reset complete. New sessions will start with a blank slate."
+                f"\n  Memory reset complete. "
+                f"New sessions will start with a blank slate."
             )
-            print(f"  Files were in: {display_hermes_home()}/memories/\n")
+            if existing:
+                print(f"  Files were in: {display_hermes_home()}/memories/")
+            if db_exists:
+                print(f"  Database: {display_hermes_home()}/state.db")
+            print()
         else:
             from hermes_cli.memory_setup import memory_command
 

--- a/tests/hermes_cli/test_memory_reset.py
+++ b/tests/hermes_cli/test_memory_reset.py
@@ -6,9 +6,15 @@ Covers:
 - Skip confirmation with --yes
 - Graceful handling when no memory files exist
 - Profile-scoped reset (uses HERMES_HOME)
+- Reset conversation history (--target conversations)
+- Reset everything (--target everything)
+
+Note: _run_memory_reset() duplicates cmd_memory logic.
+A follow-up PR should refactor tests to call cmd_memory directly.
 """
 
 import os
+import sqlite3
 import pytest
 from argparse import Namespace
 from pathlib import Path
@@ -34,30 +40,123 @@ def memory_env(tmp_path, monkeypatch):
     return hermes_home, memories
 
 
-def _run_memory_reset(target="all", yes=False, monkeypatch=None, confirm_input="no"):
+@pytest.fixture
+def full_env(tmp_path, monkeypatch):
+    """Set up a fake HERMES_HOME with memory files AND a state.db."""
+    hermes_home = tmp_path / ".hermes"
+    memories = hermes_home / "memories"
+    memories.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    # Create sample memory files
+    (memories / "MEMORY.md").write_text(
+        "§\nHermes repo is at ~/.hermes/hermes-agent\n§\nUser prefers dark themes",
+        encoding="utf-8",
+    )
+    (memories / "USER.md").write_text(
+        "§\nUser is Teknium\n§\nTimezone: US Pacific",
+        encoding="utf-8",
+    )
+
+    # Create state.db with test data
+    db_path = hermes_home / "state.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS sessions (id TEXT PRIMARY KEY, source TEXT)"
+    )
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS messages "
+        "(id INTEGER PRIMARY KEY, session_id TEXT, role TEXT, content TEXT)"
+    )
+    conn.execute("INSERT INTO sessions VALUES ('sess-1', 'cli')")
+    conn.execute("INSERT INTO sessions VALUES ('sess-2', 'telegram')")
+    conn.execute(
+        "INSERT INTO messages VALUES (1, 'sess-1', 'user', 'write me a story')"
+    )
+    conn.execute(
+        "INSERT INTO messages VALUES (2, 'sess-1', 'assistant', 'Once upon a time...')"
+    )
+    conn.execute(
+        "INSERT INTO messages VALUES (3, 'sess-2', 'user', 'hello')"
+    )
+    conn.commit()
+    conn.close()
+
+    return hermes_home, memories, db_path
+
+
+def _run_memory_reset(
+    target="all", yes=False, monkeypatch=None, confirm_input="no"
+):
     """Invoke the memory reset logic from cmd_memory in main.py.
 
     Simulates what happens when `hermes memory reset` is run.
     """
     from hermes_constants import get_hermes_home, display_hermes_home
 
-    mem_dir = get_hermes_home() / "memories"
-    files_to_reset = []
-    if target in ("all", "memory"):
-        files_to_reset.append(("MEMORY.md", "agent notes"))
-    if target in ("all", "user"):
-        files_to_reset.append(("USER.md", "user profile"))
+    hermes_home = get_hermes_home()
+    mem_dir = hermes_home / "memories"
 
-    existing = [(f, desc) for f, desc in files_to_reset if (mem_dir / f).exists()]
-    if not existing:
+    # Determine what to reset
+    reset_files = target in ("all", "memory", "user", "everything")
+    reset_db = target in ("conversations", "everything")
+
+    # Build file list
+    files_to_reset = []
+    if reset_files:
+        if target in ("all", "memory", "everything"):
+            files_to_reset.append(("MEMORY.md", "agent notes"))
+        if target in ("all", "user", "everything"):
+            files_to_reset.append(("USER.md", "user profile"))
+
+    existing = [
+        (f, desc) for f, desc in files_to_reset if (mem_dir / f).exists()
+    ]
+
+    # Check DB
+    db_path = hermes_home / "state.db"
+    db_exists = reset_db and db_path.exists()
+    if db_exists:
+        conn = sqlite3.connect(str(db_path))
+        try:
+            result = conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='table' AND name='messages'"
+            ).fetchone()
+            if not result:
+                db_exists = False
+        except Exception:
+            db_exists = False
+        finally:
+            conn.close()
+
+    # If nothing to reset, bail out
+    if not existing and not db_exists:
         return "nothing"
 
     if not yes:
         if confirm_input != "yes":
             return "cancelled"
 
+    # Delete files
     for f, desc in existing:
         (mem_dir / f).unlink()
+
+    # Clear state.db
+    if db_exists:
+        conn = sqlite3.connect(str(db_path))
+        try:
+            conn.execute("PRAGMA foreign_keys = OFF")
+            tables = conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='table' AND NOT name LIKE 'sqlite_%'"
+            ).fetchall()
+            for (table,) in tables:
+                conn.execute(f"DELETE FROM {table}")
+            conn.execute("PRAGMA foreign_keys = ON")
+            conn.commit()
+        finally:
+            conn.close()
 
     return "deleted"
 
@@ -107,7 +206,9 @@ class TestMemoryReset:
         """Without --yes and without typing 'yes', should be cancelled."""
         hermes_home, memories = memory_env
 
-        result = _run_memory_reset(target="all", yes=False, confirm_input="no")
+        result = _run_memory_reset(
+            target="all", yes=False, confirm_input="no"
+        )
         assert result == "cancelled"
         # Files should still exist
         assert (memories / "MEMORY.md").exists()
@@ -117,7 +218,9 @@ class TestMemoryReset:
         """Typing 'yes' should proceed with deletion."""
         hermes_home, memories = memory_env
 
-        result = _run_memory_reset(target="all", yes=False, confirm_input="yes")
+        result = _run_memory_reset(
+            target="all", yes=False, confirm_input="yes"
+        )
         assert result == "deleted"
         assert not (memories / "MEMORY.md").exists()
         assert not (memories / "USER.md").exists()
@@ -152,6 +255,135 @@ class TestMemoryReset:
         # No memories dir
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
-        # The memories dir won't exist; get_hermes_home() / "memories" won't have files
+        # The memories dir won't exist; get_hermes_home() / "memories" won't
+        # have files
         result = _run_memory_reset(target="all", yes=True)
         assert result == "nothing"
+
+
+class TestMemoryResetConversations:
+    """Tests for --target conversations (state.db only)."""
+
+    def test_reset_conversations_clears_db(self, full_env):
+        """--target conversations should clear state.db but keep memory files."""
+        hermes_home, memories, db_path = full_env
+
+        result = _run_memory_reset(target="conversations", yes=True)
+        assert result == "deleted"
+
+        # Memory files should still exist
+        assert (memories / "MEMORY.md").exists()
+        assert (memories / "USER.md").exists()
+
+        # DB should be empty
+        conn = sqlite3.connect(str(db_path))
+        msg_count = conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+        sess_count = conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
+        conn.close()
+        assert msg_count == 0
+        assert sess_count == 0
+
+    def test_reset_conversations_no_db(self, memory_env):
+        """--target conversations with no state.db should return 'nothing'."""
+        hermes_home, memories = memory_env
+
+        result = _run_memory_reset(target="conversations", yes=True)
+        assert result == "nothing"
+
+        # Memory files should still exist
+        assert (memories / "MEMORY.md").exists()
+        assert (memories / "USER.md").exists()
+
+    def test_reset_conversations_preserves_schema(self, full_env):
+        """--target conversations should preserve DB schema."""
+        hermes_home, memories, db_path = full_env
+
+        _run_memory_reset(target="conversations", yes=True)
+
+        # Schema should still work — insert new data
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "INSERT INTO sessions VALUES ('new-sess', 'cli')"
+        )
+        conn.execute(
+            "INSERT INTO messages VALUES (1, 'new-sess', 'user', 'test')"
+        )
+        conn.commit()
+
+        count = conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+        conn.close()
+        assert count == 1
+
+    def test_reset_conversations_confirmation_denied(self, full_env):
+        """Without --yes, conversations reset should be cancelled."""
+        hermes_home, memories, db_path = full_env
+
+        result = _run_memory_reset(
+            target="conversations", yes=False, confirm_input="no"
+        )
+        assert result == "cancelled"
+
+        # DB should still have data
+        conn = sqlite3.connect(str(db_path))
+        msg_count = conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+        conn.close()
+        assert msg_count == 3
+
+
+class TestMemoryResetEverything:
+    """Tests for --target everything (files + state.db)."""
+
+    def test_reset_everything_clears_all(self, full_env):
+        """--target everything should clear memory files AND state.db."""
+        hermes_home, memories, db_path = full_env
+
+        result = _run_memory_reset(target="everything", yes=True)
+        assert result == "deleted"
+
+        # Memory files should be gone
+        assert not (memories / "MEMORY.md").exists()
+        assert not (memories / "USER.md").exists()
+
+        # DB should be empty
+        conn = sqlite3.connect(str(db_path))
+        msg_count = conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+        sess_count = conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
+        conn.close()
+        assert msg_count == 0
+        assert sess_count == 0
+
+    def test_reset_everything_no_state_db(self, memory_env):
+        """--target everything with no state.db should still clear files."""
+        hermes_home, memories = memory_env
+
+        result = _run_memory_reset(target="everything", yes=True)
+        assert result == "deleted"
+        assert not (memories / "MEMORY.md").exists()
+        assert not (memories / "USER.md").exists()
+
+    def test_reset_everything_no_files_no_db(self, tmp_path, monkeypatch):
+        """--target everything with nothing to reset should return 'nothing'."""
+        hermes_home = tmp_path / ".hermes"
+        (hermes_home / "memories").mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        result = _run_memory_reset(target="everything", yes=True)
+        assert result == "nothing"
+
+    def test_reset_everything_preserves_schema(self, full_env):
+        """--target everything should preserve DB schema."""
+        hermes_home, memories, db_path = full_env
+
+        _run_memory_reset(target="everything", yes=True)
+
+        # Schema should still work
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("INSERT INTO sessions VALUES ('new-sess', 'cli')")
+        conn.execute(
+            "INSERT INTO messages VALUES (1, 'new-sess', 'user', 'test')"
+        )
+        conn.commit()
+
+        count = conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+        conn.close()
+        assert count == 1


### PR DESCRIPTION
## Summary

Fixes #17177

The `hermes memory reset` command only clears MEMORY.md and USER.md, but conversation history in `state.db` persists. The `session_search` tool can still find patterns from old conversations, causing the agent to repeat previous behavior (e.g., same protagonist names in stories) even after a memory reset.

**Root cause:** Users delete memory files but `state.db` (16,883+ messages across 279+ sessions) remains untouched. The `session_search` tool indexes this data, allowing the agent to retrieve and reuse old patterns.

## Changes

- Add `conversations` and `everything` to `--target` choices
- `--target conversations`: clears state.db only (keeps MEMORY.md/USER.md)
- `--target everything`: clears MEMORY.md + USER.md + state.db
- Preserve database schema after reset (`DELETE FROM`, not `DROP TABLE`)
- Graceful skip when state.db doesn't exist
- Add confirmation prompt showing row count before clearing

## Usage

```bash
# Existing behavior (unchanged)
hermes memory reset                    # MEMORY.md + USER.md
hermes memory reset --target memory    # MEMORY.md only
hermes memory reset --target user      # USER.md only

# New targets
hermes memory reset --target conversations    # state.db only
hermes memory reset --target everything       # all stores
hermes memory reset --target everything -y    # skip confirmation
```

## Test Plan

- [x] `pytest tests/hermes_cli/test_memory_reset.py -v` — 17/17 passed
- [x] `hermes memory reset` backward-compatible (no target = all)
- [x] `hermes memory reset --target conversations -y` clears state.db
- [x] `hermes memory reset --target everything -y` clears all stores
- [x] Database schema intact after reset (can insert new rows)
- [x] Graceful skip when state.db doesn't exist

## Note

`_run_memory_reset()` in tests duplicates `cmd_memory` logic. A follow-up PR should refactor tests to call `cmd_memory` directly.