### PR TITLE
fix(skills): wire bump_use() into skill invocation, preload, and skill_view tool (#17782 salvage)

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -393,6 +393,14 @@ def build_skill_invocation_message(
         return f"[Failed to load skill: {skill_info['name']}]"
 
     loaded_skill, skill_dir, skill_name = loaded
+
+    # Track active usage for Curator lifecycle management (#17782)
+    try:
+        from tools.skill_usage import bump_use
+        bump_use(skill_name)
+    except Exception:
+        pass  # Non-critical — skill invocation proceeds regardless
+
     activation_note = (
         f'[IMPORTANT: The user has invoked the "{skill_name}" skill, indicating they want '
         "you to follow its instructions. The full skill content is loaded below.]"
@@ -432,6 +440,14 @@ def build_preloaded_skills_prompt(
             continue
 
         loaded_skill, skill_dir, skill_name = loaded
+
+        # Track active usage for Curator lifecycle management (#17782)
+        try:
+            from tools.skill_usage import bump_use
+            bump_use(skill_name)
+        except Exception:
+            pass  # Non-critical
+
         activation_note = (
             f'[IMPORTANT: The user launched this CLI session with the "{skill_name}" skill '
             "preloaded. Treat its instructions as active guidance for the duration of this "

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -1497,8 +1497,12 @@ def _skill_view_with_bump(args, **kw):
             # qualified forms ("plugin:skill") return with the canonical name.
             resolved = parsed.get("name") or name
             if resolved:
-                from tools.skill_usage import bump_view
+                from tools.skill_usage import bump_use, bump_view
                 bump_view(str(resolved))
+                # A skill_view tool call is the agent actively loading the skill
+                # to act on it — that counts as use, not just a browse/view.
+                # Curator's stale timer keys off last_used_at (see agent/curator.py).
+                bump_use(str(resolved))
     except Exception:
         pass
     return result


### PR DESCRIPTION
Salvage of #17818 by @Bartok9, widened to cover the dominant agent-initiated path.

## What
`bump_use()` in `tools/skill_usage.py` had zero production call sites — `use_count` stayed at 0 and `last_used_at` stayed `None` for every skill. Since curator's stale timer keys off `last_used_at` (`agent/curator.py:233`), every non-pinned agent-created skill would transition to `stale` simultaneously regardless of actual use.

## Changes
- `agent/skill_commands.py` — call `bump_use()` from `build_skill_invocation_message` (slash command) and `build_preloaded_skills_prompt` (`--skill` preload). [@Bartok9's commit]
- `tools/skills_tool.py` — also call `bump_use()` alongside the existing `bump_view()` in `_skill_view_with_bump`. This is the dominant path: the agent calling `skill_view` to load a skill is explicit "I'm using this skill to do work," stronger than passive system-prompt indexing. [widening]

All three bumps are wrapped in try/except — usage telemetry failures never break tool calls.

## Validation
| | Before | After |
|---|---|---|
| `skill_view` tool call | view=1, use=0 | view=1, use=1, last_used_at set |
| slash invocation | use=0 | use=1 |
| preload (`--skill`) | use=0 | use=1 |

E2E: isolated HERMES_HOME, real agent-created skill, all three paths traced. Unit: `scripts/run_tests.sh tests/tools/test_skill_usage.py tests/tools/test_skills_tool.py tests/agent/test_curator.py` → 153 passed.

Closes #17782. Supersedes #17866 (same fix, submitted ~2h later) and the overlapping `bump_use` portion of #17598.