### PR TITLE
fix(gemini): capture streaming usageMetadata for token tracking

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -680,6 +680,19 @@ def translate_stream_event(event: Dict[str, Any], model: str, tool_call_indices:
     if finish_reason_raw:
         mapped = "tool_calls" if tool_call_indices else _map_gemini_finish_reason(finish_reason_raw)
         chunks.append(_make_stream_chunk(model=model, finish_reason=mapped))
+
+    # Extract usageMetadata from streaming events (Gemini includes it in the final chunk)
+    usage_meta = event.get("usageMetadata")
+    if usage_meta and chunks:
+        chunks[-1].usage = SimpleNamespace(
+            prompt_tokens=int(usage_meta.get("promptTokenCount") or 0),
+            completion_tokens=int(usage_meta.get("candidatesTokenCount") or 0),
+            total_tokens=int(usage_meta.get("totalTokenCount") or 0),
+            prompt_tokens_details=SimpleNamespace(
+                cached_tokens=int(usage_meta.get("cachedContentTokenCount") or 0),
+            ),
+        )
+
     return chunks
 
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -6701,12 +6701,16 @@ class AIAgent:
                 if self._interrupt_requested:
                     break
 
+                # Capture usage from any chunk that carries it.
+                # OpenAI sends usage in a final chunk with empty choices.
+                # Gemini sends usageMetadata in every chunk (including
+                # chunks WITH choices). Always update — the last value wins.
+                if hasattr(chunk, "usage") and chunk.usage:
+                    usage_obj = chunk.usage
+
                 if not chunk.choices:
                     if hasattr(chunk, "model") and chunk.model:
                         model_name = chunk.model
-                    # Usage comes in the final chunk with empty choices
-                    if hasattr(chunk, "usage") and chunk.usage:
-                        usage_obj = chunk.usage
                     continue
 
                 delta = chunk.choices[0].delta


### PR DESCRIPTION
## Problem

When using the Gemini native provider with streaming enabled, all token usage metrics (`input_tokens`, `output_tokens`, `cache_read_tokens`) are recorded as **0** in the session database. This affects `hermes insights`, session stats, and any downstream cost/usage tracking.

All Gemini native streaming users are affected — the data is returned by Google's API but silently dropped by two layers in the processing pipeline.

## Root Cause (two layers)

**1. Adapter layer** (`agent/gemini_native_adapter.py`):

`_make_stream_chunk()` hardcodes `usage=None` (line 589). Even though Gemini's `streamGenerateContent` includes `usageMetadata` in SSE events, `translate_stream_event()` never propagates it to the chunk objects yielded to the consumer.

**2. Consumer layer** (`run_agent.py`):

The streaming chunk loop (line ~6480) only checks `chunk.usage` inside the `if not chunk.choices` gate — following the OpenAI convention where usage arrives in a final empty-choices chunk. However, Gemini includes `usageMetadata` in **every** SSE event, including those with non-empty choices. The usage data is present on the wire but never captured.

## Fix

**`agent/gemini_native_adapter.py`**: Extract `usageMetadata` from the raw SSE event in `translate_stream_event()` and attach it to the last emitted chunk as a `usage` SimpleNamespace, matching the shape expected by `normalize_usage()`.

**`run_agent.py`**: Move the `chunk.usage` capture **before** the empty-choices gate so usage is captured from any chunk that carries it. The "last value wins" approach is safe for both protocols:
- **OpenAI**: usage only appears in the final (empty-choices) chunk — still captured ✅
- **Gemini**: usage appears in every chunk, accumulating — last value has final totals ✅

## Verification

Tested with `gemini-3.1-pro-preview` and `gemini-2.5-pro`:

| Metric | Before fix | After fix | Raw API (non-streaming) |
|--------|-----------|-----------|------------------------|
| `input_tokens` | 0 | 3,142 | 7 (no system prompt) |
| `output_tokens` | 0 | 22 | 25 |
| `cache_read_tokens` | 0 | 12,105 | N/A |

- The large input token count (3,142 vs raw 7) is correct — Hermes prepends system prompt + 27 tool definitions (~15K tokens total, with 12K from prompt cache)
- `cache_read(12,105) + prompt(3,142) = 15,247` total input context — consistent across sessions
- Streaming and non-streaming `candidatesTokenCount` match (thinking tokens vary slightly between calls, as expected for reasoning models)
- Ran sanity checks across 15+ sessions: all post-fix sessions have valid, non-zero token data

## Context

Discovered while building token usage tracking for a quantitative trading system integrated with Hermes via Telegram. The zero-token data made `hermes insights` and cost estimation non-functional for Gemini users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)