### PR TITLE
fix(agent): preserve all thinking blocks for DeepSeek /anthropic endpoint

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1648,20 +1648,24 @@ def convert_messages_to_anthropic(
 
         if _preserve_unsigned_thinking:
             # Kimi's /coding and DeepSeek's /anthropic endpoints both enable
-            # thinking server-side and require unsigned thinking blocks on
-            # replayed assistant tool-call messages.  Strip signed Anthropic
-            # blocks (neither upstream can validate Anthropic signatures) but
-            # preserve the unsigned ones we synthesised from reasoning_content.
+            # thinking server-side and require thinking blocks to round-trip on
+            # replayed assistant tool-call messages.  Preserve ALL thinking
+            # blocks here — both providers may sign their own blocks, and
+            # stripping them causes HTTP 400 ("thinking must be passed back").
+            # Anthropic-signed blocks from cross-provider conversation history
+            # are rare; if they cause a 400, the error classifier catches
+            # "signature"+"thinking" errors as retryable (FailoverReason.
+            # thinking_signature) and strips them on retry.
             new_content = []
             for b in m["content"]:
                 if not isinstance(b, dict) or b.get("type") not in _THINKING_TYPES:
                     new_content.append(b)
                     continue
-                if b.get("signature") or b.get("data"):
-                    # Anthropic-signed block — upstream can't validate, strip
+                if b.get("data"):
+                    # redacted_thinking data payload — Anthropic-proprietary,
+                    # neither DeepSeek nor Kimi support this block type
                     continue
-                # Unsigned thinking (synthesised from reasoning_content) —
-                # keep it: the upstream needs it for message-history validation.
+                # Preserve: the upstream needs it for message-history validation.
                 new_content.append(b)
             m["content"] = new_content or [{"type": "text", "text": "(empty)"}]
         elif _is_third_party or idx != last_assistant_idx:

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -439,6 +439,22 @@ def classify_api_error(
             should_compress=False,
         )
 
+    # DeepSeek /anthropic thinking block missing (400).
+    # DeepSeek's endpoint requires thinking blocks to round-trip on replayed
+    # assistant tool-call messages when thinking mode is enabled.  The error
+    # message does NOT contain "signature" so it misses the
+    # thinking_signature check above.  See hermes-agent#16748.
+    if (
+        status_code == 400
+        and "thinking" in error_msg
+        and ("passed back" in error_msg or "must be passed" in error_msg)
+    ):
+        return _result(
+            FailoverReason.thinking_signature,
+            retryable=True,
+            should_compress=False,
+        )
+
     # Anthropic long-context tier gate (429 "extra usage" + "long context")
     if (
         status_code == 429

--- a/tests/agent/test_deepseek_anthropic_thinking.py
+++ b/tests/agent/test_deepseek_anthropic_thinking.py
@@ -119,11 +119,16 @@ class TestDeepSeekAnthropicPreservesThinking:
             assert len(thinking) == 1
             assert thinking[0]["thinking"] == expected
 
-    def test_signed_anthropic_thinking_block_is_stripped(self) -> None:
-        """Anthropic-signed blocks (that leaked through) must still be stripped.
+    def test_thinking_block_with_signature_is_preserved(self) -> None:
+        """Thinking blocks with a signature must be preserved on DeepSeek.
 
-        DeepSeek issues its own signatures and cannot validate Anthropic's —
-        the strip-signed / keep-unsigned split matches the Kimi policy.
+        DeepSeek may sign its own thinking blocks, and the endpoint requires
+        them to round-trip when thinking mode is enabled.  Stripping them
+        causes HTTP 400: "The content[].thinking in the thinking mode must
+        be passed back to the API."
+
+        Only redacted_thinking data payloads are stripped (Anthropic-proprietary,
+        unsupported by DeepSeek per their compatibility matrix).
         """
         from agent.anthropic_adapter import convert_messages_to_anthropic
 
@@ -134,8 +139,8 @@ class TestDeepSeekAnthropicPreservesThinking:
                 "content": [
                     {
                         "type": "thinking",
-                        "thinking": "anthropic-signed payload",
-                        "signature": "anthropic-sig-xyz",
+                        "thinking": "deepseek-signed payload",
+                        "signature": "ds-sig-abc123",
                     },
                     {"type": "text", "text": "hello"},
                 ],
@@ -151,10 +156,12 @@ class TestDeepSeekAnthropicPreservesThinking:
             b for b in assistant_msg["content"]
             if isinstance(b, dict) and b.get("type") == "thinking"
         ]
-        assert thinking_blocks == [], (
-            "Signed Anthropic thinking blocks must be stripped on DeepSeek — "
-            "DeepSeek cannot validate Anthropic-proprietary signatures."
+        assert len(thinking_blocks) == 1, (
+            "Thinking blocks with a signature must be preserved on DeepSeek — "
+            "DeepSeek signs its own blocks and requires them to round-trip."
         )
+        assert thinking_blocks[0]["thinking"] == "deepseek-signed payload"
+        assert thinking_blocks[0]["signature"] == "ds-sig-abc123"
 
     def test_cache_control_stripped_from_thinking_block(self) -> None:
         """cache_control must still be stripped even when the block is preserved.


### PR DESCRIPTION
## Summary

- **Preserve ALL thinking blocks** for DeepSeek `/anthropic` and Kimi `/coding` endpoints, not just unsigned ones. Only `redacted_thinking` data payloads (Anthropic-proprietary) are still stripped.
- **Add error classifier pattern** for DeepSeek's specific 400 error (`"thinking must be passed back"`), which lacks the `"signature"` keyword required by the existing `thinking_signature` check.
- **Update tests** to reflect the new behavior: blocks with provider-specific signatures are preserved.

## Why

DeepSeek v4's `/anthropic` endpoint may sign its own thinking blocks. The existing `_preserve_unsigned_thinking` branch strips any block with a truthy `signature` or `data` field, assuming all signatures are Anthropic-proprietary. When DeepSeek's own signed blocks are stripped, the next replay fails with:

```
HTTP 400: The content[].thinking in the thinking mode must be passed back to the API.
```

PR #17223 adds DeepSeek to the `_preserve_unsigned_thinking` path but keeps the "strip signed" logic, which may still fail if DeepSeek signs its own blocks. This PR takes the next step: trust the upstream provider's own blocks and only strip blocks that are recognizably foreign (`redacted_thinking` data payloads).

## Changes

| File | Change |
|------|--------|
| `agent/anthropic_adapter.py` | Remove `b.get("signature")` check; only strip `redacted_thinking` data payloads |
| `agent/error_classifier.py` | Add DeepSeek-specific error pattern as retryable `thinking_signature` |
| `tests/agent/test_deepseek_anthropic_thinking.py` | Update test: signed blocks now expected to be *preserved* |

## Test plan

- [x] `pytest tests/agent/test_deepseek_anthropic_thinking.py -v` — 9 passed
- [x] `pytest tests/run_agent/test_deepseek_reasoning_content_echo.py -v` — 23 passed
- [x] `pytest tests/agent/test_error_classifier.py -v -k thinking` — 3 passed
- [x] Manual verification: DeepSeek v4-pro multi-turn tool calls on `/anthropic` endpoint no longer fails

## Related

- Fixes: #16748
- Related: #17223, #17400, #16844, #17825
- Alternative to: #17223 (this PR goes further by preserving signed blocks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)