### PR TITLE
fix(tests): make test_update_stale_dashboard immune to hermes_cli.main reload

### DIFF
--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -13,6 +13,7 @@ History:
 
 from __future__ import annotations
 
+import importlib
 import os
 import sys
 from unittest.mock import patch, MagicMock, call
@@ -24,6 +25,38 @@ from hermes_cli.main import (
     _kill_stale_dashboard_processes,
     _warn_stale_dashboard_processes,  # back-compat alias
 )
+
+
+@pytest.fixture(autouse=True)
+def _refresh_bindings_against_live_module():
+    """Rebind module-level names to the *current* ``hermes_cli.main``.
+
+    Other tests in the suite (notably ``test_env_loader.py`` and
+    ``test_skills_subparser.py``) reload or delete ``hermes_cli.main`` from
+    ``sys.modules``.  When that happens on the same xdist worker before we
+    run, our top-of-file ``from hermes_cli.main import ...`` bindings end
+    up pointing at the *old* module object.  ``patch(\"hermes_cli.main.X\")``
+    then patches the *new* module, but the function we call still resolves
+    ``_find_stale_dashboard_pids`` via its stale ``__globals__``, so every
+    patch becomes a no-op and the kill path silently returns early.
+
+    Refreshing the bindings (and the patch target) to the live module
+    object — and keeping them consistent — makes the tests immune to
+    ordering within the worker.  The fix lives in the test module because
+    the two pollutants above are load-bearing for their own tests.
+    """
+    global _find_stale_dashboard_pids
+    global _kill_stale_dashboard_processes
+    global _warn_stale_dashboard_processes
+
+    live = sys.modules.get("hermes_cli.main")
+    if live is None:
+        live = importlib.import_module("hermes_cli.main")
+
+    _find_stale_dashboard_pids = live._find_stale_dashboard_pids
+    _kill_stale_dashboard_processes = live._kill_stale_dashboard_processes
+    _warn_stale_dashboard_processes = live._warn_stale_dashboard_processes
+    yield
 
 
 def _ps_line(pid: int, cmd: str) -> str:


### PR DESCRIPTION
## Summary
Six tests in `tests/hermes_cli/test_update_stale_dashboard.py` were failing in CI after #17832 landed. All six patch `hermes_cli.main._find_stale_dashboard_pids` and expect `_kill_stale_dashboard_processes` to do something — instead every patch became a no-op (no signals sent, no output printed).

## Root cause — xdist cross-test pollution
Two other tests reload `hermes_cli.main` on the same xdist worker:

- `test_env_loader.py:85-86` — `sys.modules.pop('hermes_cli.main', None); importlib.import_module('hermes_cli.main')`
- `test_skills_subparser.py:24-25` — `del sys.modules['hermes_cli.main']`

When either runs first on a worker, the top-of-file `from hermes_cli.main import _kill_stale_dashboard_processes` captures a **stale function object** whose `__globals__` points at the old module dict. `patch('hermes_cli.main._find_stale_dashboard_pids', ...)` then patches the NEW module, but the stale function resolves its dependency via its stale `__globals__` → `pids = []` → early return.

## Changes
- `tests/hermes_cli/test_update_stale_dashboard.py`: autouse fixture rebinds the three module-level names (`_find_stale_dashboard_pids`, `_kill_stale_dashboard_processes`, `_warn_stale_dashboard_processes`) to the live `sys.modules['hermes_cli.main']` before each test.

The pollutants in the other two files are load-bearing for their own tests, so fixing it on the consumer side is correct.

## Validation
| | Before | After |
|---|---|---|
| `test_env_loader.py test_update_stale_dashboard.py` (polluted order) | 6 failed, 18 passed | 24 passed |
| `test_skills_subparser.py test_update_stale_dashboard.py` (polluted order) | 6 failed, 14 passed | 20 passed |
| `test_update_stale_dashboard.py` alone (-n 4) | 19 passed | 19 passed |

Reproduced the CI failure locally 1:1 with identical error messages before applying the fix.