### PR TITLE
chore(models): demote Vercel AI Gateway to bottom of provider picker

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -773,7 +773,6 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("nous",           "Nous Portal",              "Nous Portal (Nous Research subscription)"),
     ProviderEntry("openrouter",     "OpenRouter",               "OpenRouter (100+ models, pay-per-use)"),
     ProviderEntry("lmstudio",       "LM Studio",                "LM Studio (local desktop app with built-in model server)"),
-    ProviderEntry("ai-gateway",     "Vercel AI Gateway",        "Vercel AI Gateway (200+ models, $5 free credit, no markup)"),
     ProviderEntry("anthropic",      "Anthropic",                "Anthropic (Claude models — API key or Claude Code)"),
     ProviderEntry("openai-codex",   "OpenAI Codex",             "OpenAI Codex"),
     ProviderEntry("xiaomi",         "Xiaomi MiMo",              "Xiaomi MiMo (MiMo-V2.5 and V2 models — pro, omni, flash)"),
@@ -803,6 +802,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("opencode-go",    "OpenCode Go",              "OpenCode Go (open models, $10/month subscription)"),
     ProviderEntry("bedrock",        "AWS Bedrock",              "AWS Bedrock (Claude, Nova, Llama, DeepSeek — IAM or API key)"),
     ProviderEntry("azure-foundry",  "Azure Foundry",            "Azure Foundry (OpenAI-style or Anthropic-style endpoint — your Azure AI deployment)"),
+    ProviderEntry("ai-gateway",     "Vercel AI Gateway",        "Vercel AI Gateway"),
 ]
 
 # Derived dicts — used throughout the codebase


### PR DESCRIPTION
## Summary
Vercel AI Gateway no longer sits ahead of Anthropic / OpenAI / Xiaomi in the `hermes model` picker, and its description is stripped to just "Vercel AI Gateway".

## Changes
- `hermes_cli/models.py`: move the `ai-gateway` entry from position 4 to the end of `CANONICAL_PROVIDERS`, drop the "(200+ models, $5 free credit, no markup)" parenthetical.

## Validation
| | Before | After |
|---|---|---|
| Position | #4 | #33 (last) |
| Description | "Vercel AI Gateway (200+ models, $5 free credit, no markup)" | "Vercel AI Gateway" |

LM Studio stays at #3 (unchanged). Tests only assert membership in `CANONICAL_PROVIDERS`, not position.