### PR TITLE
context_compressor: preserve absolute threshold override across model switches

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1281,6 +1281,18 @@ def init_agent(
     except Exception:
         pass
     compression_enabled = str(_compression_cfg.get("enabled", True)).lower() in {"true", "1", "yes"}
+    try:
+        _threshold_tokens_cfg = _compression_cfg.get("threshold_tokens")
+        compression_threshold_tokens = (
+            int(_threshold_tokens_cfg)
+            if _threshold_tokens_cfg is not None
+            else None
+        )
+        if compression_threshold_tokens is not None and compression_threshold_tokens <= 0:
+            compression_threshold_tokens = None
+    except (TypeError, ValueError):
+        compression_threshold_tokens = None
+    agent._compression_threshold_tokens_config = compression_threshold_tokens
     compression_target_ratio = float(_compression_cfg.get("target_ratio", 0.20))
     compression_protect_last = int(_compression_cfg.get("protect_last_n", 20))
     # protect_first_n is the number of non-system messages to protect at
@@ -1512,6 +1524,7 @@ def init_agent(
             provider=agent.provider,
             api_mode=agent.api_mode,
             abort_on_summary_failure=compression_abort_on_summary_failure,
+            threshold_tokens_override=agent._compression_threshold_tokens_config,
         )
     agent.compression_enabled = compression_enabled
 
@@ -1703,6 +1716,7 @@ def init_agent(
         "compressor_provider": getattr(_cc, "provider", agent.provider),
         "compressor_context_length": _cc.context_length,
         "compressor_threshold_tokens": _cc.threshold_tokens,
+        "compressor_threshold_tokens_override": getattr(_cc, "threshold_tokens_override", None),
     }
     if agent.api_mode == "anthropic_messages":
         agent._primary_runtime.update({

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1045,6 +1045,17 @@ def restore_primary_runtime(agent) -> bool:
             provider=rt["compressor_provider"],
             api_mode=rt.get("compressor_api_mode", ""),
         )
+        if hasattr(cc, "set_threshold_tokens_override"):
+            cc.set_threshold_tokens_override(
+                rt.get("compressor_threshold_tokens_override")
+            )
+        runtime_threshold = rt.get("compressor_threshold_tokens")
+        if (
+            runtime_threshold
+            and hasattr(cc, "apply_runtime_threshold_cap")
+            and runtime_threshold < getattr(cc, "threshold_tokens", runtime_threshold)
+        ):
+            cc.apply_runtime_threshold_cap(runtime_threshold, update_percent=True)
 
         # ── Reset fallback chain for the new turn ──
         agent._fallback_activated = False
@@ -1662,6 +1673,7 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         "compressor_context_length": _cc.context_length if _cc else 0,
         "compressor_api_mode": getattr(_cc, "api_mode", agent.api_mode) if _cc else agent.api_mode,
         "compressor_threshold_tokens": _cc.threshold_tokens if _cc else 0,
+        "compressor_threshold_tokens_override": getattr(_cc, "threshold_tokens_override", None) if _cc else None,
     }
     if api_mode == "anthropic_messages":
         agent._primary_runtime.update({

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -605,6 +605,88 @@ class ContextCompressor(ContextEngine):
     def name(self) -> str:
         return "compressor"
 
+    def _normalize_threshold_tokens_override(
+        self,
+        threshold_tokens_override: Optional[int],
+    ) -> Optional[int]:
+        """Validate an absolute compression threshold override."""
+        if threshold_tokens_override is None:
+            return None
+        try:
+            value = int(threshold_tokens_override)
+        except (TypeError, ValueError):
+            return None
+        if value <= 0:
+            return None
+        return value
+
+    def _recompute_threshold_budget(self) -> None:
+        """Recalculate the active threshold and derived tail budget."""
+        override = getattr(self, "threshold_tokens_override", None)
+        if override is None:
+            threshold_tokens = max(
+                int(self.context_length * self.threshold_percent),
+                MINIMUM_CONTEXT_LENGTH,
+            )
+        else:
+            threshold_tokens = override
+            if self.context_length and threshold_tokens > self.context_length:
+                threshold_tokens = self.context_length
+
+        runtime_cap = getattr(self, "_runtime_threshold_tokens_cap", None)
+        if runtime_cap is not None:
+            threshold_tokens = min(threshold_tokens, runtime_cap)
+
+        self.threshold_tokens = threshold_tokens
+        self.tail_token_budget = int(
+            self.threshold_tokens * self.summary_target_ratio
+        )
+
+    def apply_runtime_threshold_cap(
+        self,
+        threshold_tokens: Optional[int],
+        *,
+        update_percent: bool = False,
+    ) -> None:
+        """Apply a live-session threshold cap without changing user override.
+
+        Auxiliary compression-model feasibility lowering is an operational
+        safety clamp for the active session.  It must survive fallback restore
+        and model updates, but it is not the user's configured absolute
+        ``threshold_tokens_override``.
+        """
+        normalized = self._normalize_threshold_tokens_override(threshold_tokens)
+        self._runtime_threshold_tokens_cap = normalized
+        if normalized is not None and update_percent and self.context_length:
+            self.threshold_percent = normalized / self.context_length
+        self._recompute_threshold_budget()
+
+    def set_threshold_tokens_override(
+        self,
+        threshold_tokens_override: Optional[int],
+        *,
+        update_percent: bool = False,
+    ) -> None:
+        """Persist a session-scoped absolute threshold and refresh budgets.
+
+        The stored override is the user's/configured absolute value.  It may be
+        larger than the current model's context window; in that case only the
+        active ``threshold_tokens`` is clamped by ``_recompute_threshold_budget``
+        so switching back to a larger model can restore the explicit value.
+        """
+        normalized = self._normalize_threshold_tokens_override(
+            threshold_tokens_override
+        )
+        if normalized is None:
+            self.threshold_tokens_override = None
+            self._recompute_threshold_budget()
+            return
+
+        self.threshold_tokens_override = normalized
+        if update_percent and self.context_length:
+            self.threshold_percent = normalized / self.context_length
+        self._recompute_threshold_budget()
+
     def on_session_reset(self) -> None:
         """Reset all per-session state for /new or /reset."""
         super().on_session_reset()
@@ -656,14 +738,9 @@ class ContextCompressor(ContextEngine):
         self.provider = provider
         self.api_mode = api_mode
         self.context_length = context_length
-        self.threshold_tokens = max(
-            int(context_length * self.threshold_percent),
-            MINIMUM_CONTEXT_LENGTH,
-        )
+        self._recompute_threshold_budget()
         # Recalculate token budgets for the new context length so the
         # compressor stays calibrated after a model switch (e.g. 200K → 32K).
-        target_tokens = int(self.threshold_tokens * self.summary_target_ratio)
-        self.tail_token_budget = target_tokens
         self.max_summary_tokens = min(
             int(context_length * 0.05), _SUMMARY_TOKENS_CEILING,
         )
@@ -683,6 +760,7 @@ class ContextCompressor(ContextEngine):
         provider: str = "",
         api_mode: str = "",
         abort_on_summary_failure: bool = False,
+        threshold_tokens_override: int | None = None,
     ):
         self.model = model
         self.base_url = base_url
@@ -690,6 +768,10 @@ class ContextCompressor(ContextEngine):
         self.provider = provider
         self.api_mode = api_mode
         self.threshold_percent = threshold_percent
+        self.threshold_tokens_override = self._normalize_threshold_tokens_override(
+            threshold_tokens_override
+        )
+        self._runtime_threshold_tokens_cap: Optional[int] = None
         self.protect_first_n = protect_first_n
         self.protect_last_n = protect_last_n
         self.summary_target_ratio = max(0.10, min(summary_target_ratio, 0.80))
@@ -705,19 +787,10 @@ class ContextCompressor(ContextEngine):
             config_context_length=config_context_length,
             provider=provider,
         )
-        # Floor: never compress below MINIMUM_CONTEXT_LENGTH tokens even if
-        # the percentage would suggest a lower value.  This prevents premature
-        # compression on large-context models at 50% while keeping the % sane
-        # for models right at the minimum.
-        self.threshold_tokens = max(
-            int(self.context_length * threshold_percent),
-            MINIMUM_CONTEXT_LENGTH,
-        )
         self.compression_count = 0
 
         # Derive token budgets: ratio is relative to the threshold, not total context
-        target_tokens = int(self.threshold_tokens * self.summary_target_ratio)
-        self.tail_token_budget = target_tokens
+        self._recompute_threshold_budget()
         self.max_summary_tokens = min(
             int(self.context_length * 0.05), _SUMMARY_TOKENS_CEILING,
         )

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -176,14 +176,31 @@ def check_compression_model_feasibility(agent: Any) -> None:
             # the raw messages plus a small summarisation instruction.
             old_threshold = threshold
             new_threshold = aux_context
-            agent.context_compressor.threshold_tokens = new_threshold
-            # Keep threshold_percent in sync so future main-model
-            # context_length changes (update_model) re-derive from a
-            # sensible number rather than the original too-high value.
             main_ctx = agent.context_compressor.context_length
-            if main_ctx:
-                agent.context_compressor.threshold_percent = (
-                    new_threshold / main_ctx
+            # This is a runtime safety clamp, not an explicit user/config
+            # absolute-threshold override.  Do not create or mutate
+            # threshold_tokens_override here: that value must continue to mean
+            # "the user's configured absolute threshold" and survive later
+            # model switches/restores unchanged.
+            if hasattr(agent.context_compressor, "apply_runtime_threshold_cap"):
+                agent.context_compressor.apply_runtime_threshold_cap(
+                    new_threshold,
+                    update_percent=True,
+                )
+            else:
+                agent.context_compressor.threshold_tokens = new_threshold
+                if hasattr(agent.context_compressor, "tail_token_budget"):
+                    agent.context_compressor.tail_token_budget = int(
+                        new_threshold
+                        * getattr(agent.context_compressor, "summary_target_ratio", 0.20)
+                    )
+                if main_ctx:
+                    agent.context_compressor.threshold_percent = (
+                        new_threshold / main_ctx
+                    )
+            if isinstance(getattr(agent, "_primary_runtime", None), dict):
+                agent._primary_runtime["compressor_threshold_tokens"] = (
+                    agent.context_compressor.threshold_tokens
                 )
             safe_pct = int((aux_context / main_ctx) * 100) if main_ctx else 50
             # Build human-readable "model (provider)" labels for both

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1143,6 +1143,7 @@ DEFAULT_CONFIG = {
     "compression": {
         "enabled": True,
         "threshold": 0.50,            # compress when context usage exceeds this ratio
+        "threshold_tokens": None,     # optional absolute token threshold; preserved across model switches
         "target_ratio": 0.20,         # fraction of threshold to preserve as recent tail
         "protect_last_n": 20,         # minimum recent messages to keep uncompressed
         "hygiene_hard_message_limit": 400,  # gateway session-hygiene force-compress threshold by message count

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -1083,6 +1083,62 @@ class TestAbortOnSummaryFailure:
         assert len(result) < len(msgs)
 
 
+class TestThresholdTokensOverride:
+    def test_explicit_threshold_tokens_override_is_honored(self):
+        with patch("agent.context_compressor.get_model_context_length", return_value=200_000):
+            c = ContextCompressor(
+                model="test",
+                threshold_percent=0.50,
+                threshold_tokens_override=180_000,
+                quiet_mode=True,
+            )
+
+        assert c.threshold_tokens_override == 180_000
+        assert c.threshold_tokens == 180_000
+        assert c.tail_token_budget == int(180_000 * c.summary_target_ratio)
+        assert c.should_compress(179_999) is False
+        assert c.should_compress(180_000) is True
+
+    def test_explicit_threshold_tokens_override_survives_model_update(self):
+        with patch("agent.context_compressor.get_model_context_length", return_value=200_000):
+            c = ContextCompressor(
+                model="test",
+                threshold_percent=0.50,
+                threshold_tokens_override=180_000,
+                quiet_mode=True,
+            )
+
+        c.update_model("smaller", context_length=128_000)
+
+        assert c.threshold_tokens_override == 180_000
+        assert c.threshold_tokens == 128_000
+        assert c.tail_token_budget == int(128_000 * c.summary_target_ratio)
+
+        c.update_model("larger", context_length=200_000)
+
+        assert c.threshold_tokens_override == 180_000
+        assert c.threshold_tokens == 180_000
+        assert c.tail_token_budget == int(180_000 * c.summary_target_ratio)
+
+    def test_set_threshold_tokens_override_clamps_active_threshold_only(self):
+        with patch("agent.context_compressor.get_model_context_length", return_value=128_000):
+            c = ContextCompressor(
+                model="small",
+                threshold_percent=0.50,
+                threshold_tokens_override=180_000,
+                quiet_mode=True,
+            )
+
+        assert c.threshold_tokens_override == 180_000
+        assert c.threshold_tokens == 128_000
+        assert c.tail_token_budget == int(128_000 * c.summary_target_ratio)
+
+        c.update_model("large", context_length=200_000)
+
+        assert c.threshold_tokens_override == 180_000
+        assert c.threshold_tokens == 180_000
+
+
 class TestSummaryPrefixNormalization:
     def test_legacy_prefix_is_replaced(self):
         summary = ContextCompressor._with_summary_prefix("[CONTEXT SUMMARY]: did work")

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -31,6 +31,7 @@ def _make_agent(
     compression_enabled: bool = True,
     threshold_percent: float = 0.50,
     main_context: int = 200_000,
+    threshold_tokens_override: int | None = None,
 ) -> AIAgent:
     """Build a minimal AIAgent with a compressor, skipping __init__."""
     agent = AIAgent.__new__(AIAgent)
@@ -56,7 +57,18 @@ def _make_agent(
 
     compressor = MagicMock(spec=ContextCompressor)
     compressor.context_length = main_context
+    compressor.threshold_percent = threshold_percent
+    compressor.summary_target_ratio = 0.20
     compressor.threshold_tokens = int(main_context * threshold_percent)
+    compressor.threshold_tokens_override = threshold_tokens_override
+
+    def _apply_runtime_threshold_cap(threshold_tokens, *, update_percent=False):
+        compressor.threshold_tokens = threshold_tokens
+        compressor._runtime_threshold_tokens_cap = threshold_tokens
+        if update_percent and compressor.context_length:
+            compressor.threshold_percent = threshold_tokens / compressor.context_length
+
+    compressor.apply_runtime_threshold_cap.side_effect = _apply_runtime_threshold_cap
     agent.context_compressor = compressor
 
     return agent
@@ -96,6 +108,31 @@ def test_auto_corrects_threshold_when_aux_context_below_threshold(mock_get_clien
     assert agent._compression_warning is not None
     # Threshold on the live compressor was actually lowered to aux_context.
     assert agent.context_compressor.threshold_tokens == 80_000
+    assert agent.context_compressor.threshold_tokens_override is None
+    agent.context_compressor.set_threshold_tokens_override.assert_not_called()
+
+
+@patch("agent.model_metadata.get_model_context_length", return_value=80_000)
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_auto_correct_does_not_mutate_explicit_threshold_override(mock_get_client, mock_ctx_len):
+    """Aux-model feasibility lowering is a runtime clamp, not a stored override."""
+    agent = _make_agent(
+        main_context=200_000,
+        threshold_percent=0.50,
+        threshold_tokens_override=100_000,
+    )
+    mock_client = MagicMock()
+    mock_client.base_url = "https://openrouter.ai/api/v1"
+    mock_client.api_key = "sk-aux"
+    mock_get_client.return_value = (mock_client, "google/gemini-3-flash-preview")
+
+    agent._emit_status = lambda msg: None
+
+    agent._check_compression_model_feasibility()
+
+    assert agent.context_compressor.threshold_tokens == 80_000
+    assert agent.context_compressor.threshold_tokens_override == 100_000
+    agent.context_compressor.set_threshold_tokens_override.assert_not_called()
 
 
 @patch("agent.model_metadata.get_model_context_length", return_value=32_768)

--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -6,7 +6,7 @@ from run_agent import AIAgent
 from agent.context_compressor import ContextCompressor
 
 
-def _make_agent_with_compressor(config_context_length=None) -> AIAgent:
+def _make_agent_with_compressor(config_context_length=None, threshold_tokens_override=None) -> AIAgent:
     """Build a minimal AIAgent with a context_compressor, skipping __init__."""
     agent = AIAgent.__new__(AIAgent)
 
@@ -31,6 +31,7 @@ def _make_agent_with_compressor(config_context_length=None) -> AIAgent:
         provider="openrouter",
         quiet_mode=True,
         config_context_length=config_context_length,
+        threshold_tokens_override=threshold_tokens_override,
     )
     agent.context_compressor = compressor
 
@@ -73,3 +74,79 @@ def test_switch_model_without_config_context_length():
         mock_ctx_len.assert_called_once()
         call_kwargs = mock_ctx_len.call_args.kwargs
         assert call_kwargs.get("config_context_length") is None
+
+
+def test_switch_model_preserves_threshold_tokens_override():
+    """Absolute compression thresholds should not be re-derived on model switch."""
+    agent = _make_agent_with_compressor(
+        config_context_length=None,
+        threshold_tokens_override=80_000,
+    )
+
+    with patch("agent.model_metadata.get_model_context_length", return_value=200_000):
+        agent.switch_model(
+            "new-model",
+            "openrouter",
+            api_key="sk-new",
+            base_url="https://openrouter.ai/api/v1",
+        )
+
+    compressor = getattr(agent, "context_compressor")
+    assert compressor.threshold_tokens_override == 80_000
+    assert compressor.threshold_tokens == 80_000
+
+
+def test_switch_model_clamps_active_threshold_but_preserves_stored_override():
+    agent = _make_agent_with_compressor(
+        config_context_length=None,
+        threshold_tokens_override=180_000,
+    )
+
+    with patch("agent.model_metadata.get_model_context_length", return_value=128_000):
+        agent.switch_model(
+            "small-model",
+            "openrouter",
+            api_key="sk-new",
+            base_url="https://openrouter.ai/api/v1",
+        )
+
+    compressor = getattr(agent, "context_compressor")
+    assert compressor.threshold_tokens_override == 180_000
+    assert compressor.threshold_tokens == 128_000
+
+
+def test_restore_primary_runtime_restores_explicit_threshold_override_only():
+    agent = _make_agent_with_compressor(
+        config_context_length=None,
+        threshold_tokens_override=180_000,
+    )
+    agent._create_openai_client = MagicMock(return_value=MagicMock())
+    agent._fallback_activated = True
+    agent._fallback_index = 1
+    agent._primary_runtime = {
+        "model": "primary-model",
+        "provider": "openrouter",
+        "base_url": "https://openrouter.ai/api/v1",
+        "api_mode": "chat_completions",
+        "api_key": "sk-primary",
+        "client_kwargs": {"api_key": "sk-primary", "base_url": "https://openrouter.ai/api/v1"},
+        "use_prompt_caching": False,
+        "use_native_cache_layout": False,
+        "compressor_model": "primary-model",
+        "compressor_base_url": "https://openrouter.ai/api/v1",
+        "compressor_api_key": "sk-primary",
+        "compressor_provider": "openrouter",
+        "compressor_context_length": 128_000,
+        "compressor_api_mode": "chat_completions",
+        "compressor_threshold_tokens": 80_000,
+        "compressor_threshold_tokens_override": 180_000,
+    }
+
+    agent.context_compressor.threshold_tokens = 80_000
+    agent.context_compressor.threshold_percent = 0.625
+
+    assert agent._restore_primary_runtime() is True
+
+    compressor = getattr(agent, "context_compressor")
+    assert compressor.threshold_tokens_override == 180_000
+    assert compressor.threshold_tokens == 80_000


### PR DESCRIPTION
## Summary
- Add `compression.threshold_tokens` as an explicit absolute compression threshold override.
- Preserve that user-configured absolute threshold across model switches, fallback restore, and context-length changes.
- Keep runtime auxiliary compression feasibility lowering separate from the stored user override.

## Implementation
- `ContextCompressor` stores the user/config absolute value in `threshold_tokens_override`.
- Active threshold is clamped to the current model context without losing the stored override, so switching back to a larger model can restore the intended threshold.
- Auxiliary compression-model feasibility lowering now uses a live-session runtime cap instead of mutating the stored override.
- The runtime cap survives primary-runtime restore/model updates, but does not become user configuration.

## Compatibility / review scope
- Existing ratio-based threshold behavior remains compatible when no absolute override is configured.
- This PR stays independent of the gateway/delegation PRs and only covers context-compressor threshold semantics.
- Current GitHub checks are green (success/skipped only).

## Testing
- `/Users/fanxuxin/.hermes/hermes-agent/venv/bin/python -m pytest -o 'addopts=' tests/agent/test_context_compressor.py tests/run_agent/test_switch_model_context.py tests/run_agent/test_compression_feasibility.py -q` — 116 passed
- `py_compile` for touched runtime/config/test files — passed
- Independent re-review verified explicit override preservation, runtime cap restore, and auxiliary feasibility semantics; no P0/P1/P2 issues.
