### PR TITLE
fix(config): preserve list-typed YAML fields in `hermes config set` (#17876)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2312,21 +2312,46 @@ def _set_nested(config: dict, dotted_key: str, value):
     ensures ``c["a"]["b"]["c"] == 1``. Numeric components index into existing
     lists (``custom_providers.0.api_key``) rather than overwriting them with
     a dict, so list-valued config fields survive ``hermes config set``.
+
+    Raises ``ValueError`` for malformed paths (non-integer list index,
+    descending into a scalar) so callers can surface a friendly CLI error
+    instead of leaking ``TypeError``/``AttributeError`` from deeper code.
     """
+    def _list_index(part: str) -> int:
+        try:
+            return int(part)
+        except ValueError:
+            raise ValueError(
+                f"invalid list index '{part}' in '{dotted_key}': "
+                f"list components must be integers"
+            ) from None
+
     parts = dotted_key.split(".")
     current = config
-    for part in parts[:-1]:
+    for i, part in enumerate(parts[:-1]):
         if isinstance(current, list):
-            current = current[int(part)]
+            current = current[_list_index(part)]
             continue
+        if not isinstance(current, dict):
+            walked = ".".join(parts[:i]) or "<root>"
+            raise ValueError(
+                f"cannot descend into '{part}' under '{walked}': value is "
+                f"a {type(current).__name__}, not a dict or list"
+            )
         if part not in current or not isinstance(current.get(part), (dict, list)):
             current[part] = {}
         current = current[part]
     last = parts[-1]
     if isinstance(current, list):
-        current[int(last)] = value
-    else:
+        current[_list_index(last)] = value
+    elif isinstance(current, dict):
         current[last] = value
+    else:
+        walked = ".".join(parts[:-1]) or "<root>"
+        raise ValueError(
+            f"cannot set '{last}' under '{walked}': value is a "
+            f"{type(current).__name__}, not a dict or list"
+        )
 
 
 def get_missing_config_fields() -> List[Dict[str, Any]]:
@@ -4440,8 +4465,14 @@ def set_config_value(key: str, value: str):
     elif value.replace('.', '', 1).isdigit():
         value = float(value)
 
-    # Handle nested keys (e.g., "tts.provider", "custom_providers.0.api_key")
-    _set_nested(user_config, key, value)
+    # Handle nested keys (e.g., "tts.provider", "custom_providers.0.api_key").
+    # Surface invalid-path errors as a clean CLI message rather than a stack
+    # trace, since the user types arbitrary strings here.
+    try:
+        _set_nested(user_config, key, value)
+    except (ValueError, IndexError) as exc:
+        print(f"Error setting {key}: {exc}")
+        sys.exit(1)
     
     # Write only user config back (not the full merged defaults)
     ensure_hermes_home()

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2309,15 +2309,24 @@ def _set_nested(config: dict, dotted_key: str, value):
     """Set a value at an arbitrarily nested dotted key path.
 
     Creates intermediate dicts as needed, e.g. ``_set_nested(c, "a.b.c", 1)``
-    ensures ``c["a"]["b"]["c"] == 1``.
+    ensures ``c["a"]["b"]["c"] == 1``. Numeric components index into existing
+    lists (``custom_providers.0.api_key``) rather than overwriting them with
+    a dict, so list-valued config fields survive ``hermes config set``.
     """
     parts = dotted_key.split(".")
     current = config
     for part in parts[:-1]:
-        if part not in current or not isinstance(current.get(part), dict):
+        if isinstance(current, list):
+            current = current[int(part)]
+            continue
+        if part not in current or not isinstance(current.get(part), (dict, list)):
             current[part] = {}
         current = current[part]
-    current[parts[-1]] = value
+    last = parts[-1]
+    if isinstance(current, list):
+        current[int(last)] = value
+    else:
+        current[last] = value
 
 
 def get_missing_config_fields() -> List[Dict[str, Any]]:
@@ -4421,15 +4430,6 @@ def set_config_value(key: str, value: str):
         except Exception:
             user_config = {}
     
-    # Handle nested keys (e.g., "tts.provider")
-    parts = key.split('.')
-    current = user_config
-    
-    for part in parts[:-1]:
-        if part not in current or not isinstance(current.get(part), dict):
-            current[part] = {}
-        current = current[part]
-    
     # Convert value to appropriate type
     if value.lower() in ('true', 'yes', 'on'):
         value = True
@@ -4439,8 +4439,9 @@ def set_config_value(key: str, value: str):
         value = int(value)
     elif value.replace('.', '', 1).isdigit():
         value = float(value)
-    
-    current[parts[-1]] = value
+
+    # Handle nested keys (e.g., "tts.provider", "custom_providers.0.api_key")
+    _set_nested(user_config, key, value)
     
     # Write only user config back (not the full merged defaults)
     ensure_hermes_home()

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -6,8 +6,9 @@ from pathlib import Path
 from unittest.mock import patch, call
 
 import pytest
+import yaml
 
-from hermes_cli.config import set_config_value, config_command
+from hermes_cli.config import set_config_value, config_command, _set_nested
 
 
 @pytest.fixture(autouse=True)
@@ -172,3 +173,87 @@ class TestFalsyValues:
         config_command(args)
         config = _read_config(_isolated_hermes_home)
         assert "model" in config
+
+
+# ---------------------------------------------------------------------------
+# List-typed config fields — regression for #17876
+#
+# `hermes config set custom_providers.0.api_key X` used to overwrite the entire
+# `custom_providers` list with `{"0": {"api_key": "X"}}`, destroying every
+# other provider entry and every other field on the targeted provider. The fix
+# teaches `_set_nested` to navigate into existing lists by integer index.
+# ---------------------------------------------------------------------------
+
+class TestListNavigation:
+    def _seed_yaml(self, tmp_path: Path, payload: dict) -> Path:
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(yaml.safe_dump(payload, sort_keys=False))
+        return config_path
+
+    def test_set_nested_helper_indexes_into_existing_list(self):
+        config = {
+            "custom_providers": [
+                {"name": "a", "api_key": "old_a", "base_url": "https://a"},
+                {"name": "b", "api_key": "old_b", "base_url": "https://b"},
+            ]
+        }
+        _set_nested(config, "custom_providers.0.api_key", "new_a")
+
+        assert isinstance(config["custom_providers"], list)
+        assert len(config["custom_providers"]) == 2
+        assert config["custom_providers"][0] == {
+            "name": "a",
+            "api_key": "new_a",
+            "base_url": "https://a",
+        }
+        assert config["custom_providers"][1]["api_key"] == "old_b"
+
+    def test_set_nested_helper_replaces_whole_list_element(self):
+        config = {"custom_providers": [{"name": "a"}, {"name": "b"}]}
+        _set_nested(config, "custom_providers.1", {"name": "c", "api_key": "k"})
+
+        assert config["custom_providers"][0] == {"name": "a"}
+        assert config["custom_providers"][1] == {"name": "c", "api_key": "k"}
+
+    def test_set_nested_helper_preserves_dict_only_paths(self):
+        config = {"tts": {"provider": "old"}}
+        _set_nested(config, "tts.provider", "new")
+        assert config == {"tts": {"provider": "new"}}
+
+    def test_set_config_value_updates_list_element_field(self, _isolated_hermes_home):
+        self._seed_yaml(_isolated_hermes_home, {
+            "custom_providers": [
+                {"name": "a", "api_key": "old_a", "base_url": "https://a"},
+                {"name": "b", "api_key": "old_b", "base_url": "https://b"},
+            ],
+        })
+
+        set_config_value("custom_providers.0.api_key", "new_a")
+
+        result = yaml.safe_load((_isolated_hermes_home / "config.yaml").read_text())
+        assert isinstance(result["custom_providers"], list), \
+            "list-typed field must remain a list, not be flattened to a dict"
+        assert len(result["custom_providers"]) == 2, \
+            "second provider entry must survive the update"
+        assert result["custom_providers"][0] == {
+            "name": "a",
+            "api_key": "new_a",
+            "base_url": "https://a",
+        }
+        assert result["custom_providers"][1] == {
+            "name": "b",
+            "api_key": "old_b",
+            "base_url": "https://b",
+        }
+
+    def test_set_config_value_does_not_collapse_list_to_dict(self, _isolated_hermes_home):
+        """Regression guard: pre-fix behavior produced ``{"0": {...}}``."""
+        self._seed_yaml(_isolated_hermes_home, {
+            "custom_providers": [{"name": "a", "api_key": "old"}],
+        })
+
+        set_config_value("custom_providers.0.api_key", "new")
+
+        raw = (_isolated_hermes_home / "config.yaml").read_text()
+        assert "custom_providers:\n- " in raw or "custom_providers:\n  - " in raw, \
+            f"YAML must keep list syntax, got:\n{raw}"

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -257,3 +257,40 @@ class TestListNavigation:
         raw = (_isolated_hermes_home / "config.yaml").read_text()
         assert "custom_providers:\n- " in raw or "custom_providers:\n  - " in raw, \
             f"YAML must keep list syntax, got:\n{raw}"
+
+    def test_set_nested_rejects_non_integer_list_index(self):
+        config = {"custom_providers": [{"name": "a"}]}
+        with pytest.raises(ValueError, match="invalid list index 'foo'"):
+            _set_nested(config, "custom_providers.foo.api_key", "x")
+
+    def test_set_nested_rejects_setting_under_scalar(self):
+        config = {"custom_providers": ["just_a_string"]}
+        with pytest.raises(ValueError, match="cannot set 'api_key'"):
+            _set_nested(config, "custom_providers.0.api_key", "x")
+
+    def test_set_nested_rejects_deep_descent_into_scalar(self):
+        config = {"custom_providers": ["just_a_string"]}
+        with pytest.raises(ValueError, match="cannot descend into 'foo'"):
+            _set_nested(config, "custom_providers.0.foo.bar", "x")
+
+    def test_set_nested_out_of_range_index_raises_index_error(self):
+        config = {"custom_providers": [{"name": "a"}]}
+        with pytest.raises(IndexError):
+            _set_nested(config, "custom_providers.5.api_key", "x")
+
+    def test_set_config_value_invalid_index_exits_with_clean_message(
+        self, _isolated_hermes_home, capsys
+    ):
+        self._seed_yaml(_isolated_hermes_home, {
+            "custom_providers": [{"name": "a", "api_key": "old"}],
+        })
+
+        with pytest.raises(SystemExit):
+            set_config_value("custom_providers.foo.api_key", "x")
+
+        captured = capsys.readouterr()
+        assert "Error setting custom_providers.foo.api_key" in captured.out
+        assert "list components must be integers" in captured.out
+        # Original config must remain intact on error.
+        result = yaml.safe_load((_isolated_hermes_home / "config.yaml").read_text())
+        assert result["custom_providers"][0]["api_key"] == "old"


### PR DESCRIPTION
## Summary

- `hermes config set custom_providers.0.api_key X` was destroying the
  entire `custom_providers` list and replacing it with
  `{"0": {"api_key": "X"}}` — wiping every other provider and every
  other field on the targeted provider.
- Root cause: `_set_nested` overwrote any non-dict intermediate
  (including lists) with `{}`, and `set_config_value` duplicated the
  same walk inline.
- Fix: teach `_set_nested` to navigate into existing lists by integer
  index, and route `set_config_value` through the helper so both paths
  share one implementation.

## The bug

`hermes_cli/config.py:_set_nested` walked the dotted key with:

```python
for part in parts[:-1]:
    if part not in current or not isinstance(current.get(part), dict):
        current[part] = {}
    current = current[part]
```

When `current` is a list (e.g. `custom_providers`), `isinstance(..., dict)`
is `False`, so the helper unconditionally replaces the list with `{}`. The
final dotted component (`"0"`) then becomes a string key on a dict.

`set_config_value` (~line 4424) inlined the same walk, so the bug was
present on the user-facing CLI path too. Reproduced on `origin/main`
(`8d302e37a`).

## The fix

`_set_nested` now:

- Navigates into existing list intermediates by `int(part)` instead of
  flattening them.
- Treats both `dict` and `list` as valid intermediates so already-list
  fields are not overwritten.
- Sets the leaf via list indexing when the parent is a list.

`set_config_value` now calls `_set_nested(user_config, key, value)`
instead of duplicating the walk.

Dict-only call sites (`_set_nested(config, "tts.provider", ...)`,
skill-config keys at `_set_nested(config, "skills.config.<x>", ...)`) are
behavior-equivalent — the new code only changes behavior when an
intermediate is a list.

## Test plan

- [x] Focused regression test — `tests/hermes_cli/test_set_config_value.py::TestListNavigation` (5 new tests):
  - `_set_nested` indexes into an existing list and updates the right
    element field, leaving siblings/other elements intact.
  - `_set_nested` can replace a whole list element (`custom_providers.1`).
  - `_set_nested` preserves dict-only paths (no behavioral change for
    `tts.provider` etc.).
  - `set_config_value` updates a list element field and round-trips
    through YAML without flattening.
  - `set_config_value` regression guard: YAML output still uses list
    syntax (`custom_providers:\n- ...`).
- [x] Adjacent suite — `tests/hermes_cli/test_set_config_value.py` 37/37
  pass; `tests/tools/test_terminal_config_env_sync.py` 4/4 pass.
- [x] Regression guard — running the pre-fix `_set_nested` against the
  same input (`{"custom_providers": [{"name": "a", "api_key": "old"},
  {"name": "b"}]}`, `_set_nested(c, "custom_providers.0.api_key",
  "new")`) produces `{"custom_providers": {"0": {"api_key": "new"}}}`
  (list collapsed to dict, second entry destroyed). The new tests
  assert list structure preservation, so they fail without this fix.

## Related

- Fixes #17876