### PR TITLE
fix(gateway): apply Discord channel policy to slash commands

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -2173,6 +2173,9 @@ class DiscordAdapter(BasePlatformAdapter):
         except Exception:
             pass  # logging must never block command dispatch
 
+        if await self._reject_disallowed_slash_channel(interaction, command_text):
+            return
+
         await interaction.response.defer(ephemeral=True)
         event = self._build_slash_event(interaction, command_text)
         await self.handle_message(event)
@@ -2313,6 +2316,8 @@ class DiscordAdapter(BasePlatformAdapter):
             message: str = "",
             auto_archive_duration: int = 1440,
         ):
+            if await self._reject_disallowed_slash_channel(interaction, "/thread"):
+                return
             await interaction.response.defer(ephemeral=True)
             await self._handle_thread_create_slash(interaction, name, message, auto_archive_duration)
 
@@ -2722,6 +2727,77 @@ class DiscordAdapter(BasePlatformAdapter):
         if isinstance(raw, str) and raw.strip():
             return {part.strip() for part in raw.split(",") if part.strip()}
         return set()
+
+    def _discord_channel_ids(
+        self,
+        channel: Any,
+        fallback_channel_id: Any = None,
+    ) -> set[str]:
+        """Return the Discord channel and parent IDs used for channel policy checks."""
+        channel_ids: set[str] = set()
+        channel_id = getattr(channel, "id", None)
+        if channel_id is None:
+            channel_id = fallback_channel_id
+        if channel_id is not None:
+            channel_ids.add(str(channel_id))
+
+        parent_channel_id = self._get_parent_channel_id(channel)
+        if parent_channel_id:
+            channel_ids.add(parent_channel_id)
+        return channel_ids
+
+    def _discord_channel_allowed_by_lists(
+        self,
+        channel: Any,
+        fallback_channel_id: Any = None,
+        is_dm: bool = False,
+    ) -> bool:
+        """Apply Discord allowed/ignored channel lists to messages and slash commands."""
+        if is_dm or isinstance(channel, discord.DMChannel):
+            return True
+
+        channel_ids = self._discord_channel_ids(channel, fallback_channel_id)
+
+        allowed_channels_raw = os.getenv("DISCORD_ALLOWED_CHANNELS", "")
+        if allowed_channels_raw:
+            allowed_channels = {ch.strip() for ch in allowed_channels_raw.split(",") if ch.strip()}
+            if "*" not in allowed_channels and not (channel_ids & allowed_channels):
+                return False
+
+        ignored_channels_raw = os.getenv("DISCORD_IGNORED_CHANNELS", "")
+        ignored_channels = {ch.strip() for ch in ignored_channels_raw.split(",") if ch.strip()}
+        if "*" in ignored_channels or (channel_ids & ignored_channels):
+            return False
+
+        return True
+
+    async def _reject_disallowed_slash_channel(
+        self,
+        interaction: discord.Interaction,
+        command_text: str,
+    ) -> bool:
+        """Reject a Discord slash command when channel allow/ignore policy blocks it."""
+        if self._discord_channel_allowed_by_lists(
+            getattr(interaction, "channel", None),
+            fallback_channel_id=getattr(interaction, "channel_id", None),
+            is_dm=getattr(interaction, "guild_id", None) is None,
+        ):
+            return False
+
+        logger.info(
+            "[%s] Ignoring slash '%s' in non-allowed or ignored channel: %s",
+            self.name,
+            command_text,
+            getattr(interaction, "channel_id", None),
+        )
+        try:
+            await interaction.response.send_message(
+                "This command is not enabled in this channel.",
+                ephemeral=True,
+            )
+        except Exception as e:
+            logger.debug("Discord slash rejection failed: %s", e)
+        return True
 
     def _thread_parent_channel(self, channel: Any) -> Any:
         """Return the parent text channel when invoked from a thread."""
@@ -3198,23 +3274,9 @@ class DiscordAdapter(BasePlatformAdapter):
             normalized_content = normalized_content.replace(f"<@!{self._client.user.id}>", "").strip()
             message.content = normalized_content
         if not isinstance(message.channel, discord.DMChannel):
-            channel_ids = {str(message.channel.id)}
-            if parent_channel_id:
-                channel_ids.add(parent_channel_id)
-
-            # Check allowed channels - if set, only respond in these channels
-            allowed_channels_raw = os.getenv("DISCORD_ALLOWED_CHANNELS", "")
-            if allowed_channels_raw:
-                allowed_channels = {ch.strip() for ch in allowed_channels_raw.split(",") if ch.strip()}
-                if "*" not in allowed_channels and not (channel_ids & allowed_channels):
-                    logger.debug("[%s] Ignoring message in non-allowed channel: %s", self.name, channel_ids)
-                    return
-
-            # Check ignored channels - never respond even when mentioned
-            ignored_channels_raw = os.getenv("DISCORD_IGNORED_CHANNELS", "")
-            ignored_channels = {ch.strip() for ch in ignored_channels_raw.split(",") if ch.strip()}
-            if "*" in ignored_channels or (channel_ids & ignored_channels):
-                logger.debug("[%s] Ignoring message in ignored channel: %s", self.name, channel_ids)
+            channel_ids = self._discord_channel_ids(message.channel)
+            if not self._discord_channel_allowed_by_lists(message.channel):
+                logger.debug("[%s] Ignoring message in non-allowed or ignored channel: %s", self.name, channel_ids)
                 return
 
             free_channels = self._discord_free_response_channels()

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -110,6 +110,12 @@ def adapter():
     return adapter
 
 
+@pytest.fixture(autouse=True)
+def _clear_discord_channel_policy_env(monkeypatch):
+    monkeypatch.delenv("DISCORD_ALLOWED_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+
+
 # ------------------------------------------------------------------
 # /thread slash command registration
 # ------------------------------------------------------------------
@@ -129,6 +135,25 @@ async def test_registers_native_thread_slash_command(adapter):
 
     interaction.response.defer.assert_awaited_once_with(ephemeral=True)
     adapter._handle_thread_create_slash.assert_awaited_once_with(interaction, "Planning", "", 1440)
+
+
+@pytest.mark.asyncio
+async def test_native_thread_slash_command_respects_channel_policy(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "999")
+    adapter._handle_thread_create_slash = AsyncMock()
+    adapter._register_slash_commands()
+
+    command = adapter._client.tree.commands["thread"]
+    interaction = _fake_slash_interaction(_FakeThreadChannel(channel_id=555, parent_id=100))
+
+    await command(interaction, name="Planning", message="", auto_archive_duration=1440)
+
+    interaction.response.defer.assert_not_awaited()
+    interaction.response.send_message.assert_awaited_once_with(
+        "This command is not enabled in this channel.",
+        ephemeral=True,
+    )
+    adapter._handle_thread_create_slash.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -635,6 +660,93 @@ def _fake_message(channel, *, content="Hello", author_id=42, display_name="Jezza
     )
 
 
+def _fake_slash_interaction(channel):
+    return SimpleNamespace(
+        channel=channel,
+        channel_id=getattr(channel, "id", None),
+        guild_id=getattr(getattr(channel, "guild", None), "id", None),
+        user=SimpleNamespace(id=42, name="jezza", display_name="Jezza"),
+        response=SimpleNamespace(
+            defer=AsyncMock(),
+            send_message=AsyncMock(),
+        ),
+        edit_original_response=AsyncMock(),
+        delete_original_response=AsyncMock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_native_slash_command_respects_allowed_parent_channel(adapter, monkeypatch):
+    """Slash commands in threads should pass when the parent channel is allowlisted."""
+    monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "100")
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+
+    interaction = _fake_slash_interaction(_FakeThreadChannel(channel_id=555, parent_id=100))
+    adapter.handle_message = AsyncMock()
+
+    await adapter._run_simple_slash(interaction, "/status", "Status sent~")
+
+    interaction.response.defer.assert_awaited_once_with(ephemeral=True)
+    interaction.response.send_message.assert_not_awaited()
+    adapter.handle_message.assert_awaited_once()
+    interaction.edit_original_response.assert_awaited_once_with(content="Status sent~")
+
+
+@pytest.mark.asyncio
+async def test_native_slash_command_rejects_non_allowed_channel(adapter, monkeypatch):
+    """Native slash commands must not bypass DISCORD_ALLOWED_CHANNELS."""
+    monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "999")
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+
+    interaction = _fake_slash_interaction(_FakeThreadChannel(channel_id=555, parent_id=100))
+    adapter.handle_message = AsyncMock()
+
+    await adapter._run_simple_slash(interaction, "/reset", "Session reset~")
+
+    interaction.response.defer.assert_not_awaited()
+    interaction.response.send_message.assert_awaited_once_with(
+        "This command is not enabled in this channel.",
+        ephemeral=True,
+    )
+    adapter.handle_message.assert_not_awaited()
+    interaction.edit_original_response.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_native_slash_command_rejects_ignored_channel(adapter, monkeypatch):
+    """Native slash commands must also respect DISCORD_IGNORED_CHANNELS."""
+    monkeypatch.delenv("DISCORD_ALLOWED_CHANNELS", raising=False)
+    monkeypatch.setenv("DISCORD_IGNORED_CHANNELS", "100")
+
+    interaction = _fake_slash_interaction(_FakeThreadChannel(channel_id=555, parent_id=100))
+    adapter.handle_message = AsyncMock()
+
+    await adapter._run_simple_slash(interaction, "/status", "Status sent~")
+
+    interaction.response.send_message.assert_awaited_once_with(
+        "This command is not enabled in this channel.",
+        ephemeral=True,
+    )
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_native_slash_command_allows_dm_with_channel_allowlist(adapter, monkeypatch):
+    """DM slash commands keep the same allowlist exemption as DM messages."""
+    monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "999")
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+
+    interaction = _fake_slash_interaction(_FakeTextChannel(channel_id=555))
+    interaction.guild_id = None
+    adapter.handle_message = AsyncMock()
+
+    await adapter._run_simple_slash(interaction, "/status")
+
+    interaction.response.defer.assert_awaited_once_with(ephemeral=True)
+    interaction.response.send_message.assert_not_awaited()
+    adapter.handle_message.assert_awaited_once()
+
+
 @pytest.mark.asyncio
 async def test_auto_thread_creates_thread_and_redirects(adapter, monkeypatch):
     """When DISCORD_AUTO_THREAD=true, a new thread is created and the event routes there."""
@@ -965,4 +1077,3 @@ def test_register_skill_command_autocomplete_filters_by_name_and_description(ada
     # (covered in other tests). The autocomplete filter itself is exercised
     # via direct function call in the real-discord integration path.
     assert skill_cmd.callback is not None
-


### PR DESCRIPTION
## What does this PR do?

Applies Discord channel allow/ignore policy checks to native slash command interactions before dispatching them to the gateway session handler. This prevents a bot whose `DISCORD_ALLOWED_CHANNELS` excludes a channel or thread parent from still executing native slash commands there.

The change also routes normal Discord messages through the same helper so message and slash command channel policy behavior stays aligned. DM slash interactions keep the same allowlist exemption as DM messages.

The `/thread` native slash command is covered too, since it creates Discord-side state directly instead of going through `_run_simple_slash()`.

## Related Issue

Fixes #17724

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `gateway/platforms/discord.py`: add shared Discord channel policy helpers and reject blocked native slash commands before deferring or dispatching.
- `gateway/platforms/discord.py`: apply the same policy to `/thread`, which bypasses `_run_simple_slash()`.
- `tests/gateway/test_discord_slash_commands.py`: add regression coverage for native slash commands in allowed, non-allowed, ignored-channel, DM, and `/thread` contexts.

## How to Test

1. Configure a Discord bot with `DISCORD_ALLOWED_CHANNELS` set to one parent channel.
2. Invoke one of its native slash commands, such as `/reset`, from a thread whose parent channel is not allowlisted.
3. Confirm the command is rejected ephemerally and does not dispatch to `handle_message`.

Targeted Discord tests passed locally:

```bash
venv/bin/python -m pytest tests/gateway/test_discord_slash_commands.py tests/gateway/test_discord_allowed_channels.py tests/gateway/test_discord_channel_controls.py tests/gateway/test_discord_free_response.py tests/gateway/test_discord_reply_mode.py -q
```

Result: `115 passed in 4.20s`

Full suite was also run locally against this branch and against current `origin/main` for comparison:

```bash
venv/bin/python -m pytest tests/ -q --tb=short --junitxml=/tmp/hermes-pr-full.xml
```

Branch result: `120 failed, 17813 passed, 48 skipped, 226 warnings in 193.31s`

Baseline `origin/main` result with the same command/environment: `131 failed, 17797 passed, 48 skipped, 225 warnings in 243.22s`

The full suite is not currently clean on `origin/main`; the targeted Discord channel-policy regression tests pass.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A, Discord gateway logic only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```text
115 passed in 4.20s

Branch full suite:
120 failed, 17813 passed, 48 skipped, 226 warnings in 193.31s

origin/main full suite baseline:
131 failed, 17797 passed, 48 skipped, 225 warnings in 243.22s
```
