### PR TITLE
ci: avoid matching exec/eval inside identifiers

### DIFF
--- a/.github/workflows/supply-chain-audit.yml
+++ b/.github/workflows/supply-chain-audit.yml
@@ -67,7 +67,8 @@ jobs:
           fi
 
           # --- base64 decode + exec/eval on the same line (the litellm attack pattern) ---
-          B64_EXEC_HITS=$(echo "$DIFF" | grep -n '^\+' | grep -iE 'base64\.(b64decode|decodebytes|urlsafe_b64decode)' | grep -iE 'exec\(|eval\(' | head -10 || true)
+          # Match standalone Python exec/eval calls only; avoid identifier suffixes like self._exec(...).
+          B64_EXEC_HITS=$(echo "$DIFF" | grep -n '^\+' | grep -iE 'base64\.(b64decode|decodebytes|urlsafe_b64decode)' | grep -iE '(^|[^[:alnum:]_.])(exec|eval)[[:space:]]*\(' | head -10 || true)
           if [ -n "$B64_EXEC_HITS" ]; then
             FINDINGS="${FINDINGS}
           ### 🚨 CRITICAL: base64 decode + exec/eval combo


### PR DESCRIPTION
## Summary

- tighten the supply-chain audit's base64+exec/eval matcher so it only catches standalone `exec(...)` or `eval(...)` calls
- avoid flagging ordinary identifiers like `self._exec(...)` or `pre_eval(...)` when they appear on the same line as base64 decoding

## Tests

- `git diff --check`
- local grep smoke test confirming `exec(payload)` / `eval (payload)` still match while `self._exec(payload)` / `pre_eval(payload)` do not
