### PR TITLE
fix(gateway): show per-model custom context in session info

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5830,9 +5830,11 @@ class GatewayRunner:
 
         model = _resolve_gateway_model()
         config_context_length = None
+        config_context_source = None
         provider = None
         base_url = None
         api_key = None
+        data = {}
         custom_provs = None
 
         try:
@@ -5844,6 +5846,7 @@ class GatewayRunner:
                     if raw_ctx is not None:
                         try:
                             config_context_length = int(raw_ctx)
+                            config_context_source = "config"
                         except (TypeError, ValueError):
                             pass
                     provider = model_cfg.get("provider") or None
@@ -5865,6 +5868,25 @@ class GatewayRunner:
         except Exception:
             pass
 
+        # For custom providers, prefer a per-model context override over the
+        # top-level model.context_length. A single custom endpoint often serves
+        # models with different windows, so the gateway reset banner must report
+        # the active model's window rather than whatever top-level default was
+        # configured for another model.
+        try:
+            from hermes_cli.config import get_custom_provider_context_length
+            model_ctx = get_custom_provider_context_length(
+                model=model,
+                base_url=base_url or "",
+                custom_providers=custom_provs,
+                config=data,
+            )
+            if model_ctx:
+                config_context_length = model_ctx
+                config_context_source = "model config"
+        except Exception:
+            pass
+
         context_length = get_model_context_length(
             model,
             base_url=base_url or "",
@@ -5876,7 +5898,7 @@ class GatewayRunner:
 
         # Format context source hint
         if config_context_length is not None:
-            ctx_source = "config"
+            ctx_source = config_context_source or "config"
         elif context_length == DEFAULT_FALLBACK_CONTEXT:
             ctx_source = "default — set model.context_length in config to override"
         else:

--- a/tests/gateway/test_session_info.py
+++ b/tests/gateway/test_session_info.py
@@ -52,6 +52,35 @@ class TestFormatSessionInfo:
         assert "32K" in info
         assert "config" in info
 
+    def test_custom_provider_model_context_length_overrides_top_level(self, runner, tmp_path):
+        config = """
+model:
+  default: gpt-5.5
+  provider: custom
+  base_url: http://10.10.1.4:8317/v1
+  context_length: 1000000
+custom_providers:
+- name: 10.10.1.4:8317
+  base_url: http://10.10.1.4:8317/v1
+  models:
+    gpt-5.4:
+      context_length: 1000000
+    gpt-5.5:
+      context_length: 272000
+"""
+        p1, p2, p3 = _patch_info(
+            tmp_path,
+            config,
+            "gpt-5.5",
+            {"provider": "custom", "base_url": "http://10.10.1.4:8317/v1", "api_key": "***"},
+        )
+        with p1, p2, p3:
+            info = runner._format_session_info()
+
+        assert "272K" in info
+        assert "1.0M" not in info
+        assert "model config" in info
+
     def test_default_fallback_hint(self, runner, tmp_path):
         p1, p2, p3 = _patch_info(tmp_path, "model:\n  default: unknown-model-xyz\n",
                                   "unknown-model-xyz",


### PR DESCRIPTION
## Summary
- Prefer per-model custom provider context overrides when formatting gateway session info
- Keep top-level `model.context_length` as a fallback
- Add regression coverage for mixed context windows on one custom endpoint

## Test Plan
- `python -m pytest tests/gateway/test_session_info.py::TestFormatSessionInfo::test_custom_provider_model_context_length_overrides_top_level -q`
- `python -m pytest tests/gateway/test_session_info.py -q`
- `python -m py_compile gateway/run.py tests/gateway/test_session_info.py`