### PR TITLE
feat(providers): add Manifest open-source LLM router

### DIFF
--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -189,6 +189,12 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         transport="openai_chat",
         base_url_env_var="OLLAMA_BASE_URL",
     ),
+    "manifest": HermesOverlay(
+        transport="openai_chat",
+        is_aggregator=True,
+        base_url_override="https://app.manifest.build/v1",
+        base_url_env_var="MANIFEST_BASE_URL",
+    ),
     # Azure Foundry: supports both OpenAI-style and Anthropic-style endpoints.
     # The transport is determined at runtime from config.yaml model.api_mode.
     "azure-foundry": HermesOverlay(
@@ -332,6 +338,9 @@ ALIASES: Dict[str, str] = {
     # gmi
     "gmi-cloud": "gmi",
     "gmicloud": "gmi",
+
+    # manifest
+    "mnfst": "manifest",
 
     # Local server aliases → virtual "local" concept (resolved via user config)
     "lmstudio": "lmstudio",

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -40,6 +40,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **Google / Gemini** | `GOOGLE_API_KEY` (or `GEMINI_API_KEY`) in `~/.hermes/.env` (provider: `gemini`) |
 | **Google Gemini (OAuth)** | `hermes model` → "Google Gemini (OAuth)" (provider: `google-gemini-cli`, free tier supported, browser PKCE login) |
 | **LM Studio** | `hermes model` → "LM Studio" (provider: `lmstudio`, optional `LM_API_KEY`) |
+| **Manifest** | `MANIFEST_API_KEY` in `~/.hermes/.env` (provider: `manifest`, alias: `mnfst`) |
 | **Custom Endpoint** | `hermes model` → choose "Custom endpoint" (saved in `config.yaml`) |
 
 :::tip Model key alias
@@ -314,7 +315,13 @@ model:
   default: "zai-org/GLM-5.1-FP8"
 ```
 
-Base URLs can be overridden with `GLM_BASE_URL`, `KIMI_BASE_URL`, `MINIMAX_BASE_URL`, `MINIMAX_CN_BASE_URL`, `DASHSCOPE_BASE_URL`, `XIAOMI_BASE_URL`, `GMI_BASE_URL`, or `TOKENHUB_BASE_URL` environment variables.
+```bash
+# Manifest (open-source LLM router, smart routing to cut inference costs)
+hermes chat --provider manifest --model auto
+# Requires: MANIFEST_API_KEY in ~/.hermes/.env
+```
+
+Base URLs can be overridden with `GLM_BASE_URL`, `KIMI_BASE_URL`, `MINIMAX_BASE_URL`, `MINIMAX_CN_BASE_URL`, `DASHSCOPE_BASE_URL`, `XIAOMI_BASE_URL`, `GMI_BASE_URL`, `TOKENHUB_BASE_URL`, or `MANIFEST_BASE_URL` environment variables.
 
 :::note Z.AI Endpoint Auto-Detection
 When using the Z.AI / GLM provider, Hermes automatically probes multiple endpoints (global, China, coding variants) to find one that accepts your API key. You don't need to set `GLM_BASE_URL` manually — the working endpoint is detected and cached automatically.
@@ -505,6 +512,30 @@ Get your token at [huggingface.co/settings/tokens](https://huggingface.co/settin
 You can append routing suffixes to model names: `:fastest` (default), `:cheapest`, or `:provider_name` to force a specific backend.
 
 The base URL can be overridden with `HF_BASE_URL`.
+
+### Manifest — Open-Source LLM Router
+
+[Manifest](https://manifest.build) is an open-source LLM router that cuts inference costs through smart routing across 16+ providers. You get full control over which model handles each request. Route by complexity tier, task-specificity (coding, web browsing, etc.) and custom tiers.
+
+```bash
+# Cloud (app.manifest.build)
+hermes chat --provider manifest --model auto
+# Requires: MANIFEST_API_KEY in ~/.hermes/.env
+
+# Self-hosted, override base URL
+MANIFEST_BASE_URL=http://localhost:2099/v1 hermes chat --provider manifest --model auto
+```
+
+Or set it permanently in `config.yaml`:
+```yaml
+model:
+  provider: "manifest"
+  default: "auto"
+```
+
+:::tip Self-hosted Manifest
+For self-hosted deployments, set `MANIFEST_BASE_URL=http://localhost:2099/v1`. Manifest exposes the same OpenAI-compatible chat completions API in both cloud and self-hosted modes, so switching is a one-line env-var change. Self-hosted Manifest can also route to local models (Ollama, vLLM, llama.cpp) for fully local inference.
+:::
 
 ## Custom & Self-Hosted LLM Providers
 
@@ -1160,9 +1191,9 @@ You can also select named custom providers from the interactive `hermes model` m
 | **Local models, easy setup** | Ollama |
 | **Production GPU serving** | vLLM or SGLang |
 | **Mac / no GPU** | Ollama or llama.cpp |
-| **Multi-provider routing** | LiteLLM Proxy or OpenRouter |
-| **Cost optimization** | ClawRouter or OpenRouter with `sort: "price"` |
-| **Maximum privacy** | Ollama, vLLM, or llama.cpp (fully local) |
+| **Multi-provider routing** | LiteLLM Proxy, OpenRouter, or Manifest |
+| **Cost optimization** | Manifest, ClawRouter, or OpenRouter with `sort: "price"` |
+| **Maximum privacy** | Ollama, vLLM, llama.cpp, or Manifest (self-hosted), fully local |
 | **Enterprise / Azure** | Azure OpenAI with custom endpoint |
 | **Chinese AI models** | z.ai (GLM), Kimi/Moonshot (`kimi-coding` or `kimi-coding-cn`), MiniMax, Xiaomi MiMo, or Tencent TokenHub (first-class providers) |
 
@@ -1239,7 +1270,7 @@ fallback_model:
 
 When activated, the fallback swaps the model and provider mid-session without losing your conversation. It fires **at most once** per session.
 
-Supported providers: `openrouter`, `nous`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `gemini`, `google-gemini-cli`, `qwen-oauth`, `huggingface`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `minimax-oauth`, `deepseek`, `nvidia`, `xai`, `ollama-cloud`, `bedrock`, `ai-gateway`, `opencode-zen`, `opencode-go`, `kilocode`, `xiaomi`, `arcee`, `gmi`, `alibaba`, `tencent-tokenhub`, `custom`.
+Supported providers: `openrouter`, `nous`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `gemini`, `google-gemini-cli`, `qwen-oauth`, `huggingface`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `minimax-oauth`, `deepseek`, `nvidia`, `xai`, `ollama-cloud`, `bedrock`, `ai-gateway`, `opencode-zen`, `opencode-go`, `kilocode`, `xiaomi`, `arcee`, `gmi`, `alibaba`, `tencent-tokenhub`, `manifest`, `custom`.
 
 :::tip
 Fallback is configured exclusively through `config.yaml` — there are no environment variables for it. For full details on when it triggers, supported providers, and how it interacts with auxiliary tasks and delegation, see [Fallback Providers](/docs/user-guide/features/fallback-providers).


### PR DESCRIPTION
## What does this PR do?

Add [Manifest](https://manifest.build) as a built-in aggregator provider. Manifest is an open-source LLM router that cuts inference costs by automatically selecting the best model across 16+ providers based on request complexity, with built-in fallback chains.

Users can now select Manifest via `hermes model --provider manifest` with the endpoint pre-filled, instead of configuring a custom provider manually.

## Related Issue

N/A — new provider integration.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/providers.py`: Added `HermesOverlay` entry for Manifest (`is_aggregator=True`, `transport="openai_chat"`, base URL `https://app.manifest.build/v1`)
- `hermes_cli/providers.py`: Added aliases `manifest-router` and `mnfst` → `manifest`
- `website/docs/integrations/providers.md`: Added Manifest to the providers table, First-Class API-Key Providers section, fallback_model supported list, and Choosing the Right Setup table

## How to Test

1. Set `MANIFEST_API_KEY=mnfst_...` in `~/.hermes/.env`
2. Run `hermes model --provider manifest`
3. Manifest should appear as a selectable provider with models fetched from the endpoint
4. Self-hosted users can override via `MANIFEST_BASE_URL=http://localhost:2099/v1`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(providers):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 14.4 (Darwin 23.4.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
Manifest in HERMES_OVERLAYS: True
  transport: openai_chat
  is_aggregator: True
  base_url_override: https://app.manifest.build/v1
  base_url_env_var: MANIFEST_BASE_URL
Alias mnfst -> manifest
Alias manifest-router -> manifest
```