### PR TITLE
feat(cli): add /free-models command to list free OpenRouter models

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7860,6 +7860,30 @@ class HermesCLI:
             self._console_print(f"    {header:40s}  {bar}  {pct_str}")
         self._console_print()
 
+    def _handle_free_models_command(self) -> None:
+        """List all free OpenRouter models with tool-calling support.
+
+        Surfaces every ``:free`` variant on OpenRouter (not just curated ones)
+        so users evaluating Hermes Agent can quickly discover zero-cost models.
+        See ``hermes-agent#17923``.
+        """
+        from hermes_cli.models import fetch_openrouter_free_models
+        with self._busy_command("Fetching free OpenRouter models..."):
+            models = fetch_openrouter_free_models()
+
+        if not models:
+            self._console_print("  [yellow]No free OpenRouter models reachable right now.[/]")
+            return
+
+        self._console_print()
+        self._console_print(f"  [bold]Free OpenRouter models[/] ({len(models)} available)")
+        self._console_print()
+        for mid, _ in models:
+            self._console_print(f"    {mid}")
+        self._console_print()
+        self._console_print("  [dim]Switch with:[/] /model <id> --provider openrouter")
+        self._console_print()
+
     def _handle_personality_command(self, cmd: str):
         """Handle the /personality command to set predefined personalities."""
         parts = cmd.split(maxsplit=1)
@@ -8457,6 +8481,8 @@ class HermesCLI:
             self._handle_codex_runtime(cmd_original)
         elif canonical == "gquota":
             self._handle_gquota_command(cmd_original)
+        elif canonical == "free-models":
+            self._handle_free_models_command()
 
         elif canonical == "personality":
             # Use original case (handler lowercases the personality name itself)

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -125,6 +125,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("codex-runtime", "Toggle codex app-server runtime for OpenAI/Codex models",
                "Configuration", aliases=("codex_runtime",),
                args_hint="[auto|codex_app_server]"),
+    CommandDef("free-models", "List all free OpenRouter models with tool support", "Info",
+               cli_only=True),
     CommandDef("gquota", "Show Google Gemini Code Assist quota usage", "Info",
                cli_only=True),
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1196,6 +1196,59 @@ def fetch_openrouter_models(
     return list(curated)
 
 
+def fetch_openrouter_free_models(timeout: float = 8.0) -> list[tuple[str, str]]:
+    """Return all live OpenRouter models with free pricing and tool support.
+
+    Unlike :func:`fetch_openrouter_models`, this bypasses the curated picker list
+    and surfaces every model on OpenRouter where ``pricing.prompt`` and
+    ``pricing.completion`` are both zero AND ``supported_parameters`` advertises
+    tool-calling. This addresses the gap where free ``:free`` variants appear on
+    OpenRouter (e.g. ``nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free``)
+    but never make it into the curated catalog.
+
+    Returns ``[(id, "free"), ...]``. On any network/parse failure, falls back
+    to the ``:free``-suffixed entries already in :data:`OPENROUTER_MODELS`
+    so the CLI keeps working offline.
+
+    See ``hermes-agent#17923``.
+    """
+    try:
+        req = urllib.request.Request(
+            "https://openrouter.ai/api/v1/models",
+            headers={"Accept": "application/json"},
+        )
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            payload = json.loads(resp.read().decode())
+    except Exception:
+        return [(mid, "free") for mid, _ in OPENROUTER_MODELS if mid.endswith(":free")]
+
+    live_items = payload.get("data", [])
+    if not isinstance(live_items, list):
+        return [(mid, "free") for mid, _ in OPENROUTER_MODELS if mid.endswith(":free")]
+
+    out: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    for item in live_items:
+        if not isinstance(item, dict):
+            continue
+        mid = str(item.get("id") or "").strip()
+        if not mid or mid in seen:
+            continue
+        if not _openrouter_model_is_free(item.get("pricing")):
+            continue
+        # Hermes-agent is tool-calling-first; surfacing models that don't
+        # advertise tools leads to immediate runtime failures when selected.
+        if not _openrouter_model_supports_tools(item):
+            continue
+        seen.add(mid)
+        out.append((mid, "free"))
+
+    if not out:
+        return [(mid, "free") for mid, _ in OPENROUTER_MODELS if mid.endswith(":free")]
+
+    return out
+
+
 def model_ids(*, force_refresh: bool = False) -> list[str]:
     """Return just the OpenRouter model-id strings."""
     return [mid for mid, _ in fetch_openrouter_models(force_refresh=force_refresh)]

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -880,3 +880,128 @@ class TestNousRecommendedModels:
             patch("hermes_cli.models.check_nous_free_tier", side_effect=RuntimeError("boom")),
         ):
             assert get_nous_recommended_aux_model(vision=False) == "paid-model"
+
+
+class TestFetchOpenRouterFreeModels:
+    """Tests for fetch_openrouter_free_models — see hermes-agent#17923."""
+
+    @staticmethod
+    def _mock_response(payload_bytes: bytes):
+        class _Resp:
+            def __enter__(self):
+                return self
+            def __exit__(self, exc_type, exc, tb):
+                return False
+            def read(self):
+                return payload_bytes
+        return _Resp()
+
+    def test_returns_only_free_models_with_tool_support(self):
+        from hermes_cli.models import fetch_openrouter_free_models
+        payload = (
+            b'{"data":['
+            b'{"id":"anthropic/claude-opus-4.6",'
+            b'"pricing":{"prompt":"0.000015","completion":"0.000075"},'
+            b'"supported_parameters":["tools"]},'
+            b'{"id":"nvidia/nemotron-3-nano-30b-a3b:free",'
+            b'"pricing":{"prompt":"0","completion":"0"},'
+            b'"supported_parameters":["tools"]},'
+            b'{"id":"nvidia/nemotron-nano-9b-v2:free",'
+            b'"pricing":{"prompt":"0","completion":"0"},'
+            b'"supported_parameters":["tools"]}'
+            b']}'
+        )
+        with patch(
+            "hermes_cli.models.urllib.request.urlopen",
+            return_value=self._mock_response(payload),
+        ):
+            models = fetch_openrouter_free_models()
+
+        assert models == [
+            ("nvidia/nemotron-3-nano-30b-a3b:free", "free"),
+            ("nvidia/nemotron-nano-9b-v2:free", "free"),
+        ]
+
+    def test_filters_out_free_models_without_tool_support(self):
+        """Free models that don't advertise tool-calling must not appear:
+        Hermes Agent is tool-calling-first."""
+        from hermes_cli.models import fetch_openrouter_free_models
+        payload = (
+            b'{"data":['
+            b'{"id":"vendor/free-no-tools:free",'
+            b'"pricing":{"prompt":"0","completion":"0"},'
+            b'"supported_parameters":["temperature"]},'
+            b'{"id":"vendor/free-with-tools:free",'
+            b'"pricing":{"prompt":"0","completion":"0"},'
+            b'"supported_parameters":["tools","temperature"]}'
+            b']}'
+        )
+        with patch(
+            "hermes_cli.models.urllib.request.urlopen",
+            return_value=self._mock_response(payload),
+        ):
+            models = fetch_openrouter_free_models()
+
+        assert models == [("vendor/free-with-tools:free", "free")]
+
+    def test_keeps_free_models_with_missing_supported_parameters(self):
+        """Permissive: when supported_parameters is absent, surface the model
+        (matches the policy in fetch_openrouter_models for offline mirrors)."""
+        from hermes_cli.models import fetch_openrouter_free_models
+        payload = (
+            b'{"data":['
+            b'{"id":"vendor/free-no-params:free",'
+            b'"pricing":{"prompt":"0","completion":"0"}}'
+            b']}'
+        )
+        with patch(
+            "hermes_cli.models.urllib.request.urlopen",
+            return_value=self._mock_response(payload),
+        ):
+            models = fetch_openrouter_free_models()
+
+        assert models == [("vendor/free-no-params:free", "free")]
+
+    def test_falls_back_to_static_free_entries_on_fetch_failure(self):
+        """Network failure → return the ``:free`` entries already in
+        OPENROUTER_MODELS so the user still sees something."""
+        from hermes_cli.models import fetch_openrouter_free_models
+        with patch(
+            "hermes_cli.models.urllib.request.urlopen",
+            side_effect=OSError("no network"),
+        ):
+            models = fetch_openrouter_free_models()
+
+        expected = [(mid, "free") for mid, _ in OPENROUTER_MODELS if mid.endswith(":free")]
+        assert models == expected
+
+    def test_falls_back_when_api_returns_malformed_payload(self):
+        from hermes_cli.models import fetch_openrouter_free_models
+        with patch(
+            "hermes_cli.models.urllib.request.urlopen",
+            return_value=self._mock_response(b'{"data": "not a list"}'),
+        ):
+            models = fetch_openrouter_free_models()
+
+        expected = [(mid, "free") for mid, _ in OPENROUTER_MODELS if mid.endswith(":free")]
+        assert models == expected
+
+    def test_dedupes_repeated_ids_in_payload(self):
+        from hermes_cli.models import fetch_openrouter_free_models
+        payload = (
+            b'{"data":['
+            b'{"id":"vendor/dup:free",'
+            b'"pricing":{"prompt":"0","completion":"0"},'
+            b'"supported_parameters":["tools"]},'
+            b'{"id":"vendor/dup:free",'
+            b'"pricing":{"prompt":"0","completion":"0"},'
+            b'"supported_parameters":["tools"]}'
+            b']}'
+        )
+        with patch(
+            "hermes_cli.models.urllib.request.urlopen",
+            return_value=self._mock_response(payload),
+        ):
+            models = fetch_openrouter_free_models()
+
+        assert models == [("vendor/dup:free", "free")]


### PR DESCRIPTION
## What

Adds `/free-models` slash command that lists every OpenRouter model with free pricing and tool-calling support, fetched live from `openrouter.ai/api/v1/models`.

Resolves #17923.

## Why

Free models are a key entry point for users evaluating Hermes Agent, but the existing `/model` picker only surfaces models that are explicitly in the curated `OPENROUTER_MODELS` list. Free `:free` variants like `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free` exist on OpenRouter but aren't discoverable through the CLI today.

## How

1. New helper `fetch_openrouter_free_models()` in `hermes_cli/models.py` that hits the live OpenRouter `/v1/models` endpoint, filters to models where `pricing.prompt` and `pricing.completion` are both zero AND `supported_parameters` advertises `tools`, then returns `[(id, "free"), ...]`. Reuses the existing `_openrouter_model_is_free` and `_openrouter_model_supports_tools` helpers so policy stays consistent with the curated picker.

2. Network/parse failures fall back to the `:free` entries already in `OPENROUTER_MODELS` so the command still works offline.

3. New `/free-models` `CommandDef` in `hermes_cli/commands.py` and handler `_handle_free_models_command` in `cli.py` that prints the list with a hint on how to switch.

4. Six tests covering: free+tool filtering, tool-support filtering, permissive handling of missing `supported_parameters`, network-failure fallback, malformed-payload fallback, and de-duplication.

## Why a separate command and not `/model --free`

The issue suggested either a `--free` flag on `/model` or a separate `/free-models` command. I went with the separate command because the `/model` picker pulls from a hardcoded curated list across multiple providers (`OPENROUTER_MODELS`, `_PROVIDER_MODELS`), and threading a free-only mode through `parse_model_flags`, `switch_model`, and `list_authenticated_providers` would be a much larger change that touches the CLI, gateway, and TUI gateway. A standalone command keeps the diff small and surface area predictable. Happy to reshape if you'd prefer the flag approach — just let me know.

## Test plan

- [x] `python3 -m py_compile` on all modified files
- [x] Manual runtime test of `fetch_openrouter_free_models` with mocked OpenRouter responses (filter, fallback, dedup paths)
- [x] `resolve_command("free-models")` returns the registered `CommandDef`
- [ ] CI runs the new test class on push

## Followup ideas

- Adding context-length info next to each model id (the live payload exposes `context_length`)
- Sorting by context length / popularity for nicer output
- Wiring the same source into the `/model` picker behind a `--free` flag (separate PR if the maintainer wants this)