### PR TITLE
fix(signal): send TTS replies as native voice notes

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -1252,7 +1252,7 @@ class SignalAdapter(BasePlatformAdapter):
             "attachments": [file_path],
         }
         if voice_note:
-            params["voiceNote"] = True
+            params["voice-note"] = True
 
         if chat_id.startswith("group:"):
             params["groupId"] = chat_id[6:]

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -1229,6 +1229,7 @@ class SignalAdapter(BasePlatformAdapter):
         file_path: str,
         media_label: str,
         caption: Optional[str] = None,
+        voice_note: bool = False,
     ) -> SendResult:
         """Send any file as a Signal attachment via RPC.
 
@@ -1250,6 +1251,8 @@ class SignalAdapter(BasePlatformAdapter):
             "message": caption or "",
             "attachments": [file_path],
         }
+        if voice_note:
+            params["voiceNote"] = True
 
         if chat_id.startswith("group:"):
             params["groupId"] = chat_id[6:]
@@ -1296,12 +1299,14 @@ class SignalAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         **kwargs,
     ) -> SendResult:
-        """Send an audio file as a Signal attachment.
-
-        Signal does not distinguish voice messages from file attachments at
-        the API level, so this routes through the same RPC send path.
-        """
-        return await self._send_attachment(chat_id, audio_path, "Audio", caption)
+        """Send an audio file as a native Signal voice note."""
+        return await self._send_attachment(
+            chat_id,
+            audio_path,
+            "Audio",
+            caption,
+            voice_note=True,
+        )
 
     async def send_video(
         self,

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -1316,8 +1316,12 @@ class SignalAdapter(BasePlatformAdapter):
                         _prepare_signal_voice_note_audio, file_path
                     )
                 except (RuntimeError, OSError) as exc:
-                    logger.warning("Signal: could not prepare voice note: %s", exc)
-                    return SendResult(success=False, error=str(exc))
+                    logger.warning(
+                        "Signal: could not prepare native voice note; "
+                        "sending regular audio attachment instead: %s",
+                        exc,
+                    )
+                    voice_note = False
 
             params: Dict[str, Any] = {
                 "account": self.account,

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -17,6 +17,8 @@ import json
 import logging
 import os
 import random
+import shutil
+import subprocess
 import time
 import uuid
 from datetime import datetime, timezone
@@ -118,6 +120,65 @@ _EXT_TO_MIME = {
 def _ext_to_mime(ext: str) -> str:
     """Map file extension to MIME type."""
     return _EXT_TO_MIME.get(ext.lower(), "application/octet-stream")
+
+
+def _signal_voice_note_cache_dir() -> Path:
+    return Path(os.path.expanduser("~")) / ".cache" / "hermes" / "voice"
+
+
+def _prepare_signal_voice_note_audio(audio_path: str) -> Tuple[str, Optional[str]]:
+    source = Path(audio_path)
+    cache_dir = _signal_voice_note_cache_dir()
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    target = cache_dir / f"signal_voice_note_{uuid.uuid4().hex[:12]}.m4a"
+
+    if source.suffix.lower() == ".m4a":
+        shutil.copyfile(source, target)
+        return str(target), str(target)
+
+    ffmpeg = shutil.which("ffmpeg")
+    if not ffmpeg:
+        raise RuntimeError("ffmpeg is required to prepare Signal voice notes")
+
+    cmd = [
+        ffmpeg,
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-y",
+        "-i",
+        str(source),
+        "-vn",
+        "-ac",
+        "1",
+        "-ar",
+        "44100",
+        "-c:a",
+        "aac",
+        "-b:a",
+        "64k",
+        str(target),
+    ]
+
+    try:
+        subprocess.run(cmd, check=True, capture_output=True, text=True, timeout=120)
+    except subprocess.TimeoutExpired as exc:
+        target.unlink(missing_ok=True)
+        raise RuntimeError("ffmpeg timed out while preparing Signal voice note") from exc
+    except subprocess.CalledProcessError as exc:
+        target.unlink(missing_ok=True)
+        detail = (exc.stderr or exc.stdout or "").strip()
+        if detail:
+            raise RuntimeError(
+                f"ffmpeg failed while preparing Signal voice note: {detail[-500:]}"
+            ) from exc
+        raise RuntimeError("ffmpeg failed while preparing Signal voice note") from exc
+
+    if not target.exists() or target.stat().st_size == 0:
+        target.unlink(missing_ok=True)
+        raise RuntimeError("ffmpeg produced an empty Signal voice note")
+
+    return str(target), str(target)
 
 
 def _render_mentions(text: str, mentions: list) -> str:
@@ -1246,24 +1307,42 @@ class SignalAdapter(BasePlatformAdapter):
         if file_size > SIGNAL_MAX_ATTACHMENT_SIZE:
             return SendResult(success=False, error=f"{media_label} too large ({file_size} bytes)")
 
-        params: Dict[str, Any] = {
-            "account": self.account,
-            "message": caption or "",
-            "attachments": [file_path],
-        }
-        if voice_note:
-            params["voice-note"] = True
+        send_path = file_path
+        cleanup_path: Optional[str] = None
+        try:
+            if voice_note:
+                try:
+                    send_path, cleanup_path = await asyncio.to_thread(
+                        _prepare_signal_voice_note_audio, file_path
+                    )
+                except (RuntimeError, OSError) as exc:
+                    logger.warning("Signal: could not prepare voice note: %s", exc)
+                    return SendResult(success=False, error=str(exc))
 
-        if chat_id.startswith("group:"):
-            params["groupId"] = chat_id[6:]
-        else:
-            params["recipient"] = [await self._resolve_recipient(chat_id)]
+            params: Dict[str, Any] = {
+                "account": self.account,
+                "message": caption or "",
+                "attachments": [send_path],
+            }
+            if voice_note:
+                params["voice-note"] = True
 
-        result = await self._rpc("send", params)
-        if result is not None:
-            self._track_sent_timestamp(result)
-            return SendResult(success=True)
-        return SendResult(success=False, error=f"RPC send {media_label.lower()} failed")
+            if chat_id.startswith("group:"):
+                params["groupId"] = chat_id[6:]
+            else:
+                params["recipient"] = [await self._resolve_recipient(chat_id)]
+
+            result = await self._rpc("send", params)
+            if result is not None:
+                self._track_sent_timestamp(result)
+                return SendResult(success=True)
+            return SendResult(success=False, error=f"RPC send {media_label.lower()} failed")
+        finally:
+            if cleanup_path:
+                try:
+                    Path(cleanup_path).unlink(missing_ok=True)
+                except OSError as exc:
+                    logger.warning("Signal: failed to clean up voice note %s: %s", cleanup_path, exc)
 
     async def send_document(
         self,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -22,7 +22,6 @@ import re
 import shlex
 import sys
 import signal
-import tempfile
 import threading
 import time
 from collections import OrderedDict
@@ -7215,10 +7214,12 @@ class GatewayRunner:
             if not tts_text:
                 return
 
+            # signal-cli may run with PrivateTmp=true, so stage voice replies
+            # under the user's cache instead of /tmp.
             # Use .mp3 extension so edge-tts conversion to opus works correctly.
             # The TTS tool may convert to .ogg — use file_path from result.
             audio_path = os.path.join(
-                tempfile.gettempdir(), "hermes_voice",
+                os.path.expanduser("~"), ".cache", "hermes", "voice",
                 f"tts_reply_{_uuid.uuid4().hex[:12]}.mp3",
             )
             os.makedirs(os.path.dirname(audio_path), exist_ok=True)

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -591,7 +591,7 @@ class TestSignalSendVoice:
         assert captured[0]["method"] == "send"
         assert captured[0]["params"]["attachments"] == [str(audio_path)]
         assert captured[0]["params"]["message"] == ""  # caption=None → ""
-        assert captured[0]["params"]["voiceNote"] is True
+        assert captured[0]["params"]["voice-note"] is True
         adapter._stop_typing_indicator.assert_awaited_once_with("+155****4567")
         assert 1234567890 in adapter._recent_sent_timestamps
 
@@ -621,7 +621,7 @@ class TestSignalSendVoice:
 
         assert result.success is True
         assert captured[0]["params"]["groupId"] == "grp1=="
-        assert captured[0]["params"]["voiceNote"] is True
+        assert captured[0]["params"]["voice-note"] is True
 
     @pytest.mark.asyncio
     async def test_send_voice_too_large(self, monkeypatch, tmp_path):

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -2,6 +2,7 @@
 import asyncio
 import base64
 import json
+import subprocess
 import pytest
 from pathlib import Path
 from unittest.mock import MagicMock, patch, AsyncMock
@@ -576,7 +577,34 @@ class TestSignalRecipientResolution:
 class TestSignalSendVoice:
     @pytest.mark.asyncio
     async def test_send_voice_sends_via_rpc(self, monkeypatch, tmp_path):
-        """send_voice should send audio as attachment via signal-cli RPC."""
+        """send_voice should send staged M4A audio as a Signal voice note."""
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        adapter = _make_signal_adapter(monkeypatch)
+        mock_rpc, captured = _stub_rpc({"timestamp": 1234567890})
+        adapter._rpc = mock_rpc
+        adapter._stop_typing_indicator = AsyncMock()
+
+        audio_path = tmp_path / "reply.m4a"
+        audio_path.write_bytes(b"\x00\x00\x00\x18ftyp" + b"\x00" * 100)
+
+        result = await adapter.send_voice(chat_id="+155****4567", audio_path=str(audio_path))
+
+        assert result.success is True
+        assert captured[0]["method"] == "send"
+        sent_path = Path(captured[0]["params"]["attachments"][0])
+        assert sent_path.suffix == ".m4a"
+        assert sent_path.parent == tmp_path / "home" / ".cache" / "hermes" / "voice"
+        assert sent_path.exists() is False
+        assert audio_path.exists() is True
+        assert captured[0]["params"]["message"] == ""  # caption=None → ""
+        assert captured[0]["params"]["voice-note"] is True
+        adapter._stop_typing_indicator.assert_awaited_once_with("+155****4567")
+        assert 1234567890 in adapter._recent_sent_timestamps
+
+    @pytest.mark.asyncio
+    async def test_send_voice_transcodes_ogg_to_m4a(self, monkeypatch, tmp_path):
+        """Ogg voice payloads should be transcoded before sending to Signal."""
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
         adapter = _make_signal_adapter(monkeypatch)
         mock_rpc, captured = _stub_rpc({"timestamp": 1234567890})
         adapter._rpc = mock_rpc
@@ -585,15 +613,23 @@ class TestSignalSendVoice:
         audio_path = tmp_path / "reply.ogg"
         audio_path.write_bytes(b"OggS" + b"\x00" * 100)
 
+        def fake_run(cmd, check, capture_output, text, timeout):
+            assert cmd[cmd.index("-c:a") + 1] == "aac"
+            Path(cmd[-1]).write_bytes(b"m4a")
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+
+        monkeypatch.setattr("gateway.platforms.signal.shutil.which", lambda name: "/usr/bin/ffmpeg")
+        monkeypatch.setattr("gateway.platforms.signal.subprocess.run", fake_run)
+
         result = await adapter.send_voice(chat_id="+155****4567", audio_path=str(audio_path))
 
         assert result.success is True
-        assert captured[0]["method"] == "send"
-        assert captured[0]["params"]["attachments"] == [str(audio_path)]
-        assert captured[0]["params"]["message"] == ""  # caption=None → ""
+        sent_path = Path(captured[0]["params"]["attachments"][0])
+        assert sent_path.suffix == ".m4a"
+        assert sent_path.parent == tmp_path / "home" / ".cache" / "hermes" / "voice"
+        assert sent_path.exists() is False
+        assert audio_path.exists() is True
         assert captured[0]["params"]["voice-note"] is True
-        adapter._stop_typing_indicator.assert_awaited_once_with("+155****4567")
-        assert 1234567890 in adapter._recent_sent_timestamps
 
     @pytest.mark.asyncio
     async def test_send_voice_missing_file(self, monkeypatch):
@@ -609,13 +645,14 @@ class TestSignalSendVoice:
     @pytest.mark.asyncio
     async def test_send_voice_to_group(self, monkeypatch, tmp_path):
         """send_voice should route group chats correctly."""
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
         adapter = _make_signal_adapter(monkeypatch)
         mock_rpc, captured = _stub_rpc({"timestamp": 9999})
         adapter._rpc = mock_rpc
         adapter._stop_typing_indicator = AsyncMock()
 
-        audio_path = tmp_path / "note.mp3"
-        audio_path.write_bytes(b"\xff\xe0" + b"\x00" * 100)
+        audio_path = tmp_path / "note.m4a"
+        audio_path.write_bytes(b"\x00\x00\x00\x18ftyp" + b"\x00" * 100)
 
         result = await adapter.send_voice(chat_id="group:grp1==", audio_path=str(audio_path))
 
@@ -646,13 +683,14 @@ class TestSignalSendVoice:
     @pytest.mark.asyncio
     async def test_send_voice_rpc_failure(self, monkeypatch, tmp_path):
         """send_voice should return error when RPC returns None."""
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
         adapter = _make_signal_adapter(monkeypatch)
         mock_rpc, _ = _stub_rpc(None)
         adapter._rpc = mock_rpc
         adapter._stop_typing_indicator = AsyncMock()
 
-        audio_path = tmp_path / "reply.ogg"
-        audio_path.write_bytes(b"OggS" + b"\x00" * 100)
+        audio_path = tmp_path / "reply.m4a"
+        audio_path.write_bytes(b"\x00\x00\x00\x18ftyp" + b"\x00" * 100)
 
         result = await adapter.send_voice(chat_id="+155****4567", audio_path=str(audio_path))
 

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -591,6 +591,7 @@ class TestSignalSendVoice:
         assert captured[0]["method"] == "send"
         assert captured[0]["params"]["attachments"] == [str(audio_path)]
         assert captured[0]["params"]["message"] == ""  # caption=None → ""
+        assert captured[0]["params"]["voiceNote"] is True
         adapter._stop_typing_indicator.assert_awaited_once_with("+155****4567")
         assert 1234567890 in adapter._recent_sent_timestamps
 
@@ -620,6 +621,7 @@ class TestSignalSendVoice:
 
         assert result.success is True
         assert captured[0]["params"]["groupId"] == "grp1=="
+        assert captured[0]["params"]["voiceNote"] is True
 
     @pytest.mark.asyncio
     async def test_send_voice_too_large(self, monkeypatch, tmp_path):

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -632,6 +632,29 @@ class TestSignalSendVoice:
         assert captured[0]["params"]["voice-note"] is True
 
     @pytest.mark.asyncio
+    async def test_send_voice_falls_back_to_attachment_without_ffmpeg(
+        self, monkeypatch, tmp_path
+    ):
+        """Non-M4A voice payloads should remain sendable without ffmpeg."""
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        adapter = _make_signal_adapter(monkeypatch)
+        mock_rpc, captured = _stub_rpc({"timestamp": 1234567890})
+        adapter._rpc = mock_rpc
+        adapter._stop_typing_indicator = AsyncMock()
+
+        audio_path = tmp_path / "reply.ogg"
+        audio_path.write_bytes(b"OggS" + b"\x00" * 100)
+
+        monkeypatch.setattr("gateway.platforms.signal.shutil.which", lambda name: None)
+
+        result = await adapter.send_voice(chat_id="+155****4567", audio_path=str(audio_path))
+
+        assert result.success is True
+        assert captured[0]["params"]["attachments"] == [str(audio_path)]
+        assert "voice-note" not in captured[0]["params"]
+        assert 1234567890 in adapter._recent_sent_timestamps
+
+    @pytest.mark.asyncio
     async def test_send_voice_missing_file(self, monkeypatch):
         """send_voice should fail for nonexistent audio."""
         adapter = _make_signal_adapter(monkeypatch)

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -422,13 +422,15 @@ class TestSendVoiceReply:
 
         tts_result = json.dumps({"success": True, "file_path": "/tmp/test.ogg"})
 
-        with patch("tools.tts_tool.text_to_speech_tool", return_value=tts_result), \
+        with patch("tools.tts_tool.text_to_speech_tool", return_value=tts_result) as mock_tts, \
              patch("tools.tts_tool._strip_markdown_for_tts", side_effect=lambda t: t), \
              patch("os.path.isfile", return_value=True), \
              patch("os.unlink"), \
              patch("os.makedirs"):
             await runner._send_voice_reply(event, "Hello world")
 
+        output_path = mock_tts.call_args.kwargs["output_path"]
+        assert os.path.dirname(output_path) == os.path.expanduser("~/.cache/hermes/voice")
         mock_adapter.send_voice.assert_called_once()
         call_args = mock_adapter.send_voice.call_args
         assert call_args.kwargs.get("chat_id") == "123"

--- a/website/docs/user-guide/messaging/signal.md
+++ b/website/docs/user-guide/messaging/signal.md
@@ -160,11 +160,11 @@ The adapter supports sending and receiving media in both directions.
 The agent can send media files via `MEDIA:` tags in responses. The following delivery methods are supported:
 
 - **Images** — `send_multiple_images` and `send_image_file` send PNG, JPEG, GIF, WebP as native Signal attachments
-- **Voice** — `send_voice` sends audio files (OGG, MP3, WAV, M4A, AAC) as attachments
+- **Voice** — `send_voice` sends audio files (OGG, MP3, WAV, M4A, AAC) as native Signal voice notes
 - **Video** — `send_video` sends MP4 video files
 - **Documents** — `send_document` sends any file type (PDF, ZIP, etc.)
 
-All outgoing media goes through Signal's standard attachment API. Unlike some platforms, Signal does not distinguish between voice messages and file attachments at the protocol level.
+Outgoing voice uses Signal's native voice-note flag; other outgoing media goes through Signal's standard attachment API.
 
 Attachment size limit: **100 MB** (both directions).
 :::warning

--- a/website/docs/user-guide/messaging/signal.md
+++ b/website/docs/user-guide/messaging/signal.md
@@ -160,11 +160,11 @@ The adapter supports sending and receiving media in both directions.
 The agent can send media files via `MEDIA:` tags in responses. The following delivery methods are supported:
 
 - **Images** — `send_multiple_images` and `send_image_file` send PNG, JPEG, GIF, WebP as native Signal attachments
-- **Voice** — `send_voice` sends audio files (OGG, MP3, WAV, M4A, AAC) as native Signal voice notes
+- **Voice** — `send_voice` sends audio files (OGG, MP3, WAV, M4A, AAC) as native Signal voice notes in the iOS and Android apps
 - **Video** — `send_video` sends MP4 video files
 - **Documents** — `send_document` sends any file type (PDF, ZIP, etc.)
 
-Outgoing voice uses Signal's native voice-note flag; other outgoing media goes through Signal's standard attachment API.
+Outgoing voice uses Signal's native voice-note flag with M4A audio so the native Signal apps render it as an inline voice note. Hermes uses `ffmpeg` to transcode non-M4A audio; without `ffmpeg`, non-M4A voice replies fall back to regular playable audio attachments. Other outgoing media goes through Signal's standard attachment API.
 
 Attachment size limit: **100 MB** (both directions).
 :::warning


### PR DESCRIPTION
## What does this PR do?

Fixes Signal TTS voice replies so they can render as native Signal voice notes, including in the native iOS Signal app.

Signal `send_voice` replies now use signal-cli's `voice-note` parameter when possible, stage generated audio somewhere signal-cli can read it, and prepare non-M4A audio as M4A/AAC for native app playback.

If `ffmpeg` is unavailable or transcoding fails, Hermes falls back to sending the original audio as a regular playable attachment instead of failing the reply.

## Related Issue

No linked issue.

I checked existing upstream PRs and found adjacent Signal audio work, but not a duplicate:
- #4117 restores voice-note transcription/captioned replies.
- #8250 preserves native TTS format and sends captioned audio replies.

This PR specifically targets native Signal voice-note rendering via signal-cli's `voice-note` parameter and M4A preparation for iOS native Signal app playback.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Tests
- [ ] Other:

## Changes Made

- Send Signal `send_voice` replies with signal-cli's `voice-note` parameter when native voice-note delivery is available.
- Stage generated voice audio under Hermes cache storage so signal-cli can read it outside Python temp paths.
- Transcode non-M4A voice replies to M4A/AAC for native Signal app voice-note rendering, including iOS.
- Fall back to a regular audio attachment when `ffmpeg` is missing or transcoding fails.
- Document Signal voice reply behavior and the `ffmpeg` dependency/fallback.
- Add gateway tests for native voice-note sending and missing-`ffmpeg` fallback.

## How to Test

1. Configure Hermes with Signal gateway support and TTS/voice mode.
2. Trigger a Signal TTS reply.
3. Confirm the reply appears as a native Signal voice note in the native Signal iOS app.
4. Confirm the reply also appears as a native voice note in the native Signal Linux desktop app.
5. Temporarily make `ffmpeg` unavailable, then trigger a non-M4A voice reply and confirm Hermes sends a regular playable audio attachment instead of failing.
6. Run:

```bash
python -m pytest -q -o addopts='' tests/gateway/test_signal.py tests/gateway/test_voice_command.py
```

## Checklist

- [x] I have read and followed the contributing guidelines.
- [x] My commits follow Conventional Commits.
- [x] I searched existing issues/PRs for duplicates.
- [x] My changes are focused and related to this PR.
- [ ] I ran the full test suite.
- [x] I added or updated relevant tests.
- [x] I tested the affected behavior manually.
- [x] I updated documentation where needed.
- [x] I considered cross-platform impact.

Notes:
- Full suite was intentionally not run in my local environment because the project-level test runner can touch the real Hermes runtime database there.
- Focused gateway tests passed: `278 passed`.
- Manual validation was done with a Linux Hermes gateway on CachyOS, the native Signal iOS app, and the native Signal Linux desktop app on CachyOS.

## For New Skills

Not applicable.

## Screenshots / Logs

Focused validation:

```bash
python -m pytest -q -o addopts='' tests/gateway/test_signal.py tests/gateway/test_voice_command.py
278 passed
```
