### PR TITLE
chore: Claude Code session checkpoint (2026-04-30)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "allow": [
+      "PowerShell(& \"C:\\\\Program Files\\\\Tailscale\\\\tailscale.exe\" ping iphone172 2>&1)",
+      "PowerShell(Get-Process | Where-Object { $_.Name -match \"node|python|mcp\" } | Select-Object Name, Id, @{N='Mem\\(MB\\)';E={[math]::Round\\($_.WorkingSet64/1MB,1\\)}})",
+      "PowerShell(Measure-Command { & \"C:\\\\Program Files\\\\PowerShell\\\\7\\\\pwsh.exe\" -NoProfile -Command \"exit\" } | Select-Object TotalSeconds)",
+      "Bash(powershell.exe -Command \"Measure-Command { pwsh -NoProfile -Command 'exit' } | Select-Object TotalSeconds, TotalMilliseconds\")"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- 新增 `.claude/settings.local.json`：儲存 Claude Code 在此 worktree 的 permission allowlist
- 作為還原點：DNS 修復 / 網路層穩定化 session 後的狀態

## What Changed
- `.claude/settings.local.json`：Tailscale ping、PowerShell 測速等指令的預核准清單

## Notes
- 無程式碼邏輯變更
- 僅為本機工作環境 checkpoint