### PR TITLE
feat(cli): add Ilmu (YTL AI Labs) as built-in LLM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,14 @@
 # GLM_BASE_URL=https://api.z.ai/api/paas/v4  # Override default base URL
 
 # =============================================================================
+# LLM PROVIDER (Ilmu / YTL AI Labs)
+# =============================================================================
+# Ilmu provides access to YTL AI Labs models (nemo-super, ilmu-nemo-nano).
+# Get your key at: https://ilmu.ai/
+# ILMU_API_KEY=
+# ILMU_BASE_URL=https://api.ilmu.ai/v1  # Override default base URL
+
+# =============================================================================
 # LLM PROVIDER (Kimi / Moonshot)
 # =============================================================================
 # Kimi Code provides access to Moonshot AI coding models (kimi-k2.5, etc.)

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -193,6 +193,9 @@ DEFAULT_CONTEXT_LENGTHS = {
     "minimax": 204800,
     # GLM
     "glm": 202752,
+    # Ilmu (YTL AI Labs) — OpenAI-compatible, 256K context for both models.
+    "nemo-super": 262144,
+    "ilmu-nemo-nano": 262144,
     # xAI Grok — xAI /v1/models does not return context_length metadata,
     # so these hardcoded fallbacks prevent Hermes from probing-down to
     # the default 128k when the user points at https://api.x.ai/v1

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -205,6 +205,14 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("GLM_API_KEY", "ZAI_API_KEY", "Z_AI_API_KEY"),
         base_url_env_var="GLM_BASE_URL",
     ),
+    "ilmu": ProviderConfig(
+        id="ilmu",
+        name="Ilmu (YTL AI Labs)",
+        auth_type="api_key",
+        inference_base_url="https://api.ilmu.ai/v1",
+        api_key_env_vars=("ILMU_API_KEY",),
+        base_url_env_var="ILMU_BASE_URL",
+    ),
     "kimi-coding": ProviderConfig(
         id="kimi-coding",
         name="Kimi / Moonshot",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1318,6 +1318,22 @@ OPTIONAL_ENV_VARS = {
         "category": "provider",
         "advanced": True,
     },
+    "ILMU_API_KEY": {
+        "description": "Ilmu (YTL AI Labs) API key",
+        "prompt": "Ilmu API key",
+        "url": "https://ilmu.ai/",
+        "password": True,
+        "category": "provider",
+        "advanced": True,
+    },
+    "ILMU_BASE_URL": {
+        "description": "Ilmu base URL override",
+        "prompt": "Ilmu base URL (leave empty for default)",
+        "url": None,
+        "password": False,
+        "category": "provider",
+        "advanced": True,
+    },
     "KIMI_API_KEY": {
         "description": "Kimi / Moonshot API key",
         "prompt": "Kimi API key",

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -44,6 +44,7 @@ _PROVIDER_ENV_HINTS = (
     "GLM_API_KEY",
     "ZAI_API_KEY",
     "Z_AI_API_KEY",
+    "ILMU_API_KEY",
     "KIMI_API_KEY",
     "KIMI_CN_API_KEY",
     "GMI_API_KEY",
@@ -997,6 +998,7 @@ def run_doctor(args):
     # If supports_models_endpoint is False, we skip the health check and just show "configured"
     _apikey_providers = [
         ("Z.AI / GLM",      ("GLM_API_KEY", "ZAI_API_KEY", "Z_AI_API_KEY"), "https://api.z.ai/api/paas/v4/models", "GLM_BASE_URL", True),
+        ("Ilmu (YTL AI Labs)", ("ILMU_API_KEY",),                          "https://api.ilmu.ai/v1/models",       "ILMU_BASE_URL", True),
         ("Kimi / Moonshot",  ("KIMI_API_KEY",),                              "https://api.moonshot.ai/v1/models",   "KIMI_BASE_URL", True),
         ("StepFun Step Plan",   ("STEPFUN_API_KEY",),                           "https://api.stepfun.ai/step_plan/v1/models", "STEPFUN_BASE_URL", True),
         ("Kimi / Moonshot (China)", ("KIMI_CN_API_KEY",),                    "https://api.moonshot.cn/v1/models",   None, True),

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -240,6 +240,10 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "glm-4.5",
         "glm-4.5-flash",
     ],
+    "ilmu": [
+        "nemo-super",
+        "ilmu-nemo-nano",
+    ],
     "xai": _xai_curated_models(),
     "nvidia": [
         # NVIDIA flagship reasoning models

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -94,6 +94,7 @@ _DEFAULT_PROVIDER_MODELS = {
         "gemini-3-flash-preview", "gemini-3.1-flash-lite-preview",
     ],
     "zai": ["glm-5.1", "glm-5", "glm-4.7", "glm-4.5", "glm-4.5-flash"],
+    "ilmu": ["nemo-super", "ilmu-nemo-nano"],
     "kimi-coding": ["kimi-k2.6", "kimi-k2.5", "kimi-k2-thinking", "kimi-k2-turbo-preview"],
     "kimi-coding-cn": ["kimi-k2.6", "kimi-k2.5", "kimi-k2-thinking", "kimi-k2-turbo-preview"],
     "stepfun": ["step-3.5-flash", "step-3.5-flash-2603"],

--- a/tests/test_empty_model_fallback.py
+++ b/tests/test_empty_model_fallback.py
@@ -118,3 +118,25 @@ class TestResolveGatewayModel:
     def test_string_model_config(self):
         from gateway.run import _resolve_gateway_model
         assert _resolve_gateway_model({"model": "my-model"}) == "my-model"
+
+
+class TestIlmuProvider:
+    """Invariant checks for the ILMU built-in provider (YTL AI Labs)."""
+
+    def test_ilmu_is_registered(self):
+        from hermes_cli.models import _PROVIDER_MODELS
+        from hermes_cli.auth import PROVIDER_REGISTRY
+        assert "ilmu" in _PROVIDER_MODELS
+        assert "ilmu" in PROVIDER_REGISTRY
+        assert len(_PROVIDER_MODELS["ilmu"]) >= 1
+
+    def test_ilmu_default_model_is_nemo_super(self):
+        from hermes_cli.models import get_default_model_for_provider
+        assert get_default_model_for_provider("ilmu") == "nemo-super"
+
+    def test_ilmu_provider_config_is_api_key_bearer(self):
+        from hermes_cli.auth import PROVIDER_REGISTRY
+        cfg = PROVIDER_REGISTRY["ilmu"]
+        assert cfg.auth_type == "api_key"
+        assert cfg.inference_base_url.startswith("https://")
+        assert "ILMU_API_KEY" in cfg.api_key_env_vars


### PR DESCRIPTION
## Why this is useful for Hermes users

Hermes ships built-in support for ~30 inference providers, but the catalogue clusters heavily in the US (OpenAI, Anthropic, Google) and China (Kimi, MiniMax, Z.AI). This PR adds a Southeast Asian option.

**Ilmu**, operated by YTL AI Labs in Malaysia, performs reasonably well on general agentic work, with one notable strength: it handles mixed-language prompts — the kind of code-switching between Bahasa Malaysia, English, and Mandarin that's normal everyday speech in the region — competently in stride. The two models in this PR (`nemo-super` and `ilmu-nemo-nano`) give SEA users a built-in regional choice that previously required the manual "custom OpenAI-compatible endpoint" dance.

The concrete wins for end users:

- **One-click setup.** `hermes setup` gains an "Ilmu" entry; picking it pre-fills the base URL, suggests the right models, and prompts only for `ILMU_API_KEY`. No manual endpoint juggling.
- **Two model tiers out of the box.** `nemo-super` (default) for general agentic work and `ilmu-nemo-nano` for cheap, fast routine calls — same mini/full split users already know from OpenAI and Anthropic.
- **256K context window correctly registered.** `agent/model_metadata.py` knows the real context length, so Hermes' compression logic and `--max-tokens` math work on day one instead of falling back to a too-small default.
- **Diagnostics work.** `hermes doctor` detects `ILMU_API_KEY` and probes `/v1/models`, so misconfigurations surface up-front (matches the UX of every other built-in provider).
- **Discoverability.** Anyone running through `hermes setup` for the first time now learns Ilmu exists — useful for the regional users who'd otherwise never find it.

For maintainers, the cost-of-merge is intentionally minimal: this PR adds **64 lines**, all additive (no existing entries modified), and follows the `zai` provider as a 1:1 pattern. There is no new client code, no schema work, no new dependency, and no runtime branch. If Ilmu's API ever diverges from OpenAI Chat Completions, that's a future PR — today this is pure registry/data.

## What changes

| Touchpoint | Change |
|---|---|
| `hermes_cli/auth.py` | `PROVIDER_REGISTRY["ilmu"]` — `api_key` auth, `https://api.ilmu.ai/v1` |
| `hermes_cli/models.py` | `_PROVIDER_MODELS["ilmu"] = ["nemo-super", "ilmu-nemo-nano"]` (first entry → default) |
| `hermes_cli/config.py` | `OPTIONAL_ENV_VARS` — `ILMU_API_KEY`, `ILMU_BASE_URL` (mirrors GLM block) |
| `hermes_cli/setup.py` | `_DEFAULT_PROVIDER_MODELS["ilmu"]` for the setup wizard |
| `hermes_cli/doctor.py` | env-hint entry + `/v1/models` connectivity probe row |
| `agent/model_metadata.py` | `DEFAULT_CONTEXT_LENGTHS` — 262144 for both models |
| `.env.example` | Documented `ILMU_API_KEY` / `ILMU_BASE_URL` block |
| `tests/test_empty_model_fallback.py` | New `TestIlmuProvider` — 3 invariant tests (registration, default-model, auth shape), invariant-style per `AGENTS.md:720–760` |

Default-model resolution reuses the existing `get_default_model_for_provider()` first-entry-of-list convention, so this introduces zero new code paths.

## Configuration changes

| Variable | Purpose |
|---|---|
| `ILMU_API_KEY` | Bearer token for `https://api.ilmu.ai/v1`. Required to use Ilmu. |
| `ILMU_BASE_URL` | Optional override (e.g. staging / on-prem). Defaults to `https://api.ilmu.ai/v1`. |