### PR TITLE
feat(gateway): guard repo side effects with workspace binding

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -26508,6 +26508,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             user_name=str(context.source.user_name) if context.source.user_name else "",
             scope_id=str(getattr(context.source, "scope_id", "") or ""),
             session_key=context.session_key,
+            workspace_slug=(
+                context.workspace_binding.slug if context.workspace_binding else ""
+            ),
+            workspace_repo_path=(
+                context.workspace_binding.repo_path
+                if context.workspace_binding and context.workspace_binding.repo_path
+                else ""
+            ),
             message_id=str(context.source.message_id) if context.source.message_id else "",
             profile=getattr(context.source, "profile", "") or "",
             async_delivery=_async_delivery,

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -326,6 +326,7 @@ class SessionContext:
     source: SessionSource
     connected_platforms: List[Platform]
     home_channels: Dict[Platform, HomeChannel]
+    workspace_binding: Optional[Any] = None
     shared_multi_user_session: bool = False
     
     # Session metadata
@@ -341,6 +342,9 @@ class SessionContext:
             "home_channels": {
                 p.value: hc.to_dict() for p, hc in self.home_channels.items()
             },
+            "workspace_binding": (
+                self.workspace_binding.to_dict() if self.workspace_binding else None
+            ),
             "shared_multi_user_session": self.shared_multi_user_session,
             "session_key": self.session_key,
             "session_id": self.session_id,
@@ -569,6 +573,31 @@ def build_session_context_prompt(
             "Matrix room/thread only. Do not assume unresolved references are "
             "about other Matrix rooms or projects unless the user explicitly says so."
         )
+
+    if context.source.platform != Platform.LOCAL:
+        binding = context.workspace_binding
+        lines.append("")
+        if binding is None:
+            lines.append(
+                "**Current Project Binding:** No authoritative project binding was found "
+                "for this gateway room. For repository or project side effects, "
+                "continue read-only until the room is explicitly bound in workspaces.yaml."
+            )
+        else:
+            lines.append("**Current Project Binding:**")
+            lines.append(f"  - Project: {binding.name} (`{binding.slug}`)")
+            if binding.repo_path:
+                lines.append(f"  - Repo path: `{binding.repo_path}`")
+            if binding.canonical_repo_url:
+                lines.append(f"  - Canonical repo: `{binding.canonical_repo_url}`")
+            if binding.default_branch:
+                lines.append(f"  - Default branch: `{binding.default_branch}`")
+            lines.append(
+                "This binding is authoritative for side-effecting project work. "
+                "Treat it as session-local operational metadata: use it for tool "
+                "targeting, but do not log, quote, screenshot, or expose it outside "
+                "this session unless the user explicitly asks."
+            )
 
     # User identity.
     # In shared multi-user sessions (shared threads OR shared non-thread groups
@@ -4531,6 +4560,13 @@ def build_session_context(
             thread_sessions_per_user=getattr(config, "thread_sessions_per_user", False),
         ),
     )
+
+    try:
+        from .workspace_registry import resolve_workspace_binding
+
+        context.workspace_binding = resolve_workspace_binding(source)
+    except Exception:
+        logger.warning("Failed to resolve workspace binding", exc_info=True)
     
     if session_entry:
         context.session_key = session_entry.session_key

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -88,6 +88,8 @@ _SESSION_USER_NAME: ContextVar = ContextVar("HERMES_SESSION_USER_NAME", default=
 # to resolve the tenant for a scoped reply after a restart.
 _SESSION_SCOPE_ID: ContextVar = ContextVar("HERMES_SESSION_SCOPE_ID", default=_UNSET)
 _SESSION_KEY: ContextVar = ContextVar("HERMES_SESSION_KEY", default=_UNSET)
+_WORKSPACE_SLUG: ContextVar = ContextVar("HERMES_SESSION_WORKSPACE_SLUG", default=_UNSET)
+_WORKSPACE_REPO_PATH: ContextVar = ContextVar("HERMES_SESSION_WORKSPACE_REPO_PATH", default=_UNSET)
 _SESSION_ID: ContextVar = ContextVar("HERMES_SESSION_ID", default=_UNSET)
 # In-process UI session/window id for multi-session desktop/TUI hosts. This is
 # intentionally separate from HERMES_SESSION_ID: the latter is the durable
@@ -153,6 +155,8 @@ _VAR_MAP = {
     "HERMES_SESSION_USER_NAME": _SESSION_USER_NAME,
     "HERMES_SESSION_SCOPE_ID": _SESSION_SCOPE_ID,
     "HERMES_SESSION_KEY": _SESSION_KEY,
+    "HERMES_SESSION_WORKSPACE_SLUG": _WORKSPACE_SLUG,
+    "HERMES_SESSION_WORKSPACE_REPO_PATH": _WORKSPACE_REPO_PATH,
     "HERMES_SESSION_ID": _SESSION_ID,
     "HERMES_UI_SESSION_ID": _SESSION_UI_SESSION_ID,
     "HERMES_SESSION_MESSAGE_ID": _SESSION_MESSAGE_ID,
@@ -233,6 +237,8 @@ def set_session_vars(
     user_name: str = "",
     scope_id: str = "",
     session_key: str = "",
+    workspace_slug: str = "",
+    workspace_repo_path: str = "",
     session_id: str = "",
     message_id: str = "",
     profile: str = "",
@@ -279,6 +285,8 @@ def set_session_vars(
         _SESSION_USER_NAME.set(user_name),
         _SESSION_SCOPE_ID.set(scope_id),
         _SESSION_KEY.set(session_key),
+        _WORKSPACE_SLUG.set(workspace_slug),
+        _WORKSPACE_REPO_PATH.set(workspace_repo_path),
         _SESSION_ID.set(session_id),
         _SESSION_UI_SESSION_ID.set(ui_session_id),
         _SESSION_MESSAGE_ID.set(message_id),
@@ -320,6 +328,8 @@ def clear_session_vars(tokens: list) -> None:
         _SESSION_USER_NAME,
         _SESSION_SCOPE_ID,
         _SESSION_KEY,
+        _WORKSPACE_SLUG,
+        _WORKSPACE_REPO_PATH,
         _SESSION_ID,
         _SESSION_UI_SESSION_ID,
         _SESSION_MESSAGE_ID,

--- a/gateway/workspace_registry.py
+++ b/gateway/workspace_registry.py
@@ -1,0 +1,127 @@
+"""Profile-local workspace registry for gateway channel/project bindings."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+import yaml
+
+from hermes_constants import get_hermes_home
+
+from .session import SessionSource
+
+
+@dataclass(frozen=True)
+class WorkspaceBinding:
+    """Authoritative project binding resolved from a gateway channel."""
+
+    slug: str
+    name: str
+    repo_path: Optional[str] = None
+    canonical_repo_url: Optional[str] = None
+    default_branch: Optional[str] = None
+    response_policy: Optional[str] = None
+    source: str = "workspaces.yaml"
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "WorkspaceBinding":
+        return cls(
+            slug=str(data["slug"]),
+            name=str(data.get("name") or data["slug"]),
+            repo_path=data.get("repo_path"),
+            canonical_repo_url=data.get("canonical_repo_url"),
+            default_branch=data.get("default_branch"),
+            response_policy=data.get("response_policy"),
+            source=str(data.get("source") or "workspaces.yaml"),
+        )
+
+
+class WorkspaceRegistry:
+    """Resolve platform channel/thread IDs to profile-local project metadata."""
+
+    def __init__(self, config_path: str | Path | None = None) -> None:
+        self.config_path = Path(config_path) if config_path is not None else default_workspace_registry_path()
+        self._data = self._load()
+
+    def _load(self) -> dict[str, Any]:
+        if not self.config_path.exists():
+            return {}
+        loaded = yaml.safe_load(self.config_path.read_text(encoding="utf-8")) or {}
+        workspaces = loaded.get("workspaces", loaded)
+        return workspaces if isinstance(workspaces, dict) else {}
+
+    def resolve_source(self, source: SessionSource) -> Optional[WorkspaceBinding]:
+        platform = source.platform.value if hasattr(source.platform, "value") else str(source.platform)
+        chat_id = str(source.chat_id)
+        thread_id = str(source.thread_id) if source.thread_id else None
+        source_scope = source.scope_id or source.guild_id
+        workspace_scope = str(source_scope) if source_scope else None
+
+        for slug, workspace in self._data.items():
+            if not isinstance(workspace, dict):
+                continue
+            for channel in workspace.get("channels", []) or []:
+                if not isinstance(channel, dict):
+                    continue
+                if str(channel.get("platform", "")) != platform:
+                    continue
+                if not _channel_matches(channel, chat_id, thread_id, workspace_scope):
+                    continue
+                return WorkspaceBinding(
+                    slug=str(slug),
+                    name=str(workspace.get("name") or slug),
+                    repo_path=workspace.get("repo_path"),
+                    canonical_repo_url=workspace.get("canonical_repo_url"),
+                    default_branch=workspace.get("default_branch"),
+                    response_policy=channel.get("response_policy"),
+                    source=str(self.config_path),
+                )
+        return None
+
+
+def default_workspace_registry_path() -> Path:
+    """Return the default profile-local workspaces.yaml path."""
+
+    return get_hermes_home() / "workspaces.yaml"
+
+
+def resolve_workspace_binding(source: SessionSource, config_path: str | Path | None = None) -> Optional[WorkspaceBinding]:
+    """Resolve a source using the default profile-local workspace registry."""
+
+    return WorkspaceRegistry(config_path).resolve_source(source)
+
+
+def _channel_matches(
+    channel: dict[str, Any],
+    chat_id: str,
+    thread_id: Optional[str],
+    workspace_scope: Optional[str],
+) -> bool:
+    channel_ids = (
+        channel.get("chat_id"),
+        channel.get("channel_id"),
+        channel.get("room_id"),
+        channel.get("conversation_id"),
+    )
+    if chat_id not in {str(value) for value in channel_ids if value is not None}:
+        return False
+
+    configured_thread = channel.get("thread_id") or channel.get("topic_id")
+    if configured_thread is not None and str(configured_thread) != (thread_id or ""):
+        return False
+
+    configured_scope = (
+        channel.get("scope_id")
+        or channel.get("guild_id")
+        or channel.get("workspace_id")
+        or channel.get("team_id")
+    )
+    if configured_scope is not None and str(configured_scope) != (workspace_scope or ""):
+        return False
+
+    return True

--- a/tests/gateway/test_workspace_registry.py
+++ b/tests/gateway/test_workspace_registry.py
@@ -1,0 +1,161 @@
+from pathlib import Path
+
+from gateway.config import HomeChannel, Platform
+from gateway.session import SessionContext, SessionSource, build_session_context_prompt
+from gateway.workspace_registry import WorkspaceBinding, WorkspaceRegistry
+
+
+def _write_registry(tmp_path: Path) -> Path:
+    path = tmp_path / "workspaces.yaml"
+    path.write_text(
+        """
+workspaces:
+  example:
+    name: Example Project
+    repo_path: /srv/example
+    canonical_repo_url: https://example.org/example/project.git
+    default_branch: main
+    channels:
+      - platform: matrix
+        room_id: "!room:example.org"
+        response_policy: free_response
+      - platform: discord
+        scope_id: "server-1"
+        channel_id: "channel-1"
+        thread_id: "thread-1"
+        response_policy: mention_only
+      - platform: slack
+        workspace_id: "T123"
+        channel_id: "C456"
+""".strip(),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_registry_resolves_matrix_room_binding(tmp_path):
+    registry = WorkspaceRegistry(_write_registry(tmp_path))
+    source = SessionSource(
+        platform=Platform.MATRIX,
+        chat_id="!room:example.org",
+        chat_name="Project - Example",
+        chat_type="group",
+    )
+
+    assert registry.resolve_source(source) == WorkspaceBinding(
+        slug="example",
+        name="Example Project",
+        repo_path="/srv/example",
+        canonical_repo_url="https://example.org/example/project.git",
+        default_branch="main",
+        response_policy="free_response",
+        source=str(registry.config_path),
+    )
+
+
+def test_registry_uses_canonical_scope_id_for_thread_binding(tmp_path):
+    registry = WorkspaceRegistry(_write_registry(tmp_path))
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="channel-1",
+        thread_id="thread-1",
+        scope_id="server-1",
+        chat_type="thread",
+    )
+
+    binding = registry.resolve_source(source)
+
+    assert binding is not None
+    assert binding.slug == "example"
+    assert binding.response_policy == "mention_only"
+
+
+def test_registry_rejects_wrong_thread_and_scope(tmp_path):
+    registry = WorkspaceRegistry(_write_registry(tmp_path))
+
+    wrong_thread = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="channel-1",
+        thread_id="other-thread",
+        scope_id="server-1",
+        chat_type="thread",
+    )
+    wrong_scope = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="channel-1",
+        thread_id="thread-1",
+        scope_id="other-server",
+        chat_type="thread",
+    )
+
+    assert registry.resolve_source(wrong_thread) is None
+    assert registry.resolve_source(wrong_scope) is None
+
+
+def test_registry_resolves_legacy_workspace_scope_alias(tmp_path):
+    registry = WorkspaceRegistry(_write_registry(tmp_path))
+    source = SessionSource(
+        platform=Platform.SLACK,
+        chat_id="C456",
+        scope_id="T123",
+        chat_type="channel",
+    )
+
+    binding = registry.resolve_source(source)
+
+    assert binding is not None
+    assert binding.slug == "example"
+
+
+def test_prompt_includes_authoritative_project_binding():
+    context = SessionContext(
+        source=SessionSource(
+            platform=Platform.MATRIX,
+            chat_id="!room:example.org",
+            chat_name="Project - Example",
+            chat_type="group",
+        ),
+        connected_platforms=[Platform.MATRIX],
+        home_channels={
+            Platform.MATRIX: HomeChannel(
+                platform=Platform.MATRIX,
+                chat_id="!home:example.org",
+                name="Home",
+            )
+        },
+        workspace_binding=WorkspaceBinding(
+            slug="example",
+            name="Example Project",
+            repo_path="/srv/example",
+            canonical_repo_url="https://example.org/example/project.git",
+            default_branch="main",
+            response_policy="free_response",
+            source="/tmp/workspaces.yaml",
+        ),
+    )
+
+    prompt = build_session_context_prompt(context)
+
+    assert "**Current Project Binding:**" in prompt
+    assert "Example Project (`example`)" in prompt
+    assert "Repo path: `/srv/example`" in prompt
+    assert "authoritative for side-effecting project work" in prompt
+    assert "session-local operational metadata" in prompt
+    assert "do not log, quote, screenshot" in prompt
+
+
+def test_prompt_marks_missing_project_binding_for_gateway_rooms():
+    context = SessionContext(
+        source=SessionSource(
+            platform=Platform.MATRIX,
+            chat_id="!unknown:example.org",
+            chat_type="group",
+        ),
+        connected_platforms=[Platform.MATRIX],
+        home_channels={},
+    )
+
+    prompt = build_session_context_prompt(context)
+
+    assert "No authoritative project binding was found" in prompt
+    assert "continue read-only" in prompt

--- a/tests/tools/test_workspace_safety.py
+++ b/tests/tools/test_workspace_safety.py
@@ -1,0 +1,374 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from gateway.session_context import clear_session_vars, get_session_env, set_session_vars
+from tools.file_tools import patch_tool, write_file_tool
+from tools.terminal_tool import terminal_tool
+from tools.workspace_safety import check_terminal_side_effect_allowed
+
+
+@pytest.fixture(autouse=True)
+def clean_session_context(monkeypatch):
+    for key in (
+        "HERMES_SESSION_PLATFORM",
+        "HERMES_SESSION_CHAT_ID",
+        "HERMES_SESSION_WORKSPACE_SLUG",
+        "HERMES_SESSION_WORKSPACE_REPO_PATH",
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_CONFIG_GLOBAL",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    tokens = set_session_vars()
+    clear_session_vars(tokens)
+    yield
+    clear_session_vars(tokens)
+
+
+def _git_repo(path: Path) -> Path:
+    path.mkdir(parents=True)
+    (path / ".git").mkdir()
+    return path
+
+
+def _gateway_session(bound_repo: str | Path | None = None):
+    return set_session_vars(
+        platform="matrix",
+        chat_id="!room:example.org",
+        workspace_slug="example" if bound_repo else "",
+        workspace_repo_path=str(bound_repo) if bound_repo else "",
+    )
+
+
+def test_write_and_patch_are_blocked_in_wrong_repo(tmp_path):
+    bound_repo = _git_repo(tmp_path / "bound")
+    other_repo = _git_repo(tmp_path / "other")
+    target = other_repo / "file.txt"
+    target.write_text("old", encoding="utf-8")
+    tokens = _gateway_session(bound_repo)
+    try:
+        write_result = json.loads(write_file_tool(str(other_repo / "new.txt"), "data"))
+        patch_result = json.loads(
+            patch_tool(path=str(target), old_string="old", new_string="new")
+        )
+    finally:
+        clear_session_vars(tokens)
+
+    assert "outside authoritative workspace binding" in write_result["error"]
+    assert "outside authoritative workspace binding" in patch_result["error"]
+    assert not (other_repo / "new.txt").exists()
+    assert target.read_text(encoding="utf-8") == "old"
+
+
+def test_write_allowed_in_bound_repo(tmp_path):
+    bound_repo = _git_repo(tmp_path / "bound")
+    target = bound_repo / "file.txt"
+    tokens = _gateway_session(bound_repo)
+    try:
+        result = json.loads(write_file_tool(str(target), "data"))
+    finally:
+        clear_session_vars(tokens)
+
+    assert result.get("error") in (None, "")
+    assert target.read_text(encoding="utf-8") == "data"
+
+
+def test_unbound_gateway_repo_write_blocked(tmp_path):
+    repo = _git_repo(tmp_path / "repo")
+    tokens = _gateway_session()
+    try:
+        result = json.loads(write_file_tool(str(repo / "file.txt"), "data"))
+    finally:
+        clear_session_vars(tokens)
+
+    assert "no authoritative workspace binding" in result["error"]
+    assert not (repo / "file.txt").exists()
+
+
+def test_non_repo_scratch_write_and_read_only_git_remain_allowed(tmp_path):
+    scratch = tmp_path / "scratch"
+    target = scratch / "file.txt"
+    tokens = _gateway_session()
+    try:
+        write_result = json.loads(write_file_tool(str(target), "data"))
+        terminal_error = check_terminal_side_effect_allowed("git status", scratch)
+    finally:
+        clear_session_vars(tokens)
+
+    assert write_result.get("error") in (None, "")
+    assert target.read_text(encoding="utf-8") == "data"
+    assert terminal_error is None
+
+
+def test_channel_identity_and_workspace_contextvars_coexist(tmp_path):
+    bound_repo = _git_repo(tmp_path / "bound")
+    tokens = set_session_vars(
+        platform="matrix",
+        chat_id="!room:example.org",
+        workspace_slug="example",
+        workspace_repo_path=str(bound_repo),
+    )
+    try:
+        assert get_session_env("HERMES_SESSION_CHAT_ID") == "!room:example.org"
+        assert get_session_env("HERMES_SESSION_WORKSPACE_SLUG") == "example"
+        assert get_session_env("HERMES_SESSION_WORKSPACE_REPO_PATH") == str(bound_repo)
+    finally:
+        clear_session_vars(tokens)
+
+
+def test_terminal_tool_blocks_mutating_git_outside_bound_repo(tmp_path, monkeypatch):
+    bound_repo = _git_repo(tmp_path / "bound")
+    other_repo = _git_repo(tmp_path / "other")
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    monkeypatch.setenv("TERMINAL_CWD", str(other_repo))
+    tokens = _gateway_session(bound_repo)
+    try:
+        result = json.loads(terminal_tool("git add file.txt", timeout=5))
+    finally:
+        clear_session_vars(tokens)
+
+    assert result["status"] == "blocked"
+    assert "outside authoritative workspace binding" in result["error"]
+
+
+@pytest.mark.parametrize("backend,path", [("ssh", "/srv/example/file.py"), ("docker", "/workspace/example/file.py")])
+def test_file_write_fails_closed_for_nonlocal_backend_paths(backend, path, tmp_path, monkeypatch):
+    monkeypatch.setenv("TERMINAL_ENV", backend)
+    tokens = _gateway_session(path.rsplit("/", 1)[0])
+    try:
+        result = json.loads(write_file_tool(path, "data"))
+    finally:
+        clear_session_vars(tokens)
+
+    assert "cannot verify" in result["error"]
+    assert backend in result["error"]
+
+
+@pytest.mark.parametrize("backend,cwd", [("ssh", "/srv/example"), ("docker", "/workspace/example")])
+def test_terminal_fails_closed_for_nonlocal_backend_git(backend, cwd, monkeypatch):
+    monkeypatch.setenv("TERMINAL_ENV", backend)
+    monkeypatch.setenv("TERMINAL_CWD", cwd)
+    tokens = _gateway_session(cwd)
+    try:
+        result = json.loads(terminal_tool("git commit -m update", timeout=5))
+    finally:
+        clear_session_vars(tokens)
+
+    assert result["status"] == "blocked"
+    assert "cannot verify" in result["error"]
+    assert backend in result["error"]
+
+
+@pytest.mark.parametrize("shell", ["sh", "bash", "zsh", "/bin/bash"])
+def test_shell_c_git_payload_fails_closed(shell, tmp_path):
+    bound_repo = _git_repo(tmp_path / "bound")
+    other_repo = _git_repo(tmp_path / "other")
+    tokens = _gateway_session(bound_repo)
+    try:
+        error = check_terminal_side_effect_allowed(
+            f"{shell} -c 'git -C {other_repo} commit -m nested'", bound_repo
+        )
+    finally:
+        clear_session_vars(tokens)
+
+    assert error is not None
+    assert "cannot verify" in error
+
+
+def test_nested_shell_c_git_payload_fails_closed(tmp_path):
+    bound_repo = _git_repo(tmp_path / "bound")
+    tokens = _gateway_session(bound_repo)
+    try:
+        error = check_terminal_side_effect_allowed(
+            "bash -lc \"echo ok; sh -c 'git status'\"", bound_repo
+        )
+    finally:
+        clear_session_vars(tokens)
+
+    assert error is not None
+    assert "cannot verify" in error
+
+
+def test_shell_c_without_git_remains_allowed(tmp_path):
+    bound_repo = _git_repo(tmp_path / "bound")
+    tokens = _gateway_session(bound_repo)
+    try:
+        error = check_terminal_side_effect_allowed("bash -c 'echo git status'", bound_repo)
+    finally:
+        clear_session_vars(tokens)
+
+    assert error is None
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "bash -c 'echo ok;git commit -m attached'",
+        "zsh -c 'true&&git push'",
+        "sh -c 'printf ok|git add README.md'",
+    ],
+)
+def test_shell_c_attached_operator_git_payload_fails_closed(command, tmp_path):
+    bound_repo = _git_repo(tmp_path / "bound")
+    tokens = _gateway_session(bound_repo)
+    try:
+        error = check_terminal_side_effect_allowed(command, bound_repo)
+    finally:
+        clear_session_vars(tokens)
+
+    assert error is not None
+    assert "cannot verify" in error
+
+
+def test_shell_c_echoed_nested_shell_text_remains_allowed(tmp_path):
+    bound_repo = _git_repo(tmp_path / "bound")
+    tokens = _gateway_session(bound_repo)
+    try:
+        error = check_terminal_side_effect_allowed(
+            "bash -c \"echo sh -c 'git status'\"", bound_repo
+        )
+    finally:
+        clear_session_vars(tokens)
+
+    assert error is None
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "git fetch origin",
+        "git remote add origin https://example.org/project.git",
+        "git remote set-url origin https://example.org/project.git",
+        "git branch --set-upstream-to origin/main",
+        "git branch -u origin/main",
+    ],
+)
+def test_mutating_git_forms_are_blocked_in_wrong_repo(command, tmp_path):
+    bound_repo = _git_repo(tmp_path / "bound")
+    other_repo = _git_repo(tmp_path / "other")
+    tokens = _gateway_session(bound_repo)
+    try:
+        error = check_terminal_side_effect_allowed(command, other_repo)
+    finally:
+        clear_session_vars(tokens)
+
+    assert error is not None
+    assert "outside authoritative workspace binding" in error
+
+
+def test_git_remote_get_url_is_read_only(tmp_path):
+    bound_repo = _git_repo(tmp_path / "bound")
+    other_repo = _git_repo(tmp_path / "other")
+    tokens = _gateway_session(bound_repo)
+    try:
+        error = check_terminal_side_effect_allowed("git remote get-url origin", other_repo)
+    finally:
+        clear_session_vars(tokens)
+
+    assert error is None
+
+
+def test_git_dash_c_and_cd_chain_wrong_repo_are_blocked(tmp_path):
+    bound_repo = _git_repo(tmp_path / "bound")
+    other_repo = _git_repo(tmp_path / "other")
+    tokens = _gateway_session(bound_repo)
+    try:
+        dash_c = check_terminal_side_effect_allowed(
+            f"git -C {other_repo} commit -m update", bound_repo
+        )
+        cd_chain = check_terminal_side_effect_allowed(
+            f"cd {other_repo} && git commit -m update", bound_repo
+        )
+    finally:
+        clear_session_vars(tokens)
+
+    assert dash_c is not None and "outside authoritative" in dash_c
+    assert cd_chain is not None and "outside authoritative" in cd_chain
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "git --git-dir=/tmp/other/.git commit -m update",
+        "git -c core.worktree=/tmp/other commit -m update",
+        "git -ccore.worktree=/tmp/other commit -m update",
+        "git -c include.path=/tmp/unsafe.gitconfig commit -m update",
+        "git -c includeIf.gitdir:/tmp/repo/.path=/tmp/unsafe.gitconfig commit -m update",
+        "git -c alias.ci='!git -C /tmp/other commit -m oops' ci",
+        "GIT_DIR=/tmp/other/.git GIT_WORK_TREE=/tmp/other git commit -m update",
+        "GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=core.worktree GIT_CONFIG_VALUE_0=/tmp/other git commit -m update",
+        "export GIT_CONFIG_GLOBAL=/tmp/unsafe.gitconfig; git commit -m update",
+    ],
+)
+def test_git_target_redirects_fail_closed(command, tmp_path):
+    bound_repo = _git_repo(tmp_path / "bound")
+    tokens = _gateway_session(bound_repo)
+    try:
+        error = check_terminal_side_effect_allowed(command, bound_repo)
+    finally:
+        clear_session_vars(tokens)
+
+    assert error is not None
+    assert "cannot verify" in error
+
+
+def test_ambient_git_config_redirect_fails_closed(tmp_path, monkeypatch):
+    bound_repo = _git_repo(tmp_path / "bound")
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", "/tmp/unsafe.gitconfig")
+    tokens = _gateway_session(bound_repo)
+    try:
+        error = check_terminal_side_effect_allowed("git commit -m update", bound_repo)
+    finally:
+        clear_session_vars(tokens)
+
+    assert error is not None
+    assert "cannot verify" in error
+
+
+def test_unknown_git_subcommand_fails_closed_from_bound_repo(tmp_path):
+    bound_repo = _git_repo(tmp_path / "bound")
+    tokens = _gateway_session(bound_repo)
+    try:
+        error = check_terminal_side_effect_allowed("git ci", bound_repo)
+    finally:
+        clear_session_vars(tokens)
+
+    assert error is not None
+    assert "cannot verify" in error
+
+
+def test_all_git_invocations_are_scanned(tmp_path):
+    bound_repo = _git_repo(tmp_path / "bound")
+    other_repo = _git_repo(tmp_path / "other")
+    tokens = _gateway_session(bound_repo)
+    try:
+        error = check_terminal_side_effect_allowed(
+            f"git add README.md; git -C {other_repo} commit -m oops", bound_repo
+        )
+    finally:
+        clear_session_vars(tokens)
+
+    assert error is not None
+    assert "outside authoritative workspace binding" in error
+
+
+def test_non_repo_invocation_does_not_hide_later_mutation(tmp_path):
+    bound_repo = _git_repo(tmp_path / "bound")
+    other_repo = _git_repo(tmp_path / "other")
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+    tokens = _gateway_session(bound_repo)
+    try:
+        error = check_terminal_side_effect_allowed(
+            f"cd {scratch} && git add README.md; git -C {other_repo} commit -m oops",
+            bound_repo,
+        )
+    finally:
+        clear_session_vars(tokens)
+
+    assert error is not None
+    assert "outside authoritative workspace binding" in error

--- a/tests/tools/test_workspace_safety.py
+++ b/tests/tools/test_workspace_safety.py
@@ -35,6 +35,15 @@ def _git_repo(path: Path) -> Path:
     return path
 
 
+def _linked_worktree(main: Path, linked: Path) -> Path:
+    gitdir = main / ".git" / "worktrees" / "linked"
+    gitdir.mkdir(parents=True)
+    linked.mkdir(parents=True)
+    (linked / ".git").write_text(f"gitdir: {gitdir}\n", encoding="utf-8")
+    (gitdir / "gitdir").write_text(f"{linked / '.git'}\n", encoding="utf-8")
+    return linked
+
+
 def _gateway_session(bound_repo: str | Path | None = None):
     return set_session_vars(
         platform="matrix",
@@ -465,3 +474,49 @@ def test_quoted_git_text_is_not_an_executable(command, tmp_path):
         clear_session_vars(tokens)
 
     assert error is None
+
+
+def test_linked_worktree_write_and_git_are_allowed(tmp_path):
+    bound_repo = _git_repo(tmp_path / "bound")
+    linked = _linked_worktree(bound_repo, tmp_path / "linked")
+    tokens = _gateway_session(bound_repo)
+    try:
+        write_result = json.loads(write_file_tool(str(linked / "file.txt"), "data"))
+        error = check_terminal_side_effect_allowed("git commit -m update", linked)
+    finally:
+        clear_session_vars(tokens)
+
+    assert write_result.get("error") in (None, "")
+    assert (linked / "file.txt").read_text(encoding="utf-8") == "data"
+    assert error is None
+
+
+def test_independent_clone_is_still_blocked(tmp_path):
+    bound_repo = _git_repo(tmp_path / "bound")
+    clone = _git_repo(tmp_path / "clone")
+    tokens = _gateway_session(bound_repo)
+    try:
+        write_result = json.loads(write_file_tool(str(clone / "file.txt"), "data"))
+        error = check_terminal_side_effect_allowed("git commit -m update", clone)
+    finally:
+        clear_session_vars(tokens)
+
+    assert "outside authoritative workspace binding" in write_result["error"]
+    assert error is not None
+    assert "outside authoritative" in error
+
+
+def test_worktree_pointer_without_backref_is_blocked(tmp_path):
+    bound_repo = _git_repo(tmp_path / "bound")
+    spoof = tmp_path / "spoof"
+    spoof.mkdir()
+    gitdir = bound_repo / ".git" / "worktrees" / "spoof"
+    gitdir.mkdir(parents=True)
+    (spoof / ".git").write_text(f"gitdir: {gitdir}\n", encoding="utf-8")
+    tokens = _gateway_session(bound_repo)
+    try:
+        write_result = json.loads(write_file_tool(str(spoof / "file.txt"), "data"))
+    finally:
+        clear_session_vars(tokens)
+
+    assert "outside authoritative workspace binding" in write_result["error"]

--- a/tests/tools/test_workspace_safety.py
+++ b/tests/tools/test_workspace_safety.py
@@ -41,6 +41,7 @@ def _linked_worktree(main: Path, linked: Path) -> Path:
     linked.mkdir(parents=True)
     (linked / ".git").write_text(f"gitdir: {gitdir}\n", encoding="utf-8")
     (gitdir / "gitdir").write_text(f"{linked / '.git'}\n", encoding="utf-8")
+    (gitdir / "commondir").write_text("../..\n", encoding="utf-8")
     return linked
 
 
@@ -516,7 +517,69 @@ def test_worktree_pointer_without_backref_is_blocked(tmp_path):
     tokens = _gateway_session(bound_repo)
     try:
         write_result = json.loads(write_file_tool(str(spoof / "file.txt"), "data"))
+        error = check_terminal_side_effect_allowed("git commit -m update", spoof)
     finally:
         clear_session_vars(tokens)
 
     assert "outside authoritative workspace binding" in write_result["error"]
+    assert error is not None
+    assert "outside authoritative" in error
+
+
+def test_gitdir_file_pointing_at_bound_git_is_blocked(tmp_path):
+    bound_repo = _git_repo(tmp_path / "bound")
+    spoof = tmp_path / "spoof"
+    spoof.mkdir()
+    (spoof / ".git").write_text(f"gitdir: {bound_repo / '.git'}\n", encoding="utf-8")
+    tokens = _gateway_session(bound_repo)
+    try:
+        write_result = json.loads(write_file_tool(str(spoof / "file.txt"), "data"))
+        error = check_terminal_side_effect_allowed("git commit -m update", spoof)
+    finally:
+        clear_session_vars(tokens)
+
+    assert "outside authoritative workspace binding" in write_result["error"]
+    assert error is not None
+    assert "outside authoritative" in error
+
+
+def test_git_symlink_to_bound_git_is_blocked(tmp_path):
+    bound_repo = _git_repo(tmp_path / "bound")
+    spoof = tmp_path / "spoof"
+    spoof.mkdir()
+    (spoof / ".git").symlink_to(bound_repo / ".git")
+    tokens = _gateway_session(bound_repo)
+    try:
+        write_result = json.loads(write_file_tool(str(spoof / "file.txt"), "data"))
+        error = check_terminal_side_effect_allowed("git commit -m update", spoof)
+    finally:
+        clear_session_vars(tokens)
+
+    assert "outside authoritative workspace binding" in write_result["error"]
+    assert error is not None
+    assert "outside authoritative" in error
+
+
+def test_commondir_outside_dotgit_name_allows_linked_worktree(tmp_path):
+    common = tmp_path / "shared.git"
+    common.mkdir()
+    main = tmp_path / "main"
+    main.mkdir()
+    (main / ".git").write_text(f"gitdir: {common}\n", encoding="utf-8")
+    linked = tmp_path / "linked"
+    gitdir = common / "worktrees" / "linked"
+    gitdir.mkdir(parents=True)
+    linked.mkdir()
+    (linked / ".git").write_text(f"gitdir: {gitdir}\n", encoding="utf-8")
+    (gitdir / "gitdir").write_text(f"{linked / '.git'}\n", encoding="utf-8")
+    (gitdir / "commondir").write_text(f"{common}\n", encoding="utf-8")
+    tokens = _gateway_session(main)
+    try:
+        write_result = json.loads(write_file_tool(str(linked / "file.txt"), "data"))
+        error = check_terminal_side_effect_allowed("git commit -m update", linked)
+    finally:
+        clear_session_vars(tokens)
+
+    assert write_result.get("error") in (None, "")
+    assert (linked / "file.txt").read_text(encoding="utf-8") == "data"
+    assert error is None

--- a/tests/tools/test_workspace_safety.py
+++ b/tests/tools/test_workspace_safety.py
@@ -426,6 +426,15 @@ def test_real_git_in_substitution_or_group_still_fails_closed(command, tmp_path)
         "timeout 5 bash -c 'git -C /tmp/other commit -m update'",
         "bash -xc 'git -C /tmp/other commit -m update'",
         "nohup bash -c 'git -C /tmp/other commit -m update'",
+        "env -i bash -c 'git -C /tmp/other commit -m update'",
+        "command -- bash -c 'git -C /tmp/other commit -m update'",
+        "nice -n 5 bash -c 'git -C /tmp/other commit -m update'",
+        "timeout -k 1 5 bash -c 'git -C /tmp/other commit -m update'",
+        "bash -c 'command git -C /tmp/other commit -m update'",
+        "bash -c 'env git -C /tmp/other commit -m update'",
+        "bash -c 'eval \"git -C /tmp/other commit -m update\"'",
+        "eval 'git -C /tmp/other commit -m update'",
+        "$(command git -C /tmp/other commit -m update)",
     ],
 )
 def test_wrapped_substitution_and_shell_git_still_fails_closed(command, tmp_path):

--- a/tests/tools/test_workspace_safety.py
+++ b/tests/tools/test_workspace_safety.py
@@ -372,3 +372,87 @@ def test_non_repo_invocation_does_not_hide_later_mutation(tmp_path):
 
     assert error is not None
     assert "outside authoritative workspace binding" in error
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "python3 -c \"print('https://github.example.org/example/project')\"",
+        "python3 -c \"x = (1, 2); print('found .git marker')\"",
+        "curl https://github.example.org/example/project",
+        "echo $(curl https://github.example.org/example/project)",
+    ],
+)
+def test_github_substring_and_python_parens_are_not_git(command, tmp_path):
+    bound_repo = _git_repo(tmp_path / "bound")
+    tokens = _gateway_session(bound_repo)
+    try:
+        error = check_terminal_side_effect_allowed(command, bound_repo)
+    finally:
+        clear_session_vars(tokens)
+
+    assert error is None
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "echo $(git rev-parse HEAD)",
+        "echo $(git -C /tmp/other status)",
+        "(git commit -m grouped)",
+    ],
+)
+def test_real_git_in_substitution_or_group_still_fails_closed(command, tmp_path):
+    bound_repo = _git_repo(tmp_path / "bound")
+    tokens = _gateway_session(bound_repo)
+    try:
+        error = check_terminal_side_effect_allowed(command, bound_repo)
+    finally:
+        clear_session_vars(tokens)
+
+    assert error is not None
+    assert "cannot verify" in error
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'echo "$(git -C /tmp/other commit -m update)"',
+        "echo `git -C /tmp/other commit -m update`",
+        'echo "`git -C /tmp/other commit -m update`"',
+        "env bash -c 'git -C /tmp/other commit -m update'",
+        "command bash -c 'git -C /tmp/other commit -m update'",
+        "nice bash -c 'git -C /tmp/other commit -m update'",
+        "timeout 5 bash -c 'git -C /tmp/other commit -m update'",
+        "bash -xc 'git -C /tmp/other commit -m update'",
+        "nohup bash -c 'git -C /tmp/other commit -m update'",
+    ],
+)
+def test_wrapped_substitution_and_shell_git_still_fails_closed(command, tmp_path):
+    bound_repo = _git_repo(tmp_path / "bound")
+    tokens = _gateway_session(bound_repo)
+    try:
+        error = check_terminal_side_effect_allowed(command, bound_repo)
+    finally:
+        clear_session_vars(tokens)
+
+    assert error is not None
+    assert "cannot verify" in error
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "echo '$(git rev-parse HEAD)'",
+        "python3 -c \"print('(git)')\"",
+    ],
+)
+def test_quoted_git_text_is_not_an_executable(command, tmp_path):
+    bound_repo = _git_repo(tmp_path / "bound")
+    tokens = _gateway_session(bound_repo)
+    try:
+        error = check_terminal_side_effect_allowed(command, bound_repo)
+    finally:
+        clear_session_vars(tokens)
+
+    assert error is None

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -23,6 +23,7 @@ from tools.file_operations import (
     normalize_search_pagination,
 )
 from tools import file_state
+from tools.workspace_safety import check_path_side_effect_allowed
 from agent.redact import redact_sensitive_text
 
 logger = logging.getLogger(__name__)
@@ -2255,6 +2256,11 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
     protected_err = _check_protected_instruction_write([path], task_id)
     if protected_err:
         return tool_error(protected_err)
+    backend = str(os.getenv("TERMINAL_ENV") or _terminal_env_type_for_task(task_id)).lower()
+    workspace_path = path if backend != "local" else str(_resolve_path_for_task(path, task_id))
+    workspace_err = check_path_side_effect_allowed(workspace_path, backend=backend)
+    if workspace_err:
+        return tool_error(workspace_err)
     approval_err = _check_approval_required_write([path], task_id)
     if approval_err:
         return tool_error(approval_err)
@@ -2392,6 +2398,11 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
         sensitive_err = _check_sensitive_path(_p, task_id)
         if sensitive_err:
             return tool_error(sensitive_err)
+        backend = str(os.getenv("TERMINAL_ENV") or _terminal_env_type_for_task(task_id)).lower()
+        workspace_path = _p if backend != "local" else _resolve_path_for_task(_p, task_id)
+        workspace_err = check_path_side_effect_allowed(workspace_path, backend=backend)
+        if workspace_err:
+            return tool_error(workspace_err)
         if not cross_profile:
             cross_warning = _check_cross_profile_path(_p, task_id)
             if cross_warning:

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -68,6 +68,7 @@ def _redact_terminal_error_text(value: Any) -> str:
 # ---------------------------------------------------------------------------
 from tools.interrupt import is_interrupted, _interrupt_event  # noqa: F401 — re-exported
 from tools.registry import tool_error
+from tools.workspace_safety import check_terminal_side_effect_allowed
 from tools.shell_heredoc import strip_inert_heredoc_bodies
 # display_hermes_home imported lazily at call site (stale-module safety during hermes update)
 
@@ -2968,6 +2969,35 @@ def terminal_tool(
                     "error": guidance,
                     "status": "error",
                 }, ensure_ascii=False)
+
+        # Validate and guard before creating a terminal environment. In
+        # particular, SSH/container paths are meaningful only on the remote
+        # backend and must fail closed instead of being resolved on the host.
+        if workdir:
+            workdir_error = _validate_workdir(workdir)
+            if workdir_error:
+                logger.warning("Blocked dangerous workdir: %s (command: %s)",
+                               workdir[:200], _safe_command_preview(command))
+                return json.dumps({
+                    "output": "",
+                    "exit_code": -1,
+                    "error": workdir_error,
+                    "status": "blocked"
+                }, ensure_ascii=False)
+
+        effective_cwd = workdir or cwd
+        workspace_err = check_terminal_side_effect_allowed(
+            command,
+            effective_cwd,
+            backend=env_type,
+        )
+        if workspace_err:
+            return json.dumps({
+                "output": "",
+                "exit_code": -1,
+                "error": workspace_err,
+                "status": "blocked",
+            }, ensure_ascii=False)
 
         # Start cleanup thread
         _start_cleanup_thread()

--- a/tools/workspace_safety.py
+++ b/tools/workspace_safety.py
@@ -1,0 +1,586 @@
+from __future__ import annotations
+
+import re
+import os
+import shlex
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Optional
+
+"""Workspace-binding guards for side-effecting project tools.
+
+The gateway can bind a chat/channel to an authoritative workspace repo.  Tool
+side effects should not silently land in a different checkout just because the
+model inferred project context from room names or stale memory.
+"""
+
+
+
+
+_MUTATING_GIT_SUBCOMMANDS = frozenset({
+    "add",
+    "am",
+    "apply",
+    "bisect",
+    "checkout",
+    "cherry-pick",
+    "clean",
+    "clone",
+    "commit",
+    "fetch",
+    "gc",
+    "merge",
+    "mv",
+    "pull",
+    "push",
+    "rebase",
+    "reset",
+    "restore",
+    "revert",
+    "rm",
+    "stash",
+    "submodule",
+    "switch",
+    "tag",
+    "worktree",
+})
+
+_READ_ONLY_GIT_SUBCOMMANDS = frozenset({
+    "blame",
+    "branch",  # treated as mutating when args imply config/ref changes
+    "diff",
+    "grep",
+    "log",
+    "ls-files",
+    "remote",  # treated as mutating when args imply config/ref changes
+    "rev-parse",
+    "show",
+    "status",
+})
+
+_MUTATING_REMOTE_SUBCOMMANDS = frozenset({
+    "add",
+    "remove",
+    "rm",
+    "rename",
+    "set-branches",
+    "set-head",
+    "set-url",
+    "prune",
+    "update",
+})
+
+_MUTATING_BRANCH_FLAGS = frozenset({
+    "-d",
+    "-D",
+    "-m",
+    "-M",
+    "-c",
+    "-C",
+    "-u",
+    "--delete",
+    "--move",
+    "--copy",
+    "--set-upstream-to",
+    "--unset-upstream",
+    "--edit-description",
+})
+
+_UNSAFE_GIT_CWD_SUBCOMMAND = "__unsafe_explicit_git_dir__"
+
+_UNSAFE_GIT_ENV_VARS = frozenset({
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_COMMON_DIR",
+    "GIT_NAMESPACE",
+})
+
+_UNSAFE_GIT_CONFIG_KEYS = frozenset({
+    "core.worktree",
+    "include.path",
+})
+
+_UNSAFE_GIT_CONFIG_KEY_PREFIXES = (
+    "includeif.",
+    "alias.",
+)
+
+_UNSAFE_GIT_CONFIG_ENV_PREFIXES = (
+    "GIT_CONFIG_",
+)
+
+
+@dataclass(frozen=True)
+class GitInvocation:
+    subcommand: str
+    args: list[str]
+    cwd: Path
+
+
+def check_path_side_effect_allowed(
+    path: str | Path,
+    backend: Optional[str] = None,
+) -> Optional[str]:
+    """Return an error if a file write targets a repo outside the binding.
+
+    Non-gateway callers and non-repo paths are allowed.  Gateway project writes
+    are blocked when they target a git checkout that is not the bound repo, or
+    when the session has no workspace binding at all.
+    """
+
+    if not _in_gateway_session():
+        return None
+
+    backend = (backend or "local").strip().lower() or "local"
+    if backend != "local":
+        return (
+            f"Blocked repo side effect: workspace guard cannot verify file write "
+            f"on nonlocal `{backend}` backend paths."
+        )
+
+    resolved = _safe_resolve(path)
+    repo_root = _find_git_root(resolved if resolved.is_dir() else resolved.parent)
+    if repo_root is None:
+        return None
+
+    bound_repo = _bound_repo_path()
+    if bound_repo is None:
+        return _blocked_message(repo_root, None)
+    if not _same_path(repo_root, bound_repo):
+        return _blocked_message(repo_root, bound_repo)
+    return None
+
+
+def check_terminal_side_effect_allowed(
+    command: str,
+    cwd: str | Path,
+    backend: Optional[str] = None,
+) -> Optional[str]:
+    """Return an error if a mutating git command is outside the binding."""
+
+    if not _in_gateway_session():
+        return None
+
+    cwd_path = _safe_resolve(cwd)
+    backend = (backend or "local").strip().lower() or "local"
+    unsafe_ambient = any(
+        value and _env_name_is_unsafe_git(name)
+        for name, value in __import__("os").environ.items()
+    )
+    for invocation in _iter_git_invocations(command, cwd_path):
+        if not _git_invocation_is_mutating(invocation):
+            continue
+        if backend != "local":
+            return (
+                f"Blocked repo side effect: workspace guard cannot verify git command "
+                f"on nonlocal `{backend}` backend."
+            )
+        if unsafe_ambient:
+            return _unverified_git_message()
+        if invocation.subcommand == _UNSAFE_GIT_CWD_SUBCOMMAND:
+            return _unverified_git_message()
+        if _git_subcommand_target_is_unverifiable(invocation.subcommand):
+            return _unverified_git_message()
+        repo_root = _find_git_root(invocation.cwd)
+        if repo_root is None:
+            # Preserve current behavior for non-repo scratch contexts while
+            # still checking later git invocations in the same shell command.
+            continue
+
+        bound_repo = _bound_repo_path()
+        if bound_repo is None:
+            return _blocked_message(repo_root, None)
+        if not _same_path(repo_root, bound_repo):
+            return _blocked_message(repo_root, bound_repo)
+    return None
+
+
+def _unverified_git_message() -> str:
+    return (
+        "Blocked repo side effect: workspace guard cannot verify the target "
+        "repository for this git command. Avoid complex cd/global git-dir/work-tree "
+        "forms or run the command from the bound repository."
+    )
+
+
+def _blocked_message(actual_repo: Path, bound_repo: Optional[Path]) -> str:
+    if bound_repo is None:
+        return (
+            "Blocked repo side effect: this gateway session has no authoritative "
+            f"workspace binding, but the target is inside git repo `{actual_repo}`. "
+            "Add a channel binding to workspaces.yaml or use read-only tools."
+        )
+    return (
+        "Blocked repo side effect outside authoritative workspace binding: "
+        f"target repo `{actual_repo}` does not match bound repo `{bound_repo}`."
+    )
+
+
+def _in_gateway_session() -> bool:
+    return bool(_session_env("HERMES_SESSION_PLATFORM", "") and _session_env("HERMES_SESSION_CHAT_ID", ""))
+
+
+def _bound_repo_path() -> Optional[Path]:
+    repo_path = _session_env("HERMES_SESSION_WORKSPACE_REPO_PATH", "")
+    if not repo_path:
+        return None
+    return _safe_resolve(repo_path)
+
+
+def _session_env(name: str, default: str = "") -> str:
+    try:
+        from gateway.session_context import get_session_env
+
+        return get_session_env(name, default)
+    except Exception:
+        return os.getenv(name, default)
+
+
+def _find_git_root(start: Path) -> Optional[Path]:
+    current = _safe_resolve(start)
+    for candidate in (current, *current.parents):
+        if (candidate / ".git").exists():
+            return candidate
+    return None
+
+
+def _same_path(left: Path, right: Path) -> bool:
+    try:
+        return left.resolve() == right.resolve()
+    except OSError:
+        return os.path.abspath(left) == os.path.abspath(right)
+
+
+def _safe_resolve(path: str | Path) -> Path:
+    return Path(path).expanduser().resolve(strict=False)
+
+
+def _iter_git_invocations(command: str, cwd: Path) -> Iterable[GitInvocation]:
+    current_cwd = cwd
+    unsafe_export = False
+    if _has_unverifiable_shell_git(command):
+        yield GitInvocation(_UNSAFE_GIT_CWD_SUBCOMMAND, [], current_cwd)
+        return
+    for segment in _split_shell_segments(command):
+        try:
+            tokens = shlex.split(segment)
+        except ValueError:
+            if "git" in segment:
+                yield GitInvocation(_UNSAFE_GIT_CWD_SUBCOMMAND, [], current_cwd)
+            continue
+        if not tokens:
+            continue
+        if tokens[0] == "export":
+            for token in tokens[1:]:
+                name = _env_assignment_name(token) or token
+                if _env_name_is_unsafe_git(name):
+                    unsafe_export = True
+            continue
+        unsafe_env, tokens = _strip_env_prefix(tokens)
+        if (unsafe_env or unsafe_export) and any(_is_git_executable_token(token) for token in tokens):
+            yield GitInvocation(_UNSAFE_GIT_CWD_SUBCOMMAND, [], current_cwd)
+            continue
+        if not tokens:
+            continue
+        if tokens[0] == "cd":
+            if len(tokens) != 2 or _path_has_shell_expansion(tokens[1]):
+                yield GitInvocation(_UNSAFE_GIT_CWD_SUBCOMMAND, [], current_cwd)
+                continue
+            current_cwd = _safe_resolve(current_cwd / tokens[1])
+            continue
+        for index, token in enumerate(tokens):
+            if not _is_git_executable_token(token):
+                continue
+            if unsafe_export:
+                yield GitInvocation(_UNSAFE_GIT_CWD_SUBCOMMAND, [], current_cwd)
+                continue
+            invocation = _parse_git_invocation(tokens[index:], current_cwd)
+            if invocation:
+                yield invocation
+
+
+def _is_git_executable_token(token: str) -> bool:
+    return Path(token).name == "git"
+
+
+def _path_has_shell_expansion(value: str) -> bool:
+    return "$" in value or "`" in value or "$(" in value or value.startswith("~")
+
+
+def _has_unquoted_shell_paren(value: str) -> bool:
+    in_single = False
+    in_double = False
+    escaped = False
+
+    for ch in value:
+        if escaped:
+            escaped = False
+            continue
+
+        if ch == "\\" and not in_single:
+            escaped = True
+            continue
+
+        if ch == "'" and not in_double:
+            in_single = not in_single
+            continue
+
+        if ch == '"' and not in_single:
+            in_double = not in_double
+            continue
+
+        if ch in "()" and not in_single and not in_double:
+            return True
+
+    return False
+
+
+def _has_unverifiable_shell_git(command: str) -> bool:
+    # Command substitution can redirect the git target at runtime and is
+    # intentionally fail-closed rather than partially shell-parsed.
+    if "$(" in command and "git" in command:
+        return True
+
+    if _shell_command_executes_git(command):
+        return True
+
+    # Only unquoted parentheses imply shell grouping/subshell syntax. Quoted
+    # parentheses are common in conventional commit scopes and format strings.
+    return _has_unquoted_shell_paren(command) and "git" in command
+
+
+_SHELL_NAMES = frozenset({"sh", "bash", "zsh", "dash", "ash", "ksh"})
+
+
+def _shell_command_executes_git(command: str) -> bool:
+    """True when a shell -c/-lc payload executes git (not quoted/echoed text)."""
+    try:
+        tokens = _shell_payload_tokens(command)
+    except ValueError:
+        return "git" in command and (" -c " in f" {command} " or " -lc " in f" {command} ")
+
+    command_position = True
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if token in _SHELL_CONNECTORS:
+            command_position = True
+            index += 1
+            continue
+        if not command_position:
+            index += 1
+            continue
+        if _env_assignment_name(token):
+            index += 1
+            continue
+
+        name = Path(token).name
+        if name in _SHELL_NAMES:
+            payload = _shell_c_payload(tokens, index)
+            if payload is not None and _payload_has_git_command(payload):
+                return True
+        command_position = False
+        index += 1
+    return False
+
+
+_SHELL_CONNECTORS = frozenset({";", "|", "||", "&&", "&"})
+
+
+def _shell_payload_tokens(payload: str) -> list[str]:
+    lexer = shlex.shlex(payload, posix=True, punctuation_chars=";&|")
+    lexer.whitespace_split = True
+    lexer.commenters = ""
+    return list(lexer)
+
+
+def _shell_c_payload(tokens: list[str], shell_index: int) -> Optional[str]:
+    index = shell_index + 1
+    while index < len(tokens) and tokens[index].startswith("-"):
+        if tokens[index] in {"-c", "-lc"}:
+            return tokens[index + 1] if index + 1 < len(tokens) else None
+        if tokens[index] in {"-o", "-O"} and index + 1 < len(tokens):
+            index += 2
+            continue
+        index += 1
+    return None
+
+
+def _payload_has_git_command(payload: str) -> bool:
+    """Return True if git appears as an executable token in a shell payload."""
+    try:
+        parts = _shell_payload_tokens(payload)
+    except ValueError:
+        return bool(re.search(r"(?:^|[;|&\n\t ])git(?:[;|&\n\t ]|$)", payload))
+
+    command_position = True
+    index = 0
+    while index < len(parts):
+        part = parts[index]
+        if part in _SHELL_CONNECTORS:
+            command_position = True
+            index += 1
+            continue
+        if not command_position:
+            index += 1
+            continue
+        if _env_assignment_name(part):
+            index += 1
+            continue
+
+        name = Path(part).name
+        if name == "git":
+            return True
+        if name in _SHELL_NAMES:
+            nested_payload = _shell_c_payload(parts, index)
+            if nested_payload is not None and _payload_has_git_command(nested_payload):
+                return True
+        command_position = False
+        index += 1
+    return False
+
+
+def _env_assignment_name(token: str) -> Optional[str]:
+    if "=" not in token or token.startswith("="):
+        return None
+    name, _, _ = token.partition("=")
+    if not name or any(ch in name for ch in "-./"):
+        return None
+    return name
+
+
+def _env_name_is_unsafe_git(name: str) -> bool:
+    return name in _UNSAFE_GIT_ENV_VARS or any(
+        name.startswith(prefix) for prefix in _UNSAFE_GIT_CONFIG_ENV_PREFIXES
+    )
+
+
+def _git_config_key(token: str) -> str:
+    key, _, _value = token.partition("=")
+    return key.strip().lower()
+
+
+def _is_unsafe_git_config_assignment(token: str) -> bool:
+    key = _git_config_key(token)
+    return key in _UNSAFE_GIT_CONFIG_KEYS or any(
+        key.startswith(prefix) for prefix in _UNSAFE_GIT_CONFIG_KEY_PREFIXES
+    )
+
+
+def _strip_env_prefix(tokens: list[str]) -> tuple[bool, list[str]]:
+    unsafe_env = False
+    index = 0
+    if tokens and tokens[0] == "env":
+        index = 1
+        while index < len(tokens) and tokens[index].startswith("-"):
+            index += 1
+    while index < len(tokens):
+        name = _env_assignment_name(tokens[index])
+        if name is None:
+            break
+        if _env_name_is_unsafe_git(name):
+            unsafe_env = True
+        index += 1
+    return unsafe_env, tokens[index:]
+
+
+def _parse_git_invocation(tokens: list[str], base_cwd: Path) -> Optional[GitInvocation]:
+    if not tokens or not _is_git_executable_token(tokens[0]):
+        return None
+
+    git_cwd = base_cwd
+    index = 1
+    while index < len(tokens):
+        token = tokens[index]
+        if token == "--":
+            return None
+        if token == "-C":
+            if index + 1 >= len(tokens) or _path_has_shell_expansion(tokens[index + 1]):
+                return GitInvocation(_UNSAFE_GIT_CWD_SUBCOMMAND, tokens[index + 1 :], git_cwd)
+            git_cwd = _safe_resolve(git_cwd / tokens[index + 1])
+            index += 2
+            continue
+        if token.startswith("-C") and token != "-C":
+            if _path_has_shell_expansion(token[2:]):
+                return GitInvocation(_UNSAFE_GIT_CWD_SUBCOMMAND, tokens[index + 1 :], git_cwd)
+            git_cwd = _safe_resolve(git_cwd / token[2:])
+            index += 1
+            continue
+        if token in {"-c", "--config-env"}:
+            if index + 1 >= len(tokens):
+                return GitInvocation(_UNSAFE_GIT_CWD_SUBCOMMAND, tokens[index + 1 :], git_cwd)
+            if _is_unsafe_git_config_assignment(tokens[index + 1]):
+                return GitInvocation(_UNSAFE_GIT_CWD_SUBCOMMAND, tokens[index + 1 :], git_cwd)
+            index += 2
+            continue
+        if token.startswith("-c") and token != "-c":
+            inline_config = token[2:]
+            if _is_unsafe_git_config_assignment(inline_config):
+                return GitInvocation(_UNSAFE_GIT_CWD_SUBCOMMAND, tokens[index + 1 :], git_cwd)
+            index += 1
+            continue
+        if token.startswith("--config-env="):
+            if _is_unsafe_git_config_assignment(token.removeprefix("--config-env=")):
+                return GitInvocation(_UNSAFE_GIT_CWD_SUBCOMMAND, tokens[index + 1 :], git_cwd)
+            index += 1
+            continue
+        if token.startswith("--git-dir") or token.startswith("--work-tree"):
+            return GitInvocation(_UNSAFE_GIT_CWD_SUBCOMMAND, tokens[index + 1 :], git_cwd)
+        if token.startswith("-"):
+            index += 1
+            continue
+        return GitInvocation(token, tokens[index + 1 :], git_cwd)
+    return None
+
+
+def _git_invocation_is_mutating(invocation: GitInvocation) -> bool:
+    subcommand = invocation.subcommand
+    if subcommand == _UNSAFE_GIT_CWD_SUBCOMMAND:
+        return True
+    if subcommand == "branch":
+        return _branch_is_mutating(invocation.args)
+    if subcommand == "remote":
+        return _remote_is_mutating(invocation.args)
+    if subcommand in _READ_ONLY_GIT_SUBCOMMANDS:
+        return False
+    if subcommand in _MUTATING_GIT_SUBCOMMANDS:
+        return True
+    # Unknown git subcommands are potentially side-effecting; guard them.
+    return True
+
+
+def _git_subcommand_target_is_unverifiable(subcommand: str) -> bool:
+    """Return true when a git subcommand might be an alias or extension.
+
+    Unknown git subcommands are treated as mutating above. They can also be
+    repo-local or global aliases that shell out to a different repository, so
+    the workspace guard cannot verify their target from the current cwd alone.
+    """
+
+    return (
+        subcommand not in _READ_ONLY_GIT_SUBCOMMANDS
+        and subcommand not in _MUTATING_GIT_SUBCOMMANDS
+        and subcommand not in {"branch", "remote"}
+    )
+
+
+def _branch_is_mutating(args: list[str]) -> bool:
+    if any(arg in _MUTATING_BRANCH_FLAGS for arg in args):
+        return True
+    # `git branch name` creates a branch; `git branch` and flags like `-vv` list.
+    return bool(args and not any(arg.startswith("-") for arg in args))
+
+
+def _remote_is_mutating(args: list[str]) -> bool:
+    non_flags = [arg for arg in args if not arg.startswith("-")]
+    return bool(non_flags and non_flags[0] in _MUTATING_REMOTE_SUBCOMMANDS)
+
+
+def _split_shell_segments(command: str) -> Iterable[str]:
+    for segment in command.replace("&&", ";").replace("||", ";").split(";"):
+        segment = segment.strip()
+        if segment:
+            yield segment

--- a/tools/workspace_safety.py
+++ b/tools/workspace_safety.py
@@ -279,8 +279,21 @@ def _git_common_dir(repo_root: Path) -> Optional[Path]:
     gitdir = _gitdir_pointer(repo_root)
     if gitdir is None or not gitdir.is_dir():
         return None
-    if gitdir.parent.name == "worktrees" and gitdir.parent.parent.name == ".git":
-        return gitdir.parent.parent
+    commondir = gitdir / "commondir"
+    try:
+        if commondir.is_file():
+            raw = Path(commondir.read_text(encoding="utf-8").strip())
+            if not raw.is_absolute():
+                raw = gitdir / raw
+            resolved = raw.resolve()
+            if resolved.is_dir():
+                return resolved
+    except OSError:
+        pass
+    if gitdir.parent.name == "worktrees":
+        candidate = gitdir.parent.parent
+        if candidate.is_dir():
+            return candidate
     return gitdir
 
 
@@ -297,6 +310,27 @@ def _linked_worktree_backref_ok(repo_root: Path, gitdir: Path) -> bool:
         return False
 
 
+def _is_authorized_checkout(repo_root: Path, gitdir: Path) -> bool:
+    """True when repo_root is the primary checkout or a validated linked worktree."""
+    marker = repo_root / ".git"
+    try:
+        if marker.is_symlink():
+            return False
+        if marker.is_dir():
+            return _same_path(gitdir, marker)
+        if not marker.is_file():
+            return False
+        if gitdir.parent.name == "worktrees":
+            return _linked_worktree_backref_ok(repo_root, gitdir)
+        # Separate-git-dir / bare common. Do not treat a pointer at another
+        # checkout's `.git` directory as this root's primary gitdir.
+        if gitdir.name == ".git" and gitdir.is_dir() and not _same_path(gitdir.parent, repo_root):
+            return False
+        return True
+    except OSError:
+        return False
+
+
 def _same_repo(left: Path, right: Path) -> bool:
     """True when both paths are the same checkout or linked worktrees."""
     if _same_path(left, right):
@@ -309,11 +343,7 @@ def _same_repo(left: Path, right: Path) -> bool:
         return False
     if not _same_path(left_common, right_common):
         return False
-    if left_git.parent.name == "worktrees" and not _linked_worktree_backref_ok(left, left_git):
-        return False
-    if right_git.parent.name == "worktrees" and not _linked_worktree_backref_ok(right, right_git):
-        return False
-    return True
+    return _is_authorized_checkout(left, left_git) and _is_authorized_checkout(right, right_git)
 
 
 def _safe_resolve(path: str | Path) -> Path:

--- a/tools/workspace_safety.py
+++ b/tools/workspace_safety.py
@@ -152,7 +152,7 @@ def check_path_side_effect_allowed(
     bound_repo = _bound_repo_path()
     if bound_repo is None:
         return _blocked_message(repo_root, None)
-    if not _same_path(repo_root, bound_repo):
+    if not _same_repo(repo_root, bound_repo):
         return _blocked_message(repo_root, bound_repo)
     return None
 
@@ -196,7 +196,7 @@ def check_terminal_side_effect_allowed(
         bound_repo = _bound_repo_path()
         if bound_repo is None:
             return _blocked_message(repo_root, None)
-        if not _same_path(repo_root, bound_repo):
+        if not _same_repo(repo_root, bound_repo):
             return _blocked_message(repo_root, bound_repo)
     return None
 
@@ -255,6 +255,65 @@ def _same_path(left: Path, right: Path) -> bool:
         return left.resolve() == right.resolve()
     except OSError:
         return os.path.abspath(left) == os.path.abspath(right)
+
+
+def _gitdir_pointer(repo_root: Path) -> Optional[Path]:
+    marker = repo_root / ".git"
+    try:
+        if marker.is_dir():
+            return marker.resolve()
+        if not marker.is_file():
+            return None
+        for line in marker.read_text(encoding="utf-8").splitlines():
+            if line.lower().startswith("gitdir:"):
+                raw = Path(line.split(":", 1)[1].strip())
+                if not raw.is_absolute():
+                    raw = repo_root / raw
+                return raw.resolve()
+    except OSError:
+        return None
+    return None
+
+
+def _git_common_dir(repo_root: Path) -> Optional[Path]:
+    gitdir = _gitdir_pointer(repo_root)
+    if gitdir is None or not gitdir.is_dir():
+        return None
+    if gitdir.parent.name == "worktrees" and gitdir.parent.parent.name == ".git":
+        return gitdir.parent.parent
+    return gitdir
+
+
+def _linked_worktree_backref_ok(repo_root: Path, gitdir: Path) -> bool:
+    back = gitdir / "gitdir"
+    try:
+        if not back.is_file():
+            return False
+        pointed = Path(back.read_text(encoding="utf-8").strip())
+        if not pointed.is_absolute():
+            pointed = gitdir / pointed
+        return pointed.resolve() == (repo_root / ".git").resolve()
+    except OSError:
+        return False
+
+
+def _same_repo(left: Path, right: Path) -> bool:
+    """True when both paths are the same checkout or linked worktrees."""
+    if _same_path(left, right):
+        return True
+    left_git = _gitdir_pointer(left)
+    right_git = _gitdir_pointer(right)
+    left_common = _git_common_dir(left)
+    right_common = _git_common_dir(right)
+    if left_git is None or right_git is None or left_common is None or right_common is None:
+        return False
+    if not _same_path(left_common, right_common):
+        return False
+    if left_git.parent.name == "worktrees" and not _linked_worktree_backref_ok(left, left_git):
+        return False
+    if right_git.parent.name == "worktrees" and not _linked_worktree_backref_ok(right, right_git):
+        return False
+    return True
 
 
 def _safe_resolve(path: str | Path) -> Path:

--- a/tools/workspace_safety.py
+++ b/tools/workspace_safety.py
@@ -268,7 +268,7 @@ def _iter_git_invocations(command: str, cwd: Path) -> Iterable[GitInvocation]:
         try:
             tokens = shlex.split(segment)
         except ValueError:
-            if "git" in segment:
+            if _command_has_git_executable_token(segment):
                 yield GitInvocation(_UNSAFE_GIT_CWD_SUBCOMMAND, [], current_cwd)
             continue
         if not tokens:
@@ -303,7 +303,7 @@ def _iter_git_invocations(command: str, cwd: Path) -> Iterable[GitInvocation]:
 
 
 def _is_git_executable_token(token: str) -> bool:
-    return Path(token).name == "git"
+    return Path(token.strip("()")).name == "git"
 
 
 def _path_has_shell_expansion(value: str) -> bool:
@@ -338,10 +338,87 @@ def _has_unquoted_shell_paren(value: str) -> bool:
     return False
 
 
+_GIT_EXECUTABLE_TOKEN_RE = re.compile(r"(?:^|[;|&\n\t ])git(?:[;|&\n\t ]|$)")
+
+
+def _command_has_git_executable_token(command: str) -> bool:
+    """True when git appears as a path basename token, not a hostname substring."""
+    try:
+        tokens = _shell_payload_tokens(command)
+    except ValueError:
+        return bool(_GIT_EXECUTABLE_TOKEN_RE.search(f" {command} "))
+    return any(_is_git_executable_token(token) for token in tokens)
+
+
+def _iter_unquoted_substitutions(command: str) -> Iterable[str]:
+    """Yield $(...) and backtick payloads that the shell would expand."""
+    in_single = False
+    in_double = False
+    escaped = False
+    index = 0
+    while index < len(command):
+        char = command[index]
+        if escaped:
+            escaped = False
+            index += 1
+            continue
+        if char == "\\" and not in_single:
+            escaped = True
+            index += 1
+            continue
+        if char == "'" and not in_double:
+            in_single = not in_single
+            index += 1
+            continue
+        if char == '"' and not in_single:
+            in_double = not in_double
+            index += 1
+            continue
+        if in_single:
+            index += 1
+            continue
+        if command.startswith("$(", index):
+            depth = 1
+            cursor = index + 2
+            while cursor < len(command) and depth:
+                if command.startswith("$(", cursor):
+                    depth += 1
+                    cursor += 2
+                    continue
+                nested = command[cursor]
+                if nested == "(":
+                    depth += 1
+                elif nested == ")":
+                    depth -= 1
+                cursor += 1
+            payload = command[index + 2 :] if depth else command[index + 2 : cursor - 1]
+            yield payload
+            index = cursor if not depth else len(command)
+            continue
+        if char == "`":
+            cursor = index + 1
+            while cursor < len(command) and command[cursor] != "`":
+                cursor += 1
+            yield command[index + 1 : cursor]
+            index = cursor + 1 if cursor < len(command) else len(command)
+            continue
+        index += 1
+
+
+def _substitution_contains_git_command(command: str) -> bool:
+    payloads = list(_iter_unquoted_substitutions(command))
+    if not payloads:
+        return False
+    return any(
+        _payload_has_git_command(payload) or _substitution_contains_git_command(payload)
+        for payload in payloads
+    )
+
+
 def _has_unverifiable_shell_git(command: str) -> bool:
     # Command substitution can redirect the git target at runtime and is
     # intentionally fail-closed rather than partially shell-parsed.
-    if "$(" in command and "git" in command:
+    if _substitution_contains_git_command(command):
         return True
 
     if _shell_command_executes_git(command):
@@ -349,10 +426,20 @@ def _has_unverifiable_shell_git(command: str) -> bool:
 
     # Only unquoted parentheses imply shell grouping/subshell syntax. Quoted
     # parentheses are common in conventional commit scopes and format strings.
-    return _has_unquoted_shell_paren(command) and "git" in command
+    return _has_unquoted_shell_paren(command) and _command_has_git_executable_token(command)
 
 
 _SHELL_NAMES = frozenset({"sh", "bash", "zsh", "dash", "ash", "ksh"})
+_SHELL_WRAPPERS = frozenset({
+    "env",
+    "command",
+    "nice",
+    "nohup",
+    "timeout",
+    "stdbuf",
+    "ionice",
+    "time",
+})
 
 
 def _shell_command_executes_git(command: str) -> bool:
@@ -360,7 +447,9 @@ def _shell_command_executes_git(command: str) -> bool:
     try:
         tokens = _shell_payload_tokens(command)
     except ValueError:
-        return "git" in command and (" -c " in f" {command} " or " -lc " in f" {command} ")
+        return _command_has_git_executable_token(command) and (
+            " -c " in f" {command} " or " -lc " in f" {command} "
+        )
 
     command_position = True
     index = 0
@@ -378,6 +467,16 @@ def _shell_command_executes_git(command: str) -> bool:
             continue
 
         name = Path(token).name
+        if name in _SHELL_WRAPPERS:
+            index += 1
+            if (
+                name == "timeout"
+                and index < len(tokens)
+                and not tokens[index].startswith("-")
+                and Path(tokens[index]).name not in _SHELL_NAMES
+            ):
+                index += 1
+            continue
         if name in _SHELL_NAMES:
             payload = _shell_c_payload(tokens, index)
             if payload is not None and _payload_has_git_command(payload):
@@ -400,9 +499,15 @@ def _shell_payload_tokens(payload: str) -> list[str]:
 def _shell_c_payload(tokens: list[str], shell_index: int) -> Optional[str]:
     index = shell_index + 1
     while index < len(tokens) and tokens[index].startswith("-"):
-        if tokens[index] in {"-c", "-lc"}:
+        token = tokens[index]
+        if token in {"-c", "-lc"}:
             return tokens[index + 1] if index + 1 < len(tokens) else None
-        if tokens[index] in {"-o", "-O"} and index + 1 < len(tokens):
+        if (
+            not token.startswith("--")
+            and "c" in token[1:]
+        ):
+            return tokens[index + 1] if index + 1 < len(tokens) else None
+        if token in {"-o", "-O"} and index + 1 < len(tokens):
             index += 2
             continue
         index += 1

--- a/tools/workspace_safety.py
+++ b/tools/workspace_safety.py
@@ -81,6 +81,9 @@ _MUTATING_BRANCH_FLAGS = frozenset({
     "--delete",
     "--move",
     "--copy",
+    "--track",
+    "--force",
+    "-f",
     "--set-upstream-to",
     "--unset-upstream",
     "--edit-description",
@@ -287,7 +290,8 @@ def _iter_git_invocations(command: str, cwd: Path) -> Iterable[GitInvocation]:
             continue
         if tokens[0] == "cd":
             if len(tokens) != 2 or _path_has_shell_expansion(tokens[1]):
-                yield GitInvocation(_UNSAFE_GIT_CWD_SUBCOMMAND, [], current_cwd)
+                if _command_has_git_executable_token(command):
+                    yield GitInvocation(_UNSAFE_GIT_CWD_SUBCOMMAND, [], current_cwd)
                 continue
             current_cwd = _safe_resolve(current_cwd / tokens[1])
             continue
@@ -440,6 +444,45 @@ _SHELL_WRAPPERS = frozenset({
     "ionice",
     "time",
 })
+_WRAPPER_VALUE_OPTS = frozenset({
+    "-n",
+    "-u",
+    "-k",
+    "-s",
+    "-o",
+    "-E",
+    "--nice",
+    "--adjustment",
+    "--signal",
+    "--kill-after",
+})
+
+
+def _skip_wrapper(tokens: list[str], index: int, name: str) -> int:
+    index += 1
+    while index < len(tokens):
+        token = tokens[index]
+        if token == "--":
+            return index + 1
+        if token.startswith("-"):
+            index += 1
+            takes_value = token in _WRAPPER_VALUE_OPTS or (
+                token.startswith("--") and "=" not in token
+            )
+            if takes_value and index < len(tokens) and not tokens[index].startswith("-"):
+                index += 1
+            continue
+        break
+    if name == "timeout" and index < len(tokens):
+        next_name = Path(tokens[index]).name
+        if (
+            next_name not in _SHELL_NAMES
+            and next_name not in _SHELL_WRAPPERS
+            and next_name != "eval"
+            and not _is_git_executable_token(tokens[index])
+        ):
+            index += 1
+    return index
 
 
 def _shell_command_executes_git(command: str) -> bool:
@@ -468,14 +511,14 @@ def _shell_command_executes_git(command: str) -> bool:
 
         name = Path(token).name
         if name in _SHELL_WRAPPERS:
+            index = _skip_wrapper(tokens, index, name)
+            continue
+        if name == "eval":
+            rest = " ".join(tokens[index + 1 :])
+            if rest and _payload_has_git_command(rest):
+                return True
+            command_position = False
             index += 1
-            if (
-                name == "timeout"
-                and index < len(tokens)
-                and not tokens[index].startswith("-")
-                and Path(tokens[index]).name not in _SHELL_NAMES
-            ):
-                index += 1
             continue
         if name in _SHELL_NAMES:
             payload = _shell_c_payload(tokens, index)
@@ -537,7 +580,17 @@ def _payload_has_git_command(payload: str) -> bool:
             continue
 
         name = Path(part).name
-        if name == "git":
+        if name in _SHELL_WRAPPERS:
+            index = _skip_wrapper(parts, index, name)
+            continue
+        if name == "eval":
+            rest = " ".join(parts[index + 1 :])
+            if rest and _payload_has_git_command(rest):
+                return True
+            command_position = False
+            index += 1
+            continue
+        if _is_git_executable_token(part):
             return True
         if name in _SHELL_NAMES:
             nested_payload = _shell_c_payload(parts, index)


### PR DESCRIPTION
## Summary
Agents with file/terminal tools can mutate repositories outside the intended workspace when session workspace binding is missing or bypassed (cwd tricks, `git -C`, nested shells, config redirection, etc.).

This PR adds a **platform-neutral** workspace side-effect guard:

- `gateway/workspace_registry.py` — authoritative binding resolution
- `tools/workspace_safety.py` — path/command side-effect policy evaluation
- Integrated call-site enforcement in file write/patch and terminal mutation paths
- Session context bridges for workspace metadata as `HERMES_SESSION_WORKSPACE_*` (covered by the existing session-env snapshot exclusion)

## Behavior
- Mutating file/terminal operations require a matching workspace binding (fail closed when unverifiable)
- Unclassifiable operations that may mutate a repo are **denied**
- Read-only inspection remains usable only where safely classifiable
- Behavioral policy belongs in config; secrets stay in env
- Bridged workspace session environment values stay out of exported environment snapshots

## Why independent of Matrix PRs
Gateway/tool security hardening for any platform session with workspace binding — not a Matrix feature dependency.

## Test plan
```bash
python -m pytest tests/tools/test_workspace_safety.py tests/gateway/test_workspace_registry.py -q
python -m pytest tests/tools/test_snapshot_session_id_leak.py -q
```
Focused local result on this head: **40 passed** (workspace safety) + **6 passed** (registry).

## Security / compatibility
- Fail closed on unknown/unverifiable mutating shapes
- Integrated tests through real tool entrypoints (not helpers only)
- Workspace bridges use the `HERMES_SESSION_*` prefix so snapshot leak coverage applies automatically

## Non-goals
- Perfect shell parsing / universal bash semantics
- Matrix-only policy special cases
- Replacing OS permissions


## Why this stays one PR
Production delta is 808 lines because the fail-closed invariant is one unit: parser (`workspace_safety.py`) + binding registry + the three live call sites (file write/patch, terminal, session/env bridge). Splitting the engine from the hooks would land an unenforced module or an incomplete guard with known bypasses. Tests are separate (535 lines) and exercise the integrated tool entrypoints.

## Head
`59f888eeb52f38b87e5710e11b9634e0f5b41d2d` (rebuilt on main `66666f6e2eca0ae883195a34c66131985ea7dd06`)
