### PR TITLE
feat: audit background memory and skill reviewers

### DIFF
--- a/agent/reviewer_audit.py
+++ b/agent/reviewer_audit.py
@@ -1,0 +1,128 @@
+"""Audit logging for background memory/skill reviewers.
+
+This module is deliberately best-effort: audit logging must never break the
+user-facing agent turn or the background reviewer itself.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from agent.redact import redact_sensitive_text
+from hermes_constants import get_hermes_home
+
+_AUDIT_LOG_RELATIVE_PATH = Path("logs") / "reviewer_audit.jsonl"
+_CONTENT_FIELD_NAMES = {
+    "content",
+    "conversation",
+    "conversation_history",
+    "messages",
+    "plaintext",
+    "prompt",
+    "response",
+    "text",
+    "user_message",
+}
+_PREVIEW_CHARS = 80
+_AUDIT_WRITE_LOCK = threading.Lock()
+_SECRET_PREVIEW_MARKERS = (
+    "api_key",
+    "apikey",
+    "auth",
+    "bearer ",
+    "cookie",
+    "password",
+    "private-key",
+    "private_key",
+    "secret",
+    "token",
+)
+
+
+def _utc_timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace(
+        "+00:00", "Z"
+    )
+
+
+def _is_content_field(name: str) -> bool:
+    lowered = name.lower()
+    return (
+        lowered in _CONTENT_FIELD_NAMES
+        or lowered.endswith("_content")
+        or lowered.endswith("_plaintext")
+    )
+
+
+def _stringify_content(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value, ensure_ascii=False, sort_keys=True, default=str)
+    except Exception:
+        return str(value)
+
+
+def _safe_scalar(value: Any) -> Any:
+    """Return JSON-safe values with secrets redacted from every string field."""
+    if isinstance(value, str):
+        return redact_sensitive_text(value)
+    if isinstance(value, (int, float, bool)) or value is None:
+        return value
+    return redact_sensitive_text(_stringify_content(value))
+
+
+def _redact_content_field(record: dict[str, Any], key: str, value: Any) -> None:
+    content = _stringify_content(value)
+    redacted_content = redact_sensitive_text(content)
+    compact = " ".join(redacted_content.split())
+    lowered = compact.lower()
+    if any(marker in lowered for marker in _SECRET_PREVIEW_MARKERS):
+        preview = "[redacted-sensitive-content]"
+    else:
+        preview = compact[:_PREVIEW_CHARS]
+        if len(compact) > _PREVIEW_CHARS:
+            preview = preview.rstrip() + "…"
+    record[f"{key}_sha256"] = hashlib.sha256(content.encode("utf-8")).hexdigest()
+    record[f"{key}_preview"] = preview
+
+
+def append_reviewer_audit_event(event: str, kind: str, **fields: Any) -> None:
+    """Append a profile-aware JSONL audit event for background reviewers.
+
+    Writes to ``get_hermes_home()/logs/reviewer_audit.jsonl``. Full-content
+    fields are replaced with a SHA-256 hash and short preview. All exceptions
+    are swallowed so audit failure cannot affect the caller.
+    """
+
+    try:
+        record: dict[str, Any] = {
+            "ts": _utc_timestamp(),
+            "event": event,
+            "kind": kind,
+        }
+        for key, value in fields.items():
+            if value is None:
+                continue
+            if _is_content_field(key):
+                _redact_content_field(record, key, value)
+            else:
+                record[key] = _safe_scalar(value)
+
+        audit_path = get_hermes_home() / _AUDIT_LOG_RELATIVE_PATH
+        audit_path.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(record, ensure_ascii=False, sort_keys=True, default=str) + "\n"
+        with _AUDIT_WRITE_LOCK:
+            fd = os.open(audit_path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+            try:
+                os.write(fd, line.encode("utf-8"))
+            finally:
+                os.close(fd)
+    except Exception:
+        return

--- a/docs/developer-guide/self-evolving-reviewers.md
+++ b/docs/developer-guide/self-evolving-reviewers.md
@@ -1,0 +1,62 @@
+# Self-Evolving Reviewers
+
+This document inventories the current Hermes self-learning stack and the shipped Phase 1-4 integration points.
+
+## Phase 1: Current stack inventory
+
+### Hot memory
+
+- Storage: `get_hermes_home()/memories/MEMORY.md` and `get_hermes_home()/memories/USER.md`.
+- Implementation: `tools/memory_tool.py`.
+- Runtime class: `MemoryStore`.
+- Validation boundary: `MemoryStore.add`, `MemoryStore.replace`, `MemoryStore.remove`, and `_scan_memory_content`.
+- Prompt injection: `run_agent.py` builds the memory context block when memory/user profile are enabled.
+
+### Procedural memory
+
+- Storage: `get_hermes_home()/skills/**/SKILL.md`, bundled `skills/**/SKILL.md`, optional `optional-skills/**/SKILL.md`, and configured `skills.external_dirs`.
+- Listing/loading: `tools/skills_tool.py` and `agent/skill_utils.py`.
+- Mutation: `tools/skill_manager_tool.py::skill_manage`.
+- Validation boundary: name/category/frontmatter/content-size/path checks plus optional security guard.
+
+### Raw/auditable history
+
+- Storage: `get_hermes_home()/state.db`.
+- Implementation: `hermes_state.py::SessionDB`.
+- Search surface: `tools/session_search_tool.py` and `session_search` tool.
+
+### Background reviewers
+
+- Trigger/orchestration: `run_agent.py`.
+- Memory cadence: `memory.nudge_interval`, default `10` user turns.
+- Skill cadence: `skills.creation_nudge_interval`, default `10` tool-loop iterations.
+- Reviewer runner: `AIAgent._spawn_background_review`.
+- Reviewer prompts: `_MEMORY_REVIEW_PROMPT`, `_SKILL_REVIEW_PROMPT`, `_COMBINED_REVIEW_PROMPT`.
+- Mutation path: reviewers must use the same `memory` and `skill_manage` tools as foreground agents.
+
+## Phase 2: Reviewer audit log
+
+Background reviewer lifecycle events are written to:
+
+```text
+get_hermes_home()/logs/reviewer_audit.jsonl
+```
+
+Implemented in `agent/reviewer_audit.py`.
+
+Events:
+
+- `review.started`
+- `review.tool_result`
+- `review.completed`
+- `review.failed`
+
+The audit writer is best-effort and must never break the main user turn. Content-like fields are hashed and previewed; all string fields pass through Hermes secret redaction before persistence.
+
+## Phase 3: Memory reviewer
+
+The existing background memory reviewer is retained and audited. It runs through normal `AIAgent.run_conversation`, with recursive reviewer nudges disabled, and uses the shared `MemoryStore` plus normal `memory` tool validation.
+
+## Phase 4: Skill reviewer
+
+The existing background skill reviewer is retained and audited. It uses the normal agent tool path and is instructed to inspect existing skills before patching or creating procedural memory. Skill writes continue through `skill_manage` validation and optional guard scanning.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -740,6 +740,7 @@ DEFAULT_CONFIG = {
         "user_profile_enabled": True,
         "memory_char_limit": 2200,   # ~800 tokens at 2.75 chars/token
         "user_char_limit": 1375,     # ~500 tokens at 2.75 chars/token
+        "nudge_interval": 10,        # user turns between background memory reviews
         # External memory provider plugin (empty = built-in only).
         # Set to a provider name to activate: "openviking", "mem0",
         # "hindsight", "holographic", "retaindb", "byterover".
@@ -797,6 +798,7 @@ DEFAULT_CONFIG = {
     # always goes to ~/.hermes/skills/.
     "skills": {
         "external_dirs": [],   # e.g. ["~/.agents/skills", "/shared/team-skills"]
+        "creation_nudge_interval": 10,  # tool iterations between background skill reviews
         # Substitute ${HERMES_SKILL_DIR} and ${HERMES_SESSION_ID} in SKILL.md
         # content with the absolute skill directory and the active session id
         # before the agent sees it.  Lets skill authors reference bundled

--- a/run_agent.py
+++ b/run_agent.py
@@ -117,6 +117,7 @@ from agent.trajectory import (
     convert_scratchpad_to_think, has_incomplete_scratchpad,
     save_trajectory as _save_trajectory_to_file,
 )
+from agent.reviewer_audit import append_reviewer_audit_event
 from utils import atomic_json_write, base_url_host_matches, base_url_hostname, env_var_enabled, normalize_proxy_url
 
 
@@ -1124,8 +1125,8 @@ class AIAgent:
         self.provider_data_collection = provider_data_collection
 
         # Store toolset filtering options
-        self.enabled_toolsets = enabled_toolsets
-        self.disabled_toolsets = disabled_toolsets
+        self.enabled_toolsets = list(enabled_toolsets) if enabled_toolsets is not None else None
+        self.disabled_toolsets = list(disabled_toolsets) if disabled_toolsets is not None else None
         
         # Model response configuration
         self.max_tokens = max_tokens  # None = use model default
@@ -3233,15 +3234,38 @@ class AIAgent:
         # Pick the right prompt based on which triggers fired
         if review_memory and review_skills:
             prompt = self._COMBINED_REVIEW_PROMPT
+            review_kind = "combined"
         elif review_memory:
             prompt = self._MEMORY_REVIEW_PROMPT
+            review_kind = "memory"
         else:
             prompt = self._SKILL_REVIEW_PROMPT
+            review_kind = "skill"
+
+        audit_base = {
+            "session_id": getattr(self, "session_id", None),
+            "parent_session_id": getattr(self, "_parent_session_id", None),
+            "platform": getattr(self, "platform", None),
+            "review_memory": review_memory,
+            "review_skills": review_skills,
+        }
+
+        def _audit(event: str, **fields: Any) -> None:
+            try:
+                append_reviewer_audit_event(
+                    event,
+                    review_kind,
+                    **audit_base,
+                    **fields,
+                )
+            except Exception:
+                pass
 
         def _run_review():
             import contextlib
             review_agent = None
             try:
+                _audit("review.started")
                 with open(os.devnull, "w") as _devnull, \
                      contextlib.redirect_stdout(_devnull), \
                      contextlib.redirect_stderr(_devnull):
@@ -3260,6 +3284,8 @@ class AIAgent:
                         quiet_mode=True,
                         platform=self.platform,
                         provider=self.provider,
+                        enabled_toolsets=getattr(self, "enabled_toolsets", None),
+                        disabled_toolsets=getattr(self, "disabled_toolsets", None),
                         api_mode=_parent_runtime.get("api_mode") or None,
                         base_url=_parent_runtime.get("base_url") or None,
                         api_key=_parent_runtime.get("api_key") or None,
@@ -3290,8 +3316,12 @@ class AIAgent:
                     messages_snapshot,
                 )
 
-                if actions:
-                    summary = " · ".join(dict.fromkeys(actions))
+                unique_actions = list(dict.fromkeys(actions))
+                for action in unique_actions:
+                    _audit("review.tool_result", action=action)
+
+                if unique_actions:
+                    summary = " · ".join(unique_actions)
                     self._safe_print(f"  💾 {summary}")
                     _bg_cb = self.background_review_callback
                     if _bg_cb:
@@ -3299,8 +3329,23 @@ class AIAgent:
                             _bg_cb(f"💾 {summary}")
                         except Exception:
                             pass
+                else:
+                    summary = ""
+
+                _audit(
+                    "review.completed",
+                    status="accepted" if unique_actions else "no_op",
+                    summary=summary,
+                    action_count=len(unique_actions),
+                )
 
             except Exception as e:
+                _audit(
+                    "review.failed",
+                    status="failed",
+                    error_type=e.__class__.__name__,
+                    error=str(e),
+                )
                 logger.warning("Background memory/skill review failed: %s", e)
                 self._emit_auxiliary_failure("background review", e)
             finally:

--- a/tests/agent/test_reviewer_audit.py
+++ b/tests/agent/test_reviewer_audit.py
@@ -1,0 +1,113 @@
+"""Tests for reviewer audit JSONL logging."""
+
+from __future__ import annotations
+
+import json
+import hashlib
+import threading
+
+from agent import reviewer_audit
+from agent.reviewer_audit import append_reviewer_audit_event
+
+
+def test_append_reviewer_audit_event_writes_jsonl_and_creates_logs_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    append_reviewer_audit_event(
+        "review.started",
+        "memory",
+        session_id="session-1",
+        parent_session_id="parent-1",
+        platform="slack",
+    )
+
+    audit_path = tmp_path / "logs" / "reviewer_audit.jsonl"
+    assert audit_path.exists()
+    lines = audit_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+
+    event = json.loads(lines[0])
+    assert event["event"] == "review.started"
+    assert event["kind"] == "memory"
+    assert event["session_id"] == "session-1"
+    assert event["parent_session_id"] == "parent-1"
+    assert event["platform"] == "slack"
+    assert event["ts"].endswith("Z")
+
+
+def test_append_reviewer_audit_event_redacts_full_content_fields(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    content = "PRIVATE-SECRET sk-test1234567890abcdef " * 50
+
+    append_reviewer_audit_event("review.tool_result", "memory", content=content)
+
+    raw_line = (tmp_path / "logs" / "reviewer_audit.jsonl").read_text(encoding="utf-8")
+    assert "sk-test1234567890abcdef" not in raw_line
+
+    event = json.loads(raw_line)
+    assert "content" not in event
+    assert event["content_sha256"] == hashlib.sha256(content.encode("utf-8")).hexdigest()
+    assert event["content_preview"] == "[redacted-sensitive-content]"
+
+
+def test_append_reviewer_audit_event_keeps_short_non_sensitive_preview(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    content = "A durable workflow detail " * 10
+
+    append_reviewer_audit_event("review.tool_result", "memory", content=content)
+
+    event = json.loads((tmp_path / "logs" / "reviewer_audit.jsonl").read_text(encoding="utf-8"))
+    assert event["content_sha256"] == hashlib.sha256(content.encode("utf-8")).hexdigest()
+    assert event["content_preview"].startswith("A durable workflow detail")
+    assert len(event["content_preview"]) < len(content)
+
+
+def test_append_reviewer_audit_event_redacts_non_content_string_fields(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    secret = "sk-test1234567890abcdef"
+
+    append_reviewer_audit_event(
+        "review.failed",
+        "skill",
+        action=f"Skill updated with token {secret}",
+        summary=f"Summary mentions {secret}",
+        error=f"Provider rejected Authorization: Bearer {secret}",
+    )
+
+    raw_line = (tmp_path / "logs" / "reviewer_audit.jsonl").read_text(encoding="utf-8")
+    assert secret not in raw_line
+    event = json.loads(raw_line)
+    assert "***" in event["action"] or "..." in event["action"]
+    assert "***" in event["summary"] or "..." in event["summary"]
+    assert "***" in event["error"] or "..." in event["error"]
+
+
+def test_append_reviewer_audit_event_serializes_concurrent_writes(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    threads = [
+        threading.Thread(
+            target=append_reviewer_audit_event,
+            args=("review.completed", "memory"),
+            kwargs={"session_id": f"session-{idx}", "status": "no_op"},
+        )
+        for idx in range(20)
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    lines = (tmp_path / "logs" / "reviewer_audit.jsonl").read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 20
+    events = [json.loads(line) for line in lines]
+    assert {event["session_id"] for event in events} == {f"session-{idx}" for idx in range(20)}
+
+
+def test_append_reviewer_audit_event_swallows_write_errors(monkeypatch):
+    def boom(*_args, **_kwargs):
+        raise PermissionError("nope")
+
+    monkeypatch.setattr(reviewer_audit.Path, "mkdir", boom)
+
+    append_reviewer_audit_event("review.started", "skill", session_id="session-1")

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 import run_agent as run_agent_module
 from run_agent import AIAgent
 
@@ -17,6 +19,8 @@ def _bare_agent() -> AIAgent:
     agent.session_id = "test-session"
     agent._parent_session_id = ""
     agent._credential_pool = None
+    agent.enabled_toolsets = ["memory", "skills"]
+    agent.disabled_toolsets = ["browser"]
     agent._memory_store = object()
     agent._memory_enabled = True
     agent._user_profile_enabled = False
@@ -71,3 +75,101 @@ def test_background_review_shuts_down_memory_provider_before_close(monkeypatch):
         "shutdown_memory_provider",
         "close",
     ]
+    init_kwargs = events[0][1]
+    assert init_kwargs["enabled_toolsets"] == ["memory", "skills"]
+    assert init_kwargs["disabled_toolsets"] == ["browser"]
+
+
+def test_background_review_emits_audit_started_tool_result_and_completed(monkeypatch):
+    audit_events = []
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            self._session_messages = [
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_new",
+                    "content": json.dumps(
+                        {"success": True, "message": "Memory entry created."}
+                    ),
+                }
+            ]
+
+        def run_conversation(self, **kwargs):
+            pass
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+    monkeypatch.setattr(
+        run_agent_module,
+        "append_reviewer_audit_event",
+        lambda event, kind, **fields: audit_events.append((event, kind, fields)),
+    )
+
+    agent = _bare_agent()
+
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=[{"role": "user", "content": "remember this"}],
+        review_memory=True,
+    )
+
+    assert [event for event, _kind, _fields in audit_events] == [
+        "review.started",
+        "review.tool_result",
+        "review.completed",
+    ]
+    assert [kind for _event, kind, _fields in audit_events] == ["memory"] * 3
+    assert audit_events[0][2]["session_id"] == "test-session"
+    assert audit_events[0][2]["platform"] == "telegram"
+    assert audit_events[1][2]["action"] == "Memory entry created."
+    assert audit_events[2][2]["status"] == "accepted"
+    assert audit_events[2][2]["summary"] == "Memory entry created."
+
+
+def test_background_review_emits_audit_failed(monkeypatch):
+    audit_events = []
+
+    class FakeReviewAgent:
+        def __init__(self, **kwargs):
+            self._session_messages = []
+
+        def run_conversation(self, **kwargs):
+            raise RuntimeError("review exploded")
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(run_agent_module, "AIAgent", FakeReviewAgent)
+    monkeypatch.setattr(run_agent_module.threading, "Thread", ImmediateThread)
+    monkeypatch.setattr(
+        run_agent_module,
+        "append_reviewer_audit_event",
+        lambda event, kind, **fields: audit_events.append((event, kind, fields)),
+    )
+
+    agent = _bare_agent()
+
+    AIAgent._spawn_background_review(
+        agent,
+        messages_snapshot=[{"role": "user", "content": "hello"}],
+        review_skills=True,
+    )
+
+    assert [event for event, _kind, _fields in audit_events] == [
+        "review.started",
+        "review.failed",
+    ]
+    assert [kind for _event, kind, _fields in audit_events] == ["skill", "skill"]
+    assert audit_events[1][2]["status"] == "failed"
+    assert audit_events[1][2]["error_type"] == "RuntimeError"
+    assert "review exploded" in audit_events[1][2]["error"]


### PR DESCRIPTION
## Summary
- Add a best-effort JSONL audit log for background memory/skill reviewer lifecycle events.
- Wire `review.started`, `review.tool_result`, `review.completed`, and `review.failed` events into the existing background reviewer.
- Preserve normal memory/skill validation by keeping reviewer mutations on the existing `memory` and `skill_manage` tool paths.
- Inherit parent enabled/disabled toolsets in reviewer child agents so reviewer policy matches the parent session.
- Add explicit config defaults for memory and skill reviewer nudge intervals.
- Document the current self-learning stack inventory and shipped reviewer integration points.

## Test plan
- [x] `scripts/run_tests.sh tests/agent/test_reviewer_audit.py tests/run_agent/test_background_review.py tests/run_agent/test_background_review_summary.py tests/hermes_cli/test_config.py tests/run_agent/test_run_agent.py` — 370 passed
- [x] `scripts/run_tests.sh tests/tools/test_memory_tool.py tests/tools/test_memory_tool_import_fallback.py tests/tools/test_skill_manager_tool.py tests/tools/test_skill_improvements.py tests/tools/test_skills_tool.py tests/tools/test_skills_guard.py tests/run_agent/test_review_prompt_class_first.py` — 246 passed
- [x] `python -m py_compile agent/reviewer_audit.py run_agent.py tests/agent/test_reviewer_audit.py tests/run_agent/test_background_review.py`
- [x] `git diff --check`

## Notes
Original direct push to `NousResearch/hermes-agent` failed because this account has read-only permission, so this PR is opened from the `daveove/hermes-agent` fork.
