### PR TITLE
fix: build Feishu tool client from env credentials

### DIFF
--- a/tests/tools/test_feishu_client_fallback.py
+++ b/tests/tools/test_feishu_client_fallback.py
@@ -22,6 +22,10 @@ class _FakeBuilder:
         self.calls.append(("log_level", value))
         return self
 
+    def domain(self, value):
+        self.calls.append(("domain", value))
+        return self
+
     def build(self):
         self.calls.append(("build", None))
         return self.built_client
@@ -37,11 +41,19 @@ class _FakeClientFactory:
 
 def _install_fake_lark(monkeypatch, built_client="env-client"):
     builder = _FakeBuilder(built_client)
-    fake_lark = types.SimpleNamespace(
-        Client=_FakeClientFactory(builder),
-        LogLevel=types.SimpleNamespace(ERROR="ERROR"),
-    )
+    fake_lark = types.ModuleType("lark_oapi")
+    setattr(fake_lark, "Client", _FakeClientFactory(builder))
+    setattr(fake_lark, "LogLevel", types.SimpleNamespace(ERROR="ERROR"))
+    setattr(fake_lark, "__path__", [])
     monkeypatch.setitem(__import__("sys").modules, "lark_oapi", fake_lark)
+    fake_core = types.ModuleType("lark_oapi.core")
+    fake_core.__path__ = []
+    monkeypatch.setitem(__import__("sys").modules, "lark_oapi.core", fake_core)
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "lark_oapi.core.const",
+        types.SimpleNamespace(FEISHU_DOMAIN="feishu.example", LARK_DOMAIN="lark.example"),
+    )
     return builder, built_client
 
 
@@ -55,6 +67,7 @@ def test_doc_tool_builds_client_from_feishu_env_when_no_comment_client(monkeypat
     builder, built_client = _install_fake_lark(monkeypatch, built_client="doc-client")
     monkeypatch.setenv("FEISHU_APP_ID", "app-id")
     monkeypatch.setenv("FEISHU_APP_SECRET", "app-secret")
+    monkeypatch.setenv("FEISHU_DOMAIN", "feishu")
     monkeypatch.delenv("LARK_APP_ID", raising=False)
     monkeypatch.delenv("LARK_APP_SECRET", raising=False)
 
@@ -62,6 +75,7 @@ def test_doc_tool_builds_client_from_feishu_env_when_no_comment_client(monkeypat
     assert ("app_id", "app-id") in builder.calls
     assert ("app_secret", "app-secret") in builder.calls
     assert ("log_level", "ERROR") in builder.calls
+    assert ("domain", "feishu.example") in builder.calls
     assert ("build", None) in builder.calls
 
 
@@ -72,10 +86,12 @@ def test_drive_tool_builds_client_from_lark_env_when_no_comment_client(monkeypat
     monkeypatch.delenv("FEISHU_APP_SECRET", raising=False)
     monkeypatch.setenv("LARK_APP_ID", "lark-id")
     monkeypatch.setenv("LARK_APP_SECRET", "lark-secret")
+    monkeypatch.setenv("FEISHU_DOMAIN", "lark")
 
     assert feishu_drive_tool.get_client() == built_client
     assert ("app_id", "lark-id") in builder.calls
     assert ("app_secret", "lark-secret") in builder.calls
+    assert ("domain", "lark.example") in builder.calls
     assert ("build", None) in builder.calls
 
 
@@ -91,6 +107,17 @@ def test_existing_comment_client_takes_precedence_over_env(monkeypatch):
         assert builder.calls == []
     finally:
         _clear_thread_client(feishu_doc_tool)
+
+
+def test_partial_feishu_credentials_do_not_mix_with_lark_secret(monkeypatch):
+    _clear_thread_client(feishu_doc_tool)
+    _install_fake_lark(monkeypatch)
+    monkeypatch.setenv("FEISHU_APP_ID", "feishu-id")
+    monkeypatch.delenv("FEISHU_APP_SECRET", raising=False)
+    monkeypatch.delenv("LARK_APP_ID", raising=False)
+    monkeypatch.setenv("LARK_APP_SECRET", "lark-secret")
+
+    assert feishu_doc_tool.get_client() is None
 
 
 def test_no_env_credentials_keeps_client_unavailable(monkeypatch):

--- a/tests/tools/test_feishu_client_fallback.py
+++ b/tests/tools/test_feishu_client_fallback.py
@@ -1,0 +1,103 @@
+"""Tests for Feishu tool client fallback outside comment contexts."""
+
+import types
+
+from tools import feishu_doc_tool, feishu_drive_tool
+
+
+class _FakeBuilder:
+    def __init__(self, built_client):
+        self.built_client = built_client
+        self.calls = []
+
+    def app_id(self, value):
+        self.calls.append(("app_id", value))
+        return self
+
+    def app_secret(self, value):
+        self.calls.append(("app_secret", value))
+        return self
+
+    def log_level(self, value):
+        self.calls.append(("log_level", value))
+        return self
+
+    def build(self):
+        self.calls.append(("build", None))
+        return self.built_client
+
+
+class _FakeClientFactory:
+    def __init__(self, builder):
+        self._builder = builder
+
+    def builder(self):
+        return self._builder
+
+
+def _install_fake_lark(monkeypatch, built_client="env-client"):
+    builder = _FakeBuilder(built_client)
+    fake_lark = types.SimpleNamespace(
+        Client=_FakeClientFactory(builder),
+        LogLevel=types.SimpleNamespace(ERROR="ERROR"),
+    )
+    monkeypatch.setitem(__import__("sys").modules, "lark_oapi", fake_lark)
+    return builder, built_client
+
+
+def _clear_thread_client(module):
+    if hasattr(module._local, "client"):
+        delattr(module._local, "client")
+
+
+def test_doc_tool_builds_client_from_feishu_env_when_no_comment_client(monkeypatch):
+    _clear_thread_client(feishu_doc_tool)
+    builder, built_client = _install_fake_lark(monkeypatch, built_client="doc-client")
+    monkeypatch.setenv("FEISHU_APP_ID", "app-id")
+    monkeypatch.setenv("FEISHU_APP_SECRET", "app-secret")
+    monkeypatch.delenv("LARK_APP_ID", raising=False)
+    monkeypatch.delenv("LARK_APP_SECRET", raising=False)
+
+    assert feishu_doc_tool.get_client() == built_client
+    assert ("app_id", "app-id") in builder.calls
+    assert ("app_secret", "app-secret") in builder.calls
+    assert ("log_level", "ERROR") in builder.calls
+    assert ("build", None) in builder.calls
+
+
+def test_drive_tool_builds_client_from_lark_env_when_no_comment_client(monkeypatch):
+    _clear_thread_client(feishu_drive_tool)
+    builder, built_client = _install_fake_lark(monkeypatch, built_client="drive-client")
+    monkeypatch.delenv("FEISHU_APP_ID", raising=False)
+    monkeypatch.delenv("FEISHU_APP_SECRET", raising=False)
+    monkeypatch.setenv("LARK_APP_ID", "lark-id")
+    monkeypatch.setenv("LARK_APP_SECRET", "lark-secret")
+
+    assert feishu_drive_tool.get_client() == built_client
+    assert ("app_id", "lark-id") in builder.calls
+    assert ("app_secret", "lark-secret") in builder.calls
+    assert ("build", None) in builder.calls
+
+
+def test_existing_comment_client_takes_precedence_over_env(monkeypatch):
+    builder, _ = _install_fake_lark(monkeypatch, built_client="env-client")
+    monkeypatch.setenv("FEISHU_APP_ID", "app-id")
+    monkeypatch.setenv("FEISHU_APP_SECRET", "app-secret")
+
+    feishu_doc_tool.set_client("comment-client")
+
+    try:
+        assert feishu_doc_tool.get_client() == "comment-client"
+        assert builder.calls == []
+    finally:
+        _clear_thread_client(feishu_doc_tool)
+
+
+def test_no_env_credentials_keeps_client_unavailable(monkeypatch):
+    _clear_thread_client(feishu_doc_tool)
+    monkeypatch.delenv("FEISHU_APP_ID", raising=False)
+    monkeypatch.delenv("FEISHU_APP_SECRET", raising=False)
+    monkeypatch.delenv("LARK_APP_ID", raising=False)
+    monkeypatch.delenv("LARK_APP_SECRET", raising=False)
+
+    assert feishu_doc_tool.get_client() is None

--- a/tools/feishu_client.py
+++ b/tools/feishu_client.py
@@ -15,21 +15,35 @@ def build_client_from_env(log: logging.Logger | None = None):
     In that case, fall back to the app credentials already configured for the
     gateway instead of reporting that the client is unavailable.
     """
-    app_id = os.getenv("FEISHU_APP_ID") or os.getenv("LARK_APP_ID")
-    app_secret = os.getenv("FEISHU_APP_SECRET") or os.getenv("LARK_APP_SECRET")
+    credential_pairs = (
+        (os.getenv("FEISHU_APP_ID"), os.getenv("FEISHU_APP_SECRET")),
+        (os.getenv("LARK_APP_ID"), os.getenv("LARK_APP_SECRET")),
+    )
+    app_id, app_secret = next(
+        (
+            (app_id, app_secret)
+            for app_id, app_secret in credential_pairs
+            if app_id and app_secret
+        ),
+        (None, None),
+    )
     if not app_id or not app_secret:
         return None
 
     try:
         import lark_oapi as lark
+        from lark_oapi.core.const import FEISHU_DOMAIN, LARK_DOMAIN
     except ImportError:
         return None
 
     try:
+        domain_name = os.getenv("FEISHU_DOMAIN", "").strip().lower()
+        domain = LARK_DOMAIN if domain_name == "lark" else FEISHU_DOMAIN
         return (
             lark.Client.builder()
             .app_id(app_id)
             .app_secret(app_secret)
+            .domain(domain)
             .log_level(lark.LogLevel.ERROR)
             .build()
         )

--- a/tools/feishu_client.py
+++ b/tools/feishu_client.py
@@ -1,0 +1,39 @@
+"""Shared helpers for Feishu/Lark tool clients."""
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+
+def build_client_from_env(log: logging.Logger | None = None):
+    """Build a lark_oapi client from configured app credentials, if present.
+
+    Feishu document tools are primarily used from document-comment events where
+    the gateway injects a request-scoped client. The same tools can also be
+    exposed in ordinary chat sessions, where no comment-context client exists.
+    In that case, fall back to the app credentials already configured for the
+    gateway instead of reporting that the client is unavailable.
+    """
+    app_id = os.getenv("FEISHU_APP_ID") or os.getenv("LARK_APP_ID")
+    app_secret = os.getenv("FEISHU_APP_SECRET") or os.getenv("LARK_APP_SECRET")
+    if not app_id or not app_secret:
+        return None
+
+    try:
+        import lark_oapi as lark
+    except ImportError:
+        return None
+
+    try:
+        return (
+            lark.Client.builder()
+            .app_id(app_id)
+            .app_secret(app_secret)
+            .log_level(lark.LogLevel.ERROR)
+            .build()
+        )
+    except Exception as exc:  # pragma: no cover - defensive SDK guard
+        active_logger = log or logger
+        active_logger.warning("Failed to build Feishu client from environment: %s", exc)
+        return None

--- a/tools/feishu_doc_tool.py
+++ b/tools/feishu_doc_tool.py
@@ -9,6 +9,7 @@ import logging
 import threading
 
 from tools.registry import registry, tool_error, tool_result
+from tools.feishu_client import build_client_from_env
 
 logger = logging.getLogger(__name__)
 
@@ -22,8 +23,15 @@ def set_client(client):
 
 
 def get_client():
-    """Return the lark client for the current thread, or None."""
-    return getattr(_local, "client", None)
+    """Return a lark client for the current thread, or app credentials fallback."""
+    client = getattr(_local, "client", None)
+    if client is not None:
+        return client
+
+    client = build_client_from_env(logger)
+    if client is not None:
+        _local.client = client
+    return client
 
 
 # ---------------------------------------------------------------------------

--- a/tools/feishu_drive_tool.py
+++ b/tools/feishu_drive_tool.py
@@ -10,6 +10,7 @@ import logging
 import threading
 
 from tools.registry import registry, tool_error, tool_result
+from tools.feishu_client import build_client_from_env
 
 logger = logging.getLogger(__name__)
 
@@ -23,8 +24,15 @@ def set_client(client):
 
 
 def get_client():
-    """Return the lark client for the current thread, or None."""
-    return getattr(_local, "client", None)
+    """Return a lark client for the current thread, or app credentials fallback."""
+    client = getattr(_local, "client", None)
+    if client is not None:
+        return client
+
+    client = build_client_from_env(logger)
+    if client is not None:
+        _local.client = client
+    return client
 
 
 def _check_feishu():


### PR DESCRIPTION
## Summary
- Add a shared Feishu/Lark client helper that builds `lark_oapi.Client` from configured app credentials when no comment-context client is injected
- Use the fallback in `feishu_doc_tool` and `feishu_drive_tool`, preserving injected comment clients when present
- Add regression tests for FEISHU_* and LARK_* env credential fallback behavior

## Test Plan
- `python -m pytest tests/tools/test_feishu_client_fallback.py tests/tools/test_feishu_tools.py -q`
- `python -m pytest tests/tools/test_registry.py -q`
- `python -m pytest tests/tools -q`
- Manual smoke test: `feishu_doc_tool._handle_feishu_doc_read` reads a docx through env-built client outside comment context
