### PR TITLE
fix(cli): pass pip.conf index to uv updates

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -44,6 +44,7 @@ Usage:
 """
 
 import argparse
+import configparser
 import json
 import os
 import shutil
@@ -5515,7 +5516,7 @@ def _update_via_zip(args):
 
     uv_bin = shutil.which("uv")
     if uv_bin:
-        uv_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
+        uv_env = _build_uv_update_env(os.environ)
         _install_python_dependencies_with_optional_fallback([uv_bin, "pip"], env=uv_env)
     else:
         # Use sys.executable to explicitly call the venv's pip module,
@@ -6051,6 +6052,43 @@ def _load_installable_optional_extras() -> list[str]:
                 referenced.append(name)
 
     return referenced
+
+
+def _pip_config_candidates(env: dict[str, str]) -> list[Path]:
+    """Return pip config files in the same precedence order pip documents."""
+    candidates: list[Path] = []
+    explicit = env.get("PIP_CONFIG_FILE")
+    if explicit:
+        return [Path(explicit)]
+
+    candidates.append(Path("/etc/pip.conf"))
+    candidates.append(Path.home() / ".config" / "pip" / "pip.conf")
+    candidates.append(Path.home() / ".pip" / "pip.conf")
+    return candidates
+
+
+def _pip_conf_index_url(env: dict[str, str]) -> str | None:
+    """Read pip's configured index-url so uv can use the same mirror."""
+    parser = configparser.ConfigParser()
+    found = parser.read([str(path) for path in _pip_config_candidates(env)])
+    if not found or not parser.has_section("global"):
+        return None
+    value = parser.get("global", "index-url", fallback="").strip()
+    return value or None
+
+
+def _build_uv_update_env(base_env: dict[str, str]) -> dict[str, str]:
+    """Build the env for uv-based dependency updates.
+
+    uv does not read pip.conf, so mirror pip's configured index-url into
+    UV_INDEX_URL unless the user already configured uv explicitly.
+    """
+    env = {**base_env, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
+    if not env.get("UV_INDEX_URL"):
+        pip_index_url = _pip_conf_index_url(env)
+        if pip_index_url:
+            env["UV_INDEX_URL"] = pip_index_url
+    return env
 
 
 def _install_python_dependencies_with_optional_fallback(

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -1,12 +1,13 @@
 """Tests for cmd_update — branch fallback when remote branch doesn't exist."""
 
 import subprocess
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 
-from hermes_cli.main import cmd_update, PROJECT_ROOT
+from hermes_cli.main import cmd_update, PROJECT_ROOT, _build_uv_update_env
 
 
 def _make_run_side_effect(branch="main", verify_ok=True, commit_count="0"):
@@ -163,3 +164,21 @@ class TestCmdUpdateBranchFallback:
             mock_input.assert_not_called()
             captured = capsys.readouterr()
             assert "Non-interactive session" in captured.out
+
+
+def test_uv_update_env_inherits_index_url_from_pip_conf(tmp_path, monkeypatch):
+    """uv does not read pip.conf, so update mirrors it into UV_INDEX_URL."""
+    home = tmp_path / "home"
+    pip_dir = home / ".pip"
+    pip_dir.mkdir(parents=True)
+    (pip_dir / "pip.conf").write_text(
+        "[global]\nindex-url = https://mirrors.aliyun.com/pypi/simple\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.delenv("UV_INDEX_URL", raising=False)
+
+    env = _build_uv_update_env({"PATH": "/usr/bin"})
+
+    assert env["VIRTUAL_ENV"] == str(PROJECT_ROOT / "venv")
+    assert env["UV_INDEX_URL"] == "https://mirrors.aliyun.com/pypi/simple"

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -182,3 +182,22 @@ def test_uv_update_env_inherits_index_url_from_pip_conf(tmp_path, monkeypatch):
 
     assert env["VIRTUAL_ENV"] == str(PROJECT_ROOT / "venv")
     assert env["UV_INDEX_URL"] == "https://mirrors.aliyun.com/pypi/simple"
+
+
+def test_does_not_override_explicit_uv_index_url(tmp_path, monkeypatch):
+    """Explicit UV_INDEX_URL in base_env should win over pip.conf."""
+    home = tmp_path / "home"
+    pip_dir = home / ".pip"
+    pip_dir.mkdir(parents=True)
+    (pip_dir / "pip.conf").write_text(
+        "[global]\nindex-url = https://from-pipconf.example.com/simple\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(Path, "home", lambda: home)
+
+    env = _build_uv_update_env({
+        "PATH": "/usr/bin",
+        "UV_INDEX_URL": "https://explicit.example.com/simple",
+    })
+
+    assert env["UV_INDEX_URL"] == "https://explicit.example.com/simple"


### PR DESCRIPTION
## What does this PR do?

- Mirror pip's configured `global.index-url` into `UV_INDEX_URL` when `uv pip` is used during dependency updates.
- Keep an explicit `UV_INDEX_URL` untouched so users with native uv config are not overridden.
- Add a regression test for the pip.conf mirror handoff.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A