### PR TITLE
fix(profiles): reserve "main" + enforce _RESERVED_NAMES in create_profile

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -122,9 +122,13 @@ _DEFAULT_EXPORT_EXCLUDE_ROOT = frozenset({
     "logs",                 # gateway logs
 })
 
-# Names that cannot be used as profile aliases
+# Names that cannot be used as profile aliases or as new-profile names.
+# "main" is reserved because creating a profile literally named "main" would
+# re-introduce #12099 — the resulting `agent:main:*` session-key prefix
+# collides with the default profile's namespace, which is exactly the bug
+# the profile-aware session-key work was meant to fix.
 _RESERVED_NAMES = frozenset({
-    "hermes", "default", "test", "tmp", "root", "sudo",
+    "hermes", "default", "main", "test", "tmp", "root", "sudo",
 })
 
 # Hermes subcommands that cannot be used as profile names/aliases
@@ -422,9 +426,10 @@ def create_profile(
     """
     validate_profile_name(name)
 
-    if name == "default":
+    if name in _RESERVED_NAMES:
         raise ValueError(
-            "Cannot create a profile named 'default' — it is the built-in profile (~/.hermes)."
+            f"Cannot create a profile named {name!r} — it is reserved. "
+            f"Reserved names: {', '.join(sorted(_RESERVED_NAMES))}."
         )
 
     profile_dir = get_profile_dir(name)

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -199,6 +199,59 @@ class TestCreateProfile:
 
 
 # ===================================================================
+# TestReservedNames — regression coverage for the corner-case branch of
+# #12099 in which a user could create a profile literally named "main"
+# (or any other supposedly-reserved name) and re-introduce the original
+# session-key collision because validate_profile_name() only enforced
+# the regex, not _RESERVED_NAMES.
+# ===================================================================
+
+class TestReservedNames:
+    """create_profile() must reject every entry in _RESERVED_NAMES."""
+
+    @pytest.mark.parametrize(
+        "name",
+        ["main", "hermes", "default", "test", "tmp", "root", "sudo"],
+    )
+    def test_reserved_name_rejected(self, profile_env, name):
+        """Each reserved name must raise ValueError before any directory is
+        created.  Without this guard, ``hermes profile create main`` would
+        succeed and silently produce ``agent:main:*`` session keys that
+        collide with the default profile — re-introducing #12099."""
+        with pytest.raises(ValueError, match="reserved"):
+            create_profile(name, no_alias=True)
+
+    def test_reserved_name_error_lists_all_reserved(self, profile_env):
+        """The error message should help the user pick a non-reserved name
+        without forcing them to read the source."""
+        from hermes_cli.profiles import _RESERVED_NAMES
+
+        with pytest.raises(ValueError) as exc_info:
+            create_profile("main", no_alias=True)
+
+        message = str(exc_info.value)
+        # Mentions the offending name and at least a few reserved names so
+        # the user can immediately see what to avoid.
+        assert "'main'" in message
+        for reserved in ("hermes", "default", "main"):
+            assert reserved in message, f"error should list {reserved!r}; got: {message}"
+        assert sorted(_RESERVED_NAMES) == sorted(
+            {"hermes", "default", "main", "test", "tmp", "root", "sudo"}
+        ), "reserved set drift — update this test if intentional"
+
+    def test_reserved_name_creates_no_directory(self, profile_env):
+        """Bug-shaped check: rejection must happen before mkdir, so a failed
+        attempt must not leave an orphan directory that blocks later use of
+        the same name once it stops being reserved."""
+        from hermes_cli.profiles import get_profile_dir
+
+        with pytest.raises(ValueError):
+            create_profile("main", no_alias=True)
+
+        assert not get_profile_dir("main").exists()
+
+
+# ===================================================================
 # TestDeleteProfile
 # ===================================================================
 


### PR DESCRIPTION
Fixes #17879.

## TL;DR

`hermes profile create main` succeeded and produced session keys with the `agent:main:*` prefix — the same prefix the default profile uses — silently re-creating the cross-profile collision that #12099 / the in-flight #12266 fix exists to eliminate. Same hole let `root`, `hermes`, `test`, `tmp`, `sudo` through. `_RESERVED_NAMES` was defined in `hermes_cli/profiles.py` but only consulted by `check_alias_collision()` (wrapper-script creation), not by profile creation itself.

This PR adds `"main"` to `_RESERVED_NAMES` and makes `create_profile()` reject any reserved name with a uniform message.

## Why this is independent of #12266

I noticed this while reviewing #12266 (which is excellent and which I think should land — see #12102 close note). #12266 fixes the **runtime behaviour** of session-key construction so two profiles with different names don't collide. This PR fixes the **input-validation** layer so a user can't ask the runtime to construct a "main"-named profile in the first place. The two fixes are orthogonal and can land in either order:

- After #12266 alone: `hermes profile create main` → `_resolve_session_key_prefix("main")` → `"agent:main"` → collision with default still happens.
- After this PR alone: collision avoided for new profiles, but already-fixed-by-#12266 cases (named profiles) still need #12266's work to disambiguate.
- Together: both vectors closed.

## Diff

```
hermes_cli/profiles.py            | +9 / -4
tests/hermes_cli/test_profiles.py | +53 / -0
```

Net 5 lines of production change.

## Behavior matrix

| Command | Before this PR | After this PR |
| --- | --- | --- |
| `hermes profile create coder` | ✓ created | ✓ created (unchanged) |
| `hermes profile create default` | ✗ "Cannot create… built-in" | ✗ "…reserved. Reserved names: …" |
| `hermes profile create main` | **✓ created (bug)** | ✗ "…reserved" |
| `hermes profile create root` | **✓ created (bug)** | ✗ "…reserved" |
| `hermes profile create hermes` / `test` / `tmp` / `sudo` | **✓ created (bug)** | ✗ "…reserved" |
| `rename_profile`, `set_active_profile`, etc. on a legacy `"main"` profile | works | works (validate_profile_name unchanged) |

## Scope — explicitly NOT changed

- **`validate_profile_name()` stays permissive.** It's called by 8 non-creation paths (`rename`, `delete`, `set_active`, `export`, `import`, `resolve_env`, …). Tightening it would break any user who somehow already has a legacy `"main"` profile on disk — they should still be able to rename or delete it. Only *creating* a new reserved-name profile is what we reject.
- **No change to `_resolve_session_key_prefix` or `build_session_key`.** That layer is #12266's scope and this PR doesn't touch it.
- **No migration of existing `"main"` profiles.** Out of scope; a follow-up could detect and warn at startup, but the realistic exposure is near-zero (you'd have had to deliberately type `hermes profile create main`, which was undocumented).

## Tests

`tests/hermes_cli/test_profiles.py::TestReservedNames` adds 9 cases:

- Parametrised across all 7 reserved names (`main`, `hermes`, `default`, `test`, `tmp`, `root`, `sudo`) — each must raise `ValueError` with `match="reserved"`.
- Error message must name the offending value AND list `hermes`, `default`, `main` so the user can correct without reading source.
- Reserved set drift canary: if someone later changes `_RESERVED_NAMES`, this test fails and forces an intentional update.
- Bug-shaped check: failed creation must not leave an orphan directory.

All 102 existing `tests/hermes_cli/test_profiles.py` cases still pass on this branch (`scripts/run_tests.sh tests/hermes_cli/test_profiles.py`). The legacy `test_default_raises_value_error` continues to pass because the new error message still contains the literal string `"default"`.

## Pre-empted review questions

**Q. Why is the new error message verbose?**  
The reserved set is small (7 names) and listing them is a lot cheaper than making the user grep `profiles.py`. If you'd rather a terser message, happy to drop the list.

**Q. Why parametrise `_RESERVED_NAMES` in tests instead of hardcoding `["main"]`?**  
The bug is that the frozenset existed but wasn't enforced. Parametrising every name pins all seven so a future contributor who adds a new reserved name automatically gets a passing test, and one who removes the enforcement gets a failing one.

**Q. Should `"default"` be removed from `_RESERVED_NAMES` since `validate_profile_name` already special-cases it?**  
No — keeping `"default"` in `_RESERVED_NAMES` makes the *creation*-side rejection uniform (one code path, one message). The `validate_profile_name` special case is for the *non-creation* paths (rename, delete, etc.) where `"default"` is a valid alias for the built-in profile.