### PR TITLE
fix(tui): allow nullable session_id in /reload-mcp params

### DIFF
--- a/ui-tui/src/app/slash/commands/ops.ts
+++ b/ui-tui/src/app/slash/commands/ops.ts
@@ -82,7 +82,7 @@ export const opsCommands: SlashCommand[] = [
       // Parse arg: `now` / `always` skip the confirmation gate.
       // `always` additionally persists approvals.mcp_reload_confirm=false.
       const a = (arg || '').trim().toLowerCase()
-      const params: { session_id: string; confirm?: boolean; always?: boolean } = {
+      const params: { session_id: string | null; confirm?: boolean; always?: boolean } = {
         session_id: ctx.sid
       }
       if (a === 'now' || a === 'approve' || a === 'once' || a === 'yes') {


### PR DESCRIPTION
Fixes #17773.

## Problem

`hermes --tui` fails to build on current `main` because the `/reload-mcp` slash command declares its params with a non-nullable `session_id: string`, but `ctx.sid` is typed as `string | null`:

```
src/app/slash/commands/ops.ts(86,9): error TS2322: Type 'string | null' is not assignable to type 'string'.
```

First invocation on a fresh install dies during the auto-build step; `dist/entry.js` is never produced; TUI is effectively unusable.

## Fix

Widen the param type to `string | null` to match `ctx.sid` and the convention used by every other slash command that forwards the session id (e.g. `session.ts` — `prompt.background`, `config.set`, `session.compress`, `session.branch`, `image.attach` all just spread `session_id: ctx.sid` without narrowing, and the gateway already handles null).

Smallest correct change; no runtime behavior difference.

## Verification

```
cd ui-tui && npm run build   # now clean
hermes --tui -z "smoke test" # → responds normally
```

## Regression introduced in

`4d7fc0f37` — `feat(gateway,cli): confirm /reload-mcp to warn about prompt cache invalidation`. The TUI dev loop (`tsx --watch`) skips `tsc -p tsconfig.build.json`, so the build-time typecheck only fires when end users hit the launcher's on-demand build path. A CI job running `npm run build` on the TUI would catch future regressions of this class.
