### PR TITLE
fix(plugins): enable aliases using manifest names

### DIFF
--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -564,6 +564,30 @@ def _save_enabled_set(enabled: set) -> None:
     save_config(config)
 
 
+def _resolve_plugin_config_name(name: str) -> str:
+    """Return the manifest-declared key used by plugin discovery/listing."""
+    user_dir = _plugins_dir()
+    if user_dir.is_dir():
+        direct = user_dir / name
+        if direct.is_dir():
+            return _read_manifest(direct).get("name") or name
+        for child in user_dir.iterdir():
+            if not child.is_dir():
+                continue
+            manifest_name = _read_manifest(child).get("name")
+            if manifest_name == name:
+                return name
+
+    from hermes_cli.plugins import get_bundled_plugins_dir
+
+    repo_plugins = get_bundled_plugins_dir()
+    if repo_plugins.is_dir():
+        direct = repo_plugins / name
+        if direct.is_dir():
+            return _read_manifest(direct).get("name") or name
+    return name
+
+
 def cmd_enable(name: str) -> None:
     """Add a plugin to the enabled allow-list (and remove it from disabled)."""
     from rich.console import Console
@@ -574,19 +598,22 @@ def cmd_enable(name: str) -> None:
         console.print(f"[red]Plugin '{name}' is not installed or bundled.[/red]")
         sys.exit(1)
 
+    config_name = _resolve_plugin_config_name(name)
     enabled = _get_enabled_set()
     disabled = _get_disabled_set()
 
-    if name in enabled and name not in disabled:
-        console.print(f"[dim]Plugin '{name}' is already enabled.[/dim]")
+    if config_name in enabled and name not in disabled and config_name not in disabled:
+        console.print(f"[dim]Plugin '{config_name}' is already enabled.[/dim]")
         return
 
-    enabled.add(name)
+    enabled.discard(name)
+    enabled.add(config_name)
     disabled.discard(name)
+    disabled.discard(config_name)
     _save_enabled_set(enabled)
     _save_disabled_set(disabled)
     console.print(
-        f"[green]✓[/green] Plugin [bold]{name}[/bold] enabled. "
+        f"[green]✓[/green] Plugin [bold]{config_name}[/bold] enabled. "
         "Takes effect on next session."
     )
 
@@ -600,19 +627,21 @@ def cmd_disable(name: str) -> None:
         console.print(f"[red]Plugin '{name}' is not installed or bundled.[/red]")
         sys.exit(1)
 
+    config_name = _resolve_plugin_config_name(name)
     enabled = _get_enabled_set()
     disabled = _get_disabled_set()
 
-    if name not in enabled and name in disabled:
-        console.print(f"[dim]Plugin '{name}' is already disabled.[/dim]")
+    if name not in enabled and config_name not in enabled and config_name in disabled:
+        console.print(f"[dim]Plugin '{config_name}' is already disabled.[/dim]")
         return
 
     enabled.discard(name)
-    disabled.add(name)
+    enabled.discard(config_name)
+    disabled.add(config_name)
     _save_enabled_set(enabled)
     _save_disabled_set(disabled)
     console.print(
-        f"[yellow]\u2298[/yellow] Plugin [bold]{name}[/bold] disabled. "
+        f"[yellow]\u2298[/yellow] Plugin [bold]{config_name}[/bold] disabled. "
         "Takes effect on next session."
     )
 

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -212,6 +212,28 @@ class TestCmdInstall:
         mock_display_after_install.assert_not_called()
 
 
+# ── cmd_enable tests ─────────────────────────────────────────────────────────
+
+
+class TestCmdEnable:
+    """Test enabling installed plugins."""
+
+    def test_enable_by_directory_stores_manifest_name(self, tmp_path, monkeypatch):
+        """Directory aliases should persist the manifest key used by plugin list."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        plugin_dir = tmp_path / "plugins" / "ping_island"
+        plugin_dir.mkdir(parents=True)
+        plugin_dir.joinpath("plugin.yaml").write_text(
+            "name: ping-island\nversion: 1.0.0\ndescription: test plugin\n"
+        )
+
+        from hermes_cli.plugins_cmd import _get_enabled_set, cmd_enable
+
+        cmd_enable("ping_island")
+
+        assert _get_enabled_set() == {"ping-island"}
+
+
 # ── cmd_update tests ─────────────────────────────────────────────────────────
 
 

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -234,6 +234,35 @@ class TestCmdEnable:
         assert _get_enabled_set() == {"ping-island"}
 
 
+# ── cmd_disable tests ────────────────────────────────────────────────────────
+
+
+class TestCmdDisable:
+    """Test disabling installed plugins."""
+
+    def test_disable_by_directory_stores_manifest_name(self, tmp_path, monkeypatch):
+        """Directory aliases should persist the manifest key on disable too."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        plugin_dir = tmp_path / "plugins" / "ping_island"
+        plugin_dir.mkdir(parents=True)
+        plugin_dir.joinpath("plugin.yaml").write_text(
+            "name: ping-island\nversion: 1.0.0\ndescription: test plugin\n"
+        )
+
+        from hermes_cli.plugins_cmd import _get_disabled_set, cmd_disable
+
+        # First enable it, then disable
+        from hermes_cli.plugins_cmd import cmd_enable, _get_enabled_set
+
+        cmd_enable("ping_island")
+        assert _get_enabled_set() == {"ping-island"}
+
+        cmd_disable("ping_island")
+
+        assert _get_disabled_set() == {"ping-island"}
+        assert "ping-island" not in _get_enabled_set()
+
+
 # ── cmd_update tests ─────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## What does this PR do?

- Store the manifest-declared plugin name when enabling a plugin by its installed directory name.
- Remove stale directory aliases from enabled/disabled config sets during enable/disable.
- Add a regression test for directory name vs manifest name mismatches.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A