### PR TITLE
feat(cli): add xfyun MaaS as a first-class LLM provider

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -93,8 +93,6 @@ _EXTRA_ENV_KEYS = frozenset({
     "LANGFUSE_PUBLIC_KEY",
     "LANGFUSE_SECRET_KEY",
     "LANGFUSE_BASE_URL",
-
-    # xfyun / iFLYTEK (科大讯飞)
     "XFYUN_API_KEY",
     "XFYUN_API_BASE_URL",
 })

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -93,6 +93,10 @@ _EXTRA_ENV_KEYS = frozenset({
     "LANGFUSE_PUBLIC_KEY",
     "LANGFUSE_SECRET_KEY",
     "LANGFUSE_BASE_URL",
+
+    # xfyun / iFLYTEK (科大讯飞)
+    "XFYUN_API_KEY",
+    "XFYUN_API_BASE_URL",
 })
 import yaml
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -255,11 +255,9 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "z-ai/glm5",
         "openai/gpt-oss-120b",
     ],
-    # xfyun / iFLYTEK (科大讯飞) - 讯飞星辰MaaS
     "xfyun": [
         # Primary coding models (Astron series)
         "astron-code-latest",
-        "astron-code-medium",
     ],
     "kimi-coding": [
         "kimi-k2.6",

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -255,6 +255,12 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "z-ai/glm5",
         "openai/gpt-oss-120b",
     ],
+    # xfyun / iFLYTEK (科大讯飞) - 讯飞星辰MaaS
+    "xfyun": [
+        # Primary coding models (Astron series)
+        "astron-code-latest",
+        "astron-code-medium",
+    ],
     "kimi-coding": [
         "kimi-k2.6",
         "kimi-k2.5",

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -199,7 +199,7 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         transport="bedrock_converse",
         auth_type="aws_sdk",
     ),
-    # Xfyun/iFLYTEK MaaS (讯飞星辰MaaS) - OpenAI-compatible API
+    # Xfyun/iFLYTEK MaaS - OpenAI-compatible API
     "xfyun": HermesOverlay(
         transport="openai_chat",
         auth_type="api_key",
@@ -351,7 +351,7 @@ ALIASES: Dict[str, str] = {
     "llama.cpp": "local",
     "llama-cpp": "local",
 
-    # xfyun / iFLYTEK (科大讯飞)
+    # xfyun / iFLYTEK
     "xfyun": "xfyun",
     "astron": "xfyun",
     "flytek": "xfyun",
@@ -375,7 +375,6 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "local": "Local endpoint",
     "bedrock": "AWS Bedrock",
     "ollama-cloud": "Ollama Cloud",
-    # xfyun / iFLYTEK (科大讯飞)
     "xfyun": "iFLYTEK Xfyun MaaS",
 }
 

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -199,6 +199,14 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         transport="bedrock_converse",
         auth_type="aws_sdk",
     ),
+    # Xfyun/iFLYTEK MaaS (讯飞星辰MaaS) - OpenAI-compatible API
+    "xfyun": HermesOverlay(
+        transport="openai_chat",
+        auth_type="api_key",
+        base_url_override="https://maas-coding-api.cn-huabei-1.xf-yun.com/v2",
+        base_url_env_var="XFYUN_API_BASE_URL",
+        extra_env_vars=("XFYUN_API_KEY",),
+    ),
 }
 
 
@@ -342,6 +350,12 @@ ALIASES: Dict[str, str] = {
     "llamacpp": "local",
     "llama.cpp": "local",
     "llama-cpp": "local",
+
+    # xfyun / iFLYTEK (科大讯飞)
+    "xfyun": "xfyun",
+    "astron": "xfyun",
+    "flytek": "xfyun",
+    "iflytek": "xfyun",
 }
 
 
@@ -361,6 +375,8 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "local": "Local endpoint",
     "bedrock": "AWS Bedrock",
     "ollama-cloud": "Ollama Cloud",
+    # xfyun / iFLYTEK (科大讯飞)
+    "xfyun": "iFLYTEK Xfyun MaaS",
 }
 
 


### PR DESCRIPTION
## What does this PR do?

This PR adds **iFLYTEK/Xfyun MaaS (讯飞)** as a first-class LLM provider in Hermes Agent. It enables users to use `--provider xfyun` to access Xfyun's MaaS platform via an OpenAI-compatible API.

## Related Issue

Fixes # (no existing issue - new feature)

## Type of Change

- [x] ✨ **New feature** (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/providers.py` - Added HermesOverlay definition, aliases (xfyun, astron, flytek, iflytek), and display label
- `hermes_cli/config.py` - Added `XFYUN_API_KEY` and `XFYUN_API_BASE_URL` to recognized env vars
- `hermes_cli/models.py` - Added xfyun provider with `astron-code-latest` model

## How to Test

1. Set environment variables:
   ```bash
   export XFYUN_API_KEY="your-api-key"
   export XFYUN_API_BASE_URL="https://maas-coding-api.cn-huabei-1.xf-yun.com/v2"
   ```

2. Test provider resolution:
   ```bash
   hermes --provider xfyun --help
   hermes --provider astron --help  # alias works
   hermes --provider iflytek --help  # alias works
   ```

3. Verify model listing:
   ```bash
   hermes --provider xfyun model
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(cli): add xfyun MaaS...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run basic Python import checks and all pass
- [ ] I've tested on Linux (placeholder - tested via Python imports)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) -->  N/A, configuration-only change
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys --> N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows --> N/A
- [x] I've considered cross-platform impact (Windows, macOS) --> N/A, pure Python and config
- [x] I've updated tool descriptions/schemas if I changed tool behavior -->N/A

## For New Skills

- N/A, this is a provider addition, not a skill

## Screenshots / Logs

N/A, this is a backend configuration change. The provider will appear in `hermes --help` and `hermes model` outputs.

---

### Additional Context:

**Why this provider:**
- Model Support: GLM5, MiniMax-M2.5, KIMI-K2.5, Qwen, Deepseek, etc.
- Easy Integration: OpenAI-compatible API
- Cost-effective: Base tier unlimited (rate limited), higher tiers generous with first-month discounts

**Caveat:** Model switching requires going to the Xfyun web portal (maas.xfyun.cn). The API always uses the model name `astron-code-latest` - the actual model (glm, minimax, kimi, etc.) can ben selected in their web portal.