### PR TITLE
fix: preserve recurring cadence on cron run

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -648,20 +648,36 @@ def resume_job(job_id: str) -> Optional[Dict[str, Any]]:
 
 
 def trigger_job(job_id: str) -> Optional[Dict[str, Any]]:
-    """Schedule a job to run on the next scheduler tick."""
+    """Schedule a job to run on the next scheduler tick.
+
+    For recurring jobs, a manual trigger is an *extra* run for testing/debugging
+    and must not permanently shift the existing cadence. Preserve the current
+    future ``next_run_at`` in sidecar metadata so ``tick()`` / ``mark_job_run()``
+    can execute once immediately while restoring the original schedule.
+    """
     job = get_job(job_id)
     if not job:
         return None
-    return update_job(
-        job_id,
-        {
-            "enabled": True,
-            "state": "scheduled",
-            "paused_at": None,
-            "paused_reason": None,
-            "next_run_at": _hermes_now().isoformat(),
-        },
-    )
+
+    now = _hermes_now().isoformat()
+    updates: Dict[str, Any] = {
+        "enabled": True,
+        "state": "scheduled",
+        "paused_at": None,
+        "paused_reason": None,
+        "next_run_at": now,
+    }
+
+    kind = job.get("schedule", {}).get("kind")
+    original_next_run_at = job.get("next_run_at")
+    if kind in ("cron", "interval") and original_next_run_at:
+        try:
+            if _ensure_aware(datetime.fromisoformat(original_next_run_at)) > _hermes_now():
+                updates["manual_trigger_original_next_run_at"] = original_next_run_at
+        except Exception:
+            pass
+
+    return update_job(job_id, updates)
 
 
 def remove_job(job_id: str) -> bool:
@@ -676,7 +692,8 @@ def remove_job(job_id: str) -> bool:
 
 
 def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
-                 delivery_error: Optional[str] = None):
+                 delivery_error: Optional[str] = None,
+                 preserve_next_run_at: Optional[str] = None):
     """
     Mark a job as having been run.
     
@@ -710,8 +727,15 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                         save_jobs(jobs)
                         return
                 
-                # Compute next run
-                job["next_run_at"] = compute_next_run(job["schedule"], now)
+                # Manual runs of recurring jobs can preserve the pre-existing
+                # cadence instead of re-anchoring the schedule to "now".
+                if preserve_next_run_at:
+                    job["next_run_at"] = preserve_next_run_at
+                else:
+                    job["next_run_at"] = compute_next_run(job["schedule"], now)
+
+                # Clear transient manual-trigger metadata once consumed.
+                job.pop("manual_trigger_original_next_run_at", None)
 
                 # If no next run, decide whether this is terminal completion
                 # (one-shot) or a transient failure (recurring schedule couldn't

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1327,7 +1327,13 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
                     success = False
                     error = "Agent completed but produced empty response (model error, timeout, or misconfiguration)"
 
-                mark_job_run(job["id"], success, error, delivery_error=delivery_error)
+                mark_job_run(
+                    job["id"],
+                    success,
+                    error,
+                    delivery_error=delivery_error,
+                    preserve_next_run_at=job.get("manual_trigger_original_next_run_at"),
+                )
                 return True
 
             except Exception as e:

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -19,6 +19,7 @@ from cron.jobs import (
     pause_job,
     resume_job,
     remove_job,
+    trigger_job,
     mark_job_run,
     advance_next_run,
     get_due_jobs,
@@ -300,6 +301,26 @@ class TestPauseResumeJob:
         assert resumed["paused_reason"] is None
 
 
+class TestTriggerJob:
+    def test_recurring_manual_trigger_preserves_original_future_cadence(self, tmp_cron_dir):
+        job = create_job(prompt="Recurring", schedule="every 1h")
+        original_next_run_at = get_job(job["id"])["next_run_at"]
+
+        triggered = trigger_job(job["id"])
+
+        assert triggered is not None
+        assert triggered["next_run_at"] != original_next_run_at
+        assert triggered["manual_trigger_original_next_run_at"] == original_next_run_at
+
+    def test_oneshot_manual_trigger_does_not_set_recurring_cadence_metadata(self, tmp_cron_dir):
+        job = create_job(prompt="Run once", schedule="30m")
+
+        triggered = trigger_job(job["id"])
+
+        assert triggered is not None
+        assert triggered.get("manual_trigger_original_next_run_at") is None
+
+
 class TestMarkJobRun:
     def test_increments_completed(self, tmp_cron_dir):
         job = create_job(prompt="Test", schedule="every 1h")
@@ -313,6 +334,21 @@ class TestMarkJobRun:
         mark_job_run(job["id"], success=True)
         # Job should be removed after hitting repeat limit
         assert get_job(job["id"]) is None
+
+    def test_preserve_next_run_at_keeps_recurring_manual_run_cadence(self, tmp_cron_dir):
+        job = create_job(prompt="Recurring", schedule="every 1h")
+        original_next_run_at = get_job(job["id"])["next_run_at"]
+
+        trigger_job(job["id"])
+        mark_job_run(
+            job["id"],
+            success=True,
+            preserve_next_run_at=original_next_run_at,
+        )
+
+        updated = get_job(job["id"])
+        assert updated["next_run_at"] == original_next_run_at
+        assert updated.get("manual_trigger_original_next_run_at") is None
 
     def test_repeat_negative_one_is_infinite(self, tmp_cron_dir):
         # LLMs often pass repeat=-1 to mean "infinite/forever".

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1844,6 +1844,33 @@ class TestParallelTick:
         assert seen["tg-job"] == {"platform": "telegram", "chat_id": "111"}
         assert seen["dc-job"] == {"platform": "discord", "chat_id": "222"}
 
+    def test_manual_triggered_recurring_job_runs_once_without_shifting_cadence(self, tmp_path):
+        from cron.jobs import create_job, get_job, trigger_job
+        from cron.scheduler import tick
+
+        cron_dir = tmp_path / "cron"
+        cron_dir.mkdir(exist_ok=True)
+
+        with patch("cron.jobs.CRON_DIR", cron_dir), \
+             patch("cron.jobs.JOBS_FILE", cron_dir / "jobs.json"), \
+             patch("cron.jobs.OUTPUT_DIR", cron_dir / "output"), \
+             patch("cron.scheduler._LOCK_DIR", cron_dir), \
+             patch("cron.scheduler._LOCK_FILE", cron_dir / ".tick.lock"), \
+             patch("cron.scheduler.run_job", return_value=(True, "doc", "final", None)) as mock_run_job, \
+             patch("cron.scheduler.save_job_output", return_value=cron_dir / "output" / "x.md"), \
+             patch("cron.scheduler._deliver_result", return_value=None):
+            job = create_job(prompt="Recurring", schedule="every 1h")
+            original_next_run_at = get_job(job["id"])["next_run_at"]
+
+            trigger_job(job["id"])
+            executed = tick(verbose=False)
+
+            assert executed == 1
+            mock_run_job.assert_called_once()
+            updated = get_job(job["id"])
+            assert updated["next_run_at"] == original_next_run_at
+            assert updated.get("manual_trigger_original_next_run_at") is None
+
     def test_max_parallel_env_var(self, monkeypatch):
         """HERMES_CRON_MAX_PARALLEL=1 should restore serial behaviour."""
         monkeypatch.setenv("HERMES_CRON_MAX_PARALLEL", "1")


### PR DESCRIPTION
## Summary
- preserve the original future cadence when manually triggering recurring cron jobs
- thread preserved cadence through scheduler completion so `cron run` executes once without re-anchoring the schedule
- add regression coverage for trigger, mark_job_run, and end-to-end tick behavior

## Root cause
`cron run` worked by forcing `next_run_at=now`. For recurring jobs, once the run completed, `mark_job_run()` recomputed the next occurrence from the manual run time, so a test/debug trigger silently shifted the real schedule.

## Testing
- python -m pytest tests/cron/test_jobs.py tests/cron/test_scheduler.py -o 'addopts=' -q
- python -m pytest tests/hermes_cli/test_cron.py tests/gateway/test_api_server_jobs.py -o 'addopts=' -q
