### PR TITLE
fix: preserve Telegram voice metadata and fast acknowledgements

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9090,6 +9090,7 @@ class GatewayRunner:
                     transcript = result["transcript"]
                     enriched_parts.append(
                         f'[The user sent a voice message~ '
+                        f'Audio file saved at: {path}. '
                         f'Here\'s what they said: "{transcript}"]'
                     )
                 else:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -62,6 +62,7 @@ from .config import (
 )
 from .whatsapp_identity import (
     canonical_whatsapp_identifier,
+    normalize_whatsapp_identifier,
 )
 from utils import atomic_replace
 
@@ -304,7 +305,20 @@ def build_session_context_prompt(
         lines.append(f"**User ID:** {uid}")
     
     # Platform-specific behavioral notes
-    if context.source.platform == Platform.SLACK:
+    if context.source.platform == Platform.TELEGRAM:
+        lines.append("")
+        lines.append(
+            "**Platform notes:** You are chatting through Telegram. "
+            "Keep replies concise and phone-friendly. For voice messages, briefly restate "
+            "what the user said so they can verify speech-to-text worked. If the request "
+            "needs tools or longer work, send a short visible acknowledgement via the "
+            "messaging tool first, then continue the work in the same turn and finish with "
+            "the actual result. The acknowledgement is not the answer; never acknowledge "
+            "and stop when work remains. Avoid CLI commands, file paths, environment "
+            "variables, and terminal-oriented instructions unless the user explicitly asks "
+            "for implementation details."
+        )
+    elif context.source.platform == Platform.SLACK:
         lines.append("")
         lines.append(
             "**Platform notes:** You are running inside Slack. "

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -188,6 +188,9 @@ class TestBuildSessionContextPrompt:
 
         assert "Telegram" in prompt
         assert "Home Chat" in prompt
+        assert "voice messages" in prompt
+        assert "visible acknowledgement" in prompt
+        assert "phone-friendly" in prompt
 
     def test_bluebubbles_prompt_mentions_short_conversational_i_message_format(self):
         config = GatewayConfig(

--- a/tests/gateway/test_voice_transcription_metadata.py
+++ b/tests/gateway/test_voice_transcription_metadata.py
@@ -1,0 +1,35 @@
+"""Gateway voice transcription metadata tests."""
+
+import asyncio
+import sys
+import types
+from types import SimpleNamespace
+
+
+def test_transcribed_voice_message_includes_cached_audio_path(monkeypatch):
+    from gateway.run import GatewayRunner
+
+    fake_tools = types.ModuleType("tools")
+    fake_transcription_tools = types.ModuleType("tools.transcription_tools")
+
+    def fake_transcribe_audio(path):
+        return {"success": True, "transcript": "hello from audio"}
+
+    fake_transcription_tools.transcribe_audio = fake_transcribe_audio
+    monkeypatch.setitem(sys.modules, "tools", fake_tools)
+    monkeypatch.setitem(sys.modules, "tools.transcription_tools", fake_transcription_tools)
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = SimpleNamespace(stt_enabled=True)
+
+    result = asyncio.run(
+        GatewayRunner._enrich_message_with_transcription(
+            runner,
+            "caption text",
+            ["/tmp/voice-note.ogg"],
+        )
+    )
+
+    assert "Audio file saved at: /tmp/voice-note.ogg." in result
+    assert 'Here\'s what they said: "hello from audio"' in result
+    assert result.endswith("caption text")


### PR DESCRIPTION
## Summary
- include cached voice-note audio paths in Telegram transcription metadata so automations can preserve original voice sources
- bake Erik/Telegram fast-ack guidance into gateway session context instead of relying on a separate skill load
- add regression coverage for voice transcription metadata and session context behavior

## Test Plan
- `python -m pytest tests/gateway/test_voice_transcription_metadata.py tests/gateway/test_session.py -q`
- `python3 -m py_compile gateway/run.py gateway/session.py`

## Notes
This prevents local Hermes updates from wiping the fixes once merged upstream. Until merge, the installed checkout still has the local commits applied.
