### PR TITLE
feat: add Astraflow provider support (global + China endpoints)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -108,6 +108,20 @@
 # HERMES_QWEN_BASE_URL=https://portal.qwen.ai/v1
 
 # =============================================================================
+# LLM PROVIDER (Astraflow / UCloud ModelVerse)
+# =============================================================================
+# Astraflow is an OpenAI-compatible aggregator with 200+ models (by UCloud / 优刻得)
+# Global endpoint — get your key at: https://www.umodelverse.ai
+# ASTRAFLOW_API_KEY=your_key_here
+# Optional base URL override (default: https://api-us-ca.umodelverse.ai/v1)
+# ASTRAFLOW_BASE_URL=https://api-us-ca.umodelverse.ai/v1
+
+# Astraflow China endpoint (for users in mainland China)
+# ASTRAFLOW_CN_API_KEY=your_cn_key_here
+# Optional base URL override (default: https://api.modelverse.cn/v1)
+# ASTRAFLOW_CN_BASE_URL=https://api.modelverse.cn/v1
+
+# =============================================================================
 # LLM PROVIDER (Xiaomi MiMo)
 # =============================================================================
 # Xiaomi MiMo models (mimo-v2-pro, mimo-v2-omni, mimo-v2-flash).

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -195,6 +195,18 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         transport="openai_chat",  # default; overridden by api_mode in config
         base_url_env_var="AZURE_FOUNDRY_BASE_URL",
     ),
+    "astraflow": HermesOverlay(
+        transport="openai_chat",
+        is_aggregator=True,
+        base_url_override="https://api-us-ca.umodelverse.ai/v1",
+        base_url_env_var="ASTRAFLOW_BASE_URL",
+    ),
+    "astraflow-cn": HermesOverlay(
+        transport="openai_chat",
+        is_aggregator=True,
+        base_url_override="https://api.modelverse.cn/v1",
+        base_url_env_var="ASTRAFLOW_CN_BASE_URL",
+    ),
     "bedrock": HermesOverlay(
         transport="bedrock_converse",
         auth_type="aws_sdk",
@@ -319,6 +331,13 @@ ALIASES: Dict[str, str] = {
     "tencent-cloud": "tencent-tokenhub",
     "tencentmaas": "tencent-tokenhub",
 
+    # astraflow
+    "ucloud": "astraflow",
+    "modelverse": "astraflow",
+    "astraflow-global": "astraflow",
+    "astraflow-china": "astraflow-cn",
+    "astraflow_cn": "astraflow-cn",
+
     # bedrock
     "aws": "bedrock",
     "aws-bedrock": "bedrock",
@@ -357,6 +376,8 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "xiaomi": "Xiaomi MiMo",
     "gmi": "GMI Cloud",
     "tencent-tokenhub": "Tencent TokenHub",
+    "astraflow": "Astraflow (UCloud)",
+    "astraflow-cn": "Astraflow China (UCloud)",
     "lmstudio": "LM Studio",
     "local": "Local endpoint",
     "bedrock": "AWS Bedrock",


### PR DESCRIPTION
## Summary

Adds **Astraflow** (by UCloud / 优刻得) as a supported LLM provider.

Astraflow is an OpenAI-compatible AI model aggregation platform supporting 200+ models with both a global and a China-region endpoint.

### Changes

- **`hermes_cli/providers.py`** — registers `astraflow` and `astraflow-cn` in `HERMES_OVERLAYS`, adds aliases, and adds a label override.
- **`.env.example`** — documents `ASTRAFLOW_API_KEY` and `ASTRAFLOW_CN_API_KEY` with links to get keys.

### Endpoints

| Provider ID | Base URL | Env Var |
|---|---|---|
| `astraflow` | `https://api-us-ca.umodelverse.ai/v1` | `ASTRAFLOW_API_KEY` |
| `astraflow-cn` | `https://api.modelverse.cn/v1` | `ASTRAFLOW_CN_API_KEY` |

### Usage

```yaml
# ~/.hermes/config.yaml
model:
  provider: astraflow
  default: deepseek-v3
```

Or for the China endpoint:
```yaml
model:
  provider: astraflow-cn
  default: deepseek-v3
```

Both endpoints are OpenAI-compatible (`openai_chat` transport), following the same dual-region pattern already used by `minimax`/`minimax-cn`.