### PR TITLE
feat(tui): add a mini help menu when u write ? in the input field

### DIFF
--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -22,6 +22,7 @@ import { GoodVibesHeart, StatusRule, StickyPromptTracker, TranscriptScrollbar } 
 import { FloatingOverlays, PromptZone } from './appOverlays.js'
 import { Banner, Panel, SessionPanel } from './branding.js'
 import { FpsOverlay } from './fpsOverlay.js'
+import { HelpHint } from './helpHint.js'
 import { MessageLine } from './messageLine.js'
 import { QueuedMessages } from './queuedMessages.js'
 import { LiveTodoPanel, StreamingAssistant } from './streamingAssistant.js'
@@ -241,6 +242,8 @@ const ComposerPane = memo(function ComposerPane({
           onPickerSelect={actions.resumeById}
           pagerPageSize={composer.pagerPageSize}
         />
+
+        {composer.input === '?' && !composer.inputBuf.length && <HelpHint t={ui.theme} />}
 
         {!isBlocked && (
           <>

--- a/ui-tui/src/components/helpHint.tsx
+++ b/ui-tui/src/components/helpHint.tsx
@@ -1,0 +1,73 @@
+import { Box, Text } from '@hermes/ink'
+
+import { HOTKEYS } from '../content/hotkeys.js'
+import type { Theme } from '../theme.js'
+
+const COMMON_COMMANDS: [string, string][] = [
+  ['/help', 'full list of commands + hotkeys'],
+  ['/clear', 'start a new session'],
+  ['/resume', 'resume a prior session'],
+  ['/details', 'control transcript detail level'],
+  ['/copy', 'copy selection or last assistant message'],
+  ['/quit', 'exit hermes']
+]
+
+const HOTKEY_PREVIEW = HOTKEYS.slice(0, 8)
+
+export function HelpHint({ t }: { t: Theme }) {
+  const labelW = Math.max(
+    ...COMMON_COMMANDS.map(([k]) => k.length),
+    ...HOTKEY_PREVIEW.map(([k]) => k.length)
+  )
+
+  const pad = (s: string) => s + ' '.repeat(Math.max(0, labelW - s.length + 2))
+
+  return (
+    <Box alignItems="flex-start" bottom="100%" flexDirection="column" left={0} position="absolute" right={0}>
+      <Box
+        alignSelf="flex-start"
+        borderColor={t.color.primary}
+        borderStyle="round"
+        flexDirection="column"
+        marginBottom={1}
+        opaque
+        paddingX={1}
+      >
+        <Text>
+          <Text bold color={t.color.primary}>
+            ? quick help
+          </Text>
+          <Text color={t.color.muted}>
+            {'  ·  type /help for the full panel  ·  backspace to dismiss'}
+          </Text>
+        </Text>
+
+        <Box marginTop={1}>
+          <Text bold color={t.color.accent}>
+            Common commands
+          </Text>
+        </Box>
+
+        {COMMON_COMMANDS.map(([k, v]) => (
+          <Text key={k}>
+            <Text color={t.color.label}>{pad(k)}</Text>
+            <Text color={t.color.muted}>{v}</Text>
+          </Text>
+        ))}
+
+        <Box marginTop={1}>
+          <Text bold color={t.color.accent}>
+            Hotkeys
+          </Text>
+        </Box>
+
+        {HOTKEY_PREVIEW.map(([k, v]) => (
+          <Text key={k}>
+            <Text color={t.color.label}>{pad(k)}</Text>
+            <Text color={t.color.muted}>{v}</Text>
+          </Text>
+        ))}
+      </Box>
+    </Box>
+  )
+}


### PR DESCRIPTION
Adds a non-intrusive mini help popup to the TUI composer. When the user types `?` into the empty input field, a small floating panel appears above the composer showing common slash commands and a preview of keyboard hotkeys. The popup does not steal focus, includes a hint to type `/help` for the full help panel, and can be dismissed with backspace. This gives new (and forgetful) users a quick reference without leaving the chat flow or opening a full overlay.

## Related Issue
<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #
## Type of Change
<!-- Check the one that applies. -->
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)

- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)
## Changes Made
<!-- List the specific changes. Include file paths for code changes. -->

- `ui-tui/src/components/helpHint.tsx` — new component: renders a positioned popup with `COMMON_COMMANDS` (6 frequently-used slash commands) and the first 8 entries from `HOTKEYS`, padded to align labels and descriptions. Uses `position="absolute"` + `bottom="100%"` so it floats above the composer without affecting layout or focus.





- `ui-tui/src/components/appLayout.tsx` — imports `HelpHint` and conditionally renders it when `composer.input === '?' && !composer.inputBuf.length`.


## How to Test
<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Run `hermes --tui` (or the dashboard `/chat` which embeds the TUI).
2. Focus the composer input and type `?` and nothing else.
3. Observe the rounded popup appears directly above the prompt, listing commands like `/help`, `/clear`, `/resume`, and hotkeys.


4. Verify the popup does not intercept typing or arrow-key focus elsewhere.

5. Press Backspace to remove `?` and confirm the popup disappears instantly.

6. Type additional characters after `?` (e.g. `?h`) and confirm the popup does **not** appear (guard requires `!composer.inputBuf.length`).

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

### Screenshots


<img width="1092" height="410" alt="image" src="https://github.com/user-attachments/assets/40ab4039-e1f7-41d5-9f6c-8e0a3483b6d4" />
