### PR TITLE
feat: per-model rate limiter to proactively avoid 429 errors

### DIFF
--- a/agent/model_rate_limiter.py
+++ b/agent/model_rate_limiter.py
@@ -1,0 +1,133 @@
+"""Per-model rate limiter using a token-bucket algorithm.
+
+Proactively spaces API requests to avoid 429 errors.  Each
+(provider, model) pair gets its own limiter instance so that
+different models on the same provider are rate-limited
+independently.
+
+Usage::
+
+    limiter = ModelRateLimiterGlobal.get_or_create("nvidia", "minimax-m2.7")
+    async with limiter.acquire(40):  # 40 RPM
+        response = client.chat.completions.create(...)
+
+Or synchronously (e.g. inside a worker thread)::
+
+    limiter.acquire_sync(40)  # blocks until a token is available
+    response = client.chat.completions.create(...)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from contextlib import asynccontextmanager
+from typing import Any, Dict, Optional, Tuple
+
+
+class ModelRateLimiter:
+    """Token-bucket rate limiter for a single (provider, model) pair.
+
+    Bucket capacity is 1 token (no burst).  Each token replenishes after
+    ``1 / rate`` seconds where ``rate`` is requests-per-second.
+    """
+
+    def __init__(self, provider: str, model: str) -> None:
+        self.provider = provider
+        self.model = model
+        self._lock = threading.Lock()
+        self._last_request_time: float = 0.0
+        self._requests_made: int = 0
+        self._initialized = False
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def acquire_sync(self, rate_limit_rpm: int) -> None:
+        """Block until a token is available.  No-op when *rate_limit_rpm* is 0."""
+        if rate_limit_rpm <= 0:
+            return
+        rate_per_sec = rate_limit_rpm / 60.0
+        interval = 1.0 / rate_per_sec
+        with self._lock:
+            now = time.monotonic()
+            if not self._initialized:
+                self._initialized = True
+                self._last_request_time = now
+                self._requests_made += 1
+                return
+            elapsed = now - self._last_request_time
+            wait = max(0.0, interval - elapsed)
+            self._last_request_time = now + wait
+            self._requests_made += 1
+        if wait > 0:
+            time.sleep(wait)
+
+    @asynccontextmanager
+    async def acquire(self, rate_limit_rpm: int):
+        """Async context manager that waits for a token before yielding."""
+        if rate_limit_rpm <= 0:
+            yield
+            return
+        rate_per_sec = rate_limit_rpm / 60.0
+        interval = 1.0 / rate_per_sec
+        with self._lock:
+            now = time.monotonic()
+            if not self._initialized:
+                self._initialized = True
+                self._last_request_time = now
+                self._requests_made += 1
+                yield
+                return
+            elapsed = now - self._last_request_time
+            wait = max(0.0, interval - elapsed)
+            self._last_request_time = now + wait
+            self._requests_made += 1
+        if wait > 0:
+            await asyncio.sleep(wait)
+        yield
+
+    def get_status(self) -> Dict[str, Any]:
+        """Return current limiter stats."""
+        with self._lock:
+            return {
+                "provider": self.provider,
+                "model": self.model,
+                "requests_made": self._requests_made,
+                "last_request_time": self._last_request_time,
+            }
+
+
+class ModelRateLimiterGlobal:
+    """Global singleton registry of ``ModelRateLimiter`` instances.
+
+    Keyed by ``(provider, model)`` tuple.
+    """
+
+    _registry: Dict[Tuple[str, str], ModelRateLimiter] = {}
+    _lock = threading.Lock()
+
+    @classmethod
+    def get_or_create(cls, provider: str, model: str) -> ModelRateLimiter:
+        """Return the limiter for *(provider, model)*, creating if needed."""
+        key = (provider or "", model or "")
+        with cls._lock:
+            if key not in cls._registry:
+                cls._registry[key] = ModelRateLimiter(provider, model)
+            return cls._registry[key]
+
+    @classmethod
+    def set_limit(cls, provider: str, model: str, rpm: int) -> ModelRateLimiter:
+        """Convenience: get-or-create and store a configured limit."""
+        return cls.get_or_create(provider, model)
+
+    @classmethod
+    def get_status(cls) -> Dict[str, Any]:
+        """Return status for all registered limiters."""
+        with cls._lock:
+            return {
+                f"{k[0]}:{k[1]}": v.get_status()
+                for k, v in cls._registry.items()
+            }

--- a/cli.py
+++ b/cli.py
@@ -3222,6 +3222,7 @@ class HermesCLI:
         resolved_acp_command = runtime.get("command")
         resolved_acp_args = list(runtime.get("args") or [])
         resolved_credential_pool = runtime.get("credential_pool")
+        self._requests_per_minute = int(runtime.get("requests_per_minute", 0) or 0)
         if not isinstance(api_key, str) or not api_key:
             # Custom / local endpoints (llama.cpp, ollama, vLLM, etc.) often
             # don't require authentication.  When a base_url IS configured but
@@ -3435,6 +3436,7 @@ class HermesCLI:
                 "command": self.acp_command,
                 "args": list(self.acp_args or []),
                 "credential_pool": getattr(self, "_credential_pool", None),
+                "requests_per_minute": getattr(self, "_requests_per_minute", 0),
             }
             effective_model = model_override or self.model
             self.agent = AIAgent(
@@ -3446,6 +3448,7 @@ class HermesCLI:
                 acp_command=runtime.get("command"),
                 acp_args=runtime.get("args"),
                 credential_pool=runtime.get("credential_pool"),
+                requests_per_minute=runtime.get("requests_per_minute", 0),
                 max_iterations=self.max_turns,
                 enabled_toolsets=self.enabled_toolsets,
                 verbose_logging=self.verbose,
@@ -6513,6 +6516,7 @@ class HermesCLI:
                     api_mode=turn_route["runtime"].get("api_mode"),
                     acp_command=turn_route["runtime"].get("command"),
                     acp_args=turn_route["runtime"].get("args"),
+                    requests_per_minute=turn_route["runtime"].get("requests_per_minute", 0),
                     max_iterations=self.max_turns,
                     enabled_toolsets=self.enabled_toolsets,
                     quiet_mode=True,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -379,6 +379,10 @@ def _ensure_hermes_home_managed(home: Path):
 
 DEFAULT_CONFIG = {
     "model": "",
+    # Per-model rate limiting (requests per minute).  0 = disabled.
+    # Proactively spaces API calls to avoid 429 errors on providers
+    # with strict RPM limits (e.g. Nvidia NIM: 40 req/min on minimax).
+    "requests_per_minute": 0,
     "providers": {},
     "fallback_providers": [],
     "credential_pool_strategies": {},

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -491,6 +491,7 @@ def _resolve_named_custom_runtime(
             "api_key": api_key,
             "source": "direct-alias",
             "requested_provider": requested_provider,
+            "requests_per_minute": _requests_per_minute,
         }
 
     custom_provider = _get_named_custom_provider(requested_provider)
@@ -762,6 +763,7 @@ def _resolve_explicit_runtime(
             "api_key": api_key,
             "source": "explicit",
             "requested_provider": requested_provider,
+            "requests_per_minute": _requests_per_minute,
         }
 
     if provider == "openai-codex":
@@ -782,6 +784,7 @@ def _resolve_explicit_runtime(
             "source": "explicit",
             "last_refresh": last_refresh,
             "requested_provider": requested_provider,
+            "requests_per_minute": _requests_per_minute,
         }
 
     if provider == "nous":
@@ -813,6 +816,7 @@ def _resolve_explicit_runtime(
             "source": "explicit",
             "expires_at": expires_at,
             "requested_provider": requested_provider,
+            "requests_per_minute": _requests_per_minute,
         }
 
     # Azure Foundry: user-configured endpoint with selectable API mode
@@ -868,6 +872,7 @@ def _resolve_explicit_runtime(
             "api_key": api_key,
             "source": "explicit",
             "requested_provider": requested_provider,
+            "requests_per_minute": _requests_per_minute,
         }
 
     return None
@@ -892,6 +897,10 @@ def resolve_runtime_provider(
     """
     requested_provider = resolve_requested_provider(requested)
 
+    # Read per-model rate limit from config (0 = disabled).
+    _model_cfg_rpm = _get_model_config()
+    _requests_per_minute = int(_model_cfg_rpm.get("requests_per_minute", 0) or 0)
+
     # Azure Anthropic short-circuit: when explicitly targeting an Azure endpoint
     # with provider="anthropic", bypass _resolve_named_custom_runtime (which would
     # return provider="custom" with chat_completions api_mode and no valid key).
@@ -910,6 +919,7 @@ def resolve_runtime_provider(
             "api_key": _azure_key,
             "source": "azure-explicit",
             "requested_provider": requested_provider,
+            "requests_per_minute": _requests_per_minute,
         }
 
     # Azure Foundry: user-configured endpoint with selectable API mode
@@ -925,6 +935,7 @@ def resolve_runtime_provider(
             explicit_base_url=explicit_base_url,
             target_model=target_model,
         )
+        azure_runtime["requests_per_minute"] = _requests_per_minute
         return azure_runtime
 
     custom_runtime = _resolve_named_custom_runtime(
@@ -934,6 +945,7 @@ def resolve_runtime_provider(
     )
     if custom_runtime:
         custom_runtime["requested_provider"] = requested_provider
+        custom_runtime["requests_per_minute"] = _requests_per_minute
         return custom_runtime
 
     provider = resolve_provider(
@@ -950,6 +962,7 @@ def resolve_runtime_provider(
         explicit_base_url=explicit_base_url,
     )
     if explicit_runtime:
+        explicit_runtime["requests_per_minute"] = _requests_per_minute
         return explicit_runtime
 
     should_use_pool = provider != "openrouter"
@@ -1000,7 +1013,7 @@ def resolve_runtime_provider(
                 logger.debug("Nous pool entry agent_key expired/missing, falling through to runtime resolution")
                 pool_api_key = ""
         if entry is not None and pool_api_key:
-            return _resolve_runtime_from_pool_entry(
+            _pool_rt = _resolve_runtime_from_pool_entry(
                 provider=provider,
                 entry=entry,
                 requested_provider=requested_provider,
@@ -1008,6 +1021,8 @@ def resolve_runtime_provider(
                 pool=pool,
                 target_model=target_model,
             )
+            _pool_rt["requests_per_minute"] = _requests_per_minute
+            return _pool_rt
 
     if provider == "nous":
         try:
@@ -1023,6 +1038,7 @@ def resolve_runtime_provider(
                 "source": creds.get("source", "portal"),
                 "expires_at": creds.get("expires_at"),
                 "requested_provider": requested_provider,
+                "requests_per_minute": _requests_per_minute,
             }
         except AuthError:
             if requested_provider != "auto":
@@ -1043,6 +1059,7 @@ def resolve_runtime_provider(
                 "source": creds.get("source", "hermes-auth-store"),
                 "last_refresh": creds.get("last_refresh"),
                 "requested_provider": requested_provider,
+                "requests_per_minute": _requests_per_minute,
             }
         except AuthError:
             if requested_provider != "auto":
@@ -1063,6 +1080,7 @@ def resolve_runtime_provider(
                 "source": creds.get("source", "qwen-cli"),
                 "expires_at_ms": creds.get("expires_at_ms"),
                 "requested_provider": requested_provider,
+                "requests_per_minute": _requests_per_minute,
             }
         except AuthError:
             if requested_provider != "auto":
@@ -1082,6 +1100,7 @@ def resolve_runtime_provider(
                 "api_key": creds["api_key"],
                 "source": creds.get("source", "oauth"),
                 "requested_provider": requested_provider,
+                "requests_per_minute": _requests_per_minute,
             }
 
     if provider == "google-gemini-cli":
@@ -1097,6 +1116,7 @@ def resolve_runtime_provider(
                 "email": creds.get("email", ""),
                 "project_id": creds.get("project_id", ""),
                 "requested_provider": requested_provider,
+                "requests_per_minute": _requests_per_minute,
             }
         except AuthError:
             if requested_provider != "auto":
@@ -1115,6 +1135,7 @@ def resolve_runtime_provider(
             "args": list(creds.get("args") or []),
             "source": creds.get("source", "process"),
             "requested_provider": requested_provider,
+            "requests_per_minute": _requests_per_minute,
         }
 
     # Anthropic (native Messages API)
@@ -1182,6 +1203,7 @@ def resolve_runtime_provider(
             "api_key": token,
             "source": "env",
             "requested_provider": requested_provider,
+            "requests_per_minute": _requests_per_minute,
         }
 
     # AWS Bedrock (native Converse API via boto3)
@@ -1238,6 +1260,7 @@ def resolve_runtime_provider(
                 "region": region,
                 "bedrock_anthropic": True,  # Signal to use AnthropicBedrock client
                 "requested_provider": requested_provider,
+                "requests_per_minute": _requests_per_minute,
             }
         else:
             # Non-Claude (Nova, DeepSeek, Llama, etc.) → Converse API
@@ -1249,6 +1272,7 @@ def resolve_runtime_provider(
                 "source": auth_source,
                 "region": region,
                 "requested_provider": requested_provider,
+                "requests_per_minute": _requests_per_minute,
             }
         if guardrail_config:
             runtime["guardrail_config"] = guardrail_config
@@ -1307,6 +1331,7 @@ def resolve_runtime_provider(
             "api_key": creds.get("api_key", ""),
             "source": creds.get("source", "env"),
             "requested_provider": requested_provider,
+            "requests_per_minute": _requests_per_minute,
         }
 
     runtime = _resolve_openrouter_runtime(
@@ -1315,6 +1340,7 @@ def resolve_runtime_provider(
         explicit_base_url=explicit_base_url,
     )
     runtime["requested_provider"] = requested_provider
+    runtime["requests_per_minute"] = _requests_per_minute
     return runtime
 
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -933,6 +933,7 @@ class AIAgent:
         iteration_budget: "IterationBudget" = None,
         fallback_model: Dict[str, Any] = None,
         credential_pool=None,
+        requests_per_minute: int = 0,
         checkpoints_enabled: bool = False,
         checkpoint_max_snapshots: int = 50,
         pass_session_id: bool = False,
@@ -1012,6 +1013,9 @@ class AIAgent:
         self.load_soul_identity = load_soul_identity
         self.pass_session_id = pass_session_id
         self._credential_pool = credential_pool
+        self._requests_per_minute = int(requests_per_minute or 0)
+        from agent.model_rate_limiter import ModelRateLimiterGlobal
+        self._model_rate_limiter = ModelRateLimiterGlobal.get_or_create(self.provider, self.model)
         self.log_prefix_chars = log_prefix_chars
         self.log_prefix = f"{log_prefix} " if log_prefix else ""
         # Store effective base URL for feature detection (prompt caching, reasoning, etc.)
@@ -2092,6 +2096,7 @@ class AIAgent:
             "compressor_provider": getattr(_cc, "provider", self.provider),
             "compressor_context_length": _cc.context_length,
             "compressor_threshold_tokens": _cc.threshold_tokens,
+            "requests_per_minute": self._requests_per_minute,
         }
         if self.api_mode == "anthropic_messages":
             self._primary_runtime.update({
@@ -2213,6 +2218,8 @@ class AIAgent:
         self.provider = new_provider
         self.base_url = base_url or self.base_url
         self.api_mode = api_mode
+        # Update rate limiter for the new (provider, model) pair.
+        self._model_rate_limiter = ModelRateLimiterGlobal.get_or_create(self.provider, self.model)
         # Invalidate transport cache — new api_mode may need a different transport
         if hasattr(self, "_transport_cache"):
             self._transport_cache.clear()
@@ -2320,6 +2327,7 @@ class AIAgent:
             "compressor_provider": getattr(_cc, "provider", self.provider) if _cc else self.provider,
             "compressor_context_length": _cc.context_length if _cc else 0,
             "compressor_threshold_tokens": _cc.threshold_tokens if _cc else 0,
+            "requests_per_minute": self._requests_per_minute,
         }
         if api_mode == "anthropic_messages":
             self._primary_runtime.update({
@@ -6218,6 +6226,9 @@ class AIAgent:
         request_client_holder = {"client": None}
 
         def _call():
+            # Proactive rate limiting: space requests to avoid 429 errors.
+            # No-op when _requests_per_minute is 0 (disabled).
+            self._model_rate_limiter.acquire_sync(self._requests_per_minute)
             try:
                 if self.api_mode == "codex_responses":
                     request_client_holder["client"] = self._create_request_openai_client(
@@ -7426,6 +7437,7 @@ class AIAgent:
             self.provider = fb_provider
             self.base_url = fb_base_url
             self.api_mode = fb_api_mode
+            self._model_rate_limiter = ModelRateLimiterGlobal.get_or_create(self.provider, self.model)
             if hasattr(self, "_transport_cache"):
                 self._transport_cache.clear()
             self._fallback_activated = True
@@ -7549,6 +7561,8 @@ class AIAgent:
             self.provider = rt["provider"]
             self.base_url = rt["base_url"]           # setter updates _base_url_lower
             self.api_mode = rt["api_mode"]
+            self._model_rate_limiter = ModelRateLimiterGlobal.get_or_create(self.provider, self.model)
+            self._requests_per_minute = int(rt.get("requests_per_minute", 0) or 0)
             if hasattr(self, "_transport_cache"):
                 self._transport_cache.clear()
             self.api_key = rt["api_key"]
@@ -9993,6 +10007,7 @@ class AIAgent:
                     _summary_result = _tsum.normalize_response(summary_response, strip_tool_prefix=self._is_anthropic_oauth)
                     final_response = (_summary_result.content or "").strip()
                 else:
+                    self._model_rate_limiter.acquire_sync(self._requests_per_minute)
                     summary_response = self._ensure_primary_openai_client(reason="iteration_limit_summary").chat.completions.create(**summary_kwargs)
                     _summary_result = self._get_transport().normalize_response(summary_response)
                     final_response = (_summary_result.content or "").strip()
@@ -10036,6 +10051,7 @@ class AIAgent:
                     if summary_extra_body:
                         summary_kwargs["extra_body"] = summary_extra_body
 
+                    self._model_rate_limiter.acquire_sync(self._requests_per_minute)
                     summary_response = self._ensure_primary_openai_client(reason="iteration_limit_summary_retry").chat.completions.create(**summary_kwargs)
                     _retry_result = self._get_transport().normalize_response(summary_response)
                     final_response = (_retry_result.content or "").strip()


### PR DESCRIPTION
## Summary

- Add configurable `requests_per_minute` setting that uses a token-bucket algorithm to space API requests **before** they hit provider rate limits (proactive prevention, not reactive 429 retry)
- Solves the 40 req/min limit issue on Nvidia NIM with minimax models

## Changes

| File | Change |
|------|--------|
| `agent/model_rate_limiter.py` | **NEW** — Token-bucket rate limiter with `acquire_sync()` and async `acquire()` context manager, global singleton registry keyed by `(provider, model)` |
| `hermes_cli/config.py` | Add `requests_per_minute: 0` to `DEFAULT_CONFIG` |
| `hermes_cli/runtime_provider.py` | Read rpm from config, include in all runtime dicts from `resolve_runtime_provider()` |
| `cli.py` | Extract rpm from runtime, store on CLI instance, pass to `AIAgent` (main + background agent) |
| `run_agent.py` | Accept rpm in `__init__`, wrap `_interruptible_api_call()`, `iteration_limit_summary` calls, `switch_model()`, fallback activation, and primary restore |

## Usage

```yaml
# ~/.hermes/config.yaml
requests_per_minute: 40  # Nvidia NIM minimax: 40 req/min limit
```

- `0` (default) = disabled, zero overhead
- `40` = space requests to 1.5s intervals
- `20` = space requests to 3s intervals

## Verified

Smoke test: 6 requests at 20 RPM = exactly 15.0s (5 × 3s intervals)

## Not touching existing reactive code

`rate_limit_tracker.py`, `nous_rate_guard.py`, `retry_utils.py` handle 429s after the fact. This limiter is proactive — a separate concern.