### PR TITLE
fix(gateway): guard yaml.safe_load and float() env var casts against crash

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3948,7 +3948,10 @@ class GatewayRunner:
         # wall-clock age alone isn't sufficient.  Evict only when the agent
         # has been *idle* beyond the inactivity threshold (or when the agent
         # object has no activity tracker and wall-clock age is extreme).
-        _raw_stale_timeout = float(os.getenv("HERMES_AGENT_TIMEOUT", 1800))
+        try:
+            _raw_stale_timeout = float(os.getenv("HERMES_AGENT_TIMEOUT", 1800))
+        except (ValueError, TypeError):
+            _raw_stale_timeout = 1800.0
         _stale_ts = self._running_agents_ts.get(_quick_key, 0)
         if _quick_key in self._running_agents and _stale_ts:
             _stale_age = time.time() - _stale_ts
@@ -11754,7 +11757,10 @@ class GatewayRunner:
         # Config: agent.gateway_notify_interval in config.yaml, or
         # HERMES_AGENT_NOTIFY_INTERVAL env var.  Default 180s (3 min).
         # 0 = disable notifications.
-        _NOTIFY_INTERVAL_RAW = float(os.getenv("HERMES_AGENT_NOTIFY_INTERVAL", 180))
+        try:
+            _NOTIFY_INTERVAL_RAW = float(os.getenv("HERMES_AGENT_NOTIFY_INTERVAL", 180))
+        except (ValueError, TypeError):
+            _NOTIFY_INTERVAL_RAW = 180.0
         _NOTIFY_INTERVAL = _NOTIFY_INTERVAL_RAW if _NOTIFY_INTERVAL_RAW > 0 else None
         _notify_start = time.time()
 
@@ -11802,9 +11808,15 @@ class GatewayRunner:
             # Config: agent.gateway_timeout in config.yaml, or
             # HERMES_AGENT_TIMEOUT env var (env var takes precedence).
             # Default 1800s (30 min inactivity).  0 = unlimited.
-            _agent_timeout_raw = float(os.getenv("HERMES_AGENT_TIMEOUT", 1800))
+            try:
+                _agent_timeout_raw = float(os.getenv("HERMES_AGENT_TIMEOUT", 1800))
+            except (ValueError, TypeError):
+                _agent_timeout_raw = 1800.0
             _agent_timeout = _agent_timeout_raw if _agent_timeout_raw > 0 else None
-            _agent_warning_raw = float(os.getenv("HERMES_AGENT_TIMEOUT_WARNING", 900))
+            try:
+                _agent_warning_raw = float(os.getenv("HERMES_AGENT_TIMEOUT_WARNING", 900))
+            except (ValueError, TypeError):
+                _agent_warning_raw = 900.0
             _agent_warning = _agent_warning_raw if _agent_warning_raw > 0 else None
             _warning_fired = False
             _executor_task = asyncio.ensure_future(
@@ -12703,7 +12715,7 @@ def main():
     if args.config:
         import yaml
         with open(args.config, encoding="utf-8") as f:
-            data = yaml.safe_load(f)
+            data = yaml.safe_load(f) or {}
             config = GatewayConfig.from_dict(data)
     
     # Run the gateway - exit with code 1 if no platforms connected,


### PR DESCRIPTION
## Summary

Two defensive fixes in `gateway/run.py` that prevent crashes from common misconfiguration:

### Bug 1: `yaml.safe_load` returning `None` on empty config files (line 12706)

`GatewayConfig.from_dict(data)` crashes with `AttributeError` when the YAML file is empty because `yaml.safe_load()` returns `None`. All **6 other** `yaml.safe_load` call sites in the same file already use `or {}` — this one was missed.

**Impact:** Gateway fails to start with an empty `--config` file.

**Reproduction:**
```bash
touch /tmp/empty.yaml
hermes gateway --config /tmp/empty.yaml
# → AttributeError: 'NoneType' object has no attribute 'get'
```

**Fix:** `yaml.safe_load(f) or {}`

### Bug 2: `float()` on env vars without `ValueError` guard (lines 3951, 11757, 11805, 11807)

`HERMES_AGENT_TIMEOUT`, `HERMES_AGENT_TIMEOUT_WARNING`, and `HERMES_AGENT_NOTIFY_INTERVAL` are cast via `float()` directly from `os.getenv()`. A typo (e.g. `"abc"`) raises `ValueError` and crashes the agent turn or gateway startup.

**Impact:** A single misconfigured env var crashes the entire gateway.

**Reproduction:**
```bash
HERMES_AGENT_TIMEOUT=abc hermes gateway
# → ValueError: could not convert string to float: 'abc'
```

**Fix:** Wrap each `float()` call in `try/except (ValueError, TypeError)` with fallback to the default value.

## Changes

| Line(s) | Before | After |
|---------|--------|-------|
| 12706 | `yaml.safe_load(f)` | `yaml.safe_load(f) or {}` |
| 3951 | `float(os.getenv(...))` | `try/except` with fallback to `1800.0` |
| 11757 | `float(os.getenv(...))` | `try/except` with fallback to `180.0` |
| 11805 | `float(os.getenv(...))` | `try/except` with fallback to `1800.0` |
| 11807 | `float(os.getenv(...))` | `try/except` with fallback to `900.0` |
