### PR TITLE
fix(weixin): prompt for and replay the 6-digit pairing code in QR login

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1090,13 +1090,47 @@ async def qr_login(
         deadline = time.monotonic() + timeout_seconds
         current_base_url = ILINK_BASE_URL
         refresh_count = 0
+        pending_verify_code: Optional[str] = None
+        scaned_printed = False
+
+        async def _refresh_qr() -> bool:
+            nonlocal qrcode_value, qrcode_url, scaned_printed, pending_verify_code
+            try:
+                qr_resp = await _api_get(
+                    session,
+                    base_url=ILINK_BASE_URL,
+                    endpoint=f"{EP_GET_BOT_QR}?bot_type={bot_type}",
+                    timeout_ms=QR_TIMEOUT_MS,
+                )
+            except Exception as exc:
+                logger.error("weixin: QR refresh failed: %s", exc)
+                return False
+            qrcode_value = str(qr_resp.get("qrcode") or "")
+            qrcode_url = str(qr_resp.get("qrcode_img_content") or "")
+            scan_data = qrcode_url if qrcode_url else qrcode_value
+            scaned_printed = False
+            pending_verify_code = None
+            if qrcode_url:
+                print(qrcode_url)
+            try:
+                import qrcode as _qrcode
+                qr = _qrcode.QRCode()
+                qr.add_data(scan_data)
+                qr.make(fit=True)
+                qr.print_ascii(invert=True)
+            except Exception:
+                pass
+            return True
 
         while time.monotonic() < deadline:
             try:
+                poll_endpoint = f"{EP_GET_QR_STATUS}?qrcode={qrcode_value}"
+                if pending_verify_code:
+                    poll_endpoint += f"&verify_code={quote(pending_verify_code, safe='')}"
                 status_resp = await _api_get(
                     session,
                     base_url=current_base_url,
-                    endpoint=f"{EP_GET_QR_STATUS}?qrcode={qrcode_value}",
+                    endpoint=poll_endpoint,
                     timeout_ms=QR_TIMEOUT_MS,
                 )
             except asyncio.TimeoutError:
@@ -1111,7 +1145,38 @@ async def qr_login(
             if status == "wait":
                 print(".", end="", flush=True)
             elif status == "scaned":
-                print("\n已扫码，请在微信里确认...")
+                if pending_verify_code:
+                    pending_verify_code = None
+                if not scaned_printed:
+                    print("\n已扫码，请在微信里确认...")
+                    scaned_printed = True
+            elif status == "need_verifycode":
+                prompt = (
+                    "\n❌ 数字不匹配，请重新输入手机微信显示的数字: "
+                    if pending_verify_code
+                    else "\n请输入手机微信显示的数字以继续连接: "
+                )
+                try:
+                    code = (await asyncio.to_thread(input, prompt)).strip()
+                except (EOFError, KeyboardInterrupt):
+                    print("\n微信登录已取消。")
+                    return None
+                if not code:
+                    continue
+                pending_verify_code = code
+                continue
+            elif status == "verify_code_blocked":
+                pending_verify_code = None
+                refresh_count += 1
+                if refresh_count > 3:
+                    print("\n⛔ 多次输入错误，请稍后重试。")
+                    return None
+                print("\n⛔ 多次输入错误，正在刷新二维码...")
+                if not await _refresh_qr():
+                    return None
+            elif status == "binded_redirect":
+                print("\n✅ 此 Hermes 已连接过该微信账号，无需重复连接。")
+                return None
             elif status == "scaned_but_redirect":
                 redirect_host = str(status_resp.get("redirect_host") or "")
                 if redirect_host:
@@ -1122,28 +1187,7 @@ async def qr_login(
                     print("\n二维码多次过期，请重新执行登录。")
                     return None
                 print(f"\n二维码已过期，正在刷新... ({refresh_count}/3)")
-                try:
-                    qr_resp = await _api_get(
-                        session,
-                        base_url=ILINK_BASE_URL,
-                        endpoint=f"{EP_GET_BOT_QR}?bot_type={bot_type}",
-                        timeout_ms=QR_TIMEOUT_MS,
-                    )
-                    qrcode_value = str(qr_resp.get("qrcode") or "")
-                    qrcode_url = str(qr_resp.get("qrcode_img_content") or "")
-                    qr_scan_data = qrcode_url if qrcode_url else qrcode_value
-                    if qrcode_url:
-                        print(qrcode_url)
-                    try:
-                        import qrcode as _qrcode
-                        qr = _qrcode.QRCode()
-                        qr.add_data(qr_scan_data)
-                        qr.make(fit=True)
-                        qr.print_ascii(invert=True)
-                    except Exception:
-                        pass
-                except Exception as exc:
-                    logger.error("weixin: QR refresh failed: %s", exc)
+                if not await _refresh_qr():
                     return None
             elif status == "confirmed":
                 account_id = str(status_resp.get("ilink_bot_id") or "")

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -883,3 +883,108 @@ class TestWeixinContentDedup:
         assert adapter.handle_message.await_count == 0
         # is_duplicate should only be called for message_id, never for content
         assert all("content:" not in str(call) for call in adapter._dedup.is_duplicate.call_args_list)
+
+
+class TestWeixinQrLoginVerifyCode:
+    """Regression tests for the 6-digit pairing-code flow added for
+    upstream issue #17706. WeChat shows a confirmation number after
+    scan; the polling loop must prompt for it and replay it on the
+    next get_qrcode_status request."""
+
+    def _run_qr_login(self, status_sequence, prompt_inputs):
+        captured_endpoints = []
+
+        async def fake_api_get(_session, *, base_url, endpoint, timeout_ms):
+            captured_endpoints.append(endpoint)
+            if endpoint.startswith(weixin.EP_GET_BOT_QR):
+                return {
+                    "qrcode": "TESTQR",
+                    "qrcode_img_content": "https://liteapp.weixin.qq.com/q/TEST",
+                }
+            return status_sequence.pop(0)
+
+        prompt_iter = iter(prompt_inputs)
+
+        def fake_input(_prompt):
+            return next(prompt_iter)
+
+        async def no_sleep(_seconds):
+            return None
+
+        with patch.object(weixin, "_api_get", side_effect=fake_api_get), \
+             patch("builtins.input", side_effect=fake_input), \
+             patch.object(weixin.asyncio, "sleep", side_effect=no_sleep), \
+             patch.object(weixin, "save_weixin_account"):
+            result = asyncio.run(
+                weixin.qr_login("/tmp/hermes-test-home", timeout_seconds=10)
+            )
+        return result, captured_endpoints
+
+    def test_need_verifycode_prompts_and_replays_code(self):
+        result, endpoints = self._run_qr_login(
+            status_sequence=[
+                {"status": "wait"},
+                {"status": "need_verifycode"},
+                {"status": "scaned"},
+                {
+                    "status": "confirmed",
+                    "ilink_bot_id": "bot-1",
+                    "bot_token": "tok-1",
+                    "baseurl": "https://ilinkai.weixin.qq.com",
+                    "ilink_user_id": "user-1",
+                },
+            ],
+            prompt_inputs=["123456"],
+        )
+        assert result is not None
+        assert result["account_id"] == "bot-1"
+        assert result["token"] == "tok-1"
+        verify_polls = [e for e in endpoints if "verify_code=" in e]
+        assert verify_polls, f"no poll carried verify_code; endpoints={endpoints}"
+        assert "verify_code=123456" in verify_polls[0]
+
+    def test_wrong_code_is_reprompted_then_accepted(self):
+        result, _endpoints = self._run_qr_login(
+            status_sequence=[
+                {"status": "need_verifycode"},
+                {"status": "need_verifycode"},
+                {"status": "scaned"},
+                {
+                    "status": "confirmed",
+                    "ilink_bot_id": "bot-2",
+                    "bot_token": "tok-2",
+                    "baseurl": "https://ilinkai.weixin.qq.com",
+                    "ilink_user_id": "u-2",
+                },
+            ],
+            prompt_inputs=["000000", "654321"],
+        )
+        assert result is not None
+        assert result["account_id"] == "bot-2"
+
+    def test_verify_code_blocked_refreshes_qr(self):
+        result, endpoints = self._run_qr_login(
+            status_sequence=[
+                {"status": "need_verifycode"},
+                {"status": "verify_code_blocked"},
+                {"status": "wait"},
+                {
+                    "status": "confirmed",
+                    "ilink_bot_id": "bot-3",
+                    "bot_token": "tok-3",
+                    "baseurl": "https://ilinkai.weixin.qq.com",
+                    "ilink_user_id": "u-3",
+                },
+            ],
+            prompt_inputs=["111111"],
+        )
+        assert result is not None
+        qr_fetches = [e for e in endpoints if e.startswith(weixin.EP_GET_BOT_QR)]
+        assert len(qr_fetches) >= 2, f"QR was not refreshed; endpoints={endpoints}"
+
+    def test_binded_redirect_short_circuits(self):
+        result, _ = self._run_qr_login(
+            status_sequence=[{"status": "binded_redirect"}],
+            prompt_inputs=[],
+        )
+        assert result is None


### PR DESCRIPTION
## Summary

Closes #17706.

After scanning the iLink QR shown by `hermes gateway setup` → Weixin (WeChat), the WeChat mobile app prompts with a 6-digit confirmation number. The current poll loop has no UI for entering this number, so login stalls at `已扫码，请在微信里确认...` and never reaches `confirmed`.

The protocol does not require a new HTTP endpoint — the existing `ilink/bot/get_qrcode_status` GET simply needs a `verify_code=<digits>` query parameter on the next poll. The reference implementation in [`@tencent-weixin/openclaw-weixin@2.3.1`](https://www.npmjs.com/package/@tencent-weixin/openclaw-weixin) (`src/auth/login-qr.ts`) confirms this and was used as the model for the state machine.

## What changed

`gateway/platforms/weixin.py::qr_login` now handles three iLink statuses it was previously ignoring:

| Status | Behavior |
|---|---|
| `need_verifycode` | Prompt via `asyncio.to_thread(input, ...)`, store pending code, skip the 1s sleep, replay it as `verify_code=` on the next poll. If the server returns `need_verifycode` again, reprompt with an error. |
| `verify_code_blocked` | Print warning, refresh QR (counts toward the existing 3-refresh budget). |
| `binded_redirect` | Bot is already paired with this Hermes — exit gracefully. |

The QR-fetch+display block, previously duplicated 3 times, is now a small local `_refresh_qr()` async helper. No public API or env-var surface changed.

## Test plan

- [x] `tests/gateway/test_weixin.py` — 53 passed (49 existing + 4 new)
- [x] `TestWeixinQrLoginVerifyCode::test_need_verifycode_prompts_and_replays_code` — happy path: prompt fires once, next poll URL contains `verify_code=123456`, login confirms.
- [x] `test_wrong_code_is_reprompted_then_accepted` — server rejects first code, second prompt is accepted.
- [x] `test_verify_code_blocked_refreshes_qr` — block triggers a second `get_bot_qrcode` call.
- [x] `test_binded_redirect_short_circuits` — returns `None` immediately.
- [x] End-to-end on macOS: `hermes gateway setup` → Weixin → scan QR → enter the 6-digit code → `~/.hermes/.env` populated with `WEIXIN_*`, gateway picks up the platform after restart, messages flow.

## Notes for reviewers

- I deliberately scoped this to the QR-login bug only. `get_bot_qrcode` is still a GET in this codebase (the reference implementation POSTs with a `local_token_list` body); leaving that for a separate change since the GET path works for fresh installs and the bug under #17706 doesn't depend on it.
- `asyncio.to_thread(input, ...)` is used so the prompt doesn't block the event loop, while still letting the existing `EOFError` / `KeyboardInterrupt` handling in the CLI's parent flow work (Ctrl-C / piped stdin both result in a graceful "微信登录已取消" exit).