### PR TITLE
fix(update): use Termux-safe extras on Android

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6150,15 +6150,25 @@ def _load_installable_optional_extras() -> list[str]:
     return referenced
 
 
+def _is_termux_runtime() -> bool:
+    """Return True when running inside Android/Termux."""
+    prefix = os.environ.get("PREFIX", "")
+    return bool(os.environ.get("TERMUX_VERSION") or "com.termux/files/usr" in prefix)
+
+
 def _install_python_dependencies_with_optional_fallback(
     install_cmd_prefix: list[str],
     *,
     env: dict[str, str] | None = None,
 ) -> None:
     """Install base deps plus as many optional extras as the environment supports."""
+    preferred_extra = "termux" if _is_termux_runtime() else "all"
+    if preferred_extra == "termux":
+        print("  → Termux detected; using the Android-safe dependency set instead of .[all]")
+
     try:
         subprocess.run(
-            install_cmd_prefix + ["install", "-e", ".[all]", "--quiet"],
+            install_cmd_prefix + ["install", "-e", f".[{preferred_extra}]", "--quiet"],
             cwd=PROJECT_ROOT,
             check=True,
             env=env,

--- a/tests/test_update_termux_dependencies.py
+++ b/tests/test_update_termux_dependencies.py
@@ -1,0 +1,34 @@
+from types import SimpleNamespace
+
+import hermes_cli.main as main
+
+
+def test_update_installs_termux_extra_on_termux(monkeypatch):
+    commands = []
+
+    def fake_run(cmd, **kwargs):
+        commands.append(cmd)
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setenv("TERMUX_VERSION", "0.118.3")
+    monkeypatch.setattr(main.subprocess, "run", fake_run)
+
+    main._install_python_dependencies_with_optional_fallback(["python", "-m", "pip"])
+
+    assert commands == [["python", "-m", "pip", "install", "-e", ".[termux]", "--quiet"]]
+
+
+def test_update_installs_all_extra_outside_termux(monkeypatch):
+    commands = []
+
+    def fake_run(cmd, **kwargs):
+        commands.append(cmd)
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.delenv("TERMUX_VERSION", raising=False)
+    monkeypatch.setenv("PREFIX", "/usr/local")
+    monkeypatch.setattr(main.subprocess, "run", fake_run)
+
+    main._install_python_dependencies_with_optional_fallback(["python", "-m", "pip"])
+
+    assert commands == [["python", "-m", "pip", "install", "-e", ".[all]", "--quiet"]]


### PR DESCRIPTION
Summary:
    - Detect Termux/Android during hermes update
    - Install .[termux] instead of .[all] on Termux
    - Add coverage for Termux and non-Termux dependency selection
    
    Why:
    hermes update currently installs .[all], which pulls optional dependency groups that are unreliable on Termux/Android aarch64, notably voice/matrix-related deps. The project already defines a termux extra, so the updater should use that Android-safe dependency set when running under Termux.
    
    Test plan:
    - venv/bin/python -m pytest tests/test_update_termux_dependencies.py -q -o 'addopts='
    - Verified locally on Termux after a stuck python -m pip install -e .[all] --quiet update path