### PR TITLE
fix(curator): scan nested archive subdirs in restore_skill

### DIFF
--- a/tests/tools/test_skill_usage.py
+++ b/tests/tools/test_skill_usage.py
@@ -315,6 +315,41 @@ def test_restore_skill_moves_back(skills_home):
     assert get_record("temp-skill")["state"] == "active"
 
 
+def test_restore_skill_finds_nested_archive_subdir(skills_home):
+    """Skills archived under nested category subdirs (e.g.
+    .archive/<category>/<skill>/) — left behind by older archive layouts or
+    external imports — must still be restorable by name."""
+    from tools.skill_usage import restore_skill, get_record
+    skills_dir = skills_home / "skills"
+    nested = skills_dir / ".archive" / "openclaw-imports" / "nested-skill"
+    nested.mkdir(parents=True)
+    (nested / "SKILL.md").write_text(
+        "---\nname: nested-skill\ndescription: x\n---\n", encoding="utf-8",
+    )
+
+    ok, msg = restore_skill("nested-skill")
+    assert ok, msg
+    assert (skills_dir / "nested-skill" / "SKILL.md").exists()
+    assert not nested.exists()
+    assert get_record("nested-skill")["state"] == "active"
+
+
+def test_restore_skill_finds_nested_timestamped_prefix(skills_home):
+    """Prefix-match path (timestamped dupes) must also descend into nested
+    archive subdirs, not just .archive/ top-level."""
+    from tools.skill_usage import restore_skill
+    skills_dir = skills_home / "skills"
+    nested = skills_dir / ".archive" / "imports" / "dup-skill-20260101000000"
+    nested.mkdir(parents=True)
+    (nested / "SKILL.md").write_text(
+        "---\nname: dup-skill\ndescription: x\n---\n", encoding="utf-8",
+    )
+
+    ok, msg = restore_skill("dup-skill")
+    assert ok, msg
+    assert (skills_dir / "dup-skill" / "SKILL.md").exists()
+
+
 def test_archive_collision_gets_suffix(skills_home):
     from tools.skill_usage import archive_skill
     skills_dir = skills_home / "skills"

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -385,11 +385,13 @@ def restore_skill(skill_name: str) -> Tuple[bool, str]:
     if not archive_root.exists():
         return False, "no archive directory"
 
-    # Try exact name match first, then any prefix match (for timestamped dupes)
-    candidates = [p for p in archive_root.iterdir() if p.is_dir() and p.name == skill_name]
+    # Try exact name match first, then any prefix match (for timestamped dupes).
+    # Recursive walk handles nested archive layouts (e.g. .archive/<category>/<skill>/)
+    # left behind by older archive paths or external imports.
+    candidates = [p for p in archive_root.rglob("*") if p.is_dir() and p.name == skill_name]
     if not candidates:
         candidates = sorted(
-            [p for p in archive_root.iterdir()
+            [p for p in archive_root.rglob("*")
              if p.is_dir() and p.name.startswith(f"{skill_name}-")],
             reverse=True,
         )


### PR DESCRIPTION
## What does this PR do?

`hermes curator restore <skill>` was failing with `skill '<name>' not found in archive` whenever the archived skill lived under a nested category subdirectory (e.g. `.archive/openclaw-imports/<skill>/`, `.archive/hermes-agent/<skill>/`). The skill directory existed on disk but was invisible to the lookup because `restore_skill()` walked only the top level of `.archive/`.

`tools/skill_usage.py:389,392` used `archive_root.iterdir()` for both the exact-name and prefix-match candidate scans. Switching both to `archive_root.rglob("*")` makes the lookup descend into nested subdirs while preserving the existing `is_dir() and p.name == skill_name` (and prefix) filter, so the scan still picks up only matching skill directories.

## Related Issue

Fixes #17942

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/skill_usage.py` — `restore_skill()`: switched the exact-match and prefix-match candidate scans from `archive_root.iterdir()` to `archive_root.rglob("*")` so nested archive subdirectories are searched.
- `tests/tools/test_skill_usage.py` — added `test_restore_skill_finds_nested_archive_subdir` (exact match under a nested category) and `test_restore_skill_finds_nested_timestamped_prefix` (timestamped-dupe prefix match under a nested category) to lock in the recursive-walk behaviour.

## How to Test

1. Place an archived skill under a nested category, e.g.:
   ```
   ~/.hermes/skills/.archive/openclaw-imports/cognitive-empathy/SKILL.md
   ```
2. Run `hermes curator restore cognitive-empathy` — before this patch this returned "not found in archive"; after, the skill is moved back to `~/.hermes/skills/cognitive-empathy/` and its `state` flips to `active`.
3. `pytest tests/tools/test_skill_usage.py -q` — 37 tests pass (35 prior + 2 new).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass <!-- skill_usage / curator suites pass cleanly; broader baseline failures on this branch (e.g. tts-kittentts, web_server, terminal-tool requirements) reproduce on `upstream/main` without this patch and are unrelated optional-dep / env issues -->
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 23.2)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (no user-visible API change; the docstring on `restore_skill` already covers behaviour)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `rglob` is `pathlib`-portable; tests use `tmp_path` and avoid OS-specific paths
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
