### PR TITLE
fix(skills): resolve skill_view by frontmatter name

### DIFF
--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -347,6 +347,28 @@ class TestSkillView:
         assert result["name"] == "my-skill"
         assert "Step 1" in result["content"]
 
+    def test_view_accepts_frontmatter_name_when_directory_differs(self, tmp_path):
+        skill_dir = tmp_path / "darwin"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            "---\n"
+            "name: darwin-skill\n"
+            "description: Darwin Skill\n"
+            "---\n\n"
+            "# Darwin\n\n"
+            "Step 1: Evolve.\n"
+        )
+
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            list_result = json.loads(skills_list())
+            raw = skill_view("darwin-skill")
+
+        result = json.loads(raw)
+        assert [skill["name"] for skill in list_result["skills"]] == ["darwin-skill"]
+        assert result["success"] is True
+        assert result["name"] == "darwin-skill"
+        assert "Step 1: Evolve." in result["content"]
+
     def test_skill_view_applies_template_vars(self, tmp_path):
         with (
             patch("tools.skills_tool.SKILLS_DIR", tmp_path),

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -976,6 +976,35 @@ def skill_view(
                 if skill_md:
                     break
 
+        # Search by displayed frontmatter name so names copied from skills_list work.
+        if not skill_md:
+            for search_dir in all_dirs:
+                from agent.skill_utils import iter_skill_index_files
+
+                for found_skill_md in iter_skill_index_files(search_dir, "SKILL.md"):
+                    try:
+                        content_head = found_skill_md.read_text(encoding="utf-8")[:4000]
+                        frontmatter, _ = _parse_frontmatter(content_head)
+                    except (UnicodeDecodeError, PermissionError):
+                        continue
+                    except Exception:
+                        logger.debug(
+                            "Skipping skill at %s: failed to parse frontmatter",
+                            found_skill_md,
+                            exc_info=True,
+                        )
+                        continue
+
+                    displayed_name = str(
+                        frontmatter.get("name", found_skill_md.parent.name)
+                    )[:MAX_NAME_LENGTH]
+                    if displayed_name == name and skill_matches_platform(frontmatter):
+                        skill_dir = found_skill_md.parent
+                        skill_md = found_skill_md
+                        break
+                if skill_md:
+                    break
+
         # Legacy: flat .md files
         if not skill_md:
             for search_dir in all_dirs:


### PR DESCRIPTION
## Summary
- Resolve local skills by the frontmatter `name` shown in `skills_list` when it differs from the directory name.
- Keep existing directory-name and direct-path lookup behavior unchanged.

## Root cause
`skills_list` displays each skill's frontmatter `name`, but `skill_view` only searched direct paths and directory names before falling back to legacy flat Markdown files. Copying a listed name like `darwin-skill` for a skill stored in `darwin/SKILL.md` therefore returned "Skill not found" even though `skill_view("darwin")` worked.

## Fix
After the existing directory-name search misses, scan skill index files for a platform-compatible frontmatter `name` that matches the requested identifier and use that `SKILL.md`.

Related: #5433 / #5784 cover builtin-vs-local classification for the same directory/frontmatter naming mismatch family, but they do not make `skill_view` accept the name displayed by `skills_list`.

## Regression coverage
- Added `TestSkillView::test_view_accepts_frontmatter_name_when_directory_differs`, which creates `darwin/SKILL.md` with `name: darwin-skill`, verifies `skills_list` displays `darwin-skill`, and then verifies `skill_view("darwin-skill")` loads the skill.

## Testing
- `scripts/run_tests.sh tests/tools/test_skills_tool.py::TestSkillView::test_view_accepts_frontmatter_name_when_directory_differs -q` (fails before fix, passes after)
- `scripts/run_tests.sh tests/tools/test_skills_tool.py -q`

Closes #17914
