### PR TITLE
fix(anthropic): omit 1m context beta for native OAuth

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -479,6 +479,17 @@ def _common_betas_for_base_url(base_url: str | None) -> list[str]:
     return _COMMON_BETAS
 
 
+def _common_betas_for_oauth(base_url: str | None) -> list[str]:
+    """Return common beta headers safe for native Anthropic OAuth.
+
+    Some OAuth subscriptions reject ``context-1m-2025-08-07`` before the
+    request reaches model/tool execution, even though 1M context is GA on
+    native Anthropic for newer Claude models. Keep Bedrock/Azure behavior in
+    ``_COMMON_BETAS`` unchanged while omitting this beta from OAuth traffic.
+    """
+    return [b for b in _common_betas_for_base_url(base_url) if b != _CONTEXT_1M_BETA]
+
+
 def build_anthropic_client(api_key: str, base_url: str = None, timeout: float = None):
     """Create an Anthropic client, auto-detecting setup-tokens vs API keys.
 
@@ -550,7 +561,8 @@ def build_anthropic_client(api_key: str, base_url: str = None, timeout: float = 
         # OAuth access token / setup-token → Bearer auth + Claude Code identity.
         # Anthropic routes OAuth requests based on user-agent and headers;
         # without Claude Code's fingerprint, requests get intermittent 500s.
-        all_betas = common_betas + _OAUTH_ONLY_BETAS
+        # Some subscriptions reject the 1M context beta before a request can run.
+        all_betas = _common_betas_for_oauth(normalized_base_url) + _OAUTH_ONLY_BETAS
         kwargs["auth_token"] = api_key
         kwargs["default_headers"] = {
             "anthropic-beta": ",".join(all_betas),
@@ -1877,7 +1889,11 @@ def build_anthropic_kwargs(
         kwargs.setdefault("extra_body", {})["speed"] = "fast"
         # Build extra_headers with ALL applicable betas (the per-request
         # extra_headers override the client-level anthropic-beta header).
-        betas = list(_common_betas_for_base_url(base_url))
+        betas = list(
+            _common_betas_for_oauth(base_url)
+            if is_oauth
+            else _common_betas_for_base_url(base_url)
+        )
         if is_oauth:
             betas.extend(_OAUTH_ONLY_BETAS)
         betas.append(_FAST_MODE_BETA)

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -58,7 +58,7 @@ class TestIsOAuthToken:
 class TestBuildAnthropicClient:
     def test_setup_token_uses_auth_token(self):
         with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
-            build_anthropic_client("sk-ant-oat01-" + "x" * 60)
+            build_anthropic_client("cc-test-token")
             kwargs = mock_sdk.Anthropic.call_args[1]
             assert "auth_token" in kwargs
             betas = kwargs["default_headers"]["anthropic-beta"]
@@ -66,6 +66,7 @@ class TestBuildAnthropicClient:
             assert "claude-code-20250219" in betas
             assert "interleaved-thinking-2025-05-14" in betas
             assert "fine-grained-tool-streaming-2025-05-14" in betas
+            assert "context-1m-2025-08-07" not in betas
             assert "api_key" not in kwargs
 
     def test_api_key_uses_api_key(self):
@@ -77,6 +78,7 @@ class TestBuildAnthropicClient:
             # API key auth should still get common betas
             betas = kwargs["default_headers"]["anthropic-beta"]
             assert "interleaved-thinking-2025-05-14" in betas
+            assert "context-1m-2025-08-07" in betas
             assert "oauth-2025-04-20" not in betas  # OAuth-only beta NOT present
             assert "claude-code-20250219" not in betas  # OAuth-only beta NOT present
 
@@ -952,6 +954,24 @@ class TestBuildAnthropicKwargs:
         assert kwargs["system"] == "Be helpful."
         assert kwargs["max_tokens"] == 4096
         assert "tools" not in kwargs
+
+    def test_oauth_fast_mode_extra_headers_omit_context_1m_beta(self):
+        kwargs = build_anthropic_kwargs(
+            model="claude-opus-4-6",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config=None,
+            is_oauth=True,
+            fast_mode=True,
+        )
+        betas = kwargs["extra_headers"]["anthropic-beta"]
+        assert "fast-mode-2026-02-01" in betas
+        assert "oauth-2025-04-20" in betas
+        assert "claude-code-20250219" in betas
+        assert "interleaved-thinking-2025-05-14" in betas
+        assert "context-1m-2025-08-07" not in betas
+
 
     def test_strips_anthropic_prefix(self):
         kwargs = build_anthropic_kwargs(


### PR DESCRIPTION
## Summary

- Omit the `context-1m-2025-08-07` beta header for native Anthropic OAuth / Claude Code-style auth.
- Keep the existing common beta behavior for API-key auth and non-native Anthropic-compatible routes.
- Also omit the 1M context beta from per-request fast-mode headers when the request is OAuth-authenticated.

## Why

Some Anthropic OAuth subscriptions reject requests before model/tool execution when the request includes:

```text
anthropic-beta: context-1m-2025-08-07
```

The observed provider error is:

```text
The long context beta is not yet available for this subscription.
```

That failure is independent of the model/tool payload. Native Anthropic 1M context availability can be account/subscription gated differently from Bedrock/Azure beta-header requirements, so OAuth requests should not unconditionally inherit this beta header.

## Behavior preserved

- API-key auth still includes `context-1m-2025-08-07` in the common beta list.
- Bedrock/Azure and other non-OAuth paths continue using `_common_betas_for_base_url(...)` unchanged.
- OAuth-only betas such as `claude-code-20250219` and `oauth-2025-04-20` remain present for OAuth requests.

## Tests

```bash
./venv/bin/python -m py_compile agent/anthropic_adapter.py
./venv/bin/python -m pytest -o 'addopts=' tests/agent/test_anthropic_adapter.py -q
```

Result:

```text
139 passed
```
