### PR TITLE
fix: align image picker columns for CJK text

### DIFF
--- a/hermes_cli/text_width.py
+++ b/hermes_cli/text_width.py
@@ -1,0 +1,32 @@
+"""Unicode-aware text width helpers for terminal output."""
+
+from __future__ import annotations
+
+import unicodedata
+
+
+_ZERO_WIDTH_CATEGORIES = {"Mn", "Me", "Cf"}
+_WIDE_EAST_ASIAN_WIDTHS = {"F", "W"}
+
+
+def display_width(value: object) -> int:
+    """Return the number of terminal cells needed to display *value*.
+
+    Python's :func:`len` counts Unicode code points, but common terminals render
+    full-width CJK characters as two cells and combining marks as zero cells.
+    Use this for column calculations in plain-text tables and picker rows.
+    """
+    text = str(value)
+    width = 0
+    for char in text:
+        if unicodedata.category(char) in _ZERO_WIDTH_CATEGORIES:
+            continue
+        width += 2 if unicodedata.east_asian_width(char) in _WIDE_EAST_ASIAN_WIDTHS else 1
+    return width
+
+
+def ljust_display(value: object, width: int) -> str:
+    """Left-pad *value* to a target terminal display width."""
+    text = str(value)
+    padding = max(0, width - display_width(text))
+    return text + (" " * padding)

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1426,10 +1426,12 @@ IMAGEGEN_BACKENDS = {
 
 def _format_imagegen_model_row(model_id: str, meta: dict, widths: dict) -> str:
     """Format a single picker row with column-aligned speed / strengths / price."""
+    from hermes_cli.text_width import ljust_display
+
     return (
-        f"{model_id:<{widths['model']}}  "
-        f"{meta.get('speed', ''):<{widths['speed']}}  "
-        f"{meta.get('strengths', ''):<{widths['strengths']}}  "
+        f"{ljust_display(model_id, widths['model'])}  "
+        f"{ljust_display(meta.get('speed', ''), widths['speed'])}  "
+        f"{ljust_display(meta.get('strengths', ''), widths['strengths'])}  "
         f"{meta.get('price', '')}"
     )
 
@@ -1462,18 +1464,21 @@ def _configure_imagegen_model(backend_name: str, config: dict) -> None:
     # Put current model at the top so the cursor lands on it by default.
     ordered = [current_model] + [m for m in model_ids if m != current_model]
 
-    # Column widths
+    from hermes_cli.text_width import display_width, ljust_display
+
+    # Column widths use terminal display cells so CJK/full-width model metadata
+    # remains aligned in standard monospace terminals.
     widths = {
-        "model": max(len(m) for m in model_ids),
-        "speed": max((len(catalog[m].get("speed", "")) for m in model_ids), default=6),
-        "strengths": max((len(catalog[m].get("strengths", "")) for m in model_ids), default=0),
+        "model": max(display_width(m) for m in model_ids),
+        "speed": max((display_width(catalog[m].get("speed", "")) for m in model_ids), default=6),
+        "strengths": max((display_width(catalog[m].get("strengths", "")) for m in model_ids), default=0),
     }
 
     print()
     header = (
-        f"  {'Model':<{widths['model']}}  "
-        f"{'Speed':<{widths['speed']}}  "
-        f"{'Strengths':<{widths['strengths']}}  "
+        f"  {ljust_display('Model', widths['model'])}  "
+        f"{ljust_display('Speed', widths['speed'])}  "
+        f"{ljust_display('Strengths', widths['strengths'])}  "
         f"Price"
     )
     print(color(header, Colors.CYAN))
@@ -1545,17 +1550,19 @@ def _configure_imagegen_model_for_plugin(plugin_name: str, config: dict) -> None
     model_ids = list(catalog.keys())
     ordered = [current_model] + [m for m in model_ids if m != current_model]
 
+    from hermes_cli.text_width import display_width, ljust_display
+
     widths = {
-        "model": max(len(m) for m in model_ids),
-        "speed": max((len(catalog[m].get("speed", "")) for m in model_ids), default=6),
-        "strengths": max((len(catalog[m].get("strengths", "")) for m in model_ids), default=0),
+        "model": max(display_width(m) for m in model_ids),
+        "speed": max((display_width(catalog[m].get("speed", "")) for m in model_ids), default=6),
+        "strengths": max((display_width(catalog[m].get("strengths", "")) for m in model_ids), default=0),
     }
 
     print()
     header = (
-        f"  {'Model':<{widths['model']}}  "
-        f"{'Speed':<{widths['speed']}}  "
-        f"{'Strengths':<{widths['strengths']}}  "
+        f"  {ljust_display('Model', widths['model'])}  "
+        f"{ljust_display('Speed', widths['speed'])}  "
+        f"{ljust_display('Strengths', widths['strengths'])}  "
         f"Price"
     )
     print(color(header, Colors.CYAN))

--- a/tests/hermes_cli/test_image_gen_picker.py
+++ b/tests/hermes_cli/test_image_gen_picker.py
@@ -10,6 +10,8 @@ from types import SimpleNamespace
 
 import pytest
 
+from hermes_cli.text_width import display_width
+
 from agent import image_gen_registry
 from agent.image_gen_provider import ImageGenProvider
 
@@ -102,6 +104,27 @@ class TestPluginPickerInjection:
         browser = tools_config.TOOL_CATEGORIES["browser"]
         visible = tools_config._visible_providers(browser, {})
         assert all(p.get("image_gen_plugin_name") is None for p in visible)
+
+
+class TestImageGenPickerFormatting:
+    def test_format_model_row_uses_display_width_for_cjk_text(self):
+        from hermes_cli import tools_config
+
+        widths = {"model": 14, "speed": 6, "strengths": 18}
+        row = tools_config._format_imagegen_model_row(
+            "模型A",
+            {"speed": "快", "strengths": "中文描述", "price": "$"},
+            widths,
+        )
+        expected_model_end = len("模型A" + " " * (14 - display_width("模型A")))
+        expected_speed_end = expected_model_end + 2 + len("快" + " " * (6 - display_width("快")))
+        expected_strengths_end = expected_speed_end + 2 + len("中文描述" + " " * (18 - display_width("中文描述")))
+
+        assert display_width(row[:expected_model_end]) == 14
+        assert display_width(row[expected_model_end:expected_model_end + 2]) == 2
+        assert display_width(row[expected_model_end + 2:expected_speed_end]) == 6
+        assert display_width(row[expected_speed_end + 2:expected_strengths_end]) == 18
+        assert row[expected_strengths_end + 2:] == "$"
 
 
 class TestPluginCatalog:


### PR DESCRIPTION
## Summary
- add Unicode display-width helpers for terminal column padding
- use display-cell widths in image generation model picker rows and headers
- cover CJK/full-width metadata alignment with a regression test

Fixes #17700

## Test Plan
- python -m pytest tests/hermes_cli/test_image_gen_picker.py tests/hermes_cli/test_tools_config.py -q -o 'addopts='