### PR TITLE
fix(cron): harden bound-home results and origin-local delivery

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -15,7 +15,7 @@ import re
 import uuid
 from datetime import datetime, timedelta
 from pathlib import Path
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_home, resolve_hermes_home, infer_profile_name
 from typing import Optional, Dict, List, Any, Union
 
 logger = logging.getLogger(__name__)
@@ -62,12 +62,27 @@ def _normalize_skill_list(skill: Optional[str] = None, skills: Optional[Any] = N
     return normalized
 
 
+def _normalize_job_binding(profile: Optional[str] = None, hermes_home: Optional[str] = None) -> Dict[str, Any]:
+    resolved_home = resolve_hermes_home(profile=profile, hermes_home=hermes_home)
+    if hermes_home is not None:
+        inferred_profile = infer_profile_name(resolved_home)
+    else:
+        inferred_profile = str(profile).strip() if isinstance(profile, str) and str(profile).strip() else infer_profile_name(resolved_home)
+    return {
+        "profile": inferred_profile,
+        "hermes_home": str(resolved_home),
+    }
+
+
 def _apply_skill_fields(job: Dict[str, Any]) -> Dict[str, Any]:
     """Return a job dict with canonical `skills` and legacy `skill` fields aligned."""
     normalized = dict(job)
     skills = _normalize_skill_list(normalized.get("skill"), normalized.get("skills"))
     normalized["skills"] = skills
     normalized["skill"] = skills[0] if skills else None
+    binding = _normalize_job_binding(normalized.get("profile"), normalized.get("hermes_home"))
+    normalized["profile"] = binding["profile"]
+    normalized["hermes_home"] = binding["hermes_home"]
     return normalized
 
 
@@ -435,6 +450,8 @@ def create_job(
     context_from: Optional[Union[str, List[str]]] = None,
     enabled_toolsets: Optional[List[str]] = None,
     workdir: Optional[str] = None,
+    profile: Optional[str] = None,
+    hermes_home: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -466,6 +483,8 @@ def create_job(
                 terminal/file/code_exec tools use it as their working directory
                 (via TERMINAL_CWD).  When unset, the old behaviour is preserved
                 (no context files injected, tools use the scheduler's cwd).
+        profile: Optional target profile name for cron execution.
+        hermes_home: Optional explicit Hermes home override for cron execution.
 
     Returns:
         The created job dict
@@ -508,6 +527,8 @@ def create_job(
     else:
         context_from = None
 
+    binding = _normalize_job_binding(profile=profile, hermes_home=hermes_home)
+
     label_source = (prompt or (normalized_skills[0] if normalized_skills else None)) or "cron job"
     job = {
         "id": job_id,
@@ -520,6 +541,8 @@ def create_job(
         "base_url": normalized_base_url,
         "script": normalized_script,
         "context_from": context_from,
+        "profile": binding["profile"],
+        "hermes_home": binding["hermes_home"],
         "schedule": parsed_schedule,
         "schedule_display": parsed_schedule.get("display", schedule),
         "repeat": {
@@ -583,13 +606,24 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
             else:
                 updates["workdir"] = _normalize_workdir(_wd)
 
-        updated = _apply_skill_fields({**job, **updates})
+        merged = {**job, **updates}
+        if "profile" in updates and "hermes_home" not in updates:
+            merged.pop("hermes_home", None)
+        updated = _apply_skill_fields(merged)
         schedule_changed = "schedule" in updates
 
         if "skills" in updates or "skill" in updates:
             normalized_skills = _normalize_skill_list(updated.get("skill"), updated.get("skills"))
             updated["skills"] = normalized_skills
             updated["skill"] = normalized_skills[0] if normalized_skills else None
+
+        if "profile" in updates or "hermes_home" in updates:
+            binding = _normalize_job_binding(
+                profile=updated.get("profile"),
+                hermes_home=updated.get("hermes_home") if "hermes_home" in updates else (None if "profile" in updates else updated.get("hermes_home")),
+            )
+            updated["profile"] = binding["profile"]
+            updated["hermes_home"] = binding["hermes_home"]
 
         if schedule_changed:
             updated_schedule = updated["schedule"]

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -34,7 +34,7 @@ from typing import List, Optional
 # the module) fail with ModuleNotFoundError for hermes_time et al.
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_home, resolve_hermes_home
 from hermes_cli.config import load_config
 from hermes_time import now as _hermes_now
 
@@ -776,7 +776,57 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
     return "\n".join(parts)
 
 
+def _resolve_job_hermes_home(job: dict) -> Path:
+    return resolve_hermes_home(profile=job.get("profile"), hermes_home=job.get("hermes_home"))
+
+
+def _run_job_in_bound_home(job: dict, hermes_home: Path) -> tuple[bool, str, str, Optional[str]]:
+    hermes_home = hermes_home.expanduser().resolve()
+    if not hermes_home.exists() or not hermes_home.is_dir():
+        error = f"Bound Hermes home does not exist or is not a directory: {hermes_home}"
+        return False, f"# Cron Job Failure\n\n```\n{error}\n```\n", "", error
+    child_env = os.environ.copy()
+    child_env["HERMES_HOME"] = str(hermes_home)
+    payload = json.dumps(job)
+    runner = (
+        "import json, sys; "
+        "from cron.scheduler import _run_job_local; "
+        "job=json.loads(sys.stdin.read()); "
+        "result=_run_job_local(job); "
+        "print(json.dumps({'success': result[0], 'output': result[1], 'final_response': result[2], 'error': result[3]}))"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", runner],
+        input=payload,
+        capture_output=True,
+        text=True,
+        env=child_env,
+        cwd=str(hermes_home),
+    )
+    if proc.returncode != 0:
+        error = (proc.stderr or proc.stdout or "subprocess execution failed").strip()
+        return False, f"# Cron Job Failure\n\n```\n{error}\n```\n", "", error
+    raw_stdout = (proc.stdout or "").strip()
+    candidate = raw_stdout.splitlines()[-1].strip() if raw_stdout else ""
+    try:
+        parsed = json.loads(candidate)
+    except Exception as exc:
+        raw = (proc.stdout or proc.stderr or "").strip()
+        error = f"Failed to parse child result: {exc}"
+        return False, f"# Cron Job Failure\n\n```\n{error}\n{raw}\n```\n", "", error
+    return bool(parsed.get("success")), str(parsed.get("output") or ""), str(parsed.get("final_response") or ""), parsed.get("error")
+
+
 def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
+    target_home = _resolve_job_hermes_home(job)
+    current_home = _hermes_home.expanduser().resolve()
+    if target_home != current_home:
+        logger.info("Running job '%s' in bound Hermes home: %s", job.get("name", job.get("id", "?")), target_home)
+        return _run_job_in_bound_home(job, target_home)
+    return _run_job_local(job)
+
+
+def _run_job_local(job: dict) -> tuple[bool, str, str, Optional[str]]:
     """
     Execute a single cron job.
     
@@ -784,6 +834,12 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         Tuple of (success, full_output_doc, final_response, error_message)
     """
     from run_agent import AIAgent
+    from tools.website_policy import (
+        reset_unattended_strict_website_policy,
+        set_unattended_strict_website_policy,
+    )
+
+    unattended_policy_token = set_unattended_strict_website_policy(True)
     
     # Initialize SQLite session store so cron job messages are persisted
     # and discoverable via session_search (same pattern as gateway/run.py).
@@ -1192,6 +1248,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         clear_session_vars(_ctx_tokens)
         for _var_name in _cron_delivery_vars:
             _VAR_MAP[_var_name].set("")
+        reset_unattended_strict_website_policy(unattended_policy_token)
         if _session_db:
             try:
                 _session_db.end_session(_cron_session_id, "cron_complete")

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -16,6 +16,7 @@ import logging
 import os
 import subprocess
 import sys
+import tempfile
 
 # fcntl is Unix-only; on Windows use msvcrt for file locking
 try:
@@ -162,21 +163,13 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
                 "chat_id": str(origin["chat_id"]),
                 "thread_id": origin.get("thread_id"),
             }
-        # Origin missing (e.g. job created via API/script) — try each
-        # platform's home channel as a fallback instead of silently dropping.
-        for platform_name in _HOME_TARGET_ENV_VARS:
-            chat_id = _get_home_target_chat_id(platform_name)
-            if chat_id:
-                logger.info(
-                    "Job '%s' has deliver=origin but no origin; falling back to %s home channel",
-                    job.get("name", job.get("id", "?")),
-                    platform_name,
-                )
-                return {
-                    "platform": platform_name,
-                    "chat_id": chat_id,
-                    "thread_id": None,
-                }
+        # Unattended/API-created jobs can carry deliver=origin with no stored
+        # origin metadata. Treat those as local-only consistently instead of
+        # opportunistically falling back to a platform home channel.
+        logger.info(
+            "Job '%s' has deliver=origin but no origin metadata; no delivery target will be resolved",
+            job.get("name", job.get("id", "?")),
+        )
         return None
 
     if ":" in deliver_value:
@@ -332,7 +325,15 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     """
     targets = _resolve_delivery_targets(job)
     if not targets:
-        if job.get("deliver", "local") != "local":
+        deliver_mode = _normalize_deliver_value(job.get("deliver", "local")).strip().lower()
+        origin = job.get("origin") or {}
+        if deliver_mode == "origin" and not origin:
+            logger.info(
+                "Job '%s': deliver=origin but no origin metadata is stored; treating as local-only",
+                job["id"],
+            )
+            return None
+        if deliver_mode != "local":
             msg = f"no delivery target resolved for deliver={job.get('deliver', 'local')}"
             logger.warning("Job '%s': %s", job["id"], msg)
             return msg
@@ -787,34 +788,68 @@ def _run_job_in_bound_home(job: dict, hermes_home: Path) -> tuple[bool, str, str
         return False, f"# Cron Job Failure\n\n```\n{error}\n```\n", "", error
     child_env = os.environ.copy()
     child_env["HERMES_HOME"] = str(hermes_home)
-    payload = json.dumps(job)
-    runner = (
-        "import json, sys; "
-        "from cron.scheduler import _run_job_local; "
-        "job=json.loads(sys.stdin.read()); "
-        "result=_run_job_local(job); "
-        "print(json.dumps({'success': result[0], 'output': result[1], 'final_response': result[2], 'error': result[3]}))"
-    )
-    proc = subprocess.run(
-        [sys.executable, "-c", runner],
-        input=payload,
-        capture_output=True,
-        text=True,
-        env=child_env,
-        cwd=str(hermes_home),
-    )
-    if proc.returncode != 0:
-        error = (proc.stderr or proc.stdout or "subprocess execution failed").strip()
-        return False, f"# Cron Job Failure\n\n```\n{error}\n```\n", "", error
-    raw_stdout = (proc.stdout or "").strip()
-    candidate = raw_stdout.splitlines()[-1].strip() if raw_stdout else ""
+    result_path: Optional[Path] = None
     try:
-        parsed = json.loads(candidate)
+        result_dir = hermes_home / "cron" / "tmp"
+        result_dir.mkdir(parents=True, exist_ok=True)
+        with tempfile.NamedTemporaryFile(prefix="child-result-", suffix=".json", dir=result_dir, delete=False) as tf:
+            result_path = Path(tf.name)
+        child_env["HERMES_CRON_CHILD_RESULT_PATH"] = str(result_path)
     except Exception as exc:
-        raw = (proc.stdout or proc.stderr or "").strip()
-        error = f"Failed to parse child result: {exc}"
-        return False, f"# Cron Job Failure\n\n```\n{error}\n{raw}\n```\n", "", error
-    return bool(parsed.get("success")), str(parsed.get("output") or ""), str(parsed.get("final_response") or ""), parsed.get("error")
+        error = f"Failed to prepare child result file in bound Hermes home: {exc}"
+        return False, f"# Cron Job Failure\n\n```\n{error}\n```\n", "", error
+    payload = json.dumps(job)
+    runner = "\n".join([
+        "import json, os, sys, traceback",
+        "payload = {'success': False, 'output': '', 'final_response': '', 'error': 'unknown child failure'}",
+        "try:",
+        "    from cron.scheduler import _run_job_local",
+        "    job = json.loads(sys.stdin.read())",
+        "    result = _run_job_local(job)",
+        "    payload = {'success': result[0], 'output': result[1], 'final_response': result[2], 'error': result[3]}",
+        "except BaseException as exc:",
+        "    payload = {'success': False, 'output': '# Cron Job Failure\\n\\n```\\n' + ''.join(traceback.format_exception_only(type(exc), exc)).strip() + '\\n```\\n', 'final_response': '', 'error': str(exc)}",
+        "text = json.dumps(payload)",
+        "path = os.environ.get('HERMES_CRON_CHILD_RESULT_PATH')",
+        "if path:",
+        "    try:",
+        "        open(path, 'w', encoding='utf-8').write(text)",
+        "    except Exception:",
+        "        pass",
+        "print(text)",
+    ])
+    try:
+        proc = subprocess.run(
+            [sys.executable, "-c", runner],
+            input=payload,
+            capture_output=True,
+            text=True,
+            env=child_env,
+            cwd=str(hermes_home),
+        )
+        if proc.returncode != 0:
+            error = (proc.stderr or proc.stdout or "subprocess execution failed").strip()
+            return False, f"# Cron Job Failure\n\n```\n{error}\n```\n", "", error
+        raw_stdout = (proc.stdout or "").strip()
+        candidate = raw_stdout.splitlines()[-1].strip() if raw_stdout else ""
+        if not candidate and result_path and result_path.exists():
+            candidate = result_path.read_text(encoding="utf-8").strip()
+        try:
+            parsed = json.loads(candidate)
+        except Exception as exc:
+            raw = (proc.stdout or proc.stderr or "").strip()
+            if result_path and result_path.exists() and not candidate:
+                raw_result = result_path.read_text(encoding="utf-8", errors="ignore").strip()
+                raw = raw_result or raw
+            error = f"Failed to parse child result: {exc}"
+            return False, f"# Cron Job Failure\n\n```\n{error}\n{raw}\n```\n", "", error
+        return bool(parsed.get("success")), str(parsed.get("output") or ""), str(parsed.get("final_response") or ""), parsed.get("error")
+    finally:
+        try:
+            if result_path:
+                result_path.unlink(missing_ok=True)
+        except Exception:
+            pass
 
 
 def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -31,8 +31,6 @@ def get_default_hermes_root() -> Path:
     returns ``<root>`` so that ``profile list`` can see all profiles.
     Works both for standard (``~/.hermes/profiles/coder``) and Docker
     (``/opt/data/profiles/coder``) layouts.
-
-    Import-safe — no dependencies beyond stdlib.
     """
     native_home = Path.home() / ".hermes"
     env_home = os.environ.get("HERMES_HOME", "")
@@ -41,20 +39,62 @@ def get_default_hermes_root() -> Path:
     env_path = Path(env_home)
     try:
         env_path.resolve().relative_to(native_home.resolve())
-        # HERMES_HOME is under ~/.hermes (normal or profile mode)
         return native_home
     except ValueError:
         pass
-
-    # Docker / custom deployment.
-    # Check if this is a profile path: <root>/profiles/<name>
-    # If the immediate parent dir is named "profiles", the root is
-    # the grandparent — this covers Docker profiles correctly.
     if env_path.parent.name == "profiles":
         return env_path.parent.parent
-
-    # Not a profile path — HERMES_HOME itself is the root
     return env_path
+
+
+def resolve_hermes_home(profile: str | None = None, hermes_home: str | Path | None = None) -> Path:
+    """Resolve an explicit Hermes home or named profile into an absolute path."""
+    root = get_default_hermes_root().expanduser().resolve()
+    profiles_root = (root / "profiles").resolve()
+    if hermes_home:
+        resolved = Path(hermes_home).expanduser().resolve()
+        if resolved == root:
+            return resolved
+        try:
+            rel = resolved.relative_to(profiles_root)
+        except ValueError as exc:
+            raise ValueError(f"Invalid Hermes home outside allowed profile roots: {resolved}") from exc
+        if len(rel.parts) != 1 or not rel.parts[0]:
+            raise ValueError(f"Invalid Hermes home outside allowed profile roots: {resolved}")
+        return resolved
+    if profile is not None:
+        normalized = str(profile).strip()
+        if not normalized or normalized == "default":
+            return root
+        if normalized in {".", ".."} or "/" in normalized or "\\" in normalized or Path(normalized).name != normalized:
+            raise ValueError(f"Invalid Hermes profile name: {normalized!r}")
+        return (profiles_root / normalized).resolve()
+    return get_hermes_home().expanduser().resolve()
+
+
+def infer_profile_name(home: Path | str | None) -> str | None:
+    """Infer a profile name from a Hermes home path when possible."""
+    if not home:
+        return None
+    path = Path(home).expanduser().resolve()
+    candidates = []
+    for candidate in (get_default_hermes_root(), Path.home() / ".hermes"):
+        resolved = Path(candidate).expanduser().resolve()
+        if resolved not in candidates:
+            candidates.append(resolved)
+
+    for root in candidates:
+        if path == root:
+            return "default"
+        profiles_root = (root / "profiles").resolve()
+        try:
+            rel = path.relative_to(profiles_root)
+        except ValueError:
+            continue
+        parts = rel.parts
+        if len(parts) == 1 and parts[0]:
+            return parts[0]
+    return None
 
 
 def get_optional_skills_dir(default: Path | None = None) -> Path:

--- a/tests/cron/test_codex_execution_paths.py
+++ b/tests/cron/test_codex_execution_paths.py
@@ -103,10 +103,15 @@ def test_cron_run_job_codex_path_handles_internal_401_refresh(monkeypatch):
             "provider": "openai-codex",
             "api_mode": "codex_responses",
             "base_url": "https://chatgpt.com/backend-api/codex",
-            "api_key": "codex-token",
+            "api_key": "***",
         },
     )
     monkeypatch.setattr("hermes_cli.runtime_provider.format_runtime_provider_error", lambda exc: str(exc))
+    monkeypatch.setattr(
+        cron_scheduler,
+        "_resolve_job_hermes_home",
+        lambda job: cron_scheduler._hermes_home.expanduser().resolve(),
+    )
 
     _Codex401ThenSuccessAgent.refresh_attempts = 0
     _Codex401ThenSuccessAgent.last_init = {}

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -44,6 +44,60 @@ def cron_env(tmp_path, monkeypatch):
 class TestJobScriptField:
     """Test that the script field is stored and retrieved correctly."""
 
+    def test_create_job_with_profile_binding(self, cron_env):
+        from cron.jobs import create_job
+
+        job = create_job(prompt="Hello", schedule="every 1h", profile="coder")
+        assert job["profile"] == "coder"
+        assert job["hermes_home"] == str((cron_env / "profiles" / "coder").resolve())
+
+    def test_create_job_with_explicit_hermes_home_infers_profile(self, cron_env):
+        from cron.jobs import create_job
+
+        explicit = cron_env / "profiles" / "ops"
+        explicit.mkdir(parents=True)
+        job = create_job(prompt="Hello", schedule="every 1h", hermes_home=str(explicit))
+        assert job["profile"] == "ops"
+        assert job["hermes_home"] == str(explicit.resolve())
+
+    def test_create_job_rejects_non_profile_hermes_home(self, cron_env):
+        from cron.jobs import create_job
+
+        invalid = cron_env / "cron"
+        with pytest.raises(ValueError, match="Invalid Hermes home outside allowed profile roots"):
+            create_job(prompt="Hello", schedule="every 1h", hermes_home=str(invalid))
+
+    def test_update_job_profile_binding_recomputes_home(self, cron_env):
+        from cron.jobs import create_job, update_job
+
+        job = create_job(prompt="Hello", schedule="every 1h")
+        updated = update_job(job["id"], {"profile": "secure-voice"})
+        assert updated["profile"] == "secure-voice"
+        assert updated["hermes_home"] == str((cron_env / "profiles" / "secure-voice").resolve())
+
+    def test_explicit_hermes_home_overrides_conflicting_profile_label(self, cron_env):
+        from cron.jobs import create_job
+
+        explicit = cron_env / "profiles" / "ops"
+        explicit.mkdir(parents=True)
+        job = create_job(prompt="Hello", schedule="every 1h", profile="coder", hermes_home=str(explicit))
+        assert job["profile"] == "ops"
+        assert job["hermes_home"] == str(explicit.resolve())
+
+    def test_cronjob_tool_create_with_profile_binding(self, cron_env, monkeypatch):
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        from tools.cronjob_tools import cronjob
+
+        result = json.loads(cronjob(
+            action="create",
+            schedule="every 1h",
+            prompt="Monitor things",
+            profile="secure-voice",
+        ))
+        assert result["success"] is True
+        assert result["job"]["profile"] == "secure-voice"
+        assert result["job"]["hermes_home"] == str((cron_env / "profiles" / "secure-voice").resolve())
+
     def test_create_job_with_script(self, cron_env):
         from cron.jobs import create_job, get_job
 
@@ -90,6 +144,31 @@ class TestJobScriptField:
 
 class TestRunJobScript:
     """Test the _run_job_script() function."""
+
+    def test_run_job_uses_bound_home_subprocess_for_other_profile(self, cron_env, monkeypatch):
+        from cron import scheduler as sched_mod
+
+        target_home = cron_env / "profiles" / "secure-voice"
+        target_home.mkdir(parents=True)
+        seen = {}
+
+        monkeypatch.setattr(sched_mod, "_hermes_home", cron_env)
+
+        def fake_bound(job, hermes_home):
+            seen["job"] = job
+            seen["home"] = hermes_home
+            return True, "bound", "[SILENT]", None
+
+        def fake_local(job):
+            raise AssertionError("local runner should not be used for bound-home jobs")
+
+        monkeypatch.setattr(sched_mod, "_run_job_in_bound_home", fake_bound)
+        monkeypatch.setattr(sched_mod, "_run_job_local", fake_local)
+
+        result = sched_mod.run_job({"id": "j1", "name": "job", "prompt": "x", "hermes_home": str(target_home)})
+
+        assert result == (True, "bound", "[SILENT]", None)
+        assert seen["home"] == target_home.resolve()
 
     def test_successful_script(self, cron_env):
         from cron.scheduler import _run_job_script

--- a/tests/cron/test_cron_workdir.py
+++ b/tests/cron/test_cron_workdir.py
@@ -208,6 +208,10 @@ class TestTickWorkdirPartition:
     def test_workdir_jobs_run_sequentially(self, tmp_path, monkeypatch):
         import cron.scheduler as sched
 
+        lock_dir = tmp_path / "cron-lock"
+        monkeypatch.setattr(sched, "_LOCK_DIR", lock_dir)
+        monkeypatch.setattr(sched, "_LOCK_FILE", lock_dir / ".tick.lock")
+
         # Two "jobs" — one with workdir, one without.  get_due_jobs returns both.
         workdir_job = {"id": "a", "name": "A", "workdir": str(tmp_path)}
         parallel_job = {"id": "b", "name": "B", "workdir": None}
@@ -298,6 +302,11 @@ class TestRunJobTerminalCwd:
 
         # Stub scheduler helpers that would otherwise hit the filesystem / config.
         monkeypatch.setattr(sched, "_build_job_prompt", lambda job, prerun_script=None: "hi")
+        monkeypatch.setattr(
+            sched,
+            "_resolve_job_hermes_home",
+            lambda job: sched._hermes_home.expanduser().resolve(),
+        )
         monkeypatch.setattr(sched, "_resolve_origin", lambda job: None)
         monkeypatch.setattr(sched, "_resolve_delivery_target", lambda job: None)
         monkeypatch.setattr(sched, "_resolve_cron_enabled_toolsets", lambda job, cfg: None)

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -64,49 +64,16 @@ class TestResolveDeliveryTarget:
             "thread_id": "17585",
         }
 
-    @pytest.mark.parametrize(
-        ("platform", "env_var", "chat_id"),
-        [
-            ("matrix", "MATRIX_HOME_ROOM", "!bot-room:example.org"),
-            ("signal", "SIGNAL_HOME_CHANNEL", "+15551234567"),
-            ("mattermost", "MATTERMOST_HOME_CHANNEL", "team-town-square"),
-            ("sms", "SMS_HOME_CHANNEL", "+15557654321"),
-            ("email", "EMAIL_HOME_ADDRESS", "home@example.com"),
-            ("dingtalk", "DINGTALK_HOME_CHANNEL", "cidNNN"),
-            ("feishu", "FEISHU_HOME_CHANNEL", "oc_home"),
-            ("wecom", "WECOM_HOME_CHANNEL", "wecom-home"),
-            ("weixin", "WEIXIN_HOME_CHANNEL", "wxid_home"),
-            ("qqbot", "QQ_HOME_CHANNEL", "group-openid-home"),
-        ],
-    )
-    def test_origin_delivery_without_origin_falls_back_to_supported_home_channels(
-        self, monkeypatch, platform, env_var, chat_id
-    ):
-        for fallback_env in (
-            "MATRIX_HOME_ROOM",
-            "MATRIX_HOME_CHANNEL",
-            "TELEGRAM_HOME_CHANNEL",
-            "DISCORD_HOME_CHANNEL",
-            "SLACK_HOME_CHANNEL",
-            "SIGNAL_HOME_CHANNEL",
-            "MATTERMOST_HOME_CHANNEL",
-            "SMS_HOME_CHANNEL",
-            "EMAIL_HOME_ADDRESS",
-            "DINGTALK_HOME_CHANNEL",
-            "BLUEBUBBLES_HOME_CHANNEL",
-            "FEISHU_HOME_CHANNEL",
-            "WECOM_HOME_CHANNEL",
-            "WEIXIN_HOME_CHANNEL",
-            "QQ_HOME_CHANNEL",
+    def test_origin_delivery_without_origin_is_local_only_even_if_home_channels_exist(self, monkeypatch):
+        for fallback_env, value in (
+            ("MATRIX_HOME_ROOM", "!bot-room:example.org"),
+            ("TELEGRAM_HOME_CHANNEL", "-1001"),
+            ("DISCORD_HOME_CHANNEL", "999888777"),
+            ("SIGNAL_HOME_CHANNEL", "+15550001111"),
         ):
-            monkeypatch.delenv(fallback_env, raising=False)
-        monkeypatch.setenv(env_var, chat_id)
+            monkeypatch.setenv(fallback_env, value)
 
-        assert _resolve_delivery_target({"deliver": "origin"}) == {
-            "platform": platform,
-            "chat_id": chat_id,
-            "thread_id": None,
-        }
+        assert _resolve_delivery_target({"deliver": "origin"}) is None
 
     def test_bare_matrix_delivery_uses_matrix_home_room(self, monkeypatch):
         monkeypatch.delenv("MATRIX_HOME_CHANNEL", raising=False)
@@ -394,6 +361,38 @@ class TestDeliverResultWrapping:
         assert sent_content == "Clean output only."
         assert "Cronjob Response" not in sent_content
         assert "The agent cannot see" not in sent_content
+
+    def test_delivery_treats_origin_without_metadata_as_local_only(self, monkeypatch):
+        """Unattended origin-less jobs must not fall back to any configured home channel."""
+        monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "-1001")
+
+        with patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock:
+            job = {
+                "id": "orphan-origin-job",
+                "name": "orphan-origin-job",
+                "deliver": "origin",
+                "origin": None,
+            }
+            result = _deliver_result(job, "No delivery expected.")
+
+        assert result is None
+        send_mock.assert_not_called()
+
+    def test_delivery_treats_list_form_origin_without_metadata_as_local_only(self, monkeypatch):
+        """Legacy/list-form deliver values should normalize before origin-local-only checks."""
+        monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "-1001")
+
+        with patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock:
+            job = {
+                "id": "orphan-origin-list-job",
+                "name": "orphan-origin-list-job",
+                "deliver": ["origin"],
+                "origin": None,
+            }
+            result = _deliver_result(job, "No delivery expected.")
+
+        assert result is None
+        send_mock.assert_not_called()
 
     def test_delivery_extracts_media_tags_before_send(self):
         """Cron delivery should pass MEDIA attachments separately to the send helper."""
@@ -693,6 +692,7 @@ class TestRunJobSessionPersistence:
         fake_db = MagicMock()
 
         with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_job_hermes_home", return_value=tmp_path), \
              patch("cron.scheduler._resolve_origin", return_value=None), \
              patch("dotenv.load_dotenv"), \
              patch("hermes_state.SessionDB", return_value=fake_db), \
@@ -740,6 +740,7 @@ class TestRunJobSessionPersistence:
         fake_db = MagicMock()
 
         with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_job_hermes_home", return_value=tmp_path), \
              patch("cron.scheduler._resolve_origin", return_value=None), \
              patch("dotenv.load_dotenv"), \
              patch("hermes_state.SessionDB", return_value=fake_db), \
@@ -777,6 +778,7 @@ class TestRunJobSessionPersistence:
         fake_db = MagicMock()
 
         with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_job_hermes_home", return_value=tmp_path), \
              patch("cron.scheduler._resolve_origin", return_value=None), \
              patch("dotenv.load_dotenv"), \
              patch("hermes_state.SessionDB", return_value=fake_db), \
@@ -805,13 +807,14 @@ class TestRunJobSessionPersistence:
         fake_db = MagicMock()
         return fake_db, [
             patch("cron.scheduler._hermes_home", tmp_path),
+            patch("cron.scheduler._resolve_job_hermes_home", return_value=tmp_path),
             patch("cron.scheduler._resolve_origin", return_value=None),
             patch("dotenv.load_dotenv"),
             patch("hermes_state.SessionDB", return_value=fake_db),
             patch(
                 "hermes_cli.runtime_provider.resolve_runtime_provider",
                 return_value={
-                    "api_key": "test-key",
+                    "api_key": "***",
                     "base_url": "https://example.invalid/v1",
                     "provider": "openrouter",
                     "api_mode": "chat_completions",
@@ -827,7 +830,7 @@ class TestRunJobSessionPersistence:
             "enabled_toolsets": ["web", "terminal", "file"],
         }
         fake_db, patches = self._make_run_job_patches(tmp_path)
-        with patches[0], patches[1], patches[2], patches[3], patches[4], \
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], \
              patch("run_agent.AIAgent") as mock_agent_cls:
             mock_agent = MagicMock()
             mock_agent.run_conversation.return_value = {"final_response": "ok"}
@@ -852,7 +855,7 @@ class TestRunJobSessionPersistence:
             "prompt": "hello",
         }
         fake_db, patches = self._make_run_job_patches(tmp_path)
-        with patches[0], patches[1], patches[2], patches[3], patches[4], \
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], \
              patch("run_agent.AIAgent") as mock_agent_cls:
             mock_agent = MagicMock()
             mock_agent.run_conversation.return_value = {"final_response": "ok"}
@@ -880,7 +883,7 @@ class TestRunJobSessionPersistence:
         fake_db, patches = self._make_run_job_patches(tmp_path)
         # Even if the user has ``hermes tools`` configured to enable web+file
         # for cron, the per-job override wins.
-        with patches[0], patches[1], patches[2], patches[3], patches[4], \
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], \
              patch("run_agent.AIAgent") as mock_agent_cls, \
              patch(
                  "hermes_cli.tools_config._get_platform_tools",
@@ -908,6 +911,7 @@ class TestRunJobSessionPersistence:
         fake_db = MagicMock()
 
         with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_job_hermes_home", return_value=tmp_path), \
              patch("cron.scheduler._resolve_origin", return_value=None), \
              patch("dotenv.load_dotenv"), \
              patch("hermes_state.SessionDB", return_value=fake_db), \
@@ -943,6 +947,8 @@ class TestRunJobSessionPersistence:
         from cron.scheduler import tick
         from cron.jobs import load_jobs, save_jobs
 
+        lock_dir = tmp_path / "cron-lock"
+
         job = {
             "id": "empty-job",
             "name": "empty-test",
@@ -957,6 +963,8 @@ class TestRunJobSessionPersistence:
         fake_db = MagicMock()
 
         with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._LOCK_DIR", lock_dir), \
+             patch("cron.scheduler._LOCK_FILE", lock_dir / ".tick.lock"), \
              patch("cron.scheduler.get_due_jobs", return_value=[job]), \
              patch("cron.scheduler.advance_next_run"), \
              patch("cron.scheduler.mark_job_run") as mock_mark, \
@@ -1000,6 +1008,7 @@ class TestRunJobSessionPersistence:
                 return {"final_response": "ok"}
 
         with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_job_hermes_home", return_value=tmp_path), \
              patch("hermes_state.SessionDB", return_value=fake_db), \
              patch(
                  "hermes_cli.runtime_provider.resolve_runtime_provider",
@@ -1066,6 +1075,7 @@ class TestRunJobSessionPersistence:
                 return {"final_response": "ok"}
 
         with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_job_hermes_home", return_value=tmp_path), \
              patch("hermes_state.SessionDB", return_value=fake_db), \
              patch(
                  "hermes_cli.runtime_provider.resolve_runtime_provider",
@@ -1117,6 +1127,7 @@ class TestRunJobConfigLogging:
         }
 
         with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_job_hermes_home", return_value=tmp_path), \
              patch("cron.scheduler._resolve_origin", return_value=None), \
              patch("dotenv.load_dotenv"), \
              patch("run_agent.AIAgent") as mock_agent_cls:
@@ -1146,6 +1157,7 @@ class TestRunJobConfigLogging:
         }
 
         with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_job_hermes_home", return_value=tmp_path), \
              patch("cron.scheduler._resolve_origin", return_value=None), \
              patch("dotenv.load_dotenv"), \
              patch("run_agent.AIAgent") as mock_agent_cls:
@@ -1185,6 +1197,7 @@ class TestRunJobSkillBacked:
             return {"final_response": "ok"}
 
         with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_job_hermes_home", return_value=tmp_path), \
              patch("cron.scheduler._resolve_origin", return_value=None), \
              patch("dotenv.load_dotenv"), \
              patch("hermes_state.SessionDB", return_value=fake_db), \
@@ -1244,6 +1257,7 @@ class TestRunJobSkillBacked:
             return {"final_response": "ok"}
 
         with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_job_hermes_home", return_value=tmp_path), \
              patch("cron.scheduler._resolve_origin", return_value=None), \
              patch("tools.credential_files._resolve_hermes_home", return_value=tmp_path), \
              patch("dotenv.load_dotenv"), \
@@ -1283,6 +1297,7 @@ class TestRunJobSkillBacked:
         fake_db = MagicMock()
 
         with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_job_hermes_home", return_value=tmp_path), \
              patch("cron.scheduler._resolve_origin", return_value=None), \
              patch("dotenv.load_dotenv"), \
              patch("hermes_state.SessionDB", return_value=fake_db), \
@@ -1329,6 +1344,7 @@ class TestRunJobSkillBacked:
             return json.dumps({"success": True, "content": f"# {name}\nInstructions for {name}."})
 
         with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_job_hermes_home", return_value=tmp_path), \
              patch("cron.scheduler._resolve_origin", return_value=None), \
              patch("dotenv.load_dotenv"), \
              patch("hermes_state.SessionDB", return_value=fake_db), \
@@ -1364,6 +1380,13 @@ class TestRunJobSkillBacked:
 
 class TestSilentDelivery:
     """Verify that [SILENT] responses suppress delivery while still saving output."""
+
+    @pytest.fixture(autouse=True)
+    def _isolated_tick_lock(self, tmp_path):
+        lock_dir = tmp_path / "cron-lock"
+        with patch("cron.scheduler._LOCK_DIR", lock_dir), \
+             patch("cron.scheduler._LOCK_FILE", lock_dir / ".tick.lock"):
+            yield
 
     def _make_job(self):
         return {
@@ -1553,9 +1576,13 @@ class TestRunJobWakeGate:
             "source": "stub",
             "requested_provider": None,
         }
+        import cron.scheduler as scheduler
         with patch(
             "hermes_cli.runtime_provider.resolve_runtime_provider",
             return_value=fake_runtime,
+        ), patch(
+            "cron.scheduler._resolve_job_hermes_home",
+            side_effect=lambda job: scheduler._hermes_home,
         ):
             yield
 
@@ -2000,3 +2027,23 @@ class TestSendMediaTimeoutCancelsFuture:
         # 2. Second file still got dispatched — one timeout doesn't abort the batch
         adapter.send_video.assert_called_once()
         assert adapter.send_video.call_args[1]["video_path"] == "/tmp/fast.mp4"
+
+
+class TestBoundHomeRunJob:
+    def test_bound_home_tempfile_setup_failure_returns_structured_error(self, tmp_path):
+        import cron.scheduler as sched
+
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+
+        with patch("cron.scheduler.tempfile.NamedTemporaryFile", side_effect=OSError("disk full")):
+            success, output, final_response, error = sched._run_job_in_bound_home(
+                {"id": "job-1", "name": "bound-home-failure", "prompt": "ping"},
+                hermes_home,
+            )
+
+        assert success is False
+        assert final_response == ""
+        assert error == "Failed to prepare child result file in bound Hermes home: disk full"
+        assert "# Cron Job Failure" in output
+        assert "disk full" in output

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -7,7 +7,12 @@ from unittest.mock import patch
 import pytest
 
 import hermes_constants
-from hermes_constants import get_default_hermes_root, is_container
+from hermes_constants import (
+    get_default_hermes_root,
+    infer_profile_name,
+    is_container,
+    resolve_hermes_home,
+)
 
 
 class TestGetDefaultHermesRoot:
@@ -61,6 +66,81 @@ class TestGetDefaultHermesRoot:
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         monkeypatch.setenv("HERMES_HOME", str(profile))
         assert get_default_hermes_root() == docker_root
+
+
+class TestResolveHermesHome:
+    def test_explicit_hermes_home_wins(self, tmp_path, monkeypatch):
+        root = tmp_path / ".hermes"
+        explicit = root / "profiles" / "custom-home"
+        explicit.mkdir(parents=True)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(root))
+        resolved = resolve_hermes_home(profile="coder", hermes_home=explicit)
+        assert resolved == explicit.resolve()
+
+    def test_explicit_hermes_home_outside_root_rejected(self, tmp_path, monkeypatch):
+        outside = tmp_path / "outside-home"
+        outside.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        with pytest.raises(ValueError, match="Invalid Hermes home outside allowed profile roots"):
+            resolve_hermes_home(hermes_home=outside)
+
+    def test_explicit_hermes_home_non_profile_descendant_rejected(self, tmp_path, monkeypatch):
+        root = tmp_path / ".hermes"
+        invalid = root / "cron"
+        invalid.mkdir(parents=True)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(root))
+        with pytest.raises(ValueError, match="Invalid Hermes home outside allowed profile roots"):
+            resolve_hermes_home(hermes_home=invalid)
+
+    def test_invalid_profile_name_rejected(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        with pytest.raises(ValueError, match="Invalid Hermes profile name"):
+            resolve_hermes_home(profile="../../escape")
+
+    def test_default_profile_resolves_to_root(self, tmp_path, monkeypatch):
+        root = tmp_path / ".hermes"
+        root.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(root / "profiles" / "ignored"))
+        assert resolve_hermes_home(profile="default") == root.resolve()
+
+    def test_named_profile_resolves_under_root(self, tmp_path, monkeypatch):
+        root = tmp_path / ".hermes"
+        (root / "profiles" / "coder").mkdir(parents=True)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(root))
+        assert resolve_hermes_home(profile="coder") == (root / "profiles" / "coder").resolve()
+
+    def test_without_inputs_uses_current_home(self, tmp_path, monkeypatch):
+        current = tmp_path / ".hermes" / "profiles" / "research"
+        current.mkdir(parents=True)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(current))
+        assert resolve_hermes_home() == current.resolve()
+
+
+class TestInferProfileName:
+    def test_infers_default_for_root_home(self, tmp_path, monkeypatch):
+        root = tmp_path / ".hermes"
+        root.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        assert infer_profile_name(root) == "default"
+
+    def test_infers_named_profile_under_root(self, tmp_path, monkeypatch):
+        root = tmp_path / ".hermes"
+        profile = root / "profiles" / "coder"
+        profile.mkdir(parents=True)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        assert infer_profile_name(profile) == "coder"
+
+    def test_returns_none_for_non_profile_path(self, tmp_path, monkeypatch):
+        other = tmp_path / "not-hermes"
+        other.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        assert infer_profile_name(other) is None
 
 
 class TestIsContainer:

--- a/tests/tools/test_website_policy_strict.py
+++ b/tests/tools/test_website_policy_strict.py
@@ -1,0 +1,112 @@
+from pathlib import Path
+
+from tools.website_policy import check_website_access
+
+
+def _write_config(path: Path, text: str) -> Path:
+    path.write_text(text)
+    return path
+
+
+def test_unattended_strict_blocks_when_policy_disabled(tmp_path, monkeypatch):
+    cfg = _write_config(
+        tmp_path / "config.yaml",
+        """
+security:
+  website_blocklist:
+    enabled: false
+""".strip()
+        + "\n",
+    )
+    monkeypatch.setenv("HERMES_UNATTENDED_STRICT_WEBSITE_POLICY", "1")
+
+    result = check_website_access("https://example.com", config_path=cfg)
+
+    assert result is not None
+    assert result["rule"] == "policy-disabled"
+
+
+def test_unattended_strict_blocks_on_allowlist_miss(tmp_path, monkeypatch):
+    allowlist = tmp_path / "allow.txt"
+    allowlist.write_text("allowed.example\n")
+    cfg = _write_config(
+        tmp_path / "config.yaml",
+        f"""
+security:
+  website_blocklist:
+    enabled: true
+    mode: allowlist
+    allowlist_files:
+      - {allowlist}
+""".strip()
+        + "\n",
+    )
+    monkeypatch.setenv("HERMES_UNATTENDED_STRICT_WEBSITE_POLICY", "1")
+
+    result = check_website_access("https://blocked.example", config_path=cfg)
+
+    assert result is not None
+    assert result["rule"] == "allowlist-miss"
+
+
+def test_unattended_strict_allows_allowlisted_host(tmp_path, monkeypatch):
+    allowlist = tmp_path / "allow.txt"
+    allowlist.write_text("allowed.example\n")
+    cfg = _write_config(
+        tmp_path / "config.yaml",
+        f"""
+security:
+  website_blocklist:
+    enabled: true
+    mode: allowlist
+    allowlist_files:
+      - {allowlist}
+""".strip()
+        + "\n",
+    )
+    monkeypatch.setenv("HERMES_UNATTENDED_STRICT_WEBSITE_POLICY", "1")
+
+    result = check_website_access("https://allowed.example/path", config_path=cfg)
+
+    assert result is None
+
+
+def test_unattended_strict_reports_empty_allowlist(tmp_path, monkeypatch):
+    cfg = _write_config(
+        tmp_path / "config.yaml",
+        """
+security:
+  website_blocklist:
+    enabled: true
+    mode: allowlist
+""".strip()
+        + "\n",
+    )
+    monkeypatch.setenv("HERMES_UNATTENDED_STRICT_WEBSITE_POLICY", "1")
+
+    result = check_website_access("https://blocked.example", config_path=cfg)
+
+    assert result is not None
+    assert result["rule"] == "allowlist-empty"
+
+
+def test_unattended_strict_fails_closed_on_default_path_policy_error(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    _write_config(
+        hermes_home / "config.yaml",
+        """
+security:
+  website_blocklist:
+    enabled: true
+    mode: invalid-mode
+""".strip()
+        + "\n",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_UNATTENDED_STRICT_WEBSITE_POLICY", "1")
+
+    result = check_website_access("https://example.com")
+
+    assert result is not None
+    assert result["rule"] == "policy-error"

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -222,6 +222,8 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         "model": job.get("model"),
         "provider": job.get("provider"),
         "base_url": job.get("base_url"),
+        "profile": job.get("profile"),
+        "hermes_home": job.get("hermes_home"),
         "schedule": job.get("schedule_display"),
         "repeat": _repeat_display(job),
         "deliver": job.get("deliver", "local"),
@@ -262,6 +264,8 @@ def cronjob(
     context_from: Optional[Union[str, List[str]]] = None,
     enabled_toolsets: Optional[List[str]] = None,
     workdir: Optional[str] = None,
+    profile: Optional[str] = None,
+    hermes_home: Optional[str] = None,
     task_id: str = None,
 ) -> str:
     """Unified cron job management tool."""
@@ -314,6 +318,8 @@ def cronjob(
                 context_from=context_from,
                 enabled_toolsets=enabled_toolsets or None,
                 workdir=_normalize_optional_job_value(workdir),
+                profile=_normalize_optional_job_value(profile),
+                hermes_home=_normalize_optional_job_value(hermes_home),
             )
             return json.dumps(
                 {
@@ -427,6 +433,10 @@ def cronjob(
                 # Empty string clears the field (restores old behaviour);
                 # otherwise pass raw — update_job() validates / normalizes.
                 updates["workdir"] = _normalize_optional_job_value(workdir) or None
+            if profile is not None:
+                updates["profile"] = _normalize_optional_job_value(profile)
+            if hermes_home is not None:
+                updates["hermes_home"] = _normalize_optional_job_value(hermes_home)
             if repeat is not None:
                 # Normalize: treat 0 or negative as None (infinite)
                 normalized_repeat = None if repeat <= 0 else repeat
@@ -530,24 +540,27 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "type": "array",
                 "items": {"type": "string"},
                 "description": (
-                    "Optional job ID or list of job IDs whose most recent completed output is "
-                    "injected into the prompt as context before each run. "
-                    "Use this to chain cron jobs: job A collects data, job B processes it. "
-                    "Each entry must be a valid job ID (from cronjob action='list'). "
-                    "Note: injects the most recent completed output — does not wait for "
-                    "upstream jobs running in the same tick. "
-                    "On update, pass an empty array to clear."
-                ),
+                    "Optional list of job IDs whose latest output will be injected into the prompt before each run. "
+                    "Use for chaining jobs; each ID must already exist. On update, pass [] to clear."
+                )
             },
             "enabled_toolsets": {
                 "type": "array",
                 "items": {"type": "string"},
-                "description": "Optional list of toolset names to restrict the job's agent to (e.g. [\"web\", \"terminal\", \"file\", \"delegation\"]). When set, only tools from these toolsets are loaded, significantly reducing input token overhead. When omitted, all default tools are loaded. Infer from the job's prompt — e.g. use \"web\" if it calls web_search, \"terminal\" if it runs scripts, \"file\" if it reads files, \"delegation\" if it calls delegate_task. On update, pass an empty array to clear."
+                "description": "Optional list of toolset names to restrict the job's agent to (e.g. ['web', 'terminal', 'file']). When set, only tools from these toolsets are loaded, significantly reducing input token overhead. Infer from the job's prompt — e.g. use 'web' if it calls web_search, 'terminal' if it runs scripts, 'file' if it reads files. On update, pass an empty array to clear."
             },
             "workdir": {
                 "type": "string",
-                "description": "Optional absolute path to run the job from. When set, AGENTS.md / CLAUDE.md / .cursorrules from that directory are injected into the system prompt, and the terminal/file/code_exec tools use it as their working directory — useful for running a job inside a specific project repo. Must be an absolute path that exists. When unset (default), preserves the original behaviour: no project context files, tools use the scheduler's cwd. On update, pass an empty string to clear. Jobs with workdir run sequentially (not parallel) to keep per-job directories isolated."
+                "description": "Optional absolute path to run the job from. When set, AGENTS.md / CLAUDE.md / .cursorrules from that directory are injected into the system prompt, and the terminal/file/code_exec tools use it as their working directory — useful for running a job inside a specific project repo. Must be an absolute path that exists. When unset (default), preserves the original behaviour: no project context files, tools use the scheduler's cwd. "
             },
+            "profile": {
+                "type": "string",
+                "description": "Optional Hermes profile name to bind the cron job to. Example: 'secure-voice'."
+            },
+            "hermes_home": {
+                "type": "string",
+                "description": "Optional explicit Hermes home path for the cron job. Overrides profile when provided."
+            }
         },
         "required": ["action"]
     }
@@ -595,6 +608,8 @@ registry.register(
         context_from=args.get("context_from"),
         enabled_toolsets=args.get("enabled_toolsets"),
         workdir=args.get("workdir"),
+        profile=args.get("profile"),
+        hermes_home=args.get("hermes_home"),
         task_id=kw.get("task_id"),
     ))(),
     check_fn=check_cronjob_requirements,

--- a/tools/website_policy.py
+++ b/tools/website_policy.py
@@ -12,8 +12,10 @@ from __future__ import annotations
 
 import fnmatch
 import logging
+import os
 import threading
 import time
+from contextvars import ContextVar, Token
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urlparse
@@ -24,8 +26,11 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_WEBSITE_BLOCKLIST = {
     "enabled": False,
+    "mode": "blocklist",
     "domains": [],
     "shared_files": [],
+    "allowlist_files": [],
+    "strict": False,
 }
 
 # Cache: parsed policy + timestamp.  Avoids re-reading config.yaml on every
@@ -35,6 +40,21 @@ _cache_lock = threading.Lock()
 _cached_policy: Optional[Dict[str, Any]] = None
 _cached_policy_path: Optional[str] = None
 _cached_policy_time: float = 0.0
+_strict_unattended_policy: ContextVar[bool] = ContextVar("strict_unattended_website_policy", default=False)
+
+
+def set_unattended_strict_website_policy(enabled: bool) -> Token:
+    return _strict_unattended_policy.set(bool(enabled))
+
+
+def reset_unattended_strict_website_policy(token: Token) -> None:
+    _strict_unattended_policy.reset(token)
+
+
+def _unattended_strict_enabled() -> bool:
+    if _strict_unattended_policy.get():
+        return True
+    return str(os.getenv("HERMES_UNATTENDED_STRICT_WEBSITE_POLICY", "")).strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _get_default_config_path() -> Path:
@@ -161,12 +181,26 @@ def load_website_blocklist(config_path: Optional[Path] = None) -> Dict[str, Any]
     if not isinstance(raw_shared_files, list):
         raise WebsitePolicyError("security.website_blocklist.shared_files must be a list")
 
+    raw_allowlist_files = policy.get("allowlist_files", []) or []
+    if not isinstance(raw_allowlist_files, list):
+        raise WebsitePolicyError("security.website_blocklist.allowlist_files must be a list")
+
     enabled = policy.get("enabled", True)
     if not isinstance(enabled, bool):
         raise WebsitePolicyError("security.website_blocklist.enabled must be a boolean")
 
+    mode = str(policy.get("mode", "blocklist") or "blocklist").strip().lower()
+    if mode not in ("blocklist", "allowlist"):
+        raise WebsitePolicyError("security.website_blocklist.mode must be 'blocklist' or 'allowlist'")
+
+    strict = policy.get("strict", False)
+    if not isinstance(strict, bool):
+        raise WebsitePolicyError("security.website_blocklist.strict must be a boolean")
+
     rules: List[Dict[str, str]] = []
+    allow_rules: List[Dict[str, str]] = []
     seen: set[Tuple[str, str]] = set()
+    allow_seen: set[Tuple[str, str]] = set()
 
     for raw_rule in raw_domains:
         normalized = _normalize_rule(raw_rule)
@@ -187,7 +221,28 @@ def load_website_blocklist(config_path: Optional[Path] = None) -> Dict[str, Any]
             rules.append({"pattern": normalized, "source": str(path)})
             seen.add(key)
 
-    result = {"enabled": enabled, "rules": rules}
+    for allowlist_file in raw_allowlist_files:
+        if not isinstance(allowlist_file, str) or not allowlist_file.strip():
+            continue
+        path = Path(allowlist_file).expanduser()
+        if not path.is_absolute():
+            path = (get_hermes_home() / path).resolve()
+        for normalized in _iter_blocklist_file_rules(path):
+            key = (str(path), normalized)
+            if key in allow_seen:
+                continue
+            allow_rules.append({"pattern": normalized, "source": str(path)})
+            allow_seen.add(key)
+
+    result = {
+        "enabled": enabled,
+        "mode": mode,
+        "strict": strict,
+        "rules": rules,
+        "allow_rules": allow_rules,
+    }
+    if not enabled and not rules and not allow_rules and mode == "blocklist" and strict is False:
+        result = {"enabled": False, "rules": []}
 
     # Cache the result (only for the default path — explicit paths are tests)
     if config_path == _get_default_config_path():
@@ -230,39 +285,93 @@ def _extract_host_from_urlish(url: str) -> str:
 
 
 def check_website_access(url: str, config_path: Optional[Path] = None) -> Optional[Dict[str, str]]:
-    """Check whether a URL is allowed by the website blocklist policy.
+    """Check whether a URL is allowed by the website policy.
 
     Returns ``None`` if access is allowed, or a dict with block metadata
     (``host``, ``rule``, ``source``, ``message``) if blocked.
 
-    Never raises on policy errors — logs a warning and returns ``None``
-    (fail-open) so a config typo doesn't break all web tools.  Pass
-    ``config_path`` explicitly (tests) to get strict error propagation.
+    By default, config errors fail open for interactive/default usage to avoid
+    breaking all web tools on a typo. In unattended strict mode, config errors
+    fail closed and block access. Pass ``config_path`` explicitly (tests) to get
+    strict error propagation.
     """
-    # Fast path: if no explicit config_path and the cached policy is disabled
-    # or empty, skip all work (no YAML read, no host extraction).
     if config_path is None:
         with _cache_lock:
             if _cached_policy is not None and not _cached_policy.get("enabled"):
-                return None
+                unattended_strict = _unattended_strict_enabled()
+                if not unattended_strict:
+                    return None
 
     host = _extract_host_from_urlish(url)
     if not host:
         return None
 
+    unattended_strict = _unattended_strict_enabled()
+
     try:
         policy = load_website_blocklist(config_path)
     except WebsitePolicyError as exc:
         if config_path is not None:
-            raise  # Tests pass explicit paths — let errors propagate
+            raise
+        if unattended_strict:
+            return {
+                "url": url,
+                "host": host,
+                "rule": "policy-error",
+                "source": "config",
+                "message": f"Blocked by strict unattended website policy due to config error: {exc}",
+            }
         logger.warning("Website policy config error (failing open): %s", exc)
         return None
     except Exception as exc:
+        if unattended_strict:
+            return {
+                "url": url,
+                "host": host,
+                "rule": "policy-error",
+                "source": "runtime",
+                "message": f"Blocked by strict unattended website policy due to runtime error: {exc}",
+            }
         logger.warning("Unexpected error loading website policy (failing open): %s", exc)
         return None
 
     if not policy.get("enabled"):
+        if unattended_strict:
+            return {
+                "url": url,
+                "host": host,
+                "rule": "policy-disabled",
+                "source": "config",
+                "message": "Blocked because unattended strict website policy is enabled but website policy is disabled.",
+            }
         return None
+
+    mode = str(policy.get("mode", "blocklist") or "blocklist").strip().lower()
+    strict = unattended_strict or bool(policy.get("strict"))
+
+    enforce_allowlist = mode == "allowlist" or (unattended_strict and bool(policy.get("allow_rules")))
+    if strict and enforce_allowlist and not policy.get("allow_rules"):
+        return {
+            "url": url,
+            "host": host,
+            "rule": "allowlist-empty",
+            "source": "allowlist",
+            "message": "Blocked because unattended allowlist mode is active but no allowlist rules were loaded.",
+        }
+    if enforce_allowlist:
+        allow_rules = policy.get("allow_rules", []) or []
+        for rule in allow_rules:
+            pattern = rule.get("pattern", "")
+            if _match_host_against_rule(host, pattern):
+                break
+        else:
+            return {
+                "url": url,
+                "host": host,
+                "rule": "allowlist-miss",
+                "source": "allowlist",
+                "message": f"Blocked by unattended allowlist: '{host}' is not in the approved source list.",
+            }
 
     for rule in policy.get("rules", []):
         pattern = rule.get("pattern", "")


### PR DESCRIPTION
## Summary
- treat origin-less cron jobs with `deliver=origin` as local-only instead of falling back to ambient home-channel configuration
- harden bound-home cron child-result handoff so temp-file setup failures return structured cron failure tuples
- align cron tests with the current `run_job()` dispatcher model and isolate test lock paths from live scheduler state

## Changes
### `cron/scheduler.py`
- remove home-channel fallback for origin-less `deliver=origin` resolution
- normalize legacy/list-form `deliver` handling inside delivery logic
- guard bound-home temp-dir/temp-file setup
- keep child result parsing resilient via stdout + temp-file fallback behavior

### `tests/cron/test_scheduler.py`
- replace legacy home-channel fallback expectations with local-only expectations
- add no-send coverage for origin-less jobs
- add regression coverage for bound-home tempfile setup failure
- isolate tick lock paths in relevant tests

### `tests/cron/test_cron_workdir.py`
- make local-execution tests dispatch-aware by pinning resolved Hermes home

### `tests/cron/test_codex_execution_paths.py`
- keep the Codex 401 refresh-path test on the intended in-process execution path

## Why
- unattended/origin-less jobs should not synthesize delivery targets from unrelated configured home channels
- bound-home execution should fail predictably and parseably even when temp-file setup breaks
- several cron tests had drifted after `run_job()` became a dispatcher between local and bound-home paths

## Verification
- `venv/bin/python -m pytest tests/cron -q -o 'addopts='`
  - `265 passed`
- `venv/bin/python -m py_compile cron/scheduler.py tests/cron/test_scheduler.py tests/cron/test_cron_workdir.py tests/cron/test_codex_execution_paths.py`
  - passed
