### PR TITLE
feat: add Voicebox local TTS provider

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -783,7 +783,7 @@ DEFAULT_CONFIG = {
     # limit (OpenAI 4096, xAI 15000, MiniMax 10000, ElevenLabs 5k-40k model-aware,
     # Gemini 5000, Edge 5000, Mistral 4000, NeuTTS/KittenTTS 2000).
     "tts": {
-        "provider": "edge",  # "edge" (free) | "elevenlabs" (premium) | "openai" | "xai" | "minimax" | "mistral" | "gemini" | "neutts" (local) | "kittentts" (local) | "piper" (local)
+        "provider": "edge",  # "edge" (free) | "elevenlabs" (premium) | "openai" | "xai" | "minimax" | "mistral" | "gemini" | "neutts" (local) | "kittentts" (local) | "piper" (local) | "voicebox" (local)
         "edge": {
             "voice": "en-US-AriaNeural",
             # Popular: AriaNeural, JennyNeural, AndrewNeural, BrianNeural, SoniaNeural
@@ -825,6 +825,16 @@ DEFAULT_CONFIG = {
             # "noise_w_scale": 0.8,
             # "volume": 1.0,
             # "normalize_audio": True,
+        },
+        "voicebox": {
+            "base_url": "http://127.0.0.1:17493",
+            "profile_id": "",
+            "engine": "kokoro",
+            "model_size": None,
+            "max_chunk_chars": 800,
+            "crossfade_ms": 50,
+            "normalize": True,
+            "language": "en",
         },
     },
     

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1083,6 +1083,7 @@ def _setup_tts_provider(config: dict):
         "gemini": "Google Gemini TTS",
         "neutts": "NeuTTS",
         "kittentts": "KittenTTS",
+        "voicebox": "Voicebox (local TTS)",
     }
     current_label = provider_labels.get(current_provider, current_provider)
 
@@ -1107,9 +1108,10 @@ def _setup_tts_provider(config: dict):
             "Google Gemini TTS (30 prebuilt voices, prompt-controllable, needs API key)",
             "NeuTTS (local on-device, free, ~300MB model download)",
             "KittenTTS (local on-device, free, lightweight ~25-80MB ONNX)",
+            "Voicebox (local-first cloned/preset voices — no API key needed)",
         ]
     )
-    providers.extend(["edge", "elevenlabs", "openai", "xai", "minimax", "mistral", "gemini", "neutts", "kittentts"])
+    providers.extend(["edge", "elevenlabs", "openai", "xai", "minimax", "mistral", "gemini", "neutts", "kittentts", "voicebox"])
     choices.append(f"Keep current ({current_label})")
     keep_current_idx = len(choices) - 1
     idx = prompt_choice("Select TTS provider:", choices, keep_current_idx)
@@ -1250,6 +1252,53 @@ def _setup_tts_provider(config: dict):
             else:
                 print_info("Skipping install. Set tts.provider to 'kittentts' after installing manually.")
                 selected = "edge"
+
+    elif selected == "voicebox":
+        import requests
+        vb_url = prompt("Voicebox base URL", default="http://127.0.0.1:17493").strip()
+        if not vb_url:
+            vb_url = "http://127.0.0.1:17493"
+        vb_url = vb_url.rstrip("/")
+        try:
+            resp = requests.get(f"{vb_url}/profiles", timeout=5)
+            if resp.status_code == 200:
+                profiles = resp.json()
+                if isinstance(profiles, list) and profiles:
+                    print()
+                    print_info("Available Voicebox profiles:")
+                    for i, p in enumerate(profiles):
+                        name = p.get("name", "Unknown")
+                        pid = p.get("id", "")
+                        default_engine = p.get("default_engine", "")
+                        print(f"  {i + 1}. {name} (engine: {default_engine}) — {pid}")
+                    print()
+                    profile_idx = prompt_choice("Select a profile:", [p.get("name", "Unknown") for p in profiles], 0)
+                    selected_profile = profiles[profile_idx]
+                    profile_id = selected_profile.get("id", "")
+                    default_engine = selected_profile.get("default_engine", "kokoro")
+                else:
+                    print_warning("Voicebox returned no profiles.")
+                    profile_id = ""
+                    default_engine = "kokoro"
+            else:
+                print_warning(f"Voicebox returned HTTP {resp.status_code}. Is the server running?")
+                profile_id = ""
+                default_engine = "kokoro"
+        except Exception as e:
+            print_warning(f"Could not reach Voicebox at {vb_url}: {e}")
+            profile_id = ""
+            default_engine = "kokoro"
+
+        engine = prompt("Voicebox engine", default=default_engine).strip() or "kokoro"
+        if "tts" not in config:
+            config["tts"] = {}
+        config["tts"]["voicebox"] = {
+            "base_url": vb_url,
+            "profile_id": profile_id,
+            "engine": engine,
+        }
+        save_config(config)
+        print_success(f"Voicebox configured: {vb_url} (engine: {engine})")
 
     # Save the selection
     if "tts" not in config:

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -149,6 +149,12 @@ DEFAULT_XAI_BASE_URL = "https://api.x.ai/v1"
 DEFAULT_GEMINI_TTS_MODEL = "gemini-2.5-flash-preview-tts"
 DEFAULT_GEMINI_TTS_VOICE = "Kore"
 DEFAULT_GEMINI_TTS_BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
+DEFAULT_VOICEBOX_BASE_URL = "http://127.0.0.1:17493"
+DEFAULT_VOICEBOX_ENGINE = "kokoro"
+DEFAULT_VOICEBOX_MAX_CHUNK_CHARS = 800
+DEFAULT_VOICEBOX_CROSSFADE_MS = 50
+DEFAULT_VOICEBOX_LANGUAGE = "en"
+DEFAULT_VOICEBOX_POLL_TIMEOUT = 120
 # PCM output specs for Gemini TTS (fixed by the API)
 GEMINI_TTS_SAMPLE_RATE = 24000
 GEMINI_TTS_CHANNELS = 1
@@ -178,6 +184,7 @@ PROVIDER_MAX_TEXT_LENGTH: Dict[str, int] = {
     "neutts": 2000,       # local model, quality falls off on long text
     "kittentts": 2000,    # local 25MB model
     "piper": 5000,        # local VITS model, phoneme-based; practical cap
+    "voicebox": 50000,    # per API schema maxLength for text field
 }
 
 # ElevenLabs caps vary by model_id. https://elevenlabs.io/docs/overview/models
@@ -324,6 +331,7 @@ BUILTIN_TTS_PROVIDERS = frozenset({
     "neutts",
     "kittentts",
     "piper",
+    "voicebox",
 })
 
 DEFAULT_COMMAND_TTS_TIMEOUT_SECONDS = 120
@@ -1225,6 +1233,138 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
 
 
 # ===========================================================================
+# Provider: Voicebox (local TTS server)
+# ===========================================================================
+
+def _check_voicebox_available(tts_config: Dict[str, Any]) -> bool:
+    """Check if the configured Voicebox server is reachable."""
+    import requests
+    vb_config = _get_provider_section(tts_config, "voicebox")
+    base_url = str(vb_config.get("base_url") or DEFAULT_VOICEBOX_BASE_URL).strip().rstrip("/")
+    try:
+        resp = requests.get(f"{base_url}/profiles", timeout=5)
+        return resp.status_code == 200
+    except Exception:
+        return False
+
+
+def _generate_voicebox(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+    """Generate audio using a local Voicebox TTS server.
+
+    Voicebox uses an async polling API:
+      1. POST /generate to submit the job
+      2. GET /history/{id} to poll until completed/failed
+      3. GET /audio/{id} to download the WAV output
+
+    The caller handles conversion to MP3 / Opus afterward.
+    """
+    import requests
+
+    vb_config = _get_provider_section(tts_config, "voicebox")
+    base_url = str(vb_config.get("base_url") or DEFAULT_VOICEBOX_BASE_URL).strip().rstrip("/")
+    profile_id = str(vb_config.get("profile_id", "")).strip()
+    if not profile_id:
+        raise ValueError(
+            "Voicebox profile_id is not configured. "
+            "Run 'hermes setup tts' or set tts.voicebox.profile_id in config.yaml."
+        )
+
+    engine = str(vb_config.get("engine") or DEFAULT_VOICEBOX_ENGINE).strip() or DEFAULT_VOICEBOX_ENGINE
+    max_chunk_chars = int(vb_config.get("max_chunk_chars", DEFAULT_VOICEBOX_MAX_CHUNK_CHARS))
+    crossfade_ms = int(vb_config.get("crossfade_ms", DEFAULT_VOICEBOX_CROSSFADE_MS))
+    normalize = bool(vb_config.get("normalize", True))
+    language = str(vb_config.get("language") or DEFAULT_VOICEBOX_LANGUAGE).strip() or DEFAULT_VOICEBOX_LANGUAGE
+
+    # Submit generation job
+    payload: Dict[str, Any] = {
+        "profile_id": profile_id,
+        "text": text,
+        "language": language,
+        "engine": engine,
+        "max_chunk_chars": max_chunk_chars,
+        "crossfade_ms": crossfade_ms,
+        "normalize": normalize,
+    }
+    # Omit null optional fields to keep the payload clean
+    for optional_key in ("model_size", "seed", "instruct", "personality", "effects_chain"):
+        value = vb_config.get(optional_key)
+        if value is not None:
+            payload[optional_key] = value
+
+    resp = requests.post(
+        f"{base_url}/generate",
+        headers={"Content-Type": "application/json"},
+        json=payload,
+        timeout=30,
+    )
+    resp.raise_for_status()
+    job = resp.json()
+    generation_id = job.get("id")
+    if not generation_id:
+        raise RuntimeError(f"Voicebox /generate did not return an id: {job}")
+
+    # Poll for completion
+    poll_timeout = int(vb_config.get("poll_timeout", DEFAULT_VOICEBOX_POLL_TIMEOUT))
+    poll_interval = 1.0
+    elapsed = 0.0
+    while elapsed < poll_timeout:
+        status_resp = requests.get(f"{base_url}/history/{generation_id}", timeout=10)
+        status_resp.raise_for_status()
+        status_data = status_resp.json()
+        status = status_data.get("status", "").lower()
+        if status == "completed":
+            break
+        if status in ("failed", "error"):
+            error_msg = status_data.get("error") or "unknown error"
+            raise RuntimeError(f"Voicebox generation failed: {error_msg}")
+        import time
+        time.sleep(poll_interval)
+        elapsed += poll_interval
+    else:
+        raise RuntimeError(f"Voicebox generation timed out after {poll_timeout}s")
+
+    # Download audio (WAV)
+    audio_resp = requests.get(f"{base_url}/audio/{generation_id}", timeout=30)
+    audio_resp.raise_for_status()
+
+    # Write WAV to a temp path, then convert if needed
+    wav_path = output_path
+    if not output_path.lower().endswith(".wav"):
+        wav_path = output_path.rsplit(".", 1)[0] + ".wav"
+
+    with open(wav_path, "wb") as f:
+        f.write(audio_resp.content)
+
+    # Convert to target format (same pattern as NeuTTS/Gemini)
+    if wav_path != output_path:
+        ffmpeg = shutil.which("ffmpeg")
+        if ffmpeg:
+            if output_path.lower().endswith(".ogg"):
+                cmd = [
+                    ffmpeg, "-i", wav_path,
+                    "-acodec", "libopus", "-ac", "1",
+                    "-b:a", "64k", "-vbr", "off",
+                    "-y", "-loglevel", "error",
+                    output_path,
+                ]
+            else:
+                cmd = [ffmpeg, "-i", wav_path, "-y", "-loglevel", "error", output_path]
+            result = subprocess.run(cmd, capture_output=True, timeout=30)
+            if result.returncode != 0:
+                stderr = result.stderr.decode("utf-8", errors="ignore")[:300]
+                raise RuntimeError(f"ffmpeg conversion failed: {stderr}")
+            os.remove(wav_path)
+        else:
+            logger.warning(
+                "ffmpeg not found; writing raw WAV to %s (extension may be misleading)",
+                output_path,
+            )
+            os.rename(wav_path, output_path)
+
+    return output_path
+
+
+# ===========================================================================
 # NeuTTS (local, on-device TTS via neutts_cli)
 # ===========================================================================
 
@@ -1707,6 +1847,10 @@ def text_to_speech_tool(
             logger.info("Generating speech with Piper (local)...")
             _generate_piper_tts(text, file_str, tts_config)
 
+        elif provider == "voicebox":
+            logger.info("Generating speech with Voicebox (local TTS server)...")
+            _generate_voicebox(text, file_str, tts_config)
+
         else:
             # Default: Edge TTS (free), with NeuTTS as local fallback
             edge_available = True
@@ -1800,7 +1944,7 @@ def text_to_speech_tool(
 # ===========================================================================
 # Requirements check
 # ===========================================================================
-def check_tts_requirements() -> bool:
+def check_tts_requirements(tts_config: Optional[Dict[str, Any]] = None) -> bool:
     """
     Check if at least one TTS provider is available.
 
@@ -1848,6 +1992,8 @@ def check_tts_requirements() -> bool:
     if _check_kittentts_available():
         return True
     if _check_piper_available():
+        return True
+    if _check_voicebox_available(tts_config or {}):
         return True
     return False
 


### PR DESCRIPTION
## Summary

Adds [Voicebox](https://github.com/xxBeanSproutxx/hermes-agent) as a native TTS provider for Hermes.

**Voicebox** is a local-first AI voice studio that runs on the user's own hardware. This integration lets Hermes speak through cloned or preset voices without any cloud API keys.

### What's included
- New built-in provider  with full async polling support (, , )
- Configurable via  (base_url, profile_id, engine, language, chunking, etc.)
- Interactive setup wizard that auto-discovers profiles from the Voicebox server
- Follows existing Hermes patterns: ffmpeg conversion, Opus for Telegram voice bubbles, graceful fallbacks
- Requirements check via lightweight  probe

### Files changed
-  — default config block
-  — generation logic, max text length, provider dispatch, availability check
-  — provider label, choice list, interactive config flow

### Tested against
- Voicebox instance at 
- Profile: `fart` (Kokoro engine, `af_heart` preset)
- Typical generation time: < 2s on RTX GPU

### No breaking changes
Edge TTS remains the default. Voicebox only activates when explicitly selected.