### PR TITLE
fix(skills): exclude .archive from skill index walk (salvage #17639)

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -234,7 +234,7 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
 
         for scan_dir in dirs_to_scan:
             for skill_md in iter_skill_index_files(scan_dir, "SKILL.md"):
-                if any(part in ('.git', '.github', '.hub') for part in skill_md.parts):
+                if any(part in ('.git', '.github', '.hub', '.archive') for part in skill_md.parts):
                     continue
                 try:
                     content = skill_md.read_text(encoding='utf-8')

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -24,7 +24,7 @@ PLATFORM_MAP = {
     "windows": "win32",
 }
 
-EXCLUDED_SKILL_DIRS = frozenset((".git", ".github", ".hub"))
+EXCLUDED_SKILL_DIRS = frozenset((".git", ".github", ".hub", ".archive"))
 
 # ── Lazy YAML loader ─────────────────────────────────────────────────────
 
@@ -440,7 +440,7 @@ def extract_skill_description(frontmatter: Dict[str, Any]) -> str:
 def iter_skill_index_files(skills_dir: Path, filename: str):
     """Walk skills_dir yielding sorted paths matching *filename*.
 
-    Excludes ``.git``, ``.github``, ``.hub`` directories.
+    Excludes ``.git``, ``.github``, ``.hub``, ``.archive`` directories.
     """
     matches = []
     for root, dirs, files in os.walk(skills_dir, followlinks=True):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -638,7 +638,7 @@ def _check_unavailable_skill(command_name: str) -> str | None:
             if not skills_dir.exists():
                 continue
             for skill_md in skills_dir.rglob("SKILL.md"):
-                if any(part in ('.git', '.github', '.hub') for part in skill_md.parts):
+                if any(part in ('.git', '.github', '.hub', '.archive') for part in skill_md.parts):
                     continue
                 name = skill_md.parent.name.lower().replace("_", "-")
                 if name == normalized and name in disabled:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -42,6 +42,7 @@ AUTHOR_MAP = {
     # teknium (multiple emails)
     "teknium1@gmail.com": "teknium1",
     "qiyin.zuo@pcitc.com": "qiyin-code",
+    "leone.parise@gmail.com": "leoneparise",
     "teknium@nousresearch.com": "teknium1",
     "127238744+teknium1@users.noreply.github.com": "teknium1",
     "2093036+exiao@users.noreply.github.com": "exiao",

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -100,7 +100,7 @@ _PLATFORM_MAP = {
     "windows": "win32",
 }
 _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
-_EXCLUDED_SKILL_DIRS = frozenset((".git", ".github", ".hub"))
+_EXCLUDED_SKILL_DIRS = frozenset((".git", ".github", ".hub", ".archive"))
 _REMOTE_ENV_BACKENDS = frozenset(
     {"docker", "singularity", "modal", "ssh", "daytona", "vercel_sandbox"}
 )


### PR DESCRIPTION
Salvage of #17639 by @leoneparise. 

## What
`EXCLUDED_SKILL_DIRS` (and three inline-duplicate tuples) didn't include `.archive`, so curator-archived skills were still indexed into the `<available_skills>` system prompt and could still resolve as slash commands.

## Changes
- `agent/skill_utils.py` — add `.archive` to `EXCLUDED_SKILL_DIRS`
- `agent/skill_commands.py` — add `.archive` to inline exclusion tuple
- `gateway/run.py` — add `.archive` to inline exclusion tuple
- `tools/skills_tool.py` — add `.archive` to `_EXCLUDED_SKILL_DIRS` (sibling site the original PR didn't touch)
- `scripts/release.py` — register `leoneparise` in AUTHOR_MAP

## Validation
`scripts/run_tests.sh tests/agent/test_curator.py tests/tools/test_skill_usage.py tests/tools/test_skills_tool.py tests/agent/test_prompt_builder.py` → 269 passed.

Closes #17639.