### PR TITLE
fix(skills): align creative ideation skill name

### DIFF
--- a/skills/creative/creative-ideation/SKILL.md
+++ b/skills/creative/creative-ideation/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ideation
+name: creative-ideation
 title: Creative Ideation — Constraint-Driven Project Generation
 description: "Generate project ideas via creative constraints."
 version: 1.0.0


### PR DESCRIPTION
## Summary
- Align the creative ideation skill frontmatter name with its directory slug.
- Avoids lookup confusion where the skill appears as `ideation` but the stable slug/path is `creative-ideation`.

## Test Plan
- `scripts/run_tests.sh tests/tools/test_skills_tool.py tests/website/test_generate_skill_docs.py tests/agent/test_skill_commands.py`
- Result: 121 passed in 9.40s

## Platform
- Linux
