### PR TITLE
fix: stabilize CI — TS widen, sys.modules restore, WS subscriber race

### DIFF
--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1957,13 +1957,30 @@ class TestPtyWebSocket:
     def test_pub_broadcasts_to_events_subscribers(self, monkeypatch):
         """Frame written to /api/pub is rebroadcast verbatim to every
         /api/events subscriber on the same channel."""
+        import time
         from urllib.parse import urlencode
+        from hermes_cli import web_server as ws_mod
 
         qs = urlencode({"token": self.token, "channel": "broadcast-test"})
         pub_path = f"/api/pub?{qs}"
         sub_path = f"/api/events?{qs}"
 
         with self.client.websocket_connect(sub_path) as sub:
+            # Wait for the subscriber to be registered on the server side.
+            # websocket_connect returns when ws.accept() completes, but the
+            # server adds us to ``_event_channels`` in a follow-up await,
+            # so a publish immediately after connect can race ahead of the
+            # subscriber registration and the message is dropped.
+            deadline = time.monotonic() + 5.0
+            while time.monotonic() < deadline:
+                if ws_mod._event_channels.get("broadcast-test"):
+                    break
+                time.sleep(0.01)
+            else:
+                raise AssertionError(
+                    "subscriber did not register on channel within 5s"
+                )
+
             with self.client.websocket_connect(pub_path) as pub:
                 pub.send_text('{"type":"tool.start","payload":{"tool_id":"t1"}}')
                 received = sub.receive_text()

--- a/tests/plugins/test_achievements_plugin.py
+++ b/tests/plugins/test_achievements_plugin.py
@@ -50,6 +50,12 @@ def plugin_api(tmp_path, monkeypatch):
     )
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
+    # Stash monkeypatch so ``_install_fake_session_db`` can use it to
+    # swap ``sys.modules['hermes_state']`` with auto-restoration. Without
+    # this, a raw ``sys.modules[...] = fake`` assignment would leak the
+    # fake into later tests in the same xdist worker — breaking every
+    # test that does ``from hermes_state import SessionDB``.
+    module._test_monkeypatch = monkeypatch
     yield module
 
 
@@ -107,10 +113,15 @@ class _FakeSessionDB:
 
 
 def _install_fake_session_db(plugin_api, fake_db):
-    """Inject a fake SessionDB so ``scan_sessions`` finds it via its local import."""
+    """Inject a fake SessionDB so ``scan_sessions`` finds it via its local import.
+
+    Uses the monkeypatch stashed on ``plugin_api`` by the fixture, so the
+    ``sys.modules['hermes_state']`` swap is auto-restored at test teardown
+    and cannot leak into unrelated tests in the same xdist worker.
+    """
     fake_module = type(sys)("hermes_state")
     fake_module.SessionDB = lambda: fake_db
-    sys.modules["hermes_state"] = fake_module
+    plugin_api._test_monkeypatch.setitem(sys.modules, "hermes_state", fake_module)
 
 
 def test_scan_sessions_default_scans_all_history_not_first_200(plugin_api):

--- a/ui-tui/src/app/slash/commands/ops.ts
+++ b/ui-tui/src/app/slash/commands/ops.ts
@@ -82,7 +82,7 @@ export const opsCommands: SlashCommand[] = [
       // Parse arg: `now` / `always` skip the confirmation gate.
       // `always` additionally persists approvals.mcp_reload_confirm=false.
       const a = (arg || '').trim().toLowerCase()
-      const params: { session_id: string; confirm?: boolean; always?: boolean } = {
+      const params: { session_id: string | null; confirm?: boolean; always?: boolean } = {
         session_id: ctx.sid
       }
       if (a === 'now' || a === 'approve' || a === 'once' || a === 'yes') {


### PR DESCRIPTION
Follow-up to #17828 to turn the remaining red checks green.

## Summary
Three narrow, unrelated fixes — each addressing one failing check on `main` after #17828 landed.

## Changes

**1. `ui-tui/src/app/slash/commands/ops.ts` — fixes Docker Build**

`/reload-mcp`'s local `params` was annotated `session_id: string`, but `ctx.sid` is typed `string | null`. TS2322 on line 86. The rpc signature is `Record<string, unknown>` (accepts null), every other rpc call site does the same `session_id: ctx.sid` without narrowing, and the existing vitest test literally passes `{ session_id: null }` to this rpc. Widening the local type from `string` to `string | null` matches reality — one line, no runtime change.

**2. `tests/plugins/test_achievements_plugin.py` — fixes 13 cascading test failures**

`_install_fake_session_db` did a raw `sys.modules['hermes_state'] = fake_module` with no restoration, leaking the fake past test boundaries. In xdist workers that run this test before `tests/test_hermes_state.py` or `tests/run_agent/test_860_dedup.py`, later tests see `SessionDB = lambda: fake_db` instead of the real class — causing `AttributeError: 'function' object has no attribute '_sanitize_fts5_query'` (6x) and `TypeError: got unexpected keyword argument 'db_path'` (7x).

Fix: stash `monkeypatch` on the `plugin_api` module via the fixture, and route the `sys.modules` swap through `monkeypatch.setitem(...)` so teardown auto-restores.

**3. `tests/hermes_cli/test_web_server.py` — fixes WS broadcast race timeout**

`TestPtyWebSocket::test_pub_broadcasts_to_events_subscribers` hit the 30s test timeout on CI. `websocket_connect` returns after `ws.accept()`, but the server registers the subscriber in `_event_channels` on the next await (inside `_event_lock`). A publish immediately after connect can race ahead, the broadcast has no subscribers, and the subsequent `receive_text()` blocks forever.

Fix: after the subscriber connects, poll `_event_channels` until the registration is visible before opening the publisher.

## Validation

| | Result |
|---|---|
| `scripts/run_tests.sh tests/plugins/test_achievements_plugin.py tests/run_agent/test_860_dedup.py tests/test_hermes_state.py tests/hermes_cli/test_web_server.py` | 338 passed |
| `cd ui-tui && npm run type-check` | clean |
| `cd ui-tui && npm run build` | clean |

## Not fixed (intentional)
Nix has been failing on `main` for 5+ consecutive runs due to GH Actions cache `TwirpErrorResponse { code: ResourceExhausted }` on ubuntu and npm openssl-legacy on macos. Pure infra flake — nothing to fix in the codebase.