### PR TITLE
fix(agent): transport-layer hardening — local-inference port match, env-var expansion, raw-socket retries

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -50,7 +50,7 @@ from agent.tool_guardrails import (
 from hermes_cli.config import cfg_get
 from hermes_cli.timeouts import get_provider_request_timeout
 from hermes_constants import get_hermes_home
-from utils import base_url_host_matches, is_truthy_value
+from utils import base_url_host_matches, expand_fallback_base_url, is_truthy_value
 
 # Use the same logger name as run_agent so tests patching ``run_agent.logger``
 # capture our warnings.  (run_agent.py also does
@@ -1034,7 +1034,7 @@ def init_agent(
                                 _fb_explicit_key = os.getenv(_fb_key_env, "").strip() or None
                         _fb_client, _fb_model = resolve_provider_client(
                             _fb["provider"], model=_fb["model"], raw_codex=True,
-                            explicit_base_url=_fb.get("base_url"),
+                            explicit_base_url=expand_fallback_base_url(_fb.get("base_url")),
                             explicit_api_key=_fb_explicit_key,
                         )
                         if _fb_client is not None:

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1335,6 +1335,7 @@ _TRANSIENT_TRANSPORT_ERRORS = frozenset({
     "ReadTimeout", "ConnectTimeout", "PoolTimeout",
     "ConnectError", "RemoteProtocolError",
     "APIConnectionError", "APITimeoutError",
+    "BrokenPipeError", "ConnectionResetError",
 })
 
 

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -29,13 +29,14 @@ from hermes_cli.timeouts import get_provider_request_timeout, get_provider_stale
 from hermes_constants import PARTIAL_STREAM_STUB_ID, FINISH_REASON_LENGTH
 from agent.error_classifier import FailoverReason
 from agent.gemini_native_adapter import is_native_gemini_base_url
+from urllib.parse import urlparse
 from agent.model_metadata import is_local_endpoint
 from agent.message_sanitization import (
     _sanitize_surrogates,
     _repair_tool_call_arguments,
 )
 from tools.terminal_tool import is_persistent_env
-from utils import base_url_host_matches, base_url_hostname, env_float, env_int
+from utils import base_url_host_matches, base_url_hostname, expand_fallback_base_url, env_float, env_int
 
 logger = logging.getLogger(__name__)
 _OPENROUTER_PROVIDER_SORT_VALUES = {"throughput", "latency", "price"}
@@ -114,6 +115,95 @@ def estimate_request_context_tokens(api_payload: Any) -> int:
         return sum(_chars(value) for value in api_payload.values()) // 4
 
     return _chars(api_payload) // 4
+
+
+# Providers that are always local inference servers (never cloud relays).
+# ``custom`` is excluded because it covers both local Ollama/llama.cpp and
+# custom cloud endpoints — the base_url + port must disambiguate.
+_LOCAL_INFERENCE_PROVIDERS = frozenset({"lmstudio", "local"})
+
+
+def _is_known_local_inference_endpoint(
+    base_url: str | None, provider: str | None = None
+) -> bool:
+    """Return True only for local endpoints that are known inference servers.
+
+    Port 8080 alone is NOT treated as inference because it is a common
+    cloud-proxy / relay port.  llama.cpp users on :8080 should set
+    ``HERMES_STREAM_STALE_TIMEOUT`` or use provider ``local``/``llamacpp``
+    so the provider identity disambiguates from generic relays.
+    """
+    if not base_url or not is_local_endpoint(base_url):
+        return False
+
+    # Provider identity is the most reliable signal — ``lmstudio`` and
+    # ``local`` (vllm, llamacpp) are always local inference.
+    if provider and provider.lower() in _LOCAL_INFERENCE_PROVIDERS:
+        return True
+
+    try:
+        parsed_port = urlparse(base_url).port
+    except Exception:
+        parsed_port = None
+
+    # 11434 = Ollama, 1234 = LM Studio — both unique enough to trust.
+    # 8080 (llama.cpp default) is deliberately excluded.
+    return parsed_port in (11434, 1234) or "omlx" in base_url.lower()
+
+
+def _compute_stream_stale_timeout(agent, api_kwargs: dict) -> float:
+    """Compute the stale-stream timeout for the current streaming request."""
+    cfg_stale = get_provider_stale_timeout(agent.provider, agent.model)
+    stream_stale_timeout_env = os.getenv("HERMES_STREAM_STALE_TIMEOUT")
+
+    if cfg_stale is not None:
+        stream_stale_timeout_base = cfg_stale
+        allow_local_inference_disable = False
+    else:
+        stream_stale_timeout_base = (
+            float(stream_stale_timeout_env)
+            if stream_stale_timeout_env
+            else 180.0
+        )
+        allow_local_inference_disable = stream_stale_timeout_env is None
+
+    # Local inference servers can take minutes for prefill on large contexts.
+    # Disable the stale detector only for known local inference endpoints. A
+    # generic localhost/cloud relay should keep the normal timeout so real
+    # provider hangs still surface.
+    if (
+        allow_local_inference_disable
+        and _is_known_local_inference_endpoint(
+            getattr(agent, "base_url", ""), getattr(agent, "provider", None)
+        )
+    ):
+        logger.debug(
+            "Local inference provider detected (%s) — stale stream timeout disabled",
+            getattr(agent, "base_url", ""),
+        )
+        return float("inf")
+
+    # Scale the stale timeout for large contexts: slow models (like Opus)
+    # can legitimately think for minutes before producing the first token.
+    est_tokens = estimate_request_context_tokens(api_kwargs)
+    if est_tokens > 100_000:
+        stream_stale_timeout = max(stream_stale_timeout_base, 300.0)
+    elif est_tokens > 50_000:
+        stream_stale_timeout = max(stream_stale_timeout_base, 240.0)
+    else:
+        stream_stale_timeout = stream_stale_timeout_base
+    # Reasoning-model floor: known reasoning models (Nemotron 3 Ultra,
+    # OpenAI o1/o3, Anthropic Opus 4.x thinking, DeepSeek R1, Qwen QwQ,
+    # xAI Grok reasoning, etc.) routinely exceed the default 180s chat-
+    # model threshold during their thinking phase.  The cloud gateway
+    # upstream kills the socket first, surfacing as BrokenPipeError.
+    # Raises the floor only — never overrides explicit user config
+    # (handled by get_provider_stale_timeout above).
+    from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
+    _reasoning_floor = get_reasoning_stale_timeout_floor(api_kwargs.get("model"))
+    if _reasoning_floor is not None:
+        stream_stale_timeout = max(stream_stale_timeout, _reasoning_floor)
+    return stream_stale_timeout
 
 
 def _is_openai_codex_backend(agent) -> bool:
@@ -1425,7 +1515,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         # Pass base_url and api_key from fallback config so custom
         # endpoints (e.g. Ollama Cloud) resolve correctly instead of
         # falling through to OpenRouter defaults.
-        fb_base_url_hint = (fb.get("base_url") or "").strip() or None
+        fb_base_url_hint = expand_fallback_base_url(fb.get("base_url"))
         fb_api_key_hint = (fb.get("api_key") or "").strip() or None
         if not fb_api_key_hint:
             # key_env and api_key_env are both documented aliases (see
@@ -2990,42 +3080,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         finally:
             _close_request_client_once("stream_request_complete")
 
-    # Provider-configured stale timeout takes priority over env default.
-    _cfg_stale = get_provider_stale_timeout(agent.provider, agent.model)
-    if _cfg_stale is not None:
-        _stream_stale_timeout_base = _cfg_stale
-    else:
-        _stream_stale_timeout_base = env_float("HERMES_STREAM_STALE_TIMEOUT", 180.0)
-    # Local providers (Ollama, oMLX, llama-cpp) can take 300+ seconds
-    # for prefill on large contexts.  Disable the stale detector unless
-    # the user explicitly set HERMES_STREAM_STALE_TIMEOUT.
-    if _stream_stale_timeout_base == 180.0 and agent.base_url and is_local_endpoint(agent.base_url):
-        _stream_stale_timeout = float("inf")
-        logger.debug("Local provider detected (%s) — stale stream timeout disabled", agent.base_url)
-    else:
-        # Scale the stale timeout for large contexts: slow models (like Opus)
-        # can legitimately think for minutes before producing the first token
-        # when the context is large.  Without this, the stale detector kills
-        # healthy connections during the model's thinking phase, producing
-        # spurious RemoteProtocolError ("peer closed connection").
-        _est_tokens = estimate_request_context_tokens(api_kwargs)
-        if _est_tokens > 100_000:
-            _stream_stale_timeout = max(_stream_stale_timeout_base, 300.0)
-        elif _est_tokens > 50_000:
-            _stream_stale_timeout = max(_stream_stale_timeout_base, 240.0)
-        else:
-            _stream_stale_timeout = _stream_stale_timeout_base
-        # Reasoning-model floor: known reasoning models (Nemotron 3 Ultra,
-        # OpenAI o1/o3, Anthropic Opus 4.x thinking, DeepSeek R1, Qwen QwQ,
-        # xAI Grok reasoning, etc.) routinely exceed the default 180s chat-
-        # model threshold during their thinking phase.  The cloud gateway
-        # upstream kills the socket first, surfacing as BrokenPipeError.
-        # Raises the floor only — never overrides explicit user config
-        # (handled by get_provider_stale_timeout above).
-        from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
-        _reasoning_floor = get_reasoning_stale_timeout_floor(api_kwargs.get("model"))
-        if _reasoning_floor is not None:
-            _stream_stale_timeout = max(_stream_stale_timeout, _reasoning_floor)
+    _stream_stale_timeout = _compute_stream_stale_timeout(agent, api_kwargs)
 
     t = threading.Thread(target=_call, daemon=True)
     t.start()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1328,7 +1328,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 # Resolve Hermes home directory (respects HERMES_HOME override)
 from hermes_constants import get_hermes_home, get_hermes_home_override
-from utils import atomic_json_write, atomic_yaml_write, base_url_host_matches, is_truthy_value
+from utils import atomic_json_write, atomic_yaml_write, base_url_host_matches, is_truthy_value, expand_fallback_base_url
 _hermes_home = get_hermes_home()
 
 # Load environment variables from ~/.hermes/.env first.
@@ -1994,7 +1994,7 @@ def _try_resolve_fallback_provider() -> dict | None:
                         explicit_api_key = os.getenv(key_env, "").strip() or None
                 runtime = resolve_runtime_provider(
                     requested=entry.get("provider"),
-                    explicit_base_url=entry.get("base_url"),
+                    explicit_base_url=expand_fallback_base_url(entry.get("base_url")),
                     explicit_api_key=explicit_api_key,
                 )
                 # Log the literal `provider` key from config, not the resolved

--- a/tests/agent/test_local_stream_timeout.py
+++ b/tests/agent/test_local_stream_timeout.py
@@ -138,3 +138,99 @@ class TestIsLocalEndpoint:
     def test_near_but_not_cgnat_is_remote(self, url):
         """Hosts adjacent to but outside 100.64.0.0/10 must not match."""
         assert is_local_endpoint(url) is False
+
+
+class TestIsKnownLocalInferenceEndpoint:
+    """Unit tests for the scoped local-inference detector.
+
+    Port 8080 alone must NOT be treated as inference because it is a
+    common cloud-proxy / relay port.  Provider identity (lmstudio, local)
+    and unique ports (11434, 1234) are reliable signals.
+    """
+
+    def _call(self, base_url, provider=None):
+        from agent.chat_completion_helpers import _is_known_local_inference_endpoint
+        return _is_known_local_inference_endpoint(base_url, provider)
+
+    @pytest.mark.parametrize("url", [
+        "http://127.0.0.1:11434/v1",
+        "http://localhost:11434/v1",
+    ])
+    def test_ollama_port_detected(self, url):
+        assert self._call(url) is True
+
+    @pytest.mark.parametrize("url", [
+        "http://127.0.0.1:1234/v1",
+        "http://localhost:1234/v1",
+    ])
+    def test_lm_studio_port_detected(self, url):
+        assert self._call(url) is True
+
+    def test_omlx_in_url_detected(self):
+        assert self._call("http://127.0.0.1:8080/omlx/v1") is True
+
+    @pytest.mark.parametrize("provider", ["lmstudio", "local"])
+    def test_provider_identity_detected(self, provider):
+        """Provider lmstudio/local on any local endpoint → True."""
+        assert self._call("http://127.0.0.1:8080/v1", provider=provider) is True
+
+    def test_cloud_proxy_on_8080_not_detected(self):
+        """Port 8080 without a known provider → NOT inference.
+
+        This is the cloud-proxy regression: a Tailscale relay or HTTP
+        CONNECT proxy on :8080 must keep stale detection enabled.
+        """
+        assert self._call("http://127.0.0.1:8080/v1") is False
+
+    def test_cloud_proxy_on_8080_with_custom_provider_not_detected(self):
+        """Provider 'custom' on :8080 → still not inference (could be cloud)."""
+        assert self._call("http://127.0.0.1:8080/v1", provider="custom") is False
+
+    def test_remote_endpoint_not_detected(self):
+        assert self._call("https://api.openai.com/v1") is False
+
+    def test_empty_base_url_not_detected(self):
+        assert self._call(None) is False
+        assert self._call("") is False
+
+
+class TestComputeStreamStaleTimeout:
+    """Verify _compute_stream_stale_timeout integrates the scoped detector."""
+
+    def _agent(self, base_url="", provider="custom", model="test-model"):
+        from unittest.mock import MagicMock
+        a = MagicMock()
+        a.base_url = base_url
+        a.provider = provider
+        a.model = model
+        return a
+
+    def test_cloud_proxy_on_8080_keeps_default_timeout(self, monkeypatch):
+        """Cloud proxy on :8080 should NOT disable stale detection."""
+        monkeypatch.delenv("HERMES_STREAM_STALE_TIMEOUT", raising=False)
+        from agent.chat_completion_helpers import _compute_stream_stale_timeout
+        agent = self._agent(base_url="http://127.0.0.1:8080/v1", provider="custom")
+        result = _compute_stream_stale_timeout(agent, {"model": "test"})
+        assert result != float("inf")
+        assert result == 180.0  # default
+
+    def test_ollama_disables_stale(self, monkeypatch):
+        monkeypatch.delenv("HERMES_STREAM_STALE_TIMEOUT", raising=False)
+        from agent.chat_completion_helpers import _compute_stream_stale_timeout
+        agent = self._agent(base_url="http://127.0.0.1:11434/v1", provider="custom")
+        assert _compute_stream_stale_timeout(agent, {"model": "test"}) == float("inf")
+
+    def test_llamacpp_via_provider_disables_stale(self, monkeypatch):
+        """llama.cpp on :8080 with provider 'local' → disabled."""
+        monkeypatch.delenv("HERMES_STREAM_STALE_TIMEOUT", raising=False)
+        from agent.chat_completion_helpers import _compute_stream_stale_timeout
+        agent = self._agent(base_url="http://127.0.0.1:8080/v1", provider="local")
+        assert _compute_stream_stale_timeout(agent, {"model": "test"}) == float("inf")
+
+    def test_user_override_keeps_timeout_for_ollama(self, monkeypatch):
+        """HERMES_STREAM_STALE_TIMEOUT set → don't auto-disable even for Ollama."""
+        monkeypatch.setenv("HERMES_STREAM_STALE_TIMEOUT", "300")
+        from agent.chat_completion_helpers import _compute_stream_stale_timeout
+        agent = self._agent(base_url="http://127.0.0.1:11434/v1", provider="custom")
+        result = _compute_stream_stale_timeout(agent, {"model": "test"})
+        assert result == 300.0

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -489,6 +489,30 @@ class TestTryRecoverPrimaryTransport:
 
         assert result is True
 
+    def test_recovers_on_broken_pipe_error(self):
+        agent = _make_agent(provider="custom")
+        error = _make_transport_error("BrokenPipeError")
+
+        with patch("run_agent.OpenAI", return_value=MagicMock()), \
+             patch("time.sleep"):
+            result = agent._try_recover_primary_transport(
+                error, retry_count=3, max_retries=3,
+            )
+
+        assert result is True
+
+    def test_recovers_on_connection_reset_error(self):
+        agent = _make_agent(provider="custom")
+        error = _make_transport_error("ConnectionResetError")
+
+        with patch("run_agent.OpenAI", return_value=MagicMock()), \
+             patch("time.sleep"):
+            result = agent._try_recover_primary_transport(
+                error, retry_count=3, max_retries=3,
+            )
+
+        assert result is True
+
     def test_skipped_when_already_on_fallback(self):
         agent = _make_agent(provider="custom")
         agent._fallback_activated = True

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -5,6 +5,7 @@ the new list-based ``fallback_providers`` config format and chain
 advancement through multiple providers.
 """
 
+import os
 from unittest.mock import MagicMock, patch
 
 from run_agent import AIAgent, _pool_may_recover_from_rate_limit
@@ -334,3 +335,46 @@ class TestFallbackChainDedup:
 
         assert ok is False
         mock_resolve.assert_not_called()
+
+
+
+class TestFallbackBaseUrlEnvExpansion:
+    """${VAR} expansion in fallback-chain base_url — runtime, init-time, and
+    gateway auth paths must all expand env vars identically."""
+
+    def test_expand_fallback_base_url_helper(self):
+        from utils import expand_fallback_base_url
+        # No env var → passthrough
+        assert expand_fallback_base_url("http://localhost:11434/v1") == "http://localhost:11434/v1"
+        # Env var expanded
+        with patch.dict(os.environ, {"OLLAMA_HOST": "http://192.168.1.10:11434"}):
+            assert expand_fallback_base_url("${OLLAMA_HOST}/v1") == "http://192.168.1.10:11434/v1"
+        # None / empty → None
+        assert expand_fallback_base_url(None) is None
+        assert expand_fallback_base_url("") is None
+        assert expand_fallback_base_url("  ") is None
+
+    def test_runtime_fallback_expands_env_vars(self):
+        """try_activate_fallback expands ${VAR} in fallback base_url."""
+        import os
+        fb = [{"provider": "custom", "model": "test-model",
+               "base_url": "${OLLAMA_HOST}/v1", "api_key": "no-key"}]
+        agent = _make_agent(fallback_model=fb)
+        agent.provider = "openrouter"
+        agent.model = "test-model"
+        agent.base_url = "https://openrouter.ai/api/v1"
+
+        mock_client = _mock_client(base_url="http://192.168.1.10:11434/v1")
+        with (
+            patch.dict(os.environ, {"OLLAMA_HOST": "http://192.168.1.10:11434"}),
+            patch("agent.auxiliary_client.resolve_provider_client",
+                  return_value=(mock_client, "test-model")) as mock_resolve,
+        ):
+            ok = agent._try_activate_fallback()
+
+        assert ok is True
+        call_kwargs = mock_resolve.call_args
+        passed_url = call_kwargs.kwargs.get("explicit_base_url")
+        assert passed_url == "http://192.168.1.10:11434/v1", (
+            f"Expected expanded URL, got {passed_url!r}"
+        )

--- a/utils.py
+++ b/utils.py
@@ -544,3 +544,13 @@ def base_url_host_matches(base_url: str, domain: str) -> bool:
     if not domain:
         return False
     return hostname == domain or hostname.endswith("." + domain)
+
+
+def expand_fallback_base_url(raw_url: str | None) -> str | None:
+    """Expand ``${VAR}`` references in a fallback-chain ``base_url``.
+
+    Centralised so runtime, init-time, and gateway auth fallback paths all
+    behave identically.  Mirrors the ``key_env`` pattern already used for
+    ``api_key`` — lets configs reference ``${OLLAMA_HOST}/v1`` etc.
+    """
+    return os.path.expandvars((raw_url or "").strip()) or None


### PR DESCRIPTION
## Summary
Three small, related fixes to the streaming transport path:

1. **Stream-stale-timeout: scope auto-disable to known local inference ports.**
   Old logic disabled stale detection for *any* localhost URL → cloud proxies on local machines (HTTP CONNECT, tailscale relays, etc.) silently masked real network hangs as "model is just thinking". Now matches by parsed port: 11434 (Ollama), 8080 (llama.cpp), 1234 (LM Studio), or `omlx` in URL. `HERMES_STREAM_STALE_TIMEOUT` escape hatch still wins.

2. **Fallback `base_url`: expand env vars.** Lets configs reference `${OLLAMA_HOST}/v1` etc. Mirrors the `key_env` pattern already used for `api_key`.

3. **Recoverable transport errors: add `BrokenPipeError` + `ConnectionResetError`.** Streaming hangups under heavy throughput surface as raw OS pipe breaks more often than the named httpx exceptions. Deliberately *not* adding the parent `OSError`, so unrelated errors (FileNotFound, PermissionError) are not retried into a loop.

## Test plan
- [ ] Manual: run with cloud proxy on `http://127.0.0.1:8080` — verify stale detector remains enabled (was incorrectly disabled before)
- [ ] Manual: run with Ollama on default port — verify stale detector disabled
- [ ] Manual: fallback config with `base_url: ${OLLAMA_HOST}/v1` resolves
- [ ] Manual: `BrokenPipeError` mid-stream triggers transport rebuild