### PR TITLE
fix(gateway): prevent historical TTS calls from suppressing voice replies

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5669,6 +5669,10 @@ class GatewayRunner:
             # Use the filtered history length (history_offset) that was actually
             # passed to the agent, not len(history) which includes session_meta
             # entries that were stripped before the agent saw them.
+            history_len = agent_result.get("history_offset", len(history))
+            current_turn_agent_messages = (
+                agent_messages[history_len:] if len(agent_messages) > history_len else []
+            )
             if is_context_overflow_failure:
                 pass  # handled above — skip all transcript writes
             elif agent_failed_early:
@@ -5681,8 +5685,7 @@ class GatewayRunner:
                     {"role": "user", "content": message_text, "timestamp": ts},
                 )
             else:
-                history_len = agent_result.get("history_offset", len(history))
-                new_messages = agent_messages[history_len:] if len(agent_messages) > history_len else []
+                new_messages = current_turn_agent_messages
 
                 # If no new messages found (edge case), fall back to simple user/assistant
                 if not new_messages:
@@ -5722,7 +5725,16 @@ class GatewayRunner:
 
             # Auto voice reply: send TTS audio before the text response
             _already_sent = bool(agent_result.get("already_sent"))
-            if self._should_send_voice_reply(event, response, agent_messages, already_sent=_already_sent):
+            voice_turn_agent_messages = agent_result.get(
+                "voice_turn_messages",
+                current_turn_agent_messages,
+            )
+            if self._should_send_voice_reply(
+                event,
+                response,
+                voice_turn_agent_messages,
+                already_sent=_already_sent,
+            ):
                 await self._send_voice_reply(event, response)
 
             # If streaming already delivered the response, extract and
@@ -7149,6 +7161,27 @@ class GatewayRunner:
 
         await adapter.handle_message(event)
 
+    def _messages_from_current_user_turn(
+        self,
+        messages: list,
+        current_user_content: Any = None,
+        fallback_offset: int = 0,
+    ) -> list:
+        """Return messages from the current inbound user turn onward.
+
+        Prefer locating the actual user message sent to the agent.  This stays
+        correct when mid-run compression rewrites the message list and the
+        transcript-persistence offset is reset to 0 so compressed context can be
+        saved.  Fallback to the caller-provided offset for older/edge paths.
+        """
+        if current_user_content is not None:
+            for idx in range(len(messages) - 1, -1, -1):
+                msg = messages[idx]
+                if msg.get("role") == "user" and msg.get("content") == current_user_content:
+                    return messages[idx:]
+
+        return messages[fallback_offset:] if len(messages) > fallback_offset else []
+
     def _should_send_voice_reply(
         self,
         event: MessageEvent,
@@ -7181,7 +7214,10 @@ class GatewayRunner:
         if not should:
             return False
 
-        # Dedup: agent already called TTS tool
+        # Dedup: agent already called TTS tool in this turn.  The gateway passes
+        # only the current-turn agent messages here so historical
+        # text_to_speech calls from resumed/compressed sessions do not
+        # permanently suppress auto-TTS for future replies.
         has_agent_tts = any(
             msg.get("role") == "assistant"
             and any(
@@ -11767,13 +11803,21 @@ class GatewayRunner:
                 except Exception:
                     pass
 
+            _result_messages = result_holder[0].get("messages", []) if result_holder[0] else []
+            _voice_turn_messages = self._messages_from_current_user_turn(
+                _result_messages,
+                current_user_content=_run_message,
+                fallback_offset=_effective_history_offset,
+            )
+
             return {
                 "final_response": final_response,
                 "last_reasoning": result.get("last_reasoning"),
-                "messages": result_holder[0].get("messages", []) if result_holder[0] else [],
+                "messages": _result_messages,
                 "api_calls": result_holder[0].get("api_calls", 0) if result_holder[0] else 0,
                 "tools": tools_holder[0] or [],
                 "history_offset": _effective_history_offset,
+                "voice_turn_messages": _voice_turn_messages,
                 "last_prompt_tokens": _last_prompt_toks,
                 "input_tokens": _input_toks,
                 "output_tokens": _output_toks,

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -391,6 +391,98 @@ class TestAutoVoiceReply:
         }]
         assert self._call(runner, "all", MessageType.TEXT, agent_messages=messages) is False
 
+    def test_current_turn_slice_excludes_historical_tts_tool_calls(self, runner):
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [{
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "text_to_speech", "arguments": "{}"},
+                }],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "{}"},
+            {"role": "user", "content": "Next message"},
+            {"role": "assistant", "content": "Fresh text reply"},
+        ]
+        current_turn_messages = runner._messages_from_current_user_turn(
+            messages,
+            current_user_content="Next message",
+            fallback_offset=0,
+        )
+        assert self._call(
+            runner,
+            "all",
+            MessageType.TEXT,
+            agent_messages=current_turn_messages,
+        ) is True
+
+    def test_current_turn_slice_ignores_compression_offset_reset(self, runner):
+        messages = [
+            {"role": "assistant", "content": "Compressed summary"},
+            {
+                "role": "assistant",
+                "tool_calls": [{
+                    "id": "old_call",
+                    "type": "function",
+                    "function": {"name": "text_to_speech", "arguments": "{}"},
+                }],
+            },
+            {"role": "tool", "tool_call_id": "old_call", "content": "{}"},
+            {"role": "user", "content": "Current message"},
+            {"role": "assistant", "content": "Fresh text reply"},
+        ]
+        current_turn_messages = runner._messages_from_current_user_turn(
+            messages,
+            current_user_content="Current message",
+            fallback_offset=0,
+        )
+        assert current_turn_messages == messages[3:]
+        assert self._call(
+            runner,
+            "all",
+            MessageType.TEXT,
+            agent_messages=current_turn_messages,
+        ) is True
+
+    def test_current_turn_tts_tool_call_still_suppresses_with_history(self, runner):
+        messages = [
+            {"role": "user", "content": "Earlier message"},
+            {"role": "assistant", "content": "Earlier reply"},
+            {"role": "user", "content": "Current message"},
+            {
+                "role": "assistant",
+                "tool_calls": [{
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "text_to_speech", "arguments": "{}"},
+                }],
+            },
+        ]
+        current_turn_messages = messages[2:]
+        assert self._call(
+            runner,
+            "all",
+            MessageType.TEXT,
+            agent_messages=current_turn_messages,
+        ) is False
+
+    def test_current_turn_tts_tool_call_suppresses_after_synthetic_user_message(self, runner):
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [{
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "text_to_speech", "arguments": "{}"},
+                }],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "{}"},
+            {"role": "user", "content": "Continue the response"},
+            {"role": "assistant", "content": "Fresh text reply"},
+        ]
+        assert self._call(runner, "all", MessageType.TEXT, agent_messages=messages) is False
+
     def test_no_dedup_for_other_tools(self, runner):
         messages = [{
             "role": "assistant",


### PR DESCRIPTION
## Summary

This fixes a bug where automatic voice replies could stop working in long or resumed gateway sessions.

Before this change, the gateway looked through the whole saved conversation to decide whether the agent had already called `text_to_speech`. That meant one old TTS tool call could make Hermes think every later reply already had audio, so it would skip sending automatic voice replies.

After this change, the gateway only checks the messages from the current user turn. Old TTS calls no longer suppress new voice replies.

## What changed

- Track the messages produced for the current inbound user message.
- Use that current-turn message slice when checking whether `text_to_speech` already ran.
- Keep the duplicate-prevention behavior for the current reply: if the agent already generated TTS for this turn, the gateway still will not send a second voice reply.
- Add regression tests for:
  - historical TTS calls in the session
  - compressed/resumed session history
  - current-turn TTS calls that should still suppress duplicate audio

## Test Plan

- `python -m pytest tests/gateway/test_voice_command.py -q -o 'addopts='`
