### PR TITLE
fix(security): apply ACL checks to QQBot guild messages and guild DMs

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -976,6 +976,18 @@ class QQAdapter(BasePlatformAdapter):
         if not channel_id:
             return
 
+        # Apply group_policy ACL — guild channels are group-like contexts.
+        # Without this check any member of any guild the bot is in could
+        # bypass the configured allowlist.
+        guild_id = str(d.get("guild_id", ""))
+        author_id = str(author.get("id", ""))
+        if not self._is_group_allowed(guild_id or channel_id, author_id):
+            logger.debug(
+                "[%s] Guild message blocked by ACL: channel=%s user=%s",
+                self._log_tag, channel_id, author_id,
+            )
+            return
+
         member = d.get("member") if isinstance(d.get("member"), dict) else {}
         nick = str(member.get("nick", "")) or str(author.get("username", ""))
 
@@ -1030,6 +1042,17 @@ class QQAdapter(BasePlatformAdapter):
         """Handle a guild DM message event."""
         guild_id = str(d.get("guild_id", ""))
         if not guild_id:
+            return
+
+        # Apply dm_policy ACL — guild DMs were previously unauthenticated.
+        # Without this check any member of any guild the bot is in could
+        # bypass the configured allowlist via direct messages.
+        author_id = str(author.get("id", ""))
+        if not self._is_dm_allowed(author_id):
+            logger.debug(
+                "[%s] Guild DM blocked by ACL: guild=%s user=%s",
+                self._log_tag, guild_id, author_id,
+            )
             return
 
         text = content

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -132,6 +132,7 @@ AUTHOR_MAP = {
     "126368201+vilkasdev@users.noreply.github.com": "vilkasdev",
     "137614867+cutepawss@users.noreply.github.com": "cutepawss",
     "96793918+memosr@users.noreply.github.com": "memosr",
+    "mehmet.sr35@gmail.com": "memosr",
     "milkoor@users.noreply.github.com": "milkoor",
     "xuerui911@gmail.com": "Fatty911",
     "131039422+SHL0MS@users.noreply.github.com": "SHL0MS",


### PR DESCRIPTION
Salvage of #17555 onto current main, authored by @memosr (commit authorship preserved).

## Summary
QQBot adapter applies access control to C2C and group handlers but not to guild channel messages or guild DMs. Operators setting `dm_policy: allowlist` / `group_policy: allowlist` believed they were locked down, but any member of any guild the bot joined could bypass the allowlist via `GUILD_AT_MESSAGE_CREATE` or `DIRECT_MESSAGE_CREATE` events.

## Changes
- `gateway/platforms/qqbot/adapter.py`: early-return ACL check in `_handle_guild_message` (`_is_group_allowed`) and `_handle_dm_message` (`_is_dm_allowed`), mirroring the existing pattern in the two already-protected handlers.
- `scripts/release.py`: add the contributor's commit email to `AUTHOR_MAP` so release-notes CI recognizes it.

## Validation
| | Before | After |
|---|---|---|
| Guild `@bot` message from non-allowlisted user | accepted | blocked |
| Guild DM from non-allowlisted user | accepted | blocked |
| Guild message with no allowlist configured | accepted | accepted (unchanged) |
| `tests/gateway/test_qqbot.py` | 71/71 pass | 71/71 pass |

Original PR: #17555