### PR TITLE
fix(qqbot): chunk direct send messages

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -1183,6 +1183,35 @@ class TestSendToPlatformDiscordMedia:
         call_kwargs = send_mock.await_args.kwargs
         assert call_kwargs["media_files"] == [("/fake/img.png", False)]
 
+    def test_qqbot_long_message_is_chunked_before_direct_send(self):
+        """QQBot direct sends should chunk long messages instead of truncating once."""
+        call_log = []
+
+        async def mock_send_qqbot(_pconfig, _chat_id, message):
+            call_log.append(message)
+            return {"success": True, "message_id": f"msg-{len(call_log)}"}
+
+        long_msg = "A" * 4001
+
+        with patch("tools.send_message_tool._send_qqbot", side_effect=mock_send_qqbot):
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.QQBOT,
+                    SimpleNamespace(enabled=True, token="tok", extra={}),
+                    "channel-1",
+                    long_msg,
+                )
+            )
+
+        assert result["success"] is True
+        assert len(call_log) == 2
+        assert call_log[0].endswith(" (1/2)")
+        assert call_log[1].endswith(" (2/2)")
+        delivered_text = call_log[0].removesuffix(" (1/2)") + call_log[1].removesuffix(" (2/2)")
+        assert delivered_text == long_msg
+        assert all(len(chunk) <= 4000 for chunk in call_log)
+
+
 
 class TestSendMatrixUrlEncoding:
     """_send_matrix URL-encodes Matrix room IDs in the API path."""

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -1188,6 +1188,34 @@ class TestSendToPlatformDiscordMedia:
         assert call_log[0]["media_files"] == []  # First chunk: no media
         assert call_log[1]["media_files"] == [("/fake/img.png", False)]  # Last chunk: media attached
 
+    def test_qqbot_long_message_is_chunked_before_direct_send(self):
+        """QQBot direct sends should chunk long messages instead of truncating once."""
+        call_log = []
+
+        async def mock_send_qqbot(_pconfig, _chat_id, message):
+            call_log.append(message)
+            return {"success": True, "message_id": f"msg-{len(call_log)}"}
+
+        long_msg = "A" * 4001
+
+        with patch("tools.send_message_tool._send_qqbot", side_effect=mock_send_qqbot):
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.QQBOT,
+                    SimpleNamespace(enabled=True, token="tok", extra={}),
+                    "channel-1",
+                    long_msg,
+                )
+            )
+
+        assert result["success"] is True
+        assert len(call_log) == 2
+        assert call_log[0].endswith(" (1/2)")
+        assert call_log[1].endswith(" (2/2)")
+        delivered_text = call_log[0].removesuffix(" (1/2)") + call_log[1].removesuffix(" (2/2)")
+        assert delivered_text == long_msg
+        assert all(len(chunk) <= 4000 for chunk in call_log)
+
 class TestSendMatrixUrlEncoding:
     """The matrix plugin's _standalone_send URL-encodes Matrix room IDs in the
     API path (was tools.send_message_tool._send_matrix before #41112)."""

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -462,6 +462,11 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     except ImportError:
         _feishu_available = False
 
+    try:
+        from gateway.platforms.qqbot.constants import MAX_MESSAGE_LENGTH as QQBOT_MAX_MESSAGE_LENGTH
+    except ImportError:
+        QQBOT_MAX_MESSAGE_LENGTH = 4000
+
     media_files = media_files or []
 
     if platform == Platform.SLACK and message:
@@ -476,6 +481,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         Platform.TELEGRAM: TelegramAdapter.MAX_MESSAGE_LENGTH if _telegram_available else 4096,
         Platform.DISCORD: DiscordAdapter.MAX_MESSAGE_LENGTH,
         Platform.SLACK: SlackAdapter.MAX_MESSAGE_LENGTH,
+        Platform.QQBOT: QQBOT_MAX_MESSAGE_LENGTH,
     }
     if _feishu_available:
         _MAX_LENGTHS[Platform.FEISHU] = FeishuAdapter.MAX_MESSAGE_LENGTH

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -810,6 +810,11 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     # Feishu adapter migrated to a plugin (#41112); its max_message_length
     # (8000) now flows through the registry fallback below.
 
+    try:
+        from gateway.platforms.qqbot.constants import MAX_MESSAGE_LENGTH as QQBOT_MAX_MESSAGE_LENGTH
+    except ImportError:
+        QQBOT_MAX_MESSAGE_LENGTH = 4000
+
     media_files = media_files or []
 
     # Slack mrkdwn formatting is applied inside the slack plugin's
@@ -822,6 +827,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     # migrated to plugins in #41112).
     _MAX_LENGTHS = {
         Platform.TELEGRAM: TelegramAdapter.MAX_MESSAGE_LENGTH if _telegram_available else 4096,
+        Platform.QQBOT: QQBOT_MAX_MESSAGE_LENGTH,
     }
 
     # Check plugin registry for max_message_length


### PR DESCRIPTION
## Summary

- include QQBot's message length limit in `send_message` tool chunking
- add a regression test proving long QQBot direct-send messages are split before reaching `_send_qqbot`

## Tests

- `python -m pytest tests/tools/test_send_message_tool.py::TestSendToPlatformDiscordMedia::test_qqbot_long_message_is_chunked_before_direct_send -q`
- `git diff --check`

Note: `uv run --extra dev ruff check tools/send_message_tool.py tests/tools/test_send_message_tool.py` currently reports pre-existing lint findings in these files that are unrelated to this change.
