### PR TITLE
feat(tips): add cost-saving tips from April 30 tip-of-the-day

### DIFF
--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -100,6 +100,9 @@ TIPS = [
     "hermes gateway install sets up Hermes as a system service (systemd/launchd).",
     "hermes memory setup lets you configure an external memory provider (Honcho, Mem0, etc.).",
     "hermes webhook subscribe creates event-driven webhook routes with HMAC validation.",
+    "Save money: hermes tools disables unused tools, hermes skills config trims skills down.",
+    "/reasoning low or /reasoning minimal cuts thinking depth below the default (medium) — faster, cheaper responses.",
+    "hermes models routes vision, compression, and aux tasks to cheaper models — cuts background token cost 85%+ without downgrading your main chat model.",
 
     # --- Configuration ---
     "Set display.bell_on_complete: true in config.yaml to hear a bell when long tasks finish.",


### PR DESCRIPTION
## Summary
Seed three new tips covering the cost-saving knobs from Teknium's April 30 tip-of-the-day tweet. Requested by @micheltamanda.

## Changes
- `hermes_cli/tips.py`: +3 entries in the CLI Subcommands section
  - Tools/skills trimming (`hermes tools`, `hermes skills config`)
  - `/reasoning low|minimal` dialing thinking depth below the medium default
  - `hermes models` for routing auxiliary tasks (vision, compression, title gen, session_search) to cheaper models

## Validation
| | Before | After |
|---|---|---|
| TIPS count | 277 | 280 |
| Duplicates | 0 | 0 |
| Max length | 150 | 150 |
| `test_tips.py` | 11 pass | 11 pass |

No new command surface — uses the existing random-tip-at-session-start wiring.