### PR TITLE
fix(tui): return JSON-RPC errors for invalid request shapes

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -59,6 +59,28 @@ def test_write_json_returns_false_on_broken_pipe(monkeypatch):
     assert server.write_json({"ok": True}) is False
 
 
+def test_dispatch_rejects_non_object_request():
+    resp = server.dispatch([])
+
+    assert resp == {
+        "jsonrpc": "2.0",
+        "id": None,
+        "error": {"code": -32600, "message": "invalid request: expected an object"},
+    }
+
+
+def test_dispatch_rejects_non_object_params():
+    resp = server.dispatch(
+        {"id": "1", "method": "session.create", "params": []}
+    )
+
+    assert resp == {
+        "jsonrpc": "2.0",
+        "id": "1",
+        "error": {"code": -32602, "message": "invalid params: expected an object"},
+    }
+
+
 def test_load_enabled_toolsets_prefers_tui_env(monkeypatch):
     monkeypatch.setenv("HERMES_TUI_TOOLSETS", "web, terminal, ,memory")
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -417,11 +417,35 @@ def method(name: str):
     return dec
 
 
+def _normalize_request(req: Any) -> tuple[Any, str, dict] | dict:
+    """Validate a JSON-RPC request enough for safe local dispatch."""
+    if not isinstance(req, dict):
+        return _err(None, -32600, "invalid request: expected an object")
+
+    rid = req.get("id")
+    method = req.get("method")
+    if not isinstance(method, str) or not method:
+        return _err(rid, -32600, "invalid request: method must be a non-empty string")
+
+    params = req.get("params", {})
+    if params is None:
+        params = {}
+    elif not isinstance(params, dict):
+        return _err(rid, -32602, "invalid params: expected an object")
+
+    return rid, method, params
+
+
 def handle_request(req: dict) -> dict | None:
-    fn = _methods.get(req.get("method", ""))
+    normalized = _normalize_request(req)
+    if isinstance(normalized, dict):
+        return normalized
+
+    rid, method, params = normalized
+    fn = _methods.get(method)
     if not fn:
-        return _err(req.get("id"), -32601, f"unknown method: {req.get('method')}")
-    return fn(req.get("id"), req.get("params", {}))
+        return _err(rid, -32601, f"unknown method: {method}")
+    return fn(rid, params)
 
 
 def dispatch(req: dict, transport: Optional[Transport] = None) -> dict | None:
@@ -439,7 +463,12 @@ def dispatch(req: dict, transport: Optional[Transport] = None) -> dict | None:
     t = transport or _stdio_transport
     token = bind_transport(t)
     try:
-        if req.get("method") not in _LONG_HANDLERS:
+        normalized = _normalize_request(req)
+        if isinstance(normalized, dict):
+            return normalized
+
+        _rid, method, _params = normalized
+        if method not in _LONG_HANDLERS:
             return handle_request(req)
 
         # Snapshot the context so the pool worker sees the bound transport.


### PR DESCRIPTION
## What does this PR do?

Hardens the TUI JSON-RPC gateway against malformed requests by validating the top-level request object and `params` shape before dispatch.

Previously, malformed inputs like a non-object request or a list-valued `params` payload could raise `AttributeError` inside `dispatch()` / `handle_request()` and crash the TUI gateway subprocess instead of returning a structured JSON-RPC error.

This change adds a small normalization layer in `tui_gateway/server.py` so invalid request shapes fail cleanly with standard JSON-RPC error responses:
- `-32600` for invalid top-level request objects
- `-32602` for invalid non-object `params`

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `_normalize_request()` in `tui_gateway/server.py`
- Validated request and `params` shape before both inline and long-handler dispatch
- Returned structured JSON-RPC errors instead of letting malformed requests crash the TUI gateway
- Added regression tests in `tests/test_tui_gateway_server.py` for non-object request payloads and non-object `params` payloads

## How to Test

1. Run:
   `scripts/run_tests.sh tests/test_tui_gateway_server.py -k "dispatch_rejects_non_object_request or dispatch_rejects_non_object_params"`
2. Verify both tests pass.
3. Optionally confirm behavior manually:
   - `server.dispatch([])` returns `-32600`
   - `server.dispatch({"id":"1","method":"session.create","params":[]})` returns `-32602`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and the targeted tests pass via `scripts/run_tests.sh`
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted test run result:

`2 passed, 2 warnings in 5.56s`
