### PR TITLE
fix(agent): reset _fallback_index when previous turn exhausted chain without activating (#17446)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7575,6 +7575,19 @@ class AIAgent:
         ``gateway/run.py``), so this restoration IS needed there too.
         """
         if not self._fallback_activated:
+            # ``_try_activate_fallback`` increments ``_fallback_index`` *before*
+            # each activation attempt so chain recursion can advance through
+            # invalid entries.  If a previous turn exhausted the chain without
+            # ever successfully activating (e.g. misconfigured fallback
+            # credentials, all entries returning ``fb_client is None``), the
+            # index is left at ``len(_fallback_chain)`` while
+            # ``_fallback_activated`` stays ``False``.  Without resetting here,
+            # every subsequent turn's ``_try_activate_fallback()`` short-
+            # circuits at the bounds check, the user sees ``trying fallback...``
+            # but nothing actually happens on the wire, and the session is
+            # permanently pinned to the broken primary.  See #17446.
+            if getattr(self, "_fallback_index", 0) > 0:
+                self._fallback_index = 0
             return False
 
         if getattr(self, "_rate_limited_until", 0) > time.monotonic():

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -168,6 +168,80 @@ class TestRestorePrimaryRuntime:
 
         assert agent._fallback_index == 0  # reset for next turn
 
+    def test_resets_fallback_index_after_failed_activation(self):
+        """Regression for #17446 — when a previous turn exhausted the chain
+        without ever successfully activating (e.g. all fallback entries had
+        ``fb_client is None`` or invalid provider/model), ``_fallback_index``
+        is left past the chain end while ``_fallback_activated`` stays False.
+        Without resetting here, every subsequent turn's fallback short-circuits
+        at the bounds check and the session is permanently pinned to the broken
+        primary model — even though a perfectly valid ``fallback_model`` is
+        configured.
+        """
+        agent = _make_agent(
+            fallback_model={"provider": "openrouter", "model": "google/gemini-2.0-flash-001"},
+        )
+        # Simulate a turn where activation failed for every chain entry:
+        # ``_try_activate_fallback`` advanced the index past the end without
+        # ever flipping ``_fallback_activated`` to True.
+        agent._fallback_activated = False
+        agent._fallback_index = len(agent._fallback_chain)
+        assert agent._fallback_index >= 1
+
+        # Without the fix, _restore_primary_runtime returned early at the
+        # ``if not self._fallback_activated`` guard, leaving the index stuck.
+        result = agent._restore_primary_runtime()
+
+        # Returns False (no actual restoration happened — never activated)
+        assert result is False
+        # …but the index MUST be reset so the next turn can retry the chain.
+        assert agent._fallback_index == 0
+
+    def test_does_not_disturb_index_when_already_zero(self):
+        """When _fallback_activated=False AND the index is already 0
+        (typical first turn / clean state), _restore_primary_runtime is a
+        pure no-op — no spurious writes.
+        """
+        agent = _make_agent(
+            fallback_model={"provider": "openrouter", "model": "model-a"},
+        )
+        agent._fallback_activated = False
+        agent._fallback_index = 0
+
+        result = agent._restore_primary_runtime()
+
+        assert result is False
+        assert agent._fallback_index == 0
+
+    def test_subsequent_fallback_attempt_succeeds_after_reset(self):
+        """End-to-end regression for #17446: simulate the buggy state
+        (chain exhausted, never activated), then verify that the next turn
+        can successfully activate the same fallback chain.
+        """
+        agent = _make_agent(
+            fallback_model={"provider": "openrouter", "model": "model-a"},
+        )
+        # Buggy state from the previous turn
+        agent._fallback_activated = False
+        agent._fallback_index = len(agent._fallback_chain)
+
+        # New turn boundary
+        agent._restore_primary_runtime()
+
+        # Now a fresh fallback attempt should reach the chain entry, not
+        # short-circuit at the bounds check.
+        mock_client = _mock_resolve()
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, None),
+        ):
+            activated = agent._try_activate_fallback()
+
+        assert activated is True
+        assert agent._fallback_activated is True
+        assert agent.model == "model-a"
+
+
     def test_restores_compressor_state(self):
         agent = _make_agent(
             fallback_model={"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},


### PR DESCRIPTION
## What
Fix #17446 — sessions get permanently pinned to a broken primary model after one fallback-activation failure, even when a perfectly valid \`fallback_model\` is configured. Every subsequent turn prints \"⚠️ Non-retryable error — trying fallback...\" but the fallback never actually engages.

## Why
\`_try_activate_fallback()\` (run_agent.py) increments \`_fallback_index\` *before* attempting activation and only flips \`_fallback_activated = True\` on the success path. If every chain entry fails (e.g. \`fb_client is None\` from a misconfigured credential, invalid provider/model, or any exception during client resolution), the recursion exhausts the chain leaving:

\`\`\`
_fallback_index    == len(_fallback_chain)   # past the end
_fallback_activated == False                 # never succeeded
\`\`\`

On the next turn, \`run_conversation()\` calls \`_restore_primary_runtime()\` at the top of the loop. The old guard returned early on \`not self._fallback_activated\`, leaving the stale index. The next \`_try_activate_fallback()\` then short-circuits at the \`if self._fallback_index >= len(...)\` bounds check, returning False instantly — so the runner announces fallback, sends nothing different, and the user sees the same primary error forever.

Reproducible scenario from the issue:
- Telegram bot configured with \`fallback_model: google/gemini-2.0-flash-001\` (valid)
- User runs \`/model deepseek/deepseek-v4\` (invalid OpenRouter ID)
- Turn 1: 400 from primary, fallback activation fails for state-machine reasons, chain exhausted
- Turn 2+: every message permanently aborts; only fix today is hand-editing the session JSON

## How
One-liner functional fix in \`_restore_primary_runtime()\`: when the early-return path runs (no fallback to roll back), still reset \`_fallback_index\` to 0 if it has drifted past 0. Guarantees a fresh chain attempt on every turn that begins on the primary, regardless of whether the previous turn's fallback path succeeded, partially advanced, or fully exhausted the chain.

## How to test
\`\`\`
scripts/run_tests.sh tests/run_agent/test_primary_runtime_restore.py
scripts/run_tests.sh tests/run_agent/test_provider_fallback.py tests/run_agent/test_compressor_fallback_update.py tests/run_agent/test_switch_model_fallback_prune.py tests/agent/test_credential_pool_routing.py
\`\`\`

Three new regression tests in \`test_primary_runtime_restore.py\`:
1. \`test_resets_fallback_index_after_failed_activation\` — buggy state (chain exhausted + activated False) is reset
2. \`test_does_not_disturb_index_when_already_zero\` — pure no-op when index is already 0
3. \`test_subsequent_fallback_attempt_succeeds_after_reset\` — end-to-end: after reset, a fresh \`_try_activate_fallback()\` succeeds

All 34 tests in the file pass; 35 related fallback tests across 4 files also green.

## Platforms
Affects all platforms (CLI, gateway, every messaging adapter) — the bug is in core agent state, not platform-specific code.