### PR TITLE
fix(openviking): commit explicit remember memories

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -729,14 +729,13 @@ class OpenVikingMemoryProvider(MemoryProvider):
 
         self._client.post(f"/api/v1/sessions/{self._session_id}/messages", {
             "role": "user",
-            "parts": [
-                {"type": "text", "text": text},
-            ],
+            "content": text,
         })
+        self._client.post(f"/api/v1/sessions/{self._session_id}/commit")
 
         return json.dumps({
             "status": "stored",
-            "message": "Memory recorded. Will be extracted and indexed on session commit.",
+            "message": "Memory recorded and session committed for extraction.",
         })
 
     def _tool_add_resource(self, args: dict) -> str:

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -60,3 +60,21 @@ def test_tool_search_sorts_missing_raw_score_after_negative_scores():
     ]
     assert [entry["score"] for entry in result["results"]] == [0.1, 0.0, -0.25]
     assert result["total"] == 3
+
+
+def test_tool_remember_posts_content_message_and_commits_session():
+    provider = OpenVikingMemoryProvider()
+    provider._client = MagicMock()
+    provider._session_id = "session-123"
+
+    result = json.loads(provider._tool_remember({"content": "Ada likes tea", "category": "entity"}))
+
+    assert result["status"] == "stored"
+    provider._client.post.assert_any_call(
+        "/api/v1/sessions/session-123/messages",
+        {
+            "role": "user",
+            "content": "[Remember — entity] Ada likes tea",
+        },
+    )
+    provider._client.post.assert_any_call("/api/v1/sessions/session-123/commit")


### PR DESCRIPTION
## Summary
- Store `viking_remember` notes with the same `content` message shape used by normal OpenViking turn sync.
- Commit the OpenViking session immediately after an explicit remember write so extraction/indexing is triggered.
- Add a regression test for the message payload and commit call.

## Root cause
`viking_remember` posted a message using a `parts` payload and then waited for a later session commit. For explicit remember-only writes, that could leave OpenViking with an empty/uncommitted session and no extracted memories.

## Fix
Use the `content` field for the remembered text and call `/commit` after the message write.

## Regression coverage
- `tests/plugins/memory/test_openviking_provider.py::test_tool_remember_posts_content_message_and_commits_session`

## Testing
- `scripts/run_tests.sh tests/plugins/memory/test_openviking_provider.py::test_tool_remember_posts_content_message_and_commits_session -q`
- `scripts/run_tests.sh tests/plugins/memory/test_openviking_provider.py tests/openviking_plugin/test_openviking.py -q`

Closes #17998
