### PR TITLE
fix(model-switch): skip "custom"/"local" sentinel when assigning picker slug (#17478)

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1497,11 +1497,22 @@ def list_authenticated_providers(
                 # If this endpoint matches the currently active one, use
                 # ``current_provider`` as the slug so picker-driven switches
                 # route through the live credential pipeline.
+                #
+                # Skip the sentinel values ``"custom"`` / ``"local"`` here:
+                # they aren't real provider names, only placeholders that
+                # earlier broken switches may have written into config.yaml
+                # (#17478). Reusing such a sentinel would persist it back
+                # to ``model.provider`` on the next switch, leaving the
+                # config in an unresolvable state ("Unknown provider
+                # 'custom'"). Always rebuild the canonical
+                # ``custom:<name>`` slug for those cases.
+                _current_lc = (current_provider or "").strip().lower()
                 if (
                     current_base_url
                     and api_url == current_base_url.strip().rstrip("/")
+                    and _current_lc not in ("", "custom", "local")
                 ):
-                    slug = current_provider or custom_provider_slug(display_name)
+                    slug = current_provider
                 else:
                     slug = custom_provider_slug(display_name)
                 groups[group_key] = {

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -296,12 +296,17 @@ def test_list_authenticated_providers_groups_same_endpoint(monkeypatch):
 def test_list_authenticated_providers_current_endpoint_uses_current_slug(monkeypatch):
     """When current_base_url matches the grouped endpoint, the slug must
     equal current_provider so picker selection routes through the live
-    credential pipeline."""
+    credential pipeline.
+
+    Note: ``"custom"`` and ``"local"`` are treated as broken-state
+    sentinels (#17478) and explicitly rebuilt to the canonical
+    ``custom:<name>`` slug; covered separately below.
+    """
     monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
     monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
 
     providers = list_authenticated_providers(
-        current_provider="custom",
+        current_provider="custom:ollama",
         current_base_url="http://localhost:11434/v1",
         user_providers={},
         custom_providers=[
@@ -314,7 +319,7 @@ def test_list_authenticated_providers_current_endpoint_uses_current_slug(monkeyp
     matches = [p for p in providers if p.get("is_user_defined")]
     assert len(matches) == 1
     group = matches[0]
-    assert group["slug"] == "custom"
+    assert group["slug"] == "custom:ollama"
     assert group["is_current"] is True
 
 
@@ -479,3 +484,90 @@ def test_lmstudio_picker_skips_probe_when_not_configured(monkeypatch):
     )
 
     assert "base_url" not in captured
+
+
+def test_custom_sentinel_provider_recovers_canonical_slug(monkeypatch):
+    """Regression for #17478: when a prior broken switch wrote the literal
+    string ``"custom"`` into ``model.provider``, the next picker pass must
+    not propagate that sentinel back as a slug. The canonical
+    ``custom:<name>`` slug should be rebuilt from the entry name so the
+    picker writes a resolvable provider on the next switch.
+    """
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    providers = list_authenticated_providers(
+        current_provider="custom",
+        current_base_url="https://token-plan-sgp.xiaomimimo.com/v1",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "xiaomi-coding",
+                "base_url": "https://token-plan-sgp.xiaomimimo.com/v1",
+                "model": "GLM-4.6",
+            }
+        ],
+        max_models=50,
+    )
+
+    rows = [p for p in providers if p["name"] == "xiaomi-coding"]
+    assert len(rows) == 1
+    assert rows[0]["slug"] == "custom:xiaomi-coding"
+    # Defensive: the literal sentinel must never appear as a slug.
+    assert "custom" not in {p["slug"] for p in providers}
+
+
+def test_local_sentinel_provider_recovers_canonical_slug(monkeypatch):
+    """Same recovery semantics for the ``"local"`` sentinel — also a
+    broken-state placeholder that must not be reused as a real provider
+    slug."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    providers = list_authenticated_providers(
+        current_provider="local",
+        current_base_url="http://127.0.0.1:4141/v1",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "Local (127.0.0.1:4141)",
+                "base_url": "http://127.0.0.1:4141/v1",
+                "model": "rotator-openrouter-coding",
+            }
+        ],
+        max_models=50,
+    )
+
+    rows = [p for p in providers if p["name"] == "Local (127.0.0.1:4141)"]
+    assert len(rows) == 1
+    assert rows[0]["slug"] == "custom:local-(127.0.0.1:4141)"
+    assert "local" not in {p["slug"] for p in providers}
+
+
+def test_real_provider_still_reused_as_slug_when_endpoints_match(monkeypatch):
+    """Guard: the recovery must not regress the live-credential routing.
+    When ``current_provider`` is a real (non-sentinel) name and the
+    endpoint matches, the entry's slug should still be the active
+    provider so picker-driven switches reuse the resolved credential
+    pipeline.
+    """
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    providers = list_authenticated_providers(
+        current_provider="custom:my-shop",
+        current_base_url="https://api.example.com/v1",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "My Shop",
+                "base_url": "https://api.example.com/v1",
+                "model": "model-a",
+            }
+        ],
+        max_models=50,
+    )
+
+    rows = [p for p in providers if p["name"] == "My Shop"]
+    assert len(rows) == 1
+    assert rows[0]["slug"] == "custom:my-shop"


### PR DESCRIPTION
## Summary

Closes #17478. Fix the `hermes model` picker so that when `model.provider` in config.yaml is the literal string `custom` (or `local`) — a leftover sentinel from an earlier broken switch — the picker rebuilds the canonical `custom:<name>` slug instead of writing the sentinel back into config and perpetuating the broken state.

## The bug

The reporter's config wedged into:

```yaml
model:
  provider: custom
  base_url: ''
custom_providers:
  - name: xiaomi-coding
    base_url: https://token-plan-sgp.xiaomimimo.com/v1
```

Every session then fails with:

```
✗ Unknown provider 'custom'. Check 'hermes model' for available providers,
  or define it in config.yaml under 'providers:'.
```

Root cause was in `hermes_cli/model_switch.py::list_authenticated_providers`. When grouping `custom_providers` by `(base_url, api_key)`, the slug-assignment branch read:

```python
if current_base_url and api_url == current_base_url.strip().rstrip("/"):
    slug = current_provider or custom_provider_slug(display_name)
```

That branch is meant to reuse the active provider's slug for the row whose endpoint matches the live session, so picker selection routes back through the credential pipeline that already resolved. But when `current_provider == "custom"` the truthy fallback skipped `custom_provider_slug(display_name)` entirely, and `"custom"` propagated back into config on the next switch.

## The fix

Treat `"custom"` and `"local"` (case-insensitive, also empty) as sentinels and always rebuild `custom:<display-name>` from the entry. Real provider IDs like `openai-codex` or `custom:my-shop` still hit the live-credential reuse path unchanged.

```python
_current_lc = (current_provider or "").strip().lower()
if (
    current_base_url
    and api_url == current_base_url.strip().rstrip("/")
    and _current_lc not in ("", "custom", "local")
):
    slug = current_provider
else:
    slug = custom_provider_slug(display_name)
```

`switch_model` and `resolve_provider_full` already accept the canonical `custom:<name>` slug, so a single picker round-trip self-heals the broken config.

## Test plan
- [x] Focused regression: `tests/hermes_cli/test_model_switch_custom_providers.py::test_custom_sentinel_provider_recovers_canonical_slug` reproduces the reporter's exact `provider: custom` + `xiaomi-coding` case and asserts the picker emits `custom:xiaomi-coding`, not `custom`.
- [x] Same coverage for the `local` sentinel: `test_local_sentinel_provider_recovers_canonical_slug`.
- [x] Non-regression for the live-credential reuse path: `test_real_provider_still_reused_as_slug_when_endpoints_match` confirms `custom:my-shop` is still preserved when endpoints match.
- [x] Existing `test_list_authenticated_providers_current_endpoint_uses_current_slug` updated to use a real provider ID (the prior assertion encoded the buggy behavior — it expected the sentinel to round-trip).
- [x] Adjacent suites: `tests/hermes_cli/test_model_switch_custom_providers.py`, `tests/hermes_cli/test_user_providers_model_switch.py`, `tests/hermes_cli/test_overlay_slug_resolution.py` — 47 passed.
- [x] Regression guard: removed the new sentinel guard locally and confirmed the new tests fail with `slug == "custom"` / `slug == "local"`; restored and they pass.

## Related
- Fixes #17478