### PR TITLE
fix(tts): add Mistral ref_audio support

### DIFF
--- a/tests/tools/test_tts_mistral.py
+++ b/tests/tools/test_tts_mistral.py
@@ -88,6 +88,73 @@ class TestGenerateMistralTts:
         call_kwargs = mock_mistral_module.audio.speech.complete.call_args[1]
         assert call_kwargs["voice_id"] == "my-voice-uuid"
 
+    def test_ref_audio_path_passed_when_configured(
+        self, tmp_path, mock_mistral_module, monkeypatch
+    ):
+        from tools.tts_tool import _generate_mistral_tts
+
+        monkeypatch.setenv("MISTRAL_API_KEY", "test-key")
+        mock_mistral_module.audio.speech.complete.return_value = MagicMock(
+            audio_data=base64.b64encode(b"data").decode()
+        )
+        ref_audio = tmp_path / "reference.mp3"
+        ref_audio.write_bytes(b"reference-audio")
+
+        config = {"mistral": {"ref_audio": str(ref_audio)}}
+        _generate_mistral_tts("Hi", str(tmp_path / "test.mp3"), config)
+
+        call_kwargs = mock_mistral_module.audio.speech.complete.call_args[1]
+        assert call_kwargs["ref_audio"] == base64.b64encode(b"reference-audio").decode()
+        assert "voice_id" not in call_kwargs
+
+    def test_ref_audio_takes_precedence_over_voice_id(
+        self, tmp_path, mock_mistral_module, monkeypatch
+    ):
+        from tools.tts_tool import _generate_mistral_tts
+
+        monkeypatch.setenv("MISTRAL_API_KEY", "test-key")
+        mock_mistral_module.audio.speech.complete.return_value = MagicMock(
+            audio_data=base64.b64encode(b"data").decode()
+        )
+        ref_audio = tmp_path / "reference.mp3"
+        ref_audio.write_bytes(b"reference-audio")
+
+        config = {
+            "mistral": {
+                "voice_id": "my-voice-uuid",
+                "ref_audio": str(ref_audio),
+            }
+        }
+        _generate_mistral_tts("Hi", str(tmp_path / "test.mp3"), config)
+
+        call_kwargs = mock_mistral_module.audio.speech.complete.call_args[1]
+        assert call_kwargs["ref_audio"] == base64.b64encode(b"reference-audio").decode()
+        assert "voice_id" not in call_kwargs
+
+    def test_ref_audio_missing_path_raises_value_error(
+        self, tmp_path, mock_mistral_module, monkeypatch
+    ):
+        from tools.tts_tool import _generate_mistral_tts
+
+        monkeypatch.setenv("MISTRAL_API_KEY", "test-key")
+        config = {"mistral": {"ref_audio": str(tmp_path / "missing.mp3")}}
+
+        with pytest.raises(ValueError, match="Mistral ref_audio file not found"):
+            _generate_mistral_tts("Hi", str(tmp_path / "test.mp3"), config)
+
+    def test_ref_audio_empty_file_raises_value_error(
+        self, tmp_path, mock_mistral_module, monkeypatch
+    ):
+        from tools.tts_tool import _generate_mistral_tts
+
+        monkeypatch.setenv("MISTRAL_API_KEY", "test-key")
+        ref_audio = tmp_path / "empty-reference.mp3"
+        ref_audio.write_bytes(b"")
+        config = {"mistral": {"ref_audio": str(ref_audio)}}
+
+        with pytest.raises(ValueError, match="Mistral ref_audio file is empty"):
+            _generate_mistral_tts("Hi", str(tmp_path / "test.mp3"), config)
+
     def test_default_voice_id_when_absent(
         self, tmp_path, mock_mistral_module, monkeypatch
     ):

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1024,6 +1024,16 @@ def _generate_mistral_tts(text: str, output_path: str, tts_config: Dict[str, Any
     mi_config = tts_config.get("mistral", {})
     model = mi_config.get("model", DEFAULT_MISTRAL_TTS_MODEL)
     voice_id = mi_config.get("voice_id") or DEFAULT_MISTRAL_TTS_VOICE_ID
+    ref_audio_path = str(mi_config.get("ref_audio") or "").strip()
+    ref_audio_b64 = None
+    if ref_audio_path:
+        ref_path = Path(ref_audio_path).expanduser()
+        if not ref_path.is_file():
+            raise ValueError(f"Mistral ref_audio file not found: {ref_path}")
+        ref_audio_bytes = ref_path.read_bytes()
+        if not ref_audio_bytes:
+            raise ValueError(f"Mistral ref_audio file is empty: {ref_path}")
+        ref_audio_b64 = base64.b64encode(ref_audio_bytes).decode("ascii")
 
     if output_path.endswith(".ogg"):
         response_format = "opus"
@@ -1037,12 +1047,16 @@ def _generate_mistral_tts(text: str, output_path: str, tts_config: Dict[str, Any
     Mistral = _import_mistral_client()
     try:
         with Mistral(api_key=api_key) as client:
-            response = client.audio.speech.complete(
-                model=model,
-                input=text,
-                voice_id=voice_id,
-                response_format=response_format,
-            )
+            speech_kwargs = {
+                "model": model,
+                "input": text,
+                "response_format": response_format,
+            }
+            if ref_audio_b64:
+                speech_kwargs["ref_audio"] = ref_audio_b64
+            else:
+                speech_kwargs["voice_id"] = voice_id
+            response = client.audio.speech.complete(**speech_kwargs)
             audio_bytes = base64.b64decode(response.audio_data)
     except ValueError:
         raise

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -64,7 +64,8 @@ tts:
     pitch: 0                    # -12 - 12
   mistral:
     model: "voxtral-mini-tts-2603"
-    voice_id: "c69964a6-ab8b-4f8a-9465-ec0925096ec8"  # Paul - Neutral (default)
+    voice_id: "c69964a6-ab8b-4f8a-9465-ec0925096ec8"  # Paul - Neutral (default); used when ref_audio is not set
+    # ref_audio: "/absolute/path/to/reference.mp3"  # Optional: existing non-empty local file; overrides voice_id
   gemini:
     model: "gemini-2.5-flash-preview-tts"  # or gemini-2.5-pro-preview-tts
     voice: "Kore"               # 30 prebuilt voices: Zephyr, Puck, Kore, Enceladus, Gacrux, etc.
@@ -96,6 +97,23 @@ tts:
 ```
 
 **Speed control**: The global `tts.speed` value applies to all providers by default. Each provider can override it with its own `speed` setting (e.g., `tts.openai.speed: 1.5`). Provider-specific speed takes precedence over the global value. Default is `1.0` (normal speed).
+
+### Mistral reference audio
+
+Mistral can synthesize against a local reference clip instead of one of the preset `voice_id` voices.
+
+```yaml
+tts:
+  provider: mistral
+  mistral:
+    model: "voxtral-mini-tts-2603"
+    ref_audio: "/absolute/path/to/reference.mp3"
+```
+
+Rules:
+- `tts.mistral.ref_audio` must point to an existing, non-empty local audio file.
+- When `ref_audio` is set, Hermes sends it to Mistral and ignores `tts.mistral.voice_id`.
+- When `ref_audio` is omitted, Hermes uses `voice_id` exactly as before.
 
 ### Telegram Voice Bubbles & ffmpeg
 


### PR DESCRIPTION
## Summary
- add `tts.mistral.ref_audio` support by reading a local reference-audio file and sending it to the Mistral TTS API
- keep the existing `voice_id` path as the fallback when `ref_audio` is not configured
- add regression coverage for happy path, precedence over `voice_id`, and missing/empty file failures
- document the new config knob and override behavior in the TTS docs

## Test Plan
- [x] `venv/bin/python -m pytest -q tests/tools/test_tts_mistral.py`