### PR TITLE
test(acp): accept prompt persistence kwargs in MCP E2E mocks

### DIFF
--- a/tests/acp/test_mcp_e2e.py
+++ b/tests/acp/test_mcp_e2e.py
@@ -124,7 +124,7 @@ class TestMcpRegistrationE2E:
         mock_conn.request_permission = AsyncMock()
         acp_agent._conn = mock_conn
 
-        def mock_run_conversation(user_message, conversation_history=None, task_id=None):
+        def mock_run_conversation(user_message, conversation_history=None, task_id=None, **kwargs):
             """Simulate an agent turn that calls terminal, gets a result, then responds."""
             agent = state.agent
 
@@ -213,7 +213,7 @@ class TestMcpRegistrationE2E:
         mock_conn.request_permission = AsyncMock()
         acp_agent._conn = mock_conn
 
-        def mock_run(user_message, conversation_history=None, task_id=None):
+        def mock_run(user_message, conversation_history=None, task_id=None, **kwargs):
             agent = state.agent
             # Fire two tool calls
             if agent.tool_progress_callback:


### PR DESCRIPTION
## What does this PR do?

Fixes the current `main` test failure in `tests/acp/test_mcp_e2e.py` after the ACP prompt path started forwarding `persist_user_message` into `AIAgent.run_conversation(...)`.

The production agent supports that keyword, but these local E2E test doubles had narrow mock signatures. This PR makes the mocks accept future optional keyword arguments so the tests continue to exercise ACP tool-call event behavior instead of failing at the adapter boundary.

## Related Issue

Fixes current `main` CI regression from Tests run `25180124129`.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated two ACP MCP E2E `run_conversation` test doubles in `tests/acp/test_mcp_e2e.py` to accept `**kwargs`.
- Preserved the behavior under test: ACP tool start/result event emission and call-id pairing.

## How to Test

1. Reproduce on current `main`: `gh run view 25180124129 --repo NousResearch/hermes-agent --log-failed`
2. Run the focused failing tests.
3. Run the full affected file with xdist.

## Validation Status

Passed locally:

```bash
HOME="$TMP/home" HERMES_HOME="$TMP/hermes" CI=true TZ=UTC LANG=C.UTF-8 LC_ALL=C.UTF-8 PYTHONHASHSEED=0 \
  OPENROUTER_API_KEY='' OPENAI_API_KEY='' NOUS_API_KEY='' \
  /home/w0lf/hermes-agent/venv/bin/python -m pytest \
  tests/acp/test_mcp_e2e.py::TestMcpRegistrationE2E::test_prompt_with_tool_calls_emits_acp_events \
  tests/acp/test_mcp_e2e.py::TestMcpRegistrationE2E::test_prompt_tool_results_paired_by_call_id \
  -q -o addopts='' --tb=short
# 2 passed in 0.72s

HOME="$TMP/home" HERMES_HOME="$TMP/hermes" CI=true TZ=UTC LANG=C.UTF-8 LC_ALL=C.UTF-8 PYTHONHASHSEED=0 \
  OPENROUTER_API_KEY='' OPENAI_API_KEY='' NOUS_API_KEY='' \
  /home/w0lf/hermes-agent/venv/bin/python -m pytest tests/acp/test_mcp_e2e.py \
  -q -o addopts='' --tb=short -n 4
# 8 passed, 1 warning in 2.05s
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux, Python 3.14 local venv

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - test-only mock signature change, no runtime platform impact
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## For New Skills

N/A

## Screenshots / Logs

Current `main` failure:

```text
TypeError: TestMcpRegistrationE2E.test_prompt_with_tool_calls_emits_acp_events.<locals>.mock_run_conversation() got an unexpected keyword argument 'persist_user_message'
TypeError: TestMcpRegistrationE2E.test_prompt_tool_results_paired_by_call_id.<locals>.mock_run() got an unexpected keyword argument 'persist_user_message'
```
