### PR TITLE
fix(hermes_time): read config yaml as utf-8

### DIFF
--- a/hermes_time.py
+++ b/hermes_time.py
@@ -50,7 +50,7 @@ def _resolve_timezone_name() -> str:
         import yaml
         config_path = get_config_path()
         if config_path.exists():
-            with open(config_path) as f:
+            with open(config_path, encoding="utf-8") as f:
                 cfg = yaml.safe_load(f) or {}
             tz_cfg = cfg.get("timezone", "")
             if isinstance(tz_cfg, str) and tz_cfg.strip():

--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -129,6 +129,35 @@ class TestGetTimezone:
         tz = hermes_time.get_timezone()
         assert tz is None
 
+    def test_config_yaml_read_as_utf8(self, tmp_path, monkeypatch):
+        """UTF-8 config files should load even when locale defaults differ."""
+        import builtins
+
+        os.environ.pop("HERMES_TIMEZONE", None)
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            "# 用户配置\nnote: café\ntimezone: Asia/Shanghai\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(hermes_time, "get_config_path", lambda: config_path)
+
+        real_open = builtins.open
+
+        def ascii_default_open(file, mode="r", *args, **kwargs):
+            if (
+                str(file) == str(config_path)
+                and "b" not in mode
+                and "encoding" not in kwargs
+            ):
+                kwargs["encoding"] = "ascii"
+            return real_open(file, mode, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "open", ascii_default_open)
+
+        tz = hermes_time.get_timezone()
+        assert isinstance(tz, ZoneInfo)
+        assert str(tz) == "Asia/Shanghai"
+
 
 
 # =========================================================================


### PR DESCRIPTION
## What does this PR do?

Fixes timezone config loading when `config.yaml` is UTF-8 but the platform default text encoding is different.

Previously, `hermes_time.py` opened the user's `config.yaml` without an explicit encoding. On systems where the default encoding is not UTF-8, a config file containing non-ASCII UTF-8 text could fail to decode and silently fall back to the local timezone. This PR reads the config as UTF-8 explicitly, matching how Hermes config files are normally written.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Updated `hermes_time.py` to read `config.yaml` with `encoding="utf-8"`.
- Added a regression test in `tests/test_timezone.py` that simulates a non-UTF-8 default encoding while reading a UTF-8 config file.

## How to Test

```bash
python -m pytest tests/test_timezone.py -q -o addopts=
```

Result:

```text
19 passed, 2 skipped
```

## Checklist

- [x] My commit messages follow Conventional Commits
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on Windows 11, Python 3.11.9
