### PR TITLE
docs: add hermescheck to community ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ scripts/run_tests.sh
 - 📚 [Skills Hub](https://agentskills.io)
 - 🐛 [Issues](https://github.com/NousResearch/hermes-agent/issues)
 - 🔌 [HermesClaw](https://github.com/AaronWong1999/hermesclaw) — Community WeChat bridge: Run Hermes Agent and OpenClaw on the same WeChat account.
+- 🧭 [hermescheck](https://github.com/huangrichao2020/hermescheck) — Community health checks for Hermes Agent forks and deployments.
 
 ---
 


### PR DESCRIPTION
## Summary

This PR adds one README Community entry for [hermescheck](https://github.com/huangrichao2020/hermescheck), a community-maintained architecture and runtime health checker for Hermes Agent forks and deployments.

This is intentionally the same README diff as #15333. I am resubmitting it with more concrete context because the original description made the tool sound like a nice-to-have docs link. After running hermescheck against a current Hermes checkout, I think the value is more practical: Hermes has become a large persistent runtime, and external contributors need a small, repeatable way to inspect whether the runtime surfaces still line up.

## Why this helps Hermes developers

Hermes is not a single CLI script anymore. The current tree spans CLI/TUI, gateway platforms, cron, session storage, memory, skills, optional skills, plugins, remote tools, browser/tool environments, ACP, website docs, and a growing test suite. For a contributor or fork maintainer, it is very easy to validate one surface while accidentally drifting another.

I ran `hermescheck` 1.3.0 against this PR branch with an 11-scanner Hermes-focused audit profile covering runtime contract, daemon lifecycle, memory/skills, RAG/retrieval, plugin/tool boundaries, pipeline middleware, observability, and knowledge consistency.

The report was intentionally not a vulnerability report. It was an architecture-quality report:

- Overall health: `acceptable`
- Architecture era score: `63/100`, `蒸汽机时代`
- Severity summary: `0 critical`, `0 high`, `1 medium`, `2 low`
- Positive signals found: methodology layer, restart session recall, memory lifecycle governance, semantic paging, stateful recovery, token-efficient context, permission policy, RAG governance, remote tool boundaries, scheduler/workers, daemon lifecycle safety, traces/evals, handoff/workbook habit, and CLI worker contracts
- Review findings found:
  - `Duplicated skill / SOP artifacts detected`: 270 overlapping skill-like files across 28 duplicate groups, useful for keeping `skills/`, `optional-skills/`, docs, and tests canonical over time
  - `Documentation references missing local paths`: durable docs can point at local paths or command references that deserve periodic verification
  - `Durable docs contain relative time language`: long-lived skill/docs surfaces can keep session-relative words like “today/recently”, which become ambiguous for future agents

That is exactly the kind of feedback a Hermes contributor can act on before opening a larger PR. It says: this runtime is already strong, here are the places where maintenance drift can creep in, and here is evidence tied to files rather than vibes.

## Why this belongs in Community

The Community section already links adjacent ecosystem resources such as Skills Hub, Issues, and HermesClaw. `hermescheck` fits that same shape: it is external, community-maintained, and useful to people building around Hermes rather than changing Hermes itself.

For any Hermes developer, it gives a fast preflight question:

> Did my change preserve the CLI, gateway, skills, memory, cron, plugin, tool, and docs contract as one runtime?

That is especially helpful for forks and deployments where maintainers may add channels, plugins, or skills without having the same context as core maintainers.

## Disclosure

I am the author of `hermescheck`, so this is a community-tool entry from the tool maintainer. I am happy to adjust the wording, move it elsewhere, or keep it out if the maintainers prefer not to list external tools. I am also happy to keep hermescheck aligned with Hermes Agent release by release.

## Validation

- `git diff --check`
- `uv run python -m hermescheck --version` -> `hermescheck 1.3.0`
- Generated and schema-validated `/tmp/hermes-agent-hermescheck-pr-audit-20260430.json` with the focused Hermes audit profile described above
