### PR TITLE
feat(delegate): add Best-of-N competitive evaluation with independent…

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -29,6 +29,7 @@ from tools.delegate_tool import (
     _build_child_agent,
     _build_child_progress_callback,
     _build_child_system_prompt,
+    _judge_best_of_n,
     _strip_blocked_tools,
     _resolve_child_credential_pool,
     _resolve_delegation_credentials,
@@ -92,6 +93,68 @@ class TestChildSystemPrompt(unittest.TestCase):
     def test_empty_context_ignored(self):
         prompt = _build_child_system_prompt("Do something", "  ")
         self.assertNotIn("CONTEXT", prompt)
+
+
+
+class TestJudgeBestOfN(unittest.TestCase):
+    @patch("agent.auxiliary_client.call_llm")
+    def test_best_of_n_selects_winner(self, mock_call_llm):
+        mock_resp = MagicMock()
+        mock_resp.choices = [MagicMock()]
+        mock_resp.choices[0].message.content = (
+            '{"winner_index": 1, "reasoning": "Better error handling"}'
+        )
+        mock_call_llm.return_value = mock_resp
+
+        results = [
+            {"task_index": 0, "summary": "Implementation A"},
+            {"task_index": 1, "summary": "Implementation B"},
+            {"task_index": 2, "summary": "Implementation C"},
+        ]
+        winner_idx = _judge_best_of_n(results, "Select best error handling")
+        self.assertEqual(winner_idx, 1)
+        mock_call_llm.assert_called_once()
+
+    @patch("agent.auxiliary_client.call_llm")
+    def test_best_of_n_no_evaluator_returns_all(self, mock_call_llm):
+        results = [
+            {"task_index": 0, "summary": "Implementation A"},
+            {"task_index": 1, "summary": "Implementation B"},
+        ]
+        winner_idx = _judge_best_of_n(results, "")
+        self.assertIsNone(winner_idx)
+        mock_call_llm.assert_not_called()
+
+    @patch("agent.auxiliary_client.call_llm")
+    def test_best_of_n_judge_failure_returns_all(self, mock_call_llm):
+        mock_call_llm.side_effect = RuntimeError("No provider")
+
+        results = [
+            {"task_index": 0, "summary": "Implementation A"},
+            {"task_index": 1, "summary": "Implementation B"},
+        ]
+        winner_idx = _judge_best_of_n(results, "Select best")
+        self.assertIsNone(winner_idx)
+        mock_call_llm.assert_called_once()
+
+    def test_best_of_n_single_task_ignores_evaluator(self):
+        results = [{"task_index": 0, "summary": "Only one"}]
+        winner_idx = _judge_best_of_n(results, "Select best")
+        self.assertIsNone(winner_idx)
+
+    @patch("agent.auxiliary_client.call_llm")
+    def test_best_of_n_invalid_winner_index_returns_none(self, mock_call_llm):
+        mock_resp = MagicMock()
+        mock_resp.choices = [MagicMock()]
+        mock_resp.choices[0].message.content = '{"winner_index": 99, "reasoning": "invalid"}'
+        mock_call_llm.return_value = mock_resp
+
+        results = [
+            {"task_index": 0, "summary": "Implementation A"},
+            {"task_index": 1, "summary": "Implementation B"},
+        ]
+        winner_idx = _judge_best_of_n(results, "Select best")
+        self.assertIsNone(winner_idx)
 
 
 class TestStripBlockedTools(unittest.TestCase):

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -111,8 +111,9 @@ class TestJudgeBestOfN(unittest.TestCase):
             {"task_index": 1, "summary": "Implementation B"},
             {"task_index": 2, "summary": "Implementation C"},
         ]
-        winner_idx = _judge_best_of_n(results, "Select best error handling")
+        winner_idx, winner_reasoning = _judge_best_of_n(results, "Select best error handling")
         self.assertEqual(winner_idx, 1)
+        self.assertEqual(winner_reasoning, "Better error handling")
         mock_call_llm.assert_called_once()
 
     @patch("agent.auxiliary_client.call_llm")
@@ -121,7 +122,7 @@ class TestJudgeBestOfN(unittest.TestCase):
             {"task_index": 0, "summary": "Implementation A"},
             {"task_index": 1, "summary": "Implementation B"},
         ]
-        winner_idx = _judge_best_of_n(results, "")
+        winner_idx, _ = _judge_best_of_n(results, "")
         self.assertIsNone(winner_idx)
         mock_call_llm.assert_not_called()
 
@@ -133,13 +134,13 @@ class TestJudgeBestOfN(unittest.TestCase):
             {"task_index": 0, "summary": "Implementation A"},
             {"task_index": 1, "summary": "Implementation B"},
         ]
-        winner_idx = _judge_best_of_n(results, "Select best")
+        winner_idx, _ = _judge_best_of_n(results, "Select best")
         self.assertIsNone(winner_idx)
         mock_call_llm.assert_called_once()
 
     def test_best_of_n_single_task_ignores_evaluator(self):
         results = [{"task_index": 0, "summary": "Only one"}]
-        winner_idx = _judge_best_of_n(results, "Select best")
+        winner_idx, _ = _judge_best_of_n(results, "Select best")
         self.assertIsNone(winner_idx)
 
     @patch("agent.auxiliary_client.call_llm")
@@ -153,7 +154,7 @@ class TestJudgeBestOfN(unittest.TestCase):
             {"task_index": 0, "summary": "Implementation A"},
             {"task_index": 1, "summary": "Implementation B"},
         ]
-        winner_idx = _judge_best_of_n(results, "Select best")
+        winner_idx, _ = _judge_best_of_n(results, "Select best")
         self.assertIsNone(winner_idx)
 
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1942,18 +1942,18 @@ def _judge_output(
 
 def _judge_best_of_n(
     results: List[Dict[str, Any]],
-    evaluator: str,
-) -> Optional[int]:
-    """Run competitive evaluation on N parallel outputs and return best index.
+    judge: str,
+) -> tuple:
+    """Run competitive evaluation on N parallel outputs and return (winner_index, reasoning).
 
     Returns the task_index of the winning entry, or None if evaluation
     fails (in which case all results are preserved and the caller decides).
     """
     if not results or len(results) < 2:
-        return None
+        return None, ""
 
-    if not evaluator or not evaluator.strip():
-        return None
+    if not judge or not judge.strip():
+        return None, ""
 
     summaries: List[str] = []
     for entry in results:
@@ -1965,7 +1965,7 @@ def _judge_best_of_n(
 
     comparison_prompt = (
         f"Evaluate the following {len(results)} implementations of the same task.\n\n"
-        f"Evaluation criteria: {evaluator}\n\n"
+        f"Evaluation criteria: {judge}\n\n"
         + "\n".join(summaries)
         + "\n\nSelect the BEST implementation based on the criteria above. "
         "Respond ONLY with valid JSON — no markdown, no backticks, no preamble:\n"
@@ -1995,7 +1995,7 @@ def _judge_best_of_n(
         raw = resp.choices[0].message.content.strip() if resp and resp.choices else ""
     except Exception as exc:
         logger.warning("Best-of-N judge call failed: %s", exc)
-        return None
+        return None, ""
 
     # Strip optional markdown code fences
     raw = re.sub(r"^```(?:json)?\s*\n?", "", raw, flags=re.IGNORECASE)
@@ -2008,12 +2008,12 @@ def _judge_best_of_n(
         reasoning = str(parsed.get("reasoning", "")).strip()
         if 0 <= winner < len(results):
             logger.debug("Best-of-N winner: index %d (%s)", winner, reasoning[:100])
-            return winner
+            return winner, reasoning
         logger.warning("Best-of-N returned invalid winner_index: %d", winner)
     except (json.JSONDecodeError, TypeError, ValueError):
         logger.warning("Best-of-N returned non-JSON: %s", raw[:200])
 
-    return None
+    return None, ""
 
 def delegate_task(
     goal: Optional[str] = None,
@@ -2023,7 +2023,7 @@ def delegate_task(
     max_iterations: Optional[int] = None,
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
-    evaluator: Optional[str] = None,
+    judge: Optional[str] = None,
     role: Optional[str] = None,
     parent_agent=None,
 ) -> str:
@@ -2304,13 +2304,14 @@ def delegate_task(
         results.sort(key=lambda r: r["task_index"])
 
     # Best-of-N competitive evaluation (#479 Phase 1)
-    if evaluator and len(results) > 1:
-        winner_idx = _judge_best_of_n(results, evaluator)
+    best_of_n_winner = None
+    if judge and len(results) > 1:
+        winner_idx, winner_reasoning = _judge_best_of_n(results, judge)
         if winner_idx is not None and 0 <= winner_idx < len(results):
-            for entry in results:
-                entry["best_of_n_winner"] = (
-                    entry["task_index"] == winner_idx
-                )
+            best_of_n_winner = {
+                "task_index": winner_idx,
+                "reasoning": winner_reasoning,
+            }
 
     # Notify parent's memory provider of delegation outcomes
     if (
@@ -2400,13 +2401,14 @@ def delegate_task(
 
     total_duration = round(time.monotonic() - overall_start, 2)
 
-    return json.dumps(
-        {
-            "results": results,
-            "total_duration_seconds": total_duration,
-        },
-        ensure_ascii=False,
-    )
+    result_payload = {
+        "results": results,
+        "total_duration_seconds": total_duration,
+    }
+    if best_of_n_winner is not None:
+        result_payload["winner"] = best_of_n_winner
+
+    return json.dumps(result_payload, ensure_ascii=False)
 
 
 def _resolve_child_credential_pool(effective_provider: Optional[str], parent_agent):
@@ -2726,7 +2728,7 @@ DELEGATE_TASK_SCHEMA = {
                     "Only used when acp_command is set."
                 ),
             },
-            "evaluator": {
+            "judge": {
                 "type": "string",
                 "description": (
                     "Optional evaluation rubric for competitive Best-of-N selection. "

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1867,6 +1867,154 @@ def _run_single_child(
             logger.debug("Failed to close child agent after delegation")
 
 
+
+
+# TODO: remove after #17980 merges into upstream
+def _judge_output(
+    objective: str,
+    acceptance_criteria: str,
+    output: str,
+) -> Dict[str, str]:
+    """Evaluate sub-agent output against acceptance criteria using a cheap LLM.
+
+    Returns a dict with verdict (PASS|FAIL) and reasoning.
+    If the auxiliary LLM is unavailable or returns unparseable output,
+    logs a warning and returns {"verdict": "FAIL", "reasoning": "..."}.
+    """
+    if not acceptance_criteria or not acceptance_criteria.strip():
+        return {"verdict": "PASS", "reasoning": "No criteria provided"}
+
+    judge_prompt = (
+        "Evaluate whether this output meets the acceptance criteria.\n\n"
+        f"Objective: {objective}\n"
+        f"Acceptance Criteria: {acceptance_criteria}\n\n"
+        f"Output:\n{output}\n\n"
+        'Respond ONLY with valid JSON — no markdown, no backticks, no preamble:\n'
+        '{"verdict": "PASS"|"FAIL", "reasoning": "explanation"}'
+    )
+
+    try:
+        import re
+        from agent.auxiliary_client import call_llm
+
+        resp = call_llm(
+            task="judge",
+            messages=[
+                {
+                    "role": "system",
+                    "content": (
+                        "You are an independent quality judge. Check if a sub-agent's "
+                        "output meets the stated acceptance criteria. Be strict but fair. "
+                        "Respond ONLY with the requested JSON."
+                    ),
+                },
+                {"role": "user", "content": judge_prompt},
+            ],
+            temperature=0.0,
+            max_tokens=512,
+        )
+        raw = resp.choices[0].message.content.strip() if resp and resp.choices else ""
+    except Exception as exc:
+        logger.warning("Judge LLM call failed: %s", exc)
+        return {"verdict": "FAIL", "reasoning": f"Judge unavailable: {exc}"}
+
+    # Strip optional markdown code fences
+    raw = re.sub(r"^```(?:json)?\s*\n?", "", raw, flags=re.IGNORECASE)
+    raw = re.sub(r"\n?```\s*$", "", raw)
+    raw = raw.strip()
+
+    try:
+        parsed = json.loads(raw)
+        verdict = str(parsed.get("verdict", "")).strip().upper()
+        reasoning = str(parsed.get("reasoning", "")).strip()
+        if verdict not in {"PASS", "FAIL"}:
+            verdict = "FAIL"
+            reasoning = f"Invalid verdict from judge: {raw[:200]}"
+        return {"verdict": verdict, "reasoning": reasoning}
+    except json.JSONDecodeError:
+        logger.warning("Judge returned non-JSON: %s", raw[:200])
+        upper = raw.upper()
+        if "PASS" in upper and "FAIL" not in upper:
+            return {"verdict": "PASS", "reasoning": raw}
+        return {"verdict": "FAIL", "reasoning": f"Judge returned non-JSON: {raw[:200]}"}
+
+
+
+def _judge_best_of_n(
+    results: List[Dict[str, Any]],
+    evaluator: str,
+) -> Optional[int]:
+    """Run competitive evaluation on N parallel outputs and return best index.
+
+    Returns the task_index of the winning entry, or None if evaluation
+    fails (in which case all results are preserved and the caller decides).
+    """
+    if not results or len(results) < 2:
+        return None
+
+    if not evaluator or not evaluator.strip():
+        return None
+
+    summaries: List[str] = []
+    for entry in results:
+        idx = entry.get("task_index", 0)
+        summary = entry.get("summary", "") or entry.get("error", "")
+        summaries.append(
+            f"--- Implementation {idx} ---\n{summary[:800]}\n"
+        )
+
+    comparison_prompt = (
+        f"Evaluate the following {len(results)} implementations of the same task.\n\n"
+        f"Evaluation criteria: {evaluator}\n\n"
+        + "\n".join(summaries)
+        + "\n\nSelect the BEST implementation based on the criteria above. "
+        "Respond ONLY with valid JSON — no markdown, no backticks, no preamble:\n"
+        '{"winner_index": <int>, "reasoning": "explanation"}'
+    )
+
+    try:
+        import re
+        from agent.auxiliary_client import call_llm
+
+        resp = call_llm(
+            task="judge",
+            messages=[
+                {
+                    "role": "system",
+                    "content": (
+                        "You are an independent competitive evaluator. "
+                        "Compare multiple implementations and select the best one. "
+                        "Respond ONLY with the requested JSON."
+                    ),
+                },
+                {"role": "user", "content": comparison_prompt},
+            ],
+            temperature=0.0,
+            max_tokens=1024,
+        )
+        raw = resp.choices[0].message.content.strip() if resp and resp.choices else ""
+    except Exception as exc:
+        logger.warning("Best-of-N judge call failed: %s", exc)
+        return None
+
+    # Strip optional markdown code fences
+    raw = re.sub(r"^```(?:json)?\s*\n?", "", raw, flags=re.IGNORECASE)
+    raw = re.sub(r"\n?```\s*$", "", raw)
+    raw = raw.strip()
+
+    try:
+        parsed = json.loads(raw)
+        winner = int(parsed.get("winner_index", -1))
+        reasoning = str(parsed.get("reasoning", "")).strip()
+        if 0 <= winner < len(results):
+            logger.debug("Best-of-N winner: index %d (%s)", winner, reasoning[:100])
+            return winner
+        logger.warning("Best-of-N returned invalid winner_index: %d", winner)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        logger.warning("Best-of-N returned non-JSON: %s", raw[:200])
+
+    return None
+
 def delegate_task(
     goal: Optional[str] = None,
     context: Optional[str] = None,
@@ -1875,6 +2023,7 @@ def delegate_task(
     max_iterations: Optional[int] = None,
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
+    evaluator: Optional[str] = None,
     role: Optional[str] = None,
     parent_agent=None,
 ) -> str:
@@ -2153,6 +2302,15 @@ def delegate_task(
 
         # Sort by task_index so results match input order
         results.sort(key=lambda r: r["task_index"])
+
+    # Best-of-N competitive evaluation (#479 Phase 1)
+    if evaluator and len(results) > 1:
+        winner_idx = _judge_best_of_n(results, evaluator)
+        if winner_idx is not None and 0 <= winner_idx < len(results):
+            for entry in results:
+                entry["best_of_n_winner"] = (
+                    entry["task_index"] == winner_idx
+                )
 
     # Notify parent's memory provider of delegation outcomes
     if (
@@ -2566,6 +2724,14 @@ DELEGATE_TASK_SCHEMA = {
                 "description": (
                     "Arguments for the ACP command (default: ['--acp', '--stdio']). "
                     "Only used when acp_command is set."
+                ),
+            },
+            "evaluator": {
+                "type": "string",
+                "description": (
+                    "Optional evaluation rubric for competitive Best-of-N selection. "
+                    "When provided with multiple tasks, all outputs are evaluated side-by-side "
+                    "by an independent judge and the best result is marked as winner."
                 ),
             },
         },


### PR DESCRIPTION
## Summary
Implements Phase 1 of #479: Best-of-N competitive evaluation with independent judge for delegate_task batch mode.

---

## Root cause
When running parallel batch tasks via delegate_task, all N results are returned to the parent agent which must manually compare and select the best output. This consumes parent context window tokens, applies ad-hoc judgment with no structured rubric, and requires N full summaries to fit in context simultaneously.

---

## Fix
Added an optional `judge` parameter to `delegate_task`. When provided with batch tasks, a new `_judge_best_of_n()` function evaluates all outputs side-by-side using an independent judge LLM and returns a `winner` object with task_index and reasoning. If no judge is provided, behavior is unchanged.

---

## What changed
* `tools/delegate_tool.py`: added `judge: Optional[str] = None` to `delegate_task` signature
* `tools/delegate_tool.py`: added `judge` to `DELEGATE_TASK_SCHEMA` top-level properties
* `tools/delegate_tool.py`: added `_judge_best_of_n()` function — compares N outputs side-by-side, returns winner index, graceful degrade on failure
* `tools/delegate_tool.py`: wired Best-of-N evaluation after `results.sort()` — adds `winner` object to result with task_index and reasoning
* `tests/tools/test_delegate.py`: added `TestJudgeBestOfN` with 5 tests

---

## What is not affected
* `delegate_task` behavior when `judge` is not provided: unchanged, zero breaking changes
* Single task mode: judge is ignored when only one task is provided
* Judge failure: if auxiliary LLM is unavailable, all results returned without winner, no exception raised

---

## Example

```python
delegate_task(
    tasks=[
        {"goal": "Implement JWT auth for Express API", "toolsets": ["terminal", "file"]},
        {"goal": "Implement JWT auth for Express API", "acp_command": "claude"},
        {"goal": "Implement JWT auth for Express API", "context": "Use TypeScript"},
    ],
    judge="Select the implementation with best security practices and test coverage"
)
# Result: result["winner"] contains {"task_index": N, "reasoning": "..."}
```

---

## Tests
5 new tests in TestJudgeBestOfN, all pass. No regressions in existing tests.
* `test_best_of_n_selects_winner` - judge selects correct winner
* `test_best_of_n_no_evaluator_returns_all` - empty judge skips evaluation
* `test_best_of_n_judge_failure_returns_all` - LLM failure returns None, no exception
* `test_best_of_n_single_task_ignores_evaluator` - single result skips evaluation
* `test_best_of_n_invalid_winner_index_returns_none` - out-of-range winner_index returns None gracefully

Note: two test names retain "evaluator" from earlier iterations — functionally identical, both test `judge` parameter behavior.

This is a prerequisite for the simplify skill (#379): Best-of-N evaluation enables selecting the best fix from parallel review agents.

Phase 2 (structured rubric scoring, configurable judge model) and Phase 3 (adaptive Best-of-N, integration with workflow DAGs) are planned as follow-up PRs.

Part of #479 (Phase 1/3)
Related: #356