### PR TITLE
tests: mock _prompt_text_input in reload-mcp test

### DIFF
--- a/tests/cli/test_cli_loading_indicator.py
+++ b/tests/cli/test_cli_loading_indicator.py
@@ -50,7 +50,8 @@ class TestCLILoadingIndicator:
             print("reload done")
 
         with patch.object(cli_obj, "_reload_mcp", side_effect=fake_reload), \
-             patch.object(cli_obj, "_invalidate") as invalidate_mock:
+             patch.object(cli_obj, "_invalidate") as invalidate_mock, \
+             patch.object(cli_obj, "_prompt_text_input", return_value="1"):
             assert cli_obj.process_command("/reload-mcp")
 
         output = capsys.readouterr().out

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -184,6 +184,13 @@ _HERMES_BEHAVIORAL_VARS = frozenset({
     "HERMES_BACKGROUND_NOTIFICATIONS",
     "HERMES_EXEC_ASK",
     "HERMES_HOME_MODE",
+    # Cron session vars — HERMES_CRON_SESSION=1 forces cron_mode=deny
+    # path, which silently bypasses blocking approval flow for dangerous
+    # commands in tests that need the gateway/ask approval path.
+    "HERMES_CRON_SESSION",
+    "HERMES_CRON_AUTO_DELIVER_ALL",
+    "HERMES_CRON_AUTO_DELIVER_PLATFORM",
+    "HERMES_CRON_AUTO_DELIVER_CHAT_ID",
     "BROWSER_CDP_URL",
     "CAMOFOX_URL",
     # Platform allowlists — not credentials, but if set from any source
@@ -293,6 +300,17 @@ def _hermetic_environment(tmp_path, monkeypatch):
     monkeypatch.delenv("GMI_API_KEY", raising=False)
     monkeypatch.delenv("GMI_BASE_URL", raising=False)
 
+    # 6. Wipe the config YAML cache so load_config() re-reads from the fake
+    #    hermes home established in step 3. Without this, module imports that
+    #    ran during test collection cached the real ~/.hermes/config.yaml and
+    #    load_permanent_allowlist() would re-populate _permanent_approved from
+    #    the real allowlist every time a test calls check_all_command_guards().
+    try:
+        from hermes_cli import config as _config_mod
+        _config_mod._RAW_CONFIG_CACHE.clear()
+    except Exception:
+        pass
+
 
 # Backward-compat alias — old tests reference this fixture name. Keep it
 # as a no-op wrapper so imports don't break.
@@ -326,6 +344,17 @@ def _reset_module_state():
     that don't exist yet (test collection before production import) are
     skipped silently — production import later creates fresh empty state.
     """
+    # --- hermes_cli.config — in-memory YAML cache ---
+    # load_config() caches by config file path (mtime, size). When
+    # _hermetic_environment redirects HERMES_HOME to a temp dir, the cache
+    # still holds the real ~/.hermes/config.yaml data. Wipe it so the next
+    # load_config() call re-reads from the fake hermes home.
+    try:
+        from hermes_cli import config as _config_mod
+        _config_mod._RAW_CONFIG_CACHE.clear()
+    except Exception:
+        pass
+
     # --- tools.approval — the single biggest source of cross-test pollution ---
     try:
         from tools import approval as _approval_mod


### PR DESCRIPTION
## Bug

`TestCLILoadingIndicator::test_reload_mcp_sets_busy_state_and_prints_status` fails in CI with xdist workers because `/reload-mcp` shows an interactive confirmation panel instead of the loading indicator.

**Root cause**: In xdist workers, `sys.stdin.isatty()` returns True (stdin is connected to the PTY of the pytest parent process). When `_confirm_and_reload_mcp` is called, it calls `_prompt_text_input` which waits for stdin input. Since there's no interactive input in the pytest worker, it returns `None` and the command cancels.

**Expected output**: `⏳ Reloading MCP servers...` (the loading indicator)
**Actual output**: The approval/cancel panel that gets cancelled with `🟡 /reload-mcp cancelled (no input).`

## Fix

Patch `_prompt_text_input` to return `"1"` (Approve Once) so the test exercises the reload path, not the cancelled path.
