### PR TITLE
fix(ssh): pass --no-overwrite-dir to tar extract to prevent clobbering directory modes

### DIFF
--- a/tests/tools/test_ssh_bulk_upload.py
+++ b/tests/tools/test_ssh_bulk_upload.py
@@ -169,7 +169,7 @@ class TestSSHBulkUpload:
         # ssh: extract from stdin at /
         ssh_str = " ".join(ssh_cmd)
         assert "ssh" in ssh_str
-        assert "tar xf - -C /" in ssh_str
+        assert "tar xf - --no-overwrite-dir -C /" in ssh_str
         assert "testuser@example.com" in ssh_str
 
     def test_mkdir_failure_raises(self, mock_env, tmp_path):

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -182,7 +182,7 @@ class SSHEnvironment(BaseEnvironment):
 
             tar_cmd = ["tar", "-chf", "-", "-C", staging, "."]
             ssh_cmd = self._build_ssh_command()
-            ssh_cmd.append("tar xf - -C /")
+            ssh_cmd.append("tar xf - --no-overwrite-dir -C /")
 
             tar_proc = subprocess.Popen(
                 tar_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE


### PR DESCRIPTION
## Summary

Fixes #17767

The SSH bulk upload (`_ssh_bulk_upload` in `tools/environments/ssh.py`) pipes a tar archive into `tar xf - -C /` on the remote host. GNU tar's default behaviour overwrites existing directory metadata with what is in the archive. When the local umask produces group-writable dirs (`0775`, common on Ubuntu with umask `002`), intermediate directories like the user's home (`/home/<user>`) get their mode overwritten to `0775`. This causes OpenSSH `StrictModes` to reject `~/.ssh/authorized_keys`, silently locking the user out of SSH with `Permission denied (publickey)`.

## Changes

- `tools/environments/ssh.py:185`: Added `--no-overwrite-dir` flag to the remote `tar xf` invocation. This preserves the metadata of directories that already exist on the remote while still extracting all file content correctly. New directories created by tar still get reasonable modes via the remote umask.
- `tests/tools/test_ssh_bulk_upload.py`: Updated assertion to match the new tar command.

## Testing

- All existing SSH environment tests pass (`34 passed, 11 skipped`).
- The fix is a single flag addition to a shell command — minimal risk of regression.

## Linked Issue

Closes #17767