### PR TITLE
docs(faq): use messaging extra for gateway deps

### DIFF
--- a/website/docs/reference/faq.md
+++ b/website/docs/reference/faq.md
@@ -418,8 +418,8 @@ Configure in `~/.hermes/config.yaml` under your gateway's settings. See the [Mes
 
 **Solution:**
 ```bash
-# Install messaging dependencies
-pip install "hermes-agent[telegram]"   # or [discord], [slack], [whatsapp]
+# Install core messaging gateway dependencies
+pip install "hermes-agent[messaging]"  # Telegram, Discord, Slack, and shared gateway deps
 
 # Check for port conflicts
 lsof -i :8080


### PR DESCRIPTION
## Summary

- update the FAQ gateway troubleshooting install command to use the supported `messaging` extra
- avoid pointing users at platform extras such as `telegram`, `discord`, or `whatsapp` that are not declared in `pyproject.toml`

## Tests

- `git diff --check`
- verified `pyproject.toml` declares `messaging` and the FAQ now references `hermes-agent[messaging]`
