### PR TITLE
fix: detect local DNS endpoints

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -8,6 +8,8 @@ import ipaddress
 import logging
 import os
 import re
+import socket
+import threading
 import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -263,6 +265,34 @@ _CONTAINER_LOCAL_SUFFIXES = (
     ".containers.internal",
     ".lima.internal",
 )
+# DNS namespaces reserved for private / internal-only use. RFC 8375 reserves
+# .home.arpa for residential home networks; RFC 6762 reserves .local for
+# multicast DNS; .internal is IANA-reserved (and used by Google Cloud DNS);
+# .lan / .home / .intranet / .private are widespread de-facto conventions
+# for internal-only zones. Hosts under these suffixes never escape the LAN,
+# so they get the same treatment as RFC-1918 IPs (timeout bumps, no
+# network-egress probes, etc.).
+_PRIVATE_DNS_SUFFIXES = (
+    ".home.arpa",
+    ".local",
+    ".internal",
+    ".intranet",
+    ".lan",
+    ".home",
+    ".localdomain",
+    ".private",
+)
+
+# DNS-resolution cache for `is_local_endpoint`. Maps hostname to
+# `(is_local, resolved_at_epoch)`. Cached so repeated calls (one per stream
+# request) don't re-issue the lookup, and so a slow resolver only hurts
+# once per TTL window.
+_dns_resolution_cache: Dict[str, tuple[bool, float]] = {}
+_DNS_CACHE_TTL = 300  # 5 minutes
+# Hard cap so a broken resolver can't stall request paths. The lookup runs
+# in a daemon thread; if it doesn't finish within this budget we treat the
+# host as non-local and cache the negative.
+_DNS_LOOKUP_TIMEOUT = 0.5
 
 
 def _normalize_base_url(base_url: str) -> str:
@@ -341,15 +371,87 @@ def _is_known_provider_base_url(base_url: str) -> bool:
     return _infer_provider_from_url(base_url) is not None
 
 
+def _ip_is_local(addr: ipaddress._BaseAddress) -> bool:
+    """Return True for any IP address Hermes treats as local/trusted."""
+    if addr.is_private or addr.is_loopback or addr.is_link_local:
+        return True
+    if isinstance(addr, ipaddress.IPv4Address) and addr in _TAILSCALE_CGNAT:
+        return True
+    return False
+
+
+def _hostname_resolves_to_local_ip(host: str) -> bool:
+    """Return True if `host` resolves to a private/loopback/link-local/CGNAT IP.
+
+    The lookup runs in a daemon thread with a hard `_DNS_LOOKUP_TIMEOUT`
+    deadline so a slow or broken resolver can't stall request paths. Both
+    positive and negative results are cached for `_DNS_CACHE_TTL` seconds —
+    negatives included so public DNS names don't pay the lookup cost on
+    every call. Resolution failures (NXDOMAIN, timeout, etc.) are treated
+    as non-local, which matches the safe default: if we can't prove it's
+    on the LAN, don't apply local-endpoint shortcuts.
+    """
+    now = time.time()
+    cached = _dns_resolution_cache.get(host)
+    if cached is not None and (now - cached[1]) < _DNS_CACHE_TTL:
+        return cached[0]
+
+    result_box: list = []
+
+    def _resolve() -> None:
+        try:
+            result_box.append(socket.getaddrinfo(host, None))
+        except Exception:
+            result_box.append([])
+
+    thread = threading.Thread(target=_resolve, daemon=True)
+    thread.start()
+    thread.join(timeout=_DNS_LOOKUP_TIMEOUT)
+
+    if not result_box:
+        # Resolver still running past the deadline — give up, cache the
+        # negative briefly. The daemon thread will be reaped at exit.
+        _dns_resolution_cache[host] = (False, now)
+        return False
+
+    is_local = False
+    for info in result_box[0]:
+        # getaddrinfo entry: (family, type, proto, canonname, sockaddr)
+        sockaddr = info[4]
+        if not sockaddr:
+            continue
+        ip_str = sockaddr[0]
+        # Strip IPv6 zone id (e.g. "fe80::1%eth0")
+        if "%" in ip_str:
+            ip_str = ip_str.split("%", 1)[0]
+        try:
+            addr = ipaddress.ip_address(ip_str)
+        except ValueError:
+            continue
+        if _ip_is_local(addr):
+            is_local = True
+            break
+
+    _dns_resolution_cache[host] = (is_local, now)
+    return is_local
+
+
 def is_local_endpoint(base_url: str) -> bool:
     """Return True if base_url points to a local machine.
 
     Recognises loopback (``localhost``, ``127.0.0.0/8``, ``::1``),
     container-internal DNS names (``host.docker.internal`` et al.),
-    RFC-1918 private ranges (``10/8``, ``172.16/12``, ``192.168/16``),
-    link-local, and Tailscale CGNAT (``100.64.0.0/10``). Tailscale CGNAT
-    is included so remote-but-trusted Ollama boxes reached over a
-    Tailscale mesh get the same timeout auto-bumps as localhost Ollama.
+    reserved private DNS namespaces (``.home.arpa``, ``.local``,
+    ``.internal``, etc.), RFC-1918 private ranges (``10/8``,
+    ``172.16/12``, ``192.168/16``), link-local, and Tailscale CGNAT
+    (``100.64.0.0/10``). Tailscale CGNAT is included so remote-but-trusted
+    Ollama boxes reached over a Tailscale mesh get the same timeout
+    auto-bumps as localhost Ollama.
+
+    For hostnames that don't match any of the literal rules above, falls
+    back to a short DNS lookup (capped at ``_DNS_LOOKUP_TIMEOUT``): if the
+    name resolves to a private/loopback/CGNAT IP, treat as local. Public
+    names and resolution failures are classified as non-local.
     """
     normalized = _normalize_base_url(base_url)
     if not normalized:
@@ -360,22 +462,28 @@ def is_local_endpoint(base_url: str) -> bool:
         host = parsed.hostname or ""
     except Exception:
         return False
+    if not host:
+        return False
     if host in _LOCAL_HOSTS:
         return True
     # Docker / Podman / Lima internal DNS names (e.g. host.docker.internal)
     if any(host.endswith(suffix) for suffix in _CONTAINER_LOCAL_SUFFIXES):
         return True
+    # Reserved private DNS namespaces (.home.arpa, .local, .internal, ...)
+    if any(host.endswith(suffix) for suffix in _PRIVATE_DNS_SUFFIXES):
+        return True
     # RFC-1918 private ranges, link-local, and Tailscale CGNAT
+    is_ip_literal = False
     try:
         addr = ipaddress.ip_address(host)
-        if addr.is_private or addr.is_loopback or addr.is_link_local:
-            return True
-        if isinstance(addr, ipaddress.IPv4Address) and addr in _TAILSCALE_CGNAT:
+        is_ip_literal = True
+        if _ip_is_local(addr):
             return True
     except ValueError:
         pass
     # Bare IP that looks like a private range (e.g. 172.26.x.x for WSL)
-    # or Tailscale CGNAT (100.64.x.x–100.127.x.x).
+    # or Tailscale CGNAT (100.64.x.x–100.127.x.x). Catches edge cases the
+    # ipaddress module might reject (e.g. leading zeros).
     parts = host.split(".")
     if len(parts) == 4:
         try:
@@ -390,7 +498,16 @@ def is_local_endpoint(base_url: str) -> bool:
                 return True
         except ValueError:
             pass
-    return False
+    # If the host parsed as a public IP literal, skip the DNS lookup —
+    # there's nothing to resolve and an IP literal can't gain local
+    # status by being resolved again.
+    if is_ip_literal:
+        return False
+    # Hostname that didn't match any literal rule: ask DNS (with a short
+    # hard timeout). If it resolves to a private IP, treat as local —
+    # this catches arbitrary internal DNS names (e.g. `myserver`,
+    # `ollama-box`, /etc/hosts entries) without baking a suffix list.
+    return _hostname_resolves_to_local_ip(host)
 
 
 def detect_local_server_type(base_url: str, api_key: str = "") -> Optional[str]:

--- a/tests/agent/test_local_stream_timeout.py
+++ b/tests/agent/test_local_stream_timeout.py
@@ -7,6 +7,8 @@ kills during long prefill phases.
 """
 
 import os
+import socket
+import time as _time
 import pytest
 from unittest.mock import patch
 
@@ -128,3 +130,148 @@ class TestIsLocalEndpoint:
     def test_near_but_not_cgnat_is_remote(self, url):
         """Hosts adjacent to but outside 100.64.0.0/10 must not match."""
         assert is_local_endpoint(url) is False
+
+
+class TestIsLocalEndpointPrivateDNS:
+    """Reserved private DNS namespaces (.home.arpa, .local, .internal, ...)."""
+
+    def setup_method(self) -> None:
+        from agent.model_metadata import _dns_resolution_cache
+        _dns_resolution_cache.clear()
+
+    @pytest.mark.parametrize("url", [
+        # RFC 8375 — home networks
+        "http://ollama.home.arpa/v1",
+        "http://ollama.home.arpa:11434",
+        "http://server.home.arpa",
+        # mDNS (RFC 6762)
+        "http://printer.local",
+        "http://nas.local:9090",
+        # IANA-reserved internal zone
+        "http://gitlab.internal:8080",
+        # de-facto private conventions
+        "http://router.lan",
+        "http://wiki.intranet",
+        "http://nas.home",
+        "http://box.localdomain",
+        "http://service.private",
+    ])
+    def test_private_dns_suffixes_are_local(self, url):
+        # Patched so a buggy resolver can't accidentally satisfy this test.
+        with patch(
+            "agent.model_metadata.socket.getaddrinfo",
+            side_effect=AssertionError("DNS lookup must not run for private suffixes"),
+        ):
+            assert is_local_endpoint(url) is True
+
+    @pytest.mark.parametrize("url", [
+        # Suffix-only collision: ".home.arpa" must match at the boundary.
+        "https://evil.home.arpa.example.com",
+        "https://homearpa.example.com",
+        "https://ranch.local.example.com",
+    ])
+    def test_private_suffix_collision_is_not_local(self, url):
+        with patch(
+            "agent.model_metadata.socket.getaddrinfo",
+            side_effect=socket.gaierror("not resolvable"),
+        ):
+            assert is_local_endpoint(url) is False
+
+
+class TestIsLocalEndpointDNSResolution:
+    """DNS-based fallback for hostnames not covered by literal rules."""
+
+    def setup_method(self) -> None:
+        from agent.model_metadata import _dns_resolution_cache
+        _dns_resolution_cache.clear()
+
+    @staticmethod
+    def _addrinfo_v4(ip: str) -> list:
+        return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", (ip, 0))]
+
+    @staticmethod
+    def _addrinfo_v6(ip: str) -> list:
+        return [(socket.AF_INET6, socket.SOCK_STREAM, 0, "", (ip, 0, 0, 0))]
+
+    @pytest.mark.parametrize("ip", [
+        "192.168.1.50",     # RFC1918 192.168/16
+        "10.0.0.5",         # RFC1918 10/8
+        "172.20.0.5",       # RFC1918 172.16/12
+        "127.0.0.1",        # loopback
+        "169.254.1.5",      # link-local
+        "100.77.243.5",     # Tailscale CGNAT
+    ])
+    def test_hostname_resolving_to_private_ip_is_local(self, ip):
+        with patch(
+            "agent.model_metadata.socket.getaddrinfo",
+            return_value=self._addrinfo_v4(ip),
+        ):
+            assert is_local_endpoint("http://my-internal-box.example.com") is True
+
+    @pytest.mark.parametrize("ip", [
+        "8.8.8.8",
+        "1.1.1.1",
+        "104.16.132.229",
+        "199.232.64.140",
+    ])
+    def test_hostname_resolving_to_public_ip_is_not_local(self, ip):
+        with patch(
+            "agent.model_metadata.socket.getaddrinfo",
+            return_value=self._addrinfo_v4(ip),
+        ):
+            assert is_local_endpoint("http://api.example.com") is False
+
+    def test_dns_resolution_failure_is_not_local(self):
+        """NXDOMAIN / unresolvable hosts must not be classified as local."""
+        with patch(
+            "agent.model_metadata.socket.getaddrinfo",
+            side_effect=socket.gaierror("nodename nor servname"),
+        ):
+            assert is_local_endpoint("http://nonexistent.example.com") is False
+
+    def test_slow_resolver_does_not_block_caller(self):
+        """If the resolver hangs past _DNS_LOOKUP_TIMEOUT, give up cleanly."""
+        from agent.model_metadata import _DNS_LOOKUP_TIMEOUT
+
+        def _slow_lookup(*args, **kwargs):
+            _time.sleep(_DNS_LOOKUP_TIMEOUT * 4)
+            return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("192.168.1.1", 0))]
+
+        start = _time.monotonic()
+        with patch(
+            "agent.model_metadata.socket.getaddrinfo", side_effect=_slow_lookup,
+        ):
+            result = is_local_endpoint("http://slow-resolver.example.com")
+        elapsed = _time.monotonic() - start
+
+        assert result is False
+        # Should return shortly after the timeout, not after the full sleep.
+        assert elapsed < _DNS_LOOKUP_TIMEOUT * 3
+
+    def test_resolution_result_is_cached(self):
+        """Repeated calls re-use the cached answer, not the resolver."""
+        with patch(
+            "agent.model_metadata.socket.getaddrinfo",
+            return_value=self._addrinfo_v4("192.168.1.50"),
+        ) as mocked:
+            assert is_local_endpoint("http://cached-host.example.com") is True
+            assert is_local_endpoint("http://cached-host.example.com") is True
+            assert is_local_endpoint("http://cached-host.example.com:9000/v1") is True
+        assert mocked.call_count == 1
+
+    def test_ipv6_ula_resolution_is_local(self):
+        """IPv6 unique-local addresses (fc00::/7) count as private."""
+        with patch(
+            "agent.model_metadata.socket.getaddrinfo",
+            return_value=self._addrinfo_v6("fd12:3456:789a::1"),
+        ):
+            assert is_local_endpoint("http://my-ula-box.example.com") is True
+
+    def test_ff_tech_home_arpa_endpoint_is_local(self):
+        """Regression: ff-tech provider with base_url http://ollama.home.arpa/v1
+        must classify as local without needing DNS resolution."""
+        with patch(
+            "agent.model_metadata.socket.getaddrinfo",
+            side_effect=AssertionError("must short-circuit on .home.arpa"),
+        ):
+            assert is_local_endpoint("http://ollama.home.arpa/v1") is True


### PR DESCRIPTION
## Summary
- Treat reserved private DNS suffixes like .home.arpa as local endpoints
- Add bounded DNS fallback for hostnames resolving to private, loopback, link-local, or Tailscale CGNAT IPs
- Add regression coverage for ff-tech's http://ollama.home.arpa/v1 endpoint

## Test Plan
- python -m pytest tests/agent/test_local_stream_timeout.py -q -o 'addopts='
- python -m pytest tests/agent/test_model_metadata_local_ctx.py tests/agent/test_local_stream_timeout.py -q -o 'addopts='
- python -m compileall -q agent/model_metadata.py tests/agent/test_local_stream_timeout.py