### PR TITLE
fix(qqbot): keep reconnecting after closed websocket

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -583,6 +583,8 @@ class QQAdapter(BasePlatformAdapter):
         """Read WebSocket frames until connection closes."""
         if not self._ws:
             raise RuntimeError("WebSocket not connected")
+        if self._ws.closed:
+            raise RuntimeError("WebSocket closed")
 
         while self._running and self._ws and not self._ws.closed:
             msg = await self._ws.receive()

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -503,9 +503,28 @@ class TestBuildTextBody:
 
 
 # ---------------------------------------------------------------------------
+# _read_events closed websocket handling
+# ---------------------------------------------------------------------------
+class TestReadEventsClosedWebSocket:
+    def _make_adapter(self, **extra):
+        from gateway.platforms.qqbot import QQAdapter
+        return QQAdapter(_make_config(**extra))
+
+    @pytest.mark.asyncio
+    async def test_closed_websocket_raises_so_listener_keeps_reconnecting(self):
+        """A closed-but-present ws must not make _listen_loop think reads ended cleanly."""
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        adapter._running = True
+        adapter._ws = mock.Mock()
+        adapter._ws.closed = True
+
+        with pytest.raises(RuntimeError, match="WebSocket closed"):
+            await adapter._read_events()
+
+
+# ---------------------------------------------------------------------------
 # _wait_for_reconnection / send reconnection wait
 # ---------------------------------------------------------------------------
-
 class TestWaitForReconnection:
     """Test that send() waits for reconnection instead of silently dropping."""
 


### PR DESCRIPTION
## Summary

- Treat an already-closed QQBot websocket as an error in `_read_events()`
- Keep the listener on the existing reconnect path after a failed reconnect leaves `self._ws` closed
- Add a regression test for closed-but-present websocket objects

Fixes #17703

## Test Plan

- `python -m pytest tests/gateway/test_qqbot.py -q`
