### PR TITLE
fix: use display-aware column width for CJK model names

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -3748,7 +3748,11 @@ def _prompt_model_selection(
 
     # Column-aligned labels when pricing is available
     has_pricing = bool(pricing and any(pricing.get(m) for m in all_models))
-    name_col = max((len(m) for m in all_models), default=0) + 2 if has_pricing else 0
+    if has_pricing:
+        import unicodedata
+        name_col = max((sum(2 if unicodedata.east_asian_width(c) in ("F", "W") else 1 for c in m) for m in all_models), default=0) + 2
+    else:
+        name_col = 0
 
     # Pre-compute formatted prices and dynamic column widths
     _price_cache: dict[str, tuple[str, str, str]] = {}

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1179,7 +1179,12 @@ def format_model_pricing_table(
             inp, out, cache = "", "", ""
         rows.append((mid, inp, out, cache, is_cur))
 
-    name_col = max(len(r[0]) for r in rows) + 2
+    import unicodedata
+
+    def _w(s: str) -> int:
+        return sum(2 if unicodedata.east_asian_width(c) in ("F", "W") else 1 for c in s)
+
+    name_col = max(_w(r[0]) for r in rows) + 2
     # Compute price column widths from the actual data so decimals align
     price_col = max(
         max((len(r[1]) for r in rows if r[1]), default=4),


### PR DESCRIPTION
## Summary

Terminal ASCII tables misalign when model names contain Chinese, Japanese, or Korean (CJK) characters because `len()` counts Unicode codepoints rather than terminal display cells. CJK characters occupy 2 cells in most terminal emulators.

## Root Cause

`hermes_cli/auth.py` (`_prompt_model_selection`) and `hermes_cli/hermes_cli/models.py` (`format_model_pricing_table`) both compute the model name column width using `len()`, which underestimates the width of CJK characters by 50-100%.

## Fix

Use `unicodedata.east_asian_width()` to compute display-aware character widths. Characters with East Asian Width property `F` (Fullwidth) or `W` (Wide) count as 2 cells; all others count as 1.

Changes:
- `hermes_cli/auth.py`: Replace `len(m)` with display-width computation in the `name_col` calculation
- `hermes_cli/models.py`: Replace `len(r[0])` with the same computation

No new imports required — `unicodedata` is part of the Python standard library.

## Verification

- `python3 -m py_compile hermes_cli/auth.py hermes_cli/models.py` passes
- `ruff check hermes_cli/hermes_cli/models.py` passes (E731 lambda warning resolved with `def`)
- 570 CLI tests pass (`tests/cli/`)

Closes #17700
