### PR TITLE
fix(matrix): preserve named room identity

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -106,6 +106,36 @@ from gateway.platforms.helpers import ThreadParticipationTracker
 
 logger = logging.getLogger(__name__)
 
+@dataclass(frozen=True)
+class MatrixRoomIdentity:
+    """Resolved Matrix room identity used for Hermes session routing."""
+
+    room_id: str
+    room_name: Optional[str] = None
+    canonical_alias: Optional[str] = None
+    joined_member_count: Optional[int] = None
+    is_direct_account_data: bool = False
+
+    @property
+    def display_name(self) -> str:
+        return self.room_name or self.canonical_alias or self.room_id
+
+    @property
+    def has_explicit_name(self) -> bool:
+        return bool(self.room_name and self.room_name.strip())
+
+    @property
+    def chat_type(self) -> str:
+        # Matrix DMs are account-data facts. Member count is metadata only,
+        # and named rooms should retain room/group context in Hermes prompts.
+        if self.has_explicit_name:
+            return "group"
+        return "dm" if self.is_direct_account_data else "group"
+
+    @property
+    def has_direct_name_conflict(self) -> bool:
+        return self.is_direct_account_data and self.has_explicit_name
+
 
 @dataclass
 class _MatrixApprovalPrompt:
@@ -945,22 +975,9 @@ class MatrixAdapter(BasePlatformAdapter):
         return SendResult(success=True, message_id=last_event_id)
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
-        """Return room name and type (dm/group)."""
-        name = chat_id
-        chat_type = "dm" if await self._is_dm_room(chat_id) else "group"
-
-        if self._client:
-            try:
-                name_evt = await self._client.get_state_event(
-                    RoomID(chat_id),
-                    EventType.ROOM_NAME,
-                )
-                if name_evt and hasattr(name_evt, "name") and name_evt.name:
-                    name = name_evt.name
-            except Exception:
-                pass
-
-        return {"name": name, "type": chat_type}
+        """Return Matrix room identity and Hermes chat type."""
+        identity = await self._resolve_room_identity(chat_id)
+        return {"name": identity.display_name, "type": identity.chat_type}
 
     # ------------------------------------------------------------------
     # Optional overrides
@@ -1542,8 +1559,9 @@ class MatrixAdapter(BasePlatformAdapter):
         Returns (body, is_dm, chat_type, thread_id, display_name, source)
         or None if the message should be dropped (mention gating).
         """
-        is_dm = await self._is_dm_room(room_id)
-        chat_type = "dm" if is_dm else "group"
+        identity = await self._resolve_room_identity(room_id)
+        chat_type = identity.chat_type
+        is_dm = chat_type == "dm"
 
         thread_id = None
         if relates_to.get("rel_type") == "m.thread":
@@ -1588,6 +1606,7 @@ class MatrixAdapter(BasePlatformAdapter):
         display_name = await self._get_display_name(room_id, sender)
         source = self.build_source(
             chat_id=room_id,
+            chat_name=identity.display_name,
             chat_type=chat_type,
             user_id=sender,
             user_name=display_name,
@@ -2284,22 +2303,119 @@ class MatrixAdapter(BasePlatformAdapter):
     # Helpers
     # ------------------------------------------------------------------
 
-    async def _is_dm_room(self, room_id: str) -> bool:
-        """Check if a room is a DM."""
-        if self._dm_rooms.get(room_id, False):
-            return True
-        # Fallback: check member count via state store.
-        state_store = (
-            getattr(self._client, "state_store", None) if self._client else None
+    async def _matrix_state_value(
+        self, room_id: str, event_type: Any, key: str
+    ) -> Optional[str]:
+        """Read one string value from Matrix room state."""
+        if not self._client:
+            return None
+
+        try:
+            evt = await self._client.get_state_event(RoomID(room_id), event_type)
+        except Exception as exc:
+            logger.debug(
+                "Matrix: failed to read state %s: %s",
+                event_type,
+                exc,
+            )
+            return None
+
+        if not evt:
+            return None
+
+        value = None
+        if isinstance(evt, dict):
+            content = evt.get("content", evt)
+            if isinstance(content, dict):
+                value = content.get(key)
+        else:
+            value = getattr(evt, key, None)
+            if value is None and hasattr(evt, "content"):
+                content = getattr(evt, "content", None)
+                if isinstance(content, dict):
+                    value = content.get(key)
+                else:
+                    value = getattr(content, key, None)
+
+        if isinstance(value, str):
+            value = value.strip()
+            return value or None
+        return None
+
+    async def _matrix_joined_member_count(self, room_id: str) -> Optional[int]:
+        """Return joined member count as metadata only."""
+        if not self._client:
+            return None
+
+        state_store = getattr(self._client, "state_store", None)
+        if not state_store:
+            return None
+
+        try:
+            members = await state_store.get_members(room_id)
+        except Exception as exc:
+            logger.debug("Matrix: failed to read Matrix room members: %s", exc)
+            return None
+
+        if not members:
+            return None
+
+        values = members.values() if isinstance(members, dict) else members
+        count = 0
+        for member in values:
+            membership = None
+            if isinstance(member, dict):
+                membership = member.get("membership")
+                content = member.get("content")
+                if membership is None and isinstance(content, dict):
+                    membership = content.get("membership")
+            else:
+                membership = getattr(member, "membership", None)
+                content = getattr(member, "content", None)
+                if membership is None and isinstance(content, dict):
+                    membership = content.get("membership")
+                elif membership is None and content is not None:
+                    membership = getattr(content, "membership", None)
+
+            if membership is None or str(membership) == "join":
+                count += 1
+
+        return count
+
+    async def _resolve_room_identity(self, room_id: str) -> MatrixRoomIdentity:
+        """Resolve Matrix room identity before Hermes session routing."""
+        if room_id not in self._dm_rooms:
+            await self._refresh_dm_cache()
+
+        is_direct = bool(self._dm_rooms.get(room_id, False))
+        room_name = await self._matrix_state_value(
+            room_id, EventType.ROOM_NAME, "name"
         )
-        if state_store:
-            try:
-                members = await state_store.get_members(room_id)
-                if members and len(members) == 2:
-                    return True
-            except Exception:
-                pass
-        return False
+        canonical_alias = await self._matrix_state_value(
+            room_id, "m.room.canonical_alias", "alias"
+        )
+        joined_member_count = await self._matrix_joined_member_count(room_id)
+
+        identity = MatrixRoomIdentity(
+            room_id=room_id,
+            room_name=room_name,
+            canonical_alias=canonical_alias,
+            joined_member_count=joined_member_count,
+            is_direct_account_data=is_direct,
+        )
+
+        if identity.has_direct_name_conflict:
+            logger.warning(
+                "Matrix: room has m.direct=true and an explicit name; "
+                "using named-room context for Hermes session routing"
+            )
+
+        return identity
+
+    async def _is_dm_room(self, room_id: str) -> bool:
+        """Return Hermes DM classification without member-count heuristics."""
+        identity = await self._resolve_room_identity(room_id)
+        return identity.chat_type == "dm"
 
     async def _refresh_dm_cache(self) -> None:
         """Refresh the DM room cache from m.direct account data."""

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -355,6 +355,7 @@ class MatrixAdapter(BasePlatformAdapter):
 
         # Cache: room_id → bool (is DM)
         self._dm_rooms: Dict[str, bool] = {}
+        self._dm_cache_loaded = False
         # Set of room IDs we've joined
         self._joined_rooms: Set[str] = set()
         # Event deduplication (bounded deque keeps newest entries)
@@ -2384,8 +2385,7 @@ class MatrixAdapter(BasePlatformAdapter):
 
     async def _resolve_room_identity(self, room_id: str) -> MatrixRoomIdentity:
         """Resolve Matrix room identity before Hermes session routing."""
-        if room_id not in self._dm_rooms:
-            await self._refresh_dm_cache()
+        await self._ensure_dm_cache_loaded()
 
         is_direct = bool(self._dm_rooms.get(room_id, False))
         room_name = await self._matrix_state_value(
@@ -2417,9 +2417,16 @@ class MatrixAdapter(BasePlatformAdapter):
         identity = await self._resolve_room_identity(room_id)
         return identity.chat_type == "dm"
 
+    async def _ensure_dm_cache_loaded(self) -> None:
+        """Load m.direct account data once so non-DM rooms cache negatively."""
+        if self._dm_cache_loaded or self._dm_rooms:
+            return
+        await self._refresh_dm_cache()
+
     async def _refresh_dm_cache(self) -> None:
         """Refresh the DM room cache from m.direct account data."""
         if not self._client:
+            self._dm_cache_loaded = True
             return
 
         dm_data: Optional[Dict] = None
@@ -2433,15 +2440,14 @@ class MatrixAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.debug("Matrix: get_account_data('m.direct') failed: %s", exc)
 
-        if dm_data is None:
-            return
-
         dm_room_ids: Set[str] = set()
-        for user_id, rooms in dm_data.items():
-            if isinstance(rooms, list):
-                dm_room_ids.update(str(r) for r in rooms)
+        if isinstance(dm_data, dict):
+            for user_id, rooms in dm_data.items():
+                if isinstance(rooms, list):
+                    dm_room_ids.update(str(r) for r in rooms)
 
         self._dm_rooms = {rid: (rid in dm_room_ids) for rid in self._joined_rooms}
+        self._dm_cache_loaded = True
 
     # ------------------------------------------------------------------
     # Mention detection helpers

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -2444,7 +2444,7 @@ class MatrixAdapter(BasePlatformAdapter):
         if isinstance(dm_data, dict):
             for user_id, rooms in dm_data.items():
                 if isinstance(rooms, list):
-                    dm_room_ids.update(str(r) for r in rooms)
+                    dm_room_ids.update(r for r in rooms if isinstance(r, str))
 
         self._dm_rooms = {rid: (rid in dm_room_ids) for rid in self._joined_rooms}
         self._dm_cache_loaded = True

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -830,6 +830,7 @@ class MatrixAdapter(BasePlatformAdapter):
                 rooms_join = sync_data.get("rooms", {}).get("join", {})
                 self._joined_rooms.clear()
                 self._joined_rooms.update(rooms_join.keys())
+                self._dm_cache_loaded = False
                 # Store the next_batch token so incremental syncs start
                 # from where the initial sync left off.
                 nb = sync_data.get("next_batch")
@@ -1357,7 +1358,10 @@ class MatrixAdapter(BasePlatformAdapter):
                     # Update joined rooms from sync response.
                     rooms_join = sync_data.get("rooms", {}).get("join", {})
                     if rooms_join:
+                        new_room_ids = set(rooms_join) - self._joined_rooms
                         self._joined_rooms.update(rooms_join.keys())
+                        if new_room_ids:
+                            self._dm_cache_loaded = False
 
                     # Advance the sync token so the next request is
                     # incremental instead of a full initial sync.
@@ -2418,8 +2422,8 @@ class MatrixAdapter(BasePlatformAdapter):
         return identity.chat_type == "dm"
 
     async def _ensure_dm_cache_loaded(self) -> None:
-        """Load m.direct account data once so non-DM rooms cache negatively."""
-        if self._dm_cache_loaded or self._dm_rooms:
+        """Load m.direct account data when the cache is absent or invalidated."""
+        if self._dm_cache_loaded:
             return
         await self._refresh_dm_cache()
 

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -1848,7 +1848,8 @@ class TestMatrixReadReceipts:
 
     @pytest.mark.asyncio
     async def test_accepted_message_schedules_read_receipt(self):
-        self.adapter._is_dm_room = AsyncMock(return_value=True)
+        self.adapter._dm_rooms = {"!room:ex": True}
+        self.adapter._require_mention = False
         self.adapter._get_display_name = AsyncMock(return_value="Alice")
         self.adapter._background_read_receipt = MagicMock()
 
@@ -1906,7 +1907,7 @@ class TestMatrixImageOnlyMediaNormalization:
         self.adapter = _make_adapter()
         self.adapter._client = MagicMock()
         self.adapter._client.download_media = AsyncMock(return_value=None)
-        self.adapter._is_dm_room = AsyncMock(return_value=True)
+        self.adapter._dm_rooms = {"!room:example.org": True}
         self.adapter._get_display_name = AsyncMock(return_value="Alice")
         self.adapter._background_read_receipt = MagicMock()
         self.adapter._mxc_to_http = (
@@ -2216,7 +2217,7 @@ class TestMatrixOnRoomMessageFilter:
 class TestMatrixDmAutoThread:
     def setup_method(self):
         self.adapter = _make_adapter()
-        self.adapter._is_dm_room = AsyncMock(return_value=True)
+        self.adapter._dm_rooms = {"!dm:ex": True}
         self.adapter._get_display_name = AsyncMock(return_value="Alice")
         self.adapter._background_read_receipt = MagicMock()
         # Disable require_mention so DMs pass gating

--- a/tests/gateway/test_matrix_room_identity.py
+++ b/tests/gateway/test_matrix_room_identity.py
@@ -1,0 +1,153 @@
+"""Tests for Matrix room identity resolution.
+
+Uses sanitized example.org identifiers only. Do not add real homeservers, room IDs,
+or person/project names to this upstream-facing test module.
+"""
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.matrix import MatrixAdapter
+
+
+ROOM_ID = "!roomid:example.org"
+SENDER_ID = "@user:example.org"
+BOT_ID = "@bot:example.org"
+
+
+class FakeStateEvent:
+    def __init__(self, **values):
+        self.__dict__.update(values)
+
+
+class FakeStateStore:
+    async def get_members(self, room_id):
+        assert str(room_id) == ROOM_ID
+        return {
+            SENDER_ID: {"membership": "join"},
+            BOT_ID: {"membership": "join"},
+        }
+
+
+class FakeClient:
+    def __init__(self, *, direct_rooms=None, room_name=None):
+        self.direct_rooms = direct_rooms or []
+        self.room_name = room_name
+        self.state_store = FakeStateStore()
+
+    async def get_account_data(self, event_type):
+        assert event_type == "m.direct"
+        return {SENDER_ID: self.direct_rooms}
+
+    async def get_state_event(self, room_id, event_type):
+        assert str(room_id) == ROOM_ID
+        event_type = str(event_type)
+        if event_type == "m.room.name":
+            return FakeStateEvent(name=self.room_name) if self.room_name else None
+        if event_type == "m.room.canonical_alias":
+            return FakeStateEvent(alias="#example-project:example.org")
+        return None
+
+
+def make_adapter(fake_client):
+    adapter = MatrixAdapter(
+        PlatformConfig(
+            enabled=True,
+            token="syt_test_token",
+            extra={
+                "homeserver": "https://matrix.example.org",
+                "user_id": BOT_ID,
+                "require_mention": False,
+            },
+        )
+    )
+    adapter._client = fake_client
+    adapter._joined_rooms = {ROOM_ID}
+    adapter._dm_rooms = {}
+    adapter._require_mention = False
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_named_two_member_room_is_not_dm():
+    adapter = make_adapter(FakeClient(direct_rooms=[], room_name="Project - Example"))
+
+    identity = await adapter._resolve_room_identity(ROOM_ID)
+
+    assert identity.room_name == "Project - Example"
+    assert identity.joined_member_count == 2
+    assert identity.is_direct_account_data is False
+    assert identity.chat_type == "group"
+    assert await adapter._is_dm_room(ROOM_ID) is False
+
+
+@pytest.mark.asyncio
+async def test_two_member_room_without_m_direct_is_not_dm():
+    adapter = make_adapter(FakeClient(direct_rooms=[], room_name=None))
+
+    identity = await adapter._resolve_room_identity(ROOM_ID)
+
+    assert identity.joined_member_count == 2
+    assert identity.is_direct_account_data is False
+    assert identity.chat_type == "group"
+
+
+@pytest.mark.asyncio
+async def test_m_direct_room_without_name_is_dm():
+    adapter = make_adapter(FakeClient(direct_rooms=[ROOM_ID], room_name=None))
+
+    identity = await adapter._resolve_room_identity(ROOM_ID)
+
+    assert identity.is_direct_account_data is True
+    assert identity.chat_type == "dm"
+
+
+@pytest.mark.asyncio
+async def test_named_m_direct_room_surfaces_conflict_but_uses_named_room_context():
+    adapter = make_adapter(FakeClient(direct_rooms=[ROOM_ID], room_name="Project - Example"))
+
+    identity = await adapter._resolve_room_identity(ROOM_ID)
+
+    assert identity.is_direct_account_data is True
+    assert identity.has_direct_name_conflict is True
+    assert identity.chat_type == "group"
+    assert identity.display_name == "Project - Example"
+
+
+@pytest.mark.asyncio
+async def test_get_chat_info_reuses_room_identity_metadata():
+    adapter = make_adapter(FakeClient(direct_rooms=[], room_name="Project - Example"))
+
+    info = await adapter.get_chat_info(ROOM_ID)
+
+    assert info == {"name": "Project - Example", "type": "group"}
+
+
+@pytest.mark.asyncio
+async def test_resolve_message_context_passes_room_name_to_source():
+    adapter = make_adapter(FakeClient(direct_rooms=[], room_name="Project - Example"))
+    adapter._background_read_receipt = lambda room_id, event_id: None
+
+    async def fake_display_name(room_id, sender):
+        assert room_id == ROOM_ID
+        assert sender == SENDER_ID
+        return "Example User"
+
+    adapter._get_display_name = fake_display_name
+
+    ctx = await adapter._resolve_message_context(
+        ROOM_ID,
+        SENDER_ID,
+        "$eventid",
+        "hello",
+        {"body": "hello"},
+        {},
+    )
+
+    assert ctx is not None
+    _body, is_dm, chat_type, _thread_id, _display_name, source = ctx
+    assert is_dm is False
+    assert chat_type == "group"
+    assert source.chat_id == ROOM_ID
+    assert source.chat_name == "Project - Example"
+    assert source.description == "group: Project - Example, thread: $eventid"

--- a/tests/gateway/test_matrix_room_identity.py
+++ b/tests/gateway/test_matrix_room_identity.py
@@ -141,6 +141,19 @@ async def test_dm_cache_negative_result_is_not_refreshed_every_message():
 
 
 @pytest.mark.asyncio
+async def test_dm_cache_ignores_non_string_m_direct_room_ids():
+    fake_client = FakeClient(direct_rooms=[None], room_name=None)
+    adapter = make_adapter(fake_client)
+    adapter._joined_rooms = {ROOM_ID, "None"}
+
+    await adapter._refresh_dm_cache()
+
+    assert adapter._dm_cache_loaded is True
+    assert adapter._dm_rooms[ROOM_ID] is False
+    assert adapter._dm_rooms["None"] is False
+
+
+@pytest.mark.asyncio
 async def test_empty_room_name_falls_back_to_alias_or_room_id():
     adapter = make_adapter(FakeClient(direct_rooms=[], room_name="   ", alias=None))
 

--- a/tests/gateway/test_matrix_room_identity.py
+++ b/tests/gateway/test_matrix_room_identity.py
@@ -30,22 +30,25 @@ class FakeStateStore:
 
 
 class FakeClient:
-    def __init__(self, *, direct_rooms=None, room_name=None):
+    def __init__(self, *, direct_rooms=None, room_name=None, alias="#example-project:example.org"):
         self.direct_rooms = direct_rooms or []
         self.room_name = room_name
+        self.alias = alias
+        self.account_data_calls = 0
         self.state_store = FakeStateStore()
 
     async def get_account_data(self, event_type):
         assert event_type == "m.direct"
+        self.account_data_calls += 1
         return {SENDER_ID: self.direct_rooms}
 
     async def get_state_event(self, room_id, event_type):
         assert str(room_id) == ROOM_ID
         event_type = str(event_type)
         if event_type == "m.room.name":
-            return FakeStateEvent(name=self.room_name) if self.room_name else None
+            return FakeStateEvent(name=self.room_name) if self.room_name is not None else None
         if event_type == "m.room.canonical_alias":
-            return FakeStateEvent(alias="#example-project:example.org")
+            return FakeStateEvent(alias=self.alias) if self.alias is not None else None
         return None
 
 
@@ -64,6 +67,7 @@ def make_adapter(fake_client):
     adapter._client = fake_client
     adapter._joined_rooms = {ROOM_ID}
     adapter._dm_rooms = {}
+    adapter._dm_cache_loaded = False
     adapter._require_mention = False
     return adapter
 
@@ -121,6 +125,61 @@ async def test_get_chat_info_reuses_room_identity_metadata():
     info = await adapter.get_chat_info(ROOM_ID)
 
     assert info == {"name": "Project - Example", "type": "group"}
+
+
+@pytest.mark.asyncio
+async def test_dm_cache_negative_result_is_not_refreshed_every_message():
+    fake_client = FakeClient(direct_rooms=[], room_name=None)
+    adapter = make_adapter(fake_client)
+
+    first = await adapter._resolve_room_identity(ROOM_ID)
+    second = await adapter._resolve_room_identity(ROOM_ID)
+
+    assert first.is_direct_account_data is False
+    assert second.is_direct_account_data is False
+    assert fake_client.account_data_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_empty_room_name_falls_back_to_alias_or_room_id():
+    adapter = make_adapter(FakeClient(direct_rooms=[], room_name="   ", alias=None))
+
+    identity = await adapter._resolve_room_identity(ROOM_ID)
+
+    assert identity.room_name is None
+    assert identity.display_name == ROOM_ID
+
+
+@pytest.mark.asyncio
+async def test_room_name_dict_state_event_is_supported():
+    class DictStateClient(FakeClient):
+        async def get_state_event(self, room_id, event_type):
+            assert str(room_id) == ROOM_ID
+            if str(event_type) == "m.room.name":
+                return {"content": {"name": "Project - Example"}}
+            if str(event_type) == "m.room.canonical_alias":
+                return {"content": {"alias": "#example-project:example.org"}}
+            return None
+
+    adapter = make_adapter(DictStateClient(direct_rooms=[]))
+
+    identity = await adapter._resolve_room_identity(ROOM_ID)
+
+    assert identity.room_name == "Project - Example"
+    assert identity.display_name == "Project - Example"
+
+
+@pytest.mark.asyncio
+async def test_canonical_alias_used_when_room_name_missing():
+    adapter = make_adapter(
+        FakeClient(direct_rooms=[], room_name=None, alias="#example-project:example.org")
+    )
+
+    identity = await adapter._resolve_room_identity(ROOM_ID)
+
+    assert identity.room_name is None
+    assert identity.canonical_alias == "#example-project:example.org"
+    assert identity.display_name == "#example-project:example.org"
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_matrix_room_identity.py
+++ b/tests/gateway/test_matrix_room_identity.py
@@ -11,6 +11,7 @@ from gateway.platforms.matrix import MatrixAdapter
 
 
 ROOM_ID = "!roomid:example.org"
+NEW_ROOM_ID = "!newroom:example.org"
 SENDER_ID = "@user:example.org"
 BOT_ID = "@bot:example.org"
 
@@ -22,7 +23,7 @@ class FakeStateEvent:
 
 class FakeStateStore:
     async def get_members(self, room_id):
-        assert str(room_id) == ROOM_ID
+        assert str(room_id) in {ROOM_ID, NEW_ROOM_ID}
         return {
             SENDER_ID: {"membership": "join"},
             BOT_ID: {"membership": "join"},
@@ -43,7 +44,7 @@ class FakeClient:
         return {SENDER_ID: self.direct_rooms}
 
     async def get_state_event(self, room_id, event_type):
-        assert str(room_id) == ROOM_ID
+        assert str(room_id) in {ROOM_ID, NEW_ROOM_ID}
         event_type = str(event_type)
         if event_type == "m.room.name":
             return FakeStateEvent(name=self.room_name) if self.room_name is not None else None
@@ -151,6 +152,26 @@ async def test_dm_cache_ignores_non_string_m_direct_room_ids():
     assert adapter._dm_cache_loaded is True
     assert adapter._dm_rooms[ROOM_ID] is False
     assert adapter._dm_rooms["None"] is False
+
+
+@pytest.mark.asyncio
+async def test_dm_cache_refreshes_after_joined_room_set_is_invalidated():
+    fake_client = FakeClient(direct_rooms=[], room_name=None)
+    adapter = make_adapter(fake_client)
+
+    await adapter._ensure_dm_cache_loaded()
+    assert fake_client.account_data_calls == 1
+    assert adapter._dm_rooms == {ROOM_ID: False}
+
+    fake_client.direct_rooms = [NEW_ROOM_ID]
+    adapter._joined_rooms.add(NEW_ROOM_ID)
+    adapter._dm_cache_loaded = False
+
+    await adapter._ensure_dm_cache_loaded()
+
+    assert fake_client.account_data_calls == 2
+    assert adapter._dm_rooms[ROOM_ID] is False
+    assert adapter._dm_rooms[NEW_ROOM_ID] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Fixes Matrix room identity resolution so Hermes preserves explicit room names before session routing. A room with two joined members is no longer treated as a DM unless Matrix `m.direct` account data identifies it as direct, and explicitly named rooms keep group context even if account data is stale or conflicting.

## Related Issue

No directly related issue/PR found in upstream search for Matrix room identity/session routing terms.

## Type of Change

- [x] Bug fix
- [x] Tests

## Changes Made

- `gateway/platforms/matrix.py`: add internal Matrix room identity resolution before DM/group routing.
- `gateway/platforms/matrix.py`: remove the two-member-room DM heuristic and rely on `m.direct` account data plus explicit room names.
- `gateway/platforms/matrix.py`: harden long-running adapter behavior by invalidating/reloading joined-room and DM cache state when needed, including newly joined rooms.
- `tests/gateway/test_matrix_room_identity.py`: add sanitized `example.org` regression coverage for named rooms, `m.direct` rooms, conflict handling, negative DM-cache reuse, empty-name fallback, dict state events, canonical aliases, non-string `m.direct` entries, and DM cache refresh after room joins.
- `tests/gateway/test_matrix.py`: update existing DM classification expectations for the corrected routing behavior.

## How to Test

Latest follow-up verification after DM cache refresh hardening:

- `python -m pytest tests/gateway/test_matrix_room_identity.py -q -o 'addopts='` → 12 passed
- `python -m py_compile gateway/platforms/matrix.py gateway/session.py` → passed
- `git diff --check` → passed

Earlier broader targeted run on this PR line:

- `python -m pytest tests/gateway/test_matrix_room_identity.py tests/gateway/test_matrix.py -q -o 'addopts='` previously covered the combined Matrix adapter regressions. I am not re-claiming a fresh all-green full-suite run here; the latest fresh verification above is the scoped identity/cache hardening test file.

## Security / Privacy Notes

- No credentials, subprocess execution, filesystem migrations, or storage schema changes.
- Tests use sanitized `example.org` Matrix-style fixtures only.
- Newly added runtime warning/debug logs avoid printing Matrix room IDs or room names.
- This PR intentionally does not expose expanded channel metadata; normalized channel identity is deferred to a follow-up PR.

## Deferred Follow-ups / Non-goals

- Exposing normalized channel identity in gateway session context.
- Workspace registry for channel-to-project bindings.
- Guarding repo side effects with workspace bindings.

## Review feedback remediation (2026-04-30)

- Confirmed `_dm_cache_loaded` is used so non-DM rooms do not repeatedly refresh `m.direct` account data on every message.
- Hardened `m.direct` cache parsing to ignore non-string room IDs instead of coercing unexpected values into strings.
- Added regression coverage for non-string `m.direct` entries.
- Added DM cache refresh hardening for newly joined/invalidated rooms so long-running Matrix adapters do not keep stale DM classification forever.
- Updated the test plan to remove stale/malformed counts and show the latest fresh 12-test identity/cache verification.

### Relationship to follow-ups

This is the Matrix-specific foundation fix. It ensures named two-person Matrix project rooms are exposed as named rooms, not inferred DMs, before the model sees session context.

Follow-ups:
- #17711 exposes normalized channel identity generically across gateway platforms.
- #17938 consumes channel/project identity to guard repo side effects.

This PR intentionally does NOT add workspace binding or repo side-effect guards.
