### PR TITLE
fix(tui): guard /reload-mcp against null ctx.sid

### DIFF
--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -352,7 +352,6 @@ describe('createSlashHandler', () => {
   it.each([
     ['/browser status', 'browser.manage', { action: 'status', session_id: null }],
     ['/browser connect', 'browser.manage', { action: 'connect', session_id: null, url: 'http://127.0.0.1:9222' }],
-    ['/reload-mcp', 'reload.mcp', { session_id: null }],
     ['/reload', 'reload.env', {}],
     ['/stop', 'process.stop', {}],
     ['/fast status', 'config.get', { key: 'fast', session_id: null }],
@@ -676,6 +675,26 @@ describe('createSlashHandler', () => {
 
     expect(rpc).not.toHaveBeenCalled()
     expect(ctx.transcript.sys).toHaveBeenCalledWith('no active session — nothing to rollback')
+  })
+
+  it('routes /reload-mcp through native RPC when a session is active', () => {
+    patchUiState({ sid: 'sid-abc' })
+    const rpc = vi.fn(() => Promise.resolve({}))
+    const ctx = buildCtx({ gateway: { ...buildGateway(), rpc } })
+
+    expect(createSlashHandler(ctx)('/reload-mcp')).toBe(true)
+    expect(rpc).toHaveBeenCalledWith('reload.mcp', { session_id: 'sid-abc' })
+    expect(ctx.gateway.gw.request).not.toHaveBeenCalled()
+  })
+
+  it('/reload-mcp without an active session tells the user instead of hitting the RPC', () => {
+    const rpc = vi.fn(() => Promise.resolve({}))
+    const ctx = buildCtx({ gateway: { ...buildGateway(), rpc } })
+
+    createSlashHandler(ctx)('/reload-mcp')
+
+    expect(rpc).not.toHaveBeenCalled()
+    expect(ctx.transcript.sys).toHaveBeenCalledWith('/reload-mcp requires an active session')
   })
 
   it('/title <name> uses session.title RPC and bypasses slash.exec', async () => {

--- a/ui-tui/src/app/slash/commands/ops.ts
+++ b/ui-tui/src/app/slash/commands/ops.ts
@@ -84,6 +84,10 @@ export const opsCommands: SlashCommand[] = [
     help: 'reload MCP servers in the live session (warns about prompt cache invalidation)',
     name: 'reload-mcp',
     run: (arg, ctx) => {
+      if (!ctx.sid) {
+        return ctx.transcript.sys('/reload-mcp requires an active session')
+      }
+
       // Parse arg: `now` / `always` skip the confirmation gate.
       // `always` additionally persists approvals.mcp_reload_confirm=false.
       const a = (arg || '').trim().toLowerCase()


### PR DESCRIPTION
## What does this PR do?

`/reload-mcp` declared `params.session_id: string` but read it directly from `ctx.sid`, which is typed as `string | null`. Triggering the command before a session was active crashed the TUI. Mirrors the null-guard pattern that `/rollback` (and `/save`) already use — surface a sys message instead of hitting the RPC with a null id.

## Related Issue

Fixes #17794

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `ui-tui/src/app/slash/commands/ops.ts` — early-return with `ctx.transcript.sys('/reload-mcp requires an active session')` when `ctx.sid` is null, before constructing `params`.
- `ui-tui/src/__tests__/createSlashHandler.test.ts`:
  - removed the table row that asserted `reload.mcp` is called with `session_id: null` (that was the bug — the typed `string` field was getting null).
  - added a positive test: active sid → RPC routed with the sid.
  - added a regression test: no sid → sys message, RPC not invoked.

## How to Test

1. `cd ui-tui && npm install`
2. `npm run build --prefix packages/hermes-ink`
3. `npx vitest run createSlashHandler` — 45 / 45 pass, including the two new cases.
4. Full TUI suite (`npx vitest run`) — 539 / 539.
5. `npm run type-check` — clean.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] Targeted vitest run + full TUI suite + tsc --noEmit pass locally
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 23.2)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation — N/A (no behavior change for users beyond the new sys message)
- [ ] I've updated `cli-config.yaml.example` — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [ ] I've considered cross-platform impact — guard is platform-agnostic
- [ ] I've updated tool descriptions/schemas — N/A
