### PR TITLE
fix(anthropic): strip thinking blocks from all assistant turns to prevent stale signature HTTP 400 (#17861)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1636,12 +1636,6 @@ def convert_messages_to_anthropic(
         or _is_deepseek_anthropic_endpoint(base_url)
     )
 
-    last_assistant_idx = None
-    for i in range(len(result) - 1, -1, -1):
-        if result[i].get("role") == "assistant":
-            last_assistant_idx = i
-            break
-
     for idx, m in enumerate(result):
         if m.get("role") != "assistant" or not isinstance(m.get("content"), list):
             continue
@@ -1664,38 +1658,21 @@ def convert_messages_to_anthropic(
                 # keep it: the upstream needs it for message-history validation.
                 new_content.append(b)
             m["content"] = new_content or [{"type": "text", "text": "(empty)"}]
-        elif _is_third_party or idx != last_assistant_idx:
-            # Third-party endpoint: strip ALL thinking blocks from every
-            # assistant message — signatures are Anthropic-proprietary.
-            # Direct Anthropic: strip from non-latest assistant messages only.
+        else:
+            # Strip ALL thinking/redacted_thinking blocks from every
+            # assistant message — including the latest turn on direct
+            # Anthropic.  Previously we preserved signed blocks on the
+            # latest turn for reasoning continuity, but persisted blocks
+            # can have stale signatures after session serialisation,
+            # context compression, or message truncation, causing
+            # HTTP 400 on multi-turn sessions (#17861).  Anthropic
+            # explicitly allows omitting thinking blocks — the model
+            # re-thinks from scratch.
             stripped = [
                 b for b in m["content"]
                 if not (isinstance(b, dict) and b.get("type") in _THINKING_TYPES)
             ]
             m["content"] = stripped or [{"type": "text", "text": "(thinking elided)"}]
-        else:
-            # Latest assistant on direct Anthropic: keep signed thinking
-            # blocks for reasoning continuity; downgrade unsigned ones to
-            # plain text.
-            new_content = []
-            for b in m["content"]:
-                if not isinstance(b, dict) or b.get("type") not in _THINKING_TYPES:
-                    new_content.append(b)
-                    continue
-                if b.get("type") == "redacted_thinking":
-                    # Redacted blocks use 'data' for the signature payload
-                    if b.get("data"):
-                        new_content.append(b)
-                    # else: drop — no data means it can't be validated
-                elif b.get("signature"):
-                    # Signed thinking block — keep it
-                    new_content.append(b)
-                else:
-                    # Unsigned thinking — downgrade to text so it's not lost
-                    thinking_text = b.get("thinking", "")
-                    if thinking_text:
-                        new_content.append({"type": "text", "text": thinking_text})
-            m["content"] = new_content or [{"type": "text", "text": "(empty)"}]
 
         # Strip cache_control from any remaining thinking/redacted_thinking
         # blocks — cache markers interfere with signature validation.

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -833,10 +833,10 @@ class TestConvertMessages:
         _, result = convert_messages_to_anthropic(messages)
         assistant_blocks = next(msg for msg in result if msg["role"] == "assistant")["content"]
 
-        assert assistant_blocks[0]["type"] == "thinking"
-        assert assistant_blocks[0]["thinking"] == "Need to inspect the tool result first."
-        assert assistant_blocks[0]["signature"] == "sig_123"
-        assert assistant_blocks[1]["type"] == "tool_use"
+        # After #17861 fix: thinking blocks are stripped from ALL assistant
+        # turns (including latest) to avoid stale signature HTTP 400 errors.
+        assert not any(b.get("type") == "thinking" for b in assistant_blocks)
+        assert any(b.get("type") == "tool_use" for b in assistant_blocks)
 
     def test_converts_data_url_image_to_anthropic_image_block(self):
         messages = [
@@ -1453,8 +1453,8 @@ class TestRoleAlternation:
 
 
 class TestThinkingBlockSignatureManagement:
-    """Tests for the thinking block handling strategy:
-    strip from old turns, preserve latest signed, downgrade unsigned."""
+    """Tests for the thinking block handling strategy (#17861):
+    strip thinking blocks from ALL assistant turns to avoid stale signature errors."""
 
     def test_thinking_stripped_from_non_last_assistant(self):
         """Thinking blocks are removed from all assistant messages except the last."""
@@ -1494,15 +1494,14 @@ class TestThinkingBlockSignatureManagement:
         assert "redacted_thinking" not in first_types
         assert "tool_use" in first_types  # tool_use should survive
 
-        # Last assistant: thinking block preserved with signature
-        last_blocks = assistants[1]["content"]
-        thinking_blocks = [b for b in last_blocks if b.get("type") == "thinking"]
-        assert len(thinking_blocks) == 1
-        assert thinking_blocks[0]["thinking"] == "Latest reasoning."
-        assert thinking_blocks[0]["signature"] == "sig_new"
+        # Last assistant: thinking blocks also stripped (#17861)
+        last_types = [b.get("type") for b in assistants[1]["content"]]
+        assert "thinking" not in last_types
+        assert "redacted_thinking" not in last_types
+        assert "tool_use" in last_types
 
-    def test_signed_thinking_preserved_on_last_turn(self):
-        """A signed thinking block on the last assistant message is kept."""
+    def test_signed_thinking_stripped_on_last_turn(self):
+        """Signed thinking blocks are stripped even from the last assistant (#17861)."""
         messages = [
             {
                 "role": "assistant",
@@ -1514,19 +1513,18 @@ class TestThinkingBlockSignatureManagement:
         ]
         _, result = convert_messages_to_anthropic(messages)
         blocks = result[0]["content"]
-        thinking = [b for b in blocks if b.get("type") == "thinking"]
-        assert len(thinking) == 1
-        assert thinking[0]["signature"] == "sig_valid"
+        assert not any(b.get("type") == "thinking" for b in blocks)
+        # Text content preserved
+        assert any(b.get("text") == "The answer is 42." for b in blocks if isinstance(b, dict))
 
-    def test_unsigned_thinking_downgraded_to_text_on_last_turn(self):
-        """Unsigned thinking blocks on the last turn become text blocks."""
+    def test_unsigned_thinking_stripped_on_last_turn(self):
+        """Unsigned thinking blocks on the last turn are stripped (#17861)."""
         messages = [
             {
                 "role": "assistant",
                 "content": "Response text.",
                 "reasoning_details": [
                     {"type": "thinking", "thinking": "Unsigned reasoning."},
-                    # No 'signature' field
                 ],
             },
         ]
@@ -1535,12 +1533,12 @@ class TestThinkingBlockSignatureManagement:
 
         # No thinking blocks should remain
         assert not any(b.get("type") == "thinking" for b in blocks)
-        # The reasoning text should be preserved as a text block
+        # Response text preserved
         text_contents = [b.get("text", "") for b in blocks if b.get("type") == "text"]
-        assert "Unsigned reasoning." in text_contents
+        assert "Response text." in text_contents
 
-    def test_redacted_thinking_with_data_preserved(self):
-        """Redacted thinking with 'data' field is kept on last turn."""
+    def test_redacted_thinking_with_data_stripped(self):
+        """Redacted thinking with 'data' is stripped from all turns (#17861)."""
         messages = [
             {
                 "role": "assistant",
@@ -1552,9 +1550,7 @@ class TestThinkingBlockSignatureManagement:
         ]
         _, result = convert_messages_to_anthropic(messages)
         blocks = result[0]["content"]
-        redacted = [b for b in blocks if b.get("type") == "redacted_thinking"]
-        assert len(redacted) == 1
-        assert redacted[0]["data"] == "opaque_signature_data"
+        assert not any(b.get("type") == "redacted_thinking" for b in blocks)
 
     def test_redacted_thinking_without_data_dropped(self):
         """Redacted thinking without 'data' is dropped — can't be validated."""
@@ -1622,11 +1618,9 @@ class TestThinkingBlockSignatureManagement:
         assistants = [m for m in result if m["role"] == "assistant"]
         assert len(assistants) == 1
 
-        # Only the first thinking block should remain (signed, on the last/only assistant)
+        # All thinking blocks stripped from merged assistant (#17861)
         blocks = assistants[0]["content"]
-        thinking = [b for b in blocks if b.get("type") == "thinking"]
-        assert len(thinking) == 1
-        assert thinking[0]["thinking"] == "First thought."
+        assert not any(b.get("type") == "thinking" for b in blocks)
 
     def test_empty_content_after_strip_gets_placeholder(self):
         """If stripping thinking leaves an empty message, a placeholder is added."""
@@ -1690,13 +1684,12 @@ class TestThinkingBlockSignatureManagement:
                 if isinstance(b, dict)
             )
 
-        # Last one: thinking preserved
-        last_thinking = [
-            b for b in assistants[2]["content"]
-            if isinstance(b, dict) and b.get("type") == "thinking"
-        ]
-        assert len(last_thinking) == 1
-        assert last_thinking[0]["signature"] == "sig_3"
+        # Last one: also stripped (#17861)
+        assert not any(
+            b.get("type") in ("thinking", "redacted_thinking")
+            for b in assistants[2]["content"]
+            if isinstance(b, dict)
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #17861 — multi-turn extended-thinking sessions (Discord, Telegram, long CLI) crash with HTTP 400 "Invalid signature in thinking block" because persisted thinking blocks accumulate stale signatures after session serialisation, context compression, or message truncation.

## Root Cause

`convert_messages_to_anthropic()` preserved signed `thinking`/`redacted_thinking` blocks on the latest assistant turn for reasoning continuity. But Anthropic signs these blocks against the full turn content — any upstream mutation (compression, truncation, merging) invalidates the signature, causing HTTP 400 on the next API call.

## Fix (Option A from the issue)

Strip ALL `thinking`/`redacted_thinking` blocks from every assistant message — including the latest turn — when targeting direct Anthropic endpoints. Anthropic explicitly allows omitting thinking blocks; the model re-thinks from scratch.

**Trade-off:** No cross-turn reasoning continuity (model re-thinks each turn). This was already unreliable due to the signature invalidation issue, so practical impact is minimal.

## Changes

- `agent/anthropic_adapter.py`: Unified the thinking block stripping to apply to ALL assistant turns on direct Anthropic (previously only non-latest were stripped). Removed the now-unused `last_assistant_idx` variable. The Kimi/DeepSeek unsigned-thinking preservation path is unchanged.
- `tests/agent/test_anthropic_adapter.py`: Updated 7 tests in `TestThinkingBlockSignatureManagement` and 1 in `TestConvertMessages` to reflect the new strip-all behavior.

## Testing

- All 120 non-OAuth anthropic adapter tests pass
- All 14 thinking-specific tests pass
- Kimi/DeepSeek endpoint behavior unchanged (unsigned blocks still preserved)

## Impact

- Extended thinking sessions on multi-turn platforms (Discord/Telegram gateway, long CLI) no longer accumulate invalid signatures
- Sessions no longer become unrecoverable after several turns
- The runtime signature recovery path in `run_agent.py` (strip `reasoning_details` on 400) remains as a safety net but should no longer be needed