### PR TITLE
fix(tui): add null guard for ctx.sid in /reload-mcp slash command

### DIFF
--- a/ui-tui/src/app/slash/commands/ops.ts
+++ b/ui-tui/src/app/slash/commands/ops.ts
@@ -79,6 +79,9 @@ export const opsCommands: SlashCommand[] = [
     help: 'reload MCP servers in the live session (warns about prompt cache invalidation)',
     name: 'reload-mcp',
     run: (arg, ctx) => {
+      if (!ctx.sid) {
+        return ctx.transcript.sys("/reload-mcp requires an active session")
+      }
       // Parse arg: `now` / `always` skip the confirmation gate.
       // `always` additionally persists approvals.mcp_reload_confirm=false.
       const a = (arg || '').trim().toLowerCase()


### PR DESCRIPTION
## Summary

Add a null guard for `ctx.sid` in the `/reload-mcp` slash command handler, matching the existing pattern used by `/rollback` and `/save`.

## Problem

When `ctx.sid` is `null` (no active session), `/reload-mcp` crashes because it passes `null` as `session_id: string` to the `reload.mcp` RPC call. The TypeScript type for `params.session_id` is `string`, but `ctx.sid` is `string | null`.

## Fix

Added an early-return null check at the top of the `run` handler, before building the RPC params:

```typescript
if (!ctx.sid) {
  return ctx.transcript.sys("/reload-mcp requires an active session")
}
```

This matches the guard pattern already used by `/rollback` (line 193) and `/save` in the same file.

## Changed Files

- `ui-tui/src/app/slash/commands/ops.ts` — 3 lines added

Closes #17794