### PR TITLE
fix(ssh): prevent tar from overwriting remote home dir permissions (#17767)

### DIFF
--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -182,7 +182,11 @@ class SSHEnvironment(BaseEnvironment):
 
             tar_cmd = ["tar", "-chf", "-", "-C", staging, "."]
             ssh_cmd = self._build_ssh_command()
-            ssh_cmd.append("tar xf - -C /")
+            # --no-overwrite-dir prevents tar from overwriting the mode of
+            # existing directories (e.g. /home/<user>) with the staging
+            # directory's mode.  Without this, a umask 002 produces 0775
+            # dirs which breaks sshd StrictModes (refuses authorized_keys).
+            ssh_cmd.append("tar xf - --no-overwrite-dir -C /")
 
             tar_proc = subprocess.Popen(
                 tar_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE


### PR DESCRIPTION
## Summary

The SSH terminal backend's `_ssh_bulk_upload()` uses `tar xf - -C /` to extract files to the remote root. GNU tar's default behavior overwrites the metadata (including mode) of existing directories. When the local umask is `002` (Ubuntu default), staging directories are created with `0775` mode, and tar overwrites `/home/<user>` to `0775`.

This breaks OpenSSH's `StrictModes yes` (default), which requires the home directory to NOT be group-writable. Subsequent SSH connections fail with `Permission denied (publickey)`.

## Fix

Add `--no-overwrite-dir` to the remote tar command:

```bash
# Before
tar xf - -C /

# After
tar xf - --no-overwrite-dir -C /
```

`--no-overwrite-dir` tells tar to skip updating the attributes of already-existing directories, preserving the remote system's correct `0755` mode.

## Impact

- Fixes SSH authentication breakage after first file sync
- No functional change to file extraction — files are still written correctly
- Only directory metadata preservation changes

Fixes #17767
