### PR TITLE
fix(anthropic): skip credential refresh for third-party endpoints

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6020,6 +6020,17 @@ class AIAgent:
         _base = getattr(self, "_anthropic_base_url", "") or ""
         if "azure.com" in _base:
             return False
+        # Third-party Anthropic-compatible endpoints (MiniMax, GLM, Kimi, ByteDance, etc.)
+        # also use static API keys. Refreshing would pick up OAuth credentials
+        # that are invalid for these providers, causing 401 errors.
+        # Check using the same detection logic as build_anthropic_client.
+        from agent.anthropic_adapter import _is_third_party_anthropic_endpoint
+        if _is_third_party_anthropic_endpoint(_base):
+            logger.debug(
+                "Skipping credential refresh for third-party Anthropic endpoint: %s",
+                _base,
+            )
+            return False
 
         try:
             from agent.anthropic_adapter import resolve_anthropic_token, build_anthropic_client

--- a/tests/run_agent/test_anthropic_third_party_oauth_guard.py
+++ b/tests/run_agent/test_anthropic_third_party_oauth_guard.py
@@ -95,6 +95,58 @@ class TestOAuthFlagOnRefresh:
         assert result is True
         assert agent._is_anthropic_oauth is True
 
+    def test_third_party_endpoint_skips_refresh(self, agent):
+        """Third-party Anthropic-compatible endpoints (MiniMax, GLM, ByteDance, etc.)
+        must not trigger credential refresh even when provider == 'anthropic'.
+
+        This protects against the case where a user configures a custom Anthropic-compatible
+        endpoint with provider='anthropic' but the endpoint is not the native Anthropic API.
+        Refreshing would pick up OAuth credentials that are invalid for these endpoints.
+        """
+        agent.api_mode = "anthropic_messages"
+        agent.provider = "anthropic"  # provider is anthropic, but...
+        agent._anthropic_api_key = "custom-api-key"
+        agent._anthropic_base_url = "https://llmbox.bytedance.net"  # ...third-party endpoint
+        agent._anthropic_client = MagicMock()
+        agent._is_anthropic_oauth = False
+
+        with (
+            patch("agent.anthropic_adapter.resolve_anthropic_token",
+                  return_value=_OAUTH_LIKE_TOKEN),
+            patch("agent.anthropic_adapter.build_anthropic_client",
+                  return_value=MagicMock()),
+        ):
+            result = agent._try_refresh_anthropic_client_credentials()
+
+        # The function must skip refresh for third-party endpoints.
+        assert result is False
+        # API key must remain unchanged.
+        assert agent._anthropic_api_key == "custom-api-key"
+        # OAuth flag must remain False.
+        assert agent._is_anthropic_oauth is False
+
+    def test_azure_endpoint_skips_refresh(self, agent):
+        """Azure endpoints use static API keys and must not trigger OAuth refresh."""
+        agent.api_mode = "anthropic_messages"
+        agent.provider = "anthropic"
+        agent._anthropic_api_key = "azure-api-key"
+        agent._anthropic_base_url = "https://my-instance.azure.com/anthropic"
+        agent._anthropic_client = MagicMock()
+        agent._is_anthropic_oauth = False
+
+        with (
+            patch("agent.anthropic_adapter.resolve_anthropic_token",
+                  return_value=_OAUTH_LIKE_TOKEN),
+            patch("agent.anthropic_adapter.build_anthropic_client",
+                  return_value=MagicMock()),
+        ):
+            result = agent._try_refresh_anthropic_client_credentials()
+
+        # The function must skip refresh for Azure endpoints.
+        assert result is False
+        # API key must remain unchanged.
+        assert agent._anthropic_api_key == "azure-api-key"
+
 
 class TestOAuthFlagOnCredentialSwap:
     """Site 4 — _swap_credential (credential pool rotation)."""


### PR DESCRIPTION
## Summary

When using third-party Anthropic-compatible endpoints (MiniMax, GLM, Kimi, ByteDance LLMBox, etc.) with `provider='anthropic'`, the credential refresh logic in `_try_refresh_anthropic_client_credentials()` would attempt to refresh using OAuth tokens from `~/.claude/.credentials.json` or `ANTHROPIC_TOKEN` env var. These tokens are invalid for third-party endpoints, causing 401 authentication errors.

The existing code only protected Azure endpoints (checking for `"azure.com"` in base_url). This fix extends the protection to all third-party endpoints using the same `_is_third_party_anthropic_endpoint()` detection logic that `build_anthropic_client()` uses.

## Problem

Subagents and the main agent using custom Anthropic-compatible endpoints would fail with 401 errors because:

1. Agent initializes correctly with the custom API key
2. On first API call, `_try_refresh_anthropic_client_credentials()` is invoked
3. The function checks `provider == "anthropic"` (True for custom endpoints configured this way)
4. It then attempts to refresh credentials using `resolve_anthropic_token()`
5. This may return OAuth tokens or other credentials invalid for the third-party endpoint
6. 401 authentication failure

## Solution

Add a check using `_is_third_party_anthropic_endpoint()` (same logic used by `build_anthropic_client()`) to skip credential refresh for any endpoint that is not the native Anthropic API (`api.anthropic.com`).

## Changes

- `run_agent.py`: Add third-party endpoint check in `_try_refresh_anthropic_client_credentials()`
- `tests/run_agent/test_anthropic_third_party_oauth_guard.py`: Add tests for third-party and Azure endpoint refresh protection

## Test Plan

- Added `test_third_party_endpoint_skips_refresh`: Verifies that custom endpoints (e.g., `llmbox.bytedance.net`) skip credential refresh
- Added `test_azure_endpoint_skips_refresh`: Verifies Azure endpoints continue to be protected
- Existing tests continue to pass