### PR TITLE
fix(dashboard): allow explicit session token env

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -68,10 +68,12 @@ app = FastAPI(title="Hermes Agent", version=__version__)
 
 # ---------------------------------------------------------------------------
 # Session token for protecting sensitive endpoints (reveal).
-# Generated fresh on every server start — dies when the process exits.
+# By default, generated fresh on every server start — dies when the process exits.
+# Operators that need service-to-service dashboard access may provide a stable
+# token through HERMES_DASHBOARD_TOKEN (kept in a local EnvironmentFile).
 # Injected into the SPA HTML so only the legitimate web UI can use it.
 # ---------------------------------------------------------------------------
-_SESSION_TOKEN = secrets.token_urlsafe(32)
+_SESSION_TOKEN = os.environ.get("HERMES_DASHBOARD_TOKEN") or secrets.token_urlsafe(32)
 _SESSION_HEADER_NAME = "X-Hermes-Session-Token"
 
 # In-browser Chat tab (/chat, /api/pty, …).  Off unless ``hermes dashboard --tui``


### PR DESCRIPTION
## Summary
- Allow the dashboard session token to be supplied via `HERMES_DASHBOARD_TOKEN`.
- Preserve existing ephemeral token generation when the env var is not set.
- Enables service-to-service clients, such as Hermes Workspace, to call protected dashboard endpoints without scraping the HTML boot token.

## Test plan
- `python -m pytest tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_reveal_env_var_custom_session_header_ignores_proxy_authorization tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_reveal_env_var_legacy_authorization_header_still_works -q`
