### PR TITLE
fix(fallback): look up custom_providers base_url before fallback API call

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2221,6 +2221,11 @@ def resolve_provider_client(
 
         creds = resolve_api_key_provider_credentials(provider)
         api_key = str(creds.get("api_key", "")).strip()
+        # An explicit api_key from a custom_providers fallback entry overrides
+        # the registered credential so the custom endpoint can authenticate even
+        # when no built-in key is configured for this provider alias.
+        if explicit_api_key:
+            api_key = explicit_api_key.strip()
         if not api_key:
             tried_sources = list(pconfig.api_key_env_vars)
             if provider == "copilot":
@@ -2233,6 +2238,13 @@ def resolve_provider_client(
         base_url = _to_openai_base_url(
             str(creds.get("base_url", "")).strip().rstrip("/") or pconfig.inference_base_url
         )
+        # An explicit base_url from a custom_providers fallback entry overrides
+        # the registered provider's default endpoint.  This handles the case
+        # where the fallback provider name aliases to a built-in (e.g. a custom
+        # provider named "kimi" resolves to "kimi-coding") but the actual target
+        # is the user-defined custom endpoint, not the built-in one.
+        if explicit_base_url:
+            base_url = _to_openai_base_url(explicit_base_url.strip().rstrip("/"))
 
         default_model = _API_KEY_PROVIDER_AUX_MODELS.get(provider, "")
         final_model = _normalize_resolved_model(model or default_model, provider)

--- a/run_agent.py
+++ b/run_agent.py
@@ -7365,6 +7365,27 @@ class AIAgent:
                 fb_key_env = (fb.get("key_env") or "").strip()
                 if fb_key_env:
                     fb_api_key_hint = os.getenv(fb_key_env, "").strip() or None
+            # When the fallback entry has no explicit base_url, look up
+            # custom_providers by the original provider name before any
+            # alias normalization occurs.  Without this, names that alias
+            # to a built-in provider (e.g. "kimi" → "kimi-coding") bypass
+            # the custom_providers lookup and inherit the primary provider's
+            # base_url instead of using the correct custom endpoint.
+            if not fb_base_url_hint:
+                try:
+                    from hermes_cli.runtime_provider import _get_named_custom_provider
+                    _cp_entry = _get_named_custom_provider(fb_provider)
+                    if _cp_entry and _cp_entry.get("base_url"):
+                        fb_base_url_hint = _cp_entry["base_url"].strip() or None
+                        if not fb_api_key_hint:
+                            _cp_key = (_cp_entry.get("api_key") or "").strip()
+                            if not _cp_key:
+                                _cp_key_env = (_cp_entry.get("key_env") or "").strip()
+                                if _cp_key_env:
+                                    _cp_key = os.getenv(_cp_key_env, "").strip()
+                            fb_api_key_hint = _cp_key or None
+                except Exception:
+                    pass
             # For Ollama Cloud endpoints, pull OLLAMA_API_KEY from env
             # when no explicit key is in the fallback config. Host match
             # (not substring) — see GHSA-76xc-57q6-vm5m.


### PR DESCRIPTION
## What does this PR do?
Fixes a bug where fallback providers defined in `custom_providers` send requests to the wrong endpoint — they inherit the primary provider's `base_url` instead of using their own.

**Root cause:** Two gaps in the fallback resolution path:
1. `_try_activate_fallback` in `run_agent.py` only reads `base_url` from the fallback entry itself. When absent, it stays `None`. If the provider name aliases to a built-in (e.g. a custom provider named `"kimi"` → normalizes to `"kimi-coding"`), `_get_named_custom_provider` returns `None` and the code falls through to the `PROVIDER_REGISTRY` path — using the primary provider's endpoint.
2. `resolve_provider_client` in `agent/auxiliary_client.py` ignores `explicit_base_url` and `explicit_api_key` in the API-key provider path, so even when hints are passed, the built-in endpoint wins.

**Fix:**
1. In `run_agent.py`: when `fb_base_url_hint` is absent, call `_get_named_custom_provider(fb_provider)` with the **original pre-normalization name** to find the custom entry and populate `fb_base_url_hint` and `fb_api_key_hint` correctly.
2. In `agent/auxiliary_client.py`: honour `explicit_base_url` and `explicit_api_key` in the API-key provider path so the custom endpoint is always used when provided.

## Related Issue
Fixes #15743

## Type of Change
- [x] Bug fix