### PR TITLE
fix: remove invalid relative date in uv exclude-newer setting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,4 +173,4 @@ not-iterable = "ignore"
 exclude = ["*"]
 
 [tool.uv]
-exclude-newer = "7 days"
+# exclude-newer removed — uv requires an absolute ISO date, not a relative string like "7 days"


### PR DESCRIPTION
## Summary

Remove `exclude-newer = "7 days"` from `[tool.uv]` in `pyproject.toml`. This value is not valid uv syntax — uv requires an absolute ISO 8601 date (e.g. `"2026-04-29"`), not a relative time string.

## Problem

The invalid value causes a TOML parse error on every fresh install via `scripts/install.sh`:

```
TOML parse error at line 176, column 17
    |
176 | exclude-newer = "7 days"
    |                 ^^^^^^^^
failed to parse year in date "7 days"
```

This blocks `uv pip install -e '.[all]'` and cascades into a secondary error where uv falls back to the wrong Python interpreter.

## Fix

Remove the `exclude-newer` line entirely. A rolling relative constraint cannot be expressed in static TOML config — it would need to be an absolute date updated on each release, or handled by a pre-commit hook.

## Testing

- Verified `uv pip install -e '.[all]' --dry-run` succeeds after the change (no parse error)
- Single-file change to `pyproject.toml`, no code logic affected

Closes #17908