### PR TITLE
fix(cli): drop max_turns env-var dual-write in setup wizard (#17534)

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1643,7 +1643,6 @@ def setup_terminal_backend(config: dict):
 def _apply_default_agent_settings(config: dict):
     """Apply recommended defaults for all agent settings without prompting."""
     config.setdefault("agent", {})["max_turns"] = 90
-    save_env_value("HERMES_MAX_ITERATIONS", "90")
 
     config.setdefault("display", {})["tool_progress"] = "all"
 
@@ -1673,9 +1672,10 @@ def setup_agent_settings(config: dict):
     print()
 
     # ── Max Iterations ──
-    current_max = get_env_value("HERMES_MAX_ITERATIONS") or str(
-        cfg_get(config, "agent", "max_turns", default=90)
-    )
+    # config.yaml is the single source of truth for agent.max_turns. Reading or
+    # writing HERMES_MAX_ITERATIONS here previously created a stale-ghost env
+    # entry whenever the user later edited config.yaml directly (issue #17534).
+    current_max = str(cfg_get(config, "agent", "max_turns", default=90))
     print_info("Maximum tool-calling iterations per conversation.")
     print_info("Higher = more complex tasks, but costs more tokens.")
     print_info(
@@ -1686,7 +1686,6 @@ def setup_agent_settings(config: dict):
     try:
         max_iter = int(max_iter_str)
         if max_iter > 0:
-            save_env_value("HERMES_MAX_ITERATIONS", str(max_iter))
             config.setdefault("agent", {})["max_turns"] = max_iter
             config.pop("max_turns", None)
             print_success(f"Max iterations set to {max_iter}")

--- a/tests/hermes_cli/test_setup_agent_settings.py
+++ b/tests/hermes_cli/test_setup_agent_settings.py
@@ -1,10 +1,32 @@
 """Tests for agent-settings copy in the interactive setup wizard."""
 
-from hermes_cli.setup import setup_agent_settings
+from hermes_cli.setup import _apply_default_agent_settings, setup_agent_settings
 
 
-def test_setup_agent_settings_uses_displayed_max_iterations_value(tmp_path, monkeypatch, capsys):
-    """The helper text should match the value shown in the prompt."""
+def _patch_io(monkeypatch, prompt_answers, *, env_max_iter=""):
+    """Wire monkeypatches shared across the wizard tests."""
+    answers = iter(prompt_answers)
+    saved_env: list[tuple] = []
+    monkeypatch.setattr(
+        "hermes_cli.setup.get_env_value",
+        lambda key: env_max_iter if key == "HERMES_MAX_ITERATIONS" else "",
+    )
+    monkeypatch.setattr(
+        "hermes_cli.setup.prompt", lambda *args, **kwargs: next(answers)
+    )
+    monkeypatch.setattr("hermes_cli.setup.prompt_choice", lambda *args, **kwargs: 4)
+    monkeypatch.setattr(
+        "hermes_cli.setup.save_env_value",
+        lambda key, value, **kwargs: saved_env.append((key, value)),
+    )
+    monkeypatch.setattr("hermes_cli.setup.save_config", lambda *args, **kwargs: None)
+    return saved_env
+
+
+def test_setup_agent_settings_helper_text_matches_config_value(
+    tmp_path, monkeypatch, capsys
+):
+    """Helper text must reflect the config.yaml value, not a stale env override."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 
     config = {
@@ -14,16 +36,55 @@ def test_setup_agent_settings_uses_displayed_max_iterations_value(tmp_path, monk
         "session_reset": {"mode": "both", "idle_minutes": 1440, "at_hour": 4},
     }
 
-    prompt_answers = iter(["60", "all", "0.5"])
-
-    monkeypatch.setattr("hermes_cli.setup.get_env_value", lambda key: "60" if key == "HERMES_MAX_ITERATIONS" else "")
-    monkeypatch.setattr("hermes_cli.setup.prompt", lambda *args, **kwargs: next(prompt_answers))
-    monkeypatch.setattr("hermes_cli.setup.prompt_choice", lambda *args, **kwargs: 4)
-    monkeypatch.setattr("hermes_cli.setup.save_env_value", lambda *args, **kwargs: None)
-    monkeypatch.setattr("hermes_cli.setup.save_config", lambda *args, **kwargs: None)
+    # A stale env value (e.g. from a previous wizard run that wrote both stores)
+    # must not override config.yaml in the prompt display. See issue #17534.
+    _patch_io(monkeypatch, ["60", "all", "0.5"], env_max_iter="60")
 
     setup_agent_settings(config)
 
     out = capsys.readouterr().out
-    assert "Press Enter to keep 60." in out
-    assert "Default is 90" not in out
+    assert "Press Enter to keep 90." in out
+    assert "Press Enter to keep 60." not in out
+
+
+def test_setup_agent_settings_does_not_write_max_iterations_env_var(
+    tmp_path, monkeypatch
+):
+    """The wizard must not dual-write max_turns to .env (issue #17534).
+
+    Before the fix, both ``setup_agent_settings`` and
+    ``_apply_default_agent_settings`` called ``save_env_value`` for
+    ``HERMES_MAX_ITERATIONS`` in addition to setting ``agent.max_turns`` in
+    config.yaml. A later edit to only one store left the other as a stale ghost,
+    which surfaced inconsistent iteration limits across CLI vs gateway sessions.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    config = {
+        "agent": {"max_turns": 90},
+        "display": {"tool_progress": "all"},
+        "compression": {"threshold": 0.50},
+        "session_reset": {"mode": "both", "idle_minutes": 1440, "at_hour": 4},
+    }
+
+    saved_env = _patch_io(monkeypatch, ["120", "all", "0.5"])
+    setup_agent_settings(config)
+
+    written_keys = {key for key, _ in saved_env}
+    assert "HERMES_MAX_ITERATIONS" not in written_keys
+    assert config["agent"]["max_turns"] == 120
+
+
+def test_apply_default_agent_settings_does_not_write_max_iterations_env_var(
+    tmp_path, monkeypatch
+):
+    """Recommended-defaults path must not dual-write to .env either."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    config: dict = {}
+    saved_env = _patch_io(monkeypatch, [])
+    _apply_default_agent_settings(config)
+
+    written_keys = {key for key, _ in saved_env}
+    assert "HERMES_MAX_ITERATIONS" not in written_keys
+    assert config["agent"]["max_turns"] == 90


### PR DESCRIPTION
## What does this PR do?

The setup wizard was dual-writing the max-iterations value to both `.env` (`HERMES_MAX_ITERATIONS`) and `config.yaml` (`agent.max_turns`) at the same time, then reading env first when re-prompting. As soon as a user later edited only one store (`hermes config set`, manual edit, AI-assisted edit), the other store became a stale ghost — `hermes config show` reported the config value while gateway/Telegram sessions surfaced the env value, leading to silent state drift like `iteration 9/300` despite `Max turns: 200` in `hermes config show`.

This PR makes `config.yaml` the single source of truth in the wizard. The legacy env-var path stays readable as a backwards-compat fallback at the bottom of `cli.py`'s priority chain (no behaviour change for users who haven't run the wizard since this fix), and `gateway/run.py` continues to bridge `agent.max_turns` into `HERMES_MAX_ITERATIONS` at startup so downstream env-only readers stay consistent.

## Related Issue

Fixes #17534

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/setup.py::_apply_default_agent_settings` no longer calls `save_env_value(\"HERMES_MAX_ITERATIONS\", \"90\")` when applying recommended defaults.
- `hermes_cli/setup.py::setup_agent_settings` no longer calls `save_env_value(\"HERMES_MAX_ITERATIONS\", ...)` after the prompt, and reads the current value from `config[\"agent\"][\"max_turns\"]` instead of preferring `HERMES_MAX_ITERATIONS` from the environment.
- `tests/hermes_cli/test_setup_agent_settings.py` updated and extended:
  - The displayed-helper test now asserts the wizard ignores a stale env value and shows the config value.
  - Two new regression tests assert that neither `setup_agent_settings` nor `_apply_default_agent_settings` writes `HERMES_MAX_ITERATIONS` to `.env`.

## How to Test

1. With a config containing `agent.max_turns: 200`, set `HERMES_MAX_ITERATIONS=300` in `~/.hermes/.env` (simulating a stale ghost from a prior wizard run).
2. Run \`hermes setup agent\`. The prompt should display \`Press Enter to keep 200.\`, not 300.
3. Set max iterations to a new value (e.g. 250). Confirm:
   - `~/.hermes/config.yaml` now has `agent.max_turns: 250`.
   - `~/.hermes/.env` is unchanged (stale `HERMES_MAX_ITERATIONS=300` is **not** rewritten — gateway will overwrite it from config at startup via `gateway/run.py:347`).
4. Run the focused tests:
   ```
   pytest tests/hermes_cli/test_setup_agent_settings.py -v
   ```
   All three tests pass with this fix and fail without it.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (\`fix(scope):\`, \`feat(scope):\`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run \`pytest tests/hermes_cli/test_setup_agent_settings.py -q\` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, \`docs/\`, docstrings) — or N/A
- [x] I've updated \`cli-config.yaml.example\` if I added/changed config keys — or N/A
- [x] I've updated \`CONTRIBUTING.md\` or \`AGENTS.md\` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before (issue repro):
\`\`\`
$ hermes config show | grep -i 'max turns'
Max turns: 200
$ # Telegram session shows: iteration 9/300  ← stale env value from prior wizard run
\`\`\`

After this fix, repeated wizard runs no longer leave `HERMES_MAX_ITERATIONS` lines in `.env`, and the config-only edit path stays consistent with what every reader sees.