### PR TITLE
fix(anthropic): use Claude Code-compatible MCP tool prefix for OAuth

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -314,7 +314,7 @@ def _detect_claude_code_version() -> str:
 
 
 _CLAUDE_CODE_SYSTEM_PREFIX = "You are Claude Code, Anthropic's official CLI for Claude."
-_MCP_TOOL_PREFIX = "mcp_"
+_MCP_TOOL_PREFIX = "mcp__"
 
 
 def _get_claude_code_version() -> str:
@@ -2146,10 +2146,10 @@ def build_anthropic_kwargs(
                 text = text.replace("Nous Research", "Anthropic")
                 block["text"] = text
 
-        # 3. Prefix tool names with mcp_ (Claude Code convention)
+        # 3. Prefix tool names with mcp__ (Claude Code convention — double underscore).
         #    Skip names that already begin with the marker — native MCP server
         #    tools (from mcp_servers: in config.yaml) are registered under their
-        #    full mcp_<server>_<tool> name and would double-prefix otherwise,
+        #    full mcp__<server>__<tool> name and would double-prefix otherwise,
         #    breaking round-trip registry lookup in normalize_response. GH-25255.
         if anthropic_tools:
             for tool in anthropic_tools:

--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -84,11 +84,10 @@ class AnthropicTransport(ProviderTransport):
         to OpenAI finish_reason, and collects reasoning_details in provider_data.
         """
         import json
-        from agent.anthropic_adapter import _to_plain_data
+        from agent.anthropic_adapter import _MCP_TOOL_PREFIX, _to_plain_data
         from agent.transports.types import ToolCall
 
         strip_tool_prefix = kwargs.get("strip_tool_prefix", False)
-        _MCP_PREFIX = "mcp_"
 
         text_parts = []
         reasoning_parts = []
@@ -105,18 +104,15 @@ class AnthropicTransport(ProviderTransport):
                     reasoning_details.append(block_dict)
             elif block.type == "tool_use":
                 name = block.name
-                if strip_tool_prefix and name.startswith(_MCP_PREFIX):
-                    stripped = name[len(_MCP_PREFIX):]
-                    # Only strip the mcp_ prefix for OAuth-injected tools
-                    # (where Hermes adds the prefix when sending to Anthropic
-                    # and must remove it on the way back).  Native MCP server
-                    # tools (from mcp_servers: in config.yaml) are registered
-                    # in the tool registry under their FULL mcp_<server>_<tool>
-                    # name and must NOT be stripped.  GH-25255.
+                if strip_tool_prefix and name.startswith(_MCP_TOOL_PREFIX):
+                    # Strip the OAuth-injected mcp__ prefix for round-trip
+                    # registry lookup.  Native MCP server tools (from
+                    # mcp_servers: in config.yaml) are registered in the
+                    # tool registry under their FULL mcp__<server>__<tool>
+                    # name — preserve those untouched.  GH-25255.
                     from tools.registry import registry as _tool_registry
-                    if (_tool_registry.get_entry(stripped)
-                            and not _tool_registry.get_entry(name)):
-                        name = stripped
+                    if not _tool_registry.get_entry(name):
+                        name = name[len(_MCP_TOOL_PREFIX):]
                 tool_calls.append(
                     ToolCall(
                         id=block.id,

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1055,6 +1055,31 @@ class TestBuildAnthropicKwargs:
         assert kwargs["max_tokens"] == 4096
         assert "tools" not in kwargs
 
+    def test_oauth_prefixes_tools_with_claude_code_mcp_marker(self):
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "terminal",
+                    "description": "Run a command",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"command": {"type": "string"}},
+                        "required": ["command"],
+                    },
+                },
+            }
+        ]
+        kwargs = build_anthropic_kwargs(
+            model="claude-opus-4-7",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=tools,
+            max_tokens=4096,
+            reasoning_config=None,
+            is_oauth=True,
+        )
+        assert kwargs["tools"][0]["name"] == "mcp__terminal"
+
     def test_strips_anthropic_prefix(self):
         kwargs = build_anthropic_kwargs(
             model="anthropic/claude-sonnet-4-20250514",
@@ -1472,6 +1497,21 @@ class TestNormalizeResponse:
         assert len(nr.tool_calls) == 1
         assert nr.tool_calls[0].name == "search"
         assert json.loads(nr.tool_calls[0].arguments) == {"query": "test"}
+
+    def test_tool_use_response_strips_oauth_mcp_prefix(self):
+        block = SimpleNamespace(
+            type="tool_use",
+            id="tc_1",
+            name="mcp__terminal",
+            input={"command": "pwd"},
+        )
+        nr = get_transport("anthropic_messages").normalize_response(
+            self._make_response([block], "tool_use"),
+            strip_tool_prefix=True,
+        )
+        assert len(nr.tool_calls) == 1
+        assert nr.tool_calls[0].name == "terminal"
+        assert json.loads(nr.tool_calls[0].arguments) == {"command": "pwd"}
 
     def test_thinking_response(self):
         blocks = [


### PR DESCRIPTION
## Summary

- Use Claude Code-compatible `mcp__` as the MCP tool-name prefix for native Anthropic OAuth requests.
- Keep stripping the MCP prefix when normalizing Anthropic `tool_use` responses back into Hermes tool calls.
- Cover both request serialization and response normalization with tests.

## Why

Claude Code's Anthropic OAuth tool protocol uses a double-underscore MCP marker, for example:

```text
mcp__terminal
```

Hermes was previously emitting a single-underscore marker on the native Anthropic OAuth path:

```text
mcp_terminal
```

That can make Hermes OAuth tool requests diverge from the Claude Code-compatible shape even though the request is otherwise using Claude Code/OAuth beta headers. Using the same `mcp__` marker makes the OAuth tool schema consistent with Claude Code-style MCP tool naming.

This PR is intentionally scoped only to tool-name compatibility. It does not claim to change Anthropic account/billing behavior such as extra-usage gating.

## Tests

```bash
./venv/bin/python -m py_compile agent/anthropic_adapter.py agent/transports/anthropic.py
./venv/bin/python -m pytest -o 'addopts=' tests/agent/test_anthropic_adapter.py -q
```

Result:

```text
140 passed
```

Additional sanity checks verified:

- OAuth request tool name serializes as `mcp__terminal`.
- Response normalization strips `mcp__terminal` back to Hermes tool name `terminal`.
