### PR TITLE
[codex] List recent sessions from gateway resume

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8101,7 +8101,7 @@ class GatewayRunner:
                 return f"📌 Session: `{session_id}`\nNo title set. Usage: `/title My Session Name`"
 
     async def _handle_resume_command(self, event: MessageEvent) -> str:
-        """Handle /resume command — switch to a previously-named session."""
+        """Handle /resume command — switch to a previous session."""
         if not self._session_db:
             return "Session database not available."
 
@@ -8110,37 +8110,43 @@ class GatewayRunner:
         name = event.get_command_args().strip()
 
         if not name:
-            # List recent titled sessions for this user/platform
+            # List recent sessions for this user/platform.  Match the CLI/TUI
+            # convention: show the first user prompt preview when a title is
+            # absent, and include an ID prefix users can copy into /resume.
             try:
                 user_source = source.platform.value if source.platform else None
                 sessions = self._session_db.list_sessions_rich(
-                    source=user_source, limit=10
+                    source=user_source, limit=20
                 )
-                titled = [s for s in sessions if s.get("title")]
-                if not titled:
-                    return (
-                        "No named sessions found.\n"
-                        "Use `/title My Session` to name your current session, "
-                        "then `/resume My Session` to return to it later."
-                    )
-                lines = ["📋 **Named Sessions**\n"]
-                for s in titled[:10]:
-                    title = s["title"]
-                    preview = s.get("preview", "")[:40]
-                    preview_part = f" — _{preview}_" if preview else ""
-                    lines.append(f"• **{title}**{preview_part}")
-                lines.append("\nUsage: `/resume <session name>`")
+                current_entry = self.session_store.get_or_create_session(source)
+                current_id = getattr(current_entry, "session_id", None)
+                recent = [s for s in sessions if s.get("id") != current_id][:10]
+                if not recent:
+                    return "No previous sessions found."
+
+                lines = ["📋 **Recent Sessions**\n"]
+                for s in recent:
+                    session_id = s.get("id") or ""
+                    short_id = session_id[:18]
+                    label = (s.get("preview") or s.get("title") or session_id).strip()
+                    label = " ".join(label.split())
+                    if len(label) > 80:
+                        label = label[:77].rstrip() + "..."
+                    lines.append(f"• `{short_id}` {label}")
+                lines.append("\nUsage: `/resume <session id or title>`")
                 return "\n".join(lines)
             except Exception as e:
-                logger.debug("Failed to list titled sessions: %s", e)
+                logger.debug("Failed to list sessions: %s", e)
                 return f"Could not list sessions: {e}"
 
-        # Resolve the name to a session ID.
-        target_id = self._session_db.resolve_session_by_title(name)
+        # Resolve the argument as an ID/prefix first, then as a title.
+        target_id = self._session_db.resolve_session_id(name)
+        if not target_id:
+            target_id = self._session_db.resolve_session_by_title(name)
         if not target_id:
             return (
                 f"No session found matching '**{name}**'.\n"
-                "Use `/resume` with no arguments to see available sessions."
+                "Use `/resume` with no arguments to see recent sessions."
             )
         # Compression creates child continuations that hold the live transcript.
         # Follow that chain so gateway /resume matches CLI behavior (#15000).

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -74,7 +74,7 @@ class TestHandleResumeCommand:
 
     @pytest.mark.asyncio
     async def test_list_named_sessions_when_no_arg(self, tmp_path):
-        """With no argument, lists recently titled sessions."""
+        """With no argument, lists recent sessions."""
         from hermes_state import SessionDB
         db = SessionDB(db_path=tmp_path / "state.db")
         db.create_session("sess_001", "telegram")
@@ -87,21 +87,23 @@ class TestHandleResumeCommand:
         result = await runner._handle_resume_command(event)
         assert "Research" in result
         assert "Coding" in result
-        assert "Named Sessions" in result
+        assert "Recent Sessions" in result
         db.close()
 
     @pytest.mark.asyncio
-    async def test_list_shows_usage_when_no_titled(self, tmp_path):
-        """With no arg and no titled sessions, shows instructions."""
+    async def test_list_uses_first_prompt_when_no_title(self, tmp_path):
+        """With no arg and no title, lists the first user prompt preview."""
         from hermes_state import SessionDB
         db = SessionDB(db_path=tmp_path / "state.db")
-        db.create_session("sess_001", "telegram")  # No title
+        db.create_session("sess_001", "telegram")
+        db.append_message("sess_001", "user", "check the broken gateway resume flow")
 
         event = _make_event(text="/resume")
         runner = _make_runner(session_db=db, event=event)
         result = await runner._handle_resume_command(event)
-        assert "No named sessions" in result
-        assert "/title" in result
+        assert "check the broken gateway resume flow" in result
+        assert "sess_001" in result
+        assert "/resume <session id or title>" in result
         db.close()
 
     @pytest.mark.asyncio
@@ -122,6 +124,24 @@ class TestHandleResumeCommand:
         assert "My Project" in result
         # Verify switch_session was called with the old session ID
         runner.session_store.switch_session.assert_called_once()
+        call_args = runner.session_store.switch_session.call_args
+        assert call_args[0][1] == "old_session_abc"
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_resume_by_session_id(self, tmp_path):
+        """Resolves a session ID or unique prefix and switches to that session."""
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("old_session_abc", "telegram")
+        db.create_session("current_session_001", "telegram")
+
+        event = _make_event(text="/resume old_session")
+        runner = _make_runner(session_db=db, current_session_id="current_session_001",
+                              event=event)
+        result = await runner._handle_resume_command(event)
+
+        assert "Resumed" in result
         call_args = runner.session_store.switch_session.call_args
         assert call_args[0][1] == "old_session_abc"
         db.close()

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -133,7 +133,7 @@ hermes gateway status --system         # Linux only: inspect the system service 
 | `/sethome` | Set this chat as the home channel |
 | `/compress` | Manually compress conversation context |
 | `/title [name]` | Set or show the session title |
-| `/resume [name]` | Resume a previously named session |
+| `/resume [id\|name]` | List recent sessions or resume by session ID/title |
 | `/usage` | Show token usage for this session |
 | `/insights [days]` | Show usage insights and analytics |
 | `/reasoning [level\|show\|hide]` | Change reasoning effort or toggle reasoning display |

--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -177,6 +177,11 @@ The `/title` command works in all gateway platforms (Telegram, Discord, Slack, W
 - `/title My Research` — set the session title
 - `/title` — show the current title
 
+Use `/resume` with no arguments in a messaging platform to list recent sessions
+for that platform. The list shows the same first-message preview used by the
+CLI/TUI session browser, plus a session ID prefix. Resume with
+`/resume <session id or title>`.
+
 ## Session Management Commands
 
 Hermes provides a full set of session management commands via `hermes sessions`:


### PR DESCRIPTION
## Summary
- make gateway `/resume` with no args list recent sessions, not only named sessions
- show the first user-message preview used by CLI/TUI session listing, plus a copyable session ID prefix
- allow `/resume` to resolve session IDs/prefixes before falling back to titles
- update gateway session docs and resume tests

## Why
Messaging users can have useful unnamed sessions. Requiring `/title` before `/resume` makes the command unusable for normal recent-session browsing, even though the session database already stores first-prompt previews.

## Validation
- `/home/juan/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_resume_command.py -q`