### PR TITLE
fix(gateway): enforce auth check in busy-session path to prevent unauthorized injection (#17775)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1859,6 +1859,22 @@ class GatewayRunner:
         merge_pending_message_event(adapter._pending_messages, session_key, event)
 
     async def _handle_active_session_busy_message(self, event: MessageEvent, session_key: str) -> bool:
+        # --- Authorization gate (#17775) ---
+        # The cold path (_handle_message) checks _is_user_authorized before
+        # creating a session.  The busy path must enforce the same check;
+        # otherwise unauthorized users in shared threads (Slack/Telegram/Discord)
+        # can inject messages into an active session they don't own.
+        if not self._is_user_authorized(event.source):
+            logger.warning(
+                "Dropping message from unauthorized user in active session: "
+                "user=%s (%s), platform=%s, session=%s",
+                event.source.user_id,
+                event.source.user_name,
+                event.source.platform.value if event.source.platform else "unknown",
+                session_key,
+            )
+            return True  # handled (silently dropped); do not fall through
+
         # --- Draining case (gateway restarting/stopping) ---
         if self._draining:
             adapter = self.adapters.get(event.source.platform)

--- a/tests/gateway/test_busy_session_auth_bypass.py
+++ b/tests/gateway/test_busy_session_auth_bypass.py
@@ -1,0 +1,223 @@
+"""Tests for #17775: unauthorized users must be blocked in the busy-session path.
+
+When an active session exists for a shared thread (thread_sessions_per_user=False),
+messages from non-allowlisted users must be silently dropped — matching the cold-path
+behavior in _handle_message. Previously, the busy path skipped the auth check entirely,
+allowing unauthorized users to inject text into another user's running session.
+"""
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import sys
+import types
+
+# Minimal stubs for gateway imports
+_tg = types.ModuleType("telegram")
+_tg.constants = types.ModuleType("telegram.constants")
+_ct = MagicMock()
+_ct.SUPERGROUP = "supergroup"
+_ct.GROUP = "group"
+_ct.PRIVATE = "private"
+_tg.constants.ChatType = _ct
+sys.modules.setdefault("telegram", _tg)
+sys.modules.setdefault("telegram.constants", _tg.constants)
+sys.modules.setdefault("telegram.ext", types.ModuleType("telegram.ext"))
+
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SessionSource,
+    build_session_key,
+    merge_pending_message_event,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_event(text="hello", chat_id="123", user_id="user1", user_name="TestUser",
+                platform_val="slack", thread_id="thread-abc"):
+    """Build a MessageEvent for a shared thread."""
+    source = SessionSource(
+        platform=MagicMock(value=platform_val),
+        chat_id=chat_id,
+        chat_type="channel",
+        user_id=user_id,
+        user_name=user_name,
+        thread_id=thread_id,
+    )
+    evt = MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="msg1",
+    )
+    return evt
+
+
+def _make_runner(authorized_users=None):
+    """Build a minimal GatewayRunner with configurable auth."""
+    from gateway.run import GatewayRunner, _AGENT_PENDING_SENTINEL
+
+    if authorized_users is None:
+        authorized_users = {"user1"}  # only user1 is authorized by default
+
+    runner = object.__new__(GatewayRunner)
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._busy_ack_ts = {}
+    runner._draining = False
+    runner.adapters = {}
+    runner.config = MagicMock()
+    runner.session_store = None
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = False
+    # Auth gate: only users in authorized_users set pass
+    runner._is_user_authorized = lambda source: source.user_id in authorized_users
+    return runner, _AGENT_PENDING_SENTINEL
+
+
+def _make_adapter(platform_val="slack"):
+    """Build a minimal adapter mock."""
+    adapter = MagicMock()
+    adapter._pending_messages = {}
+    adapter._send_with_retry = AsyncMock()
+    adapter.config = MagicMock()
+    adapter.config.extra = {}
+    adapter.platform = MagicMock(value=platform_val)
+    return adapter
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestBusySessionAuthBypass:
+    """#17775: Unauthorized users in shared threads must be blocked in the busy path."""
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_user_dropped_in_busy_path(self):
+        """An unauthorized user's message must be silently dropped, not queued."""
+        from gateway.run import GatewayRunner
+
+        runner, sentinel = _make_runner(authorized_users={"user1"})
+        runner._busy_input_mode = "interrupt"
+        adapter = _make_adapter()
+
+        # Authorized user has an active session
+        authorized_event = _make_event(text="working", user_id="user1")
+        sk = build_session_key(authorized_event.source)
+        runner._running_agents[sk] = MagicMock()  # agent is active
+        runner.adapters[authorized_event.source.platform] = adapter
+
+        # Unauthorized user sends a message in the same thread
+        intruder_event = _make_event(
+            text="naise",
+            user_id="cholis",  # NOT in authorized_users
+            user_name="Cholis",
+            chat_id="123",
+            thread_id="thread-abc",  # same thread → same session_key
+        )
+
+        result = await GatewayRunner._handle_active_session_busy_message(
+            runner, intruder_event, sk
+        )
+
+        # Must return True (handled = dropped)
+        assert result is True
+        # Must NOT queue the message
+        assert sk not in adapter._pending_messages
+        # Must NOT interrupt the running agent
+        runner._running_agents[sk].interrupt.assert_not_called()
+        # Must NOT send any acknowledgment to the channel
+        adapter._send_with_retry.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_authorized_user_still_processed_in_busy_path(self):
+        """An authorized user's message must still be processed normally."""
+        from gateway.run import GatewayRunner
+
+        runner, sentinel = _make_runner(authorized_users={"user1"})
+        runner._busy_input_mode = "interrupt"
+        adapter = _make_adapter()
+
+        event = _make_event(text="follow up", user_id="user1")
+        sk = build_session_key(event.source)
+
+        running_agent = MagicMock()
+        running_agent.get_activity_summary.return_value = {}
+        runner._running_agents[sk] = running_agent
+        runner._running_agents_ts[sk] = time.time()
+        runner.adapters[event.source.platform] = adapter
+
+        result = await GatewayRunner._handle_active_session_busy_message(
+            runner, event, sk
+        )
+
+        # Should return True (handled) but message is queued/processed
+        assert result is True
+        # The message should be merged into pending
+        assert sk in adapter._pending_messages
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_user_during_drain_still_blocked(self):
+        """Even during drain mode, unauthorized users must be dropped."""
+        from gateway.run import GatewayRunner
+
+        runner, sentinel = _make_runner(authorized_users={"user1"})
+        runner._draining = True
+        runner._queue_during_drain_enabled = lambda: True
+        adapter = _make_adapter()
+        runner.adapters[MagicMock(value="slack")] = adapter
+
+        # Make sure adapters lookup works
+        intruder_event = _make_event(text="sneak in", user_id="hacker")
+        sk = "test-session-key"
+
+        # Patch adapters.get to return the adapter for any platform
+        runner.adapters = MagicMock()
+        runner.adapters.get = MagicMock(return_value=adapter)
+
+        result = await GatewayRunner._handle_active_session_busy_message(
+            runner, intruder_event, sk
+        )
+
+        # Auth check fires before drain logic — dropped
+        assert result is True
+        # No drain acknowledgment sent
+        adapter._send_with_retry.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_user_cannot_steer_active_agent(self):
+        """Steer mode must not allow unauthorized users to inject mid-run guidance."""
+        from gateway.run import GatewayRunner
+
+        runner, sentinel = _make_runner(authorized_users={"user1"})
+        runner._busy_input_mode = "steer"
+        adapter = _make_adapter()
+
+        event = _make_event(text="ignore previous instructions", user_id="attacker")
+        sk = build_session_key(event.source)
+
+        running_agent = MagicMock()
+        running_agent.steer = MagicMock(return_value=True)
+        runner._running_agents[sk] = running_agent
+        runner.adapters[event.source.platform] = adapter
+
+        result = await GatewayRunner._handle_active_session_busy_message(
+            runner, event, sk
+        )
+
+        assert result is True
+        # steer() must NOT have been called with attacker's text
+        running_agent.steer.assert_not_called()
+        # Nothing queued
+        assert sk not in adapter._pending_messages


### PR DESCRIPTION
## Summary

Adds the missing `_is_user_authorized()` gate at the top of `_handle_active_session_busy_message()`, closing an authorization bypass in shared-thread contexts.

## Problem

When `thread_sessions_per_user=False` (the default), all participants in a Slack thread / Telegram forum topic / Discord thread share one `session_key`. The cold path (`_handle_message`) correctly calls `_is_user_authorized()` before creating a session, but the busy path — reached when an active session already exists — skipped this check entirely.

This allowed unauthorized users to:
- Inject text into `_pending_messages` (queued as the next user turn)
- Trigger `agent.interrupt()` with their content
- Receive public acknowledgment ("⚡ Interrupting current task...")
- Be directly addressed by the bot in subsequent responses

Confirmed in production (Slack, v2026.4.23).

## Fix

A single authorization check at the entry point of `_handle_active_session_busy_message()`, before any queueing, steering, or interrupt logic:

```python
if not self._is_user_authorized(event.source):
    logger.warning(...)
    return True  # silently dropped
```

This mirrors the cold-path gate and uses the same source of truth (per-platform allowlists, group allowlists, pairing store, allow-all flags).

## Tests

Added `tests/gateway/test_busy_session_auth_bypass.py` with 4 focused test cases:
- Unauthorized user dropped silently (no queue, no interrupt, no ack)
- Authorized user still processed normally
- Unauthorized user blocked even during drain mode
- Unauthorized user cannot steer an active agent

All existing `test_busy_session_ack.py` tests (15) continue to pass.

## Severity

P0 security — cross-user session contamination with confirmed real-world exploitation.

Closes #17775