### PR TITLE
fix: preserve embedded resource MCP tool results

### DIFF
--- a/tests/tools/test_mcp_structured_content.py
+++ b/tests/tools/test_mcp_structured_content.py
@@ -18,6 +18,23 @@ class _FakeContentBlock:
         self.type = block_type
 
 
+class _FakeTextResource:
+    """Minimal TextResourceContents stand-in."""
+
+    def __init__(self, text: str, uri: str = "qmd://Docs/file.md"):
+        self.text = text
+        self.uri = uri
+        self.mimeType = "text/markdown"
+
+
+class _FakeEmbeddedResourceBlock:
+    """Minimal EmbeddedResource content block."""
+
+    def __init__(self, text: str, uri: str = "qmd://Docs/file.md"):
+        self.type = "resource"
+        self.resource = _FakeTextResource(text=text, uri=uri)
+
+
 class _FakeCallToolResult:
     """Minimal CallToolResult stand-in.
 
@@ -76,6 +93,41 @@ class TestStructuredContentPreservation:
         raw = handler({})
         data = json.loads(raw)
         assert data == {"result": "hello"}
+
+    def test_embedded_resource_result_text_is_preserved(self, _patch_mcp_server):
+        """EmbeddedResource blocks expose document text via resource.text."""
+        session = _patch_mcp_server
+        body = "# QMD\n\nThis document came back as an MCP resource."
+        session.call_tool = AsyncMock(
+            return_value=_FakeCallToolResult(
+                content=[
+                    _FakeEmbeddedResourceBlock(
+                        body,
+                        uri="qmd://Hermes%20Ops%20Wiki/systems/qmd.md",
+                    )
+                ],
+            )
+        )
+        handler = mcp_tool._make_tool_handler("test-server", "get", 30.0)
+        raw = handler({"file": "systems/qmd.md"})
+        data = json.loads(raw)
+        assert data == {"result": body}
+
+    def test_mixed_text_and_embedded_resource_blocks_are_joined(self, _patch_mcp_server):
+        """Mixed text/resource tool results keep both model-visible parts."""
+        session = _patch_mcp_server
+        session.call_tool = AsyncMock(
+            return_value=_FakeCallToolResult(
+                content=[
+                    _FakeContentBlock("Intro"),
+                    _FakeEmbeddedResourceBlock("Resource body"),
+                ],
+            )
+        )
+        handler = mcp_tool._make_tool_handler("test-server", "multi_get", 30.0)
+        raw = handler({"pattern": "systems/*.md"})
+        data = json.loads(raw)
+        assert data == {"result": "Intro\nResource body"}
 
     def test_both_content_and_structured(self, _patch_mcp_server):
         """When both content and structuredContent are present, combine them."""

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -301,6 +301,50 @@ def _sanitize_error(text: str) -> str:
     return _CREDENTIAL_PATTERN.sub("[REDACTED]", text)
 
 
+def _extract_text_from_mcp_content_block(block: Any) -> str:
+    """Extract model-visible text from an MCP content block.
+
+    Tool results can contain more than plain ``TextContent``.  MCP servers may
+    return ``EmbeddedResource`` blocks whose actual payload is nested under
+    ``block.resource.text``.  Treat those as text too; otherwise valid tool
+    results appear empty to Hermes even though the server returned a document.
+    """
+    text = getattr(block, "text", None)
+    if text is not None:
+        return str(text)
+
+    resource = getattr(block, "resource", None)
+    if resource is not None:
+        resource_text = getattr(resource, "text", None)
+        if resource_text is not None:
+            return str(resource_text)
+        blob = getattr(resource, "blob", None)
+        if blob is not None:
+            try:
+                size = len(blob)
+            except TypeError:
+                size = "unknown"
+            return f"[binary resource, {size} bytes]"
+        uri = getattr(resource, "uri", None)
+        if uri is not None:
+            return f"[resource: {uri}]"
+
+    blob = getattr(block, "blob", None)
+    if blob is not None:
+        try:
+            size = len(blob)
+        except TypeError:
+            size = "unknown"
+        return f"[binary data, {size} bytes]"
+
+    # MCP ResourceLink blocks point to a resource but do not embed body text.
+    uri = getattr(block, "uri", None)
+    if uri is not None:
+        return f"[resource: {uri}]"
+
+    return ""
+
+
 # ---------------------------------------------------------------------------
 # MCP tool description content scanning
 # ---------------------------------------------------------------------------
@@ -2016,8 +2060,7 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             if result.isError:
                 error_text = ""
                 for block in (result.content or []):
-                    if hasattr(block, "text"):
-                        error_text += block.text
+                    error_text += _extract_text_from_mcp_content_block(block)
                 return json.dumps({
                     "error": _sanitize_error(
                         error_text or "MCP tool returned an error"
@@ -2027,8 +2070,9 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             # Collect text from content blocks
             parts: List[str] = []
             for block in (result.content or []):
-                if hasattr(block, "text"):
-                    parts.append(block.text)
+                block_text = _extract_text_from_mcp_content_block(block)
+                if block_text:
+                    parts.append(block_text)
             text_result = "\n".join(parts) if parts else ""
 
             # Combine content + structuredContent when both are present.


### PR DESCRIPTION
## Summary
- Preserve text returned inside MCP `EmbeddedResource` content blocks.
- Apply the same extraction path to normal tool results and error text.
- Add regression coverage for QMD-style embedded resource payloads.

## Why
Some MCP servers return document bodies as embedded resources rather than top-level text blocks. For example, QMD `get` / `multi_get` returns a valid `EmbeddedResource` whose text is nested under `resource.text`. Hermes currently only forwards top-level `block.text`, so the payload is dropped and users see an empty result even though the MCP server returned content successfully.

This change keeps existing text-block behavior and additionally extracts text from embedded resource contents.

## Test plan
- `python -m pytest tests/tools/test_mcp_structured_content.py tests/tools/test_mcp_tool.py -q`
- Result: `189 passed`
