### PR TITLE
fix(providers): kimi-coding-cn alias must not map to kimi-for-coding

### DIFF
--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -265,8 +265,11 @@ ALIASES: Dict[str, str] = {
     # kimi-for-coding (models.dev ID)
     "kimi": "kimi-for-coding",
     "kimi-coding": "kimi-for-coding",
-    "kimi-coding-cn": "kimi-for-coding",
     "moonshot": "kimi-for-coding",
+    # kimi-coding-cn must NOT alias to kimi-for-coding — it has its own
+    # ProviderConfig with KIMI_CN_API_KEY and a different base_url (issue #17739)
+    "kimi-cn": "kimi-coding-cn",
+    "moonshot-cn": "kimi-coding-cn",
 
     # stepfun
     "step": "stepfun",

--- a/tests/plugins/model_providers/test_kimi_profile.py
+++ b/tests/plugins/model_providers/test_kimi_profile.py
@@ -128,3 +128,55 @@ class TestKimiFullKwargsIntegration:
         kwargs = self._build(kimi_profile, None)
         assert "reasoning_effort" not in kwargs
         assert kwargs["extra_body"] == {"thinking": {"type": "enabled"}}
+
+
+class TestKimiCnAliasResolution:
+    """Regression tests for kimi-coding-cn alias fix (issue #17739).
+
+    kimi-coding-cn must NOT alias to kimi-for-coding -- it has its own
+    ProviderConfig with KIMI_CN_API_KEY and a different base URL.
+    kimi-cn and moonshot-cn must resolve to kimi-coding-cn (not kimi-for-coding).
+    """
+
+    def test_kimi_coding_cn_resolves_to_itself_not_kimi_for_coding(self):
+        """resolve_provider_full('kimi-coding-cn') must return a ProviderDef
+        whose id is 'kimi-coding-cn', not 'kimi-for-coding'."""
+        from hermes_cli import providers
+        result = providers.resolve_provider_full("kimi-coding-cn")
+        assert result is not None, "kimi-coding-cn must resolve to a provider"
+        assert result.id == "kimi-coding-cn", (
+            f"kimi-coding-cn must resolve to its own ProviderDef, not '{result.id}'. "
+            "This alias was incorrectly mapped to kimi-for-coding (issue #17739), "
+            "which caused KIMI_CN_API_KEY and the China endpoint to be ignored."
+        )
+
+    def test_kimi_cn_alias_resolves_to_kimi_coding_cn(self):
+        """Short alias 'kimi-cn' must resolve to kimi-coding-cn (not kimi-for-coding)."""
+        from hermes_cli import providers
+        result = providers.resolve_provider_full("kimi-cn")
+        assert result is not None, "kimi-cn must resolve to a provider"
+        assert result.id == "kimi-coding-cn", (
+            f"kimi-cn must resolve to kimi-coding-cn, got '{result.id}'"
+        )
+
+    def test_moonshot_cn_alias_resolves_to_kimi_coding_cn(self):
+        """Short alias 'moonshot-cn' must resolve to kimi-coding-cn."""
+        from hermes_cli import providers
+        result = providers.resolve_provider_full("moonshot-cn")
+        assert result is not None, "moonshot-cn must resolve to a provider"
+        assert result.id == "kimi-coding-cn", (
+            f"moonshot-cn must resolve to kimi-coding-cn, got '{result.id}'"
+        )
+
+    def test_kimi_coding_cn_has_dedicated_api_key_env(self):
+        """kimi-coding-cn ProviderConfig must use KIMI_CN_API_KEY, not KIMI_API_KEY."""
+        from hermes_cli import auth
+        config = auth.PROVIDER_REGISTRY.get("kimi-coding-cn")
+        assert config is not None, "kimi-coding-cn must be in PROVIDER_REGISTRY"
+        assert "KIMI_CN_API_KEY" in config.api_key_env_vars, (
+            "kimi-coding-cn must use KIMI_CN_API_KEY to avoid picking up "
+            "the global kimi-for-coding credential"
+        )
+        assert "KIMI_API_KEY" not in config.api_key_env_vars, (
+            "kimi-coding-cn must NOT use KIMI_API_KEY (that is for kimi-for-coding)"
+        )


### PR DESCRIPTION
## Problem

`providers.py` aliased `kimi-coding-cn` → `kimi-for-coding`, but `kimi-coding-cn` has its own `ProviderConfig` in `auth.py` with `KIMI_CN_API_KEY` and a different `base_url`. The alias caused `normalize_provider()` to return `kimi-for-coding` which has no registered credentials, leading to `unknown provider kimi-for-coding` at runtime.

## Fix

Remove the incorrect `kimi-coding-cn` → `kimi-for-coding` alias and add correct aliases `kimi-cn` and `moonshot-cn` → `kimi-coding-cn` in `providers.py` (matching the existing aliases already present in `auth.py`).

Fixes #17739