### PR TITLE
fix(nix): replace magic-nix-cache with Cachix

### DIFF
--- a/.github/actions/nix-setup/action.yml
+++ b/.github/actions/nix-setup/action.yml
@@ -1,8 +1,18 @@
 name: 'Setup Nix'
-description: 'Install Nix with DeterminateSystems and enable magic-nix-cache'
+description: 'Install Nix and configure Cachix binary cache'
+
+inputs:
+  cachix-auth-token:
+    description: 'Cachix auth token (enables push). Omit for read-only.'
+    required: false
+    default: ''
 
 runs:
   using: composite
   steps:
     - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
-    - uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
+    - uses: cachix/cachix-action@ba0204f02a42c927eca4ef5e7dc3499b55b6e21e # v17
+      with:
+        name: hermes-agent
+        authToken: ${{ inputs.cachix-auth-token }}
+      continue-on-error: true

--- a/.github/actions/nix-setup/action.yml
+++ b/.github/actions/nix-setup/action.yml
@@ -11,7 +11,7 @@ runs:
   using: composite
   steps:
     - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
-    - uses: cachix/cachix-action@ba0204f02a42c927eca4ef5e7dc3499b55b6e21e # v17
+    - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
       with:
         name: hermes-agent
         authToken: ${{ inputs.cachix-auth-token }}

--- a/.github/workflows/nix-lockfile-check.yml
+++ b/.github/workflows/nix-lockfile-check.yml
@@ -20,6 +20,8 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - uses: ./.github/actions/nix-setup
+        with:
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Resolve head SHA
         id: sha

--- a/.github/workflows/nix-lockfile-fix.yml
+++ b/.github/workflows/nix-lockfile-fix.yml
@@ -62,6 +62,8 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - uses: ./.github/actions/nix-setup
+        with:
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Apply lockfile hashes
         id: apply
@@ -200,6 +202,8 @@ jobs:
           fetch-depth: 0
 
       - uses: ./.github/actions/nix-setup
+        with:
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Apply lockfile hashes
         id: apply

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: ./.github/actions/nix-setup
+        with:
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Check flake
         if: runner.os == 'Linux'
         run: nix flake check --print-build-logs


### PR DESCRIPTION
## Problem

Nix CI has been flaky due to `DeterminateSystems/magic-nix-cache-action` hitting GitHub Actions Cache infrastructure limits:

- **`TwirpErrorResponse { code: ResourceExhausted }`** — GHA's 10 GB per-repo cache quota exceeded
- **200 req/min rate limit** — magic-nix-cache uploads one entry per store path (thousands of small entries)
- **LRU eviction** — PR branch caches evict main branch caches under pressure

This caused 10 consecutive Nix failures on main (Apr 29–30) and was declared 'unfixable infra flake' in #17836. It's actually a fixable architecture choice — DeterminateSystems themselves no longer use magic-nix-cache on their own repos.

## Solution

Replace magic-nix-cache with [Cachix](https://cachix.org) — a dedicated Nix binary cache not subject to GHA's limits.

- Public cache at https://hermes-agent.cachix.org/
- `continue-on-error: true` so cache failures are never fatal
- Devs can pull locally: `cachix use hermes-agent`

## What other Nix-heavy repos do

| Repo | Caching Strategy |
|------|-----------------|
| **NixOS/nixpkgs** | Cachix |
| **DeterminateSystems/** | FlakeHub Cache (their newer product, NOT magic-nix-cache) |
| **Ghostty** | Namespace Cloud volumes + Cachix |
| **Hyprland** | cache-nix-action + Cachix |
| **home-manager** | None |

## Changes

- `.github/actions/nix-setup/action.yml` — swap magic-nix-cache for cachix-action v17
- `.github/workflows/nix.yml` — pass `CACHIX_AUTH_TOKEN` secret
- `.github/workflows/nix-lockfile-check.yml` — same
- `.github/workflows/nix-lockfile-fix.yml` — same (both jobs)

## First-run note

The cache starts empty — the first CI run after merge will be slightly slower (fetching from `cache.nixos.org`) but will populate the Cachix cache. Subsequent runs pull from Cachix at full speed.