### PR TITLE
fix(skills): wire bump_use() into skill invocation and preload paths (#17782)

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -393,6 +393,12 @@ def build_skill_invocation_message(
         return f"[Failed to load skill: {skill_info['name']}]"
 
     loaded_skill, skill_dir, skill_name = loaded
+    # Record actual skill use (not just view)
+    try:
+        from tools.skill_usage import bump_use
+        bump_use(skill_name)
+    except Exception:
+        pass
     activation_note = (
         f'[IMPORTANT: The user has invoked the "{skill_name}" skill, indicating they want '
         "you to follow its instructions. The full skill content is loaded below.]"
@@ -432,6 +438,12 @@ def build_preloaded_skills_prompt(
             continue
 
         loaded_skill, skill_dir, skill_name = loaded
+        # Record actual skill use (not just view)
+        try:
+            from tools.skill_usage import bump_use
+            bump_use(skill_name)
+        except Exception:
+            pass
         activation_note = (
             f'[IMPORTANT: The user launched this CLI session with the "{skill_name}" skill '
             "preloaded. Treat its instructions as active guidance for the duration of this "


### PR DESCRIPTION
## Summary

`bump_use()` in `tools/skill_usage.py` had **zero production call sites** — it was only called in tests. This meant:
- `use_count` stays 0 for all skills
- `last_used_at` stays `None` forever
- Curator's stale timer (30 days) cannot distinguish "viewed" from "actively used" skills

Meanwhile `bump_view()` IS wired (from `skills_tool.py:1500-1501`) and works correctly.

## Fix

Wire `bump_use()` into two code paths in `agent/skill_commands.py`:

1. **`build_skill_command_message()`** — when user invokes `/skill-name` and the skill content is loaded for injection
2. **`build_preloaded_skills_prompt()`** — when skills are preloaded at session start via `--skill` flag or `skills.preload` config

Both use `try/except Exception: pass` to match the defensive pattern used by `bump_view()`.

## Why These Two Locations

- `build_skill_command_message()` is the gateway entry point — called when any slash command resolves to a skill
- `build_preloaded_skills_prompt()` is the CLI entry point — called when skills are loaded at session start
- Together they cover all production paths where skill content is actually used (not just viewed)

Fixes #17782
