### PR TITLE
fix: add missing hindsight dependencies for local_embedded mode

### DIFF
--- a/plugins/memory/hindsight/plugin.yaml
+++ b/plugins/memory/hindsight/plugin.yaml
@@ -3,6 +3,8 @@ version: 1.0.0
 description: "Hindsight — long-term memory with knowledge graph, entity resolution, and multi-strategy retrieval."
 pip_dependencies:
   - "hindsight-client>=0.4.22"
+  - "hindsight-embed>=0.5.0"
+  - "hindsight-all>=0.5.0"
 requires_env: []
 hooks:
   - on_session_end


### PR DESCRIPTION
## Summary

`plugins/memory/hindsight/plugin.yaml` only declared `hindsight-client` as a dependency, but the `local_embedded` code path actually imports from two more packages:

- `hindsight-embed` → `hindsight_embed.daemon_embed_manager` (line 86, 1003)
- `hindsight-all` → `hindsight.HindsightEmbedded` (line 766)

Without these, `_install_dependencies()` skips them, `_check_local_runtime()` fails, and `hermes memory status` reports "not available" even when the daemon is healthy.

## Fix

Added `hindsight-embed>=0.5.0` and `hindsight-all>=0.5.0` to `pip_dependencies`.

## Test Plan

- [x] Installed missing packages manually, verified `hermes memory status` shows "available ✓"
- [x] Verified `from hindsight import HindsightEmbedded` succeeds
- [x] Verified `import hindsight_embed.daemon_embed_manager` succeeds