### PR TITLE
fix(auxiliary): inherit provider-level base_url/api_key for auxiliary tasks

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2367,6 +2367,8 @@ def resolve_provider_client(
         # built-in provider name but targets a user-specified endpoint.
         if explicit_base_url:
             base_url = _to_openai_base_url(explicit_base_url.strip().rstrip("/"))
+        if explicit_api_key:
+            api_key = explicit_api_key
 
         default_model = _API_KEY_PROVIDER_AUX_MODELS.get(provider, "")
         final_model = _normalize_resolved_model(model or default_model, provider)
@@ -3130,7 +3132,27 @@ def _resolve_task_provider_model(
         if cfg_base_url:
             return "custom", resolved_model, cfg_base_url, cfg_api_key, resolved_api_mode
         if cfg_provider and cfg_provider != "auto":
-            return cfg_provider, resolved_model, None, None, resolved_api_mode
+            # Inherit base_url / api_key from providers.<name> when not
+            # explicitly set on the auxiliary task itself (#17737).
+            prov_base_url = None
+            prov_api_key = None
+            try:
+                from hermes_cli.config import load_config as _load_cfg
+                _pcfg = (_load_cfg() or {}).get('providers', {})
+                _pentry = _pcfg.get(cfg_provider, {}) if isinstance(_pcfg, dict) else {}
+                if isinstance(_pentry, dict):
+                    prov_base_url = (
+                        str(_pentry.get('base_url') or _pentry.get('api') or _pentry.get('url') or '').strip() or None
+                    )
+                    prov_api_key = str(_pentry.get('api_key', '')).strip() or None
+                    if not prov_api_key:
+                        _kenv = str(_pentry.get('key_env', '')).strip()
+                        if _kenv:
+                            import os as _os
+                            prov_api_key = _os.getenv(_kenv, '').strip() or None
+            except Exception:
+                pass
+            return cfg_provider, resolved_model, prov_base_url, prov_api_key, resolved_api_mode
 
         return "auto", resolved_model, None, None, resolved_api_mode
 


### PR DESCRIPTION
## Summary

When `auxiliary.<task>.provider` references a user-configured provider (e.g. `xiaomi` with a custom `base_url`), the resolved `base_url` and `api_key` were not inherited from the `providers.<name>` config entry. Instead, auxiliary tasks fell back to the hardcoded `inference_base_url` from `PROVIDER_REGISTRY`, causing silent failures (timeouts, 401s) and cascading fallback to other providers.

## Changes

**`agent/auxiliary_client.py`**

1. **`_resolve_task_provider_model()`** — When `cfg_provider` is set (not `"auto"`) but no explicit `base_url` is configured on the auxiliary task, look up `providers.<cfg_provider>` in `config.yaml` to inherit `base_url` and `api_key`. Supports `base_url`, `api`, `url` field variants and `key_env` environment variable resolution.

2. **`resolve_provider_client()`** — In the `PROVIDER_REGISTRY` code path, honor `explicit_base_url` / `explicit_api_key` over hardcoded registry defaults. This allows the inherited provider config from (1) to flow through correctly.

## Resolution Chain (as specified in #17737)

1. `auxiliary.<task>.base_url` / `api_key` (explicit override) ✅ already worked
2. `providers.<task_provider>.base_url` / `api_key` (inherited) ✅ **NEW**
3. Hardcoded `PROVIDER_REGISTRY` default ✅ already worked

## Testing

- All 231 auxiliary-related tests pass
- Syntax validated

Closes #17737