### PR TITLE
fix(ssh): prevent tar from overwriting remote home dir permissions (#17767)

### DIFF
--- a/tests/tools/test_ssh_bulk_upload.py
+++ b/tests/tools/test_ssh_bulk_upload.py
@@ -166,10 +166,12 @@ class TestSSHBulkUpload:
         assert "-" in tar_cmd  # stdout
         assert "-C" in tar_cmd
 
-        # ssh: extract from stdin at /
+        # ssh: extract from stdin at /, preserving existing dir modes (#17767)
         ssh_str = " ".join(ssh_cmd)
         assert "ssh" in ssh_str
-        assert "tar xf - -C /" in ssh_str
+        assert "tar xf -" in ssh_str
+        assert "--no-overwrite-dir" in ssh_str
+        assert "-C /" in ssh_str
         assert "testuser@example.com" in ssh_str
 
     def test_mkdir_failure_raises(self, mock_env, tmp_path):

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -182,7 +182,11 @@ class SSHEnvironment(BaseEnvironment):
 
             tar_cmd = ["tar", "-chf", "-", "-C", staging, "."]
             ssh_cmd = self._build_ssh_command()
-            ssh_cmd.append("tar xf - -C /")
+            # --no-overwrite-dir prevents tar from overwriting the mode of
+            # existing directories (e.g. /home/<user>) with the staging
+            # directory's mode.  Without this, a umask 002 produces 0775
+            # dirs which breaks sshd StrictModes (refuses authorized_keys).
+            ssh_cmd.append("tar xf - --no-overwrite-dir -C /")
 
             tar_proc = subprocess.Popen(
                 tar_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE


### PR DESCRIPTION
Salvages #17867 by @vominh1919 onto current `main`. Closes #17767.

## Problem

The SSH terminal backend's `_ssh_bulk_upload()` runs `tar xf - -C /` on the remote, extracting a staging directory tree to the remote root. GNU tar's default is to overwrite metadata (including mode) of existing directories. When the local umask is `002` (Ubuntu default), staging dirs are `0775`, and tar chmods `/home/<user>` to `0775` on the remote.

That violates sshd `StrictModes yes` (which requires non-group-writable home dirs), so subsequent SSH connections fail with `Permission denied (publickey)`. Recovery requires out-of-band console access to chmod the home dir back. Reporter (@luismartinezs) hit this on a Hetzner VPS and couldn't reconnect.

Confirmed on current main — `tools/environments/ssh.py:185` still has the bare `tar xf - -C /`.

## Fix (author: @vominh1919, 1 file, +5/-1)

Add `--no-overwrite-dir` to the remote tar command. Tar skips updating attributes of already-existing directories, so new entries (`~/.hermes/`, `~/.hermes/skills/`) are still created with reasonable modes via remote umask, but `/home/<user>` keeps its original `0755`.

## Follow-up test update

`tests/tools/test_ssh_bulk_upload.py::test_tar_pipe_commands` asserted the literal substring `"tar xf - -C /"` in the ssh command — which is no longer present with `--no-overwrite-dir` between `tar xf -` and `-C /`. Split into three separate assertions; added an explicit check for the new flag as a regression guard.

## Validation

```
scripts/run_tests.sh tests/tools/test_ssh_bulk_upload.py tests/tools/test_ssh_environment.py
34 passed, 11 skipped
```

Authorship preserved for @vominh1919 via plain cherry-pick.