### PR TITLE
fix(model_metadata): parse_context_limit_from_error matches underscore short form

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -815,8 +815,8 @@ def parse_context_limit_from_error(error_msg: str) -> Optional[int]:
     error_lower = error_msg.lower()
     # Pattern: look for numbers near context-related keywords
     patterns = [
-        r'(?:max(?:imum)?|limit)\s*(?:context\s*)?(?:length|size|window)?\s*(?:is|of|:)?\s*(\d{4,})',
-        r'context\s*(?:length|size|window)\s*(?:is|of|:)?\s*(\d{4,})',
+        r'(?:max(?:imum)?|limit)\s*(?:context[\s_]*)?(?:length|size|window)?\s*(?:is|of|:)?\s*(\d{4,})',
+        r'context[\s_]*(?:length|size|window)(?:_\w+)*\s*(?::|\s+is\s+|\s+of\s+)\s*(\d{4,})',
         r'(\d{4,})\s*(?:token)?\s*(?:context|limit)',
         r'>\s*(\d{4,})\s*(?:max|limit|token)',  # "250000 tokens > 200000 maximum"
         r'(\d{4,})\s*(?:max(?:imum)?)\b',  # "200000 maximum"

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -904,6 +904,13 @@ class TestParseContextLimitFromError:
         msg = "context_length_exceeded: maximum context length is 131072"
         assert parse_context_limit_from_error(msg) == 131072
 
+    def test_context_length_exceeded_short_form(self):
+        """Docstring lists 'context_length_exceeded: 131072' as a supported
+        format. The underscore-joined ``context_length`` token must be
+        matched even without the wordy 'maximum context length is' prefix
+        (regression for OpenAI-style short error codes)."""
+        assert parse_context_limit_from_error("context_length_exceeded: 131072") == 131072
+
     def test_context_size_exceeded(self):
         msg = "Maximum context size 65536 exceeded"
         assert parse_context_limit_from_error(msg) == 65536


### PR DESCRIPTION
## What does this PR do?

[agent/model_metadata.py::parse_context_limit_from_error](hermes-agent/agent/model_metadata.py:776:0-801:15) advertises
`"context_length_exceeded: 131072"` as a supported format in its docstring,
but actually returned `None` for that input. Two regex patterns failed:
pattern 1 had no `max`/`limit` keyword to anchor on, and pattern 2 used
`\s*` between `context` and `length` (so `_` did not match) and required
an `is`/`of`/`:` connector immediately after the keyword (so
`length_exceeded:` did not match either).

This PR widens both patterns just enough to accept the underscore short
form while keeping every existing negative case rejected. The wider
pattern still requires an explicit connector (`:` / ` is ` / ` of `) so
adversarial strings like `"context window exceeds limit (2013)"` continue
to return `None`, and the `1024 <= limit <= 10_000_000` sanity gate is
unchanged.

## Related Issue

Fixes #17983

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- [agent/model_metadata.py]— [parse_context_limit_from_error()](hermes-agent/agent/model_metadata.py:776:0-801:15):
  - Pattern 1: `context\s*` → `context[\s_]*` (allow underscore between
    `context` and the size keyword in the `max … context_length …` path).
  - Pattern 2: rewritten as
    `context[\s_]*(?:length|size|window)(?:_\w+)*\s*(?::|\s+is\s+|\s+of\s+)\s*(\d{4,})`
    — accepts underscore-suffix words like `_exceeded` but still requires
    an explicit connector to avoid false positives on unrelated trailing
    numbers.
- [tests/agent/test_model_metadata.py](hermes-agent/tests/agent/test_model_metadata.py:0:0-0:0) — added
  [TestParseContextLimitFromError::test_context_length_exceeded_short_form](hermes-agent/tests/agent/test_model_metadata.py:906:4-911:90)
  pinning the docstring contract.

## How to Test

1. Reproduce the bug on `main`:
   ```bash
   python3 -c "from agent.model_metadata import parse_context_limit_from_error as f; print(f('context_length_exceeded: 131072'))"
   # → None  (BUG)