### PR TITLE
docs(unsloth): remove duplicated word in GRPO note

### DIFF
--- a/optional-skills/mlops/training/unsloth/references/llms-full.md
+++ b/optional-skills/mlops/training/unsloth/references/llms-full.md
@@ -4128,7 +4128,7 @@ With Unsloth's new RL improvements, you NEVER have to worry about tuning or sett
 
 ## :interrobang:Why does RL use so much memory?
 
-GRPO (and many RL variants) rely heavily on generation which is primarily powered by vLLM. But this comes comes with a steep cost since it requires constant **GPU memory for weights, activations, and the KV Cache**.
+GRPO (and many RL variants) rely heavily on generation which is primarily powered by vLLM. But this comes with a steep cost since it requires constant **GPU memory for weights, activations, and the KV Cache**.
 
 {% columns %}
 {% column width="41.66666666666667%" %}


### PR DESCRIPTION
## What does this PR do?

Fixes a duplicated-word typo in the Unsloth reference docs.

## Related Issue

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Replaced `comes comes` with `comes`
- File: `skills/mlops/training/unsloth/references/llms-full.md`

## How to Test

1. Open `skills/mlops/training/unsloth/references/llms-full.md`
2. Verify the GRPO sentence reads `But this comes with a steep cost`
3. Confirm no other content changed

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

`grep -n "But this comes with a steep cost" skills/mlops/training/unsloth/references/llms-full.md`
