### PR TITLE
fix(qqbot): support C2C and group endpoints in send_message tool

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1136,7 +1136,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         qq_group_allowed = os.getenv("QQ_GROUP_ALLOWED_USERS", "").strip()
         if qq_group_allowed:
             extra["group_allow_from"] = qq_group_allowed
-        qq_home = os.getenv("QQ_HOME_CHANNEL", "").strip()
+        qq_home = os.getenv("QQ_HOME_CHANNEL", "").strip() or os.getenv("QQBOT_HOME_CHANNEL", "").strip()
         if qq_home:
             config.platforms[Platform.QQBOT].home_channel = HomeChannel(
                 platform=Platform.QQBOT,

--- a/tests/tools/test_qqbot_send_message.py
+++ b/tests/tools/test_qqbot_send_message.py
@@ -1,0 +1,289 @@
+"""Tests for QQBot send_message functionality.
+
+Tests the chat type detection logic added to _send_qqbot:
+- Numeric chat_id → guild channel endpoint
+- 32-char hex OpenID → C2C endpoint (fallback to group)
+"""
+
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import Platform
+from tools.send_message_tool import (
+    _QQBOT_TARGET_RE,
+    _parse_target_ref,
+)
+
+
+class TestQQBotTargetRegex:
+    """Test the QQBot OpenID regex pattern."""
+
+    def test_valid_32_char_hex_uppercase(self):
+        """Valid 32-char uppercase hex should match."""
+        match = _QQBOT_TARGET_RE.fullmatch("3E9A53DBB44E52DD0B7DAB6F37B4FE97")
+        assert match is not None
+        assert match.group(1) == "3E9A53DBB44E52DD0B7DAB6F37B4FE97"
+
+    def test_valid_32_char_hex_with_whitespace(self):
+        """Valid OpenID with leading/trailing whitespace should match."""
+        match = _QQBOT_TARGET_RE.fullmatch("  3E9A53DBB44E52DD0B7DAB6F37B4FE97  ")
+        assert match is not None
+        assert match.group(1) == "3E9A53DBB44E52DD0B7DAB6F37B4FE97"
+
+    def test_lowercase_hex_does_not_match(self):
+        """Lowercase hex should NOT match (QQBot uses uppercase)."""
+        match = _QQBOT_TARGET_RE.fullmatch("3e9a53dbb44e52dd0b7dab6f37b4fe97")
+        assert match is None
+
+    def test_too_short_does_not_match(self):
+        """31-char string should not match."""
+        match = _QQBOT_TARGET_RE.fullmatch("3E9A53DBB44E52DD0B7DAB6F37B4FE9")
+        assert match is None
+
+    def test_too_long_does_not_match(self):
+        """33-char string should not match."""
+        match = _QQBOT_TARGET_RE.fullmatch("3E9A53DBB44E52DD0B7DAB6F37B4FE97A")
+        assert match is None
+
+    def test_numeric_does_not_match(self):
+        """Pure numeric (guild channel ID) should not match."""
+        match = _QQBOT_TARGET_RE.fullmatch("1234567890")
+        assert match is None
+
+    def test_mixed_case_does_not_match(self):
+        """Mixed case should not match."""
+        match = _QQBOT_TARGET_RE.fullmatch("3E9a53DBB44E52DD0B7DAB6F37B4FE97")
+        assert match is None
+
+
+class TestParseTargetRefQQBot:
+    """Test _parse_target_ref for QQBot platform."""
+
+    def test_parse_qqbot_openid(self):
+        """QQBot OpenID should be recognized as explicit."""
+        chat_id, thread_id, is_explicit = _parse_target_ref(
+            "qqbot", "3E9A53DBB44E52DD0B7DAB6F37B4FE97"
+        )
+        assert chat_id == "3E9A53DBB44E52DD0B7DAB6F37B4FE97"
+        assert thread_id is None
+        assert is_explicit is True
+
+    def test_parse_qqbot_numeric_falls_through(self):
+        """QQBot numeric ID should fall through to generic numeric handling."""
+        chat_id, thread_id, is_explicit = _parse_target_ref("qqbot", "1234567890")
+        # Falls through to the generic numeric check
+        assert chat_id == "1234567890"
+        assert thread_id is None
+        assert is_explicit is True
+
+    def test_parse_qqbot_invalid_format_not_explicit(self):
+        """Invalid QQBot format should return not explicit."""
+        chat_id, thread_id, is_explicit = _parse_target_ref("qqbot", "invalid-id")
+        assert chat_id is None
+        assert thread_id is None
+        assert is_explicit is False
+
+
+class TestSendQQBotEndpoints:
+    """Test _send_qqbot endpoint selection logic.
+
+    Uses integration-style testing by mocking the httpx module in sys.modules
+    since httpx is imported dynamically inside the function.
+    """
+
+    def _setup_httpx_mock(self, mock_responses):
+        """Create a mock httpx module with AsyncClient that returns mock responses."""
+        mock_httpx = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.post = AsyncMock(side_effect=mock_responses)
+
+        mock_httpx.AsyncClient.return_value = mock_client
+        return mock_httpx, mock_client
+
+    def _make_pconfig(self):
+        """Create a mock platform config for QQBot."""
+        return MagicMock(
+            extra={
+                "app_id": "test_app_id",
+                "client_secret": "test_client_secret",
+            }
+        )
+
+    @pytest.mark.asyncio
+    async def test_guild_channel_uses_channels_endpoint(self):
+        """Numeric chat_id should use guild channel endpoint."""
+        from tools.send_message_tool import _send_qqbot
+
+        pconfig = self._make_pconfig()
+
+        mock_responses = [
+            # Token response
+            MagicMock(
+                status_code=200,
+                json=lambda: {"access_token": "test_token"}
+            ),
+            # Guild channel message response
+            MagicMock(
+                status_code=200,
+                json=lambda: {"id": "msg_123"}
+            ),
+        ]
+
+        mock_httpx, mock_client = self._setup_httpx_mock(mock_responses)
+
+        with patch.dict(sys.modules, {"httpx": mock_httpx}):
+            result = await _send_qqbot(pconfig, "1234567890", "test message")
+
+        assert result["success"] is True
+        assert result["chat_type"] == "guild"
+        # Verify guild endpoint was used (second call, after token)
+        call_args = mock_client.post.call_args_list[1]
+        assert "/channels/1234567890/messages" in str(call_args)
+
+    @pytest.mark.asyncio
+    async def test_c2c_uses_users_endpoint(self):
+        """32-char hex OpenID should use C2C endpoint."""
+        from tools.send_message_tool import _send_qqbot
+
+        pconfig = self._make_pconfig()
+
+        mock_responses = [
+            # Token response
+            MagicMock(
+                status_code=200,
+                json=lambda: {"access_token": "test_token"}
+            ),
+            # C2C message response (success)
+            MagicMock(
+                status_code=200,
+                json=lambda: {"id": "msg_c2c"}
+            ),
+        ]
+
+        mock_httpx, mock_client = self._setup_httpx_mock(mock_responses)
+
+        with patch.dict(sys.modules, {"httpx": mock_httpx}):
+            result = await _send_qqbot(
+                pconfig, "3E9A53DBB44E52DD0B7DAB6F37B4FE97", "test message"
+            )
+
+        assert result["success"] is True
+        assert result["chat_type"] == "c2c"
+        # Verify C2C endpoint was used
+        call_args = mock_client.post.call_args_list[1]
+        assert "/v2/users/" in str(call_args)
+
+    @pytest.mark.asyncio
+    async def test_c2c_fallback_to_group(self):
+        """Should fall back to group endpoint if C2C fails."""
+        from tools.send_message_tool import _send_qqbot
+
+        pconfig = self._make_pconfig()
+
+        mock_responses = [
+            # Token response
+            MagicMock(
+                status_code=200,
+                json=lambda: {"access_token": "test_token"}
+            ),
+            # C2C response (failure - 404 means user not found)
+            MagicMock(
+                status_code=404,
+                text="Not Found"
+            ),
+            # Group response (success)
+            MagicMock(
+                status_code=200,
+                json=lambda: {"id": "msg_group"}
+            ),
+        ]
+
+        mock_httpx, mock_client = self._setup_httpx_mock(mock_responses)
+
+        with patch.dict(sys.modules, {"httpx": mock_httpx}):
+            result = await _send_qqbot(
+                pconfig, "3E9A53DBB44E52DD0B7DAB6F37B4FE97", "test message"
+            )
+
+        assert result["success"] is True
+        assert result["chat_type"] == "group"
+        # Verify C2C was tried first
+        c2c_call_args = mock_client.post.call_args_list[1]
+        assert "/v2/users/" in str(c2c_call_args)
+        # Verify group was tried second
+        group_call_args = mock_client.post.call_args_list[2]
+        assert "/v2/groups/" in str(group_call_args)
+
+    @pytest.mark.asyncio
+    async def test_unknown_format_returns_error(self):
+        """Unknown chat_id format should return error without API calls."""
+        from tools.send_message_tool import _send_qqbot
+
+        pconfig = self._make_pconfig()
+
+        # No mock responses needed - validation happens before API calls
+        mock_httpx, mock_client = self._setup_httpx_mock([])
+
+        with patch.dict(sys.modules, {"httpx": mock_httpx}):
+            result = await _send_qqbot(pconfig, "invalid-format-123", "test message")
+
+        assert "error" in result
+        assert "unrecognized chat_id format" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_missing_credentials_returns_error(self):
+        """Missing app_id or client_secret should return error."""
+        from tools.send_message_tool import _send_qqbot
+
+        pconfig = MagicMock(extra={})  # No credentials
+
+        result = await _send_qqbot(pconfig, "1234567890", "test message")
+
+        assert "error" in result
+        assert "not configured" in result["error"]
+
+
+class TestQQBotHomeChannelEnvVars:
+    """Test that both QQ_HOME_CHANNEL and QQBOT_HOME_CHANNEL are recognized."""
+
+    def test_qq_home_channel_fallback(self, monkeypatch):
+        """Test that QQBOT_HOME_CHANNEL is used when QQ_HOME_CHANNEL is not set."""
+        from gateway.config import load_gateway_config
+
+        # Set up minimal credentials
+        monkeypatch.setenv("QQ_APP_ID", "test_app_id")
+        monkeypatch.setenv("QQ_CLIENT_SECRET", "test_secret")
+        monkeypatch.setenv("QQBOT_HOME_CHANNEL", "3E9A53DBB44E52DD0B7DAB6F37B4FE97")
+        # Make sure QQ_HOME_CHANNEL is not set
+        monkeypatch.delenv("QQ_HOME_CHANNEL", raising=False)
+
+        # Clear any cached config state
+        monkeypatch.delenv("QQ_HOME_CHANNEL_NAME", raising=False)
+
+        config = load_gateway_config()
+
+        assert config.platforms.get(Platform.QQBOT) is not None
+        home = config.get_home_channel(Platform.QQBOT)
+        assert home is not None
+        assert home.chat_id == "3E9A53DBB44E52DD0B7DAB6F37B4FE97"
+
+    def test_qq_home_channel_preferred(self, monkeypatch):
+        """Test that QQ_HOME_CHANNEL is preferred over QQBOT_HOME_CHANNEL."""
+        from gateway.config import load_gateway_config
+
+        monkeypatch.setenv("QQ_APP_ID", "test_app_id")
+        monkeypatch.setenv("QQ_CLIENT_SECRET", "test_secret")
+        monkeypatch.setenv("QQ_HOME_CHANNEL", "AAAAAAAABBBBBBBCCCCCCCCDDDDDDDD")
+        monkeypatch.setenv("QQBOT_HOME_CHANNEL", "3E9A53DBB44E52DD0B7DAB6F37B4FE97")
+
+        config = load_gateway_config()
+
+        home = config.get_home_channel(Platform.QQBOT)
+        assert home is not None
+        # QQ_HOME_CHANNEL should be used first
+        assert home.chat_id == "AAAAAAAABBBBBBBCCCCCCCCDDDDDDDD"

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -21,6 +21,8 @@ _FEISHU_TARGET_RE = re.compile(r"^\s*((?:oc|ou|on|chat|open)_[-A-Za-z0-9]+)(?::(
 _WEIXIN_TARGET_RE = re.compile(r"^\s*((?:wxid|gh|v\d+|wm|wb)_[A-Za-z0-9_-]+|[A-Za-z0-9._-]+@chatroom|filehelper)\s*$")
 # Discord snowflake IDs are numeric, same regex pattern as Telegram topic targets.
 _NUMERIC_TOPIC_RE = _TELEGRAM_TOPIC_TARGET_RE
+# QQBot OpenID format: uppercase hex string (32 chars)
+_QQBOT_TARGET_RE = re.compile(r"^\s*([A-F0-9]{32})\s*$")
 _IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".gif"}
 _VIDEO_EXTS = {".mp4", ".mov", ".avi", ".mkv", ".3gp"}
 _AUDIO_EXTS = {".ogg", ".opus", ".mp3", ".wav", ".m4a"}
@@ -244,6 +246,10 @@ def _parse_target_ref(platform_name: str, target_ref: str):
             return match.group(1), match.group(2), True
     if platform_name == "weixin":
         match = _WEIXIN_TARGET_RE.fullmatch(target_ref)
+        if match:
+            return match.group(1), None, True
+    if platform_name == "qqbot":
+        match = _QQBOT_TARGET_RE.fullmatch(target_ref)
         if match:
             return match.group(1), None, True
     if target_ref.lstrip("-").isdigit():
@@ -1110,8 +1116,12 @@ async def _send_qqbot(pconfig, chat_id, message):
     """Send via QQBot using the REST API directly (no WebSocket needed).
 
     Uses the QQ Bot Open Platform REST endpoints to get an access token
-    and post a message. Works for guild channels without requiring
-    a running gateway adapter.
+    and post a message. Works for guild channels, C2C, and groups without
+    requiring a running gateway adapter.
+
+    Chat type detection:
+    - Numeric chat_id → guild channel (uses /channels/{id}/messages)
+    - 32-char hex OpenID → C2C or group (tries /v2/users then /v2/groups)
     """
     try:
         import httpx
@@ -1125,8 +1135,18 @@ async def _send_qqbot(pconfig, chat_id, message):
     if not appid or not secret:
         return _error("QQBot: QQ_APP_ID / QQ_CLIENT_SECRET not configured.")
 
+    # Determine chat type based on chat_id format
+    # - Pure numeric → guild channel
+    # - 32-char uppercase hex → C2C or group OpenID
+    is_guild = chat_id.isdigit()
+    is_openid = bool(re.match(r"^[A-F0-9]{32}$", chat_id))
+
+    # Early validation: return error before making any API calls
+    if not is_guild and not is_openid:
+        return _error(f"QQBot: unrecognized chat_id format: {chat_id[:16]}...")
+
     try:
-        async with httpx.AsyncClient(timeout=15) as client:
+        async with httpx.AsyncClient(timeout=30) as client:
             # Step 1: Get access token
             token_resp = await client.post(
                 "https://bots.qq.com/app/getAppAccessToken",
@@ -1139,21 +1159,53 @@ async def _send_qqbot(pconfig, chat_id, message):
             if not access_token:
                 return _error(f"QQBot: no access_token in response")
 
-            # Step 2: Send message via REST
             headers = {
-                "Authorization": f"QQBotAccessToken {access_token}",
+                "Authorization": f"QQBot {access_token}",
                 "Content-Type": "application/json",
             }
-            url = f"https://api.sgroup.qq.com/channels/{chat_id}/messages"
+
+            # Step 2: Send message based on chat type
             payload = {"content": message[:4000], "msg_type": 0}
 
-            resp = await client.post(url, json=payload, headers=headers)
-            if resp.status_code in (200, 201):
-                data = resp.json()
-                return {"success": True, "platform": "qqbot", "chat_id": chat_id,
-                        "message_id": data.get("id")}
-            else:
-                return _error(f"QQBot send failed: {resp.status_code} {resp.text}")
+            if is_guild:
+                # Guild channel endpoint
+                url = f"https://api.sgroup.qq.com/channels/{chat_id}/messages"
+                resp = await client.post(url, json=payload, headers=headers)
+                if resp.status_code in (200, 201):
+                    data = resp.json()
+                    return {"success": True, "platform": "qqbot", "chat_id": chat_id,
+                            "message_id": data.get("id"), "chat_type": "guild"}
+                return _error(f"QQBot guild send failed: {resp.status_code} {resp.text}")
+
+            elif is_openid:
+                # Try C2C first, then group if that fails
+                # Use msg_seq in range 0..65535 (per QQBotAdapter._next_msg_seq)
+                msg_seq = int(time.time() * 1000) % 65536
+                
+                # C2C endpoint
+                c2c_url = f"https://api.sgroup.qq.com/v2/users/{chat_id}/messages"
+                c2c_payload = {**payload, "msg_seq": msg_seq}
+                c2c_resp = await client.post(c2c_url, json=c2c_payload, headers=headers)
+                if c2c_resp.status_code in (200, 201):
+                    data = c2c_resp.json()
+                    return {"success": True, "platform": "qqbot", "chat_id": chat_id,
+                            "message_id": data.get("id"), "chat_type": "c2c"}
+
+                # Try group endpoint as fallback
+                group_url = f"https://api.sgroup.qq.com/v2/groups/{chat_id}/messages"
+                group_payload = {**payload, "msg_seq": msg_seq}
+                group_resp = await client.post(group_url, json=group_payload, headers=headers)
+                if group_resp.status_code in (200, 201):
+                    data = group_resp.json()
+                    return {"success": True, "platform": "qqbot", "chat_id": chat_id,
+                            "message_id": data.get("id"), "chat_type": "group"}
+
+                return _error(
+                    f"QQBot send failed (tried C2C and group): "
+                    f"C2C={c2c_resp.status_code} {c2c_resp.text}; "
+                    f"group={group_resp.status_code} {group_resp.text}"
+                )
+
     except Exception as e:
         return _error(f"QQBot send failed: {e}")
 


### PR DESCRIPTION
The `_send_qqbot` function only used the guild channel endpoint, which fails for C2C (private) and group chats that use 32-char hex OpenIDs.

**Changes:**
- Detect chat_id format and route to correct API endpoint:
  - Numeric ID → guild channel (`/channels/{id}/messages`)
  - 32-char hex OpenID → C2C or group (`/v2/users` then `/v2/groups` as fallback)
- Fix Authorization header: use `QQBot {token}` (not `QQBotAccessToken {token}`)
- Add `_QQBOT_TARGET_RE` regex to parse 32-char hex OpenID target refs
- Update config.py to accept both `QQ_HOME_CHANNEL` and `QQBOT_HOME_CHANNEL` env vars for backward compatibility
- Add comprehensive tests (17 test cases covering regex, parsing, endpoint selection)

**Test plan:**
- ✅ All 17 new tests pass
- Tested with user QQBot C2C private chat - messages sent successfully

---

This PR was made with the help of Little Orange — rucchi AI agent assistant.