### PR TITLE
fix(curator): respect curator.auxiliary config for review model

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -758,9 +758,19 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
         from hermes_cli.config import load_config
         from hermes_cli.runtime_provider import resolve_runtime_provider
         _cfg = load_config()
-        _m = _cfg.get("model", {}) if isinstance(_cfg.get("model"), dict) else {}
-        _provider = _m.get("provider") or "auto"
-        _model_name = _m.get("default") or _m.get("model") or ""
+        
+        # Prefer curator.auxiliary when configured, fallback to main model
+        _curator_cfg = _cfg.get("curator", {}) if isinstance(_cfg.get("curator"), dict) else {}
+        _aux = _curator_cfg.get("auxiliary", {}) if isinstance(_curator_cfg.get("auxiliary"), dict) else {}
+        
+        if _aux.get("provider") or _aux.get("model"):
+            _provider = _aux.get("provider") or "auto"
+            _model_name = _aux.get("model") or ""
+        else:
+            _m = _cfg.get("model", {}) if isinstance(_cfg.get("model"), dict) else {}
+            _provider = _m.get("provider") or "auto"
+            _model_name = _m.get("default") or _m.get("model") or ""
+            
         _rp = resolve_runtime_provider(
             requested=_provider, target_model=_model_name
         )


### PR DESCRIPTION
## Problem

The `_run_llm_review` function in `agent/curator.py` was always resolving the model/provider from `cfg['model']`, ignoring any `curator.auxiliary` settings in config.yaml.

This caused the curator to always run on the user's main (often expensive) model even when `curator.auxiliary` was explicitly configured to use a cheaper auxiliary model.

## Root Cause

Introduced by commit `fa9383d` ("feat(curator): umbrella-first prompt, inherit parent config"). The fix for an OpenRouter empty-credentials path replaced the `curator.auxiliary` read entirely instead of falling back to it.

## Changes

- Read `curator.auxiliary.provider` and `curator.auxiliary.model` first
- Fall back to `cfg['model']` only when `curator.auxiliary` is unset
- Preserves backward compatibility — existing configs without `curator.auxiliary` continue to work exactly as before

## Verification

- [x] Syntax check passes (`python3 -m py_compile agent/curator.py`)
- [x] Tested locally with `curator.auxiliary` configured → curator now uses the configured auxiliary model
- [x] Tested locally without `curator.auxiliary` → curator falls back to main model (previous behavior)

Fixes #17572