### PR TITLE
fix(weixin): treat empty rate-limit message as stale session

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -96,12 +96,17 @@ MESSAGE_DEDUP_TTL_SECONDS = 300
 def _is_stale_session_ret(
     ret: "Optional[int]", errcode: "Optional[int]", errmsg: "Optional[str]",
 ) -> bool:
-    """True when iLink returns ret=-2 / errcode=-2 with 'unknown error',
-    which is a stale-session signal (same as errcode=-14) rather than
-    a genuine rate limit."""
+    """True when iLink ret=-2/errcode=-2 likely means a stale session.
+
+    iLink has been observed to return the same -2 code for both genuine rate
+    limits and stale context tokens.  Populated rate-limit messages should stay
+    on the backoff path, while ``"unknown error"`` and empty/None messages are
+    stale-session signals that should trigger the tokenless retry path.
+    """
     if ret != RATE_LIMIT_ERRCODE and errcode != RATE_LIMIT_ERRCODE:
         return False
-    return (errmsg or "").lower() == "unknown error"
+    message = (errmsg or "").strip().lower()
+    return message in {"", "unknown error"}
 
 
 MEDIA_IMAGE = 1

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -776,9 +776,13 @@ class TestIsStaleSessionRet:
         # Genuine rate limit — must NOT be treated as stale session.
         assert weixin._is_stale_session_ret(-2, None, "freq limit") is False
 
-    def test_ret_minus_2_with_no_errmsg_is_not_stale(self):
-        assert weixin._is_stale_session_ret(-2, None, None) is False
-        assert weixin._is_stale_session_ret(-2, None, "") is False
+    def test_ret_minus_2_with_no_errmsg_is_stale(self):
+        assert weixin._is_stale_session_ret(-2, None, None) is True
+        assert weixin._is_stale_session_ret(-2, None, "") is True
+
+    def test_errcode_minus_2_with_no_errmsg_is_stale(self):
+        assert weixin._is_stale_session_ret(None, -2, None) is True
+        assert weixin._is_stale_session_ret(None, -2, "") is True
 
     def test_errcode_minus_14_is_not_matched_here(self):
         # -14 is handled by the separate SESSION_EXPIRED_ERRCODE path; the


### PR DESCRIPTION
## What does this PR do?

- Treat iLink `ret=-2` / `errcode=-2` with an empty or missing `errmsg` as a stale Weixin session signal.
- Keep populated rate-limit messages on the existing rate-limit/backoff path.
- Extend the Weixin stale-session helper regression tests for empty/None `errmsg` on both `ret` and `errcode` variants.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A