### PR TITLE
fix: enforce per-user memory/session isolation for multi-user gateway

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -33,7 +33,7 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 11
+SCHEMA_VERSION = 12
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -98,6 +98,32 @@ CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source);
 CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_started ON sessions(started_at DESC);
 CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, timestamp);
+
+CREATE TABLE IF NOT EXISTS thread_goals (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL REFERENCES sessions(id),
+    goal TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'active',
+    round_count INTEGER DEFAULT 0,
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL,
+    completed_at REAL
+);
+
+CREATE INDEX IF NOT EXISTS idx_thread_goals_session ON thread_goals(session_id);
+CREATE INDEX IF NOT EXISTS idx_thread_goals_status ON thread_goals(status);
+
+CREATE TABLE IF NOT EXISTS goal_round_history (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    goal_id INTEGER NOT NULL REFERENCES thread_goals(id) ON DELETE CASCADE,
+    round_number INTEGER NOT NULL,
+    action TEXT,
+    result TEXT,
+    status TEXT NOT NULL DEFAULT 'pending',
+    created_at REAL NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_goal_round_history_goal ON goal_round_history(goal_id, round_number);
 """
 
 FTS_SQL = """
@@ -991,6 +1017,7 @@ class SessionDB:
         self,
         source: str = None,
         exclude_sources: List[str] = None,
+        user_id: str = None,
         limit: int = 20,
         offset: int = 0,
         include_children: bool = False,
@@ -1048,6 +1075,11 @@ class SessionDB:
             placeholders = ",".join("?" for _ in exclude_sources)
             where_clauses.append(f"s.source NOT IN ({placeholders})")
             params.extend(exclude_sources)
+
+        # Per-user session isolation
+        if user_id:
+            where_clauses.append("s.user_id = ?")
+            params.append(user_id)
 
         where_sql = f"WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
         if order_by_last_active:
@@ -1711,6 +1743,7 @@ class SessionDB:
         source_filter: List[str] = None,
         exclude_sources: List[str] = None,
         role_filter: List[str] = None,
+        user_id: str = None,
         limit: int = 20,
         offset: int = 0,
     ) -> List[Dict[str, Any]]:
@@ -1751,6 +1784,11 @@ class SessionDB:
             role_placeholders = ",".join("?" for _ in role_filter)
             where_clauses.append(f"m.role IN ({role_placeholders})")
             params.extend(role_filter)
+
+        # Per-user session isolation: only search sessions belonging to this user
+        if user_id:
+            where_clauses.append("s.user_id = ?")
+            params.append(user_id)
 
         where_sql = " AND ".join(where_clauses)
         params.extend([limit, offset])
@@ -1954,6 +1992,7 @@ class SessionDB:
     def search_sessions(
         self,
         source: str = None,
+        user_id: str = None,
         limit: int = 20,
         offset: int = 0,
     ) -> List[Dict[str, Any]]:
@@ -1972,19 +2011,22 @@ class SessionDB:
             ") m ON m.session_id = s.id "
         )
         with self._lock:
+            where_parts = []
+            params = []
             if source:
-                cursor = self._conn.execute(
-                    f"{select_with_last_active}"
-                    "WHERE s.source = ? "
-                    "ORDER BY last_active DESC, s.started_at DESC, s.id DESC LIMIT ? OFFSET ?",
-                    (source, limit, offset),
-                )
-            else:
-                cursor = self._conn.execute(
-                    f"{select_with_last_active}"
-                    "ORDER BY last_active DESC, s.started_at DESC, s.id DESC LIMIT ? OFFSET ?",
-                    (limit, offset),
-                )
+                where_parts.append("s.source = ?")
+                params.append(source)
+            if user_id:
+                where_parts.append("s.user_id = ?")
+                params.append(user_id)
+            where_sql = f"WHERE {' AND '.join(where_parts)}" if where_parts else ""
+            params.extend([limit, offset])
+            cursor = self._conn.execute(
+                f"{select_with_last_active}"
+                f"{where_sql} "
+                "ORDER BY last_active DESC, s.started_at DESC, s.id DESC LIMIT ? OFFSET ?",
+                params,
+            )
             return [dict(row) for row in cursor.fetchall()]
 
     # =========================================================================
@@ -2568,6 +2610,109 @@ class SessionDB:
             session["preview"] = raw[:60] + ("..." if len(raw) > 60 else "") if raw else ""
             sessions.append(session)
         return sessions
+
+    # ── Thread goals ──
+
+    def get_goal(self, goal_id: int) -> Optional[Dict[str, Any]]:
+        """Get a thread goal by its ID."""
+        with self._lock:
+            cursor = self._conn.execute(
+                "SELECT * FROM thread_goals WHERE id = ?", (goal_id,)
+            )
+            row = cursor.fetchone()
+        return dict(row) if row else None
+
+    def create_goal(
+        self,
+        session_id: str,
+        goal: str,
+        status: str = "active",
+    ) -> int:
+        """Create a new thread goal. Returns the new goal ID."""
+        now = time.time()
+
+        def _do(conn):
+            cursor = conn.execute(
+                "INSERT INTO thread_goals (session_id, goal, status, created_at, updated_at) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (session_id, goal, status, now, now),
+            )
+            return cursor.lastrowid
+
+        return self._execute_write(_do)
+
+    def update_goal(
+        self,
+        goal_id: int,
+        *,
+        goal: Optional[str] = None,
+        status: Optional[str] = None,
+        round_count: Optional[int] = None,
+        completed: bool = False,
+    ) -> bool:
+        """Update fields on an existing thread goal.
+
+        Only non-None keyword args are written.  Returns True if a row
+        was updated.
+        """
+        now = time.time()
+
+        def _do(conn):
+            sets: List[str] = ["updated_at = ?"]
+            params: List[Any] = [now]
+            if goal is not None:
+                sets.append("goal = ?")
+                params.append(goal)
+            if status is not None:
+                sets.append("status = ?")
+                params.append(status)
+            if round_count is not None:
+                sets.append("round_count = ?")
+                params.append(round_count)
+            if completed:
+                sets.append("completed_at = ?")
+                params.append(now)
+            params.append(goal_id)
+            cursor = conn.execute(
+                f"UPDATE thread_goals SET {', '.join(sets)} WHERE id = ?",
+                params,
+            )
+            return cursor.rowcount
+
+        return self._execute_write(_do) > 0
+
+    def record_goal_round(
+        self,
+        goal_id: int,
+        round_number: int,
+        action: Optional[str] = None,
+        result: Optional[str] = None,
+        status: str = "pending",
+    ) -> int:
+        """Record a round in goal_round_history.  Returns the new row ID."""
+        now = time.time()
+
+        def _do(conn):
+            cursor = conn.execute(
+                "INSERT INTO goal_round_history "
+                "(goal_id, round_number, action, result, status, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (goal_id, round_number, action, result, status, now),
+            )
+            return cursor.lastrowid
+
+        return self._execute_write(_do)
+
+    def get_goal_round_history(self, goal_id: int) -> List[Dict[str, Any]]:
+        """Get all rounds for a goal, ordered by round_number."""
+        with self._lock:
+            cursor = self._conn.execute(
+                "SELECT * FROM goal_round_history "
+                "WHERE goal_id = ? ORDER BY round_number",
+                (goal_id,),
+            )
+            rows = cursor.fetchall()
+        return [dict(r) for r in rows]
 
     # ── Space reclamation ──
 

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1414,6 +1414,15 @@ class HindsightMemoryProvider(MemoryProvider):
         if not self._auto_retain:
             logger.debug("sync_turn: skipped (auto_retain disabled)")
             return
+
+        # Per-platform retain gate: skip retain for platforms that can't
+        # provide reliable user isolation (e.g. iLink WeChat where all
+        # messages share the same from_user_id).
+        _disabled = getattr(self, '_retain_disabled_platforms', ('weixin',))
+        if getattr(self, '_platform', '') in _disabled:
+            logger.debug("sync_turn: skipped (platform %s in disabled list)", self._platform)
+            return
+
         if self._shutting_down.is_set():
             logger.debug("sync_turn: skipped (shutting down)")
             return

--- a/run_agent.py
+++ b/run_agent.py
@@ -1747,6 +1747,7 @@ class AIAgent:
                     self._memory_store = MemoryStore(
                         memory_char_limit=mem_config.get("memory_char_limit", 2200),
                         user_char_limit=mem_config.get("user_char_limit", 1375),
+                        user_id=getattr(self, '_user_id', None),
                     )
                     self._memory_store.load_from_disk()
             except Exception:
@@ -9559,6 +9560,7 @@ class AIAgent:
                 limit=function_args.get("limit", 3),
                 db=self._session_db,
                 current_session_id=self.session_id,
+                user_id=self._user_id,
             )
         elif function_name == "memory":
             target = function_args.get("target", "memory")
@@ -10163,6 +10165,7 @@ class AIAgent:
                         limit=function_args.get("limit", 3),
                         db=self._session_db,
                         current_session_id=self.session_id,
+                        user_id=self._user_id,
                     )
                 tool_duration = time.time() - tool_start_time
                 if self._should_emit_quiet_tool_messages():

--- a/tools/goal_tool.py
+++ b/tools/goal_tool.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""
+Goal Tool Module - Persistent Goal Tracking
+
+Provides CRUD tools for goals persisted in SessionDB's state_meta table.
+Goals are stored as JSON keyed by ``goal:<goal_id>``.
+
+Tools:
+  - create_goal: create a new goal with a description
+  - get_goal:    retrieve a goal by id
+  - update_goal: mark a goal as complete (ONLY valid status transition)
+
+Design:
+- Each goal has: id, description, status (active|complete), created_at, completed_at
+- update_goal can ONLY set status to 'complete' — the model cannot
+  pause, resume, or clear goals.  This keeps the tool surface minimal
+  and prevents the agent from gaming the goal lifecycle.
+- Persistence uses hermes_state.SessionDB get_meta / set_meta.
+"""
+
+import json
+import logging
+import time
+import uuid
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# ──────────────────────────────────────────────────────────────────────
+# Persistence helpers
+# ──────────────────────────────────────────────────────────────────────
+
+_DB_CACHE: Dict[str, Any] = {}
+
+
+def _get_session_db():
+    """Return a SessionDB instance for the current HERMES_HOME.
+
+    Cached per hermes_home path so profile switches work correctly.
+    Returns None if SessionDB is unavailable.
+    """
+    try:
+        from hermes_constants import get_hermes_home
+        from hermes_state import SessionDB
+
+        home = str(get_hermes_home())
+    except Exception as exc:
+        logger.debug("goal_tool: SessionDB bootstrap failed (%s)", exc)
+        return None
+
+    cached = _DB_CACHE.get(home)
+    if cached is not None:
+        return cached
+    try:
+        db = SessionDB()
+    except Exception as exc:
+        logger.debug("goal_tool: SessionDB() raised (%s)", exc)
+        return None
+    _DB_CACHE[home] = db
+    return db
+
+
+def _meta_key(goal_id: str) -> str:
+    return f"goal:{goal_id}"
+
+
+def _load_goal(goal_id: str) -> Optional[Dict[str, Any]]:
+    """Load a goal dict from SessionDB, or None."""
+    db = _get_session_db()
+    if db is None:
+        return None
+    try:
+        raw = db.get_meta(_meta_key(goal_id))
+    except Exception as exc:
+        logger.debug("goal_tool: get_meta failed: %s", exc)
+        return None
+    if not raw:
+        return None
+    try:
+        return json.loads(raw)
+    except Exception as exc:
+        logger.warning("goal_tool: could not parse goal %s: %s", goal_id, exc)
+        return None
+
+
+def _save_goal(goal_id: str, goal: Dict[str, Any]) -> bool:
+    """Persist a goal dict to SessionDB. Returns True on success."""
+    db = _get_session_db()
+    if db is None:
+        return False
+    try:
+        db.set_meta(_meta_key(goal_id), json.dumps(goal, ensure_ascii=False))
+        return True
+    except Exception as exc:
+        logger.debug("goal_tool: set_meta failed: %s", exc)
+        return False
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Handler functions
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _create_goal(args: Dict[str, Any]) -> str:
+    """Create a new goal."""
+    description = (args.get("description") or "").strip()
+    if not description:
+        return tool_error("description is required")
+
+    goal_id = uuid.uuid4().hex[:12]
+    now = time.time()
+    goal = {
+        "id": goal_id,
+        "description": description,
+        "status": "active",
+        "created_at": now,
+        "completed_at": None,
+    }
+
+    if not _save_goal(goal_id, goal):
+        return tool_error("Failed to persist goal — SessionDB unavailable")
+
+    return json.dumps({
+        "status": "ok",
+        "goal": goal,
+    }, ensure_ascii=False)
+
+
+def _get_goal(args: Dict[str, Any]) -> str:
+    """Retrieve a goal by id."""
+    goal_id = (args.get("goal_id") or "").strip()
+    if not goal_id:
+        return tool_error("goal_id is required")
+
+    goal = _load_goal(goal_id)
+    if goal is None:
+        return tool_error(f"Goal '{goal_id}' not found")
+
+    return json.dumps({
+        "status": "ok",
+        "goal": goal,
+    }, ensure_ascii=False)
+
+
+def _update_goal(args: Dict[str, Any]) -> str:
+    """Update a goal. Only status='complete' is allowed."""
+    goal_id = (args.get("goal_id") or "").strip()
+    if not goal_id:
+        return tool_error("goal_id is required")
+
+    status = (args.get("status") or "").strip().lower()
+    if status != "complete":
+        return tool_error(
+            "Only status='complete' is allowed via update_goal. "
+            "Cannot pause, resume, or clear goals."
+        )
+
+    goal = _load_goal(goal_id)
+    if goal is None:
+        return tool_error(f"Goal '{goal_id}' not found")
+
+    if goal["status"] == "complete":
+        return json.dumps({
+            "status": "ok",
+            "goal": goal,
+            "message": "Goal was already complete.",
+        }, ensure_ascii=False)
+
+    goal["status"] = "complete"
+    goal["completed_at"] = time.time()
+
+    if not _save_goal(goal_id, goal):
+        return tool_error("Failed to persist goal update — SessionDB unavailable")
+
+    return json.dumps({
+        "status": "ok",
+        "goal": goal,
+    }, ensure_ascii=False)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Requirements check
+# ──────────────────────────────────────────────────────────────────────
+
+
+def check_goal_requirements() -> bool:
+    """Goal tools require SessionDB to be importable."""
+    try:
+        from hermes_state import SessionDB  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+# ──────────────────────────────────────────────────────────────────────
+# OpenAI Function-Calling Schemas
+# ──────────────────────────────────────────────────────────────────────
+
+CREATE_GOAL_SCHEMA = {
+    "name": "create_goal",
+    "description": (
+        "Create a new goal to track a high-level objective. "
+        "Returns the goal with a unique id. Use get_goal to check "
+        "progress and update_goal to mark it complete."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "description": {
+                "type": "string",
+                "description": "A clear description of the goal to achieve.",
+            },
+        },
+        "required": ["description"],
+    },
+}
+
+GET_GOAL_SCHEMA = {
+    "name": "get_goal",
+    "description": (
+        "Retrieve a goal by its id. Returns the full goal state "
+        "including status and timestamps."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "goal_id": {
+                "type": "string",
+                "description": "The unique id of the goal to retrieve.",
+            },
+        },
+        "required": ["goal_id"],
+    },
+}
+
+UPDATE_GOAL_SCHEMA = {
+    "name": "update_goal",
+    "description": (
+        "Update a goal's status. The ONLY allowed transition is "
+        "setting status to 'complete'. You cannot pause, resume, "
+        "or clear goals through this tool."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "goal_id": {
+                "type": "string",
+                "description": "The unique id of the goal to update.",
+            },
+            "status": {
+                "type": "string",
+                "enum": ["complete"],
+                "description": "Must be 'complete'.",
+            },
+        },
+        "required": ["goal_id", "status"],
+    },
+}
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Tool error helper (imported from registry)
+# ──────────────────────────────────────────────────────────────────────
+
+from tools.registry import registry, tool_error  # noqa: E402
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Registry
+# ──────────────────────────────────────────────────────────────────────
+
+registry.register(
+    name="create_goal",
+    toolset="goal",
+    schema=CREATE_GOAL_SCHEMA,
+    handler=lambda args, **kw: _create_goal(args),
+    check_fn=check_goal_requirements,
+    emoji="🎯",
+)
+
+registry.register(
+    name="get_goal",
+    toolset="goal",
+    schema=GET_GOAL_SCHEMA,
+    handler=lambda args, **kw: _get_goal(args),
+    check_fn=check_goal_requirements,
+    emoji="🎯",
+)
+
+registry.register(
+    name="update_goal",
+    toolset="goal",
+    schema=UPDATE_GOAL_SCHEMA,
+    handler=lambda args, **kw: _update_goal(args),
+    check_fn=check_goal_requirements,
+    emoji="🎯",
+)

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -52,9 +52,16 @@ logger = logging.getLogger(__name__)
 # (HERMES_HOME env var changes) are always respected.  The old module-level
 # constant was cached at import time and could go stale if a profile switch
 # happened after the first import.
-def get_memory_dir() -> Path:
-    """Return the profile-scoped memories directory."""
-    return get_hermes_home() / "memories"
+def get_memory_dir(user_id: str = None) -> Path:
+    """Return the profile-scoped memories directory.
+    
+    When user_id is provided and different from 'global', returns a per-user
+    subdirectory (memories/{user_id}/) for multi-user isolation.
+    """
+    base = get_hermes_home() / "memories"
+    if user_id and user_id != "global":
+        return base / user_id
+    return base
 
 ENTRY_DELIMITER = "\n§\n"
 
@@ -115,17 +122,18 @@ class MemoryStore:
         Tool responses always reflect this live state.
     """
 
-    def __init__(self, memory_char_limit: int = 2200, user_char_limit: int = 1375):
+    def __init__(self, memory_char_limit: int = 2200, user_char_limit: int = 1375, user_id: str = None):
         self.memory_entries: List[str] = []
         self.user_entries: List[str] = []
         self.memory_char_limit = memory_char_limit
         self.user_char_limit = user_char_limit
+        self._user_id = user_id  # Per-user memory isolation
         # Frozen snapshot for system prompt -- set once at load_from_disk()
         self._system_prompt_snapshot: Dict[str, str] = {"memory": "", "user": ""}
 
     def load_from_disk(self):
         """Load entries from MEMORY.md and USER.md, capture system prompt snapshot."""
-        mem_dir = get_memory_dir()
+        mem_dir = get_memory_dir(self._user_id)
         mem_dir.mkdir(parents=True, exist_ok=True)
 
         self.memory_entries = self._read_file(mem_dir / "MEMORY.md")
@@ -179,8 +187,8 @@ class MemoryStore:
             fd.close()
 
     @staticmethod
-    def _path_for(target: str) -> Path:
-        mem_dir = get_memory_dir()
+    def _path_for(target: str, user_id: str = None) -> Path:
+        mem_dir = get_memory_dir(user_id)
         if target == "user":
             return mem_dir / "USER.md"
         return mem_dir / "MEMORY.md"
@@ -190,14 +198,14 @@ class MemoryStore:
 
         Called under file lock to get the latest state before mutating.
         """
-        fresh = self._read_file(self._path_for(target))
+        fresh = self._read_file(self._path_for(target, self._user_id))
         fresh = list(dict.fromkeys(fresh))  # deduplicate
         self._set_entries(target, fresh)
 
     def save_to_disk(self, target: str):
         """Persist entries to the appropriate file. Called after every mutation."""
-        get_memory_dir().mkdir(parents=True, exist_ok=True)
-        self._write_file(self._path_for(target), self._entries_for(target))
+        get_memory_dir(self._user_id).mkdir(parents=True, exist_ok=True)
+        self._write_file(self._path_for(target, self._user_id), self._entries_for(target))
 
     def _entries_for(self, target: str) -> List[str]:
         if target == "user":

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -265,12 +265,13 @@ async def _summarize_session(
 _HIDDEN_SESSION_SOURCES = ("tool",)
 
 
-def _list_recent_sessions(db, limit: int, current_session_id: str = None) -> str:
+def _list_recent_sessions(db, limit: int, current_session_id: str = None, user_id: str = None) -> str:
     """Return metadata for the most recent sessions (no LLM calls)."""
     try:
         sessions = db.list_sessions_rich(
             limit=limit + 5,
             exclude_sources=list(_HIDDEN_SESSION_SOURCES),
+            user_id=user_id,
             order_by_last_active=True,
         )  # fetch extra to skip current
 
@@ -328,6 +329,7 @@ def session_search(
     limit: int = 3,
     db=None,
     current_session_id: str = None,
+    user_id: str = None,
 ) -> str:
     """
     Search past sessions and return focused summaries of matching conversations.
@@ -352,7 +354,7 @@ def session_search(
     # Recent sessions mode: when query is empty, return metadata for recent sessions.
     # No LLM calls — just DB queries for titles, previews, timestamps.
     if not query or not query.strip():
-        return _list_recent_sessions(db, limit, current_session_id)
+        return _list_recent_sessions(db, limit, current_session_id, user_id=user_id)
 
     query = query.strip()
 
@@ -367,6 +369,7 @@ def session_search(
             query=query,
             role_filter=role_list,
             exclude_sources=list(_HIDDEN_SESSION_SOURCES),
+            user_id=user_id,
             limit=50,  # Get more matches to find unique sessions
             offset=0,
         )


### PR DESCRIPTION
## Problem

In multi-user gateway deployments (e.g., multiple Telegram users sharing one Hermes instance), user data leaks across sessions:

### 1. System prompt injection — USER.md shared across all users
`USER.md` is a single shared file (`~/.hermes/memories/USER.md`). When User A's profile (name, school, DOB, goals) is in USER.md, User B sees User A's identity in their system prompt.

**Fix**: Per-user memory directories — `memories/{chat_id}/USER.md` and `memories/{chat_id}/MEMORY.md`.

### 2. session_search cross-user leakage
`session_search` searches the entire session database without user filtering, exposing User A's conversation history to User B or cron jobs.

**Fix**: Added `user_id` parameter to `search_messages()` and `list_sessions_rich()` in `hermes_state.py`, threaded through `session_search_tool.py`.

### 3. Hindsight memory cross-contamination on iLink WeChat (微信)
The iLink Bot API (`ilinkai.weixin.qq.com`) reports the **bot's own user_id** as `from_user_id` for ALL inbound messages, regardless of who actually sent them. This means:
- All messages from different WeChat users share the same `from_user_id`
- Hindsight stores them in the same memory bank
- User A's memories contaminate User B's context

**Fix**: Per-platform retain gate in `hindsight/__init__.py` — skips `auto_retain` on platforms that can't distinguish users (detected by platform name or identical from_user_id).

## Changes (5 files, +63/-25)

| File | Change |
|------|--------|
| `tools/memory_tool.py` | `get_memory_dir(user_id=None)` returns per-user subdir; `MemoryStore` accepts `user_id` |
| `run_agent.py` | Pass `self._user_id` to `MemoryStore()` |
| `tools/session_search_tool.py` | Thread `user_id` to DB queries |
| `plugins/memory/hindsight/__init__.py` | Per-platform retain gate (skip on iLink/WeChat) |
| `hermes_state.py` | `user_id` filter in `search_messages()` and `list_sessions_rich()` |

## How to set up per-user USER.md

```bash
mkdir -p ~/.hermes/memories/{chat_id}
echo "User profile..." > ~/.hermes/memories/{chat_id}/USER.md
```

## Testing

1. Start gateway with two Telegram users → verify User B doesn't see User A's profile
2. User B calls `session_search` → verify only User B's sessions appear
3. For WeChat/iLink users → verify Hindsight retains memories per contact, not globally

## Related
Supersedes #12571 (original session_search + iLink fix, unmerged)