### PR TITLE
feat(cli): support multi-select in model picker

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -7569,8 +7569,13 @@ def _prompt_model_selection(
     confirm_provider: str = "",
     confirm_base_url: str = "",
     confirm_api_key: str = "",
-) -> Optional[str]:
-    """Interactive model selection. Puts current_model first with a marker. Returns chosen model ID or None.
+    multi_select: bool = False,
+) -> Optional[str] | list[str]:
+    """Interactively choose one model, or multiple models when requested.
+
+    ``current_model`` is placed first with a marker. The default single-select
+    mode returns a model ID or ``None``. Multi-select mode returns model IDs in
+    deterministic menu order, or ``None`` when cancelled or left empty.
 
     If *pricing* is provided (``{model_id: {prompt, completion}}``), a compact
     price indicator is shown next to each model in aligned columns.
@@ -7605,6 +7610,15 @@ def _prompt_model_selection(
         ):
             return None
         return mid
+
+    def _confirmed_selections(model_ids: list[str]) -> Optional[list[str]]:
+        confirmed: list[str] = []
+        for model_id in model_ids:
+            selected = _confirmed_selection(model_id)
+            if selected is None:
+                return None
+            confirmed.append(selected)
+        return confirmed or None
 
     # Reorder: current model first, then the rest (deduplicated)
     ordered = []
@@ -7718,12 +7732,10 @@ def _prompt_model_selection(
     default_idx = 0
 
     # Build a pricing header hint for the menu title
-    menu_title = "Select default model:"
+    menu_title = "Select model(s):" if multi_select else "Select default model:"
     if has_pricing:
-        # Align the header with the model column.
-        # Each choice is "  {label}" (2 spaces) and we prepend
-        # a 3-char cursor region ("-> " or "   "), so content starts at col 5.
-        pad = " " * 5
+        # Align the header after the curses menu's cursor/selection prefix.
+        pad = " " * (7 if multi_select else 5)
         header = f"\n{pad}{'':>{name_col}} {'In':>{price_col}}  {'Out':>{price_col}}"
         if has_cache:
             header += f"  {'Cache':>{cache_col}}"
@@ -7734,12 +7746,17 @@ def _prompt_model_selection(
             menu_title += "  ★ = on sale"
 
     # Try arrow-key menu first, fall back to number input.
+    # Uses the shared curses menus (ESC/arrow-key handling that works
+    # across terminals, incl. those that emit raw escape sequences) instead
+    # of simple_term_menu, which conflicts with /dev/tty and left ESC/arrow
+    # keys unreliable in the setup model picker.
     try:
-        from hermes_cli.curses_ui import curses_radiolist
+        from hermes_cli.curses_ui import curses_checklist, curses_radiolist
 
         choices = [_label_segments(mid) for mid in ordered]
         choices.append("Enter custom model name")
-        choices.append("Skip (keep current)")
+        if not multi_select:
+            choices.append("Skip (keep current)")
 
         _upgrade_url = (portal_url or DEFAULT_NOUS_PORTAL_URL).rstrip("/")
         unavailable_footer = unavailable_message.strip()
@@ -7776,7 +7793,32 @@ def _prompt_model_selection(
                 label if haystack == mid else f"{label} {haystack}"
             )
         model_search_labels.append("Enter custom model name")
-        model_search_labels.append("Skip (keep current)")
+        if not multi_select:
+            model_search_labels.append("Skip (keep current)")
+
+        if multi_select:
+            chosen = curses_checklist(
+                "Select models (first in menu order becomes default):",
+                choices,
+                selected=set(),
+                cancel_returns=set(),
+                description=description,
+                searchable=True,
+                search_labels=model_search_labels,
+            )
+            if not chosen:
+                return None
+            selected_models = [
+                model_id for idx, model_id in enumerate(ordered) if idx in chosen
+            ]
+            if len(ordered) in chosen:
+                try:
+                    custom = input("Enter model name: ").strip()
+                except (EOFError, KeyboardInterrupt):
+                    return None
+                if custom and custom not in selected_models:
+                    selected_models.append(custom)
+            return _confirmed_selections(selected_models)
 
         idx = curses_radiolist(
             "Select default model:",
@@ -7811,12 +7853,14 @@ def _prompt_model_selection(
             print(line.replace("★", color("★", Colors.YELLOW), 1))
         else:
             print(line)
-    num_width = len(str(len(ordered) + 2))
+    option_count = len(ordered) + (1 if multi_select else 2)
+    num_width = len(str(option_count))
     for i, mid in enumerate(ordered, 1):
         print(f"  {i:>{num_width}}. {format_radio_item_ansi(_label_segments(mid))}")
     n = len(ordered)
     print(f"  {n + 1:>{num_width}}. Enter custom model name")
-    print(f"  {n + 2:>{num_width}}. Skip (keep current)")
+    if not multi_select:
+        print(f"  {n + 2:>{num_width}}. Skip (keep current)")
 
     if _unavailable:
         _upgrade_url = (portal_url or DEFAULT_NOUS_PORTAL_URL).rstrip("/")
@@ -7831,9 +7875,24 @@ def _prompt_model_selection(
 
     while True:
         try:
-            choice = input(f"Choice [1-{n + 2}] (default: skip): ").strip()
+            prompt = (
+                f"Choices [1-{n + 1}, comma-separated] (default: skip): "
+                if multi_select
+                else f"Choice [1-{n + 2}] (default: skip): "
+            )
+            choice = input(prompt).strip()
             if not choice:
                 return None
+            if multi_select:
+                indices = sorted({int(part.strip()) for part in choice.split(",")})
+                if any(idx < 1 or idx > n + 1 for idx in indices):
+                    raise ValueError
+                selected_models = [ordered[idx - 1] for idx in indices if idx <= n]
+                if n + 1 in indices:
+                    custom = input("Enter model name: ").strip()
+                    if custom and custom not in selected_models:
+                        selected_models.append(custom)
+                return _confirmed_selections(selected_models)
             idx = int(choice)
             if 1 <= idx <= n:
                 return _confirmed_selection(ordered[idx - 1])

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -7225,8 +7225,13 @@ def _prompt_model_selection(
     confirm_provider: str = "",
     confirm_base_url: str = "",
     confirm_api_key: str = "",
-) -> Optional[str]:
-    """Interactive model selection. Puts current_model first with a marker. Returns chosen model ID or None.
+    multi_select: bool = False,
+) -> Optional[str] | list[str]:
+    """Interactively choose one model, or multiple models when requested.
+
+    ``current_model`` is placed first with a marker. The default single-select
+    mode returns a model ID or ``None``. Multi-select mode returns model IDs in
+    deterministic menu order, or ``None`` when cancelled or left empty.
 
     If *pricing* is provided (``{model_id: {prompt, completion}}``), a compact
     price indicator is shown next to each model in aligned columns.
@@ -7255,6 +7260,15 @@ def _prompt_model_selection(
         ):
             return None
         return mid
+
+    def _confirmed_selections(model_ids: list[str]) -> Optional[list[str]]:
+        confirmed: list[str] = []
+        for model_id in model_ids:
+            selected = _confirmed_selection(model_id)
+            if selected is None:
+                return None
+            confirmed.append(selected)
+        return confirmed or None
 
     # Reorder: current model first, then the rest (deduplicated)
     ordered = []
@@ -7368,12 +7382,10 @@ def _prompt_model_selection(
     default_idx = 0
 
     # Build a pricing header hint for the menu title
-    menu_title = "Select default model:"
+    menu_title = "Select model(s):" if multi_select else "Select default model:"
     if has_pricing:
-        # Align the header with the model column.
-        # Each choice is "  {label}" (2 spaces) and simple_term_menu prepends
-        # a 3-char cursor region ("-> " or "   "), so content starts at col 5.
-        pad = " " * 5
+        # Align the header after the curses menu's cursor/selection prefix.
+        pad = " " * (7 if multi_select else 5)
         header = f"\n{pad}{'':>{name_col}} {'In':>{price_col}}  {'Out':>{price_col}}"
         if has_cache:
             header += f"  {'Cache':>{cache_col}}"
@@ -7384,16 +7396,17 @@ def _prompt_model_selection(
             menu_title += "  ★ = on sale"
 
     # Try arrow-key menu first, fall back to number input.
-    # Uses the shared curses radiolist (ESC/arrow-key handling that works
+    # Uses the shared curses menus (ESC/arrow-key handling that works
     # across terminals, incl. those that emit raw escape sequences) instead
     # of simple_term_menu, which conflicts with /dev/tty and left ESC/arrow
     # keys unreliable in the setup model picker.
     try:
-        from hermes_cli.curses_ui import curses_radiolist
+        from hermes_cli.curses_ui import curses_checklist, curses_radiolist
 
         choices = [_label_segments(mid) for mid in ordered]
         choices.append("Enter custom model name")
-        choices.append("Skip (keep current)")
+        if not multi_select:
+            choices.append("Skip (keep current)")
 
         _upgrade_url = (portal_url or DEFAULT_NOUS_PORTAL_URL).rstrip("/")
         unavailable_footer = unavailable_message.strip()
@@ -7430,7 +7443,32 @@ def _prompt_model_selection(
                 label if haystack == mid else f"{label} {haystack}"
             )
         model_search_labels.append("Enter custom model name")
-        model_search_labels.append("Skip (keep current)")
+        if not multi_select:
+            model_search_labels.append("Skip (keep current)")
+
+        if multi_select:
+            chosen = curses_checklist(
+                "Select models (first in menu order becomes default):",
+                choices,
+                selected=set(),
+                cancel_returns=set(),
+                description=description,
+                searchable=True,
+                search_labels=model_search_labels,
+            )
+            if not chosen:
+                return None
+            selected_models = [
+                model_id for idx, model_id in enumerate(ordered) if idx in chosen
+            ]
+            if len(ordered) in chosen:
+                try:
+                    custom = input("Enter model name: ").strip()
+                except (EOFError, KeyboardInterrupt):
+                    return None
+                if custom and custom not in selected_models:
+                    selected_models.append(custom)
+            return _confirmed_selections(selected_models)
 
         idx = curses_radiolist(
             "Select default model:",
@@ -7465,12 +7503,14 @@ def _prompt_model_selection(
             print(line.replace("★", color("★", Colors.YELLOW), 1))
         else:
             print(line)
-    num_width = len(str(len(ordered) + 2))
+    option_count = len(ordered) + (1 if multi_select else 2)
+    num_width = len(str(option_count))
     for i, mid in enumerate(ordered, 1):
         print(f"  {i:>{num_width}}. {format_radio_item_ansi(_label_segments(mid))}")
     n = len(ordered)
     print(f"  {n + 1:>{num_width}}. Enter custom model name")
-    print(f"  {n + 2:>{num_width}}. Skip (keep current)")
+    if not multi_select:
+        print(f"  {n + 2:>{num_width}}. Skip (keep current)")
 
     if _unavailable:
         _upgrade_url = (portal_url or DEFAULT_NOUS_PORTAL_URL).rstrip("/")
@@ -7485,9 +7525,24 @@ def _prompt_model_selection(
 
     while True:
         try:
-            choice = input(f"Choice [1-{n + 2}] (default: skip): ").strip()
+            prompt = (
+                f"Choices [1-{n + 1}, comma-separated] (default: skip): "
+                if multi_select
+                else f"Choice [1-{n + 2}] (default: skip): "
+            )
+            choice = input(prompt).strip()
             if not choice:
                 return None
+            if multi_select:
+                indices = sorted({int(part.strip()) for part in choice.split(",")})
+                if any(idx < 1 or idx > n + 1 for idx in indices):
+                    raise ValueError
+                selected_models = [ordered[idx - 1] for idx in indices if idx <= n]
+                if n + 1 in indices:
+                    custom = input("Enter model name: ").strip()
+                    if custom and custom not in selected_models:
+                        selected_models.append(custom)
+                return _confirmed_selections(selected_models)
             idx = int(choice)
             if 1 <= idx <= n:
                 return _confirmed_selection(ordered[idx - 1])

--- a/hermes_cli/curses_ui.py
+++ b/hermes_cli/curses_ui.py
@@ -625,11 +625,14 @@ def _run_curses_menu(
 
 def curses_checklist(
     title: str,
-    items: List[str],
+    items: List[RadioItem],
     selected: Set[int],
     *,
     cancel_returns: Set[int] | None = None,
     status_fn: Optional[Callable[[Set[int]], str]] = None,
+    description: str | None = None,
+    searchable: bool = False,
+    search_labels: List[str] | None = None,
 ) -> Set[int]:
     """Curses multi-select checklist. Returns set of selected indices.
 
@@ -641,42 +644,58 @@ def curses_checklist(
         status_fn: Optional callback ``f(chosen_indices) -> str`` whose return
             value is rendered on the bottom row of the terminal.  Use this for
             live aggregate info (e.g. estimated token counts).
+        description: Optional multi-line text shown between the title and
+            checklist hint.
+        searchable: When true, ``/`` opens a type-to-filter prompt. Selected
+            indices always refer to the original unfiltered item list.
+        search_labels: Optional haystacks for type-to-filter (length must
+            match ``items``). Defaults to the plain display labels.
     """
     if cancel_returns is None:
         cancel_returns = set(selected)
 
     chosen = set(selected)
+    desc_lines = description.splitlines() if description else []
 
-    def _draw_header(stdscr, max_y, max_x):
+    def _draw_header(stdscr, max_y, max_x, search=None):
         import curses
+        row = 0
         try:
             hattr = curses.A_BOLD
             if curses.has_colors():
                 hattr |= curses.color_pair(2)
-            stdscr.addnstr(0, 0, title, max_x - 1, hattr)
-            stdscr.addnstr(
-                1, 0,
-                "  ↑↓ navigate  SPACE toggle  ENTER confirm  ESC cancel",
-                max_x - 1, curses.A_DIM,
-            )
+            stdscr.addnstr(row, 0, title, max_x - 1, hattr)
+            row += 1
+            for dline in desc_lines:
+                if row >= max_y - 1:
+                    break
+                stdscr.addnstr(row, 0, dline, max_x - 1, curses.A_NORMAL)
+                row += 1
+            if searchable and search is not None and search.active:
+                hint = f"  Search: {search.query}▎  BACKSPACE edit  Ctrl+U clear  ESC stop"
+            elif searchable:
+                hint = "  ↑↓ navigate  SPACE toggle  ENTER confirm  / search  ESC cancel"
+            else:
+                hint = "  ↑↓ navigate  SPACE toggle  ENTER confirm  ESC cancel"
+            stdscr.addnstr(row, 0, hint, max_x - 1, curses.A_DIM)
+            row += 1
         except curses.error:
             pass
-        return 3
+        return row + 1
 
     def _draw_row(stdscr, y, i, is_cursor, max_x):
         import curses
         check = "✓" if i in chosen else " "
         arrow = "→" if is_cursor else " "
-        line = f" {arrow} [{check}] {items[i]}"
-        attr = curses.A_NORMAL
-        if is_cursor:
-            attr = curses.A_BOLD
-            if curses.has_colors():
-                attr |= curses.color_pair(1)
+        prefix = f" {arrow} [{check}] "
+        prefix_attr = _curses_style_attr(curses, None, is_cursor=is_cursor)
         try:
-            stdscr.addnstr(y, 0, line, max_x - 1, attr)
+            stdscr.addnstr(y, 0, prefix, max_x - 1, prefix_attr)
         except curses.error:
             pass
+        _draw_radio_item(
+            stdscr, y, len(prefix), items[i], max_x, is_cursor=is_cursor
+        )
 
     def _draw_footer(stdscr, max_y, max_x):
         import curses
@@ -711,6 +730,16 @@ def curses_checklist(
         extra_color_pairs=bool(status_fn),
         fallback=lambda: _numbered_fallback(title, items, selected, cancel_returns, status_fn),
         cancel_value=cancel_returns,
+        searchable=searchable,
+        search_labels=(
+            list(search_labels)
+            if searchable and search_labels is not None
+            else (
+                [radio_item_plain(item) for item in items]
+                if searchable
+                else None
+            )
+        ),
     )
 
 
@@ -962,7 +991,7 @@ def _numbered_single_fallback(
 
 def _numbered_fallback(
     title: str,
-    items: List[str],
+    items: List[RadioItem],
     selected: Set[int],
     cancel_returns: Set[int],
     status_fn: Optional[Callable[[Set[int]], str]] = None,
@@ -975,7 +1004,7 @@ def _numbered_fallback(
     while True:
         for i, label in enumerate(items):
             marker = color("[✓]", Colors.GREEN) if i in chosen else "[ ]"
-            print(f"  {marker} {i + 1:>2}. {label}")
+            print(f"  {marker} {i + 1:>2}. {format_radio_item_ansi(label)}")
         if status_fn:
             status_text = status_fn(chosen)
             if status_text:

--- a/hermes_cli/curses_ui.py
+++ b/hermes_cli/curses_ui.py
@@ -626,11 +626,14 @@ def _run_curses_menu(
 
 def curses_checklist(
     title: str,
-    items: List[str],
+    items: List[RadioItem],
     selected: Set[int],
     *,
     cancel_returns: Set[int] | None = None,
     status_fn: Optional[Callable[[Set[int]], str]] = None,
+    description: str | None = None,
+    searchable: bool = False,
+    search_labels: List[str] | None = None,
 ) -> Set[int]:
     """Curses multi-select checklist. Returns set of selected indices.
 
@@ -642,42 +645,58 @@ def curses_checklist(
         status_fn: Optional callback ``f(chosen_indices) -> str`` whose return
             value is rendered on the bottom row of the terminal.  Use this for
             live aggregate info (e.g. estimated token counts).
+        description: Optional multi-line text shown between the title and
+            checklist hint.
+        searchable: When true, ``/`` opens a type-to-filter prompt. Selected
+            indices always refer to the original unfiltered item list.
+        search_labels: Optional haystacks for type-to-filter (length must
+            match ``items``). Defaults to the plain display labels.
     """
     if cancel_returns is None:
         cancel_returns = set(selected)
 
     chosen = set(selected)
+    desc_lines = description.splitlines() if description else []
 
-    def _draw_header(stdscr, max_y, max_x):
+    def _draw_header(stdscr, max_y, max_x, search=None):
         import curses
+        row = 0
         try:
             hattr = curses.A_BOLD
             if curses.has_colors():
                 hattr |= curses.color_pair(2)
-            stdscr.addnstr(0, 0, title, max_x - 1, hattr)
-            stdscr.addnstr(
-                1, 0,
-                "  ↑↓ navigate  SPACE toggle  ENTER confirm  ESC cancel",
-                max_x - 1, curses.A_DIM,
-            )
+            stdscr.addnstr(row, 0, title, max_x - 1, hattr)
+            row += 1
+            for dline in desc_lines:
+                if row >= max_y - 1:
+                    break
+                stdscr.addnstr(row, 0, dline, max_x - 1, curses.A_NORMAL)
+                row += 1
+            if searchable and search is not None and search.active:
+                hint = f"  Search: {search.query}▎  BACKSPACE edit  Ctrl+U clear  ESC stop"
+            elif searchable:
+                hint = "  ↑↓ navigate  SPACE toggle  ENTER confirm  / search  ESC cancel"
+            else:
+                hint = "  ↑↓ navigate  SPACE toggle  ENTER confirm  ESC cancel"
+            stdscr.addnstr(row, 0, hint, max_x - 1, curses.A_DIM)
+            row += 1
         except curses.error:
             pass
-        return 3
+        return row + 1
 
     def _draw_row(stdscr, y, i, is_cursor, max_x):
         import curses
         check = "✓" if i in chosen else " "
         arrow = "→" if is_cursor else " "
-        line = f" {arrow} [{check}] {items[i]}"
-        attr = curses.A_NORMAL
-        if is_cursor:
-            attr = curses.A_BOLD
-            if curses.has_colors():
-                attr |= curses.color_pair(1)
+        prefix = f" {arrow} [{check}] "
+        prefix_attr = _curses_style_attr(curses, None, is_cursor=is_cursor)
         try:
-            stdscr.addnstr(y, 0, line, max_x - 1, attr)
+            stdscr.addnstr(y, 0, prefix, max_x - 1, prefix_attr)
         except curses.error:
             pass
+        _draw_radio_item(
+            stdscr, y, len(prefix), items[i], max_x, is_cursor=is_cursor
+        )
 
     def _draw_footer(stdscr, max_y, max_x):
         import curses
@@ -712,6 +731,16 @@ def curses_checklist(
         extra_color_pairs=bool(status_fn),
         fallback=lambda: _numbered_fallback(title, items, selected, cancel_returns, status_fn),
         cancel_value=cancel_returns,
+        searchable=searchable,
+        search_labels=(
+            list(search_labels)
+            if searchable and search_labels is not None
+            else (
+                [radio_item_plain(item) for item in items]
+                if searchable
+                else None
+            )
+        ),
     )
 
 
@@ -964,7 +993,7 @@ def _numbered_single_fallback(
 
 def _numbered_fallback(
     title: str,
-    items: List[str],
+    items: List[RadioItem],
     selected: Set[int],
     cancel_returns: Set[int],
     status_fn: Optional[Callable[[Set[int]], str]] = None,
@@ -977,7 +1006,7 @@ def _numbered_fallback(
     while True:
         for i, label in enumerate(items):
             marker = color("[✓]", Colors.GREEN) if i in chosen else "[ ]"
-            print(f"  {marker} {i + 1:>2}. {label}")
+            print(f"  {marker} {i + 1:>2}. {format_radio_item_ansi(label)}")
         if status_fn:
             status_text = status_fn(chosen)
             if status_text:

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -24,6 +24,7 @@ import argparse
 import os
 import subprocess
 import urllib.parse
+from typing import Callable
 
 from hermes_cli.config import clear_model_endpoint_credentials
 from hermes_cli.providers import custom_provider_slug
@@ -175,6 +176,81 @@ def _prompt_auth_credentials_choice(title: str) -> str:
     return "use"
 
 
+def _normalize_model_selection(selection: object) -> list[str]:
+    """Normalize a picker result while preserving its deterministic order."""
+    if selection is None:
+        return []
+    if isinstance(selection, str):
+        value = selection.strip()
+        return [value] if value else []
+    if not isinstance(selection, (list, tuple)):
+        return []
+
+    result: list[str] = []
+    for item in selection:
+        value = str(item or "").strip()
+        if value and value not in result:
+            result.append(value)
+    return result
+
+
+def _append_fallback_models(
+    models: list[str],
+    *,
+    provider: str,
+    base_url: str = "",
+    api_mode: str = "",
+    api_mode_for_model: Callable[[str], str] | None = None,
+) -> int:
+    """Append selected models to the normalized fallback chain in order."""
+    if not models:
+        return 0
+
+    from hermes_cli.config import load_config, save_config
+    from hermes_cli.fallback_config import get_fallback_chain
+
+    cfg = load_config()
+    chain = get_fallback_chain(cfg)
+
+    def _identity(entry: dict) -> tuple[str, str, str]:
+        return (
+            str(entry.get("provider") or "").strip().lower(),
+            str(entry.get("model") or "").strip().lower(),
+            str(entry.get("base_url") or "").strip().rstrip("/").lower(),
+        )
+
+    existing = {_identity(entry) for entry in chain}
+    added = 0
+    normalized_base_url = base_url.strip().rstrip("/")
+    for model_id in models:
+        entry: dict[str, str] = {"provider": provider, "model": model_id}
+        if normalized_base_url:
+            entry["base_url"] = normalized_base_url
+        resolved_api_mode = (
+            api_mode_for_model(model_id) if api_mode_for_model else api_mode
+        )
+        if resolved_api_mode:
+            entry["api_mode"] = resolved_api_mode
+        identity = _identity(entry)
+        if identity in existing:
+            continue
+        chain.append(entry)
+        existing.add(identity)
+        added += 1
+
+    if added:
+        cfg["fallback_providers"] = chain
+        cfg.pop("fallback_model", None)
+        save_config(cfg)
+    return added
+
+
+def _print_fallback_models_added(count: int) -> None:
+    if count:
+        noun = "model" if count == 1 else "models"
+        print(f"Added {count} fallback {noun} from the extra selections.")
+
+
 def _model_flow_openrouter(config, current_model=""):
     """OpenRouter provider: ensure API key, then pick model."""
     from hermes_cli.main import _prompt_api_key
@@ -216,15 +292,17 @@ def _model_flow_openrouter(config, current_model=""):
     # Fetch live pricing (non-blocking — returns empty dict on failure)
     pricing = get_pricing_for_provider("openrouter", force_refresh=True)
 
-    selected = _prompt_model_selection(
+    selected_models = _normalize_model_selection(_prompt_model_selection(
         openrouter_models,
         current_model=current_model,
         pricing=pricing,
         confirm_provider="openrouter",
         confirm_base_url=OPENROUTER_BASE_URL,
         confirm_api_key=_resolved or existing_key,
-    )
-    if selected:
+        multi_select=True,
+    ))
+    if selected_models:
+        selected = selected_models[0]
         _save_model_choice(selected)
 
         # Update config provider and deactivate any OAuth provider
@@ -242,6 +320,14 @@ def _model_flow_openrouter(config, current_model=""):
         save_config(cfg)
         deactivate_provider()
         print(f"Default model set to: {selected} (via OpenRouter)")
+        _print_fallback_models_added(
+            _append_fallback_models(
+                selected_models[1:],
+                provider="openrouter",
+                base_url=OPENROUTER_BASE_URL,
+                api_mode="chat_completions",
+            )
+        )
     else:
         print("No change.")
 
@@ -575,7 +661,7 @@ def _model_flow_nous(config, current_model="", args=None):
         f'Showing {len(model_ids)} curated models — use "Enter custom model name" for others.'
     )
 
-    selected = _prompt_model_selection(
+    selected_models = _normalize_model_selection(_prompt_model_selection(
         model_ids,
         current_model=current_model,
         pricing=pricing,
@@ -585,8 +671,10 @@ def _model_flow_nous(config, current_model="", args=None):
         confirm_provider="nous",
         confirm_base_url=creds.get("base_url", ""),
         confirm_api_key=creds.get("api_key", ""),
-    )
-    if selected:
+        multi_select=True,
+    ))
+    if selected_models:
+        selected = selected_models[0]
         _save_model_choice(selected)
         # Reactivate Nous as the provider and update config
         inference_url = creds.get("base_url", "")
@@ -615,6 +703,13 @@ def _model_flow_nous(config, current_model="", args=None):
             save_env_value("OPENAI_API_KEY", "")
         save_config(config)
         print(f"Default model set to: {selected} (via Nous Portal)")
+        _print_fallback_models_added(
+            _append_fallback_models(
+                selected_models[1:],
+                provider="nous",
+                base_url=inference_url,
+            )
+        )
         # Offer Tool Gateway enablement for paid subscribers
         prompt_enable_tool_gateway(config)
     else:
@@ -694,17 +789,26 @@ def _model_flow_openai_codex(config, current_model=""):
 
     codex_models = get_codex_model_ids(access_token=_codex_token)
 
-    selected = _prompt_model_selection(
+    selected_models = _normalize_model_selection(_prompt_model_selection(
         codex_models,
         current_model=current_model,
         confirm_provider="openai-codex",
         confirm_base_url=DEFAULT_CODEX_BASE_URL,
         confirm_api_key=_codex_token or "",
-    )
-    if selected:
+        multi_select=True,
+    ))
+    if selected_models:
+        selected = selected_models[0]
         _save_model_choice(selected)
         _update_config_for_provider("openai-codex", DEFAULT_CODEX_BASE_URL)
         print(f"Default model set to: {selected} (via OpenAI Codex)")
+        _print_fallback_models_added(
+            _append_fallback_models(
+                selected_models[1:],
+                provider="openai-codex",
+                base_url=DEFAULT_CODEX_BASE_URL,
+            )
+        )
     else:
         print("No change.")
 
@@ -781,11 +885,23 @@ def _model_flow_xai_oauth(_config, current_model="", *, args=None):
         pass
 
     models = provider_model_ids("xai-oauth")
-    selected = _prompt_model_selection(models, current_model=current_model or (models[0] if models else "grok-4.6"))
-    if selected:
+    selected_models = _normalize_model_selection(_prompt_model_selection(
+        models,
+        current_model=current_model or (models[0] if models else "grok-4.6"),
+        multi_select=True,
+    ))
+    if selected_models:
+        selected = selected_models[0]
         _save_model_choice(selected)
         _update_config_for_provider("xai-oauth", base_url)
         print(f"Default model set to: {selected} (via xAI Grok OAuth — SuperGrok / Premium+)")
+        _print_fallback_models_added(
+            _append_fallback_models(
+                selected_models[1:],
+                provider="xai-oauth",
+                base_url=base_url,
+            )
+        )
     else:
         print("No change.")
 
@@ -824,16 +940,25 @@ def _model_flow_qwen_oauth(_config, current_model=""):
         models = list(_DEFAULT_QWEN_PORTAL_MODELS)
 
     default = current_model or (models[0] if models else "qwen3-coder-plus")
-    selected = _prompt_model_selection(
+    selected_models = _normalize_model_selection(_prompt_model_selection(
         models,
         current_model=default,
         confirm_provider="qwen-oauth",
         confirm_base_url=DEFAULT_QWEN_BASE_URL,
-    )
-    if selected:
+        multi_select=True,
+    ))
+    if selected_models:
+        selected = selected_models[0]
         _save_model_choice(selected)
         _update_config_for_provider("qwen-oauth", DEFAULT_QWEN_BASE_URL)
         print(f"Default model set to: {selected} (via Qwen OAuth)")
+        _print_fallback_models_added(
+            _append_fallback_models(
+                selected_models[1:],
+                provider="qwen-oauth",
+                base_url=DEFAULT_QWEN_BASE_URL,
+            )
+        )
     else:
         print("No change.")
 
@@ -878,17 +1003,26 @@ def _model_flow_minimax_oauth(config, current_model="", args=None):
     from hermes_cli.models import _PROVIDER_MODELS
 
     model_ids = _PROVIDER_MODELS.get("minimax-oauth", [])
-    selected = _prompt_model_selection(
+    selected_models = _normalize_model_selection(_prompt_model_selection(
         model_ids,
         current_model,
         confirm_provider="minimax-oauth",
         confirm_base_url=creds["base_url"],
-    )
-    if not selected:
+        multi_select=True,
+    ))
+    if not selected_models:
         return
+    selected = selected_models[0]
     _save_model_choice(selected)
     _update_config_for_provider("minimax-oauth", creds["base_url"])
     print(f"\u2713 Using MiniMax model: {selected}")
+    _print_fallback_models_added(
+        _append_fallback_models(
+            selected_models[1:],
+            provider="minimax-oauth",
+            base_url=creds["base_url"],
+        )
+    )
 
 
 def _model_flow_custom(config):
@@ -1841,28 +1975,32 @@ def _model_flow_copilot(config, current_model=""):
             print('    Use "Enter custom model name" if you do not see your model.')
 
     if model_list:
-        selected = _prompt_model_selection(
+        selection = _prompt_model_selection(
             model_list,
             current_model=normalized_current_model,
             confirm_provider=provider_id,
             confirm_base_url=effective_base,
             confirm_api_key=api_key,
+            multi_select=True,
         )
     else:
         try:
-            selected = input("Model name: ").strip()
+            selection = input("Model name: ").strip()
         except (KeyboardInterrupt, EOFError):
-            selected = None
+            selection = None
 
-    if selected:
-        selected = (
+    selected_models = _normalize_model_selection(selection)
+    if selected_models:
+        selected_models = [
             normalize_copilot_model_id(
-                selected,
+                model_id,
                 catalog=catalog,
                 api_key=api_key,
             )
-            or selected
-        )
+            or model_id
+            for model_id in selected_models
+        ]
+        selected = selected_models[0]
         initial_cfg = load_config()
         current_effort = _current_reasoning_effort(initial_cfg)
         reasoning_efforts = github_model_reasoning_efforts(
@@ -1898,6 +2036,18 @@ def _model_flow_copilot(config, current_model=""):
         deactivate_provider()
 
         print(f"Default model set to: {selected} (via {pconfig.name})")
+        _print_fallback_models_added(
+            _append_fallback_models(
+                selected_models[1:],
+                provider=provider_id,
+                base_url=effective_base,
+                api_mode_for_model=lambda model_id: copilot_model_api_mode(
+                    model_id,
+                    catalog=catalog,
+                    api_key=api_key,
+                ),
+            )
+        )
         if reasoning_efforts:
             if selected_effort == "none":
                 print("Reasoning disabled for this model.")
@@ -1982,31 +2132,35 @@ def _model_flow_copilot_acp(config, current_model=""):
             print('    Use "Enter custom model name" if you do not see your model.')
 
     if model_list:
-        selected = _prompt_model_selection(
+        selection = _prompt_model_selection(
             model_list,
             current_model=normalized_current_model,
             confirm_provider=provider_id,
             confirm_base_url=effective_base,
             confirm_api_key=catalog_api_key,
+            multi_select=True,
         )
     else:
         try:
-            selected = input("Model name: ").strip()
+            selection = input("Model name: ").strip()
         except (KeyboardInterrupt, EOFError):
-            selected = None
+            selection = None
 
-    if not selected:
+    selected_models = _normalize_model_selection(selection)
+    if not selected_models:
         print("No change.")
         return
 
-    selected = (
+    selected_models = [
         normalize_copilot_model_id(
-            selected,
+            model_id,
             catalog=catalog,
             api_key=catalog_api_key,
         )
-        or selected
-    )
+        or model_id
+        for model_id in selected_models
+    ]
+    selected = selected_models[0]
     _save_model_choice(selected)
 
     cfg = load_config()
@@ -2022,6 +2176,14 @@ def _model_flow_copilot_acp(config, current_model=""):
     deactivate_provider()
 
     print(f"Default model set to: {selected} (via {pconfig.name})")
+    _print_fallback_models_added(
+        _append_fallback_models(
+            selected_models[1:],
+            provider=provider_id,
+            base_url=effective_base,
+            api_mode="chat_completions",
+        )
+    )
 
 def _model_flow_kimi(config, current_model=""):
     """Kimi / Moonshot model selection with automatic endpoint routing.
@@ -2080,20 +2242,23 @@ def _model_flow_kimi(config, current_model=""):
     model_list = _PROVIDER_MODELS.get("kimi-coding" if is_coding_plan else "moonshot", [])
 
     if model_list:
-        selected = _prompt_model_selection(
+        selection = _prompt_model_selection(
             model_list,
             current_model=current_model,
             confirm_provider=provider_id,
             confirm_base_url=effective_base,
             confirm_api_key=existing_key,
+            multi_select=True,
         )
     else:
         try:
-            selected = input("Enter model name: ").strip()
+            selection = input("Enter model name: ").strip()
         except (KeyboardInterrupt, EOFError):
-            selected = None
+            selection = None
 
-    if selected:
+    selected_models = _normalize_model_selection(selection)
+    if selected_models:
+        selected = selected_models[0]
         _save_model_choice(selected)
 
         # Update config with provider and base URL
@@ -2111,6 +2276,13 @@ def _model_flow_kimi(config, current_model=""):
 
         endpoint_label = "Kimi Coding" if is_coding_plan else "Moonshot"
         print(f"Default model set to: {selected} (via {endpoint_label})")
+        _print_fallback_models_added(
+            _append_fallback_models(
+                selected_models[1:],
+                provider=provider_id,
+                base_url=effective_base,
+            )
+        )
     else:
         print("No change.")
 
@@ -2193,20 +2365,23 @@ def _model_flow_stepfun(config, current_model=""):
             )
 
     if model_list:
-        selected = _prompt_model_selection(
+        selection = _prompt_model_selection(
             model_list,
             current_model=current_model,
             confirm_provider=provider_id,
             confirm_base_url=effective_base,
             confirm_api_key=existing_key,
+            multi_select=True,
         )
     else:
         try:
-            selected = input("Model name: ").strip()
+            selection = input("Model name: ").strip()
         except (KeyboardInterrupt, EOFError):
-            selected = None
+            selection = None
 
-    if selected:
+    selected_models = _normalize_model_selection(selection)
+    if selected_models:
+        selected = selected_models[0]
         _save_model_choice(selected)
 
         cfg = load_config()
@@ -2223,6 +2398,13 @@ def _model_flow_stepfun(config, current_model=""):
 
         config["model"] = dict(model)
         print(f"Default model set to: {selected} (via {pconfig.name})")
+        _print_fallback_models_added(
+            _append_fallback_models(
+                selected_models[1:],
+                provider=provider_id,
+                base_url=effective_base,
+            )
+        )
     else:
         print("No change.")
 
@@ -2286,20 +2468,23 @@ def _model_flow_bedrock_api_key(config, region, current_model=""):
     print(f"  Showing {len(model_list)} curated models")
 
     if model_list:
-        selected = _prompt_model_selection(
+        selection = _prompt_model_selection(
             model_list,
             current_model=current_model,
             confirm_provider="custom",
             confirm_base_url=mantle_base_url,
             confirm_api_key=existing_key,
+            multi_select=True,
         )
     else:
         try:
-            selected = input("  Model ID: ").strip()
+            selection = input("  Model ID: ").strip()
         except (KeyboardInterrupt, EOFError):
-            selected = None
+            selection = None
 
-    if selected:
+    selected_models = _normalize_model_selection(selection)
+    if selected_models:
+        selected = selected_models[0]
         _save_model_choice(selected)
 
         # Save as custom provider pointing to bedrock-mantle
@@ -2339,6 +2524,13 @@ def _model_flow_bedrock_api_key(config, region, current_model=""):
         deactivate_provider()
 
         print(f"  Default model set to: {selected} (via Bedrock API Key, {region})")
+        _print_fallback_models_added(
+            _append_fallback_models(
+                selected_models[1:],
+                provider="custom",
+                base_url=mantle_base_url,
+            )
+        )
         print(f"  Endpoint: {mantle_base_url}")
     else:
         print("  No change.")
@@ -2510,19 +2702,22 @@ def _model_flow_bedrock(config, current_model=""):
 
     # 4. Model selection
     if model_list:
-        selected = _prompt_model_selection(
+        selection = _prompt_model_selection(
             model_list,
             current_model=current_model,
             confirm_provider="bedrock",
             confirm_base_url=f"https://bedrock-runtime.{region}.amazonaws.com",
+            multi_select=True,
         )
     else:
         try:
-            selected = input("  Model ID: ").strip()
+            selection = input("  Model ID: ").strip()
         except (KeyboardInterrupt, EOFError):
-            selected = None
+            selection = None
 
-    if selected:
+    selected_models = _normalize_model_selection(selection)
+    if selected_models:
+        selected = selected_models[0]
         _save_model_choice(selected)
 
         cfg = load_config()
@@ -2545,6 +2740,13 @@ def _model_flow_bedrock(config, current_model=""):
         deactivate_provider()
 
         print(f"  Default model set to: {selected} (via AWS Bedrock, {region})")
+        _print_fallback_models_added(
+            _append_fallback_models(
+                selected_models[1:],
+                provider="bedrock",
+                base_url=f"https://bedrock-runtime.{region}.amazonaws.com",
+            )
+        )
     else:
         print("  No change.")
 
@@ -2617,14 +2819,16 @@ def _model_flow_vertex(config, current_model=""):
         else f"https://{region}-aiplatform.googleapis.com/v1beta1/projects/<project>/"
         f"locations/{region}/endpoints/openapi"
     )
-    selected = _prompt_model_selection(
+    selected_models = _normalize_model_selection(_prompt_model_selection(
         model_list,
         current_model=current_model,
         confirm_provider="vertex",
         confirm_base_url=base_url_preview,
-    )
+        multi_select=True,
+    ))
 
-    if selected:
+    if selected_models:
+        selected = selected_models[0]
         _save_model_choice(selected)
 
         cfg = load_config()
@@ -2649,6 +2853,12 @@ def _model_flow_vertex(config, current_model=""):
         deactivate_provider()
 
         print(f"  Default model set to: {selected} (via Google Vertex AI, {region})")
+        _print_fallback_models_added(
+            _append_fallback_models(
+                selected_models[1:],
+                provider="vertex",
+            )
+        )
     else:
         print("  No change.")
 
@@ -2983,24 +3193,30 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
             pricing = get_pricing_for_provider(provider_id) or {}
         except Exception:
             pricing = {}
-        selected = _prompt_model_selection(
+        selection = _prompt_model_selection(
             model_list,
             current_model=current_model,
             pricing=pricing,
             confirm_provider=provider_id,
             confirm_base_url=effective_base,
             confirm_api_key=existing_key,
+            multi_select=True,
         )
     else:
         try:
-            selected = input("Model name: ").strip()
+            selection = input("Model name: ").strip()
         except (KeyboardInterrupt, EOFError):
-            selected = None
+            selection = None
 
-    if selected:
+    selected_models = _normalize_model_selection(selection)
+    if selected_models:
         if provider_id in {"opencode-zen", "opencode-go"}:
-            selected = normalize_opencode_model_id(provider_id, selected)
+            selected_models = [
+                normalize_opencode_model_id(provider_id, model_id)
+                for model_id in selected_models
+            ]
 
+        selected = selected_models[0]
         _save_model_choice(selected)
 
         # Update config with provider, base URL, and provider-specific API mode
@@ -3020,6 +3236,18 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
         deactivate_provider()
 
         print(f"Default model set to: {selected} (via {pconfig.name})")
+        _print_fallback_models_added(
+            _append_fallback_models(
+                selected_models[1:],
+                provider=provider_id,
+                base_url=effective_base,
+                api_mode_for_model=(
+                    (lambda model_id: opencode_model_api_mode(provider_id, model_id))
+                    if provider_id in {"opencode-zen", "opencode-go"}
+                    else None
+                ),
+            )
+        )
     else:
         print("No change.")
 
@@ -3141,18 +3369,21 @@ def _model_flow_anthropic(config, current_model=""):
     # Model selection
     model_list = _PROVIDER_MODELS.get("anthropic", [])
     if model_list:
-        selected = _prompt_model_selection(
+        selection = _prompt_model_selection(
             model_list,
             current_model=current_model,
             confirm_provider="anthropic",
+            multi_select=True,
         )
     else:
         try:
-            selected = input("Model name (e.g., claude-sonnet-4-20250514): ").strip()
+            selection = input("Model name (e.g., claude-sonnet-4-20250514): ").strip()
         except (KeyboardInterrupt, EOFError):
-            selected = None
+            selection = None
 
-    if selected:
+    selected_models = _normalize_model_selection(selection)
+    if selected_models:
+        selected = selected_models[0]
         _save_model_choice(selected)
 
         # Update config with provider — clear base_url since
@@ -3171,5 +3402,11 @@ def _model_flow_anthropic(config, current_model=""):
         deactivate_provider()
 
         print(f"Default model set to: {selected} (via Anthropic)")
+        _print_fallback_models_added(
+            _append_fallback_models(
+                selected_models[1:],
+                provider="anthropic",
+            )
+        )
     else:
         print("No change.")

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -24,6 +24,7 @@ import argparse
 import os
 import subprocess
 import urllib.parse
+from typing import Callable
 
 from hermes_cli.config import clear_model_endpoint_credentials
 
@@ -174,6 +175,81 @@ def _prompt_auth_credentials_choice(title: str) -> str:
     return "use"
 
 
+def _normalize_model_selection(selection: object) -> list[str]:
+    """Normalize a picker result while preserving its deterministic order."""
+    if selection is None:
+        return []
+    if isinstance(selection, str):
+        value = selection.strip()
+        return [value] if value else []
+    if not isinstance(selection, (list, tuple)):
+        return []
+
+    result: list[str] = []
+    for item in selection:
+        value = str(item or "").strip()
+        if value and value not in result:
+            result.append(value)
+    return result
+
+
+def _append_fallback_models(
+    models: list[str],
+    *,
+    provider: str,
+    base_url: str = "",
+    api_mode: str = "",
+    api_mode_for_model: Callable[[str], str] | None = None,
+) -> int:
+    """Append selected models to the normalized fallback chain in order."""
+    if not models:
+        return 0
+
+    from hermes_cli.config import load_config, save_config
+    from hermes_cli.fallback_config import get_fallback_chain
+
+    cfg = load_config()
+    chain = get_fallback_chain(cfg)
+
+    def _identity(entry: dict) -> tuple[str, str, str]:
+        return (
+            str(entry.get("provider") or "").strip().lower(),
+            str(entry.get("model") or "").strip().lower(),
+            str(entry.get("base_url") or "").strip().rstrip("/").lower(),
+        )
+
+    existing = {_identity(entry) for entry in chain}
+    added = 0
+    normalized_base_url = base_url.strip().rstrip("/")
+    for model_id in models:
+        entry: dict[str, str] = {"provider": provider, "model": model_id}
+        if normalized_base_url:
+            entry["base_url"] = normalized_base_url
+        resolved_api_mode = (
+            api_mode_for_model(model_id) if api_mode_for_model else api_mode
+        )
+        if resolved_api_mode:
+            entry["api_mode"] = resolved_api_mode
+        identity = _identity(entry)
+        if identity in existing:
+            continue
+        chain.append(entry)
+        existing.add(identity)
+        added += 1
+
+    if added:
+        cfg["fallback_providers"] = chain
+        cfg.pop("fallback_model", None)
+        save_config(cfg)
+    return added
+
+
+def _print_fallback_models_added(count: int) -> None:
+    if count:
+        noun = "model" if count == 1 else "models"
+        print(f"Added {count} fallback {noun} from the extra selections.")
+
+
 def _model_flow_openrouter(config, current_model=""):
     """OpenRouter provider: ensure API key, then pick model."""
     from hermes_cli.main import _prompt_api_key
@@ -215,15 +291,17 @@ def _model_flow_openrouter(config, current_model=""):
     # Fetch live pricing (non-blocking — returns empty dict on failure)
     pricing = get_pricing_for_provider("openrouter", force_refresh=True)
 
-    selected = _prompt_model_selection(
+    selected_models = _normalize_model_selection(_prompt_model_selection(
         openrouter_models,
         current_model=current_model,
         pricing=pricing,
         confirm_provider="openrouter",
         confirm_base_url=OPENROUTER_BASE_URL,
         confirm_api_key=_resolved or existing_key,
-    )
-    if selected:
+        multi_select=True,
+    ))
+    if selected_models:
+        selected = selected_models[0]
         _save_model_choice(selected)
 
         # Update config provider and deactivate any OAuth provider
@@ -241,6 +319,14 @@ def _model_flow_openrouter(config, current_model=""):
         save_config(cfg)
         deactivate_provider()
         print(f"Default model set to: {selected} (via OpenRouter)")
+        _print_fallback_models_added(
+            _append_fallback_models(
+                selected_models[1:],
+                provider="openrouter",
+                base_url=OPENROUTER_BASE_URL,
+                api_mode="chat_completions",
+            )
+        )
     else:
         print("No change.")
 
@@ -574,7 +660,7 @@ def _model_flow_nous(config, current_model="", args=None):
         f'Showing {len(model_ids)} curated models — use "Enter custom model name" for others.'
     )
 
-    selected = _prompt_model_selection(
+    selected_models = _normalize_model_selection(_prompt_model_selection(
         model_ids,
         current_model=current_model,
         pricing=pricing,
@@ -584,8 +670,10 @@ def _model_flow_nous(config, current_model="", args=None):
         confirm_provider="nous",
         confirm_base_url=creds.get("base_url", ""),
         confirm_api_key=creds.get("api_key", ""),
-    )
-    if selected:
+        multi_select=True,
+    ))
+    if selected_models:
+        selected = selected_models[0]
         _save_model_choice(selected)
         # Reactivate Nous as the provider and update config
         inference_url = creds.get("base_url", "")
@@ -614,6 +702,13 @@ def _model_flow_nous(config, current_model="", args=None):
             save_env_value("OPENAI_API_KEY", "")
         save_config(config)
         print(f"Default model set to: {selected} (via Nous Portal)")
+        _print_fallback_models_added(
+            _append_fallback_models(
+                selected_models[1:],
+                provider="nous",
+                base_url=inference_url,
+            )
+        )
         # Offer Tool Gateway enablement for paid subscribers
         prompt_enable_tool_gateway(config)
     else:
@@ -693,17 +788,26 @@ def _model_flow_openai_codex(config, current_model=""):
 
     codex_models = get_codex_model_ids(access_token=_codex_token)
 
-    selected = _prompt_model_selection(
+    selected_models = _normalize_model_selection(_prompt_model_selection(
         codex_models,
         current_model=current_model,
         confirm_provider="openai-codex",
         confirm_base_url=DEFAULT_CODEX_BASE_URL,
         confirm_api_key=_codex_token or "",
-    )
-    if selected:
+        multi_select=True,
+    ))
+    if selected_models:
+        selected = selected_models[0]
         _save_model_choice(selected)
         _update_config_for_provider("openai-codex", DEFAULT_CODEX_BASE_URL)
         print(f"Default model set to: {selected} (via OpenAI Codex)")
+        _print_fallback_models_added(
+            _append_fallback_models(
+                selected_models[1:],
+                provider="openai-codex",
+                base_url=DEFAULT_CODEX_BASE_URL,
+            )
+        )
     else:
         print("No change.")
 
@@ -780,11 +884,23 @@ def _model_flow_xai_oauth(_config, current_model="", *, args=None):
         pass
 
     models = list(_PROVIDER_MODELS.get("xai-oauth") or _PROVIDER_MODELS.get("xai") or [])
-    selected = _prompt_model_selection(models, current_model=current_model or (models[0] if models else "grok-build-0.1"))
-    if selected:
+    selected_models = _normalize_model_selection(_prompt_model_selection(
+        models,
+        current_model=current_model or (models[0] if models else "grok-build-0.1"),
+        multi_select=True,
+    ))
+    if selected_models:
+        selected = selected_models[0]
         _save_model_choice(selected)
         _update_config_for_provider("xai-oauth", base_url)
         print(f"Default model set to: {selected} (via xAI Grok OAuth — SuperGrok / Premium+)")
+        _print_fallback_models_added(
+            _append_fallback_models(
+                selected_models[1:],
+                provider="xai-oauth",
+                base_url=base_url,
+            )
+        )
     else:
         print("No change.")
 
@@ -823,16 +939,25 @@ def _model_flow_qwen_oauth(_config, current_model=""):
         models = list(_DEFAULT_QWEN_PORTAL_MODELS)
 
     default = current_model or (models[0] if models else "qwen3-coder-plus")
-    selected = _prompt_model_selection(
+    selected_models = _normalize_model_selection(_prompt_model_selection(
         models,
         current_model=default,
         confirm_provider="qwen-oauth",
         confirm_base_url=DEFAULT_QWEN_BASE_URL,
-    )
-    if selected:
+        multi_select=True,
+    ))
+    if selected_models:
+        selected = selected_models[0]
         _save_model_choice(selected)
         _update_config_for_provider("qwen-oauth", DEFAULT_QWEN_BASE_URL)
         print(f"Default model set to: {selected} (via Qwen OAuth)")
+        _print_fallback_models_added(
+            _append_fallback_models(
+                selected_models[1:],
+                provider="qwen-oauth",
+                base_url=DEFAULT_QWEN_BASE_URL,
+            )
+        )
     else:
         print("No change.")
 
@@ -877,17 +1002,26 @@ def _model_flow_minimax_oauth(config, current_model="", args=None):
     from hermes_cli.models import _PROVIDER_MODELS
 
     model_ids = _PROVIDER_MODELS.get("minimax-oauth", [])
-    selected = _prompt_model_selection(
+    selected_models = _normalize_model_selection(_prompt_model_selection(
         model_ids,
         current_model,
         confirm_provider="minimax-oauth",
         confirm_base_url=creds["base_url"],
-    )
-    if not selected:
+        multi_select=True,
+    ))
+    if not selected_models:
         return
+    selected = selected_models[0]
     _save_model_choice(selected)
     _update_config_for_provider("minimax-oauth", creds["base_url"])
     print(f"\u2713 Using MiniMax model: {selected}")
+    _print_fallback_models_added(
+        _append_fallback_models(
+            selected_models[1:],
+            provider="minimax-oauth",
+            base_url=creds["base_url"],
+        )
+    )
 
 
 def _model_flow_custom(config):
@@ -1827,28 +1961,32 @@ def _model_flow_copilot(config, current_model=""):
             print('    Use "Enter custom model name" if you do not see your model.')
 
     if model_list:
-        selected = _prompt_model_selection(
+        selection = _prompt_model_selection(
             model_list,
             current_model=normalized_current_model,
             confirm_provider=provider_id,
             confirm_base_url=effective_base,
             confirm_api_key=api_key,
+            multi_select=True,
         )
     else:
         try:
-            selected = input("Model name: ").strip()
+            selection = input("Model name: ").strip()
         except (KeyboardInterrupt, EOFError):
-            selected = None
+            selection = None
 
-    if selected:
-        selected = (
+    selected_models = _normalize_model_selection(selection)
+    if selected_models:
+        selected_models = [
             normalize_copilot_model_id(
-                selected,
+                model_id,
                 catalog=catalog,
                 api_key=api_key,
             )
-            or selected
-        )
+            or model_id
+            for model_id in selected_models
+        ]
+        selected = selected_models[0]
         initial_cfg = load_config()
         current_effort = _current_reasoning_effort(initial_cfg)
         reasoning_efforts = github_model_reasoning_efforts(
@@ -1884,6 +2022,18 @@ def _model_flow_copilot(config, current_model=""):
         deactivate_provider()
 
         print(f"Default model set to: {selected} (via {pconfig.name})")
+        _print_fallback_models_added(
+            _append_fallback_models(
+                selected_models[1:],
+                provider=provider_id,
+                base_url=effective_base,
+                api_mode_for_model=lambda model_id: copilot_model_api_mode(
+                    model_id,
+                    catalog=catalog,
+                    api_key=api_key,
+                ),
+            )
+        )
         if reasoning_efforts:
             if selected_effort == "none":
                 print("Reasoning disabled for this model.")
@@ -1968,31 +2118,35 @@ def _model_flow_copilot_acp(config, current_model=""):
             print('    Use "Enter custom model name" if you do not see your model.')
 
     if model_list:
-        selected = _prompt_model_selection(
+        selection = _prompt_model_selection(
             model_list,
             current_model=normalized_current_model,
             confirm_provider=provider_id,
             confirm_base_url=effective_base,
             confirm_api_key=catalog_api_key,
+            multi_select=True,
         )
     else:
         try:
-            selected = input("Model name: ").strip()
+            selection = input("Model name: ").strip()
         except (KeyboardInterrupt, EOFError):
-            selected = None
+            selection = None
 
-    if not selected:
+    selected_models = _normalize_model_selection(selection)
+    if not selected_models:
         print("No change.")
         return
 
-    selected = (
+    selected_models = [
         normalize_copilot_model_id(
-            selected,
+            model_id,
             catalog=catalog,
             api_key=catalog_api_key,
         )
-        or selected
-    )
+        or model_id
+        for model_id in selected_models
+    ]
+    selected = selected_models[0]
     _save_model_choice(selected)
 
     cfg = load_config()
@@ -2008,6 +2162,14 @@ def _model_flow_copilot_acp(config, current_model=""):
     deactivate_provider()
 
     print(f"Default model set to: {selected} (via {pconfig.name})")
+    _print_fallback_models_added(
+        _append_fallback_models(
+            selected_models[1:],
+            provider=provider_id,
+            base_url=effective_base,
+            api_mode="chat_completions",
+        )
+    )
 
 def _model_flow_kimi(config, current_model=""):
     """Kimi / Moonshot model selection with automatic endpoint routing.
@@ -2066,20 +2228,23 @@ def _model_flow_kimi(config, current_model=""):
     model_list = _PROVIDER_MODELS.get("kimi-coding" if is_coding_plan else "moonshot", [])
 
     if model_list:
-        selected = _prompt_model_selection(
+        selection = _prompt_model_selection(
             model_list,
             current_model=current_model,
             confirm_provider=provider_id,
             confirm_base_url=effective_base,
             confirm_api_key=existing_key,
+            multi_select=True,
         )
     else:
         try:
-            selected = input("Enter model name: ").strip()
+            selection = input("Enter model name: ").strip()
         except (KeyboardInterrupt, EOFError):
-            selected = None
+            selection = None
 
-    if selected:
+    selected_models = _normalize_model_selection(selection)
+    if selected_models:
+        selected = selected_models[0]
         _save_model_choice(selected)
 
         # Update config with provider and base URL
@@ -2097,6 +2262,13 @@ def _model_flow_kimi(config, current_model=""):
 
         endpoint_label = "Kimi Coding" if is_coding_plan else "Moonshot"
         print(f"Default model set to: {selected} (via {endpoint_label})")
+        _print_fallback_models_added(
+            _append_fallback_models(
+                selected_models[1:],
+                provider=provider_id,
+                base_url=effective_base,
+            )
+        )
     else:
         print("No change.")
 
@@ -2179,20 +2351,23 @@ def _model_flow_stepfun(config, current_model=""):
             )
 
     if model_list:
-        selected = _prompt_model_selection(
+        selection = _prompt_model_selection(
             model_list,
             current_model=current_model,
             confirm_provider=provider_id,
             confirm_base_url=effective_base,
             confirm_api_key=existing_key,
+            multi_select=True,
         )
     else:
         try:
-            selected = input("Model name: ").strip()
+            selection = input("Model name: ").strip()
         except (KeyboardInterrupt, EOFError):
-            selected = None
+            selection = None
 
-    if selected:
+    selected_models = _normalize_model_selection(selection)
+    if selected_models:
+        selected = selected_models[0]
         _save_model_choice(selected)
 
         cfg = load_config()
@@ -2209,6 +2384,13 @@ def _model_flow_stepfun(config, current_model=""):
 
         config["model"] = dict(model)
         print(f"Default model set to: {selected} (via {pconfig.name})")
+        _print_fallback_models_added(
+            _append_fallback_models(
+                selected_models[1:],
+                provider=provider_id,
+                base_url=effective_base,
+            )
+        )
     else:
         print("No change.")
 
@@ -2272,20 +2454,23 @@ def _model_flow_bedrock_api_key(config, region, current_model=""):
     print(f"  Showing {len(model_list)} curated models")
 
     if model_list:
-        selected = _prompt_model_selection(
+        selection = _prompt_model_selection(
             model_list,
             current_model=current_model,
             confirm_provider="custom",
             confirm_base_url=mantle_base_url,
             confirm_api_key=existing_key,
+            multi_select=True,
         )
     else:
         try:
-            selected = input("  Model ID: ").strip()
+            selection = input("  Model ID: ").strip()
         except (KeyboardInterrupt, EOFError):
-            selected = None
+            selection = None
 
-    if selected:
+    selected_models = _normalize_model_selection(selection)
+    if selected_models:
+        selected = selected_models[0]
         _save_model_choice(selected)
 
         # Save as custom provider pointing to bedrock-mantle
@@ -2314,6 +2499,13 @@ def _model_flow_bedrock_api_key(config, region, current_model=""):
         deactivate_provider()
 
         print(f"  Default model set to: {selected} (via Bedrock API Key, {region})")
+        _print_fallback_models_added(
+            _append_fallback_models(
+                selected_models[1:],
+                provider="custom",
+                base_url=mantle_base_url,
+            )
+        )
         print(f"  Endpoint: {mantle_base_url}")
     else:
         print("  No change.")
@@ -2485,19 +2677,22 @@ def _model_flow_bedrock(config, current_model=""):
 
     # 4. Model selection
     if model_list:
-        selected = _prompt_model_selection(
+        selection = _prompt_model_selection(
             model_list,
             current_model=current_model,
             confirm_provider="bedrock",
             confirm_base_url=f"https://bedrock-runtime.{region}.amazonaws.com",
+            multi_select=True,
         )
     else:
         try:
-            selected = input("  Model ID: ").strip()
+            selection = input("  Model ID: ").strip()
         except (KeyboardInterrupt, EOFError):
-            selected = None
+            selection = None
 
-    if selected:
+    selected_models = _normalize_model_selection(selection)
+    if selected_models:
+        selected = selected_models[0]
         _save_model_choice(selected)
 
         cfg = load_config()
@@ -2520,6 +2715,13 @@ def _model_flow_bedrock(config, current_model=""):
         deactivate_provider()
 
         print(f"  Default model set to: {selected} (via AWS Bedrock, {region})")
+        _print_fallback_models_added(
+            _append_fallback_models(
+                selected_models[1:],
+                provider="bedrock",
+                base_url=f"https://bedrock-runtime.{region}.amazonaws.com",
+            )
+        )
     else:
         print("  No change.")
 
@@ -2592,14 +2794,16 @@ def _model_flow_vertex(config, current_model=""):
         else f"https://{region}-aiplatform.googleapis.com/v1beta1/projects/<project>/"
         f"locations/{region}/endpoints/openapi"
     )
-    selected = _prompt_model_selection(
+    selected_models = _normalize_model_selection(_prompt_model_selection(
         model_list,
         current_model=current_model,
         confirm_provider="vertex",
         confirm_base_url=base_url_preview,
-    )
+        multi_select=True,
+    ))
 
-    if selected:
+    if selected_models:
+        selected = selected_models[0]
         _save_model_choice(selected)
 
         cfg = load_config()
@@ -2624,6 +2828,12 @@ def _model_flow_vertex(config, current_model=""):
         deactivate_provider()
 
         print(f"  Default model set to: {selected} (via Google Vertex AI, {region})")
+        _print_fallback_models_added(
+            _append_fallback_models(
+                selected_models[1:],
+                provider="vertex",
+            )
+        )
     else:
         print("  No change.")
 
@@ -2958,24 +3168,30 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
             pricing = get_pricing_for_provider(provider_id) or {}
         except Exception:
             pricing = {}
-        selected = _prompt_model_selection(
+        selection = _prompt_model_selection(
             model_list,
             current_model=current_model,
             pricing=pricing,
             confirm_provider=provider_id,
             confirm_base_url=effective_base,
             confirm_api_key=existing_key,
+            multi_select=True,
         )
     else:
         try:
-            selected = input("Model name: ").strip()
+            selection = input("Model name: ").strip()
         except (KeyboardInterrupt, EOFError):
-            selected = None
+            selection = None
 
-    if selected:
+    selected_models = _normalize_model_selection(selection)
+    if selected_models:
         if provider_id in {"opencode-zen", "opencode-go"}:
-            selected = normalize_opencode_model_id(provider_id, selected)
+            selected_models = [
+                normalize_opencode_model_id(provider_id, model_id)
+                for model_id in selected_models
+            ]
 
+        selected = selected_models[0]
         _save_model_choice(selected)
 
         # Update config with provider, base URL, and provider-specific API mode
@@ -2995,6 +3211,18 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
         deactivate_provider()
 
         print(f"Default model set to: {selected} (via {pconfig.name})")
+        _print_fallback_models_added(
+            _append_fallback_models(
+                selected_models[1:],
+                provider=provider_id,
+                base_url=effective_base,
+                api_mode_for_model=(
+                    (lambda model_id: opencode_model_api_mode(provider_id, model_id))
+                    if provider_id in {"opencode-zen", "opencode-go"}
+                    else None
+                ),
+            )
+        )
     else:
         print("No change.")
 
@@ -3116,18 +3344,21 @@ def _model_flow_anthropic(config, current_model=""):
     # Model selection
     model_list = _PROVIDER_MODELS.get("anthropic", [])
     if model_list:
-        selected = _prompt_model_selection(
+        selection = _prompt_model_selection(
             model_list,
             current_model=current_model,
             confirm_provider="anthropic",
+            multi_select=True,
         )
     else:
         try:
-            selected = input("Model name (e.g., claude-sonnet-4-20250514): ").strip()
+            selection = input("Model name (e.g., claude-sonnet-4-20250514): ").strip()
         except (KeyboardInterrupt, EOFError):
-            selected = None
+            selection = None
 
-    if selected:
+    selected_models = _normalize_model_selection(selection)
+    if selected_models:
+        selected = selected_models[0]
         _save_model_choice(selected)
 
         # Update config with provider — clear base_url since
@@ -3146,5 +3377,11 @@ def _model_flow_anthropic(config, current_model=""):
         deactivate_provider()
 
         print(f"Default model set to: {selected} (via Anthropic)")
+        _print_fallback_models_added(
+            _append_fallback_models(
+                selected_models[1:],
+                provider="anthropic",
+            )
+        )
     else:
         print("No change.")

--- a/tests/hermes_cli/test_curses_ui_search.py
+++ b/tests/hermes_cli/test_curses_ui_search.py
@@ -1,9 +1,12 @@
+from unittest.mock import patch
+
 from hermes_cli.curses_ui import (
     _SearchState,
     _filter_indices,
     _handle_active_search_key,
     _move_filtered_cursor,
     _reconcile_cursor,
+    curses_checklist,
 )
 
 
@@ -33,3 +36,40 @@ def test_active_search_consumes_query_editing_and_confirm_keys():
         True,
         False,
     )
+
+
+def test_checklist_search_filters_against_original_item_labels():
+    items = ["model-a", "model-b"]
+
+    with patch("hermes_cli.curses_ui._run_curses_menu", return_value={1}) as run:
+        selected = curses_checklist(
+            "Select models:",
+            items,
+            set(),
+            description="Pricing information",
+            searchable=True,
+        )
+
+    assert selected == {1}
+    assert run.call_args.kwargs["searchable"] is True
+    assert run.call_args.kwargs["search_labels"] == items
+
+
+def test_checklist_search_accepts_rich_items_and_explicit_aliases():
+    items = [
+        [("★ ", "yellow"), ("k3", None), ("  $1/Mtok", "dim")],
+        "model-b",
+    ]
+    search_labels = ["k3 kimi coding", "model-b"]
+
+    with patch("hermes_cli.curses_ui._run_curses_menu", return_value={0}) as run:
+        selected = curses_checklist(
+            "Select models:",
+            items,
+            set(),
+            searchable=True,
+            search_labels=search_labels,
+        )
+
+    assert selected == {0}
+    assert run.call_args.kwargs["search_labels"] == search_labels

--- a/tests/hermes_cli/test_model_multiselect.py
+++ b/tests/hermes_cli/test_model_multiselect.py
@@ -1,0 +1,86 @@
+from unittest.mock import call, patch
+
+
+def test_model_picker_keeps_single_select_contract():
+    from hermes_cli.auth import _prompt_model_selection
+
+    with (
+        patch("hermes_cli.curses_ui.curses_radiolist", return_value=1),
+        patch("hermes_cli.curses_ui.curses_checklist") as checklist,
+    ):
+        selected = _prompt_model_selection(["model-a", "model-b"])
+
+    assert selected == "model-b"
+    checklist.assert_not_called()
+
+
+def test_model_picker_multiselect_uses_menu_order_and_confirms_every_model():
+    from hermes_cli.auth import _prompt_model_selection
+
+    with (
+        patch(
+            "hermes_cli.curses_ui.curses_checklist",
+            return_value={0, 2},
+        ) as checklist,
+        patch(
+            "hermes_cli.auth._confirm_selection_guards",
+            return_value=True,
+        ) as confirm,
+    ):
+        selected = _prompt_model_selection(
+            ["model-a", "model-b", "model-c"],
+            current_model="model-b",
+            confirm_provider="openrouter",
+            confirm_base_url="https://openrouter.ai/api/v1",
+            confirm_api_key="test-key",
+            multi_select=True,
+        )
+
+    # The current model is first in the displayed menu, followed by catalog
+    # order. A set returned by curses therefore still produces stable order.
+    assert selected == ["model-b", "model-c"]
+    assert checklist.call_args.kwargs["searchable"] is True
+    assert checklist.call_args.kwargs["search_labels"] == [
+        "model-b  ← currently in use",
+        "model-a",
+        "model-c",
+        "Enter custom model name",
+    ]
+    confirm.assert_has_calls(
+        [
+            call(
+                "model-b",
+                provider="openrouter",
+                base_url="https://openrouter.ai/api/v1",
+                api_key="test-key",
+                include_kinds=None,
+            ),
+            call(
+                "model-c",
+                provider="openrouter",
+                base_url="https://openrouter.ai/api/v1",
+                api_key="test-key",
+                include_kinds=None,
+            ),
+        ]
+    )
+
+
+def test_model_picker_aborts_group_when_expensive_confirmation_is_declined():
+    from hermes_cli.auth import _prompt_model_selection
+
+    with (
+        patch("hermes_cli.curses_ui.curses_checklist", return_value={0, 1}),
+        patch(
+            "hermes_cli.auth._confirm_selection_guards",
+            side_effect=[True, False],
+        ) as confirm,
+    ):
+        selected = _prompt_model_selection(
+            ["model-a", "model-b"],
+            confirm_provider="openrouter",
+            multi_select=True,
+        )
+
+    assert selected is None
+    assert confirm.call_count == 2

--- a/tests/hermes_cli/test_model_multiselect.py
+++ b/tests/hermes_cli/test_model_multiselect.py
@@ -1,0 +1,84 @@
+from unittest.mock import call, patch
+
+
+def test_model_picker_keeps_single_select_contract():
+    from hermes_cli.auth import _prompt_model_selection
+
+    with (
+        patch("hermes_cli.curses_ui.curses_radiolist", return_value=1),
+        patch("hermes_cli.curses_ui.curses_checklist") as checklist,
+    ):
+        selected = _prompt_model_selection(["model-a", "model-b"])
+
+    assert selected == "model-b"
+    checklist.assert_not_called()
+
+
+def test_model_picker_multiselect_uses_menu_order_and_confirms_every_model():
+    from hermes_cli.auth import _prompt_model_selection
+
+    with (
+        patch(
+            "hermes_cli.curses_ui.curses_checklist",
+            return_value={0, 2},
+        ) as checklist,
+        patch(
+            "hermes_cli.auth._confirm_expensive_model_selection",
+            return_value=True,
+        ) as confirm,
+    ):
+        selected = _prompt_model_selection(
+            ["model-a", "model-b", "model-c"],
+            current_model="model-b",
+            confirm_provider="openrouter",
+            confirm_base_url="https://openrouter.ai/api/v1",
+            confirm_api_key="test-key",
+            multi_select=True,
+        )
+
+    # The current model is first in the displayed menu, followed by catalog
+    # order. A set returned by curses therefore still produces stable order.
+    assert selected == ["model-b", "model-c"]
+    assert checklist.call_args.kwargs["searchable"] is True
+    assert checklist.call_args.kwargs["search_labels"] == [
+        "model-b  ← currently in use",
+        "model-a",
+        "model-c",
+        "Enter custom model name",
+    ]
+    confirm.assert_has_calls(
+        [
+            call(
+                "model-b",
+                provider="openrouter",
+                base_url="https://openrouter.ai/api/v1",
+                api_key="test-key",
+            ),
+            call(
+                "model-c",
+                provider="openrouter",
+                base_url="https://openrouter.ai/api/v1",
+                api_key="test-key",
+            ),
+        ]
+    )
+
+
+def test_model_picker_aborts_group_when_expensive_confirmation_is_declined():
+    from hermes_cli.auth import _prompt_model_selection
+
+    with (
+        patch("hermes_cli.curses_ui.curses_checklist", return_value={0, 1}),
+        patch(
+            "hermes_cli.auth._confirm_expensive_model_selection",
+            side_effect=[True, False],
+        ) as confirm,
+    ):
+        selected = _prompt_model_selection(
+            ["model-a", "model-b"],
+            confirm_provider="openrouter",
+            multi_select=True,
+        )
+
+    assert selected is None
+    assert confirm.call_count == 2

--- a/tests/hermes_cli/test_model_provider_persistence.py
+++ b/tests/hermes_cli/test_model_provider_persistence.py
@@ -6,6 +6,8 @@ isinstance(model, dict)) to silently fail — leaving the provider unset and
 falling back to auto-detection.
 """
 
+import sys
+import types
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -79,6 +81,79 @@ class TestProviderPersistsAfterModelSave:
 
         assert mock_write.call_count == 1
         assert config_path.read_text(encoding="utf-8") == original_text
+
+    def test_openrouter_multi_select_preserves_legacy_fallbacks_in_order(
+        self, config_home, monkeypatch
+    ):
+        """The first choice is primary; normalized old fallbacks precede extras."""
+        import yaml
+
+        from hermes_cli.config import load_config
+        from hermes_cli.model_setup_flows import _model_flow_openrouter
+
+        config_path = config_home / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "model": {"default": "old-model"},
+                    "fallback_providers": [
+                        {"provider": "anthropic", "model": "claude-existing"}
+                    ],
+                    "fallback_model": {
+                        "provider": "openai-api",
+                        "model": "gpt-legacy",
+                    },
+                },
+                sort_keys=False,
+            )
+        )
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test-key")
+
+        fake_main = types.ModuleType("hermes_cli.main")
+        fake_main._prompt_api_key = lambda *_args, **_kwargs: (
+            "sk-or-test-key",
+            False,
+        )
+        monkeypatch.setitem(sys.modules, "hermes_cli.main", fake_main)
+
+        captured = {}
+
+        def _select(_models, **kwargs):
+            captured.update(kwargs)
+            return ["model-a", "model-b", "model-c"]
+
+        with (
+            patch(
+                "hermes_cli.models.model_ids",
+                return_value=["model-a", "model-b", "model-c"],
+            ),
+            patch("hermes_cli.models.get_pricing_for_provider", return_value={}),
+            patch("hermes_cli.auth._prompt_model_selection", side_effect=_select),
+            patch("hermes_cli.auth.deactivate_provider"),
+        ):
+            _model_flow_openrouter(load_config(), "old-model")
+
+        config = yaml.safe_load(config_path.read_text()) or {}
+        assert captured["multi_select"] is True
+        assert config["model"]["default"] == "model-a"
+        assert config["model"]["provider"] == "openrouter"
+        assert config["fallback_providers"] == [
+            {"provider": "anthropic", "model": "claude-existing"},
+            {"provider": "openai-api", "model": "gpt-legacy"},
+            {
+                "provider": "openrouter",
+                "model": "model-b",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_mode": "chat_completions",
+            },
+            {
+                "provider": "openrouter",
+                "model": "model-c",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_mode": "chat_completions",
+            },
+        ]
+        assert "fallback_model" not in config
 
     def test_api_key_provider_saved_when_model_was_string(self, config_home, monkeypatch):
         """_model_flow_api_key_provider must persist the provider even when


### PR DESCRIPTION
## Summary

- add multi-select support to `hermes model` with the shared curses checklist
- keep the first selected model as the primary and append the rest as ordered fallbacks
- port the behavior to the current provider flows in `model_setup_flows.py`
- preserve and normalize existing `fallback_providers` and legacy `fallback_model` entries

## Review fixes

- use `curses_checklist`; do not reintroduce `simple_term_menu`
- leave `main.py` and dashboard `--status` / `--stop` behavior unchanged
- run the current model-selection guards for every selected model
- keep fallback ordering deterministic and retain legacy fallback configuration
- add regression coverage for selection ordering, confirmation, and fallback migration

## Validation

- rebased onto `main` at `4323c67dc`
- `scripts/run_tests.sh` on 10 related model-picker, fallback, guard, and terminal-menu test files — 62 passed
- `python -m ruff check` on all changed Python files
- `python -m py_compile` on all changed Python files
- `git diff --check upstream/main..HEAD`
