### PR TITLE
fix(dashboard): validate web UI dist before startup

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5290,6 +5290,15 @@ def _run_npm_install_deterministic(
     )
 
 
+def _web_dist_ready(web_dist: Path) -> bool:
+    """Return True when a built web UI distribution is available."""
+    web_dist = web_dist.resolve()
+    return (
+        (web_dist / "index.html").is_file()
+        and (web_dist / "assets").is_dir()
+    )
+
+
 def _build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
     """Build the web UI frontend if npm is available.
 
@@ -5310,9 +5319,9 @@ def _build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
     if not npm:
         if fatal:
             print("Web UI frontend not built and npm is not available.")
-            print("Install Node.js, then run:  cd web && npm install && npm run build")
+            print(f"Install Node.js, then run:  cd {web_dir} && npm install && npm run build")
         return not fatal
-    print("→ Building web UI...")
+    print(f"→ Building web UI from {web_dir}...")
     r1 = _run_npm_install_deterministic(npm, web_dir, extra_args=("--silent",))
     if r1.returncode != 0:
         print(
@@ -7887,9 +7896,25 @@ def cmd_dashboard(args):
         print(f"Import error: {e}")
         sys.exit(1)
 
-    if "HERMES_WEB_DIST" not in os.environ:
+    web_dist_env = os.environ.get("HERMES_WEB_DIST")
+    if web_dist_env:
+        web_dist = Path(web_dist_env).expanduser().resolve()
+        if not _web_dist_ready(web_dist):
+            print(f"Web UI distribution not found or incomplete: {web_dist}")
+            print("Unset HERMES_WEB_DIST to build and use the default web UI distribution.")
+            sys.exit(1)
+        os.environ["HERMES_WEB_DIST"] = str(web_dist)
+    else:
         if not _build_web_ui(PROJECT_ROOT / "web", fatal=True):
             sys.exit(1)
+
+        web_dist = (PROJECT_ROOT / "hermes_cli" / "web_dist").resolve()
+        if not _web_dist_ready(web_dist):
+            print(f"Web UI build completed, but built assets were not found in {web_dist}")
+            sys.exit(1)
+
+        # Make the resolved default explicit for the web server.
+        os.environ["HERMES_WEB_DIST"] = str(web_dist)
 
     from hermes_cli.web_server import start_server
 


### PR DESCRIPTION
## Summary

This refines dashboard startup behavior around the web UI distribution while
preserving the upstream web UI rebuild logic.

Upstream already added `_web_ui_build_needed()` to decide whether the default
web UI needs to be rebuilt. That logic remains authoritative for the default
`hermes_cli/web_dist` path: `hermes dashboard` still calls `_build_web_ui()`,
and `_build_web_ui()` decides whether the existing output is fresh or stale.

This patch does **not** replace that stale-check behavior with a simple
`index.html` / `assets/` existence check.

Instead, it adds a small `_web_dist_ready()` helper for distribution readiness
validation only:

- For custom `HERMES_WEB_DIST`, it verifies that the provided dist directory is
  actually serveable before starting the web server.
- For the default dist, it validates that built assets exist after
  `_build_web_ui()` has either skipped or completed the build.
- It then sets `HERMES_WEB_DIST` explicitly to the resolved default
  `hermes_cli/web_dist` path before starting the server.

The conflict resolution intentionally preserves upstream's
`_web_ui_build_needed()` stale-check behavior and
`_run_npm_install_deterministic()` install path. The only build-path change is
diagnostic: when a build is needed, the log now prints the resolved web source
path.

## Behavior changes

- Preserves upstream's stale-check rebuild logic for the default web UI.
- Preserves upstream's deterministic npm install helper.
- Fails fast when a custom `HERMES_WEB_DIST` is set but incomplete.
- Validates that the default built distribution exists after `_build_web_ui()`
  returns.
- Sets `HERMES_WEB_DIST` explicitly to the resolved default distribution path
  before starting the web server.
- Prints the resolved web source path when a frontend build is needed or manual
  recovery is required.

## Why this matters

`hermes dashboard` is often run under long-running service managers such as
systemd. In those environments, startup should be deterministic: the dashboard
should either serve a valid web distribution, rebuild only when the upstream
stale-check says it is needed, or fail fast with actionable diagnostics.

This patch avoids starting the server with an invalid dist path while respecting
the upstream rebuild policy.

## Test plan

- `python3 -m py_compile hermes_cli/main.py`
- `git diff --check`
- `env -u HERMES_WEB_DIST hermes dashboard --no-open --port 9120`
  - Confirmed dashboard starts successfully with the default web distribution
- `hermes dashboard --no-open --port 9119`
  - Confirmed dashboard starts successfully on the default port
- `gh pr diff 17845 --repo NousResearch/hermes-agent --name-only`
  - Confirmed the PR only changes `hermes_cli/main.py`