### PR TITLE
fix(cli): suppress unterminated streamed reasoning blocks

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2946,6 +2946,7 @@ class HermesCLI:
                             self._emit_stream_text(preceding)
                             self._stream_last_was_newline = preceding.endswith("\n")
                         self._in_reasoning_block = True
+                        self._reasoning_block_opened_by_tag = True
                         self._stream_prefilt = self._stream_prefilt[idx + len(tag):]
                         break
                     # Not a block boundary — keep searching after this occurrence
@@ -2976,6 +2977,7 @@ class HermesCLI:
                 idx = self._stream_prefilt.find(tag)
                 if idx != -1:
                     self._in_reasoning_block = False
+                    self._reasoning_block_opened_by_tag = False
                     # When show_reasoning is on, route inner content to
                     # the reasoning display box instead of discarding.
                     if self.show_reasoning:
@@ -3056,12 +3058,20 @@ class HermesCLI:
 
     def _flush_stream(self) -> None:
         """Emit any remaining partial line from the stream buffer and close the box."""
-        # If we're still inside a "reasoning block" at end-of-stream, it was
-        # a false positive — the model mentioned a tag like <think> in prose
-        # but never closed it.  Recover the buffered content as regular text.
+        # If a model started a block-boundary reasoning tag and never closed
+        # it, discard the buffered tail. Models such as MiniMax can stream
+        # scratchpads through content and drop the closing tag; recovering that
+        # buffer would leak hidden reasoning into the CLI at final flush.  Keep
+        # the old recovery behavior for manually seeded/legacy false-positive
+        # states where we cannot prove a real opening tag was seen.
         if getattr(self, "_in_reasoning_block", False) and getattr(self, "_stream_prefilt", ""):
             self._in_reasoning_block = False
-            self._emit_stream_text(self._stream_prefilt)
+            if getattr(self, "_reasoning_block_opened_by_tag", False):
+                if self.show_reasoning:
+                    self._stream_reasoning_delta(self._stream_prefilt)
+            else:
+                self._emit_stream_text(self._stream_prefilt)
+            self._reasoning_block_opened_by_tag = False
             self._stream_prefilt = ""
 
         # Close reasoning box if still open (in case no content tokens arrived)
@@ -3086,6 +3096,7 @@ class HermesCLI:
         self._stream_text_ansi = ""
         self._stream_prefilt = ""
         self._in_reasoning_block = False
+        self._reasoning_block_opened_by_tag = False
         self._stream_last_was_newline = True
         self._reasoning_box_opened = False
         self._reasoning_buf = ""

--- a/tests/cli/test_stream_delta_think_tag.py
+++ b/tests/cli/test_stream_delta_think_tag.py
@@ -17,6 +17,7 @@ def _make_cli_stub():
     cli._stream_box_opened = False
     cli._stream_prefilt = ""
     cli._in_reasoning_block = False
+    cli._reasoning_block_opened_by_tag = False
     cli._reasoning_stream_started = False
     cli._reasoning_box_opened = False
     cli._reasoning_buf = ""
@@ -90,6 +91,25 @@ class TestRealReasoningBlock:
         full = "".join(cli._emitted)
         assert "Here is my answer" in full
         assert "I need to analyze" not in full  # reasoning was suppressed
+
+    def test_unterminated_think_at_stream_end_is_suppressed(self):
+        """Unclosed reasoning blocks should not leak during final stream flush."""
+        cli = _make_cli_stub()
+        cli._close_reasoning_box = lambda: None
+        cli._stream_delta("<think>")
+        cli._stream_delta("MiniMax scratchpad that never closes")
+
+        from unittest.mock import patch
+        import shutil
+        with patch.object(shutil, "get_terminal_size", return_value=os.terminal_size((80, 24))):
+            with patch("cli._cprint"):
+                cli._flush_stream()
+
+        full = "".join(cli._emitted)
+        assert "MiniMax" not in full
+        assert "scratchpad" not in full
+        assert "never closes" not in full
+        assert not cli._in_reasoning_block
 
     def test_think_after_newline(self):
         """'text\\n<think>' should trigger reasoning block."""


### PR DESCRIPTION
## What does this PR do?

- Suppress unterminated CLI-streamed reasoning blocks that start with a real block-boundary reasoning tag.
- Preserve the existing legacy/manual false-positive recovery path for states that were not opened by `_stream_delta` seeing a reasoning tag.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A