### PR TITLE
fix(run_agent): stop raising InterruptedError from streaming worker thread

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6921,8 +6921,18 @@ class AIAgent:
                     # interrupt entirely.  On slow providers (ollama-cloud) each
                     # retry can block for the full stream-read timeout (120s+),
                     # causing multi-minute delays between /stop and response.
+                    #
+                    # Return silently rather than raising: the main polling
+                    # thread (below, ~L7249) observes self._interrupt_requested
+                    # on its next 0.3s tick and raises InterruptedError from
+                    # there, which the outer run_conversation loop handles
+                    # cleanly.  Raising from here instead would escape this
+                    # worker thread unhandled (this function has only a
+                    # finally, no except) and dump a noisy "Exception in
+                    # thread Thread-N" traceback to stderr in parallel with
+                    # the clean interrupt path.
                     if self._interrupt_requested:
-                        raise InterruptedError("Agent interrupted before stream retry")
+                        return
                     try:
                         if self.api_mode == "anthropic_messages":
                             self._try_refresh_anthropic_client_credentials()


### PR DESCRIPTION
## Summary
Stops the noisy `Exception in thread Thread-N (_call)` traceback that appeared on stderr whenever a subagent was interrupted mid-stream (e.g. during parallel `delegate_task` with one child timing out), by not raising in the first place.

## Root cause
The pre-retry interrupt check in the streaming worker (run_agent.py:6925) raised `InterruptedError`. The worker's outer `try` block has only a `finally` — no `except` — so the exception escaped into Python's `Thread._bootstrap_inner`, which printed an unhandled-thread traceback. Meanwhile the main polling thread's own interrupt handler (L7249) had *already* fired the clean `⚡ Interrupted during API call.` marker, so the stderr dump was pure cosmetic noise running in parallel with the correct path.

## Change
`run_agent.py`: replace `raise InterruptedError(...)` with `return` inside the worker's pre-retry check. The original intent — stop the retry loop so a fresh HTTP connection isn't opened post-interrupt — is preserved (loop exits on `return` too). The main thread's 0.3s polling tick observes `self._interrupt_requested` and raises from there, same as it does today when the worker is still mid-API-call.

## Validation
| | Before | After |
|---|---|---|
| Subagent interrupt during stream | Clean `⚡ Interrupted` marker **+** unhandled-thread traceback dumped to stderr | Clean `⚡ Interrupted` marker only |
| `py_compile` | ok | ok |

No new exception handler, no behavior change in the interrupt propagation path — just stops generating the exception that was noisy to catch.