### PR TITLE
feat: QMD memory provider (Hermes-native MemoryProvider plugin)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,7 @@ mini-swe-agent/
 result
 website/static/api/skills-index.json
 models-dev-upstream/
+
+# habibiserver-local — never commit
+.venv-pr/
+PR_BODY.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ hermes-agent/
 │   │                     #   webhook, api_server, ...). See ADDING_A_PLATFORM.md.
 │   └── builtin_hooks/    # Extension point for always-registered gateway hooks (none shipped)
 ├── plugins/              # Plugin system (see "Plugins" section below)
-│   ├── memory/           # Memory-provider plugins (honcho, mem0, supermemory, ...)
+│   ├── memory/           # Memory-provider plugins (honcho, mem0, supermemory, qmd, ...)
 │   ├── context_engine/   # Context-engine plugins
 │   └── <others>/         # Dashboard, image-gen, disk-cleanup, examples, ...
 ├── optional-skills/      # Heavier/niche skills shipped but NOT active by default
@@ -461,7 +461,7 @@ explicitly (it's idempotent).
 
 Separate discovery system for pluggable memory backends. Current built-in
 providers include **honcho, mem0, supermemory, byterover, hindsight,
-holographic, openviking, retaindb**.
+holographic, openviking, retaindb, qmd**.
 
 Each provider implements the `MemoryProvider` ABC (see `agent/memory_provider.py`)
 and is orchestrated by `agent/memory_manager.py`. Lifecycle hooks include

--- a/plugins/memory/qmd/README.md
+++ b/plugins/memory/qmd/README.md
@@ -1,0 +1,120 @@
+# QMD memory provider
+
+Read-only Hermes `MemoryProvider` plugin that queries a self-hosted
+**QMD-compatible HTTP API**: a small JSON gateway over a vector index
+(e.g. sqlite-vec) with optional cross-encoder reranking.
+
+> This plugin connects to a remote QMD-compatible HTTP API. It does
+> not vendor or depend on `@tobilu/qmd`. The protocol is OpenClaw's
+> wire format — `POST /search` and `GET /health`.
+
+This plugin only **reads**. Writes still flow through:
+
+- the built-in `MEMORY.md` / `USER.md` path on the Hermes side, and
+- the QMD ingest pipeline running alongside the QMD server.
+
+Treat this provider as a remote RAG layer on top of curated memory
+collections.
+
+## Tools exposed
+
+### `qmd_search(query, top_k=5, index=None, collection_filter=None)`
+Semantic search against the remote QMD index. Returns ranked hits with
+`docid`, `file` (a `qmd://collection/path` URI), `title`, `score`,
+`rerank_score`, plus a truncated `context` and `snippet`.
+
+- `query` (string, required) — natural-language query.
+- `top_k` (int, default 5, max 25) — number of hits to return.
+- `index` (string, default `default`) — index name. Use `qmd_status`
+  to enumerate available indexes on your deployment.
+- `collection_filter` (string, optional) — restrict hits whose
+  `qmd://<collection>/...` URI's collection equals or starts with this
+  prefix (e.g. `session-logs`, `global-facts`).
+
+### `qmd_status()`
+Hits the remote `/health` endpoint and returns the JSON: uptime,
+monitored indexes, per-index document counts, embedding dimensions,
+and the active rerank URL. Use to diagnose retrieval problems.
+
+## System-prompt block
+Three-line markdown summary identifying the active default index and
+host, plus a one-liner reminder that the provider is read-only.
+
+## Prefetch
+Each turn, if the user message is at least
+`MIN_PREFETCH_QUERY_LEN` (12) characters and the circuit breaker is
+closed, a background thread fires a `top_k=3` search against the
+default index. The result is stitched into the next-turn prefetch
+context as `## QMD Memory` followed by `- **title** (uri)\n  snippet`
+lines. Overlapping prefetches are guarded — if a previous thread is
+still alive, the new one is skipped.
+
+## Circuit breaker
+Mirrors the mem0 plugin: 5 consecutive failures pauses calls for
+120 seconds. Successes reset the counter. Cooldown reads
+`time.monotonic()`.
+
+## Configuration
+
+Secrets live in `$HERMES_HOME/.env`:
+
+```
+QMD_REMOTE_API_TOKEN=<bearer token>
+QMD_REMOTE_API_BASE_URL=http://localhost:18181   # optional
+QMD_DEFAULT_INDEX=default                         # optional
+QMD_TIMEOUT=30                                    # optional
+```
+
+Non-secret overrides go to `$HERMES_HOME/qmd.json`:
+
+```json
+{
+  "base_url": "http://localhost:18181",
+  "default_index": "default",
+  "timeout": 30,
+  "prefetch_top_k": 3,
+  "manual_top_k": 5,
+  "snippet_max": 300
+}
+```
+
+`save_config()` only ever writes to `qmd.json`. The `api_token` field
+is filtered out — it must come from the environment (the `hermes
+memory setup` wizard sends it to `.env` because the schema marks it
+`secret: True`).
+
+## Wire protocol
+
+The remote service must implement two endpoints:
+
+- `POST /search` with body `{"query": str, "topK": int, "index": str}`
+  returning `{"results": [{"docid", "file", "title", "score",
+  "externalRerankScore" (optional), "context", "snippet"}]}`.
+- `GET /health` returning a JSON object with at minimum `indexes`
+  (per-index metadata) and `uptime_s`.
+
+Both endpoints expect `Authorization: Bearer <QMD_REMOTE_API_TOKEN>`.
+
+## Activation
+
+Set the active provider in `$HERMES_HOME/config.yaml`:
+
+```yaml
+memory:
+  provider: qmd
+```
+
+Or run `hermes memory setup` and select **qmd**.
+
+## Limitations
+- Read-only. Writes are out of scope.
+- Single index per call; cross-index fan-out is intentionally not
+  implemented — pick the right index or use `qmd_status` to enumerate
+  what's available.
+- The `collection_filter` is a simple prefix match on the
+  `qmd://collection/...` URI segment — it is **not** a server-side
+  filter. The full `top_k` results are fetched first, then filtered
+  client-side. If you need precise scoping for a small collection,
+  bump `top_k` accordingly.
+- HTTP timeout defaults to 30 s. The underlying `httpx.Client` keeps
+  up to 8 connections (4 keep-alive) for thread-safe concurrent use.

--- a/plugins/memory/qmd/__init__.py
+++ b/plugins/memory/qmd/__init__.py
@@ -1,0 +1,625 @@
+"""QMD memory provider — read-only retrieval against a QMD HTTP API.
+
+QMD is a small JSON HTTP API on top of a vector index (e.g.
+sqlite-vec) with optional cross-encoder reranking. This provider
+sends queries to it and returns ranked snippets. Point it at a
+self-hosted QMD instance via ``QMD_REMOTE_API_BASE_URL``.
+
+This plugin connects to a remote QMD-compatible HTTP API. It does
+not vendor or depend on @tobilu/qmd. The protocol is OpenClaw's
+wire format (``POST /search``, ``GET /health``).
+
+This provider is intentionally **read-only**: writes still go through
+the existing built-in MEMORY.md path and the QMD ingest pipeline on
+the QMD server. Hermes only queries.
+
+Config via environment variables (preferred — token lives in
+$HERMES_HOME/.env so the secret never lands in the JSON file):
+
+  QMD_REMOTE_API_TOKEN     — bearer token for the remote API (required)
+  QMD_REMOTE_API_BASE_URL  — base URL (default: http://localhost:18181)
+  QMD_DEFAULT_INDEX        — default index name (default: default)
+  QMD_TIMEOUT              — HTTP timeout in seconds (default: 30)
+
+Or via $HERMES_HOME/qmd.json (non-secret keys only):
+
+  {
+    "base_url":      "http://localhost:18181",
+    "default_index": "default",
+    "timeout":       30,
+    "prefetch_top_k": 3,
+    "manual_top_k":  5,
+    "snippet_max":   300
+  }
+
+Tools exposed:
+
+  qmd_search(query, top_k=5, index=None, collection_filter=None)
+      — semantic search against the QMD remote API.  Returns top hits
+        with snippets, scores, source URIs, and rerank scores.
+
+  qmd_status()
+      — fetch the remote /health payload (uptime, monitored indexes,
+        per-index document counts).  No params.
+
+Lifecycle hooks implemented:
+
+  is_available           — true iff QMD_REMOTE_API_TOKEN is set
+  initialize             — loads config, primes httpx client lazily
+  shutdown               — closes httpx client, joins prefetch thread
+  system_prompt_block    — 3-line markdown summary
+  queue_prefetch         — background thread, mem0 pattern
+  prefetch               — drains the queued result
+  sync_turn              — no-op (read-only)
+  get_tool_schemas       — qmd_search + qmd_status
+  handle_tool_call       — dispatches to _qmd_search / _qmd_status
+  get_config_schema      — used by `hermes memory setup`
+  save_config            — writes only $HERMES_HOME/qmd.json (never .env)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from agent.memory_provider import MemoryProvider
+from tools.registry import tool_error
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_BASE_URL = "http://localhost:18181"
+DEFAULT_INDEX = "default"
+DEFAULT_TIMEOUT = 30
+PREFETCH_TOP_K = 3
+MANUAL_TOP_K = 5
+SNIPPET_MAX = 300
+MIN_PREFETCH_QUERY_LEN = 12
+
+# Circuit breaker — mirrors mem0's: N consecutive failures pauses calls
+# for COOLDOWN seconds to avoid hammering a down server.
+_BREAKER_THRESHOLD = 5
+_BREAKER_COOLDOWN_SECS = 120
+
+# qmd:// URI: qmd://<collection>/<relative/path>
+_QMD_URI_RE = re.compile(r"^qmd://([^/]+)/(.+)$")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _truncate(s: str, n: int = SNIPPET_MAX) -> str:
+    """Truncate *s* to at most *n* chars, appending an ellipsis if cut."""
+    if not s:
+        return ""
+    if len(s) <= n:
+        return s
+    return s[: max(0, n - 1)].rstrip() + "…"
+
+
+def _collection_from_file(file_field: str) -> Optional[str]:
+    """Extract the collection name from a ``qmd://<collection>/<path>`` URI."""
+    if not file_field:
+        return None
+    m = _QMD_URI_RE.match(file_field)
+    if m:
+        return m.group(1)
+    return None
+
+
+def _load_config() -> dict:
+    """Load config from env vars, with $HERMES_HOME/qmd.json overrides.
+
+    Env vars provide defaults; qmd.json (if present) overrides individual
+    keys.  ``api_token`` is intentionally never read from JSON — it must
+    come from the env so secrets stay in .env.
+    """
+    # Lazy import to avoid circular import at module load time
+    from hermes_constants import get_hermes_home
+
+    config = {
+        "api_token": os.environ.get("QMD_REMOTE_API_TOKEN", ""),
+        "base_url": os.environ.get("QMD_REMOTE_API_BASE_URL", DEFAULT_BASE_URL),
+        "default_index": os.environ.get("QMD_DEFAULT_INDEX", DEFAULT_INDEX),
+        "timeout": int(os.environ.get("QMD_TIMEOUT", str(DEFAULT_TIMEOUT))),
+        "prefetch_top_k": PREFETCH_TOP_K,
+        "manual_top_k": MANUAL_TOP_K,
+        "snippet_max": SNIPPET_MAX,
+    }
+
+    config_path = get_hermes_home() / "qmd.json"
+    if config_path.exists():
+        try:
+            file_cfg = json.loads(config_path.read_text(encoding="utf-8"))
+            # Never let the JSON file inject api_token — secret stays in .env
+            for k, v in file_cfg.items():
+                if k == "api_token":
+                    continue
+                if v is None or v == "":
+                    continue
+                config[k] = v
+        except Exception as e:
+            logger.debug("Failed to read qmd.json: %s", e)
+
+    return config
+
+
+# ---------------------------------------------------------------------------
+# Tool schemas
+# ---------------------------------------------------------------------------
+
+SEARCH_SCHEMA = {
+    "name": "qmd_search",
+    "description": (
+        "Search a QMD memory index by meaning. Returns ranked snippets "
+        "with source URIs (qmd://collection/path), vector score, and an "
+        "optional rerank score. Use for cross-session recall, distilled "
+        "facts, and curated long-term memory. Read-only — writes still "
+        "go through MEMORY.md and the QMD ingest pipeline."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "What to search for (natural language).",
+            },
+            "top_k": {
+                "type": "integer",
+                "description": f"Max results (default: {MANUAL_TOP_K}, max: 25).",
+            },
+            "index": {
+                "type": "string",
+                "description": (
+                    f"Index name to query. Defaults to '{DEFAULT_INDEX}'. "
+                    "Use qmd_status to list available indexes."
+                ),
+            },
+            "collection_filter": {
+                "type": "string",
+                "description": (
+                    "Optional collection prefix to filter by, e.g. "
+                    "'session-logs'. Matches against the qmd:// URI's "
+                    "collection segment as a prefix (client-side filter)."
+                ),
+            },
+        },
+        "required": ["query"],
+    },
+}
+
+STATUS_SCHEMA = {
+    "name": "qmd_status",
+    "description": (
+        "Fetch the QMD service /health status: uptime, monitored "
+        "indexes, per-index document counts and embedding dimensions, "
+        "rerank URL. Use to diagnose retrieval issues."
+    ),
+    "parameters": {"type": "object", "properties": {}, "required": []},
+}
+
+
+# ---------------------------------------------------------------------------
+# MemoryProvider implementation
+# ---------------------------------------------------------------------------
+
+class QMDMemoryProvider(MemoryProvider):
+    """QMD remote-API memory provider (read-only retrieval)."""
+
+    def __init__(self):
+        self._config: Optional[dict] = None
+        self._api_token: str = ""
+        self._base_url: str = DEFAULT_BASE_URL
+        self._default_index: str = DEFAULT_INDEX
+        self._timeout: int = DEFAULT_TIMEOUT
+        self._prefetch_top_k: int = PREFETCH_TOP_K
+        self._manual_top_k: int = MANUAL_TOP_K
+        self._snippet_max: int = SNIPPET_MAX
+
+        self._client: Optional[httpx.Client] = None
+        self._client_lock = threading.Lock()
+
+        self._prefetch_result: str = ""
+        self._prefetch_lock = threading.Lock()
+        self._prefetch_thread: Optional[threading.Thread] = None
+
+        # Circuit breaker state
+        self._consecutive_failures: int = 0
+        self._breaker_open_until: float = 0.0
+
+    # -- Identity ----------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        return "qmd"
+
+    def is_available(self) -> bool:
+        cfg = _load_config()
+        return bool(cfg.get("api_token"))
+
+    # -- Config ------------------------------------------------------------
+
+    def get_config_schema(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "key": "api_token",
+                "description": "QMD remote API bearer token",
+                "secret": True,
+                "required": True,
+                "env_var": "QMD_REMOTE_API_TOKEN",
+            },
+            {
+                "key": "base_url",
+                "description": "QMD remote API base URL",
+                "default": DEFAULT_BASE_URL,
+                "env_var": "QMD_REMOTE_API_BASE_URL",
+            },
+            {
+                "key": "default_index",
+                "description": "Default index name",
+                "default": DEFAULT_INDEX,
+                # No fixed choices — depends on the deployment
+            },
+            {
+                "key": "timeout",
+                "description": "HTTP timeout (seconds)",
+                "default": str(DEFAULT_TIMEOUT),
+            },
+        ]
+
+    def save_config(self, values: Dict[str, Any], hermes_home: str) -> None:
+        """Write non-secret config to $HERMES_HOME/qmd.json.
+
+        ``api_token`` is filtered out — it lives in .env via the wizard's
+        ``secret: True`` field.  Never write secrets to qmd.json.
+        """
+        config_path = Path(hermes_home) / "qmd.json"
+        existing: Dict[str, Any] = {}
+        if config_path.exists():
+            try:
+                existing = json.loads(config_path.read_text(encoding="utf-8"))
+            except Exception:
+                existing = {}
+
+        for k, v in values.items():
+            if k == "api_token":
+                # Never persist the token to the JSON file
+                continue
+            if v is None or v == "":
+                continue
+            existing[k] = v
+
+        config_path.write_text(json.dumps(existing, indent=2), encoding="utf-8")
+
+    # -- Lifecycle ---------------------------------------------------------
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        cfg = _load_config()
+        self._config = cfg
+        self._api_token = cfg.get("api_token", "")
+        self._base_url = (cfg.get("base_url") or DEFAULT_BASE_URL).rstrip("/")
+        self._default_index = cfg.get("default_index") or DEFAULT_INDEX
+        try:
+            self._timeout = int(cfg.get("timeout") or DEFAULT_TIMEOUT)
+        except (TypeError, ValueError):
+            self._timeout = DEFAULT_TIMEOUT
+        try:
+            self._prefetch_top_k = int(cfg.get("prefetch_top_k") or PREFETCH_TOP_K)
+        except (TypeError, ValueError):
+            self._prefetch_top_k = PREFETCH_TOP_K
+        try:
+            self._manual_top_k = int(cfg.get("manual_top_k") or MANUAL_TOP_K)
+        except (TypeError, ValueError):
+            self._manual_top_k = MANUAL_TOP_K
+        try:
+            self._snippet_max = int(cfg.get("snippet_max") or SNIPPET_MAX)
+        except (TypeError, ValueError):
+            self._snippet_max = SNIPPET_MAX
+
+    def shutdown(self) -> None:
+        # Wait briefly for any in-flight prefetch
+        t = self._prefetch_thread
+        if t and t.is_alive():
+            try:
+                t.join(timeout=3.0)
+            except Exception:
+                pass
+        # Close the httpx client
+        with self._client_lock:
+            if self._client is not None:
+                try:
+                    self._client.close()
+                except Exception:
+                    pass
+                self._client = None
+
+    # -- HTTP plumbing -----------------------------------------------------
+
+    def _get_client(self) -> httpx.Client:
+        """Return a cached httpx.Client with connection pooling.
+
+        Lock-protected so concurrent threads (prefetch + tool call) don't
+        race on creation.
+        """
+        with self._client_lock:
+            if self._client is not None:
+                return self._client
+            self._client = httpx.Client(
+                base_url=self._base_url,
+                timeout=self._timeout,
+                limits=httpx.Limits(max_connections=8, max_keepalive_connections=4),
+            )
+            return self._client
+
+    def _auth_headers(self) -> Dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self._api_token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+    # -- Circuit breaker ---------------------------------------------------
+
+    def _is_breaker_open(self) -> bool:
+        if self._consecutive_failures < _BREAKER_THRESHOLD:
+            return False
+        if time.monotonic() >= self._breaker_open_until:
+            self._consecutive_failures = 0
+            return False
+        return True
+
+    def _record_success(self) -> None:
+        self._consecutive_failures = 0
+
+    def _record_failure(self) -> None:
+        self._consecutive_failures += 1
+        if self._consecutive_failures >= _BREAKER_THRESHOLD:
+            self._breaker_open_until = time.monotonic() + _BREAKER_COOLDOWN_SECS
+            logger.warning(
+                "QMD circuit breaker tripped after %d consecutive failures. "
+                "Pausing API calls for %ds.",
+                self._consecutive_failures, _BREAKER_COOLDOWN_SECS,
+            )
+
+    # -- System-prompt block ----------------------------------------------
+
+    def system_prompt_block(self) -> str:
+        return (
+            "# QMD Memory\n"
+            f"Active. Index: {self._default_index} (host: {self._base_url}).\n"
+            "Use qmd_search to recall facts and curated memory; "
+            "qmd_status to check the remote service. Read-only."
+        )
+
+    # -- Prefetch ----------------------------------------------------------
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        # Drain any queued background result
+        t = self._prefetch_thread
+        if t and t.is_alive():
+            try:
+                t.join(timeout=2.0)
+            except Exception:
+                pass
+        with self._prefetch_lock:
+            result = self._prefetch_result
+            self._prefetch_result = ""
+        if not result:
+            return ""
+        return f"## QMD Memory\n{result}"
+
+    def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
+        if not self._api_token:
+            return
+        if not query or len(query) < MIN_PREFETCH_QUERY_LEN:
+            return
+        if self._is_breaker_open():
+            return
+
+        # Guard against overlapping background threads (mem0 pattern)
+        prev = self._prefetch_thread
+        if prev and prev.is_alive():
+            return
+
+        def _run():
+            try:
+                hits = self._search_remote(
+                    query=query,
+                    top_k=self._prefetch_top_k,
+                    index=self._default_index,
+                    collection_filter=None,
+                )
+                self._record_success()
+                if not hits:
+                    return
+                lines = []
+                for h in hits:
+                    title = h.get("title") or h.get("file") or h.get("docid") or ""
+                    snippet = _truncate(h.get("snippet") or "", self._snippet_max)
+                    src = h.get("file") or ""
+                    line = f"- **{title}** ({src})\n  {snippet}" if snippet else f"- **{title}** ({src})"
+                    lines.append(line)
+                with self._prefetch_lock:
+                    self._prefetch_result = "\n".join(lines)
+            except Exception as e:
+                self._record_failure()
+                logger.debug("QMD prefetch failed: %s", e)
+
+        self._prefetch_thread = threading.Thread(
+            target=_run, daemon=True, name="qmd-prefetch",
+        )
+        self._prefetch_thread.start()
+
+    # -- sync_turn — no-op (read-only) ------------------------------------
+
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+        return
+
+    # -- Tools -------------------------------------------------------------
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        return [SEARCH_SCHEMA, STATUS_SCHEMA]
+
+    def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs) -> str:
+        if not self._api_token:
+            return tool_error(
+                "QMD_REMOTE_API_TOKEN not set. Run `hermes memory setup qmd`."
+            )
+        if self._is_breaker_open():
+            return tool_error(
+                "QMD remote API temporarily unavailable (consecutive failures). "
+                "Will retry automatically after cooldown."
+            )
+
+        if tool_name == "qmd_search":
+            return self._qmd_search(args)
+        if tool_name == "qmd_status":
+            return self._qmd_status()
+        return tool_error(f"Unknown tool: {tool_name}")
+
+    # -- Tool implementations ---------------------------------------------
+
+    def _qmd_search(self, args: Dict[str, Any]) -> str:
+        query = (args.get("query") or "").strip()
+        if not query:
+            return tool_error("Missing required parameter: query")
+        try:
+            top_k = int(args.get("top_k") or self._manual_top_k)
+        except (TypeError, ValueError):
+            top_k = self._manual_top_k
+        top_k = max(1, min(top_k, 25))
+        index = args.get("index") or self._default_index
+        collection_filter = args.get("collection_filter") or None
+
+        try:
+            hits = self._search_remote(
+                query=query,
+                top_k=top_k,
+                index=index,
+                collection_filter=collection_filter,
+            )
+            self._record_success()
+        except Exception as e:
+            self._record_failure()
+            return tool_error(f"QMD search failed: {e}")
+
+        if not hits:
+            return json.dumps({
+                "result": "No relevant QMD memories found.",
+                "query": query,
+                "index": index,
+                "count": 0,
+            })
+
+        items = []
+        for h in hits:
+            items.append({
+                "docid": h.get("docid"),
+                "file": h.get("file"),
+                "title": h.get("title"),
+                "score": h.get("score"),
+                "rerank_score": h.get("externalRerankScore"),
+                "context": _truncate(h.get("context") or "", self._snippet_max),
+                "snippet": _truncate(h.get("snippet") or "", self._snippet_max),
+            })
+
+        return json.dumps({
+            "results": items,
+            "count": len(items),
+            "index": index,
+            "query": query,
+        })
+
+    def _qmd_status(self) -> str:
+        try:
+            payload = self._status_remote()
+            self._record_success()
+        except Exception as e:
+            self._record_failure()
+            return tool_error(f"QMD status failed: {e}")
+        return json.dumps(payload)
+
+    # -- Remote calls ------------------------------------------------------
+
+    def _search_remote(
+        self,
+        *,
+        query: str,
+        top_k: int,
+        index: str,
+        collection_filter: Optional[str],
+    ) -> List[Dict[str, Any]]:
+        """POST /search and return the (optionally filtered) hits list."""
+        client = self._get_client()
+        body: Dict[str, Any] = {
+            "query": query,
+            "topK": int(top_k),
+            "index": index,
+        }
+        try:
+            r = client.post("/search", headers=self._auth_headers(), json=body)
+        except httpx.HTTPError as e:
+            raise RuntimeError(f"HTTP error: {e}") from e
+        if r.status_code >= 400:
+            raise RuntimeError(
+                f"QMD /search returned {r.status_code}: {r.text[:200]}"
+            )
+        try:
+            data = r.json()
+        except Exception as e:
+            raise RuntimeError(f"QMD /search returned non-JSON: {e}") from e
+        if not isinstance(data, dict) or not data.get("ok", True) is True and "results" not in data:
+            # Some QMD responses omit "ok" — accept anything with results
+            if "results" not in data:
+                raise RuntimeError(f"QMD /search bad payload: {str(data)[:200]}")
+        results = data.get("results") or []
+
+        if collection_filter:
+            cf = str(collection_filter).strip()
+            filtered = []
+            for h in results:
+                col = _collection_from_file(h.get("file") or "")
+                if col and (col == cf or col.startswith(cf)):
+                    filtered.append(h)
+            results = filtered
+
+        return list(results)
+
+    def _status_remote(self) -> Dict[str, Any]:
+        """GET /health and return the parsed JSON dict."""
+        client = self._get_client()
+        try:
+            r = client.get("/health", headers=self._auth_headers())
+        except httpx.HTTPError as e:
+            raise RuntimeError(f"HTTP error: {e}") from e
+        if r.status_code >= 400:
+            raise RuntimeError(
+                f"QMD /health returned {r.status_code}: {r.text[:200]}"
+            )
+        try:
+            data = r.json()
+        except Exception as e:
+            raise RuntimeError(f"QMD /health returned non-JSON: {e}") from e
+        return data
+
+
+# ---------------------------------------------------------------------------
+# Plugin entry point
+# ---------------------------------------------------------------------------
+
+def register(ctx) -> None:
+    """Register QMD as a memory provider plugin."""
+    ctx.register_memory_provider(QMDMemoryProvider())

--- a/plugins/memory/qmd/plugin.yaml
+++ b/plugins/memory/qmd/plugin.yaml
@@ -1,0 +1,7 @@
+name: qmd
+version: 0.1.0
+description: "QMD — read-only memory provider for self-hosted QMD-compatible HTTP API (vector + optional rerank)."
+author: "Hussam Alkurdi"
+pip_dependencies: []
+requires_env:
+  - QMD_REMOTE_API_TOKEN

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -54,6 +54,7 @@ AUTHOR_MAP = {
     "nbot@liizfq.top": "liizfq",
     "274096618+hermes-agent-dhabibi@users.noreply.github.com": "dhabibi",
     "dejie.guo@gmail.com": "JayGwod",
+    "hussam.alkurdi@sonymusic.com": "TheMHD1",
     "johnnncenaaa77@gmail.com": "johnncenae",
     "thomasjhon6666@gmail.com": "ThomassJonax",
     "focusflow.app.help@gmail.com": "yes999zc",

--- a/tests/plugins/memory/test_qmd_provider.py
+++ b/tests/plugins/memory/test_qmd_provider.py
@@ -1,0 +1,396 @@
+"""Tests for the QMD memory provider plugin.
+
+Uses ``httpx.MockTransport`` (no external mocking lib required) by
+patching the provider's ``_get_client`` factory to return a client
+backed by the test transport.
+"""
+from __future__ import annotations
+
+import json
+import threading
+import time
+from typing import Any, Dict, List, Optional
+
+import httpx
+import pytest
+
+from plugins.memory.qmd import (
+    DEFAULT_BASE_URL,
+    DEFAULT_INDEX,
+    QMDMemoryProvider,
+    SEARCH_SCHEMA,
+    STATUS_SCHEMA,
+    _BREAKER_COOLDOWN_SECS,
+    _BREAKER_THRESHOLD,
+    _collection_from_file,
+    _load_config,
+    _truncate,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _search_payload(results=None):
+    return {
+        "ok": True,
+        "results": results if results is not None else [
+            {
+                "docid": "doc-1",
+                "file": "qmd://session-logs/2025/01/15.md",
+                "title": "January planning",
+                "score": 0.91,
+                "externalRerankScore": 0.88,
+                "context": "Plans for January.",
+                "snippet": "We agreed to ship the QMD plugin upstream.",
+            },
+        ],
+    }
+
+
+def _health_payload():
+    return {
+        "ok": True,
+        "uptime_s": 12345,
+        "indexes": {
+            "default": {"docs": 4321, "dim": 2560},
+        },
+        "rerank_url": "http://localhost:8010/v1/rerank",
+    }
+
+
+def _make_provider(monkeypatch, tmp_path, *, search_handler=None,
+                   health_handler=None):
+    """Build a QMDMemoryProvider whose httpx.Client uses a MockTransport."""
+    # Isolate $HERMES_HOME
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+    monkeypatch.setenv("QMD_REMOTE_API_TOKEN", "test-token")
+    monkeypatch.setenv("QMD_REMOTE_API_BASE_URL", "http://localhost:18181")
+    monkeypatch.delenv("QMD_DEFAULT_INDEX", raising=False)
+    monkeypatch.delenv("QMD_TIMEOUT", raising=False)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/search" and request.method == "POST":
+            return search_handler(request) if search_handler \
+                else httpx.Response(200, json=_search_payload())
+        if request.url.path == "/health" and request.method == "GET":
+            return health_handler(request) if health_handler \
+                else httpx.Response(200, json=_health_payload())
+        return httpx.Response(404, text="not found")
+
+    transport = httpx.MockTransport(handler)
+    p = QMDMemoryProvider()
+    p.initialize("session-1", hermes_home=str(tmp_path), platform="cli")
+
+    # Inject the mock transport: replace cached client construction.
+    real_get_client = p._get_client
+    cached: Dict[str, httpx.Client] = {}
+
+    def patched_get_client():
+        if "c" not in cached:
+            cached["c"] = httpx.Client(
+                base_url=p._base_url,
+                timeout=p._timeout,
+                transport=transport,
+            )
+        p._client = cached["c"]
+        return cached["c"]
+
+    p._get_client = patched_get_client  # type: ignore
+    return p
+
+
+@pytest.fixture
+def provider(monkeypatch, tmp_path):
+    p = _make_provider(monkeypatch, tmp_path)
+    yield p
+    p.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+def test_truncate_short_string_unchanged():
+    assert _truncate("hi", 10) == "hi"
+
+
+def test_truncate_long_string_appends_ellipsis():
+    out = _truncate("a" * 50, 10)
+    assert out.endswith("…")
+    assert len(out) == 10
+
+
+def test_collection_from_file_extracts_segment():
+    assert _collection_from_file("qmd://session-logs/foo/bar.md") == "session-logs"
+
+
+def test_collection_from_file_returns_none_on_non_qmd():
+    assert _collection_from_file("file:///etc/hosts") is None
+    assert _collection_from_file("") is None
+
+
+# ---------------------------------------------------------------------------
+# Config loading
+# ---------------------------------------------------------------------------
+
+def test_load_config_env_only(monkeypatch, tmp_path):
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+    monkeypatch.setenv("QMD_REMOTE_API_TOKEN", "tok-from-env")
+    monkeypatch.setenv("QMD_REMOTE_API_BASE_URL", "http://example.test:9999")
+    monkeypatch.delenv("QMD_DEFAULT_INDEX", raising=False)
+    cfg = _load_config()
+    assert cfg["api_token"] == "tok-from-env"
+    assert cfg["base_url"] == "http://example.test:9999"
+    assert cfg["default_index"] == DEFAULT_INDEX
+
+
+def test_load_config_json_overrides_non_secret(monkeypatch, tmp_path):
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+    monkeypatch.setenv("QMD_REMOTE_API_TOKEN", "tok-from-env")
+    (tmp_path / "qmd.json").write_text(json.dumps({
+        "base_url": "http://from-json:1234",
+        "default_index": "json-index",
+        "api_token": "MUST-BE-IGNORED",
+    }))
+    cfg = _load_config()
+    assert cfg["api_token"] == "tok-from-env"   # never from JSON
+    assert cfg["base_url"] == "http://from-json:1234"
+    assert cfg["default_index"] == "json-index"
+
+
+def test_save_config_drops_secret(tmp_path):
+    p = QMDMemoryProvider()
+    p.save_config(
+        {"api_token": "secret", "base_url": "http://x", "timeout": 99},
+        str(tmp_path),
+    )
+    saved = json.loads((tmp_path / "qmd.json").read_text())
+    assert "api_token" not in saved
+    assert saved["base_url"] == "http://x"
+    assert saved["timeout"] == 99
+
+
+# ---------------------------------------------------------------------------
+# Availability
+# ---------------------------------------------------------------------------
+
+def test_is_available_false_without_token(monkeypatch, tmp_path):
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+    monkeypatch.delenv("QMD_REMOTE_API_TOKEN", raising=False)
+    assert QMDMemoryProvider().is_available() is False
+
+
+def test_is_available_true_with_token(monkeypatch, tmp_path):
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+    monkeypatch.setenv("QMD_REMOTE_API_TOKEN", "x")
+    assert QMDMemoryProvider().is_available() is True
+
+
+# ---------------------------------------------------------------------------
+# Search — happy path / error / breaker
+# ---------------------------------------------------------------------------
+
+def test_qmd_search_happy_path(provider):
+    raw = provider.handle_tool_call("qmd_search", {"query": "January plans"})
+    out = json.loads(raw)
+    assert out["count"] == 1
+    assert out["results"][0]["title"] == "January planning"
+    assert out["results"][0]["rerank_score"] == 0.88
+    assert out["query"] == "January plans"
+
+
+def test_qmd_search_collection_filter(monkeypatch, tmp_path):
+    payload = _search_payload(results=[
+        {"docid": "1", "file": "qmd://session-logs/a.md", "title": "A",
+         "score": 0.9, "snippet": "x", "context": "x"},
+        {"docid": "2", "file": "qmd://global-facts/b.md", "title": "B",
+         "score": 0.8, "snippet": "y", "context": "y"},
+    ])
+
+    def search_handler(req):
+        return httpx.Response(200, json=payload)
+
+    p = _make_provider(monkeypatch, tmp_path, search_handler=search_handler)
+    try:
+        raw = p.handle_tool_call(
+            "qmd_search",
+            {"query": "...", "collection_filter": "session-logs"},
+        )
+        out = json.loads(raw)
+        assert out["count"] == 1
+        assert out["results"][0]["docid"] == "1"
+    finally:
+        p.shutdown()
+
+
+def test_qmd_search_4xx_returns_error(monkeypatch, tmp_path):
+    def search_handler(req):
+        return httpx.Response(401, text="bad token")
+
+    p = _make_provider(monkeypatch, tmp_path, search_handler=search_handler)
+    try:
+        raw = p.handle_tool_call("qmd_search", {"query": "x"})
+        out = json.loads(raw)
+        assert "error" in out
+    finally:
+        p.shutdown()
+
+
+def test_qmd_search_circuit_breaker_trips(monkeypatch, tmp_path):
+    call_count = {"n": 0}
+
+    def search_handler(req):
+        call_count["n"] += 1
+        return httpx.Response(503, text="down")
+
+    p = _make_provider(monkeypatch, tmp_path, search_handler=search_handler)
+    try:
+        for _ in range(_BREAKER_THRESHOLD):
+            p.handle_tool_call("qmd_search", {"query": "x"})
+        # Breaker should now be open. Next call short-circuits.
+        before = call_count["n"]
+        raw = p.handle_tool_call("qmd_search", {"query": "x"})
+        out = json.loads(raw)
+        assert "error" in out
+        assert "temporarily unavailable" in out["error"]
+        assert call_count["n"] == before  # no extra HTTP request
+    finally:
+        p.shutdown()
+
+
+def test_qmd_search_missing_query(provider):
+    out = json.loads(provider.handle_tool_call("qmd_search", {}))
+    assert "error" in out
+
+
+def test_handle_tool_call_unknown_tool_errors(provider):
+    out = json.loads(provider.handle_tool_call("qmd_nope", {}))
+    assert "error" in out
+
+
+# ---------------------------------------------------------------------------
+# Status
+# ---------------------------------------------------------------------------
+
+def test_qmd_status_happy_path(provider):
+    raw = provider.handle_tool_call("qmd_status", {})
+    out = json.loads(raw)
+    assert out["uptime_s"] == 12345
+    assert "default" in out["indexes"]
+
+
+def test_qmd_status_5xx_returns_error(monkeypatch, tmp_path):
+    def health_handler(req):
+        return httpx.Response(500, text="boom")
+
+    p = _make_provider(monkeypatch, tmp_path, health_handler=health_handler)
+    try:
+        out = json.loads(p.handle_tool_call("qmd_status", {}))
+        assert "error" in out
+    finally:
+        p.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Prefetch
+# ---------------------------------------------------------------------------
+
+def test_queue_prefetch_populates_result(provider):
+    provider.queue_prefetch("a long enough query to trigger prefetch")
+    # join the background thread
+    if provider._prefetch_thread:
+        provider._prefetch_thread.join(timeout=2)
+    block = provider.prefetch("anything")
+    assert "QMD Memory" in block
+    assert "January planning" in block
+
+
+def test_queue_prefetch_skips_short_query(provider):
+    provider.queue_prefetch("hi")
+    assert provider._prefetch_thread is None
+
+
+def test_queue_prefetch_skips_when_thread_alive(provider):
+    """Overlapping prefetches must not spawn a second thread."""
+    started = threading.Event()
+    release = threading.Event()
+
+    def _slow_search(*_, **__):
+        started.set()
+        release.wait(timeout=2)
+        return []
+
+    provider._search_remote = _slow_search    # type: ignore
+    provider.queue_prefetch("a long enough query to trigger prefetch")
+    assert started.wait(timeout=1)
+    first = provider._prefetch_thread
+
+    provider.queue_prefetch("another long enough query to trigger prefetch")
+    assert provider._prefetch_thread is first   # second call no-ops
+
+    release.set()
+    if first:
+        first.join(timeout=2)
+
+
+# ---------------------------------------------------------------------------
+# Schema completeness
+# ---------------------------------------------------------------------------
+
+def test_search_schema_required_fields():
+    assert SEARCH_SCHEMA["name"] == "qmd_search"
+    assert "query" in SEARCH_SCHEMA["parameters"]["required"]
+    props = SEARCH_SCHEMA["parameters"]["properties"]
+    for key in ("query", "top_k", "index", "collection_filter"):
+        assert key in props, f"missing property: {key}"
+
+
+def test_status_schema_no_params():
+    assert STATUS_SCHEMA["name"] == "qmd_status"
+    assert STATUS_SCHEMA["parameters"]["required"] == []
+
+
+def test_get_tool_schemas_lists_both(provider):
+    names = {s["name"] for s in provider.get_tool_schemas()}
+    assert names == {"qmd_search", "qmd_status"}
+
+
+def test_get_config_schema_has_token_marked_secret():
+    p = QMDMemoryProvider()
+    schema = p.get_config_schema()
+    keys = {f["key"] for f in schema}
+    assert "api_token" in keys
+    token_field = next(f for f in schema if f["key"] == "api_token")
+    assert token_field.get("secret") is True
+    assert token_field.get("required") is True
+
+
+# ---------------------------------------------------------------------------
+# System prompt block
+# ---------------------------------------------------------------------------
+
+def test_system_prompt_block_mentions_index_and_host(provider):
+    block = provider.system_prompt_block()
+    assert provider._default_index in block
+    assert provider._base_url in block
+    assert "Read-only" in block
+
+
+# ---------------------------------------------------------------------------
+# sync_turn — read-only no-op
+# ---------------------------------------------------------------------------
+
+def test_sync_turn_is_noop(provider):
+    # Should not raise, should not record anything.
+    provider.sync_turn("user msg", "assistant reply", session_id="s1")
+
+
+# ---------------------------------------------------------------------------
+# Shutdown idempotence
+# ---------------------------------------------------------------------------
+
+def test_shutdown_is_idempotent(provider):
+    provider.shutdown()
+    provider.shutdown()    # second call must not raise

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -1132,6 +1132,7 @@ You can switch between providers at any time with `hermes model` — no restart 
 | RL Training | [Tinker](https://tinker-console.thinkingmachines.ai/) + [WandB](https://wandb.ai/) | `TINKER_API_KEY`, `WANDB_API_KEY` |
 | Cross-session user modeling | [Honcho](https://honcho.dev/) | `HONCHO_API_KEY` |
 | Semantic long-term memory | [Supermemory](https://supermemory.ai) | `SUPERMEMORY_API_KEY` |
+| Self-hosted vector RAG | QMD-compatible HTTP API | `QMD_REMOTE_API_TOKEN` |
 
 ### Self-Hosting Firecrawl
 

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -665,7 +665,7 @@ Subcommands:
 hermes memory <subcommand>
 ```
 
-Set up and manage external memory provider plugins. Available providers: honcho, openviking, mem0, hindsight, holographic, retaindb, byterover, supermemory. Only one external provider can be active at a time. Built-in memory (MEMORY.md/USER.md) is always active.
+Set up and manage external memory provider plugins. Available providers: honcho, openviking, mem0, hindsight, holographic, retaindb, byterover, supermemory, qmd. Only one external provider can be active at a time. Built-in memory (MEMORY.md/USER.md) is always active.
 
 Subcommands:
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -129,6 +129,10 @@ For native Anthropic auth, Hermes prefers Claude Code's own credential files whe
 | `HONCHO_API_KEY` | Cross-session user modeling ([honcho.dev](https://honcho.dev/)) |
 | `HONCHO_BASE_URL` | Base URL for self-hosted Honcho instances (default: Honcho cloud). No API key required for local instances |
 | `SUPERMEMORY_API_KEY` | Semantic long-term memory with profile recall and session ingest ([supermemory.ai](https://supermemory.ai)) |
+| `QMD_REMOTE_API_TOKEN` | Self-hosted QMD memory provider — bearer token for the remote HTTP API |
+| `QMD_REMOTE_API_BASE_URL` | QMD service base URL (default `http://localhost:18181`) |
+| `QMD_DEFAULT_INDEX` | QMD default index name (default `default`) |
+| `QMD_TIMEOUT` | QMD HTTP timeout in seconds (default `30`) |
 | `TINKER_API_KEY` | RL training ([tinker-console.thinkingmachines.ai](https://tinker-console.thinkingmachines.ai/)) |
 | `WANDB_API_KEY` | RL training metrics ([wandb.ai](https://wandb.ai/)) |
 | `DAYTONA_API_KEY` | Daytona cloud sandboxes ([daytona.io](https://daytona.io/)) |

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -1,12 +1,12 @@
 ---
 sidebar_position: 4
 title: "Memory Providers"
-description: "External memory provider plugins — Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover, Supermemory"
+description: "External memory provider plugins — Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover, Supermemory, QMD"
 ---
 
 # Memory Providers
 
-Hermes Agent ships with 8 external memory provider plugins that give the agent persistent, cross-session knowledge beyond the built-in MEMORY.md and USER.md. Only **one** external provider can be active at a time — the built-in memory is always active alongside it.
+Hermes Agent ships with 9 external memory provider plugins that give the agent persistent, cross-session knowledge beyond the built-in MEMORY.md and USER.md. Only **one** external provider can be active at a time — the built-in memory is always active alongside it.
 
 ## Quick Start
 
@@ -22,7 +22,7 @@ Or set manually in `~/.hermes/config.yaml`:
 
 ```yaml
 memory:
-  provider: openviking   # or honcho, mem0, hindsight, holographic, retaindb, byterover, supermemory
+  provider: openviking   # or honcho, mem0, hindsight, holographic, retaindb, byterover, supermemory, qmd
 ```
 
 ## How It Works
@@ -522,6 +522,48 @@ echo 'SUPERMEMORY_API_KEY=***' >> ~/.hermes/.env
 
 ---
 
+### QMD
+
+Read-only retrieval against a self-hosted **QMD-compatible HTTP API** — a small JSON gateway over a vector index (e.g. sqlite-vec) with optional cross-encoder reranking. Designed for users running their own RAG layer over a curated markdown corpus.
+
+| | |
+|---|---|
+| **Best for** | Self-hosted vector RAG over markdown corpora; users who already run a QMD-compatible HTTP service |
+| **Requires** | A reachable QMD-compatible HTTP service + bearer token. No Python dependencies beyond `httpx` (already a Hermes core dep). |
+| **Data storage** | Self-hosted (wherever the QMD service runs) |
+| **Cost** | Free (self-hosted) |
+
+**Tools (2):** `qmd_search` (semantic search with optional `collection_filter` and per-call `index`), `qmd_status` (fetch `/health` for uptime, indexes, document counts, embedding dim).
+
+**Setup:**
+```bash
+hermes memory setup    # select "qmd"
+# Or manually:
+hermes config set memory.provider qmd
+echo 'QMD_REMOTE_API_TOKEN=***' >> ~/.hermes/.env
+```
+
+**Config:** `$HERMES_HOME/qmd.json` (non-secret keys only)
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `base_url` | `http://localhost:18181` | QMD service base URL |
+| `default_index` | `default` | Index name for searches without an explicit `index` arg |
+| `timeout` | `30` | HTTP timeout (seconds) |
+| `prefetch_top_k` | `3` | Hits to fetch in the per-turn background prefetch |
+| `manual_top_k` | `5` | Default `top_k` for explicit `qmd_search` calls (max 25) |
+| `snippet_max` | `300` | Truncation cap for the `snippet` and `context` fields |
+
+**Environment variables:** `QMD_REMOTE_API_TOKEN` (required), `QMD_REMOTE_API_BASE_URL`, `QMD_DEFAULT_INDEX`, `QMD_TIMEOUT`.
+
+**Key features:**
+- Read-only by design — writes flow through `MEMORY.md` and the QMD ingest pipeline running alongside the QMD server
+- Wire protocol is a thin HTTP shape: `POST /search {query, topK, index}` and `GET /health`
+- Mem0-style circuit breaker (5 consecutive failures → 120s cooldown)
+- Per-turn prefetch with a thread-overlap guard (no duplicate background work)
+- Connection-pooled `httpx.Client` (8 connections / 4 keepalive) for thread-safe concurrent use
+- `collection_filter` is a client-side prefix match on the `qmd://collection/...` URI segment
+
 ## Provider Comparison
 
 | Provider | Storage | Cost | Tools | Dependencies | Unique Feature |
@@ -534,6 +576,7 @@ echo 'SUPERMEMORY_API_KEY=***' >> ~/.hermes/.env
 | **RetainDB** | Cloud | $20/mo | 5 | `requests` | Delta compression |
 | **ByteRover** | Local/Cloud | Free/Paid | 3 | `brv` CLI | Pre-compression extraction |
 | **Supermemory** | Cloud | Paid | 4 | `supermemory` | Context fencing + session graph ingest + multi-container |
+| **QMD** | Self-hosted | Free | 2 | `httpx` (core) | Read-only HTTP RAG over a self-hosted QMD-compatible vector index |
 
 ## Profile Isolation
 


### PR DESCRIPTION
## Summary

Adds a new read-only `MemoryProvider` plugin at `plugins/memory/qmd/` for self-hosted QMD-compatible HTTP indexes (JSON gateway over a vector index such as sqlite-vec, with optional cross-encoder reranking).

The plugin exposes two tools:
- **`qmd_search`** — semantic search with `collection_filter` and `top_k`.
- **`qmd_status`** — `/health` probe of the upstream QMD service.

## Why

The previously-published PyPI `hindsight` provider has been broken for several Hermes releases (import errors against the current `MemoryProvider` ABC and incompatible config schema). Locally I had been routing memory through a small QMD service in front of a LiteLLM gateway, and it made more sense to upstream a first-class provider than to keep monkey-patching `hindsight`. This gives users a clean drop-in option for self-hosted RAG-style memory without dragging in heavyweight Mem0/Letta dependencies.

## Implementation Notes

- **Lifecycle:** prefetch with thread-overlap guard, circuit breaker (5 failures -> 120s cooldown, same pattern Mem0 uses), sync `httpx.Client` with connection pooling.
- **Config precedence:** env vars + JSON merged with secret-filtering (4 new env vars documented in `website/docs/reference/environment-variables.md`).
- **Tests:** ~400 LOC at `tests/plugins/memory/test_qmd_provider.py`, using `httpx.MockTransport` (no `respx` dependency added). Covers config precedence, search happy path + 4xx + breaker trip, status endpoint, prefetch overlap guard, and schema completeness.
- **Docs updated:** `memory-providers` (new section + comparison row), `environment-variables`, `integrations/providers` (table entry), `cli-commands`, `AGENTS.md` memory list, `AUTHOR_MAP`.

## Testing

Verified locally against a running QMD instance routed through a LiteLLM gateway:

```
$ hermes memory status
Provider: qmd
Status:   available ✓
```

`qmd_search` returns reranked hits; `qmd_status` reflects the upstream `/health` payload. Unit tests pass under `pytest tests/plugins/memory/test_qmd_provider.py`.

## Known Limitations

- **Read-only by design.** The QMD remote API has no write endpoints, so this provider does not implement `sync_turn` or `retain`. Writes are expected to flow through `MEMORY.md` plus the QMD ingest pipeline that runs alongside the server. This is documented in the new memory-providers section and the plugin README.
- No streaming/iterator API yet — `qmd_search` is a single request/response.

## Files

- `plugins/memory/qmd/__init__.py` (provider + tools, 625 LOC)
- `plugins/memory/qmd/plugin.yaml`
- `plugins/memory/qmd/README.md`
- `tests/plugins/memory/test_qmd_provider.py`
- Docs + `AGENTS.md` + `scripts/release.py` (`AUTHOR_MAP`).

## Test plan

- [ ] CI passes (`pytest`, lint, type check).
- [ ] Reviewer can stand up a stub QMD server (or use `httpx.MockTransport` per the tests) and confirm `hermes memory status` and `qmd_search`.
- [ ] Confirm docs render correctly on the website preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)