### PR TITLE
Fix empty auto-routed model on agent startup

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -984,9 +984,11 @@ class AIAgent:
             else:
                 # No explicit creds — use the centralized provider router
                 from agent.auxiliary_client import resolve_provider_client
-                _routed_client, _ = resolve_provider_client(
+                _routed_client, _resolved_model = resolve_provider_client(
                     self.provider or "auto", model=self.model, raw_codex=True)
                 if _routed_client is not None:
+                    if not self.model and _resolved_model:
+                        self.model = str(_resolved_model)
                     client_kwargs = {
                         "api_key": _routed_client.api_key,
                         "base_url": str(_routed_client.base_url),

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -139,6 +139,30 @@ def test_aiagent_reuses_existing_errors_log_handler():
 
 
 class TestProviderModelNormalization:
+    def test_aiagent_adopts_auto_router_resolved_model_when_no_model_was_passed(self):
+        routed_client = MagicMock()
+        routed_client.api_key = "minimax-key"
+        routed_client.base_url = "https://api.minimax.io/v1"
+
+        with (
+            patch(
+                "run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")
+            ),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("agent.auxiliary_client.resolve_provider_client") as resolve_provider_client,
+            patch("run_agent.OpenAI"),
+        ):
+            resolve_provider_client.return_value = (routed_client, "MiniMax-M2.7")
+
+            agent = AIAgent(
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+        assert agent.model == "MiniMax-M2.7"
+        assert agent._primary_runtime["model"] == "MiniMax-M2.7"
+
     def test_aiagent_strips_matching_native_provider_prefix(self):
         with (
             patch(


### PR DESCRIPTION
## Summary
- adopt the provider router resolved model when `AIAgent` starts without an explicit model
- add regression coverage for auto-routed startup model normalization

## Root cause
`AIAgent()` could be constructed with an empty model while the provider router still resolved a concrete model such as `MiniMax-M2.7`. The runtime used the routed client but left `self.model` empty, so later requests could be sent with `model: ""`.

## Validation
- targeted regression test passed in the Hermes v2026 worktree
- scoped Hermes runtime suite passed: `42 passed`
- live BohtPY handoff audit captured in `docs/ops/hermes-handoff/` with patch, bundle, and checksum

## Notes
This PR was pushed from the `parimple/hermes-agent` fork because the current token has read-only permission on `NousResearch/hermes-agent`.
