### PR TITLE
fix(gateway): clear Slack assistant status after replies

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -601,6 +601,10 @@ class SlackAdapter(BasePlatformAdapter):
 
                 last_result = await self._get_client(chat_id).chat_postMessage(**kwargs)
 
+            # Clear Slack Assistant status as soon as the final message is posted.
+            if thread_ts:
+                await self.stop_typing(chat_id)
+
             # Track the sent message ts so we can auto-respond to thread
             # replies without requiring @mention.
             sent_ts = last_result.get("ts") if last_result else None
@@ -642,6 +646,8 @@ class SlackAdapter(BasePlatformAdapter):
                 ts=message_id,
                 text=formatted,
             )
+            if finalize:
+                await self.stop_typing(chat_id)
             return SendResult(success=True, message_id=message_id)
         except Exception as e:  # pragma: no cover - defensive logging
             logger.error(
@@ -682,7 +688,7 @@ class SlackAdapter(BasePlatformAdapter):
             # in an assistant-enabled context. Falls back to reactions.
             logger.debug("[Slack] assistant.threads.setStatus failed: %s", e)
 
-    async def stop_typing(self, chat_id: str) -> None:
+    async def stop_typing(self, chat_id: str, metadata=None) -> None:
         """Clear the assistant thread status indicator."""
         if not self._app:
             return

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -360,6 +360,40 @@ class TestLoadGatewayConfig:
             "C01ABC": "Code review mode",
         }
 
+    def test_bridges_slack_reactions_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "slack:\n"
+            "  reactions: false\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("SLACK_REACTIONS", raising=False)
+
+        load_gateway_config()
+
+        assert os.environ["SLACK_REACTIONS"] == "false"
+
+    def test_slack_reactions_env_takes_precedence_over_config(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "slack:\n"
+            "  reactions: false\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("SLACK_REACTIONS", "true")
+
+        load_gateway_config()
+
+        assert os.environ["SLACK_REACTIONS"] == "true"
+
     def test_invalid_quick_commands_in_config_yaml_are_ignored(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1088,6 +1088,104 @@ class TestSendTyping:
             status="is thinking...",
         )
 
+    @pytest.mark.asyncio
+    async def test_stop_typing_clears_tracked_thread(self, adapter):
+        adapter._app.client.assistant_threads_setStatus = AsyncMock()
+        await adapter.send_typing("C123", metadata={"thread_id": "parent_ts"})
+
+        await adapter.stop_typing("C123", metadata={"thread_id": "parent_ts"})
+
+        assert adapter._app.client.assistant_threads_setStatus.call_args_list[1] == call(
+            channel_id="C123",
+            thread_ts="parent_ts",
+            status="",
+        )
+        assert "C123" not in adapter._active_status_threads
+
+    @pytest.mark.asyncio
+    async def test_stop_typing_noop_without_tracked_thread(self, adapter):
+        adapter._app.client.assistant_threads_setStatus = AsyncMock()
+
+        await adapter.stop_typing("C123")
+
+        adapter._app.client.assistant_threads_setStatus.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_stop_typing_handles_api_error_gracefully(self, adapter):
+        adapter._active_status_threads["C123"] = "parent_ts"
+        adapter._app.client.assistant_threads_setStatus = AsyncMock(
+            side_effect=Exception("missing_scope")
+        )
+
+        await adapter.stop_typing("C123")
+
+        adapter._app.client.assistant_threads_setStatus.assert_called_once_with(
+            channel_id="C123",
+            thread_ts="parent_ts",
+            status="",
+        )
+        assert "C123" not in adapter._active_status_threads
+
+    @pytest.mark.asyncio
+    async def test_send_clears_status_after_final_post(self, adapter):
+        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "reply_ts"})
+        adapter._app.client.assistant_threads_setStatus = AsyncMock()
+        adapter._active_status_threads["C123"] = "parent_ts"
+
+        result = await adapter.send("C123", "done", metadata={"thread_id": "parent_ts"})
+
+        assert result.success
+        adapter._app.client.chat_postMessage.assert_called_once()
+        adapter._app.client.assistant_threads_setStatus.assert_called_once_with(
+            channel_id="C123",
+            thread_ts="parent_ts",
+            status="",
+        )
+        assert "C123" not in adapter._active_status_threads
+
+    @pytest.mark.asyncio
+    async def test_streaming_final_edit_clears_status(self, adapter):
+        adapter._app.client.chat_update = AsyncMock()
+        adapter._app.client.assistant_threads_setStatus = AsyncMock()
+        adapter._active_status_threads["C123"] = "parent_ts"
+
+        result = await adapter.edit_message(
+            "C123",
+            "reply_ts",
+            "done",
+            finalize=True,
+        )
+
+        assert result.success
+        adapter._app.client.chat_update.assert_called_once_with(
+            channel="C123",
+            ts="reply_ts",
+            text="done",
+        )
+        adapter._app.client.assistant_threads_setStatus.assert_called_once_with(
+            channel_id="C123",
+            thread_ts="parent_ts",
+            status="",
+        )
+        assert "C123" not in adapter._active_status_threads
+
+    @pytest.mark.asyncio
+    async def test_streaming_intermediate_edit_keeps_status(self, adapter):
+        adapter._app.client.chat_update = AsyncMock()
+        adapter._app.client.assistant_threads_setStatus = AsyncMock()
+        adapter._active_status_threads["C123"] = "parent_ts"
+
+        result = await adapter.edit_message(
+            "C123",
+            "reply_ts",
+            "partial",
+            finalize=False,
+        )
+
+        assert result.success
+        adapter._app.client.assistant_threads_setStatus.assert_not_called()
+        assert adapter._active_status_threads["C123"] == "parent_ts"
+
 
 # ---------------------------------------------------------------------------
 # TestFormatMessage — Markdown → mrkdwn conversion


### PR DESCRIPTION
## Problem

Slack Assistant thread status can keep showing `is thinking...` after the final reply is visible. This is especially noticeable for streamed replies, where the final user-visible update is delivered through `edit_message(..., finalize=True)` rather than the normal final `send()` path.

## Cause

Slack implements `send_typing()` with persistent `assistant_threads_setStatus(..., status="is thinking...")`. Cleanup existed later in the generic gateway lifecycle, but Slack did not clear status immediately when the final Slack delivery completed, so the UI could lag behind the final message.

## Fix

- Clear Slack Assistant thread status immediately after the final `chat_postMessage()` succeeds.
- Clear Slack Assistant thread status immediately after a streaming final edit, `edit_message(..., finalize=True)`, succeeds.
- Keep intermediate streaming edits active by not clearing status when `finalize=False`.
- Keep the existing later `stop_typing()` cleanup as a fallback.
- Add coverage for Slack reaction config mapping so `platforms.slack.reactions: false` maps to `SLACK_REACTIONS=false` while preserving env precedence.

## How to Test

Validated locally:

```bash
uv run --extra dev --extra slack pytest tests/gateway/test_slack.py -v
uv run --extra dev pytest tests/gateway/test_config.py -v
```

Expected broader validation before merge:

```bash
uv run --extra dev --extra slack pytest tests/ -v
```

## Platform Tested

Slack.
