### PR TITLE
feat: surface security policy posture

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 
 def _hermes_home_path() -> Path:
@@ -16,36 +16,126 @@ def _hermes_home_path() -> Path:
         return Path(os.path.expanduser("~/.hermes"))
 
 
+def _load_security_policy_config() -> dict[str, Any]:
+    """Read the security policy block from active config.yaml.
+
+    This module sits under ``agent/`` and is imported by low-level file tools,
+    so avoid importing the full config loader here. A tiny raw YAML read keeps
+    the write guard profile-aware without introducing a circular dependency.
+    """
+    config_path = _hermes_home_path() / "config.yaml"
+    if not config_path.exists():
+        return {}
+    try:
+        import yaml
+
+        data = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    except Exception:
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    security = data.get("security")
+    if not isinstance(security, dict):
+        return {}
+    policy = security.get("policy")
+    return policy if isinstance(policy, dict) else {}
+
+
+def _load_security_policy_filesystem_config() -> dict[str, Any]:
+    """Read the legacy Hermes filesystem policy block from active config.yaml."""
+    filesystem = _load_security_policy_config().get("filesystem")
+    return filesystem if isinstance(filesystem, dict) else {}
+
+
+def _load_openshell_filesystem_policy_config() -> dict[str, Any]:
+    """Read the OpenShell-shaped filesystem_policy block from config.yaml."""
+    filesystem = _load_security_policy_config().get("filesystem_policy")
+    return filesystem if isinstance(filesystem, dict) else {}
+
+
+def _as_config_bool(value: Any, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "off"}:
+            return False
+    return default
+
+
+def _deny_hermes_control_plane_enabled() -> bool:
+    fs_cfg = _load_security_policy_filesystem_config()
+    if "deny_hermes_control_plane" in fs_cfg:
+        return _as_config_bool(fs_cfg.get("deny_hermes_control_plane"), True)
+    openshell_policy = _load_openshell_filesystem_policy_config()
+    return _as_config_bool(openshell_policy.get("deny_hermes_control_plane"), True)
+
+
+def _configured_safe_write_root() -> str:
+    fs_cfg = _load_security_policy_filesystem_config()
+    raw = fs_cfg.get("write_safe_root", "")
+    return str(raw).strip() if raw is not None else ""
+
+
+def _configured_safe_write_roots() -> list[str]:
+    roots: list[str] = []
+    legacy_root = _configured_safe_write_root()
+    if legacy_root:
+        roots.append(legacy_root)
+
+    openshell_policy = _load_openshell_filesystem_policy_config()
+    read_write = openshell_policy.get("read_write", [])
+    if isinstance(read_write, list):
+        roots.extend(str(path).strip() for path in read_write if str(path).strip())
+
+    return roots
+
+
 def build_write_denied_paths(home: str) -> set[str]:
     """Return exact sensitive paths that must never be written."""
     hermes_home = _hermes_home_path()
-    return {
-        os.path.realpath(p)
-        for p in [
-            os.path.join(home, ".ssh", "authorized_keys"),
-            os.path.join(home, ".ssh", "id_rsa"),
-            os.path.join(home, ".ssh", "id_ed25519"),
-            os.path.join(home, ".ssh", "config"),
-            str(hermes_home / ".env"),
-            os.path.join(home, ".bashrc"),
-            os.path.join(home, ".zshrc"),
-            os.path.join(home, ".profile"),
-            os.path.join(home, ".bash_profile"),
-            os.path.join(home, ".zprofile"),
-            os.path.join(home, ".netrc"),
-            os.path.join(home, ".pgpass"),
-            os.path.join(home, ".npmrc"),
-            os.path.join(home, ".pypirc"),
-            "/etc/sudoers",
-            "/etc/passwd",
-            "/etc/shadow",
-        ]
-    }
+    paths = [
+        os.path.join(home, ".ssh", "authorized_keys"),
+        os.path.join(home, ".ssh", "id_rsa"),
+        os.path.join(home, ".ssh", "id_ed25519"),
+        os.path.join(home, ".ssh", "config"),
+        str(hermes_home / ".env"),
+        os.path.join(home, ".bashrc"),
+        os.path.join(home, ".zshrc"),
+        os.path.join(home, ".profile"),
+        os.path.join(home, ".bash_profile"),
+        os.path.join(home, ".zprofile"),
+        os.path.join(home, ".netrc"),
+        os.path.join(home, ".pgpass"),
+        os.path.join(home, ".npmrc"),
+        os.path.join(home, ".pypirc"),
+        "/etc/sudoers",
+        "/etc/passwd",
+        "/etc/shadow",
+    ]
+
+    if _deny_hermes_control_plane_enabled():
+        paths.extend(
+            [
+                str(hermes_home / "auth.json"),
+                str(hermes_home / "config.yaml"),
+                str(hermes_home / "gateway.json"),
+                str(hermes_home / "webhook_subscriptions.json"),
+                str(hermes_home / ".anthropic_oauth.json"),
+            ]
+        )
+
+    return {os.path.realpath(p) for p in paths}
 
 
 def build_write_denied_prefixes(home: str) -> list[str]:
     """Return sensitive directory prefixes that must never be written."""
-    return [
+    hermes_home = _hermes_home_path()
+    prefixes = [
         os.path.realpath(p) + os.sep
         for p in [
             os.path.join(home, ".ssh"),
@@ -59,17 +149,55 @@ def build_write_denied_prefixes(home: str) -> list[str]:
             os.path.join(home, ".config", "gh"),
         ]
     ]
+    if _deny_hermes_control_plane_enabled():
+        prefixes.extend(
+            os.path.realpath(p) + os.sep
+            for p in [
+                str(hermes_home / "auth"),
+                str(hermes_home / "mcp-tokens"),
+            ]
+        )
+    return prefixes
+
+
+def get_safe_write_roots() -> list[str]:
+    """Return resolved write-safe roots, or an empty list if unset.
+
+    ``HERMES_WRITE_SAFE_ROOT`` wins for backwards compatibility. Otherwise
+    Hermes accepts the legacy ``security.policy.filesystem.write_safe_root``
+    and the OpenShell-shaped ``security.policy.filesystem_policy.read_write``
+    list from config.yaml.
+    """
+    root = os.getenv("HERMES_WRITE_SAFE_ROOT", "").strip()
+    roots = [root] if root else _configured_safe_write_roots()
+    resolved: list[str] = []
+    seen: set[str] = set()
+    for item in roots:
+        if not item:
+            continue
+        try:
+            real = os.path.realpath(os.path.expandvars(os.path.expanduser(item)))
+        except Exception:
+            continue
+        if real not in seen:
+            resolved.append(real)
+            seen.add(real)
+    return resolved
 
 
 def get_safe_write_root() -> Optional[str]:
-    """Return the resolved HERMES_WRITE_SAFE_ROOT path, or None if unset."""
-    root = os.getenv("HERMES_WRITE_SAFE_ROOT", "")
-    if not root:
+    """Return the first resolved write-safe root for legacy callers."""
+    roots = get_safe_write_roots()
+    if not roots:
         return None
-    try:
-        return os.path.realpath(os.path.expanduser(root))
-    except Exception:
-        return None
+    return roots[0]
+
+
+def _is_under_any_root(resolved: str, roots: list[str]) -> bool:
+    for safe_root in roots:
+        if resolved == safe_root or resolved.startswith(safe_root + os.sep):
+            return True
+    return False
 
 
 def is_write_denied(path: str) -> bool:
@@ -83,8 +211,8 @@ def is_write_denied(path: str) -> bool:
         if resolved.startswith(prefix):
             return True
 
-    safe_root = get_safe_write_root()
-    if safe_root and not (resolved == safe_root or resolved.startswith(safe_root + os.sep)):
+    safe_roots = get_safe_write_roots()
+    if safe_roots and not _is_under_any_root(resolved, safe_roots):
         return True
 
     return False

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1082,6 +1082,52 @@ DEFAULT_CONFIG = {
     "security": {
         "allow_private_urls": False,  # Allow requests to private/internal IPs (for OpenWrt, proxies, VPNs)
         "redact_secrets": False,
+        "policy": {
+            "version": 1,
+            "filesystem": {
+                # Constrain write_file/patch operations to this subtree when set.
+                # Equivalent to HERMES_WRITE_SAFE_ROOT, which takes precedence.
+                "write_safe_root": "",
+                # Block write_file/patch from mutating active Hermes control-plane
+                # files such as config.yaml, auth.json, and MCP token stores.
+                "deny_hermes_control_plane": True,
+            },
+            "filesystem_policy": {
+                # OpenShell-shaped policy block. read_write is enforced by
+                # Hermes file tools as multiple write-safe roots; read_only is
+                # currently reported for posture compatibility.
+                "read_only": [],
+                "read_write": [],
+                "include_workdir": False,
+                "deny_hermes_control_plane": True,
+            },
+            "landlock": {
+                # Accepted for policy compatibility. Hermes itself does not
+                # provide Landlock; run inside OpenShell for kernel MAC.
+                "compatibility": "best_effort",
+            },
+            "commands": {
+                "deny": [],
+                "allow": [],
+            },
+            "network_policies": {},
+            "permissions": {
+                "toolsets_allow": [],
+                "toolsets_deny": [],
+                "tools_allow": [],
+                "tools_deny": [],
+                "mcp_reload_confirm": True,
+            },
+            "gateway": {
+                "require_user_allowlist": True,
+                "allow_pairing": True,
+                "control_commands_bypass_busy_queue": True,
+                "approval_commands_inline": True,
+            },
+            "inference": {
+                "managed_provider_routing": False,
+            },
+        },
         "tirith_enabled": True,
         "tirith_path": "tirith",
         "tirith_timeout": 5,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5061,6 +5061,13 @@ def cmd_doctor(args):
     run_doctor(args)
 
 
+def cmd_security(args):
+    """Enterprise security posture and policy helpers."""
+    from hermes_cli.security_policy import security_command
+
+    security_command(args)
+
+
 def cmd_dump(args):
     """Dump setup summary for support/debugging."""
     from hermes_cli.dump import run_dump
@@ -7530,6 +7537,7 @@ def _coalesce_session_name_args(argv: list) -> list:
         "status",
         "cron",
         "doctor",
+        "security",
         "config",
         "pairing",
         "skills",
@@ -8727,6 +8735,47 @@ def main():
         "--fix", action="store_true", help="Attempt to fix issues automatically"
     )
     doctor_parser.set_defaults(func=cmd_doctor)
+
+    # =========================================================================
+    # security command
+    # =========================================================================
+    security_parser = subparsers.add_parser(
+        "security",
+        help="Inspect enterprise security posture",
+        description=(
+            "Inspect Hermes' effective security posture and validate "
+            "OpenShell-inspired security policy files."
+        ),
+    )
+    security_sub = security_parser.add_subparsers(dest="security_action")
+    security_doctor = security_sub.add_parser(
+        "doctor",
+        help="Check enterprise security posture",
+    )
+    security_doctor.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit non-zero when any posture check is not pass",
+    )
+    security_doctor.add_argument("--json", action="store_true", help="Output JSON")
+
+    security_policy = security_sub.add_parser(
+        "policy",
+        help="Show or validate the effective security policy",
+    )
+    security_policy_sub = security_policy.add_subparsers(dest="policy_action")
+    security_policy_show = security_policy_sub.add_parser(
+        "show",
+        help="Show the effective policy derived from config and env",
+    )
+    security_policy_show.add_argument("--json", action="store_true", help="Output JSON")
+    security_policy_validate = security_policy_sub.add_parser(
+        "validate",
+        help="Validate a security policy YAML/JSON file",
+    )
+    security_policy_validate.add_argument("file", help="Policy file to validate")
+    security_policy_validate.add_argument("--json", action="store_true", help="Output JSON")
+    security_parser.set_defaults(func=cmd_security)
 
     # =========================================================================
     # dump command

--- a/hermes_cli/security_policy.py
+++ b/hermes_cli/security_policy.py
@@ -1,0 +1,823 @@
+"""Enterprise security posture reporting for Hermes.
+
+Hermes accepts an OpenShell-shaped policy surface where it can map policy
+intent onto existing controls. The doctor distinguishes host-enforced controls
+from policy-compatible controls that need an external sandbox/proxy runtime
+such as OpenShell for true kernel or network-gateway enforcement.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+
+HERMES_POLICY_SCHEMA: dict[str, dict[str, str]] = {
+    "filesystem": {
+        "write_safe_root": "string",
+        "deny_hermes_control_plane": "boolean",
+    },
+    "filesystem_policy": {
+        "read_only": "list[string]",
+        "read_write": "list[string]",
+        "include_workdir": "boolean",
+        "deny_hermes_control_plane": "boolean",
+    },
+    "landlock": {
+        "compatibility": "best_effort|hard_requirement",
+    },
+    "commands": {
+        "deny": "list[string]",
+        "allow": "list[string]",
+    },
+    "environment": {
+        "env_passthrough": "list[string]",
+    },
+    "process": {
+        "run_as_user": "string",
+        "run_as_group": "string",
+        "approvals_mode": "manual|smart|off",
+        "cron_mode": "deny|approve",
+        "tirith_enabled": "boolean",
+        "tirith_fail_open": "boolean",
+        "command_denylist": "list[string]",
+        "command_allowlist": "list[string]",
+    },
+    "network": {
+        "allow_private_urls": "boolean",
+        "website_blocklist_enabled": "boolean",
+    },
+    "network_policies": {"*": "network_policy_entry"},
+    "permissions": {
+        "toolsets_allow": "list[string]",
+        "toolsets_deny": "list[string]",
+        "tools_allow": "list[string]",
+        "tools_deny": "list[string]",
+        "mcp_reload_confirm": "boolean",
+    },
+    "gateway": {
+        "require_user_allowlist": "boolean",
+        "allow_pairing": "boolean",
+        "control_commands_bypass_busy_queue": "boolean",
+        "approval_commands_inline": "boolean",
+    },
+    "inference": {
+        "redact_secrets": "boolean",
+        "managed_provider_routing": "boolean",
+    },
+}
+
+OPENSHELL_TOP_LEVEL_KEYS = {
+    "version",
+    "filesystem_policy",
+    "landlock",
+    "process",
+    "network_policies",
+}
+
+GATEWAY_ALLOWLIST_ENV_NAMES = (
+    "GATEWAY_ALLOWED_USERS",
+    "TELEGRAM_ALLOWED_USERS",
+    "TELEGRAM_GROUP_ALLOWED_USERS",
+    "DISCORD_ALLOWED_USERS",
+    "DISCORD_GROUP_ALLOWED_USERS",
+    "SLACK_ALLOWED_USERS",
+    "WHATSAPP_ALLOWED_USERS",
+    "SIGNAL_ALLOWED_USERS",
+    "SIGNAL_GROUP_ALLOWED_USERS",
+    "EMAIL_ALLOWED_SENDERS",
+    "SMS_ALLOWED_NUMBERS",
+)
+
+
+@dataclass(frozen=True)
+class PostureCheck:
+    domain: str
+    name: str
+    status: str
+    detail: str
+    recommendation: str = ""
+    enforcement: str = "hermes"
+
+
+def _get(config: Mapping[str, Any], *keys: str, default: Any = None) -> Any:
+    cur: Any = config
+    for key in keys:
+        if not isinstance(cur, Mapping):
+            return default
+        cur = cur.get(key)
+    return default if cur is None else cur
+
+
+def _as_bool(value: Any, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "off"}:
+            return False
+    return default
+
+
+def _as_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item.strip() for item in value if isinstance(item, str) and item.strip()]
+
+
+def _as_mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _policy_config(config: Mapping[str, Any]) -> Mapping[str, Any]:
+    return _as_mapping(_get(config, "security", "policy", default={}))
+
+
+def _provider_env_blocklist() -> frozenset[str]:
+    try:
+        from tools.environments.local import _HERMES_PROVIDER_ENV_BLOCKLIST
+
+        return _HERMES_PROVIDER_ENV_BLOCKLIST
+    except Exception:
+        return frozenset({
+            "OPENAI_API_KEY",
+            "OPENROUTER_API_KEY",
+            "ANTHROPIC_API_KEY",
+            "ANTHROPIC_TOKEN",
+            "GOOGLE_API_KEY",
+            "GITHUB_TOKEN",
+            "GH_TOKEN",
+        })
+
+
+def _resolve_safe_roots_source(
+    config: Mapping[str, Any], env: Mapping[str, str]
+) -> tuple[list[str], str]:
+    env_root = str(env.get("HERMES_WRITE_SAFE_ROOT", "")).strip()
+    if env_root:
+        return [env_root], "HERMES_WRITE_SAFE_ROOT"
+
+    policy_cfg = _policy_config(config)
+    legacy_filesystem = _as_mapping(policy_cfg.get("filesystem"))
+    cfg_root = str(legacy_filesystem.get("write_safe_root") or "").strip()
+    if cfg_root:
+        return [cfg_root], "security.policy.filesystem.write_safe_root"
+
+    openshell_filesystem = _as_mapping(policy_cfg.get("filesystem_policy"))
+    read_write = _as_list(openshell_filesystem.get("read_write"))
+    if read_write:
+        return read_write, "security.policy.filesystem_policy.read_write"
+
+    return [], "unset"
+
+
+def _gateway_allowlist_sources(env: Mapping[str, str]) -> list[str]:
+    return sorted(
+        name for name in GATEWAY_ALLOWLIST_ENV_NAMES if str(env.get(name, "")).strip()
+    )
+
+
+def build_effective_policy(
+    config: Mapping[str, Any] | None = None,
+    env: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    """Return Hermes' effective security posture as a serializable dict."""
+    if config is None:
+        from hermes_cli.config import load_config
+
+        config = load_config()
+    if env is None:
+        env = os.environ
+
+    policy_cfg = _policy_config(config)
+    filesystem_cfg = _as_mapping(policy_cfg.get("filesystem"))
+    filesystem_policy_cfg = _as_mapping(policy_cfg.get("filesystem_policy"))
+    landlock_cfg = _as_mapping(policy_cfg.get("landlock"))
+    commands_cfg = _as_mapping(policy_cfg.get("commands"))
+    permissions_cfg = _as_mapping(policy_cfg.get("permissions"))
+    gateway_policy_cfg = _as_mapping(policy_cfg.get("gateway"))
+    inference_policy_cfg = _as_mapping(policy_cfg.get("inference"))
+
+    safe_roots, safe_root_source = _resolve_safe_roots_source(config, env)
+    env_passthrough = _as_list(_get(config, "terminal", "env_passthrough", default=[]))
+    provider_passthrough = sorted(
+        name for name in env_passthrough if name in _provider_env_blocklist()
+    )
+    website_blocklist = _get(config, "security", "website_blocklist", default={})
+    if not isinstance(website_blocklist, Mapping):
+        website_blocklist = {}
+
+    approvals_mode = str(_get(config, "approvals", "mode", default="manual") or "manual")
+    cron_mode = str(_get(config, "approvals", "cron_mode", default="deny") or "deny")
+    terminal_backend = str(_get(config, "terminal", "backend", default="local") or "local")
+    network_policies = _as_mapping(policy_cfg.get("network_policies"))
+    configured_tool_permissions = any(
+        _as_list(permissions_cfg.get(key))
+        for key in ("toolsets_allow", "toolsets_deny", "tools_allow", "tools_deny")
+    )
+    allowlist_sources = _gateway_allowlist_sources(env)
+    inference_redact = inference_policy_cfg.get("redact_secrets")
+    if not isinstance(inference_redact, bool):
+        inference_redact = _get(config, "security", "redact_secrets", default=False)
+
+    return {
+        "filesystem": {
+            "write_safe_root": safe_roots[0] if safe_roots else "",
+            "write_safe_root_source": safe_root_source,
+            "read_only_paths": _as_list(filesystem_policy_cfg.get("read_only")),
+            "read_write_paths": safe_roots,
+            "include_workdir": _as_bool(
+                filesystem_policy_cfg.get("include_workdir"), False
+            ),
+            "deny_hermes_control_plane": _as_bool(
+                (
+                    filesystem_cfg.get("deny_hermes_control_plane")
+                    if "deny_hermes_control_plane" in filesystem_cfg
+                    else filesystem_policy_cfg.get("deny_hermes_control_plane")
+                ),
+                True,
+            ),
+            "deny_home_credentials": True,
+            "landlock_compatibility": str(
+                landlock_cfg.get("compatibility") or "not_configured"
+            ),
+            "kernel_filesystem_enforcement": False,
+        },
+        "environment": {
+            "scrub_provider_credentials": True,
+            "env_passthrough": env_passthrough,
+            "provider_credentials_in_passthrough": provider_passthrough,
+        },
+        "process": {
+            "hardline_blocklist": True,
+            "approvals_mode": approvals_mode,
+            "cron_mode": cron_mode,
+            "run_as_user": str(
+                _as_mapping(policy_cfg.get("process")).get("run_as_user") or ""
+            ),
+            "run_as_group": str(
+                _as_mapping(policy_cfg.get("process")).get("run_as_group") or ""
+            ),
+            "terminal_backend": terminal_backend,
+            "tirith_enabled": _as_bool(
+                _get(config, "security", "tirith_enabled", default=True), True
+            ),
+            "tirith_fail_open": _as_bool(
+                _get(config, "security", "tirith_fail_open", default=True), True
+            ),
+            "command_denylist": _as_list(commands_cfg.get("deny"))
+            + _as_list(_as_mapping(policy_cfg.get("process")).get("command_denylist")),
+            "command_allowlist": _as_list(_get(config, "command_allowlist", default=[]))
+            + _as_list(commands_cfg.get("allow"))
+            + _as_list(_as_mapping(policy_cfg.get("process")).get("command_allowlist")),
+            "kernel_process_enforcement": False,
+        },
+        "network": {
+            "allow_private_urls": _as_bool(
+                _get(config, "security", "allow_private_urls", default=False), False
+            ),
+            "website_blocklist_enabled": _as_bool(
+                website_blocklist.get("enabled"), False
+            ),
+            "website_blocklist_domains": _as_list(website_blocklist.get("domains")),
+            "network_policies": network_policies,
+            "policy_entry_count": len(network_policies),
+            "gateway_proxy_enforced": False,
+        },
+        "permissions": {
+            "toolsets_allow": _as_list(permissions_cfg.get("toolsets_allow")),
+            "toolsets_deny": _as_list(permissions_cfg.get("toolsets_deny")),
+            "tools_allow": _as_list(permissions_cfg.get("tools_allow")),
+            "tools_deny": _as_list(permissions_cfg.get("tools_deny")),
+            "configured": configured_tool_permissions,
+            "mcp_reload_confirm": _as_bool(
+                _get(config, "approvals", "mcp_reload_confirm", default=True), True
+            ),
+        },
+        "gateway": {
+            "require_user_allowlist": _as_bool(
+                gateway_policy_cfg.get("require_user_allowlist"), True
+            ),
+            "allow_pairing": _as_bool(gateway_policy_cfg.get("allow_pairing"), True),
+            "allowlist_sources": allowlist_sources,
+            "control_commands_bypass_busy_queue": True,
+            "approval_commands_inline": True,
+        },
+        "inference": {
+            "redact_secrets": _as_bool(inference_redact, False),
+            "provider_credentials_stripped_from_tools": True,
+            "managed_provider_routing": _as_bool(
+                inference_policy_cfg.get("managed_provider_routing"), False
+            ),
+        },
+    }
+
+
+def evaluate_posture(policy: Mapping[str, Any]) -> list[PostureCheck]:
+    checks: list[PostureCheck] = []
+
+    def add(
+        domain: str,
+        name: str,
+        status: str,
+        detail: str,
+        recommendation: str = "",
+        enforcement: str = "hermes",
+    ) -> None:
+        checks.append(
+            PostureCheck(domain, name, status, detail, recommendation, enforcement)
+        )
+
+    filesystem = policy.get("filesystem", {})
+    read_write_paths = filesystem.get("read_write_paths") or []
+    safe_root = str(filesystem.get("write_safe_root") or "")
+    add(
+        "filesystem",
+        "read_write_policy",
+        "pass" if read_write_paths else "warn",
+        (
+            "write operations are constrained to: " + ", ".join(read_write_paths)
+            if read_write_paths
+            else "write operations are not constrained to policy read_write paths"
+        ),
+        (
+            "Set HERMES_WRITE_SAFE_ROOT, security.policy.filesystem.write_safe_root, "
+            "or security.policy.filesystem_policy.read_write."
+        ),
+        "file-tools",
+    )
+    if safe_root and len(read_write_paths) > 1:
+        add(
+            "filesystem",
+            "multiple_read_write_paths",
+            "pass",
+            f"{len(read_write_paths)} write roots are enforced by file tools",
+            enforcement="file-tools",
+        )
+    add(
+        "filesystem",
+        "control_plane_write_deny",
+        "pass" if filesystem.get("deny_hermes_control_plane") else "fail",
+        "active Hermes control-plane files are write-denied"
+        if filesystem.get("deny_hermes_control_plane")
+        else "active Hermes control-plane files are not write-denied",
+        "Set security.policy.filesystem.deny_hermes_control_plane: true.",
+        "file-tools",
+    )
+    add(
+        "filesystem",
+        "home_credential_write_deny",
+        "pass",
+        "home credential paths are statically write-denied",
+        enforcement="file-tools",
+    )
+    add(
+        "filesystem",
+        "kernel_filesystem_enforcement",
+        "warn",
+        "Hermes file tools enforce policy paths, but local shell redirection is not kernel-confined",
+        (
+            "Run Hermes inside OpenShell, Docker, Singularity, or another "
+            "sandbox for mandatory filesystem controls."
+        ),
+        "external-runtime",
+    )
+
+    environment = policy.get("environment", {})
+    provider_passthrough = environment.get("provider_credentials_in_passthrough") or []
+    add(
+        "environment",
+        "provider_credential_scrubbing",
+        "pass",
+        "Hermes-managed provider credentials are scrubbed from local subprocesses by default",
+        enforcement="subprocess-env",
+    )
+    add(
+        "environment",
+        "provider_env_passthrough",
+        "fail" if provider_passthrough else "pass",
+        "provider credentials allowed through terminal.env_passthrough: "
+        + ", ".join(provider_passthrough)
+        if provider_passthrough
+        else "terminal.env_passthrough does not include Hermes provider credentials",
+        "Remove Hermes provider credentials from terminal.env_passthrough.",
+        "subprocess-env",
+    )
+
+    process = policy.get("process", {})
+    approvals_mode = str(process.get("approvals_mode") or "manual").lower()
+    add(
+        "process",
+        "hardline_blocklist",
+        "pass" if process.get("hardline_blocklist") else "fail",
+        "unconditional hardline command blocklist is enabled"
+        if process.get("hardline_blocklist")
+        else "unconditional hardline command blocklist is disabled",
+        enforcement="terminal-approval",
+    )
+    add(
+        "process",
+        "dangerous_command_approvals",
+        "fail" if approvals_mode == "off" else "pass",
+        f"approvals.mode is {approvals_mode}",
+        "Use approvals.mode: manual or smart for enterprise deployments.",
+        "terminal-approval",
+    )
+    add(
+        "process",
+        "cron_command_approvals",
+        (
+            "pass"
+            if str(process.get("cron_mode") or "deny").lower() == "deny"
+            else "warn"
+        ),
+        f"approvals.cron_mode is {process.get('cron_mode')}",
+        "Use approvals.cron_mode: deny for unattended jobs.",
+        "terminal-approval",
+    )
+    add(
+        "process",
+        "tirith_scanner",
+        "pass" if process.get("tirith_enabled") else "warn",
+        "Tirith command scanner is enabled"
+        if process.get("tirith_enabled")
+        else "Tirith command scanner is disabled",
+        "Set security.tirith_enabled: true.",
+        "terminal-approval",
+    )
+    add(
+        "process",
+        "tirith_fail_closed",
+        "warn" if process.get("tirith_fail_open") else "pass",
+        "Tirith is configured fail-open"
+        if process.get("tirith_fail_open")
+        else "Tirith is configured fail-closed",
+        "Set security.tirith_fail_open: false for strict enterprise posture.",
+        "terminal-approval",
+    )
+    add(
+        "process",
+        "kernel_process_enforcement",
+        "warn",
+        (
+            "Hermes approval scanners are active, but local commands do not "
+            "run under seccomp or privilege drop"
+        ),
+        "Use a sandbox backend or OpenShell for syscall filters and non-root process identity.",
+        "external-runtime",
+    )
+
+    network = policy.get("network", {})
+    add(
+        "network",
+        "private_url_guard",
+        "warn" if network.get("allow_private_urls") else "pass",
+        "private/internal URLs are allowed"
+        if network.get("allow_private_urls")
+        else "private/internal URLs are blocked by default",
+        "Keep security.allow_private_urls: false unless explicitly required.",
+        "browser-tools",
+    )
+    add(
+        "network",
+        "website_blocklist",
+        "pass" if network.get("website_blocklist_enabled") else "warn",
+        "website blocklist is enabled"
+        if network.get("website_blocklist_enabled")
+        else "website blocklist is disabled",
+        "Enable security.website_blocklist for enterprise deny rules.",
+        "browser-tools",
+    )
+    policy_entry_count = int(network.get("policy_entry_count") or 0)
+    add(
+        "network",
+        "network_policy_entries",
+        "pass" if policy_entry_count else "warn",
+        f"{policy_entry_count} OpenShell-style network policy entries configured",
+        "Add security.policy.network_policies entries for destination-specific egress intent.",
+        "policy",
+    )
+    add(
+        "network",
+        "gateway_proxy_enforcement",
+        (
+            "fail"
+            if policy_entry_count and not network.get("gateway_proxy_enforced")
+            else "warn"
+        ),
+        "Hermes does not provide a CONNECT proxy for terminal egress",
+        "Use OpenShell or another egress proxy when network_policies must be mandatory.",
+        "external-runtime",
+    )
+
+    permissions = policy.get("permissions", {})
+    add(
+        "permissions",
+        "tool_permission_policy",
+        "pass" if permissions.get("configured") else "warn",
+        "tool allow/deny policy is configured"
+        if permissions.get("configured")
+        else "no explicit tool allow/deny policy is configured",
+        "Use security.policy.permissions to document expected tool/toolset exposure.",
+        "tool-loader",
+    )
+    add(
+        "permissions",
+        "mcp_reload_confirmation",
+        "pass" if permissions.get("mcp_reload_confirm") else "warn",
+        "MCP reloads require confirmation"
+        if permissions.get("mcp_reload_confirm")
+        else "MCP reload confirmation is disabled",
+        "Set approvals.mcp_reload_confirm: true.",
+        "cli-gateway",
+    )
+
+    gateway = policy.get("gateway", {})
+    allowlists = gateway.get("allowlist_sources") or []
+    require_user_allowlist = bool(gateway.get("require_user_allowlist"))
+    add(
+        "gateway",
+        "user_allowlist",
+        "pass" if allowlists or not require_user_allowlist else "warn",
+        "gateway allowlists configured via: " + ", ".join(allowlists)
+        if allowlists
+        else "no gateway user allowlist env vars are configured",
+        "Configure platform allowlists or disable require_user_allowlist deliberately.",
+        "gateway",
+    )
+    add(
+        "gateway",
+        "approval_commands_inline",
+        "pass" if gateway.get("approval_commands_inline") else "fail",
+        "/approve and /deny bypass busy queues and unblock pending command approvals",
+        enforcement="gateway",
+    )
+    add(
+        "gateway",
+        "control_commands_bypass_busy_queue",
+        "pass" if gateway.get("control_commands_bypass_busy_queue") else "fail",
+        "gateway control commands are dispatched before running-agent interruption",
+        enforcement="gateway",
+    )
+
+    inference = policy.get("inference", {})
+    add(
+        "inference",
+        "secret_redaction",
+        "pass" if inference.get("redact_secrets") else "warn",
+        "secret redaction is enabled"
+        if inference.get("redact_secrets")
+        else "secret redaction is disabled",
+        "Set security.redact_secrets: true to scrub tool output and logs.",
+        "output-redaction",
+    )
+    add(
+        "inference",
+        "provider_credentials_stripped",
+        "pass" if inference.get("provider_credentials_stripped_from_tools") else "fail",
+        "provider credentials are stripped from tool subprocess environments",
+        enforcement="subprocess-env",
+    )
+    add(
+        "inference",
+        "managed_provider_routing",
+        "pass" if inference.get("managed_provider_routing") else "warn",
+        "inference is routed through a managed provider gateway"
+        if inference.get("managed_provider_routing")
+        else "Hermes does not expose an inference.local privacy router",
+        (
+            "Use OpenShell inference routing or a managed provider gateway "
+            "when model credentials must stay outside the agent runtime."
+        ),
+        "external-runtime",
+    )
+
+    return checks
+
+
+def _load_policy_document(path: str) -> Mapping[str, Any]:
+    p = Path(path)
+    try:
+        raw = p.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ValueError(f"could not read policy file: {exc}") from exc
+    try:
+        if p.suffix.lower() == ".json":
+            data = json.loads(raw)
+        else:
+            import yaml
+
+            data = yaml.safe_load(raw)
+    except Exception as exc:
+        raise ValueError(f"could not parse policy file: {exc}") from exc
+    if not isinstance(data, Mapping):
+        raise ValueError("policy file must contain a mapping")
+    return data
+
+
+def _extract_policy_mapping(data: Mapping[str, Any]) -> Mapping[str, Any]:
+    if isinstance(data.get("security"), Mapping):
+        security = data["security"]
+        if isinstance(security.get("policy"), Mapping):
+            return security["policy"]
+    if isinstance(data.get("policy"), Mapping):
+        return data["policy"]
+    return data
+
+
+def _validate_expected_type(
+    errors: list[str],
+    domain: str,
+    key: str,
+    item: Any,
+    expected: str,
+) -> None:
+    label = f"{domain}.{key}"
+    if expected == "boolean" and not isinstance(item, bool):
+        errors.append(f"{label} must be a boolean")
+    elif expected == "integer" and not isinstance(item, int):
+        errors.append(f"{label} must be an integer")
+    elif expected == "string" and not isinstance(item, str):
+        errors.append(f"{label} must be a string")
+    elif expected == "list[string]":
+        if not isinstance(item, list) or not all(isinstance(x, str) for x in item):
+            errors.append(f"{label} must be a list of strings")
+    elif "|" in expected:
+        choices = set(expected.split("|"))
+        if str(item) not in choices:
+            errors.append(f"{label} must be one of: {', '.join(sorted(choices))}")
+
+
+def _validate_network_policies(value: Any, errors: list[str]) -> None:
+    if not isinstance(value, Mapping):
+        errors.append("network_policies must be a mapping")
+        return
+    for name, entry in value.items():
+        label = f"network_policies.{name}"
+        if not isinstance(entry, Mapping):
+            errors.append(f"{label} must be a mapping")
+            continue
+        endpoints = entry.get("endpoints")
+        binaries = entry.get("binaries")
+        if not isinstance(endpoints, list) or not endpoints:
+            errors.append(f"{label}.endpoints must be a non-empty list")
+        else:
+            for idx, endpoint in enumerate(endpoints):
+                endpoint_label = f"{label}.endpoints[{idx}]"
+                if not isinstance(endpoint, Mapping):
+                    errors.append(f"{endpoint_label} must be a mapping")
+                    continue
+                if not isinstance(endpoint.get("host"), str):
+                    errors.append(f"{endpoint_label}.host must be a string")
+                if not isinstance(endpoint.get("port"), int):
+                    errors.append(f"{endpoint_label}.port must be an integer")
+                protocol = endpoint.get("protocol")
+                if protocol is not None and not isinstance(protocol, str):
+                    errors.append(f"{endpoint_label}.protocol must be a string")
+                enforcement = endpoint.get("enforcement")
+                if enforcement is not None and enforcement not in {"audit", "enforce"}:
+                    errors.append(f"{endpoint_label}.enforcement must be audit or enforce")
+                access = endpoint.get("access")
+                if access is not None and access not in {"read-only", "read-write", "full"}:
+                    errors.append(
+                        f"{endpoint_label}.access must be one of: full, read-only, read-write"
+                    )
+                for list_key in ("rules", "deny_rules", "allowed_ips"):
+                    if list_key in endpoint and not isinstance(endpoint[list_key], list):
+                        errors.append(f"{endpoint_label}.{list_key} must be a list")
+        if not isinstance(binaries, list) or not binaries:
+            errors.append(f"{label}.binaries must be a non-empty list")
+        else:
+            for idx, binary in enumerate(binaries):
+                binary_label = f"{label}.binaries[{idx}]"
+                if not isinstance(binary, Mapping):
+                    errors.append(f"{binary_label} must be a mapping")
+                    continue
+                if not isinstance(binary.get("path"), str):
+                    errors.append(f"{binary_label}.path must be a string")
+
+
+def validate_policy_mapping(data: Mapping[str, Any]) -> tuple[list[str], list[str]]:
+    policy = _extract_policy_mapping(data)
+    errors: list[str] = []
+    warnings: list[str] = []
+    for domain, value in policy.items():
+        if domain == "version":
+            if value != 1:
+                errors.append("version must be 1")
+            continue
+
+        if domain not in HERMES_POLICY_SCHEMA:
+            errors.append(f"unsupported policy domain: {domain}")
+            continue
+        if domain == "network_policies":
+            _validate_network_policies(value, errors)
+            continue
+        if not isinstance(value, Mapping):
+            errors.append(f"{domain} must be a mapping")
+            continue
+        allowed = HERMES_POLICY_SCHEMA[domain]
+        for key, item in value.items():
+            expected = allowed.get(key)
+            if expected is None:
+                errors.append(f"unsupported policy key: {domain}.{key}")
+                continue
+            _validate_expected_type(errors, domain, key, item, expected)
+            if domain == "process" and key in {"run_as_user", "run_as_group"}:
+                if str(item).strip().lower() in {"root", "0"}:
+                    errors.append(f"{domain}.{key} must not be root or 0")
+    openshell_specific_keys = OPENSHELL_TOP_LEVEL_KEYS - {"process"}
+    if any(key in policy for key in openshell_specific_keys):
+        if policy.get("version") != 1:
+            errors.append("OpenShell-shaped policies must include version: 1")
+    if not errors and not policy:
+        warnings.append("policy file did not contain any supported policy domains")
+    return errors, warnings
+
+
+def _print_policy_text(policy: Mapping[str, Any]) -> None:
+    print("Hermes Security Policy (effective)")
+    for domain in (
+        "filesystem",
+        "environment",
+        "process",
+        "network",
+        "permissions",
+        "gateway",
+        "inference",
+    ):
+        print(f"\n{domain}:")
+        values = policy.get(domain, {})
+        if isinstance(values, Mapping):
+            for key, value in values.items():
+                display = "<unset>" if value == "" else value
+                print(f"  {key}: {display}")
+
+
+def _print_checks_text(checks: list[PostureCheck]) -> None:
+    print("Hermes Security Doctor")
+    for check in checks:
+        label = check.status.upper()
+        print(
+            f"{label:<4} {check.domain}.{check.name} "
+            f"[{check.enforcement}]: {check.detail}"
+        )
+        if check.status != "pass" and check.recommendation:
+            print(f"     {check.recommendation}")
+
+
+def security_command(args: Any) -> None:
+    action = getattr(args, "security_action", None) or "doctor"
+    if action == "doctor":
+        policy = build_effective_policy()
+        checks = evaluate_posture(policy)
+        if getattr(args, "json", False):
+            print(json.dumps([asdict(check) for check in checks], indent=2))
+        else:
+            _print_checks_text(checks)
+        code = (
+            1
+            if getattr(args, "strict", False)
+            and any(c.status != "pass" for c in checks)
+            else 0
+        )
+        raise SystemExit(code)
+
+    if action == "policy":
+        policy_action = getattr(args, "policy_action", None) or "show"
+        if policy_action == "show":
+            policy = build_effective_policy()
+            if getattr(args, "json", False):
+                print(json.dumps(policy, indent=2, sort_keys=True))
+            else:
+                _print_policy_text(policy)
+            raise SystemExit(0)
+        if policy_action == "validate":
+            try:
+                data = _load_policy_document(args.file)
+                errors, warnings = validate_policy_mapping(data)
+            except ValueError as exc:
+                errors, warnings = [str(exc)], []
+            if getattr(args, "json", False):
+                print(json.dumps({"errors": errors, "warnings": warnings}, indent=2))
+            else:
+                if errors:
+                    print("Policy invalid:")
+                    for error in errors:
+                        print(f"  - {error}")
+                else:
+                    print("Policy valid.")
+                for warning in warnings:
+                    print(f"Warning: {warning}")
+            raise SystemExit(1 if errors else 0)
+
+    print("Unknown security command", file=sys.stderr)
+    raise SystemExit(2)

--- a/tests/hermes_cli/test_security_policy.py
+++ b/tests/hermes_cli/test_security_policy.py
@@ -1,0 +1,208 @@
+"""Tests for the OpenShell-inspired Hermes security posture surface."""
+
+from __future__ import annotations
+
+from argparse import Namespace
+
+import pytest
+
+from hermes_cli.security_policy import (
+    build_effective_policy,
+    evaluate_posture,
+    security_command,
+    validate_policy_mapping,
+)
+
+
+def test_effective_policy_prefers_env_safe_root():
+    cfg = {
+        "security": {
+            "policy": {"filesystem": {"write_safe_root": "/from-config"}},
+            "redact_secrets": True,
+        }
+    }
+    policy = build_effective_policy(cfg, {"HERMES_WRITE_SAFE_ROOT": "/from-env"})
+
+    assert policy["filesystem"]["write_safe_root"] == "/from-env"
+    assert policy["filesystem"]["write_safe_root_source"] == "HERMES_WRITE_SAFE_ROOT"
+    assert policy["inference"]["redact_secrets"] is True
+
+
+def test_effective_policy_reports_provider_env_passthrough():
+    cfg = {"terminal": {"env_passthrough": ["OPENAI_API_KEY", "NOTION_TOKEN"]}}
+    policy = build_effective_policy(cfg, {})
+
+    passthrough = policy["environment"]["provider_credentials_in_passthrough"]
+    assert "OPENAI_API_KEY" in passthrough
+    assert "NOTION_TOKEN" not in passthrough
+
+
+def test_effective_policy_maps_openshell_domains():
+    cfg = {
+        "security": {
+            "policy": {
+                "version": 1,
+                "filesystem_policy": {
+                    "read_only": ["/usr"],
+                    "read_write": ["/workspace", "/tmp/cache"],
+                    "deny_hermes_control_plane": True,
+                },
+                "network_policies": {
+                    "github_api": {
+                        "endpoints": [
+                            {
+                                "host": "api.github.com",
+                                "port": 443,
+                                "protocol": "rest",
+                                "access": "read-only",
+                                "enforcement": "enforce",
+                            }
+                        ],
+                        "binaries": [{"path": "/usr/bin/curl"}],
+                    }
+                },
+                "permissions": {"tools_deny": ["terminal"]},
+                "gateway": {"require_user_allowlist": True},
+                "inference": {"managed_provider_routing": True},
+            },
+            "redact_secrets": True,
+        },
+        "approvals": {"mcp_reload_confirm": True},
+    }
+    policy = build_effective_policy(cfg, {"GATEWAY_ALLOWED_USERS": "123"})
+
+    assert policy["filesystem"]["read_write_paths"] == ["/workspace", "/tmp/cache"]
+    assert policy["network"]["policy_entry_count"] == 1
+    assert policy["permissions"]["tools_deny"] == ["terminal"]
+    assert policy["gateway"]["allowlist_sources"] == ["GATEWAY_ALLOWED_USERS"]
+    assert policy["inference"]["managed_provider_routing"] is True
+
+
+def test_posture_strict_flags_enterprise_gaps():
+    policy = build_effective_policy(
+        {
+            "approvals": {"mode": "off"},
+            "security": {
+                "redact_secrets": False,
+                "tirith_enabled": False,
+                "tirith_fail_open": True,
+                "allow_private_urls": True,
+                "policy": {"filesystem": {"deny_hermes_control_plane": False}},
+            },
+            "terminal": {"env_passthrough": ["OPENAI_API_KEY"]},
+        },
+        {},
+    )
+    checks = evaluate_posture(policy)
+    failing = {(check.domain, check.name) for check in checks if check.status == "fail"}
+    warning = {(check.domain, check.name) for check in checks if check.status == "warn"}
+
+    assert ("filesystem", "control_plane_write_deny") in failing
+    assert ("environment", "provider_env_passthrough") in failing
+    assert ("process", "dangerous_command_approvals") in failing
+    assert ("inference", "secret_redaction") in warning
+
+
+def test_validate_policy_mapping_accepts_legacy_supported_shape():
+    errors, warnings = validate_policy_mapping(
+        {
+            "security": {
+                "policy": {
+                    "filesystem": {
+                        "write_safe_root": "/workspace",
+                        "deny_hermes_control_plane": True,
+                    },
+                    "process": {
+                        "approvals_mode": "manual",
+                        "tirith_enabled": True,
+                        "tirith_fail_open": False,
+                    },
+                }
+            }
+        }
+    )
+
+    assert errors == []
+    assert warnings == []
+
+
+def test_validate_policy_mapping_accepts_openshell_shape():
+    errors, warnings = validate_policy_mapping(
+        {
+            "version": 1,
+            "filesystem_policy": {
+                "read_only": ["/usr", "/lib"],
+                "read_write": ["/workspace"],
+                "include_workdir": True,
+            },
+            "landlock": {"compatibility": "best_effort"},
+            "process": {"run_as_user": "sandbox", "run_as_group": "sandbox"},
+            "network_policies": {
+                "github_api": {
+                    "name": "github-api",
+                    "endpoints": [
+                        {
+                            "host": "api.github.com",
+                            "port": 443,
+                            "protocol": "rest",
+                            "access": "read-only",
+                            "enforcement": "enforce",
+                        }
+                    ],
+                    "binaries": [{"path": "/usr/bin/curl"}],
+                }
+            },
+        }
+    )
+
+    assert errors == []
+    assert warnings == []
+
+
+def test_validate_policy_mapping_rejects_unknown_and_wrong_types():
+    errors, _warnings = validate_policy_mapping(
+        {
+            "filesystem": {
+                "write_safe_root": 123,
+                "unknown": True,
+            },
+            "kernel": {"landlock": True},
+        }
+    )
+
+    assert "filesystem.write_safe_root must be a string" in errors
+    assert "unsupported policy key: filesystem.unknown" in errors
+    assert "unsupported policy domain: kernel" in errors
+
+
+def test_validate_policy_mapping_rejects_invalid_openshell_shape():
+    errors, _warnings = validate_policy_mapping(
+        {
+            "version": 2,
+            "process": {"run_as_user": "root"},
+            "network_policies": {
+                "bad": {
+                    "endpoints": [{"host": "api.github.com", "port": "443"}],
+                    "binaries": [{"path": 123}],
+                }
+            },
+        }
+    )
+
+    assert "version must be 1" in errors
+    assert "process.run_as_user must not be root or 0" in errors
+    assert "network_policies.bad.endpoints[0].port must be an integer" in errors
+    assert "network_policies.bad.binaries[0].path must be a string" in errors
+
+
+def test_security_doctor_strict_exits_nonzero(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "hermes_cli.security_policy.build_effective_policy",
+        lambda: build_effective_policy({"approvals": {"mode": "off"}}, {}),
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        security_command(Namespace(security_action="doctor", strict=True, json=False))
+
+    assert exc.value.code == 1
+    assert "dangerous_command_approvals" in capsys.readouterr().out

--- a/tests/tools/test_file_write_safety.py
+++ b/tests/tools/test_file_write_safety.py
@@ -78,6 +78,87 @@ class TestSafeWriteRoot:
         monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", os.path.expanduser("~"))
         assert _is_write_denied(os.path.expanduser("~/.ssh/id_rsa")) is True
 
+    def test_safe_root_from_config(self, tmp_path: Path, monkeypatch):
+        safe_root = tmp_path / "workspace"
+        outside = tmp_path / "outside.txt"
+        safe_root.mkdir()
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        safe_root_yaml = str(safe_root).replace("'", "''")
+        (hermes_home / "config.yaml").write_text(
+            "security:\n"
+            "  policy:\n"
+            "    filesystem:\n"
+            f"      write_safe_root: '{safe_root_yaml}'\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("HERMES_WRITE_SAFE_ROOT", raising=False)
+
+        assert _is_write_denied(str(safe_root / "file.txt")) is False
+        assert _is_write_denied(str(outside)) is True
+
+    def test_openshell_read_write_policy_from_config(self, tmp_path: Path, monkeypatch):
+        workspace = tmp_path / "workspace"
+        cache = tmp_path / "cache"
+        outside = tmp_path / "outside.txt"
+        workspace.mkdir()
+        cache.mkdir()
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        workspace_yaml = str(workspace).replace("'", "''")
+        cache_yaml = str(cache).replace("'", "''")
+        (hermes_home / "config.yaml").write_text(
+            "security:\n"
+            "  policy:\n"
+            "    version: 1\n"
+            "    filesystem_policy:\n"
+            "      read_write:\n"
+            f"        - '{workspace_yaml}'\n"
+            f"        - '{cache_yaml}'\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("HERMES_WRITE_SAFE_ROOT", raising=False)
+
+        assert _is_write_denied(str(workspace / "file.txt")) is False
+        assert _is_write_denied(str(cache / "state.json")) is False
+        assert _is_write_denied(str(outside)) is True
+
+    def test_disable_hermes_control_plane_write_deny(self, tmp_path: Path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "security:\n"
+            "  policy:\n"
+            "    filesystem:\n"
+            "      deny_hermes_control_plane: false\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        assert _is_write_denied(str(hermes_home / "config.yaml")) is False
+        assert _is_write_denied(str(hermes_home / ".env")) is True
+
+    def test_openshell_control_plane_write_deny_opt_out(
+        self, tmp_path: Path, monkeypatch
+    ):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "security:\n"
+            "  policy:\n"
+            "    filesystem_policy:\n"
+            "      deny_hermes_control_plane: false\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        assert _is_write_denied(str(hermes_home / "config.yaml")) is False
+        assert _is_write_denied(str(hermes_home / ".env")) is True
+
 
 class TestCheckSensitivePathMacOSBypass:
     """Verify _check_sensitive_path blocks /private/etc paths (issue #8734)."""

--- a/tests/tools/test_write_deny.py
+++ b/tests/tools/test_write_deny.py
@@ -83,6 +83,17 @@ class TestWriteAllowed:
     def test_project_file(self):
         assert _is_write_denied("/home/user/project/main.py") is False
 
-    def test_hermes_config_not_env(self):
-        path = os.path.join(str(Path.home()), ".hermes", "config.yaml")
-        assert _is_write_denied(path) is False
+    def test_active_hermes_config_denied(self):
+        from hermes_constants import get_hermes_home
+        path = str(get_hermes_home() / "config.yaml")
+        assert _is_write_denied(path) is True
+
+    def test_active_hermes_auth_denied(self):
+        from hermes_constants import get_hermes_home
+        path = str(get_hermes_home() / "auth.json")
+        assert _is_write_denied(path) is True
+
+    def test_active_hermes_mcp_tokens_denied(self):
+        from hermes_constants import get_hermes_home
+        path = str(get_hermes_home() / "mcp-tokens" / "server.json")
+        assert _is_write_denied(path) is True

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1489,11 +1489,40 @@ discord:
 
 ## Security
 
-Pre-execution security scanning and secret redaction:
+Pre-execution security scanning, secret redaction, and policy posture:
 
 ```yaml
 security:
   redact_secrets: false          # Redact API key patterns in tool output and logs (off by default)
+  policy:
+    version: 1
+    filesystem:
+      write_safe_root: ""        # Legacy single write_file/patch safe root
+      deny_hermes_control_plane: true
+    filesystem_policy:           # OpenShell-shaped filesystem policy
+      read_only: []
+      read_write: []             # Multiple write_file/patch safe roots
+      include_workdir: false
+      deny_hermes_control_plane: true
+    landlock:
+      compatibility: best_effort # Accepted for policy compatibility; external runtime required
+    commands:
+      deny: []
+      allow: []
+    network_policies: {}         # OpenShell-shaped egress intent, reported by doctor
+    permissions:
+      toolsets_allow: []
+      toolsets_deny: []
+      tools_allow: []
+      tools_deny: []
+      mcp_reload_confirm: true
+    gateway:
+      require_user_allowlist: true
+      allow_pairing: true
+      control_commands_bypass_busy_queue: true
+      approval_commands_inline: true
+    inference:
+      managed_provider_routing: false
   tirith_enabled: true           # Enable Tirith security scanning for terminal commands
   tirith_path: "tirith"          # Path to tirith binary (default: "tirith" in $PATH)
   tirith_timeout: 5              # Seconds to wait for tirith scan before timing out
@@ -1505,10 +1534,34 @@ security:
 ```
 
 - `redact_secrets` — when `true`, automatically detects and redacts patterns that look like API keys, tokens, and passwords in tool output before it enters the conversation context and logs. **Off by default** — enable if you commonly work with real credentials in tool output and want a safety net. Set to `true` explicitly to turn on.
+- `policy.filesystem.write_safe_root` — when set, constrains file write and patch operations to that directory tree. `HERMES_WRITE_SAFE_ROOT` still takes precedence for backwards compatibility.
+- `policy.filesystem_policy.read_write` — OpenShell-shaped list of write roots. Hermes enforces these for file write and patch tools when `HERMES_WRITE_SAFE_ROOT` and the legacy single root are unset.
+- `policy.filesystem_policy.read_only` and `policy.landlock` — accepted and reported for OpenShell policy compatibility. Hermes does not provide Landlock itself; use OpenShell or another sandbox runtime for mandatory kernel filesystem controls.
+- `policy.filesystem.deny_hermes_control_plane` — when `true` (default), blocks file write and patch operations from mutating active Hermes control-plane state such as `config.yaml`, `auth.json`, OAuth files, webhook subscriptions, and MCP token stores.
+- `policy.network_policies` — OpenShell-shaped egress intent with endpoint and binary blocks. Hermes reports and validates this shape, but it does not provide a CONNECT proxy for terminal egress; mandatory network enforcement requires OpenShell or an equivalent gateway/proxy runtime.
+- `policy.commands` and `policy.permissions` — document command and tool exposure intent. Hermes' active enforcement comes from hardline command blocks, Tirith scanning, dangerous-command approvals, configured toolsets, and MCP reload confirmation.
+- `policy.gateway` — documents gateway posture such as required user allowlists and inline approval/control command handling. `hermes security doctor` checks the effective gateway allowlist environment and built-in approval command routing.
+- `policy.inference` — documents managed provider routing intent. Hermes strips provider credentials from tool subprocesses; a true `inference.local` privacy router requires an external runtime such as OpenShell.
 - `tirith_enabled` — when `true`, terminal commands are scanned by [Tirith](https://github.com/StackGuardian/tirith) before execution to detect potentially dangerous operations.
 - `tirith_path` — path to the tirith binary. Set this if tirith is installed in a non-standard location.
 - `tirith_timeout` — maximum seconds to wait for a tirith scan. Commands proceed if the scan times out.
 - `tirith_fail_open` — when `true` (default), commands are allowed to execute if tirith is unavailable or fails. Set to `false` to block commands when tirith cannot verify them.
+
+Inspect the effective security posture with:
+
+```bash
+hermes security doctor
+hermes security doctor --strict
+hermes security policy show --json
+hermes security policy validate policy.yaml
+```
+
+The `security` command accepts and validates OpenShell-shaped policy sections
+(`filesystem_policy`, `landlock`, `process`, and `network_policies`) plus
+Hermes-specific `commands`, `permissions`, `gateway`, `environment`, and
+`inference` sections. Doctor output includes the enforcement point for each
+check so operators can distinguish Hermes-enforced controls from controls that
+need an external sandbox, CONNECT proxy, or inference gateway.
 
 ## Website Blocklist
 


### PR DESCRIPTION
## What does this PR do?

  Adds an OpenShell-shaped security policy posture surface for Hermes.

  This gives operators a single CLI path to validate policy documents and inspect the effective filesystem, command, permission, network, gateway, environment, and inference posture. The implementation deliberately separates
  controls Hermes can enforce locally from controls that require an external runtime such as OpenShell, Docker, a CONNECT proxy, or an inference gateway.

  This avoids overstating security guarantees while still making Hermes more enterprise-friendly: file-tool writes can now be constrained by `filesystem_policy.read_write`, control-plane files remain denied by default, and
  `hermes security doctor` reports unsupported kernel/proxy controls as posture gaps instead of silently accepting paper policy.


  ## Type of Change

  - [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
  - [x] ✨ New feature (non-breaking change that adds functionality)
  - [ ] 🔒 Security fix
  - [x] 📝 Documentation update
  - [x] ✅ Tests (adding or improving test coverage)
  - [ ] ♻️ Refactor (no behavior change)
  - [ ] 🎯 New skill (bundled or hub)

  ## Changes Made

  - Added `hermes_cli/security_policy.py` with policy validation, effective posture building, and doctor checks.
  - Added `hermes security doctor`, `hermes security policy show`, and `hermes security policy validate` in `hermes_cli/main.py`.
  - Updated `agent/file_safety.py` to enforce multiple write roots from `security.policy.filesystem_policy.read_write`, while preserving `HERMES_WRITE_SAFE_ROOT` precedence and active Hermes control-plane denials.
  - Added OpenShell-shaped policy defaults under `security.policy` in `hermes_cli/config.py`.
  - Added tests in `tests/hermes_cli/test_security_policy.py`.
  - Expanded file safety coverage in `tests/tools/test_file_write_safety.py` and updated write-deny expectations in `tests/tools/test_write_deny.py`.
  - Documented the policy surface and enforcement boundaries in `website/docs/user-guide/configuration.md`.

  ## How to Test

  1. Run the focused regression suite:

     ```bash
     scripts/run_tests.sh tests/hermes_cli/test_security_policy.py tests/hermes_cli/test_redact_config_bridge.py tests/tools/test_file_write_safety.py tests/tools/test_write_deny.py tests/tools/test_file_operations.py tests/
  tools/test_file_tools.py tests/tools/test_env_passthrough.py tests/agent/test_copilot_acp_client.py

  2. Validate an OpenShell-shaped policy:

     hermes security policy validate policy.yaml
  3. Inspect effective posture:

     hermes security doctor
     hermes security doctor --strict
     hermes security policy show --json

  ## Checklist

  ### Code

  - [x] I've read the Contributing Guide (https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
  - [x] My commit messages follow Conventional Commits (https://www.conventionalcommits.org/) (fix(scope):, feat(scope):, etc.)
  - [x] I searched for existing PRs (https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
  - [x] My PR contains only changes related to this fix/feature (no unrelated commits)
  - [x] I've run pytest tests/ -q and all tests pass
  - [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
  - [x] I've tested on my platform: macOS

  ### Documentation & Housekeeping

  - [x] I've updated relevant documentation (README, docs/, docstrings) — or N/A
  - [ ] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
  - [ ] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
  - [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide (https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
  - [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

  ## Screenshots / Logs

  Focused regression suite:

  151 passed, 4 warnings

  CLI smoke covered:

  hermes security doctor
  hermes security doctor --strict
  hermes security policy show --json
  hermes security policy validate policy.yaml
