### PR TITLE
fix(vision): use HERMES_HOME-based cache dir instead of cwd

### DIFF
--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -38,6 +38,7 @@ from typing import Any, Awaitable, Dict, Optional
 from urllib.parse import urlparse
 import httpx
 from agent.auxiliary_client import async_call_llm, extract_content_or_reasoning
+from hermes_constants import get_hermes_dir
 from tools.debug_helpers import DebugSession
 from tools.website_policy import check_website_access
 
@@ -435,7 +436,7 @@ async def vision_analyze_tool(
         Exception: If download fails, analysis fails, or API key is not set
         
     Note:
-        - For URLs, temporary images are stored in ./temp_vision_images/ and cleaned up
+        - For URLs, temporary images are stored under $HERMES_HOME/cache/vision/ and cleaned up
         - For local file paths, the file is used directly and NOT deleted
         - Supports common image formats (JPEG, PNG, GIF, WebP, etc.)
     """
@@ -483,7 +484,7 @@ async def vision_analyze_tool(
             if blocked:
                 raise PermissionError(blocked["message"])
             logger.info("Downloading image from URL...")
-            temp_dir = Path("./temp_vision_images")
+            temp_dir = get_hermes_dir("cache/vision", "temp_vision_images")
             temp_image_path = temp_dir / f"temp_image_{uuid.uuid4()}.jpg"
             await _download_image(image_url, temp_image_path)
             should_cleanup = True


### PR DESCRIPTION
## Summary
Docker users running vision_analyze on a remote URL now get a writable temp dir instead of PermissionError.

Root cause: `tools/vision_tools.py` built the download temp dir as `Path("./temp_vision_images")` — a relative path resolving against cwd. Docker image `WORKDIR=/opt/hermes` is root-owned and chmoded `a+rX` (read + traversal only). Since #5811 landed (run as non-root hermes UID 10000, Apr 12), mkdir in cwd fails.

## Changes
- `tools/vision_tools.py`: switch temp dir to `get_hermes_dir('cache/vision', 'temp_vision_images')` — resolves to `$HERMES_HOME/cache/vision/` (= `/opt/data/cache/vision/` in Docker, the user-owned volume). Existing installs with the old dir keep using it via the helper's back-compat path; no migration needed.
- Updated docstring to reference the new path.

Only site in the codebase using `Path("./...")` for runtime storage.

## Validation
| | Before | After |
|---|---|---|
| Docker non-root vision call | PermissionError on mkdir | writes to `/opt/data/cache/vision/` |
| `tests/tools/test_vision_tools.py` | 70 passed | 70 passed |
| E2E (HERMES_HOME + unwritable cwd) | PermissionError | writes and reads temp file |
| E2E back-compat (old dir exists) | — | resolves to old `temp_vision_images` path |

## Reporter
Nicolas on Discord — `vision_analyze` on a Telegram image URL consistently failed with `[Errno 13] Permission denied: 'temp_vision_images'` on `:latest`, worked on `:v2026.4.16` (predates the non-root switch). Ollama/Telegram were red herrings — this happens for any vision_analyze on a remote URL inside Docker.