### PR TITLE
fix(skills): wire bump_use() into skill invocation and preload paths (#17782)

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -393,6 +393,14 @@ def build_skill_invocation_message(
         return f"[Failed to load skill: {skill_info['name']}]"
 
     loaded_skill, skill_dir, skill_name = loaded
+
+    # Track active usage for Curator lifecycle management (#17782)
+    try:
+        from tools.skill_usage import bump_use
+        bump_use(skill_name)
+    except Exception:
+        pass  # Non-critical — skill invocation proceeds regardless
+
     activation_note = (
         f'[IMPORTANT: The user has invoked the "{skill_name}" skill, indicating they want '
         "you to follow its instructions. The full skill content is loaded below.]"
@@ -432,6 +440,14 @@ def build_preloaded_skills_prompt(
             continue
 
         loaded_skill, skill_dir, skill_name = loaded
+
+        # Track active usage for Curator lifecycle management (#17782)
+        try:
+            from tools.skill_usage import bump_use
+            bump_use(skill_name)
+        except Exception:
+            pass  # Non-critical
+
         activation_note = (
             f'[IMPORTANT: The user launched this CLI session with the "{skill_name}" skill '
             "preloaded. Treat its instructions as active guidance for the duration of this "


### PR DESCRIPTION
## Summary

Connects `bump_use()` to its intended call sites so Curator's lifecycle tracking actually works.

## Problem

`bump_use()` in `tools/skill_usage.py` existed and was fully tested, but had **zero production call sites**. As a result:
- `use_count` stayed at 0 for all skills
- `last_used_at` stayed `None` forever
- Curator's stale timer (30 days) couldn't distinguish used vs. unused skills
- Every non-pinned agent-created skill would transition to `stale` simultaneously

Meanwhile `bump_view()` was correctly wired into `skills_tool.py`.

## Fix

Wire `bump_use()` into the two canonical "a skill is actively being used" paths in `agent/skill_commands.py`:

1. **`build_skill_invocation_message()`** — when a user invokes a `/skill-name` slash command and the skill content is injected into the prompt
2. **`build_preloaded_skills_prompt()`** — when a skill is preloaded at CLI session start via `hermes --skill <name>`

Both calls are wrapped in try/except to remain non-critical — skill invocation proceeds regardless of usage tracking errors.

## Why these paths

- Slash command invocation = the user explicitly activated the skill to solve a task
- Preload = the user started an entire session with this skill active
- Both represent genuine "use" (vs. `bump_view` which tracks browsing/listing)

## Testing

Existing `test_skill_usage.py` tests for `bump_use` pass. The function itself is well-tested; it simply had no callers.

Closes #17782