### PR TITLE
fix: clean up defensive shims and finish CI stabilization from #17660

### DIFF
--- a/tests/cli/test_cli_loading_indicator.py
+++ b/tests/cli/test_cli_loading_indicator.py
@@ -49,8 +49,15 @@ class TestCLILoadingIndicator:
             seen["status"] = cli_obj._command_status
             print("reload done")
 
+        # /reload-mcp now wraps the actual reload in a prompt-cache-invalidation
+        # confirmation prompt (commit 4d7fc0f37).  This test exercises the
+        # loading-indicator path, not the confirmation UX, so pre-approve the
+        # reload via config so the handler goes straight into _reload_mcp().
+        fake_cfg = {"approvals": {"mcp_reload_confirm": False}}
+
         with patch.object(cli_obj, "_reload_mcp", side_effect=fake_reload), \
-             patch.object(cli_obj, "_invalidate") as invalidate_mock:
+             patch.object(cli_obj, "_invalidate") as invalidate_mock, \
+             patch("cli.load_cli_config", return_value=fake_cfg):
             assert cli_obj.process_command("/reload-mcp")
 
         output = capsys.readouterr().out

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2010,12 +2010,8 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             }, ensure_ascii=False)
 
         async def _call():
-            rpc_lock = getattr(server, "_rpc_lock", None)
-            if rpc_lock is None:
+            async with server._rpc_lock:
                 result = await server.session.call_tool(tool_name, arguments=args)
-            else:
-                async with rpc_lock:
-                    result = await server.session.call_tool(tool_name, arguments=args)
             # MCP CallToolResult has .content (list of content blocks) and .isError
             if result.isError:
                 error_text = ""

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1860,18 +1860,6 @@ def _enrich_with_attached_images(user_text: str, image_paths: list[str]) -> str:
     return text or "What do you see in this image?"
 
 
-def _messages_as_conversation(db, session_id: str, *, include_ancestors: bool = False):
-    if include_ancestors:
-        try:
-            return db.get_messages_as_conversation(
-                session_id, include_ancestors=True
-            )
-        except TypeError as exc:
-            if "include_ancestors" not in str(exc):
-                raise
-    return db.get_messages_as_conversation(session_id)
-
-
 def _history_to_messages(history: list[dict]) -> list[dict]:
     messages = []
     tool_call_args = {}
@@ -2080,9 +2068,9 @@ def _(rid, params: dict) -> dict:
     _enable_gateway_prompts()
     try:
         db.reopen_session(target)
-        history = _messages_as_conversation(db, target)
-        display_history = _messages_as_conversation(
-            db, target, include_ancestors=True
+        history = db.get_messages_as_conversation(target)
+        display_history = db.get_messages_as_conversation(
+            target, include_ancestors=True
         )
         messages = _history_to_messages(display_history)
         tokens = _set_session_context(target)
@@ -2227,8 +2215,8 @@ def _(rid, params: dict) -> dict:
     db = _get_db()
     if db is not None and session.get("session_key"):
         try:
-            history = _messages_as_conversation(
-                db, session["session_key"], include_ancestors=True
+            history = db.get_messages_as_conversation(
+                session["session_key"], include_ancestors=True
             )
         except Exception:
             pass


### PR DESCRIPTION
## Summary
Follow-up to #17660. Fixes one deterministic test failure that PR missed and removes two defensive shims that were either wrong or dead.

## Changes
- **`tests/cli/test_cli_loading_indicator.py`** — Test for `/reload-mcp` never got updated when the prompt-cache-invalidation confirmation landed in 4d7fc0f37. Pre-approve via config so the test exercises the loading-indicator path as intended. Fixes the one deterministic CI failure left over after #17660.
- **`tools/mcp_tool.py`** — Remove `getattr(server, '_rpc_lock', None)` + 'skip lock if missing' branch added to `_make_tool_handler`. Inconsistent with four sibling call sites that direct-access `server._rpc_lock`, and `MCPServerTask.__init__` always sets the lock. If the guard ever triggered in prod, it would silently run an RPC without the serialization lock.
- **`tui_gateway/server.py`** — Remove `_messages_as_conversation` helper. It existed to catch `TypeError` on `include_ancestors` from a SessionDB that doesn't exist — the real `SessionDB.get_messages_as_conversation` accepts the kwarg, and every test FakeDB in the repo already declares it. Inlined the two call sites back to direct `db.get_messages_as_conversation(...)`.

## Validation
- Targeted tests: `tests/cli/test_cli_loading_indicator.py tests/tools/test_mcp_structured_content.py tests/test_tui_gateway_server.py tests/tui_gateway/` → **215 passed**.
- Before: `test_reload_mcp_sets_busy_state_and_prints_status` failed with `OSError: pytest: reading from stdin while output is captured`.
- After: passes.