### PR TITLE
fix(tui): Shift+Enter inserts newline instead of submitting

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/parse-keypress.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/parse-keypress.test.ts
@@ -39,3 +39,61 @@ describe('parseMultipleKeypresses bracketed paste recovery', () => {
     expect(state.pasteBuffer).toBe('')
   })
 })
+
+describe('parseMultipleKeypresses CSI u (Kitty keyboard protocol)', () => {
+  it('parses Shift+Enter (CSI 13;2u) as return with shift=true', () => {
+    const [keys] = parseMultipleKeypresses(INITIAL_STATE, '\x1b[13;2u')
+
+    expect(keys).toHaveLength(1)
+    expect(keys[0]).toMatchObject({
+      kind: 'key',
+      name: 'return',
+      shift: true,
+      ctrl: false,
+      meta: false,
+      super: false
+    })
+  })
+
+  it('parses Ctrl+Enter (CSI 13;5u) as return with ctrl=true', () => {
+    const [keys] = parseMultipleKeypresses(INITIAL_STATE, '\x1b[13;5u')
+
+    expect(keys).toHaveLength(1)
+    expect(keys[0]).toMatchObject({
+      kind: 'key',
+      name: 'return',
+      shift: false,
+      ctrl: true,
+      meta: false,
+      super: false
+    })
+  })
+
+  it('parses Cmd+Enter (CSI 13;9u) as return with super=true', () => {
+    const [keys] = parseMultipleKeypresses(INITIAL_STATE, '\x1b[13;9u')
+
+    expect(keys).toHaveLength(1)
+    expect(keys[0]).toMatchObject({
+      kind: 'key',
+      name: 'return',
+      shift: false,
+      ctrl: false,
+      meta: false,
+      super: true
+    })
+  })
+
+  it('parses plain Enter (CSI 13u) as return with no modifiers', () => {
+    const [keys] = parseMultipleKeypresses(INITIAL_STATE, '\x1b[13u')
+
+    expect(keys).toHaveLength(1)
+    expect(keys[0]).toMatchObject({
+      kind: 'key',
+      name: 'return',
+      shift: false,
+      ctrl: false,
+      meta: false,
+      super: false
+    })
+  })
+})

--- a/ui-tui/src/__tests__/terminalParity.test.ts
+++ b/ui-tui/src/__tests__/terminalParity.test.ts
@@ -38,6 +38,56 @@ describe('terminalParityHints', () => {
           key: 'shift+enter',
           command: 'workbench.action.terminal.sendSequence',
           when: 'terminalFocus',
+          args: { text: '\u001b[13;2u' }
+        },
+        {
+          key: 'ctrl+enter',
+          command: 'workbench.action.terminal.sendSequence',
+          when: 'terminalFocus',
+          args: { text: '\u001b[13;5u' }
+        },
+        {
+          key: 'cmd+enter',
+          command: 'workbench.action.terminal.sendSequence',
+          when: 'terminalFocus',
+          args: { text: '\u001b[13;9u' }
+        },
+        {
+          key: 'cmd+z',
+          command: 'workbench.action.terminal.sendSequence',
+          when: 'terminalFocus',
+          args: { text: '\u001b[122;9u' }
+        },
+        {
+          key: 'shift+cmd+z',
+          command: 'workbench.action.terminal.sendSequence',
+          when: 'terminalFocus',
+          args: { text: '\u001b[122;10u' }
+        }
+      ])
+    )
+
+    const hints = await terminalParityHints({ TERM_PROGRAM: 'vscode' } as NodeJS.ProcessEnv, {
+      fileOps: { readFile },
+      homeDir: '/tmp/fake-home'
+    })
+
+    expect(hints.some(h => h.key === 'ide-setup')).toBe(false)
+  })
+
+  it('shows IDE setup hint when keybindings use legacy sequences', async () => {
+    const readFile = vi.fn().mockResolvedValue(
+      JSON.stringify([
+        {
+          key: 'cmd+c',
+          command: 'workbench.action.terminal.sendSequence',
+          when: 'terminalFocus && terminalTextSelected',
+          args: { text: '\u001b[99;13u' }
+        },
+        {
+          key: 'shift+enter',
+          command: 'workbench.action.terminal.sendSequence',
+          when: 'terminalFocus',
           args: { text: '\\\r\n' }
         },
         {
@@ -72,6 +122,7 @@ describe('terminalParityHints', () => {
       homeDir: '/tmp/fake-home'
     })
 
-    expect(hints.some(h => h.key === 'ide-setup')).toBe(false)
+    // Legacy bindings don't match current CSI u targets, so setup is still needed
+    expect(hints.some(h => h.key === 'ide-setup')).toBe(true)
   })
 })

--- a/ui-tui/src/__tests__/terminalSetup.test.ts
+++ b/ui-tui/src/__tests__/terminalSetup.test.ts
@@ -83,7 +83,11 @@ describe('configureTerminalKeybindings', () => {
     expect(written).toContain('terminalTextSelected')
     expect(written).toContain('\\u001b[99;13u')
     expect(written).toContain('shift+enter')
+    expect(written).toContain('\\u001b[13;2u')
     expect(written).toContain('cmd+enter')
+    expect(written).toContain('\\u001b[13;9u')
+    expect(written).toContain('ctrl+enter')
+    expect(written).toContain('\\u001b[13;5u')
     expect(written).toContain('cmd+z')
   })
 
@@ -339,6 +343,66 @@ describe('configureTerminalKeybindings', () => {
           key: 'shift+enter',
           command: 'workbench.action.terminal.sendSequence',
           when: 'terminalFocus',
+          args: { text: '\u001b[13;2u' }
+        },
+        {
+          key: 'ctrl+enter',
+          command: 'workbench.action.terminal.sendSequence',
+          when: 'terminalFocus',
+          args: { text: '\u001b[13;5u' }
+        },
+        {
+          key: 'cmd+enter',
+          command: 'workbench.action.terminal.sendSequence',
+          when: 'terminalFocus',
+          args: { text: '\u001b[13;9u' }
+        },
+        {
+          key: 'cmd+z',
+          command: 'workbench.action.terminal.sendSequence',
+          when: 'terminalFocus',
+          args: { text: '\u001b[122;9u' }
+        },
+        {
+          key: 'shift+cmd+z',
+          command: 'workbench.action.terminal.sendSequence',
+          when: 'terminalFocus',
+          args: { text: '\u001b[122;10u' }
+        }
+      ])
+    )
+
+    await expect(
+      shouldPromptForTerminalSetup({
+        env: { TERM_PROGRAM: 'vscode' } as NodeJS.ProcessEnv,
+        fileOps: { readFile: readComplete }
+      })
+    ).resolves.toBe(false)
+  })
+
+  it('suppresses terminal setup prompts inside SSH sessions', async () => {
+    await expect(
+      shouldPromptForTerminalSetup({
+        env: { SSH_CONNECTION: '1 2 3 4', TERM_PROGRAM: 'vscode' } as NodeJS.ProcessEnv
+      })
+    ).resolves.toBe(false)
+  })
+
+  it('prompts for setup when legacy \\\r\n bindings are present', async () => {
+    // Old keybindings using the legacy \\\r\n sequence should be detected as
+    // incomplete — they need migration to the CSI u encoding.
+    const readLegacy = vi.fn().mockResolvedValue(
+      JSON.stringify([
+        {
+          key: 'cmd+c',
+          command: 'workbench.action.terminal.sendSequence',
+          when: 'terminalFocus && terminalTextSelected',
+          args: { text: '\u001b[99;13u' }
+        },
+        {
+          key: 'shift+enter',
+          command: 'workbench.action.terminal.sendSequence',
+          when: 'terminalFocus',
           args: { text: '\\\r\n' }
         },
         {
@@ -371,16 +435,56 @@ describe('configureTerminalKeybindings', () => {
     await expect(
       shouldPromptForTerminalSetup({
         env: { TERM_PROGRAM: 'vscode' } as NodeJS.ProcessEnv,
-        fileOps: { readFile: readComplete }
+        fileOps: { readFile: readLegacy }
       })
-    ).resolves.toBe(false)
+    ).resolves.toBe(true)
   })
 
-  it('suppresses terminal setup prompts inside SSH sessions', async () => {
-    await expect(
-      shouldPromptForTerminalSetup({
-        env: { SSH_CONNECTION: '1 2 3 4', TERM_PROGRAM: 'vscode' } as NodeJS.ProcessEnv
-      })
-    ).resolves.toBe(false)
+  it('migrates legacy \\\r\n bindings to CSI u sequences', async () => {
+    const mkdir = vi.fn().mockResolvedValue(undefined)
+    const readFile = vi.fn().mockResolvedValue(
+      JSON.stringify([
+        {
+          key: 'shift+enter',
+          command: 'workbench.action.terminal.sendSequence',
+          when: 'terminalFocus',
+          args: { text: '\\\r\n' }
+        },
+        {
+          key: 'ctrl+enter',
+          command: 'workbench.action.terminal.sendSequence',
+          when: 'terminalFocus',
+          args: { text: '\\\r\n' }
+        },
+        {
+          key: 'cmd+enter',
+          command: 'workbench.action.terminal.sendSequence',
+          when: 'terminalFocus',
+          args: { text: '\\\r\n' }
+        }
+      ])
+    )
+    const writeFile = vi.fn().mockResolvedValue(undefined)
+    const copyFile = vi.fn().mockResolvedValue(undefined)
+
+    const result = await configureTerminalKeybindings('vscode', {
+      fileOps: { copyFile, mkdir, readFile, writeFile },
+      homeDir: '/Users/me',
+      platform: 'darwin'
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.requiresRestart).toBe(true)
+    expect(result.message).toContain('migrated 3 legacy bindings to CSI u encoding')
+    const written = writeFile.mock.calls[0]?.[1] as string
+    const parsed = JSON.parse(written)
+    // All three Enter bindings should now use CSI u sequences
+    const enterBindings = parsed.filter((b: { key: string }) =>
+      ['shift+enter', 'ctrl+enter', 'cmd+enter'].includes(b.key)
+    )
+    expect(enterBindings).toHaveLength(3)
+    expect(enterBindings.find((b: { key: string }) => b.key === 'shift+enter')?.args?.text).toBe('\u001b[13;2u')
+    expect(enterBindings.find((b: { key: string }) => b.key === 'ctrl+enter')?.args?.text).toBe('\u001b[13;5u')
+    expect(enterBindings.find((b: { key: string }) => b.key === 'cmd+enter')?.args?.text).toBe('\u001b[13;9u')
   })
 })

--- a/ui-tui/src/lib/terminalSetup.ts
+++ b/ui-tui/src/lib/terminalSetup.ts
@@ -26,7 +26,57 @@ export type TerminalSetupResult = {
 
 const DEFAULT_FILE_OPS: FileOps = { copyFile, mkdir, readFile, writeFile }
 const COPY_SEQUENCE = '\u001b[99;13u'
-const MULTILINE_SEQUENCE = '\\\r\n'
+// Kitty keyboard protocol CSI u sequences for modified Enter keys.
+// Codepoint 13 = Enter; modifier encoding: 1 + (shift?1:0) + (alt?2:0) + (ctrl?4:0) + (super?8:0).
+// These are recognized by Ink's parse-keypress CSI u handler and produce
+// key.return=true with the correct modifier flags, so textInput.tsx's
+// existing k.return && (k.shift || k.ctrl || ...) branch inserts a newline.
+const SHIFT_ENTER_SEQUENCE = '\u001b[13;2u' // modifier 2 = shift
+const CTRL_ENTER_SEQUENCE = '\u001b[13;5u' // modifier 5 = ctrl
+const SUPER_ENTER_SEQUENCE = '\u001b[13;9u' // modifier 9 = super (Cmd on macOS)
+
+// Legacy multiline sequence used before CSI u migration. Old keybindings
+// that still send this will be auto-replaced on next terminal setup.
+const LEGACY_MULTILINE_SEQUENCE = '\\\r\n'
+
+/**
+ * Migrate legacy keybindings that used the old \\\r\n escape sequence
+ * for modified Enter keys.  Those sequences arrived at Ink as separate
+ * key events (backslash + return), causing unintended submissions.
+ * The replacement CSI u sequences are parsed correctly by Ink's
+ * parse-keypress handler and produce the proper modifier flags.
+ */
+function migrateLegacyBindings(keybindings: unknown[]): number {
+  let migrated = 0
+
+  const replacements: Map<string, string> = new Map([
+    ['shift+enter', SHIFT_ENTER_SEQUENCE],
+    ['ctrl+enter', CTRL_ENTER_SEQUENCE],
+    ['cmd+enter', SUPER_ENTER_SEQUENCE]
+  ])
+
+  for (let i = 0; i < keybindings.length; i++) {
+    const entry = keybindings[i]
+
+    if (!isKeybinding(entry)) {
+      continue
+    }
+
+    const replacement = replacements.get(entry.key ?? '')
+
+    if (
+      replacement &&
+      entry.command === 'workbench.action.terminal.sendSequence' &&
+      entry.when === 'terminalFocus' &&
+      entry.args?.text === LEGACY_MULTILINE_SEQUENCE
+    ) {
+      keybindings[i] = { ...entry, args: { text: replacement } }
+      migrated += 1
+    }
+  }
+
+  return migrated
+}
 
 const TERMINAL_META: Record<SupportedTerminal, { appName: string; label: string }> = {
   vscode: { appName: 'Code', label: 'VS Code' },
@@ -46,19 +96,19 @@ const BASE_BINDINGS: Keybinding[] = [
     key: 'shift+enter',
     command: 'workbench.action.terminal.sendSequence',
     when: 'terminalFocus',
-    args: { text: MULTILINE_SEQUENCE }
+    args: { text: SHIFT_ENTER_SEQUENCE }
   },
   {
     key: 'ctrl+enter',
     command: 'workbench.action.terminal.sendSequence',
     when: 'terminalFocus',
-    args: { text: MULTILINE_SEQUENCE }
+    args: { text: CTRL_ENTER_SEQUENCE }
   },
   {
     key: 'cmd+enter',
     command: 'workbench.action.terminal.sendSequence',
     when: 'terminalFocus',
-    args: { text: MULTILINE_SEQUENCE }
+    args: { text: SUPER_ENTER_SEQUENCE }
   },
   {
     key: 'cmd+z',
@@ -335,6 +385,7 @@ export async function configureTerminalKeybindings(
       }
     }
 
+    const migrated = migrateLegacyBindings(keybindings)
     const targets = targetBindings(platform)
 
     const conflicts = targets.filter(target =>
@@ -360,23 +411,33 @@ export async function configureTerminalKeybindings(
       }
     }
 
-    if (!added) {
+    if (!added && !migrated) {
       return {
         success: true,
         message: `${meta.label} terminal keybindings already configured.`
       }
     }
 
-    if (hasExistingFile) {
+    if (hasExistingFile && (added || migrated)) {
       await backupFile(keybindingsFile, ops)
     }
 
     await ops.writeFile(keybindingsFile, `${JSON.stringify(keybindings, null, 2)}\n`, 'utf8')
 
+    const parts: string[] = []
+
+    if (added) {
+      parts.push(`Added ${added} ${meta.label} terminal keybinding${added === 1 ? '' : 's'}`)
+    }
+
+    if (migrated) {
+      parts.push(`migrated ${migrated} legacy binding${migrated === 1 ? '' : 's'} to CSI u encoding`)
+    }
+
     return {
       success: true,
       requiresRestart: true,
-      message: `Added ${added} ${meta.label} terminal keybinding${added === 1 ? '' : 's'} in ${keybindingsFile}`
+      message: `${parts.join(', ')} in ${keybindingsFile}`
     }
   } catch (error) {
     return {


### PR DESCRIPTION
## Problem

When pressing Shift+Enter in the TUI, the prompt is submitted instead of inserting a newline. This also affects Ctrl+Enter and Cmd+Enter.

## Root Cause

`terminalSetup.ts` used a legacy `MULTILINE_SEQUENCE` (`\\\r\n`) for the modified Enter keybindings in VS Code/Cursor/Windsurf terminals. When the IDE terminal sent this sequence, Ink's `parse-keypress` treated it as **two separate events**:

1. A backslash character (`\`) — inserted into input text
2. A plain Return (`\r`) — triggered `onSubmit` because the `shift` flag was missing

The `\n` at the end was consumed by the terminal as part of the Return.

## Fix

Replace the legacy sequence with **Kitty keyboard protocol CSI u** sequences that encode modifier flags atomically:

| Key | Sequence | Modifier |
|-----|----------|----------|
| Shift+Enter | `\x1b[13;2u` | 2 = shift |
| Ctrl+Enter | `\x1b[13;5u` | 5 = ctrl |
| Cmd+Enter | `\x1b[13;9u` | 9 = super |

Ink's existing CSI u handler in `parse-keypress.ts` already parses these correctly, producing `key.return` with the right modifier flags. The `textInput.tsx` component already has a branch for `k.return && (k.shift || k.ctrl || ...)` that inserts a newline — **no changes needed there**.

## Migration

Users with existing `keybindings.json` files containing the old `\\\r\n` sequences will be auto-migrated on next `/terminal-setup` run. The `migrateLegacyBindings()` function replaces legacy entries with the correct CSI u sequences per key.

## Files Changed

- **`ui-tui/src/lib/terminalSetup.ts`** — Replaced `MULTILINE_SEQUENCE` with individual CSI u constants; added `migrateLegacyBindings()` for auto-migration; updated `configureTerminalKeybindings()` to run migration and report it
- **`ui-tui/src/__tests__/terminalSetup.test.ts`** — Updated existing test data from legacy to CSI u sequences; added tests for legacy detection and migration
- **`ui-tui/src/__tests__/terminalParity.test.ts`** — Updated test data to use CSI u sequences; added test that legacy bindings trigger setup hint
- **`ui-tui/packages/hermes-ink/src/ink/parse-keypress.test.ts`** — 4 new tests verifying CSI u sequences produce correct modifier flags

## Test Results

```
✓ src/__tests__/terminalParity.test.ts (4 tests)
✓ src/__tests__/terminalSetup.test.ts (22 tests)
✓ packages/hermes-ink/src/ink/parse-keypress.test.ts (7 tests)

Test Files  3 passed (3)
     Tests  33 passed (33)
```