### PR TITLE
chore(deps): regenerate uv.lock and add CI uv lock --check (#17556)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Set up Python 3.11
         run: uv python install 3.11
 
+      - name: Verify uv.lock is in sync with pyproject.toml
+        run: uv lock --check
+
       - name: Install dependencies
         run: |
           uv venv .venv --python 3.11


### PR DESCRIPTION
## What does this PR do?

The \`[google]\` optional extra was added to \`pyproject.toml\` in 13038dc7 but \`uv.lock\` was never regenerated to match, so on a fresh clone \`uv lock --check\` fails. Nix flakes, Homebrew formulae, and reproducible-build consumers that pin to the lockfile silently miss the deps the commit was meant to ship; \`uv sync\` from a clean clone re-resolves and may pick a newer wheel set than intended.

This PR is the two-part fix the issue recommends:

1. **Regenerate \`uv.lock\`.** The lockfile now records the dependency closure for the \`google\` extra (\`google-api-core\`, \`google-api-python-client\`, \`google-auth\`, \`google-auth-httplib2\`, \`google-auth-oauthlib\`, plus \`pyasn1\`, \`oauthlib\`, \`httplib2\`, etc.) and \`provides-extras\` lists \`google\`. \`uv lock --check\` exits 0.
2. **Add a \`uv lock --check\` step** to \`.github/workflows/tests.yml\` so the same drift can't merge silently again. The check runs immediately after \`uv python install 3.11\`, before the dependency install and test run, so a stale lockfile fails fast and doesn't burn the slower steps.

## Related Issue

Fixes #17556

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- \`uv.lock\` regenerated against the current \`pyproject.toml\`. 188 lines added (5 \`google-*\` direct deps + transitive closure), 8 removed. \`provides-extras\` now lists \`google\`.
- \`.github/workflows/tests.yml\`: new \`Verify uv.lock is in sync with pyproject.toml\` step that runs \`uv lock --check\`.

## How to Test

1. Locally:
   \`\`\`
   git fetch && git checkout fix/17556-uv-lock-regen-and-ci-check
   uv lock --check
   \`\`\`
   exits 0 with no output. (On main, the same command currently reports \`The lockfile at uv.lock needs to be updated\`.)
2. CI: the new \`Verify uv.lock is in sync with pyproject.toml\` step runs in the \`test\` job and will fail any future PR that drifts \`pyproject.toml\` against \`uv.lock\`.
3. Sanity-check the closure includes the google extra:
   \`\`\`
   grep -c '^name = \"google-' uv.lock     # → 5
   grep -A1 '^provides-extras' uv.lock     # → includes \"google\"
   \`\`\`

This supersedes the stalled draft #17494 (which only does part 1) by adding the CI prevention the issue explicitly asks for.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (\`fix(scope):\`, \`feat(scope):\`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run \`uv lock --check\` and it passes
- [x] I've added tests for my changes (the new CI step is the regression test for the underlying class of bug)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, \`docs/\`, docstrings) — or N/A
- [x] I've updated \`cli-config.yaml.example\` if I added/changed config keys — or N/A
- [x] I've updated \`CONTRIBUTING.md\` or \`AGENTS.md\` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before this PR (on main):
\`\`\`
$ uv lock --check
Resolved 258 packages in 741ms
The lockfile at \`uv.lock\` needs to be updated, but \`--check\` was provided. To update the lockfile, run \`uv lock\`.
\`\`\`

After:
\`\`\`
$ uv lock --check
Resolved 258 packages in 10ms
\`\`\`