### PR TITLE
fix(providers): align proxy routing and model catalogs

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -39,9 +39,10 @@ def is_native_gemini_base_url(base_url: str) -> bool:
     normalized = str(base_url or "").strip().rstrip("/").lower()
     if not normalized:
         return False
-    if "generativelanguage.googleapis.com" not in normalized:
-        return False
-    return not normalized.endswith("/openai")
+    return normalized.endswith("/v1beta") or (
+        "generativelanguage.googleapis.com" in normalized
+        and not normalized.endswith("/openai")
+    )
 
 
 def probe_gemini_tier(

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -708,13 +708,74 @@ def fetch_endpoint_model_metadata(
     return {}
 
 
+def _fetch_gemini_native_model_metadata(
+    base_url: str,
+    api_key: str = "",
+) -> Dict[str, Dict[str, Any]]:
+    """Fetch model metadata from a Gemini native-compatible ``/v1beta`` endpoint."""
+    normalized = _normalize_base_url(base_url)
+    if not normalized.lower().endswith("/v1beta"):
+        return {}
+    if not api_key:
+        api_key = os.getenv("GEMINI_API_KEY", "") or os.getenv("GOOGLE_API_KEY", "")
+    cache_key = f"{normalized}|gemini|{hash(api_key or '')}"
+
+    cached = _endpoint_model_metadata_cache.get(cache_key)
+    cached_at = _endpoint_model_metadata_cache_time.get(cache_key, 0)
+    if cached is not None and (time.time() - cached_at) < _ENDPOINT_MODEL_CACHE_TTL:
+        return cached
+
+    headers = {"x-goog-api-key": api_key} if api_key else {}
+    try:
+        response = requests.get(
+            normalized.rstrip("/") + "/models",
+            headers=headers,
+            timeout=10,
+            verify=_resolve_requests_verify(),
+        )
+        response.raise_for_status()
+        payload = response.json()
+        cache: Dict[str, Dict[str, Any]] = {}
+        for model in payload.get("models", []):
+            if not isinstance(model, dict):
+                continue
+            model_id = str(model.get("name") or "").strip()
+            if model_id.startswith("models/"):
+                model_id = model_id.split("/", 1)[1]
+            if not model_id:
+                continue
+            entry: Dict[str, Any] = {"name": model_id}
+            context_length = _extract_context_length(model)
+            if context_length is None:
+                context_length = DEFAULT_CONTEXT_LENGTHS.get(model_id)
+            if context_length is None and "gemini" in model_id.lower():
+                context_length = DEFAULT_CONTEXT_LENGTHS.get("gemini")
+            if context_length is not None:
+                entry["context_length"] = context_length
+            max_completion_tokens = _extract_max_completion_tokens(model)
+            if max_completion_tokens is not None:
+                entry["max_completion_tokens"] = max_completion_tokens
+            _add_model_aliases(cache, model_id, entry)
+
+        _endpoint_model_metadata_cache[cache_key] = cache
+        _endpoint_model_metadata_cache_time[cache_key] = time.time()
+        return cache
+    except Exception as exc:
+        logger.debug("Failed to fetch Gemini native model metadata from %s/models: %s", normalized, exc)
+        _endpoint_model_metadata_cache[cache_key] = {}
+        _endpoint_model_metadata_cache_time[cache_key] = time.time()
+        return {}
+
+
 def _resolve_endpoint_context_length(
     model: str,
     base_url: str,
     api_key: str = "",
 ) -> Optional[int]:
     """Resolve context length from an endpoint's live ``/models`` metadata."""
-    endpoint_metadata = fetch_endpoint_model_metadata(base_url, api_key=api_key)
+    endpoint_metadata = _fetch_gemini_native_model_metadata(base_url, api_key=api_key)
+    if not endpoint_metadata:
+        endpoint_metadata = fetch_endpoint_model_metadata(base_url, api_key=api_key)
     matched = endpoint_metadata.get(model)
     if not matched:
         if len(endpoint_metadata) == 1:
@@ -1253,6 +1314,17 @@ def get_model_context_length(
     if config_context_length is not None and isinstance(config_context_length, int) and config_context_length > 0:
         return config_context_length
 
+    # 0a. providers.<id>.models.<model>.context_length override. This is the
+    # canonical schema for named user providers.
+    if provider and model:
+        try:
+            from hermes_cli.config import get_provider_model_context_length
+            provider_ctx = get_provider_model_context_length(provider, model)
+            if provider_ctx:
+                return provider_ctx
+        except Exception:
+            pass
+
     # 0b. custom_providers per-model override — check before any probe.
     # This closes the gap where /model switch and display paths used to fall
     # back to 128K despite the user having a per-model context_length set.
@@ -1323,7 +1395,11 @@ def get_model_context_length(
     # /models endpoint may report a provider-imposed limit (e.g. Copilot
     # returns 128k) instead of the model's full context (400k).  models.dev
     # has the correct per-provider values and is checked at step 5+.
-    if _is_custom_endpoint(base_url) and not _is_known_provider_base_url(base_url):
+    if (
+        provider == "gemini"
+        or str(base_url or "").strip().rstrip("/").lower().endswith("/v1beta")
+        or (_is_custom_endpoint(base_url) and not _is_known_provider_base_url(base_url))
+    ):
         context_length = _resolve_endpoint_context_length(model, base_url, api_key=api_key)
         if context_length is not None:
             return context_length

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2617,6 +2617,38 @@ def get_custom_provider_context_length(
     return None
 
 
+def get_provider_model_context_length(
+    provider: str,
+    model: str,
+    config: Optional[Dict[str, Any]] = None,
+) -> Optional[int]:
+    """Look up ``providers.<provider>.models.<model>.context_length``."""
+    if not provider or not model:
+        return None
+    if config is None:
+        config = load_config()
+    providers = config.get("providers")
+    if not isinstance(providers, dict):
+        return None
+    entry = providers.get(provider)
+    if not isinstance(entry, dict):
+        return None
+    models = entry.get("models")
+    if not isinstance(models, dict):
+        return None
+    model_cfg = models.get(model)
+    if not isinstance(model_cfg, dict):
+        return None
+    raw_ctx = model_cfg.get("context_length")
+    if raw_ctx is None:
+        return None
+    try:
+        ctx = int(raw_ctx)
+    except (TypeError, ValueError):
+        return None
+    return ctx if ctx > 0 else None
+
+
 def check_config_version() -> Tuple[int, int]:
     """
     Check config version.

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -558,6 +558,13 @@ def resolve_display_context_length(
     only if the resolver returns nothing.
     """
     try:
+        from hermes_cli.config import get_provider_model_context_length
+        cfg_ctx = get_provider_model_context_length(provider, model)
+        if cfg_ctx:
+            return int(cfg_ctx)
+    except Exception:
+        pass
+    try:
         from agent.model_metadata import get_model_context_length
         ctx = get_model_context_length(
             model,
@@ -1135,7 +1142,9 @@ def list_authenticated_providers(
         # catalog so newly released models (e.g. mimo-v2.5-pro on opencode-go)
         # show up in the picker without requiring a Hermes release.
         model_ids = curated.get(hermes_id, [])
-        if hermes_id in _MODELS_DEV_PREFERRED:
+        if hermes_id == "gemini":
+            model_ids = provider_model_ids(hermes_id)
+        elif hermes_id in _MODELS_DEV_PREFERRED:
             model_ids = _merge_with_models_dev(hermes_id, model_ids)
         total = len(model_ids)
         top = model_ids[:max_models]

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1975,6 +1975,16 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
                     return live
             except Exception:
                 pass
+    if normalized == "gemini":
+        api_key = os.getenv("GEMINI_API_KEY", "").strip() or os.getenv("GOOGLE_API_KEY", "").strip()
+        if api_key:
+            base = os.getenv("GEMINI_BASE_URL", "").strip().rstrip("/") or "https://generativelanguage.googleapis.com/v1beta"
+            try:
+                live = fetch_api_models(api_key, base)
+                if live:
+                    return live
+            except Exception:
+                pass
     if normalized == "gmi":
         try:
             from hermes_cli.auth import resolve_api_key_provider_credentials
@@ -2796,6 +2806,40 @@ def probe_api_models(
             "suggested_base_url": None,
             "used_fallback": False,
         }
+
+    if normalized.lower().endswith("/v1beta"):
+        headers = {"User-Agent": _HERMES_USER_AGENT}
+        if api_key:
+            headers["x-goog-api-key"] = api_key
+        url = normalized.rstrip("/") + "/models"
+        req = urllib.request.Request(url, headers=headers)
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                data = json.loads(resp.read().decode())
+                models = []
+                for item in data.get("models", []):
+                    if not isinstance(item, dict):
+                        continue
+                    name = str(item.get("name") or "").strip()
+                    if name.startswith("models/"):
+                        name = name.split("/", 1)[1]
+                    if name:
+                        models.append(name)
+                return {
+                    "models": models,
+                    "probed_url": url,
+                    "resolved_base_url": normalized,
+                    "suggested_base_url": None,
+                    "used_fallback": False,
+                }
+        except Exception:
+            return {
+                "models": None,
+                "probed_url": url,
+                "resolved_base_url": normalized,
+                "suggested_base_url": None,
+                "used_fallback": False,
+            }
 
     if normalized.endswith("/v1"):
         alternate_base = normalized[:-3].rstrip("/")

--- a/run_agent.py
+++ b/run_agent.py
@@ -7437,7 +7437,14 @@ class AIAgent:
             _fb_is_azure = self._is_azure_openai_url(fb_base_url)
             if fb_provider == "openai-codex":
                 fb_api_mode = "codex_responses"
-            elif fb_provider == "anthropic" or fb_base_url.rstrip("/").lower().endswith("/anthropic"):
+            elif (
+                fb_provider == "anthropic"
+                or fb_base_url.rstrip("/").lower().endswith("/anthropic")
+                or (
+                    base_url_host_matches(fb_base_url, "api.kimi.com")
+                    and "/coding" in fb_base_url.lower()
+                )
+            ):
                 fb_api_mode = "anthropic_messages"
             elif _fb_is_azure:
                 # Azure OpenAI serves gpt-5.x on /chat/completions — does NOT

--- a/run_agent.py
+++ b/run_agent.py
@@ -8078,6 +8078,7 @@ class AIAgent:
         MiniMax keeps dots (e.g. MiniMax-M2.7).
         OpenCode Go/Zen keeps dots for non-Claude models (e.g. minimax-m2.5-free).
         ZAI/Zhipu keeps dots (e.g. glm-4.7, glm-5.1).
+        Xiaomi MiMo keeps dots (e.g. mimo-v2.5-pro).
         AWS Bedrock uses dotted inference-profile IDs
         (e.g. ``global.anthropic.claude-opus-4-7``,
         ``us.anthropic.claude-sonnet-4-5-20250929-v1:0``) and rejects
@@ -8088,7 +8089,7 @@ class AIAgent:
         if (getattr(self, "provider", "") or "").lower() in {
             "alibaba", "minimax", "minimax-cn",
             "opencode-go", "opencode-zen",
-            "zai", "bedrock",
+            "zai", "xiaomi", "bedrock",
         }:
             return True
         base = (getattr(self, "base_url", "") or "").lower()
@@ -8098,6 +8099,7 @@ class AIAgent:
             or "minimax" in base
             or "opencode.ai/zen/" in base
             or "bigmodel.cn" in base
+            or "xiaomimimo.com" in base
             # AWS Bedrock runtime endpoints — defense-in-depth when
             # ``provider`` is unset but ``base_url`` still names Bedrock.
             or "bedrock-runtime." in base

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -19,6 +19,19 @@ class DummyResponse:
         return self._payload
 
 
+def test_native_gemini_base_url_accepts_v1beta_proxy():
+    """Sub2API-style Gemini native-compatible proxies expose ``/v1beta``
+    without using Google's hostname.
+    """
+    from agent.gemini_native_adapter import is_native_gemini_base_url
+
+    assert is_native_gemini_base_url("http://127.0.0.1:8080/v1beta")
+    assert is_native_gemini_base_url("https://generativelanguage.googleapis.com/v1beta")
+    assert not is_native_gemini_base_url(
+        "https://generativelanguage.googleapis.com/v1beta/openai"
+    )
+
+
 def test_build_native_request_preserves_thought_signature_on_tool_replay():
     from agent.gemini_native_adapter import build_gemini_request
 

--- a/tests/hermes_cli/test_gemini_provider.py
+++ b/tests/hermes_cli/test_gemini_provider.py
@@ -5,7 +5,13 @@ import pytest
 from unittest.mock import patch, MagicMock
 
 from hermes_cli.auth import PROVIDER_REGISTRY, resolve_provider, resolve_api_key_provider_credentials
-from hermes_cli.models import _PROVIDER_MODELS, _PROVIDER_LABELS, _PROVIDER_ALIASES, normalize_provider
+from hermes_cli.models import (
+    _PROVIDER_MODELS,
+    _PROVIDER_LABELS,
+    _PROVIDER_ALIASES,
+    normalize_provider,
+    provider_model_ids,
+)
 from hermes_cli.model_normalize import normalize_model_for_provider, detect_vendor
 from agent.model_metadata import get_model_context_length
 from agent.models_dev import PROVIDER_TO_MODELS_DEV, list_agentic_models, _NOISE_PATTERNS
@@ -135,6 +141,24 @@ class TestGeminiModelCatalog:
     def test_provider_label(self):
         assert "gemini" in _PROVIDER_LABELS
         assert _PROVIDER_LABELS["gemini"] == "Google AI Studio"
+
+    def test_provider_model_ids_prefers_live_v1beta_endpoint(self, monkeypatch):
+        monkeypatch.setenv("GEMINI_API_KEY", "proxy-key")
+        monkeypatch.setenv("GEMINI_BASE_URL", "http://127.0.0.1:8080/v1beta")
+
+        calls = []
+
+        def fake_fetch_api_models(api_key, base_url):
+            calls.append((api_key, base_url))
+            return ["gemini-3-flash-preview", "gemini-3-pro-preview"]
+
+        monkeypatch.setattr("hermes_cli.models.fetch_api_models", fake_fetch_api_models)
+
+        assert provider_model_ids("gemini") == [
+            "gemini-3-flash-preview",
+            "gemini-3-pro-preview",
+        ]
+        assert calls == [("proxy-key", "http://127.0.0.1:8080/v1beta")]
 
 
 # ── Model Normalization ──

--- a/tests/hermes_cli/test_model_switch_context_display.py
+++ b/tests/hermes_cli/test_model_switch_context_display.py
@@ -146,3 +146,31 @@ class TestResolveDisplayContextLength:
                 custom_providers=custom_provs,
             )
         assert ctx == 400_000
+
+    def test_providers_dict_context_length_wins(self):
+        """Named ``providers:`` entries are the canonical config schema and
+        should drive /model context display without probing the endpoint.
+        """
+        fake_config = {
+            "providers": {
+                "sub2api-openai": {
+                    "models": {
+                        "gpt-5.5": {"context_length": 1_050_000},
+                    }
+                }
+            }
+        }
+        with patch("hermes_cli.config.load_config", return_value=fake_config), \
+             patch(
+                 "agent.model_metadata.get_model_context_length",
+                 return_value=256_000,
+             ) as mock_resolver:
+            ctx = resolve_display_context_length(
+                "gpt-5.5",
+                "sub2api-openai",
+                base_url="http://127.0.0.1:8080/v1",
+                api_key="k",
+            )
+
+        assert ctx == 1_050_000
+        mock_resolver.assert_not_called()

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -285,6 +285,32 @@ class TestFetchApiModels:
         assert probe["resolved_base_url"] == "http://localhost:8000/v1"
         assert probe["used_fallback"] is True
 
+    def test_probe_api_models_reads_gemini_native_v1beta_models(self):
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return (
+                    b'{"models": ['
+                    b'{"name": "models/gemini-3-flash-preview"},'
+                    b'{"name": "gemini-3-pro-preview"}'
+                    b"]}"
+                )
+
+        with patch("hermes_cli.models.urllib.request.urlopen", return_value=_Resp()) as mock_urlopen:
+            probe = probe_api_models("proxy-key", "http://127.0.0.1:8080/v1beta")
+
+        req = mock_urlopen.call_args[0][0]
+        assert req.full_url == "http://127.0.0.1:8080/v1beta/models"
+        assert req.get_header("X-goog-api-key") == "proxy-key"
+        assert probe["models"] == ["gemini-3-flash-preview", "gemini-3-pro-preview"]
+        assert probe["resolved_base_url"] == "http://127.0.0.1:8080/v1beta"
+        assert probe["used_fallback"] is False
+
     def test_probe_api_models_uses_copilot_catalog(self):
         class _Resp:
             def __enter__(self):

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3913,6 +3913,29 @@ class TestFallbackAnthropicProvider:
         assert agent.api_mode == "chat_completions"
         assert agent.client is mock_client
 
+    def test_fallback_to_kimi_coding_uses_anthropic_messages(self, agent):
+        agent._fallback_activated = False
+        agent._fallback_model = {"provider": "kimi-coding", "model": "kimi-k2.6"}
+        agent._fallback_chain = [agent._fallback_model]
+        agent._fallback_index = 0
+
+        mock_client = MagicMock()
+        mock_client.base_url = "https://api.kimi.com/coding"
+        mock_client.api_key = "sk-kimi-test"
+
+        with (
+            patch("agent.auxiliary_client.resolve_provider_client", return_value=(mock_client, None)),
+            patch("agent.anthropic_adapter.build_anthropic_client", return_value=MagicMock()) as mock_build,
+        ):
+            result = agent._try_activate_fallback()
+
+        assert result is True
+        assert agent.model == "kimi-k2.6"
+        assert agent.provider == "kimi-coding"
+        assert agent.api_mode == "anthropic_messages"
+        assert agent.client is None
+        mock_build.assert_called_once_with("sk-kimi-test", "https://api.kimi.com/coding", timeout=None)
+
 
 def test_aiagent_uses_copilot_acp_client():
     with (

--- a/tests/run_agent/test_xiaomi_anthropic_model.py
+++ b/tests/run_agent/test_xiaomi_anthropic_model.py
@@ -1,0 +1,26 @@
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+def test_xiaomi_anthropic_transport_preserves_dotted_model_id():
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("agent.anthropic_adapter.build_anthropic_client", return_value=MagicMock()),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://token-plan-cn.xiaomimimo.com/anthropic",
+            provider="xiaomi",
+            api_mode="anthropic_messages",
+            model="mimo-v2.5-pro",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    kwargs = agent._build_api_kwargs([{"role": "user", "content": "ping"}])
+
+    assert agent._anthropic_preserve_dots() is True
+    assert kwargs["model"] == "mimo-v2.5-pro"


### PR DESCRIPTION
## Summary

Provider-backed routing now handles three compatibility gaps that showed up with custom model gateways: Kimi coding fallbacks route through the Anthropic transport, Xiaomi MiMo keeps dotted model IDs intact, and Gemini-native `/v1beta` proxies can drive model discovery and context display.

The Gemini path now treats any `/v1beta` base URL as native Gemini, including proxy endpoints that do not use Google's hostname. Model discovery reads `/v1beta/models` with `x-goog-api-key`, strips `models/` prefixes, and lets the `/model` picker prefer the live Gemini catalog. Named `providers:` entries can also supply per-model `context_length`, so user-defined gateways can keep Hermes display and compression behavior aligned with their upstream model source.

Kimi and Xiaomi ship in the same PR because they touch the same provider compatibility surface in the agent runtime.

## Tests

- `scripts/run_tests.sh tests/agent/test_gemini_native_adapter.py tests/hermes_cli/test_model_validation.py::TestFetchApiModels tests/hermes_cli/test_gemini_provider.py::TestGeminiModelCatalog tests/hermes_cli/test_model_switch_context_display.py tests/hermes_cli/test_custom_provider_context_length.py tests/run_agent/test_run_agent.py tests/run_agent/test_xiaomi_anthropic_model.py -q`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-111827?logo=openai&logoColor=white)