### PR TITLE
fix(tools): ensure cronjob list defaults to hiding disabled jobs

### DIFF
--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -9,6 +9,7 @@ from tools.cronjob_tools import (
     check_cronjob_requirements,
     cronjob,
 )
+from tools.registry import registry
 
 
 # =========================================================================
@@ -133,6 +134,18 @@ class TestUnifiedCronjobTool:
         resumed = json.loads(cronjob(action="resume", job_id=job_id))
         assert resumed["success"] is True
         assert resumed["job"]["state"] == "scheduled"
+
+    def test_registry_handler_list_omits_disabled_jobs_by_default(self):
+        created = json.loads(cronjob(action="create", prompt="Check", schedule="every 1h"))
+        job_id = created["job_id"]
+
+        paused = json.loads(cronjob(action="pause", job_id=job_id))
+        assert paused["success"] is True
+
+        listing = json.loads(registry.get_entry("cronjob").handler({"action": "list"}))
+        assert listing["success"] is True
+        assert listing["count"] == 0
+        assert listing["jobs"] == []
 
     def test_update_schedule_recomputes_display(self):
         created = json.loads(cronjob(action="create", prompt="Check", schedule="every 1h"))

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -584,7 +584,7 @@ registry.register(
         name=args.get("name"),
         repeat=args.get("repeat"),
         deliver=args.get("deliver"),
-        include_disabled=args.get("include_disabled", True),
+        include_disabled=args.get("include_disabled", False),
         skill=args.get("skill"),
         skills=args.get("skills"),
         model=_mo[1],


### PR DESCRIPTION
## Summary

Fix the `cronjob` tool registry wrapper so `action="list"` matches the underlying tool/function default behavior and does not include paused/disabled jobs unless `include_disabled=true` is explicitly requested.

Before this change, the wrapper passed:

- `include_disabled=args.get("include_disabled", True)`

even though:

- `cronjob(..., include_disabled=False)` defaults to hiding disabled jobs
- `cron.jobs.list_jobs(include_disabled=False)` also defaults to hiding them

That meant tool-call execution could return paused jobs by default, while direct function behavior did not.

## Fix

- Change the registry wrapper default in `tools/cronjob_tools.py` from `True` to `False`

## Regression test

Add a test that exercises the actual registry handler path:

- create a job
- pause it
- call the registered `cronjob` handler with `{"action": "list"}`
- assert the paused job is omitted by default

This locks the wrapper behavior to the intended default and prevents future drift between the handler and the underlying function.

## User impact

This fixes incorrect default results for cron job listing in the tool-call path. Users and models now see only active jobs unless disabled jobs are explicitly requested.

## Validation

Passed locally in PowerShell using the available pytest environment:

- `tests/tools/test_cronjob_tools.py -k registry_handler_list_omits_disabled_jobs_by_default`
- `tests/tools/test_cronjob_tools.py`

Results:
- `1 passed`
- `29 passed`

The run emitted only an existing `asyncio.get_event_loop_policy` deprecation warning unrelated to this change.
