### PR TITLE
Add shared skill locking for multi-process Hermes homes

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -24,6 +24,7 @@ from agent.skill_utils import (
     parse_frontmatter,
     skill_matches_platform,
 )
+from tools.skill_shared_state import skills_epoch_value
 from utils import atomic_json_write
 
 logger = logging.getLogger(__name__)
@@ -688,6 +689,7 @@ def build_skills_system_prompt(
     cache_key = (
         str(skills_dir.resolve()),
         tuple(str(d) for d in external_dirs),
+        skills_epoch_value(),
         tuple(sorted(str(t) for t in (available_tools or set()))),
         tuple(sorted(str(ts) for ts in (available_toolsets or set()))),
         _platform_hint,

--- a/tests/tools/test_skill_shared_state.py
+++ b/tests/tools/test_skill_shared_state.py
@@ -1,0 +1,69 @@
+import multiprocessing
+import os
+import queue
+import time
+
+
+def _lock_child(hermes_home: str, output: multiprocessing.Queue) -> None:
+    os.environ["HERMES_HOME"] = hermes_home
+    from tools.skill_shared_state import shared_skill_write_lock
+
+    with shared_skill_write_lock(timeout_seconds=2):
+        output.put("acquired")
+
+
+def test_shared_skill_write_lock_blocks_other_processes(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    from tools.skill_shared_state import shared_skill_write_lock
+
+    output: multiprocessing.Queue = multiprocessing.Queue()
+    with shared_skill_write_lock(timeout_seconds=2):
+        process = multiprocessing.Process(target=_lock_child, args=(os.environ["HERMES_HOME"], output))
+        process.start()
+        try:
+            try:
+                output.get(timeout=0.25)
+                raise AssertionError("child acquired shared skill lock while parent held it")
+            except queue.Empty:
+                pass
+        finally:
+            pass
+
+    assert output.get(timeout=2) == "acquired"
+    process.join(timeout=2)
+    assert process.exitcode == 0
+
+
+def test_skill_epoch_invalidates_in_process_prompt_cache(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    skills_dir = hermes_home / "skills"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    from agent import prompt_builder
+    from tools.skill_shared_state import mark_skills_changed
+
+    prompt_builder.clear_skills_system_prompt_cache(clear_snapshot=True)
+    alpha = skills_dir / "alpha"
+    alpha.mkdir(parents=True)
+    (alpha / "SKILL.md").write_text(
+        "---\nname: alpha\ndescription: Alpha workflow\n---\nUse alpha.\n",
+        encoding="utf-8",
+    )
+    mark_skills_changed()
+
+    first = prompt_builder.build_skills_system_prompt()
+    assert "alpha" in first
+    assert "beta" not in first
+
+    beta = skills_dir / "beta"
+    beta.mkdir(parents=True)
+    (beta / "SKILL.md").write_text(
+        "---\nname: beta\ndescription: Beta workflow\n---\nUse beta.\n",
+        encoding="utf-8",
+    )
+    time.sleep(0.001)
+    mark_skills_changed()
+
+    second = prompt_builder.build_skills_system_prompt()
+    assert "alpha" in second
+    assert "beta" in second

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -42,6 +42,7 @@ from pathlib import Path
 from hermes_constants import get_hermes_home, display_hermes_home
 from typing import Dict, Any, Optional, Tuple
 
+from tools.skill_shared_state import mark_skills_changed, shared_skill_write_lock
 from utils import atomic_replace
 from hermes_cli.config import cfg_get
 
@@ -705,42 +706,44 @@ def skill_manage(
 
     Returns JSON string with results.
     """
-    if action == "create":
-        if not content:
-            return tool_error("content is required for 'create'. Provide the full SKILL.md text (frontmatter + body).", success=False)
-        result = _create_skill(name, content, category)
+    with shared_skill_write_lock():
+        if action == "create":
+            if not content:
+                return tool_error("content is required for 'create'. Provide the full SKILL.md text (frontmatter + body).", success=False)
+            result = _create_skill(name, content, category)
 
-    elif action == "edit":
-        if not content:
-            return tool_error("content is required for 'edit'. Provide the full updated SKILL.md text.", success=False)
-        result = _edit_skill(name, content)
+        elif action == "edit":
+            if not content:
+                return tool_error("content is required for 'edit'. Provide the full updated SKILL.md text.", success=False)
+            result = _edit_skill(name, content)
 
-    elif action == "patch":
-        if not old_string:
-            return tool_error("old_string is required for 'patch'. Provide the text to find.", success=False)
-        if new_string is None:
-            return tool_error("new_string is required for 'patch'. Use empty string to delete matched text.", success=False)
-        result = _patch_skill(name, old_string, new_string, file_path, replace_all)
+        elif action == "patch":
+            if not old_string:
+                return tool_error("old_string is required for 'patch'. Provide the text to find.", success=False)
+            if new_string is None:
+                return tool_error("new_string is required for 'patch'. Use empty string to delete matched text.", success=False)
+            result = _patch_skill(name, old_string, new_string, file_path, replace_all)
 
-    elif action == "delete":
-        result = _delete_skill(name)
+        elif action == "delete":
+            result = _delete_skill(name)
 
-    elif action == "write_file":
-        if not file_path:
-            return tool_error("file_path is required for 'write_file'. Example: 'references/api-guide.md'", success=False)
-        if file_content is None:
-            return tool_error("file_content is required for 'write_file'.", success=False)
-        result = _write_file(name, file_path, file_content)
+        elif action == "write_file":
+            if not file_path:
+                return tool_error("file_path is required for 'write_file'. Example: 'references/api-guide.md'", success=False)
+            if file_content is None:
+                return tool_error("file_content is required for 'write_file'.", success=False)
+            result = _write_file(name, file_path, file_content)
 
-    elif action == "remove_file":
-        if not file_path:
-            return tool_error("file_path is required for 'remove_file'.", success=False)
-        result = _remove_file(name, file_path)
+        elif action == "remove_file":
+            if not file_path:
+                return tool_error("file_path is required for 'remove_file'.", success=False)
+            result = _remove_file(name, file_path)
 
-    else:
-        result = {"success": False, "error": f"Unknown action '{action}'. Use: create, edit, patch, delete, write_file, remove_file"}
+        else:
+            result = {"success": False, "error": f"Unknown action '{action}'. Use: create, edit, patch, delete, write_file, remove_file"}
 
     if result.get("success"):
+        mark_skills_changed()
         try:
             from agent.prompt_builder import clear_skills_system_prompt_cache
             clear_skills_system_prompt_cache(clear_snapshot=True)

--- a/tools/skill_shared_state.py
+++ b/tools/skill_shared_state.py
@@ -1,0 +1,94 @@
+"""Shared coordination for mutable Hermes skills state.
+
+Hermes supports multiple agent processes sharing one ``HERMES_HOME``.  Skill
+files are ordinary filesystem state, so multi-process deployments need a small
+coordination layer around writes and prompt-cache invalidation.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+import os
+from pathlib import Path
+import random
+import time
+from typing import Iterator
+
+from hermes_constants import get_hermes_home
+
+try:  # pragma: no cover - Windows is not a supported production target.
+    import fcntl
+except ImportError:  # pragma: no cover
+    fcntl = None  # type: ignore[assignment]
+
+
+DEFAULT_LOCK_TIMEOUT_SECONDS = 120.0
+
+
+def _lock_timeout_seconds() -> float:
+    raw = os.getenv("HERMES_SKILLS_LOCK_TIMEOUT_SECONDS", "").strip()
+    if not raw:
+        return DEFAULT_LOCK_TIMEOUT_SECONDS
+    try:
+        parsed = float(raw)
+    except ValueError:
+        return DEFAULT_LOCK_TIMEOUT_SECONDS
+    return max(1.0, parsed)
+
+
+def skills_lock_path() -> Path:
+    home = get_hermes_home()
+    home.mkdir(parents=True, exist_ok=True)
+    return home / ".skills_write.lock"
+
+
+def skills_epoch_path() -> Path:
+    home = get_hermes_home()
+    home.mkdir(parents=True, exist_ok=True)
+    return home / ".skills_epoch"
+
+
+@contextmanager
+def shared_skill_write_lock(*, timeout_seconds: float | None = None) -> Iterator[None]:
+    """Serialize skill tree mutations across Hermes processes."""
+    lock_path = skills_lock_path()
+    timeout = _lock_timeout_seconds() if timeout_seconds is None else max(1.0, timeout_seconds)
+    deadline = time.monotonic() + timeout
+
+    with lock_path.open("a+", encoding="utf-8") as handle:
+        if fcntl is None:  # pragma: no cover
+            yield
+            return
+
+        while True:
+            try:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                break
+            except BlockingIOError as exc:
+                if time.monotonic() >= deadline:
+                    raise TimeoutError(f"Timed out waiting for Hermes skills lock at {lock_path}") from exc
+                time.sleep(random.uniform(0.02, 0.15))
+
+        try:
+            yield
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def mark_skills_changed() -> None:
+    """Touch the shared skill epoch so other processes drop skill caches."""
+    path = skills_epoch_path()
+    now = time.time_ns()
+    tmp = path.with_name(f".{path.name}.{os.getpid()}.{now}.tmp")
+    tmp.write_text(str(now), encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def skills_epoch_value() -> tuple[int, int]:
+    """Return a stable cache-key value for the current shared skill epoch."""
+    path = skills_epoch_path()
+    try:
+        st = path.stat()
+    except OSError:
+        return (0, 0)
+    return (st.st_mtime_ns, st.st_size)

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -35,6 +35,7 @@ import yaml
 from tools.skills_guard import (
     ScanResult, content_hash, TRUSTED_REPOS,
 )
+from tools.skill_shared_state import mark_skills_changed, shared_skill_write_lock
 
 logger = logging.getLogger(__name__)
 
@@ -2730,71 +2731,75 @@ def install_from_quarantine(
     if not quarantine_resolved.is_relative_to(quarantine_root):
         raise ValueError(f"Unsafe quarantine path: {quarantine_path}")
 
-    if safe_category:
-        install_dir = SKILLS_DIR / safe_category / safe_skill_name
-    else:
-        install_dir = SKILLS_DIR / safe_skill_name
+    with shared_skill_write_lock():
+        if safe_category:
+            install_dir = SKILLS_DIR / safe_category / safe_skill_name
+        else:
+            install_dir = SKILLS_DIR / safe_skill_name
 
-    if install_dir.exists():
-        shutil.rmtree(install_dir)
+        if install_dir.exists():
+            shutil.rmtree(install_dir)
 
-    # Warn (but don't block) if SKILL.md is very large
-    skill_md = quarantine_path / "SKILL.md"
-    if skill_md.exists():
-        try:
-            skill_size = skill_md.stat().st_size
-            if skill_size > 100_000:
-                logger.warning(
-                    "Skill '%s' has a large SKILL.md (%s chars). "
-                    "Large skills consume significant context when loaded. "
-                    "Consider asking the author to split it into smaller files.",
-                    safe_skill_name,
-                    f"{skill_size:,}",
-                )
-        except OSError:
-            pass
+        # Warn (but don't block) if SKILL.md is very large
+        skill_md = quarantine_path / "SKILL.md"
+        if skill_md.exists():
+            try:
+                skill_size = skill_md.stat().st_size
+                if skill_size > 100_000:
+                    logger.warning(
+                        "Skill '%s' has a large SKILL.md (%s chars). "
+                        "Large skills consume significant context when loaded. "
+                        "Consider asking the author to split it into smaller files.",
+                        safe_skill_name,
+                        f"{skill_size:,}",
+                    )
+            except OSError:
+                pass
 
-    install_dir.parent.mkdir(parents=True, exist_ok=True)
-    shutil.move(str(quarantine_path), str(install_dir))
+        install_dir.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(quarantine_path), str(install_dir))
 
-    # Record in lock file
-    lock = HubLockFile()
-    lock.record_install(
-        name=safe_skill_name,
-        source=bundle.source,
-        identifier=bundle.identifier,
-        trust_level=bundle.trust_level,
-        scan_verdict=scan_result.verdict,
-        skill_hash=content_hash(install_dir),
-        install_path=str(install_dir.relative_to(SKILLS_DIR)),
-        files=list(bundle.files.keys()),
-        metadata=bundle.metadata,
-    )
+        # Record in lock file
+        lock = HubLockFile()
+        lock.record_install(
+            name=safe_skill_name,
+            source=bundle.source,
+            identifier=bundle.identifier,
+            trust_level=bundle.trust_level,
+            scan_verdict=scan_result.verdict,
+            skill_hash=content_hash(install_dir),
+            install_path=str(install_dir.relative_to(SKILLS_DIR)),
+            files=list(bundle.files.keys()),
+            metadata=bundle.metadata,
+        )
 
-    append_audit_log(
-        "INSTALL", safe_skill_name, bundle.source,
-        bundle.trust_level, scan_result.verdict,
-        content_hash(install_dir),
-    )
+        append_audit_log(
+            "INSTALL", safe_skill_name, bundle.source,
+            bundle.trust_level, scan_result.verdict,
+            content_hash(install_dir),
+        )
+        mark_skills_changed()
 
-    return install_dir
+        return install_dir
 
 
 def uninstall_skill(skill_name: str) -> Tuple[bool, str]:
     """Remove a hub-installed skill. Refuses to remove builtins."""
-    lock = HubLockFile()
-    entry = lock.get_installed(skill_name)
-    if not entry:
-        return False, f"'{skill_name}' is not a hub-installed skill (may be a builtin)"
+    with shared_skill_write_lock():
+        lock = HubLockFile()
+        entry = lock.get_installed(skill_name)
+        if not entry:
+            return False, f"'{skill_name}' is not a hub-installed skill (may be a builtin)"
 
-    install_path = SKILLS_DIR / entry["install_path"]
-    if install_path.exists():
-        shutil.rmtree(install_path)
+        install_path = SKILLS_DIR / entry["install_path"]
+        if install_path.exists():
+            shutil.rmtree(install_path)
 
-    lock.record_uninstall(skill_name)
-    append_audit_log("UNINSTALL", skill_name, entry["source"], entry["trust_level"], "n/a", "user_request")
+        lock.record_uninstall(skill_name)
+        append_audit_log("UNINSTALL", skill_name, entry["source"], entry["trust_level"], "n/a", "user_request")
+        mark_skills_changed()
 
-    return True, f"Uninstalled '{skill_name}' from {entry['install_path']}"
+        return True, f"Uninstalled '{skill_name}' from {entry['install_path']}"
 
 
 def bundle_content_hash(bundle: SkillBundle) -> str:

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -28,6 +28,7 @@ import shutil
 from pathlib import Path
 from hermes_constants import get_hermes_home
 from typing import Dict, List, Tuple
+from tools.skill_shared_state import mark_skills_changed, shared_skill_write_lock
 from utils import atomic_replace
 
 logger = logging.getLogger(__name__)
@@ -174,7 +175,7 @@ def _dir_hash(directory: Path) -> str:
     return hasher.hexdigest()
 
 
-def sync_skills(quiet: bool = False) -> dict:
+def _sync_skills_unlocked(quiet: bool = False) -> dict:
     """
     Sync bundled skills into ~/.hermes/skills/ using the manifest.
 
@@ -318,7 +319,15 @@ def sync_skills(quiet: bool = False) -> dict:
     }
 
 
-def reset_bundled_skill(name: str, restore: bool = False) -> dict:
+def sync_skills(quiet: bool = False) -> dict:
+    """Sync bundled skills while serializing writes across Hermes processes."""
+    with shared_skill_write_lock():
+        result = _sync_skills_unlocked(quiet=quiet)
+        mark_skills_changed()
+        return result
+
+
+def _reset_bundled_skill_unlocked(name: str, restore: bool = False) -> dict:
     """
     Reset a bundled skill's manifest tracking so future syncs work normally.
 
@@ -397,7 +406,7 @@ def reset_bundled_skill(name: str, restore: bool = False) -> dict:
                 }
 
     # Step 3: run sync to re-baseline (or re-copy if we deleted)
-    synced = sync_skills(quiet=True)
+    synced = _sync_skills_unlocked(quiet=True)
 
     if restore and deleted_user_copy:
         action = "restored"
@@ -414,6 +423,15 @@ def reset_bundled_skill(name: str, restore: bool = False) -> dict:
         )
 
     return {"ok": True, "action": action, "message": message, "synced": synced}
+
+
+def reset_bundled_skill(name: str, restore: bool = False) -> dict:
+    """Reset bundled-skill tracking while serializing skill tree mutations."""
+    with shared_skill_write_lock():
+        result = _reset_bundled_skill_unlocked(name, restore=restore)
+        if result.get("ok"):
+            mark_skills_changed()
+        return result
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a shared flock-based skill write lock under HERMES_HOME
- mark a shared skill epoch after skill_manage, bundled skill sync, and skill hub mutations
- include the shared epoch in prompt skill-cache keys so another process sees skill edits without restart

## Tests
- python3 -m py_compile tools/skill_shared_state.py tools/skill_manager_tool.py tools/skills_sync.py tools/skills_hub.py agent/prompt_builder.py tests/tools/test_skill_shared_state.py
- uv run --python 3.12 --with pytest --with pytest-xdist pytest tests/tools/test_skill_shared_state.py -q

Note: uv still warns that pyproject.toml `exclude-newer = "7 days"` is not parseable as a timestamp during settings discovery.