### PR TITLE
feat(acp): add steer and queue slash commands

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -569,6 +569,9 @@ class HermesACPAgent(acp.Agent):
     async def cancel(self, session_id: str, **kwargs: Any) -> None:
         state = self.session_manager.get_session(session_id)
         if state and state.cancel_event:
+            with state.runtime_lock:
+                if state.is_running and state.current_prompt_text:
+                    state.interrupted_prompt_text = state.current_prompt_text
             state.cancel_event.set()
             try:
                 if getattr(state, "agent", None) and hasattr(state.agent, "interrupt"):
@@ -666,6 +669,25 @@ class HermesACPAgent(acp.Agent):
         if not has_content:
             return PromptResponse(stop_reason="end_turn")
 
+        # Zed currently interrupts an active ACP request before delivering a
+        # follow-up slash command. If that follow-up is /steer, there may be no
+        # live AIAgent left to steer by the time this method runs. Salvage that
+        # UX by replaying the interrupted prompt with the steer text attached as
+        # explicit correction/guidance.
+        if isinstance(user_content, str) and user_text.startswith("/steer"):
+            steer_text = user_text.split(maxsplit=1)[1].strip() if len(user_text.split(maxsplit=1)) > 1 else ""
+            interrupted_prompt = ""
+            with state.runtime_lock:
+                if not state.is_running and steer_text and state.interrupted_prompt_text:
+                    interrupted_prompt = state.interrupted_prompt_text
+                    state.interrupted_prompt_text = ""
+            if interrupted_prompt:
+                user_text = (
+                    f"{interrupted_prompt}\n\n"
+                    f"User correction/guidance after interrupt: {steer_text}"
+                )
+                user_content = user_text
+
         # Intercept slash commands — handle locally without calling the LLM.
         # Slash commands are text-only; if the client included images/resources,
         # send the whole multimodal prompt to the agent instead of treating it as
@@ -694,6 +716,7 @@ class HermesACPAgent(acp.Agent):
                     await self._conn.session_update(session_id, update)
                 return PromptResponse(stop_reason="end_turn")
             state.is_running = True
+            state.current_prompt_text = user_text or "[Image attachment]"
 
         logger.info("Prompt on session %s: %s", session_id, user_text[:100])
 
@@ -808,6 +831,7 @@ class HermesACPAgent(acp.Agent):
             logger.exception("Executor error for session %s", session_id)
             with state.runtime_lock:
                 state.is_running = False
+                state.current_prompt_text = ""
             return PromptResponse(stop_reason="end_turn")
 
         if result.get("messages"):
@@ -838,6 +862,7 @@ class HermesACPAgent(acp.Agent):
         # normal follow-up user prompts, preserving role alternation and history.
         with state.runtime_lock:
             state.is_running = False
+            state.current_prompt_text = ""
 
         while True:
             with state.runtime_lock:

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -164,6 +164,8 @@ class HermesACPAgent(acp.Agent):
         "context": "Show conversation context info",
         "reset": "Clear conversation history",
         "compact": "Compress conversation context",
+        "steer": "Inject guidance into the currently running agent turn",
+        "queue": "Queue a prompt to run after the current turn finishes",
         "version": "Show Hermes version",
     }
 
@@ -192,6 +194,16 @@ class HermesACPAgent(acp.Agent):
         {
             "name": "compact",
             "description": "Compress conversation context",
+        },
+        {
+            "name": "steer",
+            "description": "Inject guidance into the currently running agent turn",
+            "input_hint": "guidance for the active turn",
+        },
+        {
+            "name": "queue",
+            "description": "Queue a prompt to run after the current turn finishes",
+            "input_hint": "prompt to run next",
         },
         {
             "name": "version",
@@ -666,6 +678,23 @@ class HermesACPAgent(acp.Agent):
                     await self._conn.session_update(session_id, update)
                 return PromptResponse(stop_reason="end_turn")
 
+        # If Zed sends another regular prompt while the same ACP session is
+        # still running, queue it instead of racing two AIAgent loops against
+        # the same state.history. /steer and /queue are handled above and can
+        # land immediately.
+        with state.runtime_lock:
+            if state.is_running:
+                queued_text = user_text or "[Image attachment]"
+                state.queued_prompts.append(queued_text)
+                depth = len(state.queued_prompts)
+                if self._conn:
+                    update = acp.update_agent_message_text(
+                        f"Queued for the next turn. ({depth} queued)"
+                    )
+                    await self._conn.session_update(session_id, update)
+                return PromptResponse(stop_reason="end_turn")
+            state.is_running = True
+
         logger.info("Prompt on session %s: %s", session_id, user_text[:100])
 
         conn = self._conn
@@ -777,6 +806,8 @@ class HermesACPAgent(acp.Agent):
             result = await loop.run_in_executor(_executor, ctx.run, _run_agent)
         except Exception:
             logger.exception("Executor error for session %s", session_id)
+            with state.runtime_lock:
+                state.is_running = False
             return PromptResponse(stop_reason="end_turn")
 
         if result.get("messages"):
@@ -801,6 +832,27 @@ class HermesACPAgent(acp.Agent):
         if final_response and conn:
             update = acp.update_agent_message_text(final_response)
             await conn.session_update(session_id, update)
+
+        # Mark this turn idle before draining queued work so recursive prompt()
+        # calls can acquire the session. Queued turns are intentionally run as
+        # normal follow-up user prompts, preserving role alternation and history.
+        with state.runtime_lock:
+            state.is_running = False
+
+        while True:
+            with state.runtime_lock:
+                if not state.queued_prompts:
+                    break
+                next_prompt = state.queued_prompts.pop(0)
+            if conn:
+                await conn.session_update(
+                    session_id,
+                    acp.update_user_message_text(next_prompt),
+                )
+            await self.prompt(
+                prompt=[TextContentBlock(type="text", text=next_prompt)],
+                session_id=session_id,
+            )
 
         usage = None
         if any(result.get(key) is not None for key in ("prompt_tokens", "completion_tokens", "total_tokens")):
@@ -879,6 +931,8 @@ class HermesACPAgent(acp.Agent):
             "context": self._cmd_context,
             "reset": self._cmd_reset,
             "compact": self._cmd_compact,
+            "steer": self._cmd_steer,
+            "queue": self._cmd_queue,
             "version": self._cmd_version,
         }.get(cmd)
 
@@ -1005,6 +1059,34 @@ class HermesACPAgent(acp.Agent):
             )
         except Exception as e:
             return f"Compression failed: {e}"
+
+    def _cmd_steer(self, args: str, state: SessionState) -> str:
+        steer_text = args.strip()
+        if not steer_text:
+            return "Usage: /steer <guidance>"
+
+        if state.is_running and hasattr(state.agent, "steer"):
+            try:
+                if state.agent.steer(steer_text):
+                    preview = steer_text[:80] + ("..." if len(steer_text) > 80 else "")
+                    return f"⏩ Steer queued for the active turn: {preview}"
+            except Exception as exc:
+                logger.warning("ACP steer failed for session %s: %s", state.session_id, exc)
+                return f"⚠️ Steer failed: {exc}"
+
+        with state.runtime_lock:
+            state.queued_prompts.append(steer_text)
+            depth = len(state.queued_prompts)
+        return f"No active turn — queued for the next turn. ({depth} queued)"
+
+    def _cmd_queue(self, args: str, state: SessionState) -> str:
+        queued_text = args.strip()
+        if not queued_text:
+            return "Usage: /queue <prompt>"
+        with state.runtime_lock:
+            state.queued_prompts.append(queued_text)
+            depth = len(state.queued_prompts)
+        return f"Queued for the next turn. ({depth} queued)"
 
     def _cmd_version(self, args: str, state: SessionState) -> str:
         return f"Hermes Agent v{HERMES_VERSION}"

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -148,6 +148,8 @@ class SessionState:
     is_running: bool = False
     queued_prompts: List[str] = field(default_factory=list)
     runtime_lock: Any = field(default_factory=Lock)
+    current_prompt_text: str = ""
+    interrupted_prompt_text: str = ""
 
 
 class SessionManager:

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -145,6 +145,9 @@ class SessionState:
     model: str = ""
     history: List[Dict[str, Any]] = field(default_factory=list)
     cancel_event: Any = None  # threading.Event
+    is_running: bool = False
+    queued_prompts: List[str] = field(default_factory=list)
+    runtime_lock: Any = field(default_factory=Lock)
 
 
 class SessionManager:

--- a/tests/acp_adapter/test_acp_commands.py
+++ b/tests/acp_adapter/test_acp_commands.py
@@ -82,6 +82,24 @@ async def test_acp_steer_slash_command_injects_into_running_agent():
 
 
 @pytest.mark.asyncio
+async def test_acp_steer_after_zed_interrupt_replays_interrupted_prompt_with_guidance():
+    acp_agent, state, fake, _conn = make_agent_and_state()
+    state.interrupted_prompt_text = "write hi to a text file"
+
+    response = await acp_agent.prompt(
+        session_id=state.session_id,
+        prompt=[TextContentBlock(type="text", text="/steer write HELLO instead")],
+    )
+
+    assert response.stop_reason == "end_turn"
+    assert fake.steers == []
+    assert fake.runs == [
+        "write hi to a text file\n\nUser correction/guidance after interrupt: write HELLO instead"
+    ]
+    assert state.interrupted_prompt_text == ""
+
+
+@pytest.mark.asyncio
 async def test_acp_queue_slash_command_adds_next_turn_without_running_now():
     acp_agent, state, fake, _conn = make_agent_and_state()
 

--- a/tests/acp_adapter/test_acp_commands.py
+++ b/tests/acp_adapter/test_acp_commands.py
@@ -1,0 +1,112 @@
+from types import SimpleNamespace
+
+import pytest
+from acp.schema import TextContentBlock
+
+from acp_adapter.server import HermesACPAgent
+from acp_adapter.session import SessionManager
+
+
+class FakeAgent:
+    def __init__(self):
+        self.model = "fake-model"
+        self.provider = "fake-provider"
+        self.enabled_toolsets = ["hermes-acp"]
+        self.disabled_toolsets = []
+        self.tools = []
+        self.valid_tool_names = set()
+        self.steers = []
+        self.runs = []
+
+    def steer(self, text):
+        self.steers.append(text)
+        return True
+
+    def run_conversation(self, *, user_message, conversation_history, task_id, **kwargs):
+        self.runs.append(user_message)
+        messages = list(conversation_history or [])
+        messages.append({"role": "user", "content": user_message})
+        final = f"ran: {user_message}"
+        messages.append({"role": "assistant", "content": final})
+        return {"final_response": final, "messages": messages}
+
+
+class CaptureConn:
+    def __init__(self):
+        self.updates = []
+
+    async def session_update(self, *args, **kwargs):
+        if kwargs:
+            self.updates.append((kwargs.get("session_id"), kwargs.get("update")))
+        else:
+            self.updates.append((args[0], args[1]))
+
+    async def request_permission(self, *args, **kwargs):
+        return SimpleNamespace(outcome="allow")
+
+
+class NoopDb:
+    def get_session(self, *_args, **_kwargs):
+        return None
+
+    def create_session(self, *_args, **_kwargs):
+        return None
+
+    def update_session(self, *_args, **_kwargs):
+        return None
+
+
+def make_agent_and_state():
+    fake = FakeAgent()
+    manager = SessionManager(agent_factory=lambda **kwargs: fake, db=NoopDb())
+    acp_agent = HermesACPAgent(session_manager=manager)
+    state = manager.create_session(cwd=".")
+    conn = CaptureConn()
+    acp_agent.on_connect(conn)
+    return acp_agent, state, fake, conn
+
+
+@pytest.mark.asyncio
+async def test_acp_steer_slash_command_injects_into_running_agent():
+    acp_agent, state, fake, _conn = make_agent_and_state()
+    state.is_running = True
+
+    response = await acp_agent.prompt(
+        session_id=state.session_id,
+        prompt=[TextContentBlock(type="text", text="/steer prefer the simpler fix")],
+    )
+
+    assert response.stop_reason == "end_turn"
+    assert fake.steers == ["prefer the simpler fix"]
+    assert fake.runs == []
+
+
+@pytest.mark.asyncio
+async def test_acp_queue_slash_command_adds_next_turn_without_running_now():
+    acp_agent, state, fake, _conn = make_agent_and_state()
+
+    response = await acp_agent.prompt(
+        session_id=state.session_id,
+        prompt=[TextContentBlock(type="text", text="/queue run the tests after this")],
+    )
+
+    assert response.stop_reason == "end_turn"
+    assert state.queued_prompts == ["run the tests after this"]
+    assert fake.runs == []
+
+
+@pytest.mark.asyncio
+async def test_acp_prompt_drains_queued_turns_after_current_run():
+    acp_agent, state, fake, conn = make_agent_and_state()
+    state.queued_prompts.append("then run tests")
+
+    response = await acp_agent.prompt(
+        session_id=state.session_id,
+        prompt=[TextContentBlock(type="text", text="make the change")],
+    )
+
+    assert response.stop_reason == "end_turn"
+    assert fake.runs == ["make the change", "then run tests"]
+    assert state.queued_prompts == []
+    agent_messages = [u for _sid, u in conn.updates if getattr(u, "session_update", None) == "agent_message_chunk"]
+    assert len(agent_messages) >= 2


### PR DESCRIPTION
## Summary
- advertise /steer and /queue in ACP available commands
- route /steer into the existing AIAgent.steer() mechanism when a turn is active
- queue /queue prompts and regular prompts submitted during an active ACP turn
- drain queued prompts after the current turn without racing session history

## Test Plan
- source venv/bin/activate && python -m pytest tests/acp_adapter/test_acp_commands.py tests/acp_adapter/test_acp_images.py tests/run_agent/test_vision_aware_preprocessing.py -q -n 4