### PR TITLE
fix(tts): split long speech by provider and platform limits

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -11216,8 +11216,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             from tools.tts_tool import text_to_speech_tool
             from tools.voice_mode import play_audio_file
 
-            # Strip markdown and non-speech content for cleaner TTS
-            tts_text = text[:4000] if len(text) > 4000 else text
+            # Strip markdown and non-speech content for cleaner TTS. Provider
+            # request limits and long-form chunking belong to the TTS tool.
+            tts_text = text
             tts_text = re.sub(r'```[\s\S]*?```', ' ', tts_text)   # fenced code blocks
             tts_text = re.sub(r'\[([^\]]+)\]\([^)]+\)', r'\1', tts_text)  # [text](url) -> text
             tts_text = re.sub(r'https?://\S+', '', tts_text)      # URLs
@@ -11232,25 +11233,30 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             if not tts_text:
                 return
 
-            # Use MP3 output for CLI playback (afplay doesn't handle OGG well).
-            # The TTS tool may auto-convert MP3->OGG, but the original MP3 remains.
+            # Prefer MP3 for local playback (afplay doesn't handle OGG well).
+            # The tool result remains authoritative if a provider rewrites the
+            # path or long-form delivery produces more than one file.
             os.makedirs(os.path.join(tempfile.gettempdir(), "hermes_voice"), exist_ok=True)
             mp3_path = os.path.join(
                 tempfile.gettempdir(), "hermes_voice",
                 f"tts_{time.strftime('%Y%m%d_%H%M%S')}.mp3",
             )
 
-            text_to_speech_tool(text=tts_text, output_path=mp3_path)
-
-            # Play the MP3 directly (the TTS tool returns OGG path but MP3 still exists)
-            if os.path.isfile(mp3_path) and os.path.getsize(mp3_path) > 0:
-                play_audio_file(mp3_path)
-                # Clean up
+            import json as _json
+            result = _json.loads(
+                text_to_speech_tool(text=tts_text, output_path=mp3_path)
+            )
+            play_paths = result.get("file_paths") or [
+                result.get("file_path") or mp3_path
+            ]
+            for play_path in play_paths if result.get("success") else []:
+                if os.path.isfile(play_path) and os.path.getsize(play_path) > 0:
+                    play_audio_file(play_path)
+            for cleanup_path in set(play_paths + [
+                mp3_path, mp3_path.rsplit(".", 1)[0] + ".ogg",
+            ]):
                 try:
-                    os.unlink(mp3_path)
-                    ogg_path = mp3_path.rsplit(".", 1)[0] + ".ogg"
-                    if os.path.isfile(ogg_path):
-                        os.unlink(ogg_path)
+                    os.unlink(cleanup_path)
                 except OSError:
                     pass
         except Exception as e:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3556,9 +3556,10 @@ class BasePlatformAdapter(ABC):
     def prepare_tts_text(self, text: str) -> str:
         """Prepare text for TTS. Override to filter tool output, code, etc.
 
-        Default strips markdown formatting and truncates to 4000 chars.
+        Default strips markdown formatting. Provider-safe chunking and
+        platform delivery limits are enforced by the TTS tool.
         """
-        return re.sub(r'[*_`#\[\]()]', '', text)[:4000].strip()
+        return re.sub(r'[*_`#\[\]()]', '', text).strip()
 
     async def play_tts(
         self,
@@ -5185,7 +5186,7 @@ class BasePlatformAdapter(ABC):
                 # Gated via ``_should_auto_tts_for_chat``: fires when the chat has
                 # an explicit ``/voice on|tts`` opt-in OR when ``voice.auto_tts`` is
                 # True globally and no ``/voice off`` has been issued.
-                _tts_path = None
+                _tts_paths: List[str] = []
                 if (self._should_auto_tts_for_chat(event.source.chat_id)
                         and event.message_type == MessageType.VOICE
                         and text_content
@@ -5201,17 +5202,24 @@ class BasePlatformAdapter(ABC):
                                 text_to_speech_tool, text=speech_text
                             )
                             tts_data = _json.loads(tts_result_str)
-                            _tts_path = tts_data.get("file_path")
+                            raw_tts_paths = tts_data.get("file_paths") or [
+                                tts_data.get("file_path")
+                            ]
+                            _tts_paths = [
+                                str(path) for path in raw_tts_paths
+                                if path and Path(path).exists()
+                            ]
                     except Exception as tts_err:
                         logger.warning("[%s] Auto-TTS failed: %s", self.name, tts_err)
 
                 # Play TTS audio before text (voice-first experience)
                 _tts_caption_delivered = False
-                if _tts_path and Path(_tts_path).exists():
+                for _tts_index, _tts_path in enumerate(_tts_paths):
                     try:
                         telegram_tts_caption = None
                         if (
-                            self.platform == Platform.TELEGRAM
+                            _tts_index == 0
+                            and self.platform == Platform.TELEGRAM
                             and text_content
                             and text_content[:1024] == text_content
                         ):
@@ -5222,8 +5230,13 @@ class BasePlatformAdapter(ABC):
                             caption=telegram_tts_caption,
                             metadata=_final_thread_metadata,
                         )
+                        _record_delivery(tts_result)
                         _tts_caption_delivered = bool(
-                            telegram_tts_caption and getattr(tts_result, "success", False)
+                            _tts_caption_delivered
+                            or (
+                                telegram_tts_caption
+                                and getattr(tts_result, "success", False)
+                            )
                         )
                     finally:
                         try:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14771,11 +14771,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """Generate TTS audio and send as a voice message before the text reply."""
         import uuid as _uuid
         audio_path = None
-        actual_path = None
+        actual_paths: List[str] = []
         try:
             from tools.tts_tool import text_to_speech_tool, _strip_markdown_for_tts
 
-            tts_text = _strip_markdown_for_tts(text[:4000])
+            tts_text = _strip_markdown_for_tts(text)
             if not tts_text:
                 return
 
@@ -14797,9 +14797,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 logger.warning("Auto voice reply TTS returned invalid JSON: %s", result_json[:200] if result_json else result_json)
                 return
 
-            # Use the actual file path from result (may differ after opus conversion)
-            actual_path = result.get("file_path", audio_path)
-            if not result.get("success") or not os.path.isfile(actual_path):
+            # Final delivery may be one combined file or multiple separately
+            # valid files when combination is unavailable or would exceed a
+            # platform limit. Preserve legacy single-file results.
+            actual_paths = result.get("file_paths") or [
+                result.get("file_path", audio_path)
+            ]
+            actual_paths = [
+                str(path) for path in actual_paths
+                if path and os.path.isfile(path)
+            ]
+            if not result.get("success") or not actual_paths:
                 logger.warning("Auto voice reply TTS failed: %s", result.get("error"))
                 return
 
@@ -14807,14 +14815,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             # If connected to a voice channel, play there instead of sending a file
             guild_id = self._get_guild_id(event)
-            if (guild_id
-                    and hasattr(adapter, "play_in_voice_channel")
-                    and hasattr(adapter, "is_in_voice_channel")
-                    and adapter.is_in_voice_channel(guild_id)):
-                await adapter.play_in_voice_channel(guild_id, actual_path)
-            elif adapter and hasattr(adapter, "send_voice"):
-                reply_anchor = self._reply_anchor_for_event(event)
-                thread_meta = self._thread_metadata_for_source(event.source, reply_anchor)
+            play_in_voice_channel = getattr(adapter, "play_in_voice_channel", None)
+            is_in_voice_channel = getattr(adapter, "is_in_voice_channel", None)
+            send_voice = getattr(adapter, "send_voice", None)
+            in_voice_channel = bool(
+                guild_id
+                and callable(play_in_voice_channel)
+                and callable(is_in_voice_channel)
+                and is_in_voice_channel(guild_id)
+            )
+            reply_anchor = self._reply_anchor_for_event(event)
+            thread_meta = self._thread_metadata_for_source(event.source, reply_anchor)
+            if not in_voice_channel and callable(send_voice):
                 # Mark the auto voice reply as notify-worthy.  Mirrors the
                 # final-text path in gateway/platforms/base.py which sets
                 # ``notify=True`` so platform adapters that gate push
@@ -14827,17 +14839,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     thread_meta["notify"] = True
                 else:
                     thread_meta = {"notify": True}
-                send_kwargs: Dict[str, Any] = {
-                    "chat_id": event.source.chat_id,
-                    "audio_path": actual_path,
-                    "reply_to": reply_anchor,
-                    "metadata": thread_meta,
-                }
-                await adapter.send_voice(**send_kwargs)
+            for actual_path in actual_paths:
+                if in_voice_channel:
+                    play_voice = cast(Callable[..., Awaitable[Any]], play_in_voice_channel)
+                    await play_voice(guild_id, actual_path)
+                elif callable(send_voice):
+                    send_voice_call = cast(Callable[..., Awaitable[Any]], send_voice)
+                    send_kwargs: Dict[str, Any] = {
+                        "chat_id": event.source.chat_id,
+                        "audio_path": actual_path,
+                        "reply_to": reply_anchor,
+                        "metadata": thread_meta,
+                    }
+                    await send_voice_call(**send_kwargs)
         except Exception as e:
             logger.warning("Auto voice reply failed: %s", e, exc_info=True)
         finally:
-            for p in {audio_path, actual_path} - {None}:
+            for p in ({audio_path, *actual_paths} - {None}):
                 try:
                     os.unlink(p)
                 except OSError:

--- a/hermes_cli/voice.py
+++ b/hermes_cli/voice.py
@@ -741,10 +741,10 @@ def speak_text(text: str) -> None:
     """Synthesize ``text`` with the configured TTS provider and play it.
 
     Mirrors cli.py:_voice_speak_response exactly — same markdown strip
-    pipeline, same 4000-char cap, same explicit mp3 output path, same
-    MP3-over-OGG playback choice (afplay misbehaves on OGG), same cleanup
-    of both extensions. Keeping these in sync means a voice-mode TTS
-    session in the TUI sounds identical to one in the classic CLI.
+    pipeline, same explicit MP3 preference (afplay misbehaves on OGG), and
+    the same result-driven multi-file playback and cleanup. Keeping these in
+    sync means a voice-mode TTS session in the TUI sounds identical to one in
+    the classic CLI.
 
     While playback is in flight the module-level _tts_playing Event is
     cleared so the continuous-recording loop knows to wait before
@@ -781,7 +781,8 @@ def speak_text(text: str) -> None:
     try:
         from tools.tts_tool import text_to_speech_tool
 
-        tts_text = text[:4000] if len(text) > 4000 else text
+        # The TTS tool owns provider request limits and long-form chunking.
+        tts_text = text
         tts_text = re.sub(r'```[\s\S]*?```', ' ', tts_text)             # fenced code blocks
         tts_text = re.sub(r'\[([^\]]+)\]\([^)]+\)', r'\1', tts_text)    # [text](url) → text
         tts_text = re.sub(r'https?://\S+', '', tts_text)                # bare URLs
@@ -796,9 +797,8 @@ def speak_text(text: str) -> None:
         if not tts_text:
             return
 
-        # MP3 output path, pre-chosen so we can play the MP3 directly even
-        # when text_to_speech_tool auto-converts to OGG for messaging
-        # platforms.  afplay's OGG support is flaky, MP3 always works.
+        # Prefer MP3 for local playback; the tool result remains authoritative
+        # if a provider rewrites the path or returns multiple delivery files.
         os.makedirs(os.path.join(tempfile.gettempdir(), "hermes_voice"), exist_ok=True)
         mp3_path = os.path.join(
             tempfile.gettempdir(),
@@ -807,19 +807,30 @@ def speak_text(text: str) -> None:
         )
 
         _debug(f"speak_text: synthesizing {len(tts_text)} chars -> {mp3_path}")
-        text_to_speech_tool(text=tts_text, output_path=mp3_path)
-
-        if os.path.isfile(mp3_path) and os.path.getsize(mp3_path) > 0:
-            _debug(f"speak_text: playing {mp3_path} ({os.path.getsize(mp3_path)} bytes)")
-            play_audio_file(mp3_path)
+        import json as _json
+        result = _json.loads(
+            text_to_speech_tool(text=tts_text, output_path=mp3_path)
+        )
+        play_paths = result.get("file_paths") or [
+            result.get("file_path") or mp3_path
+        ]
+        played_any = False
+        for play_path in play_paths if result.get("success") else []:
+            if os.path.isfile(play_path) and os.path.getsize(play_path) > 0:
+                _debug(
+                    f"speak_text: playing {play_path} "
+                    f"({os.path.getsize(play_path)} bytes)"
+                )
+                play_audio_file(play_path)
+                played_any = True
+        for cleanup_path in set(play_paths + [
+            mp3_path, mp3_path.rsplit(".", 1)[0] + ".ogg",
+        ]):
             try:
-                os.unlink(mp3_path)
-                ogg_path = mp3_path.rsplit(".", 1)[0] + ".ogg"
-                if os.path.isfile(ogg_path):
-                    os.unlink(ogg_path)
+                os.unlink(cleanup_path)
             except OSError:
                 pass
-        else:
+        if not played_any:
             _debug(f"speak_text: TTS tool produced no audio at {mp3_path}")
     except Exception as e:
         logger.warning("Voice TTS playback failed: %s", e)

--- a/tests/gateway/test_auto_voice_reply_format.py
+++ b/tests/gateway/test_auto_voice_reply_format.py
@@ -71,6 +71,41 @@ class TestAutoVoiceReplyFormat:
         adapter.send_voice.assert_awaited_once()
         assert adapter.send_voice.await_args.kwargs["audio_path"].endswith(".mp3")
 
+    @pytest.mark.asyncio
+    async def test_multi_file_fallback_sends_every_audio_file_in_order(self):
+        runner = _make_runner()
+        adapter = _make_adapter(Platform.TELEGRAM)
+        runner.adapters[Platform.TELEGRAM] = adapter
+        event = _make_event(Platform.TELEGRAM)
+
+        def fake_tts(*, text, output_path):
+            first = str(Path(output_path).with_name("reply.part01.ogg"))
+            second = str(Path(output_path).with_name("reply.part02.ogg"))
+            for path in (first, second):
+                Path(path).parent.mkdir(parents=True, exist_ok=True)
+                Path(path).write_bytes(b"valid audio")
+            return json.dumps({
+                "success": True,
+                "file_path": first,
+                "file_paths": [first, second],
+                "provider": "gemini",
+                "voice_compatible": True,
+            })
+
+        with patch("tools.tts_tool.text_to_speech_tool", side_effect=fake_tts):
+            await runner._send_voice_reply(event, "A" * 5000)
+
+        assert adapter.send_voice.await_count == 2
+        sent_paths = [
+            call.kwargs["audio_path"]
+            for call in adapter.send_voice.await_args_list
+        ]
+        assert [Path(path).name for path in sent_paths] == [
+            "reply.part01.ogg", "reply.part02.ogg",
+        ]
+        assert all(call.kwargs["metadata"]["notify"] for call in adapter.send_voice.await_args_list)
+        assert all(not Path(path).exists() for path in sent_paths)
+
 
 def _make_runner() -> GatewayRunner:
     with patch("gateway.run.GatewayRunner._load_voice_modes", return_value={}):

--- a/tests/gateway/test_base_topic_sessions.py
+++ b/tests/gateway/test_base_topic_sessions.py
@@ -334,6 +334,39 @@ class TestTelegramAutoTtsCaptionDelivery:
         ]
 
     @pytest.mark.asyncio
+    async def test_long_auto_tts_passes_full_cleaned_reply_to_chunker(self, tmp_path):
+        adapter = DummyTelegramAdapter()
+        adapter._keep_typing = self._hold_typing()
+        adapter._should_auto_tts_for_chat = lambda _chat_id: True
+        adapter.play_tts = AsyncMock(
+            return_value=SendResult(success=True, message_id="tts-1")
+        )
+        long_reply = "A" * 2500 + " **middle** " + "B" * 2500
+        expected_tts_text = "A" * 2500 + " middle " + "B" * 2500
+        adapter.set_message_handler(
+            lambda _event: asyncio.sleep(0, result=long_reply)
+        )
+
+        tts_path = tmp_path / "reply.ogg"
+        tts_path.write_text("audio", encoding="utf-8")
+        event = self._make_voice_event()
+        received_text = []
+
+        def fake_tts(*, text, output_path=None):
+            received_text.append(text)
+            return json.dumps({"file_path": str(tts_path)})
+
+        with patch(
+            "tools.tts_tool.check_tts_requirements", return_value=True
+        ), patch("tools.tts_tool.text_to_speech_tool", side_effect=fake_tts):
+            await adapter._process_message_background(
+                event, build_session_key(event.source)
+            )
+
+        assert received_text == [expected_tts_text]
+        assert len(received_text[0]) > 4000
+
+    @pytest.mark.asyncio
     async def test_telegram_auto_tts_send_failure_keeps_followup_text(self, tmp_path):
         adapter = DummyTelegramAdapter()
         adapter._keep_typing = self._hold_typing()
@@ -361,3 +394,42 @@ class TestTelegramAutoTtsCaptionDelivery:
                 "metadata": {"thread_id": "17585", "notify": True},
             }
         ]
+
+    @pytest.mark.asyncio
+    async def test_multi_file_auto_tts_sends_all_clips_and_records_delivery(self, tmp_path):
+        adapter = DummyTelegramAdapter()
+        adapter._keep_typing = self._hold_typing()
+        adapter._should_auto_tts_for_chat = lambda _chat_id: True
+        adapter.play_tts = AsyncMock(
+            side_effect=[
+                SendResult(success=True, message_id="tts-1"),
+                SendResult(success=True, message_id="tts-2"),
+            ]
+        )
+        adapter.set_message_handler(lambda _event: asyncio.sleep(0, result="Short reply"))
+
+        first = tmp_path / "reply.part01.ogg"
+        second = tmp_path / "reply.part02.ogg"
+        first.write_text("audio one", encoding="utf-8")
+        second.write_text("audio two", encoding="utf-8")
+        event = self._make_voice_event()
+
+        with patch("tools.tts_tool.check_tts_requirements", return_value=True), patch(
+            "tools.tts_tool.text_to_speech_tool",
+            return_value=json.dumps({
+                "file_path": str(first),
+                "file_paths": [str(first), str(second)],
+            }),
+        ):
+            await adapter._process_message_background(event, build_session_key(event.source))
+
+        assert adapter.play_tts.await_count == 2
+        assert [
+            call.kwargs["caption"] for call in adapter.play_tts.await_args_list
+        ] == ["Short reply", None]
+        assert adapter.sent == []
+        assert adapter.processing_hooks[-1] == (
+            "complete", "voice-1", ProcessingOutcome.SUCCESS,
+        )
+        assert not first.exists()
+        assert not second.exists()

--- a/tests/tools/test_tts_long_form_chunking.py
+++ b/tests/tools/test_tts_long_form_chunking.py
@@ -1,0 +1,217 @@
+"""Regressions for lossless long-form TTS and final-artifact delivery limits."""
+
+import json
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from tools.tts_tool import (
+    AudioDeliveryProfile,
+    _build_audio_delivery_files,
+    _concat_audio_files,
+    _split_text_for_tts,
+    text_to_speech_tool,
+)
+
+
+def test_split_text_for_tts_preserves_normalized_text_under_request_cap():
+    text = (
+        "First sentence has useful shape. Second sentence stays intact.\n\n"
+        "A final sentence closes the thought cleanly."
+    )
+
+    chunks = _split_text_for_tts(text, max_chars=48)
+
+    assert len(chunks) > 1
+    assert all(len(chunk) <= 48 for chunk in chunks)
+    assert " ".join(chunks) == " ".join(text.split())
+
+
+def test_voice_chunk_combine_reencodes_opus_without_stream_copy(
+    tmp_path, monkeypatch,
+):
+    first = tmp_path / "first.ogg"
+    second = tmp_path / "second.ogg"
+    first.write_bytes(b"first")
+    second.write_bytes(b"second")
+    commands = []
+
+    monkeypatch.setattr("tools.tts_tool.shutil.which", lambda name: "/usr/bin/ffmpeg")
+
+    def fake_run(command, **kwargs):
+        commands.append(command)
+        Path(command[-1]).write_bytes(b"combined opus")
+        return SimpleNamespace(returncode=0, stderr=b"")
+
+    monkeypatch.setattr("tools.tts_tool.subprocess.run", fake_run)
+    output = tmp_path / "combined.ogg"
+
+    result = _concat_audio_files(
+        [str(first), str(second)], str(output), voice_compatible=True,
+    )
+
+    assert result == str(output)
+    assert output.read_bytes() == b"combined opus"
+    command = commands[0]
+    assert "libopus" in command
+    assert command[command.index("-ac") + 1] == "1"
+    assert command[command.index("-b:a") + 1] == "64k"
+    assert command[command.index("-vbr") + 1] == "off"
+    assert "copy" not in command
+
+
+def test_failed_combine_preserves_ordered_separate_deliverables(
+    tmp_path, monkeypatch,
+):
+    sources = []
+    for index, payload in enumerate((b"one", b"two"), start=1):
+        path = tmp_path / f"chunk{index}.mp3"
+        path.write_bytes(payload)
+        sources.append(str(path))
+
+    monkeypatch.setattr("tools.tts_tool._concat_audio_files", lambda *a, **k: None)
+    profile = AudioDeliveryProfile("test", max_file_bytes=1000, safety_ratio=1.0)
+
+    paths, combined = _build_audio_delivery_files(
+        sources, str(tmp_path / "reply.mp3"), profile,
+    )
+
+    assert combined is False
+    assert [Path(path).read_bytes() for path in paths] == [b"one", b"two"]
+    assert [Path(path).name for path in paths] == [
+        "reply.part01.mp3", "reply.part02.mp3",
+    ]
+
+
+def test_post_encode_growth_is_repacked_into_compliant_outputs(
+    tmp_path, monkeypatch,
+):
+    sources = []
+    for index in range(3):
+        path = tmp_path / f"chunk{index}.ogg"
+        path.write_bytes(b"x" * 300)
+        sources.append(str(path))
+
+    def fake_combine(paths, output_path, *, voice_compatible=False):
+        # The first three-way final encoding grows beyond the hard cap. Smaller
+        # recursive groups remain compliant.
+        size = 1200 if len(paths) == 3 else sum(Path(path).stat().st_size for path in paths)
+        Path(output_path).write_bytes(b"z" * size)
+        return output_path
+
+    monkeypatch.setattr("tools.tts_tool._concat_audio_files", fake_combine)
+    profile = AudioDeliveryProfile("test", max_file_bytes=1000, safety_ratio=1.0)
+
+    paths, combined = _build_audio_delivery_files(
+        sources,
+        str(tmp_path / "reply.ogg"),
+        profile,
+        voice_compatible=True,
+    )
+
+    assert combined is True
+    assert len(paths) == 2
+    assert all(Path(path).stat().st_size <= profile.max_file_bytes for path in paths)
+
+
+def test_single_final_encoded_chunk_over_hard_limit_fails_closed(tmp_path):
+    source = tmp_path / "oversize.ogg"
+    source.write_bytes(b"x" * 1001)
+    profile = AudioDeliveryProfile("test", max_file_bytes=1000, safety_ratio=1.0)
+
+    with pytest.raises(ValueError, match="Final-encoded TTS chunk exceeds"):
+        _build_audio_delivery_files(
+            [str(source)], str(tmp_path / "reply.ogg"), profile,
+        )
+
+
+def test_text_to_speech_tool_chunks_all_input_in_order(tmp_path, monkeypatch):
+    calls = []
+
+    def fake_openai(text, output_path, config):
+        calls.append(text)
+        Path(output_path).write_bytes(("audio:" + text).encode())
+        return output_path
+
+    def fake_combine(paths, output_path, *, voice_compatible=False):
+        Path(output_path).write_bytes(b"".join(Path(path).read_bytes() for path in paths))
+        return output_path
+
+    monkeypatch.setattr("tools.tts_tool._import_openai_client", lambda: object)
+    monkeypatch.setattr("tools.tts_tool._generate_openai_tts", fake_openai)
+    monkeypatch.setattr("tools.tts_tool._concat_audio_files", fake_combine)
+    monkeypatch.setattr(
+        "tools.tts_tool._load_tts_config",
+        lambda: {
+            "provider": "openai",
+            "openai": {"max_text_length": 60},
+            "delivery_profiles": {
+                "default": {"max_file_bytes": 1_000_000, "safety_ratio": 1.0},
+            },
+        },
+    )
+
+    text = " ".join(
+        f"Sentence {index} contains enough words for natural chunking."
+        for index in range(12)
+    )
+    result = json.loads(
+        text_to_speech_tool(text=text, output_path=str(tmp_path / "reply.mp3"))
+    )
+
+    assert result["success"] is True
+    assert result["chunk_count"] == len(calls) > 1
+    assert all(len(call) <= 60 for call in calls)
+    assert " ".join(calls) == " ".join(text.split())
+    assert result["delivery_file_count"] == 1
+    assert result["combined_chunks"] is True
+    assert os.path.isfile(result["file_path"])
+
+
+def test_long_form_generation_uses_one_config_snapshot(tmp_path, monkeypatch):
+    calls = []
+    config_loads = 0
+
+    def load_config_once():
+        nonlocal config_loads
+        config_loads += 1
+        if config_loads > 1:
+            raise AssertionError("TTS config was reloaded between chunks")
+        return {
+            "provider": "openai",
+            "openai": {"max_text_length": 40},
+            "delivery_profiles": {
+                "default": {
+                    "max_file_bytes": 1_000_000,
+                    "safety_ratio": 1.0,
+                },
+            },
+        }
+
+    def fake_openai(text, output_path, config):
+        calls.append(text)
+        Path(output_path).write_bytes(("audio:" + text).encode())
+        return output_path
+
+    def fake_combine(paths, output_path, *, voice_compatible=False):
+        Path(output_path).write_bytes(
+            b"".join(Path(path).read_bytes() for path in paths)
+        )
+        return output_path
+
+    monkeypatch.setattr("tools.tts_tool._load_tts_config", load_config_once)
+    monkeypatch.setattr("tools.tts_tool._import_openai_client", lambda: object)
+    monkeypatch.setattr("tools.tts_tool._generate_openai_tts", fake_openai)
+    monkeypatch.setattr("tools.tts_tool._concat_audio_files", fake_combine)
+
+    text = "One stable provider must render every long-form chunk without loss. " * 4
+    result = json.loads(
+        text_to_speech_tool(text=text, output_path=str(tmp_path / "reply.mp3"))
+    )
+
+    assert result["success"] is True
+    assert config_loads == 1
+    assert len(calls) > 1
+    assert " ".join(calls) == " ".join(text.split())

--- a/tests/tools/test_tts_long_form_chunking.py
+++ b/tests/tools/test_tts_long_form_chunking.py
@@ -90,6 +90,33 @@ def test_non_voice_chunk_combine_preserves_provider_encoded_frames(
     assert "libopus" not in command
 
 
+def test_ogg_combine_reencodes_even_without_voice_presentation_opt_in(
+    tmp_path, monkeypatch,
+):
+    first = tmp_path / "first.ogg"
+    second = tmp_path / "second.ogg"
+    first.write_bytes(b"first")
+    second.write_bytes(b"second")
+    commands = []
+
+    monkeypatch.setattr("tools.tts_tool.shutil.which", lambda name: "/usr/bin/ffmpeg")
+
+    def fake_run(command, **kwargs):
+        commands.append(command)
+        Path(command[-1]).write_bytes(b"combined opus")
+        return SimpleNamespace(returncode=0, stderr=b"")
+
+    monkeypatch.setattr("tools.tts_tool.subprocess.run", fake_run)
+    output = tmp_path / "combined.ogg"
+
+    result = _concat_audio_files([str(first), str(second)], str(output))
+
+    assert result == str(output)
+    command = commands[0]
+    assert command[command.index("-c:a") + 1] == "libopus"
+    assert "copy" not in command
+
+
 def test_failed_combine_preserves_ordered_separate_deliverables(
     tmp_path, monkeypatch,
 ):

--- a/tests/tools/test_tts_long_form_chunking.py
+++ b/tests/tools/test_tts_long_form_chunking.py
@@ -62,6 +62,34 @@ def test_voice_chunk_combine_reencodes_opus_without_stream_copy(
     assert "copy" not in command
 
 
+def test_non_voice_chunk_combine_preserves_provider_encoded_frames(
+    tmp_path, monkeypatch,
+):
+    first = tmp_path / "first.mp3"
+    second = tmp_path / "second.mp3"
+    first.write_bytes(b"first")
+    second.write_bytes(b"second")
+    commands = []
+
+    monkeypatch.setattr("tools.tts_tool.shutil.which", lambda name: "/usr/bin/ffmpeg")
+
+    def fake_run(command, **kwargs):
+        commands.append(command)
+        Path(command[-1]).write_bytes(b"combined mp3")
+        return SimpleNamespace(returncode=0, stderr=b"")
+
+    monkeypatch.setattr("tools.tts_tool.subprocess.run", fake_run)
+    output = tmp_path / "combined.mp3"
+
+    result = _concat_audio_files([str(first), str(second)], str(output))
+
+    assert result == str(output)
+    assert output.read_bytes() == b"combined mp3"
+    command = commands[0]
+    assert command[command.index("-c:a") + 1] == "copy"
+    assert "libopus" not in command
+
+
 def test_failed_combine_preserves_ordered_separate_deliverables(
     tmp_path, monkeypatch,
 ):

--- a/tests/tools/test_tts_max_text_length.py
+++ b/tests/tools/test_tts_max_text_length.py
@@ -115,25 +115,30 @@ class TestResolveMaxTextLength:
         assert expected.issubset(PROVIDER_MAX_TEXT_LENGTH.keys())
 
 
-class TestTextToSpeechToolTruncation:
+class TestTextToSpeechToolChunking:
     """End-to-end: verify the resolver actually drives the text_to_speech_tool
-    truncation path rather than the old 4000-char global."""
+    per-request chunks rather than the old 4000-char global truncation."""
 
-    def test_openai_truncates_at_4096_not_4000(self, tmp_path, monkeypatch, caplog):
-        import logging
-        caplog.set_level(logging.WARNING, logger="tools.tts_tool")
-
+    def test_openai_chunks_at_4096_without_dropping_text(self, tmp_path, monkeypatch):
         # 5000 chars -- over OpenAI's 4096 limit but under xAI's 15k
         text = "A" * 5000
-        captured_text = {}
+        captured_text = []
 
         def fake_openai(t, out, cfg):
-            captured_text["text"] = t
+            captured_text.append(t)
             with open(out, "wb") as f:
                 f.write(b"\x00")
             return out
 
+        def fake_combine(paths, output_path, *, voice_compatible=False):
+            with open(output_path, "wb") as destination:
+                for path in paths:
+                    with open(path, "rb") as source:
+                        destination.write(source.read())
+            return output_path
+
         monkeypatch.setattr("tools.tts_tool._generate_openai_tts", fake_openai)
+        monkeypatch.setattr("tools.tts_tool._concat_audio_files", fake_combine)
         monkeypatch.setattr("tools.tts_tool._load_tts_config",
                             lambda: {"provider": "openai"})
 
@@ -142,10 +147,9 @@ class TestTextToSpeechToolTruncation:
         result = json.loads(text_to_speech_tool(text=text, output_path=out))
 
         assert result["success"] is True
-        # Should be truncated to 4096, not the old 4000
-        assert len(captured_text["text"]) == 4096
-        # And the warning should mention the provider
-        assert any("openai" in rec.message.lower() for rec in caplog.records)
+        assert [len(chunk) for chunk in captured_text] == [4096, 904]
+        assert "".join(captured_text) == text
+        assert result["chunk_count"] == 2
 
     def test_xai_accepts_much_longer_input(self, tmp_path, monkeypatch):
         # 12000 chars -- over old global 4000, under xAI's 15000

--- a/tests/tools/test_voice_cli_integration.py
+++ b/tests/tools/test_voice_cli_integration.py
@@ -1105,11 +1105,11 @@ class TestVoiceSpeakResponseReal:
     @patch("cli._cprint")
     @patch("cli.os.makedirs")
     @patch("tools.tts_tool.text_to_speech_tool", return_value='{"success": true}')
-    def test_long_text_truncated(self, mock_tts, _mkd, _cp):
+    def test_long_text_reaches_tts_tool_without_caller_truncation(self, mock_tts, _mkd, _cp):
         cli = _make_voice_cli(_voice_tts=True)
         cli._voice_speak_response("A" * 5000)
         call_text = mock_tts.call_args.kwargs["text"]
-        assert len(call_text) <= 4000
+        assert len(call_text) == 5000
 
     @patch("cli._cprint")
     @patch("cli.os.makedirs")

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1149,6 +1149,12 @@ def _concat_audio_files(
             command.extend([
                 "-c:a", "libopus", "-ac", "1", "-b:a", "64k", "-vbr", "off",
             ])
+        else:
+            # Provider chunks already share one output codec/configuration. Preserve
+            # those encoded frames instead of imposing a second lossy encode. The
+            # concat demuxer will fail cleanly on incompatible streams, allowing the
+            # caller to preserve the ordered source files as its safe fallback.
+            command.extend(["-c:a", "copy"])
         command.append(str(temp_output))
 
         result = subprocess.run(

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1105,9 +1105,11 @@ def _concat_audio_files(
 ) -> Optional[str]:
     """Combine independently encoded chunks with ffmpeg.
 
-    Voice-compatible OGG/Opus is always decoded and re-encoded. A failed or
-    unavailable combine returns ``None`` so callers can preserve the original,
-    individually valid files. Structured audio containers are never byte-joined.
+    OGG/Opus is always decoded and re-encoded, even when a custom provider did
+    not opt in to voice-message presentation. Matching MP3 chunks preserve their
+    encoded frames. A failed or unavailable combine returns ``None`` so callers
+    can preserve the original, individually valid files. Structured audio
+    containers are never byte-joined.
     """
     if not audio_paths:
         raise ValueError("No audio chunks to combine")
@@ -1145,15 +1147,16 @@ def _concat_audio_files(
             str(concat_path),
             "-vn",
         ]
-        if voice_compatible:
+        suffix = destination.suffix.lower()
+        if voice_compatible or suffix in {".ogg", ".opus"}:
             command.extend([
                 "-c:a", "libopus", "-ac", "1", "-b:a", "64k", "-vbr", "off",
             ])
-        else:
-            # Provider chunks already share one output codec/configuration. Preserve
-            # those encoded frames instead of imposing a second lossy encode. The
-            # concat demuxer will fail cleanly on incompatible streams, allowing the
-            # caller to preserve the ordered source files as its safe fallback.
+        elif suffix == ".mp3" and all(
+            Path(path).suffix.lower() == ".mp3" for path in audio_paths
+        ):
+            # Matching MP3 provider chunks already share one output codec/config.
+            # Preserve those encoded frames instead of imposing a second lossy pass.
             command.extend(["-c:a", "copy"])
         command.append(str(temp_output))
 

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -48,8 +48,9 @@ import subprocess
 import tempfile
 import threading
 import uuid
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Dict, Any, Optional
+from typing import Callable, Dict, Any, List, Optional, Tuple
 from urllib.parse import urljoin, urlparse
 
 from hermes_cli._subprocess_compat import windows_hide_flags
@@ -291,7 +292,7 @@ def _resolve_max_text_length(
       6. ``FALLBACK_MAX_TEXT_LENGTH`` (4000)
 
     Non-positive or non-integer overrides fall through to the default so a
-    broken config can't accidentally disable truncation entirely.
+    broken config can't accidentally disable provider request chunking.
     """
     if not provider:
         return FALLBACK_MAX_TEXT_LENGTH
@@ -328,6 +329,161 @@ def _resolve_max_text_length(
             return DEFAULT_COMMAND_TTS_MAX_TEXT_LENGTH
 
     return FALLBACK_MAX_TEXT_LENGTH
+
+
+@dataclass(frozen=True)
+class AudioDeliveryProfile:
+    """Destination-platform constraints for generated TTS audio."""
+
+    platform: str
+    max_file_bytes: int
+    safety_ratio: float = 0.85
+
+    @property
+    def target_file_bytes(self) -> int:
+        """Conservative packing target below the platform hard limit."""
+        return max(1, int(self.max_file_bytes * self.safety_ratio))
+
+
+_PLATFORM_AUDIO_DEFAULTS: Dict[str, Dict[str, Any]] = {
+    "discord": {
+        "max_file_bytes": 10 * 1024 * 1024,
+        "safety_ratio": 0.85,
+    },
+    "telegram": {
+        "max_file_bytes": 50 * 1024 * 1024,
+        "safety_ratio": 0.85,
+    },
+    "default": {
+        "max_file_bytes": 10 * 1024 * 1024,
+        "safety_ratio": 0.85,
+    },
+}
+
+
+def _resolve_audio_delivery_profile(
+    platform: Optional[str],
+    tts_config: Optional[Dict[str, Any]] = None,
+) -> AudioDeliveryProfile:
+    """Resolve upload constraints, including optional per-platform overrides."""
+    key = (platform or "default").lower().strip() or "default"
+    defaults = dict(
+        _PLATFORM_AUDIO_DEFAULTS.get(key) or _PLATFORM_AUDIO_DEFAULTS["default"]
+    )
+    cfg = tts_config or {}
+    profiles = cfg.get("delivery_profiles")
+    overrides = profiles.get(key, {}) if isinstance(profiles, dict) else {}
+    if isinstance(overrides, dict):
+        defaults.update({k: v for k, v in overrides.items() if v is not None})
+
+    max_file_bytes = defaults.get("max_file_bytes")
+    if (
+        isinstance(max_file_bytes, bool)
+        or not isinstance(max_file_bytes, int)
+        or max_file_bytes <= 0
+    ):
+        max_file_bytes = _PLATFORM_AUDIO_DEFAULTS["default"]["max_file_bytes"]
+
+    safety_ratio = defaults.get("safety_ratio", 0.85)
+    if (
+        isinstance(safety_ratio, bool)
+        or not isinstance(safety_ratio, (int, float))
+        or not 0 < safety_ratio <= 1
+    ):
+        safety_ratio = 0.85
+
+    return AudioDeliveryProfile(
+        platform=key,
+        max_file_bytes=max_file_bytes,
+        safety_ratio=float(safety_ratio),
+    )
+
+
+def _split_oversized_sentence(sentence: str, max_chars: int) -> List[str]:
+    """Split one over-limit sentence on word boundaries, then hard boundaries."""
+    words = sentence.split()
+    chunks: List[str] = []
+    current = ""
+    for word in words:
+        if len(word) > max_chars:
+            if current:
+                chunks.append(current)
+                current = ""
+            chunks.extend(word[i:i + max_chars] for i in range(0, len(word), max_chars))
+            continue
+        candidate = f"{current} {word}".strip()
+        if current and len(candidate) > max_chars:
+            chunks.append(current)
+            current = word
+        else:
+            current = candidate
+    if current:
+        chunks.append(current)
+    return chunks
+
+
+def _split_text_for_tts(text: str, max_chars: int) -> List[str]:
+    """Split text under a provider cap without dropping normalized content."""
+    if max_chars <= 0:
+        max_chars = FALLBACK_MAX_TEXT_LENGTH
+    normalized = " ".join((text or "").split())
+    if not normalized:
+        return []
+    if len(normalized) <= max_chars:
+        return [normalized]
+
+    sentences = [
+        sentence.strip()
+        for sentence in re.split(r"(?<=[.!?;:,])\s+", normalized)
+        if sentence.strip()
+    ]
+    expanded: List[str] = []
+    for sentence in sentences:
+        if len(sentence) <= max_chars:
+            expanded.append(sentence)
+        else:
+            expanded.extend(_split_oversized_sentence(sentence, max_chars))
+
+    chunks: List[str] = []
+    current = ""
+    for sentence in expanded:
+        candidate = f"{current} {sentence}".strip()
+        if current and len(candidate) > max_chars:
+            chunks.append(current)
+            current = sentence
+        else:
+            current = candidate
+    if current:
+        chunks.append(current)
+    return chunks
+
+
+def _pack_audio_files_for_delivery(
+    audio_paths: List[str],
+    profile: AudioDeliveryProfile,
+) -> List[List[str]]:
+    """Group already-final-encoded chunks under the conservative size target."""
+    groups: List[List[str]] = []
+    current: List[str] = []
+    current_size = 0
+    current_suffix = ""
+    for path in audio_paths:
+        size = Path(path).stat().st_size
+        suffix = Path(path).suffix.lower()
+        if current and (
+            current_size + size > profile.target_file_bytes
+            or suffix != current_suffix
+        ):
+            groups.append(current)
+            current = []
+            current_size = 0
+            current_suffix = ""
+        current.append(path)
+        current_size += size
+        current_suffix = suffix
+    if current:
+        groups.append(current)
+    return groups
 
 
 # ===========================================================================
@@ -939,6 +1095,178 @@ def _convert_to_opus(mp3_path: str) -> Optional[str]:
     except Exception as e:
         logger.warning("ffmpeg OGG conversion failed: %s", e, exc_info=True)
     return None
+
+
+def _concat_audio_files(
+    audio_paths: List[str],
+    output_path: str,
+    *,
+    voice_compatible: bool = False,
+) -> Optional[str]:
+    """Combine independently encoded chunks with ffmpeg.
+
+    Voice-compatible OGG/Opus is always decoded and re-encoded. A failed or
+    unavailable combine returns ``None`` so callers can preserve the original,
+    individually valid files. Structured audio containers are never byte-joined.
+    """
+    if not audio_paths:
+        raise ValueError("No audio chunks to combine")
+    if len(audio_paths) == 1:
+        source = audio_paths[0]
+        if os.path.abspath(source) != os.path.abspath(output_path):
+            shutil.copyfile(source, output_path)
+        return output_path
+
+    ffmpeg = shutil.which("ffmpeg")
+    if not ffmpeg:
+        return None
+
+    destination = Path(output_path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    concat_path = destination.with_name(f".{destination.name}.{uuid.uuid4().hex}.concat.txt")
+    temp_output = destination.with_name(
+        f".{destination.stem}.{uuid.uuid4().hex}.combining{destination.suffix}"
+    )
+    try:
+        with concat_path.open("w", encoding="utf-8") as concat_file:
+            for path in audio_paths:
+                concat_file.write(f"file {shlex.quote(os.path.abspath(path))}\n")
+
+        command = [
+            ffmpeg,
+            "-y",
+            "-loglevel",
+            "error",
+            "-f",
+            "concat",
+            "-safe",
+            "0",
+            "-i",
+            str(concat_path),
+            "-vn",
+        ]
+        if voice_compatible:
+            command.extend([
+                "-c:a", "libopus", "-ac", "1", "-b:a", "64k", "-vbr", "off",
+            ])
+        command.append(str(temp_output))
+
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            timeout=120,
+            stdin=subprocess.DEVNULL,
+            creationflags=windows_hide_flags(),
+        )
+        if (
+            result.returncode == 0
+            and temp_output.exists()
+            and temp_output.stat().st_size > 0
+        ):
+            os.replace(temp_output, destination)
+            return str(destination)
+        logger.warning(
+            "ffmpeg audio combine failed: %s",
+            result.stderr.decode("utf-8", errors="ignore")[:500],
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        logger.warning("ffmpeg audio combine failed: %s", exc)
+    finally:
+        for path in (concat_path, temp_output):
+            try:
+                path.unlink()
+            except OSError:
+                pass
+    return None
+
+
+def _build_audio_delivery_files(
+    audio_paths: List[str],
+    output_path: str,
+    profile: AudioDeliveryProfile,
+    *,
+    voice_compatible: bool = False,
+) -> Tuple[List[str], bool]:
+    """Pack final-encoded chunks and enforce the hard upload limit.
+
+    Packing uses the conservative target. Every combined artifact is then
+    checked at its actual post-encoding size; an over-limit group is split and
+    retried. If combining fails, the valid constituent files are returned
+    separately. A single final-encoded chunk above the hard limit fails closed
+    rather than returning an upload that the destination will reject.
+    """
+    if not audio_paths:
+        raise ValueError("No final-encoded TTS audio chunks")
+    for path in audio_paths:
+        size = Path(path).stat().st_size
+        if size > profile.max_file_bytes:
+            raise ValueError(
+                f"Final-encoded TTS chunk exceeds {profile.platform} delivery "
+                f"limit ({size} > {profile.max_file_bytes} bytes): {path}"
+            )
+
+    base = Path(output_path)
+    scratch_outputs: List[str] = []
+    combined_any = False
+    combine_index = 0
+
+    def emit(group: List[str]) -> List[str]:
+        nonlocal combined_any, combine_index
+        if len(group) == 1:
+            return list(group)
+
+        combine_index += 1
+        scratch = base.with_name(
+            f".{base.stem}.delivery{combine_index:03d}.{uuid.uuid4().hex}{base.suffix}"
+        )
+        combined = _concat_audio_files(
+            group, str(scratch), voice_compatible=voice_compatible,
+        )
+        if not combined:
+            return list(group)
+        scratch_outputs.append(combined)
+        combined_size = Path(combined).stat().st_size
+        if combined_size <= profile.max_file_bytes:
+            combined_any = True
+            return [combined]
+
+        try:
+            Path(combined).unlink()
+        except OSError:
+            pass
+        midpoint = max(1, len(group) // 2)
+        return emit(group[:midpoint]) + emit(group[midpoint:])
+
+    packed: List[str] = []
+    for group in _pack_audio_files_for_delivery(audio_paths, profile):
+        packed.extend(emit(group))
+
+    final_paths: List[str] = []
+    for index, source in enumerate(packed, start=1):
+        if len(packed) == 1:
+            destination = base
+        else:
+            source_suffix = Path(source).suffix or base.suffix
+            destination = base.with_name(
+                f"{base.stem}.part{index:02d}{source_suffix}"
+            )
+        if os.path.abspath(source) != os.path.abspath(destination):
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            os.replace(source, destination)
+        if destination.stat().st_size > profile.max_file_bytes:
+            raise ValueError(
+                f"Final TTS deliverable exceeds {profile.platform} delivery limit: "
+                f"{destination}"
+            )
+        final_paths.append(str(destination))
+
+    for scratch in scratch_outputs:
+        if scratch not in final_paths:
+            try:
+                Path(scratch).unlink()
+            except OSError:
+                pass
+    return final_paths, combined_any
 
 
 # ===========================================================================
@@ -1832,11 +2160,12 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
     )
     max_len = _resolve_max_text_length("gemini", tts_config)
     if len(prompt_text) > max_len:
-        logger.warning(
-            "Gemini TTS composed prompt too long (%d chars), truncating to %d",
-            len(prompt_text), max_len,
+        raise ValueError(
+            "Gemini TTS composed prompt exceeds the provider request limit "
+            f"({len(prompt_text)} > {max_len} chars). Reduce the persona/audio-tag "
+            "prompt or lower tts.gemini.max_text_length so long-form text is "
+            "split with enough prompt headroom."
         )
-        prompt_text = prompt_text[:max_len]
 
     payload: Dict[str, Any] = {
         "contents": [{"parts": [{"text": prompt_text}]}],
@@ -2281,31 +2610,25 @@ def _generate_kittentts(text: str, output_path: str, tts_config: Dict[str, Any])
 # ===========================================================================
 # Main tool function
 # ===========================================================================
-def text_to_speech_tool(
+def _text_to_speech_single(
     text: str,
     output_path: Optional[str] = None,
+    *,
+    tts_config_override: Optional[Dict[str, Any]] = None,
 ) -> str:
-    """
-    Convert text to speech audio.
+    """Synthesize one provider-safe text chunk and return one final-encoded file.
 
-    Reads provider/voice config from ~/.hermes/config.yaml (tts: section).
-    The model sends text; the user configures voice and provider.
-
-    On messaging platforms, the returned MEDIA:<path> tag is intercepted
-    by the send pipeline and delivered as a native voice message.
-    In CLI mode, the file is saved to ~/voice-memos/.
-
-    Args:
-        text: The text to convert to speech.
-        output_path: Optional custom save path. Defaults to ~/voice-memos/<timestamp>.mp3
-
-    Returns:
-        str: JSON result with success, file_path, and optionally MEDIA tag.
+    The public :func:`text_to_speech_tool` wrapper owns long-form splitting,
+    delivery packing, and post-encoding size enforcement.
     """
     if not text or not text.strip():
         return tool_error("Text is required", success=False)
 
-    tts_config = _load_tts_config()
+    tts_config = (
+        tts_config_override
+        if tts_config_override is not None
+        else _load_tts_config()
+    )
     provider = _get_provider(tts_config)
 
     # User-declared command provider (type: command under tts.providers.<name>)
@@ -2602,6 +2925,163 @@ def text_to_speech_tool(
         error_msg = f"TTS generation failed ({provider}): {e}"
         logger.error("%s", error_msg, exc_info=True)
         return tool_error(error_msg, success=False)
+
+
+def text_to_speech_tool(
+    text: str,
+    output_path: Optional[str] = None,
+) -> str:
+    """Convert all input text to provider-safe, delivery-safe audio files.
+
+    Long text is split without truncation. Each provider request is encoded to
+    its final format before files are packed for the destination. Multi-chunk
+    voice output is re-encoded when combined; failed combines preserve separate
+    valid files, and no over-limit final artifact is returned.
+    """
+    if not text or not text.strip():
+        return tool_error("Text is required", success=False)
+
+    tts_config = _load_tts_config()
+    provider = _get_provider(tts_config)
+    command_provider_config = _resolve_command_provider_config(provider, tts_config)
+    max_len = _resolve_max_text_length(provider, tts_config)
+    chunks = _split_text_for_tts(text, max_len)
+    if not chunks:
+        return tool_error("Text is required", success=False)
+    if len(chunks) > 1:
+        logger.info(
+            "TTS text for provider %s split into %d chunks (input=%d chars, cap=%d)",
+            provider,
+            len(chunks),
+            len(text),
+            max_len,
+        )
+
+    from gateway.session_context import get_session_env
+    platform = get_session_env("HERMES_SESSION_PLATFORM", "").lower()
+    want_opus = platform == "telegram"
+    delivery_profile = _resolve_audio_delivery_profile(platform, tts_config)
+
+    if output_path:
+        from tools.path_security import has_traversal_component
+        if has_traversal_component(output_path):
+            return json.dumps({
+                "success": False,
+                "error": (
+                    f"output_path contains '..' traversal component: {output_path}. "
+                    "Use an absolute path or one relative to the current directory "
+                    "without '..'."
+                ),
+            }, ensure_ascii=False)
+        base_path = Path(output_path).expanduser()
+        if command_provider_config is not None:
+            base_path = _configured_command_tts_output_path(
+                base_path, command_provider_config,
+            )
+    else:
+        timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+        out_dir = Path(DEFAULT_OUTPUT_DIR)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        if command_provider_config is not None:
+            fmt = _get_command_tts_output_format(command_provider_config)
+            base_path = out_dir / f"tts_{timestamp}.{fmt}"
+        elif want_opus and provider in {"openai", "elevenlabs", "mistral", "gemini"}:
+            base_path = out_dir / f"tts_{timestamp}.ogg"
+        else:
+            base_path = out_dir / f"tts_{timestamp}.mp3"
+    base_path.parent.mkdir(parents=True, exist_ok=True)
+
+    generated_artifacts: set[str] = set()
+    final_paths: List[str] = []
+    chunk_results: List[Dict[str, Any]] = []
+    try:
+        encoded_paths: List[str] = []
+        for index, chunk in enumerate(chunks, start=1):
+            if len(chunks) == 1:
+                chunk_path = base_path
+            else:
+                chunk_path = base_path.with_name(
+                    f"{base_path.stem}.chunk{index:03d}{base_path.suffix}"
+                )
+            generated_artifacts.add(str(chunk_path))
+            raw_result = _text_to_speech_single(
+                text=chunk,
+                output_path=str(chunk_path),
+                tts_config_override=tts_config,
+            )
+            try:
+                chunk_result = json.loads(raw_result)
+            except (json.JSONDecodeError, TypeError):
+                raise RuntimeError(
+                    f"TTS chunk {index} returned invalid JSON: {str(raw_result)[:200]}"
+                )
+            if not chunk_result.get("success"):
+                return json.dumps(chunk_result, ensure_ascii=False)
+            actual_path = str(chunk_result.get("file_path") or chunk_path)
+            if not os.path.isfile(actual_path) or os.path.getsize(actual_path) <= 0:
+                raise RuntimeError(
+                    f"TTS chunk {index} produced no final audio: {actual_path}"
+                )
+            generated_artifacts.add(actual_path)
+            encoded_paths.append(actual_path)
+            chunk_results.append(chunk_result)
+
+        voice_compatible = bool(chunk_results) and all(
+            bool(result.get("voice_compatible")) for result in chunk_results
+        )
+        delivery_base = base_path.with_suffix(Path(encoded_paths[0]).suffix)
+        final_paths, combined_chunks = _build_audio_delivery_files(
+            encoded_paths,
+            str(delivery_base),
+            delivery_profile,
+            voice_compatible=voice_compatible,
+        )
+
+        for path in final_paths:
+            logger.info(
+                "TTS audio saved: %s (%s bytes, provider: %s)",
+                path,
+                f"{os.path.getsize(path):,}",
+                provider,
+            )
+        media_tag = "\n".join(f"MEDIA:{path}" for path in final_paths)
+        if voice_compatible:
+            media_tag = f"[[audio_as_voice]]\n{media_tag}"
+
+        return json.dumps({
+            "success": True,
+            "file_path": final_paths[0],
+            "file_paths": final_paths,
+            "media_tag": media_tag,
+            "provider": chunk_results[0].get("provider", provider),
+            "voice_compatible": voice_compatible,
+            "chunks": len(chunks),
+            "chunk_count": len(chunks),
+            "delivery_file_count": len(final_paths),
+            "combined_chunks": bool(combined_chunks),
+            "delivery_profile": {
+                "platform": delivery_profile.platform,
+                "max_file_bytes": delivery_profile.max_file_bytes,
+                "target_file_bytes": delivery_profile.target_file_bytes,
+            },
+        }, ensure_ascii=False)
+    except ValueError as exc:
+        error_msg = f"TTS delivery error ({provider}): {exc}"
+        logger.error("%s", error_msg)
+        return tool_error(error_msg, success=False)
+    except Exception as exc:
+        error_msg = f"TTS long-form generation failed ({provider}): {exc}"
+        logger.error("%s", error_msg, exc_info=True)
+        return tool_error(error_msg, success=False)
+    finally:
+        final_absolute = {os.path.abspath(path) for path in final_paths}
+        for artifact in generated_artifacts:
+            if os.path.abspath(artifact) in final_absolute:
+                continue
+            try:
+                os.unlink(artifact)
+            except OSError:
+                pass
 
 
 # ===========================================================================
@@ -3004,7 +3484,7 @@ TTS_SCHEMA = {
         "properties": {
             "text": {
                 "type": "string",
-                "description": "The text to convert to speech. Provider-specific character caps apply and are enforced automatically (OpenAI 4096, xAI 15000, MiniMax 10000, ElevenLabs 5k-40k depending on model); over-long input is truncated."
+                "description": "The text to convert to speech. Provider-specific per-request character caps apply automatically (OpenAI 4096, xAI 15000, MiniMax 10000, ElevenLabs 5k-40k depending on model); longer input is split into ordered chunks without silent truncation."
             },
             "output_path": {
                 "type": "string",

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -130,7 +130,7 @@ The rewrite uses `auxiliary.tts_audio_tags` and defaults to your main chat model
 
 ### Input length limits
 
-Each provider has a documented per-request input-character cap. Hermes truncates text before calling the provider so requests never fail with a length error:
+Each provider has a documented per-request input-character cap. Hermes splits longer replies into ordered, sentence-aware chunks before calling the provider, so the full normalized text is preserved instead of silently truncated:
 
 | Provider | Default cap (chars) |
 |----------|---------------------|
@@ -155,7 +155,7 @@ Each provider has a documented per-request input-character cap. Hermes truncates
 | `eleven_v3`, `eleven_ttv_v3` | 5000 |
 | Unknown model | Falls back to provider default (10000) |
 
-**Override per provider** with `max_text_length:` under the provider section of your TTS config:
+**Override the per-request chunk size** with `max_text_length:` under the provider section of your TTS config:
 
 ```yaml
 tts:
@@ -163,7 +163,7 @@ tts:
     max_text_length: 8192   # raise or lower the provider cap
 ```
 
-Only positive integers are honored. Zero, negative, non-numeric, or boolean values fall through to the provider default, so a broken config can't accidentally disable truncation.
+Only positive integers are honored. Zero, negative, non-numeric, or boolean values fall through to the provider default, so a broken config can't accidentally bypass the provider request limit.
 
 ### Telegram Voice Bubbles & ffmpeg
 
@@ -190,6 +190,8 @@ sudo dnf install ffmpeg
 ```
 
 Without ffmpeg, Edge TTS, MiniMax TTS, NeuTTS, KittenTTS, and Piper audio are sent as regular audio files (playable, but shown as a rectangular player instead of a voice bubble).
+
+For long replies, Hermes applies platform upload limits to the final encoded audio. It combines provider chunks when possible; Telegram-compatible OGG/Opus chunks are decoded and re-encoded with ffmpeg rather than stream-copied. If combination is unavailable or fails, Hermes preserves the ordered chunks as separate valid attachments. An artifact that still exceeds the platform hard limit after final encoding returns an explicit error instead of attempting a doomed upload.
 
 :::tip
 If you want voice bubbles without installing ffmpeg, switch to the OpenAI, ElevenLabs, or Mistral provider.
@@ -313,7 +315,7 @@ Use `{{` and `}}` for literal braces.
 | `timeout`          | `120`   | Seconds; the process tree is killed on expiry (Unix `killpg`, Windows `taskkill /T`).                       |
 | `output_format`    | `mp3`   | One of `mp3` / `wav` / `ogg` / `flac`. Auto-inferred from the output extension if Hermes picks a path.      |
 | `voice_compatible` | `false` | When `true`, Hermes converts MP3/WAV output to Opus/OGG via ffmpeg so Telegram renders a voice bubble.      |
-| `max_text_length`  | `5000`  | Input is truncated to this length before rendering the command.                                             |
+| `max_text_length`  | `5000`  | Maximum input characters per command invocation; longer text is split into ordered chunks.                  |
 | `voice` / `model`  | empty   | Passed to the command as placeholder values only.                                                           |
 
 #### Behavior notes


### PR DESCRIPTION
## Summary

- Split long TTS responses into provider-safe chunks instead of truncating at fixed caller-side limits.
- Pack generated audio against destination platform upload limits so large speech output becomes one or more deliverable media files.
- Remove hard `[:4000]` truncation from CLI/gateway voice paths and update voice delivery paths to handle multiple returned files.

## Details

This keeps the TTS tool as the owner of provider caps and delivery packing:

- Text is split by paragraphs, sentences, clauses, words, and finally hard chunks only when needed.
- Provider `max_text_length` config is treated as a per-request chunk cap, not as permission to drop the rest of the response.
- Discord defaults to a conservative 10 MB max / 85% target profile.
- Telegram defaults to a 50 MB max / 85% target profile.
- Existing consumers still receive `file_path`, while multi-file aware consumers can use `file_paths` and `media_tag`.

## Test Plan

- [x] `python -m pytest tests/tools/test_tts_long_form_chunking.py tests/tools/test_tts_max_text_length.py tests/tools/test_voice_cli_integration.py tests/gateway/test_voice_command.py -q`
- [x] `python -m pytest tests/tools/test_tts*.py tests/tools/test_voice_cli_integration.py tests/gateway/test_voice_command.py -q`
- [x] `python -m py_compile tools/tts_tool.py gateway/run.py gateway/platforms/base.py cli.py hermes_cli/voice.py`
- [x] `git diff --check`
- [x] Local Kokoro/OpenAI-compatible smoke: forced 4 provider chunks packed into 1 Discord-safe file.
- [x] Local Kokoro/OpenAI-compatible smoke: forced 14 provider chunks packed into 14 Discord delivery files under an intentionally tiny test profile.
