### PR TITLE
fix(cli): coerce tls insecure flag safely in auth state

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -43,7 +43,7 @@ import yaml
 
 from hermes_cli.config import get_hermes_home, get_config_path, read_raw_config
 from hermes_constants import OPENROUTER_BASE_URL
-from utils import atomic_replace
+from utils import atomic_replace, is_truthy_value
 
 logger = logging.getLogger(__name__)
 
@@ -2480,8 +2480,8 @@ def _resolve_verify(
     tls_state = tls_state if isinstance(tls_state, dict) else {}
 
     effective_insecure = (
-        bool(insecure) if insecure is not None
-        else bool(tls_state.get("insecure", False))
+        is_truthy_value(insecure, default=False) if insecure is not None
+        else is_truthy_value(tls_state.get("insecure", False), default=False)
     )
     effective_ca = (
         ca_bundle

--- a/tests/hermes_cli/test_auth_nous_provider.py
+++ b/tests/hermes_cli/test_auth_nous_provider.py
@@ -77,10 +77,12 @@ class TestResolveVerifyFallback:
         assert result is False
 
     def test_string_false_in_auth_state_does_not_disable_tls_verify(self):
+        import ssl
         from hermes_cli.auth import _resolve_verify
 
         result = _resolve_verify(auth_state={"tls": {"insecure": "false"}})
-        assert result is True
+        assert result is not False
+        assert result is True or isinstance(result, ssl.SSLContext)
 
     def test_string_true_in_auth_state_disables_tls_verify(self):
         from hermes_cli.auth import _resolve_verify

--- a/tests/hermes_cli/test_auth_nous_provider.py
+++ b/tests/hermes_cli/test_auth_nous_provider.py
@@ -76,6 +76,18 @@ class TestResolveVerifyFallback:
         )
         assert result is False
 
+    def test_string_false_in_auth_state_does_not_disable_tls_verify(self):
+        from hermes_cli.auth import _resolve_verify
+
+        result = _resolve_verify(auth_state={"tls": {"insecure": "false"}})
+        assert result is True
+
+    def test_string_true_in_auth_state_disables_tls_verify(self):
+        from hermes_cli.auth import _resolve_verify
+
+        result = _resolve_verify(auth_state={"tls": {"insecure": "true"}})
+        assert result is False
+
     def test_no_ca_bundle_returns_true(self, monkeypatch):
         from hermes_cli.auth import _resolve_verify
 


### PR DESCRIPTION
## Summary

This fixes TLS verification flag parsing in hermes_cli.auth._resolve_verify().

Previously, persisted auth state like:

{"tls": {"insecure": "false"}}

was interpreted with Python truthiness via bool(...), which incorrectly treated the string "false" as truthy and disabled certificate verification.

This patch switches insecure parsing to the shared boolean coercion helper so string values are handled safely and consistently.

## What changed

- Replaced raw bool(...) parsing for _resolve_verify()'s insecure handling
- Reused the shared is_truthy_value(..., default=False) helper
- Added regression tests for quoted boolean values in persisted auth state

## Why this matters

insecure is a security-sensitive flag. Using raw Python truthiness on persisted config or auth state can silently downgrade TLS verification when a value is stored as a quoted string instead of a native boolean.

## Regression cases covered

- tls.insecure = "false" keeps TLS verification enabled
- tls.insecure = "true" disables TLS verification
- existing native boolean behavior remains unchanged

## Testing

Validated the targeted auth test module after the change:

uv run pytest tests/hermes_cli/test_auth_nous_provider.py -q

Result:

- 30 passed