### PR TITLE
fix: use main_runtime api_key for custom provider in auxiliary tasks

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2113,6 +2113,7 @@ def resolve_provider_client(
             custom_key = (
                 (explicit_api_key or "").strip()
                 or os.getenv("OPENAI_API_KEY", "").strip()
+                or (main_runtime.get("api_key", "").strip() if main_runtime else "")
                 or "no-key-required"  # local servers don't need auth
             )
             if not custom_base:


### PR DESCRIPTION
When auxiliary.title_generation (or other auxiliary tasks) resolve to the 'custom' provider via an explicit base_url, the api_key fallback chain did not include the main runtime's api_key. This caused title generation to fail with 401 'login fail: Please carry the API secret key' when the main model was configured with minimax-cn credentials.

## Root cause
In resolve_provider_client(), the 'custom' provider branch builds custom_key with this fallback order:
1. explicit_api_key
2. OPENAI_API_KEY env var
3. 'no-key-required'

It was missing: main_runtime.get('api_key'). When an auxiliary task (e.g. title_generation) uses a base_url that resolves to 'custom' provider, and that base_url matches the main runtime's endpoint, the main runtime's api_key should be used as a fallback.

## Fix
Added main_runtime.get('api_key') to the custom_key fallback chain, so auxiliary tasks that reuse the main model's endpoint credentials work correctly.

Fixes: (title generation 401 with minimax-cn provider)