### PR TITLE
fix: add per-turn current time context

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1671,7 +1671,13 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
 
 
 
-def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
+def handle_max_iterations(
+    agent,
+    messages: list,
+    api_call_count: int,
+    *,
+    current_user_context: str = "",
+) -> str:
     """Request a summary when max iterations are reached. Returns the final response text."""
     print(f"⚠️  Reached maximum iterations ({agent.max_iterations}). Requesting summary...")
 
@@ -1681,14 +1687,23 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
         "without calling any more tools."
     )
     messages.append({"role": "user", "content": summary_request})
+    summary_user_idx = len(messages) - 1
 
     try:
         # Build API messages, stripping internal-only fields
         # (finish_reason, reasoning) that strict APIs like Mistral reject with 422
         _needs_sanitize = agent._should_sanitize_tool_calls()
         api_messages = []
-        for msg in messages:
+        for idx, msg in enumerate(messages):
             api_msg = msg.copy()
+            if (
+                idx == summary_user_idx
+                and current_user_context
+                and isinstance(api_msg.get("content"), str)
+            ):
+                api_msg["content"] = (
+                    f"{api_msg['content']}\n\n{current_user_context}"
+                )
             agent._copy_reasoning_content_for_api(msg, api_msg)
             for internal_field in ("reasoning", "finish_reason", "_thinking_prefill"):
                 api_msg.pop(internal_field, None)

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -79,6 +79,20 @@ logger = logging.getLogger(__name__)
 INTERRUPT_WAITING_FOR_MODEL_PREFIX = "Operation interrupted: waiting for model response ("
 
 
+def _append_ephemeral_user_context(content: Any, context_parts: List[str]) -> Any:
+    """Append runtime-only context without mutating persisted user content."""
+    clean_parts = [part for part in context_parts if isinstance(part, str) and part]
+    if not clean_parts:
+        return content
+
+    context = "\n\n".join(clean_parts)
+    if isinstance(content, str):
+        return f"{content}\n\n{context}"
+    if isinstance(content, list):
+        return list(content) + [{"type": "text", "text": context}]
+    return content
+
+
 def _image_error_max_dimension(error: Exception) -> Optional[int]:
     """Extract a provider-reported image dimension ceiling, if present."""
     parts = []
@@ -598,6 +612,7 @@ def run_conversation(
     effective_task_id = _ctx.effective_task_id
     turn_id = _ctx.turn_id
     current_turn_user_idx = _ctx.current_turn_user_idx
+    _current_user_context = _ctx.current_user_context
     _should_review_memory = _ctx.should_review_memory
     _plugin_user_context = _ctx.plugin_user_context
     _ext_prefetch_cache = _ctx.ext_prefetch_cache
@@ -632,8 +647,12 @@ def run_conversation(
     # See agent/transports/codex_app_server_session.py for the adapter
     # and references/codex-app-server-runtime.md for the rationale.
     if agent.api_mode == "codex_app_server":
+        _codex_user_message = _append_ephemeral_user_context(
+            user_message,
+            [_current_user_context],
+        )
         return agent._run_codex_app_server_turn(
-            user_message=user_message,
+            user_message=_codex_user_message,
             original_user_message=original_user_message,
             messages=messages,
             effective_task_id=effective_task_id,
@@ -794,12 +813,15 @@ def run_conversation(
             api_msg = msg.copy()
 
             # Inject ephemeral context into the current turn's user message.
-            # Sources: memory manager prefetch + plugin pre_llm_call hooks
-            # with target="user_message" (the default).  Both are
-            # API-call-time only — the original message in `messages` is
-            # never mutated, so nothing leaks into session persistence.
+            # Sources: per-turn runtime context, memory manager prefetch, and
+            # plugin pre_llm_call hooks with target="user_message" (the
+            # default). All are API-call-time only — the original message in
+            # `messages` is never mutated, so nothing leaks into session
+            # persistence.
             if idx == current_turn_user_idx and msg.get("role") == "user":
                 _injections = []
+                if _current_user_context:
+                    _injections.append(_current_user_context)
                 if _ext_prefetch_cache:
                     _fenced = build_memory_context_block(_ext_prefetch_cache)
                     if _fenced:
@@ -807,9 +829,10 @@ def run_conversation(
                 if _plugin_user_context:
                     _injections.append(_plugin_user_context)
                 if _injections:
-                    _base = api_msg.get("content", "")
-                    if isinstance(_base, str):
-                        api_msg["content"] = _base + "\n\n" + "\n\n".join(_injections)
+                    api_msg["content"] = _append_ephemeral_user_context(
+                        api_msg.get("content", ""),
+                        _injections,
+                    )
 
             # For ALL assistant messages, pass reasoning back to the API
             # This ensures multi-turn reasoning context is preserved
@@ -5348,6 +5371,7 @@ def run_conversation(
         _should_review_memory=_should_review_memory,
         _turn_exit_reason=_turn_exit_reason,
         _pending_verification_response=_pending_verification_response,
+        current_user_context=_current_user_context,
     )
 
 

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -34,6 +34,7 @@ from agent.model_metadata import (
     estimate_messages_tokens_rough,
     estimate_request_tokens_rough,
 )
+from hermes_time import format_current_time_note
 
 logger = logging.getLogger(__name__)
 
@@ -108,6 +109,8 @@ class TurnContext:
     turn_id: str
     # Index of the current user turn within ``messages``.
     current_turn_user_idx: int
+    # Runtime-only context appended to the outbound copy of the current user turn.
+    current_user_context: str = ""
     # Whether the post-turn memory review should fire.
     should_review_memory: bool = False
     # Context contributed by ``pre_llm_call`` plugins (appended to user message).
@@ -303,6 +306,15 @@ def build_turn_context(
     # Preserve the original user message (no nudge injection).
     original_user_message = persist_user_message if persist_user_message is not None else user_message
 
+    # Fresh wall-clock context is carried separately from ``messages`` so every
+    # runtime can add it to its outbound request without polluting transcripts,
+    # session search, memory queries, or trajectories.
+    try:
+        current_user_context = format_current_time_note()
+    except Exception:
+        logger.debug("current-time turn context unavailable", exc_info=True)
+        current_user_context = ""
+
     # Track memory nudge trigger (turn-based, checked here).
     should_review_memory = False
     if (agent._memory_nudge_interval > 0
@@ -451,6 +463,14 @@ def build_turn_context(
                     messages, system_message, approx_tokens=_preflight_tokens,
                     task_id=effective_task_id,
                 )
+                # Compression may replace/shorten the list. Rebind both indexes
+                # to the preserved current user turn so API-only context and any
+                # persistence override still target the right message.
+                for _idx in range(len(messages) - 1, -1, -1):
+                    if messages[_idx].get("role") == "user":
+                        current_turn_user_idx = _idx
+                        agent._persist_user_message_idx = _idx
+                        break
                 # Re-estimate now so size-only compression (same row count,
                 # lower token count — e.g. summarising tool outputs) is
                 # recognised as progress instead of being misread as
@@ -573,6 +593,7 @@ def build_turn_context(
         effective_task_id=effective_task_id,
         turn_id=turn_id,
         current_turn_user_idx=current_turn_user_idx,
+        current_user_context=current_user_context,
         should_review_memory=should_review_memory,
         plugin_user_context=plugin_user_context,
         ext_prefetch_cache=ext_prefetch_cache,

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -43,6 +43,7 @@ def finalize_turn(
     _should_review_memory,
     _turn_exit_reason,
     _pending_verification_response=None,
+    current_user_context="",
 ):
     """Run the post-loop finalization and return the turn ``result`` dict.
 
@@ -93,7 +94,11 @@ def finalize_turn(
                 f"\n⚠️  Iteration budget exhausted ({api_call_count}/{agent.max_iterations}) "
                 "— requesting summary..."
             )
-        final_response = agent._handle_max_iterations(messages, api_call_count)
+        final_response = agent._handle_max_iterations(
+            messages,
+            api_call_count,
+            current_user_context=current_user_context,
+        )
         iteration_limit_fallback = True
 
     if iteration_limit_fallback:

--- a/hermes_time.py
+++ b/hermes_time.py
@@ -133,3 +133,14 @@ def now() -> datetime:
     return datetime.now().astimezone()
 
 
+_CURRENT_TIME_NOTE_PREFIX = "[System note: Current time is "
+
+
+def format_current_time_note(current: Optional[datetime] = None) -> str:
+    """Return the standard ephemeral current-time note for an LLM turn."""
+    current = current or now()
+    formatted = current.strftime("%A, %B %d, %Y %I:%M %p")
+    tz_label = current.strftime("%Z").strip()
+    if tz_label:
+        formatted = f"{formatted} {tz_label}"
+    return f"{_CURRENT_TIME_NOTE_PREFIX}{formatted}.]"

--- a/run_agent.py
+++ b/run_agent.py
@@ -5779,10 +5779,21 @@ class AIAgent:
         from agent.tool_executor import execute_tool_calls_sequential
         return execute_tool_calls_sequential(self, assistant_message, messages, effective_task_id, api_call_count)
 
-    def _handle_max_iterations(self, messages: list, api_call_count: int) -> str:
+    def _handle_max_iterations(
+        self,
+        messages: list,
+        api_call_count: int,
+        *,
+        current_user_context: str = "",
+    ) -> str:
         """Forwarder — see ``agent.chat_completion_helpers.handle_max_iterations``."""
         from agent.chat_completion_helpers import handle_max_iterations
-        return handle_max_iterations(self, messages, api_call_count)
+        return handle_max_iterations(
+            self,
+            messages,
+            api_call_count,
+            current_user_context=current_user_context,
+        )
 
     def run_conversation(
         self,

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -166,9 +166,14 @@ def _build(agent, **overrides):
 
 def test_returns_turn_context_with_user_message_appended():
     agent = _FakeAgent()
-    ctx = _build(agent)
+    with patch(
+        "agent.turn_context.format_current_time_note",
+        return_value="[System note: Current time is TEST.]",
+    ):
+        ctx = _build(agent)
     assert isinstance(ctx, TurnContext)
     assert ctx.user_message == "hello"
+    assert ctx.current_user_context == "[System note: Current time is TEST.]"
     # The user turn was appended and indexed.
     assert ctx.messages[-1] == {"role": "user", "content": "hello"}
     assert ctx.current_turn_user_idx == len(ctx.messages) - 1
@@ -363,4 +368,46 @@ def test_expired_cooldown_allows_preflight(tmp_path):
     assert isinstance(ctx, TurnContext)
     agent._emit_status.assert_called_once()
     agent._compress_context.assert_called()
+
+
+def test_preflight_compression_reindexes_current_user_turn():
+    agent = _FakeAgent()
+    agent.compression_enabled = True
+    agent.context_compressor = types.SimpleNamespace(
+        protect_first_n=1,
+        protect_last_n=1,
+        threshold_tokens=100,
+        context_length=10_000,
+        last_prompt_tokens=0,
+        last_real_prompt_tokens=0,
+        should_defer_preflight_to_real_usage=lambda _tokens: False,
+        get_active_compression_failure_cooldown=lambda: None,
+        should_compress=MagicMock(side_effect=[True, False]),
+    )
+    compressed = [
+        {"role": "assistant", "content": "compressed history"},
+        {"role": "user", "content": "hello"},
+    ]
+    setattr(agent, "_compress_context", MagicMock(return_value=(compressed, "SYSTEM")))
+    history = [
+        {"role": "user", "content": "old question"},
+        {"role": "assistant", "content": "old answer"},
+        {"role": "user", "content": "older question"},
+        {"role": "assistant", "content": "older answer"},
+    ]
+
+    with patch("agent.turn_context._should_run_preflight_estimate", return_value=True), \
+         patch(
+             "agent.turn_context.estimate_request_tokens_rough",
+             side_effect=[1_000, 50],
+         ), \
+         patch(
+             "agent.turn_context.conversation_history_after_compression",
+             return_value=[],
+         ):
+        ctx = _build(agent, conversation_history=history)
+
+    assert ctx.messages == compressed
+    assert ctx.current_turn_user_idx == 1
+    assert getattr(agent, "_persist_user_message_idx") == 1
 

--- a/tests/agent/test_turn_finalizer_cleanup_guard.py
+++ b/tests/agent/test_turn_finalizer_cleanup_guard.py
@@ -81,7 +81,9 @@ class _StubAgent:
     def _safe_print(self, *a, **k):
         pass
 
-    def _handle_max_iterations(self, messages, n):
+    def _handle_max_iterations(
+        self, messages, n, *, current_user_context=""
+    ):
         return "PARTIAL SUMMARY FROM MODEL"
 
     def _file_mutation_verifier_enabled(self):

--- a/tests/agent/test_turn_finalizer_final_response_persistence.py
+++ b/tests/agent/test_turn_finalizer_final_response_persistence.py
@@ -32,7 +32,9 @@ class FakeAgent:
         self.valid_tool_names = []
         self.persisted_messages = None
 
-    def _handle_max_iterations(self, messages, api_call_count):
+    def _handle_max_iterations(
+        self, messages, api_call_count, *, current_user_context=""
+    ):
         raise AssertionError("not expected")
 
     def _emit_status(self, *_args, **_kwargs):

--- a/tests/agent/test_turn_finalizer_iteration_limit_exit.py
+++ b/tests/agent/test_turn_finalizer_iteration_limit_exit.py
@@ -45,10 +45,14 @@ class _LimitAgent:
         self.valid_tool_names = []
         self.persisted_messages = None
         self._handle_max_iterations_called = False
+        self._handle_max_iterations_context = None
         self._completion_explainer = completion_explainer
 
-    def _handle_max_iterations(self, messages, api_call_count):
+    def _handle_max_iterations(
+        self, messages, api_call_count, *, current_user_context=""
+    ):
         self._handle_max_iterations_called = True
+        self._handle_max_iterations_context = current_user_context
         return "summary from extra call"
 
     def _emit_status(self, *_args, **_kwargs):
@@ -95,6 +99,7 @@ def _finalize(
     exit_reason,
     api_call_count=60,
     pending_verification_response=None,
+    current_user_context="",
 ):
     return finalize_turn(
         agent,
@@ -111,6 +116,7 @@ def _finalize(
         _should_review_memory=False,
         _turn_exit_reason=exit_reason,
         _pending_verification_response=pending_verification_response,
+        current_user_context=current_user_context,
     )
 
 
@@ -165,10 +171,26 @@ def test_empty_pending_verification_response_uses_summary_fallback(monkeypatch):
     assert agent._handle_max_iterations_called is True
 
 
+def test_summary_fallback_receives_current_user_context(monkeypatch):
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    agent = _LimitAgent()
+    current_context = "[System note: Current time is TEST.]"
+
+    result = _finalize(
+        agent,
+        final_response=None,
+        exit_reason="unknown",
+        current_user_context=current_context,
+    )
+
+    assert result["final_response"] == "summary from extra call"
+    assert agent._handle_max_iterations_context == current_context
+
+
 def test_short_generated_summary_keeps_abnormal_turn_explainer(monkeypatch):
     monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
     agent = _LimitAgent(completion_explainer=True)
-    agent._handle_max_iterations = lambda *_args: "The"
+    agent._handle_max_iterations = MagicMock(return_value="The")
 
     result = _finalize(agent, final_response=None, exit_reason="unknown")
 

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -77,7 +77,9 @@ class TestRunConversationCodexPath:
         # No background review fork during tests
         with patch.object(agent, "_spawn_background_review", return_value=None):
             result = agent.run_conversation("hello there")
-        assert result["final_response"] == "echo: hello there"
+        assert result["final_response"].startswith(
+            "echo: hello there\n\n[System note: Current time is "
+        )
         assert result["completed"] is True
         assert result["partial"] is False
         assert result["error"] is None
@@ -194,9 +196,17 @@ class TestRunConversationCodexPath:
         assert len(msgs) >= 4
         assert msgs[0]["role"] == "user"
         assert msgs[0]["content"] == "hello"
-        # Last assistant message has the final text
-        final = [m for m in msgs if m.get("role") == "assistant"
-                 and m.get("content") == "echo: hello"]
+        # The Codex request receives ephemeral runtime context, while the clean
+        # user row above remains suitable for persistence.
+        final = [
+            m
+            for m in msgs
+            if m.get("role") == "assistant"
+            and isinstance(m.get("content"), str)
+            and m["content"].startswith(
+                "echo: hello\n\n[System note: Current time is "
+            )
+        ]
         assert final, f"expected final assistant message in {msgs}"
 
     def test_projected_messages_are_synced_to_external_memory(self, fake_session):

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3655,6 +3655,25 @@ class TestHandleMaxIterations:
         assert len(result) > 0
         assert "summary" in result.lower()
 
+    def test_current_time_context_is_api_only_on_summary_request(self, agent):
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="Summary",
+        )
+        agent._cached_system_prompt = "You are helpful."
+        messages = [{"role": "user", "content": "do stuff"}]
+        current_context = "[System note: Current time is TEST.]"
+
+        result = agent._handle_max_iterations(
+            messages,
+            60,
+            current_user_context=current_context,
+        )
+
+        assert result == "Summary"
+        sent_messages = agent.client.chat.completions.create.call_args.kwargs["messages"]
+        assert sent_messages[-1]["content"].endswith(f"\n\n{current_context}")
+        assert current_context not in messages[-1]["content"]
+
     def test_api_failure_returns_error(self, agent):
         agent.client.chat.completions.create.side_effect = Exception("API down")
         agent._cached_system_prompt = "You are helpful."
@@ -3983,6 +4002,124 @@ class TestRunConversation:
         assert result["final_response"] == "Final answer"
         assert result["completed"] is True
 
+    def test_current_time_context_is_api_only(self, agent):
+        self._setup_agent(agent)
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="Final answer",
+            finish_reason="stop",
+        )
+        current_context = "[System note: Current time is TEST.]"
+
+        with (
+            patch(
+                "agent.turn_context.format_current_time_note",
+                return_value=current_context,
+            ),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory") as save_trajectory,
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        api_messages = agent.client.chat.completions.create.call_args.kwargs["messages"]
+        assert api_messages[-1]["content"] == f"hello\n\n{current_context}"
+        assert result["messages"][0]["content"] == "hello"
+        assert save_trajectory.call_args.args[0][0]["content"] == "hello"
+
+    def test_ephemeral_context_appender_preserves_multimodal_user_turn(self):
+        from agent.conversation_loop import _append_ephemeral_user_context
+
+        current_context = "[System note: Current time is TEST.]"
+        original = [
+            {"type": "text", "text": "describe this"},
+            {
+                "type": "image_url",
+                "image_url": {"url": "https://example.com/image.png"},
+            },
+        ]
+
+        api_content = _append_ephemeral_user_context(original, [current_context])
+
+        assert api_content is not original
+        assert api_content[:-1] == original
+        assert api_content[-1] == {"type": "text", "text": current_context}
+        assert len(original) == 2
+
+    def test_current_time_context_reaches_codex_app_server_without_persistence_leak(
+        self, agent
+    ):
+        self._setup_agent(agent)
+        agent.api_mode = "codex_app_server"
+        current_context = "[System note: Current time is TEST.]"
+        codex_result = {
+            "final_response": "Codex answer",
+            "messages": [{"role": "user", "content": "hello"}],
+            "api_calls": 1,
+            "completed": True,
+        }
+
+        with (
+            patch(
+                "agent.turn_context.format_current_time_note",
+                return_value=current_context,
+            ),
+            patch.object(agent, "_persist_session"),
+            patch.object(
+                agent,
+                "_run_codex_app_server_turn",
+                return_value=codex_result,
+            ) as run_codex,
+        ):
+            result = agent.run_conversation("hello")
+
+        kwargs = run_codex.call_args.kwargs
+        assert kwargs["user_message"] == f"hello\n\n{current_context}"
+        assert kwargs["original_user_message"] == "hello"
+        assert kwargs["messages"][0]["content"] == "hello"
+        assert result == codex_result
+
+    def test_current_time_context_reaches_codex_multimodal_turn(self, agent):
+        self._setup_agent(agent)
+        agent.api_mode = "codex_app_server"
+        current_context = "[System note: Current time is TEST.]"
+        original = [
+            {"type": "text", "text": "describe this"},
+            {
+                "type": "image_url",
+                "image_url": {"url": "https://example.com/image.png"},
+            },
+        ]
+        codex_result = {
+            "final_response": "Codex answer",
+            "messages": [{"role": "user", "content": original}],
+            "api_calls": 1,
+            "completed": True,
+        }
+
+        with (
+            patch(
+                "agent.turn_context.format_current_time_note",
+                return_value=current_context,
+            ),
+            patch.object(agent, "_persist_session"),
+            patch.object(
+                agent,
+                "_run_codex_app_server_turn",
+                return_value=codex_result,
+            ) as run_codex,
+        ):
+            result = agent.run_conversation(original)
+
+        kwargs = run_codex.call_args.kwargs
+        assert kwargs["user_message"][:-1] == original
+        assert kwargs["user_message"][-1] == {
+            "type": "text",
+            "text": current_context,
+        }
+        assert kwargs["messages"][0]["content"] == original
+        assert len(original) == 2
+        assert result == codex_result
+
     def test_ollama_small_runtime_context_fails_before_api_call(self, agent, caplog):
         self._setup_agent(agent)
         agent.model = "qwen3.5:9b"
@@ -4066,7 +4203,14 @@ class TestRunConversation:
         ]
         assert all("message_count" in c and isinstance(c.get("request_messages"), list) for c in pre_request_calls)
         assert all("request" in c and "messages" in c["request"]["body"] for c in pre_request_calls)
-        assert any(msg.get("role") == "user" and msg.get("content") == "search something" for msg in pre_request_calls[0]["request_messages"])
+        assert any(
+            msg.get("role") == "user"
+            and isinstance(msg.get("content"), str)
+            and msg["content"].startswith(
+                "search something\n\n[System note: Current time is "
+            )
+            for msg in pre_request_calls[0]["request_messages"]
+        )
         assert all("usage" in c and "response" in c for c in post_request_calls)
         assert all("assistant_message" in c["response"] for c in post_request_calls)
 

--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -103,6 +103,26 @@ class TestHermesTimeNow:
         assert r2.utcoffset() == timedelta(hours=5, minutes=30)
 
 
+class TestCurrentTimeContext:
+    """Current-time context has a stable, deterministic request-note shape."""
+
+    def test_format_current_time_note_includes_wall_clock_and_timezone(self):
+        current = datetime(
+            2026,
+            7,
+            13,
+            9,
+            45,
+            tzinfo=timezone(timedelta(hours=8), name="SGT"),
+        )
+
+        note = hermes_time.format_current_time_note(current)
+
+        assert note == (
+            "[System note: Current time is Monday, July 13, 2026 09:45 AM SGT.]"
+        )
+
+
 class TestGetTimezone:
     """Test get_timezone()."""
 


### PR DESCRIPTION
## Summary
- add centralized helpers for formatting and prepending current-time context
- inject current time into the API-facing user turn instead of mutating the system prompt
- keep persisted transcripts, resumed history, and trajectories free of synthetic time notes
- support idempotent injection for both string and multimodal user content

## Test Plan
- `python -m pytest tests/run_agent/test_run_agent.py tests/test_timezone.py -q`
