### PR TITLE
fix(ci): stabilize current main test regressions

### DIFF
--- a/tests/tools/test_file_sync_back.py
+++ b/tests/tools/test_file_sync_back.py
@@ -216,7 +216,7 @@ class TestSyncBackConflict:
 class TestSyncBackRetries:
     """Retry behaviour with exponential backoff."""
 
-    @patch("tools.environments.file_sync.time.sleep")
+    @patch("tools.environments.file_sync._sleep")
     def test_sync_back_retries_on_failure(self, mock_sleep, tmp_path):
         call_count = 0
 
@@ -237,7 +237,7 @@ class TestSyncBackRetries:
         mock_sleep.assert_any_call(_SYNC_BACK_BACKOFF[0])
         mock_sleep.assert_any_call(_SYNC_BACK_BACKOFF[1])
 
-    @patch("tools.environments.file_sync.time.sleep")
+    @patch("tools.environments.file_sync._sleep")
     def test_sync_back_all_retries_exhausted(self, mock_sleep, tmp_path, caplog):
         def always_fail(dest: Path):
             raise RuntimeError("persistent failure")

--- a/tools/environments/file_sync.py
+++ b/tools/environments/file_sync.py
@@ -29,6 +29,12 @@ from tools.environments.base import _file_mtime_key
 
 logger = logging.getLogger(__name__)
 
+# Keep retry sleeps patchable without mutating the shared stdlib ``time``
+# module. Patching ``tools.environments.file_sync.time.sleep`` replaces
+# ``time.sleep`` globally because ``time`` is the module object; under xdist
+# that lets unrelated background threads inflate retry-test call counts.
+_sleep = time.sleep
+
 _SYNC_INTERVAL_SECONDS = 5.0
 _FORCE_SYNC_ENV = "HERMES_FORCE_FILE_SYNC"
 
@@ -243,7 +249,7 @@ class FileSyncManager:
                         "sync_back: attempt %d failed (%s), retrying in %ds",
                         attempt + 1, exc, delay,
                     )
-                    time.sleep(delay)
+                    _sleep(delay)
 
         logger.warning("sync_back: all %d attempts failed: %s", _SYNC_BACK_MAX_RETRIES, last_exc)
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -383,6 +383,36 @@ class LocalEnvironment(BaseEnvironment):
 
     def _kill_process(self, proc):
         """Kill the entire process group (all children)."""
+
+        def _group_alive(pgid: int) -> bool:
+            try:
+                # POSIX-only: _IS_WINDOWS is handled before this helper is used.
+                os.killpg(pgid, 0)
+                return True
+            except ProcessLookupError:
+                return False
+            except PermissionError:
+                # The group exists, even if this process cannot signal it.
+                return True
+
+        def _wait_for_group_exit(pgid: int, timeout: float) -> bool:
+            deadline = time.monotonic() + timeout
+            while time.monotonic() < deadline:
+                # Reap the wrapper promptly. A dead but unreaped group leader
+                # still makes killpg(pgid, 0) report the group as alive.
+                try:
+                    proc.poll()
+                except Exception:
+                    pass
+                if not _group_alive(pgid):
+                    return True
+                time.sleep(0.05)
+            try:
+                proc.poll()
+            except Exception:
+                pass
+            return not _group_alive(pgid)
+
         try:
             if _IS_WINDOWS:
                 proc.terminate()
@@ -393,37 +423,29 @@ class LocalEnvironment(BaseEnvironment):
                     pgid = getattr(proc, "_hermes_pgid", None)
                     if pgid is None:
                         raise
-                os.killpg(pgid, signal.SIGTERM)
-                deadline = time.monotonic() + 1.0
-                while time.monotonic() < deadline:
-                    if proc.poll() is not None:
-                        try:
-                            os.killpg(pgid, 0)
-                        except ProcessLookupError:
-                            return
-                    time.sleep(0.05)
 
-                # The shell can exit quickly while a child in the same process
-                # group is still shutting down. Escalate based on the process
-                # group, not just the shell wrapper, so interrupted commands do
-                # not leave orphaned grandchildren under load.
                 try:
-                    # _IS_WINDOWS is guarded by the enclosing else branch.
+                    os.killpg(pgid, signal.SIGTERM)
+                except ProcessLookupError:
+                    return
+
+                # Wait on the process group, not just the shell wrapper. Under
+                # load the wrapper can exit before grandchildren do; returning
+                # at that point leaves orphaned process-group members behind.
+                if _wait_for_group_exit(pgid, 1.0):
+                    return
+
+                try:
+                    # POSIX-only: _IS_WINDOWS is handled by the outer branch.
                     os.killpg(pgid, signal.SIGKILL)
                 except ProcessLookupError:
                     return
+                _wait_for_group_exit(pgid, 2.0)
                 try:
-                    proc.wait(timeout=1.0)
-                except subprocess.TimeoutExpired:
+                    proc.wait(timeout=0.2)
+                except (subprocess.TimeoutExpired, OSError):
                     pass
-                deadline = time.monotonic() + 1.0
-                while time.monotonic() < deadline:
-                    try:
-                        os.killpg(pgid, 0)
-                    except ProcessLookupError:
-                        return
-                    time.sleep(0.05)
-        except (ProcessLookupError, PermissionError):
+        except (ProcessLookupError, PermissionError, OSError):
             try:
                 proc.kill()
             except Exception:


### PR DESCRIPTION
## What does this PR do?

Stabilizes the current main test suite after the latest main run failed on two CI-only regressions:

- `tests/tools/test_file_sync_back.py::TestSyncBackRetries::test_sync_back_retries_on_failure`
- `tests/tools/test_local_interrupt_cleanup.py::test_wait_for_process_kills_subprocess_on_keyboardinterrupt`

This keeps the base test check trustworthy so follow-up PRs can rebase onto a green main again.

## Related Issue

Runtime reproduction note: current `main` Tests run failed at `9a1454060` with 2 failures in the GitHub Actions `test` job.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `tools/environments/file_sync.py`
  - Adds a module-local `_sleep` alias for sync-back retry sleeps so tests can patch retry backoff without replacing global stdlib `time.sleep` across unrelated threads.
- `tests/tools/test_file_sync_back.py`
  - Patches `tools.environments.file_sync._sleep` instead of `tools.environments.file_sync.time.sleep`, avoiding xdist/background-thread call-count pollution.
- `tools/environments/local.py`
  - Reaps the shell wrapper while waiting for process-group shutdown.
  - Keeps cleanup based on the subprocess group, not only the shell wrapper, before falling back to SIGKILL.
  - Preserves Windows guards for POSIX-only process-group calls.

## How to Test

1. Run focused validation:
   ```bash
   /home/w0lf/.hermes/hermes-agent/venv/bin/python -m compileall -q tools/environments/file_sync.py tools/environments/local.py tests/tools/test_file_sync_back.py tests/tools/test_local_interrupt_cleanup.py tests/tools/test_local_background_child_hang.py tests/tools/test_windows_compat.py
   /home/w0lf/.hermes/hermes-agent/venv/bin/python -m pytest tests/tools/test_file_sync_back.py tests/tools/test_local_interrupt_cleanup.py tests/tools/test_local_background_child_hang.py tests/tools/test_windows_compat.py -q --tb=short -n auto -o addopts=''
   ```
   Result:
   ```text
   40 passed, 40 warnings in 4.96s
   ```

2. Run broader validation:
   ```bash
   tmpdir=$(mktemp -d)
   export HOME="$tmpdir/home"
   export HERMES_HOME="$tmpdir/hermes"
   export HERMES_CONFIG_DIR="$tmpdir/hermes"
   mkdir -p "$HOME" "$HERMES_HOME"
   unset TERM
   /home/w0lf/.hermes/hermes-agent/venv/bin/python -m pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e --tb=short -n auto -o addopts=''
   ```
   Result:
   ```text
   18313 passed, 50 skipped, 16935 warnings in 166.43s (0:02:46)
   ```

3. Manual exercise of changed path:
   ```text
   Manual interactive testing not applicable. The changed paths are process cleanup and retry-test isolation; automated focused and full non-integration suites cover the affected behavior.
   ```

## Validation Status

- Focused regression tests: passing.
- Broader suite: passing locally, excluding integration and e2e, with isolated HOME/HERMES_HOME.
- GitHub checks: all passing (`check-attribution`, `Scan PR for critical supply chain risks`, `nix-lockfile-check`, `nix (ubuntu-latest)`, `nix (macos-latest)`, `test`, `e2e`).
- Full-suite checklist is complete for local non-integration validation.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass locally for the non-integration suite
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux, Python 3.14.4

### Documentation and Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior or N/A

## For New Skills

N/A.

## Screenshots / Logs

```text
Latest failing main Tests run before this branch:
FAILED tests/tools/test_file_sync_back.py::TestSyncBackRetries::test_sync_back_retries_on_failure - AssertionError: assert 37077 == 2
FAILED tests/tools/test_local_interrupt_cleanup.py::test_wait_for_process_kills_subprocess_on_keyboardinterrupt - AssertionError: subprocess group ... is STILL ALIVE after worker received KeyboardInterrupt

Local validation after this fix:
18313 passed, 50 skipped, 16935 warnings in 166.43s (0:02:46)
```
