### PR TITLE
feat(delegate): add acceptance criteria and independent judge to dele…

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -29,6 +29,7 @@ from tools.delegate_tool import (
     _build_child_agent,
     _build_child_progress_callback,
     _build_child_system_prompt,
+    _judge_output,
     _strip_blocked_tools,
     _resolve_child_credential_pool,
     _resolve_delegation_credentials,
@@ -92,6 +93,85 @@ class TestChildSystemPrompt(unittest.TestCase):
     def test_empty_context_ignored(self):
         prompt = _build_child_system_prompt("Do something", "  ")
         self.assertNotIn("CONTEXT", prompt)
+
+
+
+class TestJudgeOutput(unittest.TestCase):
+    @patch("agent.auxiliary_client.call_llm")
+    def test_judge_pass(self, mock_call_llm):
+        mock_resp = MagicMock()
+        mock_resp.choices = [MagicMock()]
+        mock_resp.choices[0].message.content = (
+            '{"verdict": "PASS", "reasoning": "Output contains required columns"}'
+        )
+        mock_call_llm.return_value = mock_resp
+
+        result = _judge_output(
+            objective="Cross-reference vendors",
+            acceptance_criteria="Output CSV contains columns: vendor_name, sdn_match",
+            output="vendor_name,sdn_match\nFooCorp,YES",
+        )
+        self.assertEqual(result["verdict"], "PASS")
+        self.assertEqual(result["reasoning"], "Output contains required columns")
+        mock_call_llm.assert_called_once()
+
+    @patch("agent.auxiliary_client.call_llm")
+    def test_judge_fail(self, mock_call_llm):
+        mock_resp = MagicMock()
+        mock_resp.choices = [MagicMock()]
+        mock_resp.choices[0].message.content = (
+            '{"verdict": "FAIL", "reasoning": "Missing sdn_match column"}'
+        )
+        mock_call_llm.return_value = mock_resp
+
+        result = _judge_output(
+            objective="Cross-reference vendors",
+            acceptance_criteria="Output CSV contains columns: vendor_name, sdn_match",
+            output="vendor_name\nFooCorp",
+        )
+        self.assertEqual(result["verdict"], "FAIL")
+        self.assertEqual(result["reasoning"], "Missing sdn_match column")
+        mock_call_llm.assert_called_once()
+
+    def test_no_criteria_no_judge(self):
+        result = _judge_output(
+            objective="List files",
+            acceptance_criteria="",
+            output="file1.py, file2.py",
+        )
+        self.assertEqual(result["verdict"], "PASS")
+        self.assertEqual(result["reasoning"], "No criteria provided")
+
+    @patch("agent.auxiliary_client.call_llm")
+    def test_judge_unavailable_skips(self, mock_call_llm):
+        mock_call_llm.side_effect = RuntimeError("No provider configured")
+
+        result = _judge_output(
+            objective="List files",
+            acceptance_criteria="Return at least 3 files",
+            output="file1.py, file2.py",
+        )
+        self.assertEqual(result["verdict"], "FAIL")
+        self.assertIn("Judge unavailable", result["reasoning"])
+        mock_call_llm.assert_called_once()
+
+    @patch("tools.delegate_tool._run_single_child")
+    def test_delegate_task_passes_acceptance_criteria(self, mock_run):
+        mock_run.return_value = {"task_index": 0, "status": "completed"}
+        parent = _make_mock_parent()
+
+        delegate_task(
+            goal="List files",
+            acceptance_criteria="Return at least 3 files",
+            parent_agent=parent,
+        )
+
+        mock_run.assert_called_once()
+        call_kwargs = mock_run.call_args.kwargs
+        self.assertEqual(
+            call_kwargs.get("acceptance_criteria"),
+            "Return at least 3 files",
+        )
 
 
 class TestStripBlockedTools(unittest.TestCase):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1792,6 +1792,15 @@ def _run_single_child(
             except Exception as e:
                 logger.debug("Progress callback completion failed: %s", e)
 
+        # Judge evaluation (#356 Phase 1)
+        _acceptance_criteria = _kwargs.get("acceptance_criteria")
+        if _acceptance_criteria:
+            entry["judge"] = _judge_output(
+                objective=goal,
+                acceptance_criteria=_acceptance_criteria,
+                output=entry.get("summary", ""),
+            )
+
         return entry
 
     except Exception as exc:
@@ -1867,6 +1876,76 @@ def _run_single_child(
             logger.debug("Failed to close child agent after delegation")
 
 
+
+
+def _judge_output(
+    objective: str,
+    acceptance_criteria: str,
+    output: str,
+) -> Dict[str, str]:
+    """Evaluate sub-agent output against acceptance criteria using a cheap LLM.
+
+    Returns a dict with verdict (PASS|FAIL) and reasoning.
+    If the auxiliary LLM is unavailable or returns unparseable output,
+    logs a warning and returns {"verdict": "FAIL", "reasoning": "..."}.
+    """
+    if not acceptance_criteria or not acceptance_criteria.strip():
+        return {"verdict": "PASS", "reasoning": "No criteria provided"}
+
+    judge_prompt = (
+        "Evaluate whether this output meets the acceptance criteria.\n\n"
+        f"Objective: {objective}\n"
+        f"Acceptance Criteria: {acceptance_criteria}\n\n"
+        f"Output:\n{output}\n\n"
+        'Respond ONLY with valid JSON — no markdown, no backticks, no preamble:\n'
+        '{"verdict": "PASS"|"FAIL", "reasoning": "explanation"}'
+    )
+
+    try:
+        import re
+        from agent.auxiliary_client import call_llm
+
+        resp = call_llm(
+            task="judge",
+            messages=[
+                {
+                    "role": "system",
+                    "content": (
+                        "You are an independent quality judge. Check if a sub-agent's "
+                        "output meets the stated acceptance criteria. Be strict but fair. "
+                        "Respond ONLY with the requested JSON."
+                    ),
+                },
+                {"role": "user", "content": judge_prompt},
+            ],
+            temperature=0.0,
+            max_tokens=512,
+        )
+        raw = resp.choices[0].message.content.strip() if resp and resp.choices else ""
+    except Exception as exc:
+        logger.warning("Judge LLM call failed: %s", exc)
+        return {"verdict": "FAIL", "reasoning": f"Judge unavailable: {exc}"}
+
+    # Strip optional markdown code fences
+    raw = re.sub(r"^```(?:json)?\s*\n?", "", raw, flags=re.IGNORECASE)
+    raw = re.sub(r"\n?```\s*$", "", raw)
+    raw = raw.strip()
+
+    try:
+        parsed = json.loads(raw)
+        verdict = str(parsed.get("verdict", "")).strip().upper()
+        reasoning = str(parsed.get("reasoning", "")).strip()
+        if verdict not in {"PASS", "FAIL"}:
+            verdict = "FAIL"
+            reasoning = f"Invalid verdict from judge: {raw[:200]}"
+        return {"verdict": verdict, "reasoning": reasoning}
+    except json.JSONDecodeError:
+        logger.warning("Judge returned non-JSON: %s", raw[:200])
+        upper = raw.upper()
+        if "PASS" in upper and "FAIL" not in upper:
+            return {"verdict": "PASS", "reasoning": raw}
+        return {"verdict": "FAIL", "reasoning": f"Judge returned non-JSON: {raw[:200]}"}
+
 def delegate_task(
     goal: Optional[str] = None,
     context: Optional[str] = None,
@@ -1875,6 +1954,7 @@ def delegate_task(
     max_iterations: Optional[int] = None,
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
+    acceptance_criteria: Optional[str] = None,
     role: Optional[str] = None,
     parent_agent=None,
 ) -> str:
@@ -1963,7 +2043,7 @@ def delegate_task(
         task_list = tasks
     elif goal and isinstance(goal, str) and goal.strip():
         task_list = [
-            {"goal": goal, "context": context, "toolsets": toolsets, "role": top_role}
+            {"goal": goal, "context": context, "toolsets": toolsets, "role": top_role, "acceptance_criteria": acceptance_criteria}
         ]
     else:
         return tool_error("Provide either 'goal' (single task) or 'tasks' (batch).")
@@ -2033,7 +2113,8 @@ def delegate_task(
     if n_tasks == 1:
         # Single task -- run directly (no thread pool overhead)
         _i, _t, child = children[0]
-        result = _run_single_child(0, _t["goal"], child, parent_agent)
+        result = _run_single_child(0, _t["goal"], child, parent_agent,
+                                    acceptance_criteria=_t.get("acceptance_criteria"))
         results.append(result)
     else:
         # Batch -- run in parallel with per-task progress lines
@@ -2049,6 +2130,7 @@ def delegate_task(
                     goal=t["goal"],
                     child=child,
                     parent_agent=parent_agent,
+                    acceptance_criteria=t.get("acceptance_criteria"),
                 )
                 futures[future] = i
 
@@ -2520,6 +2602,14 @@ DELEGATE_TASK_SCHEMA = {
                             "items": {"type": "string"},
                             "description": "Per-task ACP args override.",
                         },
+                        "acceptance_criteria": {
+                            "type": "string",
+                            "description": (
+                                "Optional acceptance criteria for this task. If provided, a cheap "
+                                "independent judge evaluates the sub-agent output against these "
+                                "criteria and returns PASS or FAIL with reasoning."
+                            ),
+                        },
                         "role": {
                             "type": "string",
                             "enum": ["leaf", "orchestrator"],
@@ -2566,6 +2656,15 @@ DELEGATE_TASK_SCHEMA = {
                 "description": (
                     "Arguments for the ACP command (default: ['--acp', '--stdio']). "
                     "Only used when acp_command is set."
+                ),
+            },
+            "acceptance_criteria": {
+                "type": "string",
+                "description": (
+                    "Optional acceptance criteria for this task. If provided, a cheap "
+                    "independent judge evaluates the sub-agent output against these "
+                    "criteria and returns PASS or FAIL with reasoning. Be specific: "
+                    "e.g., 'Output contains columns A, B, C with at least one row per input.'"
                 ),
             },
         },


### PR DESCRIPTION
## Summary
Implements Phase 1 of #356: acceptance criteria and independent judge for delegate_task.

---

## Root cause
Sub-agent results returned by `delegate_task` are self-reports with no independent verification. The parent agent must manually evaluate every result, consuming tokens and adding latency. There is no way to specify what "done" looks like when delegating, and no quality signal on whether the output actually meets the goal.

---

## Fix
Added an optional `acceptance_criteria` parameter to `delegate_task`. When provided, a new `_judge_output()` function evaluates the sub-agent's output against the criteria using a cheap auxiliary LLM and returns a PASS/FAIL verdict with reasoning. The result is enriched with a `judge` field. If no criteria are provided, behavior is unchanged.

---

## What changed
* `tools/delegate_tool.py`: added `acceptance_criteria: Optional[str] = None` to `delegate_task` signature
* `tools/delegate_tool.py`: added `acceptance_criteria` to `DELEGATE_TASK_SCHEMA` — both top-level and per-task in batch mode
* `tools/delegate_tool.py`: added `_judge_output()` function — calls `call_llm(task="judge")`, parses PASS/FAIL JSON, graceful degrade on failure
* `tools/delegate_tool.py`: wired judge evaluation in `_run_single_child` — enriches `entry["judge"]` when criteria provided
* `tests/tools/test_delegate.py`: added `TestJudgeOutput` with 5 tests

---

## What is not affected
* `delegate_task` behavior when `acceptance_criteria` is not provided: unchanged, zero breaking changes
* Batch mode: each task can have its own per-task `acceptance_criteria`
* Judge failure: if auxiliary LLM is unavailable, returns `{"verdict": "FAIL", "reasoning": "Judge unavailable: ..."}` — no exception raised

---

## Behavioral change
When `acceptance_criteria` is provided, `delegate_task` results now include a `judge` field:
```json
{
  "task_index": 0,
  "status": "completed",
  "summary": "...",
  "judge": {
    "verdict": "PASS",
    "reasoning": "Output contains required columns"
  }
}
```

---

## Tests
5 new tests in TestJudgeOutput, all pass. No regressions in existing tests.
* `test_judge_pass` - judge returns PASS when criteria are met
* `test_judge_fail` - judge returns FAIL when criteria are not met
* `test_no_criteria_no_judge` - no criteria skips judge, returns PASS
* `test_judge_unavailable_skips` - LLM failure returns FAIL with reasoning, no exception
* `test_delegate_task_passes_acceptance_criteria` - integration: acceptance_criteria flows through to _run_single_child

Phase 2 (think tool for self-verification) is planned as a follow-up PR.

This is a prerequisite for the simplify skill (#379): independent judge evaluation directly addresses the need for quality-gating of parallel review agents.

Part of #356 (Phase 1/3)