### PR TITLE
fix(tui): restore Control-C (SIGINT) handling

### DIFF
--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -132,7 +132,7 @@ def _log_signal(signum: int, frame) -> None:
 signal.signal(signal.SIGPIPE, signal.SIG_IGN)
 signal.signal(signal.SIGTERM, _log_signal)
 signal.signal(signal.SIGHUP, _log_signal)
-signal.signal(signal.SIGINT, signal.SIG_IGN)
+signal.signal(signal.SIGINT, _log_signal)
 
 
 def _log_exit(reason: str) -> None:


### PR DESCRIPTION
## Problem

Control-C (SIGINT) does not work in `hermes --tui`. The process ignores the signal entirely and cannot be interrupted from the terminal.

## Root Cause

`tui_gateway/entry.py` line 135 explicitly set SIGINT to SIG_IGN:

```python
signal.signal(signal.SIGINT, signal.SIG_IGN)
```

This was added as part of a fix for SIGPIPE (background threads writing to a half-closed stdout pipe), but it over-corrected — SIGINT is a user terminal signal, not a pipe error. It should be handled, not ignored.

## Fix

Route SIGINT through the existing `_log_signal` handler (same as SIGTERM/SIGHUP):

```python
signal.signal(signal.SIGINT, _log_signal)
```

This handler:
1. Logs the signal + all thread stacks to `tui_gateway_crash.log` for forensics
2. Starts a 1s grace timer for orderly shutdown
3. Calls `sys.exit(0)` to break the stdin loop cleanly
4. Falls back to `os._exit(0)` if a worker thread is wedged mid-flush

## Verification

- `hermes --tui` now responds to Control-C and exits cleanly
- Crash log captures the stack trace for debugging if something is stuck

## Related

The `_log_signal` handler and grace-timer mechanism were introduced in previous PRs to solve phantom voice-mode crashes and SIGPIPE kills. This change extends that same diagnosable shutdown path to SIGINT.