### PR TITLE
fix: guard fcntl.flock(LOCK_UN) in memory_tool to prevent file descriptor leak

### DIFF
--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -167,7 +167,10 @@ class MemoryStore:
             yield
         finally:
             if fcntl:
-                fcntl.flock(fd, fcntl.LOCK_UN)
+                try:
+                    fcntl.flock(fd, fcntl.LOCK_UN)
+                except (OSError, IOError):
+                    pass
             elif msvcrt:
                 try:
                     fd.seek(0)


### PR DESCRIPTION
## Problem

The `_file_lock()` context manager in `tools/memory_tool.py` calls `fcntl.flock(fd, LOCK_UN)` in a `finally` block without `try/except`. If the unlock raises (e.g., fd already invalid, NFS issue), the subsequent `fd.close()` is skipped, leaking the file descriptor.

The `msvcrt` (Windows) path at lines 172-176 already has proper `try/except` guarding, but the `fcntl` (Unix) path does not — making this an inconsistency that affects all Unix users.

## Fix

Wrap `fcntl.flock(fd, LOCK_UN)` in `try/except (OSError, IOError): pass`, matching the existing `msvcrt` guard pattern.

**Diff:** +4 lines, -1 line

## Before vs After

| Scenario | Before | After |
|----------|--------|-------|
| `flock(LOCK_UN)` succeeds | Works | Works (identical) |
| `flock(LOCK_UN)` raises OSError | `fd.close()` skipped → fd leak | Exception caught, `fd.close()` runs |

## Impact

- **Severity:** HIGH — file descriptor leak under error conditions
- **Scope:** All Unix users of the memory tool (read/write operations)
- **Risk:** Minimal — only adds error handling around existing code, no behavioral change on success path