### PR TITLE
fix: honor per-task model override in delegate_task

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2225,7 +2225,7 @@ def delegate_task(
                 goal=t["goal"],
                 context=t.get("context"),
                 toolsets=t.get("toolsets") or toolsets,
-                model=creds["model"],
+                model=t.get("model") or creds["model"],
                 max_iterations=effective_max_iter,
                 task_count=n_tasks,
                 parent_agent=parent_agent,


### PR DESCRIPTION
## Summary

The `delegate_task` tool was silently ignoring the per-task `model` override field, causing all child subagents to always use the parent's model regardless of per-task specification.

## Root Cause

In `_build_child_agent()` calls within `delegate_task()`, the `model` parameter always resolved to `creds["model"]` (the global delegation model), ignoring any per-task `model` field. Other per-task fields like `role` and `toolsets` correctly used the `t.get(...) or global_default` pattern.

## Fix

Apply the same fallback pattern used for `role` and `toolsets`:

```python
# Before (broken):
model=creds["model"],

# After (fixed):
model=t.get("model") or creds["model"],
```

This allows each task dict in a batch delegation to optionally specify its own model while preserving the default behavior.

## Verification

- `python3 -m py_compile tools/delegate_tool.py` passes
- 29 existing subagent/delegate tests pass (tests/agent/test_subagent_*.py, tests/cli/test_cli_interrupt_subagent.py)

Closes #17685
