### PR TITLE
fix(curator): honor curator.auxiliary.{provider,model} override (#17572)

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -761,6 +761,20 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
         _m = _cfg.get("model", {}) if isinstance(_cfg.get("model"), dict) else {}
         _provider = _m.get("provider") or "auto"
         _model_name = _m.get("default") or _m.get("model") or ""
+        # Per-task auxiliary override: if curator.auxiliary.{provider,model}
+        # is set, prefer it over the main-model defaults so users can pin
+        # the curator to a cheaper aux model without changing their main.
+        # Either field can be set independently — provider falls back to
+        # the main provider, model falls back to the main model.
+        _cur = _cfg.get("curator") or {}
+        _aux = _cur.get("auxiliary") or {} if isinstance(_cur, dict) else {}
+        if isinstance(_aux, dict):
+            _aux_provider = _aux.get("provider")
+            _aux_model = _aux.get("model")
+            if _aux_provider:
+                _provider = _aux_provider
+            if _aux_model:
+                _model_name = _aux_model
         _rp = resolve_runtime_provider(
             requested=_provider, target_model=_model_name
         )

--- a/tests/agent/test_curator.py
+++ b/tests/agent/test_curator.py
@@ -470,6 +470,112 @@ def test_cli_unpin_refuses_bundled_skill(curator_env, capsys):
     assert "bundled" in captured.out.lower() or "hub" in captured.out.lower()
 
 
+# ---------------------------------------------------------------------------
+# _run_llm_review provider/model resolution — curator.auxiliary override (#17572)
+# ---------------------------------------------------------------------------
+
+
+def _patch_run_llm_review_deps(monkeypatch, cfg):
+    """Patch the inner imports of _run_llm_review to capture AIAgent kwargs."""
+    captured = {}
+
+    class _StubAgent:
+        def __init__(self, **kwargs):
+            captured["agent_kwargs"] = kwargs
+            self._review_skipped = True
+
+        def disable_curator_review(self):
+            pass
+
+        def run_conversation(self, *a, **kw):
+            return {"final_response": "ok", "messages": []}
+
+    import hermes_cli.config as cfg_mod
+    import hermes_cli.runtime_provider as rp_mod
+    import run_agent
+
+    def _stub_resolve(requested=None, target_model=None, **_):
+        captured["resolve_args"] = {
+            "requested": requested,
+            "target_model": target_model,
+        }
+        return {
+            "api_key": "k",
+            "base_url": "https://example/api",
+            "api_mode": "chat_completions",
+            "provider": requested,
+        }
+
+    monkeypatch.setattr(cfg_mod, "load_config", lambda: cfg)
+    monkeypatch.setattr(rp_mod, "resolve_runtime_provider", _stub_resolve)
+    monkeypatch.setattr(run_agent, "AIAgent", _StubAgent)
+    return captured
+
+
+def test_run_llm_review_uses_main_model_when_auxiliary_unset(
+    curator_env, monkeypatch
+):
+    curator = curator_env["curator"]
+    cfg = {
+        "model": {"provider": "anthropic", "default": "claude-opus-4-7"},
+        "curator": {"auxiliary": {"provider": None, "model": None}},
+    }
+    captured = _patch_run_llm_review_deps(monkeypatch, cfg)
+    # Bypass the default neutralization installed by curator_env.
+    monkeypatch.undo()
+    monkeypatch.setattr(Path, "home", lambda: curator_env["home"].parent)
+    monkeypatch.setenv("HERMES_HOME", str(curator_env["home"]))
+    captured = _patch_run_llm_review_deps(monkeypatch, cfg)
+
+    curator._run_llm_review("prompt")
+    assert captured["resolve_args"]["requested"] == "anthropic"
+    assert captured["resolve_args"]["target_model"] == "claude-opus-4-7"
+    assert captured["agent_kwargs"]["model"] == "claude-opus-4-7"
+    assert captured["agent_kwargs"]["provider"] == "anthropic"
+
+
+def test_run_llm_review_honors_auxiliary_model_override(
+    curator_env, monkeypatch
+):
+    curator = curator_env["curator"]
+    cfg = {
+        "model": {"provider": "anthropic", "default": "claude-opus-4-7"},
+        "curator": {
+            "auxiliary": {"provider": "anthropic", "model": "claude-haiku-4-6"}
+        },
+    }
+    monkeypatch.undo()
+    monkeypatch.setattr(Path, "home", lambda: curator_env["home"].parent)
+    monkeypatch.setenv("HERMES_HOME", str(curator_env["home"]))
+    captured = _patch_run_llm_review_deps(monkeypatch, cfg)
+
+    curator._run_llm_review("prompt")
+    assert captured["resolve_args"]["target_model"] == "claude-haiku-4-6"
+    assert captured["agent_kwargs"]["model"] == "claude-haiku-4-6"
+    assert captured["agent_kwargs"]["provider"] == "anthropic"
+
+
+def test_run_llm_review_partial_auxiliary_provider_only(
+    curator_env, monkeypatch
+):
+    """Provider override alone should keep the main model."""
+    curator = curator_env["curator"]
+    cfg = {
+        "model": {"provider": "anthropic", "default": "claude-opus-4-7"},
+        "curator": {
+            "auxiliary": {"provider": "openrouter", "model": None}
+        },
+    }
+    monkeypatch.undo()
+    monkeypatch.setattr(Path, "home", lambda: curator_env["home"].parent)
+    monkeypatch.setenv("HERMES_HOME", str(curator_env["home"]))
+    captured = _patch_run_llm_review_deps(monkeypatch, cfg)
+
+    curator._run_llm_review("prompt")
+    assert captured["resolve_args"]["requested"] == "openrouter"
+    assert captured["resolve_args"]["target_model"] == "claude-opus-4-7"
+
+
 def test_cli_pin_refuses_bundled_skill(curator_env, capsys):
     from hermes_cli import curator as cli
     skills_dir = curator_env["home"] / "skills"


### PR DESCRIPTION
## Summary

Fixes #17572. The curator's `_run_llm_review()` resolved provider and model exclusively from `cfg["model"]`, silently ignoring the `curator.auxiliary.{provider, model}` schema documented in `hermes_cli/config.py:950-955`. As a result the curator always ran on the user's main model — for Opus users this means weekly runs on the most expensive model when the whole point of an auxiliary slot is to pin a cheaper one.

## The bug

`agent/curator.py:761-763` (before this patch):

```python
_m = _cfg.get("model", {}) if isinstance(_cfg.get("model"), dict) else {}
_provider = _m.get("provider") or "auto"
_model_name = _m.get("default") or _m.get("model") or ""
```

No reference to `cfg["curator"]["auxiliary"]` anywhere in the resolution path, even though the default config block reserves it:

```yaml
# Optional per-task override for the curator's aux model. Leave null
# to use Hermes' main auxiliary client resolution.
auxiliary:
  provider: null
  model: null
```

## Fix

Read `curator.auxiliary` first and fall back to the main model fields when either side is null. Provider and model can be overridden independently (provider-only override keeps the main model, and vice versa).

## Tests

Three new cases in `tests/agent/test_curator.py`:

- `auxiliary` unset → main model (current behavior preserved)
- both fields set → aux wins
- partial override (provider only) → main model retained

`pytest tests/agent/test_curator.py` → 34 passed.

## Notes

- Behavior when both aux fields are null is byte-identical to today.
- `resolve_runtime_provider()` is still called with the resolved provider+model, so credential pool / OAuth / pool-backed flows continue to work for the aux model.
- No config schema change — the `auxiliary` block has been in `DEFAULT_CONFIG` for a while; this just wires it up.
