### PR TITLE
feat(agent): allow declaring supports_vision via user config

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7867,8 +7867,16 @@ class AIAgent:
             cfg = load_config()
             provider = (getattr(self, "provider", "") or "").strip()
             model = (getattr(self, "model", "") or "").strip()
-            for keys in (("model", "supports_vision"),
-                         ("providers", provider, "models", model, "supports_vision")):
+            # self.provider is the runtime-resolved value, which is rewritten
+            # to "custom" for named custom providers (see
+            # hermes_cli/runtime_provider.py:_resolve_named_custom_runtime),
+            # while the config still holds the user-declared name (e.g.
+            # "my-vllm") under model.provider. Try both as provider keys.
+            config_provider = str(cfg_get(cfg, "model", "provider") or "").strip()
+            candidates = [("model", "supports_vision")]
+            for p in dict.fromkeys(filter(None, (provider, config_provider))):
+                candidates.append(("providers", p, "models", model, "supports_vision"))
+            for keys in candidates:
                 override = cfg_get(cfg, *keys)
                 if override is not None:
                     return bool(override)

--- a/run_agent.py
+++ b/run_agent.py
@@ -7854,17 +7854,29 @@ class AIAgent:
         Used to decide whether to strip image content parts from API-bound
         messages (for non-vision models) or let the provider adapter handle
         them natively (for vision-capable models).
+
+        Resolution order:
+          1. ``model.supports_vision`` (top-level, single-model shortcut)
+          2. ``providers.<provider>.models.<model>.supports_vision``
+          3. models.dev capability lookup
+        Custom/local models absent from models.dev would otherwise be
+        misclassified as non-vision and have their images stripped.
         """
         try:
-            from agent.models_dev import get_model_capabilities
+            from hermes_cli.config import cfg_get, load_config
+            cfg = load_config()
             provider = (getattr(self, "provider", "") or "").strip()
             model = (getattr(self, "model", "") or "").strip()
+            for keys in (("model", "supports_vision"),
+                         ("providers", provider, "models", model, "supports_vision")):
+                override = cfg_get(cfg, *keys)
+                if override is not None:
+                    return bool(override)
+            from agent.models_dev import get_model_capabilities
             if not provider or not model:
                 return False
             caps = get_model_capabilities(provider, model)
-            if caps is None:
-                return False
-            return bool(caps.supports_vision)
+            return bool(caps and caps.supports_vision)
         except Exception:
             return False
 

--- a/tests/run_agent/test_vision_aware_preprocessing.py
+++ b/tests/run_agent/test_vision_aware_preprocessing.py
@@ -186,6 +186,21 @@ class TestModelSupportsVision:
              patch("agent.models_dev.get_model_capabilities", return_value=None):
             assert agent._model_supports_vision() is True
 
+    def test_named_custom_provider_resolved_via_config_provider(self):
+        # Named custom providers get runtime self.provider rewritten to
+        # "custom" while the config keeps the original name under
+        # model.provider. The override must still resolve.
+        agent = _make_agent()
+        agent.provider = "custom"
+        agent.model = "my-llava"
+        cfg = {
+            "model": {"provider": "my-vllm", "default": "my-llava"},
+            "providers": {"my-vllm": {"models": {"my-llava": {"supports_vision": True}}}},
+        }
+        with patch("hermes_cli.config.load_config", return_value=cfg), \
+             patch("agent.models_dev.get_model_capabilities", return_value=None):
+            assert agent._model_supports_vision() is True
+
     def test_override_false_disables_vision_for_models_dev_models(self):
         agent = _make_agent()
         fake_caps = MagicMock()

--- a/tests/run_agent/test_vision_aware_preprocessing.py
+++ b/tests/run_agent/test_vision_aware_preprocessing.py
@@ -168,3 +168,28 @@ class TestModelSupportsVision:
         agent = _make_agent()
         with patch("agent.models_dev.get_model_capabilities", side_effect=RuntimeError("boom")):
             assert agent._model_supports_vision() is False
+
+    def test_top_level_model_override_wins(self):
+        agent = _make_agent()
+        agent.provider = "custom"
+        agent.model = "my-llava"
+        with patch("hermes_cli.config.load_config", return_value={"model": {"supports_vision": True}}), \
+             patch("agent.models_dev.get_model_capabilities", return_value=None):
+            assert agent._model_supports_vision() is True
+
+    def test_per_provider_per_model_override_wins(self):
+        agent = _make_agent()
+        agent.provider = "custom"
+        agent.model = "my-llava"
+        cfg = {"providers": {"custom": {"models": {"my-llava": {"supports_vision": True}}}}}
+        with patch("hermes_cli.config.load_config", return_value=cfg), \
+             patch("agent.models_dev.get_model_capabilities", return_value=None):
+            assert agent._model_supports_vision() is True
+
+    def test_override_false_disables_vision_for_models_dev_models(self):
+        agent = _make_agent()
+        fake_caps = MagicMock()
+        fake_caps.supports_vision = True
+        with patch("hermes_cli.config.load_config", return_value={"model": {"supports_vision": False}}), \
+             patch("agent.models_dev.get_model_capabilities", return_value=fake_caps):
+            assert agent._model_supports_vision() is False


### PR DESCRIPTION
Closes #17940. Refs #8731.

## What

Allow users to declare that a custom-provider model supports native image input, via either of:

```yaml
# Top-level shortcut for the active model
model:
  provider: custom
  default: my-llava
  supports_vision: true

# Or per-model under providers (matches the schema in #8731)
model:
  provider: my-vllm     # name of the custom provider entry
  default: my-llava
providers:
  my-vllm:
    base_url: http://localhost:8000/v1
    models:
      my-llava:
        supports_vision: true
```

## Why

Model capability is currently sourced exclusively from the models.dev catalog. For a custom provider — local vLLM, an internal proxy, an OpenAI-compatible endpoint with a non-public model — `get_model_capabilities()` returns `None`, `_model_supports_vision()` returns `False`, and `_prepare_messages_for_non_vision_model()` strips every image part out of the user turn before the request leaves the process. The user uploads a screenshot to a perfectly capable LLaVA fine-tune and the model never sees it.

With the override set, the strip path is bypassed and the existing provider adapters attach the image natively (OpenAI `image_url`, Anthropic `image` block, Gemini `inlineData`, etc.) on whatever transport the user has configured.

## Scope (please read before reviewing)

**This patch only fixes the strip path.** It does **not** change the `auto`-mode routing in `agent/image_routing.py:_lookup_supports_vision`. So the override declared above only takes full effect when the user also pins:

```yaml
agent:
  image_input_mode: native    # required for the override to drive routing
```

Without this, default `auto` mode still pre-processes images through `vision_analyze` even after the override is set. If reviewers prefer, I'm happy to extend `_lookup_supports_vision` in this same PR with an identical fallback — let me know.

Narrow scope on purpose — see #8942 for a broader, multi-capability take that's been waiting on review since 2026-04-13. This patch is the smallest change that unblocks the vision-only use case.

## Named custom providers

Named entries under `providers.<name>` work even though `_resolve_named_custom_runtime` rewrites `self.provider` to the literal string `"custom"` at runtime: the lookup tries both `self.provider` and `cfg.model.provider` as candidate provider keys, so a config like the second example above resolves correctly. Covered by `test_named_custom_provider_resolved_via_config_provider`.

## How to test

```bash
uv run pytest tests/run_agent/test_vision_aware_preprocessing.py -o addopts= -q
```

Four new tests:
- `test_top_level_model_override_wins` — `model.supports_vision: true` shortcut
- `test_per_provider_per_model_override_wins` — `providers.<id>.models.<id>.supports_vision: true`
- `test_named_custom_provider_resolved_via_config_provider` — runtime `self.provider == "custom"` while config holds the original name
- `test_override_false_disables_vision_for_models_dev_models` — explicit `false` overrides a vision-capable models.dev entry

## Notes

- No change to `_normalize_custom_provider_entry` schema — `models.<id>` dicts already pass through unchanged so per-model `supports_vision` reaches `cfg_get` without a warning.
- `bool(override)` coerces the YAML value as-is. YAML's native `true`/`false` (no quotes) round-trip to Python booleans, which is the supported form. Quoted strings like `"false"` would coerce to truthy — open to a stricter coercion if reviewers want.
