### PR TITLE
feat(skill): extend llm-wiki with multi-wiki support per profile

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -47,6 +47,9 @@ _PROFILE_DIRS = [
     # this also ensures tool configs land inside the persistent volume.
     # See hermes_constants.get_subprocess_home() and issue #4426.
     "home",
+    # Per-profile wiki storage for llm-wiki skill (multi-wiki support).
+    # Each wiki is a subdirectory: wikis/default, wikis/research, etc.
+    "wikis",
 ]
 
 # Files copied during --clone (if they exist in the source)

--- a/skills/research/llm-wiki/SKILL.md
+++ b/skills/research/llm-wiki/SKILL.md
@@ -43,16 +43,41 @@ Use this skill when the user:
 
 ## Wiki Location
 
-**Location:** Set via `WIKI_PATH` environment variable (e.g. in `~/.hermes/.env`).
+The agent resolves the active wiki path from config on every operation. The skill
+config system injects two values:
 
-If unset, defaults to `~/wiki`.
+- `llm-wiki.active_wiki` — which wiki is currently selected (e.g. "default", "research")
+- `llm-wiki.wikis` — JSON registry of all wikis with their paths and descriptions
+
+**Path resolution:**
 
 ```bash
-WIKI="${WIKI_PATH:-$HOME/wiki}"
+# Config values are injected by the agent as [Skill config: ...]
+# Parse the registry and resolve the active wiki path:
+WIKI="${HERMES_HOME}/wikis/${resolved_active_wiki_path}"
 ```
 
-The wiki is just a directory of markdown files — open it in Obsidian, VS Code, or
-any editor. No database, no special tooling required.
+The resolved path is always under `{HERMES_HOME}/wikis/`. Each wiki is a
+subdirectory — open it in Obsidian, VS Code, or any editor. No database,
+no special tooling required.
+
+**Profile isolation:** In named profiles, wikis live under
+`~/.hermes/profiles/<profile>/wikis/`. The `HERMES_HOME` env var already
+points to the profile root, so path resolution works identically.
+
+**Backward compatibility:** On first use after upgrading, if the agent detects
+an existing `~/wiki` directory and no `~/.hermes/wikis/default` exists, it
+silently creates a symlink:
+
+```
+~/.hermes/wikis/default → ~/wiki
+```
+
+The user's existing wiki and Obsidian vault continue working unchanged. If
+`WIKI_PATH` env var is set, it takes priority (existing behavior preserved).
+
+**Edge case:** If no `~/wiki` exists and no `WIKI_PATH` is set, the agent
+creates `~/.hermes/wikis/default/` with fresh structure on first use.
 
 ## Architecture: Three Layers
 
@@ -86,7 +111,7 @@ When the user has an existing wiki, **always orient yourself before doing anythi
 ③ **Scan recent `log.md`** — read the last 20-30 entries to understand recent activity.
 
 ```bash
-WIKI="${WIKI_PATH:-$HOME/wiki}"
+# WIKI is resolved from skill config (see Wiki Location above)
 # Orientation reads at session start
 read_file "$WIKI/SCHEMA.md"
 read_file "$WIKI/index.md"

--- a/skills/research/llm-wiki/SKILL.md
+++ b/skills/research/llm-wiki/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: llm-wiki
 description: "Karpathy's LLM Wiki: build/query interlinked markdown KB."
-version: 2.1.0
+version: 2.2.0
 author: Hermes Agent
 license: MIT
 metadata:
@@ -9,6 +9,15 @@ metadata:
     tags: [wiki, knowledge-base, research, notes, markdown, rag-alternative]
     category: research
     related_skills: [obsidian, arxiv]
+    config:
+      - key: llm-wiki.active_wiki
+        description: Currently active wiki name
+        default: "default"
+        prompt: Active wiki name
+      - key: llm-wiki.wikis
+        description: Wiki registry (JSON object mapping wiki names to {path, description})
+        default: '{"default":{"path":"default","description":"Default wiki"}}'
+        prompt: Wiki registry
 ---
 
 # Karpathy's LLM Wiki

--- a/skills/research/llm-wiki/SKILL.md
+++ b/skills/research/llm-wiki/SKILL.md
@@ -44,23 +44,29 @@ Use this skill when the user:
 
 ## Wiki Location
 
-The agent resolves the active wiki path from config on every operation. The skill
-config system injects two values:
+The agent resolves the active wiki path from the config system. When this skill
+triggers, config values are injected in this format:
 
-- `llm-wiki.active_wiki` — which wiki is currently selected (e.g. "default", "research")
-- `llm-wiki.wikis` — JSON registry of all wikis with their paths and descriptions
-
-**Path resolution:**
-
-```bash
-# Config values are injected by the agent as [Skill config: ...]
-# Parse the registry and resolve the active wiki path:
-WIKI="${HERMES_HOME}/wikis/${resolved_active_wiki_path}"
+```
+[Skill config (from ~/.hermes/config.yaml):
+  llm-wiki.active_wiki = default
+  llm-wiki.wikis = {"default":{"path":"default","description":"Default wiki"}}
+]
 ```
 
+**Before every operation, resolve the active wiki:**
+
+1. From the injected config, read `llm-wiki.active_wiki` — this is the wiki name (e.g. "default")
+2. From the injected config, read `llm-wiki.wikis` — parse the JSON string into a dict
+3. Look up `wikis[active_wiki_name]["path"]` — this is the subdirectory name (e.g. "default")
+4. Construct the full path: `WIKI="${HERMES_HOME}/wikis/<path>"`
+
+Example: if `active_wiki = "default"` and the wiki entry is `{"path":"default",...}`,
+then `WIKI="${HERMES_HOME}/wikis/default"`.
+
 The resolved path is always under `{HERMES_HOME}/wikis/`. Each wiki is a
-subdirectory — open it in Obsidian, VS Code, or any editor. No database,
-no special tooling required.
+subdirectory of markdown files — open it in Obsidian, VS Code, or any editor.
+No database, no special tooling required.
 
 **Profile isolation:** In named profiles, wikis live under
 `~/.hermes/profiles/<profile>/wikis/`. The `HERMES_HOME` env var already
@@ -68,10 +74,13 @@ points to the profile root, so path resolution works identically.
 
 **Backward compatibility:** On first use after upgrading, if the agent detects
 an existing `~/wiki` directory and no `~/.hermes/wikis/default` exists, it
-silently creates a symlink:
+creates a symlink:
 
-```
-~/.hermes/wikis/default → ~/wiki
+```bash
+if [ -d ~/wiki ] && [ ! -e ~/.hermes/wikis/default ]; then
+  mkdir -p ~/.hermes/wikis
+  ln -s ~/wiki ~/.hermes/wikis/default
+fi
 ```
 
 The user's existing wiki and Obsidian vault continue working unchanged. If
@@ -135,7 +144,7 @@ When the user asks to create or start a wiki:
 1. Determine the wiki path:
    - If `WIKI_PATH` env var is set, use that (existing behavior)
    - Otherwise, use `{HERMES_HOME}/wikis/default/` (create if needed)
-   - Initialize config: set `llm-wiki.active_wiki` to "default", add default entry to `llm-wiki.wikis`
+   - Initialize config: `save_config_value("skills.config.llm-wiki.active_wiki", "default")` and `save_config_value("skills.config.llm-wiki.wikis", '{"default":{"path":"default","description":"Default wiki"}}')`
 2. Create the directory structure above
 3. Ask the user what domain the wiki covers — be specific
 4. Write `SCHEMA.md` customized to the domain (see template below)
@@ -409,8 +418,8 @@ wiki = "<WIKI_PATH>"
 When the user says something like "switch to the research wiki" or
 "use my personal wiki":
 
-1. Read `llm-wiki.wikis` config to check the requested wiki exists
-2. If it exists, update `llm-wiki.active_wiki` via `save_config_value()`
+1. Read `llm-wiki.wikis` from injected config, parse JSON, check the requested wiki exists
+2. If it exists, update the config: `save_config_value("skills.config.llm-wiki.active_wiki", "<wiki-name>")`
 3. Orient to the new wiki (read its SCHEMA.md, index.md, recent log.md)
 4. Confirm the switch: "Switched to `research` wiki. [Brief summary of what's in it.]"
 5. If the wiki doesn't exist, offer to create it
@@ -420,19 +429,19 @@ When the user says something like "switch to the research wiki" or
 When the user asks to create a new wiki:
 
 1. Ask for a name (lowercase, hyphens, used as directory name) and description
-2. Read current `llm-wiki.wikis` config
+2. Read `llm-wiki.wikis` from injected config, parse JSON
 3. Check no name collision with existing wikis
-4. Add entry to `llm-wiki.wikis` config: `{"name": {"path": "name", "description": "..."}}`
+4. Update the registry: add the new entry to the wikis dict, then `save_config_value("skills.config.llm-wiki.wikis", json.dumps(updated_wikis))`
 5. Create directory structure under `{HERMES_HOME}/wikis/{name}/`
 6. Initialize SCHEMA.md, index.md, log.md (same as Initializing a New Wiki)
-7. Set `llm-wiki.active_wiki` to the new wiki name
+7. Set active: `save_config_value("skills.config.llm-wiki.active_wiki", "<name>")`
 8. Confirm: "Created `research` wiki and switched to it."
 
 ### Listing Wikis
 
 When the user asks what wikis they have or which is active:
 
-1. Read `llm-wiki.wikis` and `llm-wiki.active_wiki` from config
+1. Read `llm-wiki.wikis` and `llm-wiki.active_wiki` from injected config, parse wikis JSON
 2. List each wiki with its description and page count
 3. Mark which one is active
 
@@ -499,62 +508,6 @@ For best results:
 
 If using the Obsidian skill alongside this one, set `OBSIDIAN_VAULT_PATH` to the
 same directory as the wiki path.
-
-### Obsidian Headless (servers and headless machines)
-
-On machines without a display, use `obsidian-headless` instead of the desktop app.
-It syncs vaults via Obsidian Sync without a GUI — perfect for agents running on
-servers that write to the wiki while Obsidian desktop reads it on another device.
-
-**Setup:**
-```bash
-# Requires Node.js 22+
-npm install -g obsidian-headless
-
-# Login (requires Obsidian account with Sync subscription)
-ob login --email <email> --password '<password>'
-
-# Create a remote vault for the wiki
-ob sync-create-remote --name "LLM Wiki"
-
-# Connect the wiki directory to the vault
-cd ~/wiki
-ob sync-setup --vault "<vault-id>"
-
-# Initial sync
-ob sync
-
-# Continuous sync (foreground — use systemd for background)
-ob sync --continuous
-```
-
-**Continuous background sync via systemd:**
-```ini
-# ~/.config/systemd/user/obsidian-wiki-sync.service
-[Unit]
-Description=Obsidian LLM Wiki Sync
-After=network-online.target
-Wants=network-online.target
-
-[Service]
-ExecStart=/path/to/ob sync --continuous
-WorkingDirectory=/home/user/wiki
-Restart=on-failure
-RestartSec=10
-
-[Install]
-WantedBy=default.target
-```
-
-```bash
-systemctl --user daemon-reload
-systemctl --user enable --now obsidian-wiki-sync
-# Enable linger so sync survives logout:
-sudo loginctl enable-linger $USER
-```
-
-This lets the agent write to `~/wiki` on a server while you browse the same
-vault in Obsidian on your laptop/phone — changes appear within seconds.
 
 ## Pitfalls
 

--- a/skills/research/llm-wiki/SKILL.md
+++ b/skills/research/llm-wiki/SKILL.md
@@ -40,6 +40,7 @@ Use this skill when the user:
 - Asks a question and an existing wiki is present at the configured path
 - Asks to lint, audit, or health-check their wiki
 - References their wiki, knowledge base, or "notes" in a research context
+- Asks to switch wikis, create a new wiki, or list their wikis
 
 ## Wiki Location
 
@@ -131,7 +132,10 @@ at hand before creating anything new.
 
 When the user asks to create or start a wiki:
 
-1. Determine the wiki path (from `$WIKI_PATH` env var, or ask the user; default `~/wiki`)
+1. Determine the wiki path:
+   - If `WIKI_PATH` env var is set, use that (existing behavior)
+   - Otherwise, use `{HERMES_HOME}/wikis/default/` (create if needed)
+   - Initialize config: set `llm-wiki.active_wiki` to "default", add default entry to `llm-wiki.wikis`
 2. Create the directory structure above
 3. Ask the user what domain the wiki covers — be specific
 4. Write `SCHEMA.md` customized to the domain (see template below)
@@ -397,6 +401,51 @@ wiki = "<WIKI_PATH>"
    severity (broken links > orphans > source drift > contested pages > stale content > style issues).
 
 ⑬ **Append to log.md:** `## [YYYY-MM-DD] lint | N issues found`
+
+## Wiki Management
+
+### Switching Wikis
+
+When the user says something like "switch to the research wiki" or
+"use my personal wiki":
+
+1. Read `llm-wiki.wikis` config to check the requested wiki exists
+2. If it exists, update `llm-wiki.active_wiki` via `save_config_value()`
+3. Orient to the new wiki (read its SCHEMA.md, index.md, recent log.md)
+4. Confirm the switch: "Switched to `research` wiki. [Brief summary of what's in it.]"
+5. If the wiki doesn't exist, offer to create it
+
+### Creating a New Wiki
+
+When the user asks to create a new wiki:
+
+1. Ask for a name (lowercase, hyphens, used as directory name) and description
+2. Read current `llm-wiki.wikis` config
+3. Check no name collision with existing wikis
+4. Add entry to `llm-wiki.wikis` config: `{"name": {"path": "name", "description": "..."}}`
+5. Create directory structure under `{HERMES_HOME}/wikis/{name}/`
+6. Initialize SCHEMA.md, index.md, log.md (same as Initializing a New Wiki)
+7. Set `llm-wiki.active_wiki` to the new wiki name
+8. Confirm: "Created `research` wiki and switched to it."
+
+### Listing Wikis
+
+When the user asks what wikis they have or which is active:
+
+1. Read `llm-wiki.wikis` and `llm-wiki.active_wiki` from config
+2. List each wiki with its description and page count
+3. Mark which one is active
+
+### Pre-Write Content Check
+
+Before any ingest operation, the agent should analyze content relevance to the
+current `active_wiki`. If the content is a better fit for another wiki:
+
+> "This looks like it belongs in the `research` wiki, but `personal` is currently
+> active. Should I switch to `research` for this, or keep it in `personal`?"
+
+This is a judgment call based on the wiki descriptions and existing content.
+Don't ask for every source — only when there's a clear mismatch.
 
 ## Working with the Wiki
 

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -583,3 +583,332 @@ class TestInlineShellExpansion:
         # The command's intended stdout never made it through — only the
         # timeout marker (which echoes the command text) survives.
         assert "DYN_MARKER" not in msg.replace("sleep 5 && printf DYN_MARKER", "")
+
+
+class TestExtractSkillConfigVars:
+    """Tests for extract_skill_config_vars() — parsing metadata.hermes.config from frontmatter."""
+
+    def test_extracts_valid_config(self):
+        from agent.skill_utils import extract_skill_config_vars
+
+        frontmatter = {
+            "metadata": {
+                "hermes": {
+                    "config": [
+                        {
+                            "key": "llm-wiki.active_wiki",
+                            "description": "Currently active wiki name",
+                            "default": "default",
+                            "prompt": "Active wiki name",
+                        },
+                        {
+                            "key": "llm-wiki.wikis",
+                            "description": "Wiki registry",
+                            "default": '{"default":{"path":"default","description":"Default wiki"}}',
+                            "prompt": "Wiki registry",
+                        },
+                    ]
+                }
+            }
+        }
+        result = extract_skill_config_vars(frontmatter)
+        assert len(result) == 2
+        assert result[0]["key"] == "llm-wiki.active_wiki"
+        assert result[0]["description"] == "Currently active wiki name"
+        assert result[0]["default"] == "default"
+        assert result[0]["prompt"] == "Active wiki name"
+        assert result[1]["key"] == "llm-wiki.wikis"
+        assert result[1]["prompt"] == "Wiki registry"
+
+    def test_returns_empty_for_missing_metadata(self):
+        from agent.skill_utils import extract_skill_config_vars
+
+        assert extract_skill_config_vars({}) == []
+        assert extract_skill_config_vars({"metadata": {}}) == []
+        assert extract_skill_config_vars({"metadata": {"hermes": {}}}) == []
+        assert extract_skill_config_vars({"metadata": {"hermes": {"config": []}}}) == []
+
+    def test_skips_entries_missing_key(self):
+        from agent.skill_utils import extract_skill_config_vars
+
+        frontmatter = {
+            "metadata": {
+                "hermes": {
+                    "config": [
+                        {"description": "No key provided"},
+                        {"key": "valid.key", "description": "Has key"},
+                    ]
+                }
+            }
+        }
+        result = extract_skill_config_vars(frontmatter)
+        assert len(result) == 1
+        assert result[0]["key"] == "valid.key"
+
+    def test_skips_entries_missing_description(self):
+        from agent.skill_utils import extract_skill_config_vars
+
+        frontmatter = {
+            "metadata": {
+                "hermes": {
+                    "config": [
+                        {"key": "no.desc"},
+                        {"key": "has.desc", "description": "Has description"},
+                    ]
+                }
+            }
+        }
+        result = extract_skill_config_vars(frontmatter)
+        assert len(result) == 1
+        assert result[0]["key"] == "has.desc"
+
+    def test_deduplicates_by_key(self):
+        from agent.skill_utils import extract_skill_config_vars
+
+        frontmatter = {
+            "metadata": {
+                "hermes": {
+                    "config": [
+                        {"key": "dup.key", "description": "First"},
+                        {"key": "dup.key", "description": "Second"},
+                        {"key": "unique.key", "description": "Only one"},
+                    ]
+                }
+            }
+        }
+        result = extract_skill_config_vars(frontmatter)
+        assert len(result) == 2
+        assert result[0]["key"] == "dup.key"
+        assert result[0]["description"] == "First"
+        assert result[1]["key"] == "unique.key"
+
+    def test_prompt_falls_back_to_description(self):
+        from agent.skill_utils import extract_skill_config_vars
+
+        frontmatter = {
+            "metadata": {
+                "hermes": {
+                    "config": [
+                        {
+                            "key": "test.key",
+                            "description": "My description",
+                        },
+                    ]
+                }
+            }
+        }
+        result = extract_skill_config_vars(frontmatter)
+        assert result[0]["prompt"] == "My description"
+
+    def test_handles_dict_instead_of_list(self):
+        """Config can be a single dict instead of a list."""
+        from agent.skill_utils import extract_skill_config_vars
+
+        frontmatter = {
+            "metadata": {
+                "hermes": {
+                    "config": {
+                        "key": "single.key",
+                        "description": "Single entry",
+                        "default": "val",
+                    }
+                }
+            }
+        }
+        result = extract_skill_config_vars(frontmatter)
+        assert len(result) == 1
+        assert result[0]["key"] == "single.key"
+
+
+class TestResolveSkillConfigValues:
+    """Tests for resolve_skill_config_values() — reading values from config.yaml."""
+
+    def test_returns_defaults_when_no_config_file(self, tmp_path, monkeypatch):
+        from agent.skill_utils import resolve_skill_config_values
+
+        config_vars = [
+            {"key": "test.key", "description": "A test key", "default": "default_val"},
+        ]
+        monkeypatch.setattr(
+            "agent.skill_utils.get_config_path",
+            lambda: tmp_path / "nonexistent_config.yaml",
+        )
+        result = resolve_skill_config_values(config_vars)
+        assert result == {"test.key": "default_val"}
+
+    def test_reads_value_from_config_yaml(self, tmp_path, monkeypatch):
+        from agent.skill_utils import resolve_skill_config_values
+
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(
+            "skills:\n"
+            "  config:\n"
+            "    llm-wiki:\n"
+            "      active_wiki: research\n"
+        )
+        monkeypatch.setattr(
+            "agent.skill_utils.get_config_path",
+            lambda: config_file,
+        )
+        config_vars = [
+            {"key": "llm-wiki.active_wiki", "description": "Active wiki", "default": "default"},
+        ]
+        result = resolve_skill_config_values(config_vars)
+        assert result == {"llm-wiki.active_wiki": "research"}
+
+    def test_falls_back_to_default_when_key_missing(self, tmp_path, monkeypatch):
+        from agent.skill_utils import resolve_skill_config_values
+
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("other: value\n")
+        monkeypatch.setattr(
+            "agent.skill_utils.get_config_path",
+            lambda: config_file,
+        )
+        config_vars = [
+            {"key": "missing.key", "description": "Not in config", "default": "fallback"},
+        ]
+        result = resolve_skill_config_values(config_vars)
+        assert result == {"missing.key": "fallback"}
+
+    def test_expands_tilde_in_path_values(self, tmp_path, monkeypatch):
+        import os
+
+        from agent.skill_utils import resolve_skill_config_values
+
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(
+            "skills:\n  config:\n    wiki:\n      path: ~/my-wiki\n"
+        )
+        monkeypatch.setattr(
+            "agent.skill_utils.get_config_path",
+            lambda: config_file,
+        )
+        config_vars = [
+            {"key": "wiki.path", "description": "Wiki path", "default": "~/default-wiki"},
+        ]
+        result = resolve_skill_config_values(config_vars)
+        home = os.path.expanduser("~")
+        assert result == {"wiki.path": f"{home}/my-wiki"}
+
+    def test_empty_string_value_uses_default(self, tmp_path, monkeypatch):
+        from agent.skill_utils import resolve_skill_config_values
+
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(
+            "skills:\n  config:\n    test:\n      key: \"\"\n"
+        )
+        monkeypatch.setattr(
+            "agent.skill_utils.get_config_path",
+            lambda: config_file,
+        )
+        config_vars = [
+            {"key": "test.key", "description": "A key", "default": "fallback_val"},
+        ]
+        result = resolve_skill_config_values(config_vars)
+        assert result == {"test.key": "fallback_val"}
+
+    def test_multiple_vars_resolved_independently(self, tmp_path, monkeypatch):
+        from agent.skill_utils import resolve_skill_config_values
+
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(
+            "skills:\n"
+            "  config:\n"
+            "    llm-wiki:\n"
+            "      active_wiki: personal\n"
+        )
+        monkeypatch.setattr(
+            "agent.skill_utils.get_config_path",
+            lambda: config_file,
+        )
+        config_vars = [
+            {"key": "llm-wiki.active_wiki", "description": "Active", "default": "default"},
+            {
+                "key": "llm-wiki.wikis",
+                "description": "Registry",
+                "default": '{"default":{"path":"default"}}',
+            },
+        ]
+        result = resolve_skill_config_values(config_vars)
+        assert result["llm-wiki.active_wiki"] == "personal"
+        assert result["llm-wiki.wikis"] == '{"default":{"path":"default"}}'
+
+
+class TestInjectSkillConfig:
+    """Integration tests: config block appears in build_skill_invocation_message."""
+
+    def test_config_injected_in_skill_message(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("TENOR_API_KEY", raising=False)
+
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(
+            "skills:\n"
+            "  config:\n"
+            "    wiki:\n"
+            "      path: /custom/wiki\n"
+        )
+
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "cfg-skill",
+                frontmatter_extra=(
+                    "metadata:\n"
+                    "  hermes:\n"
+                    "    config:\n"
+                    "      - key: wiki.path\n"
+                    "        description: Wiki directory path\n"
+                    "        default: ~/wiki\n"
+                    "        prompt: Wiki path\n"
+                ),
+            )
+            scan_skill_commands()
+            with patch(
+                "agent.skill_utils.get_config_path",
+                lambda: config_file,
+            ):
+                msg = build_skill_invocation_message("/cfg-skill")
+
+        assert msg is not None
+        assert "[Skill config" in msg
+        assert "wiki.path = /custom/wiki" in msg
+
+    def test_config_defaults_used_when_no_config_file(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("TENOR_API_KEY", raising=False)
+
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "default-skill",
+                frontmatter_extra=(
+                    "metadata:\n"
+                    "  hermes:\n"
+                    "    config:\n"
+                    "      - key: test.key\n"
+                    "        description: A test key\n"
+                    "        default: my-default\n"
+                    "        prompt: Test key\n"
+                ),
+            )
+            scan_skill_commands()
+            with patch(
+                "agent.skill_utils.get_config_path",
+                lambda: tmp_path / "does_not_exist.yaml",
+            ):
+                msg = build_skill_invocation_message("/default-skill")
+
+        assert msg is not None
+        assert "[Skill config" in msg
+        assert "test.key = my-default" in msg
+
+    def test_no_config_block_when_skill_has_no_config(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("TENOR_API_KEY", raising=False)
+
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "plain-skill")
+            scan_skill_commands()
+            msg = build_skill_invocation_message("/plain-skill")
+
+        assert msg is not None
+        assert "[Skill config" not in msg

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -917,6 +917,18 @@ class TestInternalHelpers:
 
 
 # ===================================================================
+# Profile directory configuration
+# ===================================================================
+
+class TestProfileDirsConfig:
+    """Tests for _PROFILE_DIRS configuration."""
+
+    def test_profile_dirs_includes_wikis(self):
+        from hermes_cli.profiles import _PROFILE_DIRS
+        assert "wikis" in _PROFILE_DIRS
+
+
+# ===================================================================
 # Edge cases and additional coverage
 # ===================================================================
 

--- a/website/docs/user-guide/skills/bundled/research/research-llm-wiki.md
+++ b/website/docs/user-guide/skills/bundled/research/research-llm-wiki.md
@@ -52,23 +52,29 @@ Use this skill when the user:
 
 ## Wiki Location
 
-The agent resolves the active wiki path from config on every operation. The skill
-config system injects two values:
+The agent resolves the active wiki path from the config system. When this skill
+triggers, config values are injected in this format:
 
-- `llm-wiki.active_wiki` — which wiki is currently selected (e.g. "default", "research")
-- `llm-wiki.wikis` — JSON registry of all wikis with their paths and descriptions
-
-**Path resolution:**
-
-```bash
-# Config values are injected by the agent as [Skill config: ...]
-# Parse the registry and resolve the active wiki path:
-WIKI="${HERMES_HOME}/wikis/${resolved_active_wiki_path}"
+```
+[Skill config (from ~/.hermes/config.yaml):
+  llm-wiki.active_wiki = default
+  llm-wiki.wikis = {"default":{"path":"default","description":"Default wiki"}}
+]
 ```
 
+**Before every operation, resolve the active wiki:**
+
+1. From the injected config, read `llm-wiki.active_wiki` — this is the wiki name (e.g. "default")
+2. From the injected config, read `llm-wiki.wikis` — parse the JSON string into a dict
+3. Look up `wikis[active_wiki_name]["path"]` — this is the subdirectory name (e.g. "default")
+4. Construct the full path: `WIKI="${HERMES_HOME}/wikis/<path>"`
+
+Example: if `active_wiki = "default"` and the wiki entry is `{"path":"default",...}`,
+then `WIKI="${HERMES_HOME}/wikis/default"`.
+
 The resolved path is always under `{HERMES_HOME}/wikis/`. Each wiki is a
-subdirectory — open it in Obsidian, VS Code, or any editor. No database,
-no special tooling required.
+subdirectory of markdown files — open it in Obsidian, VS Code, or any editor.
+No database, no special tooling required.
 
 **Profile isolation:** In named profiles, wikis live under
 `~/.hermes/profiles/<profile>/wikis/`. The `HERMES_HOME` env var already
@@ -76,10 +82,13 @@ points to the profile root, so path resolution works identically.
 
 **Backward compatibility:** On first use after upgrading, if the agent detects
 an existing `~/wiki` directory and no `~/.hermes/wikis/default` exists, it
-silently creates a symlink:
+creates a symlink:
 
-```
-~/.hermes/wikis/default → ~/wiki
+```bash
+if [ -d ~/wiki ] && [ ! -e ~/.hermes/wikis/default ]; then
+  mkdir -p ~/.hermes/wikis
+  ln -s ~/wiki ~/.hermes/wikis/default
+fi
 ```
 
 The user's existing wiki and Obsidian vault continue working unchanged. If
@@ -145,7 +154,7 @@ When the user asks to create or start a wiki:
 1. Determine the wiki path:
    - If `WIKI_PATH` env var is set, use that (existing behavior)
    - Otherwise, use `{HERMES_HOME}/wikis/default/` (create if needed)
-   - Initialize config: set `llm-wiki.active_wiki` to "default", add default entry to `llm-wiki.wikis`
+   - Initialize config: `save_config_value("skills.config.llm-wiki.active_wiki", "default")` and `save_config_value("skills.config.llm-wiki.wikis", '{"default":{"path":"default","description":"Default wiki"}}')`
 2. Create the directory structure above
 3. Ask the user what domain the wiki covers — be specific
 4. Write `SCHEMA.md` customized to the domain (see template below)
@@ -419,8 +428,8 @@ wiki = "<WIKI_PATH>"
 When the user says something like "switch to the research wiki" or
 "use my personal wiki":
 
-1. Read `llm-wiki.wikis` config to check the requested wiki exists
-2. If it exists, update `llm-wiki.active_wiki` via `save_config_value()`
+1. Read `llm-wiki.wikis` from injected config, parse JSON, check the requested wiki exists
+2. If it exists, update the config: `save_config_value("skills.config.llm-wiki.active_wiki", "<wiki-name>")`
 3. Orient to the new wiki (read its SCHEMA.md, index.md, recent log.md)
 4. Confirm the switch: "Switched to `research` wiki. [Brief summary of what's in it.]"
 5. If the wiki doesn't exist, offer to create it
@@ -430,19 +439,19 @@ When the user says something like "switch to the research wiki" or
 When the user asks to create a new wiki:
 
 1. Ask for a name (lowercase, hyphens, used as directory name) and description
-2. Read current `llm-wiki.wikis` config
+2. Read `llm-wiki.wikis` from injected config, parse JSON
 3. Check no name collision with existing wikis
-4. Add entry to `llm-wiki.wikis` config: `{"name": {"path": "name", "description": "..."}}`
+4. Update the registry: add the new entry to the wikis dict, then `save_config_value("skills.config.llm-wiki.wikis", json.dumps(updated_wikis))`
 5. Create directory structure under `{HERMES_HOME}/wikis/{name}/`
 6. Initialize SCHEMA.md, index.md, log.md (same as Initializing a New Wiki)
-7. Set `llm-wiki.active_wiki` to the new wiki name
+7. Set active: `save_config_value("skills.config.llm-wiki.active_wiki", "<name>")`
 8. Confirm: "Created `research` wiki and switched to it."
 
 ### Listing Wikis
 
 When the user asks what wikis they have or which is active:
 
-1. Read `llm-wiki.wikis` and `llm-wiki.active_wiki` from config
+1. Read `llm-wiki.wikis` and `llm-wiki.active_wiki` from injected config, parse wikis JSON
 2. List each wiki with its description and page count
 3. Mark which one is active
 
@@ -509,62 +518,6 @@ For best results:
 
 If using the Obsidian skill alongside this one, set `OBSIDIAN_VAULT_PATH` to the
 same directory as the wiki path.
-
-### Obsidian Headless (servers and headless machines)
-
-On machines without a display, use `obsidian-headless` instead of the desktop app.
-It syncs vaults via Obsidian Sync without a GUI — perfect for agents running on
-servers that write to the wiki while Obsidian desktop reads it on another device.
-
-**Setup:**
-```bash
-# Requires Node.js 22+
-npm install -g obsidian-headless
-
-# Login (requires Obsidian account with Sync subscription)
-ob login --email <email> --password '<password>'
-
-# Create a remote vault for the wiki
-ob sync-create-remote --name "LLM Wiki"
-
-# Connect the wiki directory to the vault
-cd ~/wiki
-ob sync-setup --vault "<vault-id>"
-
-# Initial sync
-ob sync
-
-# Continuous sync (foreground — use systemd for background)
-ob sync --continuous
-```
-
-**Continuous background sync via systemd:**
-```ini
-# ~/.config/systemd/user/obsidian-wiki-sync.service
-[Unit]
-Description=Obsidian LLM Wiki Sync
-After=network-online.target
-Wants=network-online.target
-
-[Service]
-ExecStart=/path/to/ob sync --continuous
-WorkingDirectory=/home/user/wiki
-Restart=on-failure
-RestartSec=10
-
-[Install]
-WantedBy=default.target
-```
-
-```bash
-systemctl --user daemon-reload
-systemctl --user enable --now obsidian-wiki-sync
-# Enable linger so sync survives logout:
-sudo loginctl enable-linger $USER
-```
-
-This lets the agent write to `~/wiki` on a server while you browse the same
-vault in Obsidian on your laptop/phone — changes appear within seconds.
 
 ## Pitfalls
 

--- a/website/docs/user-guide/skills/bundled/research/research-llm-wiki.md
+++ b/website/docs/user-guide/skills/bundled/research/research-llm-wiki.md
@@ -16,7 +16,7 @@ Karpathy's LLM Wiki: build/query interlinked markdown KB.
 |---|---|
 | Source | Bundled (installed by default) |
 | Path | `skills/research/llm-wiki` |
-| Version | `2.1.0` |
+| Version | `2.2.0` |
 | Author | Hermes Agent |
 | License | MIT |
 | Tags | `wiki`, `knowledge-base`, `research`, `notes`, `markdown`, `rag-alternative` |
@@ -48,19 +48,45 @@ Use this skill when the user:
 - Asks a question and an existing wiki is present at the configured path
 - Asks to lint, audit, or health-check their wiki
 - References their wiki, knowledge base, or "notes" in a research context
+- Asks to switch wikis, create a new wiki, or list their wikis
 
 ## Wiki Location
 
-**Location:** Set via `WIKI_PATH` environment variable (e.g. in `~/.hermes/.env`).
+The agent resolves the active wiki path from config on every operation. The skill
+config system injects two values:
 
-If unset, defaults to `~/wiki`.
+- `llm-wiki.active_wiki` — which wiki is currently selected (e.g. "default", "research")
+- `llm-wiki.wikis` — JSON registry of all wikis with their paths and descriptions
+
+**Path resolution:**
 
 ```bash
-WIKI="${WIKI_PATH:-$HOME/wiki}"
+# Config values are injected by the agent as [Skill config: ...]
+# Parse the registry and resolve the active wiki path:
+WIKI="${HERMES_HOME}/wikis/${resolved_active_wiki_path}"
 ```
 
-The wiki is just a directory of markdown files — open it in Obsidian, VS Code, or
-any editor. No database, no special tooling required.
+The resolved path is always under `{HERMES_HOME}/wikis/`. Each wiki is a
+subdirectory — open it in Obsidian, VS Code, or any editor. No database,
+no special tooling required.
+
+**Profile isolation:** In named profiles, wikis live under
+`~/.hermes/profiles/<profile>/wikis/`. The `HERMES_HOME` env var already
+points to the profile root, so path resolution works identically.
+
+**Backward compatibility:** On first use after upgrading, if the agent detects
+an existing `~/wiki` directory and no `~/.hermes/wikis/default` exists, it
+silently creates a symlink:
+
+```
+~/.hermes/wikis/default → ~/wiki
+```
+
+The user's existing wiki and Obsidian vault continue working unchanged. If
+`WIKI_PATH` env var is set, it takes priority (existing behavior preserved).
+
+**Edge case:** If no `~/wiki` exists and no `WIKI_PATH` is set, the agent
+creates `~/.hermes/wikis/default/` with fresh structure on first use.
 
 ## Architecture: Three Layers
 
@@ -96,7 +122,7 @@ When the user has an existing wiki, **always orient yourself before doing anythi
 ③ **Scan recent `log.md`** — read the last 20-30 entries to understand recent activity.
 
 ```bash
-WIKI="${WIKI_PATH:-$HOME/wiki}"
+# WIKI is resolved from skill config (see Wiki Location above)
 # Orientation reads at session start
 read_file "$WIKI/SCHEMA.md"
 read_file "$WIKI/index.md"
@@ -116,7 +142,10 @@ at hand before creating anything new.
 
 When the user asks to create or start a wiki:
 
-1. Determine the wiki path (from `$WIKI_PATH` env var, or ask the user; default `~/wiki`)
+1. Determine the wiki path:
+   - If `WIKI_PATH` env var is set, use that (existing behavior)
+   - Otherwise, use `{HERMES_HOME}/wikis/default/` (create if needed)
+   - Initialize config: set `llm-wiki.active_wiki` to "default", add default entry to `llm-wiki.wikis`
 2. Create the directory structure above
 3. Ask the user what domain the wiki covers — be specific
 4. Write `SCHEMA.md` customized to the domain (see template below)
@@ -382,6 +411,51 @@ wiki = "<WIKI_PATH>"
    severity (broken links > orphans > source drift > contested pages > stale content > style issues).
 
 ⑬ **Append to log.md:** `## [YYYY-MM-DD] lint | N issues found`
+
+## Wiki Management
+
+### Switching Wikis
+
+When the user says something like "switch to the research wiki" or
+"use my personal wiki":
+
+1. Read `llm-wiki.wikis` config to check the requested wiki exists
+2. If it exists, update `llm-wiki.active_wiki` via `save_config_value()`
+3. Orient to the new wiki (read its SCHEMA.md, index.md, recent log.md)
+4. Confirm the switch: "Switched to `research` wiki. [Brief summary of what's in it.]"
+5. If the wiki doesn't exist, offer to create it
+
+### Creating a New Wiki
+
+When the user asks to create a new wiki:
+
+1. Ask for a name (lowercase, hyphens, used as directory name) and description
+2. Read current `llm-wiki.wikis` config
+3. Check no name collision with existing wikis
+4. Add entry to `llm-wiki.wikis` config: `{"name": {"path": "name", "description": "..."}}`
+5. Create directory structure under `{HERMES_HOME}/wikis/{name}/`
+6. Initialize SCHEMA.md, index.md, log.md (same as Initializing a New Wiki)
+7. Set `llm-wiki.active_wiki` to the new wiki name
+8. Confirm: "Created `research` wiki and switched to it."
+
+### Listing Wikis
+
+When the user asks what wikis they have or which is active:
+
+1. Read `llm-wiki.wikis` and `llm-wiki.active_wiki` from config
+2. List each wiki with its description and page count
+3. Mark which one is active
+
+### Pre-Write Content Check
+
+Before any ingest operation, the agent should analyze content relevance to the
+current `active_wiki`. If the content is a better fit for another wiki:
+
+> "This looks like it belongs in the `research` wiki, but `personal` is currently
+> active. Should I switch to `research` for this, or keep it in `personal`?"
+
+This is a judgment call based on the wiki descriptions and existing content.
+Don't ask for every source — only when there's a clear mismatch.
 
 ## Working with the Wiki
 


### PR DESCRIPTION
## What does this PR do?

This PR extends the bundled `llm-wiki` skill to support multiple wikis per profile, addressing a common user need to maintain separate knowledge bases for different domains (e.g., research, personal, business) without manual directory management.

### Problem

The current `llm-wiki` skill supports only a single wiki at a hardcoded path (`~/wiki` or `WIKI_PATH` env var). Users working across multiple domains either:
- Mix everything into one wiki (loses organizational clarity)
- Manually manage separate directories and switch env vars (error-prone)
- Don't use the skill for secondary domains

### Solution

A config-driven multi-wiki system that's fully backward compatible:

1. **Multiple wikis per profile** — stored under `{HERMES_HOME}/wikis/<name>/`, each with independent SCHEMA.md, index.md, log.md
2. **Config-based management** — uses the existing `metadata.hermes.config` system with two keys:
   - `llm-wiki.active_wiki` — which wiki is currently selected (flat string)
   - `llm-wiki.wikis` — JSON registry of all wikis with paths and descriptions
3. **Conversational wiki selection** — "switch to research wiki", "create a new personal wiki", "what wikis do I have?"
4. **Silent backward compatibility** — existing `~/wiki` users get an automatic symlink (`~/.hermes/wikis/default → ~/wiki`), no migration needed
5. **Profile isolation** — each Hermes profile gets independent wikis via the existing `_PROFILE_DIRS` bootstrap

### What Changed

| File | Change |
|------|--------|
| `hermes_cli/profiles.py` | +3 lines: added `"wikis"` to `_PROFILE_DIRS` |
| `skills/research/llm-wiki/SKILL.md` | ~160 lines changed: new frontmatter config, path resolution, wiki management operations |
| `tests/agent/test_skill_commands.py` | +329 lines: tests for config extraction, resolution, injection |
| `tests/hermes_cli/test_profiles.py` | +12 lines: test for wikis directory bootstrap |
| `website/docs/.../research-llm-wiki.md` | Regenerated from SKILL.md |

### Key Design Decisions

- **Config keys use `skills.config.*` prefix** for storage — consistent with `SKILL_CONFIG_PREFIX` in `agent/skill_utils.py`
- **All `save_config_value()` calls specify the full path** (e.g., `skills.config.llm-wiki.active_wiki`) to match the `_resolve_dotpath` read path
- **Wiki paths are relative** (subdirectory names under `wikis/`), never absolute — prevents path traversal
- **`WIKI_PATH` env var still takes priority** when set — existing users are unaffected

### Backward Compatibility

- Existing `~/wiki` directory is detected and silently symlinked
- `WIKI_PATH` env var override preserved
- No config migration needed — defaults are provided in frontmatter
- Single-wiki users see no behavior change

### Verification

- [x] All 94 profile tests pass
- [x] New config injection tests pass (329 lines covering extraction, resolution, injection)
- [x] SKILL.md YAML frontmatter validates correctly
- [x] All config write/read paths use consistent `skills.config.*` prefix
- [x] Auto-generated documentation regenerated

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding or improving test coverage)

## Checklist

- [x] I've read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] PR contains only changes related to this feature
- [x] All tests pass
- [x] Tests added for new behavior
- [x] SKILL.md follows the standard format (frontmatter, trigger conditions, steps, pitfalls)