### PR TITLE
docs(unsloth): fix duplicated words in RL guide sentence

### DIFF
--- a/optional-skills/mlops/training/unsloth/references/llms-txt.md
+++ b/optional-skills/mlops/training/unsloth/references/llms-txt.md
@@ -9287,7 +9287,7 @@ training_args = GRPOConfig(
 
 Overall, Unsloth now with VLM vLLM fast inference enables for both 90% reduced memory usage but also 1.5-2x faster speed with GRPO and GSPO!
 
-If you'd like to read more about reinforcement learning, check out out RL guide:
+If you'd like to read more about reinforcement learning, check out our RL guide:
 
 [reinforcement-learning-rl-guide](https://docs.unsloth.ai/get-started/reinforcement-learning-rl-guide "mention")
 


### PR DESCRIPTION
## What does this PR do?

Fixes a duplicated-word typo in the Unsloth reference docs.

## Related Issue

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Replaced `check out out RL guide` with `check out our RL guide`
- File: `skills/mlops/training/unsloth/references/llms-txt.md`

## How to Test

1. Open `skills/mlops/training/unsloth/references/llms-txt.md`
2. Verify the sentence reads `check out our RL guide`
3. Confirm no other content changed

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

`grep -n "check out our RL guide" skills/mlops/training/unsloth/references/llms-txt.md`
