### PR TITLE
fix(cron): surface agent run_conversation failure flags as job failure

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1150,6 +1150,21 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 f"agent.run_conversation returned {type(result).__name__} instead of dict: {result!r}"
             )
 
+        # If the agent itself reported failure (e.g. all retries exhausted on
+        # API errors, model abort, mid-run interrupt), do not silently mark the
+        # job as successful. run_agent populates `failed=True`/`completed=False`
+        # on these paths and may put the error into `final_response`, which
+        # would otherwise be delivered as if it were the agent's reply and the
+        # job's `last_status` set to "ok". Raise so the except handler below
+        # builds the proper failure tuple. (issue #17855)
+        if result.get("failed") is True or result.get("completed") is False:
+            _err_text = (
+                result.get("error")
+                or (result.get("final_response") or "").strip()
+                or "agent reported failure"
+            )
+            raise RuntimeError(_err_text)
+
         final_response = result.get("final_response", "") or ""
         # Strip leaked placeholder text that upstream may inject on empty completions.
         if final_response.strip() == "(No response generated)":

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -935,6 +935,120 @@ class TestRunJobSessionPersistence:
         # But the output log should show the placeholder
         assert "(No response generated)" in output
 
+    @pytest.mark.parametrize(
+        "agent_result,expected_err_substring",
+        [
+            (
+                {
+                    "final_response": "API call failed after 3 retries: Request timed out.",
+                    "failed": True,
+                    "completed": False,
+                    "error": "API call failed after 3 retries: Request timed out.",
+                },
+                "API call failed",
+            ),
+            (
+                {"final_response": None, "completed": False, "failed": True},
+                "agent reported failure",
+            ),
+            (
+                {"final_response": "", "completed": False},
+                "agent reported failure",
+            ),
+            (
+                {
+                    "final_response": "partial reply before crash",
+                    "failed": True,
+                    "completed": False,
+                    "error": "model abort: connection reset",
+                },
+                "model abort",
+            ),
+        ],
+    )
+    def test_run_job_treats_agent_failure_flag_as_failure(
+        self, tmp_path, agent_result, expected_err_substring
+    ):
+        """Issue #17855: run_conversation returns ``failed=True``/``completed=False``
+        when the agent's API call exhausts retries or aborts mid-run. run_job
+        must surface this as success=False so cron's last_status reflects the
+        failure and the user gets an error notification, instead of treating
+        the (often non-empty) error string in final_response as a legitimate
+        agent reply.
+        """
+        job = {
+            "id": "failing-api-job",
+            "name": "failing api",
+            "prompt": "do something",
+        }
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = agent_result
+            mock_agent_cls.return_value = mock_agent
+
+            success, output, final_response, error = run_job(job)
+
+        assert success is False
+        assert final_response == ""
+        assert error is not None and expected_err_substring in error
+        # Output should be the FAILED template, not the success template.
+        assert "(FAILED)" in output
+        # Ephemeral cron agent must still be closed even on agent-flagged failure.
+        mock_agent.close.assert_called_once()
+
+    def test_run_job_completed_true_without_failed_flag_succeeds(self, tmp_path):
+        """Regression guard: a normal success result (``completed=True``,
+        ``failed`` absent) must not trip the failure-flag check.
+        """
+        job = {
+            "id": "ok-job",
+            "name": "ok",
+            "prompt": "hello",
+        }
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {
+                "final_response": "all good",
+                "completed": True,
+            }
+            mock_agent_cls.return_value = mock_agent
+
+            success, output, final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        assert final_response == "all good"
+
     def test_tick_marks_empty_response_as_error(self, tmp_path):
         """When run_job returns success=True but final_response is empty,
         tick() should mark the job as error so last_status != 'ok'.


### PR DESCRIPTION
## Summary

- Cron jobs were silently marked `last_status=\"ok\"` when the agent's API call exhausted retries — the failure was never delivered to the user even though the agent reported it.
- `run_job()` now consults the `failed` / `completed` flags that `agent.run_conversation` populates on those paths and raises so the existing except handler emits the proper failure tuple.
- Adds a parametrized regression covering API exhaustion, mid-run interrupts, and partial-reply failure shapes; plus a success-path guard.

## The bug

`agent.run_conversation()` returns `{\"final_response\": \"API call failed after 3 retries: Request timed out.\", \"failed\": True, \"completed\": False, \"error\": \"...\"}` on hard failure paths in `run_agent.py` (multiple paths around lines 10811–12292 set this shape). `cron/scheduler.py:run_job` only read `final_response` and returned `True, output, final_response, None` regardless. The downstream `_process_job` empty-response soft-fail at line 1342 only triggers when `final_response == \"\"` — but in this scenario the error text *is* the final_response, so:

1. `should_deliver = bool(\"API call failed...\")` → `True`, so `_deliver_result` ships the error text to the user as the agent's reply.
2. `success` stays `True`, so `mark_job_run` records `last_status=\"ok\"` with `last_error=null`.

Production repro from the issue: a job pointed at a slow self-hosted endpoint timed out after 3 retries; output file showed the error, status showed \"ok\", no notification fired.

## The fix

Right after the existing dict-shape guard in `run_job`, check `result.get(\"failed\") is True or result.get(\"completed\") is False` and raise `RuntimeError` with the agent's `error` (falling back to the trimmed `final_response`, then a generic string). The pre-existing except block already builds the FAILED output template and returns `False, output, \"\", error_msg`, so `mark_job_run` sees the failure and `_process_job` builds the user-visible error notification (`\"⚠️ Cron job '…' failed: …\"`).

The check uses `is True` / `is False` so a result with neither flag (older or simpler success paths) keeps its current success behavior; only explicit failure markers trip it.

## Test plan

- [x] Focused regression: `tests/cron/test_scheduler.py::test_run_job_treats_agent_failure_flag_as_failure` (parametrized — 4 cases: API-retry exhaustion with error text in final_response; failed+completed=False with no final_response; completed=False without an explicit failed flag; partial-reply + failed=True).
- [x] Success-path guard: `test_run_job_completed_true_without_failed_flag_succeeds` confirms a normal `{completed: True, final_response: ...}` result still succeeds.
- [x] Adjacent suite: full `tests/cron/test_scheduler.py` (103 passed). No prior tests stub `failed=True`, so no existing assertion changes.
- [x] Regression guard: with the production fix reverted, all 4 parametrized cases fail with `assert True is False` (success was wrongly True); restoring the fix passes all 5.

## Related

Fixes #17855