### PR TITLE
feat(tui): line-by-line scroll mode on modified mouse wheel

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/parse-keypress.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/parse-keypress.test.ts
@@ -39,3 +39,60 @@ describe('parseMultipleKeypresses bracketed paste recovery', () => {
     expect(state.pasteBuffer).toBe('')
   })
 })
+
+describe('mouse wheel modifier decoding', () => {
+  // SGR mouse format: ESC [ < button ; col ; row M
+  // Wheel up = 64 (0x40), wheel down = 65 (0x41).
+  // Modifier bits: shift = 0x04, meta = 0x08, ctrl = 0x10.
+  const sgrWheel = (button: number) => `\x1b[<${button};10;10M`
+
+  it('plain wheel up has no modifiers', () => {
+    const [[key]] = parseMultipleKeypresses(INITIAL_STATE, sgrWheel(0x40))
+
+    expect(key).toMatchObject({ name: 'wheelup', ctrl: false, meta: false, shift: false })
+  })
+
+  it('plain wheel down has no modifiers', () => {
+    const [[key]] = parseMultipleKeypresses(INITIAL_STATE, sgrWheel(0x41))
+
+    expect(key).toMatchObject({ name: 'wheeldown', ctrl: false, meta: false, shift: false })
+  })
+
+  it('decodes meta (Alt/Option) on wheel up', () => {
+    const [[key]] = parseMultipleKeypresses(INITIAL_STATE, sgrWheel(0x40 | 0x08))
+
+    expect(key).toMatchObject({ name: 'wheelup', ctrl: false, meta: true, shift: false })
+  })
+
+  it('decodes meta (Alt/Option) on wheel down', () => {
+    const [[key]] = parseMultipleKeypresses(INITIAL_STATE, sgrWheel(0x41 | 0x08))
+
+    expect(key).toMatchObject({ name: 'wheeldown', ctrl: false, meta: true, shift: false })
+  })
+
+  it('decodes ctrl on wheel events', () => {
+    const [[key]] = parseMultipleKeypresses(INITIAL_STATE, sgrWheel(0x40 | 0x10))
+
+    expect(key).toMatchObject({ name: 'wheelup', ctrl: true, meta: false, shift: false })
+  })
+
+  it('decodes shift on wheel events', () => {
+    const [[key]] = parseMultipleKeypresses(INITIAL_STATE, sgrWheel(0x41 | 0x04))
+
+    expect(key).toMatchObject({ name: 'wheeldown', ctrl: false, meta: false, shift: true })
+  })
+
+  it('decodes combined modifiers', () => {
+    const [[key]] = parseMultipleKeypresses(INITIAL_STATE, sgrWheel(0x40 | 0x08 | 0x10))
+
+    expect(key).toMatchObject({ name: 'wheelup', ctrl: true, meta: true, shift: false })
+  })
+
+  it('decodes meta on legacy X10 wheel encoding', () => {
+    // X10: ESC [ M Cb Cx Cy where each byte is value+32.
+    const x10 = `\x1b[M${String.fromCharCode(0x40 + 0x08 + 32)}${String.fromCharCode(10 + 32)}${String.fromCharCode(10 + 32)}`
+    const [[key]] = parseMultipleKeypresses(INITIAL_STATE, x10)
+
+    expect(key).toMatchObject({ name: 'wheelup', meta: true })
+  })
+})

--- a/ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts
@@ -697,16 +697,17 @@ function parseKeypress(s: string = ''): ParsedKey {
   // never reach here. Mask with 0x43 (bits 6+1+0) to check wheel-flag
   // + direction while ignoring modifier bits (Shift=0x04, Meta=0x08,
   // Ctrl=0x10) — modified wheel events (e.g. Ctrl+scroll, button=80)
-  // should still be recognized as wheelup/wheeldown.
+  // should still be recognized as wheelup/wheeldown. Preserve those
+  // modifier bits for callers that bind modified wheel gestures.
   if ((match = SGR_MOUSE_RE.exec(s))) {
     const button = parseInt(match[1]!, 10)
 
     if ((button & 0x43) === 0x40) {
-      return createNavKey(s, 'wheelup', false)
+      return createWheelKey(s, 'wheelup', button)
     }
 
     if ((button & 0x43) === 0x41) {
-      return createNavKey(s, 'wheeldown', false)
+      return createWheelKey(s, 'wheeldown', button)
     }
 
     // Shouldn't reach here (parseMouseEvent catches non-wheel) but be safe
@@ -722,11 +723,11 @@ function parseKeypress(s: string = ''): ParsedKey {
     const button = s.charCodeAt(3) - 32
 
     if ((button & 0x43) === 0x40) {
-      return createNavKey(s, 'wheelup', false)
+      return createWheelKey(s, 'wheelup', button)
     }
 
     if ((button & 0x43) === 0x41) {
-      return createNavKey(s, 'wheeldown', false)
+      return createWheelKey(s, 'wheeldown', button)
     }
 
     return createNavKey(s, 'mouse', false)
@@ -826,6 +827,22 @@ function createNavKey(s: string, name: string, ctrl: boolean): ParsedKey {
     ctrl,
     meta: false,
     shift: false,
+    option: false,
+    super: false,
+    fn: false,
+    sequence: s,
+    raw: s,
+    isPasted: false
+  }
+}
+
+function createWheelKey(s: string, name: 'wheelup' | 'wheeldown', button: number): ParsedKey {
+  return {
+    kind: 'key',
+    name,
+    ctrl: !!(button & 0x10),
+    meta: !!(button & 0x08),
+    shift: !!(button & 0x04),
     option: false,
     super: false,
     fn: false,

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -21,6 +21,8 @@ import { patchTurnState } from './turnStore.js'
 import { getUiState } from './uiStore.js'
 
 const isCtrl = (key: { ctrl: boolean }, ch: string, target: string) => key.ctrl && ch.toLowerCase() === target
+const PRECISION_WHEEL_MIN_GAP_MS = 80
+const PRECISION_WHEEL_STICKY_MS = 80
 
 export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
   const { actions, composer, gateway, terminal, voice, wheelStep } = ctx
@@ -35,6 +37,10 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
   // direction flips reset. wheelStep (WHEEL_SCROLL_STEP) is the base; final
   // rows = wheelStep × accelMult. State mutates in place across renders.
   const wheelAccelRef = useRef(initWheelAccelForHost())
+
+  const precisionWheelRef = useRef<{ active: boolean; dir: 0 | -1 | 1; lastEventAtMs: number; lastScrollAtMs: number }>(
+    { active: false, dir: 0, lastEventAtMs: 0, lastScrollAtMs: 0 }
+  )
 
   useEffect(() => () => clearTimeout(scrollIdleTimer.current ?? undefined), [])
 
@@ -284,8 +290,43 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
 
     if (key.wheelUp || key.wheelDown) {
       const dir: -1 | 1 = key.wheelUp ? -1 : 1
+      const now = Date.now()
+      // Modifier-held wheel = precision mode: at most one wheelStep per short
+      // interval. Smooth mice / trackpads emit many raw wheel events for one
+      // intended line step, so raw 1:1 still moves too far.
+      // SGR/X10 mouse encoding only carries shift/meta/ctrl bits; Cmd on
+      // macOS is intercepted by the terminal, so we honor Option (meta) on
+      // Mac / Alt (meta) on Win+Linux / Ctrl as a portable fallback. Shift
+      // is reserved for selection extension.
+      const hasModifier = key.meta || key.ctrl
+      const precision = precisionWheelRef.current
+      // Keep precision active through the current wheel burst after the
+      // modifier is released. Otherwise a stream of queued/momentum wheel
+      // events can hand off mid-burst into the accelerated path and jump.
+      const precisionSticky = now - precision.lastEventAtMs < PRECISION_WHEEL_STICKY_MS
+
+      if (hasModifier || precisionSticky) {
+        if (!precision.active) {
+          precision.active = true
+          wheelAccelRef.current = initWheelAccelForHost()
+        }
+
+        precision.lastEventAtMs = now
+
+        if (dir === precision.dir && now - precision.lastScrollAtMs < PRECISION_WHEEL_MIN_GAP_MS) {
+          return
+        }
+
+        precision.lastScrollAtMs = now
+        precision.dir = dir
+
+        return scrollTranscript(dir * wheelStep)
+      }
+
+      precision.active = false
+
       // 0 = direction-flip bounce deferred; skip the no-op scroll.
-      const rows = computeWheelStep(wheelAccelRef.current, dir, Date.now())
+      const rows = computeWheelStep(wheelAccelRef.current, dir, now)
 
       return rows ? scrollTranscript(dir * rows * wheelStep) : undefined
     }


### PR DESCRIPTION
## Summary

Adds modifier-held precision scrolling for the TUI transcript.

- Option/Alt or Ctrl + mouse wheel scrolls at most one row per short interval, so smooth mice and trackpads do not move multiple rows for one intended line step.
- Plain mouse wheel keeps the existing accelerated scrolling behavior.
- Releasing the modifier keeps precision active until the current wheel burst idles, so queued/momentum wheel events do not switch into acceleration mid-stream.

## Notes

Cmd + wheel is not available to the TUI in common macOS terminals because the terminal handles it before forwarding mouse events. Option/Alt is the portable modifier carried by SGR/X10 mouse events.

## Test plan

- `npm test -- --run wheelAccel.test.ts parse-keypress.test.ts`
- `npm run type-check`
- `npx eslint src/app/useInputHandlers.ts src/lib/wheelAccel.ts src/__tests__/wheelAccel.test.ts`