### PR TITLE
fix(feishu): enable native media attachment delivery (image/video/file)

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -584,11 +584,28 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             last_result = result
         return last_result
 
+    # --- Feishu: native media attachment support already in _send_feishu ---
+    if platform == Platform.FEISHU and media_files:
+        last_result = None
+        for i, chunk in enumerate(chunks):
+            is_last = (i == len(chunks) - 1)
+            result = await _send_feishu(
+                pconfig,
+                chat_id,
+                chunk,
+                media_files=media_files if is_last else [],
+                thread_id=thread_id,
+            )
+            if isinstance(result, dict) and result.get("error"):
+                return result
+            last_result = result
+        return last_result
+
     # --- Non-media platforms ---
     if media_files and not message.strip():
         return {
             "error": (
-                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal and yuanbao; "
+                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao and feishu; "
                 f"target {platform.value} had only media attachments"
             )
         }
@@ -596,7 +613,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if media_files:
         warning = (
             f"MEDIA attachments were omitted for {platform.value}; "
-            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal and yuanbao"
+            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao and feishu"
         )
 
     last_result = None


### PR DESCRIPTION


## Problem

Feishu's `_send_feishu` already supports uploading images, videos, and documents via the Feishu Open API. However, the `send_message_tool.py` routing logic had Feishu falling through to the 'Non-media platforms' block, which silently drops media attachments.

## Root Cause

The media-attachment routing only handled Telegram, Discord, Matrix, Signal, and Yuanbao with dedicated pre-routing branches. Feishu — along with its native media support inside `_send_feishu` — was left out.

## Solution

Added a dedicated Feishu media branch (mirroring the existing Signal/Yuanbao pattern) that routes media-enabled messages directly to `_send_feishu` with the `media_files` parameter. Also updated the error/warning messages to list feishu as a supported platform.

## Changes

- `tools/send_message_tool.py`: +19 lines, -2 lines
  - New `# --- Feishu: native media attachment support ---` branch before the non-media fallback block
  - Error/warning messages updated to include 'feishu'

## Verification

Tested in production: image sent successfully via the Feishu gateway after applying this fix. The `mirrored: true` response confirmed upload + delivery worked.
