### PR TITLE
fix: track asyncio.create_task() for long-running gateway watchers

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2724,13 +2724,17 @@ class GatewayRunner:
             from tools.process_registry import process_registry
             while process_registry.pending_watchers:
                 watcher = process_registry.pending_watchers.pop(0)
-                asyncio.create_task(self._run_process_watcher(watcher))
+                task = asyncio.create_task(self._run_process_watcher(watcher))
+                self._background_tasks.add(task)
+                task.add_done_callback(self._background_tasks.discard)
                 logger.info("Resumed watcher for recovered process %s", watcher.get("session_id"))
         except Exception as e:
             logger.error("Recovered watcher setup error: %s", e)
 
         # Start background session expiry watcher to finalize expired sessions
-        asyncio.create_task(self._session_expiry_watcher())
+        _expiry_task = asyncio.create_task(self._session_expiry_watcher())
+        self._background_tasks.add(_expiry_task)
+        _expiry_task.add_done_callback(self._background_tasks.discard)
 
         # Start background reconnection watcher for platforms that failed at startup
         if self._failed_platforms:
@@ -2739,7 +2743,9 @@ class GatewayRunner:
                 len(self._failed_platforms),
                 ", ".join(p.value for p in self._failed_platforms),
             )
-        asyncio.create_task(self._platform_reconnect_watcher())
+        _reconnect_task = asyncio.create_task(self._platform_reconnect_watcher())
+        self._background_tasks.add(_reconnect_task)
+        _reconnect_task.add_done_callback(self._background_tasks.discard)
 
         logger.info("Press Ctrl+C to stop")
         
@@ -5545,7 +5551,9 @@ class GatewayRunner:
                 from tools.process_registry import process_registry
                 while process_registry.pending_watchers:
                     watcher = process_registry.pending_watchers.pop(0)
-                    asyncio.create_task(self._run_process_watcher(watcher))
+                    _watcher_task = asyncio.create_task(self._run_process_watcher(watcher))
+                    self._background_tasks.add(_watcher_task)
+                    _watcher_task.add_done_callback(self._background_tasks.discard)
             except Exception as e:
                 logger.error("Process watcher setup error: %s", e)
 


### PR DESCRIPTION
## Problem

Four `asyncio.create_task()` calls in `gateway/run.py` do not store task references, risking garbage collection of the tasks while still running:

- `_run_process_watcher` (startup crash recovery, line 2727)
- `_session_expiry_watcher` (proactive memory flushing, line 2733)
- `_platform_reconnect_watcher` (failed platform reconnection, line 2742)
- `_run_process_watcher` (per-message handler path, line 5548)

Without stored references, Python's GC can silently collect these tasks, causing watchers to die without any error or log message. Long-running watchers like `_session_expiry_watcher` (runs every 5 minutes) and `_platform_reconnect_watcher` are particularly vulnerable.

The codebase already uses `self._background_tasks` set with done callbacks in other locations (e.g., restart task at line 2366, update notification task at line 7447).

## Fix

Store each task in `self._background_tasks` with the standard done callback pattern:
```python
task = asyncio.create_task(...)
self._background_tasks.add(task)
task.add_done_callback(self._background_tasks.discard)
```

**Diff:** +12 lines, -4 lines

## Impact

- **Severity:** HIGH — silent failure of background watchers
- **Scope:** Gateway startup and per-message handler
- **Risk:** Minimal — follows existing codebase convention exactly