### PR TITLE
fix(config): preserve optional custom_providers fields on v11→v12 migration

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2999,6 +2999,46 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                 if entry.get("api_mode"):
                     new_entry["transport"] = entry["api_mode"]
 
+                # Preserve the remaining fields ``_normalize_custom_provider_entry``
+                # recognises so the migration is lossless.  Without these, hand-edited
+                # configs that declared per-model context windows, env-var-sourced
+                # API keys, or custom timeout / rate-limit settings would silently
+                # lose them on upgrade.  Most commonly this surfaces as runtime
+                # falling back to the 128K default context length for every
+                # custom-provider model, even though the user had explicit
+                # ``models.<m>.context_length`` overrides in the legacy shape.
+                models = entry.get("models")
+                if isinstance(models, dict) and models:
+                    new_entry["models"] = models
+                elif isinstance(models, list) and models:
+                    # Hand-edited configs sometimes write ``models`` as a flat
+                    # list of model ids; the runtime normaliser converts this
+                    # to the dict shape.  Preserve as-is here.
+                    new_entry["models"] = models
+
+                provider_context_length = entry.get("context_length")
+                if isinstance(provider_context_length, int) and provider_context_length > 0:
+                    new_entry["context_length"] = provider_context_length
+
+                # ``api_key_env`` is a documented alias for ``key_env`` (see
+                # website/docs/guides/azure-foundry.md).  Normalise to the
+                # canonical name on the way out.
+                key_env = entry.get("key_env") or entry.get("api_key_env")
+                if isinstance(key_env, str) and key_env.strip():
+                    new_entry["key_env"] = key_env.strip()
+
+                rate_limit_delay = entry.get("rate_limit_delay")
+                if isinstance(rate_limit_delay, (int, float)) and rate_limit_delay >= 0:
+                    new_entry["rate_limit_delay"] = rate_limit_delay
+
+                request_timeout_seconds = entry.get("request_timeout_seconds")
+                if isinstance(request_timeout_seconds, int) and request_timeout_seconds > 0:
+                    new_entry["request_timeout_seconds"] = request_timeout_seconds
+
+                stale_timeout_seconds = entry.get("stale_timeout_seconds")
+                if isinstance(stale_timeout_seconds, int) and stale_timeout_seconds > 0:
+                    new_entry["stale_timeout_seconds"] = stale_timeout_seconds
+
                 providers_dict[key] = new_entry
                 migrated_count += 1
 

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -488,6 +488,133 @@ class TestCustomProviderCompatibility:
         # custom_providers removed by migration — runtime reads via compat layer
         assert "custom_providers" not in raw
 
+    def test_v11_upgrade_preserves_optional_fields(self, tmp_path):
+        """v11→v12 must carry all `_normalize_custom_provider_entry` fields forward.
+
+        Without this, configs with per-model context_length overrides, env-var-
+        sourced API keys, or explicit timeout / rate-limit settings silently
+        lose them on upgrade — runtime then falls back to the 128K default for
+        every custom-provider model regardless of what the user configured.
+        """
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "_config_version": 11,
+                    "model": {"default": "gpt-5-mini", "provider": "openai-direct"},
+                    "custom_providers": [
+                        {
+                            "name": "OpenAI Direct",
+                            "base_url": "https://api.openai.com/v1",
+                            "api_key": "test-key",
+                            "api_mode": "codex_responses",
+                            "model": "gpt-5-mini",
+                            # Optional fields the original migration silently
+                            "models": {
+                                "gpt-5-mini": {"context_length": 400000},
+                                "gpt-5-codex": {"context_length": 1050000},
+                            },
+                            "context_length": 200000,
+                            "key_env": "OPENAI_DIRECT_KEY",
+                            "rate_limit_delay": 0.5,
+                            "request_timeout_seconds": 60,
+                            "stale_timeout_seconds": 300,
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            migrate_config(interactive=False, quiet=True)
+            raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+
+        entry = raw["providers"]["openai-direct"]
+        assert entry["models"] == {
+            "gpt-5-mini": {"context_length": 400000},
+            "gpt-5-codex": {"context_length": 1050000},
+        }
+        assert entry["context_length"] == 200000
+        assert entry["key_env"] == "OPENAI_DIRECT_KEY"
+        assert entry["rate_limit_delay"] == 0.5
+        assert entry["request_timeout_seconds"] == 60
+        assert entry["stale_timeout_seconds"] == 300
+
+    def test_v11_upgrade_normalises_api_key_env_alias(self, tmp_path):
+        """`api_key_env` is a documented alias for `key_env` (azure-foundry
+        guide).  The migration must normalise to the canonical name so the
+        runtime normaliser doesn't have to keep the alias logic in sync."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "_config_version": 11,
+                    "custom_providers": [
+                        {
+                            "name": "Azure Foundry",
+                            "base_url": "https://example.cognitiveservices.azure.com/openai/v1",
+                            "api_key_env": "AZURE_FOUNDRY_API_KEY",
+                            "model": "gpt-5",
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            migrate_config(interactive=False, quiet=True)
+            raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+
+        entry = raw["providers"]["azure-foundry"]
+        assert entry["key_env"] == "AZURE_FOUNDRY_API_KEY"
+        # ``api_key_env`` itself should not appear under the new dict shape —
+        # canonical name only.
+        assert "api_key_env" not in entry
+
+    def test_v11_upgrade_skips_empty_or_invalid_optional_fields(self, tmp_path):
+        """Optional fields with empty / zero / wrong-type values must not be
+        copied — they would either confuse the runtime normaliser or display
+        as user-meaningful overrides when they are not."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "_config_version": 11,
+                    "custom_providers": [
+                        {
+                            "name": "Sparse",
+                            "base_url": "https://example.com/v1",
+                            "model": "x",
+                            "models": {},  # empty -> drop
+                            "context_length": 0,  # zero -> drop
+                            "key_env": "",  # empty -> drop
+                            "rate_limit_delay": -1,  # negative -> drop
+                            "request_timeout_seconds": 0,  # zero -> drop
+                            "stale_timeout_seconds": "not-a-number",  # wrong type -> drop
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            migrate_config(interactive=False, quiet=True)
+            raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+
+        entry = raw["providers"]["sparse"]
+        for dropped_key in (
+            "models",
+            "context_length",
+            "key_env",
+            "rate_limit_delay",
+            "request_timeout_seconds",
+            "stale_timeout_seconds",
+        ):
+            assert dropped_key not in entry, f"{dropped_key} unexpectedly preserved"
+
     def test_providers_dict_resolves_at_runtime(self, tmp_path):
         """After migration deleted custom_providers, get_compatible_custom_providers
         still finds entries from the providers dict."""


### PR DESCRIPTION
## Summary

The v11→v12 migration in `migrate_config()` builds a new `providers.<key>` dict by copying only `name / api / api_key / default_model / transport` from the legacy `custom_providers` entry. Every other field that `_normalize_custom_provider_entry` recognises (the runtime read-side normaliser in this same module) is silently dropped on upgrade:

- `models` — per-model dict (most painful loss; see below)
- `context_length` — provider-level default context window
- `key_env` / `api_key_env` — env var name for api_key
- `rate_limit_delay`
- `request_timeout_seconds`
- `stale_timeout_seconds`

## Motivation — the per-model `context_length` loss

A config like:

```yaml
custom_providers:
  - name: my-provider
    base_url: https://example.com/v1
    api_key: ...
    api_mode: codex_responses
    model: gpt-5.4
    models:
      gpt-5.4: {context_length: 1050000}
      gpt-5.4-mini: {context_length: 400000}
```

migrates cleanly into `providers.my-provider` with the right `api`, `transport`, `api_key`, `default_model` — but loses the `models:` map entirely. Runtime then falls back to the 128K default for every model on this provider, silently truncating long-context conversations to 1/8 the configured window. There's no warning, no log message — the user only notices when the agent starts forgetting things mid-conversation or when the gateway emits the per-model `without declared context_length` warnings introduced for context-length validation.

The other dropped fields each surface their own breakage:
- `key_env`: api keys sourced from env vars stop being applied; runtime receives no key for that provider.
- `context_length`: provider-level default context window override is lost.
- `rate_limit_delay` / `*_timeout_seconds`: rate-limiting and timeout overrides on slow custom endpoints are lost; some self-hosted setups rely on these for stability.

## Fix

Extend the `new_entry` construction to copy every field listed in `_normalize_custom_provider_entry`'s `_KNOWN_KEYS`, with appropriate type/value validation matching the runtime normaliser:

- `models`: dict (preserved as-is) or list (preserved as-is — runtime normaliser converts list → dict on read)
- `context_length`, `request_timeout_seconds`, `stale_timeout_seconds`: positive int only
- `rate_limit_delay`: int or float, ≥ 0
- `key_env` / `api_key_env`: non-empty string; normalised to canonical `key_env` on the way out (the alias is documented in `website/docs/guides/azure-foundry.md`)

Empty / zero / wrong-type values are skipped — they would either confuse the runtime normaliser or display as user-meaningful overrides when they are not.

## Test plan

- [x] `tests/hermes_cli/test_config.py::TestCustomProviderCompatibility::test_v11_upgrade_preserves_optional_fields` — full-shape round-trip
- [x] `tests/hermes_cli/test_config.py::TestCustomProviderCompatibility::test_v11_upgrade_normalises_api_key_env_alias` — `api_key_env` → `key_env` canonicalisation
- [x] `tests/hermes_cli/test_config.py::TestCustomProviderCompatibility::test_v11_upgrade_skips_empty_or_invalid_optional_fields` — zero-value / wrong-type / empty values must not be copied
- [x] Existing `test_v11_upgrade_moves_custom_providers_into_providers` still passes — exact-dict assertion unchanged

```
$ pytest tests/hermes_cli/test_config.py::TestCustomProviderCompatibility -q
======================== 8 passed in 2.33s ========================
```