### PR TITLE
fix(mcp): gate utility stubs on server-advertised capabilities

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -869,6 +869,7 @@ class MCPServerTask:
         "_tools", "_error", "_config",
         "_sampling", "_registered_tool_names", "_auth_type", "_refresh_lock",
         "_rpc_lock", "_pending_refresh_tasks",
+        "initialize_result",  # patched: cache `initialize()` response so capabilities are inspectable
     )
 
     def __init__(self, name: str):
@@ -889,6 +890,7 @@ class MCPServerTask:
         self._config: dict = {}
         self._sampling: Optional[SamplingHandler] = None
         self._registered_tool_names: list[str] = []
+        self.initialize_result: Optional[Any] = None  # patched: populated after `await session.initialize()`
         self._auth_type: str = ""
         self._refresh_lock = asyncio.Lock()
         # MCP stdio sessions are a single JSON-RPC stream. Some servers emit
@@ -1115,7 +1117,7 @@ class MCPServerTask:
                 async with ClientSession(
                     read_stream, write_stream, **sampling_kwargs
                 ) as session:
-                    await session.initialize()
+                    self.initialize_result = await session.initialize()
                     self.session = session
                     await self._discover_tools()
                     self._ready.set()
@@ -1216,7 +1218,7 @@ class MCPServerTask:
                     read_stream, write_stream, _get_session_id,
                 ):
                     async with ClientSession(read_stream, write_stream, **sampling_kwargs) as session:
-                        await session.initialize()
+                        self.initialize_result = await session.initialize()
                         self.session = session
                         await self._discover_tools()
                         self._ready.set()
@@ -1239,7 +1241,7 @@ class MCPServerTask:
                 read_stream, write_stream, _get_session_id,
             ):
                 async with ClientSession(read_stream, write_stream, **sampling_kwargs) as session:
-                    await session.initialize()
+                    self.initialize_result = await session.initialize()
                     self.session = session
                     await self._discover_tools()
                     self._ready.set()
@@ -2629,15 +2631,37 @@ def _select_utility_schemas(server_name: str, server: MCPServerTask, config: dic
             logger.debug("MCP server '%s': skipping utility '%s' (prompts disabled)", server_name, handler_key)
             continue
 
-        required_method = _UTILITY_CAPABILITY_METHODS[handler_key]
-        if not hasattr(server.session, required_method):
-            logger.debug(
-                "MCP server '%s': skipping utility '%s' (session lacks %s)",
-                server_name,
-                handler_key,
-                required_method,
-            )
-            continue
+        # patched: gate MCP utility stubs by server-advertised capabilities
+        # (https://modelcontextprotocol.io/specification — capabilities sub-objects
+        # are non-None only when the server implements the corresponding requests).
+        init_result = getattr(server, "initialize_result", None)
+        caps = getattr(init_result, "capabilities", None) if init_result is not None else None
+        if caps is not None:
+            if handler_key in {"list_resources", "read_resource"} and getattr(caps, "resources", None) is None:
+                logger.debug(
+                    "MCP server '%s': skipping utility '%s' (server does not advertise resources capability)",
+                    server_name,
+                    handler_key,
+                )
+                continue
+            if handler_key in {"list_prompts", "get_prompt"} and getattr(caps, "prompts", None) is None:
+                logger.debug(
+                    "MCP server '%s': skipping utility '%s' (server does not advertise prompts capability)",
+                    server_name,
+                    handler_key,
+                )
+                continue
+        else:
+            # Fallback when no initialize result is captured (older test fixtures).
+            required_method = _UTILITY_CAPABILITY_METHODS[handler_key]
+            if not hasattr(server.session, required_method):
+                logger.debug(
+                    "MCP server '%s': skipping utility '%s' (session lacks %s)",
+                    server_name,
+                    handler_key,
+                    required_method,
+                )
+                continue
         selected.append(entry)
     return selected
 


### PR DESCRIPTION
## Summary

Fixes #18051. The four MCP utility schemas (`list_resources` / `read_resource` / `list_prompts` / `get_prompt`) are registered for every connected MCP server, even when the server advertises only the `tools` capability. Today's gate uses `hasattr(server.session, required_method)`, which is always `True` because `mcp.ClientSession` defines all four methods on the class regardless of what the remote server actually supports.

The InitializeResult returned from `await session.initialize()` is the source of truth — `result.capabilities.resources` and `result.capabilities.prompts` are non-`None` only when the server implements those request types — but it was being discarded.

## Changes

- `MCPServerTask.__slots__`: add `"initialize_result"`.
- `MCPServerTask.__init__`: initialise `self.initialize_result: Optional[Any] = None`.
- All three `await session.initialize()` call sites (`_run_http`, `_run_http` reconnect path, `_run_stdio`): assign the result into `self.initialize_result`.
- `_select_utility_schemas`: when `initialize_result` is present, skip `list_resources` / `read_resource` if `capabilities.resources is None`, and skip `list_prompts` / `get_prompt` if `capabilities.prompts is None`. When `initialize_result` is `None` (older test fixtures, no real connect), fall back to the existing `hasattr` check so behaviour on that path is unchanged.

## Verification

Direct unit-style test against a freshly patched tree (`venv/bin/python` against `tools.mcp_tool`):

```python
from types import SimpleNamespace
from tools.mcp_tool import _select_utility_schemas, MCPServerTask

# tools-only server (Context7 case)
s1 = MCPServerTask("tools_only")
s1.session = SimpleNamespace(list_resources=lambda: None, read_resource=lambda x: None,
                              list_prompts=lambda: None, get_prompt=lambda *a: None)
s1.initialize_result = SimpleNamespace(capabilities=SimpleNamespace(
    tools=SimpleNamespace(listChanged=True), prompts=None, resources=None))
print([e["handler_key"] for e in _select_utility_schemas("x", s1, {})])
# -> []

# full-caps server
s2 = MCPServerTask("full")
s2.session = s1.session
s2.initialize_result = SimpleNamespace(capabilities=SimpleNamespace(
    tools=True, prompts=SimpleNamespace(), resources=SimpleNamespace()))
print([e["handler_key"] for e in _select_utility_schemas("x", s2, {})])
# -> ['list_resources', 'read_resource', 'list_prompts', 'get_prompt']

# legacy fallback (no initialize_result)
s3 = MCPServerTask("legacy")
s3.session = s1.session
print([e["handler_key"] for e in _select_utility_schemas("x", s3, {})])
# -> ['list_resources', 'read_resource', 'list_prompts', 'get_prompt']
```

End-to-end: I have this running locally against `@upstash/context7-mcp` (which is the canonical "tools-only" server). With the patch applied, `_register_server_tools` registers exactly two LLM-visible tools (`mcp_context7_resolve_library_id`, `mcp_context7_query_docs`) instead of the previous six.

## Risk

- The new `initialize_result` slot is `None` until the first successful `initialize()`. The fallback path keeps existing behaviour for code paths that haven't reached that point yet.
- No production behaviour change for servers that *do* advertise prompts/resources — they get the same schemas as before.
- Minimal blast radius: one new slot, three single-line assignments, one if/else block in the existing utility-selection function. No public-API change.

## Notes

I haven't added a unit test in this PR because the existing tests in `tests/tools/test_mcp_tool.py` mock `ClientSession` rather than the full connect/initialize flow, and adding a capabilities-gating test would require either a new fixture for `InitializeResult` or relaxing the existing fixtures. Happy to follow up with one in a separate commit if you'd like — let me know which fixture style you prefer.