### PR TITLE
fix(curator): preserve last_report_path in state

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -55,6 +55,7 @@ def _default_state() -> Dict[str, Any]:
         "last_run_at": None,
         "last_run_duration_seconds": None,
         "last_run_summary": None,
+        "last_report_path": None,
         "paused": False,
         "run_count": 0,
     }

--- a/tests/agent/test_curator.py
+++ b/tests/agent/test_curator.py
@@ -363,6 +363,19 @@ def test_state_atomic_write_no_tmp_leftovers(curator_env):
         assert not p.name.startswith(".curator_state_"), f"tmp leftover: {p.name}"
 
 
+def test_state_preserves_last_report_path(curator_env):
+    c = curator_env["curator"]
+    c.save_state({
+        "last_run_at": "2026-04-30T12:00:00+00:00",
+        "last_run_summary": "ok",
+        "last_report_path": "/tmp/curator-report",
+        "paused": False,
+        "run_count": 1,
+    })
+    state = c.load_state()
+    assert state["last_report_path"] == "/tmp/curator-report"
+
+
 def test_curator_review_prompt_has_invariants():
     """Core invariants must be in the review prompt text."""
     from agent.curator import CURATOR_REVIEW_PROMPT


### PR DESCRIPTION
## What does this PR do?

Fixes a curator state persistence bug where `last_report_path` was written after a run, but then dropped on the next `load_state()` call.

The curator CLI already expects this field and prints it in `hermes curator status`, but the state loader only preserved keys present in `_default_state()`. Since `last_report_path` was missing there, the value never survived a round-trip through `.curator_state`.

This change adds `last_report_path` to the default curator state schema and covers it with a regression test.

## Related Issue

Fixes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- Added `last_report_path` to the default curator state in `agent/curator.py`
- Added a regression test in `tests/agent/test_curator.py` to verify the field survives `save_state()` / `load_state()` round-trip

## How to Test

1. Run:
   $env:TZ='UTC'; $env:LANG='C.UTF-8'; $env:LC_ALL='C.UTF-8'; $env:PYTHONHASHSEED='0'; uv run --extra dev --extra web pytest -n 4 -o 'addopts=' --ignore=tests/integration --ignore=tests/e2e -m 'not integration' tests/agent/test_curator.py -q
2. Verify `test_state_preserves_last_report_path` passes.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant tests and they pass
- [x] I've added tests for my changes

### Documentation & Housekeeping

- [x] No documentation update needed
- [x] No config changes
- [x] Cross-platform impact considered — behavior is state-schema-only
