### PR TITLE
test(toolsets): include kanban in expected post-#17805 toolset assertions

### DIFF
--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -120,7 +120,16 @@ def test_get_platform_tools_preserves_explicit_empty_selection():
 
     enabled = _get_platform_tools(config, "cli")
 
-    assert enabled == set()
+    # An explicit empty list disables every CONFIGURABLE toolset (web,
+    # terminal, memory, …). Non-configurable platform toolsets that ride
+    # along on the platform's default composite (e.g. `kanban`, whose tools
+    # live in _HERMES_CORE_TOOLS but aren't user-toggleable) are still
+    # auto-recovered by _get_platform_tools so saving via `hermes tools`
+    # doesn't silently drop them. The contract this test guards is the
+    # configurable side: nothing the user could have checked in the TUI
+    # checklist should reappear here.
+    configurable = {ts_key for ts_key, _, _ in CONFIGURABLE_TOOLSETS}
+    assert enabled.isdisjoint(configurable)
 
 
 def test_apply_toolset_change_from_default_does_not_enable_default_off_toolsets():

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -115,7 +115,10 @@ def test_load_enabled_toolsets_rejects_disabled_mcp_env(monkeypatch, capsys):
     )
     monkeypatch.setattr(config_mod, "load_config", lambda: {"platform_toolsets": {"cli": ["memory"]}})
 
-    assert server._load_enabled_toolsets() == ["memory"]
+    # Sorted: ["kanban", "memory"]. `kanban` is auto-recovered by
+    # _get_platform_tools because it's a non-configurable platform toolset
+    # whose tools live in hermes-cli's universe (see toolsets.py).
+    assert server._load_enabled_toolsets() == ["kanban", "memory"]
     err = capsys.readouterr().err
     assert "ignoring disabled MCP servers" in err
     assert "mcp-off" in err
@@ -134,7 +137,7 @@ def test_load_enabled_toolsets_falls_back_when_tui_env_invalid(monkeypatch, caps
 
     monkeypatch.setattr(config_mod, "load_config", lambda: {"platform_toolsets": {"cli": ["memory"]}})
 
-    assert server._load_enabled_toolsets() == ["memory"]
+    assert server._load_enabled_toolsets() == ["kanban", "memory"]
     assert "using configured CLI toolsets" in capsys.readouterr().err
 
 

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -304,6 +304,7 @@ class TestBuiltinDiscovery:
             "tools.file_tools",
             "tools.homeassistant_tool",
             "tools.image_generation_tool",
+            "tools.kanban_tools",
             "tools.memory_tool",
             "tools.mixture_of_agents_tool",
             "tools.process_registry",


### PR DESCRIPTION
## Summary
- The kanban PR (#17805, c86842546) added the `kanban` toolset (in `toolsets.py`) and `tools/kanban_tools.py` but did not update three pre-existing test assertions that bake the full toolset/tool inventory.
- CI on `main` itself is red on these tests right now (last push, 8fed9696, fails the same four). This commit restores green so unrelated PRs stop inheriting these failures.

## The bug
Four tests fail on clean `origin/main`:

| Test | Expected | Actual |
|---|---|---|
| `tests/tools/test_registry.py::TestBuiltinDiscovery::test_matches_previous_manual_builtin_tool_set` | manual builtin list excluding kanban | includes new `tools.kanban_tools` |
| `tests/hermes_cli/test_tools_config.py::test_get_platform_tools_preserves_explicit_empty_selection` | `set()` | `{'kanban'}` |
| `tests/test_tui_gateway_server.py::test_load_enabled_toolsets_rejects_disabled_mcp_env` | `['memory']` | `['kanban', 'memory']` |
| `tests/test_tui_gateway_server.py::test_load_enabled_toolsets_falls_back_when_tui_env_invalid` | `['memory']` | `['kanban', 'memory']` |

Root cause for the three resolver-driven failures: `_get_platform_tools` runs a recovery loop that adds non-configurable platform toolsets whose tools live inside `hermes-cli`'s universe but are absent from `CONFIGURABLE_TOOLSETS` (so they can't appear in the TUI checklist and would otherwise be silently dropped on save). `kanban` is exactly such a toolset — the kanban tools are in `_HERMES_CORE_TOOLS` but `kanban` is not in `CONFIGURABLE_TOOLSETS`, so the loop now picks it up. That is the intended behavior of the recovery loop; the tests just predate it.

## The fix
Test-only:

- **`test_matches_previous_manual_builtin_tool_set`**: add `tools.kanban_tools` to the expected manual list.
- **`test_load_enabled_toolsets_*`** (both): expect `['kanban', 'memory']` and add a one-line comment pointing future readers at `_get_platform_tools` so the auto-recovery isn't surprising.
- **`test_get_platform_tools_preserves_explicit_empty_selection`**: replace `assert enabled == set()` with `assert enabled.isdisjoint(CONFIGURABLE_TOOLSETS)` and a comment explaining the actual contract — no toolset the user could have unchecked in the TUI gets re-enabled. This keeps the test honest as more non-configurable platform toolsets land (kanban is unlikely to be the last).

No production change.

## Test plan
- [x] Reproduced all four failures on clean `origin/main` (180a7036b) with `uv run --with pytest --with pytest-xdist --with fastapi --with starlette --with httpx --with pytest-asyncio` — same install shape CI uses for `[all,dev]`.
- [x] All four pass with this commit applied.
- [x] Adjacent suites green: `tests/hermes_cli/test_tools_config.py`, `tests/tools/test_registry.py`, `tests/tools/test_kanban_tools.py`, `tests/hermes_cli/test_kanban_cli.py`, `tests/test_tui_gateway_server.py` — 238/239 pass; the 1 unrelated failure (`test_browser_manage_connect_default_local_reports_launch_hint`) reproduces on clean main and is about Chrome executable detection on the test runner.
- [x] Regression guard: `assert enabled == set()` failed (`{'kanban'}`); reframed assertion passes; pre-#17805 behavior (no kanban) would still pass under the new assertion since `kanban` was never in `CONFIGURABLE_TOOLSETS`.

## Related
- Follow-up to #17805 (kanban v1).