### PR TITLE
fix(osv_check): ignore latest tag for scoped npm packages

### DIFF
--- a/tests/tools/test_osv_check.py
+++ b/tests/tools/test_osv_check.py
@@ -50,6 +50,14 @@ class TestParseNpmPackage:
     def test_latest_ignored(self):
         assert _parse_npm_package("react@latest") == ("react", None)
 
+    def test_scoped_latest_ignored(self):
+        assert _parse_npm_package("@scope/pkg@latest") == ("@scope/pkg", None)
+
+    def test_scoped_mcp_latest_ignored(self):
+        assert _parse_npm_package(
+            "@modelcontextprotocol/server-filesystem@latest"
+        ) == ("@modelcontextprotocol/server-filesystem", None)
+
 
 class TestParsePypiPackage:
     def test_simple(self):

--- a/tools/osv_check.py
+++ b/tools/osv_check.py
@@ -108,7 +108,10 @@ def _parse_npm_package(token: str) -> Tuple[Optional[str], Optional[str]]:
         # Scoped: @scope/name@version
         match = re.match(r"^(@[^/]+/[^@]+)(?:@(.+))?$", token)
         if match:
-            return match.group(1), match.group(2)
+            name, version = match.group(1), match.group(2)
+            if version == "latest":
+                version = None
+            return name, version
         return token, None
     # Unscoped: name@version
     if "@" in token:


### PR DESCRIPTION
## What does this PR do?

Fixes npm package parsing in the OSV malware check for scoped packages using the `latest` dist-tag.

Previously, `react@latest` ignored `latest`, but `@scope/pkg@latest` parsed `latest` as a concrete version. This PR makes scoped packages match the existing unscoped behavior.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Updated `tools/osv_check.py` to ignore `latest` for scoped npm package specs.
- Added regression tests in `tests/tools/test_osv_check.py`.

## How to Test

```bash
python -m pytest tests/tools/test_osv_check.py -q -o addopts=
```

Result:

```text
26 passed
```

## Checklist

- [x] My commit messages follow Conventional Commits
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on Windows 11, Python 3.11.9
