### PR TITLE
fix: wire bump_use() into skill loading paths

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -393,6 +393,11 @@ def build_skill_invocation_message(
         return f"[Failed to load skill: {skill_info['name']}]"
 
     loaded_skill, skill_dir, skill_name = loaded
+    try:
+        from tools.skill_usage import bump_use
+        bump_use(skill_name)
+    except Exception:
+        pass  # best-effort — never break skill loading
     activation_note = (
         f'[IMPORTANT: The user has invoked the "{skill_name}" skill, indicating they want '
         "you to follow its instructions. The full skill content is loaded below.]"
@@ -432,6 +437,11 @@ def build_preloaded_skills_prompt(
             continue
 
         loaded_skill, skill_dir, skill_name = loaded
+        try:
+            from tools.skill_usage import bump_use
+            bump_use(skill_name)
+        except Exception:
+            pass  # best-effort — never break skill loading
         activation_note = (
             f'[IMPORTANT: The user launched this CLI session with the "{skill_name}" skill '
             "preloaded. Treat its instructions as active guidance for the duration of this "


### PR DESCRIPTION
## Summary

`bump_use()` in `tools/skill_usage.py` existed and was tested, but had **zero production call sites** — `use_count` stayed at 0 and `last_used_at` stayed `None` forever, making the Curator's stale timer unable to distinguish actively-used skills from never-used ones.

### Changes

Adds `bump_use()` calls to two skill loading paths in `agent/skill_commands.py`:

1. **`build_skill_invocation_message()`** — when a `/skill` slash command is resolved and its content is injected into the prompt
2. **`build_preloaded_skills_prompt()`** — when skills are loaded via the CLI `--skills` flag at session start

Both calls follow the same pattern as the existing `bump_view()` call in `skills_tool.py`: wrapped in `try/except Exception` for best-effort operation that never breaks skill loading.

### Why these paths

Per the issue's analysis, option 1 (slash command resolution) is the most precise: a skill is "used" when its content is actually injected to solve a task, not just when it's listed or browsed. The preload path is included because it represents intentional, active use of a skill for a session.

### Before
```
$ grep -rn 'bump_use(' tools/ --include='*.py'
tools/skill_usage.py:277:def bump_use(skill_name: str) -> None:
# ← zero production call sites

# .usage.json: all skills show use_count: 0, last_used_at: null
```

### After
```
# After invoking /my-skill or loading via --skills:
# .usage.json shows use_count: 1, last_used_at: <timestamp>
```

Fixes #17782