### PR TITLE
fix(gateway): Clean shutdown while preserving SIGTERM failure semantics

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -69,6 +69,37 @@ _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
 _AUTO_CONTINUE_FRESHNESS_SECS_DEFAULT = 60 * 60
 
 
+def _install_gateway_signal_handler(loop, sig, callback) -> bool:
+    """Install an asyncio-compatible gateway signal handler.
+
+    ``loop.add_signal_handler`` is unavailable on Windows. In that case,
+    fall back to ``signal.signal`` and bounce the callback onto the running
+    event loop so Ctrl+C still enters the normal gateway shutdown path.
+    """
+    try:
+        loop.add_signal_handler(sig, callback, sig)
+        return True
+    except NotImplementedError:
+        pass
+
+    try:
+        previous_handler = signal.getsignal(sig)
+
+        def _fallback_handler(signum, frame):
+            try:
+                loop.call_soon_threadsafe(callback, signum)
+            except RuntimeError:
+                if callable(previous_handler):
+                    previous_handler(signum, frame)
+                elif previous_handler == signal.SIG_DFL and signum == signal.SIGINT:
+                    raise KeyboardInterrupt
+
+        signal.signal(sig, _fallback_handler)
+        return True
+    except (AttributeError, OSError, RuntimeError, ValueError):
+        return False
+
+
 def _coerce_gateway_timestamp(value: Any) -> Optional[float]:
     """Best-effort conversion of stored gateway timestamps to epoch seconds.
 
@@ -12511,15 +12542,16 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     runner = GatewayRunner(config)
     
     # Track whether a signal initiated the shutdown (vs. internal request).
-    # When an unexpected SIGTERM kills the gateway, we exit non-zero so
-    # systemd's Restart=on-failure revives the process.  systemctl stop
-    # is safe: systemd tracks stop-requested state independently of exit
-    # code, so Restart= never fires for a deliberate stop.
+    # Unexpected SIGTERM exits non-zero so systemd's Restart=on-failure revives
+    # the process. Ctrl+C/SIGINT is a foreground user stop and exits cleanly.
+    # systemctl stop is safe: systemd tracks stop-requested state independently
+    # of exit code, so Restart= never fires for a deliberate stop.
     _signal_initiated_shutdown = False
+    _shutdown_signal: Optional[int] = None
 
     # Set up signal handlers
-    def shutdown_signal_handler():
-        nonlocal _signal_initiated_shutdown
+    def shutdown_signal_handler(sig: Optional[int] = None):
+        nonlocal _signal_initiated_shutdown, _shutdown_signal
         # Planned --replace takeover check: when a sibling gateway is
         # taking over via --replace, it wrote a marker naming this PID
         # before sending SIGTERM. If present, treat the signal as a
@@ -12540,7 +12572,12 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             )
         else:
             _signal_initiated_shutdown = True
-            logger.info("Received SIGTERM/SIGINT — initiating shutdown")
+            _shutdown_signal = sig
+            try:
+                sig_name = signal.Signals(sig).name if sig is not None else "signal"
+            except (TypeError, ValueError):
+                sig_name = str(sig)
+            logger.info("Received %s — initiating shutdown", sig_name)
         # Diagnostic: log all hermes-related processes so we can identify
         # what triggered the signal (hermes update, hermes gateway restart,
         # a stale detached subprocess, etc.).
@@ -12572,10 +12609,8 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     loop = asyncio.get_running_loop()
     if threading.current_thread() is threading.main_thread():
         for sig in (signal.SIGINT, signal.SIGTERM):
-            try:
-                loop.add_signal_handler(sig, shutdown_signal_handler)
-            except NotImplementedError:
-                pass
+            if not _install_gateway_signal_handler(loop, sig, shutdown_signal_handler):
+                logger.debug("Could not install gateway signal handler for %s", sig)
         if hasattr(signal, "SIGUSR1"):
             try:
                 loop.add_signal_handler(signal.SIGUSR1, restart_signal_handler)
@@ -12671,8 +12706,8 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     if runner.exit_code is not None:
         raise SystemExit(runner.exit_code)
 
-    # When a signal (SIGTERM/SIGINT) caused the shutdown and it wasn't a
-    # planned restart (/restart, /update, SIGUSR1), exit non-zero so
+    # When SIGTERM caused the shutdown and it wasn't a planned restart
+    # (/restart, /update, SIGUSR1), exit non-zero so
     # systemd's Restart=on-failure revives the process.  This covers:
     #   - hermes update killing the gateway mid-work
     #   - External kill commands
@@ -12680,6 +12715,11 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # systemctl stop is safe: systemd tracks "stop requested" state
     # independently of exit code, so Restart= never fires for it.
     if _signal_initiated_shutdown and not runner._restart_requested:
+        if _shutdown_signal == signal.SIGINT:
+            print()
+            print("Gateway stopped.")
+            logger.info("Exiting cleanly after SIGINT user interrupt.")
+            return True
         logger.info(
             "Exiting with code 1 (signal-initiated shutdown without restart "
             "request) so systemd Restart=on-failure can revive the gateway."

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2368,7 +2368,12 @@ def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False):
     # Exit with code 1 if gateway fails to connect any platform,
     # so systemd Restart=on-failure will retry on transient errors
     verbosity = None if quiet else verbose
-    success = asyncio.run(start_gateway(replace=replace, verbosity=verbosity))
+    try:
+        success = asyncio.run(start_gateway(replace=replace, verbosity=verbosity))
+    except KeyboardInterrupt:
+        print()
+        print("Gateway stopped.")
+        return
     if not success:
         sys.exit(1)
 

--- a/tests/gateway/test_runner_startup_failures.py
+++ b/tests/gateway/test_runner_startup_failures.py
@@ -1,3 +1,6 @@
+import asyncio
+import signal
+
 import pytest
 from unittest.mock import AsyncMock
 
@@ -5,6 +8,40 @@ from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.base import BasePlatformAdapter
 from gateway.run import GatewayRunner
 from gateway.status import read_runtime_status
+
+
+def test_install_gateway_signal_handler_falls_back_to_signal_signal(monkeypatch):
+    from gateway import run as gateway_run
+
+    calls = []
+    installed = {}
+
+    class _LoopWithoutAsyncioSignals:
+        def add_signal_handler(self, *args, **kwargs):
+            raise NotImplementedError()
+
+        def call_soon_threadsafe(self, callback, *args):
+            calls.append((callback, args))
+
+    def callback(sig):
+        return sig
+
+    monkeypatch.setattr(gateway_run.signal, "getsignal", lambda sig: signal.SIG_DFL)
+    monkeypatch.setattr(
+        gateway_run.signal,
+        "signal",
+        lambda sig, handler: installed.setdefault(sig, handler),
+    )
+
+    assert gateway_run._install_gateway_signal_handler(
+        _LoopWithoutAsyncioSignals(),
+        signal.SIGINT,
+        callback,
+    ) is True
+
+    installed[signal.SIGINT](signal.SIGINT, None)
+
+    assert calls == [(callback, (signal.SIGINT,))]
 
 
 class _RetryableFailureAdapter(BasePlatformAdapter):
@@ -163,6 +200,114 @@ async def test_start_gateway_verbosity_imports_redacting_formatter(monkeypatch, 
     ok = await start_gateway(config=GatewayConfig(), replace=False, verbosity=1)
 
     assert ok is True
+
+
+@pytest.mark.asyncio
+async def test_start_gateway_sigint_enters_clean_shutdown_path(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    handlers = {}
+    stop_calls = []
+
+    class _SignalRunner:
+        def __init__(self, config):
+            self.config = config
+            self.should_exit_cleanly = False
+            self.should_exit_with_failure = False
+            self.exit_reason = None
+            self.exit_code = None
+            self._restart_requested = False
+            self.adapters = {}
+            self._shutdown = None
+
+        async def start(self):
+            self._shutdown = asyncio.Event()
+            asyncio.get_running_loop().call_soon(handlers[signal.SIGINT], signal.SIGINT)
+            return True
+
+        async def wait_for_shutdown(self):
+            await self._shutdown.wait()
+
+        async def stop(self):
+            stop_calls.append("stop")
+            self._shutdown.set()
+
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+    monkeypatch.setattr("gateway.status.acquire_gateway_runtime_lock", lambda: True)
+    monkeypatch.setattr("gateway.status.write_pid_file", lambda: None)
+    monkeypatch.setattr("gateway.status.remove_pid_file", lambda: None)
+    monkeypatch.setattr("gateway.status.release_gateway_runtime_lock", lambda: None)
+    monkeypatch.setattr("tools.skills_sync.sync_skills", lambda quiet=True: None)
+    monkeypatch.setattr("hermes_logging.setup_logging", lambda hermes_home, mode: tmp_path)
+    monkeypatch.setattr("hermes_logging._add_rotating_handler", lambda *args, **kwargs: None)
+    monkeypatch.setattr("tools.mcp_tool.discover_mcp_tools", lambda: None)
+    monkeypatch.setattr("tools.mcp_tool.shutdown_mcp_servers", lambda: None)
+    monkeypatch.setattr("gateway.run._start_cron_ticker", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        "gateway.run._install_gateway_signal_handler",
+        lambda loop, sig, callback: handlers.setdefault(sig, callback) or True,
+    )
+    monkeypatch.setattr("gateway.run.GatewayRunner", _SignalRunner)
+
+    from gateway.run import start_gateway
+
+    ok = await start_gateway(config=GatewayConfig(), replace=False, verbosity=None)
+
+    assert ok is True
+    assert stop_calls == ["stop"]
+    assert "Gateway stopped." in capsys.readouterr().out
+
+
+@pytest.mark.asyncio
+async def test_start_gateway_sigterm_still_exits_with_failure(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    handlers = {}
+
+    class _SignalRunner:
+        def __init__(self, config):
+            self.config = config
+            self.should_exit_cleanly = False
+            self.should_exit_with_failure = False
+            self.exit_reason = None
+            self.exit_code = None
+            self._restart_requested = False
+            self.adapters = {}
+            self._shutdown = None
+
+        async def start(self):
+            self._shutdown = asyncio.Event()
+            asyncio.get_running_loop().call_soon(handlers[signal.SIGTERM], signal.SIGTERM)
+            return True
+
+        async def wait_for_shutdown(self):
+            await self._shutdown.wait()
+
+        async def stop(self):
+            self._shutdown.set()
+
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+    monkeypatch.setattr("gateway.status.acquire_gateway_runtime_lock", lambda: True)
+    monkeypatch.setattr("gateway.status.write_pid_file", lambda: None)
+    monkeypatch.setattr("gateway.status.remove_pid_file", lambda: None)
+    monkeypatch.setattr("gateway.status.release_gateway_runtime_lock", lambda: None)
+    monkeypatch.setattr("tools.skills_sync.sync_skills", lambda quiet=True: None)
+    monkeypatch.setattr("hermes_logging.setup_logging", lambda hermes_home, mode: tmp_path)
+    monkeypatch.setattr("hermes_logging._add_rotating_handler", lambda *args, **kwargs: None)
+    monkeypatch.setattr("tools.mcp_tool.discover_mcp_tools", lambda: None)
+    monkeypatch.setattr("tools.mcp_tool.shutdown_mcp_servers", lambda: None)
+    monkeypatch.setattr("gateway.run._start_cron_ticker", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        "gateway.run._install_gateway_signal_handler",
+        lambda loop, sig, callback: handlers.setdefault(sig, callback) or True,
+    )
+    monkeypatch.setattr("gateway.run.GatewayRunner", _SignalRunner)
+
+    from gateway.run import start_gateway
+
+    ok = await start_gateway(config=GatewayConfig(), replace=False, verbosity=None)
+
+    assert ok is False
 
 
 @pytest.mark.asyncio

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -1,6 +1,7 @@
 """Tests for hermes_cli.gateway."""
 
-from types import SimpleNamespace
+import sys
+from types import ModuleType, SimpleNamespace
 from unittest.mock import patch, call
 
 import hermes_cli.gateway as gateway
@@ -107,6 +108,23 @@ def test_gateway_start_in_container_with_operational_systemd_uses_systemd(monkey
     gateway.gateway_command(args)
 
     assert calls == [False]
+
+
+def test_run_gateway_handles_keyboardinterrupt_cleanly(monkeypatch, capsys):
+    fake_gateway_run = ModuleType("gateway.run")
+    fake_gateway_run.start_gateway = lambda **kwargs: object()
+    monkeypatch.setitem(sys.modules, "gateway.run", fake_gateway_run)
+
+    def raise_keyboardinterrupt(_coro):
+        raise KeyboardInterrupt()
+
+    monkeypatch.setattr(gateway.asyncio, "run", raise_keyboardinterrupt)
+
+    gateway.run_gateway()
+
+    captured = capsys.readouterr()
+    assert "Gateway stopped." in captured.out
+    assert "KeyboardInterrupt" not in captured.err
 
 
 def test_systemd_status_warns_when_linger_disabled(monkeypatch, tmp_path, capsys):


### PR DESCRIPTION
## Summary
- Handle foreground gateway Ctrl+C without printing a chained `CancelledError` / `KeyboardInterrupt` traceback.
- Install a `signal.signal` fallback when `loop.add_signal_handler()` is unavailable, so Windows-style Ctrl+C enters the normal gateway shutdown path.
- Keep SIGTERM restart-on-failure semantics intact for systemd recovery, while treating SIGINT as a clean user stop.

Closes #17810

## Validation
- `scripts/run_tests.sh tests/hermes_cli/test_gateway.py tests/gateway/test_runner_startup_failures.py -q` -> 33 passed
- `git diff --check`
- Manual simulated Windows/no-`add_signal_handler` Ctrl+C path exits with `Gateway stopped.` and code 0
