### PR TITLE
feat(cli): add picker_configured_only flag + /model configured (#13796)

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -45,6 +45,22 @@ model:
   # api_key: "your-key-here"  # Uncomment to set here instead of .env
   base_url: "https://openrouter.ai/api/v1"
 
+  # ── /model picker scope ───────────────────────────────────────────────────
+  #
+  # Restrict the /model picker (and `hermes model` REST surface) to entries
+  # the user has explicitly defined in ``providers:`` and ``custom_providers:``
+  # below.  Built-in / curated rows (anthropic, openrouter, copilot, …) are
+  # hidden even when their credentials are present in ~/.hermes/.env, and the
+  # live ``/v1/models`` override that normally replaces a user-defined
+  # endpoint's ``models:`` list is skipped so the picker reflects exactly what
+  # was written here.
+  #
+  # Default is false (show every authenticated provider — current behaviour).
+  # For a one-off configured-only view without setting this flag, type
+  # ``/model configured`` inside a chat session.
+  #
+  # picker_configured_only: false
+
   # ── Token limits — two settings, easy to confuse ──────────────────────────
   #
   # context_length: TOTAL context window (input + output tokens combined).

--- a/cli.py
+++ b/cli.py
@@ -5437,19 +5437,34 @@ class HermesCLI:
         parts = cmd_original.split(None, 1)  # split off '/model'
         raw_args = parts[1].strip() if len(parts) > 1 else ""
 
+        # Pseudo-arg: /model configured opens the picker filtered to entries
+        # the user has explicitly defined in providers: / custom_providers:,
+        # regardless of the model.picker_configured_only config setting.
+        configured_only_override = raw_args.lower() == "configured"
+        if configured_only_override:
+            raw_args = ""
+
         # Parse --provider and --global flags
         model_input, explicit_provider, persist_global = parse_model_flags(raw_args)
 
         # Load providers for switch_model (picker path needs them below)
         user_provs = None
         custom_provs = None
+        picker_configured_only = False
         try:
             from hermes_cli.config import get_compatible_custom_providers, load_config
             cfg = load_config()
             user_provs = cfg.get("providers")
             custom_provs = get_compatible_custom_providers(cfg)
+            model_cfg = cfg.get("model")
+            if isinstance(model_cfg, dict):
+                picker_configured_only = bool(
+                    model_cfg.get("picker_configured_only", False)
+                )
         except Exception:
             pass
+
+        effective_configured_only = configured_only_override or picker_configured_only
 
         # No args at all: open prompt_toolkit-native picker modal
         if not model_input and not explicit_provider:
@@ -5464,6 +5479,7 @@ class HermesCLI:
                     user_providers=user_provs,
                     custom_providers=custom_provs,
                     max_models=50,
+                    picker_configured_only=effective_configured_only,
                 )
             except Exception:
                 providers = []

--- a/cli.py
+++ b/cli.py
@@ -5228,7 +5228,7 @@ class HermesCLI:
             _ask()
         return result[0]
 
-    def _open_model_picker(self, providers: list, current_model: str, current_provider: str, user_provs=None, custom_provs=None) -> None:
+    def _open_model_picker(self, providers: list, current_model: str, current_provider: str, user_provs=None, custom_provs=None, picker_configured_only: bool = False) -> None:
         """Open prompt_toolkit-native /model picker modal."""
         self._capture_modal_input_snapshot()
         default_idx = next((i for i, p in enumerate(providers) if p.get("is_current")), 0)
@@ -5240,6 +5240,7 @@ class HermesCLI:
             "current_provider": current_provider,
             "user_provs": user_provs,
             "custom_provs": custom_provs,
+            "picker_configured_only": picker_configured_only,
         }
         self._invalidate(min_interval=0.0)
 
@@ -5373,8 +5374,12 @@ class HermesCLI:
             # (same lists as `hermes model` and gateway pickers).
             # Only fall back to the live provider catalog when the curated
             # list is empty (e.g. user-defined endpoints with no curated list).
+            #
+            # picker_configured_only also opts out of the live fallback so the
+            # drill-down is faithful to config even when ``models:`` is empty
+            # (the picker just shows nothing for that row).
             model_list = provider_data.get("models", [])
-            if not model_list:
+            if not model_list and not state.get("picker_configured_only"):
                 try:
                     from hermes_cli.models import provider_model_ids
                     live = provider_model_ids(provider_data["slug"])
@@ -5497,6 +5502,7 @@ class HermesCLI:
                 provider_display,
                 user_provs=user_provs,
                 custom_provs=custom_provs,
+                picker_configured_only=effective_configured_only,
             )
             return
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6424,6 +6424,13 @@ class GatewayRunner:
 
         raw_args = event.get_command_args().strip()
 
+        # Pseudo-arg: /model configured opens the picker filtered to entries
+        # the user has explicitly defined in providers: / custom_providers:,
+        # regardless of the model.picker_configured_only config setting.
+        configured_only_override = raw_args.lower() == "configured"
+        if configured_only_override:
+            raw_args = ""
+
         # Parse --provider and --global flags
         model_input, explicit_provider, persist_global = parse_model_flags(raw_args)
 
@@ -6434,6 +6441,7 @@ class GatewayRunner:
         current_api_key = ""
         user_provs = None
         custom_provs = None
+        picker_configured_only = False
         config_path = _hermes_home / "config.yaml"
         try:
             cfg = _load_gateway_config()
@@ -6443,6 +6451,9 @@ class GatewayRunner:
                     current_model = model_cfg.get("default", "")
                     current_provider = model_cfg.get("provider", current_provider)
                     current_base_url = model_cfg.get("base_url", "")
+                    picker_configured_only = bool(
+                        model_cfg.get("picker_configured_only", False)
+                    )
                 user_provs = cfg.get("providers")
                 try:
                     from hermes_cli.config import get_compatible_custom_providers
@@ -6451,6 +6462,8 @@ class GatewayRunner:
                     custom_provs = cfg.get("custom_providers")
         except Exception:
             pass
+
+        effective_configured_only = configured_only_override or picker_configured_only
 
         # Check for session override
         source = event.source
@@ -6480,6 +6493,7 @@ class GatewayRunner:
                         user_providers=user_provs,
                         custom_providers=custom_provs,
                         max_models=50,
+                        picker_configured_only=effective_configured_only,
                     )
                 except Exception:
                     providers = []
@@ -6613,6 +6627,7 @@ class GatewayRunner:
                     user_providers=user_provs,
                     custom_providers=custom_provs,
                     max_models=5,
+                    picker_configured_only=effective_configured_only,
                 )
                 for p in providers:
                     tag = " (current)" if p["is_current"] else ""

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -987,6 +987,7 @@ def list_authenticated_providers(
     custom_providers: list | None = None,
     max_models: int = 8,
     current_model: str = "",
+    picker_configured_only: bool = False,
 ) -> List[dict]:
     """Detect which providers have credentials and list their curated models.
 
@@ -1004,6 +1005,14 @@ def list_authenticated_providers(
       - source: str — "built-in", "models.dev", "user-config"
 
     Only includes providers that have API keys set or are user-defined endpoints.
+
+    When ``picker_configured_only=True`` the picker is restricted to rows the
+    user has explicitly defined in config — entries from ``providers:`` and
+    ``custom_providers:``.  Built-in / curated rows (anthropic, openrouter,
+    copilot, …) are hidden even when their credentials are present, and the
+    live ``/v1/models`` override that normally replaces a user-defined
+    endpoint's configured ``models:`` list is skipped so the picker reflects
+    exactly what the user wrote in config.  See #13796.
     """
     import os
     from agent.models_dev import (
@@ -1094,7 +1103,14 @@ def list_authenticated_providers(
         curated["lmstudio"] = live
 
     # --- 1. Check Hermes-mapped providers ---
+    # When picker_configured_only is set, sections 1, 2, and 2b (built-in /
+    # curated rows) are suppressed so only user-defined endpoints from
+    # ``providers:`` and ``custom_providers:`` reach the picker.  We
+    # short-circuit at the loop body rather than wrapping each section so
+    # the existing structure stays readable in diffs.
     for hermes_id, mdev_id in PROVIDER_TO_MODELS_DEV.items():
+        if picker_configured_only:
+            break
         # Skip aliases that map to the same models.dev provider (e.g.
         # kimi-coding and kimi-coding-cn both → kimi-for-coding).
         # The first one with valid credentials wins (#10526).
@@ -1169,6 +1185,8 @@ def list_authenticated_providers(
     _mdev_to_hermes = {v: k for k, v in PROVIDER_TO_MODELS_DEV.items()}
 
     for pid, overlay in HERMES_OVERLAYS.items():
+        if picker_configured_only:
+            break
         if pid.lower() in seen_slugs:
             continue
 
@@ -1284,6 +1302,8 @@ def list_authenticated_providers(
         _canon_provs = []
 
     for _cp in _canon_provs:
+        if picker_configured_only:
+            break
         if _cp.slug.lower() in seen_slugs:
             continue
 
@@ -1415,11 +1435,15 @@ def list_authenticated_providers(
             # available. This keeps OpenAI-compatible relays (for example CRS)
             # in sync when the server catalog changes without requiring the
             # user to mirror every model into config.yaml.
+            #
+            # picker_configured_only opts out of this override: the user has
+            # asked to see exactly what they wrote in ``models:``, not whatever
+            # the upstream catalog currently exposes.
             api_key = str(ep_cfg.get("api_key", "") or "").strip()
             if not api_key:
                 key_env = str(ep_cfg.get("key_env", "") or "").strip()
                 api_key = os.environ.get(key_env, "").strip() if key_env else ""
-            if api_url and api_key:
+            if api_url and api_key and not picker_configured_only:
                 try:
                     from hermes_cli.models import fetch_api_models
                     live_models = fetch_api_models(api_key, api_url)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -974,10 +974,14 @@ def get_model_options():
             current_model = model_cfg.get("default", model_cfg.get("name", "")) or ""
             current_provider = model_cfg.get("provider", "") or ""
             current_base_url = model_cfg.get("base_url", "") or ""
+            picker_configured_only = bool(
+                model_cfg.get("picker_configured_only", False)
+            )
         else:
             current_model = str(model_cfg) if model_cfg else ""
             current_provider = ""
             current_base_url = ""
+            picker_configured_only = False
 
         user_providers = cfg.get("providers") if isinstance(cfg.get("providers"), dict) else {}
         custom_providers = (
@@ -993,6 +997,7 @@ def get_model_options():
             user_providers=user_providers,
             custom_providers=custom_providers,
             max_models=50,
+            picker_configured_only=picker_configured_only,
         )
         return {
             "providers": providers,

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -599,6 +599,101 @@ def test_cmd_model_forwards_nous_login_tls_options(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# /model configured + model.picker_configured_only threading (#13796)
+# ---------------------------------------------------------------------------
+
+def _stub_model_picker_environment(monkeypatch, cli, shell, model_cfg):
+    """Wire HermesCLI._handle_model_switch to a captured fake picker."""
+    captured: dict = {}
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"model": model_cfg},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.config.get_compatible_custom_providers",
+        lambda cfg: [],
+    )
+
+    def _fake_list_authenticated_providers(**kwargs):
+        captured.update(kwargs)
+        return [{"slug": "local-ollama", "name": "Local Ollama", "models": []}]
+
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.list_authenticated_providers",
+        _fake_list_authenticated_providers,
+    )
+    monkeypatch.setattr(
+        shell,
+        "_open_model_picker",
+        lambda *args, **kwargs: captured.setdefault("opened", (args, kwargs)),
+    )
+    return captured
+
+
+def test_cli_model_picker_forwards_configured_only_from_config(monkeypatch):
+    cli = _import_cli()
+    shell = cli.HermesCLI(model="gpt-5", compact=True, max_turns=1)
+    shell.model = "gpt-5"
+    shell.provider = "openrouter"
+
+    captured = _stub_model_picker_environment(
+        monkeypatch,
+        cli,
+        shell,
+        {
+            "default": "gpt-5",
+            "provider": "openrouter",
+            "picker_configured_only": True,
+        },
+    )
+
+    shell._handle_model_switch("/model")
+
+    assert captured["picker_configured_only"] is True
+    assert "opened" in captured
+
+
+def test_cli_model_configured_pseudo_arg_overrides_config(monkeypatch):
+    cli = _import_cli()
+    shell = cli.HermesCLI(model="gpt-5", compact=True, max_turns=1)
+    shell.model = "gpt-5"
+    shell.provider = "openrouter"
+
+    # Config flag is off, but the user typed `/model configured` — the
+    # pseudo-arg must still flip the picker into configured-only mode.
+    captured = _stub_model_picker_environment(
+        monkeypatch,
+        cli,
+        shell,
+        {"default": "gpt-5", "provider": "openrouter"},
+    )
+
+    shell._handle_model_switch("/model configured")
+
+    assert captured["picker_configured_only"] is True
+    assert "opened" in captured
+
+
+def test_cli_model_picker_default_does_not_filter(monkeypatch):
+    cli = _import_cli()
+    shell = cli.HermesCLI(model="gpt-5", compact=True, max_turns=1)
+    shell.model = "gpt-5"
+    shell.provider = "openrouter"
+
+    captured = _stub_model_picker_environment(
+        monkeypatch,
+        cli,
+        shell,
+        {"default": "gpt-5", "provider": "openrouter"},
+    )
+
+    shell._handle_model_switch("/model")
+
+    assert captured["picker_configured_only"] is False
+
+
+# ---------------------------------------------------------------------------
 # _auto_provider_name — unit tests
 # ---------------------------------------------------------------------------
 

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -631,6 +631,14 @@ def _stub_model_picker_environment(monkeypatch, cli, shell, model_cfg):
     return captured
 
 
+def _picker_kwargs(captured):
+    """Extract the kwargs ``_handle_model_switch`` passed to ``_open_model_picker``."""
+    opened = captured.get("opened")
+    assert opened is not None, "picker was never opened"
+    _args, kwargs = opened
+    return kwargs
+
+
 def test_cli_model_picker_forwards_configured_only_from_config(monkeypatch):
     cli = _import_cli()
     shell = cli.HermesCLI(model="gpt-5", compact=True, max_turns=1)
@@ -650,8 +658,10 @@ def test_cli_model_picker_forwards_configured_only_from_config(monkeypatch):
 
     shell._handle_model_switch("/model")
 
+    # Both the catalog query and the picker modal must see the flag — the
+    # latter so the drill-down skips its live ``provider_model_ids`` fallback.
     assert captured["picker_configured_only"] is True
-    assert "opened" in captured
+    assert _picker_kwargs(captured)["picker_configured_only"] is True
 
 
 def test_cli_model_configured_pseudo_arg_overrides_config(monkeypatch):
@@ -672,7 +682,7 @@ def test_cli_model_configured_pseudo_arg_overrides_config(monkeypatch):
     shell._handle_model_switch("/model configured")
 
     assert captured["picker_configured_only"] is True
-    assert "opened" in captured
+    assert _picker_kwargs(captured)["picker_configured_only"] is True
 
 
 def test_cli_model_picker_default_does_not_filter(monkeypatch):
@@ -691,6 +701,81 @@ def test_cli_model_picker_default_does_not_filter(monkeypatch):
     shell._handle_model_switch("/model")
 
     assert captured["picker_configured_only"] is False
+    assert _picker_kwargs(captured)["picker_configured_only"] is False
+
+
+def test_cli_model_picker_drill_down_skips_live_fallback_when_configured_only(monkeypatch):
+    """When picker_configured_only is on, picking a provider whose ``models``
+    list is empty must NOT fall back to ``provider_model_ids`` — the row
+    stays empty so the picker is faithful to config."""
+    cli = _import_cli()
+    shell = cli.HermesCLI(model="gpt-5", compact=True, max_turns=1)
+    shell.model = "gpt-5"
+    shell.provider = "openrouter"
+
+    fallback_calls: list = []
+
+    def _fake_provider_model_ids(slug, **_kwargs):  # pragma: no cover - asserted via list
+        fallback_calls.append(slug)
+        return ["live-model"]
+
+    monkeypatch.setattr(
+        "hermes_cli.models.provider_model_ids",
+        _fake_provider_model_ids,
+    )
+
+    # Build a picker state directly; the row carries an empty models list.
+    shell._model_picker_state = {
+        "stage": "provider",
+        "providers": [
+            {"slug": "shadow", "name": "Shadow", "models": [], "is_current": True}
+        ],
+        "selected": 0,
+        "current_model": "gpt-5",
+        "current_provider": "openrouter",
+        "user_provs": None,
+        "custom_provs": None,
+        "picker_configured_only": True,
+    }
+    monkeypatch.setattr(shell, "_invalidate", lambda *a, **kw: None)
+
+    shell._handle_model_picker_selection()
+
+    assert fallback_calls == []
+    assert shell._model_picker_state["model_list"] == []
+
+
+def test_cli_model_picker_drill_down_keeps_live_fallback_by_default(monkeypatch):
+    """Regression guard: with the flag off, the existing live fallback path
+    is preserved so users with empty user-defined ``models:`` keep getting
+    catalog-driven completions."""
+    cli = _import_cli()
+    shell = cli.HermesCLI(model="gpt-5", compact=True, max_turns=1)
+    shell.model = "gpt-5"
+    shell.provider = "openrouter"
+
+    monkeypatch.setattr(
+        "hermes_cli.models.provider_model_ids",
+        lambda slug, **_kwargs: ["live-a", "live-b"],
+    )
+
+    shell._model_picker_state = {
+        "stage": "provider",
+        "providers": [
+            {"slug": "openrouter", "name": "OpenRouter", "models": [], "is_current": True}
+        ],
+        "selected": 0,
+        "current_model": "gpt-5",
+        "current_provider": "openrouter",
+        "user_provs": None,
+        "custom_provs": None,
+        "picker_configured_only": False,
+    }
+    monkeypatch.setattr(shell, "_invalidate", lambda *a, **kw: None)
+
+    shell._handle_model_picker_selection()
+
+    assert shell._model_picker_state["model_list"] == ["live-a", "live-b"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_model_command_custom_providers.py
+++ b/tests/gateway/test_model_command_custom_providers.py
@@ -1,5 +1,7 @@
 """Regression tests for gateway /model support of config.yaml custom_providers."""
 
+import types
+
 import yaml
 import pytest
 
@@ -61,3 +63,128 @@ async def test_handle_model_command_lists_saved_custom_provider(tmp_path, monkey
     assert "Local (127.0.0.1:4141)" in result
     assert "custom:local-(127.0.0.1:4141)" in result
     assert "rotator-openrouter-coding" in result
+
+
+# ---------------------------------------------------------------------------
+# /model configured + model.picker_configured_only threading (#13796)
+# ---------------------------------------------------------------------------
+
+
+def _write_picker_config(home, *, picker_configured_only=False):
+    home.mkdir(exist_ok=True)
+    (home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "model": {
+                    "default": "gpt-5.4",
+                    "provider": "openrouter",
+                    **(
+                        {"picker_configured_only": True}
+                        if picker_configured_only
+                        else {}
+                    ),
+                },
+                "providers": {},
+                "custom_providers": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_model_command_text_list_forwards_configured_only_flag(
+    tmp_path, monkeypatch
+):
+    """The text-list fallback (no platform picker) must forward the config
+    flag into ``list_authenticated_providers``."""
+    hermes_home = tmp_path / ".hermes"
+    _write_picker_config(hermes_home, picker_configured_only=True)
+
+    import gateway.run as gateway_run
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+
+    captured: dict = {}
+
+    def _fake_list_authenticated_providers(**kwargs):
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.list_authenticated_providers",
+        _fake_list_authenticated_providers,
+    )
+
+    await _make_runner()._handle_model_command(_make_event())
+
+    assert captured["picker_configured_only"] is True
+
+
+@pytest.mark.asyncio
+async def test_handle_model_command_picker_forwards_configured_only_flag(
+    tmp_path, monkeypatch
+):
+    """When the platform supports an interactive picker, the same flag must
+    flow into the picker query."""
+    hermes_home = tmp_path / ".hermes"
+    _write_picker_config(hermes_home, picker_configured_only=True)
+
+    class _PickerAdapter:
+        async def send_model_picker(self, **kwargs):
+            return types.SimpleNamespace(success=True)
+
+    import gateway.run as gateway_run
+
+    runner = _make_runner()
+    runner.adapters = {Platform.TELEGRAM: _PickerAdapter()}
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+
+    captured: dict = {}
+
+    def _fake_list_authenticated_providers(**kwargs):
+        captured.update(kwargs)
+        return [{"slug": "anthropic", "name": "Anthropic", "models": []}]
+
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.list_authenticated_providers",
+        _fake_list_authenticated_providers,
+    )
+
+    result = await runner._handle_model_command(_make_event())
+
+    assert result is None  # picker took over the response
+    assert captured["picker_configured_only"] is True
+
+
+@pytest.mark.asyncio
+async def test_handle_model_command_configured_pseudo_arg_overrides_config(
+    tmp_path, monkeypatch
+):
+    """Even with the config flag off, ``/model configured`` should still
+    surface only configured rows for that one invocation."""
+    hermes_home = tmp_path / ".hermes"
+    _write_picker_config(hermes_home, picker_configured_only=False)
+
+    import gateway.run as gateway_run
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+
+    captured: dict = {}
+
+    def _fake_list_authenticated_providers(**kwargs):
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.list_authenticated_providers",
+        _fake_list_authenticated_providers,
+    )
+
+    await _make_runner()._handle_model_command(_make_event(text="/model configured"))
+
+    assert captured["picker_configured_only"] is True

--- a/tests/hermes_cli/test_picker_configured_only.py
+++ b/tests/hermes_cli/test_picker_configured_only.py
@@ -1,0 +1,152 @@
+"""Tests for ``picker_configured_only`` on ``list_authenticated_providers``.
+
+When the flag is on, the /model picker should hide built-in / curated rows
+even when their credentials are present, and skip the live ``/v1/models``
+override that normally replaces a user-defined endpoint's configured
+``models:`` list.  See #13796.
+"""
+
+from hermes_cli.model_switch import list_authenticated_providers
+
+
+def _suppress_curated_rows(monkeypatch):
+    """Common monkeypatching to neutralize the section 1/2/2b machinery so a
+    test only has to assert what reaches results, not what was filtered out
+    by credential checks. ``picker_configured_only`` should still work even
+    without these patches; they keep tests fast and offline."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+
+def test_picker_configured_only_hides_credentialed_builtin_rows(monkeypatch):
+    """A user with ANTHROPIC_API_KEY but no ``providers:``/``custom_providers:``
+    should see an empty picker when picker_configured_only is on, because no
+    row in the result is user-defined."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {"anthropic": {}})
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+
+    without_filter = list_authenticated_providers(
+        user_providers={},
+        custom_providers=[],
+    )
+    with_filter = list_authenticated_providers(
+        user_providers={},
+        custom_providers=[],
+        picker_configured_only=True,
+    )
+
+    assert any(p["slug"] == "anthropic" for p in without_filter)
+    assert with_filter == []
+
+
+def test_picker_configured_only_keeps_user_provider_rows(monkeypatch):
+    """``providers:`` entries (section 3) must survive the filter."""
+    _suppress_curated_rows(monkeypatch)
+
+    user_providers = {
+        "local-ollama": {
+            "name": "Local Ollama",
+            "api": "http://localhost:11434/v1",
+            "default_model": "qwen3.5:cloud",
+            "models": ["qwen3.5:cloud", "kimi-k2.5:cloud"],
+        }
+    }
+
+    providers = list_authenticated_providers(
+        user_providers=user_providers,
+        custom_providers=[],
+        picker_configured_only=True,
+    )
+
+    assert [p["slug"] for p in providers] == ["local-ollama"]
+    assert providers[0]["models"] == ["qwen3.5:cloud", "kimi-k2.5:cloud"]
+
+
+def test_picker_configured_only_keeps_custom_provider_rows(monkeypatch):
+    """``custom_providers:`` entries (section 4) must survive the filter."""
+    _suppress_curated_rows(monkeypatch)
+
+    custom_providers = [
+        {
+            "name": "Remote Cloud",
+            "base_url": "https://example.com/v1",
+            "model": "gpt-5.4",
+        }
+    ]
+
+    providers = list_authenticated_providers(
+        user_providers={},
+        custom_providers=custom_providers,
+        picker_configured_only=True,
+    )
+
+    assert [p["slug"] for p in providers] == ["custom:remote-cloud"]
+    assert providers[0]["models"] == ["gpt-5.4"]
+
+
+def test_picker_configured_only_skips_live_models_override(monkeypatch):
+    """Section 3 normally calls ``fetch_api_models`` and overwrites the
+    configured ``models:`` list with the upstream catalog. Under the
+    configured-only flag, that override is skipped so the picker shows
+    exactly what the user wrote in config."""
+    _suppress_curated_rows(monkeypatch)
+    monkeypatch.setenv("CRS_TEST_KEY", "sk-test")
+
+    fetch_calls: list[tuple] = []
+
+    def fake_fetch_api_models(api_key, base_url):  # pragma: no cover - asserted via call list
+        fetch_calls.append((api_key, base_url))
+        return ["server-extra-1", "server-extra-2"]
+
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", fake_fetch_api_models)
+
+    user_providers = {
+        "crs": {
+            "name": "CRS",
+            "base_url": "http://127.0.0.1:3000/api/v1",
+            "key_env": "CRS_TEST_KEY",
+            "model": "configured-a",
+            "models": {
+                "configured-a": {"context_length": 200000},
+                "configured-b": {"context_length": 200000},
+            },
+        }
+    }
+
+    providers = list_authenticated_providers(
+        user_providers=user_providers,
+        custom_providers=[],
+        picker_configured_only=True,
+    )
+
+    assert fetch_calls == []
+    assert [p["slug"] for p in providers] == ["crs"]
+    assert providers[0]["models"] == ["configured-a", "configured-b"]
+
+
+def test_picker_configured_only_off_preserves_existing_behaviour(monkeypatch):
+    """Default (flag off) keeps live override + built-in rows — regression
+    guard so this PR doesn't accidentally invert defaults."""
+    _suppress_curated_rows(monkeypatch)
+    monkeypatch.setenv("CRS_TEST_KEY", "sk-test")
+    monkeypatch.setattr(
+        "hermes_cli.models.fetch_api_models",
+        lambda api_key, base_url: ["live-only"],
+    )
+
+    user_providers = {
+        "crs": {
+            "base_url": "http://127.0.0.1:3000/api/v1",
+            "key_env": "CRS_TEST_KEY",
+            "model": "configured-a",
+            "models": {"configured-a": {}},
+        }
+    }
+
+    providers = list_authenticated_providers(
+        user_providers=user_providers,
+        custom_providers=[],
+    )
+
+    crs = next(p for p in providers if p["slug"] == "crs")
+    assert crs["models"] == ["live-only"]

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4659,6 +4659,11 @@ def _(rid, params: dict) -> dict:
         current_provider = getattr(agent, "provider", "") or ""
         current_model = getattr(agent, "model", "") or _resolve_model()
         current_base_url = getattr(agent, "base_url", "") or ""
+        model_cfg = cfg.get("model")
+        picker_configured_only = bool(
+            isinstance(model_cfg, dict)
+            and model_cfg.get("picker_configured_only", False)
+        )
         # list_authenticated_providers already populates each provider's
         # "models" with the curated list (same source as `hermes model` and
         # classic CLI's /model picker). Do NOT overwrite with live
@@ -4678,6 +4683,7 @@ def _(rid, params: dict) -> dict:
                 else []
             ),
             max_models=50,
+            picker_configured_only=picker_configured_only,
         )
         return _ok(
             rid,

--- a/website/docs/user-guide/configuring-models.md
+++ b/website/docs/user-guide/configuring-models.md
@@ -157,9 +157,12 @@ Inside any `hermes chat` session:
 ```
 /model gpt-5.4 --provider openrouter             # session-only
 /model gpt-5.4 --provider openrouter --global    # also persists to config.yaml
+/model configured                                # picker filtered to configured rows
 ```
 
 `--global` does the same thing the dashboard's **Change** button does, plus it switches the running session in-place.
+
+`/model configured` opens the picker scoped to entries you've explicitly defined in `providers:` and `custom_providers:`, hiding the curated rows for built-in providers. To make this the default for the no-arg picker, set `model.picker_configured_only: true` in `~/.hermes/config.yaml` — see the [Configuration reference](./configuration.md).
 
 ### `hermes model` subcommand
 


### PR DESCRIPTION
## Summary

Add `model.picker_configured_only` (default `false`) and a `/model configured` pseudo-arg that scope the `/model` picker to entries the user has explicitly defined in `providers:` and `custom_providers:`. Built-in / curated rows are hidden even when their credentials are present, the live `/v1/models` override that normally replaces a user-defined endpoint's `models:` list is skipped, and the picker modal's drill-down also stops falling back to `provider_model_ids()` so the picker is faithful to config end-to-end.

Fixes #13796.

## Why

The picker draws from a hardcoded curated list keyed off whatever credentials happen to live on disk (`~/.claude/.credentials.json`, `OPENROUTER_API_KEY`, etc.). Users who only use one or two configured endpoints see eight or more rows for providers they never intended to wire into Hermes. #15267, #16608, #12655, and #13796 all describe this in different shapes; this PR addresses #13796 specifically (model-level "show only configured") and is composable with #14571's `picker_providers` (provider-slug allowlist) if both land — they cover different axes (slug allowlist vs. configuredness) and the kwargs are independent.

A second papercut surfaced while implementing: for `providers:` entries the picker calls `/v1/models` and overwrites the configured `models:` list (`hermes_cli/model_switch.py:1422-1429`). A third one — only caught on self-review — is the picker modal's drill-down (`cli.py:5377`) calling `provider_model_ids()` for any row whose `models:` is empty, which on certain slugs hits live catalog endpoints. The flag opts out of all three so the picker reflects exactly what was written.

## Behavior

| Surface | Off (default) | On |
|---|---|---|
| `/model` (no args) | All authenticated providers | Only `providers:` + `custom_providers:` rows |
| `providers:` `models:` | Live `/v1/models` override | Trusted as-written |
| Picker drill-down with empty `models:` | Live `provider_model_ids()` fallback | Empty (faithful to config) |
| `/model configured` | Same as on, for one invocation | (n/a) |

## Files touched

- `hermes_cli/model_switch.py` — new kwarg, three early-`break`s in sections 1/2/2b, one `and not picker_configured_only` guard on section 3's live override
- `cli.py` — read flag, parse `/model configured` pseudo-arg, forward into `list_authenticated_providers` and `_open_model_picker`, gate drill-down live fallback in `_handle_model_picker_selection`
- `gateway/run.py` — same plumbing for the gateway `/model` command (text fallback + interactive picker)
- `hermes_cli/web_server.py`, `tui_gateway/server.py` — forward kwarg through dashboard surfaces
- `cli-config.yaml.example`, `website/docs/user-guide/configuring-models.md` — document the knob

The aux model picker (`hermes_cli/main.py::_aux_select_for_task`) is deliberately not threaded — auxiliary task routing should still see every authenticated provider so users can route vision/summarization to a different backend than their main `/model` filter.

## Test plan

- [x] `pytest tests/hermes_cli/test_picker_configured_only.py -v` — 5 unit tests (credentialed-builtin hiding, user-provider preservation, custom-provider preservation, live-fetch skip, default-off regression)
- [x] `pytest tests/cli/test_cli_provider_resolution.py -k "configured or drill_down"` — 5 tests (config flag, pseudo-arg override, default off, drill-down skips live fallback under flag, drill-down keeps live fallback by default)
- [x] `pytest tests/gateway/test_model_command_custom_providers.py -v` — 3 new threading tests + existing test still green
- [x] `pytest tests/test_tui_gateway_server.py -k model` — 14 existing tests green
- [x] `pytest tests/hermes_cli/test_user_providers_model_switch.py` — 19 existing tests green (live-fetch override regression guard)
- [ ] Manual: `/model` shows everything; set `model.picker_configured_only: true`, `/model` shows only configured rows; `/model configured` does the same one-shot without the flag

## Platforms tested

- macOS (Darwin 25.3.0, Python 3.14)