### PR TITLE
fix(openviking): resolve viking_read 500/412 on file URIs and pseudo-summary URIs (salvage #5886 + #12757 + #12937)

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -545,6 +545,29 @@ class OpenVikingMemoryProvider(MemoryProvider):
                 return uri[: -len(suffix)] or "viking://"
         return uri
 
+    def _is_directory_uri(self, uri: str) -> bool | None:
+        """Probe fs/stat to decide if a URI is a directory.
+
+        Returns True/False when the server answers cleanly, and None when the
+        probe itself fails (network error, unexpected shape). Callers should
+        treat None as "unknown" and fall back to the exception-based path.
+        """
+        try:
+            resp = self._client.get("/api/v1/fs/stat", params={"uri": uri})
+        except Exception:
+            return None
+        result = self._unwrap_result(resp)
+        if isinstance(result, dict):
+            if "isDir" in result:
+                return bool(result.get("isDir"))
+            if "is_dir" in result:
+                return bool(result.get("is_dir"))
+            if result.get("type") == "dir":
+                return True
+            if result.get("type") == "file":
+                return False
+        return None
+
     def _tool_search(self, args: dict) -> str:
         query = args.get("query", "")
         if not query:
@@ -600,19 +623,32 @@ class OpenVikingMemoryProvider(MemoryProvider):
         resolved_uri = self._normalize_summary_uri(uri) if summary_level else uri
         used_fallback = False
 
+        # abstract/overview endpoints are directory-only on OpenViking
+        # (v0.3.x returns 500/412 for file URIs). When the caller asks for a
+        # summary level on a non-pseudo URI, probe fs/stat first and route
+        # file URIs straight to /content/read instead of eating a failing
+        # round-trip. The pseudo-URI path already points at a directory, so
+        # skip the probe there.
+        if summary_level and resolved_uri == uri:
+            is_dir = self._is_directory_uri(uri)
+            if is_dir is False:
+                resolved_uri = uri
+                used_fallback = True
+
         # Map our level names to OpenViking GET endpoints.
         endpoint = "/api/v1/content/read"
-        if level == "abstract":
-            endpoint = "/api/v1/content/abstract"
-        elif level == "overview":
-            endpoint = "/api/v1/content/overview"
+        if not used_fallback:
+            if level == "abstract":
+                endpoint = "/api/v1/content/abstract"
+            elif level == "overview":
+                endpoint = "/api/v1/content/overview"
 
         try:
             resp = self._client.get(endpoint, params={"uri": resolved_uri})
         except Exception:
             # OpenViking may return HTTP 500 for abstract/overview reads on normal
             # file URIs (mem_*.md). For those, gracefully fallback to full read.
-            if not summary_level or resolved_uri != uri:
+            if not summary_level or resolved_uri != uri or used_fallback:
                 raise
             resp = self._client.get("/api/v1/content/read", params={"uri": uri})
             used_fallback = True

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -528,6 +528,23 @@ class OpenVikingMemoryProvider(MemoryProvider):
 
     # -- Tool implementations ------------------------------------------------
 
+    @staticmethod
+    def _unwrap_result(resp: Any) -> Any:
+        """Return OpenViking payload body regardless of wrapped/unwrapped shape."""
+        if isinstance(resp, dict) and "result" in resp:
+            return resp.get("result")
+        return resp
+
+    @staticmethod
+    def _normalize_summary_uri(uri: str) -> str:
+        """Map pseudo summary files to their parent directory URI for L0/L1 reads."""
+        if not uri:
+            return uri
+        for suffix in ("/.abstract.md", "/.overview.md", "/.read.md", "/.full.md"):
+            if uri.endswith(suffix):
+                return uri[: -len(suffix)] or "viking://"
+        return uri
+
     def _tool_search(self, args: dict) -> str:
         query = args.get("query", "")
         if not query:
@@ -576,17 +593,26 @@ class OpenVikingMemoryProvider(MemoryProvider):
             return tool_error("uri is required")
 
         level = args.get("level", "overview")
+
+        # OpenViking v0.3.3 expects directory URIs for abstract/overview.
+        resolved_uri = self._normalize_summary_uri(uri) if level in ("abstract", "overview") else uri
+
         # Map our level names to OpenViking GET endpoints
         if level == "abstract":
-            resp = self._client.get("/api/v1/content/abstract", params={"uri": uri})
+            resp = self._client.get("/api/v1/content/abstract", params={"uri": resolved_uri})
         elif level == "full":
-            resp = self._client.get("/api/v1/content/read", params={"uri": uri})
+            resp = self._client.get("/api/v1/content/read", params={"uri": resolved_uri})
         else:  # overview
-            resp = self._client.get("/api/v1/content/overview", params={"uri": uri})
+            resp = self._client.get("/api/v1/content/overview", params={"uri": resolved_uri})
 
-        result = resp.get("result", "")
-        # result is a plain string from the content endpoints
-        content = result if isinstance(result, str) else result.get("content", "")
+        result = self._unwrap_result(resp)
+        # Content endpoints may return either plain strings or objects.
+        if isinstance(result, str):
+            content = result
+        elif isinstance(result, dict):
+            content = result.get("content", "") or result.get("text", "")
+        else:
+            content = ""
 
         # Truncate very long content to avoid flooding the context
         if len(content) > 8000:
@@ -594,6 +620,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
 
         return json.dumps({
             "uri": uri,
+            "resolved_uri": resolved_uri,
             "level": level,
             "content": content,
         }, ensure_ascii=False)
@@ -606,19 +633,27 @@ class OpenVikingMemoryProvider(MemoryProvider):
         endpoint_map = {"tree": "/api/v1/fs/tree", "list": "/api/v1/fs/ls", "stat": "/api/v1/fs/stat"}
         endpoint = endpoint_map.get(action, "/api/v1/fs/ls")
         resp = self._client.get(endpoint, params={"uri": path})
-        result = resp.get("result", {})
+        result = self._unwrap_result(resp)
 
         # Format list/tree results for readability
-        if action in ("list", "tree") and isinstance(result, list):
-            entries = []
-            for e in result[:50]:  # cap at 50 entries
-                entries.append({
-                    "name": e.get("rel_path", e.get("name", "")),
-                    "uri": e.get("uri", ""),
-                    "type": "dir" if e.get("isDir") else "file",
-                    "abstract": e.get("abstract", ""),
-                })
-            return json.dumps({"path": path, "entries": entries}, ensure_ascii=False)
+        if action in ("list", "tree"):
+            raw_entries = result
+            if isinstance(result, dict):
+                raw_entries = result.get("entries") or result.get("items") or result.get("children") or []
+
+            if isinstance(raw_entries, list):
+                entries = []
+                for e in raw_entries[:50]:  # cap at 50 entries
+                    uri = e.get("uri", "")
+                    name = e.get("rel_path") or e.get("name") or (uri.rsplit("/", 1)[-1] if uri else "")
+                    is_dir = bool(e.get("isDir") or e.get("is_dir") or e.get("type") == "dir")
+                    entries.append({
+                        "name": name,
+                        "uri": uri,
+                        "type": "dir" if is_dir else "file",
+                        "abstract": e.get("abstract", ""),
+                    })
+                return json.dumps({"path": path, "entries": entries}, ensure_ascii=False)
 
         return json.dumps(result, ensure_ascii=False)
 

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -594,16 +594,28 @@ class OpenVikingMemoryProvider(MemoryProvider):
 
         level = args.get("level", "overview")
 
-        # OpenViking v0.3.3 expects directory URIs for abstract/overview.
-        resolved_uri = self._normalize_summary_uri(uri) if level in ("abstract", "overview") else uri
+        summary_level = level in ("abstract", "overview")
+        # OpenViking expects directory URIs for pseudo summary files
+        # (e.g. viking://user/hermes/.overview.md).
+        resolved_uri = self._normalize_summary_uri(uri) if summary_level else uri
+        used_fallback = False
 
-        # Map our level names to OpenViking GET endpoints
+        # Map our level names to OpenViking GET endpoints.
+        endpoint = "/api/v1/content/read"
         if level == "abstract":
-            resp = self._client.get("/api/v1/content/abstract", params={"uri": resolved_uri})
-        elif level == "full":
-            resp = self._client.get("/api/v1/content/read", params={"uri": resolved_uri})
-        else:  # overview
-            resp = self._client.get("/api/v1/content/overview", params={"uri": resolved_uri})
+            endpoint = "/api/v1/content/abstract"
+        elif level == "overview":
+            endpoint = "/api/v1/content/overview"
+
+        try:
+            resp = self._client.get(endpoint, params={"uri": resolved_uri})
+        except Exception:
+            # OpenViking may return HTTP 500 for abstract/overview reads on normal
+            # file URIs (mem_*.md). For those, gracefully fallback to full read.
+            if not summary_level or resolved_uri != uri:
+                raise
+            resp = self._client.get("/api/v1/content/read", params={"uri": uri})
+            used_fallback = True
 
         result = self._unwrap_result(resp)
         # Content endpoints may return either plain strings or objects.
@@ -614,16 +626,26 @@ class OpenVikingMemoryProvider(MemoryProvider):
         else:
             content = ""
 
-        # Truncate very long content to avoid flooding the context
-        if len(content) > 8000:
-            content = content[:8000] + "\n\n[... truncated, use a more specific URI or abstract level]"
+        # Truncate long content to avoid flooding context.
+        max_len = 8000
+        if level == "overview":
+            max_len = 4000
+        elif level == "abstract":
+            max_len = 1200
 
-        return json.dumps({
+        if len(content) > max_len:
+            content = content[:max_len] + "\n\n[... truncated, use a more specific URI or full level]"
+
+        payload = {
             "uri": uri,
             "resolved_uri": resolved_uri,
             "level": level,
             "content": content,
-        }, ensure_ascii=False)
+        }
+        if used_fallback:
+            payload["fallback"] = "content/read"
+
+        return json.dumps(payload, ensure_ascii=False)
 
     def _tool_browse(self, args: dict) -> str:
         action = args.get("action", "list")

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -58,6 +58,11 @@ AUTHOR_MAP = {
     "nbot@liizfq.top": "liizfq",
     "274096618+hermes-agent-dhabibi@users.noreply.github.com": "dhabibi",
     "dejie.guo@gmail.com": "JayGwod",
+    # OpenViking viking_read salvage (April 2026)
+    "hitesh@gmail.com": "htsh",
+    "pty819@outlook.com": "pty819",
+    "pty819@users.noreply.github.com": "pty819",
+    "517024110@qq.com": "chennest",
     "aamirjawaid@microsoft.com": "heyitsaamir",
     "johnnncenaaa77@gmail.com": "johnncenae",
     "thomasjhon6666@gmail.com": "ThomassJonax",

--- a/tests/openviking_plugin/test_openviking.py
+++ b/tests/openviking_plugin/test_openviking.py
@@ -71,11 +71,91 @@ class TestOpenVikingRead:
             {"uri": "viking://user/hermes/memories/profile.md"},
         )]
 
-    def test_overview_file_uri_falls_back_to_content_read_on_summary_error(self):
+    def test_overview_file_uri_routes_straight_to_content_read_via_stat_probe(self):
+        """Pre-check via fs/stat: file URIs skip the directory-only endpoint entirely."""
         provider = OpenVikingMemoryProvider()
         file_uri = "viking://user/hermes/memories/entities/mem_abc.md"
         provider._client = FakeVikingClient(
             {
+                (
+                    "/api/v1/fs/stat",
+                    (("uri", file_uri),),
+                ): {"result": {"isDir": False}},
+                (
+                    "/api/v1/content/read",
+                    (("uri", file_uri),),
+                ): {"result": {"content": "full content"}},
+            }
+        )
+
+        result = json.loads(provider._tool_read({"uri": file_uri, "level": "overview"}))
+
+        assert result["uri"] == file_uri
+        assert result["resolved_uri"] == file_uri
+        assert result["level"] == "overview"
+        assert result["fallback"] == "content/read"
+        assert result["content"] == "full content"
+        assert provider._client.calls == [
+            ("/api/v1/fs/stat", {"uri": file_uri}),
+            ("/api/v1/content/read", {"uri": file_uri}),
+        ]
+
+    def test_overview_dir_uri_skips_stat_when_pseudo_summary(self):
+        """Pseudo-URI path already resolves to dir, so no stat probe needed."""
+        provider = OpenVikingMemoryProvider()
+        provider._client = FakeVikingClient(
+            {
+                (
+                    "/api/v1/content/overview",
+                    (("uri", "viking://user/hermes"),),
+                ): {"result": "overview"},
+            }
+        )
+
+        result = json.loads(provider._tool_read({"uri": "viking://user/hermes/.overview.md", "level": "overview"}))
+
+        assert result["content"] == "overview"
+        # No fs/stat call — normalization already determined it's a directory.
+        assert provider._client.calls == [
+            ("/api/v1/content/overview", {"uri": "viking://user/hermes"}),
+        ]
+
+    def test_overview_directory_uri_uses_stat_probe_then_overview(self):
+        """Non-pseudo directory URI: stat → isDir=True → summary endpoint."""
+        provider = OpenVikingMemoryProvider()
+        dir_uri = "viking://user/hermes/memories"
+        provider._client = FakeVikingClient(
+            {
+                (
+                    "/api/v1/fs/stat",
+                    (("uri", dir_uri),),
+                ): {"result": {"isDir": True}},
+                (
+                    "/api/v1/content/overview",
+                    (("uri", dir_uri),),
+                ): {"result": "dir overview"},
+            }
+        )
+
+        result = json.loads(provider._tool_read({"uri": dir_uri, "level": "overview"}))
+
+        assert result["content"] == "dir overview"
+        assert "fallback" not in result
+        assert provider._client.calls == [
+            ("/api/v1/fs/stat", {"uri": dir_uri}),
+            ("/api/v1/content/overview", {"uri": dir_uri}),
+        ]
+
+    def test_overview_file_uri_falls_back_via_exception_when_stat_indeterminate(self):
+        """If fs/stat raises or returns unknown shape, legacy exception fallback still kicks in."""
+        provider = OpenVikingMemoryProvider()
+        file_uri = "viking://user/hermes/memories/entities/mem_abc.md"
+        provider._client = FakeVikingClient(
+            {
+                (
+                    "/api/v1/fs/stat",
+                    (("uri", file_uri),),
+                ): RuntimeError("stat unavailable"),
                 (
                     "/api/v1/content/overview",
                     (("uri", file_uri),),
@@ -90,11 +170,11 @@ class TestOpenVikingRead:
         result = json.loads(provider._tool_read({"uri": file_uri, "level": "overview"}))
 
         assert result["uri"] == file_uri
-        assert result["resolved_uri"] == file_uri
         assert result["level"] == "overview"
         assert result["fallback"] == "content/read"
         assert result["content"] == "fallback full content"
         assert provider._client.calls == [
+            ("/api/v1/fs/stat", {"uri": file_uri}),
             ("/api/v1/content/overview", {"uri": file_uri}),
             ("/api/v1/content/read", {"uri": file_uri}),
         ]

--- a/tests/openviking_plugin/test_openviking.py
+++ b/tests/openviking_plugin/test_openviking.py
@@ -12,7 +12,10 @@ class FakeVikingClient:
 
     def get(self, path, params=None, **kwargs):
         self.calls.append((path, params or {}))
-        return self.responses[(path, tuple(sorted((params or {}).items())))]
+        response = self.responses[(path, tuple(sorted((params or {}).items())))]
+        if isinstance(response, Exception):
+            raise response
+        return response
 
 
 class TestOpenVikingSummaryUriNormalization:
@@ -67,6 +70,55 @@ class TestOpenVikingRead:
             "/api/v1/content/read",
             {"uri": "viking://user/hermes/memories/profile.md"},
         )]
+
+    def test_overview_file_uri_falls_back_to_content_read_on_summary_error(self):
+        provider = OpenVikingMemoryProvider()
+        file_uri = "viking://user/hermes/memories/entities/mem_abc.md"
+        provider._client = FakeVikingClient(
+            {
+                (
+                    "/api/v1/content/overview",
+                    (("uri", file_uri),),
+                ): RuntimeError("500 Internal Server Error"),
+                (
+                    "/api/v1/content/read",
+                    (("uri", file_uri),),
+                ): {"result": {"content": "fallback full content"}},
+            }
+        )
+
+        result = json.loads(provider._tool_read({"uri": file_uri, "level": "overview"}))
+
+        assert result["uri"] == file_uri
+        assert result["resolved_uri"] == file_uri
+        assert result["level"] == "overview"
+        assert result["fallback"] == "content/read"
+        assert result["content"] == "fallback full content"
+        assert provider._client.calls == [
+            ("/api/v1/content/overview", {"uri": file_uri}),
+            ("/api/v1/content/read", {"uri": file_uri}),
+        ]
+
+    def test_summary_uri_error_does_not_fallback_and_raises(self):
+        provider = OpenVikingMemoryProvider()
+        provider._client = FakeVikingClient(
+            {
+                (
+                    "/api/v1/content/overview",
+                    (("uri", "viking://user/hermes"),),
+                ): RuntimeError("500 Internal Server Error"),
+            }
+        )
+
+        try:
+            provider._tool_read({"uri": "viking://user/hermes/.overview.md", "level": "overview"})
+            assert False, "Expected summary endpoint error to be raised"
+        except RuntimeError:
+            pass
+
+        assert provider._client.calls == [
+            ("/api/v1/content/overview", {"uri": "viking://user/hermes"}),
+        ]
 
 
 class TestOpenVikingBrowse:

--- a/tests/openviking_plugin/test_openviking.py
+++ b/tests/openviking_plugin/test_openviking.py
@@ -1,0 +1,101 @@
+"""Tests for plugins/memory/openviking/__init__.py — URI normalization and payload handling."""
+
+import json
+
+from plugins.memory.openviking import OpenVikingMemoryProvider
+
+
+class FakeVikingClient:
+    def __init__(self, responses):
+        self.responses = responses
+        self.calls = []
+
+    def get(self, path, params=None, **kwargs):
+        self.calls.append((path, params or {}))
+        return self.responses[(path, tuple(sorted((params or {}).items())))]
+
+
+class TestOpenVikingSummaryUriNormalization:
+    def test_normalize_summary_uri_maps_pseudo_files_to_parent_directory(self):
+        assert OpenVikingMemoryProvider._normalize_summary_uri("viking://user/hermes/.overview.md") == "viking://user/hermes"
+        assert OpenVikingMemoryProvider._normalize_summary_uri("viking://resources/.abstract.md") == "viking://resources"
+        assert OpenVikingMemoryProvider._normalize_summary_uri("viking://") == "viking://"
+        assert OpenVikingMemoryProvider._normalize_summary_uri("viking://user/hermes/memories/profile.md") == "viking://user/hermes/memories/profile.md"
+
+
+class TestOpenVikingRead:
+    def test_overview_read_normalizes_uri_and_unwraps_result(self):
+        provider = OpenVikingMemoryProvider()
+        provider._client = FakeVikingClient(
+            {
+                (
+                    "/api/v1/content/overview",
+                    (("uri", "viking://user/hermes"),),
+                ): {"result": {"content": "overview text"}},
+            }
+        )
+
+        result = json.loads(provider._tool_read({"uri": "viking://user/hermes/.overview.md", "level": "overview"}))
+
+        assert result["uri"] == "viking://user/hermes/.overview.md"
+        assert result["resolved_uri"] == "viking://user/hermes"
+        assert result["level"] == "overview"
+        assert result["content"] == "overview text"
+        assert provider._client.calls == [(
+            "/api/v1/content/overview",
+            {"uri": "viking://user/hermes"},
+        )]
+
+    def test_full_read_keeps_original_uri(self):
+        provider = OpenVikingMemoryProvider()
+        provider._client = FakeVikingClient(
+            {
+                (
+                    "/api/v1/content/read",
+                    (("uri", "viking://user/hermes/memories/profile.md"),),
+                ): {"result": "full text"},
+            }
+        )
+
+        result = json.loads(provider._tool_read({"uri": "viking://user/hermes/memories/profile.md", "level": "full"}))
+
+        assert result["uri"] == "viking://user/hermes/memories/profile.md"
+        assert result["resolved_uri"] == "viking://user/hermes/memories/profile.md"
+        assert result["level"] == "full"
+        assert result["content"] == "full text"
+        assert provider._client.calls == [(
+            "/api/v1/content/read",
+            {"uri": "viking://user/hermes/memories/profile.md"},
+        )]
+
+
+class TestOpenVikingBrowse:
+    def test_list_browse_unwraps_and_normalizes_entry_shapes(self):
+        provider = OpenVikingMemoryProvider()
+        provider._client = FakeVikingClient(
+            {
+                (
+                    "/api/v1/fs/ls",
+                    (("uri", "viking://user/hermes"),),
+                ): {
+                    "result": {
+                        "entries": [
+                            {"name": "memories", "uri": "viking://user/hermes/memories", "type": "dir"},
+                            {"rel_path": "profile.md", "uri": "viking://user/hermes/memories/profile.md", "isDir": False, "abstract": "Profile"},
+                        ]
+                    }
+                },
+            }
+        )
+
+        result = json.loads(provider._tool_browse({"action": "list", "path": "viking://user/hermes"}))
+
+        assert result["path"] == "viking://user/hermes"
+        assert result["entries"] == [
+            {"name": "memories", "uri": "viking://user/hermes/memories", "type": "dir", "abstract": ""},
+            {"name": "profile.md", "uri": "viking://user/hermes/memories/profile.md", "type": "file", "abstract": "Profile"},
+        ]
+        assert provider._client.calls == [(
+            "/api/v1/fs/ls",
+            {"uri": "viking://user/hermes"},
+        )]


### PR DESCRIPTION
## Summary
`viking_read` no longer returns 500/412 against live OpenViking servers for file URIs or pseudo-summary URIs.

Salvages @htsh's PR #5886 with its 3 original commits intact, then adds an `fs/stat` pre-check on top — the same idea @pty819 (#12757) and @chennest (#12937) independently arrived at.

## Root cause
OpenViking's `/api/v1/content/abstract` and `/api/v1/content/overview` endpoints are **directory-only**. The plugin was forwarding both pseudo-summary file URIs (`viking://.../.overview.md`) and real file URIs (`mem_*.md`) to them, which the server rejected with HTTP 500 (v0.3.3) / 412 (newer builds).

## Changes
- `plugins/memory/openviking/__init__.py`:
  - Normalize pseudo-summary URIs (`/.overview.md`, `/.abstract.md`, `/.read.md`, `/.full.md`) to parent directory before the request (from #5886)
  - Unwrap `{result: ...}` payloads regardless of shape (from #5886)
  - Harden `browse` parsing for v0.3.3 response drift — `list` vs `dict`, `isDir` vs `is_dir`, missing `name` (from #5886)
  - Per-level truncation tuning — overview 4k, abstract 1.2k, full 8k (from #5886)
  - Exception fallback to `/content/read` on summary-level failure (from #5886)
  - **New:** `_is_directory_uri()` — pre-check via `/api/v1/fs/stat` before a summary request. If the server says it's a file, route straight to `/content/read` and avoid the failing round-trip (idea from #12757 / #12937)
- `tests/openviking_plugin/test_openviking.py`: 9 tests covering URI normalization, pseudo-URI path, stat-probe fast path, stat-probe-unavailable → exception fallback, directory URI via stat, full reads, browse shape handling
- `scripts/release.py` AUTHOR_MAP: credit htsh, pty819, chennest

## Why keep both the pre-check AND the exception fallback
The pre-check (`fs/stat`) is the fast path when the server cooperates — it avoids a failing `/content/overview` round-trip. The exception fallback (#5886's original approach) is the safety net when `fs/stat` is unavailable, returns an unfamiliar shape, or is slower than eating the 500. Keeping both means no regression for any OpenViking version that #5886 already supported.

## Credit
- @htsh (#5886) — pseudo-URI normalization, response unwrapping, v0.3.3 browse hardening, tests. Commits preserved via rebase-merge.
- @pty819 (#12757) and @chennest (#12937) — independently proposed the `fs/stat` pre-check. Wired in here on top of htsh's base.

## Validation
| | Before | After |
|---|---|---|
| `tests/openviking_plugin/` | no tests shipped | 9 passing |
| File URI + `level=overview` | HTTP 500/412 | `fs/stat` → `/content/read` |
| Pseudo `/.overview.md` | HTTP 500 | normalized to dir → `/content/overview` |
| Directory URI + `level=overview` | works | still works (stat → overview) |

Closes #5886
Closes #12757
Closes #12937
Fixes #12755
