### PR TITLE
fix(gateway): forward webhook approvals to delivery target

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2438,33 +2438,51 @@ class BasePlatformAdapter(ABC):
                         and text_content
                         and not media_files):
                     try:
-                        from tools.tts_tool import text_to_speech_tool, check_tts_requirements
+                        from tools.tts_tool import check_tts_requirements, split_text_for_tts, text_to_speech_tool
                         if check_tts_requirements():
                             import json as _json
-                            speech_text = re.sub(r'[*_`#\[\]()]', '', text_content)[:4000].strip()
-                            if not speech_text:
-                                raise ValueError("Empty text after markdown cleanup")
-                            tts_result_str = await asyncio.to_thread(
-                                text_to_speech_tool, text=speech_text
+                            from hermes_cli.config import load_config as _load_full_config
+                            tts_cfg = (_load_full_config().get("tts") or {})
+                            max_chunk_chars = int(os.getenv("HERMES_AUTO_TTS_CHUNK_CHARS", tts_cfg.get("auto_chunk_chars", 1200)))
+                            max_chunks = int(os.getenv("HERMES_AUTO_TTS_MAX_CHUNKS", tts_cfg.get("auto_max_chunks", 3)))
+                            speech_chunks = split_text_for_tts(
+                                text_content[:4000],
+                                max_chars=max_chunk_chars,
+                                max_chunks=max_chunks,
                             )
-                            tts_data = _json.loads(tts_result_str)
-                            _tts_path = tts_data.get("file_path")
+                            if not speech_chunks:
+                                raise ValueError("Empty text after markdown cleanup")
+                            _tts_path = []
+                            for speech_text in speech_chunks:
+                                if not speech_text:
+                                    continue
+                                tts_result_str = await asyncio.to_thread(
+                                    text_to_speech_tool, text=speech_text
+                                )
+                                tts_data = _json.loads(tts_result_str)
+                                path = tts_data.get("file_path")
+                                if path:
+                                    _tts_path.append(path)
                     except Exception as tts_err:
                         logger.warning("[%s] Auto-TTS failed: %s", self.name, tts_err)
 
                 # Play TTS audio before text (voice-first experience)
-                if _tts_path and Path(_tts_path).exists():
-                    try:
-                        await self.play_tts(
-                            chat_id=event.source.chat_id,
-                            audio_path=_tts_path,
-                            metadata=_thread_metadata,
-                        )
-                    finally:
+                if _tts_path:
+                    paths = _tts_path if isinstance(_tts_path, list) else [_tts_path]
+                    for tts_path in paths:
+                        if not (tts_path and Path(tts_path).exists()):
+                            continue
                         try:
-                            os.remove(_tts_path)
-                        except OSError:
-                            pass
+                            await self.play_tts(
+                                chat_id=event.source.chat_id,
+                                audio_path=tts_path,
+                                metadata=_thread_metadata,
+                            )
+                        finally:
+                            try:
+                                os.remove(tts_path)
+                            except OSError:
+                                pass
 
                 # Send the text portion
                 if text_content:

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -273,6 +273,80 @@ class WebhookAdapter(BasePlatformAdapter):
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         return {"name": chat_id, "type": "webhook"}
 
+    def _delivery_for_chat_id(self, chat_id: str, *, purpose: str = "delivery") -> Dict[str, Any]:
+        """Return stored or route-recovered delivery config for a webhook chat."""
+        delivery = self._delivery_info.get(chat_id, {})
+        if not delivery and chat_id.startswith("webhook:"):
+            try:
+                route_name = chat_id.split(":", 2)[1]
+                route_config = self._routes.get(route_name) or {}
+                if route_config:
+                    delivery = {
+                        "deliver": route_config.get("deliver", "log"),
+                        "deliver_extra": route_config.get("deliver_extra", {}),
+                        "payload": {},
+                    }
+                    logger.info(
+                        "[webhook] Recovered %s config for %s from route %s",
+                        purpose,
+                        chat_id,
+                        route_name,
+                    )
+            except Exception:
+                logger.debug("[webhook] Could not recover %s config for %s", purpose, chat_id, exc_info=True)
+        return delivery
+
+    async def send_typing(self, chat_id: str, metadata: Optional[Dict[str, Any]] = None) -> None:
+        """Forward typing indicators to the configured delivery target.
+
+        Webhook-originated agent runs execute under the synthetic webhook
+        adapter, so BasePlatformAdapter's keep-typing loop naturally calls
+        ``WebhookAdapter.send_typing``.  For routes that ultimately deliver to
+        Telegram/Discord/etc., forward that indicator to the real target chat
+        so voice-sphere and other webhook bridges show the same "typing..." UI
+        as native platform messages.
+        """
+        delivery = self._delivery_for_chat_id(chat_id, purpose="typing delivery")
+        deliver_type = delivery.get("deliver", "log")
+        if deliver_type in ("log", "github_comment"):
+            return
+        if not self.gateway_runner:
+            return
+
+        try:
+            target_platform = Platform(deliver_type)
+        except ValueError:
+            return
+
+        adapter = self.gateway_runner.adapters.get(target_platform)
+        if not adapter or not hasattr(adapter, "send_typing"):
+            return
+
+        extra = delivery.get("deliver_extra", {}) or {}
+        target_chat_id = extra.get("chat_id", "")
+        if not target_chat_id:
+            home = self.gateway_runner.config.get_home_channel(target_platform)
+            if not home:
+                return
+            target_chat_id = home.chat_id
+
+        target_metadata: Dict[str, Any] = {}
+        thread_id = extra.get("message_thread_id") or extra.get("thread_id")
+        if thread_id:
+            target_metadata["thread_id"] = thread_id
+        if metadata:
+            target_metadata.update(metadata)
+
+        try:
+            await adapter.send_typing(str(target_chat_id), metadata=target_metadata or None)
+        except Exception:
+            logger.debug(
+                "[webhook] Failed to forward typing indicator to %s:%s",
+                deliver_type,
+                target_chat_id,
+                exc_info=True,
+            )
+
     async def send_exec_approval(
         self,
         chat_id: str,

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -273,6 +273,84 @@ class WebhookAdapter(BasePlatformAdapter):
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         return {"name": chat_id, "type": "webhook"}
 
+    async def send_exec_approval(
+        self,
+        chat_id: str,
+        command: str,
+        session_key: str,
+        description: str = "dangerous command",
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Forward interactive command-approval prompts to the delivery target.
+
+        Agent-mode webhooks run under a ``webhook:{route}:{delivery}`` session
+        key, but many routes deliver their responses to a rich chat platform
+        like Telegram or Discord.  Without this bridge, gateway approvals fall
+        back to plain text via ``send()``, so the user sees instructions like
+        ``/approve`` in Telegram while the pending approval actually belongs to
+        the webhook session key.  Telegram then quite correctly says "No pending
+        command" — a tiny distributed-systems comedy with one actor missing.
+
+        If the route's delivery adapter supports button-based approvals, pass
+        through the original webhook ``session_key`` so its callback resolves
+        the blocked webhook agent thread directly.
+        """
+        delivery = self._delivery_info.get(chat_id, {})
+        if not delivery and chat_id.startswith("webhook:"):
+            try:
+                route_name = chat_id.split(":", 2)[1]
+                route_config = self._routes.get(route_name) or {}
+                if route_config:
+                    delivery = {
+                        "deliver": route_config.get("deliver", "log"),
+                        "deliver_extra": route_config.get("deliver_extra", {}),
+                        "payload": {},
+                    }
+            except Exception:
+                logger.debug("[webhook] Could not recover approval delivery config for %s", chat_id, exc_info=True)
+
+        deliver_type = delivery.get("deliver", "log")
+        if deliver_type in ("log", "github_comment"):
+            return SendResult(success=False, error=f"Approval buttons unsupported for deliver={deliver_type}")
+
+        if not self.gateway_runner:
+            return SendResult(success=False, error="No gateway runner for cross-platform approval delivery")
+
+        try:
+            target_platform = Platform(deliver_type)
+        except ValueError:
+            return SendResult(success=False, error=f"Unknown platform: {deliver_type}")
+
+        adapter = self.gateway_runner.adapters.get(target_platform)
+        if not adapter:
+            return SendResult(success=False, error=f"Platform {deliver_type} not connected")
+        if getattr(type(adapter), "send_exec_approval", None) is None:
+            return SendResult(success=False, error=f"Platform {deliver_type} does not support approval buttons")
+
+        extra = delivery.get("deliver_extra", {}) or {}
+        target_chat_id = extra.get("chat_id", "")
+        if not target_chat_id:
+            home = self.gateway_runner.config.get_home_channel(target_platform)
+            if home:
+                target_chat_id = home.chat_id
+            else:
+                return SendResult(success=False, error=f"No chat_id or home channel for {deliver_type}")
+
+        target_metadata: Dict[str, Any] = {}
+        thread_id = extra.get("message_thread_id") or extra.get("thread_id")
+        if thread_id:
+            target_metadata["thread_id"] = thread_id
+        if metadata:
+            target_metadata.update(metadata)
+
+        return await adapter.send_exec_approval(
+            chat_id=str(target_chat_id),
+            command=command,
+            session_key=session_key,
+            description=description,
+            metadata=target_metadata or None,
+        )
+
     # ------------------------------------------------------------------
     # HTTP handlers
     # ------------------------------------------------------------------

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -193,6 +193,28 @@ class WebhookAdapter(BasePlatformAdapter):
         to the ``log`` deliver type.  TTL cleanup happens on POST.
         """
         delivery = self._delivery_info.get(chat_id, {})
+        if not delivery and chat_id.startswith("webhook:"):
+            # Defensive fallback for long-running / restarted webhook sessions.
+            # The normal path stores delivery info during _handle_webhook(), but
+            # if that in-memory map is missing we can still recover the route
+            # configuration from chat_id = webhook:{route}:{delivery_id}.
+            try:
+                route_name = chat_id.split(":", 2)[1]
+                route_config = self._routes.get(route_name) or {}
+                if route_config:
+                    delivery = {
+                        "deliver": route_config.get("deliver", "log"),
+                        "deliver_extra": route_config.get("deliver_extra", {}),
+                        "payload": {},
+                    }
+                    logger.info(
+                        "[webhook] Recovered delivery config for %s from route %s",
+                        chat_id,
+                        route_name,
+                    )
+            except Exception:
+                logger.debug("[webhook] Could not recover delivery config for %s", chat_id, exc_info=True)
+
         deliver_type = delivery.get("deliver", "log")
 
         if deliver_type == "log":

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -285,6 +285,8 @@ class WebhookAdapter(BasePlatformAdapter):
                         "deliver": route_config.get("deliver", "log"),
                         "deliver_extra": route_config.get("deliver_extra", {}),
                         "payload": {},
+                        "voice_reply": bool(route_config.get("voice_reply", False)),
+                        "text_reply": route_config.get("text_reply", True),
                     }
                     logger.info(
                         "[webhook] Recovered %s config for %s from route %s",
@@ -296,6 +298,57 @@ class WebhookAdapter(BasePlatformAdapter):
                 logger.debug("[webhook] Could not recover %s config for %s", purpose, chat_id, exc_info=True)
         return delivery
 
+    def _resolve_delivery_target(
+        self,
+        chat_id: str,
+        *,
+        purpose: str = "delivery",
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Optional[tuple[BasePlatformAdapter, str, Dict[str, Any], str]]:
+        """Resolve a webhook chat_id to its configured target adapter/chat.
+
+        Returns ``(adapter, target_chat_id, target_metadata, deliver_type)`` or
+        ``None`` when the target is non-interactive/log-only/unavailable.
+        """
+        delivery = self._delivery_for_chat_id(chat_id, purpose=purpose)
+        deliver_type = delivery.get("deliver", "log")
+        if deliver_type in ("log", "github_comment") or not self.gateway_runner:
+            return None
+
+        try:
+            target_platform = Platform(deliver_type)
+        except ValueError:
+            return None
+
+        adapter = self.gateway_runner.adapters.get(target_platform)
+        if not adapter:
+            return None
+
+        extra = delivery.get("deliver_extra", {}) or {}
+        target_chat_id = extra.get("chat_id", "")
+        if not target_chat_id:
+            home = self.gateway_runner.config.get_home_channel(target_platform)
+            if not home:
+                return None
+            target_chat_id = home.chat_id
+
+        target_metadata: Dict[str, Any] = {}
+        thread_id = extra.get("message_thread_id") or extra.get("thread_id")
+        if thread_id:
+            target_metadata["thread_id"] = thread_id
+        if metadata:
+            target_metadata.update(metadata)
+
+        return adapter, str(target_chat_id), target_metadata, deliver_type
+
+    def delivery_platform_key_for_chat(self, chat_id: str) -> Optional[str]:
+        """Return the visible delivery platform for display-setting resolution."""
+        delivery = self._delivery_for_chat_id(chat_id, purpose="display delivery")
+        deliver_type = delivery.get("deliver")
+        if deliver_type and deliver_type not in ("log", "github_comment"):
+            return str(deliver_type)
+        return None
+
     async def send_typing(self, chat_id: str, metadata: Optional[Dict[str, Any]] = None) -> None:
         """Forward typing indicators to the configured delivery target.
 
@@ -306,39 +359,14 @@ class WebhookAdapter(BasePlatformAdapter):
         so voice-sphere and other webhook bridges show the same "typing..." UI
         as native platform messages.
         """
-        delivery = self._delivery_for_chat_id(chat_id, purpose="typing delivery")
-        deliver_type = delivery.get("deliver", "log")
-        if deliver_type in ("log", "github_comment"):
+        resolved = self._resolve_delivery_target(chat_id, purpose="typing delivery", metadata=metadata)
+        if not resolved:
             return
-        if not self.gateway_runner:
+        adapter, target_chat_id, target_metadata, deliver_type = resolved
+        if not hasattr(adapter, "send_typing"):
             return
-
         try:
-            target_platform = Platform(deliver_type)
-        except ValueError:
-            return
-
-        adapter = self.gateway_runner.adapters.get(target_platform)
-        if not adapter or not hasattr(adapter, "send_typing"):
-            return
-
-        extra = delivery.get("deliver_extra", {}) or {}
-        target_chat_id = extra.get("chat_id", "")
-        if not target_chat_id:
-            home = self.gateway_runner.config.get_home_channel(target_platform)
-            if not home:
-                return
-            target_chat_id = home.chat_id
-
-        target_metadata: Dict[str, Any] = {}
-        thread_id = extra.get("message_thread_id") or extra.get("thread_id")
-        if thread_id:
-            target_metadata["thread_id"] = thread_id
-        if metadata:
-            target_metadata.update(metadata)
-
-        try:
-            await adapter.send_typing(str(target_chat_id), metadata=target_metadata or None)
+            await adapter.send_typing(target_chat_id, metadata=target_metadata or None)
         except Exception:
             logger.debug(
                 "[webhook] Failed to forward typing indicator to %s:%s",
@@ -346,6 +374,87 @@ class WebhookAdapter(BasePlatformAdapter):
                 target_chat_id,
                 exc_info=True,
             )
+
+    async def edit_message(
+        self,
+        chat_id: str,
+        message_id: str,
+        content: str,
+        *,
+        finalize: bool = False,
+    ) -> SendResult:
+        """Forward streaming/tool-progress edits to the delivery target."""
+        resolved = self._resolve_delivery_target(chat_id, purpose="edit delivery")
+        if not resolved:
+            return SendResult(success=False, error="No webhook delivery target for edit")
+        adapter, target_chat_id, _target_metadata, _deliver_type = resolved
+        return await adapter.edit_message(
+            chat_id=target_chat_id,
+            message_id=message_id,
+            content=content,
+            finalize=finalize,
+        )
+
+    async def delete_message(self, chat_id: str, message_id: str) -> bool:
+        """Forward deletion of streamed preview/progress messages to the target."""
+        resolved = self._resolve_delivery_target(chat_id, purpose="delete delivery")
+        if not resolved:
+            return False
+        adapter, target_chat_id, _target_metadata, _deliver_type = resolved
+        try:
+            return bool(await adapter.delete_message(target_chat_id, message_id))
+        except Exception:
+            logger.debug("[webhook] Failed to forward delete_message", exc_info=True)
+            return False
+
+    async def send_voice(self, chat_id: str, audio_path: str, caption: Optional[str] = None, reply_to: Optional[str] = None, **kwargs) -> SendResult:
+        resolved = self._resolve_delivery_target(chat_id, purpose="voice delivery", metadata=kwargs.pop("metadata", None))
+        if not resolved:
+            return await super().send_voice(chat_id, audio_path, caption=caption, reply_to=reply_to, **kwargs)
+        adapter, target_chat_id, target_metadata, _deliver_type = resolved
+        return await adapter.send_voice(target_chat_id, audio_path, caption=caption, reply_to=reply_to, metadata=target_metadata or None, **kwargs)
+
+    async def play_tts(self, chat_id: str, audio_path: str, **kwargs) -> SendResult:
+        resolved = self._resolve_delivery_target(chat_id, purpose="tts playback", metadata=kwargs.pop("metadata", None))
+        if not resolved:
+            return await super().play_tts(chat_id, audio_path, **kwargs)
+        adapter, target_chat_id, target_metadata, _deliver_type = resolved
+        return await adapter.play_tts(target_chat_id, audio_path, metadata=target_metadata or None, **kwargs)
+
+    async def send_image(self, chat_id: str, image_url: str, caption: Optional[str] = None, reply_to: Optional[str] = None, metadata: Optional[Dict[str, Any]] = None) -> SendResult:
+        resolved = self._resolve_delivery_target(chat_id, purpose="image delivery", metadata=metadata)
+        if not resolved:
+            return await super().send_image(chat_id, image_url, caption=caption, reply_to=reply_to, metadata=metadata)
+        adapter, target_chat_id, target_metadata, _deliver_type = resolved
+        return await adapter.send_image(target_chat_id, image_url, caption=caption, reply_to=reply_to, metadata=target_metadata or None)
+
+    async def send_animation(self, chat_id: str, animation_url: str, caption: Optional[str] = None, reply_to: Optional[str] = None, metadata: Optional[Dict[str, Any]] = None) -> SendResult:
+        resolved = self._resolve_delivery_target(chat_id, purpose="animation delivery", metadata=metadata)
+        if not resolved:
+            return await super().send_animation(chat_id, animation_url, caption=caption, reply_to=reply_to, metadata=metadata)
+        adapter, target_chat_id, target_metadata, _deliver_type = resolved
+        return await adapter.send_animation(target_chat_id, animation_url, caption=caption, reply_to=reply_to, metadata=target_metadata or None)
+
+    async def send_image_file(self, chat_id: str, image_path: str, caption: Optional[str] = None, reply_to: Optional[str] = None, **kwargs) -> SendResult:
+        resolved = self._resolve_delivery_target(chat_id, purpose="image-file delivery", metadata=kwargs.pop("metadata", None))
+        if not resolved:
+            return await super().send_image_file(chat_id, image_path, caption=caption, reply_to=reply_to, **kwargs)
+        adapter, target_chat_id, target_metadata, _deliver_type = resolved
+        return await adapter.send_image_file(target_chat_id, image_path, caption=caption, reply_to=reply_to, metadata=target_metadata or None, **kwargs)
+
+    async def send_video(self, chat_id: str, video_path: str, caption: Optional[str] = None, reply_to: Optional[str] = None, **kwargs) -> SendResult:
+        resolved = self._resolve_delivery_target(chat_id, purpose="video delivery", metadata=kwargs.pop("metadata", None))
+        if not resolved:
+            return await super().send_video(chat_id, video_path, caption=caption, reply_to=reply_to, **kwargs)
+        adapter, target_chat_id, target_metadata, _deliver_type = resolved
+        return await adapter.send_video(target_chat_id, video_path, caption=caption, reply_to=reply_to, metadata=target_metadata or None, **kwargs)
+
+    async def send_document(self, chat_id: str, file_path: str, caption: Optional[str] = None, file_name: Optional[str] = None, reply_to: Optional[str] = None, **kwargs) -> SendResult:
+        resolved = self._resolve_delivery_target(chat_id, purpose="document delivery", metadata=kwargs.pop("metadata", None))
+        if not resolved:
+            return await super().send_document(chat_id, file_path, caption=caption, file_name=file_name, reply_to=reply_to, **kwargs)
+        adapter, target_chat_id, target_metadata, _deliver_type = resolved
+        return await adapter.send_document(target_chat_id, file_path, caption=caption, file_name=file_name, reply_to=reply_to, metadata=target_metadata or None, **kwargs)
 
     async def send_exec_approval(
         self,

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -607,6 +607,12 @@ class WebhookAdapter(BasePlatformAdapter):
                 route_config.get("deliver_extra", {}), payload
             ),
             "payload": payload,
+            # Optional route-level voice delivery.  Useful for webhook-originated
+            # voice commands that are delivered into a chat as a cross-platform
+            # response, where the original event is MessageType.TEXT and the
+            # normal per-chat voice auto-TTS gate cannot fire.
+            "voice_reply": bool(route_config.get("voice_reply", False)),
+            "text_reply": route_config.get("text_reply", True),
         }
         self._delivery_info[session_chat_id] = deliver_config
         self._delivery_info_created[session_chat_id] = now
@@ -872,4 +878,93 @@ class WebhookAdapter(BasePlatformAdapter):
         if thread_id:
             metadata = {"thread_id": thread_id}
 
+        voice_reply = bool(delivery.get("voice_reply") or extra.get("voice_reply"))
+        text_reply = delivery.get("text_reply", extra.get("text_reply", True))
+        if voice_reply and content:
+            tts_result = await self._deliver_cross_platform_tts(
+                adapter=adapter,
+                chat_id=str(chat_id),
+                content=content,
+                metadata=metadata,
+            )
+            if not text_reply:
+                return tts_result
+
         return await adapter.send(chat_id, content, metadata=metadata)
+
+    async def _deliver_cross_platform_tts(
+        self,
+        *,
+        adapter: BasePlatformAdapter,
+        chat_id: str,
+        content: str,
+        metadata: Optional[Dict[str, Any]],
+    ) -> SendResult:
+        """Generate TTS for a webhook cross-platform delivery and send it.
+
+        Webhook events are synthetic TEXT messages, so BasePlatformAdapter's
+        normal auto-TTS path (which requires MessageType.VOICE) cannot see that
+        the original upstream input was spoken.  Routes can opt in with
+        ``voice_reply: true`` to provide the voice-first behaviour expected by
+        local voice-command bridges.
+        """
+        try:
+            from pathlib import Path
+            from tools.tts_tool import (
+                check_tts_requirements,
+                split_text_for_tts,
+                text_to_speech_tool,
+            )
+            import json as _json
+            from hermes_cli.config import load_config as _load_full_config
+
+            if not check_tts_requirements():
+                return SendResult(success=False, error="TTS provider unavailable")
+
+            clean = content.replace("[[audio_as_voice]]", "").strip()
+            clean = re.sub(r"MEDIA:\s*\S+", "", clean).strip()
+            clean = re.sub(r"```[\s\S]*?```", " ", clean)
+            clean = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", clean)
+            clean = re.sub(r"https?://\S+", "", clean)
+            clean = re.sub(r"\*\*(.+?)\*\*", r"\1", clean)
+            clean = re.sub(r"\*(.+?)\*", r"\1", clean)
+            clean = re.sub(r"`(.+?)`", r"\1", clean)
+            clean = re.sub(r"^#+\s*", "", clean, flags=re.MULTILINE)
+            clean = re.sub(r"^\s*[-*]\s+", "", clean, flags=re.MULTILINE)
+            clean = re.sub(r"---+", "", clean)
+            clean = re.sub(r"\n{3,}", "\n\n", clean).strip()
+            if not clean:
+                return SendResult(success=False, error="No speakable text")
+
+            tts_cfg = (_load_full_config().get("tts") or {})
+            max_chunk_chars = int(tts_cfg.get("auto_chunk_chars", 1200))
+            max_chunks = int(tts_cfg.get("auto_max_chunks", 3))
+            chunks = split_text_for_tts(clean[:4000], max_chars=max_chunk_chars, max_chunks=max_chunks)
+            if not chunks:
+                return SendResult(success=False, error="No TTS chunks")
+
+            last_result = SendResult(success=True)
+            for speech_text in chunks:
+                if not speech_text:
+                    continue
+                tts_result_str = await asyncio.to_thread(text_to_speech_tool, text=speech_text)
+                tts_data = _json.loads(tts_result_str)
+                audio_path = tts_data.get("file_path")
+                if not audio_path:
+                    continue
+                try:
+                    if Path(audio_path).exists():
+                        last_result = await adapter.play_tts(
+                            chat_id=chat_id,
+                            audio_path=audio_path,
+                            metadata=metadata,
+                        )
+                finally:
+                    try:
+                        Path(audio_path).unlink()
+                    except OSError:
+                        pass
+            return last_result
+        except Exception as exc:
+            logger.warning("[webhook] Cross-platform TTS delivery failed: %s", exc)
+            return SendResult(success=False, error=str(exc))

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9993,8 +9993,18 @@ class GatewayRunner:
                 return True
             return self._is_session_run_current(session_key, run_generation)
         
+        from gateway.config import Platform
         user_config = _load_gateway_config()
         platform_key = _platform_config_key(source.platform)
+        visible_platform_key = platform_key
+        if source.platform == Platform.WEBHOOK:
+            try:
+                _source_adapter = self.adapters.get(source.platform)
+                _delivery_key_fn = getattr(_source_adapter, "delivery_platform_key_for_chat", None)
+                if callable(_delivery_key_fn):
+                    visible_platform_key = _delivery_key_fn(source.chat_id) or platform_key
+            except Exception:
+                visible_platform_key = platform_key
 
         from hermes_cli.tools_config import _get_platform_tools
         enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
@@ -10011,31 +10021,33 @@ class GatewayRunner:
         # Apply tool preview length config (0 = no limit)
         try:
             from agent.display import set_tool_preview_max_len
-            _tpl = resolve_display_setting(user_config, platform_key, "tool_preview_length", 0)
+            _tpl = resolve_display_setting(user_config, visible_platform_key, "tool_preview_length", 0)
             set_tool_preview_max_len(int(_tpl) if _tpl else 0)
         except Exception:
             pass
 
         # Tool progress mode — resolved per-platform with env var fallback
-        _resolved_tp = resolve_display_setting(user_config, platform_key, "tool_progress")
+        _resolved_tp = resolve_display_setting(user_config, visible_platform_key, "tool_progress")
         progress_mode = (
-            _resolved_tp
-            or os.getenv("HERMES_TOOL_PROGRESS_MODE")
+            os.getenv("HERMES_TOOL_PROGRESS_MODE")
+            or _resolved_tp
             or "all"
         )
-        # Disable tool progress for webhooks - they don't support message editing,
-        # so each progress line would be sent as a separate message.
-        from gateway.config import Platform
-        tool_progress_enabled = progress_mode != "off" and source.platform != Platform.WEBHOOK
+        # Webhook routes can deliver into rich chat platforms (Telegram, Discord,
+        # etc.).  Use the visible delivery platform's settings/capabilities so
+        # voice-sphere behaves like native Telegram instead of a log-only webhook.
+        tool_progress_enabled = progress_mode != "off"
         # Natural assistant status messages are intentionally independent from
         # tool progress and token streaming. Users can keep tool_progress quiet
         # in chat platforms while opting into concise mid-turn updates.
-        interim_assistant_messages_enabled = (
-            source.platform != Platform.WEBHOOK
-            and is_truthy_value(
+        interim_assistant_messages_enabled = is_truthy_value(
+            resolve_display_setting(
+                user_config,
+                visible_platform_key,
+                "interim_assistant_messages",
                 display_config.get("interim_assistant_messages"),
-                default=True,
-            )
+            ),
+            default=True,
         )
         
         # Queue for progress messages (thread-safe)
@@ -10448,7 +10460,7 @@ class GatewayRunner:
             # can disable streaming for specific platforms even when the global
             # streaming config is enabled.
             _plat_streaming = resolve_display_setting(
-                user_config, platform_key, "streaming"
+                user_config, visible_platform_key, "streaming"
             )
             # None = no per-platform override → follow global config
             _streaming_enabled = (

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6872,49 +6872,63 @@ class GatewayRunner:
         audio_path = None
         actual_path = None
         try:
-            from tools.tts_tool import text_to_speech_tool, _strip_markdown_for_tts
+            from tools.tts_tool import split_text_for_tts, text_to_speech_tool
 
-            tts_text = _strip_markdown_for_tts(text[:4000])
-            if not tts_text:
-                return
-
-            # Use .mp3 extension so edge-tts conversion to opus works correctly.
-            # The TTS tool may convert to .ogg — use file_path from result.
-            audio_path = os.path.join(
-                tempfile.gettempdir(), "hermes_voice",
-                f"tts_reply_{_uuid.uuid4().hex[:12]}.mp3",
-            )
-            os.makedirs(os.path.dirname(audio_path), exist_ok=True)
-
-            result_json = await asyncio.to_thread(
-                text_to_speech_tool, text=tts_text, output_path=audio_path
-            )
-            result = json.loads(result_json)
-
-            # Use the actual file path from result (may differ after opus conversion)
-            actual_path = result.get("file_path", audio_path)
-            if not result.get("success") or not os.path.isfile(actual_path):
-                logger.warning("Auto voice reply TTS failed: %s", result.get("error"))
+            from hermes_cli.config import load_config as _load_full_config
+            tts_cfg = (_load_full_config().get("tts") or {})
+            max_chunk_chars = int(os.getenv("HERMES_AUTO_TTS_CHUNK_CHARS", tts_cfg.get("auto_chunk_chars", 1200)))
+            max_chunks = int(os.getenv("HERMES_AUTO_TTS_MAX_CHUNKS", tts_cfg.get("auto_max_chunks", 3)))
+            tts_chunks = split_text_for_tts(text[:4000], max_chars=max_chunk_chars, max_chunks=max_chunks)
+            if not tts_chunks:
                 return
 
             adapter = self.adapters.get(event.source.platform)
-
-            # If connected to a voice channel, play there instead of sending a file
             guild_id = self._get_guild_id(event)
-            if (guild_id
-                    and hasattr(adapter, "play_in_voice_channel")
-                    and hasattr(adapter, "is_in_voice_channel")
-                    and adapter.is_in_voice_channel(guild_id)):
-                await adapter.play_in_voice_channel(guild_id, actual_path)
-            elif adapter and hasattr(adapter, "send_voice"):
-                send_kwargs: Dict[str, Any] = {
-                    "chat_id": event.source.chat_id,
-                    "audio_path": actual_path,
-                    "reply_to": event.message_id,
-                }
-                if event.source.thread_id:
-                    send_kwargs["metadata"] = {"thread_id": event.source.thread_id}
-                await adapter.send_voice(**send_kwargs)
+
+            for tts_text in tts_chunks:
+                audio_path = None
+                actual_path = None
+                try:
+                    # Use .mp3 extension so edge-tts conversion to opus works correctly.
+                    # The TTS tool may convert to .ogg — use file_path from result.
+                    audio_path = os.path.join(
+                        tempfile.gettempdir(), "hermes_voice",
+                        f"tts_reply_{_uuid.uuid4().hex[:12]}.mp3",
+                    )
+                    os.makedirs(os.path.dirname(audio_path), exist_ok=True)
+
+                    result_json = await asyncio.to_thread(
+                        text_to_speech_tool, text=tts_text, output_path=audio_path
+                    )
+                    result = json.loads(result_json)
+
+                    # Use the actual file path from result (may differ after opus conversion)
+                    actual_path = result.get("file_path", audio_path)
+                    if not result.get("success") or not os.path.isfile(actual_path):
+                        logger.warning("Auto voice reply TTS failed: %s", result.get("error"))
+                        return
+
+                    # If connected to a voice channel, play there instead of sending a file
+                    if (guild_id
+                            and hasattr(adapter, "play_in_voice_channel")
+                            and hasattr(adapter, "is_in_voice_channel")
+                            and adapter.is_in_voice_channel(guild_id)):
+                        await adapter.play_in_voice_channel(guild_id, actual_path)
+                    elif adapter and hasattr(adapter, "send_voice"):
+                        send_kwargs: Dict[str, Any] = {
+                            "chat_id": event.source.chat_id,
+                            "audio_path": actual_path,
+                            "reply_to": event.message_id,
+                        }
+                        if event.source.thread_id:
+                            send_kwargs["metadata"] = {"thread_id": event.source.thread_id}
+                        await adapter.send_voice(**send_kwargs)
+                finally:
+                    for p in {audio_path, actual_path} - {None}:
+                        try:
+                            os.unlink(p)
+                        except OSError:
+                            pass
         except Exception as e:
             logger.warning("Auto voice reply failed: %s", e, exc_info=True)
         finally:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -743,9 +743,10 @@ DEFAULT_CONFIG = {
     # Each provider supports an optional `max_text_length:` override for the
     # per-request input-character cap. Omit it to use the provider's documented
     # limit (OpenAI 4096, xAI 15000, MiniMax 10000, ElevenLabs 5k-40k model-aware,
-    # Gemini 5000, Edge 5000, Mistral 4000, NeuTTS/KittenTTS/Piper/MeloTTS 2000).
+    # Gemini/Google Cloud/Edge 5000, Mistral 4000,
+    # NeuTTS/KittenTTS/Piper/MeloTTS 2000).
     "tts": {
-        "provider": "edge",  # "edge" (free) | "elevenlabs" (premium) | "openai" | "xai" | "minimax" | "mistral" | "neutts" | "kittentts" | "piper" | "melotts"
+        "provider": "edge",  # "edge" (free) | "elevenlabs" (premium) | "openai" | "xai" | "minimax" | "mistral" | "gemini" | "google_cloud" | "neutts" | "kittentts" | "piper" | "melotts"
         "edge": {
             "voice": "en-US-AriaNeural",
             # Popular: AriaNeural, JennyNeural, AndrewNeural, BrianNeural, SoniaNeural
@@ -774,6 +775,13 @@ DEFAULT_CONFIG = {
         "mistral": {
             "model": "voxtral-mini-tts-2603",
             "voice_id": "c69964a6-ab8b-4f8a-9465-ec0925096ec8",  # Paul - Neutral
+        },
+        "google_cloud": {
+            "language_code": "ko-KR",
+            "voice": "ko-KR-Chirp3-HD-Kore",
+            "audio_encoding": "LINEAR16",  # Hermes converts WAV/LINEAR16 to Telegram OGG/Opus
+            "speaking_rate": 1.0,
+            "pitch": 0.0,
         },
         "neutts": {
             "ref_audio": "",  # Path to reference voice audio (empty = bundled default)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -783,6 +783,7 @@ DEFAULT_CONFIG = {
             "speaking_rate": 1.0,
             "pitch": 0.0,
             "monthly_character_limit": 1000000,  # Stay within Google Cloud TTS monthly free tier
+            "fallback_provider": "edge",  # Used when the monthly character limit is exhausted
             "usage_path": "",  # Empty = ~/.hermes/state/tts/google_cloud_usage.json
         },
         "neutts": {

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -766,6 +766,14 @@ DEFAULT_CONFIG = {
             "enabled": False,
             "preset": "none",  # none, clean, hybrid, dark, cyber_autotune
         },
+        "visualizer": {
+            "enabled": False,
+            # Optional best-effort command run after each successful TTS output.
+            # Placeholders: {audio_path}, {audio_path_q}, {text}, {text_q}, {provider}
+            "command": [],
+            "timeout": 3,
+            "async": True,
+        },
         "xai": {
             "voice_id": "eve",
             "language": "en",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -782,6 +782,8 @@ DEFAULT_CONFIG = {
             "audio_encoding": "LINEAR16",  # Hermes converts WAV/LINEAR16 to Telegram OGG/Opus
             "speaking_rate": 1.0,
             "pitch": 0.0,
+            "monthly_character_limit": 1000000,  # Stay within Google Cloud TTS monthly free tier
+            "usage_path": "",  # Empty = ~/.hermes/state/tts/google_cloud_usage.json
         },
         "neutts": {
             "ref_audio": "",  # Path to reference voice audio (empty = bundled default)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -743,9 +743,9 @@ DEFAULT_CONFIG = {
     # Each provider supports an optional `max_text_length:` override for the
     # per-request input-character cap. Omit it to use the provider's documented
     # limit (OpenAI 4096, xAI 15000, MiniMax 10000, ElevenLabs 5k-40k model-aware,
-    # Gemini 5000, Edge 5000, Mistral 4000, NeuTTS/KittenTTS 2000).
+    # Gemini 5000, Edge 5000, Mistral 4000, NeuTTS/KittenTTS/Piper/MeloTTS 2000).
     "tts": {
-        "provider": "edge",  # "edge" (free) | "elevenlabs" (premium) | "openai" | "xai" | "minimax" | "mistral" | "neutts" (local)
+        "provider": "edge",  # "edge" (free) | "elevenlabs" (premium) | "openai" | "xai" | "minimax" | "mistral" | "neutts" | "kittentts" | "piper" | "melotts"
         "edge": {
             "voice": "en-US-AriaNeural",
             # Popular: AriaNeural, JennyNeural, AndrewNeural, BrianNeural, SoniaNeural
@@ -757,7 +757,13 @@ DEFAULT_CONFIG = {
         "openai": {
             "model": "gpt-4o-mini-tts",
             "voice": "alloy",
-            # Voices: alloy, echo, fable, onyx, nova, shimmer
+            "instructions": "",  # Supported by gpt-4o-mini-tts for style/tone control
+            # Voices include alloy, ash, ballad, coral, echo, fable, nova, onyx,
+            # sage, shimmer, verse, marin, cedar. API/model decides support.
+        },
+        "postprocess": {
+            "enabled": False,
+            "preset": "none",  # none, clean, hybrid, dark, cyber_autotune
         },
         "xai": {
             "voice_id": "eve",
@@ -774,6 +780,19 @@ DEFAULT_CONFIG = {
             "ref_text": "",   # Path to reference voice transcript (empty = bundled default)
             "model": "neuphonic/neutts-air-q4-gguf",  # HuggingFace model repo
             "device": "cpu",  # cpu, cuda, or mps
+        },
+        "piper": {
+            "base_url": "http://127.0.0.1:5005",  # Local Piper HTTP server
+            "timeout": 60,
+            "health_timeout": 2,
+        },
+        "melotts": {
+            "python": "/home/ubuntu/melotts-venv/bin/python",  # Isolated MeloTTS venv
+            "language": "KR",
+            "speaker": "KR",
+            "device": "cpu",
+            "speed": 1.0,
+            "timeout": 180,
         },
     },
     

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,8 @@ google = [
   "google-api-python-client>=2.100,<3",
   "google-auth-oauthlib>=1.0,<2",
   "google-auth-httplib2>=0.2,<1",
+  # Google Cloud Text-to-Speech (Chirp 3 HD) provider.
+  "google-cloud-texttospeech>=2.31.0,<3",
 ]
 # `hermes dashboard` (localhost SPA + API).  Not in core to keep the default install lean.
 web = ["fastapi>=0.104.0,<1", "uvicorn[standard]>=0.24.0,<1"]

--- a/scripts/tts_visualizer_bridge.py
+++ b/scripts/tts_visualizer_bridge.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Bridge Hermes TTS output to a Windows desktop sound visualizer.
+
+This script is intended for use from ``tts.visualizer.command``.  It copies the
+final TTS audio file to a Windows machine reachable through the existing reverse
+SSH tunnel, then asks Python on Windows to open an always-on-top bottom-right
+visualizer window for that audio.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+
+
+def run(cmd: list[str], timeout: float = 10) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout, check=False)
+
+
+def ps_quote(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Send a TTS audio file to the main Windows PC visualizer")
+    parser.add_argument("--audio", required=True, help="Local audio path produced by Hermes TTS")
+    parser.add_argument("--text", default="", help="TTS text, shown as a small caption")
+    parser.add_argument("--provider", default=os.environ.get("HERMES_TTS_PROVIDER", ""))
+    parser.add_argument("--host", default=os.environ.get("MAINPC_SSH_HOST", "127.0.0.1"))
+    parser.add_argument("--port", default=os.environ.get("MAINPC_SSH_PORT", "2222"))
+    parser.add_argument("--user", default=os.environ.get("MAINPC_SSH_USER", "home"))
+    parser.add_argument("--key", default=os.environ.get("MAINPC_SSH_KEY", "/home/ubuntu/.ssh/reverse_to_windows"))
+    parser.add_argument("--remote-dir", default="C:/Users/home/AppData/Local/HermesTTSVisualizer")
+    parser.add_argument("--remote-script", default="C:/Users/home/AppData/Local/HermesTTSVisualizer/tts_visualizer_win.py")
+    parser.add_argument("--python", default="python")
+    parser.add_argument("--timeout", type=float, default=10)
+    args = parser.parse_args()
+
+    audio = Path(args.audio).expanduser().resolve()
+    if not audio.exists() or audio.stat().st_size <= 0:
+        print(f"audio file missing or empty: {audio}", file=sys.stderr)
+        return 2
+
+    dest_name = f"tts_{uuid.uuid4().hex}{audio.suffix.lower() or '.ogg'}"
+    remote_inbox = args.remote_dir.rstrip("/") + "/inbox"
+    remote_audio = remote_inbox + "/" + dest_name
+    target = f"{args.user}@{args.host}"
+    ssh_base = [
+        "ssh", "-p", str(args.port), "-i", str(Path(args.key).expanduser()),
+        "-o", "BatchMode=yes", "-o", "IdentitiesOnly=yes", "-o", "ConnectTimeout=5",
+        "-o", "StrictHostKeyChecking=accept-new", target,
+    ]
+    scp_base = [
+        "scp", "-P", str(args.port), "-i", str(Path(args.key).expanduser()),
+        "-o", "BatchMode=yes", "-o", "IdentitiesOnly=yes", "-o", "ConnectTimeout=5",
+        "-o", "StrictHostKeyChecking=accept-new",
+    ]
+
+    mkdir_cmd = f"powershell -NoProfile -ExecutionPolicy Bypass -Command \"New-Item -ItemType Directory -Force -Path {ps_quote(remote_inbox)} | Out-Null\""
+    created = run(ssh_base + [mkdir_cmd], timeout=args.timeout)
+    if created.returncode != 0:
+        print(created.stderr or created.stdout, file=sys.stderr)
+        return created.returncode or 3
+
+    copied = run(scp_base + [str(audio), f"{target}:{remote_audio}"], timeout=max(args.timeout, 20))
+    if copied.returncode != 0:
+        print(copied.stderr or copied.stdout, file=sys.stderr)
+        return copied.returncode or 4
+
+    text = args.text[:220]
+    ps = (
+        "$p = Start-Process -WindowStyle Hidden -PassThru "
+        f"-FilePath {ps_quote(args.python)} "
+        f"-ArgumentList @({ps_quote(args.remote_script)}, '--audio', {ps_quote(remote_audio)}, '--text', {ps_quote(text)}, '--provider', {ps_quote(args.provider)})"
+    )
+    launched = run(
+        ssh_base + [f"powershell -NoProfile -ExecutionPolicy Bypass -Command {shlex.quote(ps)}"],
+        timeout=args.timeout,
+    )
+    if launched.returncode != 0:
+        print(launched.stderr or launched.stdout, file=sys.stderr)
+        return launched.returncode or 5
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tts_visualizer_bridge.py
+++ b/scripts/tts_visualizer_bridge.py
@@ -9,10 +9,11 @@ visualizer window for that audio.
 from __future__ import annotations
 
 import argparse
+import json
 import os
-import shlex
 import subprocess
 import sys
+import tempfile
 import uuid
 from pathlib import Path
 
@@ -35,8 +36,6 @@ def main() -> int:
     parser.add_argument("--user", default=os.environ.get("MAINPC_SSH_USER", "home"))
     parser.add_argument("--key", default=os.environ.get("MAINPC_SSH_KEY", "/home/ubuntu/.ssh/reverse_to_windows"))
     parser.add_argument("--remote-dir", default="C:/Users/home/AppData/Local/HermesTTSVisualizer")
-    parser.add_argument("--remote-script", default="C:/Users/home/AppData/Local/HermesTTSVisualizer/tts_visualizer_win.py")
-    parser.add_argument("--python", default="python")
     parser.add_argument("--timeout", type=float, default=10)
     args = parser.parse_args()
 
@@ -72,18 +71,27 @@ def main() -> int:
         return copied.returncode or 4
 
     text = args.text[:220]
-    ps = (
-        "$p = Start-Process -WindowStyle Hidden -PassThru "
-        f"-FilePath {ps_quote(args.python)} "
-        f"-ArgumentList @({ps_quote(args.remote_script)}, '--audio', {ps_quote(remote_audio)}, '--text', {ps_quote(text)}, '--provider', {ps_quote(args.provider)})"
-    )
-    launched = run(
-        ssh_base + [f"powershell -NoProfile -ExecutionPolicy Bypass -Command {shlex.quote(ps)}"],
-        timeout=args.timeout,
-    )
-    if launched.returncode != 0:
-        print(launched.stderr or launched.stdout, file=sys.stderr)
-        return launched.returncode or 5
+    meta_name = f"{Path(dest_name).stem}.json"
+    meta_payload = {
+        "audio": remote_audio,
+        "text": text,
+        "provider": args.provider,
+        "source": str(audio),
+        "created_at": uuid.uuid4().hex,
+    }
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", suffix=".json", delete=False) as fh:
+        json.dump(meta_payload, fh, ensure_ascii=False, indent=2)
+        local_meta = Path(fh.name)
+    try:
+        copied_meta = run(scp_base + [str(local_meta), f"{target}:{remote_inbox}/{meta_name}"], timeout=max(args.timeout, 20))
+    finally:
+        try:
+            local_meta.unlink()
+        except OSError:
+            pass
+    if copied_meta.returncode != 0:
+        print(copied_meta.stderr or copied_meta.stdout, file=sys.stderr)
+        return copied_meta.returncode or 5
     return 0
 
 

--- a/scripts/tts_visualizer_listener.py
+++ b/scripts/tts_visualizer_listener.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Resident Windows listener for Hermes TTS visualizer inbox.
+
+Runs in the interactive Windows logon session (preferably via Scheduled Task).
+It watches the inbox for metadata JSON files written by the server bridge and
+launches the Tk visualizer from the same desktop session, avoiding SSH session
+isolation where GUI windows may be invisible.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+AUDIO_SUFFIXES = {".ogg", ".opus", ".mp3", ".wav", ".m4a", ".flac"}
+DEFAULT_BASE = Path(os.environ.get("LOCALAPPDATA", str(Path.home() / "AppData/Local"))) / "HermesTTSVisualizer"
+DEFAULT_INBOX = DEFAULT_BASE / "inbox"
+DEFAULT_SCRIPT = DEFAULT_BASE / "tts_visualizer_win.py"
+LOG_PATH = DEFAULT_BASE / "listener.log"
+SEEN_PATH = DEFAULT_BASE / "listener_seen.json"
+
+
+def log(message: str) -> None:
+    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    ts = time.strftime("%Y-%m-%d %H:%M:%S")
+    with LOG_PATH.open("a", encoding="utf-8") as fh:
+        fh.write(f"[{ts}] {message}\n")
+
+
+def load_seen() -> dict[str, float]:
+    try:
+        data = json.loads(SEEN_PATH.read_text(encoding="utf-8"))
+        if isinstance(data, dict):
+            return {str(k): float(v) for k, v in data.items()}
+    except Exception:
+        pass
+    return {}
+
+
+def save_seen(seen: dict[str, float]) -> None:
+    # Keep this small; old files in inbox should not grow state forever.
+    cutoff = time.time() - 7 * 24 * 3600
+    compact = {k: v for k, v in seen.items() if v >= cutoff}
+    SEEN_PATH.write_text(json.dumps(compact, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def stable(path: Path, delay: float = 0.25) -> bool:
+    try:
+        size1 = path.stat().st_size
+        time.sleep(delay)
+        size2 = path.stat().st_size
+        return size1 > 0 and size1 == size2
+    except OSError:
+        return False
+
+
+def launch_visualizer(python_exe: str, visualizer_script: Path, audio: Path, text: str = "", provider: str = "") -> bool:
+    if not visualizer_script.exists():
+        log(f"visualizer script missing: {visualizer_script}")
+        return False
+    if not audio.exists():
+        log(f"audio missing: {audio}")
+        return False
+    cmd = [python_exe, str(visualizer_script), "--audio", str(audio), "--text", text or "", "--provider", provider or ""]
+    try:
+        subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, close_fds=True)
+        log(f"launched visualizer for {audio.name}")
+        return True
+    except Exception as exc:
+        log(f"launch failed for {audio}: {exc!r}")
+        return False
+
+
+def handle_meta(meta: Path, python_exe: str, visualizer_script: Path) -> bool:
+    if not stable(meta):
+        return False
+    try:
+        payload = json.loads(meta.read_text(encoding="utf-8"))
+    except Exception as exc:
+        log(f"metadata parse failed {meta.name}: {exc!r}")
+        return False
+    audio_value = payload.get("audio") or payload.get("audio_path") or payload.get("path")
+    if not audio_value:
+        log(f"metadata has no audio path: {meta.name}")
+        return False
+    audio = Path(str(audio_value))
+    if not audio.is_absolute():
+        audio = meta.parent / audio
+    if not stable(audio):
+        log(f"audio not stable yet: {audio}")
+        return False
+    text = str(payload.get("text") or "")[:220]
+    provider = str(payload.get("provider") or "")[:80]
+    return launch_visualizer(python_exe, visualizer_script, audio, text=text, provider=provider)
+
+
+def handle_audio(audio: Path, python_exe: str, visualizer_script: Path) -> bool:
+    if not stable(audio):
+        return False
+    return launch_visualizer(python_exe, visualizer_script, audio, text=audio.name, provider="")
+
+
+def run_once(inbox: Path, python_exe: str, visualizer_script: Path, seen: dict[str, float], audio_fallback: bool = False) -> int:
+    inbox.mkdir(parents=True, exist_ok=True)
+    launched = 0
+    # Metadata files are the normal bridge contract. Audio-only fallback is opt-in
+    # for manual tests; otherwise the listener can race the bridge and launch once
+    # for the raw audio and again when metadata arrives.
+    candidates = sorted(inbox.glob("*.json"), key=lambda p: p.stat().st_mtime)
+    if audio_fallback:
+        candidates += sorted((p for p in inbox.iterdir() if p.suffix.lower() in AUDIO_SUFFIXES), key=lambda p: p.stat().st_mtime)
+    for path in candidates:
+        key = str(path.resolve())
+        mtime = path.stat().st_mtime
+        if seen.get(key) == mtime:
+            continue
+        ok = handle_meta(path, python_exe, visualizer_script) if path.suffix.lower() == ".json" else handle_audio(path, python_exe, visualizer_script)
+        if ok:
+            seen[key] = mtime
+            launched += 1
+        else:
+            # Mark very old bad items as seen so the log does not get carpet-bombed.
+            if time.time() - mtime > 3600:
+                seen[key] = mtime
+    return launched
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Watch Hermes TTS visualizer inbox and launch visible desktop windows")
+    parser.add_argument("--inbox", default=str(DEFAULT_INBOX))
+    parser.add_argument("--visualizer-script", default=str(DEFAULT_SCRIPT))
+    parser.add_argument("--python", default=sys.executable)
+    parser.add_argument("--interval", type=float, default=0.7)
+    parser.add_argument("--once", action="store_true")
+    parser.add_argument("--audio-fallback", action="store_true", help="Also launch for bare audio files without metadata")
+    args = parser.parse_args()
+
+    inbox = Path(args.inbox)
+    visualizer_script = Path(args.visualizer_script)
+    DEFAULT_BASE.mkdir(parents=True, exist_ok=True)
+    seen = load_seen()
+    log(f"listener start inbox={inbox} python={args.python} script={visualizer_script} once={args.once}")
+    while True:
+        try:
+            launched = run_once(inbox, args.python, visualizer_script, seen, audio_fallback=args.audio_fallback)
+            if launched:
+                save_seen(seen)
+        except Exception as exc:
+            log(f"listener loop error: {exc!r}")
+        if args.once:
+            save_seen(seen)
+            return 0
+        time.sleep(max(0.2, args.interval))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tts_visualizer_listener.py
+++ b/scripts/tts_visualizer_listener.py
@@ -93,7 +93,9 @@ def handle_meta(meta: Path, python_exe: str, visualizer_script: Path) -> bool:
     if not stable(audio):
         log(f"audio not stable yet: {audio}")
         return False
-    text = str(payload.get("text") or "")[:220]
+    # Keep enough text for the visualizer's marquee. It scrolls/clips its own
+    # header, so the listener should not pre-truncate normal TTS replies.
+    text = str(payload.get("text") or "")[:2000]
     provider = str(payload.get("provider") or "")[:80]
     return launch_visualizer(python_exe, visualizer_script, audio, text=text, provider=provider)
 

--- a/scripts/tts_visualizer_win.py
+++ b/scripts/tts_visualizer_win.py
@@ -391,7 +391,7 @@ class Visualizer:
         self.canvas.create_text(31, 17, anchor="w", text=label, fill="#cbd5e1", font=("Segoe UI", 8, "bold"))
 
     def _wait_then_start(self) -> None:
-        # Keep playback and bars aligned: wait briefly for ffmpeg decoding before
+        # Keep playback and motion aligned: wait briefly for ffmpeg decoding before
         # starting ffplay. If decoding is slow or unavailable, start anyway rather
         # than leaving a polite but useless dark rectangle.
         if not self.loaded and time.monotonic() - self.load_started_at < 2.0:
@@ -401,6 +401,99 @@ class Visualizer:
         self.index = 0
         self._start_playback()
         self.draw()
+
+    def _blend_hex(self, a: str, b: str, t: float) -> str:
+        t = max(0.0, min(1.0, t))
+        ar, ag, ab = int(a[1:3], 16), int(a[3:5], 16), int(a[5:7], 16)
+        br, bg, bb = int(b[1:3], 16), int(b[3:5], 16), int(b[5:7], 16)
+        return f"#{int(ar + (br - ar) * t):02x}{int(ag + (bg - ag) * t):02x}{int(ab + (bb - ab) * t):02x}"
+
+    def _draw_radial_visualizer(self, frame: list[float], elapsed: float, progress: float) -> None:
+        # A tiny Processing-style sketch implemented directly on Tk Canvas:
+        # polar samples, orbital phase, translucent-looking layers, and no
+        # external dependency. Processing itself is marvellous, but requiring it
+        # for a corner HUD would be a rather theatrical way to draw a circle.
+        cx = WINDOW_W / 2
+        cy = HEADER_H + (WINDOW_H - HEADER_H) / 2 + 5
+        pulse = sum(frame) / max(1, len(frame))
+        beat = min(1.0, pulse * 1.8)
+        spin = elapsed * 0.92
+        inner_r = 19 + beat * 6
+        base_r = 42 + beat * 13
+        outer_r = 54 + beat * 23
+
+        # Soft neon halo, faked with concentric outlines because Tk has the
+        # alpha support of a Victorian gas lamp.
+        for layer in range(7, 0, -1):
+            r = outer_r + layer * 5 + math.sin(elapsed * 1.7 + layer) * 1.8
+            color = self._blend_hex("#05070d", "#155e75", layer / 9)
+            self.canvas.create_oval(cx - r, cy - r, cx + r, cy + r, outline=color, width=1)
+
+        # Outer organic waveform: closed polar spline-ish polyline.
+        points: list[float] = []
+        n = len(frame)
+        for i, amp in enumerate(frame):
+            theta = (math.tau * i / n) - math.pi / 2 + spin * 0.18
+            eased = amp ** 0.55
+            wobble = math.sin(theta * 3.0 + elapsed * 2.2) * 4.5 + math.sin(theta * 7.0 - elapsed * 1.4) * 2.4
+            r = base_r + eased * 49 + wobble
+            points.extend([cx + math.cos(theta) * r, cy + math.sin(theta) * r])
+        if len(points) >= 6:
+            self.canvas.create_polygon(points, fill="", outline="#22d3ee", width=2, smooth=True)
+
+        # Counter-rotating violet trace for that pleasantly ominous lab-instrument look.
+        trace: list[float] = []
+        for i, amp in enumerate(reversed(frame)):
+            theta = (math.tau * i / n) - math.pi / 2 - spin * 0.12
+            eased = amp ** 0.65
+            r = inner_r + eased * 38 + math.sin(theta * 5.0 + elapsed) * 3
+            trace.extend([cx + math.cos(theta) * r, cy + math.sin(theta) * r])
+        if len(trace) >= 6:
+            self.canvas.create_polygon(trace, fill="", outline="#a78bfa", width=1, smooth=True)
+
+        # Radial shards: not bars, more like a small cybernetic sea urchin.
+        for i in range(0, n, 2):
+            amp = frame[i]
+            eased = amp ** 0.5
+            theta = (math.tau * i / n) - math.pi / 2 + spin * 0.24
+            r0 = inner_r + eased * 9
+            r1 = base_r + 12 + eased * 54
+            color = self._blend_hex("#38bdf8", "#c084fc", (math.sin(theta + elapsed) + 1) / 2)
+            self.canvas.create_line(
+                cx + math.cos(theta) * r0,
+                cy + math.sin(theta) * r0,
+                cx + math.cos(theta) * r1,
+                cy + math.sin(theta) * r1,
+                fill=color,
+                width=max(1, int(1 + eased * 3)),
+            )
+
+        # Orbiting particles driven by local amplitude.
+        for i in range(12):
+            amp = frame[(i * 4 + self.index) % n]
+            theta = math.tau * i / 12 + spin * (0.45 + (i % 3) * 0.07)
+            r = outer_r + 12 + math.sin(elapsed * 2 + i) * 8 + amp * 23
+            size = 2.0 + amp * 5.0
+            px = cx + math.cos(theta) * r
+            py = cy + math.sin(theta) * r
+            self.canvas.create_oval(px - size, py - size, px + size, py + size, fill="#67e8f9", outline="")
+
+        # Core and circular progress ring.
+        core_r = inner_r + beat * 5
+        self.canvas.create_oval(cx - core_r, cy - core_r, cx + core_r, cy + core_r, fill="#07111f", outline="#67e8f9", width=2)
+        self.canvas.create_text(cx, cy, text="◌", fill="#e0f2fe", font=("Segoe UI Symbol", 20, "bold"))
+        ring_r = outer_r + 28
+        self.canvas.create_arc(
+            cx - ring_r,
+            cy - ring_r,
+            cx + ring_r,
+            cy + ring_r,
+            start=90,
+            extent=-359.5 * progress,
+            style="arc",
+            outline="#38bdf8",
+            width=3,
+        )
 
     def draw(self) -> None:
         elapsed = time.monotonic() - self.started_at
@@ -417,19 +510,8 @@ class Visualizer:
         self.canvas.create_rectangle(0, 0, WINDOW_W, WINDOW_H, fill="#05070d", outline="#152033")
         self._draw_header()
         frame = self.frames[min(self.index, len(self.frames) - 1)]
-        usable_w = WINDOW_W - MARGIN * 2
-        bar_w = usable_w / BAR_COUNT
-        base_y = WINDOW_H - 25
-        for i, amp in enumerate(frame):
-            eased = min(1.0, amp ** 0.55)
-            h = 7 + eased * 82
-            x0 = MARGIN + i * bar_w + 1
-            x1 = MARGIN + (i + 1) * bar_w - 1
-            y0 = base_y - h
-            color = "#22d3ee" if i % 3 else "#a78bfa"
-            self.canvas.create_rectangle(x0, y0, x1, base_y, fill=color, outline="")
         progress = min(1.0, self.index / max(1, len(self.frames)))
-        self.canvas.create_rectangle(MARGIN, WINDOW_H - 11, MARGIN + usable_w * progress, WINDOW_H - 8, fill="#38bdf8", outline="")
+        self._draw_radial_visualizer(frame, elapsed, progress)
         self.index += 1
         if elapsed <= total_life:
             self.root.after(int(1000 / FPS), self.draw)

--- a/scripts/tts_visualizer_win.py
+++ b/scripts/tts_visualizer_win.py
@@ -1,14 +1,16 @@
 #!/usr/bin/env python3
 """Always-on-top corner visualizer for Hermes TTS audio on Windows.
 
-No third-party Python packages are required.  ffmpeg is used when available so
+No third-party Python packages are required. ffmpeg is used when available so
 Telegram-friendly OGG/Opus files work; WAV files fall back to the stdlib wave
 module.
 """
 from __future__ import annotations
 
 import argparse
+import json
 import math
+import os
 import shutil
 import struct
 import subprocess
@@ -24,7 +26,17 @@ FPS = 30
 BAR_COUNT = 48
 WINDOW_W = 460
 WINDOW_H = 150
+MINI_W = 168
+MINI_H = 34
 MARGIN = 16
+TARGET_ALPHA = 0.92
+FADE_IN_SECONDS = 0.35
+FADE_OUT_SECONDS = 0.65
+HOLD_SECONDS = 1.4
+HEADER_H = 31
+
+DEFAULT_BASE = Path(os.environ.get("LOCALAPPDATA", str(Path.home() / "AppData/Local"))) / "HermesTTSVisualizer"
+SETTINGS_PATH = DEFAULT_BASE / "visualizer_settings.json"
 
 
 def decode_with_ffmpeg(path: Path) -> list[int]:
@@ -87,46 +99,249 @@ def load_envelope(path: Path) -> tuple[list[list[float]], float]:
     return frames or [[0.0] * BAR_COUNT], max(0.8, duration)
 
 
+def load_settings() -> dict[str, object]:
+    try:
+        data = json.loads(SETTINGS_PATH.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def save_settings(data: dict[str, object]) -> None:
+    try:
+        SETTINGS_PATH.parent.mkdir(parents=True, exist_ok=True)
+        SETTINGS_PATH.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+    except Exception:
+        pass
+
+
+def clamp(value: int, low: int, high: int) -> int:
+    return max(low, min(high, value))
+
+
 class Visualizer:
     def __init__(self, audio: Path, text: str, provider: str):
         self.audio = audio
-        self.text = text
+        self.text = " ".join((text or audio.name).replace("\n", " ").split())
         self.provider = provider
         self.frames: list[list[float]] = [[0.0] * BAR_COUNT]
         self.duration = 2.0
         self.index = 0
+        self.started_at = time.monotonic()
+        self.minimized = False
+        self.drag_offset: tuple[int, int] | None = None
+        self.settings = load_settings()
+        self.topmost = bool(self.settings.get("topmost", True))
+        self.alpha_target = float(self.settings.get("alpha", TARGET_ALPHA) or TARGET_ALPHA)
+        self.alpha_target = max(0.35, min(1.0, self.alpha_target))
+
         self.root = Tk()
         self.root.overrideredirect(True)
-        self.root.attributes("-topmost", True)
+        self.root.attributes("-topmost", self.topmost)
         try:
-            self.root.attributes("-alpha", 0.92)
+            self.root.attributes("-toolwindow", True)
         except Exception:
             pass
+        self._set_alpha(0.0)
+
         screen_w = self.root.winfo_screenwidth()
         screen_h = self.root.winfo_screenheight()
-        x = max(0, screen_w - WINDOW_W - 18)
-        y = max(0, screen_h - WINDOW_H - 58)
+        saved_x = self.settings.get("x")
+        saved_y = self.settings.get("y")
+        if isinstance(saved_x, int) and isinstance(saved_y, int):
+            x = clamp(saved_x, 0, max(0, screen_w - WINDOW_W))
+            y = clamp(saved_y, 0, max(0, screen_h - WINDOW_H))
+        else:
+            x = max(0, screen_w - WINDOW_W - 18)
+            y = max(0, screen_h - WINDOW_H - 58)
         self.root.geometry(f"{WINDOW_W}x{WINDOW_H}+{x}+{y}")
+
         self.canvas = Canvas(self.root, width=WINDOW_W, height=WINDOW_H, bg="#05070d", bd=0, highlightthickness=0)
         self.canvas.pack(fill=BOTH, expand=True)
+        self.canvas.bind("<ButtonPress-1>", self._on_press)
+        self.canvas.bind("<B1-Motion>", self._on_drag)
+        self.canvas.bind("<ButtonRelease-1>", self._on_release)
+        self.canvas.bind("<Double-Button-1>", lambda _event: self.toggle_minimize())
+        self.root.bind("<Escape>", lambda _event: self.fade_close())
         threading.Thread(target=self._load, daemon=True).start()
 
     def _load(self) -> None:
         self.frames, self.duration = load_envelope(self.audio)
 
+    def _set_alpha(self, alpha: float) -> None:
+        try:
+            self.root.attributes("-alpha", max(0.0, min(1.0, alpha)))
+        except Exception:
+            pass
+
+    def _window_pos(self) -> tuple[int, int]:
+        self.root.update_idletasks()
+        return self.root.winfo_x(), self.root.winfo_y()
+
+    def _save_position(self) -> None:
+        x, y = self._window_pos()
+        self.settings["x"] = int(x)
+        self.settings["y"] = int(y)
+        self.settings["topmost"] = bool(self.topmost)
+        self.settings["alpha"] = float(self.alpha_target)
+        save_settings(self.settings)
+
+    def _button_at(self, x: int, y: int) -> str | None:
+        if y > HEADER_H:
+            return None
+        # Right-side custom controls: minimize, layer/topmost, close.
+        if WINDOW_W - 35 <= x <= WINDOW_W - 12:
+            return "close"
+        if WINDOW_W - 64 <= x <= WINDOW_W - 41:
+            return "layer"
+        if WINDOW_W - 93 <= x <= WINDOW_W - 70:
+            return "minimize"
+        if self.minimized and 0 <= x <= MINI_W and 0 <= y <= MINI_H:
+            return "restore"
+        return None
+
+    def _on_press(self, event) -> None:  # tkinter event, intentionally untyped
+        button = self._button_at(event.x, event.y)
+        if button == "close":
+            self.fade_close()
+            return
+        if button == "layer":
+            self.toggle_layer()
+            return
+        if button in {"minimize", "restore"}:
+            self.toggle_minimize()
+            return
+        self.drag_offset = (event.x_root - self.root.winfo_x(), event.y_root - self.root.winfo_y())
+
+    def _on_drag(self, event) -> None:
+        if not self.drag_offset:
+            return
+        dx, dy = self.drag_offset
+        self.root.geometry(f"+{event.x_root - dx}+{event.y_root - dy}")
+
+    def _on_release(self, _event) -> None:
+        if self.drag_offset:
+            self.drag_offset = None
+            self._save_position()
+
+    def toggle_minimize(self) -> None:
+        self.minimized = not self.minimized
+        x, y = self._window_pos()
+        if self.minimized:
+            self.root.geometry(f"{MINI_W}x{MINI_H}+{x}+{y}")
+            self.canvas.config(width=MINI_W, height=MINI_H)
+        else:
+            self.root.geometry(f"{WINDOW_W}x{WINDOW_H}+{x}+{y}")
+            self.canvas.config(width=WINDOW_W, height=WINDOW_H)
+        self.draw()
+
+    def toggle_layer(self) -> None:
+        self.topmost = not self.topmost
+        self.root.attributes("-topmost", self.topmost)
+        if not self.topmost:
+            try:
+                self.root.lower()
+            except Exception:
+                pass
+        self._save_position()
+        self.draw()
+
+    def fade_close(self) -> None:
+        self.index = len(self.frames) + int(HOLD_SECONDS * FPS) + 1
+        self._fade_out_step()
+
+    def _fade_out_step(self) -> None:
+        try:
+            alpha = float(self.root.attributes("-alpha"))
+        except Exception:
+            alpha = self.alpha_target
+        next_alpha = alpha - max(0.03, self.alpha_target / (FADE_OUT_SECONDS * FPS))
+        if next_alpha <= 0.02:
+            self.root.destroy()
+            return
+        self._set_alpha(next_alpha)
+        self.root.after(int(1000 / FPS), self._fade_out_step)
+
+    def _apply_timed_alpha(self, elapsed: float, total_life: float) -> bool:
+        if elapsed < FADE_IN_SECONDS:
+            self._set_alpha(self.alpha_target * (elapsed / FADE_IN_SECONDS))
+            return True
+        remaining = total_life - elapsed
+        if remaining < FADE_OUT_SECONDS:
+            if remaining <= 0:
+                self._set_alpha(0.0)
+                return False
+            self._set_alpha(self.alpha_target * (remaining / FADE_OUT_SECONDS))
+            return True
+        self._set_alpha(self.alpha_target)
+        return True
+
+    def _draw_controls(self) -> None:
+        # Small, intentionally quiet controls. Apparently windows behave better when
+        # given manners and a few buttons.
+        fill = "#162033"
+        outline = "#334155"
+        controls = [
+            (WINDOW_W - 92, WINDOW_W - 70, "—", "minimize"),
+            (WINDOW_W - 63, WINDOW_W - 41, "T" if self.topmost else "L", "layer"),
+            (WINDOW_W - 34, WINDOW_W - 12, "×", "close"),
+        ]
+        for x0, x1, label, _name in controls:
+            self.canvas.create_rectangle(x0, 7, x1, 25, fill=fill, outline=outline)
+            self.canvas.create_text((x0 + x1) / 2, 15, text=label, fill="#cbd5e1", font=("Segoe UI", 8, "bold"))
+
+    def _draw_header(self) -> None:
+        self.canvas.create_rectangle(0, 0, WINDOW_W, HEADER_H, fill="#07111f", outline="#152033")
+        self.canvas.create_text(MARGIN, 15, anchor="w", text="HERMES TTS", fill="#7dd3fc", font=("Segoe UI", 9, "bold"))
+        caption_x = MARGIN + 92
+        caption_right = WINDOW_W - 104
+        caption_w = max(40, caption_right - caption_x)
+        caption = self.text or self.audio.name
+        item = self.canvas.create_text(0, -100, anchor="w", text=caption, fill="#cbd5e1", font=("Segoe UI", 8))
+        bbox = self.canvas.bbox(item)
+        text_w = (bbox[2] - bbox[0]) if bbox else caption_w
+        self.canvas.delete(item)
+        if text_w <= caption_w:
+            x = caption_x
+        else:
+            cycle_w = text_w + caption_w + 42
+            offset = (time.monotonic() - self.started_at) * 42 % cycle_w
+            x = caption_x + caption_w - offset
+        self.canvas.create_text(x, 15, anchor="w", text=caption, fill="#cbd5e1", font=("Segoe UI", 8))
+        # Mask the marquee so it does not wander into title/buttons like a drunk ticker.
+        self.canvas.create_rectangle(0, 0, caption_x - 2, HEADER_H, fill="#07111f", outline="")
+        self.canvas.create_rectangle(caption_right + 2, 0, WINDOW_W, HEADER_H, fill="#07111f", outline="")
+        self.canvas.create_text(MARGIN, 15, anchor="w", text="HERMES TTS", fill="#7dd3fc", font=("Segoe UI", 9, "bold"))
+        self._draw_controls()
+
+    def _draw_minimized(self) -> None:
+        self.canvas.delete("all")
+        self.canvas.create_rectangle(0, 0, MINI_W, MINI_H, fill="#05070d", outline="#334155")
+        self.canvas.create_oval(10, 11, 22, 23, fill="#22d3ee", outline="")
+        label = "HERMES TTS  ▣" if self.topmost else "HERMES TTS  □"
+        self.canvas.create_text(31, 17, anchor="w", text=label, fill="#cbd5e1", font=("Segoe UI", 8, "bold"))
+
     def draw(self) -> None:
+        elapsed = time.monotonic() - self.started_at
+        total_life = max(self.duration, len(self.frames) / FPS) + HOLD_SECONDS + FADE_OUT_SECONDS
+        if not self._apply_timed_alpha(elapsed, total_life):
+            self.root.destroy()
+            return
+        if self.minimized:
+            self._draw_minimized()
+            self.root.after(int(1000 / FPS), self.draw)
+            return
+
         self.canvas.delete("all")
         self.canvas.create_rectangle(0, 0, WINDOW_W, WINDOW_H, fill="#05070d", outline="#152033")
-        self.canvas.create_text(MARGIN, 15, anchor="w", text="HERMES TTS", fill="#7dd3fc", font=("Segoe UI", 9, "bold"))
-        caption = self.text.replace("\n", " ")[:72] or self.audio.name
-        self.canvas.create_text(MARGIN + 92, 15, anchor="w", text=caption, fill="#cbd5e1", font=("Segoe UI", 8))
+        self._draw_header()
         frame = self.frames[min(self.index, len(self.frames) - 1)]
         usable_w = WINDOW_W - MARGIN * 2
         bar_w = usable_w / BAR_COUNT
         base_y = WINDOW_H - 25
         for i, amp in enumerate(frame):
             eased = min(1.0, amp ** 0.55)
-            h = 7 + eased * 88
+            h = 7 + eased * 82
             x0 = MARGIN + i * bar_w + 1
             x1 = MARGIN + (i + 1) * bar_w - 1
             y0 = base_y - h
@@ -135,7 +350,7 @@ class Visualizer:
         progress = min(1.0, self.index / max(1, len(self.frames)))
         self.canvas.create_rectangle(MARGIN, WINDOW_H - 11, MARGIN + usable_w * progress, WINDOW_H - 8, fill="#38bdf8", outline="")
         self.index += 1
-        if self.index <= len(self.frames) + FPS * 2:
+        if elapsed <= total_life:
             self.root.after(int(1000 / FPS), self.draw)
         else:
             self.root.destroy()

--- a/scripts/tts_visualizer_win.py
+++ b/scripts/tts_visualizer_win.py
@@ -1,21 +1,24 @@
 #!/usr/bin/env python3
-"""Always-on-top corner visualizer for Hermes TTS audio on Windows.
+"""Circular Hermes TTS audio visualizer for Windows.
 
-No third-party Python packages are required. ffmpeg is used when available so
-Telegram-friendly OGG/Opus files work; WAV files fall back to the stdlib wave
-module.
+Resident listener launches this script in the interactive desktop session.
+No third-party Python packages are required. ffmpeg/ffplay are used when present
+for OGG/Opus decoding and desktop playback.
 """
 from __future__ import annotations
 
 import argparse
+import ctypes
 import json
 import math
 import os
+import random
 import shutil
 import struct
 import subprocess
 import sys
 import threading
+import traceback
 import time
 import wave
 from pathlib import Path
@@ -23,21 +26,24 @@ from tkinter import BOTH, Canvas, Tk
 
 SAMPLE_RATE = 48_000
 FPS = 30
-BAR_COUNT = 48
-WINDOW_W = 460
-WINDOW_H = 150
+BAR_COUNT = 128
+WINDOW_W = 520
+WINDOW_H = 520
 MINI_W = 168
 MINI_H = 34
-MARGIN = 16
+MARGIN = 18
 TARGET_ALPHA = 0.92
 FADE_IN_SECONDS = 0.35
 FADE_OUT_SECONDS = 0.65
+VISUAL_FADE_IN_SECONDS = 0.85
+VISUAL_FADE_OUT_SECONDS = 0.95
 HOLD_SECONDS = 1.4
-HEADER_H = 31
+HEADER_H = 34
 
 DEFAULT_BASE = Path(os.environ.get("LOCALAPPDATA", str(Path.home() / "AppData/Local"))) / "HermesTTSVisualizer"
 SETTINGS_PATH = DEFAULT_BASE / "visualizer_settings.json"
 LOG_PATH = DEFAULT_BASE / "listener.log"
+PROCESS_SUSPEND_RESUME = 0x0800
 
 
 def log(message: str) -> None:
@@ -85,13 +91,14 @@ def load_envelope(path: Path) -> tuple[list[list[float]], float]:
     if not samples and path.suffix.lower() == ".wav":
         samples, sample_rate = decode_wave(path)
     if not samples:
-        # A graceful failure still gives the user a visible pulse rather than a
-        # dead square in the corner. Technology must at least look guilty.
-        frames = [[0.15 + 0.1 * math.sin(i / 3 + b / 4) for b in range(BAR_COUNT)] for i in range(FPS * 3)]
+        frames = []
+        for i in range(FPS * 3):
+            frames.append([0.18 + 0.12 * math.sin(i / 3 + b / 5) for b in range(BAR_COUNT)])
         return frames, 3.0
 
     samples_per_frame = max(1, int(sample_rate / FPS))
     frames: list[list[float]] = []
+    prev = [0.0] * BAR_COUNT
     for start in range(0, len(samples), samples_per_frame):
         chunk = samples[start : start + samples_per_frame]
         if not chunk:
@@ -101,10 +108,13 @@ def load_envelope(path: Path) -> tuple[list[list[float]], float]:
         for b in range(BAR_COUNT):
             band = chunk[b * band_size : (b + 1) * band_size]
             if not band:
-                bars.append(0.0)
+                bars.append(prev[b] * 0.84)
                 continue
             rms = math.sqrt(sum(x * x for x in band) / len(band)) / 32768.0
-            bars.append(min(1.0, rms * 4.8))
+            value = min(1.0, rms * 5.4)
+            # Smooth enough to feel deliberate, not like a nervous ECG.
+            bars.append(prev[b] * 0.58 + value * 0.42)
+        prev = bars
         frames.append(bars)
     duration = len(samples) / sample_rate
     return frames or [[0.0] * BAR_COUNT], max(0.8, duration)
@@ -144,12 +154,18 @@ class Visualizer:
         self.play_audio = play_audio
         self.play_started = False
         self.audio_proc: subprocess.Popen | None = None
+        self.audio_paused = False
+        self.audio_skipped = False
         self.minimized = False
         self.drag_offset: tuple[int, int] | None = None
         self.settings = load_settings()
         self.topmost = bool(self.settings.get("topmost", True))
         self.alpha_target = float(self.settings.get("alpha", TARGET_ALPHA) or TARGET_ALPHA)
         self.alpha_target = max(0.35, min(1.0, self.alpha_target))
+        self.phase = random.random() * math.tau
+        self.visual_fade = 0.0
+        self.particles: list[dict[str, float]] = []
+        self.last_particle_t = time.monotonic()
 
         self.root = Tk()
         self.root.overrideredirect(True)
@@ -168,11 +184,11 @@ class Visualizer:
             x = clamp(saved_x, 0, max(0, screen_w - WINDOW_W))
             y = clamp(saved_y, 0, max(0, screen_h - WINDOW_H))
         else:
-            x = max(0, screen_w - WINDOW_W - 18)
-            y = max(0, screen_h - WINDOW_H - 58)
+            x = max(0, screen_w - WINDOW_W - 24)
+            y = max(0, screen_h - WINDOW_H - 70)
         self.root.geometry(f"{WINDOW_W}x{WINDOW_H}+{x}+{y}")
 
-        self.canvas = Canvas(self.root, width=WINDOW_W, height=WINDOW_H, bg="#05070d", bd=0, highlightthickness=0)
+        self.canvas = Canvas(self.root, width=WINDOW_W, height=WINDOW_H, bg="#030712", bd=0, highlightthickness=0)
         self.canvas.pack(fill=BOTH, expand=True)
         self.canvas.bind("<ButtonPress-1>", self._on_press)
         self.canvas.bind("<B1-Motion>", self._on_drag)
@@ -221,10 +237,58 @@ class Visualizer:
             log(f"audio playback failed for {self.audio.name}: {exc!r}")
             self.audio_proc = None
 
+    def _ntdll_call(self, func_name: str, pid: int) -> bool:
+        if not sys.platform.startswith("win"):
+            return False
+        try:
+            kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+            ntdll = ctypes.WinDLL("ntdll", use_last_error=True)
+            handle = kernel32.OpenProcess(PROCESS_SUSPEND_RESUME, False, int(pid))
+            if not handle:
+                return False
+            try:
+                result = getattr(ntdll, func_name)(handle)
+                return int(result) == 0
+            finally:
+                kernel32.CloseHandle(handle)
+        except Exception as exc:
+            log(f"{func_name} failed for pid={pid}: {exc!r}")
+            return False
+
+    def _toggle_pause_audio(self) -> None:
+        proc = self.audio_proc
+        if not proc or proc.poll() is not None or self.audio_skipped:
+            log(f"audio pause ignored for {self.audio.name}: no active playback")
+            return
+        if self.audio_paused:
+            if self._ntdll_call("NtResumeProcess", proc.pid):
+                self.audio_paused = False
+                log(f"resumed desktop audio playback for {self.audio.name} pid={proc.pid}")
+            return
+        if self._ntdll_call("NtSuspendProcess", proc.pid):
+            self.audio_paused = True
+            log(f"paused desktop audio playback for {self.audio.name} pid={proc.pid}")
+
+    def _skip_audio(self) -> None:
+        proc = self.audio_proc
+        self.audio_skipped = True
+        self.audio_paused = False
+        if not proc or proc.poll() is not None:
+            log(f"audio skip ignored for {self.audio.name}: no active playback")
+            return
+        try:
+            proc.terminate()
+            log(f"skipped desktop audio playback for {self.audio.name} pid={proc.pid}")
+        except Exception as exc:
+            log(f"audio skip failed for {self.audio.name}: {exc!r}")
+
     def _stop_playback(self) -> None:
         proc = self.audio_proc
         if not proc or proc.poll() is not None:
             return
+        if self.audio_paused:
+            self._ntdll_call("NtResumeProcess", proc.pid)
+            self.audio_paused = False
         try:
             proc.terminate()
         except Exception:
@@ -253,23 +317,27 @@ class Visualizer:
         self.settings["y"] = int(y)
         self.settings["topmost"] = bool(self.topmost)
         self.settings["alpha"] = float(self.alpha_target)
+        self.settings["mode"] = "kuhung_3d"
         save_settings(self.settings)
 
     def _button_at(self, x: int, y: int) -> str | None:
         if y > HEADER_H:
             return None
-        # Right-side custom controls: minimize, layer/topmost, close.
         if WINDOW_W - 35 <= x <= WINDOW_W - 12:
             return "close"
         if WINDOW_W - 64 <= x <= WINDOW_W - 41:
             return "layer"
         if WINDOW_W - 93 <= x <= WINDOW_W - 70:
             return "minimize"
+        if WINDOW_W - 122 <= x <= WINDOW_W - 100:
+            return "skip_audio"
+        if WINDOW_W - 151 <= x <= WINDOW_W - 129:
+            return "pause_audio"
         if self.minimized and 0 <= x <= MINI_W and 0 <= y <= MINI_H:
             return "restore"
         return None
 
-    def _on_press(self, event) -> None:  # tkinter event, intentionally untyped
+    def _on_press(self, event) -> None:
         button = self._button_at(event.x, event.y)
         if button == "close":
             self.fade_close()
@@ -279,6 +347,14 @@ class Visualizer:
             return
         if button in {"minimize", "restore"}:
             self.toggle_minimize()
+            return
+        if button == "pause_audio":
+            self._toggle_pause_audio()
+            self.draw()
+            return
+        if button == "skip_audio":
+            self._skip_audio()
+            self.draw()
             return
         self.drag_offset = (event.x_root - self.root.winfo_x(), event.y_root - self.root.winfo_y())
 
@@ -345,25 +421,47 @@ class Visualizer:
         self._set_alpha(self.alpha_target)
         return True
 
+    def _smoothstep(self, value: float) -> float:
+        value = max(0.0, min(1.0, value))
+        return value * value * (3.0 - 2.0 * value)
+
+    def _visual_visibility(self, elapsed: float, total_life: float) -> float:
+        # Window alpha fades the whole HUD. This second envelope fades the sphere
+        # itself as a soft cyan/violet gradient so it blooms in and dissolves out,
+        # instead of popping like a bureaucratic PowerPoint transition.
+        in_v = self._smoothstep(elapsed / max(0.01, VISUAL_FADE_IN_SECONDS))
+        remaining = total_life - elapsed
+        out_v = self._smoothstep(remaining / max(0.01, VISUAL_FADE_OUT_SECONDS))
+        return max(0.0, min(1.0, in_v, out_v))
+
+    def _blend_hex(self, a: str, b: str, t: float) -> str:
+        t = max(0.0, min(1.0, t))
+        ar, ag, ab = int(a[1:3], 16), int(a[3:5], 16), int(a[5:7], 16)
+        br, bg, bb = int(b[1:3], 16), int(b[3:5], 16), int(b[5:7], 16)
+        return f"#{int(ar + (br - ar) * t):02x}{int(ag + (bg - ag) * t):02x}{int(ab + (bb - ab) * t):02x}"
+
+    def _fade_hex(self, color: str, visibility: float, background: str = "#020617") -> str:
+        return self._blend_hex(background, color, self._smoothstep(visibility))
+
     def _draw_controls(self) -> None:
-        # Small, intentionally quiet controls. Apparently windows behave better when
-        # given manners and a few buttons.
-        fill = "#162033"
+        fill = "#111827"
         outline = "#334155"
         controls = [
-            (WINDOW_W - 92, WINDOW_W - 70, "—", "minimize"),
+            (WINDOW_W - 150, WINDOW_W - 129, "R" if self.audio_paused else "P", "pause_audio"),
+            (WINDOW_W - 121, WINDOW_W - 100, "S", "skip_audio"),
+            (WINDOW_W - 92, WINDOW_W - 70, "–", "minimize"),
             (WINDOW_W - 63, WINDOW_W - 41, "T" if self.topmost else "L", "layer"),
             (WINDOW_W - 34, WINDOW_W - 12, "×", "close"),
         ]
         for x0, x1, label, _name in controls:
-            self.canvas.create_rectangle(x0, 7, x1, 25, fill=fill, outline=outline)
-            self.canvas.create_text((x0 + x1) / 2, 15, text=label, fill="#cbd5e1", font=("Segoe UI", 8, "bold"))
+            self.canvas.create_rectangle(x0, 8, x1, 26, fill=fill, outline=outline)
+            self.canvas.create_text((x0 + x1) / 2, 16, text=label, fill="#cbd5e1", font=("Segoe UI", 8, "bold"))
 
     def _draw_header(self) -> None:
-        self.canvas.create_rectangle(0, 0, WINDOW_W, HEADER_H, fill="#07111f", outline="#152033")
-        self.canvas.create_text(MARGIN, 15, anchor="w", text="HERMES TTS", fill="#7dd3fc", font=("Segoe UI", 9, "bold"))
-        caption_x = MARGIN + 92
-        caption_right = WINDOW_W - 104
+        self.canvas.create_rectangle(0, 0, WINDOW_W, HEADER_H, fill="#06111f", outline="#132033")
+        self.canvas.create_text(MARGIN, 17, anchor="w", text="HERMES TTS · 3D BLOOM", fill="#f8fafc", font=("Segoe UI", 9, "bold"))
+        caption_x = MARGIN + 142
+        caption_right = WINDOW_W - 160
         caption_w = max(40, caption_right - caption_x)
         caption = self.text or self.audio.name
         item = self.canvas.create_text(0, -100, anchor="w", text=caption, fill="#cbd5e1", font=("Segoe UI", 8))
@@ -376,24 +474,22 @@ class Visualizer:
             cycle_w = text_w + caption_w + 42
             offset = (time.monotonic() - self.started_at) * 42 % cycle_w
             x = caption_x + caption_w - offset
-        self.canvas.create_text(x, 15, anchor="w", text=caption, fill="#cbd5e1", font=("Segoe UI", 8))
-        # Mask the marquee so it does not wander into title/buttons like a drunk ticker.
-        self.canvas.create_rectangle(0, 0, caption_x - 2, HEADER_H, fill="#07111f", outline="")
-        self.canvas.create_rectangle(caption_right + 2, 0, WINDOW_W, HEADER_H, fill="#07111f", outline="")
-        self.canvas.create_text(MARGIN, 15, anchor="w", text="HERMES TTS", fill="#7dd3fc", font=("Segoe UI", 9, "bold"))
+        self.canvas.create_text(x, 17, anchor="w", text=caption, fill="#cbd5e1", font=("Segoe UI", 8))
+        self.canvas.create_rectangle(0, 0, caption_x - 2, HEADER_H, fill="#06111f", outline="")
+        self.canvas.create_rectangle(caption_right + 2, 0, WINDOW_W, HEADER_H, fill="#06111f", outline="")
+        self.canvas.create_text(MARGIN, 17, anchor="w", text="HERMES TTS · 3D BLOOM", fill="#f8fafc", font=("Segoe UI", 9, "bold"))
         self._draw_controls()
 
     def _draw_minimized(self) -> None:
         self.canvas.delete("all")
-        self.canvas.create_rectangle(0, 0, MINI_W, MINI_H, fill="#05070d", outline="#334155")
-        self.canvas.create_oval(10, 11, 22, 23, fill="#22d3ee", outline="")
-        label = "HERMES TTS  ▣" if self.topmost else "HERMES TTS  □"
-        self.canvas.create_text(31, 17, anchor="w", text=label, fill="#cbd5e1", font=("Segoe UI", 8, "bold"))
+        self.canvas.create_rectangle(0, 0, MINI_W, MINI_H, fill="#030712", outline="#334155")
+        cx, cy = 18, 17
+        pulse = 5 + 2.5 * math.sin(time.monotonic() * 4)
+        self.canvas.create_oval(cx - pulse, cy - pulse, cx + pulse, cy + pulse, outline="#22d3ee", width=2)
+        label = ("PAUSED" if self.audio_paused else "HERMES · 3D BLOOM") if self.topmost else "HERMES · LAYER"
+        self.canvas.create_text(34, 17, anchor="w", text=label, fill="#cbd5e1", font=("Segoe UI", 8, "bold"))
 
     def _wait_then_start(self) -> None:
-        # Keep playback and motion aligned: wait briefly for ffmpeg decoding before
-        # starting ffplay. If decoding is slow or unavailable, start anyway rather
-        # than leaving a polite but useless dark rectangle.
         if not self.loaded and time.monotonic() - self.load_started_at < 2.0:
             self.root.after(50, self._wait_then_start)
             return
@@ -402,98 +498,186 @@ class Visualizer:
         self._start_playback()
         self.draw()
 
-    def _blend_hex(self, a: str, b: str, t: float) -> str:
-        t = max(0.0, min(1.0, t))
-        ar, ag, ab = int(a[1:3], 16), int(a[3:5], 16), int(a[5:7], 16)
-        br, bg, bb = int(b[1:3], 16), int(b[3:5], 16), int(b[5:7], 16)
-        return f"#{int(ar + (br - ar) * t):02x}{int(ag + (bg - ag) * t):02x}{int(ab + (bb - ab) * t):02x}"
+    def _current_frame(self) -> list[float]:
+        return self.frames[min(self.index, len(self.frames) - 1)]
 
-    def _draw_radial_visualizer(self, frame: list[float], elapsed: float, progress: float) -> None:
-        # A tiny Processing-style sketch implemented directly on Tk Canvas:
-        # polar samples, orbital phase, translucent-looking layers, and no
-        # external dependency. Processing itself is marvellous, but requiring it
-        # for a corner HUD would be a rather theatrical way to draw a circle.
-        cx = WINDOW_W / 2
-        cy = HEADER_H + (WINDOW_H - HEADER_H) / 2 + 5
-        pulse = sum(frame) / max(1, len(frame))
-        beat = min(1.0, pulse * 1.8)
-        spin = elapsed * 0.92
-        inner_r = 19 + beat * 6
-        base_r = 42 + beat * 13
-        outer_r = 54 + beat * 23
+    def _frame_energy(self, frame: list[float]) -> float:
+        if not frame:
+            return 0.0
+        return min(1.0, sum(frame) / len(frame) * 1.75)
 
-        # Soft neon halo, faked with concentric outlines because Tk has the
-        # alpha support of a Victorian gas lamp.
-        for layer in range(7, 0, -1):
-            r = outer_r + layer * 5 + math.sin(elapsed * 1.7 + layer) * 1.8
-            color = self._blend_hex("#05070d", "#155e75", layer / 9)
-            self.canvas.create_oval(cx - r, cy - r, cx + r, cy + r, outline=color, width=1)
-
-        # Outer organic waveform: closed polar spline-ish polyline.
-        points: list[float] = []
+    def _split_energy(self, frame: list[float]) -> tuple[float, float, float]:
+        if not frame:
+            return 0.0, 0.0, 0.0
         n = len(frame)
-        for i, amp in enumerate(frame):
-            theta = (math.tau * i / n) - math.pi / 2 + spin * 0.18
-            eased = amp ** 0.55
-            wobble = math.sin(theta * 3.0 + elapsed * 2.2) * 4.5 + math.sin(theta * 7.0 - elapsed * 1.4) * 2.4
-            r = base_r + eased * 49 + wobble
-            points.extend([cx + math.cos(theta) * r, cy + math.sin(theta) * r])
-        if len(points) >= 6:
-            self.canvas.create_polygon(points, fill="", outline="#22d3ee", width=2, smooth=True)
+        low = sum(frame[: max(1, n // 4)]) / max(1, n // 4)
+        mid = sum(frame[n // 4 : max(n // 4 + 1, n * 2 // 3)]) / max(1, n * 2 // 3 - n // 4)
+        high = sum(frame[n * 2 // 3 :]) / max(1, n - n * 2 // 3)
+        return min(1.0, low * 1.9), min(1.0, mid * 2.2), min(1.0, high * 2.8)
 
-        # Counter-rotating violet trace for that pleasantly ominous lab-instrument look.
-        trace: list[float] = []
-        for i, amp in enumerate(reversed(frame)):
-            theta = (math.tau * i / n) - math.pi / 2 - spin * 0.12
-            eased = amp ** 0.65
-            r = inner_r + eased * 38 + math.sin(theta * 5.0 + elapsed) * 3
-            trace.extend([cx + math.cos(theta) * r, cy + math.sin(theta) * r])
-        if len(trace) >= 6:
-            self.canvas.create_polygon(trace, fill="", outline="#a78bfa", width=1, smooth=True)
+    def _pseudo_noise(self, x: float, y: float, z: float, t: float) -> float:
+        # Lightweight Perlin-ish layered sine noise. It mirrors the WebGL shader's
+        # role without pulling in a shader runtime or extra dependencies.
+        return (
+            math.sin(x * 1.85 + t * 1.27 + self.phase)
+            + 0.62 * math.sin(y * 2.35 - t * 1.71)
+            + 0.45 * math.sin((x + z) * 2.8 + t * 0.84)
+            + 0.32 * math.sin(math.sqrt(x * x + y * y + z * z) * 4.2 - t * 2.1)
+        ) / 2.39
 
-        # Radial shards: not bars, more like a small cybernetic sea urchin.
-        for i in range(0, n, 2):
-            amp = frame[i]
-            eased = amp ** 0.5
-            theta = (math.tau * i / n) - math.pi / 2 + spin * 0.24
-            r0 = inner_r + eased * 9
-            r1 = base_r + 12 + eased * 54
-            color = self._blend_hex("#38bdf8", "#c084fc", (math.sin(theta + elapsed) + 1) / 2)
-            self.canvas.create_line(
-                cx + math.cos(theta) * r0,
-                cy + math.sin(theta) * r0,
-                cx + math.cos(theta) * r1,
-                cy + math.sin(theta) * r1,
-                fill=color,
-                width=max(1, int(1 + eased * 3)),
-            )
+    def _rotate_project(self, x: float, y: float, z: float, t: float, cx: float, cy: float, scale: float) -> tuple[float, float, float]:
+        ay = t * 0.34 + self.phase * 0.25
+        ax = -0.62 + math.sin(t * 0.23) * 0.12
+        ca, sa = math.cos(ay), math.sin(ay)
+        x, z = x * ca + z * sa, -x * sa + z * ca
+        ca, sa = math.cos(ax), math.sin(ax)
+        y, z = y * ca - z * sa, y * sa + z * ca
+        perspective = 1.0 / max(0.34, 1.95 - z * 0.38)
+        return cx + x * scale * perspective, cy + y * scale * perspective, perspective
 
-        # Orbiting particles driven by local amplitude.
-        for i in range(12):
-            amp = frame[(i * 4 + self.index) % n]
-            theta = math.tau * i / 12 + spin * (0.45 + (i % 3) * 0.07)
-            r = outer_r + 12 + math.sin(elapsed * 2 + i) * 8 + amp * 23
-            size = 2.0 + amp * 5.0
-            px = cx + math.cos(theta) * r
-            py = cy + math.sin(theta) * r
-            self.canvas.create_oval(px - size, py - size, px + size, py + size, fill="#67e8f9", outline="")
+    def _draw_glow_line(self, x0: float, y0: float, x1: float, y1: float, color: str, width: int = 1, visibility: float = 1.0) -> None:
+        if visibility <= 0.015:
+            return
+        v = self._smoothstep(visibility)
+        glow_w = max(1, int((width + 5) * (0.35 + 0.65 * v)))
+        mid_w = max(1, int((width + 2) * (0.45 + 0.55 * v)))
+        core_w = max(1, int(width * (0.65 + 0.35 * v)))
+        self.canvas.create_line(x0, y0, x1, y1, fill=self._fade_hex("#172554", visibility), width=glow_w, capstyle="round")
+        self.canvas.create_line(x0, y0, x1, y1, fill=self._fade_hex("#0e7490", visibility), width=mid_w, capstyle="round")
+        self.canvas.create_line(x0, y0, x1, y1, fill=self._fade_hex(color, visibility), width=core_w, capstyle="round")
 
-        # Core and circular progress ring.
-        core_r = inner_r + beat * 5
-        self.canvas.create_oval(cx - core_r, cy - core_r, cx + core_r, cy + core_r, fill="#07111f", outline="#67e8f9", width=2)
-        self.canvas.create_text(cx, cy, text="◌", fill="#e0f2fe", font=("Segoe UI Symbol", 20, "bold"))
-        ring_r = outer_r + 28
-        self.canvas.create_arc(
-            cx - ring_r,
-            cy - ring_r,
-            cx + ring_r,
-            cy + ring_r,
-            start=90,
-            extent=-359.5 * progress,
-            style="arc",
-            outline="#38bdf8",
-            width=3,
-        )
+    def _draw_wire_sphere(self, cx: float, cy: float, frame: list[float], energy: float, progress: float, t: float, visibility: float = 1.0) -> None:
+        lat_steps = 9
+        lon_steps = 22
+        v = self._smoothstep(visibility)
+        sphere_scale = 0.58 + 0.42 * v
+        base = 1.0 + energy * 0.12
+        amp = (0.18 + energy * 0.42) * (0.35 + 0.65 * v)
+        points: list[list[tuple[float, float, float]]] = []
+        for lat in range(1, lat_steps):
+            theta = -math.pi / 2 + math.pi * lat / lat_steps
+            row = []
+            for lon in range(lon_steps):
+                phi = math.tau * lon / lon_steps
+                sx = math.cos(theta) * math.cos(phi)
+                sy = math.sin(theta)
+                sz = math.cos(theta) * math.sin(phi)
+                band = frame[(lon * len(frame) // lon_steps) % len(frame)] if frame else 0.0
+                noise = self._pseudo_noise(sx, sy, sz, t)
+                r = base + noise * amp + min(1.0, band * 2.4) * 0.16
+                row.append(self._rotate_project(sx * r, sy * r, sz * r, t, cx, cy, 116 * sphere_scale))
+            points.append(row)
+
+        # Latitude rings.
+        for row_i, row in enumerate(points):
+            for lon in range(lon_steps):
+                x0, y0, p0 = row[lon]
+                x1, y1, p1 = row[(lon + 1) % lon_steps]
+                depth = (p0 + p1) * 0.5
+                color = "#f8fafc" if depth > 0.72 and row_i % 3 == 0 else ("#67e8f9" if row_i % 2 else "#a78bfa")
+                self._draw_glow_line(x0, y0, x1, y1, color, 1 if depth < 0.72 else 2, visibility)
+
+        # Longitude arcs.
+        for lon in range(0, lon_steps, 2):
+            for row_i in range(len(points) - 1):
+                x0, y0, p0 = points[row_i][lon]
+                x1, y1, p1 = points[row_i + 1][lon]
+                depth = (p0 + p1) * 0.5
+                color = "#38bdf8" if lon % 4 else "#c084fc"
+                self._draw_glow_line(x0, y0, x1, y1, color, 1 if depth < 0.78 else 2, visibility)
+
+        # Icosahedron-like triangular chords over the sphere, giving the original repo's wireframe mesh feeling.
+        for lon in range(0, lon_steps, 3):
+            for row_i in range(0, len(points) - 2, 2):
+                a = points[row_i][lon]
+                b = points[row_i + 1][(lon + 2) % lon_steps]
+                c = points[row_i + 2][(lon + 1) % lon_steps]
+                color = "#f0f9ff" if (lon + row_i) % 4 == 0 else "#22d3ee"
+                self._draw_glow_line(a[0], a[1], b[0], b[1], color, 1, visibility)
+                self._draw_glow_line(b[0], b[1], c[0], c[1], color, 1, visibility)
+
+        # Progress halo.
+        ring_r = (190 + energy * 20) * sphere_scale
+        self.canvas.create_arc(cx - ring_r, cy - ring_r, cx + ring_r, cy + ring_r, start=90, extent=-359.9, outline=self._fade_hex("#111827", visibility), width=5, style="arc")
+        self.canvas.create_arc(cx - ring_r, cy - ring_r, cx + ring_r, cy + ring_r, start=90, extent=-359.9 * progress, outline=self._fade_hex("#f8fafc", visibility), width=2, style="arc")
+        self.canvas.create_arc(cx - ring_r, cy - ring_r, cx + ring_r, cy + ring_r, start=90, extent=-359.9 * progress, outline=self._fade_hex("#22d3ee", visibility), width=5, style="arc")
+
+    def _spawn_particles(self, energy: float, low: float) -> None:
+        spawn = 2 + int(energy * 8) + int(low * 6)
+        max_particles = 260
+        for _ in range(spawn):
+            if len(self.particles) >= max_particles:
+                self.particles.pop(0)
+            angle = random.random() * math.tau
+            self.particles.append({
+                "a": angle,
+                "r": random.random() * 9.0,
+                "vr": 1.3 + random.random() * 2.2 + energy * 4.6,
+                "y": 0.0,
+                "vy": 0.9 + low * 4.2 + random.random() * 1.8,
+                "life": 1.0,
+                "size": 1.1 + random.random() * 2.2 + energy * 2.2,
+            })
+
+    def _draw_particles(self, cx: float, cy: float, energy: float, low: float, t: float, visibility: float = 1.0) -> None:
+        now = time.monotonic()
+        dt = max(0.01, min(0.08, now - self.last_particle_t))
+        self.last_particle_t = now
+        if energy > 0.035 and visibility > 0.18:
+            self._spawn_particles(energy * visibility, low * visibility)
+        alive: list[dict[str, float]] = []
+        for p in self.particles:
+            p["r"] += p["vr"] * dt * 42
+            p["vy"] -= 4.9 * dt
+            p["y"] = max(0.0, p["y"] + p["vy"] * dt * 34)
+            p["life"] -= dt * (0.42 + p["r"] / 620)
+            if p["life"] <= 0 or p["r"] > 230:
+                continue
+            alive.append(p)
+            a = p["a"] + math.sin(t * 0.7 + p["r"] * 0.01) * 0.12
+            x = cx + math.cos(a) * p["r"]
+            z = math.sin(a) * p["r"]
+            y = cy + z * 0.34 - p["y"]
+            fade = max(0.0, min(1.0, p["life"]))
+            particle_visibility = visibility * fade
+            size = p["size"] * (0.45 + fade) * (0.45 + 0.55 * self._smoothstep(visibility))
+            color = "#f8fafc" if p["r"] < 44 else ("#67e8f9" if int(p["r"]) % 2 else "#a78bfa")
+            self.canvas.create_oval(x - size * 2.4, y - size * 2.4, x + size * 2.4, y + size * 2.4, outline=self._fade_hex("#0e7490", particle_visibility), width=1)
+            self.canvas.create_oval(x - size, y - size, x + size, y + size, fill=self._fade_hex(color, particle_visibility), outline="")
+        self.particles = alive
+
+    def _draw_circular_body(self, frame: list[float], progress: float, visibility: float = 1.0) -> None:
+        cx = WINDOW_W / 2
+        cy = HEADER_H + (WINDOW_H - HEADER_H) / 2 + 14
+        energy = self._frame_energy(frame)
+        low, mid, high = self._split_energy(frame)
+        t = time.monotonic() - self.started_at
+
+        # Dark WebGL-like scene background with bloom-friendly rings.
+        self.canvas.create_rectangle(0, HEADER_H, WINDOW_W, WINDOW_H, fill="#020617", outline="")
+        v = self._smoothstep(visibility)
+        scene_scale = 0.82 + 0.18 * v
+        for k, (r, color) in enumerate([(238, "#050b1e"), (205, "#081427"), (166, "#0b1735"), (126, "#061d2d")]):
+            rr = r * scene_scale
+            self.canvas.create_oval(cx - rr, cy - rr * 0.82, cx + rr, cy + rr * 0.82, outline=self._fade_hex(color, visibility), width=max(1, int((8 - k) * (0.55 + 0.45 * v))))
+        for r, color, width in [(218, "#172554", 1), (174, "#0e7490", 1), (132, "#312e81", 1), (84, "#164e63", 1)]:
+            rr = r * scene_scale
+            self.canvas.create_oval(cx - rr, cy - rr, cx + rr, cy + rr, outline=self._fade_hex(color, visibility), width=width)
+
+        # Particle/ripple system: center spawn, outward spread, vertical kick.
+        self._draw_particles(cx, cy + 42, energy, low, t, visibility)
+
+        # Shader-like displaced wireframe 3D object.
+        self._draw_wire_sphere(cx, cy - 8, frame, energy, progress, t, visibility)
+
+        # Core label and status.
+        core = (42 + low * 16 + mid * 10) * (0.72 + 0.28 * v)
+        self.canvas.create_oval(cx - core * 1.55, cy - 8 - core * 1.55, cx + core * 1.55, cy - 8 + core * 1.55, outline=self._fade_hex("#0e7490", visibility), width=max(1, int(7 * (0.45 + 0.55 * v))))
+        self.canvas.create_oval(cx - core, cy - 8 - core, cx + core, cy - 8 + core, fill="#020617", outline=self._fade_hex("#f8fafc", visibility), width=2)
+        self.canvas.create_text(cx, cy - 22, text="HERMES", fill=self._fade_hex("#f8fafc", visibility), font=("Segoe UI", 17, "bold"))
+        status = "SKIPPED" if self.audio_skipped else ("PAUSED" if self.audio_paused else (self.provider or "3D AUDIO").upper()[:18])
+        self.canvas.create_text(cx, cy + 5, text=status, fill=self._fade_hex("#67e8f9", visibility), font=("Segoe UI", 8, "bold"))
+        self.canvas.create_text(cx, cy + 22, text="WIREFRAME · BLOOM · PARTICLES", fill=self._fade_hex("#a5b4fc", visibility), font=("Segoe UI", 7, "bold"))
 
     def draw(self) -> None:
         elapsed = time.monotonic() - self.started_at
@@ -501,17 +685,19 @@ class Visualizer:
         if not self._apply_timed_alpha(elapsed, total_life):
             self._close_window()
             return
+        visibility = self._visual_visibility(elapsed, total_life)
+        self.visual_fade = visibility
         if self.minimized:
             self._draw_minimized()
             self.root.after(int(1000 / FPS), self.draw)
             return
 
         self.canvas.delete("all")
-        self.canvas.create_rectangle(0, 0, WINDOW_W, WINDOW_H, fill="#05070d", outline="#152033")
+        self.canvas.create_rectangle(0, 0, WINDOW_W, WINDOW_H, fill="#030712", outline="#172033")
         self._draw_header()
-        frame = self.frames[min(self.index, len(self.frames) - 1)]
+        frame = self._current_frame()
         progress = min(1.0, self.index / max(1, len(self.frames)))
-        self._draw_radial_visualizer(frame, elapsed, progress)
+        self._draw_circular_body(frame, progress, visibility)
         self.index += 1
         if elapsed <= total_life:
             self.root.after(int(1000 / FPS), self.draw)
@@ -539,4 +725,8 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    try:
+        raise SystemExit(main())
+    except Exception:
+        log("visualizer fatal error:\n" + traceback.format_exc())
+        raise

--- a/scripts/tts_visualizer_win.py
+++ b/scripts/tts_visualizer_win.py
@@ -37,6 +37,17 @@ HEADER_H = 31
 
 DEFAULT_BASE = Path(os.environ.get("LOCALAPPDATA", str(Path.home() / "AppData/Local"))) / "HermesTTSVisualizer"
 SETTINGS_PATH = DEFAULT_BASE / "visualizer_settings.json"
+LOG_PATH = DEFAULT_BASE / "listener.log"
+
+
+def log(message: str) -> None:
+    try:
+        LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        ts = time.strftime("%Y-%m-%d %H:%M:%S")
+        with LOG_PATH.open("a", encoding="utf-8") as fh:
+            fh.write(f"[{ts}] {message}\n")
+    except Exception:
+        pass
 
 
 def decode_with_ffmpeg(path: Path) -> list[int]:
@@ -120,7 +131,7 @@ def clamp(value: int, low: int, high: int) -> int:
 
 
 class Visualizer:
-    def __init__(self, audio: Path, text: str, provider: str):
+    def __init__(self, audio: Path, text: str, provider: str, play_audio: bool = True):
         self.audio = audio
         self.text = " ".join((text or audio.name).replace("\n", " ").split())
         self.provider = provider
@@ -128,6 +139,11 @@ class Visualizer:
         self.duration = 2.0
         self.index = 0
         self.started_at = time.monotonic()
+        self.loaded = False
+        self.load_started_at = time.monotonic()
+        self.play_audio = play_audio
+        self.play_started = False
+        self.audio_proc: subprocess.Popen | None = None
         self.minimized = False
         self.drag_offset: tuple[int, int] | None = None
         self.settings = load_settings()
@@ -167,6 +183,59 @@ class Visualizer:
 
     def _load(self) -> None:
         self.frames, self.duration = load_envelope(self.audio)
+        self.loaded = True
+
+    def _find_ffplay(self) -> str | None:
+        ffplay = shutil.which("ffplay")
+        if ffplay:
+            return ffplay
+        ffmpeg = shutil.which("ffmpeg")
+        if ffmpeg:
+            candidate = Path(ffmpeg).with_name("ffplay.exe" if sys.platform.startswith("win") else "ffplay")
+            if candidate.exists():
+                return str(candidate)
+        return None
+
+    def _start_playback(self) -> None:
+        if self.play_started or not self.play_audio:
+            return
+        self.play_started = True
+        ffplay = self._find_ffplay()
+        if not ffplay:
+            log(f"audio playback skipped for {self.audio.name}: ffplay not found")
+            return
+        cmd = [ffplay, "-nodisp", "-autoexit", "-loglevel", "error", str(self.audio)]
+        try:
+            creationflags = 0
+            if sys.platform.startswith("win") and hasattr(subprocess, "CREATE_NO_WINDOW"):
+                creationflags = subprocess.CREATE_NO_WINDOW
+            self.audio_proc = subprocess.Popen(
+                cmd,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                creationflags=creationflags,
+            )
+            log(f"started desktop audio playback for {self.audio.name} pid={self.audio_proc.pid}")
+        except Exception as exc:
+            log(f"audio playback failed for {self.audio.name}: {exc!r}")
+            self.audio_proc = None
+
+    def _stop_playback(self) -> None:
+        proc = self.audio_proc
+        if not proc or proc.poll() is not None:
+            return
+        try:
+            proc.terminate()
+        except Exception:
+            pass
+
+    def _close_window(self) -> None:
+        self._stop_playback()
+        try:
+            self.root.destroy()
+        except Exception:
+            pass
 
     def _set_alpha(self, alpha: float) -> None:
         try:
@@ -257,7 +326,7 @@ class Visualizer:
             alpha = self.alpha_target
         next_alpha = alpha - max(0.03, self.alpha_target / (FADE_OUT_SECONDS * FPS))
         if next_alpha <= 0.02:
-            self.root.destroy()
+            self._close_window()
             return
         self._set_alpha(next_alpha)
         self.root.after(int(1000 / FPS), self._fade_out_step)
@@ -321,11 +390,23 @@ class Visualizer:
         label = "HERMES TTS  ▣" if self.topmost else "HERMES TTS  □"
         self.canvas.create_text(31, 17, anchor="w", text=label, fill="#cbd5e1", font=("Segoe UI", 8, "bold"))
 
+    def _wait_then_start(self) -> None:
+        # Keep playback and bars aligned: wait briefly for ffmpeg decoding before
+        # starting ffplay. If decoding is slow or unavailable, start anyway rather
+        # than leaving a polite but useless dark rectangle.
+        if not self.loaded and time.monotonic() - self.load_started_at < 2.0:
+            self.root.after(50, self._wait_then_start)
+            return
+        self.started_at = time.monotonic()
+        self.index = 0
+        self._start_playback()
+        self.draw()
+
     def draw(self) -> None:
         elapsed = time.monotonic() - self.started_at
         total_life = max(self.duration, len(self.frames) / FPS) + HOLD_SECONDS + FADE_OUT_SECONDS
         if not self._apply_timed_alpha(elapsed, total_life):
-            self.root.destroy()
+            self._close_window()
             return
         if self.minimized:
             self._draw_minimized()
@@ -353,10 +434,10 @@ class Visualizer:
         if elapsed <= total_life:
             self.root.after(int(1000 / FPS), self.draw)
         else:
-            self.root.destroy()
+            self._close_window()
 
     def run(self) -> None:
-        self.root.after(40, self.draw)
+        self.root.after(40, self._wait_then_start)
         self.root.mainloop()
 
 
@@ -365,11 +446,13 @@ def main() -> int:
     parser.add_argument("--audio", required=True)
     parser.add_argument("--text", default="")
     parser.add_argument("--provider", default="")
+    parser.add_argument("--play", dest="play_audio", action="store_true", default=True, help="Play the same audio on this Windows desktop while visualizing")
+    parser.add_argument("--no-play", dest="play_audio", action="store_false", help="Visualize only; do not play audio on this Windows desktop")
     args = parser.parse_args()
     audio = Path(args.audio)
     if not audio.exists():
         return 2
-    Visualizer(audio, args.text, args.provider).run()
+    Visualizer(audio, args.text, args.provider, play_audio=args.play_audio).run()
     return 0
 
 

--- a/scripts/tts_visualizer_win.py
+++ b/scripts/tts_visualizer_win.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Always-on-top corner visualizer for Hermes TTS audio on Windows.
+
+No third-party Python packages are required.  ffmpeg is used when available so
+Telegram-friendly OGG/Opus files work; WAV files fall back to the stdlib wave
+module.
+"""
+from __future__ import annotations
+
+import argparse
+import math
+import shutil
+import struct
+import subprocess
+import sys
+import threading
+import time
+import wave
+from pathlib import Path
+from tkinter import BOTH, Canvas, Tk
+
+SAMPLE_RATE = 48_000
+FPS = 30
+BAR_COUNT = 48
+WINDOW_W = 460
+WINDOW_H = 150
+MARGIN = 16
+
+
+def decode_with_ffmpeg(path: Path) -> list[int]:
+    ffmpeg = shutil.which("ffmpeg")
+    if not ffmpeg:
+        return []
+    proc = subprocess.run(
+        [ffmpeg, "-v", "error", "-i", str(path), "-f", "s16le", "-ac", "1", "-ar", str(SAMPLE_RATE), "pipe:1"],
+        capture_output=True,
+        check=False,
+    )
+    if proc.returncode != 0 or not proc.stdout:
+        return []
+    count = len(proc.stdout) // 2
+    return list(struct.unpack("<" + "h" * count, proc.stdout[: count * 2]))
+
+
+def decode_wave(path: Path) -> tuple[list[int], int]:
+    with wave.open(str(path), "rb") as wf:
+        channels = wf.getnchannels()
+        sample_rate = wf.getframerate()
+        width = wf.getsampwidth()
+        raw = wf.readframes(wf.getnframes())
+    if width != 2:
+        return [], sample_rate
+    values = struct.unpack("<" + "h" * (len(raw) // 2), raw)
+    if channels <= 1:
+        return list(values), sample_rate
+    return [int(sum(values[i : i + channels]) / channels) for i in range(0, len(values), channels)], sample_rate
+
+
+def load_envelope(path: Path) -> tuple[list[list[float]], float]:
+    samples = decode_with_ffmpeg(path)
+    sample_rate = SAMPLE_RATE
+    if not samples and path.suffix.lower() == ".wav":
+        samples, sample_rate = decode_wave(path)
+    if not samples:
+        # A graceful failure still gives the user a visible pulse rather than a
+        # dead square in the corner. Technology must at least look guilty.
+        frames = [[0.15 + 0.1 * math.sin(i / 3 + b / 4) for b in range(BAR_COUNT)] for i in range(FPS * 3)]
+        return frames, 3.0
+
+    samples_per_frame = max(1, int(sample_rate / FPS))
+    frames: list[list[float]] = []
+    for start in range(0, len(samples), samples_per_frame):
+        chunk = samples[start : start + samples_per_frame]
+        if not chunk:
+            continue
+        band_size = max(1, len(chunk) // BAR_COUNT)
+        bars: list[float] = []
+        for b in range(BAR_COUNT):
+            band = chunk[b * band_size : (b + 1) * band_size]
+            if not band:
+                bars.append(0.0)
+                continue
+            rms = math.sqrt(sum(x * x for x in band) / len(band)) / 32768.0
+            bars.append(min(1.0, rms * 4.8))
+        frames.append(bars)
+    duration = len(samples) / sample_rate
+    return frames or [[0.0] * BAR_COUNT], max(0.8, duration)
+
+
+class Visualizer:
+    def __init__(self, audio: Path, text: str, provider: str):
+        self.audio = audio
+        self.text = text
+        self.provider = provider
+        self.frames: list[list[float]] = [[0.0] * BAR_COUNT]
+        self.duration = 2.0
+        self.index = 0
+        self.root = Tk()
+        self.root.overrideredirect(True)
+        self.root.attributes("-topmost", True)
+        try:
+            self.root.attributes("-alpha", 0.92)
+        except Exception:
+            pass
+        screen_w = self.root.winfo_screenwidth()
+        screen_h = self.root.winfo_screenheight()
+        x = max(0, screen_w - WINDOW_W - 18)
+        y = max(0, screen_h - WINDOW_H - 58)
+        self.root.geometry(f"{WINDOW_W}x{WINDOW_H}+{x}+{y}")
+        self.canvas = Canvas(self.root, width=WINDOW_W, height=WINDOW_H, bg="#05070d", bd=0, highlightthickness=0)
+        self.canvas.pack(fill=BOTH, expand=True)
+        threading.Thread(target=self._load, daemon=True).start()
+
+    def _load(self) -> None:
+        self.frames, self.duration = load_envelope(self.audio)
+
+    def draw(self) -> None:
+        self.canvas.delete("all")
+        self.canvas.create_rectangle(0, 0, WINDOW_W, WINDOW_H, fill="#05070d", outline="#152033")
+        self.canvas.create_text(MARGIN, 15, anchor="w", text="HERMES TTS", fill="#7dd3fc", font=("Segoe UI", 9, "bold"))
+        caption = self.text.replace("\n", " ")[:72] or self.audio.name
+        self.canvas.create_text(MARGIN + 92, 15, anchor="w", text=caption, fill="#cbd5e1", font=("Segoe UI", 8))
+        frame = self.frames[min(self.index, len(self.frames) - 1)]
+        usable_w = WINDOW_W - MARGIN * 2
+        bar_w = usable_w / BAR_COUNT
+        base_y = WINDOW_H - 25
+        for i, amp in enumerate(frame):
+            eased = min(1.0, amp ** 0.55)
+            h = 7 + eased * 88
+            x0 = MARGIN + i * bar_w + 1
+            x1 = MARGIN + (i + 1) * bar_w - 1
+            y0 = base_y - h
+            color = "#22d3ee" if i % 3 else "#a78bfa"
+            self.canvas.create_rectangle(x0, y0, x1, base_y, fill=color, outline="")
+        progress = min(1.0, self.index / max(1, len(self.frames)))
+        self.canvas.create_rectangle(MARGIN, WINDOW_H - 11, MARGIN + usable_w * progress, WINDOW_H - 8, fill="#38bdf8", outline="")
+        self.index += 1
+        if self.index <= len(self.frames) + FPS * 2:
+            self.root.after(int(1000 / FPS), self.draw)
+        else:
+            self.root.destroy()
+
+    def run(self) -> None:
+        self.root.after(40, self.draw)
+        self.root.mainloop()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--audio", required=True)
+    parser.add_argument("--text", default="")
+    parser.add_argument("--provider", default="")
+    args = parser.parse_args()
+    audio = Path(args.audio)
+    if not audio.exists():
+        return 2
+    Visualizer(audio, args.text, args.provider).run()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/cli/test_fast_command.py
+++ b/tests/cli/test_fast_command.py
@@ -149,6 +149,7 @@ class TestPriorityProcessingModels(unittest.TestCase):
     def test_vendor_prefix_stripped(self):
         from hermes_cli.models import model_supports_fast_mode
 
+        assert model_supports_fast_mode("openai/gpt-5.5") is True
         assert model_supports_fast_mode("openai/gpt-5.4") is True
         assert model_supports_fast_mode("openai/gpt-4.1") is True
         assert model_supports_fast_mode("openai/o3") is True
@@ -170,6 +171,9 @@ class TestPriorityProcessingModels(unittest.TestCase):
 
     def test_resolve_overrides_returns_service_tier(self):
         from hermes_cli.models import resolve_fast_mode_overrides
+
+        result = resolve_fast_mode_overrides("gpt-5.5")
+        assert result == {"service_tier": "priority"}
 
         result = resolve_fast_mode_overrides("gpt-5.4")
         assert result == {"service_tier": "priority"}

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -11,6 +11,7 @@ import pytest
 
 from gateway.config import Platform, PlatformConfig, StreamingConfig
 from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
+from gateway.platforms.webhook import WebhookAdapter
 from gateway.session import SessionSource
 
 
@@ -38,12 +39,13 @@ class ProgressCaptureAdapter(BasePlatformAdapter):
         )
         return SendResult(success=True, message_id="progress-1")
 
-    async def edit_message(self, chat_id, message_id, content) -> SendResult:
+    async def edit_message(self, chat_id, message_id, content, *, finalize=False) -> SendResult:
         self.edits.append(
             {
                 "chat_id": chat_id,
                 "message_id": message_id,
                 "content": content,
+                "finalize": finalize,
             }
         )
         return SendResult(success=True, message_id=message_id)
@@ -61,7 +63,7 @@ class ProgressCaptureAdapter(BasePlatformAdapter):
 class NonEditingProgressCaptureAdapter(ProgressCaptureAdapter):
     SUPPORTS_MESSAGE_EDITING = False
 
-    async def edit_message(self, chat_id, message_id, content) -> SendResult:
+    async def edit_message(self, chat_id, message_id, content, *, finalize=False) -> SendResult:
         raise AssertionError("non-editable adapters should not receive edit_message calls")
 
 
@@ -956,6 +958,77 @@ async def test_keep_typing_stops_immediately_when_interrupt_event_is_set():
     ]
     assert len(normal_typing_calls) == 1
     assert len(stopped_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_webhook_delivery_uses_visible_telegram_progress_settings(monkeypatch, tmp_path):
+    """Webhook routes delivered to Telegram should show Telegram-style progress."""
+    import yaml
+
+    monkeypatch.delenv("HERMES_TOOL_PROGRESS_MODE", raising=False)
+    (tmp_path / "config.yaml").write_text(
+        yaml.dump(
+            {
+                "display": {
+                    "tool_progress": "off",
+                    "platforms": {"telegram": {"tool_progress": "all"}},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = FakeAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+    import tools.terminal_tool  # noqa: F401 - register terminal tool metadata
+
+    telegram = ProgressCaptureAdapter(platform=Platform.TELEGRAM)
+    webhook = WebhookAdapter(PlatformConfig(enabled=True, extra={"routes": {}, "port": 0}))
+    source_chat = "webhook:voice-sphere:req-progress"
+    webhook._delivery_info[source_chat] = {
+        "deliver": "telegram",
+        "deliver_extra": {"chat_id": "1403442542", "thread_id": "17585"},
+        "payload": {},
+    }
+
+    runner = _make_runner(webhook)
+    runner.adapters = {Platform.WEBHOOK: webhook, Platform.TELEGRAM: telegram}
+    runner.config.get_home_channel = lambda platform: None
+    webhook.gateway_runner = runner
+
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+
+    source = SessionSource(
+        platform=Platform.WEBHOOK,
+        chat_id=source_chat,
+        chat_type="webhook",
+        thread_id=None,
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-webhook-progress",
+        session_key=source_chat,
+    )
+
+    assert result["final_response"] == "done"
+    assert telegram.sent
+    assert telegram.sent[0]["chat_id"] == "1403442542"
+    assert telegram.sent[0]["metadata"] == {"thread_id": "17585"}
+    progress_text = " ".join(call["content"] for call in telegram.sent)
+    progress_text += " ".join(call["content"] for call in telegram.edits)
+    assert "pwd" in progress_text
+    assert telegram.edits
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -707,6 +707,7 @@ class TestDeliverCrossPlatformThreadId:
         adapter = _make_adapter()
         mock_target = AsyncMock()
         mock_target.send = AsyncMock(return_value=SendResult(success=True))
+        mock_target.play_tts = AsyncMock(return_value=SendResult(success=True))
 
         mock_runner = MagicMock()
         mock_runner.adapters = {Platform("telegram"): mock_target}
@@ -758,3 +759,51 @@ class TestDeliverCrossPlatformThreadId:
         mock_target.send.assert_awaited_once_with(
             "12345", "hello", metadata=None
         )
+
+    @pytest.mark.asyncio
+    async def test_voice_reply_sends_tts_before_text(self, tmp_path):
+        """voice_reply=true generates TTS and sends it before the text response."""
+        adapter, mock_target = self._setup_adapter_with_mock_target()
+        audio_path = tmp_path / "reply.ogg"
+        audio_path.write_bytes(b"fake audio")
+        delivery = {
+            "voice_reply": True,
+            "deliver_extra": {
+                "chat_id": "12345",
+                "thread_id": "999",
+            },
+        }
+        with patch("tools.tts_tool.check_tts_requirements", return_value=True), \
+             patch("tools.tts_tool.text_to_speech_tool", return_value=json.dumps({"file_path": str(audio_path)})), \
+             patch("hermes_cli.config.load_config", return_value={"tts": {"auto_chunk_chars": 1200, "auto_max_chunks": 3}}):
+            await adapter._deliver_cross_platform("telegram", "hello **voice**", delivery)
+
+        mock_target.play_tts.assert_awaited_once_with(
+            chat_id="12345",
+            audio_path=str(audio_path),
+            metadata={"thread_id": "999"},
+        )
+        mock_target.send.assert_awaited_once_with(
+            "12345", "hello **voice**", metadata={"thread_id": "999"}
+        )
+        assert not audio_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_voice_reply_can_skip_text(self, tmp_path):
+        """text_reply=false makes webhook delivery voice-only."""
+        adapter, mock_target = self._setup_adapter_with_mock_target()
+        audio_path = tmp_path / "reply.ogg"
+        audio_path.write_bytes(b"fake audio")
+        delivery = {
+            "voice_reply": True,
+            "text_reply": False,
+            "deliver_extra": {"chat_id": "12345"},
+        }
+        with patch("tools.tts_tool.check_tts_requirements", return_value=True), \
+             patch("tools.tts_tool.text_to_speech_tool", return_value=json.dumps({"file_path": str(audio_path)})), \
+             patch("hermes_cli.config.load_config", return_value={"tts": {"auto_chunk_chars": 1200, "auto_max_chunks": 3}}):
+            result = await adapter._deliver_cross_platform("telegram", "hello voice", delivery)
+
+        assert result.success is True
+        mock_target.play_tts.assert_awaited_once()
+        mock_target.send.assert_not_awaited()

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -706,8 +706,17 @@ class TestDeliverCrossPlatformThreadId:
         """Set up a webhook adapter with a mocked gateway_runner and target adapter."""
         adapter = _make_adapter()
         mock_target = AsyncMock()
-        mock_target.send = AsyncMock(return_value=SendResult(success=True))
+        mock_target.send = AsyncMock(return_value=SendResult(success=True, message_id="m1"))
+        mock_target.edit_message = AsyncMock(return_value=SendResult(success=True))
+        mock_target.delete_message = AsyncMock(return_value=True)
+        mock_target.send_typing = AsyncMock()
         mock_target.play_tts = AsyncMock(return_value=SendResult(success=True))
+        mock_target.send_voice = AsyncMock(return_value=SendResult(success=True))
+        mock_target.send_image = AsyncMock(return_value=SendResult(success=True))
+        mock_target.send_animation = AsyncMock(return_value=SendResult(success=True))
+        mock_target.send_image_file = AsyncMock(return_value=SendResult(success=True))
+        mock_target.send_video = AsyncMock(return_value=SendResult(success=True))
+        mock_target.send_document = AsyncMock(return_value=SendResult(success=True))
 
         mock_runner = MagicMock()
         mock_runner.adapters = {Platform("telegram"): mock_target}
@@ -802,6 +811,81 @@ class TestDeliverCrossPlatformThreadId:
 
         mock_target.send_typing.assert_awaited_once_with(
             "12345", metadata={"thread_id": "888"}
+        )
+
+    def test_delivery_platform_key_for_chat_uses_target_platform(self):
+        """Display settings can resolve against the visible delivery platform."""
+        adapter, _mock_target = self._setup_adapter_with_mock_target()
+        chat_id = "webhook:voice-sphere:req-display"
+        adapter._delivery_info[chat_id] = {
+            "deliver": "telegram",
+            "deliver_extra": {"chat_id": "12345"},
+        }
+
+        assert adapter.delivery_platform_key_for_chat(chat_id) == "telegram"
+
+    @pytest.mark.asyncio
+    async def test_edit_and_delete_forward_to_delivery_target(self):
+        """Webhook progress/stream edits use the target platform message APIs."""
+        adapter, mock_target = self._setup_adapter_with_mock_target()
+        chat_id = "webhook:voice-sphere:req-progress"
+        adapter._delivery_info[chat_id] = {
+            "deliver": "telegram",
+            "deliver_extra": {"chat_id": "12345", "thread_id": "999"},
+        }
+
+        result = await adapter.edit_message(chat_id, "777", "working", finalize=True)
+        deleted = await adapter.delete_message(chat_id, "777")
+
+        assert result.success is True
+        assert deleted is True
+        mock_target.edit_message.assert_awaited_once_with(
+            chat_id="12345",
+            message_id="777",
+            content="working",
+            finalize=True,
+        )
+        mock_target.delete_message.assert_awaited_once_with("12345", "777")
+
+    @pytest.mark.asyncio
+    async def test_native_media_methods_forward_to_delivery_target(self):
+        """Webhook-originated MEDIA outputs stay native when delivered to Telegram."""
+        adapter, mock_target = self._setup_adapter_with_mock_target()
+        chat_id = "webhook:voice-sphere:req-media"
+        adapter._delivery_info[chat_id] = {
+            "deliver": "telegram",
+            "deliver_extra": {"chat_id": "12345", "thread_id": "999"},
+        }
+
+        await adapter.send_voice(chat_id, "/tmp/reply.ogg", caption="voice")
+        await adapter.play_tts(chat_id, "/tmp/tts.ogg")
+        await adapter.send_image(chat_id, "https://example.com/a.png", caption="img")
+        await adapter.send_animation(chat_id, "https://example.com/a.gif", caption="gif")
+        await adapter.send_image_file(chat_id, "/tmp/a.png", caption="file-img")
+        await adapter.send_video(chat_id, "/tmp/a.mp4", caption="video")
+        await adapter.send_document(chat_id, "/tmp/a.pdf", caption="doc", file_name="a.pdf")
+
+        meta = {"thread_id": "999"}
+        mock_target.send_voice.assert_awaited_once_with(
+            "12345", "/tmp/reply.ogg", caption="voice", reply_to=None, metadata=meta
+        )
+        mock_target.play_tts.assert_awaited_once_with(
+            "12345", "/tmp/tts.ogg", metadata=meta
+        )
+        mock_target.send_image.assert_awaited_once_with(
+            "12345", "https://example.com/a.png", caption="img", reply_to=None, metadata=meta
+        )
+        mock_target.send_animation.assert_awaited_once_with(
+            "12345", "https://example.com/a.gif", caption="gif", reply_to=None, metadata=meta
+        )
+        mock_target.send_image_file.assert_awaited_once_with(
+            "12345", "/tmp/a.png", caption="file-img", reply_to=None, metadata=meta
+        )
+        mock_target.send_video.assert_awaited_once_with(
+            "12345", "/tmp/a.mp4", caption="video", reply_to=None, metadata=meta
+        )
+        mock_target.send_document.assert_awaited_once_with(
+            "12345", "/tmp/a.pdf", caption="doc", file_name="a.pdf", reply_to=None, metadata=meta
         )
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -761,6 +761,50 @@ class TestDeliverCrossPlatformThreadId:
         )
 
     @pytest.mark.asyncio
+    async def test_send_typing_forwarded_to_delivery_target(self):
+        """Webhook typing indicators are forwarded to the configured platform chat."""
+        adapter, mock_target = self._setup_adapter_with_mock_target()
+        mock_target.send_typing = AsyncMock()
+        chat_id = "webhook:voice-sphere:req-1"
+        adapter._delivery_info[chat_id] = {
+            "deliver": "telegram",
+            "deliver_extra": {
+                "chat_id": "12345",
+                "thread_id": "999",
+            },
+        }
+
+        await adapter.send_typing(chat_id)
+
+        mock_target.send_typing.assert_awaited_once_with(
+            "12345", metadata={"thread_id": "999"}
+        )
+
+    @pytest.mark.asyncio
+    async def test_send_typing_recovers_delivery_from_route_config(self):
+        """Typing forwarding still works if in-memory delivery_info is missing."""
+        routes = {
+            "voice-sphere": {
+                "secret": _INSECURE_NO_AUTH,
+                "deliver": "telegram",
+                "deliver_extra": {"chat_id": "12345", "message_thread_id": "888"},
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+        mock_target = AsyncMock()
+        mock_target.send_typing = AsyncMock()
+        mock_runner = MagicMock()
+        mock_runner.adapters = {Platform("telegram"): mock_target}
+        mock_runner.config.get_home_channel.return_value = None
+        adapter.gateway_runner = mock_runner
+
+        await adapter.send_typing("webhook:voice-sphere:req-2")
+
+        mock_target.send_typing.assert_awaited_once_with(
+            "12345", metadata={"thread_id": "888"}
+        )
+
+    @pytest.mark.asyncio
     async def test_voice_reply_sends_tts_before_text(self, tmp_path):
         """voice_reply=true generates TTS and sends it before the text response."""
         adapter, mock_target = self._setup_adapter_with_mock_target()

--- a/tests/tools/test_tts_edge_postprocess.py
+++ b/tests/tools/test_tts_edge_postprocess.py
@@ -1,0 +1,50 @@
+"""Tests for Edge TTS Telegram/FFmpeg postprocess behavior."""
+
+import json
+
+
+def test_edge_requested_ogg_synthesizes_mp3_then_converts_to_telegram_opus(monkeypatch, tmp_path):
+    from tools import tts_tool as _tt
+
+    requested_ogg = tmp_path / "out.ogg"
+    generated = {}
+
+    async def fake_edge(text, output_path, config):
+        generated["edge_output_path"] = output_path
+        assert output_path.endswith(".mp3")
+        with open(output_path, "wb") as f:
+            f.write(b"ID3 fake mp3")
+        return output_path
+
+    def fake_postprocess(path, config):
+        generated["postprocess_input"] = path
+        processed = tmp_path / "out_cyber_autotune.mp3"
+        processed.write_bytes(b"ID3 processed mp3")
+        return str(processed)
+
+    def fake_convert(path):
+        generated["convert_input"] = path
+        opus = tmp_path / "out_cyber_autotune.ogg"
+        opus.write_bytes(b"OggS opus")
+        return str(opus)
+
+    monkeypatch.setattr(
+        _tt,
+        "_load_tts_config",
+        lambda: {"provider": "edge", "postprocess": {"enabled": True, "preset": "cyber_autotune"}},
+    )
+    monkeypatch.setattr(_tt, "_generate_edge_tts", fake_edge)
+    monkeypatch.setattr(_tt, "_apply_tts_postprocess", fake_postprocess)
+    monkeypatch.setattr(_tt, "_convert_to_opus", fake_convert)
+    monkeypatch.setattr(_tt, "_import_edge_tts", lambda: object())
+
+    result = json.loads(_tt.text_to_speech_tool("안녕하세요", str(requested_ogg)))
+
+    assert result["success"] is True
+    assert result["provider"] == "edge"
+    assert result["file_path"].endswith("out_cyber_autotune.ogg")
+    assert result["voice_compatible"] is True
+    assert result["media_tag"].startswith("[[audio_as_voice]]")
+    assert generated["edge_output_path"].endswith("out.mp3")
+    assert generated["postprocess_input"] == generated["edge_output_path"]
+    assert generated["convert_input"].endswith("out_cyber_autotune.mp3")

--- a/tests/tools/test_tts_effect_filter.py
+++ b/tests/tools/test_tts_effect_filter.py
@@ -1,0 +1,13 @@
+"""Tests for TTS FFmpeg effect filter construction."""
+
+
+def test_cyber_autotune_pitch_chain_uses_input_sample_rate(monkeypatch):
+    from tools import tts_tool as _tt
+
+    monkeypatch.delenv("HERMES_TTS_USE_RUBBERBAND", raising=False)
+
+    chain = _tt._tts_effect_filter("cyber_autotune", sample_rate=24000)
+
+    assert "asetrate=24000*1.05" in chain
+    assert "aresample=24000" in chain
+    assert "asetrate=48000*1.05" not in chain

--- a/tests/tools/test_tts_google_cloud.py
+++ b/tests/tools/test_tts_google_cloud.py
@@ -142,3 +142,118 @@ def test_google_cloud_has_default_text_limit():
 
     assert PROVIDER_MAX_TEXT_LENGTH["google_cloud"] == 5000
     assert _resolve_max_text_length("google_cloud", {}) == 5000
+
+
+def test_google_cloud_records_successful_monthly_character_usage(monkeypatch, tmp_path):
+    from tools import tts_tool as _tt
+
+    monkeypatch.setattr(_tt, "_google_cloud_usage_month", lambda: "2026-04")
+    monkeypatch.setattr(_tt, "_google_cloud_usage_path", lambda config: tmp_path / "usage.json")
+
+    class FakeTextToSpeechClient:
+        def synthesize_speech(self, request):
+            return SimpleNamespace(audio_content=b"RIFF fake wav")
+
+    class FakeTextToSpeech:
+        TextToSpeechClient = FakeTextToSpeechClient
+        SynthesisInput = lambda self, text: {"text": text}
+        VoiceSelectionParams = lambda self, language_code, name: {
+            "language_code": language_code,
+            "name": name,
+        }
+        AudioConfig = lambda self, audio_encoding, speaking_rate, pitch: {
+            "audio_encoding": audio_encoding,
+            "speaking_rate": speaking_rate,
+            "pitch": pitch,
+        }
+        AudioEncoding = SimpleNamespace(LINEAR16="LINEAR16", MP3="MP3")
+
+    monkeypatch.setattr(_tt, "_import_google_cloud_tts", lambda: FakeTextToSpeech())
+
+    _tt._generate_google_cloud_tts("가나다", str(tmp_path / "out.wav"), {})
+
+    usage = json.loads((tmp_path / "usage.json").read_text(encoding="utf-8"))
+    assert usage == {"month": "2026-04", "characters": 3}
+
+
+def test_google_cloud_monthly_character_limit_blocks_before_api_call(monkeypatch, tmp_path):
+    from tools import tts_tool as _tt
+
+    usage_path = tmp_path / "usage.json"
+    usage_path.write_text(json.dumps({"month": "2026-04", "characters": 999_998}), encoding="utf-8")
+    monkeypatch.setattr(_tt, "_google_cloud_usage_month", lambda: "2026-04")
+    monkeypatch.setattr(_tt, "_google_cloud_usage_path", lambda config: usage_path)
+
+    called = {"api": False}
+
+    class FakeTextToSpeechClient:
+        def synthesize_speech(self, request):
+            called["api"] = True
+            return SimpleNamespace(audio_content=b"RIFF fake wav")
+
+    class FakeTextToSpeech:
+        TextToSpeechClient = FakeTextToSpeechClient
+        SynthesisInput = lambda self, text: {"text": text}
+        VoiceSelectionParams = lambda self, language_code, name: {
+            "language_code": language_code,
+            "name": name,
+        }
+        AudioConfig = lambda self, audio_encoding, speaking_rate, pitch: {
+            "audio_encoding": audio_encoding,
+            "speaking_rate": speaking_rate,
+            "pitch": pitch,
+        }
+        AudioEncoding = SimpleNamespace(LINEAR16="LINEAR16", MP3="MP3")
+
+    monkeypatch.setattr(_tt, "_import_google_cloud_tts", lambda: FakeTextToSpeech())
+
+    try:
+        _tt._generate_google_cloud_tts("초과됨", str(tmp_path / "out.wav"), {})
+    except ValueError as e:
+        assert "monthly character limit" in str(e)
+        assert "1,000,000" in str(e)
+    else:
+        raise AssertionError("Expected monthly quota ValueError")
+
+    assert called["api"] is False
+    assert json.loads(usage_path.read_text(encoding="utf-8"))["characters"] == 999_998
+
+
+def test_google_cloud_monthly_character_limit_can_be_configured(monkeypatch, tmp_path):
+    from tools import tts_tool as _tt
+
+    usage_path = tmp_path / "usage.json"
+    usage_path.write_text(json.dumps({"month": "2026-04", "characters": 10}), encoding="utf-8")
+    monkeypatch.setattr(_tt, "_google_cloud_usage_month", lambda: "2026-04")
+    monkeypatch.setattr(_tt, "_google_cloud_usage_path", lambda config: usage_path)
+
+    class FakeTextToSpeechClient:
+        def synthesize_speech(self, request):
+            return SimpleNamespace(audio_content=b"RIFF fake wav")
+
+    class FakeTextToSpeech:
+        TextToSpeechClient = FakeTextToSpeechClient
+        SynthesisInput = lambda self, text: {"text": text}
+        VoiceSelectionParams = lambda self, language_code, name: {
+            "language_code": language_code,
+            "name": name,
+        }
+        AudioConfig = lambda self, audio_encoding, speaking_rate, pitch: {
+            "audio_encoding": audio_encoding,
+            "speaking_rate": speaking_rate,
+            "pitch": pitch,
+        }
+        AudioEncoding = SimpleNamespace(LINEAR16="LINEAR16", MP3="MP3")
+
+    monkeypatch.setattr(_tt, "_import_google_cloud_tts", lambda: FakeTextToSpeech())
+    config = {"google_cloud": {"monthly_character_limit": 20}}
+
+    _tt._generate_google_cloud_tts("12345", str(tmp_path / "ok.wav"), config)
+    assert json.loads(usage_path.read_text(encoding="utf-8"))["characters"] == 15
+
+    try:
+        _tt._generate_google_cloud_tts("123456", str(tmp_path / "blocked.wav"), config)
+    except ValueError as e:
+        assert "20" in str(e)
+    else:
+        raise AssertionError("Expected configured monthly quota ValueError")

--- a/tests/tools/test_tts_google_cloud.py
+++ b/tests/tools/test_tts_google_cloud.py
@@ -1,0 +1,144 @@
+"""Tests for the Google Cloud Text-to-Speech provider."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+def test_google_cloud_tts_uses_chirp3_hd_defaults(monkeypatch, tmp_path):
+    from tools import tts_tool as _tt
+
+    captured = {}
+
+    class FakeTextToSpeechClient:
+        def synthesize_speech(self, request):
+            captured["request"] = request
+            return SimpleNamespace(audio_content=b"RIFF fake wav")
+
+    class FakeTextToSpeech:
+        TextToSpeechClient = FakeTextToSpeechClient
+        SynthesisInput = lambda self, text: {"text": text}
+        VoiceSelectionParams = lambda self, language_code, name: {
+            "language_code": language_code,
+            "name": name,
+        }
+        AudioConfig = lambda self, audio_encoding, speaking_rate, pitch: {
+            "audio_encoding": audio_encoding,
+            "speaking_rate": speaking_rate,
+            "pitch": pitch,
+        }
+        AudioEncoding = SimpleNamespace(LINEAR16="LINEAR16", MP3="MP3")
+
+    monkeypatch.setattr(_tt, "_import_google_cloud_tts", lambda: FakeTextToSpeech())
+
+    output = tmp_path / "out.wav"
+    result = _tt._generate_google_cloud_tts("안녕하세요", str(output), {})
+
+    assert result == str(output)
+    assert output.read_bytes() == b"RIFF fake wav"
+    request = captured["request"]
+    assert request["input"] == {"text": "안녕하세요"}
+    assert request["voice"]["language_code"] == "ko-KR"
+    assert request["voice"]["name"] == "ko-KR-Chirp3-HD-Kore"
+    assert request["audio_config"]["audio_encoding"] == "LINEAR16"
+    assert request["audio_config"]["speaking_rate"] == 1.0
+    assert request["audio_config"]["pitch"] == 0.0
+
+
+def test_google_cloud_tts_accepts_custom_voice_and_rate(monkeypatch, tmp_path):
+    from tools import tts_tool as _tt
+
+    captured = {}
+
+    class FakeTextToSpeechClient:
+        def synthesize_speech(self, request):
+            captured["request"] = request
+            return SimpleNamespace(audio_content=b"mp3 bytes")
+
+    class FakeTextToSpeech:
+        TextToSpeechClient = FakeTextToSpeechClient
+        SynthesisInput = lambda self, text: {"text": text}
+        VoiceSelectionParams = lambda self, language_code, name: {
+            "language_code": language_code,
+            "name": name,
+        }
+        AudioConfig = lambda self, audio_encoding, speaking_rate, pitch: {
+            "audio_encoding": audio_encoding,
+            "speaking_rate": speaking_rate,
+            "pitch": pitch,
+        }
+        AudioEncoding = SimpleNamespace(LINEAR16="LINEAR16", MP3="MP3")
+
+    monkeypatch.setattr(_tt, "_import_google_cloud_tts", lambda: FakeTextToSpeech())
+
+    config = {
+        "google_cloud": {
+            "language_code": "ko-KR",
+            "voice": "ko-KR-Chirp3-HD-Aoede",
+            "audio_encoding": "MP3",
+            "speaking_rate": 1.08,
+            "pitch": -1.5,
+        }
+    }
+    output = tmp_path / "out.mp3"
+    _tt._generate_google_cloud_tts("안녕하세요", str(output), config)
+
+    request = captured["request"]
+    assert request["voice"]["name"] == "ko-KR-Chirp3-HD-Aoede"
+    assert request["audio_config"]["audio_encoding"] == "MP3"
+    assert request["audio_config"]["speaking_rate"] == 1.08
+    assert request["audio_config"]["pitch"] == -1.5
+    assert output.read_bytes() == b"mp3 bytes"
+
+
+def test_text_to_speech_dispatches_google_cloud_to_wav_then_telegram_opus(monkeypatch, tmp_path):
+    from tools import tts_tool as _tt
+
+    requested_ogg = tmp_path / "out.ogg"
+    generated = {}
+
+    def fake_google_cloud(text, output_path, config):
+        generated["output_path"] = output_path
+        assert output_path.endswith(".wav")
+        with open(output_path, "wb") as f:
+            f.write(b"RIFF fake wav")
+        return output_path
+
+    def fake_postprocess(path, config):
+        generated["postprocess_input"] = path
+        processed = tmp_path / "out_cyber_autotune.wav"
+        processed.write_bytes(b"RIFF processed wav")
+        return str(processed)
+
+    def fake_convert(path):
+        generated["convert_input"] = path
+        opus = tmp_path / "out_cyber_autotune.ogg"
+        opus.write_bytes(b"OggS opus")
+        return str(opus)
+
+    monkeypatch.setattr(
+        _tt,
+        "_load_tts_config",
+        lambda: {"provider": "google_cloud", "postprocess": {"enabled": True, "preset": "cyber_autotune"}},
+    )
+    monkeypatch.setattr(_tt, "_generate_google_cloud_tts", fake_google_cloud)
+    monkeypatch.setattr(_tt, "_apply_tts_postprocess", fake_postprocess)
+    monkeypatch.setattr(_tt, "_convert_to_opus", fake_convert)
+
+    result = json.loads(_tt.text_to_speech_tool("안녕하세요", str(requested_ogg)))
+
+    assert result["success"] is True
+    assert result["provider"] == "google_cloud"
+    assert result["file_path"].endswith("out_cyber_autotune.ogg")
+    assert result["voice_compatible"] is True
+    assert result["media_tag"].startswith("[[audio_as_voice]]")
+    assert generated["output_path"].endswith("out.wav")
+    assert generated["postprocess_input"] == generated["output_path"]
+    assert generated["convert_input"].endswith("out_cyber_autotune.wav")
+
+
+def test_google_cloud_has_default_text_limit():
+    from tools.tts_tool import PROVIDER_MAX_TEXT_LENGTH, _resolve_max_text_length
+
+    assert PROVIDER_MAX_TEXT_LENGTH["google_cloud"] == 5000
+    assert _resolve_max_text_length("google_cloud", {}) == 5000

--- a/tests/tools/test_tts_google_cloud.py
+++ b/tests/tools/test_tts_google_cloud.py
@@ -137,6 +137,57 @@ def test_text_to_speech_dispatches_google_cloud_to_wav_then_telegram_opus(monkey
     assert generated["convert_input"].endswith("out_cyber_autotune.wav")
 
 
+def test_text_to_speech_falls_back_to_edge_when_google_cloud_monthly_quota_exhausted(monkeypatch, tmp_path):
+    from tools import tts_tool as _tt
+
+    requested_ogg = tmp_path / "quota_fallback.ogg"
+    generated = {}
+
+    def fake_google_cloud(text, output_path, config):
+        generated["google_cloud_called"] = True
+        raise ValueError("Google Cloud TTS monthly character limit would be exceeded: used 999,999/1,000,000")
+
+    async def fake_edge(text, output_path, config):
+        generated["edge_output_path"] = output_path
+        assert output_path.endswith(".mp3")
+        with open(output_path, "wb") as f:
+            f.write(b"fake edge mp3")
+        return output_path
+
+    def fake_convert(path):
+        generated["convert_input"] = path
+        opus = tmp_path / "quota_fallback.ogg"
+        opus.write_bytes(b"OggS opus")
+        return str(opus)
+
+    monkeypatch.setattr(
+        _tt,
+        "_load_tts_config",
+        lambda: {
+            "provider": "google_cloud",
+            "google_cloud": {"fallback_provider": "edge"},
+            "edge": {"voice": "ko-KR-SunHiNeural"},
+            "postprocess": {"enabled": False, "preset": "none"},
+        },
+    )
+    monkeypatch.setattr(_tt, "_generate_google_cloud_tts", fake_google_cloud)
+    monkeypatch.setattr(_tt, "_import_edge_tts", lambda: object())
+    monkeypatch.setattr(_tt, "_generate_edge_tts", fake_edge)
+    monkeypatch.setattr(_tt, "_convert_to_opus", fake_convert)
+
+    result = json.loads(_tt.text_to_speech_tool("안녕하세요", str(requested_ogg)))
+
+    assert result["success"] is True
+    assert result["provider"] == "edge"
+    assert result["fallback_from"] == "google_cloud"
+    assert "monthly character limit" in result["fallback_reason"]
+    assert result["file_path"].endswith("quota_fallback.ogg")
+    assert result["voice_compatible"] is True
+    assert generated["google_cloud_called"] is True
+    assert generated["edge_output_path"].endswith("quota_fallback.mp3")
+    assert generated["convert_input"] == generated["edge_output_path"]
+
+
 def test_google_cloud_has_default_text_limit():
     from tools.tts_tool import PROVIDER_MAX_TEXT_LENGTH, _resolve_max_text_length
 

--- a/tests/tools/test_tts_max_text_length.py
+++ b/tests/tools/test_tts_max_text_length.py
@@ -114,7 +114,7 @@ class TestResolveMaxTextLength:
 
     def test_all_documented_providers_have_defaults(self):
         expected = {"edge", "openai", "xai", "minimax", "mistral",
-                    "gemini", "elevenlabs", "neutts", "kittentts"}
+                    "gemini", "elevenlabs", "neutts", "kittentts", "piper", "melotts"}
         assert expected.issubset(PROVIDER_MAX_TEXT_LENGTH.keys())
 
 

--- a/tests/tools/test_tts_melotts.py
+++ b/tests/tools/test_tts_melotts.py
@@ -1,0 +1,128 @@
+"""Tests for the local MeloTTS provider."""
+
+import json
+import os
+import subprocess
+
+
+def test_generate_melotts_invokes_external_python(monkeypatch, tmp_path):
+    from tools.tts_tool import _generate_melotts_tts
+
+    calls = []
+
+    def fake_run(cmd, check, timeout, env):
+        calls.append((cmd, check, timeout, env))
+        output_path = cmd[-1]
+        with open(output_path, "wb") as f:
+            f.write(b"RIFF\x24\x00\x00\x00WAVEfmt fake-wav")
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    output = tmp_path / "out.wav"
+    result = _generate_melotts_tts(
+        "안녕하세요",
+        str(output),
+        {
+            "melotts": {
+                "python": "/home/ubuntu/melotts-venv/bin/python",
+                "language": "KR",
+                "speaker": "KR",
+                "speed": 1.1,
+                "device": "cpu",
+                "timeout": 123,
+            }
+        },
+    )
+
+    assert result == str(output)
+    assert output.read_bytes().startswith(b"RIFF")
+    assert len(calls) == 1
+    cmd, check, timeout, env = calls[0]
+    assert cmd[0] == "/home/ubuntu/melotts-venv/bin/python"
+    assert cmd[1:3] == ["-m", "tools.melotts_runner"]
+    assert cmd[cmd.index("--language") + 1] == "KR"
+    assert cmd[cmd.index("--speaker") + 1] == "KR"
+    assert cmd[cmd.index("--speed") + 1] == "1.1"
+    assert cmd[cmd.index("--device") + 1] == "cpu"
+    assert cmd[cmd.index("--text") + 1] == "안녕하세요"
+    assert cmd[-1] == str(output)
+    assert check is True
+    assert timeout == 123
+    assert env["TOKENIZERS_PARALLELISM"] == "false"
+
+
+def test_melotts_missing_output_raises(monkeypatch, tmp_path):
+    from tools.tts_tool import _generate_melotts_tts
+
+    def fake_run(cmd, check, timeout, env):
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    try:
+        _generate_melotts_tts("안녕하세요", str(tmp_path / "missing.wav"), {"melotts": {}})
+    except FileNotFoundError as exc:
+        assert "produced no output" in str(exc)
+    else:
+        raise AssertionError("expected FileNotFoundError")
+
+
+def test_text_to_speech_dispatches_to_melotts(monkeypatch, tmp_path):
+    from tools import tts_tool as _tt
+
+    captured = {}
+
+    def fake_melotts(text, output_path, config):
+        captured["text"] = text
+        captured["output_path"] = output_path
+        Path = __import__("pathlib").Path
+        Path(output_path).write_bytes(b"RIFF\x24\x00\x00\x00WAVEfmt fake-wav")
+        return output_path
+
+    monkeypatch.setattr(_tt, "_load_tts_config", lambda: {"provider": "melotts"})
+    monkeypatch.setattr(_tt, "_generate_melotts_tts", fake_melotts)
+
+    result = json.loads(_tt.text_to_speech_tool("안녕하세요", str(tmp_path / "out.wav")))
+
+    assert result["success"] is True
+    assert result["provider"] == "melotts"
+    assert captured["text"] == "안녕하세요"
+
+
+def test_melotts_requested_ogg_is_converted_to_telegram_opus(monkeypatch, tmp_path):
+    from tools import tts_tool as _tt
+
+    requested_ogg = tmp_path / "out.ogg"
+    generated = {}
+
+    def fake_melotts(text, output_path, config):
+        generated["output_path"] = output_path
+        with open(output_path, "wb") as f:
+            f.write(b"RIFF\x24\x00\x00\x00WAVEfmt fake-wav")
+        return output_path
+
+    def fake_convert(path):
+        generated["convert_input"] = path
+        requested_ogg.write_bytes(b"OggS opus")
+        return str(requested_ogg)
+
+    monkeypatch.setattr(_tt, "_load_tts_config", lambda: {"provider": "melotts"})
+    monkeypatch.setattr(_tt, "_generate_melotts_tts", fake_melotts)
+    monkeypatch.setattr(_tt, "_convert_to_opus", fake_convert)
+
+    result = json.loads(_tt.text_to_speech_tool("안녕하세요", str(requested_ogg)))
+
+    assert result["success"] is True
+    assert result["file_path"] == str(requested_ogg)
+    assert result["voice_compatible"] is True
+    assert result["media_tag"].startswith("[[audio_as_voice]]")
+    assert generated["output_path"].endswith(".wav")
+    assert generated["convert_input"] == generated["output_path"]
+
+
+def test_melotts_has_default_text_limit():
+    from tools.tts_tool import PROVIDER_MAX_TEXT_LENGTH, _resolve_max_text_length
+
+    assert PROVIDER_MAX_TEXT_LENGTH["melotts"] == 2000
+    assert _resolve_max_text_length("melotts", {}) == 2000

--- a/tests/tools/test_tts_melotts.py
+++ b/tests/tools/test_tts_melotts.py
@@ -18,6 +18,7 @@ def test_generate_melotts_invokes_external_python(monkeypatch, tmp_path):
         return subprocess.CompletedProcess(cmd, 0)
 
     monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(os.path, "exists", lambda path: path == "/home/ubuntu/melotts-venv/bin/python")
 
     output = tmp_path / "out.wav"
     result = _generate_melotts_tts(
@@ -59,6 +60,7 @@ def test_melotts_missing_output_raises(monkeypatch, tmp_path):
         return subprocess.CompletedProcess(cmd, 0)
 
     monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(os.path, "exists", lambda path: path == "/home/ubuntu/melotts-venv/bin/python")
 
     try:
         _generate_melotts_tts("안녕하세요", str(tmp_path / "missing.wav"), {"melotts": {}})

--- a/tests/tools/test_tts_mistral.py
+++ b/tests/tools/test_tts_mistral.py
@@ -207,7 +207,9 @@ class TestCheckTtsRequirementsMistral:
         with patch("tools.tts_tool._import_edge_tts", side_effect=ImportError), \
              patch("tools.tts_tool._import_elevenlabs", side_effect=ImportError), \
              patch("tools.tts_tool._import_openai_client", side_effect=ImportError), \
+             patch("tools.tts_tool._import_google_cloud_tts", side_effect=ImportError), \
              patch("tools.tts_tool._check_neutts_available", return_value=False), \
+             patch("tools.tts_tool._check_kittentts_available", return_value=False), \
              patch("tools.tts_tool._check_piper_available", return_value=False), \
              patch("tools.tts_tool._check_melotts_available", return_value=False):
             assert check_tts_requirements() is True
@@ -218,7 +220,9 @@ class TestCheckTtsRequirementsMistral:
         with patch("tools.tts_tool._import_edge_tts", side_effect=ImportError), \
              patch("tools.tts_tool._import_elevenlabs", side_effect=ImportError), \
              patch("tools.tts_tool._import_openai_client", side_effect=ImportError), \
+             patch("tools.tts_tool._import_google_cloud_tts", side_effect=ImportError), \
              patch("tools.tts_tool._check_neutts_available", return_value=False), \
+             patch("tools.tts_tool._check_kittentts_available", return_value=False), \
              patch("tools.tts_tool._check_piper_available", return_value=False), \
              patch("tools.tts_tool._check_melotts_available", return_value=False):
             assert check_tts_requirements() is False

--- a/tests/tools/test_tts_mistral.py
+++ b/tests/tools/test_tts_mistral.py
@@ -207,7 +207,9 @@ class TestCheckTtsRequirementsMistral:
         with patch("tools.tts_tool._import_edge_tts", side_effect=ImportError), \
              patch("tools.tts_tool._import_elevenlabs", side_effect=ImportError), \
              patch("tools.tts_tool._import_openai_client", side_effect=ImportError), \
-             patch("tools.tts_tool._check_neutts_available", return_value=False):
+             patch("tools.tts_tool._check_neutts_available", return_value=False), \
+             patch("tools.tts_tool._check_piper_available", return_value=False), \
+             patch("tools.tts_tool._check_melotts_available", return_value=False):
             assert check_tts_requirements() is True
 
     def test_mistral_key_missing_returns_false(self, mock_mistral_module):
@@ -216,5 +218,7 @@ class TestCheckTtsRequirementsMistral:
         with patch("tools.tts_tool._import_edge_tts", side_effect=ImportError), \
              patch("tools.tts_tool._import_elevenlabs", side_effect=ImportError), \
              patch("tools.tts_tool._import_openai_client", side_effect=ImportError), \
-             patch("tools.tts_tool._check_neutts_available", return_value=False):
+             patch("tools.tts_tool._check_neutts_available", return_value=False), \
+             patch("tools.tts_tool._check_piper_available", return_value=False), \
+             patch("tools.tts_tool._check_melotts_available", return_value=False):
             assert check_tts_requirements() is False

--- a/tests/tools/test_tts_piper.py
+++ b/tests/tools/test_tts_piper.py
@@ -1,0 +1,125 @@
+"""Tests for the local Piper HTTP TTS provider."""
+
+import json
+import urllib.request
+from unittest.mock import MagicMock
+
+
+class FakeUrlopenResponse:
+    def __init__(self, body: bytes):
+        self.body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self, *args):
+        return self.body
+
+
+def test_check_piper_available_uses_health_endpoint(monkeypatch):
+    from tools.tts_tool import _check_piper_available
+
+    calls = []
+
+    def fake_urlopen(request, timeout=None):
+        calls.append((request.full_url, timeout))
+        return FakeUrlopenResponse(b'{"ok": true}')
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    assert _check_piper_available({"piper": {"base_url": "http://127.0.0.1:5005"}}) is True
+    assert calls == [("http://127.0.0.1:5005/health", 2)]
+
+
+def test_generate_piper_posts_text_and_writes_wav(monkeypatch, tmp_path):
+    from tools.tts_tool import _generate_piper_tts
+
+    calls = []
+    wav_bytes = b"RIFF\x24\x00\x00\x00WAVEfmt fake-wav"
+
+    def fake_urlopen(request, timeout=None):
+        calls.append(request)
+        assert timeout == 12
+        return FakeUrlopenResponse(wav_bytes)
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    output = tmp_path / "out.wav"
+    result = _generate_piper_tts(
+        "안녕하세요",
+        str(output),
+        {"piper": {"base_url": "http://127.0.0.1:5005", "timeout": 12}},
+    )
+
+    assert result == str(output)
+    assert output.read_bytes() == wav_bytes
+    assert len(calls) == 1
+    request = calls[0]
+    assert request.full_url == "http://127.0.0.1:5005/tts"
+    assert json.loads(request.data.decode("utf-8")) == {"text": "안녕하세요"}
+    assert request.get_method() == "POST"
+    assert request.get_header("Content-type") == "application/json"
+
+
+def test_text_to_speech_dispatches_to_piper(monkeypatch, tmp_path):
+    from tools import tts_tool as _tt
+
+    captured = {}
+
+    def fake_piper(text, output_path, config):
+        captured["text"] = text
+        captured["output_path"] = output_path
+        captured["config"] = config
+        with open(output_path, "wb") as f:
+            f.write(b"RIFF\x24\x00\x00\x00WAVEfmt fake-wav")
+        return output_path
+
+    monkeypatch.setattr(_tt, "_load_tts_config", lambda: {"provider": "piper"})
+    monkeypatch.setattr(_tt, "_generate_piper_tts", fake_piper)
+
+    result = json.loads(_tt.text_to_speech_tool("안녕하세요", str(tmp_path / "out.wav")))
+
+    assert result["success"] is True
+    assert result["provider"] == "piper"
+    assert captured["text"] == "안녕하세요"
+
+
+def test_piper_requested_ogg_is_converted_to_telegram_opus(monkeypatch, tmp_path):
+    from tools import tts_tool as _tt
+
+    requested_ogg = tmp_path / "out.ogg"
+    generated = {}
+
+    def fake_piper(text, output_path, config):
+        generated["output_path"] = output_path
+        with open(output_path, "wb") as f:
+            f.write(b"RIFF\x24\x00\x00\x00WAVEfmt fake-wav")
+        return output_path
+
+    def fake_convert(path):
+        generated["convert_input"] = path
+        requested_ogg.write_bytes(b"OggS opus")
+        return str(requested_ogg)
+
+    monkeypatch.setattr(_tt, "_load_tts_config", lambda: {"provider": "piper"})
+    monkeypatch.setattr(_tt, "_generate_piper_tts", fake_piper)
+    monkeypatch.setattr(_tt, "_convert_to_opus", fake_convert)
+
+    result = json.loads(_tt.text_to_speech_tool("안녕하세요", str(requested_ogg)))
+
+    assert result["success"] is True
+    assert result["file_path"] == str(requested_ogg)
+    assert result["voice_compatible"] is True
+    assert result["media_tag"].startswith("[[audio_as_voice]]")
+    assert generated["output_path"].endswith(".wav")
+    assert generated["convert_input"] == generated["output_path"]
+
+
+def test_piper_has_default_text_limit():
+    from tools.tts_tool import PROVIDER_MAX_TEXT_LENGTH, _resolve_max_text_length
+
+    assert PROVIDER_MAX_TEXT_LENGTH["piper"] == 2000
+    assert _resolve_max_text_length("piper", {}) == 2000

--- a/tests/tools/test_tts_speed.py
+++ b/tests/tools/test_tts_speed.py
@@ -134,16 +134,17 @@ class TestTtsPostprocessPresets:
             assert "loudnorm" in filt
             assert "acrusher" in filt
 
-    def test_cyber_autotune_uses_jarvis_voice_chain_without_bitcrusher(self):
+    def test_cyber_autotune_uses_jarvis_voice_chain_without_bitcrusher_or_speedup(self):
         from tools.tts_tool import _tts_effect_filter
 
         filt = _tts_effect_filter("cyber_autotune")
         assert "asetrate=48000*1.05" in filt
+        assert "atempo=0.952" in filt  # compensates the pitch-style asetrate shift
         assert "flanger=delay=0:depth=2:regen=50:width=71:speed=0.5" in filt
         assert "aecho=0.8:0.88:15:0.5" in filt
         assert "highpass=f=200" in filt
         assert "treble=g=6" in filt
-        assert "atempo=1.25" in filt
+        assert "atempo=1.25" not in filt
         assert "loudnorm" in filt
         assert "acrusher" not in filt
 

--- a/tests/tools/test_tts_speed.py
+++ b/tests/tools/test_tts_speed.py
@@ -108,6 +108,56 @@ class TestOpenaiTtsSpeed:
         kwargs = create.call_args[1]
         assert kwargs["speed"] == 4.0
 
+    def test_instructions_passed_when_configured(self, tmp_path, monkeypatch):
+        """gpt-4o-mini-tts supports style instructions; pass them through."""
+        create = self._run({"openai": {"instructions": "Speak calmly."}}, tmp_path, monkeypatch)
+        kwargs = create.call_args[1]
+        assert kwargs["instructions"] == "Speak calmly."
+
+    def test_empty_instructions_not_passed(self, tmp_path, monkeypatch):
+        """Avoid sending blank instructions."""
+        create = self._run({"openai": {"instructions": "   "}}, tmp_path, monkeypatch)
+        kwargs = create.call_args[1]
+        assert "instructions" not in kwargs
+
+
+# ---------------------------------------------------------------------------
+# TTS postprocess presets
+# ---------------------------------------------------------------------------
+
+class TestTtsPostprocessPresets:
+    def test_known_presets_build_filters(self):
+        from tools.tts_tool import _tts_effect_filter
+
+        for preset in ("clean", "hybrid", "dark"):
+            filt = _tts_effect_filter(preset)
+            assert "loudnorm" in filt
+            assert "acrusher" in filt
+
+    def test_cyber_autotune_uses_jarvis_voice_chain_without_bitcrusher(self):
+        from tools.tts_tool import _tts_effect_filter
+
+        filt = _tts_effect_filter("cyber_autotune")
+        assert "asetrate=48000*1.05" in filt
+        assert "flanger=delay=0:depth=2:regen=50:width=71:speed=0.5" in filt
+        assert "aecho=0.8:0.88:15:0.5" in filt
+        assert "highpass=f=200" in filt
+        assert "treble=g=6" in filt
+        assert "atempo=1.25" in filt
+        assert "loudnorm" in filt
+        assert "acrusher" not in filt
+
+    def test_none_preset_has_no_filter(self):
+        from tools.tts_tool import _tts_effect_filter
+
+        assert _tts_effect_filter("none") is None
+
+    def test_unknown_preset_rejected(self):
+        from tools.tts_tool import _tts_effect_filter
+
+        with pytest.raises(ValueError):
+            _tts_effect_filter("explode")
+
 
 # ---------------------------------------------------------------------------
 # MiniMax TTS speed (global fallback wired)

--- a/tests/tools/test_tts_visualizer.py
+++ b/tests/tools/test_tts_visualizer.py
@@ -1,0 +1,47 @@
+"""Tests for the optional TTS visualizer hook."""
+
+import json
+
+
+def test_tts_visualizer_hook_runs_after_success(monkeypatch, tmp_path):
+    from tools import tts_tool as _tt
+
+    requested = tmp_path / "out.mp3"
+    called = {}
+
+    async def fake_edge(text, output_path, config):
+        with open(output_path, "wb") as f:
+            f.write(b"ID3 fake mp3")
+        return output_path
+
+    def fake_visualizer(audio_path, text, provider, config):
+        called["audio_path"] = audio_path
+        called["text"] = text
+        called["provider"] = provider
+        called["config"] = config
+        return True
+
+    monkeypatch.setattr(
+        _tt,
+        "_load_tts_config",
+        lambda: {"provider": "edge", "visualizer": {"enabled": True, "command": ["true"]}},
+    )
+    monkeypatch.setattr(_tt, "_generate_edge_tts", fake_edge)
+    monkeypatch.setattr(_tt, "_apply_tts_postprocess", lambda path, config: None)
+    monkeypatch.setattr(_tt, "_convert_to_opus", lambda path: None)
+    monkeypatch.setattr(_tt, "_import_edge_tts", lambda: object())
+    monkeypatch.setattr(_tt, "_notify_tts_visualizer", fake_visualizer)
+
+    result = json.loads(_tt.text_to_speech_tool("안녕하세요", str(requested)))
+
+    assert result["success"] is True
+    assert result["visualizer_notified"] is True
+    assert called["audio_path"] == str(requested)
+    assert called["text"] == "안녕하세요"
+    assert called["provider"] == "edge"
+
+
+def test_tts_visualizer_disabled_is_noop():
+    from tools import tts_tool as _tt
+
+    assert _tt._notify_tts_visualizer("/tmp/nope.ogg", "hello", "edge", {"visualizer": {"enabled": False}}) is False

--- a/tools/melotts_runner.py
+++ b/tools/melotts_runner.py
@@ -1,0 +1,44 @@
+"""Subprocess runner for MeloTTS synthesis.
+
+This module is intentionally tiny so Hermes can call a separate MeloTTS virtualenv
+without importing MeloTTS/Torch into the main Hermes process.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate speech with MeloTTS")
+    parser.add_argument("--text", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--language", default="KR")
+    parser.add_argument("--speaker", default="KR")
+    parser.add_argument("--speed", type=float, default=1.0)
+    parser.add_argument("--device", default="cpu")
+    args = parser.parse_args()
+
+    from melo.api import TTS
+
+    model = TTS(language=args.language, device=args.device)
+    speaker_ids = model.hps.data.spk2id
+    speaker = args.speaker or args.language
+    try:
+        speaker_id = speaker_ids[speaker]
+    except Exception as exc:
+        try:
+            available = ", ".join(sorted(speaker_ids.keys()))
+        except Exception:
+            available = str(speaker_ids)
+        raise SystemExit(f"Unknown MeloTTS speaker {speaker!r}; available: {available}") from exc
+
+    output = Path(args.output).expanduser()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    model.tts_to_file(args.text, speaker_id, str(output), speed=args.speed)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -74,6 +74,12 @@ def _import_mistral_client():
     from mistralai.client import Mistral
     return Mistral
 
+
+def _import_google_cloud_tts():
+    """Lazy import Google Cloud Text-to-Speech client module."""
+    from google.cloud import texttospeech
+    return texttospeech
+
 def _import_sounddevice():
     """Lazy import sounddevice. Returns the module or raises ImportError/OSError."""
     import sounddevice as sd
@@ -115,6 +121,11 @@ DEFAULT_XAI_BASE_URL = "https://api.x.ai/v1"
 DEFAULT_GEMINI_TTS_MODEL = "gemini-2.5-flash-preview-tts"
 DEFAULT_GEMINI_TTS_VOICE = "Kore"
 DEFAULT_GEMINI_TTS_BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
+DEFAULT_GOOGLE_CLOUD_LANGUAGE_CODE = "ko-KR"
+DEFAULT_GOOGLE_CLOUD_VOICE = "ko-KR-Chirp3-HD-Kore"
+DEFAULT_GOOGLE_CLOUD_AUDIO_ENCODING = "LINEAR16"
+DEFAULT_GOOGLE_CLOUD_SPEAKING_RATE = 1.0
+DEFAULT_GOOGLE_CLOUD_PITCH = 0.0
 DEFAULT_PIPER_BASE_URL = "http://127.0.0.1:5005"
 DEFAULT_PIPER_TIMEOUT = 60
 DEFAULT_PIPER_HEALTH_TIMEOUT = 2
@@ -149,6 +160,7 @@ PROVIDER_MAX_TEXT_LENGTH: Dict[str, int] = {
     "minimax": 10000,     # https://platform.minimax.io/docs/api-reference/speech-t2a-http (sync)
     "mistral": 4000,      # conservative; no published per-request cap
     "gemini": 5000,       # Gemini TTS caps at ~8k input tokens / ~655s audio
+    "google_cloud": 5000, # Google Cloud TTS per-request practical cap; free tier is monthly
     "elevenlabs": 10000,  # fallback when model-aware lookup can't resolve (multilingual_v2)
     "neutts": 2000,       # local model, quality falls off on long text
     "kittentts": 2000,    # local 25MB model
@@ -941,6 +953,57 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
     return output_path
 
 
+
+# ===========================================================================
+# Provider: Google Cloud Text-to-Speech (Chirp 3 HD)
+# ===========================================================================
+def _generate_google_cloud_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+    """Generate audio using Google Cloud Text-to-Speech Chirp 3 HD voices.
+
+    Authentication uses Google Application Default Credentials, for example
+    ``GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json``.  The
+    provider writes Google Cloud's audio bytes directly; callers that need
+    Telegram voice bubbles request WAV first, then use Hermes' shared
+    postprocess/Opus conversion path.
+    """
+    gc_config = tts_config.get("google_cloud", {})
+    language_code = str(
+        gc_config.get("language_code", DEFAULT_GOOGLE_CLOUD_LANGUAGE_CODE)
+    ).strip() or DEFAULT_GOOGLE_CLOUD_LANGUAGE_CODE
+    voice = str(gc_config.get("voice", DEFAULT_GOOGLE_CLOUD_VOICE)).strip() or DEFAULT_GOOGLE_CLOUD_VOICE
+    encoding_name = str(
+        gc_config.get("audio_encoding", DEFAULT_GOOGLE_CLOUD_AUDIO_ENCODING)
+    ).strip().upper() or DEFAULT_GOOGLE_CLOUD_AUDIO_ENCODING
+    speaking_rate = float(gc_config.get("speaking_rate", tts_config.get("speed", DEFAULT_GOOGLE_CLOUD_SPEAKING_RATE)))
+    pitch = float(gc_config.get("pitch", DEFAULT_GOOGLE_CLOUD_PITCH))
+
+    texttospeech = _import_google_cloud_tts()
+    audio_encoding = getattr(texttospeech.AudioEncoding, encoding_name, None)
+    if audio_encoding is None:
+        raise ValueError(f"Unsupported Google Cloud TTS audio_encoding: {encoding_name}")
+
+    client = texttospeech.TextToSpeechClient()
+    request = {
+        "input": texttospeech.SynthesisInput(text=text),
+        "voice": texttospeech.VoiceSelectionParams(
+            language_code=language_code,
+            name=voice,
+        ),
+        "audio_config": texttospeech.AudioConfig(
+            audio_encoding=audio_encoding,
+            speaking_rate=max(0.25, min(4.0, speaking_rate)),
+            pitch=max(-20.0, min(20.0, pitch)),
+        ),
+    }
+    response = client.synthesize_speech(request=request)
+    audio_content = getattr(response, "audio_content", b"")
+    if not audio_content:
+        raise RuntimeError("Google Cloud TTS returned empty audio data")
+
+    with open(output_path, "wb") as f:
+        f.write(audio_content)
+    return output_path
+
 # ===========================================================================
 # NeuTTS (local, on-device TTS via neutts_cli)
 # ===========================================================================
@@ -1369,6 +1432,17 @@ def text_to_speech_tool(
             logger.info("Generating speech with Google Gemini TTS...")
             _generate_gemini_tts(text, file_str, tts_config)
 
+        elif provider == "google_cloud":
+            logger.info("Generating speech with Google Cloud Text-to-Speech...")
+            google_output = file_str
+            # Google Cloud Chirp 3 HD can return LINEAR16/MP3, not Opus. For
+            # Telegram, synthesize WAV first, then postprocess and convert to
+            # OGG/Opus through the shared path below.
+            if file_str.endswith(".ogg"):
+                google_output = str(file_path.with_suffix(".wav"))
+            _generate_google_cloud_tts(text, google_output, tts_config)
+            file_str = google_output
+
         elif provider == "neutts":
             if not _check_neutts_available():
                 return json.dumps({
@@ -1464,7 +1538,7 @@ def text_to_speech_tool(
         # Edge TTS outputs MP3; NeuTTS/KittenTTS/Piper/MeloTTS output WAV; MiniMax/xAI
         # output MP3. All need ffmpeg conversion for Telegram voice bubbles.
         voice_compatible = False
-        if provider in ("edge", "neutts", "minimax", "xai", "kittentts", "piper", "melotts") and not file_str.endswith(".ogg"):
+        if provider in ("edge", "neutts", "minimax", "xai", "kittentts", "piper", "melotts", "google_cloud") and not file_str.endswith(".ogg"):
             opus_path = _convert_to_opus(file_str)
             if opus_path:
                 file_str = opus_path
@@ -1544,6 +1618,12 @@ def check_tts_requirements() -> bool:
     try:
         _import_mistral_client()
         if os.getenv("MISTRAL_API_KEY"):
+            return True
+    except ImportError:
+        pass
+    try:
+        _import_google_cloud_tts()
+        if os.getenv("GOOGLE_APPLICATION_CREDENTIALS") or os.getenv("GOOGLE_CLOUD_PROJECT"):
             return True
     except ImportError:
         pass

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1469,6 +1469,9 @@ def text_to_speech_tool(
     file_path.parent.mkdir(parents=True, exist_ok=True)
     file_str = str(file_path)
 
+    fallback_from = None
+    fallback_reason = None
+
     try:
         # Generate audio with the configured provider
         if provider == "elevenlabs":
@@ -1525,8 +1528,34 @@ def text_to_speech_tool(
             # OGG/Opus through the shared path below.
             if file_str.endswith(".ogg"):
                 google_output = str(file_path.with_suffix(".wav"))
-            _generate_google_cloud_tts(text, google_output, tts_config)
-            file_str = google_output
+            try:
+                _generate_google_cloud_tts(text, google_output, tts_config)
+                file_str = google_output
+            except ValueError as e:
+                gc_config = tts_config.get("google_cloud", {}) if isinstance(tts_config.get("google_cloud"), dict) else {}
+                fallback_provider = str(gc_config.get("fallback_provider", "edge")).strip().lower()
+                if "monthly character limit" not in str(e) or fallback_provider != "edge":
+                    raise
+                logger.warning("Google Cloud TTS quota exhausted; falling back to Edge TTS: %s", e)
+                try:
+                    _import_edge_tts()
+                except ImportError as import_error:
+                    raise FileNotFoundError("Edge TTS fallback requested but 'edge_tts' package is not installed") from import_error
+                fallback_from = "google_cloud"
+                fallback_reason = str(e)
+                provider = "edge"
+                edge_output = str(file_path)
+                if edge_output.endswith(".ogg"):
+                    edge_output = str(Path(edge_output).with_suffix(".mp3"))
+                try:
+                    import concurrent.futures
+                    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                        pool.submit(
+                            lambda: asyncio.run(_generate_edge_tts(text, edge_output, tts_config))
+                        ).result(timeout=60)
+                except RuntimeError:
+                    asyncio.run(_generate_edge_tts(text, edge_output, tts_config))
+                file_str = edge_output
 
         elif provider == "neutts":
             if not _check_neutts_available():
@@ -1639,13 +1668,17 @@ def text_to_speech_tool(
         if voice_compatible:
             media_tag = f"[[audio_as_voice]]\n{media_tag}"
 
-        return json.dumps({
+        result = {
             "success": True,
             "file_path": file_str,
             "media_tag": media_tag,
             "provider": provider,
             "voice_compatible": voice_compatible,
-        }, ensure_ascii=False)
+        }
+        if fallback_from:
+            result["fallback_from"] = fallback_from
+            result["fallback_reason"] = fallback_reason or ""
+        return json.dumps(result, ensure_ascii=False)
 
     except ValueError as e:
         # Configuration errors (missing API keys, etc.)

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -10,6 +10,7 @@ Supports seven TTS providers:
 - Mistral (Voxtral TTS): Multilingual, native Opus, needs MISTRAL_API_KEY
 - Google Gemini TTS: Controllable, 30 prebuilt voices, needs GEMINI_API_KEY
 - NeuTTS (local, free, no API key): On-device TTS via neutts_cli, needs neutts installed
+- Piper HTTP (local, free, no API key): Local Piper server returning WAV bytes
 
 Output formats:
 - Opus (.ogg) for Telegram voice bubbles (requires ffmpeg for Edge TTS)
@@ -98,6 +99,9 @@ DEFAULT_KITTENTTS_MODEL = "KittenML/kitten-tts-nano-0.8-int8"  # 25MB
 DEFAULT_KITTENTTS_VOICE = "Jasper"
 DEFAULT_OPENAI_VOICE = "alloy"
 DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1"
+DEFAULT_TTS_POSTPROCESS_ENABLED = False
+DEFAULT_TTS_POSTPROCESS_PRESET = "none"
+TTS_POSTPROCESS_PRESETS = {"none", "clean", "hybrid", "dark", "cyber_autotune"}
 DEFAULT_MINIMAX_MODEL = "speech-2.8-hd"
 DEFAULT_MINIMAX_VOICE_ID = "English_Graceful_Lady"
 DEFAULT_MINIMAX_BASE_URL = "https://api.minimax.io/v1/t2a_v2"
@@ -111,6 +115,15 @@ DEFAULT_XAI_BASE_URL = "https://api.x.ai/v1"
 DEFAULT_GEMINI_TTS_MODEL = "gemini-2.5-flash-preview-tts"
 DEFAULT_GEMINI_TTS_VOICE = "Kore"
 DEFAULT_GEMINI_TTS_BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
+DEFAULT_PIPER_BASE_URL = "http://127.0.0.1:5005"
+DEFAULT_PIPER_TIMEOUT = 60
+DEFAULT_PIPER_HEALTH_TIMEOUT = 2
+DEFAULT_MELOTTS_PYTHON = "/home/ubuntu/melotts-venv/bin/python"
+DEFAULT_MELOTTS_LANGUAGE = "KR"
+DEFAULT_MELOTTS_SPEAKER = "KR"
+DEFAULT_MELOTTS_DEVICE = "cpu"
+DEFAULT_MELOTTS_SPEED = 1.0
+DEFAULT_MELOTTS_TIMEOUT = 180
 # PCM output specs for Gemini TTS (fixed by the API)
 GEMINI_TTS_SAMPLE_RATE = 24000
 GEMINI_TTS_CHANNELS = 1
@@ -139,6 +152,8 @@ PROVIDER_MAX_TEXT_LENGTH: Dict[str, int] = {
     "elevenlabs": 10000,  # fallback when model-aware lookup can't resolve (multilingual_v2)
     "neutts": 2000,       # local model, quality falls off on long text
     "kittentts": 2000,    # local 25MB model
+    "piper": 2000,        # local Piper server, Korean model quality falls off on long text
+    "melotts": 2000,      # local MeloTTS subprocess, keep latency bounded
 }
 
 # ElevenLabs caps vary by model_id. https://elevenlabs.io/docs/overview/models
@@ -267,6 +282,133 @@ def _convert_to_opus(mp3_path: str) -> Optional[str]:
     return None
 
 
+def _ffmpeg_has_filter(filter_name: str) -> bool:
+    """Return True if the local ffmpeg build exposes *filter_name*."""
+    if not _has_ffmpeg():
+        return False
+    try:
+        result = subprocess.run(
+            ["ffmpeg", "-hide_banner", "-filters"],
+            capture_output=True, text=True, timeout=10,
+        )
+    except Exception:
+        return False
+    return result.returncode == 0 and re.search(rf"\s{re.escape(filter_name)}\s", result.stdout) is not None
+
+
+def _tts_effect_filter(preset: str) -> Optional[str]:
+    """Build a conservative ffmpeg filter chain for lab-AI TTS effects."""
+    preset = (preset or "none").lower().strip()
+    if preset in ("", "none", "off", "false"):
+        return None
+    if preset not in TTS_POSTPROCESS_PRESETS:
+        raise ValueError(
+            f"Unknown TTS postprocess preset: {preset}. "
+            f"Expected one of: {', '.join(sorted(TTS_POSTPROCESS_PRESETS))}"
+        )
+
+    # On this host rubberband has previously produced near-silent output in
+    # some chains, so only use it when the user explicitly allows it.
+    use_rubberband = os.getenv("HERMES_TTS_USE_RUBBERBAND", "").lower() in {"1", "true", "yes"}
+    pitch = ""
+    if use_rubberband and _ffmpeg_has_filter("rubberband"):
+        pitch_by_preset = {"clean": "0.96", "hybrid": "0.90", "dark": "0.84", "cyber_autotune": "1.06"}
+        pitch = f"rubberband=pitch={pitch_by_preset[preset]}:formant=preserved:tempo=1.0,"
+
+    if preset == "cyber_autotune":
+        # Based on openclaw/skills globalcaos/jarvis-voice's metallic ffmpeg
+        # chain, adapted for Hermes/OpenAI's 48 kHz Opus path and Korean TTS.
+        # Keep bitcrusher/acrusher out; the Jarvis-style character comes from
+        # +5% asetrate pitch, strong flanger, short echo, highpass, and treble.
+        if not pitch:
+            pitch = "asetrate=48000*1.05,aresample=48000,atempo=0.952,"
+        body = (
+            "flanger=delay=0:depth=2:regen=50:width=71:speed=0.5,"
+            "aecho=0.8:0.88:15:0.5,"
+            "highpass=f=200,"
+            "treble=g=6,"
+            "atempo=1.25,"
+            "loudnorm=I=-16:TP=-1.5:LRA=6"
+        )
+    elif preset == "clean":
+        body = (
+            "highpass=f=120,lowpass=f=6500,"
+            "equalizer=f=900:t=q:w=1.2:g=1.5,"
+            "equalizer=f=2600:t=q:w=1.1:g=2.0,"
+            "flanger=delay=1.2:depth=1.5:regen=8:width=18:speed=0.12,"
+            "aecho=0.82:0.88:12:0.08,"
+            "acrusher=bits=12:samples=4:mix=0.04,"
+            "loudnorm=I=-16:TP=-1.5:LRA=8"
+        )
+    elif preset == "hybrid":
+        body = (
+            "highpass=f=140,lowpass=f=5400,"
+            "equalizer=f=850:t=q:w=1.2:g=2.5,"
+            "equalizer=f=2400:t=q:w=1.0:g=3.5,"
+            "equalizer=f=4200:t=q:w=1.5:g=1.5,"
+            "tremolo=f=34:d=0.055,"
+            "vibrato=f=2.2:d=0.035,"
+            "flanger=delay=1.8:depth=2.4:regen=14:width=32:speed=0.16,"
+            "aecho=0.80:0.88:9|19:0.12|0.06,"
+            "acrusher=bits=10:samples=8:mix=0.09,"
+            "loudnorm=I=-16:TP=-1.5:LRA=7"
+        )
+    else:  # dark
+        body = (
+            "highpass=f=160,lowpass=f=4600,"
+            "equalizer=f=700:t=q:w=1.0:g=3.0,"
+            "equalizer=f=1800:t=q:w=1.0:g=2.0,"
+            "equalizer=f=2900:t=q:w=1.0:g=4.5,"
+            "tremolo=f=48:d=0.12,"
+            "vibrato=f=3.1:d=0.055,"
+            "flanger=delay=2.4:depth=3.8:regen=24:width=48:speed=0.22,"
+            "aecho=0.78:0.90:6|13|27:0.18|0.10|0.05,"
+            "acrusher=bits=9:samples=12:mix=0.16,"
+            "loudnorm=I=-16:TP=-1.5:LRA=6"
+        )
+    return f"{pitch}{body}"
+
+
+def _apply_tts_postprocess(audio_path: str, tts_config: Dict[str, Any]) -> Optional[str]:
+    """Apply optional ffmpeg postprocessing before the file is delivered."""
+    post_cfg = tts_config.get("postprocess", {})
+    if not isinstance(post_cfg, dict):
+        return None
+    enabled = bool(post_cfg.get("enabled", DEFAULT_TTS_POSTPROCESS_ENABLED))
+    preset = str(post_cfg.get("preset", DEFAULT_TTS_POSTPROCESS_PRESET)).lower().strip()
+    if not enabled or preset in ("", "none", "off", "false"):
+        return None
+    if not _has_ffmpeg():
+        logger.warning("TTS postprocess requested but ffmpeg is not available")
+        return None
+
+    filter_chain = _tts_effect_filter(preset)
+    if not filter_chain:
+        return None
+
+    src = Path(audio_path)
+    out = src.with_name(f"{src.stem}_{preset}{src.suffix}")
+    cmd = [
+        "ffmpeg", "-hide_banner", "-y", "-i", str(src),
+        "-af", filter_chain, "-ar", "48000", "-ac", "1",
+    ]
+    if out.suffix.lower() == ".ogg":
+        cmd += ["-c:a", "libopus", "-b:a", "64k", "-vbr", "off"]
+    cmd.append(str(out))
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+    except subprocess.TimeoutExpired:
+        logger.warning("TTS postprocess preset %s timed out", preset)
+        return None
+    if result.returncode != 0:
+        logger.warning("TTS postprocess preset %s failed: %s", preset, result.stderr[-500:])
+        return None
+    if out.exists() and out.stat().st_size > 0:
+        return str(out)
+    return None
+
+
 # ===========================================================================
 # Provider: Edge TTS (free)
 # ===========================================================================
@@ -365,6 +507,7 @@ def _generate_openai_tts(text: str, output_path: str, tts_config: Dict[str, Any]
     voice = oai_config.get("voice", DEFAULT_OPENAI_VOICE)
     base_url = oai_config.get("base_url", base_url)
     speed = float(oai_config.get("speed", tts_config.get("speed", 1.0)))
+    instructions = str(oai_config.get("instructions", "")).strip()
 
     # Determine response format from extension
     if output_path.endswith(".ogg"):
@@ -384,6 +527,8 @@ def _generate_openai_tts(text: str, output_path: str, tts_config: Dict[str, Any]
         )
         if speed != 1.0:
             create_kwargs["speed"] = max(0.25, min(4.0, speed))
+        if instructions:
+            create_kwargs["instructions"] = instructions
         response = client.audio.speech.create(**create_kwargs)
 
         response.stream_to_file(output_path)
@@ -912,6 +1057,172 @@ def _generate_kittentts(text: str, output_path: str, tts_config: Dict[str, Any])
 
 
 # ===========================================================================
+# Provider: Piper HTTP (local server, e.g. piper-rs-server)
+# ===========================================================================
+def _get_piper_base_url(tts_config: Dict[str, Any]) -> str:
+    """Return the configured Piper HTTP base URL without a trailing slash."""
+    piper_config = tts_config.get("piper", {}) if isinstance(tts_config.get("piper"), dict) else {}
+    return str(piper_config.get("base_url") or DEFAULT_PIPER_BASE_URL).rstrip("/")
+
+
+def _check_piper_available(tts_config: Optional[Dict[str, Any]] = None) -> bool:
+    """Check whether the configured Piper HTTP server responds to /health."""
+    import urllib.request
+
+    config = tts_config or _load_tts_config()
+    piper_config = config.get("piper", {}) if isinstance(config.get("piper"), dict) else {}
+    base_url = _get_piper_base_url(config)
+    timeout = piper_config.get("health_timeout", DEFAULT_PIPER_HEALTH_TIMEOUT)
+    try:
+        timeout = float(timeout)
+    except (TypeError, ValueError):
+        timeout = DEFAULT_PIPER_HEALTH_TIMEOUT
+
+    try:
+        request = urllib.request.Request(f"{base_url}/health", method="GET")
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            body = response.read(4096)
+        return b"ok" in body.lower() or body.strip() in (b"true", b"1")
+    except Exception:
+        return False
+
+
+def _generate_piper_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+    """Generate speech by POSTing text to a local Piper HTTP server.
+
+    The server is expected to expose:
+      * GET /health -> JSON/text health signal
+      * POST /tts {"text": "..."} -> audio/wav bytes
+
+    If *output_path* is not .wav, ffmpeg converts the returned WAV to the
+    requested extension so the rest of the TTS pipeline can stay provider-agnostic.
+    """
+    import urllib.error
+    import urllib.request
+
+    piper_config = tts_config.get("piper", {}) if isinstance(tts_config.get("piper"), dict) else {}
+    base_url = _get_piper_base_url(tts_config)
+    timeout = piper_config.get("timeout", DEFAULT_PIPER_TIMEOUT)
+    try:
+        timeout = float(timeout)
+    except (TypeError, ValueError):
+        timeout = DEFAULT_PIPER_TIMEOUT
+
+    payload = json.dumps({"text": text}, ensure_ascii=False).encode("utf-8")
+    request = urllib.request.Request(
+        f"{base_url}/tts",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            wav_bytes = response.read()
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode("utf-8", errors="ignore")[:500]
+        raise ValueError(f"Piper TTS server returned HTTP {e.code}: {detail}") from e
+    except urllib.error.URLError as e:
+        raise FileNotFoundError(f"Piper TTS server not reachable at {base_url}: {e}") from e
+
+    if not wav_bytes:
+        raise ValueError("Piper TTS server returned an empty audio response")
+
+    wav_path = output_path
+    if not output_path.endswith(".wav"):
+        wav_path = output_path.rsplit(".", 1)[0] + ".wav"
+
+    with open(wav_path, "wb") as f:
+        f.write(wav_bytes)
+
+    if wav_path != output_path:
+        ffmpeg = shutil.which("ffmpeg")
+        if ffmpeg:
+            conv_cmd = [ffmpeg, "-i", wav_path, "-y", "-loglevel", "error", output_path]
+            subprocess.run(conv_cmd, check=True, timeout=30)
+            os.remove(wav_path)
+        else:
+            os.rename(wav_path, output_path)
+
+    return output_path
+
+
+# ===========================================================================
+# Provider: MeloTTS (local subprocess in an isolated virtualenv)
+# ===========================================================================
+def _get_melotts_config(tts_config: Dict[str, Any]) -> Dict[str, Any]:
+    """Return normalized MeloTTS provider config."""
+    raw = tts_config.get("melotts", {}) if isinstance(tts_config.get("melotts"), dict) else {}
+    return {
+        "python": str(raw.get("python") or raw.get("python_path") or DEFAULT_MELOTTS_PYTHON),
+        "language": str(raw.get("language") or DEFAULT_MELOTTS_LANGUAGE),
+        "speaker": str(raw.get("speaker") or DEFAULT_MELOTTS_SPEAKER),
+        "device": str(raw.get("device") or DEFAULT_MELOTTS_DEVICE),
+        "speed": raw.get("speed", DEFAULT_MELOTTS_SPEED),
+        "timeout": raw.get("timeout", DEFAULT_MELOTTS_TIMEOUT),
+    }
+
+
+def _check_melotts_available(tts_config: Optional[Dict[str, Any]] = None) -> bool:
+    """Check whether the configured MeloTTS Python executable exists."""
+    config = _get_melotts_config(tts_config or _load_tts_config())
+    py = config["python"]
+    return bool(py and os.path.exists(py) and os.access(py, os.X_OK))
+
+
+def _generate_melotts_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+    """Generate speech with MeloTTS via a separate Python environment.
+
+    MeloTTS pulls in Torch and older text-processing dependencies. Running it
+    in its own venv avoids contaminating the main Hermes runtime.
+    """
+    cfg = _get_melotts_config(tts_config)
+    try:
+        speed = float(cfg["speed"])
+    except (TypeError, ValueError):
+        speed = DEFAULT_MELOTTS_SPEED
+    try:
+        timeout = float(cfg["timeout"])
+    except (TypeError, ValueError):
+        timeout = DEFAULT_MELOTTS_TIMEOUT
+
+    py = cfg["python"]
+    if not os.path.exists(py):
+        raise FileNotFoundError(f"MeloTTS Python executable not found: {py}")
+
+    output = Path(output_path).expanduser()
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    env = os.environ.copy()
+    env.setdefault("TOKENIZERS_PARALLELISM", "false")
+    repo_root = Path(__file__).resolve().parents[1]
+    env["PYTHONPATH"] = f"{repo_root}{os.pathsep}{env.get('PYTHONPATH', '')}" if env.get("PYTHONPATH") else str(repo_root)
+
+    cmd = [
+        py,
+        "-m",
+        "tools.melotts_runner",
+        "--language",
+        cfg["language"],
+        "--speaker",
+        cfg["speaker"],
+        "--speed",
+        str(speed),
+        "--device",
+        cfg["device"],
+        "--text",
+        text,
+        "--output",
+        str(output),
+    ]
+    subprocess.run(cmd, check=True, timeout=timeout, env=env)
+
+    if not output.exists() or output.stat().st_size == 0:
+        raise FileNotFoundError(f"MeloTTS produced no output: {output}")
+    return str(output)
+
+
+# ===========================================================================
 # Main tool function
 # ===========================================================================
 def text_to_speech_tool(
@@ -1048,6 +1359,26 @@ def text_to_speech_tool(
             logger.info("Generating speech with KittenTTS (local, ~25MB)...")
             _generate_kittentts(text, file_str, tts_config)
 
+        elif provider == "piper":
+            logger.info("Generating speech with Piper HTTP TTS (local)...")
+            piper_output = file_str
+            # Piper returns WAV. If the caller requested .ogg, synthesize WAV first
+            # and let the shared Opus conversion path create Telegram voice audio.
+            if file_str.endswith(".ogg"):
+                piper_output = str(file_path.with_suffix(".wav"))
+            _generate_piper_tts(text, piper_output, tts_config)
+            file_str = piper_output
+
+        elif provider == "melotts":
+            logger.info("Generating speech with MeloTTS (local)...")
+            melotts_output = file_str
+            # MeloTTS returns WAV. If the caller requested .ogg, synthesize WAV first
+            # and let the shared Opus conversion path create Telegram voice audio.
+            if file_str.endswith(".ogg"):
+                melotts_output = str(file_path.with_suffix(".wav"))
+            _generate_melotts_tts(text, melotts_output, tts_config)
+            file_str = melotts_output
+
         else:
             # Default: Edge TTS (free), with NeuTTS as local fallback
             edge_available = True
@@ -1084,10 +1415,15 @@ def text_to_speech_tool(
                 "error": f"TTS generation produced no output (provider: {provider})"
             }, ensure_ascii=False)
 
+        postprocessed = _apply_tts_postprocess(file_str, tts_config)
+        if postprocessed:
+            file_str = postprocessed
+
         # Try Opus conversion for Telegram compatibility
-        # Edge TTS outputs MP3, NeuTTS/KittenTTS output WAV — all need ffmpeg conversion
+        # Edge TTS outputs MP3; NeuTTS/KittenTTS/Piper/MeloTTS output WAV; MiniMax/xAI
+        # output MP3. All need ffmpeg conversion for Telegram voice bubbles.
         voice_compatible = False
-        if provider in ("edge", "neutts", "minimax", "xai", "kittentts") and not file_str.endswith(".ogg"):
+        if provider in ("edge", "neutts", "minimax", "xai", "kittentts", "piper", "melotts") and not file_str.endswith(".ogg"):
             opus_path = _convert_to_opus(file_str)
             if opus_path:
                 file_str = opus_path
@@ -1173,6 +1509,10 @@ def check_tts_requirements() -> bool:
     if _check_neutts_available():
         return True
     if _check_kittentts_available():
+        return True
+    if _check_piper_available():
+        return True
+    if _check_melotts_available():
         return True
     return False
 
@@ -1461,6 +1801,8 @@ if __name__ == "__main__":
         except ImportError:
             return False
 
+    config = _load_tts_config()
+
     print("\nProvider availability:")
     print(f"  Edge TTS:   {'installed' if _check(_import_edge_tts, 'edge') else 'not installed (pip install edge-tts)'}")
     print(f"  ElevenLabs: {'installed' if _check(_import_elevenlabs, 'el') else 'not installed (pip install elevenlabs)'}")
@@ -1471,10 +1813,10 @@ if __name__ == "__main__":
         f"{'set' if resolve_openai_audio_api_key() else 'not set (VOICE_TOOLS_OPENAI_KEY or OPENAI_API_KEY)'}"
     )
     print(f"  MiniMax:    {'API key set' if os.getenv('MINIMAX_API_KEY') else 'not set (MINIMAX_API_KEY)'}")
+    print(f"  Piper HTTP: {'available' if _check_piper_available(config) else 'not reachable'}")
     print(f"  ffmpeg:     {'✅ found' if _has_ffmpeg() else '❌ not found (needed for Telegram Opus)'}")
     print(f"\n  Output dir: {DEFAULT_OUTPUT_DIR}")
 
-    config = _load_tts_config()
     provider = _get_provider(config)
     print(f"  Configured provider: {provider}")
 

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -320,6 +320,9 @@ def _tts_effect_filter(preset: str) -> Optional[str]:
         # chain, adapted for Hermes/OpenAI's 48 kHz Opus path and Korean TTS.
         # Keep bitcrusher/acrusher out; the Jarvis-style character comes from
         # +5% asetrate pitch, strong flanger, short echo, highpass, and treble.
+        # The pitch compensation keeps the playback duration near the original;
+        # do not add a separate speed-up here because it makes Korean voice
+        # replies sound unnaturally rushed in Telegram.
         if not pitch:
             pitch = "asetrate=48000*1.05,aresample=48000,atempo=0.952,"
         body = (
@@ -327,7 +330,6 @@ def _tts_effect_filter(preset: str) -> Optional[str]:
             "aecho=0.8:0.88:15:0.5,"
             "highpass=f=200,"
             "treble=g=6,"
-            "atempo=1.25,"
             "loudnorm=I=-16:TP=-1.5:LRA=6"
         )
     elif preset == "clean":

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1392,14 +1392,22 @@ def text_to_speech_tool(
 
             if edge_available:
                 logger.info("Generating speech with Edge TTS...")
+                # Edge TTS always writes MP3 bytes regardless of the extension
+                # requested by the caller.  When Telegram requests .ogg, synthesize
+                # MP3 first so optional postprocessing runs on a correctly named
+                # container, then convert the final result to OGG/Opus below.
+                edge_output = file_str
+                if edge_output.endswith(".ogg"):
+                    edge_output = str(Path(edge_output).with_suffix(".mp3"))
                 try:
                     import concurrent.futures
                     with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
                         pool.submit(
-                            lambda: asyncio.run(_generate_edge_tts(text, file_str, tts_config))
+                            lambda: asyncio.run(_generate_edge_tts(text, edge_output, tts_config))
                         ).result(timeout=60)
                 except RuntimeError:
-                    asyncio.run(_generate_edge_tts(text, file_str, tts_config))
+                    asyncio.run(_generate_edge_tts(text, edge_output, tts_config))
+                file_str = edge_output
             elif _check_neutts_available():
                 logger.info("Edge TTS not available, falling back to NeuTTS (local)...")
                 provider = "neutts"

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -42,7 +42,7 @@ from pathlib import Path
 from typing import Callable, Dict, Any, Optional
 from urllib.parse import urljoin
 
-from hermes_constants import display_hermes_home
+from hermes_constants import display_hermes_home, get_hermes_dir
 
 logger = logging.getLogger(__name__)
 from tools.managed_tool_gateway import resolve_managed_tool_gateway
@@ -126,6 +126,7 @@ DEFAULT_GOOGLE_CLOUD_VOICE = "ko-KR-Chirp3-HD-Kore"
 DEFAULT_GOOGLE_CLOUD_AUDIO_ENCODING = "LINEAR16"
 DEFAULT_GOOGLE_CLOUD_SPEAKING_RATE = 1.0
 DEFAULT_GOOGLE_CLOUD_PITCH = 0.0
+DEFAULT_GOOGLE_CLOUD_MONTHLY_CHARACTER_LIMIT = 1_000_000
 DEFAULT_PIPER_BASE_URL = "http://127.0.0.1:5005"
 DEFAULT_PIPER_TIMEOUT = 60
 DEFAULT_PIPER_HEALTH_TIMEOUT = 2
@@ -954,6 +955,87 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
 
 
 
+def _google_cloud_usage_month(now: Optional[datetime.datetime] = None) -> str:
+    """Return the UTC usage bucket month for Google Cloud TTS metering."""
+    current = now or datetime.datetime.now(datetime.timezone.utc)
+    return current.strftime("%Y-%m")
+
+
+def _google_cloud_usage_path(tts_config: Dict[str, Any]) -> Path:
+    """Return the persistent local usage counter path for Google Cloud TTS."""
+    gc_config = tts_config.get("google_cloud", {}) if isinstance(tts_config.get("google_cloud"), dict) else {}
+    configured = str(gc_config.get("usage_path") or "").strip()
+    if configured:
+        return Path(configured).expanduser()
+    return get_hermes_dir("state/tts", "tts_usage") / "google_cloud_usage.json"
+
+
+def _google_cloud_monthly_limit(tts_config: Dict[str, Any]) -> int:
+    """Return the configured Google Cloud TTS monthly character limit."""
+    gc_config = tts_config.get("google_cloud", {}) if isinstance(tts_config.get("google_cloud"), dict) else {}
+    limit = gc_config.get("monthly_character_limit", DEFAULT_GOOGLE_CLOUD_MONTHLY_CHARACTER_LIMIT)
+    if isinstance(limit, bool):
+        return DEFAULT_GOOGLE_CLOUD_MONTHLY_CHARACTER_LIMIT
+    try:
+        parsed = int(limit)
+    except (TypeError, ValueError):
+        return DEFAULT_GOOGLE_CLOUD_MONTHLY_CHARACTER_LIMIT
+    return parsed if parsed > 0 else DEFAULT_GOOGLE_CLOUD_MONTHLY_CHARACTER_LIMIT
+
+
+def _read_google_cloud_usage(tts_config: Dict[str, Any]) -> Dict[str, Any]:
+    """Read the local Google Cloud TTS usage counter, resetting stale months."""
+    month = _google_cloud_usage_month()
+    path = _google_cloud_usage_path(tts_config)
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {"month": month, "characters": 0}
+
+    if not isinstance(data, dict) or data.get("month") != month:
+        return {"month": month, "characters": 0}
+    try:
+        characters = int(data.get("characters", 0))
+    except (TypeError, ValueError):
+        characters = 0
+    return {"month": month, "characters": max(0, characters)}
+
+
+def _write_google_cloud_usage(tts_config: Dict[str, Any], usage: Dict[str, Any]) -> None:
+    """Persist the local Google Cloud TTS usage counter atomically."""
+    path = _google_cloud_usage_path(tts_config)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+    tmp_path.write_text(json.dumps(usage, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    os.replace(tmp_path, path)
+
+
+def _ensure_google_cloud_monthly_quota(text: str, tts_config: Dict[str, Any]) -> Dict[str, Any]:
+    """Raise before calling the paid API if this request would exceed quota."""
+    limit = _google_cloud_monthly_limit(tts_config)
+    usage = _read_google_cloud_usage(tts_config)
+    requested = len(text)
+    projected = usage["characters"] + requested
+    if projected > limit:
+        remaining = max(0, limit - usage["characters"])
+        raise ValueError(
+            "Google Cloud TTS monthly character limit would be exceeded: "
+            f"used {usage['characters']:,}/{limit:,}, requested {requested:,}, "
+            f"remaining {remaining:,}."
+        )
+    return usage
+
+
+def _record_google_cloud_usage(text: str, tts_config: Dict[str, Any], prior_usage: Optional[Dict[str, Any]] = None) -> None:
+    """Record characters after a successful Google Cloud TTS synthesis."""
+    usage = prior_usage or _read_google_cloud_usage(tts_config)
+    current_month = _google_cloud_usage_month()
+    if usage.get("month") != current_month:
+        usage = {"month": current_month, "characters": 0}
+    usage["characters"] = int(usage.get("characters", 0)) + len(text)
+    _write_google_cloud_usage(tts_config, usage)
+
+
 # ===========================================================================
 # Provider: Google Cloud Text-to-Speech (Chirp 3 HD)
 # ===========================================================================
@@ -976,6 +1058,8 @@ def _generate_google_cloud_tts(text: str, output_path: str, tts_config: Dict[str
     ).strip().upper() or DEFAULT_GOOGLE_CLOUD_AUDIO_ENCODING
     speaking_rate = float(gc_config.get("speaking_rate", tts_config.get("speed", DEFAULT_GOOGLE_CLOUD_SPEAKING_RATE)))
     pitch = float(gc_config.get("pitch", DEFAULT_GOOGLE_CLOUD_PITCH))
+
+    quota_usage = _ensure_google_cloud_monthly_quota(text, tts_config)
 
     texttospeech = _import_google_cloud_tts()
     audio_encoding = getattr(texttospeech.AudioEncoding, encoding_name, None)
@@ -1002,6 +1086,7 @@ def _generate_google_cloud_tts(text: str, output_path: str, tts_config: Dict[str
 
     with open(output_path, "wb") as f:
         f.write(audio_content)
+    _record_google_cloud_usage(text, tts_config, quota_usage)
     return output_path
 
 # ===========================================================================

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -321,7 +321,9 @@ def _tts_effect_filter(preset: str) -> Optional[str]:
         # Keep bitcrusher/acrusher out; the Jarvis-style character comes from
         # +5% asetrate pitch, strong flanger, short echo, highpass, and treble.
         # The pitch compensation keeps pitch-shift duration near the original;
-        # the final atempo=1.25 is the user-requested Telegram speaking speed.
+        # do not add a final speaking-speed boost here. Long replies already
+        # feel dense, and forcing a fixed atempo speedup makes them harder to
+        # understand in Telegram voice bubbles.
         if not pitch:
             pitch = "asetrate=48000*1.05,aresample=48000,atempo=0.952,"
         body = (
@@ -329,7 +331,6 @@ def _tts_effect_filter(preset: str) -> Optional[str]:
             "aecho=0.8:0.88:15:0.5,"
             "highpass=f=200,"
             "treble=g=6,"
-            "atempo=1.25,"
             "loudnorm=I=-16:TP=-1.5:LRA=6"
         )
     elif preset == "clean":
@@ -1578,6 +1579,60 @@ def _strip_markdown_for_tts(text: str) -> str:
     text = _MD_HR.sub('', text)
     text = _MD_EXCESS_NL.sub('\n\n', text)
     return text.strip()
+
+
+def split_text_for_tts(text: str, max_chars: int = 1200, max_chunks: int = 3) -> list[str]:
+    """Split long auto-TTS text into natural chunks.
+
+    Messaging auto-TTS should not cram a long assistant reply into one voice
+    bubble. Some providers respond to dense, long inputs with rushed prosody,
+    and a single multi-minute Telegram voice note is hard to follow. Keep
+    chunks modest and sentence-aware; callers may cap ``max_chunks`` to avoid
+    spamming the chat.
+    """
+    cleaned = _strip_markdown_for_tts(text)
+    if not cleaned:
+        return []
+    max_chars = max(200, int(max_chars or 1200))
+    max_chunks = max(1, int(max_chunks or 1))
+    if len(cleaned) <= max_chars:
+        return [cleaned]
+
+    import re
+
+    sentences = re.split(r"(?<=[.!?。！？…]|[다요죠니다까네음함됨])\s+", cleaned)
+    chunks: list[str] = []
+    current = ""
+    for sentence in sentences:
+        sentence = sentence.strip()
+        if not sentence:
+            continue
+        while len(sentence) > max_chars:
+            cut = max(sentence.rfind(" ", 0, max_chars), sentence.rfind("\n", 0, max_chars))
+            if cut < max_chars // 2:
+                cut = max_chars
+            part, sentence = sentence[:cut].strip(), sentence[cut:].strip()
+            if current:
+                chunks.append(current)
+                current = ""
+            if part:
+                chunks.append(part)
+            if len(chunks) >= max_chunks:
+                return chunks[:max_chunks]
+        if not sentence:
+            continue
+        candidate = f"{current} {sentence}".strip() if current else sentence
+        if len(candidate) <= max_chars:
+            current = candidate
+        else:
+            if current:
+                chunks.append(current)
+                if len(chunks) >= max_chunks:
+                    return chunks[:max_chunks]
+            current = sentence
+    if current and len(chunks) < max_chunks:
+        chunks.append(current)
+    return chunks[:max_chunks]
 
 
 def stream_tts_to_speaker(

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -296,7 +296,7 @@ def _ffmpeg_has_filter(filter_name: str) -> bool:
     return result.returncode == 0 and re.search(rf"\s{re.escape(filter_name)}\s", result.stdout) is not None
 
 
-def _tts_effect_filter(preset: str) -> Optional[str]:
+def _tts_effect_filter(preset: str, sample_rate: Optional[int] = None) -> Optional[str]:
     """Build a conservative ffmpeg filter chain for lab-AI TTS effects."""
     preset = (preset or "none").lower().strip()
     if preset in ("", "none", "off", "false"):
@@ -325,7 +325,10 @@ def _tts_effect_filter(preset: str) -> Optional[str]:
         # feel dense, and forcing a fixed atempo speedup makes them harder to
         # understand in Telegram voice bubbles.
         if not pitch:
-            pitch = "asetrate=48000*1.05,aresample=48000,atempo=0.952,"
+            # Match the input stream's sample rate. Hard-coding 48000 here made
+            # 24 kHz Edge TTS output play about 2x too fast after resampling.
+            pitch_rate = int(sample_rate or 48000)
+            pitch = f"asetrate={pitch_rate}*1.05,aresample={pitch_rate},atempo=0.952,"
         body = (
             "flanger=delay=0:depth=2:regen=50:width=71:speed=0.5,"
             "aecho=0.8:0.88:15:0.5,"
@@ -372,6 +375,32 @@ def _tts_effect_filter(preset: str) -> Optional[str]:
     return f"{pitch}{body}"
 
 
+def _audio_sample_rate(audio_path: str) -> Optional[int]:
+    """Return the first audio stream sample rate using ffprobe, if available."""
+    if shutil.which("ffprobe") is None:
+        return None
+    try:
+        result = subprocess.run(
+            [
+                "ffprobe", "-v", "error",
+                "-select_streams", "a:0",
+                "-show_entries", "stream=sample_rate",
+                "-of", "default=noprint_wrappers=1:nokey=1",
+                audio_path,
+            ],
+            capture_output=True, text=True, timeout=10,
+        )
+    except Exception:
+        return None
+    if result.returncode != 0:
+        return None
+    try:
+        value = int((result.stdout or "").strip().splitlines()[0])
+    except (IndexError, TypeError, ValueError):
+        return None
+    return value if value > 0 else None
+
+
 def _apply_tts_postprocess(audio_path: str, tts_config: Dict[str, Any]) -> Optional[str]:
     """Apply optional ffmpeg postprocessing before the file is delivered."""
     post_cfg = tts_config.get("postprocess", {})
@@ -385,7 +414,8 @@ def _apply_tts_postprocess(audio_path: str, tts_config: Dict[str, Any]) -> Optio
         logger.warning("TTS postprocess requested but ffmpeg is not available")
         return None
 
-    filter_chain = _tts_effect_filter(preset)
+    sample_rate = _audio_sample_rate(audio_path)
+    filter_chain = _tts_effect_filter(preset, sample_rate=sample_rate)
     if not filter_chain:
         return None
 

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -33,6 +33,7 @@ import logging
 import os
 import queue
 import re
+import shlex
 import shutil
 import subprocess
 import tempfile
@@ -453,6 +454,86 @@ def _apply_tts_postprocess(audio_path: str, tts_config: Dict[str, Any]) -> Optio
     if out.exists() and out.stat().st_size > 0:
         return str(out)
     return None
+
+
+def _format_visualizer_arg(value: Any, *, audio_path: str, text: str, provider: str) -> str:
+    """Format one configured visualizer command argument."""
+    return str(value).format(
+        audio_path=audio_path,
+        audio_path_q=shlex.quote(audio_path),
+        text=text,
+        text_q=shlex.quote(text),
+        provider=provider,
+    )
+
+
+def _notify_tts_visualizer(audio_path: str, text: str, provider: str, tts_config: Dict[str, Any]) -> bool:
+    """Notify an optional external TTS visualizer command.
+
+    Config shape::
+
+        tts:
+          visualizer:
+            enabled: true
+            command: ["python3", "~/.hermes/scripts/tts_visualizer_bridge.py", "--audio", "{audio_path}", "--text", "{text}"]
+            timeout: 3
+            async: true
+
+    The hook is best-effort: it never makes TTS generation fail.
+    """
+    visualizer_cfg = tts_config.get("visualizer", {}) if isinstance(tts_config.get("visualizer"), dict) else {}
+    if not visualizer_cfg.get("enabled", False):
+        return False
+
+    command = visualizer_cfg.get("command")
+    if not command:
+        logger.warning("TTS visualizer enabled but no command configured")
+        return False
+
+    try:
+        if isinstance(command, (list, tuple)):
+            argv = [
+                _format_visualizer_arg(part, audio_path=audio_path, text=text, provider=provider)
+                for part in command
+            ]
+        else:
+            formatted = _format_visualizer_arg(command, audio_path=audio_path, text=text, provider=provider)
+            argv = shlex.split(formatted)
+
+        if not argv:
+            return False
+
+        argv[0] = os.path.expanduser(argv[0])
+        env = os.environ.copy()
+        env.update({
+            "HERMES_TTS_AUDIO_PATH": audio_path,
+            "HERMES_TTS_TEXT": text,
+            "HERMES_TTS_PROVIDER": provider,
+        })
+        timeout = float(visualizer_cfg.get("timeout", 3))
+        run_async = bool(visualizer_cfg.get("async", True))
+        if run_async:
+            subprocess.Popen(
+                argv,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                stdin=subprocess.DEVNULL,
+                close_fds=True,
+                env=env,
+            )
+        else:
+            subprocess.run(
+                argv,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=timeout,
+                check=False,
+                env=env,
+            )
+        return True
+    except Exception as e:
+        logger.warning("TTS visualizer notification failed: %s", e, exc_info=True)
+        return False
 
 
 # ===========================================================================
@@ -1675,6 +1756,7 @@ def text_to_speech_tool(
             "provider": provider,
             "voice_compatible": voice_compatible,
         }
+        result["visualizer_notified"] = _notify_tts_visualizer(file_str, text, provider, tts_config)
         if fallback_from:
             result["fallback_from"] = fallback_from
             result["fallback_reason"] = fallback_reason or ""

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -320,9 +320,8 @@ def _tts_effect_filter(preset: str) -> Optional[str]:
         # chain, adapted for Hermes/OpenAI's 48 kHz Opus path and Korean TTS.
         # Keep bitcrusher/acrusher out; the Jarvis-style character comes from
         # +5% asetrate pitch, strong flanger, short echo, highpass, and treble.
-        # The pitch compensation keeps the playback duration near the original;
-        # do not add a separate speed-up here because it makes Korean voice
-        # replies sound unnaturally rushed in Telegram.
+        # The pitch compensation keeps pitch-shift duration near the original;
+        # the final atempo=1.25 is the user-requested Telegram speaking speed.
         if not pitch:
             pitch = "asetrate=48000*1.05,aresample=48000,atempo=0.952,"
         body = (
@@ -330,6 +329,7 @@ def _tts_effect_filter(preset: str) -> Optional[str]:
             "aecho=0.8:0.88:15:0.5,"
             "highpass=f=200,"
             "treble=g=6,"
+            "atempo=1.25,"
             "loudnorm=I=-16:TP=-1.5:LRA=6"
         )
     elif preset == "clean":

--- a/uv.lock
+++ b/uv.lock
@@ -157,6 +157,19 @@ wheels = [
 ]
 
 [[package]]
+name = "aiohttp-socks"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "python-socks" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/cc/e5bbd54f76bd56291522251e47267b645dac76327b2657ade9545e30522c/aiohttp_socks-0.11.0.tar.gz", hash = "sha256:0afe51638527c79077e4bd6e57052c87c4824233d6e20bb061c53766421b10f0", size = 11196, upload-time = "2025-12-09T13:35:52.564Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/7d/4b633d709b8901d59444d2e512b93e72fe62d2b492a040097c3f7ba017bb/aiohttp_socks-0.11.0-py3-none-any.whl", hash = "sha256:9aacce57c931b8fbf8f6d333cf3cafe4c35b971b35430309e167a35a8aab9ec1", size = 10556, upload-time = "2025-12-09T13:35:50.18Z" },
+]
+
+[[package]]
 name = "aiosignal"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1760,6 +1773,99 @@ wheels = [
 ]
 
 [[package]]
+name = "google-api-core"
+version = "2.30.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/ce/502a57fb0ec752026d24df1280b162294b22a0afb98a326084f9a979138b/google_api_core-2.30.3.tar.gz", hash = "sha256:e601a37f148585319b26db36e219df68c5d07b6382cff2d580e83404e44d641b", size = 177001, upload-time = "2026-04-10T00:41:28.035Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/15/e56f351cf6ef1cfea58e6ac226a7318ed1deb2218c4b3cc9bd9e4b786c5a/google_api_core-2.30.3-py3-none-any.whl", hash = "sha256:a85761ba72c444dad5d611c2220633480b2b6be2521eca69cca2dbb3ffd6bfe8", size = 173274, upload-time = "2026-04-09T22:57:16.198Z" },
+]
+
+[package.optional-dependencies]
+grpc = [
+    { name = "grpcio" },
+    { name = "grpcio-status" },
+]
+
+[[package]]
+name = "google-api-python-client"
+version = "2.194.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+    { name = "google-auth-httplib2" },
+    { name = "httplib2" },
+    { name = "uritemplate" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/ab/e83af0eb043e4ccc49571ca7a6a49984e9d00f4e9e6e6f1238d60bc84dce/google_api_python_client-2.194.0.tar.gz", hash = "sha256:db92647bd1a90f40b79c9618461553c2b20b6a43ce7395fa6de07132dc14f023", size = 14443469, upload-time = "2026-04-08T23:07:35.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/34/5a624e49f179aa5b0cb87b2ce8093960299030ff40423bfbde09360eb908/google_api_python_client-2.194.0-py3-none-any.whl", hash = "sha256:61eaaac3b8fc8fdf11c08af87abc3d1342d1b37319cc1b57405f86ef7697e717", size = 15016514, upload-time = "2026-04-08T23:07:33.093Z" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.49.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/fc/e925290a1ad95c975c459e2df070fac2b90954e13a0370ac505dff78cb99/google_auth-2.49.2.tar.gz", hash = "sha256:c1ae38500e73065dcae57355adb6278cf8b5c8e391994ae9cbadbcb9631ab409", size = 333958, upload-time = "2026-04-10T00:41:21.888Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/76/d241a5c927433420507215df6cac1b1fa4ac0ba7a794df42a84326c68da8/google_auth-2.49.2-py3-none-any.whl", hash = "sha256:c2720924dfc82dedb962c9f52cabb2ab16714fd0a6a707e40561d217574ed6d5", size = 240638, upload-time = "2026-04-10T00:41:14.501Z" },
+]
+
+[[package]]
+name = "google-auth-httplib2"
+version = "0.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "httplib2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ed/99/107612bef8d24b298bb5a7c8466f908ecda791d43f9466f5c3978f5b24c1/google_auth_httplib2-0.3.1.tar.gz", hash = "sha256:0af542e815784cb64159b4469aa5d71dd41069ba93effa006e1916b1dcd88e55", size = 11152, upload-time = "2026-03-30T22:50:26.766Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/e9/93afb14d23a949acaa3f4e7cc51a0024671174e116e35f42850764b99634/google_auth_httplib2-0.3.1-py3-none-any.whl", hash = "sha256:682356a90ef4ba3d06548c37e9112eea6fc00395a11b0303a644c1a86abc275c", size = 9534, upload-time = "2026-03-30T22:49:03.384Z" },
+]
+
+[[package]]
+name = "google-auth-oauthlib"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "requests-oauthlib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a6/82/62482931dcbe5266a2680d0da17096f2aab983ecb320277d9556700ce00e/google_auth_oauthlib-1.3.1.tar.gz", hash = "sha256:14c22c7b3dd3d06dbe44264144409039465effdd1eef94f7ce3710e486cc4bfa", size = 21663, upload-time = "2026-03-30T22:49:56.408Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/e0/cb454a95f460903e39f101e950038ec24a072ca69d0a294a6df625cc1627/google_auth_oauthlib-1.3.1-py3-none-any.whl", hash = "sha256:1a139ef23f1318756805b0e95f655c238bffd29655329a2978218248da4ee7f8", size = 19247, upload-time = "2026-03-30T20:02:23.894Z" },
+]
+
+[[package]]
+name = "google-cloud-texttospeech"
+version = "2.36.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core", extra = ["grpc"] },
+    { name = "google-auth" },
+    { name = "grpcio" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/fe/670610dce6852c8fbdd723101a2ffb497d196bc242cb04a1312339f49d67/google_cloud_texttospeech-2.36.0.tar.gz", hash = "sha256:6c605af7e4774c1bac99fcaaf4538f152b10bba7738a23f42184557f444dc6b7", size = 196558, upload-time = "2026-04-02T21:23:42.236Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/1a/0317eaa1ccd6e3645d570851574bb7c1a1cfa3504bb114b7211db59b154d/google_cloud_texttospeech-2.36.0-py3-none-any.whl", hash = "sha256:03f76162543e9d77ecbab823c1cc3728c42ef40547353bcfdbd9ac0e71cb8121", size = 200086, upload-time = "2026-04-02T21:23:13.444Z" },
+]
+
+[[package]]
 name = "googleapis-common-protos"
 version = "1.73.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1816,6 +1922,71 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/fd/d05a4b7acd0154ed758797f0a43b4c0962a843bedfe980115e842c5b2d08/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1fb39a11ee2e4d94be9a76671482be9398560955c9e568550de0224e41104727", size = 1618857, upload-time = "2026-02-20T20:49:37.309Z" },
     { url = "https://files.pythonhosted.org/packages/6f/e1/50ee92a5db521de8f35075b5eff060dd43d39ebd46c2181a2042f7070385/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:20154044d9085151bc309e7689d6f7ba10027f8f5a8c0676ad398b951913d89e", size = 1680010, upload-time = "2026-02-20T20:21:13.427Z" },
     { url = "https://files.pythonhosted.org/packages/29/4b/45d90626aef8e65336bed690106d1382f7a43665e2249017e9527df8823b/greenlet-3.3.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c04c5e06ec3e022cbfe2cd4a846e1d4e50087444f875ff6d2c2ad8445495cf1a", size = 237086, upload-time = "2026-02-20T20:20:45.786Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.80.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b7/48/af6173dbca4454f4637a4678b67f52ca7e0c1ed7d5894d89d434fecede05/grpcio-1.80.0.tar.gz", hash = "sha256:29aca15edd0688c22ba01d7cc01cb000d72b2033f4a3c72a81a19b56fd143257", size = 12978905, upload-time = "2026-03-30T08:49:10.502Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/db/1d56e5f5823257b291962d6c0ce106146c6447f405b60b234c4f222a7cde/grpcio-1.80.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:dfab85db094068ff42e2a3563f60ab3dddcc9d6488a35abf0132daec13209c8a", size = 6055009, upload-time = "2026-03-30T08:46:46.265Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/18/c83f3cad64c5ca63bca7e91e5e46b0d026afc5af9d0a9972472ceba294b3/grpcio-1.80.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:5c07e82e822e1161354e32da2662f741a4944ea955f9f580ec8fb409dd6f6060", size = 12035295, upload-time = "2026-03-30T08:46:49.099Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/8e/e14966b435be2dda99fbe89db9525ea436edc79780431a1c2875a3582644/grpcio-1.80.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ba0915d51fd4ced2db5ff719f84e270afe0e2d4c45a7bdb1e8d036e4502928c2", size = 6610297, upload-time = "2026-03-30T08:46:52.123Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/26/d5eb38f42ce0e3fdc8174ea4d52036ef8d58cc4426cb800f2610f625dd75/grpcio-1.80.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:3cb8130ba457d2aa09fa6b7c3ed6b6e4e6a2685fce63cb803d479576c4d80e21", size = 7300208, upload-time = "2026-03-30T08:46:54.859Z" },
+    { url = "https://files.pythonhosted.org/packages/25/51/bd267c989f85a17a5b3eea65a6feb4ff672af41ca614e5a0279cc0ea381c/grpcio-1.80.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:09e5e478b3d14afd23f12e49e8b44c8684ac3c5f08561c43a5b9691c54d136ab", size = 6813442, upload-time = "2026-03-30T08:46:57.056Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/d9/d80eef735b19e9169e30164bbf889b46f9df9127598a83d174eb13a48b26/grpcio-1.80.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:00168469238b022500e486c1c33916acf2f2a9b2c022202cf8a1885d2e3073c1", size = 7414743, upload-time = "2026-03-30T08:46:59.682Z" },
+    { url = "https://files.pythonhosted.org/packages/de/f2/567f5bd5054398ed6b0509b9a30900376dcf2786bd936812098808b49d8d/grpcio-1.80.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8502122a3cc1714038e39a0b071acb1207ca7844208d5ea0d091317555ee7106", size = 8426046, upload-time = "2026-03-30T08:47:02.474Z" },
+    { url = "https://files.pythonhosted.org/packages/62/29/73ef0141b4732ff5eacd68430ff2512a65c004696997f70476a83e548e7e/grpcio-1.80.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ce1794f4ea6cc3ca29463f42d665c32ba1b964b48958a66497917fe9069f26e6", size = 7851641, upload-time = "2026-03-30T08:47:05.462Z" },
+    { url = "https://files.pythonhosted.org/packages/46/69/abbfa360eb229a8623bab5f5a4f8105e445bd38ce81a89514ba55d281ad0/grpcio-1.80.0-cp311-cp311-win32.whl", hash = "sha256:51b4a7189b0bef2aa30adce3c78f09c83526cf3dddb24c6a96555e3b97340440", size = 4154368, upload-time = "2026-03-30T08:47:08.027Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d4/ae92206d01183b08613e846076115f5ac5991bae358d2a749fa864da5699/grpcio-1.80.0-cp311-cp311-win_amd64.whl", hash = "sha256:02e64bb0bb2da14d947a49e6f120a75e947250aebe65f9629b62bb1f5c14e6e9", size = 4894235, upload-time = "2026-03-30T08:47:10.839Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e8/a2b749265eb3415abc94f2e619bbd9e9707bebdda787e61c593004ec927a/grpcio-1.80.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:c624cc9f1008361014378c9d776de7182b11fe8b2e5a81bc69f23a295f2a1ad0", size = 6015616, upload-time = "2026-03-30T08:47:13.428Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/97/b1282161a15d699d1e90c360df18d19165a045ce1c343c7f313f5e8a0b77/grpcio-1.80.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:f49eddcac43c3bf350c0385366a58f36bed8cc2c0ec35ef7b74b49e56552c0c2", size = 12014204, upload-time = "2026-03-30T08:47:15.873Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/5e/d319c6e997b50c155ac5a8cb12f5173d5b42677510e886d250d50264949d/grpcio-1.80.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d334591df610ab94714048e0d5b4f3dd5ad1bee74dfec11eee344220077a79de", size = 6563866, upload-time = "2026-03-30T08:47:18.588Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/f6/fdd975a2cb4d78eb67769a7b3b3830970bfa2e919f1decf724ae4445f42c/grpcio-1.80.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:0cb517eb1d0d0aaf1d87af7cc5b801d686557c1d88b2619f5e31fab3c2315921", size = 7273060, upload-time = "2026-03-30T08:47:21.113Z" },
+    { url = "https://files.pythonhosted.org/packages/db/f0/a3deb5feba60d9538a962913e37bd2e69a195f1c3376a3dd44fe0427e996/grpcio-1.80.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4e78c4ac0d97dc2e569b2f4bcbbb447491167cb358d1a389fc4af71ab6f70411", size = 6782121, upload-time = "2026-03-30T08:47:23.827Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/84/36c6dcfddc093e108141f757c407902a05085e0c328007cb090d56646cdf/grpcio-1.80.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2ed770b4c06984f3b47eb0517b1c69ad0b84ef3f40128f51448433be904634cd", size = 7383811, upload-time = "2026-03-30T08:47:26.517Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/ef/f3a77e3dc5b471a0ec86c564c98d6adfa3510d38f8ee99010410858d591e/grpcio-1.80.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:256507e2f524092f1473071a05e65a5b10d84b82e3ff24c5b571513cfaa61e2f", size = 8393860, upload-time = "2026-03-30T08:47:29.439Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/8d/9d4d27ed7f33d109c50d6b5ce578a9914aa68edab75d65869a17e630a8d1/grpcio-1.80.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9a6284a5d907c37db53350645567c522be314bac859a64a7a5ca63b77bb7958f", size = 7830132, upload-time = "2026-03-30T08:47:33.254Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e4/9990b41c6d7a44e1e9dee8ac11d7a9802ba1378b40d77468a7761d1ad288/grpcio-1.80.0-cp312-cp312-win32.whl", hash = "sha256:c71309cfce2f22be26aa4a847357c502db6c621f1a49825ae98aa0907595b193", size = 4140904, upload-time = "2026-03-30T08:47:35.319Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/2c/296f6138caca1f4b92a31ace4ae1b87dab692fc16a7a3417af3bb3c805bf/grpcio-1.80.0-cp312-cp312-win_amd64.whl", hash = "sha256:9fe648599c0e37594c4809d81a9e77bd138cc82eb8baa71b6a86af65426723ff", size = 4880944, upload-time = "2026-03-30T08:47:37.831Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/3a/7c3c25789e3f069e581dc342e03613c5b1cb012c4e8c7d9d5cf960a75856/grpcio-1.80.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:e9e408fc016dffd20661f0126c53d8a31c2821b5c13c5d67a0f5ed5de93319ad", size = 6017243, upload-time = "2026-03-30T08:47:40.075Z" },
+    { url = "https://files.pythonhosted.org/packages/04/19/21a9806eb8240e174fd1ab0cd5b9aa948bb0e05c2f2f55f9d5d7405e6d08/grpcio-1.80.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:92d787312e613754d4d8b9ca6d3297e69994a7912a32fa38c4c4e01c272974b0", size = 12010840, upload-time = "2026-03-30T08:47:43.11Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3a/23347d35f76f639e807fb7a36fad3068aed100996849a33809591f26eca6/grpcio-1.80.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8ac393b58aa16991a2f1144ec578084d544038c12242da3a215966b512904d0f", size = 6567644, upload-time = "2026-03-30T08:47:46.806Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/40/96e07ecb604a6a67ae6ab151e3e35b132875d98bc68ec65f3e5ab3e781d7/grpcio-1.80.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:68e5851ac4b9afe07e7f84483803ad167852570d65326b34d54ca560bfa53fb6", size = 7277830, upload-time = "2026-03-30T08:47:49.643Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e2/da1506ecea1f34a5e365964644b35edef53803052b763ca214ba3870c856/grpcio-1.80.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:873ff5d17d68992ef6605330127425d2fc4e77e612fa3c3e0ed4e668685e3140", size = 6783216, upload-time = "2026-03-30T08:47:52.817Z" },
+    { url = "https://files.pythonhosted.org/packages/44/83/3b20ff58d0c3b7f6caaa3af9a4174d4023701df40a3f39f7f1c8e7c48f9d/grpcio-1.80.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2bea16af2750fd0a899bf1abd9022244418b55d1f37da2202249ba4ba673838d", size = 7385866, upload-time = "2026-03-30T08:47:55.687Z" },
+    { url = "https://files.pythonhosted.org/packages/47/45/55c507599c5520416de5eefecc927d6a0d7af55e91cfffb2e410607e5744/grpcio-1.80.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba0db34f7e1d803a878284cd70e4c63cb6ae2510ba51937bf8f45ba997cefcf7", size = 8391602, upload-time = "2026-03-30T08:47:58.303Z" },
+    { url = "https://files.pythonhosted.org/packages/10/bb/dd06f4c24c01db9cf11341b547d0a016b2c90ed7dbbb086a5710df7dd1d7/grpcio-1.80.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8eb613f02d34721f1acf3626dfdb3545bd3c8505b0e52bf8b5710a28d02e8aa7", size = 7826752, upload-time = "2026-03-30T08:48:01.311Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/1e/9d67992ba23371fd63d4527096eb8c6b76d74d52b500df992a3343fd7251/grpcio-1.80.0-cp313-cp313-win32.whl", hash = "sha256:93b6f823810720912fd131f561f91f5fed0fda372b6b7028a2681b8194d5d294", size = 4142310, upload-time = "2026-03-30T08:48:04.594Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e6/283326a27da9e2c3038bc93eeea36fb118ce0b2d03922a9cda6688f53c5b/grpcio-1.80.0-cp313-cp313-win_amd64.whl", hash = "sha256:e172cf795a3ba5246d3529e4d34c53db70e888fa582a8ffebd2e6e48bc0cba50", size = 4882833, upload-time = "2026-03-30T08:48:07.363Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/6d/e65307ce20f5a09244ba9e9d8476e99fb039de7154f37fb85f26978b59c3/grpcio-1.80.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:3d4147a97c8344d065d01bbf8b6acec2cf86fb0400d40696c8bdad34a64ffc0e", size = 6017376, upload-time = "2026-03-30T08:48:10.005Z" },
+    { url = "https://files.pythonhosted.org/packages/69/10/9cef5d9650c72625a699c549940f0abb3c4bfdb5ed45a5ce431f92f31806/grpcio-1.80.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d8e11f167935b3eb089ac9038e1a063e6d7dbe995c0bb4a661e614583352e76f", size = 12018133, upload-time = "2026-03-30T08:48:12.927Z" },
+    { url = "https://files.pythonhosted.org/packages/04/82/983aabaad82ba26113caceeb9091706a0696b25da004fe3defb5b346e15b/grpcio-1.80.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f14b618fc30de822681ee986cfdcc2d9327229dc4c98aed16896761cacd468b9", size = 6574748, upload-time = "2026-03-30T08:48:16.386Z" },
+    { url = "https://files.pythonhosted.org/packages/07/d7/031666ef155aa0bf399ed7e19439656c38bbd143779ae0861b038ce82abd/grpcio-1.80.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4ed39fbdcf9b87370f6e8df4e39ca7b38b3e5e9d1b0013c7b6be9639d6578d14", size = 7277711, upload-time = "2026-03-30T08:48:19.627Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/43/f437a78f7f4f1d311804189e8f11fb311a01049b2e08557c1068d470cb2e/grpcio-1.80.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2dcc70e9f0ba987526e8e8603a610fb4f460e42899e74e7a518bf3c68fe1bf05", size = 6785372, upload-time = "2026-03-30T08:48:22.373Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3d/f6558e9c6296cb4227faa5c43c54a34c68d32654b829f53288313d16a86e/grpcio-1.80.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:448c884b668b868562b1bda833c5fce6272d26e1926ec46747cda05741d302c1", size = 7395268, upload-time = "2026-03-30T08:48:25.638Z" },
+    { url = "https://files.pythonhosted.org/packages/06/21/0fdd77e84720b08843c371a2efa6f2e19dbebf56adc72df73d891f5506f0/grpcio-1.80.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a1dc80fe55685b4a543555e6eef975303b36c8db1023b1599b094b92aa77965f", size = 8392000, upload-time = "2026-03-30T08:48:28.974Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/68/67f4947ed55d2e69f2cc199ab9fd85e0a0034d813bbeef84df6d2ba4d4b7/grpcio-1.80.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:31b9ac4ad1aa28ffee5503821fafd09e4da0a261ce1c1281c6c8da0423c83b6e", size = 7828477, upload-time = "2026-03-30T08:48:32.054Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b6/8d4096691b2e385e8271911a0de4f35f0a6c7d05aff7098e296c3de86939/grpcio-1.80.0-cp314-cp314-win32.whl", hash = "sha256:367ce30ba67d05e0592470428f0ec1c31714cab9ef19b8f2e37be1f4c7d32fae", size = 4218563, upload-time = "2026-03-30T08:48:34.538Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/8c/bbe6baf2557262834f2070cf668515fa308b2d38a4bbf771f8f7872a7036/grpcio-1.80.0-cp314-cp314-win_amd64.whl", hash = "sha256:3b01e1f5464c583d2f567b2e46ff0d516ef979978f72091fd81f5ab7fa6e2e7f", size = 5019457, upload-time = "2026-03-30T08:48:37.308Z" },
+]
+
+[[package]]
+name = "grpcio-status"
+version = "1.80.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/ed/105f619bdd00cb47a49aa2feea6232ea2bbb04199d52a22cc6a7d603b5cb/grpcio_status-1.80.0.tar.gz", hash = "sha256:df73802a4c89a3ea88aa2aff971e886fccce162bc2e6511408b3d67a144381cd", size = 13901, upload-time = "2026-03-30T08:54:34.784Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/80/58cd2dfc19a07d022abe44bde7c365627f6c7cb6f692ada6c65ca437d09a/grpcio_status-1.80.0-py3-none-any.whl", hash = "sha256:4b56990363af50dbf2c2ebb80f1967185c07d87aa25aa2bea45ddb75fc181dbe", size = 14638, upload-time = "2026-03-30T08:54:01.569Z" },
 ]
 
 [[package]]
@@ -1900,6 +2071,7 @@ acp = [
 all = [
     { name = "agent-client-protocol" },
     { name = "aiohttp" },
+    { name = "aiohttp-socks", marker = "sys_platform == 'linux'" },
     { name = "aiosqlite", marker = "sys_platform == 'linux'" },
     { name = "alibabacloud-dingtalk" },
     { name = "asyncpg", marker = "sys_platform == 'linux'" },
@@ -1912,6 +2084,10 @@ all = [
     { name = "elevenlabs" },
     { name = "fastapi" },
     { name = "faster-whisper" },
+    { name = "google-api-python-client" },
+    { name = "google-auth-httplib2" },
+    { name = "google-auth-oauthlib" },
+    { name = "google-cloud-texttospeech" },
     { name = "honcho-ai" },
     { name = "lark-oapi" },
     { name = "markdown", marker = "sys_platform == 'linux'" },
@@ -1965,6 +2141,12 @@ feishu = [
     { name = "lark-oapi" },
     { name = "qrcode" },
 ]
+google = [
+    { name = "google-api-python-client" },
+    { name = "google-auth-httplib2" },
+    { name = "google-auth-oauthlib" },
+    { name = "google-cloud-texttospeech" },
+]
 homeassistant = [
     { name = "aiohttp" },
 ]
@@ -1972,6 +2154,7 @@ honcho = [
     { name = "honcho-ai" },
 ]
 matrix = [
+    { name = "aiohttp-socks" },
     { name = "aiosqlite" },
     { name = "asyncpg" },
     { name = "markdown" },
@@ -2044,6 +2227,7 @@ requires-dist = [
     { name = "aiohttp", marker = "extra == 'homeassistant'", specifier = ">=3.9.0,<4" },
     { name = "aiohttp", marker = "extra == 'messaging'", specifier = ">=3.13.3,<4" },
     { name = "aiohttp", marker = "extra == 'sms'", specifier = ">=3.9.0,<4" },
+    { name = "aiohttp-socks", marker = "extra == 'matrix'", specifier = ">=0.10,<1" },
     { name = "aiosqlite", marker = "extra == 'matrix'", specifier = ">=0.20" },
     { name = "alibabacloud-dingtalk", marker = "extra == 'dingtalk'", specifier = ">=2.0.0" },
     { name = "anthropic", specifier = ">=0.39.0,<1" },
@@ -2064,6 +2248,10 @@ requires-dist = [
     { name = "faster-whisper", marker = "extra == 'voice'", specifier = ">=1.0.0,<2" },
     { name = "fire", specifier = ">=0.7.1,<1" },
     { name = "firecrawl-py", specifier = ">=4.16.0,<5" },
+    { name = "google-api-python-client", marker = "extra == 'google'", specifier = ">=2.100,<3" },
+    { name = "google-auth-httplib2", marker = "extra == 'google'", specifier = ">=0.2,<1" },
+    { name = "google-auth-oauthlib", marker = "extra == 'google'", specifier = ">=1.0,<2" },
+    { name = "google-cloud-texttospeech", marker = "extra == 'google'", specifier = ">=2.31.0,<3" },
     { name = "hermes-agent", extras = ["acp"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["acp"], marker = "extra == 'termux'" },
     { name = "hermes-agent", extras = ["bedrock"], marker = "extra == 'all'" },
@@ -2075,6 +2263,7 @@ requires-dist = [
     { name = "hermes-agent", extras = ["dev"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["dingtalk"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["feishu"], marker = "extra == 'all'" },
+    { name = "hermes-agent", extras = ["google"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["homeassistant"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["honcho"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["honcho"], marker = "extra == 'termux'" },
@@ -2136,7 +2325,7 @@ requires-dist = [
     { name = "wandb", marker = "extra == 'rl'", specifier = ">=0.15.0,<1" },
     { name = "yc-bench", marker = "python_full_version >= '3.12' and extra == 'yc-bench'", git = "https://github.com/collinear-ai/yc-bench.git?rev=bfb0c88062450f46341bd9a5298903fc2e952a5c" },
 ]
-provides-extras = ["modal", "daytona", "dev", "messaging", "cron", "slack", "matrix", "cli", "tts-premium", "voice", "pty", "honcho", "mcp", "homeassistant", "sms", "acp", "mistral", "bedrock", "termux", "dingtalk", "feishu", "web", "rl", "yc-bench", "all"]
+provides-extras = ["modal", "daytona", "dev", "messaging", "cron", "slack", "matrix", "cli", "tts-premium", "voice", "pty", "honcho", "mcp", "homeassistant", "sms", "acp", "mistral", "bedrock", "termux", "dingtalk", "feishu", "google", "web", "rl", "yc-bench", "all"]
 
 [[package]]
 name = "hf-transfer"
@@ -2236,6 +2425,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httplib2"
+version = "0.31.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/1f/e86365613582c027dda5ddb64e1010e57a3d53e99ab8a72093fa13d565ec/httplib2-0.31.2.tar.gz", hash = "sha256:385e0869d7397484f4eab426197a4c020b606edd43372492337c0b4010ae5d24", size = 250800, upload-time = "2026-01-23T11:04:44.165Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/90/fd509079dfcab01102c0fdd87f3a9506894bc70afcf9e9785ef6b2b3aff6/httplib2-0.31.2-py3-none-any.whl", hash = "sha256:dbf0c2fa3862acf3c55c078ea9c0bc4481d7dc5117cae71be9514912cf9f8349", size = 91099, upload-time = "2026-01-23T11:04:42.78Z" },
 ]
 
 [[package]]
@@ -3278,6 +3479,15 @@ wheels = [
 ]
 
 [[package]]
+name = "oauthlib"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
+]
+
+[[package]]
 name = "obstore"
 version = "0.8.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3856,6 +4066,18 @@ wheels = [
 ]
 
 [[package]]
+name = "proto-plus"
+version = "1.27.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/0d/94dfe80193e79d55258345901acd2917523d56e8381bc4dee7fd38e3868a/proto_plus-1.27.2.tar.gz", hash = "sha256:b2adde53adadf75737c44d3dcb0104fde65250dfc83ad59168b4aa3e574b6a24", size = 57204, upload-time = "2026-03-26T22:18:57.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/f3/1fba73eeffafc998a25d59703b63f8be4fe8a5cb12eaff7386a0ba0f7125/proto_plus-1.27.2-py3-none-any.whl", hash = "sha256:6432f75893d3b9e70b9c412f1d2f03f65b11fb164b793d14ae2ca01821d22718", size = 50450, upload-time = "2026-03-26T22:13:42.927Z" },
+]
+
+[[package]]
 name = "protobuf"
 version = "6.33.5"
 source = { registry = "https://pypi.org/simple" }
@@ -3927,6 +4149,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/88/a3/d2c462d4ef313521eaf2eff04d204ac60775263f1fb08c374b543f79f610/pyarrow-23.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:46718a220d64677c93bc243af1d44b55998255427588e400677d7192671845c7", size = 48259435, upload-time = "2026-02-16T10:13:49.226Z" },
     { url = "https://files.pythonhosted.org/packages/cc/f1/11a544b8c3d38a759eb3fbb022039117fd633e9a7b19e4841cc3da091915/pyarrow-23.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a09f3876e87f48bc2f13583ab551f0379e5dfb83210391e68ace404181a20690", size = 50629149, upload-time = "2026-02-16T10:13:57.238Z" },
     { url = "https://files.pythonhosted.org/packages/50/f2/c0e76a0b451ffdf0cf788932e182758eb7558953f4f27f1aff8e2518b653/pyarrow-23.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:527e8d899f14bd15b740cd5a54ad56b7f98044955373a17179d5956ddb93d9ce", size = 28365807, upload-time = "2026-02-16T10:14:03.892Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]
@@ -4270,6 +4513,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-socks"
+version = "2.8.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/0b/cd77011c1bc01b76404f7aba07fca18aca02a19c7626e329b40201217624/python_socks-2.8.1.tar.gz", hash = "sha256:698daa9616d46dddaffe65b87db222f2902177a2d2b2c0b9a9361df607ab3687", size = 38909, upload-time = "2026-02-16T05:24:00.745Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/fe/9a58cb6eec633ff6afae150ca53c16f8cc8b65862ccb3d088051efdfceb7/python_socks-2.8.1-py3-none-any.whl", hash = "sha256:28232739c4988064e725cdbcd15be194743dd23f1c910f784163365b9d7be035", size = 55087, upload-time = "2026-02-16T05:23:59.147Z" },
+]
+
+[[package]]
 name = "python-telegram-bot"
 version = "22.6"
 source = { registry = "https://pypi.org/simple" }
@@ -4527,6 +4779,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/34/64/8860370b167a9721e8956ae116825caff829224fbca0ca6e7bf8ddef8430/requests-2.33.0.tar.gz", hash = "sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652", size = 134232, upload-time = "2026-03-25T15:10:41.586Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl", hash = "sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b", size = 65017, upload-time = "2026-03-25T15:10:40.382Z" },
+]
+
+[[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "oauthlib" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
 ]
 
 [[package]]
@@ -5266,6 +5531,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4d/f8/114266b21a7a9e3d09b352bb63c9d61d918bb7aa35d08c722793bfbfd28f/unpaddedbase64-2.1.0.tar.gz", hash = "sha256:7273c60c089de39d90f5d6d4a7883a79e319dc9d9b1c8924a7fab96178a5f005", size = 5621, upload-time = "2021-03-09T11:35:47.729Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4c/a7/563b2d8fb7edc07320bf69ac6a7eedcd7a1a9d663a6bb90a4d9bd2eda5f7/unpaddedbase64-2.1.0-py3-none-any.whl", hash = "sha256:485eff129c30175d2cd6f0cd8d2310dff51e666f7f36175f738d75dfdbd0b1c6", size = 6083, upload-time = "2021-03-09T11:35:46.7Z" },
+]
+
+[[package]]
+name = "uritemplate"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/60/f174043244c5306c9988380d2cb10009f91563fc4b31293d27e17201af56/uritemplate-4.2.0.tar.gz", hash = "sha256:480c2ed180878955863323eea31b0ede668795de182617fef9c6ca09e6ec9d0e", size = 33267, upload-time = "2025-06-02T15:12:06.318Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/99/3ae339466c9183ea5b8ae87b34c0b897eda475d2aec2307cae60e5cd4f29/uritemplate-4.2.0-py3-none-any.whl", hash = "sha256:962201ba1c4edcab02e60f9a0d3821e82dfc5d2d6662a21abd533879bdb8a686", size = 11488, upload-time = "2025-06-02T15:12:03.405Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add WebhookAdapter.send_exec_approval to forward approval prompts to the route delivery adapter
- preserve the webhook session key so Telegram/Discord approval buttons unblock the correct pending webhook run
- keep existing text fallback behavior when the delivery target cannot render approval buttons

## Test Plan
- venv/bin/python -m py_compile gateway/platforms/webhook.py
- venv/bin/python -m pytest tests/gateway/test_telegram_approval_buttons.py tests/gateway/test_approve_deny_commands.py -q
- manual smoke: WebhookAdapter forwards a dummy approval to Telegram with the webhook session_key