### PR TITLE
[codex] add enterprise security policy posture

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 
 def _hermes_home_path() -> Path:
@@ -16,36 +16,100 @@ def _hermes_home_path() -> Path:
         return Path(os.path.expanduser("~/.hermes"))
 
 
+def _load_security_policy_filesystem_config() -> dict[str, Any]:
+    """Read the filesystem policy block from active config.yaml.
+
+    This module sits under ``agent/`` and is imported by low-level file tools,
+    so avoid importing the full config loader here. A tiny raw YAML read keeps
+    the write guard profile-aware without introducing a circular dependency.
+    """
+    config_path = _hermes_home_path() / "config.yaml"
+    if not config_path.exists():
+        return {}
+    try:
+        import yaml
+
+        data = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    except Exception:
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    security = data.get("security")
+    if not isinstance(security, dict):
+        return {}
+    policy = security.get("policy")
+    if not isinstance(policy, dict):
+        return {}
+    filesystem = policy.get("filesystem")
+    return filesystem if isinstance(filesystem, dict) else {}
+
+
+def _as_config_bool(value: Any, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "off"}:
+            return False
+    return default
+
+
+def _deny_hermes_control_plane_enabled() -> bool:
+    fs_cfg = _load_security_policy_filesystem_config()
+    return _as_config_bool(fs_cfg.get("deny_hermes_control_plane"), True)
+
+
+def _configured_safe_write_root() -> str:
+    fs_cfg = _load_security_policy_filesystem_config()
+    raw = fs_cfg.get("write_safe_root", "")
+    return str(raw).strip() if raw is not None else ""
+
+
 def build_write_denied_paths(home: str) -> set[str]:
     """Return exact sensitive paths that must never be written."""
     hermes_home = _hermes_home_path()
-    return {
-        os.path.realpath(p)
-        for p in [
-            os.path.join(home, ".ssh", "authorized_keys"),
-            os.path.join(home, ".ssh", "id_rsa"),
-            os.path.join(home, ".ssh", "id_ed25519"),
-            os.path.join(home, ".ssh", "config"),
-            str(hermes_home / ".env"),
-            os.path.join(home, ".bashrc"),
-            os.path.join(home, ".zshrc"),
-            os.path.join(home, ".profile"),
-            os.path.join(home, ".bash_profile"),
-            os.path.join(home, ".zprofile"),
-            os.path.join(home, ".netrc"),
-            os.path.join(home, ".pgpass"),
-            os.path.join(home, ".npmrc"),
-            os.path.join(home, ".pypirc"),
-            "/etc/sudoers",
-            "/etc/passwd",
-            "/etc/shadow",
-        ]
-    }
+    paths = [
+        os.path.join(home, ".ssh", "authorized_keys"),
+        os.path.join(home, ".ssh", "id_rsa"),
+        os.path.join(home, ".ssh", "id_ed25519"),
+        os.path.join(home, ".ssh", "config"),
+        str(hermes_home / ".env"),
+        os.path.join(home, ".bashrc"),
+        os.path.join(home, ".zshrc"),
+        os.path.join(home, ".profile"),
+        os.path.join(home, ".bash_profile"),
+        os.path.join(home, ".zprofile"),
+        os.path.join(home, ".netrc"),
+        os.path.join(home, ".pgpass"),
+        os.path.join(home, ".npmrc"),
+        os.path.join(home, ".pypirc"),
+        "/etc/sudoers",
+        "/etc/passwd",
+        "/etc/shadow",
+    ]
+
+    if _deny_hermes_control_plane_enabled():
+        paths.extend(
+            [
+                str(hermes_home / "auth.json"),
+                str(hermes_home / "config.yaml"),
+                str(hermes_home / "gateway.json"),
+                str(hermes_home / "webhook_subscriptions.json"),
+                str(hermes_home / ".anthropic_oauth.json"),
+            ]
+        )
+
+    return {os.path.realpath(p) for p in paths}
 
 
 def build_write_denied_prefixes(home: str) -> list[str]:
     """Return sensitive directory prefixes that must never be written."""
-    return [
+    hermes_home = _hermes_home_path()
+    prefixes = [
         os.path.realpath(p) + os.sep
         for p in [
             os.path.join(home, ".ssh"),
@@ -59,15 +123,31 @@ def build_write_denied_prefixes(home: str) -> list[str]:
             os.path.join(home, ".config", "gh"),
         ]
     ]
+    if _deny_hermes_control_plane_enabled():
+        prefixes.extend(
+            os.path.realpath(p) + os.sep
+            for p in [
+                str(hermes_home / "auth"),
+                str(hermes_home / "mcp-tokens"),
+            ]
+        )
+    return prefixes
 
 
 def get_safe_write_root() -> Optional[str]:
-    """Return the resolved HERMES_WRITE_SAFE_ROOT path, or None if unset."""
-    root = os.getenv("HERMES_WRITE_SAFE_ROOT", "")
+    """Return the resolved write-safe root path, or None if unset.
+
+    ``HERMES_WRITE_SAFE_ROOT`` wins for backwards compatibility. The
+    OpenShell-inspired policy surface also supports
+    ``security.policy.filesystem.write_safe_root`` in config.yaml.
+    """
+    root = os.getenv("HERMES_WRITE_SAFE_ROOT", "").strip()
+    if not root:
+        root = _configured_safe_write_root()
     if not root:
         return None
     try:
-        return os.path.realpath(os.path.expanduser(root))
+        return os.path.realpath(os.path.expandvars(os.path.expanduser(root)))
     except Exception:
         return None
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1082,6 +1082,16 @@ DEFAULT_CONFIG = {
     "security": {
         "allow_private_urls": False,  # Allow requests to private/internal IPs (for OpenWrt, proxies, VPNs)
         "redact_secrets": False,
+        "policy": {
+            "filesystem": {
+                # Constrain write_file/patch operations to this subtree when set.
+                # Equivalent to HERMES_WRITE_SAFE_ROOT, which takes precedence.
+                "write_safe_root": "",
+                # Block write_file/patch from mutating active Hermes control-plane
+                # files such as config.yaml, auth.json, and MCP token stores.
+                "deny_hermes_control_plane": True,
+            },
+        },
         "tirith_enabled": True,
         "tirith_path": "tirith",
         "tirith_timeout": 5,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5061,6 +5061,13 @@ def cmd_doctor(args):
     run_doctor(args)
 
 
+def cmd_security(args):
+    """Enterprise security posture and policy helpers."""
+    from hermes_cli.security_policy import security_command
+
+    security_command(args)
+
+
 def cmd_dump(args):
     """Dump setup summary for support/debugging."""
     from hermes_cli.dump import run_dump
@@ -7530,6 +7537,7 @@ def _coalesce_session_name_args(argv: list) -> list:
         "status",
         "cron",
         "doctor",
+        "security",
         "config",
         "pairing",
         "skills",
@@ -8727,6 +8735,47 @@ def main():
         "--fix", action="store_true", help="Attempt to fix issues automatically"
     )
     doctor_parser.set_defaults(func=cmd_doctor)
+
+    # =========================================================================
+    # security command
+    # =========================================================================
+    security_parser = subparsers.add_parser(
+        "security",
+        help="Inspect enterprise security posture",
+        description=(
+            "Inspect Hermes' effective security posture and validate "
+            "OpenShell-inspired security policy files."
+        ),
+    )
+    security_sub = security_parser.add_subparsers(dest="security_action")
+    security_doctor = security_sub.add_parser(
+        "doctor",
+        help="Check enterprise security posture",
+    )
+    security_doctor.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit non-zero when any posture check is not pass",
+    )
+    security_doctor.add_argument("--json", action="store_true", help="Output JSON")
+
+    security_policy = security_sub.add_parser(
+        "policy",
+        help="Show or validate the effective security policy",
+    )
+    security_policy_sub = security_policy.add_subparsers(dest="policy_action")
+    security_policy_show = security_policy_sub.add_parser(
+        "show",
+        help="Show the effective policy derived from config and env",
+    )
+    security_policy_show.add_argument("--json", action="store_true", help="Output JSON")
+    security_policy_validate = security_policy_sub.add_parser(
+        "validate",
+        help="Validate a security policy YAML/JSON file",
+    )
+    security_policy_validate.add_argument("file", help="Policy file to validate")
+    security_policy_validate.add_argument("--json", action="store_true", help="Output JSON")
+    security_parser.set_defaults(func=cmd_security)
 
     # =========================================================================
     # dump command

--- a/hermes_cli/security_policy.py
+++ b/hermes_cli/security_policy.py
@@ -1,0 +1,450 @@
+"""Enterprise security posture reporting for Hermes.
+
+This is intentionally a thin OpenShell-inspired policy surface over controls
+Hermes already has: filesystem write guards, environment scrubbing, command
+approvals, URL guard settings, and redaction. It does not claim network proxy
+or kernel-level enforcement that Hermes does not currently provide.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+
+SUPPORTED_POLICY_SCHEMA: dict[str, dict[str, str]] = {
+    "filesystem": {
+        "write_safe_root": "string",
+        "deny_hermes_control_plane": "boolean",
+    },
+    "environment": {
+        "env_passthrough": "list[string]",
+    },
+    "process": {
+        "approvals_mode": "manual|smart|off",
+        "tirith_enabled": "boolean",
+        "tirith_fail_open": "boolean",
+    },
+    "network": {
+        "allow_private_urls": "boolean",
+        "website_blocklist_enabled": "boolean",
+    },
+    "inference": {
+        "redact_secrets": "boolean",
+    },
+}
+
+
+@dataclass(frozen=True)
+class PostureCheck:
+    domain: str
+    name: str
+    status: str
+    detail: str
+    recommendation: str = ""
+
+
+def _get(config: Mapping[str, Any], *keys: str, default: Any = None) -> Any:
+    cur: Any = config
+    for key in keys:
+        if not isinstance(cur, Mapping):
+            return default
+        cur = cur.get(key)
+    return default if cur is None else cur
+
+
+def _as_bool(value: Any, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "off"}:
+            return False
+    return default
+
+
+def _as_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item.strip() for item in value if isinstance(item, str) and item.strip()]
+
+
+def _provider_env_blocklist() -> frozenset[str]:
+    try:
+        from tools.environments.local import _HERMES_PROVIDER_ENV_BLOCKLIST
+
+        return _HERMES_PROVIDER_ENV_BLOCKLIST
+    except Exception:
+        return frozenset({
+            "OPENAI_API_KEY",
+            "OPENROUTER_API_KEY",
+            "ANTHROPIC_API_KEY",
+            "ANTHROPIC_TOKEN",
+            "GOOGLE_API_KEY",
+            "GITHUB_TOKEN",
+            "GH_TOKEN",
+        })
+
+
+def _resolve_safe_root_source(
+    config: Mapping[str, Any], env: Mapping[str, str]
+) -> tuple[str, str]:
+    env_root = str(env.get("HERMES_WRITE_SAFE_ROOT", "")).strip()
+    if env_root:
+        return env_root, "HERMES_WRITE_SAFE_ROOT"
+    cfg_root = str(
+        _get(config, "security", "policy", "filesystem", "write_safe_root", default="")
+        or ""
+    ).strip()
+    if cfg_root:
+        return cfg_root, "security.policy.filesystem.write_safe_root"
+    return "", "unset"
+
+
+def build_effective_policy(
+    config: Mapping[str, Any] | None = None,
+    env: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    """Return Hermes' effective security posture as a serializable dict."""
+    if config is None:
+        from hermes_cli.config import load_config
+
+        config = load_config()
+    if env is None:
+        env = os.environ
+
+    safe_root, safe_root_source = _resolve_safe_root_source(config, env)
+    env_passthrough = _as_list(_get(config, "terminal", "env_passthrough", default=[]))
+    provider_passthrough = sorted(
+        name for name in env_passthrough if name in _provider_env_blocklist()
+    )
+    website_blocklist = _get(config, "security", "website_blocklist", default={})
+    if not isinstance(website_blocklist, Mapping):
+        website_blocklist = {}
+
+    approvals_mode = str(_get(config, "approvals", "mode", default="manual") or "manual")
+
+    return {
+        "filesystem": {
+            "write_safe_root": safe_root,
+            "write_safe_root_source": safe_root_source,
+            "deny_hermes_control_plane": _as_bool(
+                _get(
+                    config,
+                    "security",
+                    "policy",
+                    "filesystem",
+                    "deny_hermes_control_plane",
+                    default=True,
+                ),
+                True,
+            ),
+            "deny_home_credentials": True,
+        },
+        "environment": {
+            "scrub_provider_credentials": True,
+            "env_passthrough": env_passthrough,
+            "provider_credentials_in_passthrough": provider_passthrough,
+        },
+        "process": {
+            "hardline_blocklist": True,
+            "approvals_mode": approvals_mode,
+            "tirith_enabled": _as_bool(
+                _get(config, "security", "tirith_enabled", default=True), True
+            ),
+            "tirith_fail_open": _as_bool(
+                _get(config, "security", "tirith_fail_open", default=True), True
+            ),
+        },
+        "network": {
+            "allow_private_urls": _as_bool(
+                _get(config, "security", "allow_private_urls", default=False), False
+            ),
+            "website_blocklist_enabled": _as_bool(
+                website_blocklist.get("enabled"), False
+            ),
+            "website_blocklist_domains": _as_list(website_blocklist.get("domains")),
+        },
+        "inference": {
+            "redact_secrets": _as_bool(
+                _get(config, "security", "redact_secrets", default=False), False
+            ),
+        },
+    }
+
+
+def evaluate_posture(policy: Mapping[str, Any]) -> list[PostureCheck]:
+    checks: list[PostureCheck] = []
+
+    def add(
+        domain: str,
+        name: str,
+        status: str,
+        detail: str,
+        recommendation: str = "",
+    ) -> None:
+        checks.append(PostureCheck(domain, name, status, detail, recommendation))
+
+    filesystem = policy.get("filesystem", {})
+    safe_root = str(filesystem.get("write_safe_root") or "")
+    add(
+        "filesystem",
+        "write_safe_root",
+        "pass" if safe_root else "warn",
+        (
+            f"write-safe root is {safe_root!r}"
+            if safe_root
+            else "write-safe root is not set"
+        ),
+        (
+            "Set security.policy.filesystem.write_safe_root or "
+            "HERMES_WRITE_SAFE_ROOT for workspace-only writes."
+        ),
+    )
+    add(
+        "filesystem",
+        "control_plane_write_deny",
+        "pass" if filesystem.get("deny_hermes_control_plane") else "fail",
+        "active Hermes control-plane files are write-denied"
+        if filesystem.get("deny_hermes_control_plane")
+        else "active Hermes control-plane files are not write-denied",
+        "Set security.policy.filesystem.deny_hermes_control_plane: true.",
+    )
+    add(
+        "filesystem",
+        "home_credential_write_deny",
+        "pass",
+        "home credential paths are statically write-denied",
+    )
+
+    environment = policy.get("environment", {})
+    provider_passthrough = environment.get("provider_credentials_in_passthrough") or []
+    add(
+        "environment",
+        "provider_credential_scrubbing",
+        "pass",
+        "Hermes-managed provider credentials are scrubbed from local subprocesses by default",
+    )
+    add(
+        "environment",
+        "provider_env_passthrough",
+        "fail" if provider_passthrough else "pass",
+        "provider credentials allowed through terminal.env_passthrough: "
+        + ", ".join(provider_passthrough)
+        if provider_passthrough
+        else "terminal.env_passthrough does not include Hermes provider credentials",
+        "Remove Hermes provider credentials from terminal.env_passthrough.",
+    )
+
+    process = policy.get("process", {})
+    approvals_mode = str(process.get("approvals_mode") or "manual").lower()
+    add(
+        "process",
+        "hardline_blocklist",
+        "pass" if process.get("hardline_blocklist") else "fail",
+        "unconditional hardline command blocklist is enabled"
+        if process.get("hardline_blocklist")
+        else "unconditional hardline command blocklist is disabled",
+    )
+    add(
+        "process",
+        "dangerous_command_approvals",
+        "fail" if approvals_mode == "off" else "pass",
+        f"approvals.mode is {approvals_mode}",
+        "Use approvals.mode: manual or smart for enterprise deployments.",
+    )
+    add(
+        "process",
+        "tirith_scanner",
+        "pass" if process.get("tirith_enabled") else "warn",
+        "Tirith command scanner is enabled"
+        if process.get("tirith_enabled")
+        else "Tirith command scanner is disabled",
+        "Set security.tirith_enabled: true.",
+    )
+    add(
+        "process",
+        "tirith_fail_closed",
+        "warn" if process.get("tirith_fail_open") else "pass",
+        "Tirith is configured fail-open"
+        if process.get("tirith_fail_open")
+        else "Tirith is configured fail-closed",
+        "Set security.tirith_fail_open: false for strict enterprise posture.",
+    )
+
+    network = policy.get("network", {})
+    add(
+        "network",
+        "private_url_guard",
+        "warn" if network.get("allow_private_urls") else "pass",
+        "private/internal URLs are allowed"
+        if network.get("allow_private_urls")
+        else "private/internal URLs are blocked by default",
+        "Keep security.allow_private_urls: false unless explicitly required.",
+    )
+    add(
+        "network",
+        "website_blocklist",
+        "pass" if network.get("website_blocklist_enabled") else "warn",
+        "website blocklist is enabled"
+        if network.get("website_blocklist_enabled")
+        else "website blocklist is disabled",
+        "Enable security.website_blocklist for enterprise deny rules.",
+    )
+
+    inference = policy.get("inference", {})
+    add(
+        "inference",
+        "secret_redaction",
+        "pass" if inference.get("redact_secrets") else "warn",
+        "secret redaction is enabled"
+        if inference.get("redact_secrets")
+        else "secret redaction is disabled",
+        "Set security.redact_secrets: true to scrub tool output and logs.",
+    )
+
+    return checks
+
+
+def _load_policy_document(path: str) -> Mapping[str, Any]:
+    p = Path(path)
+    try:
+        raw = p.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ValueError(f"could not read policy file: {exc}") from exc
+    try:
+        if p.suffix.lower() == ".json":
+            data = json.loads(raw)
+        else:
+            import yaml
+
+            data = yaml.safe_load(raw)
+    except Exception as exc:
+        raise ValueError(f"could not parse policy file: {exc}") from exc
+    if not isinstance(data, Mapping):
+        raise ValueError("policy file must contain a mapping")
+    return data
+
+
+def _extract_policy_mapping(data: Mapping[str, Any]) -> Mapping[str, Any]:
+    if isinstance(data.get("security"), Mapping):
+        security = data["security"]
+        if isinstance(security.get("policy"), Mapping):
+            return security["policy"]
+    if isinstance(data.get("policy"), Mapping):
+        return data["policy"]
+    return data
+
+
+def validate_policy_mapping(data: Mapping[str, Any]) -> tuple[list[str], list[str]]:
+    policy = _extract_policy_mapping(data)
+    errors: list[str] = []
+    warnings: list[str] = []
+    for domain, value in policy.items():
+        if domain not in SUPPORTED_POLICY_SCHEMA:
+            errors.append(f"unsupported policy domain: {domain}")
+            continue
+        if not isinstance(value, Mapping):
+            errors.append(f"{domain} must be a mapping")
+            continue
+        allowed = SUPPORTED_POLICY_SCHEMA[domain]
+        for key, item in value.items():
+            expected = allowed.get(key)
+            if expected is None:
+                errors.append(f"unsupported policy key: {domain}.{key}")
+                continue
+            if expected == "boolean" and not isinstance(item, bool):
+                errors.append(f"{domain}.{key} must be a boolean")
+            elif expected == "string" and not isinstance(item, str):
+                errors.append(f"{domain}.{key} must be a string")
+            elif expected == "list[string]":
+                if not isinstance(item, list) or not all(
+                    isinstance(x, str) for x in item
+                ):
+                    errors.append(f"{domain}.{key} must be a list of strings")
+            elif "|" in expected:
+                choices = set(expected.split("|"))
+                if str(item) not in choices:
+                    errors.append(
+                        f"{domain}.{key} must be one of: {', '.join(sorted(choices))}"
+                    )
+    if not errors and not policy:
+        warnings.append("policy file did not contain any supported policy domains")
+    return errors, warnings
+
+
+def _print_policy_text(policy: Mapping[str, Any]) -> None:
+    print("Hermes Security Policy (effective)")
+    for domain in ("filesystem", "environment", "process", "network", "inference"):
+        print(f"\n{domain}:")
+        values = policy.get(domain, {})
+        if isinstance(values, Mapping):
+            for key, value in values.items():
+                display = "<unset>" if value == "" else value
+                print(f"  {key}: {display}")
+
+
+def _print_checks_text(checks: list[PostureCheck]) -> None:
+    print("Hermes Security Doctor")
+    for check in checks:
+        label = check.status.upper()
+        print(f"{label:<4} {check.domain}.{check.name}: {check.detail}")
+        if check.status != "pass" and check.recommendation:
+            print(f"     {check.recommendation}")
+
+
+def security_command(args: Any) -> None:
+    action = getattr(args, "security_action", None) or "doctor"
+    if action == "doctor":
+        policy = build_effective_policy()
+        checks = evaluate_posture(policy)
+        if getattr(args, "json", False):
+            print(json.dumps([asdict(check) for check in checks], indent=2))
+        else:
+            _print_checks_text(checks)
+        code = (
+            1
+            if getattr(args, "strict", False)
+            and any(c.status != "pass" for c in checks)
+            else 0
+        )
+        raise SystemExit(code)
+
+    if action == "policy":
+        policy_action = getattr(args, "policy_action", None) or "show"
+        if policy_action == "show":
+            policy = build_effective_policy()
+            if getattr(args, "json", False):
+                print(json.dumps(policy, indent=2, sort_keys=True))
+            else:
+                _print_policy_text(policy)
+            raise SystemExit(0)
+        if policy_action == "validate":
+            try:
+                data = _load_policy_document(args.file)
+                errors, warnings = validate_policy_mapping(data)
+            except ValueError as exc:
+                errors, warnings = [str(exc)], []
+            if getattr(args, "json", False):
+                print(json.dumps({"errors": errors, "warnings": warnings}, indent=2))
+            else:
+                if errors:
+                    print("Policy invalid:")
+                    for error in errors:
+                        print(f"  - {error}")
+                else:
+                    print("Policy valid.")
+                for warning in warnings:
+                    print(f"Warning: {warning}")
+            raise SystemExit(1 if errors else 0)
+
+    print("Unknown security command", file=sys.stderr)
+    raise SystemExit(2)

--- a/tests/hermes_cli/test_security_policy.py
+++ b/tests/hermes_cli/test_security_policy.py
@@ -1,0 +1,114 @@
+"""Tests for the OpenShell-inspired Hermes security posture surface."""
+
+from __future__ import annotations
+
+from argparse import Namespace
+
+import pytest
+
+from hermes_cli.security_policy import (
+    build_effective_policy,
+    evaluate_posture,
+    security_command,
+    validate_policy_mapping,
+)
+
+
+def test_effective_policy_prefers_env_safe_root():
+    cfg = {
+        "security": {
+            "policy": {"filesystem": {"write_safe_root": "/from-config"}},
+            "redact_secrets": True,
+        }
+    }
+    policy = build_effective_policy(cfg, {"HERMES_WRITE_SAFE_ROOT": "/from-env"})
+
+    assert policy["filesystem"]["write_safe_root"] == "/from-env"
+    assert policy["filesystem"]["write_safe_root_source"] == "HERMES_WRITE_SAFE_ROOT"
+    assert policy["inference"]["redact_secrets"] is True
+
+
+def test_effective_policy_reports_provider_env_passthrough():
+    cfg = {"terminal": {"env_passthrough": ["OPENAI_API_KEY", "NOTION_TOKEN"]}}
+    policy = build_effective_policy(cfg, {})
+
+    passthrough = policy["environment"]["provider_credentials_in_passthrough"]
+    assert "OPENAI_API_KEY" in passthrough
+    assert "NOTION_TOKEN" not in passthrough
+
+
+def test_posture_strict_flags_enterprise_gaps():
+    policy = build_effective_policy(
+        {
+            "approvals": {"mode": "off"},
+            "security": {
+                "redact_secrets": False,
+                "tirith_enabled": False,
+                "tirith_fail_open": True,
+                "allow_private_urls": True,
+                "policy": {"filesystem": {"deny_hermes_control_plane": False}},
+            },
+            "terminal": {"env_passthrough": ["OPENAI_API_KEY"]},
+        },
+        {},
+    )
+    checks = evaluate_posture(policy)
+    failing = {(check.domain, check.name) for check in checks if check.status == "fail"}
+    warning = {(check.domain, check.name) for check in checks if check.status == "warn"}
+
+    assert ("filesystem", "control_plane_write_deny") in failing
+    assert ("environment", "provider_env_passthrough") in failing
+    assert ("process", "dangerous_command_approvals") in failing
+    assert ("inference", "secret_redaction") in warning
+
+
+def test_validate_policy_mapping_accepts_supported_shape():
+    errors, warnings = validate_policy_mapping(
+        {
+            "security": {
+                "policy": {
+                    "filesystem": {
+                        "write_safe_root": "/workspace",
+                        "deny_hermes_control_plane": True,
+                    },
+                    "process": {
+                        "approvals_mode": "manual",
+                        "tirith_enabled": True,
+                        "tirith_fail_open": False,
+                    },
+                }
+            }
+        }
+    )
+
+    assert errors == []
+    assert warnings == []
+
+
+def test_validate_policy_mapping_rejects_unknown_and_wrong_types():
+    errors, _warnings = validate_policy_mapping(
+        {
+            "filesystem": {
+                "write_safe_root": 123,
+                "unknown": True,
+            },
+            "kernel": {"landlock": True},
+        }
+    )
+
+    assert "filesystem.write_safe_root must be a string" in errors
+    assert "unsupported policy key: filesystem.unknown" in errors
+    assert "unsupported policy domain: kernel" in errors
+
+
+def test_security_doctor_strict_exits_nonzero(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "hermes_cli.security_policy.build_effective_policy",
+        lambda: build_effective_policy({"approvals": {"mode": "off"}}, {}),
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        security_command(Namespace(security_action="doctor", strict=True, json=False))
+
+    assert exc.value.code == 1
+    assert "dangerous_command_approvals" in capsys.readouterr().out

--- a/tests/tools/test_file_write_safety.py
+++ b/tests/tools/test_file_write_safety.py
@@ -78,6 +78,42 @@ class TestSafeWriteRoot:
         monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", os.path.expanduser("~"))
         assert _is_write_denied(os.path.expanduser("~/.ssh/id_rsa")) is True
 
+    def test_safe_root_from_config(self, tmp_path: Path, monkeypatch):
+        safe_root = tmp_path / "workspace"
+        outside = tmp_path / "outside.txt"
+        safe_root.mkdir()
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        safe_root_yaml = str(safe_root).replace("'", "''")
+        (hermes_home / "config.yaml").write_text(
+            "security:\n"
+            "  policy:\n"
+            "    filesystem:\n"
+            f"      write_safe_root: '{safe_root_yaml}'\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("HERMES_WRITE_SAFE_ROOT", raising=False)
+
+        assert _is_write_denied(str(safe_root / "file.txt")) is False
+        assert _is_write_denied(str(outside)) is True
+
+    def test_disable_hermes_control_plane_write_deny(self, tmp_path: Path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "security:\n"
+            "  policy:\n"
+            "    filesystem:\n"
+            "      deny_hermes_control_plane: false\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        assert _is_write_denied(str(hermes_home / "config.yaml")) is False
+        assert _is_write_denied(str(hermes_home / ".env")) is True
+
 
 class TestCheckSensitivePathMacOSBypass:
     """Verify _check_sensitive_path blocks /private/etc paths (issue #8734)."""

--- a/tests/tools/test_write_deny.py
+++ b/tests/tools/test_write_deny.py
@@ -83,6 +83,17 @@ class TestWriteAllowed:
     def test_project_file(self):
         assert _is_write_denied("/home/user/project/main.py") is False
 
-    def test_hermes_config_not_env(self):
-        path = os.path.join(str(Path.home()), ".hermes", "config.yaml")
-        assert _is_write_denied(path) is False
+    def test_active_hermes_config_denied(self):
+        from hermes_constants import get_hermes_home
+        path = str(get_hermes_home() / "config.yaml")
+        assert _is_write_denied(path) is True
+
+    def test_active_hermes_auth_denied(self):
+        from hermes_constants import get_hermes_home
+        path = str(get_hermes_home() / "auth.json")
+        assert _is_write_denied(path) is True
+
+    def test_active_hermes_mcp_tokens_denied(self):
+        from hermes_constants import get_hermes_home
+        path = str(get_hermes_home() / "mcp-tokens" / "server.json")
+        assert _is_write_denied(path) is True

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1494,6 +1494,10 @@ Pre-execution security scanning and secret redaction:
 ```yaml
 security:
   redact_secrets: false          # Redact API key patterns in tool output and logs (off by default)
+  policy:
+    filesystem:
+      write_safe_root: ""        # Optional write_file/patch safe root
+      deny_hermes_control_plane: true
   tirith_enabled: true           # Enable Tirith security scanning for terminal commands
   tirith_path: "tirith"          # Path to tirith binary (default: "tirith" in $PATH)
   tirith_timeout: 5              # Seconds to wait for tirith scan before timing out
@@ -1505,10 +1509,27 @@ security:
 ```
 
 - `redact_secrets` — when `true`, automatically detects and redacts patterns that look like API keys, tokens, and passwords in tool output before it enters the conversation context and logs. **Off by default** — enable if you commonly work with real credentials in tool output and want a safety net. Set to `true` explicitly to turn on.
+- `policy.filesystem.write_safe_root` — when set, constrains file write and patch operations to that directory tree. `HERMES_WRITE_SAFE_ROOT` still takes precedence for backwards compatibility.
+- `policy.filesystem.deny_hermes_control_plane` — when `true` (default), blocks file write and patch operations from mutating active Hermes control-plane state such as `config.yaml`, `auth.json`, OAuth files, webhook subscriptions, and MCP token stores.
 - `tirith_enabled` — when `true`, terminal commands are scanned by [Tirith](https://github.com/StackGuardian/tirith) before execution to detect potentially dangerous operations.
 - `tirith_path` — path to the tirith binary. Set this if tirith is installed in a non-standard location.
 - `tirith_timeout` — maximum seconds to wait for a tirith scan. Commands proceed if the scan times out.
 - `tirith_fail_open` — when `true` (default), commands are allowed to execute if tirith is unavailable or fails. Set to `false` to block commands when tirith cannot verify them.
+
+Inspect the effective security posture with:
+
+```bash
+hermes security doctor
+hermes security doctor --strict
+hermes security policy show --json
+hermes security policy validate policy.yaml
+```
+
+The `security` command is inspired by OpenShell-style declarative posture
+checks: it reports the effective filesystem, environment, process, network,
+and inference controls that Hermes can enforce or inspect locally. It does not
+claim kernel-level or proxy-level enforcement beyond Hermes' existing runtime
+guards.
 
 ## Website Blocklist
 


### PR DESCRIPTION
## Summary

Adds an OpenShell-inspired `hermes security` CLI surface for enterprise security posture inspection and policy validation.

This PR also wires the first filesystem policy knob into real enforcement:

- `security.policy.filesystem.write_safe_root` constrains file write/patch operations to a configured subtree, with `HERMES_WRITE_SAFE_ROOT` still taking precedence.
- `security.policy.filesystem.deny_hermes_control_plane` blocks direct file write/patch mutation of active Hermes control-plane files such as `config.yaml`, `auth.json`, OAuth state, webhook subscriptions, and MCP token stores.

The new posture command reports existing Hermes controls across filesystem, environment, process, network, and inference domains without claiming OpenShell-style kernel or proxy enforcement that Hermes does not currently provide.

## Commands

- `hermes security doctor`
- `hermes security doctor --strict`
- `hermes security policy show --json`
- `hermes security policy validate policy.yaml`

## Validation

- `scripts/run_tests.sh tests/hermes_cli/test_security_policy.py tests/tools/test_file_write_safety.py tests/tools/test_write_deny.py tests/tools/test_file_operations.py`
- `.venv/bin/hermes security policy show --json`
- `.venv/bin/hermes security policy validate <sample policy>`
