### PR TITLE
fix(qqbot): trigger fatal error + reconnect when max reconnect attempts reached

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -484,6 +484,9 @@ class QQAdapter(BasePlatformAdapter):
                         RATE_LIMIT_DELAY,
                     )
                     if backoff_idx >= MAX_RECONNECT_ATTEMPTS:
+                        logger.error("[%s] Rate limit max reconnect attempts reached", self._log_tag)
+                        self._set_fatal_error("qqbot_rate_limit_reconnect", "Max reconnect attempts reached under rate limit", retryable=True)
+                        await self._notify_fatal_error()
                         return
                     await asyncio.sleep(RATE_LIMIT_DELAY)
                     if await self._reconnect(backoff_idx):
@@ -537,6 +540,8 @@ class QQAdapter(BasePlatformAdapter):
                     backoff_idx += 1
                     if backoff_idx >= MAX_RECONNECT_ATTEMPTS:
                         logger.error("[%s] Max reconnect attempts reached (QQCloseError)", self._log_tag)
+                        self._set_fatal_error("qqbot_close_error_reconnect", "Max reconnect attempts reached after QQCloseError", retryable=True)
+                        await self._notify_fatal_error()
                         return
 
             except Exception as exc:
@@ -548,6 +553,8 @@ class QQAdapter(BasePlatformAdapter):
 
                 if backoff_idx >= MAX_RECONNECT_ATTEMPTS:
                     logger.error("[%s] Max reconnect attempts reached", self._log_tag)
+                    self._set_fatal_error("qqbot_ws_reconnect", "Max reconnect attempts reached after WebSocket errors", retryable=True)
+                    await self._notify_fatal_error()
                     return
 
                 if await self._reconnect(backoff_idx):


### PR DESCRIPTION
## Summary

When the QQ adapters _listen_loop() exhausts all reconnect attempts (MAX_RECONNECT_ATTEMPTS=100), it previously returned silently without notifying the gateway. This left the bot in a zombie state: the gateway believed the platform was connected (is_connected returned True) while the adapter was dead.

## Fix

Use the same _set_fatal_error() + _notify_fatal_error() pattern that telegram.py uses. This triggers:

1. _handle_adapter_fatal_error() in the gateway run loop
2. Adapter removed from self.adapters
3. Platform added to _failed_platforms for background reconnection
4. _platform_reconnect_watcher() picks it up and retries with exponential backoff

Three paths are covered:
- Rate limit (code 4008) exhausts retries
- QQCloseError reconnect failures exceed limit
- General WebSocket exception reconnect failures exceed limit

## Root Cause

Analyzed 11 Reconnect failed events in errors.log:
- All 11 occurred after hermes-gateway restarts
- Pattern: gateway crashes -> adapter is stopped -> REST API calls fail -> gateway restarted -> adapter reconnects
- Fix ensures adapter proactively signals fatal error so gateway reconnects automatically without manual restart