### PR TITLE
fix: guard float(os.getenv) against ValueError in gateway platform adapters

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -501,8 +501,14 @@ class DiscordAdapter(BasePlatformAdapter):
         self._voice_clients: Dict[int, Any] = {}  # guild_id -> VoiceClient
         self._voice_locks: Dict[int, asyncio.Lock] = {}  # guild_id -> serialize join/leave
         # Text batching: merge rapid successive messages (Telegram-style)
-        self._text_batch_delay_seconds = float(os.getenv("HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS", "0.6"))
-        self._text_batch_split_delay_seconds = float(os.getenv("HERMES_DISCORD_TEXT_BATCH_SPLIT_DELAY_SECONDS", "2.0"))
+        try:
+            self._text_batch_delay_seconds = float(os.getenv("HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS", "0.6"))
+        except (ValueError, TypeError):
+            self._text_batch_delay_seconds = 0.6
+        try:
+            self._text_batch_split_delay_seconds = float(os.getenv("HERMES_DISCORD_TEXT_BATCH_SPLIT_DELAY_SECONDS", "2.0"))
+        except (ValueError, TypeError):
+            self._text_batch_split_delay_seconds = 2.0
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
         self._voice_text_channels: Dict[int, int] = {}  # guild_id -> text_channel_id

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -263,15 +263,24 @@ class TelegramAdapter(BasePlatformAdapter):
         self._disable_link_previews: bool = self._coerce_bool_extra("disable_link_previews", False)
         # Buffer rapid/album photo updates so Telegram image bursts are handled
         # as a single MessageEvent instead of self-interrupting multiple turns.
-        self._media_batch_delay_seconds = float(os.getenv("HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS", "0.8"))
+        try:
+            self._media_batch_delay_seconds = float(os.getenv("HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS", "0.8"))
+        except (ValueError, TypeError):
+            self._media_batch_delay_seconds = 0.8
         self._pending_photo_batches: Dict[str, MessageEvent] = {}
         self._pending_photo_batch_tasks: Dict[str, asyncio.Task] = {}
         self._media_group_events: Dict[str, MessageEvent] = {}
         self._media_group_tasks: Dict[str, asyncio.Task] = {}
         # Buffer rapid text messages so Telegram client-side splits of long
         # messages are aggregated into a single MessageEvent.
-        self._text_batch_delay_seconds = float(os.getenv("HERMES_TELEGRAM_TEXT_BATCH_DELAY_SECONDS", "0.6"))
-        self._text_batch_split_delay_seconds = float(os.getenv("HERMES_TELEGRAM_TEXT_BATCH_SPLIT_DELAY_SECONDS", "2.0"))
+        try:
+            self._text_batch_delay_seconds = float(os.getenv("HERMES_TELEGRAM_TEXT_BATCH_DELAY_SECONDS", "0.6"))
+        except (ValueError, TypeError):
+            self._text_batch_delay_seconds = 0.6
+        try:
+            self._text_batch_split_delay_seconds = float(os.getenv("HERMES_TELEGRAM_TEXT_BATCH_SPLIT_DELAY_SECONDS", "2.0"))
+        except (ValueError, TypeError):
+            self._text_batch_split_delay_seconds = 2.0
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
         self._polling_error_task: Optional[asyncio.Task] = None

--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -176,8 +176,14 @@ class WeComAdapter(BasePlatformAdapter):
 
         # Text batching: merge rapid successive messages (Telegram-style).
         # WeCom clients split long messages around 4000 chars.
-        self._text_batch_delay_seconds = float(os.getenv("HERMES_WECOM_TEXT_BATCH_DELAY_SECONDS", "0.6"))
-        self._text_batch_split_delay_seconds = float(os.getenv("HERMES_WECOM_TEXT_BATCH_SPLIT_DELAY_SECONDS", "2.0"))
+        try:
+            self._text_batch_delay_seconds = float(os.getenv("HERMES_WECOM_TEXT_BATCH_DELAY_SECONDS", "0.6"))
+        except (ValueError, TypeError):
+            self._text_batch_delay_seconds = 0.6
+        try:
+            self._text_batch_split_delay_seconds = float(os.getenv("HERMES_WECOM_TEXT_BATCH_SPLIT_DELAY_SECONDS", "2.0"))
+        except (ValueError, TypeError):
+            self._text_batch_split_delay_seconds = 2.0
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
         self._device_id = uuid.uuid4().hex


### PR DESCRIPTION
## Problem

Several gateway platform adapters cast environment variables directly via `float(os.getenv(...))` without `try/except`. If any env var is set to a non-numeric string (e.g., `HERMES_TELEGRAM_TEXT_BATCH_DELAY_SECONDS=abc`), the platform adapter crashes with `ValueError` during `__init__`, preventing the entire gateway from starting.

**Affected files and variables:**
- `telegram.py`: `MEDIA_BATCH_DELAY_SECONDS`, `TEXT_BATCH_DELAY_SECONDS`, `TEXT_BATCH_SPLIT_DELAY_SECONDS` (3 instances)
- `discord.py`: `TEXT_BATCH_DELAY_SECONDS`, `TEXT_BATCH_SPLIT_DELAY_SECONDS` (2 instances)
- `wecom.py`: `TEXT_BATCH_DELAY_SECONDS`, `TEXT_BATCH_SPLIT_DELAY_SECONDS` (2 instances)

Note: `telegram.py` already has a `_env_float()` helper (line 776) with proper `try/except` handling, but it was not used in `__init__`.

## Fix

Each `float(os.getenv(...))` call is wrapped in `try/except (ValueError, TypeError)` with the original default value as fallback.

**Diff:** +28 lines, -7 lines across 3 files

## Before vs After

| Scenario | Before | After |
|----------|--------|-------|
| Valid env var | Works | Works (identical) |
| Env var set to "abc" | `ValueError` crash → gateway won't start | Falls back to default value |
| Env var set to None string | `TypeError` crash | Falls back to default value |

## Impact

- **Severity:** MEDIUM — gateway startup crash from misconfigured env var
- **Scope:** Telegram, Discord, WeCom platform adapters
- **Risk:** Minimal — only adds error handling, no behavioral change on valid input