### PR TITLE
fix(gateway): drain pending messages via independent task, not recursive await

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2670,8 +2670,19 @@ class BasePlatformAdapter(ABC):
                 if _active is not None:
                     _active.clear()
                 await _stop_typing_task()
-                # Process pending message in new background task
-                await self._process_message_background(pending_event, session_key)
+                # Spawn pending-message drain as an independent task instead
+                # of recursive await — unbounded recursion exhausts the C
+                # stack and SIGSEGVs under sustained pending-queue activity.
+                # (#17758)
+                drain_task = asyncio.create_task(
+                    self._process_message_background(pending_event, session_key)
+                )
+                self._session_tasks[session_key] = drain_task
+                try:
+                    self._background_tasks.add(drain_task)
+                    drain_task.add_done_callback(self._background_tasks.discard)
+                except TypeError:
+                    pass
                 return  # Already cleaned up
                 
         except asyncio.CancelledError:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3948,7 +3948,10 @@ class GatewayRunner:
         # wall-clock age alone isn't sufficient.  Evict only when the agent
         # has been *idle* beyond the inactivity threshold (or when the agent
         # object has no activity tracker and wall-clock age is extreme).
-        _raw_stale_timeout = float(os.getenv("HERMES_AGENT_TIMEOUT", 1800))
+        try:
+            _raw_stale_timeout = float(os.getenv("HERMES_AGENT_TIMEOUT", 1800))
+        except (ValueError, TypeError):
+            _raw_stale_timeout = 1800.0
         _stale_ts = self._running_agents_ts.get(_quick_key, 0)
         if _quick_key in self._running_agents and _stale_ts:
             _stale_age = time.time() - _stale_ts
@@ -11754,7 +11757,10 @@ class GatewayRunner:
         # Config: agent.gateway_notify_interval in config.yaml, or
         # HERMES_AGENT_NOTIFY_INTERVAL env var.  Default 180s (3 min).
         # 0 = disable notifications.
-        _NOTIFY_INTERVAL_RAW = float(os.getenv("HERMES_AGENT_NOTIFY_INTERVAL", 180))
+        try:
+            _NOTIFY_INTERVAL_RAW = float(os.getenv("HERMES_AGENT_NOTIFY_INTERVAL", 180))
+        except (ValueError, TypeError):
+            _NOTIFY_INTERVAL_RAW = 180.0
         _NOTIFY_INTERVAL = _NOTIFY_INTERVAL_RAW if _NOTIFY_INTERVAL_RAW > 0 else None
         _notify_start = time.time()
 
@@ -11802,9 +11808,15 @@ class GatewayRunner:
             # Config: agent.gateway_timeout in config.yaml, or
             # HERMES_AGENT_TIMEOUT env var (env var takes precedence).
             # Default 1800s (30 min inactivity).  0 = unlimited.
-            _agent_timeout_raw = float(os.getenv("HERMES_AGENT_TIMEOUT", 1800))
+            try:
+                _agent_timeout_raw = float(os.getenv("HERMES_AGENT_TIMEOUT", 1800))
+            except (ValueError, TypeError):
+                _agent_timeout_raw = 1800.0
             _agent_timeout = _agent_timeout_raw if _agent_timeout_raw > 0 else None
-            _agent_warning_raw = float(os.getenv("HERMES_AGENT_TIMEOUT_WARNING", 900))
+            try:
+                _agent_warning_raw = float(os.getenv("HERMES_AGENT_TIMEOUT_WARNING", 900))
+            except (ValueError, TypeError):
+                _agent_warning_raw = 900.0
             _agent_warning = _agent_warning_raw if _agent_warning_raw > 0 else None
             _warning_fired = False
             _executor_task = asyncio.ensure_future(
@@ -12703,7 +12715,7 @@ def main():
     if args.config:
         import yaml
         with open(args.config, encoding="utf-8") as f:
-            data = yaml.safe_load(f)
+            data = yaml.safe_load(f) or {}
             config = GatewayConfig.from_dict(data)
     
     # Run the gateway - exit with code 1 if no platforms connected,


### PR DESCRIPTION
## Summary

`_process_message_background()` in `gateway/platforms/base.py` recursively `await`s itself when a pending message is queued during processing. Each follow-up message adds another frame to the call stack. Under sustained pending-queue activity, the stack grows to ~2000 nested frames and the process crashes with **SIGSEGV**.

## Root Cause

At line 2674, after processing message A, if message B was queued during A's processing:
```python
# Recursive — each pending message adds a stack frame
await self._process_message_background(pending_event, session_key)
return
```

If message C arrives during B's processing, B recursively calls itself for C, and so on. No bound on recursion depth.

## Fix

Replace the direct `await` with `asyncio.create_task()`, which schedules the drain as an independent task on the event loop with **zero stack growth**. This matches the existing pattern already used for late-arrival pending messages at line ~2745:

```python
drain_task = asyncio.create_task(
    self._process_message_background(pending_event, session_key)
)
self._session_tasks[session_key] = drain_task
try:
    self._background_tasks.add(drain_task)
    drain_task.add_done_callback(self._background_tasks.discard)
except TypeError:
    pass
return
```

## Why This Is Safe

- The `_active_sessions` guard is preserved — the interrupt event is cleared but the entry stays live, preventing concurrent agents on the same session key
- Task tracking (`_session_tasks`, `_background_tasks`) ensures the drain task participates in graceful shutdown via `cancel_background_tasks()`
- The `try/except TypeError` mirrors the defensive pattern at line ~2753 for test stubs

Fixes #17758
