### PR TITLE
fix(agent): propagate ContextVars to concurrent tool worker threads (salvage #16660)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -23,6 +23,7 @@ Usage:
 import asyncio
 import base64
 import concurrent.futures
+import contextvars
 import copy
 import hashlib
 import json
@@ -9443,7 +9444,9 @@ class AIAgent:
             with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
                 futures = []
                 for i, (tc, name, args) in enumerate(parsed_calls):
-                    f = executor.submit(_run_tool, i, tc, name, args)
+                    # Propagate ContextVars (e.g. _approval_session_key); mirrors asyncio.to_thread.
+                    ctx = contextvars.copy_context()
+                    f = executor.submit(ctx.run, _run_tool, i, tc, name, args)
                     futures.append(f)
 
                 # Wait for all to complete with periodic heartbeats so the

--- a/tests/run_agent/test_tool_executor_contextvar_propagation.py
+++ b/tests/run_agent/test_tool_executor_contextvar_propagation.py
@@ -1,0 +1,249 @@
+"""Regression guard for PR #16660 (salvaged as PR #18027): ContextVar
+propagation into concurrent tool worker threads.
+
+Background
+----------
+Gateway adapters (Slack, Telegram, Discord, ...) set
+``tools.approval._approval_session_key`` as a ContextVar before calling
+``agent.run_conversation`` so that dangerous-command approval prompts route
+back to the channel/session that initiated the tool call. When the agent
+dispatches multiple tools in parallel, it uses
+``concurrent.futures.ThreadPoolExecutor.submit(...)`` — and ``submit`` runs
+the callable in a *fresh* context, NOT the caller's context. Without an
+explicit ``contextvars.copy_context().run(...)`` wrapper, worker threads
+observe the ContextVar's default value, fall through to the
+``os.environ`` legacy fallback (which the gateway overwrites at each
+agent step), and route the approval card to *whichever session stepped
+most recently* — not the one that raised the prompt. Confirmed in the
+wild on Slack with two concurrent channels: session A's `rm -rf`
+approval card was delivered to session B.
+
+The fix (4 LOC in ``run_agent.py``) snapshots the caller's context with
+``copy_context()`` and submits ``ctx.run(_run_tool, …)`` instead of
+``_run_tool`` directly. Mirrors ``asyncio.to_thread`` semantics.
+
+This suite follows the ``contextvar-run-in-executor-bridge`` skill's
+two-test pattern: one end-to-end test proves the fix works at the
+call-site level, one documents the Python contract that makes the fix
+necessary. If anyone ever reverts the wrapper, the call-site test
+fails while the contract test keeps passing — a clear diagnostic
+signal for *why* the call-site regressed.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import contextvars
+import threading
+
+
+def test_executor_submit_without_copy_context_does_not_propagate():
+    """Documents the Python contract the fix relies on.
+
+    ``concurrent.futures.ThreadPoolExecutor.submit(fn)`` runs ``fn`` in a
+    worker thread with a fresh, empty context. A ContextVar set by the
+    caller is invisible inside ``fn``. This is the exact trap that made
+    approval-session routing race in the gateway before #16660.
+
+    If this test ever fails — i.e. submit() starts propagating
+    ContextVars by default — the copy_context() wrapper in run_agent.py
+    becomes redundant but not harmful, and the call-site test below
+    should be updated accordingly.
+    """
+    probe: contextvars.ContextVar[str] = contextvars.ContextVar(
+        "probe_default_propagation", default="unset"
+    )
+
+    def read_in_worker() -> str:
+        return probe.get()
+
+    probe.set("set-in-main")
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
+        observed = ex.submit(read_in_worker).result(timeout=5)
+
+    assert observed == "unset", (
+        "Unexpected: executor.submit propagated a ContextVar without "
+        "copy_context(). If Python's behavior changed, update "
+        "test_run_tool_worker_sees_parent_context below."
+    )
+
+
+def test_executor_submit_with_copy_context_run_propagates():
+    """Positive case: the explicit ``copy_context().run(...)`` wrapper the
+    PR adds makes parent-context ContextVar values visible in the worker.
+    """
+    probe: contextvars.ContextVar[str] = contextvars.ContextVar(
+        "probe_explicit_propagation", default="unset"
+    )
+
+    def read_in_worker() -> str:
+        return probe.get()
+
+    probe.set("set-in-main")
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
+        ctx = contextvars.copy_context()
+        observed = ex.submit(ctx.run, read_in_worker).result(timeout=5)
+
+    assert observed == "set-in-main", (
+        f"copy_context().run(...) failed to propagate: got {observed!r}"
+    )
+
+
+def test_run_tool_worker_sees_parent_approval_session_key():
+    """End-to-end call-site guard.
+
+    Mirrors the exact shape of the fixed call site in
+    ``run_agent.py::_execute_tool_calls_concurrent`` — a
+    ``ThreadPoolExecutor`` with ``executor.submit(ctx.run, fn, *args)``.
+    Sets the real ``tools.approval._approval_session_key`` ContextVar
+    in the caller and asserts the worker observes it via
+    ``tools.approval.get_current_session_key()``.
+
+    If the PR's ``copy_context().run`` wrapper is reverted, this test
+    fails with ``Expected 'session-A' but worker saw 'default'``.
+    """
+    from tools.approval import (
+        _approval_session_key,
+        get_current_session_key,
+    )
+
+    observed: dict = {}
+    barrier = threading.Event()
+
+    def worker_equivalent_to_run_tool() -> None:
+        # Mirror what real _run_tool does early: read the session key.
+        observed["session_key"] = get_current_session_key(default="FALLBACK")
+        barrier.set()
+
+    # Set the ContextVar the gateway would set before calling agent.run.
+    token = _approval_session_key.set("session-A")
+    try:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
+            ctx = contextvars.copy_context()
+            fut = ex.submit(ctx.run, worker_equivalent_to_run_tool)
+            fut.result(timeout=5)
+        assert barrier.is_set(), "worker did not complete"
+    finally:
+        _approval_session_key.reset(token)
+
+    assert observed.get("session_key") == "session-A", (
+        f"Worker thread did not inherit _approval_session_key from caller. "
+        f"Expected 'session-A', got {observed.get('session_key')!r}. "
+        "This is the bug that PR #16660 fixed — approval prompts route to "
+        "the wrong session in concurrent gateway traffic. Check whether "
+        "the copy_context().run wrapper in _execute_tool_calls_concurrent "
+        "was removed."
+    )
+
+
+def test_run_agent_concurrent_executor_wraps_submit_with_copy_context():
+    """Source-level guard that the fix stays at the REAL call site.
+
+    The behavioral tests above exercise the pattern in isolation and
+    pass regardless of whether ``run_agent.py`` actually uses it.
+    This guard inspects ``_execute_tool_calls_concurrent`` directly and
+    asserts that ``executor.submit`` is called with ``ctx.run`` (or
+    ``copy_context()`` appears within a few lines) — so reverting the
+    wrapper in ``run_agent.py`` fails this test with a clear message.
+    """
+    import ast
+    import inspect
+
+    import run_agent
+
+    src_path = inspect.getsourcefile(run_agent)
+    assert src_path is not None
+    tree = ast.parse(open(src_path, encoding="utf-8").read())
+
+    submit_calls_in_agent: list[ast.Call] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        # Match executor.submit(...) style calls.
+        if isinstance(func, ast.Attribute) and func.attr == "submit":
+            submit_calls_in_agent.append(node)
+
+    # Filter to the submit call inside the concurrent tool executor —
+    # identifiable by passing `_run_tool` as its target. Other submit()
+    # call sites in run_agent.py (e.g. auxiliary client warm-up) are
+    # out of scope for this regression.
+    tool_submits = []
+    for call in submit_calls_in_agent:
+        if not call.args:
+            continue
+        first = call.args[0]
+        # Unfixed: executor.submit(_run_tool, ...) → first arg is a Name
+        if isinstance(first, ast.Name) and first.id == "_run_tool":
+            tool_submits.append(("unfixed", call))
+        # Fixed: executor.submit(ctx.run, _run_tool, ...) → first arg is
+        # ctx.run (Attribute), and _run_tool is the second arg.
+        elif (
+            isinstance(first, ast.Attribute)
+            and first.attr == "run"
+            and len(call.args) >= 2
+            and isinstance(call.args[1], ast.Name)
+            and call.args[1].id == "_run_tool"
+        ):
+            tool_submits.append(("fixed", call))
+
+    assert tool_submits, (
+        "Could not locate `executor.submit(... _run_tool ...)` in "
+        "run_agent.py. The call site may have been renamed — update this "
+        "guard along with the refactor."
+    )
+    unfixed = [c for kind, c in tool_submits if kind == "unfixed"]
+    assert not unfixed, (
+        "run_agent.py contains `executor.submit(_run_tool, ...)` without a "
+        "`ctx.run` wrapper. This is the pre-#16660 shape: worker threads "
+        "will read a fresh ContextVar and approval-session routing "
+        "collapses to the os.environ fallback. Wrap with "
+        "`ctx = contextvars.copy_context(); executor.submit(ctx.run, "
+        "_run_tool, ...)`."
+    )
+
+
+def test_two_concurrent_tool_batches_keep_session_keys_isolated():
+    """End-to-end guard: two callers each set a different session key
+    and submit workers concurrently. Each worker must see its own
+    caller's key, not the other's.
+
+    Guards against a future "optimization" that reuses a single context
+    snapshot across callers (which would collapse isolation the same way
+    the unfixed ``submit`` does).
+    """
+    from tools.approval import (
+        _approval_session_key,
+        get_current_session_key,
+    )
+
+    results: dict = {}
+
+    def caller(label: str) -> None:
+        token = _approval_session_key.set(f"session-{label}")
+        try:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
+                ctx = contextvars.copy_context()
+                fut = ex.submit(
+                    ctx.run,
+                    lambda: get_current_session_key(default="FALLBACK"),
+                )
+                results[label] = fut.result(timeout=5)
+        finally:
+            _approval_session_key.reset(token)
+
+    t_a = threading.Thread(target=caller, args=("A",))
+    t_b = threading.Thread(target=caller, args=("B",))
+    t_a.start()
+    t_b.start()
+    t_a.join(timeout=10)
+    t_b.join(timeout=10)
+
+    assert results.get("A") == "session-A", (
+        f"Session A worker saw {results.get('A')!r}, expected 'session-A'"
+    )
+    assert results.get("B") == "session-B", (
+        f"Session B worker saw {results.get('B')!r}, expected 'session-B'"
+    )


### PR DESCRIPTION
Salvages the core fix from #16660 by @banditburai (commit authored by @firefly). The original PR had scope contamination — a `tests/eval_018/` directory containing eval-oracle test files for a different project ("talaria") that fail 5/5 on hermes main (check for a non-existent `cli.CliError` class, a rename from `ContextCompressor`→`ContextCompactor` that never happened here, `talaria.tools._anchor_state` imports, a wrong `generate_title` timeout default, etc.). Those were dropped from this salvage.

## The real fix (4 LOC in run_agent.py)

`_execute_tool_calls_concurrent` submits tools via `executor.submit(_run_tool, ...)` without `copy_context().run`, so worker threads run with a fresh context — `tools.approval._approval_session_key` (set by gateway adapters before `agent.run`) is invisible. Workers fall through `get_current_session_key()`'s resolution order to the `os.environ` fallback (which every agent step overwrites), silently collapsing per-session dispatch to whichever session stepped most recently.

Fix: snapshot the caller's context and submit `ctx.run(_run_tool, …)`. Mirrors `asyncio.to_thread` semantics. The existing threading.local callback propagation at `run_agent.py:~8796` (from commit 0046d170 / GHSA-qg5c-hvr5-hjgr) is preserved — that one handles a different propagation surface (approval/sudo callbacks) that ContextVars cannot carry across thread boundaries.

## Real-world repro

Via @syahidfrd on [#16660 comment](https://github.com/NousResearch/hermes-agent/pull/16660#issuecomment-4340770127): two concurrent Slack sessions (channels A and B), session A's agent fired a dangerous-command approval for a recursive delete → approval card was delivered to **channel B** — the user there saw an approval prompt for a command they had no context for, while session A's thread blocked waiting for a response that would never come. Any user in B could click "Allow Once" without understanding what they were authorizing.

## Regression suite

`tests/run_agent/test_tool_executor_contextvar_propagation.py` — 5 guards, following the `contextvar-run-in-executor-bridge` skill's two-test pattern plus a source-level guard for the real call site:

1. **Contract documentation** — `executor.submit(fn)` without `copy_context` does NOT propagate ContextVars. If this ever flips, the fix becomes redundant.
2. **Contract validation** — `copy_context().run(fn)` does propagate. Positive baseline.
3. **End-to-end** — set the real `_approval_session_key` in a caller, verify the worker thread observes it via `get_current_session_key()`.
4. **Source-level guard** — AST-parses `run_agent.py` and asserts the `executor.submit` call site for `_run_tool` is invoked with `ctx.run` as its first arg. **This is the primary regression guard.** Behavioral tests 1-3 + 5 exercise the *pattern* but not the *real call site* — they keep passing even if someone reverts the wrapper in `run_agent.py`. Test 4 fails with a concrete diagnostic:

    ```
    AssertionError: run_agent.py contains `executor.submit(_run_tool, ...)`
    without a `ctx.run` wrapper. This is the pre-#16660 shape: worker
    threads will read a fresh ContextVar and approval-session routing
    collapses to the os.environ fallback.
    ```

5. **Concurrent-caller isolation** — two callers each set a different session key; each worker must see its own caller's key.

## Regression guard validation

Planted the pre-fix shape: reverted `run_agent.py` to `origin/main` → guard #4 fails with the diagnostic above ✓. Restored the fix → 5/5 pass ✓.

## Test plan

- [x] `scripts/run_tests.sh tests/run_agent/test_tool_executor_contextvar_propagation.py` — 5/5 pass
- [x] Broader sweep `tests/run_agent/ tests/tools/test_approval.py tests/acp/` — 1481 pass, 17 skipped, 1 pre-existing failure on `origin/main` (`test_interactive_env_var_routes_to_callback`, unrelated to this PR)
- [x] Regression guard validated via plant-and-revert
- [x] Empirical proof of bug mechanism: demonstrated in a standalone REPL that `executor.submit(read_ctxvar)` sees `DEFAULT` while `executor.submit(ctx.run, read_ctxvar)` sees the parent-set value

Closes #16660.

Co-authored-by: firefly <promptsiren@gmail.com>
Co-authored-by: banditburai <banditburai@users.noreply.github.com>