### PR TITLE
fix(gateway): refresh cached agents after MCP tool changes

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9269,11 +9269,17 @@ class GatewayRunner:
 
     @classmethod
     def _extract_cache_busting_config(cls, user_config: dict | None) -> dict:
-        """Pull the subset of config values that must bust the agent cache.
+        """Pull values that must bust the cached agent.
 
-        Returns a flat dict keyed by 'section.key'.  Missing keys and
-        non-dict sections yield None values, which still contribute to
-        the signature (so 'absent' vs 'present-and-null' differ).
+        Returns a flat dict keyed by 'section.key'.  Missing config keys and
+        non-dict sections yield None values, which still contribute to the
+        signature (so 'absent' vs 'present-and-null' differ).
+
+        The live tool registry generation is included too.  MCP reloads and
+        dynamic MCP tool-list changes mutate the registry without necessarily
+        changing config.yaml.  Cached AIAgent instances freeze their tool
+        schemas at construction time, so a registry generation change must
+        rebuild the agent before the next turn.
         """
         out: Dict[str, Any] = {}
         cfg = user_config if isinstance(user_config, dict) else {}
@@ -9283,6 +9289,12 @@ class GatewayRunner:
                 out[f"{section}.{key}"] = section_val.get(key)
             else:
                 out[f"{section}.{key}"] = None
+        try:
+            from tools.registry import registry
+
+            out["tools.registry_generation"] = getattr(registry, "_generation", None)
+        except Exception:
+            out["tools.registry_generation"] = None
         return out
 
     @staticmethod

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -170,6 +170,22 @@ class TestAgentConfigSignature:
         )
         assert sig_a == sig_b
 
+    def test_tool_registry_generation_change_busts_cache(self):
+        """MCP reloads mutate the tool registry, so cached agents must rebuild."""
+        from gateway.run import GatewayRunner
+
+        runtime = {"api_key": "k", "base_url": "u", "provider": "p"}
+        sig_before = GatewayRunner._agent_config_signature(
+            "m", runtime, ["telegram"], "",
+            cache_keys={"tools.registry_generation": 10},
+        )
+        sig_after = GatewayRunner._agent_config_signature(
+            "m", runtime, ["telegram"], "",
+            cache_keys={"tools.registry_generation": 11},
+        )
+
+        assert sig_before != sig_after
+
 
 class TestExtractCacheBustingConfig:
     """Verify _extract_cache_busting_config pulls the documented subset of
@@ -229,6 +245,17 @@ class TestExtractCacheBustingConfig:
         out = GatewayRunner._extract_cache_busting_config(None)
         for section, key in GatewayRunner._CACHE_BUSTING_CONFIG_KEYS:
             assert out[f"{section}.{key}"] is None
+        assert "tools.registry_generation" in out
+
+    def test_extract_includes_live_tool_registry_generation(self, monkeypatch):
+        from gateway.run import GatewayRunner
+        from tools.registry import registry
+
+        monkeypatch.setattr(registry, "_generation", 12345)
+
+        out = GatewayRunner._extract_cache_busting_config({})
+
+        assert out["tools.registry_generation"] == 12345
 
     def test_full_round_trip_busts_cache_on_real_edit(self):
         """End-to-end: simulate a config edit on main and verify the


### PR DESCRIPTION
## What does this PR do?

Includes the live tool registry generation in the gateway cached-agent signature so dynamic MCP tool changes rebuild the cached `AIAgent` on the next turn.

This fixes a stale-tool-schema path where `/reload-mcp` could reconnect MCP servers and register tools successfully, but an existing gateway session would keep reusing a cached agent constructed before those MCP tools existed.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`: adds `tools.registry_generation` to the cache-busting signature inputs used by gateway agent caching.
- `tests/gateway/test_agent_cache.py`: covers registry generation changes in the signature and verifies extraction reads the live registry generation.

## How to Test

1. Configure an MCP server and start the gateway.
2. Build a session before the MCP tools are loaded, then run `/reload-mcp`.
3. Send another message in the same session and verify the rebuilt agent can see the newly registered MCP tools.

Validation run locally:

`pytest -n 4 tests/gateway/test_agent_cache.py::TestAgentConfigSignature tests/gateway/test_agent_cache.py::TestExtractCacheBustingConfig`

Result: `19 passed`.

Also ran:

`pytest -n 4 tests/gateway/test_agent_cache.py`

Result: `54 passed, 1 failed`. The failure was `TestAgentCacheSpilloverLive.test_concurrent_inserts_settle_at_cap`, where an existing concurrent spillover worker thread exceeded the 30s join timeout while creating many real agents. The new signature/extraction coverage passed in that run and passed again in the focused rerun above.

Full suite run:

`pytest -n 4 tests/`

Result: `110 failed, 17716 passed, 50 skipped, 1 error in 418.47s`.

The full suite does not pass on this checkout. The collection error was `tests/gateway/test_session.py`, which imports missing `normalize_whatsapp_identifier` from `gateway.session`. Other failures were spread across existing gateway/platform/config/tool tests, including API server default port/config expectations, auxiliary client routing, blocking approval E2E, Dingtalk AI card mocks, Discord allowed mentions/connect/reply/slash command tests, profile backup/import, update autostash, config env expansion, tool resolution, MCP structured content, clipboard WSL detection, Tirith security, and transcription/TTS dotenv fallback tests.

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I have run `pytest tests/ -q` and all tests pass
- [x] I have added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I have tested on my platform: Ubuntu/WSL local checkout

### Documentation & Housekeeping

- [x] I have updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I have updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I have updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I have considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I have updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

N/A
