### PR TITLE
fix(gateway): delegate Telegram callback auth to shared user authorizer

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1177,7 +1177,8 @@ class BasePlatformAdapter(ABC):
         self._fatal_error_message: Optional[str] = None
         self._fatal_error_retryable = True
         self._fatal_error_handler: Optional[Callable[["BasePlatformAdapter"], Awaitable[None] | None]] = None
-        
+        self._user_authorizer: Optional[Callable[[Platform, str], bool]] = None
+
         # Track active message handlers per session for interrupt support.
         # _active_sessions stores the per-session interrupt Event; _session_tasks
         # maps session → the specific Task currently processing it so that
@@ -1353,12 +1354,24 @@ class BasePlatformAdapter(ABC):
     def set_session_store(self, session_store: Any) -> None:
         """
         Set the session store for checking active sessions.
-        
+
         Used by adapters that need to check if a thread/conversation
         has an active session before processing messages (e.g., Slack
         thread replies without explicit mentions).
         """
         self._session_store = session_store
+
+    def set_user_authorizer(self, authorizer: Callable[[Platform, str], bool]) -> None:
+        """
+        Set the shared authorization function used by gated interactive
+        elements (inline-button callbacks, slash commands on callback data).
+
+        Without this, adapters fall back to adapter-local env-only checks,
+        which can diverge from the main message-path auth (pairing store,
+        global allowlists, platform allow-all flags). Keeping a single
+        authorizer for both paths prevents that drift.
+        """
+        self._user_authorizer = authorizer
     
     @abstractmethod
     async def connect(self) -> bool:

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -290,9 +290,21 @@ class TelegramAdapter(BasePlatformAdapter):
         # and any other slash-confirm prompts; see GatewayRunner._request_slash_confirm).
         self._slash_confirm_state: Dict[str, str] = {}
 
-    @staticmethod
-    def _is_callback_user_authorized(user_id: str) -> bool:
-        """Return whether a Telegram inline-button caller may perform gated actions."""
+    def _is_callback_user_authorized(self, user_id: str) -> bool:
+        """
+        Return whether a Telegram inline-button caller may perform gated actions.
+
+        Prefers the gateway's shared authorizer (which also consults the pairing
+        store and global allowlists) so button auth matches text-message auth.
+        Falls back to an env-only check when no authorizer is wired — the adapter
+        can be instantiated without a gateway in tests.
+        """
+        if self._user_authorizer is not None:
+            try:
+                return bool(self._user_authorizer(Platform.TELEGRAM, user_id))
+            except Exception:
+                logger.exception("Telegram callback authorizer raised; falling back to env check")
+
         allowed_csv = os.getenv("TELEGRAM_ALLOWED_USERS", "").strip()
         if not allowed_csv:
             return True

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2564,6 +2564,7 @@ class GatewayRunner:
             adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
             adapter.set_session_store(self.session_store)
             adapter.set_busy_session_handler(self._handle_active_session_busy_message)
+            adapter.set_user_authorizer(self._is_user_id_authorized)
             
             # Try to connect
             logger.info("Connecting to %s...", platform.value)
@@ -2964,6 +2965,7 @@ class GatewayRunner:
                     adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
                     adapter.set_session_store(self.session_store)
                     adapter.set_busy_session_handler(self._handle_active_session_busy_message)
+                    adapter.set_user_authorizer(self._is_user_id_authorized)
 
                     success = await self._connect_adapter_with_timeout(adapter, platform)
                     if success:
@@ -3677,6 +3679,19 @@ class GatewayRunner:
                 check_ids.add(normalized_user_id)
 
         return bool(check_ids & allowed_ids)
+
+    def _is_user_id_authorized(self, platform: Platform, user_id: str) -> bool:
+        """
+        Auth check callable from platform adapter callbacks (inline button
+        clicks, etc.) that lack a full MessageEvent. Mirrors the main
+        message-path check in ``_is_user_authorized`` so gated interactive
+        elements can't diverge from text-message auth (pairing store,
+        global allowlists, platform allow-all flags).
+        """
+        if not user_id:
+            return False
+        source = SessionSource(platform=platform, chat_id="", user_id=str(user_id))
+        return self._is_user_authorized(source)
 
     def _get_unauthorized_dm_behavior(self, platform: Optional[Platform]) -> str:
         """Return how unauthorized DMs should be handled for a platform.

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -358,3 +358,44 @@ class TestTelegramApprovalCallback:
         query.answer.assert_called_once()
         query.edit_message_text.assert_called_once()
         assert (tmp_path / ".update_response").read_text() == "n"
+
+    @pytest.mark.asyncio
+    async def test_callback_auth_delegates_to_injected_authorizer(self, tmp_path):
+        """
+        When the gateway injects an authorizer via set_user_authorizer, the
+        callback auth must delegate to it — not the env-only check. This
+        prevents button-auth from diverging from message-path auth (pairing
+        store + global allowlists live only on the gateway's check).
+        """
+        adapter = _make_adapter()
+        # Env says user 111 is the only authorized one — but the authorizer
+        # below will approve user 222 instead (simulating pairing-store approval).
+        calls = []
+
+        def fake_authorizer(platform, user_id):
+            calls.append((platform, user_id))
+            return user_id == "222"
+
+        adapter.set_user_authorizer(fake_authorizer)
+
+        query = AsyncMock()
+        query.data = "update_prompt:n"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.from_user = MagicMock()
+        query.from_user.id = 222
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        with patch("hermes_constants.get_hermes_home", return_value=tmp_path):
+            with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "111"}):
+                await adapter._handle_callback_query(update, context)
+
+        assert calls and calls[0][1] == "222"
+        query.answer.assert_called_once()
+        query.edit_message_text.assert_called_once()
+        assert (tmp_path / ".update_response").read_text() == "n"


### PR DESCRIPTION
## Summary
`TelegramAdapter._is_callback_user_authorized` only checked the `TELEGRAM_ALLOWED_USERS` env var, bypassing the gateway's full auth path (pairing store + global allowlists). This meant inline-button callback events were authorized inconsistently with inbound messages — users paired through the gateway could be silently rejected on approval-button clicks even though their messages were accepted.

## Changes
- `BasePlatformAdapter`: add `_user_authorizer` field + `set_user_authorizer()` injector
- `TelegramAdapter._is_callback_user_authorized`: call the injected authorizer when present; fall back to the env-only check for tests / unwired adapters
- `GatewayRunner`: wire `_is_user_id_authorized` into every adapter on connect so callbacks go through the same auth path as inbound messages
- Add regression test confirming callback auth delegates to the injected authorizer

## Test plan
- [x] New unit test: `tests/gateway/test_telegram_approval_buttons.py` — callback auth delegates to injected authorizer
- [x] Manual: paired user can approve via inline button; un-paired user cannot
- [x] In production on a Hermes deploy for ~10 days before the most recent `hermes update` accidentally reverted it