### PR TITLE
fix(agent): retry on empty assistant response with finish_reason=stop

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -11057,6 +11057,27 @@ class AIAgent:
                                 error_details.append("response.choices is None")
                             else:
                                 error_details.append("response.choices is empty")
+                        else:
+                            # Some providers (e.g. GLM 5.1 via Ollama) sometimes
+                            # return a well-shaped choice with empty text
+                            # content, finish_reason="stop", and no tool calls.
+                            # Without this guard, the assistant turn is recorded
+                            # as the placeholder "(empty)" and the user sees a
+                            # blank reply.  Route through the existing
+                            # retry/fallback machinery.
+                            _choice0 = response.choices[0]
+                            _msg0 = getattr(_choice0, "message", None)
+                            _content0 = getattr(_msg0, "content", None) if _msg0 is not None else None
+                            _reasoning0 = getattr(_msg0, "reasoning_content", None) if _msg0 is not None else None
+                            _tool_calls0 = getattr(_msg0, "tool_calls", None) if _msg0 is not None else None
+                            _finish0 = getattr(_choice0, "finish_reason", None)
+                            _content_empty = (_content0 is None) or (isinstance(_content0, str) and not _content0.strip())
+                            _reasoning_empty = (_reasoning0 is None) or (isinstance(_reasoning0, str) and not _reasoning0.strip())
+                            if _content_empty and _reasoning_empty and not _tool_calls0 and _finish0 in (None, "stop"):
+                                response_invalid = True
+                                error_details.append(
+                                    f"empty assistant content with finish_reason={_finish0!r}"
+                                )
 
                     if response_invalid:
                         # Stop spinner before printing error messages


### PR DESCRIPTION
## Problem

Some OpenAI-compatible providers (notably GLM 5.1 via Ollama, and observed sporadically with other reasoning models routed through the OpenAI client path) occasionally return a structurally valid choice that's logically empty:

- `message.content` is `None` or whitespace-only
- `message.reasoning_content` is `None` or whitespace-only
- `message.tool_calls` is empty/`None`
- `finish_reason` is `\"stop\"` (or absent)

The existing validity check in `AIAgent`'s response-handling block only flags `response.choices is None` or `response.choices` being empty, so these silent-empty turns slip through. They get recorded as the `\"(empty)\"` placeholder assistant message and surfaced to the user as a blank reply, with no automatic retry.

## Fix

Add an `else` arm to the existing branch that detects \"valid choice list, but the first choice has no usable payload,\" sets `response_invalid = True`, and falls through to the same retry/fallback machinery already used for the other invalid-response cases.

The detection is conservative — it only triggers when **all** of: content empty, reasoning empty, no tool calls, and `finish_reason in (None, \"stop\")`. That avoids flagging tool-only turns or turns that legitimately end with reasoning content.

## Repro

Run a non-trivial conversation against `glm-4.5` (or similar) via Ollama's OpenAI-compatible endpoint. Roughly one in N turns the user gets a blank reply where the model intended a normal stop. With this patch, the same scenarios surface a retry attempt and usually recover on the second try.

## Notes

- No public API changes. Pure additive guard in the existing validity-check site.
- Carried as a local patch on a v0.8.0 install for several weeks before submitting; behavior in production has been stable.
- I reviewed v0.12.0's compression and aux-failure surfacing changes (\"Notify users when configured aux model fails even if main-model fallback recovers\" in this release) — those address a different code path (auxiliary client failures during compression) and don't catch this case.