### PR TITLE
fix(docker): chown .venv to hermes user for plugin installs (#17636)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,8 +62,11 @@ RUN chmod -R a+rX /opt/hermes
 # If HERMES_UID is unset, the entrypoint drops to the default hermes user (10000).
 
 # ---------- Python virtualenv ----------
+# .venv must be writable by the runtime hermes user so plugin installs
+# (`hermes memory setup`, `hermes skills install`) work. See #17636.
 RUN uv venv && \
-    uv pip install --no-cache-dir -e ".[all]"
+    uv pip install --no-cache-dir -e ".[all]" && \
+    chown -R hermes:hermes /opt/hermes/.venv
 
 # ---------- Runtime ----------
 ENV HERMES_WEB_DIST=/opt/hermes/hermes_cli/web_dist

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -39,6 +39,11 @@ if [ "$(id -u)" = "0" ]; then
         # by the mapped user on the host side.
         chown -R hermes:hermes "$HERMES_HOME" 2>/dev/null || \
             echo "Warning: chown failed (rootless container?) — continuing anyway"
+        # The venv lives outside the data volume.  Without this, plugin
+        # installs (e.g. `hermes memory setup`) fail with EACCES whenever
+        # HERMES_UID is remapped away from the build-time uid 10000. See #17636.
+        chown -R hermes:hermes "$INSTALL_DIR/.venv" 2>/dev/null || \
+            echo "Warning: chown of $INSTALL_DIR/.venv failed — plugin installs may need root"
     fi
 
     # Ensure config.yaml is readable by the hermes runtime user even if it was

--- a/tests/tools/test_dockerfile_venv_perms.py
+++ b/tests/tools/test_dockerfile_venv_perms.py
@@ -1,0 +1,125 @@
+"""Contract tests for the runtime hermes-user's write access to the venv.
+
+Issue #17636: when the container runs as the unprivileged ``hermes`` user
+(the default for `docker compose up` and `docker run`), the in-image venv
+``/opt/hermes/.venv`` was created by ``uv venv`` while the build was still
+``USER root`` and therefore root-owned. ``hermes memory setup``,
+``hermes skills install``, and any other path that calls
+``uv pip install --python /opt/hermes/.venv/bin/python ...`` then failed
+with ``EACCES`` on
+``/opt/hermes/.venv/lib/.../site-packages/...``.
+
+These tests assert two invariants needed for plugin installation to work
+inside the container, regardless of whether the operator overrides
+``HERMES_UID`` at runtime:
+
+1. The Dockerfile transfers ownership of ``/opt/hermes/.venv`` to the
+   ``hermes`` user before the image is finalised.
+2. ``docker/entrypoint.sh`` re-chowns the venv whenever it remaps the
+   ``hermes`` user's UID/GID — otherwise the build-time ownership becomes
+   stale and the bug returns under ``HERMES_UID=$(id -u) docker compose
+   up``.
+
+The tests deliberately avoid snapshotting line numbers or exact flag
+choices (mirroring the style of test_dockerfile_pid1_reaping.py).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCKERFILE = REPO_ROOT / "Dockerfile"
+ENTRYPOINT = REPO_ROOT / "docker" / "entrypoint.sh"
+
+
+@pytest.fixture(scope="module")
+def dockerfile_text() -> str:
+    if not DOCKERFILE.exists():
+        pytest.skip("Dockerfile not present in this checkout")
+    return DOCKERFILE.read_text()
+
+
+@pytest.fixture(scope="module")
+def entrypoint_text() -> str:
+    if not ENTRYPOINT.exists():
+        pytest.skip("docker/entrypoint.sh not present in this checkout")
+    return ENTRYPOINT.read_text()
+
+
+def _dockerfile_instructions(dockerfile_text: str) -> list[str]:
+    instructions: list[str] = []
+    current = ""
+
+    for raw_line in dockerfile_text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+
+        continued = line.removesuffix("\\").strip()
+        current = f"{current} {continued}".strip()
+        if not line.endswith("\\"):
+            instructions.append(current)
+            current = ""
+
+    return instructions
+
+
+def _run_steps(dockerfile_text: str) -> list[str]:
+    return [
+        instruction
+        for instruction in _dockerfile_instructions(dockerfile_text)
+        if instruction.startswith("RUN ")
+    ]
+
+
+def test_dockerfile_makes_venv_writable_by_hermes_user(dockerfile_text):
+    """The image must hand ``/opt/hermes/.venv`` ownership to ``hermes``.
+
+    Either the venv is created while the runtime user owns it, or a
+    subsequent ``chown`` step restores ownership. Without one of these,
+    ``uv pip install`` from the running container (e.g. ``hermes memory
+    setup``) fails with EACCES (#17636).
+    """
+    venv_owned_by_hermes = any(
+        ".venv" in step
+        and (
+            ("chown" in step and "hermes" in step)
+            or ("gosu hermes" in step and "uv venv" in step)
+        )
+        for step in _run_steps(dockerfile_text)
+    )
+
+    assert venv_owned_by_hermes, (
+        "Dockerfile leaves /opt/hermes/.venv owned by root: no `chown ... "
+        "hermes ... .venv` step and no `gosu hermes uv venv` step found. "
+        "Plugin installs (`hermes memory setup`, skills install) fail with "
+        "EACCES under the default unprivileged hermes user. See #17636."
+    )
+
+
+def test_entrypoint_rechowns_venv_when_hermes_uid_is_remapped(entrypoint_text):
+    """When the entrypoint remaps the hermes UID, the venv must follow.
+
+    ``docker compose up`` defaults to ``HERMES_UID=$(id -u)``. After
+    ``usermod`` changes the runtime UID, files owned by the build-time
+    UID 10000 are no longer writable by the now-renumbered hermes user.
+    The existing ``$HERMES_HOME`` chown handles the data volume; the
+    venv lives outside the volume and needs the same treatment.
+    """
+    chown_targets = [
+        line.strip()
+        for line in entrypoint_text.splitlines()
+        if "chown" in line and "hermes" in line and ".venv" in line
+    ]
+
+    assert chown_targets, (
+        "docker/entrypoint.sh does not chown the venv to the hermes user. "
+        "When HERMES_UID is remapped, /opt/hermes/.venv stays owned by the "
+        "stale build-time UID and `hermes memory setup` fails with EACCES "
+        "(#17636). Extend the existing $HERMES_HOME chown block to also "
+        "chown $INSTALL_DIR/.venv."
+    )


### PR DESCRIPTION
## What does this PR do?

\`uv venv\` and \`uv pip install --no-cache-dir -e \".[all]\"\` ran while the build was still \`USER root\`, so \`/opt/hermes/.venv\` ended up root-owned. When the container started as the unprivileged \`hermes\` user (the default for \`docker compose up\` and \`docker run\`), \`hermes memory setup\`, \`hermes skills install\`, and any other path that called \`uv pip install --python /opt/hermes/.venv/bin/python ...\` failed with \`EACCES\` on the venv's site-packages directory:

\`\`\`
⚠ Failed to install hindsight-client>=0.4.22
  error: Failed to create directory \`/opt/hermes/.venv/lib/python3.13/site-packages/hindsight_client_api\`
  Caused by: Permission denied (os error 13)
\`\`\`

This means **no plugin install path** (memory plugins, knowledge bases, hub-installed skills) works under Docker out-of-the-box.

Two-part fix:

1. **Dockerfile**: \`chown -R hermes:hermes /opt/hermes/.venv\` immediately after \`uv pip install\` so the default uid-10000 case works without any \`HERMES_UID\` override.
2. **\`docker/entrypoint.sh\`**: extend the existing \`\$HERMES_HOME\` chown block to also chown \`\$INSTALL_DIR/.venv\` whenever the entrypoint remaps the hermes UID/GID. Without this, the build-time chown becomes stale as soon as someone runs \`HERMES_UID=\$(id -u) docker compose up\` (the documented \`docker-compose.yml\` pattern) and the bug returns.

## Related Issue

Fixes #17636

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- \`Dockerfile\`: the \`Python virtualenv\` RUN step now ends with \`chown -R hermes:hermes /opt/hermes/.venv\` (3-line diff incl. comment).
- \`docker/entrypoint.sh\`: the existing \`if [ \"\$needs_chown\" = true ]\` block now also chowns \`\$INSTALL_DIR/.venv\` after \`\$HERMES_HOME\`. The new step uses the same \`2>/dev/null || echo Warning…\` pattern as the existing chown for rootless-Podman compatibility.
- \`tests/tools/test_dockerfile_venv_perms.py\`: two new contract tests (\`test_dockerfile_makes_venv_writable_by_hermes_user\`, \`test_entrypoint_rechowns_venv_when_hermes_uid_is_remapped\`) that mirror the line-number-agnostic style of \`test_dockerfile_pid1_reaping.py\`. Both tests fail on main and pass with this fix.

## How to Test

1. **Without HERMES_UID override** (default case):
   \`\`\`
   docker build -t hermes-agent .
   docker run --rm -d --name hermes hermes-agent sleep infinity
   docker exec -it -u hermes hermes /opt/hermes/.venv/bin/hermes memory setup
   \`\`\`
   This currently fails on main with \`Failed to create directory ... Permission denied\`. With this PR, the install proceeds.

2. **With HERMES_UID override** (\`docker compose\` default pattern):
   \`\`\`
   HERMES_UID=\$(id -u) HERMES_GID=\$(id -g) docker compose up -d
   docker exec -it -u hermes hermes hermes memory setup
   \`\`\`
   The entrypoint logs \`Fixing ownership of /opt/data ...\` and the new \`chown of /opt/hermes/.venv\` step. \`uv pip install\` works.

3. **Contract tests**:
   \`\`\`
   pytest tests/tools/test_dockerfile_venv_perms.py tests/tools/test_dockerfile_pid1_reaping.py -v
   \`\`\`
   8 pass (2 new + 6 existing). The 2 new tests fail without this fix.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (\`fix(scope):\`, \`feat(scope):\`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run \`pytest tests/tools/test_dockerfile_venv_perms.py tests/tools/test_dockerfile_pid1_reaping.py -q\` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x (Dockerfile linting + contract tests; Docker exec verification noted above)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, \`docs/\`, docstrings) — or N/A
- [x] I've updated \`cli-config.yaml.example\` if I added/changed config keys — or N/A
- [x] I've updated \`CONTRIBUTING.md\` or \`AGENTS.md\` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A. Rootless Podman is preserved by reusing the existing \`2>/dev/null || echo Warning…\` pattern.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A