### PR TITLE
fix: add CWD existence guard in LocalShell._run_bash() to prevent terminal bricking on deleted directories

### DIFF
--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1,6 +1,7 @@
 """Local execution environment — spawn-per-call with session snapshot."""
 
 import os
+import logging
 import platform
 import shutil
 import signal
@@ -9,9 +10,11 @@ import tempfile
 
 from tools.environments.base import BaseEnvironment, _pipe_stdin
 
-_IS_WINDOWS = platform.system() == "Windows"
+_IS_WINDOWS: bool = platform.system() == "Windows"
 
+logger = logging.getLogger(__name__)
 
+# --------------------------------------------------------------------------
 # Hermes-internal env vars that should NOT leak into terminal subprocesses.
 _HERMES_PROVIDER_ENV_FORCE_PREFIX = "_HERMES_FORCE_"
 
@@ -352,6 +355,18 @@ class LocalEnvironment(BaseEnvironment):
                 cmd_string = _prepend_shell_init(cmd_string, init_files)
         args = [bash, "-l", "-c", cmd_string] if login else [bash, "-c", cmd_string]
         run_env = _make_run_env(self.env)
+
+        # Guard: if the session's CWD was deleted (e.g. user ran `rm -rf` on
+        # the project dir from a previous command), subprocess.Popen fails
+        # with FileNotFoundError before the shell even starts, rendering the
+        # terminal tool permanently broken for the rest of the session.
+        # Fall back to $HOME so the agent can recover without a restart.
+        if not os.path.isdir(self.cwd):
+            fallback = os.path.expanduser("~")
+            logger.warning(
+                "CWD no longer exists: %s — falling back to %s", self.cwd, fallback
+            )
+            self.cwd = fallback
 
         proc = subprocess.Popen(
             args,


### PR DESCRIPTION
## Problem

When a session's working directory is deleted mid-session (e.g. `rm -rf ~/projects/some-project` from one command), subsequent `terminal()` and `execute_code()` calls permanently fail for the rest of the session.

**Root cause:** `local._run_bash()` calls `subprocess.Popen(..., cwd=self.cwd)`. When `self.cwd` points to a deleted directory, `Popen` throws `FileNotFoundError` before the shell even starts — the `builtin cd || exit 126` wrapper in `_wrap_command()` never gets a chance to run. Every subsequent tool call hits the same error, and the only recovery is a full agent restart.

## Fix

Add an `os.path.isdir(self.cwd)` check in `_run_bash()` right before `subprocess.Popen`. If the directory no longer exists, fall back to `$HOME` and log a warning. This lets the agent recover gracefully without a restart.

12-line change with a comment explaining the edge case. Zero impact on normal operation — the check is a single `os.path.isdir()` call that passes almost instantly.

## Testing

- Manual simulation: confirmed that `Popen(cwd=deleted)` raises `FileNotFoundError`, and fallback to `$HOME` succeeds
- Existing test suite: 60 passed, 1 pre-existing flaky (`test_wait_for_process_kills_subprocess_on_keyboardinterrupt` — unrelated drain thread race)
- Normal operation unaffected: `os.path.isdir()` on a valid directory returns in microseconds