### PR TITLE
fix: ignore invalid file-drop paths

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1356,7 +1356,10 @@ def _resolve_attachment_path(raw_path: str) -> Path | None:
     except Exception:
         resolved = path
 
-    if not resolved.exists() or not resolved.is_file():
+    try:
+        if not resolved.exists() or not resolved.is_file():
+            return None
+    except OSError:
         return None
     return resolved
 

--- a/tests/cli/test_cli_file_drop.py
+++ b/tests/cli/test_cli_file_drop.py
@@ -52,6 +52,10 @@ class TestNonFileInputs:
     def test_slash_command_with_args(self):
         assert _detect_file_drop("/config set key value") is None
 
+    def test_long_slash_command_with_pasted_text_is_not_file_drop(self):
+        long_pasted_text = "제 SNS 말투에 맞춰서 더 쉽게 설명해주세요. " + ("Hermes aux 모델 설명 " * 200)
+        assert _detect_file_drop(f"/plan {long_pasted_text}") is None
+
     def test_empty_string(self):
         assert _detect_file_drop("") is None
 


### PR DESCRIPTION
## Summary
- Catch OS-level path errors while probing local file-drop candidates
- Prevent long slash-command prompts such as `/plan ...large pasted text...` from crashing with `Errno 63 File name too long`
- Add a regression test for long slash-command input with pasted text

## Test Plan
- `source venv/bin/activate && python -m pytest tests/cli/test_cli_file_drop.py::TestNonFileInputs::test_long_slash_command_with_pasted_text_is_not_file_drop -q -o 'addopts='`
- `source venv/bin/activate && python -m pytest tests/cli/test_cli_file_drop.py -q -o 'addopts='`