### PR TITLE
fix(slack): resolve channel IDs to human-readable names

### DIFF
--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -190,10 +190,49 @@ async def _build_slack(adapter) -> List[Dict[str, Any]]:
             continue
 
     # Merge in DM/group entries discovered from session history.
+    # Build a lookup from API-discovered channels so we can enrich session entries.
+    api_name_lookup = {ch["id"]: ch["name"] for ch in channels}
+
     for entry in _build_from_sessions("slack"):
-        if entry.get("id") not in seen_ids:
+        eid = entry.get("id")
+        if eid not in seen_ids:
+            # If the entry name is still a raw Slack ID (e.g. C0xxx / D0xxx),
+            # try to resolve it from the API lookup first.
+            if entry.get("name", "").startswith(("C0", "D0", "G0")):
+                if eid in api_name_lookup:
+                    entry["name"] = api_name_lookup[eid]
             channels.append(entry)
-            seen_ids.add(entry.get("id"))
+            seen_ids.add(eid)
+
+    # Resolve remaining raw-ID entries (DMs, private channels not in bot scope)
+    # by calling conversations.info + users.info for each.
+    unresolved = [ch for ch in channels if ch.get("name", "").startswith(("C0", "D0", "G0"))]
+    if unresolved and team_clients:
+        client = next(iter(team_clients.values()))
+        for entry in unresolved:
+            try:
+                resp = await client.conversations_info(channel=entry["id"])
+                if not resp.get("ok"):
+                    continue
+                ch_info = resp.get("channel", {})
+                if ch_info.get("is_im"):
+                    peer_user = ch_info.get("user", "")
+                    if peer_user:
+                        user_resp = await client.users_info(user=peer_user)
+                        if user_resp.get("ok"):
+                            u = user_resp["user"]
+                            entry["name"] = (
+                                u.get("profile", {}).get("display_name")
+                                or u.get("real_name")
+                                or u.get("name")
+                                or entry["id"]
+                            )
+                            entry["type"] = "dm"
+                else:
+                    entry["name"] = ch_info.get("name") or ch_info.get("name_normalized") or entry["id"]
+            except Exception as e:
+                logger.debug("Channel directory: failed to resolve %s: %s", entry["id"], e)
+                continue
 
     return channels
 

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -277,6 +277,7 @@ class SlackAdapter(BasePlatformAdapter):
         self._handler: Optional[Any] = None
         self._bot_user_id: Optional[str] = None
         self._user_name_cache: Dict[str, str] = {}  # user_id → display name
+        self._channel_name_cache: Dict[str, str] = {}  # channel_id → resolved name
         self._socket_mode_task: Optional[asyncio.Task] = None
         # Multi-workspace support
         self._team_clients: Dict[str, Any] = {}   # team_id → WebClient
@@ -1021,6 +1022,33 @@ class SlackAdapter(BasePlatformAdapter):
             self._user_name_cache[user_id] = user_id
             return user_id
 
+    async def _resolve_channel_name(self, channel_id: str) -> str:
+        """Resolve a Slack channel ID to a human-readable name (cached).
+
+        For public/private channels returns the channel name.
+        For DMs (im) returns the peer user's display name.
+        Falls back to the raw channel_id on any error.
+        """
+        if channel_id in self._channel_name_cache:
+            return self._channel_name_cache[channel_id]
+        try:
+            resp = await self._get_client(channel_id).conversations_info(channel=channel_id)
+            if not resp.get("ok"):
+                self._channel_name_cache[channel_id] = channel_id
+                return channel_id
+            ch = resp.get("channel", {})
+            if ch.get("is_im"):
+                peer_user = ch.get("user", "")
+                name = await self._resolve_user_name(peer_user, chat_id=channel_id) if peer_user else channel_id
+            else:
+                name = ch.get("name") or ch.get("name_normalized") or channel_id
+            self._channel_name_cache[channel_id] = name
+            return name
+        except Exception as e:
+            logger.debug("[Slack] conversations.info failed for %s: %s", channel_id, e)
+            self._channel_name_cache[channel_id] = channel_id
+            return channel_id
+
     async def send_image_file(
         self,
         chat_id: str,
@@ -1379,7 +1407,7 @@ class SlackAdapter(BasePlatformAdapter):
 
         source = self.build_source(
             chat_id=channel_id,
-            chat_name=channel_id,
+            chat_name=self._channel_name_cache.get(channel_id, channel_id),
             chat_type="dm",
             user_id=user_id,
             thread_id=thread_ts,
@@ -1791,10 +1819,13 @@ class SlackAdapter(BasePlatformAdapter):
         # Resolve user display name (cached after first lookup)
         user_name = await self._resolve_user_name(user_id, chat_id=channel_id)
 
+        # Resolve channel name (cached after first lookup)
+        channel_name = await self._resolve_channel_name(channel_id)
+
         # Build source
         source = self.build_source(
             chat_id=channel_id,
-            chat_name=channel_id,  # Will be resolved later if needed
+            chat_name=channel_name,
             chat_type="dm" if is_dm else "group",
             user_id=user_id,
             user_name=user_name,


### PR DESCRIPTION
## Problem

Slack sessions and the channel directory store raw channel IDs (e.g. `C0ATFHY907L`, `D0B00SF5BL3`) as `chat_name`, making it impossible for operators to identify channels when using `send_message(action='list')` or reviewing session data.

**Before:**
```
slack:C0ATFHY907L
slack:D0B00SF5BL3
```

**After:**
```
slack:o11y-ai-agent
slack:John Doe
```

## Root Cause

Two gaps in the Slack platform adapter:

1. **`_handle_slack_message()`** passes the raw `channel_id` as `chat_name` to `build_source()` — the comment even says `"Will be resolved later if needed"` but it never was.
2. **`channel_directory._build_slack()`** merges session-sourced entries (DMs, threads) that still carry raw IDs from `sessions.json`, without resolving them against the Slack API.

## Changes

### `gateway/platforms/slack.py`
- Add `_channel_name_cache: Dict[str, str]` to `SlackAdapter.__init__` for in-memory caching
- Add `_resolve_channel_name()` async method that calls `conversations.info` (channels) or `users.info` (DMs) with in-memory caching
- Update `_handle_slack_message()` to resolve channel name before `build_source()`
- Update `_seed_assistant_thread_session()` to use cached channel name

### `gateway/channel_directory.py`
- Build `api_name_lookup` from API-enumerated channels before merging session entries
- Cross-reference session entries against lookup to replace raw IDs
- Resolve remaining entries (DMs, private channels) via `conversations.info` + `users.info`
- DM entries resolved to peer user's display name

## Performance

- All resolutions cached in-memory — each channel resolved at most once per adapter lifecycle
- Channel directory enrichment only runs for entries with raw-ID names
- Sequential API calls for unresolved DMs (typically < 20), acceptable at 5-min refresh cadence

## Testing

Verified on a production Slack workspace with ~1500 channels:
- All channel directory entries resolve to human-readable names
- DMs resolve to peer user display names
- Sessions created after the patch carry resolved `chat_name`
- No regressions in message handling or session creation
