### PR TITLE
feat: Allow pnpm dependency installs in installer

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -6,6 +6,7 @@
 #
 # Usage:
 #   irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1 | iex
+#   $env:HERMES_NODE_PACKAGE_MANAGER="pnpm"; irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1 | iex
 #
 # Or download and run with options:
 #   .\install.ps1 -NoVenv -SkipSetup
@@ -703,6 +704,41 @@ Delete the contents (or this file) to use the default personality.
     }
 }
 
+function Invoke-NodePackageInstall {
+    param(
+        [string]$Directory,
+        [string]$FailureHint
+    )
+
+    $packageManager = $env:HERMES_NODE_PACKAGE_MANAGER
+    if ([string]::IsNullOrWhiteSpace($packageManager)) {
+        $packageManager = "npm"
+    }
+    $packageManager = $packageManager.Trim().ToLowerInvariant()
+
+    if ($packageManager -notin @("npm", "pnpm")) {
+        Write-Warn "Unsupported HERMES_NODE_PACKAGE_MANAGER=$packageManager (expected npm or pnpm)"
+        return $false
+    }
+
+    if (-not (Get-Command $packageManager -ErrorAction SilentlyContinue)) {
+        Write-Warn "$packageManager not found; set HERMES_NODE_PACKAGE_MANAGER=npm or install $packageManager"
+        return $false
+    }
+
+    Push-Location $Directory
+    try {
+        & $packageManager install --silent 2>&1 | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warn "$packageManager install failed ($FailureHint)"
+            return $false
+        }
+        return $true
+    } finally {
+        Pop-Location
+    }
+}
+
 function Install-NodeDeps {
     if (-not $HasNode) {
         Write-Info "Skipping Node.js dependencies (Node not installed)"
@@ -713,11 +749,8 @@ function Install-NodeDeps {
     
     if (Test-Path "package.json") {
         Write-Info "Installing Node.js dependencies (browser tools)..."
-        try {
-            npm install --silent 2>&1 | Out-Null
+        if (Invoke-NodePackageInstall -Directory $InstallDir -FailureHint "browser tools may not work") {
             Write-Success "Node.js dependencies installed"
-        } catch {
-            Write-Warn "npm install failed (browser tools may not work)"
         }
     }
     
@@ -725,14 +758,9 @@ function Install-NodeDeps {
     $tuiDir = "$InstallDir\ui-tui"
     if (Test-Path "$tuiDir\package.json") {
         Write-Info "Installing TUI dependencies..."
-        Push-Location $tuiDir
-        try {
-            npm install --silent 2>&1 | Out-Null
+        if (Invoke-NodePackageInstall -Directory $tuiDir -FailureHint "hermes --tui may not work") {
             Write-Success "TUI dependencies installed"
-        } catch {
-            Write-Warn "TUI npm install failed (hermes --tui may not work)"
         }
-        Pop-Location
     }
 
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -101,6 +101,11 @@ while [[ $# -gt 0 ]]; do
             echo "  --hermes-home PATH  Data directory (default: ~/.hermes, or \$HERMES_HOME)"
             echo "  -h, --help     Show this help"
             echo ""
+            echo "Environment:"
+            echo "  HERMES_NODE_PACKAGE_MANAGER=npm|pnpm"
+            echo "                  JavaScript package manager for Node dependencies"
+            echo "                  (default: npm)"
+            echo ""
             echo "Notes:"
             echo "  When running as root on Linux, Hermes installs the code under"
             echo "  /usr/local/lib/hermes-agent and links the command into"
@@ -1231,6 +1236,38 @@ SOUL_EOF
     fi
 }
 
+install_node_package_deps() {
+    local install_dir="$1"
+    local failure_hint="$2"
+    local package_manager="${HERMES_NODE_PACKAGE_MANAGER:-npm}"
+
+    # Keep macOS /bin/bash 3.2 compatibility: avoid ${var,,}.
+    case "$package_manager" in
+        [nN][pP][mM])
+            package_manager="npm"
+            ;;
+        [pP][nN][pP][mM])
+            package_manager="pnpm"
+            ;;
+        *)
+            log_warn "Unsupported HERMES_NODE_PACKAGE_MANAGER=$package_manager (expected npm or pnpm)"
+            return 1
+            ;;
+    esac
+
+    if ! command -v "$package_manager" >/dev/null 2>&1; then
+        log_warn "$package_manager not found; set HERMES_NODE_PACKAGE_MANAGER=npm or install $package_manager"
+        return 1
+    fi
+
+    if ! (cd "$install_dir" && "$package_manager" install --silent 2>/dev/null); then
+        log_warn "$package_manager install failed ($failure_hint)"
+        return 1
+    fi
+
+    return 0
+}
+
 install_node_deps() {
     if [ "$HAS_NODE" = false ]; then
         log_info "Skipping Node.js dependencies (Node not installed)"
@@ -1240,17 +1277,15 @@ install_node_deps() {
     if [ "$DISTRO" = "termux" ]; then
         log_info "Skipping automatic Node/browser dependency setup on Termux"
         log_info "Browser automation is not part of the tested Termux install path yet."
-        log_info "If you want to experiment manually later, run: cd $INSTALL_DIR && npm install"
+        log_info "If you want to experiment manually later, run: cd $INSTALL_DIR && ${HERMES_NODE_PACKAGE_MANAGER:-npm} install"
         return 0
     fi
 
     if [ -f "$INSTALL_DIR/package.json" ]; then
         log_info "Installing Node.js dependencies (browser tools)..."
-        cd "$INSTALL_DIR"
-        npm install --silent 2>/dev/null || {
-            log_warn "npm install failed (browser tools may not work)"
-        }
-        log_success "Node.js dependencies installed"
+        if install_node_package_deps "$INSTALL_DIR" "browser tools may not work"; then
+            log_success "Node.js dependencies installed"
+        fi
 
         # Install Playwright browser + system dependencies.
         # Playwright's --with-deps only supports apt-based systems natively.
@@ -1314,11 +1349,9 @@ install_node_deps() {
     # Install TUI dependencies
     if [ -f "$INSTALL_DIR/ui-tui/package.json" ]; then
         log_info "Installing TUI dependencies..."
-        cd "$INSTALL_DIR/ui-tui"
-        npm install --silent 2>/dev/null || {
-            log_warn "TUI npm install failed (hermes --tui may not work)"
-        }
-        log_success "TUI dependencies installed"
+        if install_node_package_deps "$INSTALL_DIR/ui-tui" "hermes --tui may not work"; then
+            log_success "TUI dependencies installed"
+        fi
     fi
 
 

--- a/tests/test_install_node_package_manager.py
+++ b/tests/test_install_node_package_manager.py
@@ -1,0 +1,66 @@
+"""Installer support for selecting npm or pnpm via environment variable."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+INSTALL_PS1 = REPO_ROOT / "scripts" / "install.ps1"
+
+
+def _extract_shell_function(name: str) -> str:
+    text = INSTALL_SH.read_text()
+    match = re.search(
+        rf"^{re.escape(name)}\(\)\s*\{{\s*\n(?P<body>.*?)^\}}",
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert match is not None, f"{name}() not found in scripts/install.sh"
+    return match["body"]
+
+
+def _extract_powershell_function(name: str) -> str:
+    text = INSTALL_PS1.read_text()
+    match = re.search(
+        rf"^function\s+{re.escape(name)}\s*\{{\s*\n(?P<body>.*?)^\}}",
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert match is not None, f"{name} function not found in scripts/install.ps1"
+    return match["body"]
+
+
+def test_install_sh_node_dependencies_respect_env_package_manager() -> None:
+    helper = _extract_shell_function("install_node_package_deps")
+    install_body = _extract_shell_function("install_node_deps")
+
+    assert "HERMES_NODE_PACKAGE_MANAGER" in helper
+    assert "npm" in helper
+    assert "pnpm" in helper
+    assert 'command -v "$package_manager"' in helper
+    assert '"$package_manager" install --silent' in helper
+
+    assert 'install_node_package_deps "$INSTALL_DIR" "browser tools may not work"' in install_body
+    assert (
+        'install_node_package_deps "$INSTALL_DIR/ui-tui" "hermes --tui may not work"'
+        in install_body
+    )
+    assert not re.search(r"(?m)^\s*npm\s+install\s+--silent\b", install_body)
+
+
+def test_install_ps1_node_dependencies_respect_env_package_manager() -> None:
+    helper = _extract_powershell_function("Invoke-NodePackageInstall")
+    install_body = _extract_powershell_function("Install-NodeDeps")
+
+    assert "HERMES_NODE_PACKAGE_MANAGER" in helper
+    assert "npm" in helper
+    assert "pnpm" in helper
+    assert "Get-Command $packageManager" in helper
+    assert "& $packageManager install --silent" in helper
+
+    assert "Invoke-NodePackageInstall -Directory $InstallDir" in install_body
+    assert "Invoke-NodePackageInstall -Directory $tuiDir" in install_body
+    assert not re.search(r"(?m)^\s*npm\s+install\s+--silent\b", install_body)


### PR DESCRIPTION
## Summary

Adds `HERMES_NODE_PACKAGE_MANAGER` so users can choose the JavaScript package manager used by the installer for Node dependencies. The default remains `npm`, while setting `HERMES_NODE_PACKAGE_MANAGER=pnpm` makes both the root Node dependency install and the `ui-tui` dependency install use `pnpm`.

This is implemented for both `scripts/install.sh` and `scripts/install.ps1`, with unsupported values or missing package-manager binaries reported as warnings instead of silently falling back.

## Why

The installer previously hardcoded `npm install`, which made it difficult for users who prefer or standardize on `pnpm` to install Hermes dependencies through the main install path. Using an environment variable preserves backwards compatibility while allowing explicit `pnpm` installs.

## Validation

- `bash -n scripts/install.sh`
- `git diff --check`
- `scripts/run_tests.sh tests/test_install_node_package_manager.py tests/test_install_sh_setup_wizard_tty_probe.py -v --tb=short`