### PR TITLE
fix(memory): omit inline data URLs from Hindsight retain

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -35,6 +35,7 @@ import json
 import logging
 import os
 import queue
+import re
 import threading
 
 from datetime import datetime, timezone
@@ -75,6 +76,80 @@ def _parse_int_setting(value: Any, default: int) -> int:
     except (TypeError, ValueError):
         logger.warning("Invalid integer Hindsight setting %r; using default %s", value, default)
         return default
+
+
+_DATA_URL_RE = re.compile(r"data:([^,\s]*?);base64,[A-Za-z0-9+/=_\-]+", re.IGNORECASE)
+
+
+def _data_url_mime(header: str) -> str:
+    """Return a normalized MIME type from a data URL header."""
+    return (header.split(";", 1)[0] or "unknown").lower()
+
+
+def _omit_inline_data_urls(text: str) -> str:
+    """Replace inline base64 data URLs with metadata-only placeholders."""
+    def _replace(match: re.Match[str]) -> str:
+        mime = _data_url_mime(match.group(1) or "")
+        return (
+            f"[base64 {mime} data URL omitted from Hindsight retain: "
+            f"data_url_chars={len(match.group(0))}]"
+        )
+
+    return _DATA_URL_RE.sub(_replace, str(text or ""))
+
+
+def _sanitize_retain_message_content(value: Any) -> str:
+    """Render auto-retained turn content without binary attachment payloads.
+
+    Gateway adapters can pass multimodal user messages as structured lists.
+    Discord image uploads may arrive as inline base64 ``data:image/...`` URLs;
+    retaining those blobs as text is expensive and not useful for memory
+    extraction. Keep user-visible text and replace attachments with compact
+    metadata placeholders before auto-retain serializes the turn.
+    """
+    if isinstance(value, list):
+        rendered: list[str] = []
+        for part in value:
+            if isinstance(part, dict):
+                part_type = str(part.get("type") or "attachment")
+                if part_type in {"text", "input_text"}:
+                    text = part.get("text")
+                    if text:
+                        rendered.append(_omit_inline_data_urls(str(text)))
+                    continue
+
+                if part_type in {"image_url", "input_image", "image"}:
+                    image_obj = part.get("image_url") if isinstance(part.get("image_url"), dict) else part
+                    url = ""
+                    if isinstance(image_obj, dict):
+                        url = str(image_obj.get("url") or image_obj.get("image_url") or "")
+                    elif isinstance(image_obj, str):
+                        url = image_obj
+                    if url.lower().startswith("data:"):
+                        header = url.split(",", 1)[0]
+                        mime = _data_url_mime(header[5:])
+                        rendered.append(
+                            f"[image attachment omitted from Hindsight retain: {mime}, "
+                            f"data_url_chars={len(url)}]"
+                        )
+                    else:
+                        rendered.append(
+                            f"[image attachment omitted from Hindsight retain: url_chars={len(url)}]"
+                        )
+                    continue
+
+                rendered.append(
+                    f"[{part_type} attachment omitted from Hindsight retain: "
+                    f"json_chars={len(json.dumps(part, ensure_ascii=False))}]"
+                )
+            else:
+                rendered.append(_omit_inline_data_urls(str(part)))
+        return "\n".join(piece for piece in rendered if piece)
+
+    if isinstance(value, dict):
+        return _sanitize_retain_message_content([value])
+
+    return _omit_inline_data_urls(str(value or ""))
 
 
 def _check_local_runtime() -> tuple[bool, str | None]:
@@ -1207,12 +1282,12 @@ class HindsightMemoryProvider(MemoryProvider):
         return [
             {
                 "role": "user",
-                "content": f"{self._retain_user_prefix}: {user_content}",
+                "content": f"{self._retain_user_prefix}: {_sanitize_retain_message_content(user_content)}",
                 "timestamp": now,
             },
             {
                 "role": "assistant",
-                "content": f"{self._retain_assistant_prefix}: {assistant_content}",
+                "content": f"{self._retain_assistant_prefix}: {_sanitize_retain_message_content(assistant_content)}",
                 "timestamp": now,
             },
         ]

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -777,6 +777,91 @@ class TestSyncTurn:
         assert "turn3-user" in content
         assert "turn4-user" in content
 
+    def test_sync_turn_omits_inline_base64_data_url_from_auto_retain(self, provider_with_config):
+        """Auto-retain should not send inline base64 data URLs to Hindsight."""
+        p = provider_with_config()
+        p._client = _make_mock_client()
+        data_url = "data:image/png;base64," + ("A" * 200_000)
+
+        p.sync_turn(f"please inspect {data_url}", "done")
+        p._retain_queue.join()
+
+        item = p._client.aretain_batch.call_args.kwargs["items"][0]
+        assert data_url not in item["content"]
+        assert "A" * 1_000 not in item["content"]
+        assert "please inspect" in item["content"]
+        assert "base64 image/png data URL omitted" in item["content"]
+        assert len(item["content"]) < 2_000
+
+    def test_sync_turn_omits_variant_base64_data_urls_from_auto_retain(self, provider_with_config):
+        """Auto-retain should catch valid data URL casing and parameter variants."""
+        p = provider_with_config()
+        p._client = _make_mock_client()
+        parameterized = "data:image/png;charset=utf-8;base64," + ("D" * 200_000)
+        unknown_mime = "data:;base64," + ("E" * 200_000)
+        mixed_case = "DATA:IMAGE/JPEG;BASE64," + ("F" * 200_000)
+
+        p.sync_turn(f"variants {parameterized} {unknown_mime} {mixed_case}", "done")
+        p._retain_queue.join()
+
+        item = p._client.aretain_batch.call_args.kwargs["items"][0]
+        assert parameterized not in item["content"]
+        assert unknown_mime not in item["content"]
+        assert mixed_case not in item["content"]
+        assert "D" * 1_000 not in item["content"]
+        assert "E" * 1_000 not in item["content"]
+        assert "F" * 1_000 not in item["content"]
+        assert "base64 image/png data URL omitted" in item["content"]
+        assert "base64 unknown data URL omitted" in item["content"]
+        assert "base64 image/jpeg data URL omitted" in item["content"]
+        assert len(item["content"]) < 2_000
+
+    def test_sync_turn_preserves_text_after_inline_data_url(self, provider_with_config):
+        """Inline sanitizer should not consume normal text after a data URL line."""
+        p = provider_with_config()
+        p._client = _make_mock_client()
+        data_url = "data:image/png;base64," + ("A" * 1_000)
+
+        p.sync_turn(f"before {data_url}\nKeep this follow-up text", "done")
+        p._retain_queue.join()
+
+        item = p._client.aretain_batch.call_args.kwargs["items"][0]
+        assert data_url not in item["content"]
+        assert "before" in item["content"]
+        assert "Keep this follow-up text" in item["content"]
+
+    def test_sync_turn_omits_multimodal_image_data_from_auto_retain(self, provider_with_config):
+        """Gateway multimodal image payloads should be retained as metadata only."""
+        p = provider_with_config()
+        p._client = _make_mock_client()
+        data_url = "data:image/jpeg;base64," + ("B" * 250_000)
+        user_content = [
+            {"type": "text", "text": "remember my preference for concise diagrams"},
+            {"type": "image_url", "image_url": {"url": data_url, "detail": "high"}},
+        ]
+
+        p.sync_turn(user_content, "noted")
+        p._retain_queue.join()
+
+        item = p._client.aretain_batch.call_args.kwargs["items"][0]
+        content = json.loads(item["content"])
+        user_turn = content[0][0]["content"]
+        assert data_url not in item["content"]
+        assert "B" * 1_000 not in item["content"]
+        assert "remember my preference for concise diagrams" in user_turn
+        assert "image/jpeg" in user_turn
+        assert "data_url_chars=" in user_turn
+        assert len(item["content"]) < 2_000
+
+    def test_hindsight_retain_tool_preserves_explicit_content(self, provider):
+        """Sanitization is scoped to automatic transcript retain, not explicit tool calls."""
+        data_url = "data:image/png;base64," + ("C" * 1_000)
+
+        provider.handle_tool_call("hindsight_retain", {"content": data_url, "context": "manual test"})
+
+        call_kwargs = provider._client.aretain.call_args.kwargs
+        assert call_kwargs["content"] == data_url
+
     def test_sync_turn_passes_document_id(self, provider):
         """sync_turn should pass document_id (session_id + per-startup ts)."""
         provider.sync_turn("hello", "hi")


### PR DESCRIPTION
## What does this PR do?

Prevents automatic Hindsight transcript retain from sending inline base64 `data:` URLs to the Hindsight service.

Gateway / multimodal adapters can pass image uploads as either text containing `data:image/...;base64,...` URLs or structured `image_url` parts. Before this change, automatic retain serialized those blobs into the retained transcript, which is expensive and not useful for memory extraction. This PR keeps the user-visible text and replaces binary payloads with compact metadata placeholders.

Explicit `hindsight_retain` tool calls are intentionally unchanged, so user/requested manual retention preserves exactly what was passed.

## Related Issue

No linked issue; found while investigating Hindsight retain payload/cost blow-ups from multimodal Discord turns.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/memory/hindsight/__init__.py`
  - Adds automatic-retain content sanitization for inline base64 `data:` URLs.
  - Handles common valid variants: parameterized data URLs, omitted MIME type, and mixed-case `DATA:...;BASE64`.
  - Handles structured multimodal image parts by retaining only compact metadata (`mime`, payload length), not the raw URL/blob.
  - Preserves normal surrounding text, including text after a data URL line.
  - Leaves explicit `hindsight_retain` tool calls unchanged.
- `tests/plugins/memory/test_hindsight_provider.py`
  - Adds regression coverage for plain-text inline data URLs, valid variant forms, text preservation after a data URL, structured multimodal image payloads, and explicit retain preservation.

## How to Test

1. Compile changed files:
   ```bash
   python -m py_compile plugins/memory/hindsight/__init__.py tests/plugins/memory/test_hindsight_provider.py
   ```
2. Run focused regression tests:
   ```bash
   python -m pytest \
     tests/plugins/memory/test_hindsight_provider.py::TestSyncTurn::test_sync_turn_omits_inline_base64_data_url_from_auto_retain \
     tests/plugins/memory/test_hindsight_provider.py::TestSyncTurn::test_sync_turn_omits_variant_base64_data_urls_from_auto_retain \
     tests/plugins/memory/test_hindsight_provider.py::TestSyncTurn::test_sync_turn_preserves_text_after_inline_data_url \
     tests/plugins/memory/test_hindsight_provider.py::TestSyncTurn::test_sync_turn_omits_multimodal_image_data_from_auto_retain \
     tests/plugins/memory/test_hindsight_provider.py::TestSyncTurn::test_hindsight_retain_tool_preserves_explicit_content \
     -q -o 'addopts='
   ```
3. Run the Hindsight provider test file:
   ```bash
   python -m pytest tests/plugins/memory/test_hindsight_provider.py -q -o 'addopts='
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Fedora Linux / Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Local verification:

```text
python -m pytest tests/plugins/memory/test_hindsight_provider.py -q -o 'addopts='
96 passed in 0.53s
```

Full CI-like local suite was also attempted:

```bash
OPENROUTER_API_KEY='' OPENAI_API_KEY='' NOUS_API_KEY='' \
python -m pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e --tb=short -n auto -o 'addopts='
```

Result in this local environment: `41 failed, 18641 passed, 48 skipped`. The failures were outside the Hindsight provider area (Discord gateway/config/tool timeout expectations). Representative failures reproduce on a clean `origin/main` worktree in the same environment, e.g. `tests/tools/test_terminal_foreground_timeout_cap.py::TestForegroundMaxTimeoutConstant::test_default_value_is_600` and `tests/gateway/test_discord_free_response.py::test_discord_auto_thread_enabled_by_default`.
