### PR TITLE
fix: catch KeyboardInterrupt in gateway for clean Ctrl+C exit

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2368,7 +2368,11 @@ def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False):
     # Exit with code 1 if gateway fails to connect any platform,
     # so systemd Restart=on-failure will retry on transient errors
     verbosity = None if quiet else verbose
-    success = asyncio.run(start_gateway(replace=replace, verbosity=verbosity))
+    try:
+        success = asyncio.run(start_gateway(replace=replace, verbosity=verbosity))
+    except KeyboardInterrupt:
+        print("\nGateway stopped.")
+        success = True
     if not success:
         sys.exit(1)
 


### PR DESCRIPTION
## Summary

Wraps `asyncio.run(start_gateway(...))` in `try/except KeyboardInterrupt` so that pressing Ctrl+C — the documented way to stop the gateway — exits with a clean message instead of printing a chained `CancelledError` / `KeyboardInterrupt` traceback.

### Before
```
Press Ctrl+C to stop
Traceback (most recent call last):
  File ".../asyncio/runners.py", line 118, in run
    ...
asyncio.exceptions.CancelledError
...
KeyboardInterrupt
```

### After
```
Press Ctrl+C to stop
^C
Gateway stopped.
```

### Changes
- `hermes_cli/gateway.py`: Wrap the `asyncio.run()` call in a `try/except KeyboardInterrupt` block that prints `"\nGateway stopped."` and sets `success = True`

This is platform-agnostic — the same exception is raised on Linux, macOS, and Windows.

Fixes #17810