### PR TITLE
fix(tools): fail closed on stale Nous gateway auth

### DIFF
--- a/tests/tools/test_managed_tool_gateway.py
+++ b/tests/tools/test_managed_tool_gateway.py
@@ -97,3 +97,29 @@ def test_read_nous_access_token_refreshes_expiring_cached_token(tmp_path, monkey
     )
 
     assert managed_tool_gateway.read_nous_access_token() == "fresh-token"
+
+
+def test_read_nous_access_token_fails_closed_when_refresh_fails(tmp_path, monkeypatch):
+    monkeypatch.delenv("TOOL_GATEWAY_USER_TOKEN", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    expires_at = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+    (tmp_path / "auth.json").write_text(json.dumps({
+        "providers": {
+            "nous": {
+                "access_token": "stale-token",
+                "refresh_token": "revoked-refresh-token",
+                "expires_at": expires_at,
+            }
+        }
+    }))
+
+    def fail_refresh(refresh_skew_seconds=120):
+        raise RuntimeError("Refresh session has been revoked")
+
+    monkeypatch.setattr("hermes_cli.auth.resolve_nous_access_token", fail_refresh)
+
+    assert managed_tool_gateway.read_nous_access_token() is None
+    assert managed_tool_gateway.is_managed_tool_gateway_ready(
+        "firecrawl",
+        token_reader=managed_tool_gateway.read_nous_access_token,
+    ) is False

--- a/tools/managed_tool_gateway.py
+++ b/tools/managed_tool_gateway.py
@@ -82,6 +82,9 @@ def read_nous_access_token() -> Optional[str]:
     access_token = nous_provider.get("access_token")
     cached_token = access_token.strip() if isinstance(access_token, str) and access_token.strip() else None
 
+    if cached_token and not nous_provider.get("expires_at"):
+        return cached_token
+
     if cached_token and not _access_token_is_expiring(
         nous_provider.get("expires_at"),
         _NOUS_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
@@ -98,8 +101,9 @@ def read_nous_access_token() -> Optional[str]:
             return refreshed_token.strip()
     except Exception as exc:
         logger.debug("Nous access token refresh failed: %s", exc)
+        return None
 
-    return cached_token
+    return None
 
 
 def get_tool_gateway_scheme() -> str:


### PR DESCRIPTION
## What does this PR do?

- Fail closed when an expired Nous Portal token cannot be refreshed for managed tool gateways
- Preserve legacy cached-token behavior when no expiry metadata is present
- Add regression coverage for revoked/stale refresh failures disabling gateway readiness

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A