### PR TITLE
fix: suppress Telegram internal tool messages

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -818,6 +818,44 @@ class TelegramAdapter(BasePlatformAdapter):
         else:  # "first" (default)
             return chunk_index == 0
 
+    # 내부 처리 메시지 필터 — 텔레그램 전송 직전에 적용
+    _HIDE_PREFIXES = (
+        "⚠️ Context:",
+        "🐍 execute_code:",
+        "📚 skill_view:",
+        "⏰ cronjob:",
+        "🌐 browser_navigate:",
+        "📸 browser_snapshot",
+        "👆 browser_click:",
+        "🚪 browser_close",
+        "📜 browser_scroll",
+        "🔎 search_files:",
+        "✍️ write_file:",
+        "📖 read_file:",
+        "🔧 patch:",
+        "💻 terminal:",
+        "Context compaction",
+        "⚙️ Compressed context",
+        "┊ execute_code",
+        "┊ skill_view",
+        "┊ browser_",
+        "┊ search_files",
+        "┊ write_file",
+        "┊ read_file",
+        "┊ patch",
+        "┊ terminal",
+        "┊ cronjob",
+        "╎ execute_code",
+        "╎ skill_view",
+        "╎ browser_",
+        "╎ search_files",
+        "╎ write_file",
+        "╎ read_file",
+        "╎ patch",
+        "╎ terminal",
+        "╎ cronjob",
+    )
+
     async def send(
         self,
         chat_id: str,
@@ -828,11 +866,18 @@ class TelegramAdapter(BasePlatformAdapter):
         """Send a message to a Telegram chat."""
         if not self._bot:
             return SendResult(success=False, error="Not connected")
-        
+
         # Skip whitespace-only text to prevent Telegram 400 empty-text errors.
         if not content or not content.strip():
             return SendResult(success=True, message_id=None)
-        
+
+        # 내부 처리 메시지 숨기기
+        stripped = content.strip()
+        for pfx in self._HIDE_PREFIXES:
+            if stripped.startswith(pfx):
+                logger.debug("Hiding internal message: %s...", stripped[:60])
+                return SendResult(success=True, message_id=None)
+
         try:
             # Format and split message if needed
             formatted = self.format_message(content)

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -60,10 +60,44 @@ def _make_adapter(extra=None):
 
 
 # ===========================================================================
+# send — internal tool-output filtering
+# ===========================================================================
+class TestTelegramSendFiltering:
+    """Test that internal tool chatter is not forwarded to Telegram users."""
+
+    @pytest.mark.asyncio
+    async def test_hides_internal_tool_message_before_bot_send(self):
+        adapter = _make_adapter()
+        adapter._bot.send_message = AsyncMock()
+
+        result = await adapter.send(
+            chat_id="12345",
+            content="💻 terminal: git status --short",
+        )
+
+        assert result.success is True
+        assert result.message_id is None
+        adapter._bot.send_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_normal_message_still_sends(self):
+        adapter = _make_adapter()
+        mock_msg = MagicMock()
+        mock_msg.message_id = 77
+        adapter._bot.send_message = AsyncMock(return_value=mock_msg)
+
+        result = await adapter.send(chat_id="12345", content="대표님 보고 완료")
+
+        assert result.success is True
+        assert result.message_id == "77"
+        adapter._bot.send_message.assert_called_once()
+
+
+# ===========================================================================
 # send_exec_approval — inline keyboard buttons
 # ===========================================================================
-
 class TestTelegramExecApproval:
+
     """Test the send_exec_approval method sends InlineKeyboard buttons."""
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- suppress Telegram delivery of internal tool call/result messages
- keep user-facing replies clean on messaging platforms

## Test plan
- not run in this push step; commit d5742aea was already prepared locally

Created from fork because sosobaeklaw-source has read-only access to NousResearch/hermes-agent.