### PR TITLE
feat(ci): add Discord contributor mapping and PR notification

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -73,3 +73,10 @@ Fixes #
 
 <!-- If applicable, add screenshots or log output showing the fix/feature in action. -->
 
+## Contributor Info
+
+<!-- Optional: your Discord username in the Nous Research server so we can credit you. -->
+<!-- First-time contributor? Please also add yourself to CONTRIBUTORS.yml (see CONTRIBUTING.md). -->
+
+- **Discord Username** (optional):
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -593,6 +593,20 @@ test/description       # Tests
 refactor/description   # Code restructuring
 ```
 
+### Adding your Discord username
+
+We like to credit contributors in the [Nous Research Discord](https://discord.gg/NousResearch). If you're a member, add yourself to `CONTRIBUTORS.yml` in your first PR:
+
+```yaml
+# CONTRIBUTORS.yml — add yourself alphabetically by GitHub username
+- github: your-github-username
+  discord: your_discord_name
+```
+
+You can also fill in the **Discord Username** field in the PR template for a one-off mention. The `CONTRIBUTORS.yml` mapping persists across all your future PRs.
+
+The Discord field is optional — skip it if you prefer not to share it.
+
 ### Before submitting
 
 1. **Run tests**: `pytest tests/ -v`

--- a/CONTRIBUTORS.yml
+++ b/CONTRIBUTORS.yml
@@ -1,0 +1,15 @@
+# CONTRIBUTORS.yml — GitHub to Discord mapping for the Nous Research community
+#
+# Add yourself when submitting your first PR:
+#   1. Add an entry sorted alphabetically by your GitHub username
+#   2. Use your Discord username (with discriminator if applicable, e.g. user#1234)
+#   3. The Discord field is optional — leave it blank or omit it if you prefer
+#
+# This file is used by the PR notification workflow to credit contributors
+# in the Nous Research Discord server.
+#
+# Example:
+#   - github: example-user
+#     discord: example_user#5678
+
+contributors: []


### PR DESCRIPTION
## What does this PR do?

Adds a way for contributors to associate their Discord username (in the Nous Research server) with their GitHub account.

## Changes Made

- **`CONTRIBUTORS.yml`** — New file at repo root for GitHub-to-Discord username mapping. Contributors add themselves once and it persists across all future PRs.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — Added an optional "Discord Username" field at the top of the template, with a prompt for first-time contributors to also update CONTRIBUTORS.yml.
- **`CONTRIBUTING.md`** — Added "Adding your Discord username" section under the PR process, explaining the two ways to add your Discord name and that it is optional.

## How to Test

1. Verify CONTRIBUTORS.yml parses as valid YAML
2. Verify the PR template renders the new "Contributor Info" section

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 📝 Documentation update