### PR TITLE
fix(approval): tighten 'delete in root path' regex to system-root targets only

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -123,6 +123,19 @@ class TestRmRootPathRegexPrecision:
         assert is_dangerous is True
         assert "recursive" in desc.lower() or "delete" in desc.lower()
 
+    def test_prior_legacy_allowlist_key_still_approves(self):
+        """Pre-#18089 command_allowlist entries used the legacy key derived
+        from the OLD regex (`rm\\s+(-[^\\s]*\\s+)*/`). After tightening the
+        regex the canonical key is still 'delete in root path' and the new
+        legacy key changed shape, so without an explicit historical alias
+        existing user approvals would be silently dropped and re-prompted.
+        """
+        _, current_key, _ = detect_dangerous_command("rm -rf /etc/passwd")
+        prior_legacy_key = r'rm\s+(-[^\s]*\s+)*/'
+        with mock_patch.object(approval_module, "_permanent_approved", set()):
+            load_permanent({prior_legacy_key})
+            assert is_approved("legacy-rootpath", current_key) is True
+
 
 class TestDetectDangerousSudo:
     def test_shell_via_c_flag(self):

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -57,6 +57,73 @@ class TestDetectDangerousRm:
         assert "delete" in desc.lower()
 
 
+class TestRmRootPathRegexPrecision:
+    """The "delete in root path" pattern must fire on actual system-root targets
+    only, not on every absolute path. The previous shape required just a single
+    `/` after the rm flags, so any `rm /home/<user>/<file>`, `rm /tmp/x`, etc.
+    was incorrectly flagged as "delete in root path" and forced an approval
+    prompt for routine cleanup. See #18083.
+
+    True-positives (system root + top-level system directories) must still
+    fire; false-positives (deep paths under non-system top-level dirs) must
+    no longer fire from this rule. Recursive-rm of any path is still caught
+    by the separate "recursive delete" pattern (`-r`/`--recursive`).
+    """
+
+    def test_rm_root_filesystem_still_flagged(self):
+        is_dangerous, _, desc = detect_dangerous_command("rm -rf /")
+        assert is_dangerous is True
+        assert "delete" in desc.lower() or "root" in desc.lower()
+
+    def test_rm_root_glob_still_flagged(self):
+        is_dangerous, _, _ = detect_dangerous_command("rm -rf /*")
+        assert is_dangerous is True
+
+    def test_rm_root_dotglob_still_flagged(self):
+        is_dangerous, _, _ = detect_dangerous_command("rm -rf /.*")
+        assert is_dangerous is True
+
+    def test_rm_etc_subpath_still_flagged(self):
+        is_dangerous, _, _ = detect_dangerous_command("rm -rf /etc/passwd")
+        assert is_dangerous is True
+
+    def test_rm_var_log_still_flagged(self):
+        is_dangerous, _, _ = detect_dangerous_command("rm -rf /var/log")
+        assert is_dangerous is True
+
+    def test_rm_usr_bin_still_flagged(self):
+        is_dangerous, _, _ = detect_dangerous_command("rm /usr/bin/something")
+        assert is_dangerous is True
+
+    def test_rm_home_user_file_not_flagged(self):
+        """Plain non-recursive rm of a file under /home must not require approval."""
+        is_dangerous, _, _ = detect_dangerous_command("rm /home/user/foo")
+        assert is_dangerous is False
+
+    def test_rm_dash_f_home_user_file_not_flagged(self):
+        """rm -f under /home is the routine cleanup case from #18083."""
+        is_dangerous, _, _ = detect_dangerous_command(
+            "rm -f /home/scott/hermes-home/fawn_lily_temp.html"
+        )
+        assert is_dangerous is False
+
+    def test_rm_tmp_file_not_flagged(self):
+        is_dangerous, _, _ = detect_dangerous_command("rm /tmp/x")
+        assert is_dangerous is False
+
+    def test_rm_mnt_path_not_flagged(self):
+        """WSL-style /mnt/c/... must not trigger root-path approval."""
+        is_dangerous, _, _ = detect_dangerous_command("rm /mnt/c/Users/user/foo")
+        assert is_dangerous is False
+
+    def test_rm_recursive_under_home_still_flagged_by_recursive_rule(self):
+        """Recursive rm of any path stays dangerous via the -r/--recursive
+        rule, regardless of the root-path tightening."""
+        is_dangerous, _, desc = detect_dangerous_command("rm -rf /home/user/.cache")
+        assert is_dangerous is True
+        assert "recursive" in desc.lower() or "delete" in desc.lower()
+
+
 class TestDetectDangerousSudo:
     def test_shell_via_c_flag(self):
         is_dangerous, key, desc = detect_dangerous_command("bash -c 'echo pwned'")

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -212,6 +212,12 @@ def _hardline_block_result(description: str) -> dict:
 # =========================================================================
 
 DANGEROUS_PATTERNS = [
+    # System-root single-file rm. The dir list intentionally diverges from
+    # HARDLINE_PATTERNS' recursive-delete list (line ~147): single-file rm of
+    # `/dev/sda`, `/proc/sysrq-trigger`, `/sys/...`, `/lib64/...`, `/opt/...`,
+    # `/run/...`, `/srv/...` is dangerous, but `rm -rf /opt` and `rm -rf /home`
+    # belong in HARDLINE — and `/home` here would false-positive on every
+    # `rm /home/<user>/file`. Keep the lists separate by design.
     (r'\brm\s+(-[^\s]*\s+)*/(\s|\*|$|\.\*|(bin|boot|dev|etc|lib|lib64|opt|proc|root|run|sbin|srv|sys|usr|var)(/|\s|$))', "delete in root path"),
     (r'\brm\s+-[^\s]*r', "recursive delete"),
     (r'\brm\s+--recursive\b', "recursive delete (long flag)"),
@@ -298,6 +304,19 @@ for _pattern, _description in DANGEROUS_PATTERNS:
     _canonical_key = _description
     _PATTERN_KEY_ALIASES.setdefault(_canonical_key, set()).update({_canonical_key, _legacy_key})
     _PATTERN_KEY_ALIASES.setdefault(_legacy_key, set()).update({_legacy_key, _canonical_key})
+
+# Historical legacy keys for patterns whose regex has been tightened. Existing
+# user command_allowlist / session approvals stored under the *prior* legacy
+# key would otherwise be ignored after the regex update, forcing a re-prompt.
+# Each entry: (current canonical description, prior legacy key string).
+_HISTORICAL_LEGACY_KEYS: list[tuple[str, str]] = [
+    # "delete in root path" — regex tightened in #18089 to match only system-root
+    # targets (was: any absolute path).
+    ("delete in root path", r'rm\s+(-[^\s]*\s+)*/'),
+]
+for _canonical_key, _historical_key in _HISTORICAL_LEGACY_KEYS:
+    _PATTERN_KEY_ALIASES.setdefault(_canonical_key, set()).update({_canonical_key, _historical_key})
+    _PATTERN_KEY_ALIASES.setdefault(_historical_key, set()).update({_historical_key, _canonical_key})
 
 
 def _approval_key_aliases(pattern_key: str) -> set[str]:

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -212,7 +212,7 @@ def _hardline_block_result(description: str) -> dict:
 # =========================================================================
 
 DANGEROUS_PATTERNS = [
-    (r'\brm\s+(-[^\s]*\s+)*/', "delete in root path"),
+    (r'\brm\s+(-[^\s]*\s+)*/(\s|\*|$|\.\*|(bin|boot|dev|etc|lib|lib64|opt|proc|root|run|sbin|srv|sys|usr|var)(/|\s|$))', "delete in root path"),
     (r'\brm\s+-[^\s]*r', "recursive delete"),
     (r'\brm\s+--recursive\b', "recursive delete (long flag)"),
     (r'\bchmod\s+(-[^\s]*\s+)*(777|666|o\+[rwx]*w|a\+[rwx]*w)\b', "world/other-writable permissions"),


### PR DESCRIPTION
## Summary

The `delete in root path` rule in `DANGEROUS_PATTERNS` ([tools/approval.py:215](tools/approval.py)) matched ANY `rm` with an absolute path because the regex required only a single `/` after the optional flags. Tighten it so it fires on real system-root targets only — plain `/`, root globs, and the system top-level dirs already enumerated by `HARDLINE_PATTERNS`.

## The bug

```python
(r'\brm\s+(-[^\s]*\s+)*/', "delete in root path"),
```

The `/` after the flag group matches the leading `/` of any absolute path, regardless of where in the filesystem the target lives. Every `rm /home/<user>/...`, `rm /tmp/...`, `rm /mnt/c/...` is flagged as `delete in root path` and forced through an approval prompt — including routine cleanup of the agent's own working files. From the reporter's run:

```
rm -f /home/scott/hermes-home/fawn_lily_temp.html
↳ Reason: delete in root path
```

That's deleting one file in the user's home directory; nothing about it is near the system root.

## The fix

Constrain what comes after the `/` to the genuinely-dangerous shapes:

```python
(r'\brm\s+(-[^\s]*\s+)*/(\s|\*|$|\.\*|(bin|boot|dev|etc|lib|lib64|opt|proc|root|run|sbin|srv|sys|usr|var)(/|\s|$))', "delete in root path"),
```

System top-level dirs match the set already enumerated by the `HARDLINE_PATTERNS` rules at lines 144-148, so the two layers stay aligned. Recursive `rm` of any deeper path (including `/home/...`) is still caught by the separate `-r`/`--recursive` rules at lines 216-217 — coverage is unchanged for actually-recursive deletes.

| Command | Old rule | New rule | Source of approval (if any) |
|---|---|---|---|
| `rm -rf /` | matches | matches | hardline + this rule |
| `rm -rf /*` | matches | matches | hardline + this rule |
| `rm -rf /.*` | matches | matches | this rule |
| `rm -rf /etc/passwd` | matches | matches | this rule |
| `rm -rf /var/log` | matches | matches | this rule |
| `rm /usr/bin/something` | matches | matches | this rule |
| `rm /home/user/foo` | **matches (false positive)** | does not match | none — non-recursive single-file rm |
| `rm -f /home/user/foo` | **matches (false positive)** | does not match | none — non-recursive single-file rm |
| `rm /tmp/x` | **matches (false positive)** | does not match | none — non-recursive single-file rm |
| `rm -rf /mnt/c/Users/user/foo` | **matches (false positive)** | does not match | recursive-delete rule still flags |
| `rm -rf /home/user/.cache` | **matches (false positive)** | does not match | recursive-delete rule still flags |

## Test plan

- [x] Focused: `tests/tools/test_approval.py` — 143 passed (11 new in `TestRmRootPathRegexPrecision`)
- [x] Adjacent: `tests/tools/test_force_dangerous_override.py`, `test_approval_plugin_hooks.py`, `test_approval_heartbeat.py`, `test_cron_approval_mode.py` — 37 passed
- [x] Regression guard: each false-positive case in the table fails the old regex (`old=True`) and passes the new one (`new=False`); each true-positive case matches both. Verified end-to-end with `re.compile(...).search(cmd)`.
- [x] Confirmed `rm -rf /home/user/.cache` stays dangerous via the separate `recursive delete` rule (not via this rule), so coverage of recursive deletes is unchanged.

Pre-existing baseline failures in `tests/tools/test_mcp_tool.py`, `test_mcp_oauth.py`, `test_mcp_reconnect_signal.py`, `test_tts_kittentts.py` are orthogonal — those modules are untouched.

## Related

- Fixes #18083
- Aligns the system-dir enumeration in `DANGEROUS_PATTERNS` with the existing `HARDLINE_PATTERNS` set at [tools/approval.py:144-148](tools/approval.py)
- Independent from #17962 (different rules; reverse-shell-via-flag and two-stage download-execute)