### PR TITLE
fix(tests): reload permanent allowlist in _reset_module_state

### DIFF
--- a/tests/cli/test_cli_loading_indicator.py
+++ b/tests/cli/test_cli_loading_indicator.py
@@ -50,7 +50,8 @@ class TestCLILoadingIndicator:
             print("reload done")
 
         with patch.object(cli_obj, "_reload_mcp", side_effect=fake_reload), \
-             patch.object(cli_obj, "_invalidate") as invalidate_mock:
+             patch.object(cli_obj, "_invalidate") as invalidate_mock, \
+             patch.object(cli_obj, "_prompt_text_input", return_value="1"):
             assert cli_obj.process_command("/reload-mcp")
 
         output = capsys.readouterr().out

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -184,6 +184,13 @@ _HERMES_BEHAVIORAL_VARS = frozenset({
     "HERMES_BACKGROUND_NOTIFICATIONS",
     "HERMES_EXEC_ASK",
     "HERMES_HOME_MODE",
+    # Cron session vars — HERMES_CRON_SESSION=1 forces cron_mode=deny
+    # path, which silently bypasses blocking approval flow for dangerous
+    # commands in tests that need the gateway/ask approval path.
+    "HERMES_CRON_SESSION",
+    "HERMES_CRON_AUTO_DELIVER_ALL",
+    "HERMES_CRON_AUTO_DELIVER_PLATFORM",
+    "HERMES_CRON_AUTO_DELIVER_CHAT_ID",
     "BROWSER_CDP_URL",
     "CAMOFOX_URL",
     # Platform allowlists — not credentials, but if set from any source
@@ -293,6 +300,17 @@ def _hermetic_environment(tmp_path, monkeypatch):
     monkeypatch.delenv("GMI_API_KEY", raising=False)
     monkeypatch.delenv("GMI_BASE_URL", raising=False)
 
+    # 6. Wipe the config YAML cache so load_config() re-reads from the fake
+    #    hermes home established in step 3. Without this, module imports that
+    #    ran during test collection cached the real ~/.hermes/config.yaml and
+    #    load_permanent_allowlist() would re-populate _permanent_approved from
+    #    the real allowlist every time a test calls check_all_command_guards().
+    try:
+        from hermes_cli import config as _config_mod
+        _config_mod._RAW_CONFIG_CACHE.clear()
+    except Exception:
+        pass
+
 
 # Backward-compat alias — old tests reference this fixture name. Keep it
 # as a no-op wrapper so imports don't break.
@@ -326,6 +344,17 @@ def _reset_module_state():
     that don't exist yet (test collection before production import) are
     skipped silently — production import later creates fresh empty state.
     """
+    # --- hermes_cli.config — in-memory YAML cache ---
+    # load_config() caches by config file path (mtime, size). When
+    # _hermetic_environment redirects HERMES_HOME to a temp dir, the cache
+    # still holds the real ~/.hermes/config.yaml data. Wipe it so the next
+    # load_config() call re-reads from the fake hermes home.
+    try:
+        from hermes_cli import config as _config_mod
+        _config_mod._RAW_CONFIG_CACHE.clear()
+    except Exception:
+        pass
+
     # --- tools.approval — the single biggest source of cross-test pollution ---
     try:
         from tools import approval as _approval_mod

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,23 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 
+# ── pytest hooks ────────────────────────────────────────────────────────────
+#
+# pytest_configure runs BEFORE xdist worker processes are spawned, so this is
+# the only place that can clear env vars (like HERMES_CRON_SESSION) that
+# xdist workers would otherwise inherit from the parent shell.
+#
+
+
+def pytest_configure(config):
+    """Clear HERMES_CRON_SESSION before workers are forked — cannot wait for
+    the hermetic_environment fixture since that runs inside each worker."""
+    os.environ.pop("HERMES_CRON_SESSION", None)
+    os.environ.pop("HERMES_CRON_AUTO_DELIVER_ALL", None)
+    os.environ.pop("HERMES_CRON_AUTO_DELIVER_PLATFORM", None)
+    os.environ.pop("HERMES_CRON_AUTO_DELIVER_CHAT_ID", None)
+
+
 # ── Credential env-var filter ──────────────────────────────────────────────
 #
 # Any env var in the current process matching ONE of these patterns is
@@ -364,10 +381,12 @@ def _reset_module_state():
         _approval_mod._pending.clear()
         _approval_mod._gateway_queues.clear()
         _approval_mod._gateway_notify_cbs.clear()
-        # ContextVar: reset to empty string so get_current_session_key()
-        # falls through to the env var / default path, matching a fresh
-        # process.
         _approval_mod._approval_session_key.set("")
+        # Re-load the allowlist from the (now-fake) HERMES_HOME so the test
+        # body runs with a clean _permanent_approved instead of data that was
+        # loaded from the real ~/.hermes/config.yaml when the module was first
+        # imported (before the hermetic environment was active).
+        _approval_mod.load_permanent_allowlist()
     except Exception:
         pass
 


### PR DESCRIPTION
Ensure _permanent_approved is repopulated from the fake HERMES_HOME instead of the real ~/.hermes/config.yaml that was cached at import time. Without this, tests that rely on gateway/ask approval path find _permanent_approved pre-populated with real data, bypassing the blocking flow.