### PR TITLE
fix: gateway startup race conditions on restart

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -491,8 +491,8 @@ class TelegramAdapter(BasePlatformAdapter):
         # giving up, so the old session has time to expire.
         self._polling_conflict_count += 1
 
-        MAX_CONFLICT_RETRIES = 3
-        RETRY_DELAY = 10  # seconds
+        MAX_CONFLICT_RETRIES = 5  # Increased from 3 for longer Telegram session release time
+        RETRY_DELAY = 15  # Increased from 10 seconds
 
         if self._polling_conflict_count <= MAX_CONFLICT_RETRIES:
             logger.warning(
@@ -505,6 +505,16 @@ class TelegramAdapter(BasePlatformAdapter):
                     await self._app.updater.stop()
             except Exception:
                 pass
+            
+            # Clear any stale webhook that might interfere with polling
+            delete_webhook = getattr(self._bot, "delete_webhook", None)
+            if callable(delete_webhook):
+                try:
+                    await delete_webhook(drop_pending_updates=True)
+                    logger.info("[%s] Cleared webhook before polling retry", self.name)
+                except Exception as e:
+                    logger.warning("[%s] delete_webhook failed: %s", self.name, e)
+            
             await asyncio.sleep(RETRY_DELAY)
             await self._drain_polling_connections()
             try:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12102,14 +12102,45 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             "Gateway runtime lock is already held by another instance. Exiting."
         )
         return False
-    try:
-        write_pid_file()
-    except FileExistsError:
-        release_gateway_runtime_lock()
-        logger.error(
-            "PID file race lost to another gateway instance. Exiting."
-        )
-        return False
+    # Retry PID file acquisition when stale files from SIGKILL'd processes remain.
+    # The gap between get_running_pid() (cleanup) and write_pid_file() (creation)
+    # can be exploited by another restart race, leaving a stale file that blocks us.
+    MAX_PID_RETRIES = 3
+    PID_RETRY_DELAY = 0.5  # seconds
+    import time
+    for pid_attempt in range(MAX_PID_RETRIES):
+        try:
+            write_pid_file()
+            break  # Success
+        except FileExistsError:
+            # Check if another gateway is actually running
+            other_pid = get_running_pid()
+            if other_pid is not None and other_pid != os.getpid():
+                release_gateway_runtime_lock()
+                logger.error(
+                    "Another gateway instance (PID %d) is running. Exiting.",
+                    other_pid
+                )
+                return False
+            # Stale PID file from a killed process — clean it and retry
+            logger.warning(
+                "Stale PID file detected (attempt %d/%d), cleaning up...",
+                pid_attempt + 1, MAX_PID_RETRIES
+            )
+            from gateway.status import _get_pid_path
+            try:
+                _get_pid_path().unlink(missing_ok=True)
+            except Exception:
+                pass
+            if pid_attempt == MAX_PID_RETRIES - 1:
+                release_gateway_runtime_lock()
+                logger.error(
+                    "PID file race lost after %d retries. Exiting.",
+                    MAX_PID_RETRIES
+                )
+                return False
+            # Brief pause to reduce race window with concurrent restarts
+            time.sleep(PID_RETRY_DELAY)
     atexit.register(remove_pid_file)
     atexit.register(release_gateway_runtime_lock)
 


### PR DESCRIPTION
## Problem

Gateway fails to start after systemd SIGKILL due to two race conditions:

### 1. PID File Race

When systemd SIGKILLs the gateway process:
- `atexit` cleanup doesn't fire → PID file remains stale
- New gateway instance tries to start
- `get_running_pid()` detects stale file and cleans it
- But another restart races in during the cleanup→write gap
- `write_pid_file()` fails with `FileExistsError`
- Gateway exits with "PID file race lost"

### 2. Telegram Polling Conflict

When gateway restarts after SIGKILL:
- Old long-poll session not released on Telegram servers (~10-30s delay)
- New instance starts polling immediately
- Telegram returns 409 Conflict: "terminated by other getUpdates request"
- Current retry logic (3 retries × 10s = 30s) insufficient
- Gateway gives up on Telegram connection

## Solution

### Fix 1: PID File Retry Logic (`gateway/run.py`)
- On `FileExistsError`, check if another gateway is actually running
- If not, clean stale file and retry (max 3 attempts, 0.5s delay)
- Only fail if another process is confirmed running

### Fix 2: Telegram Polling Retry (`gateway/platforms/telegram.py`)
- Increase `MAX_CONFLICT_RETRIES` from 3 to 5
- Increase `RETRY_DELAY` from 10s to 15s (total wait: 75s)
- Call `delete_webhook()` before retry to clear stale sessions

## Testing

Manually tested by:
1. SIGKILL gateway process
2. systemd auto-restart
3. Verified gateway starts successfully without race errors
4. Verified Telegram reconnects after brief conflict retries

## Impact

- Users with systemd-managed gateways will no longer see startup failures after crashes/SIGKILL
- Telegram reconnection more resilient during rapid restarts
- No breaking changes — all changes are in error handling paths