### PR TITLE
fix(gateway): load ~/.hermes/.env in load_gateway_config

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -584,6 +584,17 @@ def load_gateway_config() -> GatewayConfig:
     4. Built-in defaults
     """
     _home = get_hermes_home()
+
+    # Ensure gateway config reads the same user-managed env file regardless of
+    # entrypoint. Without this, standalone cron delivery can see Telegram as
+    # disabled even when ~/.hermes/.env has a valid token, making delivery
+    # depend on whether some earlier startup path happened to source the env.
+    try:
+        from hermes_cli.env_loader import load_hermes_dotenv
+        load_hermes_dotenv(hermes_home=_home)
+    except Exception:
+        pass
+
     gw_data: dict = {}
 
     # Legacy fallback: gateway.json provides the base layer.

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -611,6 +611,7 @@ AUTHOR_MAP = {
     "nfb0408@163.com": "ningfangbin",
     "164839249+Joseph19820124@users.noreply.github.com": "Joseph19820124",
     "rugved@lmstudio.ai": "rugvedS07",
+    "psikonetik@gmail.com": "el-analista",
 }
 
 

--- a/tests/test_gateway_config_loads_hermes_env.py
+++ b/tests/test_gateway_config_loads_hermes_env.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from gateway.config import Platform, load_gateway_config
+
+
+def test_load_gateway_config_reads_hermes_env(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / ".env").write_text("TELEGRAM_BOT_TOKEN=test-token\n", encoding="utf-8")
+    (hermes_home / "config.yaml").write_text("platforms:\n  telegram: {}\n", encoding="utf-8")
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+
+    cfg = load_gateway_config()
+
+    telegram = cfg.platforms[Platform.TELEGRAM]
+    assert telegram.enabled is True
+    assert telegram.token == "test-token"


### PR DESCRIPTION
## Summary
- Standalone entrypoints (e.g. `hermes cron run`) call `load_gateway_config()` without going through the gateway's startup-time env sourcing.
- That left platform tokens like `TELEGRAM_BOT_TOKEN` empty in `os.environ`, so platforms were silently marked `enabled=False` and cron delivery dropped the message with no user-visible error.
- Eagerly `load_hermes_dotenv()` at the top of `load_gateway_config()`. The loader is idempotent and respects pre-existing env vars, so operator-set values still win.

## Test plan
- [x] `pytest tests/test_gateway_config_loads_hermes_env.py` — 1 passed (writes a fake `.env`, deletes the var, asserts platform comes up enabled)
- [ ] Manual: `hermes cron run` from a fresh shell delivers Telegram messages using the token from `~/.hermes/.env`