### PR TITLE
fix(agent): spawn OpenRouter pre-warm thread only once per process

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -323,6 +323,12 @@ _PATH_SCOPED_TOOLS = frozenset({"read_file", "write_file", "patch"})
 # Maximum number of concurrent worker threads for parallel tool execution.
 _MAX_TOOL_WORKERS = 8
 
+# Guard so the OpenRouter metadata pre-warm thread is only spawned once per
+# process, not once per AIAgent instantiation.  Without this, long-running
+# gateway processes leak one OS thread per incoming message and eventually
+# exhaust the system thread limit (RuntimeError: can't start new thread).
+_openrouter_prewarm_done = threading.Event()
+
 # Patterns that indicate a terminal command may modify/delete files.
 _DESTRUCTIVE_PATTERNS = re.compile(
     r"""(?:^|\s|&&|\|\||;|`)(?:
@@ -1107,10 +1113,17 @@ class AIAgent:
         # Pre-warm OpenRouter model metadata cache in a background thread.
         # fetch_model_metadata() is cached for 1 hour; this avoids a blocking
         # HTTP request on the first API response when pricing is estimated.
-        if self.provider == "openrouter" or self._is_openrouter_url():
+        # Use a process-level Event so this thread is only spawned once — a new
+        # AIAgent is created for every gateway request, so without the guard
+        # each message leaks one OS thread and the process eventually exhausts
+        # the system thread limit (RuntimeError: can't start new thread).
+        if (self.provider == "openrouter" or self._is_openrouter_url()) and \
+                not _openrouter_prewarm_done.is_set():
+            _openrouter_prewarm_done.set()
             threading.Thread(
-                target=lambda: fetch_model_metadata(),
+                target=fetch_model_metadata,
                 daemon=True,
+                name="openrouter-prewarm",
             ).start()
 
         self.tool_progress_callback = tool_progress_callback

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -53,6 +53,7 @@ AUTHOR_MAP = {
     "angelclaw@AngelMacBook.local": "angel12",
     "charles@cryptoassetrecovery.com": "charles-brooks",
     "heathley@Heathley-MacBook-Air.local": "heathley",
+    "vlad19@gmail.com": "dandaka",
     "adamrummer@gmail.com": "cyclingwithelephants",
     "nbot@liizfq.top": "liizfq",
     "274096618+hermes-agent-dhabibi@users.noreply.github.com": "dhabibi",


### PR DESCRIPTION
Long-running gateway processes no longer leak one OS thread per incoming message.

`AIAgent.__init__` unconditionally spawned a daemon thread to pre-warm OpenRouter model metadata. The gateway creates a fresh `AIAgent` per message, so after ~1000 messages the process hit the Linux thread limit with `RuntimeError: can't start new thread`. `fetch_model_metadata()` is already cached for 1 hour at module level, so a single pre-warm per process is sufficient.

## Changes
- \`run_agent.py\`: module-level \`_openrouter_prewarm_done = threading.Event()\`; spawn-and-set guarded by \`is_set()\` check; thread now named \`openrouter-prewarm\`; dropped unnecessary lambda.

## Validation
E2E: spawn 50 AIAgents with \`provider=openrouter\`, monkeypatch \`fetch_model_metadata\` to sleep so live threads are observable.

| | fetch calls | lingering prewarm daemons |
|---|---|---|
| origin/main (before) | 50 | 49 |
| this PR (after) | 1 | 0 |

## Salvage notes
Cherry-picked from #17495 by @dandaka, authorship preserved. Added \`vlad19@gmail.com -> dandaka\` to \`AUTHOR_MAP\` in \`scripts/release.py\` for CI.

Closes #17495