### PR TITLE
fix(model_switch): prevent bare 'custom' slug in model.provider (#17478)

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1501,7 +1501,14 @@ def list_authenticated_providers(
                     current_base_url
                     and api_url == current_base_url.strip().rstrip("/")
                 ):
-                    slug = current_provider or custom_provider_slug(display_name)
+                    # Guard against bare "custom" slug left by a prior
+                    # failed switch — always resolve to the canonical
+                    # custom:<name> form.  (GH #17478)
+                    slug = (
+                        current_provider
+                        if current_provider and current_provider != "custom"
+                        else custom_provider_slug(display_name)
+                    )
                 else:
                     slug = custom_provider_slug(display_name)
                 groups[group_key] = {

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -585,6 +585,12 @@ def resolve_custom_provider(
     if not requested:
         return None
 
+    # If the stored provider is the bare string "custom" (corrupt state
+    # from a prior model-switch bug), fall back to the first custom
+    # provider entry so existing configs self-heal.  (GH #17478)
+    bare_custom_fallback = requested == "custom"
+    first_valid = None
+
     for entry in custom_providers:
         if not isinstance(entry, dict):
             continue
@@ -599,6 +605,10 @@ def resolve_custom_provider(
         if not display_name or not api_url:
             continue
 
+        # Stash the first valid entry for bare-"custom" fallback
+        if first_valid is None:
+            first_valid = (display_name, api_url)
+
         slug = custom_provider_slug(display_name)
         if requested not in {display_name.lower(), slug}:
             continue
@@ -609,6 +619,21 @@ def resolve_custom_provider(
             transport="openai_chat",
             api_key_env_vars=(),
             base_url=api_url,
+            is_aggregator=False,
+            auth_type="api_key",
+            source="user-config",
+        )
+
+    # Self-heal: bare "custom" matched nothing — return first valid entry
+    if bare_custom_fallback and first_valid:
+        dname, aurl = first_valid
+        slug = custom_provider_slug(dname)
+        return ProviderDef(
+            id=slug,
+            name=dname,
+            transport="openai_chat",
+            api_key_env_vars=(),
+            base_url=aurl,
             is_aggregator=False,
             auth_type="api_key",
             source="user-config",

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -349,6 +349,7 @@ AUTHOR_MAP = {
     "hgk324@gmail.com": "houziershi",
     "176644217+PStarH@users.noreply.github.com": "PStarH",
     "51058514+Sanjays2402@users.noreply.github.com": "Sanjays2402",
+    "16577466+andy825@user.noreply.gitee.com": "Andy283",
     "906014227@qq.com": "bingo906",
     "aaronwong1999@icloud.com": "AaronWong1999",
     "agents@kylefrench.dev": "DeployFaith",

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -296,7 +296,34 @@ def test_list_authenticated_providers_groups_same_endpoint(monkeypatch):
 def test_list_authenticated_providers_current_endpoint_uses_current_slug(monkeypatch):
     """When current_base_url matches the grouped endpoint, the slug must
     equal current_provider so picker selection routes through the live
-    credential pipeline."""
+    credential pipeline — provided current_provider is a real slug, not
+    the corrupt bare "custom" (see #17478)."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    providers = list_authenticated_providers(
+        current_provider="custom:ollama",
+        current_base_url="http://localhost:11434/v1",
+        user_providers={},
+        custom_providers=[
+            {"name": "Ollama — GLM 5.1", "base_url": "http://localhost:11434/v1",
+             "api_key": "ollama", "model": "glm-5.1"},
+        ],
+        max_models=50,
+    )
+
+    matches = [p for p in providers if p.get("is_user_defined")]
+    assert len(matches) == 1
+    group = matches[0]
+    assert group["slug"] == "custom:ollama"
+    assert group["is_current"] is True
+
+
+def test_list_authenticated_providers_bare_custom_slug_recovers(monkeypatch):
+    """Regression for #17478: when a prior failed switch left the bare
+    literal "custom" in model.provider, the picker must NOT propagate
+    that broken slug. It must fall back to the canonical
+    ``custom:<name>`` form so the picker stays usable."""
     monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
     monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
 
@@ -314,8 +341,8 @@ def test_list_authenticated_providers_current_endpoint_uses_current_slug(monkeyp
     matches = [p for p in providers if p.get("is_user_defined")]
     assert len(matches) == 1
     group = matches[0]
-    assert group["slug"] == "custom"
-    assert group["is_current"] is True
+    # Canonical slug, NOT the bare "custom" that caused #17478
+    assert group["slug"] == "custom:ollama"
 
 
 def test_list_authenticated_providers_distinct_endpoints_stay_separate(monkeypatch):


### PR DESCRIPTION
Salvages #17481 by @Andy283 onto current `main`. Closes #17478.

## Problem

After a prior failed `/model` switch leaves the bare literal `"custom"` in `model.provider`, the picker perpetuates the broken state on every subsequent invocation (endpoint matches → slug propagates as `"custom"`). Every agent session then fails with `Unknown provider 'custom'`.

## Fix (author: @Andy283, 2 files, +33/-1)

- **hermes_cli/model_switch.py** — slug assignment guards against bare `"custom"`; falls back to canonical `custom:<name>` form via `custom_provider_slug(display_name)`.
- **hermes_cli/providers.py** — `resolve_custom_provider()` self-heals when `requested == "custom"` by returning the first valid `custom_providers` entry, so existing corrupted configs recover instead of hard-failing.

## Follow-up commits on top of the salvage

- `chore(release)`: map `16577466+andy825@user.noreply.gitee.com` → `Andy283` in AUTHOR_MAP (otherwise the contributor-check CI job fails).
- `test(model_switch)`: update the existing `test_list_authenticated_providers_current_endpoint_uses_current_slug` test (it was asserting the **bug** behavior — slug equals `"custom"` when that's what was passed in). New assertion reflects the fix; a companion regression test `test_list_authenticated_providers_bare_custom_slug_recovers` pins the recovery path for #17478.

## Validation

```
scripts/run_tests.sh tests/hermes_cli/test_model_switch_custom_providers.py \
                     tests/hermes_cli/test_custom_provider_model_switch.py \
                     tests/hermes_cli/test_user_providers_model_switch.py
50 passed in 2.10s
```

Authorship preserved via plain cherry-pick for @Andy283's original fix commit.