### PR TITLE
fix: add Telegram topic gating and clarify bridge

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -544,6 +544,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["reply_prefix"] = platform_cfg["reply_prefix"]
                 if "require_mention" in platform_cfg:
                     bridged["require_mention"] = platform_cfg["require_mention"]
+                if "allowed_threads" in platform_cfg:
+                    bridged["allowed_threads"] = platform_cfg["allowed_threads"]
                 if "free_response_channels" in platform_cfg:
                     bridged["free_response_channels"] = platform_cfg["free_response_channels"]
                 if "mention_patterns" in platform_cfg:
@@ -621,6 +623,11 @@ def load_gateway_config() -> GatewayConfig:
                     if isinstance(frc, list):
                         frc = ",".join(str(v) for v in frc)
                     os.environ["TELEGRAM_FREE_RESPONSE_CHATS"] = str(frc)
+                allowed_threads = telegram_cfg.get("allowed_threads")
+                if allowed_threads is not None and not os.getenv("TELEGRAM_ALLOWED_THREADS"):
+                    if isinstance(allowed_threads, list):
+                        allowed_threads = ",".join(str(v) for v in allowed_threads)
+                    os.environ["TELEGRAM_ALLOWED_THREADS"] = str(allowed_threads)
                 if "reactions" in telegram_cfg and not os.getenv("TELEGRAM_REACTIONS"):
                     os.environ["TELEGRAM_REACTIONS"] = str(telegram_cfg["reactions"]).lower()
 

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -8,6 +8,8 @@ Uses python-telegram-bot library for:
 """
 
 import asyncio
+import concurrent.futures
+import itertools
 import json
 import logging
 import os
@@ -162,6 +164,8 @@ class TelegramAdapter(BasePlatformAdapter):
         self._model_picker_state: Dict[str, dict] = {}
         # Approval button state: message_id → session_key
         self._approval_state: Dict[int, str] = {}
+        # Clarify prompt state: clarify_id -> pending response metadata
+        self._clarify_state: Dict[int, Dict[str, Any]] = {}
 
     def _fallback_ips(self) -> list[str]:
         """Return validated fallback IPs from config (populated by _apply_env_overrides)."""
@@ -1025,13 +1029,16 @@ class TelegramAdapter(BasePlatformAdapter):
         self, chat_id: str, prompt: str, default: str = "",
         session_key: str = "",
     ) -> SendResult:
-        """Send an inline-keyboard update prompt (Yes / No buttons).
+        """Send an inline update prompt (Yes/No) to Telegram.
 
-        Used by the gateway ``/update`` watcher when ``hermes update --gateway``
-        needs user input (stash restore, config migration).
+        The response will be written to ``~/.hermes/.update_response`` by the
+        callback-query handler.  ``session_key`` is accepted for API symmetry but
+        isn't currently needed because there is only ever one update prompt at a
+        time.
         """
         if not self._bot:
             return SendResult(success=False, error="Not connected")
+
         try:
             default_hint = f" (default: {default})" if default else ""
             text = f"⚕ *Update needs your input:*\n\n{prompt}{default_hint}"
@@ -1050,6 +1057,77 @@ class TelegramAdapter(BasePlatformAdapter):
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
             logger.warning("[%s] send_update_prompt failed: %s", self.name, e)
+            return SendResult(success=False, error=str(e))
+
+    async def send_clarify_prompt(
+        self,
+        chat_id: str,
+        question: str,
+        choices: Optional[List[str]] = None,
+        session_key: str = "",
+        response_future: Optional[concurrent.futures.Future] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a clarify prompt to Telegram and track the pending response."""
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            if not hasattr(self, "_clarify_counter"):
+                self._clarify_counter = itertools.count(1)
+            clarify_id = next(self._clarify_counter)
+            cleaned_choices = [str(c).strip() for c in (choices or []) if str(c).strip()]
+            is_open_ended = len(cleaned_choices) == 0
+
+            thread_id = None
+            if metadata:
+                thread_id = metadata.get("thread_id") or metadata.get("message_thread_id")
+
+            text_lines = ["❓ 需要你的选择", "", question.strip()]
+            reply_markup = None
+            if is_open_ended:
+                text_lines.extend(["", "请直接回复你的答案。"])
+            else:
+                text_lines.append("")
+                for idx, choice in enumerate(cleaned_choices, start=1):
+                    text_lines.append(f"{idx}. {choice}")
+                text_lines.extend(["", "也可以点“其他”后直接回复。"])
+
+                rows = []
+                row = []
+                for idx, choice in enumerate(cleaned_choices):
+                    label = choice if len(choice) <= 28 else choice[:25] + "..."
+                    row.append(InlineKeyboardButton(label, callback_data=f"cq:{clarify_id}:{idx}"))
+                    if len(row) == 2:
+                        rows.append(row)
+                        row = []
+                if row:
+                    rows.append(row)
+                rows.append([InlineKeyboardButton("其他", callback_data=f"cq:{clarify_id}:other")])
+                reply_markup = InlineKeyboardMarkup(rows)
+
+            kwargs = {
+                "chat_id": int(chat_id),
+                "text": "\n".join(text_lines),
+                "reply_markup": reply_markup,
+            }
+            if thread_id is not None:
+                kwargs["message_thread_id"] = int(thread_id)
+
+            msg = await self._bot.send_message(**kwargs)
+            self._clarify_state[clarify_id] = {
+                "session_key": session_key,
+                "question": question.strip(),
+                "choices": cleaned_choices or None,
+                "response_future": response_future,
+                "awaiting_text": is_open_ended,
+                "chat_id": str(chat_id),
+                "thread_id": str(thread_id) if thread_id is not None else None,
+                "message_id": str(getattr(msg, "message_id", "")) or None,
+            }
+            return SendResult(success=True, message_id=str(msg.message_id))
+        except Exception as e:
+            logger.warning("[%s] send_clarify_prompt failed: %s", self.name, e)
             return SendResult(success=False, error=str(e))
 
     async def send_exec_approval(
@@ -1484,6 +1562,58 @@ class TelegramAdapter(BasePlatformAdapter):
                     )
                 except Exception as exc:
                     logger.error("Failed to resolve gateway approval from Telegram button: %s", exc)
+            return
+
+        # --- Clarify callbacks (cq:clarify_id:choice) ---
+        if data.startswith("cq:"):
+            parts = data.split(":", 2)
+            if len(parts) != 3:
+                await query.answer(text="Invalid clarify data.")
+                return
+            try:
+                clarify_id = int(parts[1])
+            except ValueError:
+                await query.answer(text="Invalid clarify ID.")
+                return
+
+            state = self._clarify_state.get(clarify_id)
+            if not state:
+                await query.answer(text="This choice has expired.")
+                return
+
+            choice_token = parts[2]
+            if choice_token == "other":
+                state["awaiting_text"] = True
+                await query.answer(text="请直接回复你的答案。")
+                try:
+                    await query.edit_message_text(
+                        text="❓ 请输入你的自定义答案\n\n请直接发送下一条消息回复。",
+                        reply_markup=None,
+                    )
+                except Exception:
+                    pass
+                return
+
+            choices = state.get("choices") or []
+            try:
+                choice_index = int(choice_token)
+                selected = choices[choice_index]
+            except (ValueError, IndexError, TypeError):
+                await query.answer(text="Invalid choice.")
+                return
+
+            future = state.get("response_future")
+            if future is not None and not future.done():
+                future.set_result(selected)
+            self._clarify_state.pop(clarify_id, None)
+            await query.answer(text=f"已选择：{selected}")
+            try:
+                await query.edit_message_text(
+                    text=f"❓ 已选择：{selected}",
+                    reply_markup=None,
+                )
+            except Exception:
+                pass
             return
 
         # --- Update prompt callbacks ---
@@ -1991,6 +2121,27 @@ class TelegramAdapter(BasePlatformAdapter):
             return {str(part).strip() for part in raw if str(part).strip()}
         return {part.strip() for part in str(raw).split(",") if part.strip()}
 
+    def _telegram_allowed_threads(self) -> set[str]:
+        """Return group-thread keys where the bot is allowed to respond.
+
+        Entries use ``<chat_id>:<thread_id>`` so a single forum topic can be
+        allowlisted without opening the rest of the group.
+        """
+        raw = self.config.extra.get("allowed_threads")
+        if raw is None:
+            raw = os.getenv("TELEGRAM_ALLOWED_THREADS", "")
+        if isinstance(raw, list):
+            return {str(part).strip() for part in raw if str(part).strip()}
+        return {part.strip() for part in str(raw).split(",") if part.strip()}
+
+    def _message_thread_key(self, message: Message) -> Optional[str]:
+        """Return a stable ``chat_id:thread_id`` key for forum topic messages."""
+        chat_id = getattr(getattr(message, "chat", None), "id", None)
+        thread_id = getattr(message, "message_thread_id", None)
+        if chat_id is None or thread_id is None:
+            return None
+        return f"{chat_id}:{thread_id}"
+
     def _compile_mention_patterns(self) -> List[re.Pattern]:
         """Compile optional regex wake-word patterns for group triggers."""
         patterns = self.config.extra.get("mention_patterns")
@@ -2102,6 +2253,11 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         if not self._is_group_chat(message):
             return True
+        allowed_threads = self._telegram_allowed_threads()
+        if allowed_threads:
+            thread_key = self._message_thread_key(message)
+            if thread_key not in allowed_threads:
+                return False
         if str(getattr(getattr(message, "chat", None), "id", "")) in self._telegram_free_response_chats():
             return True
         if not self._telegram_require_mention():
@@ -2123,12 +2279,37 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         if not update.message or not update.message.text:
             return
+        pending_clarify_id = self._match_pending_clarify(update.message)
+        if pending_clarify_id is not None:
+            response = (update.message.text or "").strip()
+            state = self._clarify_state.pop(pending_clarify_id, None)
+            if state:
+                future = state.get("response_future")
+                if future is not None and not future.done():
+                    future.set_result(response)
+            return
         if not self._should_process_message(update.message):
             return
 
         event = self._build_message_event(update.message, MessageType.TEXT)
         event.text = self._clean_bot_trigger_text(event.text)
         self._enqueue_text_event(event)
+
+    def _match_pending_clarify(self, message: Message) -> Optional[int]:
+        """Return clarify_id when a text reply should resolve a pending clarify prompt."""
+        chat_id = str(getattr(message, "chat_id", "") or getattr(getattr(message, "chat", None), "id", ""))
+        thread_id = getattr(message, "message_thread_id", None)
+        thread_id = str(thread_id) if thread_id is not None else None
+        for clarify_id, state in list(self._clarify_state.items()):
+            if not state.get("awaiting_text"):
+                continue
+            if str(state.get("chat_id") or "") != chat_id:
+                continue
+            state_thread = state.get("thread_id")
+            if state_thread is not None and state_thread != thread_id:
+                continue
+            return clarify_id
+        return None
     
     async def _handle_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming command messages."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14,6 +14,7 @@ Usage:
 """
 
 import asyncio
+import concurrent.futures
 import json
 import logging
 import os
@@ -2320,6 +2321,22 @@ class GatewayRunner:
         if platform_allow_all_var and os.getenv(platform_allow_all_var, "").lower() in ("true", "1", "yes"):
             return True
 
+        # Telegram free-response chats are intended to behave like open group
+        # topics where any participant may speak without mention-gating. Honor
+        # that allowlist at the authorization layer too; otherwise strangers in
+        # those chats are still dropped before TelegramAdapter can process them.
+        if (
+            source.platform == Platform.TELEGRAM
+            and source.chat_type in ("group", "thread")
+            and source.chat_id
+        ):
+            telegram_chat_allowlist = os.getenv("TELEGRAM_FREE_RESPONSE_CHATS", "")
+            allowed_chat_ids = {
+                part.strip() for part in telegram_chat_allowlist.split(",") if part.strip()
+            }
+            if str(source.chat_id).strip() in allowed_chat_ids:
+                return True
+
         # Check pairing store (always checked, regardless of allowlists)
         platform_name = source.platform.value if source.platform else ""
         if self.pairing_store.is_approved(platform_name, user_id):
@@ -3088,6 +3105,50 @@ class GatewayRunner:
                 logger.debug("@ context reference expansion failed: %s", exc)
 
         return message_text
+
+    def _build_clarify_callback(
+        self,
+        adapter,
+        source,
+        session_key: str,
+        loop,
+        metadata: Optional[Dict[str, Any]] = None,
+        timeout_seconds: int = 600,
+    ):
+        """Bridge the sync clarify tool callback to an async platform prompt."""
+        if getattr(type(adapter), "send_clarify_prompt", None) is None:
+            return None
+
+        def _clarify_sync(question: str, choices: Optional[List[str]] = None) -> str:
+            response_future: concurrent.futures.Future = concurrent.futures.Future()
+            try:
+                asyncio.run_coroutine_threadsafe(
+                    adapter.send_clarify_prompt(
+                        chat_id=source.chat_id,
+                        question=question,
+                        choices=choices,
+                        session_key=session_key,
+                        response_future=response_future,
+                        metadata=metadata,
+                    ),
+                    loop,
+                ).result(timeout=15)
+            except Exception as exc:
+                logger.error("Failed to send clarify prompt: %s", exc)
+                return (
+                    "The clarify prompt could not be delivered to the user. "
+                    f"Send failure: {exc}"
+                )
+
+            try:
+                return str(response_future.result(timeout=timeout_seconds)).strip()
+            except concurrent.futures.TimeoutError:
+                return (
+                    "The user did not provide a response within the time limit. "
+                    "Use your best judgment and proceed with a reasonable default."
+                )
+
+        return _clarify_sync
 
     async def _handle_message_with_agent(self, event, source, _quick_key: str):
         """Inner handler that runs under the _running_agents sentinel guard."""
@@ -7918,6 +7979,13 @@ class GatewayRunner:
             agent.stream_delta_callback = _stream_delta_cb
             agent.interim_assistant_callback = _interim_assistant_cb if _want_interim_messages else None
             agent.status_callback = _status_callback_sync
+            agent.clarify_callback = self._build_clarify_callback(
+                adapter=_status_adapter,
+                source=source,
+                session_key=session_key,
+                loop=_loop_for_step,
+                metadata=_status_thread_metadata,
+            ) if _status_adapter else None
             agent.reasoning_config = reasoning_config
             agent.service_tier = self._service_tier
             agent.request_overrides = turn_route.get("request_overrides")

--- a/tests/gateway/test_gateway_clarify_bridge.py
+++ b/tests/gateway/test_gateway_clarify_bridge.py
@@ -1,0 +1,58 @@
+"""Tests for the GatewayRunner clarify callback bridge."""
+
+import asyncio
+import concurrent.futures
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+class _FakeAdapter:
+    async def send_clarify_prompt(self, **kwargs):
+        fut = kwargs["response_future"]
+        fut.set_result("按钮选择")
+        return MagicMock(success=True)
+
+
+def _make_runner():
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")}
+    )
+    runner.adapters = {Platform.TELEGRAM: _FakeAdapter()}
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_build_clarify_callback_sends_prompt_and_waits_for_result():
+    runner = _make_runner()
+    adapter = runner.adapters[Platform.TELEGRAM]
+    adapter.send_clarify_prompt = AsyncMock(side_effect=adapter.send_clarify_prompt)
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="group",
+        user_id="u1",
+        thread_id="159975",
+    )
+
+    callback = runner._build_clarify_callback(
+        adapter=adapter,
+        source=source,
+        session_key="agent:main:telegram:group:12345:159975",
+        loop=asyncio.get_running_loop(),
+        metadata={"thread_id": "159975"},
+    )
+
+    result = await asyncio.to_thread(callback, "下一步？", ["修复", "跳过"])
+
+    assert result == "按钮选择"
+    adapter.send_clarify_prompt.assert_awaited_once()
+    kwargs = adapter.send_clarify_prompt.call_args.kwargs
+    assert kwargs["question"] == "下一步？"
+    assert kwargs["choices"] == ["修复", "跳过"]
+    assert isinstance(kwargs["response_future"], concurrent.futures.Future)

--- a/tests/gateway/test_telegram_clarify_buttons.py
+++ b/tests/gateway/test_telegram_clarify_buttons.py
@@ -1,0 +1,199 @@
+"""Tests for Telegram clarify prompts and callback handling."""
+
+import concurrent.futures
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+def _ensure_telegram_mock():
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+
+    mod = MagicMock()
+    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    mod.constants.ParseMode.MARKDOWN = "Markdown"
+    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    mod.constants.ParseMode.HTML = "HTML"
+    mod.constants.ChatType.PRIVATE = "private"
+    mod.constants.ChatType.GROUP = "group"
+    mod.constants.ChatType.SUPERGROUP = "supergroup"
+    mod.constants.ChatType.CHANNEL = "channel"
+    mod.error.NetworkError = type("NetworkError", (OSError,), {})
+    mod.error.TimedOut = type("TimedOut", (OSError,), {})
+    mod.error.BadRequest = type("BadRequest", (Exception,), {})
+
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, mod)
+    sys.modules.setdefault("telegram.error", mod.error)
+
+
+_ensure_telegram_mock()
+
+from gateway.config import PlatformConfig
+from gateway.platforms.telegram import TelegramAdapter
+
+
+def _make_adapter():
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    adapter._bot = AsyncMock()
+    adapter._app = MagicMock()
+    return adapter
+
+
+class TestTelegramClarifyPrompt:
+    @pytest.mark.asyncio
+    async def test_sends_inline_keyboard_and_stores_state(self):
+        adapter = _make_adapter()
+        mock_msg = MagicMock()
+        mock_msg.message_id = 77
+        adapter._bot.send_message = AsyncMock(return_value=mock_msg)
+        response_future = concurrent.futures.Future()
+
+        result = await adapter.send_clarify_prompt(
+            chat_id="12345",
+            question="下一步做什么？",
+            choices=["修复", "跳过"],
+            session_key="agent:main:telegram:group:12345:159975",
+            response_future=response_future,
+            metadata={"thread_id": "159975"},
+        )
+
+        assert result.success is True
+        kwargs = adapter._bot.send_message.call_args[1]
+        assert kwargs["chat_id"] == 12345
+        assert kwargs["message_thread_id"] == 159975
+        assert kwargs["reply_markup"] is not None
+        assert len(adapter._clarify_state) == 1
+        clarify_id = list(adapter._clarify_state.keys())[0]
+        state = adapter._clarify_state[clarify_id]
+        assert state["session_key"] == "agent:main:telegram:group:12345:159975"
+        assert state["response_future"] is response_future
+        assert state["choices"] == ["修复", "跳过"]
+
+    @pytest.mark.asyncio
+    async def test_open_ended_prompt_tracks_awaiting_text(self):
+        adapter = _make_adapter()
+        mock_msg = MagicMock()
+        mock_msg.message_id = 88
+        adapter._bot.send_message = AsyncMock(return_value=mock_msg)
+        response_future = concurrent.futures.Future()
+
+        await adapter.send_clarify_prompt(
+            chat_id="12345",
+            question="请补充说明",
+            choices=None,
+            session_key="s1",
+            response_future=response_future,
+        )
+
+        state = adapter._clarify_state[list(adapter._clarify_state.keys())[0]]
+        assert state["awaiting_text"] is True
+        assert state["response_future"] is response_future
+
+
+class TestTelegramClarifyCallbacks:
+    @pytest.mark.asyncio
+    async def test_button_click_resolves_future(self):
+        adapter = _make_adapter()
+        response_future = concurrent.futures.Future()
+        adapter._clarify_state[1] = {
+            "session_key": "s1",
+            "question": "下一步？",
+            "choices": ["修复", "跳过"],
+            "response_future": response_future,
+            "awaiting_text": False,
+            "chat_id": "12345",
+            "thread_id": "159975",
+        }
+
+        query = AsyncMock()
+        query.data = "cq:1:0"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.from_user = MagicMock()
+        query.from_user.first_name = "Gimi"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+
+        await adapter._handle_callback_query(update, MagicMock())
+
+        assert response_future.result(timeout=0.1) == "修复"
+        assert 1 not in adapter._clarify_state
+        query.edit_message_text.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_other_button_switches_to_text_mode(self):
+        adapter = _make_adapter()
+        response_future = concurrent.futures.Future()
+        adapter._clarify_state[2] = {
+            "session_key": "s2",
+            "question": "下一步？",
+            "choices": ["修复", "跳过"],
+            "response_future": response_future,
+            "awaiting_text": False,
+            "chat_id": "12345",
+            "thread_id": "159975",
+        }
+
+        query = AsyncMock()
+        query.data = "cq:2:other"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.from_user = MagicMock()
+        query.from_user.first_name = "Gimi"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+
+        await adapter._handle_callback_query(update, MagicMock())
+
+        assert adapter._clarify_state[2]["awaiting_text"] is True
+        assert response_future.done() is False
+        query.edit_message_text.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_text_reply_resolves_open_clarify_without_forwarding(self):
+        adapter = _make_adapter()
+        adapter.handle_message = AsyncMock()
+        response_future = concurrent.futures.Future()
+        adapter._clarify_state[3] = {
+            "session_key": "agent:main:telegram:group:12345:159975",
+            "question": "请补充说明",
+            "choices": None,
+            "response_future": response_future,
+            "awaiting_text": True,
+            "chat_id": "12345",
+            "thread_id": "159975",
+        }
+
+        update = MagicMock()
+        update.message = MagicMock()
+        update.message.text = "我选自定义方案"
+        update.message.chat_id = 12345
+        update.message.message_thread_id = 159975
+        update.message.chat = MagicMock()
+        update.message.chat.type = "supergroup"
+        update.message.from_user = MagicMock()
+        update.message.from_user.id = 1
+        update.message.from_user.username = "gimi"
+        update.message.from_user.full_name = "Gimi"
+        update.message.reply_to_message = None
+        update.message.message_id = 999
+
+        await adapter._handle_text_message(update, MagicMock())
+
+        assert response_future.result(timeout=0.1) == "我选自定义方案"
+        assert 3 not in adapter._clarify_state
+        adapter.handle_message.assert_not_called()

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -2,10 +2,20 @@ import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
+import pytest
+
 from gateway.config import Platform, PlatformConfig, load_gateway_config
 
 
-def _make_adapter(require_mention=None, free_response_chats=None, mention_patterns=None):
+@pytest.fixture(autouse=True)
+def _clear_telegram_group_env(monkeypatch):
+    monkeypatch.delenv("TELEGRAM_ALLOWED_THREADS", raising=False)
+    monkeypatch.delenv("TELEGRAM_FREE_RESPONSE_CHATS", raising=False)
+    monkeypatch.delenv("TELEGRAM_REQUIRE_MENTION", raising=False)
+    monkeypatch.delenv("TELEGRAM_MENTION_PATTERNS", raising=False)
+
+
+def _make_adapter(require_mention=None, free_response_chats=None, mention_patterns=None, allowed_threads=None):
     from gateway.platforms.telegram import TelegramAdapter
 
     extra = {}
@@ -13,6 +23,8 @@ def _make_adapter(require_mention=None, free_response_chats=None, mention_patter
         extra["require_mention"] = require_mention
     if free_response_chats is not None:
         extra["free_response_chats"] = free_response_chats
+    if allowed_threads is not None:
+        extra["allowed_threads"] = allowed_threads
     if mention_patterns is not None:
         extra["mention_patterns"] = mention_patterns
 
@@ -28,7 +40,16 @@ def _make_adapter(require_mention=None, free_response_chats=None, mention_patter
     return adapter
 
 
-def _group_message(text="hello", *, chat_id=-100, reply_to_bot=False, entities=None, caption=None, caption_entities=None):
+def _group_message(
+    text="hello",
+    *,
+    chat_id=-100,
+    thread_id=None,
+    reply_to_bot=False,
+    entities=None,
+    caption=None,
+    caption_entities=None,
+):
     reply_to_message = None
     if reply_to_bot:
         reply_to_message = SimpleNamespace(from_user=SimpleNamespace(id=999))
@@ -38,6 +59,7 @@ def _group_message(text="hello", *, chat_id=-100, reply_to_bot=False, entities=N
         entities=entities or [],
         caption_entities=caption_entities or [],
         chat=SimpleNamespace(id=chat_id, type="group"),
+        message_thread_id=thread_id,
         reply_to_message=reply_to_message,
     )
 
@@ -69,6 +91,44 @@ def test_free_response_chats_bypass_mention_requirement():
     assert adapter._should_process_message(_group_message("hello everyone", chat_id=-201)) is False
 
 
+def test_allowed_threads_limit_processing_to_one_topic():
+    adapter = _make_adapter(
+        require_mention=True,
+        free_response_chats=["-200"],
+        allowed_threads=["-200:159975"],
+    )
+
+    assert adapter._should_process_message(
+        _group_message("hello everyone", chat_id=-200, thread_id=159975)
+    ) is True
+    assert adapter._should_process_message(
+        _group_message("hello everyone", chat_id=-200, thread_id=159976)
+    ) is False
+    assert adapter._should_process_message(
+        _group_message("hello everyone", chat_id=-200)
+    ) is False
+
+
+def test_allowed_threads_block_other_topics_even_when_explicitly_triggered():
+    adapter = _make_adapter(
+        require_mention=True,
+        free_response_chats=["-200"],
+        allowed_threads=["-200:159975"],
+    )
+    mentioned = _group_message(
+        "hi @hermes_bot",
+        chat_id=-200,
+        thread_id=159976,
+        entities=[_mention_entity("hi @hermes_bot")],
+    )
+    replied = _group_message("replying", chat_id=-200, thread_id=159976, reply_to_bot=True)
+    commanded = _group_message("/status", chat_id=-200, thread_id=159976)
+
+    assert adapter._should_process_message(mentioned) is False
+    assert adapter._should_process_message(replied) is False
+    assert adapter._should_process_message(commanded, is_command=True) is False
+
+
 def test_regex_mention_patterns_allow_custom_wake_words():
     adapter = _make_adapter(require_mention=True, mention_patterns=[r"^\s*chompy\b"])
 
@@ -93,7 +153,9 @@ def test_config_bridges_telegram_group_settings(monkeypatch, tmp_path):
         "  mention_patterns:\n"
         "    - \"^\\\\s*chompy\\\\b\"\n"
         "  free_response_chats:\n"
-        "    - \"-123\"\n",
+        "    - \"-123\"\n"
+        "  allowed_threads:\n"
+        "    - \"-123:456\"\n",
         encoding="utf-8",
     )
 
@@ -101,6 +163,7 @@ def test_config_bridges_telegram_group_settings(monkeypatch, tmp_path):
     monkeypatch.delenv("TELEGRAM_REQUIRE_MENTION", raising=False)
     monkeypatch.delenv("TELEGRAM_MENTION_PATTERNS", raising=False)
     monkeypatch.delenv("TELEGRAM_FREE_RESPONSE_CHATS", raising=False)
+    monkeypatch.delenv("TELEGRAM_ALLOWED_THREADS", raising=False)
 
     config = load_gateway_config()
 
@@ -108,3 +171,4 @@ def test_config_bridges_telegram_group_settings(monkeypatch, tmp_path):
     assert __import__("os").environ["TELEGRAM_REQUIRE_MENTION"] == "true"
     assert json.loads(__import__("os").environ["TELEGRAM_MENTION_PATTERNS"]) == [r"^\s*chompy\b"]
     assert __import__("os").environ["TELEGRAM_FREE_RESPONSE_CHATS"] == "-123"
+    assert __import__("os").environ["TELEGRAM_ALLOWED_THREADS"] == "-123:456"

--- a/tests/gateway/test_unauthorized_dm_behavior.py
+++ b/tests/gateway/test_unauthorized_dm_behavior.py
@@ -37,7 +37,7 @@ def _clear_auth_env(monkeypatch) -> None:
         monkeypatch.delenv(key, raising=False)
 
 
-def _make_event(platform: Platform, user_id: str, chat_id: str) -> MessageEvent:
+def _make_event(platform: Platform, user_id: str, chat_id: str, *, chat_type: str = "dm") -> MessageEvent:
     return MessageEvent(
         text="hello",
         message_id="m1",
@@ -46,7 +46,7 @@ def _make_event(platform: Platform, user_id: str, chat_id: str) -> MessageEvent:
             user_id=user_id,
             chat_id=chat_id,
             user_name="tester",
-            chat_type="dm",
+            chat_type=chat_type,
         ),
     )
 
@@ -126,6 +126,26 @@ def test_star_wildcard_works_for_any_platform(monkeypatch):
         chat_id="123456789",
         user_name="stranger",
         chat_type="dm",
+    )
+    assert runner._is_user_authorized(source) is True
+
+
+def test_telegram_free_response_chat_authorizes_group_participants(monkeypatch):
+    """Configured Telegram free-response chats should bypass user auth in groups."""
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("TELEGRAM_FREE_RESPONSE_CHATS", "-1003839624196")
+
+    runner, _adapter = _make_runner(
+        Platform.TELEGRAM,
+        GatewayConfig(platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="t")}),
+    )
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="5313240810",
+        chat_id="-1003839624196",
+        user_name="block chain",
+        chat_type="group",
     )
     assert runner._is_user_authorized(source) is True
 


### PR DESCRIPTION
## Summary
- add Telegram allowed_threads support so one forum topic can be allowlisted without opening the full group
- bridge the clarify callback into Telegram inline buttons plus custom text replies
- honor TELEGRAM_FREE_RESPONSE_CHATS at the gateway authorization layer
- add focused gateway tests and isolate group-gating tests from host env vars

## Testing
- pytest -q tests/gateway/test_telegram_group_gating.py tests/gateway/test_unauthorized_dm_behavior.py tests/gateway/test_gateway_clarify_bridge.py tests/gateway/test_telegram_clarify_buttons.py