### PR TITLE
feat(models): add openrouter/owl-alpha (free) to curated OpenRouter list

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -40,6 +40,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("anthropic/claude-sonnet-4.5",     ""),
     ("anthropic/claude-haiku-4.5",      ""),
     ("openrouter/elephant-alpha",       "free"),
+    ("openrouter/owl-alpha",            "free"),
     ("openai/gpt-5.5",                  ""),
     ("openai/gpt-5.4-mini",             ""),
     ("xiaomi/mimo-v2.5-pro",             ""),


### PR DESCRIPTION
## Summary
Adds `openrouter/owl-alpha` to the curated OpenRouter model list, tagged `(free)` in the picker alongside `elephant-alpha`.

## Changes
- `hermes_cli/models.py`: one new entry in `OPENROUTER_MODELS`.