### PR TITLE
fix: use stash list instead of rev-parse to get stash ref

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -811,7 +811,7 @@ clone_repo() {
                 stash_name="hermes-install-autostash-$(date -u +%Y%m%d-%H%M%S)"
                 log_info "Local changes detected, stashing before update..."
                 git stash push --include-untracked -m "$stash_name"
-                autostash_ref="$(git rev-parse --verify refs/stash)"
+                autostash_ref="$(git stash list | tail -1 | sed 's/:.*//')"
             fi
 
             git fetch origin


### PR DESCRIPTION
## Summary

- `git rev-parse --verify refs/stash` returns a commit hash
- `git stash apply/drop` expects a stash ref like `stash@{0}`
- This caused the installer to fail with `"is not a stash reference"` error on every update when local changes exist

## Fix

Use `git stash list | tail -1 | sed 's/:.*//'` to extract the proper stash ref.

## Test plan

- [x] Verified fix works with patched install script
- [x] No stash error on reinstallation
- [ ] CI should pass